### PR TITLE
Add deadlink checker plugin for Jekyll builds

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,17 +1,20 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 4.3.3" # installed by `gem jekyll`
+gem 'jekyll', '~> 4.3.3' # installed by `gem jekyll`
 # gem "webrick"        # required when using Ruby >= 3 and Jekyll <= 4.2.2
 
 # Theme
-gem "just-the-docs"
+gem 'just-the-docs'
 
 # Dependencies
-gem "csv"
-gem "base64"
+gem 'base64'
+gem 'csv'
+gem 'deadfinder', '~> 1.6', '>= 1.6.1'
 
 # Plugins
 group :jekyll_plugins do
-  gem "jekyll-securitytxt"
-  gem "jekyll-sitemap"
+  gem 'jekyll-securitytxt'
+  gem 'jekyll-sitemap'
 end

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -6,11 +6,26 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.8)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
+    colorize (0.8.1)
+    concurrent-ruby (1.1.10)
+    concurrent-ruby-edge (0.6.0)
+      concurrent-ruby (~> 1.1.6)
     csv (3.3.2)
+    date (3.4.1)
+    deadfinder (1.6.1)
+      colorize (~> 0.8.0, >= 0.8.0)
+      concurrent-ruby-edge (~> 0.6.0, >= 0.6.0)
+      json (~> 2.6.0, >= 2.6.0)
+      nokogiri (~> 1.13.0, >= 1.13.0)
+      open-uri (~> 0.2.0, >= 0.2.0)
+      set (~> 1.1.0, >= 1.1.0)
+      sitemap-parser (~> 0.5.0, >= 0.5.0)
+      thor (~> 1.2.0, >= 1.2.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -52,6 +67,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.6.3)
     just-the-docs (0.10.0)
       jekyll (>= 3.8.5)
       jekyll-include-cache
@@ -66,9 +82,18 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    mini_portile2 (2.8.8)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    open-uri (0.2.0)
+      stringio
+      time
+      uri
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
+    racc (1.8.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -80,9 +105,20 @@ GEM
       google-protobuf (~> 4.27)
     sass-embedded (1.79.4-x86_64-linux-gnu)
       google-protobuf (~> 4.27)
+    set (1.1.1)
+    sitemap-parser (0.5.6)
+      nokogiri (~> 1.6)
+      typhoeus (>= 0.6, < 2.0)
+    stringio (3.1.5)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thor (1.2.2)
+    time (0.4.1)
+      date
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
     unicode-display_width (2.6.0)
+    uri (1.0.3)
     webrick (1.8.2)
 
 PLATFORMS
@@ -92,6 +128,7 @@ PLATFORMS
 DEPENDENCIES
   base64
   csv
+  deadfinder (~> 1.6, >= 1.6.1)
   jekyll (~> 4.3.3)
   jekyll-securitytxt
   jekyll-sitemap

--- a/docs/_plugins/deadlink_checker.rb
+++ b/docs/_plugins/deadlink_checker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# _plugins/deadlink_checker.rb
+require 'deadfinder'
+
+Jekyll::Hooks.register :site, :post_write do |_site|
+  puts 'Checking deadlinks after Jekyll build...'
+  runner = DeadFinder::Runner.new
+  options = runner.default_options
+  options['concurrency'] = 30
+
+  site_url = 'https://owasp-noir.github.io'
+  DeadFinder.run_url(site_url, options)
+  puts DeadFinder.output
+end

--- a/docs/_plugins/deadlink_checker.rb
+++ b/docs/_plugins/deadlink_checker.rb
@@ -10,6 +10,10 @@ Jekyll::Hooks.register :site, :post_write do |_site|
   options['concurrency'] = 30
 
   site_url = 'https://owasp-noir.github.io'
-  DeadFinder.run_url(site_url, options)
-  puts DeadFinder.output
+  begin
+    DeadFinder.run_url(site_url, options)
+    puts DeadFinder.output
+  rescue StandardError => e
+    puts "Deadlink checker failed: #{e.message}"
+  end
 end


### PR DESCRIPTION
Integrate a deadlink checker plugin to verify links after the Jekyll build process, enhancing the site's reliability.