### PR TITLE
Prevent duplicate URL printing in output

### DIFF
--- a/src/output_builder/only-url.cr
+++ b/src/output_builder/only-url.cr
@@ -3,10 +3,17 @@ require "../models/endpoint"
 
 class OutputBuilderOnlyUrl < OutputBuilder
   def print(endpoints : Array(Endpoint))
+    printed_urls = Set(String).new
+
     endpoints.each do |endpoint|
       baked = bake_endpoint(endpoint.url, endpoint.params)
-      r_url = baked[:url].colorize(:light_yellow).toggle(@is_color)
-      ob_puts "#{r_url}"
+      plain_url = baked[:url]
+      r_url = plain_url.colorize(:light_yellow).toggle(@is_color)
+
+      unless printed_urls.includes?(plain_url)
+        ob_puts "#{r_url}"
+        printed_urls.add(plain_url)
+      end
     end
   end
 end


### PR DESCRIPTION
Prevent the output of duplicate URLs when printing endpoints by tracking printed URLs in a set.

Signed-off-by: HAHWUL <hahwul@gmail.com>