### PR TITLE
Add Crystal version 1.16.0 to CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.14.1, 1.15.0]
+        crystal-version: [1.14.1, 1.15.0, 1.16.0]
     steps:
       - uses: actions/checkout@v4
       - uses: MeilCli/setup-crystal-action@v4


### PR DESCRIPTION
Include Crystal version 1.16.0 in the CI build matrix to ensure compatibility and testing with the latest version.