### PR TITLE
Refactor code to use YAML::Any for all options

### DIFF
--- a/docs/_advanced/configuration.md
+++ b/docs/_advanced/configuration.md
@@ -31,7 +31,7 @@ layout: page
 base: ""
 
 # Whether to use color in the output
-color: "yes"
+color: true
 
 # The configuration file to use
 config_file: ""
@@ -40,7 +40,7 @@ config_file: ""
 concurrency: "100"
 
 # Whether to enable debug mode
-debug: "no"
+debug: false
 
 # Technologies to exclude
 exclude_techs: ""
@@ -49,10 +49,10 @@ exclude_techs: ""
 format: "plain"
 
 # Whether to include the path in the output
-include_path: "no"
+include_path: false
 
 # Whether to disable logging
-nolog: "no"
+nolog: false
 
 # The output file to write to
 output: ""
@@ -64,7 +64,7 @@ send_es: ""
 send_proxy: ""
 
 # Whether to send a request
-send_req: "no"
+send_req: false
 
 # Whether to send headers with the request
 send_with_headers: ""
@@ -85,7 +85,7 @@ use_filters: ""
 use_matchers: ""
 
 # Whether to use all taggers
-all_taggers: "no"
+all_taggers: false
 
 # The taggers to use
 use_taggers: ""

--- a/docs/_advanced/configuration.md
+++ b/docs/_advanced/configuration.md
@@ -67,7 +67,9 @@ send_proxy: ""
 send_req: false
 
 # Whether to send headers with the request
-send_with_headers: ""
+send_with_headers: 
+    - "Authorization: ABCD1234"
+    - "X-API-Key: ABCD1234"
 
 # The value to set for pvalue
 set_pvalue: ""
@@ -79,10 +81,12 @@ techs: ""
 url: ""
 
 # Whether to use filters
-use_filters: ""
+use_filters: 
+    - "/admin"
 
 # Whether to use matchers
-use_matchers: ""
+use_matchers: 
+    - "/user"
 
 # Whether to use all taggers
 all_taggers: false

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -18,7 +18,7 @@ class FunctionalTester
     config_init = ConfigInitializer.new
     noir_options = config_init.default_options
     noir_options["base"] = "./spec/functional_test/#{@path}"
-    noir_options["nolog"] = "yes"
+    noir_options["nolog"] = true
 
     if !expected_count.nil?
       @expected_count = expected_count

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -17,8 +17,8 @@ class FunctionalTester
   def initialize(@path, expected_count, expected_endpoints)
     config_init = ConfigInitializer.new
     noir_options = config_init.default_options
-    noir_options["base"] = "./spec/functional_test/#{@path}"
-    noir_options["nolog"] = true
+    noir_options["base"] = YAML::Any.new("./spec/functional_test/#{@path}")
+    noir_options["nolog"] = YAML::Any.new(true)
 
     if !expected_count.nil?
       @expected_count = expected_count
@@ -131,6 +131,6 @@ class FunctionalTester
   end
 
   def set_url(url)
-    @app.options["url"] = url
+    @app.options["url"] = YAML::Any.new(url)
   end
 end

--- a/spec/functional_test/testers/file_based_spec.cr
+++ b/spec/functional_test/testers/file_based_spec.cr
@@ -15,5 +15,5 @@ tester = FunctionalTester.new("fixtures/file_based/", {
   :endpoints => extected_endpoints.size,
 }, extected_endpoints)
 
-tester.app.options["url"] = "https://www.hahwul.com"
+tester.app.options["url"] = YAML::Any.new("https://www.hahwul.com")
 tester.test_all

--- a/spec/unit_test/models/analyzer_spec.cr
+++ b/spec/unit_test/models/analyzer_spec.cr
@@ -4,7 +4,7 @@ require "../../../src/options.cr"
 describe "Initialize Analyzer" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
+  options["base"] = YAML::Any.new("noir")
   object = Analyzer.new(options)
 
   it "getter - url" do
@@ -24,7 +24,7 @@ end
 describe "Initialize FileAnalyzer" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
+  options["base"] = YAML::Any.new("noir")
   object = FileAnalyzer.new(options)
 
   it "getter - url" do

--- a/spec/unit_test/models/deliver_spec.cr
+++ b/spec/unit_test/models/deliver_spec.cr
@@ -4,9 +4,9 @@ require "../../../src/options.cr"
 describe "Initialize" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
-  options["send_proxy"] = "http://localhost:8090"
-  options["nolog"] = true
+  options["base"] = YAML::Any.new("noir")
+  options["send_proxy"] = YAML::Any.new("http://localhost:8090")
+  options["nolog"] = YAML::Any.new(true)
 
   it "Deliver" do
     object = Deliver.new options
@@ -14,26 +14,26 @@ describe "Initialize" do
   end
 
   it "Deliver with headers" do
-    options["send_with_headers"] = "X-API-Key: abcdssss"
+    options["send_with_headers"] = YAML::Any.new([YAML::Any.new("X-API-Key: abcdssss")])
     object = Deliver.new options
     object.headers["X-API-Key"].should eq("abcdssss")
   end
 
   it "Deliver with headers (bearer case)" do
-    options["send_with_headers"] = "Authorization: Bearer gAAAAABl3qwaQqol243Np"
+    options["send_with_headers"] = YAML::Any.new([YAML::Any.new("Authorization: Bearer gAAAAABl3qwaQqol243Np")])
     object = Deliver.new options
     object.headers["Authorization"].should eq("Bearer gAAAAABl3qwaQqol243Np")
   end
 
   it "Deliver with matchers" do
-    options["use_matchers"] = "/admin"
+    options["use_matchers"] = YAML::Any.new([YAML::Any.new("/admin")])
     object = Deliver.new options
-    object.matchers.should eq(["/admin"])
+    object.matchers[0].to_s.should eq("/admin")
   end
 
   it "Deliver with filters" do
-    options["use_filters"] = "/admin"
+    options["use_filters"] = YAML::Any.new([YAML::Any.new("/admin")])
     object = Deliver.new options
-    object.filters.should eq(["/admin"])
+    object.filters[0].to_s.should eq("/admin")
   end
 end

--- a/spec/unit_test/models/deliver_spec.cr
+++ b/spec/unit_test/models/deliver_spec.cr
@@ -6,7 +6,7 @@ describe "Initialize" do
   options = config_init.default_options
   options["base"] = "noir"
   options["send_proxy"] = "http://localhost:8090"
-  options["nolog"] = "yes"
+  options["nolog"] = true
 
   it "Deliver" do
     object = Deliver.new options

--- a/spec/unit_test/models/detector_spec.cr
+++ b/spec/unit_test/models/detector_spec.cr
@@ -4,7 +4,7 @@ require "../../../src/config_initializer.cr"
 describe "Initialize" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
+  options["base"] = YAML::Any.new("noir")
   object = Detector.new(options)
 
   it "getter - name" do

--- a/spec/unit_test/models/noir_spec.cr
+++ b/spec/unit_test/models/noir_spec.cr
@@ -19,7 +19,7 @@ describe "Methods" do
   options = config_init.default_options
   options["base"] = "noir"
   options["url"] = "https://www.hahwul.com"
-  options["nolog"] = "yes"
+  options["nolog"] = true
   runner = NoirRunner.new(options)
 
   runner.endpoints << Endpoint.new("/abcd", "GET")

