### PR TITLE
Update crystal-version in ci.yml to include 1.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.10.1, 1.11.2, 1.12.2, 1.13.3]
+        crystal-version: [1.10.1, 1.11.2, 1.12.2, 1.13.3, 1.14.0]
     steps:
       - uses: actions/checkout@v4
       - uses: MeilCli/setup-crystal-action@v4


### PR DESCRIPTION
This pull request updates the `ci.yml` file to include Crystal version 1.14.0 in the matrix of versions used for the job. This ensures that the CI workflow tests the code against the latest Crystal version.

Signed-off-by: HAHWUL <hahwul@gmail.com>