### PR TITLE
Refactor status codes handing logic

### DIFF
--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -86,7 +86,7 @@ class NoirRunner
     add_path_parameters
 
     # Set status code
-    if any_to_bool(@options["status_codes"]) == true || any_to_bool(@options["exclude_codes"]) != ""
+    if any_to_bool(@options["status_codes"]) == true || @options["exclude_codes"].to_s != ""
       update_status_codes
     end
 


### PR DESCRIPTION
@ksg97031 
먼저 좋은 기능 만들어주셔서 감사합니다! #406 
dev 브랜치에서 테스트해보는데 `--status-codes`가 사용되지 않는 경우에도 `update_status_codes` 가 호출되는 것 같습니다. 

![](https://github.com/user-attachments/assets/4d3456a5-ecec-4b16-acf7-b7aa73022e15)

코드를 살펴봤는데, exclude_codes가 Bool 타입으로 사용되는 것 같진 않은데 any_to_bool의 인자값으로 쓰이고 있어 이로 인해 해당 부분에서 false가 되고 "" 가 아니기에 무조건 돌아가지 않았을까 싶습니다. 의도된 로직일 수도 있어 일단 조심스럽게 수정 버전으로 PR 드려봅니다.

```crystal
    # Set status code
    if any_to_bool(@options["status_codes"]) == true || any_to_bool(@options["exclude_codes"]) != ""
      update_status_codes
    end
```

검토 부탁드려요 :D