--- a/spec/unit_test/models/noir_spec.cr
+++ b/spec/unit_test/models/noir_spec.cr
@@ -5,7 +5,7 @@ require "../../../src/models/endpoint.cr"
 describe "Initialize" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
+  options["base"] = YAML::Any.new("noir")
   runner = NoirRunner.new(options)
 
   it "getter - options" do
@@ -17,9 +17,9 @@ end
 describe "Methods" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
-  options["url"] = "https://www.hahwul.com"
-  options["nolog"] = true
+  options["base"] = YAML::Any.new("noir")
+  options["url"] = YAML::Any.new("https://www.hahwul.com")
+  options["nolog"] = YAML::Any.new(true)
   runner = NoirRunner.new(options)
 
   runner.endpoints << Endpoint.new("/abcd", "GET")

--- a/spec/unit_test/models/output_builder_spec.cr
+++ b/spec/unit_test/models/output_builder_spec.cr
@@ -4,9 +4,9 @@ require "../../../src/options.cr"
 describe "Initialize" do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
-  options["format"] = "json"
-  options["output"] = "output.json"
+  options["base"] = YAML::Any.new("noir")
+  options["format"] = YAML::Any.new("json")
+  options["output"] = YAML::Any.new("output.json")
 
   it "OutputBuilder" do
     object = OutputBuilder.new options
@@ -72,8 +72,8 @@ end
 describe OutputBuilderDiff do
   config_init = ConfigInitializer.new
   options = config_init.default_options
-  options["base"] = "noir"
-  options["format"] = "json"
+  options["base"] = YAML::Any.new("noir")
+  options["format"] = YAML::Any.new("json")
 
   it "calculates the diff correctly" do
     old_endpoints = [Endpoint.new("GET", "/old")]

--- a/spec/unit_test/utils/utils_spec.cr
+++ b/spec/unit_test/utils/utils_spec.cr
@@ -54,11 +54,11 @@ describe "get_symbol" do
 end
 
 describe "str_to_bool" do
-  it "yes" do
-    str_to_bool("yes").should eq(true)
+  it true do
+    str_to_bool(true).should eq(true)
   end
-  it "no" do
-    str_to_bool("no").should eq(false)
+  it false do
+    str_to_bool(false).should eq(false)
   end
   it "any string" do
     str_to_bool("hahwul").should eq(false)

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -3,36 +3,36 @@ require "./analyzers/file_analyzers/*"
 
 def initialize_analyzers(logger : NoirLogger)
   # Initializing analyzers
-  analyzers = {} of String => Proc(Hash(String, String), Array(Endpoint))
+  analyzers = {} of String => Proc(Hash(String, YAML::Any), Array(Endpoint))
 
   # Mapping analyzers to their respective functions
-  analyzers["c#-aspnet-mvc"] = ->analyzer_cs_aspnet_mvc(Hash(String, String))
-  analyzers["crystal_kemal"] = ->analyzer_crystal_kemal(Hash(String, String))
-  analyzers["crystal_lucky"] = ->analyzer_crystal_lucky(Hash(String, String))
-  analyzers["elixir_phoenix"] = ->analyzer_elixir_phoenix(Hash(String, String))
-  analyzers["go_beego"] = ->analyzer_go_beego(Hash(String, String))
-  analyzers["go_echo"] = ->analyzer_go_echo(Hash(String, String))
-  analyzers["go_fiber"] = ->analyzer_go_fiber(Hash(String, String))
-  analyzers["go_gin"] = ->analyzer_go_gin(Hash(String, String))
-  analyzers["har"] = ->analyzer_har(Hash(String, String))
-  analyzers["java_armeria"] = ->analyzer_armeria(Hash(String, String))
-  analyzers["java_jsp"] = ->analyzer_jsp(Hash(String, String))
-  analyzers["java_spring"] = ->analyzer_java_spring(Hash(String, String))
-  analyzers["js_express"] = ->analyzer_express(Hash(String, String))
-  analyzers["js_restify"] = ->analyzer_restify(Hash(String, String))
-  analyzers["kotlin_spring"] = ->analyzer_kotlin_spring(Hash(String, String))
-  analyzers["oas2"] = ->analyzer_oas2(Hash(String, String))
-  analyzers["oas3"] = ->analyzer_oas3(Hash(String, String))
-  analyzers["php_pure"] = ->analyzer_php_pure(Hash(String, String))
-  analyzers["python_django"] = ->analyzer_python_django(Hash(String, String))
-  analyzers["python_fastapi"] = ->analyzer_python_fastapi(Hash(String, String))
-  analyzers["python_flask"] = ->analyzer_python_flask(Hash(String, String))
-  analyzers["raml"] = ->analyzer_raml(Hash(String, String))
-  analyzers["ruby_hanami"] = ->analyzer_ruby_hanami(Hash(String, String))
-  analyzers["ruby_rails"] = ->analyzer_ruby_rails(Hash(String, String))
-  analyzers["ruby_sinatra"] = ->analyzer_ruby_sinatra(Hash(String, String))
-  analyzers["rust_axum"] = ->analyzer_rust_axum(Hash(String, String))
-  analyzers["rust_rocket"] = ->analyzer_rust_rocket(Hash(String, String))
+  analyzers["c#-aspnet-mvc"] = ->analyzer_cs_aspnet_mvc(Hash(String, YAML::Any))
+  analyzers["crystal_kemal"] = ->analyzer_crystal_kemal(Hash(String, YAML::Any))
+  analyzers["crystal_lucky"] = ->analyzer_crystal_lucky(Hash(String, YAML::Any))
+  analyzers["elixir_phoenix"] = ->analyzer_elixir_phoenix(Hash(String, YAML::Any))
+  analyzers["go_beego"] = ->analyzer_go_beego(Hash(String, YAML::Any))
+  analyzers["go_echo"] = ->analyzer_go_echo(Hash(String, YAML::Any))
+  analyzers["go_fiber"] = ->analyzer_go_fiber(Hash(String, YAML::Any))
+  analyzers["go_gin"] = ->analyzer_go_gin(Hash(String, YAML::Any))
+  analyzers["har"] = ->analyzer_har(Hash(String, YAML::Any))
+  analyzers["java_armeria"] = ->analyzer_armeria(Hash(String, YAML::Any))
+  analyzers["java_jsp"] = ->analyzer_jsp(Hash(String, YAML::Any))
+  analyzers["java_spring"] = ->analyzer_java_spring(Hash(String, YAML::Any))
+  analyzers["js_express"] = ->analyzer_express(Hash(String, YAML::Any))
+  analyzers["js_restify"] = ->analyzer_restify(Hash(String, YAML::Any))
+  analyzers["kotlin_spring"] = ->analyzer_kotlin_spring(Hash(String, YAML::Any))
+  analyzers["oas2"] = ->analyzer_oas2(Hash(String, YAML::Any))
+  analyzers["oas3"] = ->analyzer_oas3(Hash(String, YAML::Any))
+  analyzers["php_pure"] = ->analyzer_php_pure(Hash(String, YAML::Any))
+  analyzers["python_django"] = ->analyzer_python_django(Hash(String, YAML::Any))
+  analyzers["python_fastapi"] = ->analyzer_python_fastapi(Hash(String, YAML::Any))
+  analyzers["python_flask"] = ->analyzer_python_flask(Hash(String, YAML::Any))
+  analyzers["raml"] = ->analyzer_raml(Hash(String, YAML::Any))
+  analyzers["ruby_hanami"] = ->analyzer_ruby_hanami(Hash(String, YAML::Any))
+  analyzers["ruby_rails"] = ->analyzer_ruby_rails(Hash(String, YAML::Any))
+  analyzers["ruby_sinatra"] = ->analyzer_ruby_sinatra(Hash(String, YAML::Any))
+  analyzers["rust_axum"] = ->analyzer_rust_axum(Hash(String, YAML::Any))
+  analyzers["rust_rocket"] = ->analyzer_rust_rocket(Hash(String, YAML::Any))
 
   logger.success "#{analyzers.size} Analyzers initialized"
   logger.debug "Analyzers:"
