### PR TITLE
Fix URL Path Handling Issues in Django and Spring Analyzers

### DIFF
--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -143,11 +143,13 @@ module Analyzer::Java
               class_annotation = class_model.annotations["RequestMapping"]?
               if !class_annotation.nil?
                 next if class_annotation.params.size == 0
-                class_path_token = class_annotation.params[0][-1]
-                if class_path_token.type == :STRING_LITERAL
-                  url = class_path_token.value[1..-2]
-                  if url.ends_with? "*"
-                    url = url[0..-2]
+                if class_annotation.params[0].size > 0
+                  class_path_token = class_annotation.params[0][-1]
+                  if class_path_token.type == :STRING_LITERAL
+                    url = class_path_token.value[1..-2]
+                    if url.ends_with? "*"
+                      url = url[0..-2]
+                    end
                   end
                 end
               end


### PR DESCRIPTION
This PR addresses two issues in the URL handling logic within Django and Spring analyzers.

### Fixes
- **Django Analyzer**: Added `@visited_url_paths` to track and avoid duplicate processing of URL paths, optimizing endpoint extraction.
- **Spring Analyzer**: Introduced a size check for `class_annotation.params[0]` to prevent potential out-of-bounds errors during URL extraction.

### Testing
The updates were tested to ensure accurate endpoint extraction and to prevent any unintended behavior changes.
