### PR TITLE
Fix: Improve Java lexer and endpoint parsing to resolve crashes and newline issues

### DIFF
--- a/spec/functional_test/fixtures/java/spring/src/RequestMethodClass.java
+++ b/spec/functional_test/fixtures/java/spring/src/RequestMethodClass.java
@@ -1,0 +1,13 @@
+package com.test;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/empty") // Comment
+
+public class RequestMethodClass {
+	
+	@GetMapping("")
+	public void getData() {
+	}
+}

--- a/spec/functional_test/testers/java/spring_spec.cr
+++ b/spec/functional_test/testers/java/spring_spec.cr
@@ -34,6 +34,8 @@ extected_endpoints = [
     Param.new("b", "", "query"),
     Param.new("name", "", "query"),
   ]),
+  # EmptyController.java
+  Endpoint.new("/empty", "GET"),
 ]
 
 FunctionalTester.new("fixtures/java/spring/", {

--- a/src/minilexers/java.cr
+++ b/src/minilexers/java.cr
@@ -217,7 +217,6 @@ class JavaLexer < MiniLexer
         @position += 2
         while @position < @input.size
           if @input[@position] == '\n'
-            @position += 1
             break
           end
           @position += 1

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -151,16 +151,16 @@ class NoirRunner
         end
       end
 
-      # Check start with slash
-      if tiny_tmp.url[0] != "/"
-        tiny_tmp.url = "/#{tiny_tmp.url}"
-      end
-
-      # Check double slash
-      tiny_tmp.url = tiny_tmp.url.gsub_repeatedly("//", "/")
-
       # Duplicate check
       if tiny_tmp.url != ""
+        # Check start with slash
+        if tiny_tmp.url[0] != "/"
+          tiny_tmp.url = "/#{tiny_tmp.url}"
+        end
+
+        # Check double slash
+        tiny_tmp.url = tiny_tmp.url.gsub_repeatedly("//", "/")
+
         is_new = true
         final.each do |dup|
           if dup.method == tiny_tmp.method && dup.url == tiny_tmp.url


### PR DESCRIPTION
## Description
This PR addresses two critical issues identified during testing and development:

1. **Handling Empty URLs in Endpoint Parsing**
   - Fixed an issue where endpoints with empty URLs were generated, causing crashes during runtime.
   - Added validation to ensure that empty URL strings are properly handled.

2. **Improving Java Lexer for Newline Sanitization**
   - Resolved a parsing issue where comments between class declarations and `RequestMapping` annotations were improperly sanitized along with newlines.
   - Adjusted the lexer to correctly process comments and newlines without affecting subsequent mappings.

These changes improve the stability and reliability of endpoint parsing and Java annotation handling in the application.

## Changes
- **Commit `8650dd4`**: Added handling for empty URLs in endpoint parsing.
- **Commit `e04cc638`**: Prevented crashes caused by empty URL strings.
- **Commit `9e70456`**: Adjusted Java lexer to handle newline sanitization correctly.

## Testing
- Verified that endpoints with empty URLs are no longer created.
- Confirmed that comments and newlines between class declarations and annotations are processed correctly.
- Updated unit tests to cover these edge cases.