@@ -42,7 +42,7 @@ def initialize_analyzers(logger : NoirLogger)
   analyzers
 end
 
-def analysis_endpoints(options : Hash(String, String), techs, logger : NoirLogger)
+def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLogger)
   result = [] of Endpoint
   file_analyzer = FileAnalyzer.new options
   logger.info "Initializing analyzers"
@@ -57,7 +57,7 @@ def analysis_endpoints(options : Hash(String, String), techs, logger : NoirLogge
 
   techs.each do |tech|
     if analyzer.has_key?(tech)
-      if NoirTechs.similar_to_tech(options["exclude_techs"]).includes?(tech)
+      if NoirTechs.similar_to_tech(options["exclude_techs"].to_s).includes?(tech)
         logger.sub "➔ Skipping #{tech} analysis"
         next
       end

--- a/src/analyzer/analyzers/analyzer_armeria.cr
+++ b/src/analyzer/analyzers/analyzer_armeria.cr
@@ -63,7 +63,7 @@ class AnalyzerArmeria < Analyzer
   end
 end
 
-def analyzer_armeria(options : Hash(String, String))
+def analyzer_armeria(options : Hash(String, YAML::Any))
   instance = AnalyzerArmeria.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_crystal_kemal.cr
+++ b/src/analyzer/analyzers/analyzer_crystal_kemal.cr
@@ -170,7 +170,7 @@ class AnalyzerCrystalKemal < Analyzer
   end
 end
 
-def analyzer_crystal_kemal(options : Hash(String, String))
+def analyzer_crystal_kemal(options : Hash(String, YAML::Any))
   instance = AnalyzerCrystalKemal.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_crystal_lucky.cr
+++ b/src/analyzer/analyzers/analyzer_crystal_lucky.cr
@@ -135,7 +135,7 @@ class AnalyzerCrystalLucky < Analyzer
   end
 end
 
-def analyzer_crystal_lucky(options : Hash(String, String))
+def analyzer_crystal_lucky(options : Hash(String, YAML::Any))
   instance = AnalyzerCrystalLucky.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_cs_aspnet_mvc.cr
+++ b/src/analyzer/analyzers/analyzer_cs_aspnet_mvc.cr
@@ -45,7 +45,7 @@ class AnalyzerCsAspNetMvc < Analyzer
   end
 end
 
-def analyzer_cs_aspnet_mvc(options : Hash(String, String))
+def analyzer_cs_aspnet_mvc(options : Hash(String, YAML::Any))
   instance = AnalyzerCsAspNetMvc.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_elixir_phoenix.cr
+++ b/src/analyzer/analyzers/analyzer_elixir_phoenix.cr
@@ -61,7 +61,7 @@ class AnalyzerElixirPhoenix < Analyzer
   end
 end
 
-def analyzer_elixir_phoenix(options : Hash(String, String))
+def analyzer_elixir_phoenix(options : Hash(String, YAML::Any))
   instance = AnalyzerElixirPhoenix.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_example.cr
+++ b/src/analyzer/analyzers/analyzer_example.cr
@@ -26,7 +26,7 @@ class AnalyzerExample < Analyzer
   end
 end
 
-def analyzer_example(options : Hash(String, String))
+def analyzer_example(options : Hash(String, YAML::Any))
   instance = AnalyzerExample.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_express.cr
+++ b/src/analyzer/analyzers/analyzer_express.cr
@@ -105,7 +105,7 @@ class AnalyzerExpress < Analyzer
   end
 end
 
-def analyzer_express(options : Hash(String, String))
+def analyzer_express(options : Hash(String, YAML::Any))
   instance = AnalyzerExpress.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_go_beego.cr
+++ b/src/analyzer/analyzers/analyzer_go_beego.cr
@@ -144,7 +144,7 @@ class AnalyzerGoBeego < Analyzer
   end
 end
 
-def analyzer_go_beego(options : Hash(String, String))
+def analyzer_go_beego(options : Hash(String, YAML::Any))
   instance = AnalyzerGoBeego.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_go_echo.cr
+++ b/src/analyzer/analyzers/analyzer_go_echo.cr
@@ -186,7 +186,7 @@ class AnalyzerGoEcho < Analyzer
   end
 end
 
-def analyzer_go_echo(options : Hash(String, String))
+def analyzer_go_echo(options : Hash(String, YAML::Any))
   instance = AnalyzerGoEcho.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_go_fiber.cr
+++ b/src/analyzer/analyzers/analyzer_go_fiber.cr
@@ -197,7 +197,7 @@ class AnalyzerGoFiber < Analyzer
   end
 end
 
-def analyzer_go_fiber(options : Hash(String, String))
+def analyzer_go_fiber(options : Hash(String, YAML::Any))
   instance = AnalyzerGoFiber.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_go_gin.cr
+++ b/src/analyzer/analyzers/analyzer_go_gin.cr
@@ -188,7 +188,7 @@ class AnalyzerGoGin < Analyzer
   end
 end
 
-def analyzer_go_gin(options : Hash(String, String))
+def analyzer_go_gin(options : Hash(String, YAML::Any))
   instance = AnalyzerGoGin.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_har.cr
+++ b/src/analyzer/analyzers/analyzer_har.cr
@@ -62,7 +62,7 @@ class AnalyzerHar < Analyzer
   end
 end
 
-def analyzer_har(options : Hash(String, String))
+def analyzer_har(options : Hash(String, YAML::Any))
   instance = AnalyzerHar.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_java_spring.cr
+++ b/src/analyzer/analyzers/analyzer_java_spring.cr
@@ -447,7 +447,7 @@ class AnalyzerJavaSpring < Analyzer
   end
 end
 
-def analyzer_java_spring(options : Hash(String, String))
+def analyzer_java_spring(options : Hash(String, YAML::Any))
   instance = AnalyzerJavaSpring.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_jsp.cr
+++ b/src/analyzer/analyzers/analyzer_jsp.cr
@@ -51,7 +51,7 @@ class AnalyzerJsp < Analyzer
   end
 end
 
-def analyzer_jsp(options : Hash(String, String))
+def analyzer_jsp(options : Hash(String, YAML::Any))
   instance = AnalyzerJsp.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_kotlin_spring.cr
+++ b/src/analyzer/analyzers/analyzer_kotlin_spring.cr
@@ -489,7 +489,7 @@ class AnalyzerKotlinSpring < Analyzer
 end
 
 # Function to instantiate and run the AnalyzerKotlinSpring
-def analyzer_kotlin_spring(options : Hash(String, String))
+def analyzer_kotlin_spring(options : Hash(String, YAML::Any))
   instance = AnalyzerKotlinSpring.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_oas2.cr
+++ b/src/analyzer/analyzers/analyzer_oas2.cr
@@ -128,7 +128,7 @@ class AnalyzerOAS2 < Analyzer
   end
 end
 
-def analyzer_oas2(options : Hash(String, String))
+def analyzer_oas2(options : Hash(String, YAML::Any))
   instance = AnalyzerOAS2.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_oas3.cr
+++ b/src/analyzer/analyzers/analyzer_oas3.cr
@@ -283,7 +283,7 @@ class AnalyzerOAS3 < Analyzer
   end
 end
 
-def analyzer_oas3(options : Hash(String, String))
+def analyzer_oas3(options : Hash(String, YAML::Any))
   instance = AnalyzerOAS3.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_php_pure.cr
+++ b/src/analyzer/analyzers/analyzer_php_pure.cr
@@ -67,7 +67,7 @@ class AnalyzerPhpPure < Analyzer
   end
 end
 
-def analyzer_php_pure(options : Hash(String, String))
+def analyzer_php_pure(options : Hash(String, YAML::Any))
   instance = AnalyzerPhpPure.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_python_django.cr
+++ b/src/analyzer/analyzers/analyzer_python_django.cr
@@ -394,7 +394,7 @@ class AnalyzerDjango < AnalyzerPython
 end
 
 # Main function to analyze a Django project
-def analyzer_python_django(options : Hash(String, String))
+def analyzer_python_django(options : Hash(String, YAML::Any))
   instance = AnalyzerDjango.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_python_fastapi.cr
+++ b/src/analyzer/analyzers/analyzer_python_fastapi.cr
@@ -320,7 +320,7 @@ class Router
 end
 
 # Analyzer function for FastAPI
-def analyzer_python_fastapi(options : Hash(String, String))
+def analyzer_python_fastapi(options : Hash(String, YAML::Any))
   instance = AnalyzerFastAPI.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_python_flask.cr
+++ b/src/analyzer/analyzers/analyzer_python_flask.cr
@@ -492,7 +492,7 @@ class AnalyzerFlask < AnalyzerPython
 end
 
 # Analyzer function for Flask
-def analyzer_python_flask(options : Hash(String, String))
+def analyzer_python_flask(options : Hash(String, YAML::Any))
   instance = AnalyzerFlask.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_raml.cr
+++ b/src/analyzer/analyzers/analyzer_raml.cr
@@ -65,7 +65,7 @@ class AnalyzerRAML < Analyzer
   end
 end
 
-def analyzer_raml(options : Hash(String, String))
+def analyzer_raml(options : Hash(String, YAML::Any))
   instance = AnalyzerRAML.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_restify.cr
+++ b/src/analyzer/analyzers/analyzer_restify.cr
@@ -105,7 +105,7 @@ class AnalyzerRestify < Analyzer
   end
 end
 
-def analyzer_restify(options : Hash(String, String))
+def analyzer_restify(options : Hash(String, YAML::Any))
   instance = AnalyzerRestify.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_ruby_hanami.cr
+++ b/src/analyzer/analyzers/analyzer_ruby_hanami.cr
@@ -69,7 +69,7 @@ class AnalyzerRubyHanami < Analyzer
   end
 end
 
-def analyzer_ruby_hanami(options : Hash(String, String))
+def analyzer_ruby_hanami(options : Hash(String, YAML::Any))
   instance = AnalyzerRubyHanami.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_ruby_rails.cr
+++ b/src/analyzer/analyzers/analyzer_ruby_rails.cr
@@ -256,7 +256,7 @@ class AnalyzerRubyRails < Analyzer
   end
 end
 
-def analyzer_ruby_rails(options : Hash(String, String))
+def analyzer_ruby_rails(options : Hash(String, YAML::Any))
   instance = AnalyzerRubyRails.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_ruby_sinatra.cr
+++ b/src/analyzer/analyzers/analyzer_ruby_sinatra.cr
@@ -111,7 +111,7 @@ class AnalyzerRubySinatra < Analyzer
   end
 end
 
-def analyzer_ruby_sinatra(options : Hash(String, String))
+def analyzer_ruby_sinatra(options : Hash(String, YAML::Any))
   instance = AnalyzerRubySinatra.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_rust_axum.cr
+++ b/src/analyzer/analyzers/analyzer_rust_axum.cr
@@ -44,7 +44,7 @@ class AnalyzerRustAxum < Analyzer
   end
 end
 
-def analyzer_rust_axum(options : Hash(String, String))
+def analyzer_rust_axum(options : Hash(String, YAML::Any))
   instance = AnalyzerRustAxum.new(options)
   instance.analyze
 end

--- a/src/analyzer/analyzers/analyzer_rust_rocket.cr
+++ b/src/analyzer/analyzers/analyzer_rust_rocket.cr
@@ -45,7 +45,7 @@ class AnalyzerRustRocket < Analyzer
   end
 end
 
-def analyzer_rust_rocket(options : Hash(String, String))
+def analyzer_rust_rocket(options : Hash(String, YAML::Any))
   instance = AnalyzerRustRocket.new(options)
   instance.analyze
 end

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -46,13 +46,22 @@ class ConfigInitializer
       parsed_yaml = YAML.parse(File.read(@config_file)).as_h
       symbolized_hash = parsed_yaml.transform_keys(&.to_s)
       # stringlized_hash = symbolized_hash.transform_values(&.to_s)
-      
-      # Transform specific keys from "yes"/"no" to true/false for old version noir
+
+      # Transform specific keys from "yes"/"no" to true/false for old version noir config
       ["color", "debug", "include_path", "nolog", "send_req", "all_taggers"].each do |key|
         if symbolized_hash[key] == "yes"
           symbolized_hash[key] = YAML::Any.new(true)
         elsif symbolized_hash[key] == "no"
           symbolized_hash[key] = YAML::Any.new(false)
+        end
+      end
+
+      # Transform specific keys from "" to [""] or ["value"] for old version noir config
+      ["send_with_headers", "use_filters", "use_matchers"].each do |key|
+        if symbolized_hash[key] == ""
+          symbolized_hash[key] = YAML::Any.new([] of YAML::Any)
+        elsif symbolized_hash[key].is_a?(String)
+          symbolized_hash[key] = YAML::Any.new([YAML::Any.new(symbolized_hash[key].to_s)])
         end
       end
 
@@ -80,12 +89,12 @@ class ConfigInitializer
       "send_es"           => YAML::Any.new(""),
       "send_proxy"        => YAML::Any.new(""),
       "send_req"          => YAML::Any.new(false),
-      "send_with_headers" => YAML::Any.new(""),
+      "send_with_headers" => YAML::Any.new([] of YAML::Any),
       "set_pvalue"        => YAML::Any.new(""),
       "techs"             => YAML::Any.new(""),
       "url"               => YAML::Any.new(""),
-      "use_filters"       => YAML::Any.new(""),
-      "use_matchers"      => YAML::Any.new(""),
+      "use_filters"       => YAML::Any.new([] of YAML::Any),
+      "use_matchers"      => YAML::Any.new([] of YAML::Any),
       "all_taggers"       => YAML::Any.new(false),
       "use_taggers"       => YAML::Any.new(""),
       "diff"              => YAML::Any.new(""),

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -157,7 +157,7 @@ class ConfigInitializer
 
     # Whether to send headers with the request (Array of strings)
     # e.g "Authorization: Bearer token"
-    send_with_headers: 
+    send_with_headers:
 
     # The value to set for pvalue
     set_pvalue: "#{options["set_pvalue"]}"
@@ -169,10 +169,10 @@ class ConfigInitializer
     url: "#{options["url"]}"
 
     # Whether to use filters (Array of strings)
-    use_filters: 
+    use_filters:
 
     # Whether to use matchers (Array of strings)
-    use_matchers: 
+    use_matchers:
 
     # Whether to use all taggers
     all_taggers: "#{options["all_taggers"]}"

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -155,9 +155,9 @@ class ConfigInitializer
     # Whether to send a request
     send_req: "#{options["send_req"]}"
 
-    # Whether to send headers with the request
+    # Whether to send headers with the request (Array of strings)
     # e.g "Authorization: Bearer token"
-    send_with_headers: "#{options["send_with_headers"]}"
+    send_with_headers: 
 
     # The value to set for pvalue
     set_pvalue: "#{options["set_pvalue"]}"
@@ -168,11 +168,11 @@ class ConfigInitializer
     # The URL to use
     url: "#{options["url"]}"
 
-    # Whether to use filters
-    use_filters: "#{options["use_filters"]}"
+    # Whether to use filters (Array of strings)
+    use_filters: 
 
-    # Whether to use matchers
-    use_matchers: "#{options["use_matchers"]}"
+    # Whether to use matchers (Array of strings)
+    use_matchers: 
 
     # Whether to use all taggers
     all_taggers: "#{options["all_taggers"]}"

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -46,6 +46,15 @@ class ConfigInitializer
       parsed_yaml = YAML.parse(File.read(@config_file)).as_h
       symbolized_hash = parsed_yaml.transform_keys(&.to_s)
       # stringlized_hash = symbolized_hash.transform_values(&.to_s)
+      
+      # Transform specific keys from "yes"/"no" to true/false for old version noir
+      ["color", "debug", "include_path", "nolog", "send_req", "all_taggers"].each do |key|
+        if symbolized_hash[key] == "yes"
+          symbolized_hash[key] = YAML::Any.new(true)
+        elsif symbolized_hash[key] == "no"
+          symbolized_hash[key] = YAML::Any.new(false)
+        end
+      end
 
       symbolized_hash
     rescue e : Exception

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -4,7 +4,7 @@ require "yaml"
 class ConfigInitializer
   @config_dir : String
   @config_file : String
-  @default_config : Hash(String, String) = {"key" => "default_value"} # Replace with your default config
+  @default_config : Hash(String, YAML::Any) = {"key" => YAML::Any.new("default_value")} # Replace with your default config
 
   def initialize
     # Define the config directory and file based on ENV variables
@@ -45,9 +45,9 @@ class ConfigInitializer
     begin
       parsed_yaml = YAML.parse(File.read(@config_file)).as_h
       symbolized_hash = parsed_yaml.transform_keys(&.to_s)
-      stringlized_hash = symbolized_hash.transform_values(&.to_s)
+      # stringlized_hash = symbolized_hash.transform_values(&.to_s)
 
-      stringlized_hash
+      symbolized_hash
     rescue e : Exception
       puts "Failed to read config file: #{e.message}"
       puts "Using default config."
@@ -58,28 +58,28 @@ class ConfigInitializer
 
   def default_options
     noir_options = {
-      "base"              => "",
-      "color"             => "yes",
-      "config_file"       => "",
-      "concurrency"       => "100",
-      "debug"             => "no",
-      "exclude_techs"     => "",
-      "format"            => "plain",
-      "include_path"      => "no",
-      "nolog"             => "no",
-      "output"            => "",
-      "send_es"           => "",
-      "send_proxy"        => "",
-      "send_req"          => "no",
-      "send_with_headers" => "",
-      "set_pvalue"        => "",
-      "techs"             => "",
-      "url"               => "",
-      "use_filters"       => "",
-      "use_matchers"      => "",
-      "all_taggers"       => "no",
-      "use_taggers"       => "",
-      "diff"              => "",
+      "base"              => YAML::Any.new(""),
+      "color"             => YAML::Any.new(true),
+      "config_file"       => YAML::Any.new(""),
+      "concurrency"       => YAML::Any.new("100"),
+      "debug"             => YAML::Any.new(false),
+      "exclude_techs"     => YAML::Any.new(""),
+      "format"            => YAML::Any.new("plain"),
+      "include_path"      => YAML::Any.new(false),
+      "nolog"             => YAML::Any.new(false),
+      "output"            => YAML::Any.new(""),
+      "send_es"           => YAML::Any.new(""),
+      "send_proxy"        => YAML::Any.new(""),
+      "send_req"          => YAML::Any.new(false),
+      "send_with_headers" => YAML::Any.new(""),
+      "set_pvalue"        => YAML::Any.new(""),
+      "techs"             => YAML::Any.new(""),
+      "url"               => YAML::Any.new(""),
+      "use_filters"       => YAML::Any.new(""),
+      "use_matchers"      => YAML::Any.new(""),
+      "all_taggers"       => YAML::Any.new(false),
+      "use_taggers"       => YAML::Any.new(""),
+      "diff"              => YAML::Any.new(""),
     }
 
     noir_options

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -1,5 +1,6 @@
 require "./detectors/*"
 require "../models/detector"
+require "yaml"
 
 macro defind_detectors(detectors)
   {% for detector, index in detectors %}
@@ -9,7 +10,7 @@ macro defind_detectors(detectors)
   {% end %}
 end
 
-def detect_techs(base_path : String, options : Hash(String, String), logger : NoirLogger)
+def detect_techs(base_path : String, options : Hash(String, YAML::Any), logger : NoirLogger)
   techs = [] of String
   detector_list = [] of Detector
 
@@ -51,7 +52,7 @@ def detect_techs(base_path : String, options : Hash(String, String), logger : No
     end
   end
 
-  options["concurrency"].to_i.times do
+  options["concurrency"].to_s.to_i.times do
     spawn do
       loop do
         begin

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -10,11 +10,11 @@ class Analyzer
   @is_debug : Bool
   @is_color : Bool
   @is_log : Bool
-  @options : Hash(String, String)
+  @options : Hash(String, YAML::Any)
 
-  def initialize(options : Hash(String, String))
-    @base_path = options["base"]
-    @url = options["url"]
+  def initialize(options : Hash(String, YAML::Any))
+    @base_path = options["base"].to_s
+    @url = options["url"].to_s
     @result = [] of Endpoint
     @endpoint_references = [] of EndpointReference
     @is_debug = str_to_bool(options["debug"])
@@ -59,7 +59,7 @@ class FileAnalyzer < Analyzer
       end
     end
 
-    @options["concurrency"].to_i.times do
+    @options["concurrency"].to_s.to_i.times do
       spawn do
         loop do
           begin

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -19,37 +19,35 @@ class Deliver
     @proxy = options["send_proxy"].to_s
     @logger = NoirLogger.new @is_debug, @is_color, @is_log
 
-    if options["send_with_headers"] != ""
-      headers_tmp = options["send_with_headers"].to_s.split("::NOIR::HEADERS::SPLIT::")
-      @logger.info "Setting headers from command line."
-      headers_tmp.each do |header|
-        if header.includes? ":"
-          @logger.debug "Adding '#{header}' to headers."
-          splited = header.split(":")
-          value = ""
-          begin
-            if splited[1][0].to_s == " "
-              value = splited[1][1..-1].to_s
-            else
-              value = splited[1].to_s
-            end
-          rescue
+    options["send_with_headers"].as_a.each do |set_header|
+      if set_header.to_s.includes? ":"
+        splited = set_header.to_s.split(":")
+        value = ""
+        begin
+          if splited[1][0].to_s == " "
+            value = splited[1][1..-1].to_s
+          else
             value = splited[1].to_s
           end
-
-          @headers[splited[0]] = value
+        rescue
+          value = splited[1].to_s
         end
+
+        @headers[splited[0]] = value
       end
-      @logger.sub "➔ #{@headers.size} headers added."
     end
 
-    @matchers = options["use_matchers"].to_s.split("::NOIR::MATCHER::SPLIT::")
+    options["use_matchers"].as_a.each do |matcher|
+      @matchers << matcher.to_s
+    end
     @matchers.delete("")
     if @matchers.size > 0
       @logger.info "#{@matchers.size} matchers added."
     end
 
-    @filters = options["use_filters"].to_s.split("::NOIR::FILTER::SPLIT::")
+    options["use_filters"].as_a.each do |filter|
+      @filters << filter.to_s
+    end
     @filters.delete("")
     if @filters.size > 0
       @logger.info "#{@filters.size} filters added."

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -2,7 +2,7 @@ require "./logger"
 
 class Deliver
   @logger : NoirLogger
-  @options : Hash(String, String)
+  @options : Hash(String, YAML::Any)
   @is_debug : Bool
   @is_color : Bool
   @is_log : Bool
@@ -11,16 +11,16 @@ class Deliver
   @matchers : Array(String) = [] of String
   @filters : Array(String) = [] of String
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     @options = options
     @is_debug = str_to_bool(options["debug"])
     @is_color = str_to_bool(options["color"])
     @is_log = str_to_bool(options["nolog"])
-    @proxy = options["send_proxy"]
+    @proxy = options["send_proxy"].to_s
     @logger = NoirLogger.new @is_debug, @is_color, @is_log
 
     if options["send_with_headers"] != ""
-      headers_tmp = options["send_with_headers"].split("::NOIR::HEADERS::SPLIT::")
+      headers_tmp = options["send_with_headers"].to_s.split("::NOIR::HEADERS::SPLIT::")
       @logger.info "Setting headers from command line."
       headers_tmp.each do |header|
         if header.includes? ":"
@@ -43,13 +43,13 @@ class Deliver
       @logger.sub "➔ #{@headers.size} headers added."
     end
 
-    @matchers = options["use_matchers"].split("::NOIR::MATCHER::SPLIT::")
+    @matchers = options["use_matchers"].to_s.split("::NOIR::MATCHER::SPLIT::")
     @matchers.delete("")
     if @matchers.size > 0
       @logger.info "#{@matchers.size} matchers added."
     end
 
-    @filters = options["use_filters"].split("::NOIR::FILTER::SPLIT::")
+    @filters = options["use_filters"].to_s.split("::NOIR::FILTER::SPLIT::")
     @filters.delete("")
     if @filters.size > 0
       @logger.info "#{@filters.size} filters added."

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "yaml"
 
 class Detector
   @logger : NoirLogger
@@ -8,12 +9,12 @@ class Detector
   @name : String
   @base_path : String
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     @is_debug = str_to_bool(options["debug"])
     @is_color = str_to_bool(options["color"])
     @is_log = str_to_bool(options["nolog"])
     @name = ""
-    @base_path = options["base"]
+    @base_path = options["base"].to_s
 
     @logger = NoirLogger.new @is_debug, @is_color, @is_log
   end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -40,7 +40,7 @@ class NoirRunner
     if @config_file != ""
       config = YAML.parse(File.read(@config_file)).as_h
       symbolized_hash = config.transform_keys(&.to_s)
-      @options = @options.merge(symbolized_hash) { |key, old_val, new_val| new_val }
+      @options = @options.merge(symbolized_hash) { |_, _, new_val| new_val }
     end
 
     @techs = [] of String

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -7,9 +7,10 @@ require "./endpoint.cr"
 require "./logger.cr"
 require "../utils/string_extension.cr"
 require "json"
+require "yaml"
 
 class NoirRunner
-  @options : Hash(String, String)
+  @options : Hash(String, YAML::Any)
   @techs : Array(String)
   @endpoints : Array(Endpoint)
   @logger : NoirLogger
@@ -34,38 +35,28 @@ class NoirRunner
 
   def initialize(options)
     @options = options
-    @config_file = @options["config_file"]
+    @config_file = @options["config_file"].to_s
 
     if @config_file != ""
-      config = YAML.parse(File.read(@config_file))
-      @options.each do |key, _|
-        string_key = key.to_s
-        begin
-          if config[string_key] != "" && string_key != "base"
-            @options[key] = "yes" if config[string_key] == true
-            @options[key] = "no" if config[string_key] == false
-
-            @options[key] = config[string_key].as_s
-          end
-        rescue
-        end
-      end
+      config = YAML.parse(File.read(@config_file)).as_h
+      symbolized_hash = config.transform_keys(&.to_s)
+      @options = @options.merge(symbolized_hash) { |key, old_val, new_val| new_val }
     end
 
     @techs = [] of String
     @endpoints = [] of Endpoint
-    @send_proxy = @options["send_proxy"]
-    @send_req = @options["send_req"]
-    @send_es = @options["send_es"]
+    @send_proxy = @options["send_proxy"].to_s
+    @send_req = @options["send_req"].to_s
+    @send_es = @options["send_es"].to_s
     @is_debug = str_to_bool(@options["debug"])
     @is_color = str_to_bool(@options["color"])
     @is_log = str_to_bool(@options["nolog"])
-    @concurrency = @options["concurrency"].to_i
+    @concurrency = @options["concurrency"].to_s.to_i
 
     @logger = NoirLogger.new @is_debug, @is_color, @is_log
 
-    if @options["techs"].size > 0
-      techs_tmp = @options["techs"].split(",")
+    if @options["techs"].to_s.size > 0
+      techs_tmp = @options["techs"].to_s.split(",")
       @logger.success "Setting #{techs_tmp.size} techs from command line."
       techs_tmp.each do |tech|
         @techs << NoirTechs.similar_to_tech(tech)
@@ -79,7 +70,7 @@ class NoirRunner
   end
 
   def detect
-    detected_techs = detect_techs options["base"], options, @logger
+    detected_techs = detect_techs options["base"].to_s, options, @logger
     @techs += detected_techs
     if @is_debug
       @logger.debug("CodeLocator Table:")
@@ -95,7 +86,7 @@ class NoirRunner
     add_path_parameters
 
     # Run tagger
-    if @options["all_taggers"] == "yes"
+    if @options["all_taggers"] == true
       @logger.success "Running all taggers."
       NoirTaggers.run_tagger @endpoints, @options, "all"
       if @is_debug
@@ -105,7 +96,7 @@ class NoirRunner
       end
     elsif @options["use_taggers"] != ""
       @logger.success "Running #{@options["use_taggers"]} taggers."
-      NoirTaggers.run_tagger @endpoints, @options, @options["use_taggers"]
+      NoirTaggers.run_tagger @endpoints, @options, @options["use_taggers"].to_s
     end
 
     # Run deliver
@@ -123,7 +114,7 @@ class NoirRunner
         endpoint.params.each do |param|
           if !param.name.includes? " "
             if @options["set_pvalue"] != ""
-              param.value = @options["set_pvalue"]
+              param.value = @options["set_pvalue"].to_s
             end
             tiny_tmp.params << param
           end
@@ -154,7 +145,7 @@ class NoirRunner
 
   def combine_url_and_endpoints
     tmp = [] of Endpoint
-    target_url = @options["url"]
+    target_url = @options["url"].to_s
 
     if target_url != ""
       @logger.info "Combining url and endpoints."
@@ -228,7 +219,7 @@ class NoirRunner
       deliver.run(@endpoints)
     end
 
-    if @send_req != "no"
+    if @send_req != false
       @logger.info "Sending requests without proxy."
       deliver = SendReq.new(@options)
       deliver.run(@endpoints)

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -2,18 +2,18 @@ require "./logger"
 
 class OutputBuilder
   @logger : NoirLogger
-  @options : Hash(String, String)
+  @options : Hash(String, YAML::Any)
   @is_debug : Bool
   @is_color : Bool
   @is_log : Bool
   @output_file : String
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     @is_debug = str_to_bool(options["debug"])
     @options = options
     @is_color = str_to_bool(options["color"])
     @is_log = str_to_bool(options["nolog"])
-    @output_file = options["output"]
+    @output_file = options["output"].to_s
 
     @logger = NoirLogger.new @is_debug, @is_color, @is_log
   end

--- a/src/models/tagger.cr
+++ b/src/models/tagger.cr
@@ -2,13 +2,13 @@ require "./logger"
 
 class Tagger
   @logger : NoirLogger
-  @options : Hash(String, String)
+  @options : Hash(String, YAML::Any)
   @is_debug : Bool
   @is_color : Bool
   @is_log : Bool
   @name : String
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     @is_debug = str_to_bool(options["debug"])
     @options = options
     @is_color = str_to_bool(options["color"])

--- a/src/noir.cr
+++ b/src/noir.cr
@@ -43,8 +43,8 @@ app_diff = nil
 if noir_options["diff"] != ""
   # Diff mode
   diff_options = noir_options.dup
-  diff_options["base"] = noir_options["diff"].to_s
-  diff_options["nolog"] = "yes"
+  diff_options["base"] = noir_options["diff"]
+  diff_options["nolog"] = YAML::Any.new(false)
 
   app_diff = NoirRunner.new diff_options
   app.logger.info "Running Noir with Diff mode."

--- a/src/options.cr
+++ b/src/options.cr
@@ -2,6 +2,15 @@ require "./completions.cr"
 require "./config_initializer.cr"
 require "yaml"
 
+macro append_to_yaml_array(hash, key, value)
+  tmp = [] of YAML::Any
+  {{hash.id}}[{{key.stringify}}].as_a.each do |item|
+    tmp << item
+  end
+  tmp << YAML::Any.new({{value}})
+  {{hash.id}}[{{key.stringify}}] = YAML::Any.new(tmp)
+end
+
 def run_options_parser
   # Check config file
   config_init = ConfigInitializer.new
@@ -48,13 +57,13 @@ def run_options_parser
     parser.on "--send-proxy http://proxy..", "Send results to a web request via an HTTP proxy" { |var| noir_options["send_proxy"] = YAML::Any.new(var) }
     parser.on "--send-es http://es..", "Send results to Elasticsearch" { |var| noir_options["send_es"] = YAML::Any.new(var) }
     parser.on "--with-headers X-Header:Value", "Add custom headers to be included in the delivery" do |var|
-      noir_options["send_with_headers"] = YAML::Any.new("#{var}::NOIR::HEADERS::SPLIT::")
+      append_to_yaml_array(noir_options, send_with_headers, var)
     end
     parser.on "--use-matchers string", "Send URLs that match specific conditions to the Deliver" do |var|
-      noir_options["use_matchers"] = YAML::Any.new("#{var}::NOIR::MATCHER::SPLIT::")
+      append_to_yaml_array(noir_options, use_matchers, var)
     end
     parser.on "--use-filters string", "Exclude URLs that match specified conditions and send the rest to Deliver" do |var|
-      noir_options["use_filters"] = YAML::Any.new("#{var}::NOIR::FILTER::SPLIT::")
+      append_to_yaml_array(noir_options, use_filters, var)
     end
 
     parser.separator "\n  DIFF:".colorize(:blue)

--- a/src/options.cr
+++ b/src/options.cr
@@ -1,5 +1,6 @@
 require "./completions.cr"
 require "./config_initializer.cr"
+require "yaml"
 
 def run_options_parser
   # Check config file
@@ -10,26 +11,26 @@ def run_options_parser
     parser.banner = "USAGE: noir <flags>\n"
     parser.separator "FLAGS:"
     parser.separator "  BASE:".colorize(:blue)
-    parser.on "-b PATH", "--base-path ./app", "(Required) Set base path" { |var| noir_options["base"] = var }
-    parser.on "-u URL", "--url http://..", "Set base url for endpoints" { |var| noir_options["url"] = var }
+    parser.on "-b PATH", "--base-path ./app", "(Required) Set base path" { |var| noir_options["base"] = YAML::Any.new(var) }
+    parser.on "-u URL", "--url http://..", "Set base url for endpoints" { |var| noir_options["url"] = YAML::Any.new(var) }
 
     parser.separator "\n  OUTPUT:".colorize(:blue)
-    parser.on "-f FORMAT", "--format json", "Set output format\n  * plain yaml json jsonl markdown-table\n  * curl httpie oas2 oas3\n  * only-url only-param only-header only-cookie only-tag" { |var| noir_options["format"] = var }
-    parser.on "-o PATH", "--output out.txt", "Write result to file" { |var| noir_options["output"] = var }
-    parser.on "--set-pvalue VALUE", "Specifies the value of the identified parameter" { |var| noir_options["set_pvalue"] = var }
+    parser.on "-f FORMAT", "--format json", "Set output format\n  * plain yaml json jsonl markdown-table\n  * curl httpie oas2 oas3\n  * only-url only-param only-header only-cookie only-tag" { |var| noir_options["format"] = YAML::Any.new(var) }
+    parser.on "-o PATH", "--output out.txt", "Write result to file" { |var| noir_options["output"] = YAML::Any.new(var) }
+    parser.on "--set-pvalue VALUE", "Specifies the value of the identified parameter" { |var| noir_options["set_pvalue"] = YAML::Any.new(var) }
     parser.on "--include-path", "Include file path in the plain result" do
-      noir_options["include_path"] = "yes"
+      noir_options["include_path"] = YAML::Any.new(true)
     end
     parser.on "--no-color", "Disable color output" do
-      noir_options["color"] = "no"
+      noir_options["color"] = YAML::Any.new(false)
     end
     parser.on "--no-log", "Displaying only the results" do
-      noir_options["nolog"] = "yes"
+      noir_options["nolog"] = YAML::Any.new(true)
     end
 
     parser.separator "\n  TAGGER:".colorize(:blue)
-    parser.on "-T", "--use-all-taggers", "Activates all taggers for full analysis coverage" { |_| noir_options["all_taggers"] = "yes" }
-    parser.on "--use-taggers VALUES", "Activates specific taggers (e.g., --use-taggers hunt,oauth)" { |var| noir_options["use_taggers"] = var }
+    parser.on "-T", "--use-all-taggers", "Activates all taggers for full analysis coverage" { |_| noir_options["all_taggers"] = YAML::Any.new(true) }
+    parser.on "--use-taggers VALUES", "Activates specific taggers (e.g., --use-taggers hunt,oauth)" { |var| noir_options["use_taggers"] = YAML::Any.new(var) }
     parser.on "--list-taggers", "Lists all available taggers" do
       puts "Available taggers:"
       techs = NoirTaggers.get_taggers
@@ -43,25 +44,25 @@ def run_options_parser
     end
 
     parser.separator "\n  DELIVER:".colorize(:blue)
-    parser.on "--send-req", "Send results to a web request" { |_| noir_options["send_req"] = "yes" }
-    parser.on "--send-proxy http://proxy..", "Send results to a web request via an HTTP proxy" { |var| noir_options["send_proxy"] = var }
-    parser.on "--send-es http://es..", "Send results to Elasticsearch" { |var| noir_options["send_es"] = var }
+    parser.on "--send-req", "Send results to a web request" { |_| noir_options["send_req"] = YAML::Any.new(true) }
+    parser.on "--send-proxy http://proxy..", "Send results to a web request via an HTTP proxy" { |var| noir_options["send_proxy"] = YAML::Any.new(var) }
+    parser.on "--send-es http://es..", "Send results to Elasticsearch" { |var| noir_options["send_es"] = YAML::Any.new(var) }
     parser.on "--with-headers X-Header:Value", "Add custom headers to be included in the delivery" do |var|
-      noir_options["send_with_headers"] += "#{var}::NOIR::HEADERS::SPLIT::"
+      noir_options["send_with_headers"] = YAML::Any.new("#{var}::NOIR::HEADERS::SPLIT::")
     end
     parser.on "--use-matchers string", "Send URLs that match specific conditions to the Deliver" do |var|
-      noir_options["use_matchers"] += "#{var}::NOIR::MATCHER::SPLIT::"
+      noir_options["use_matchers"] = YAML::Any.new("#{var}::NOIR::MATCHER::SPLIT::")
     end
     parser.on "--use-filters string", "Exclude URLs that match specified conditions and send the rest to Deliver" do |var|
-      noir_options["use_filters"] += "#{var}::NOIR::FILTER::SPLIT::"
+      noir_options["use_filters"] = YAML::Any.new("#{var}::NOIR::FILTER::SPLIT::")
     end
 
     parser.separator "\n  DIFF:".colorize(:blue)
-    parser.on "--diff-path ./app2", "Specify the path to the old version of the source code for comparison" { |var| noir_options["diff"] = var }
+    parser.on "--diff-path ./app2", "Specify the path to the old version of the source code for comparison" { |var| noir_options["diff"] = YAML::Any.new(var) }
 
     parser.separator "\n  TECHNOLOGIES:".colorize(:blue)
-    parser.on "-t TECHS", "--techs rails,php", "Specify the technologies to use" { |var| noir_options["techs"] = var }
-    parser.on "--exclude-techs rails,php", "Specify the technologies to be excluded" { |var| noir_options["exclude_techs"] = var }
+    parser.on "-t TECHS", "--techs rails,php", "Specify the technologies to use" { |var| noir_options["techs"] = YAML::Any.new(var) }
+    parser.on "--exclude-techs rails,php", "Specify the technologies to be excluded" { |var| noir_options["exclude_techs"] = YAML::Any.new(var) }
     parser.on "--list-techs", "Show all technologies" do
       puts "Available technologies:"
       techs = NoirTechs.get_techs
@@ -75,8 +76,8 @@ def run_options_parser
     end
 
     parser.separator "\n  CONFIG:".colorize(:blue)
-    parser.on "--config-file ./config.yaml", "Specify the path to a configuration file in YAML format" { |var| noir_options["config_file"] = var }
-    parser.on "--concurrency 100", "Set concurrency" { |var| noir_options["concurrency"] = var }
+    parser.on "--config-file ./config.yaml", "Specify the path to a configuration file in YAML format" { |var| noir_options["config_file"] = YAML::Any.new(var) }
+    parser.on "--concurrency 100", "Set concurrency" { |var| noir_options["concurrency"] = YAML::Any.new(var) }
     parser.on "--generate-completion zsh", "Generate Zsh/Bash completion script" do |var|
       case var
       when "zsh"
@@ -98,7 +99,7 @@ def run_options_parser
 
     parser.separator "\n  DEBUG:".colorize(:blue)
     parser.on "-d", "--debug", "Show debug messages" do
-      noir_options["debug"] = "yes"
+      noir_options["debug"] = YAML::Any.new(true)
     end
     parser.on "-v", "--version", "Show version" do
       puts Noir::VERSION

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -63,7 +63,7 @@ class OutputBuilderCommon < OutputBuilder
         r_buffer += "\n  ○ tags: #{r_tags}"
       end
 
-      if @options["include_path"] == "yes"
+      if @options["include_path"] == true
         details = endpoint.details
         if details.code_paths && details.code_paths.size > 0
           details.code_paths.each do |code_path|

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -34,7 +34,7 @@ module NoirTaggers
     HasTaggers
   end
 
-  def self.run_tagger(endpoints : Array(Endpoint), options : Hash(String, String), use_taggers : String)
+  def self.run_tagger(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers : String)
     tagger_list = [] of Tagger # This will hold instances of taggers
 
     # Define taggers by creating instances

--- a/src/tagger/taggers/cors.cr
+++ b/src/tagger/taggers/cors.cr
@@ -4,7 +4,7 @@ require "../../models/endpoint"
 class CorsTagger < Tagger
   WORDS = ["origin", "access-control-allow-origin", "access-control-request-method"]
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     super
     @name = "cors"
   end

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -16,7 +16,7 @@ class HuntParamTagger < Tagger
       "description" => "This parameter may be vulnerable to SQL Injection attacks.",
     },
     "idor" => {
-      "words"       => ["id", "user", "account", "number", "order", "no", "doc", "key", "email", "group", "profile", "edit", "report"],
+      "words"       => ["id", "user", "account", "number", "order", "false", "doc", "key", "email", "group", "profile", "edit", "report"],
       "description" => "This parameter may be vulnerable to Insecure Direct Object Reference (IDOR) attacks.",
     },
     "file-inclusion" => {
@@ -33,7 +33,7 @@ class HuntParamTagger < Tagger
     },
   }
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     super
     @name = "hunt"
   end

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -4,7 +4,7 @@ require "../../models/endpoint"
 class OAuthTagger < Tagger
   WORDS = ["grant_type", "code", "redirect_uri", "redirect_url", "client_id", "client_secret"]
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     super
     @name = "oauth"
   end

