### PR TITLE
`--techs`, `--exclude-techs` 동작 개선

### DIFF
--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -71,13 +71,8 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   end
 
   techs.each do |tech|
-    if analyzer.has_key?(tech)
-      if NoirTechs.similar_to_tech(options["exclude_techs"].to_s).includes?(tech)
-        logger.sub "➔ Skipping #{tech} analysis"
-        next
-      end
-      result = result + analyzer[tech].call(options)
-    end
+    next unless analyzer.has_key?(tech)
+    result = result + analyzer[tech].call(options)
   end
 
   if options["url"] != ""

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -53,7 +53,17 @@ def detect_techs(base_path : String, options : Hash(String, YAML::Any), passive_
   ])
 
   if options["techs"].to_s.size > 0
-    techs << options["techs"].to_s
+    techs_tmp = options["techs"].to_s.split(",")
+    logger.success "Setting #{techs_tmp.size} techs from command line."
+    techs_tmp.each do |tech|
+      similar_tech = NoirTechs.similar_to_tech(tech)
+      if similar_tech.empty?
+        logger.error "#{tech} is not recognized in the predefined tech list."
+      else
+        logger.success "Added #{tech} to techs."
+        techs << similar_tech
+      end
+    end
   end
 
   channel = Channel(Tuple(String, String)).new

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -62,15 +62,6 @@ class NoirRunner
 
     @logger = NoirLogger.new @is_debug, @is_color, @is_log
 
-    if @options["techs"].to_s.size > 0
-      techs_tmp = @options["techs"].to_s.split(",")
-      @logger.success "Setting #{techs_tmp.size} techs from command line."
-      techs_tmp.each do |tech|
-        @techs << NoirTechs.similar_to_tech(tech)
-        @logger.debug "Added #{tech} to techs."
-      end
-    end
-
     if any_to_bool(@options["passive_scan"])
       @logger.info "Passive scanner enabled."
       if @options["passive_scan_path"].as_a.size > 0
@@ -470,5 +461,9 @@ class NoirRunner
       builder = OutputBuilderPassiveScan.new @options
       builder.print @passive_results, @logger, @is_color
     end
+  end
+
+  def techs=(value : Array(String))
+    @techs = value
   end
 end


### PR DESCRIPTION
@hahwul 
이것도 시간 괜찮으실 때 리뷰 부탁드립니다~

1. `--techs`, `--exclude-techs` 쉼표 입력 시에도 정상처리
Fixes: https://github.com/owasp-noir/noir/issues/502
2. `--techs` 에러메시지 추가
``` 
crystal run src/noir.cr -- -b ../malll/ --techs asdf  # 등록되지 않은 tech 입력 시

░█▄─░█ ░█▀▀▀█ ▀█▀ ░█▀▀█
░█░█░█ ░█──░█ ░█─ ░█▄▄▀
░█──▀█ ░█▄▄▄█ ▄█▄ ░█─░█ {v0.18.3}

⚑ Detecting technologies to base directory.
✔ Setting 1 techs from command line.
✖︎ asdf is not recognized in the predefined tech list.      <<<< 에러메시지 출력
▲ No technologies detected.
  ➔ If you know the technology, use the -t flag to specify it.
  ➔ Please check tech lists using the --list-techs flag.
```
3. `exclude-techs` 개선 (skip 표시 + analyzer.cr 보다 앞단인 noir.cr에서 처리)
```
$ crystal run src/noir.cr -- -b ../github_repos/Destiny-Api/ --exclude-techs java_spring  # exclude 설정 시

░█▄─░█ ░█▀▀▀█ ▀█▀ ░█▀▀█
░█░█░█ ░█──░█ ░█─ ░█▄▄▀
░█──▀█ ░█▄▄▄█ ▄█▄ ░█─░█ {v0.18.3}

⚑ Detecting technologies to base directory.
✔ Detected 2 technologies.
  ├── kotlin_spring
  └── java_spring (skip)       <<< skip한다는 내용 출력
⚑ Start code analysis based on the detected technology.
⚑ Initializing analyzers
⚑ Analysis Started
  ➔ Code Analyzer: 1 in use       <<< analyzer에서 스킵 안된 대상만 동작
⚑ Found 23 endpoints
⚑ Optimizing endpoints.
  ➔ Removing duplicated endpoints and params.
  ➔ Adding path parameters by URL.
✔ Finally identified 21 endpoints.
⚑ Scan completed in 0.5437 s.
⚑ Generating Report.
★ Endpoint Results:
```