### PR TITLE
Fix documentation link for output formats in basic.md

### DIFF
--- a/docs/_get_started/basic.md
+++ b/docs/_get_started/basic.md
@@ -24,7 +24,7 @@ noir -b <BASE_PATH>
 
 ## Outputs
 
-The output will display endpoints (such as paths, methods, parameters, headers, etc.), and you can specify the output format using flags `-f` or `--format`. If you're curious about the supported formats, please refer to [this](/get_started/output/) document.
+The output will display endpoints (such as paths, methods, parameters, headers, etc.), and you can specify the output format using flags `-f` or `--format`. If you're curious about the supported formats, please refer to [this](/noir/get_started/output/) document.
 
 ![](../../images/get_started/basic.png)
 


### PR DESCRIPTION
Correct the link to the output formats documentation in the basic.md file.

Close #453