--- a/src/tagger/taggers/soap.cr
+++ b/src/tagger/taggers/soap.cr
@@ -4,7 +4,7 @@ require "../../models/endpoint"
 class SoapTagger < Tagger
   WORDS = ["soapaction"]
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     super
     @name = "soap"
   end

--- a/src/tagger/taggers/websocket.cr
+++ b/src/tagger/taggers/websocket.cr
@@ -4,7 +4,7 @@ require "../../models/endpoint"
 class WebsocketTagger < Tagger
   WORDS = ["sec-websocket-key", "sec-websocket-accept", "sec-websocket-version"]
 
-  def initialize(options : Hash(String, String))
+  def initialize(options : Hash(String, YAML::Any))
     super
     @name = "websocket"
   end

--- a/src/utils/utils.cr
+++ b/src/utils/utils.cr
@@ -25,7 +25,7 @@ def join_path(*segments : String) : String
 end
 
 def str_to_bool(str)
-  if str == "yes"
+  if str == true
     return true
   end
 


### PR DESCRIPTION
Previously, we used complex option handling to maintain `Hash(String, String)`. Now, we use YAML-based Options(`Hash(String, YAML::Any)`), which allows for easy handling of various types and more.

For #398 
Refer: #395

![스크린샷 2024-09-18 오후 6 57 32](https://github.com/user-attachments/assets/a06b238d-d6a8-462b-9866-01a5e84ca873)
