### PR TITLE
feat: Add --ai-max-token flag for LLM token limit control

### DIFF
--- a/spec/unit_test/analyzer/analyzers/llm_analyzers/general_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/llm_analyzers/general_spec.cr
@@ -1,0 +1,65 @@
+require "../../../../spec_helper"
+require "../../../../../src/analyzer/analyzers/llm_analyzers/general"
+require "../../../../../src/llm/general/client" # To mock LLM module
+
+module LLM
+  # Mocking get_max_tokens for testing purposes
+  def self.get_max_tokens(provider_url : String, model_name : String)
+    # Allow dynamic mock behavior if needed, otherwise return a default
+    @@mock_max_tokens_value || 1024 # Default mock value
+  end
+
+  # Helper to set the mock return value for get_max_tokens
+  def self.set_mock_max_tokens(value : Int32)
+    @@mock_max_tokens_value = value
+  end
+
+  def self.reset_mock_max_tokens
+    @@mock_max_tokens_value = nil
+  end
+end
+
+describe Analyzer::AI::General do
+  before_each do
+    LLM.reset_mock_max_tokens
+  end
+
+  describe "#initialize" do
+    it "uses ai_max_token from options if provided" do
+      options = Hash{
+        "ai_provider"  => YAML::Any.new("http://localhost:8000"),
+        "ai_model"     => YAML::Any.new("test-model"),
+        "ai_key"       => YAML::Any.new("test-key"),
+        "ai_max_token" => YAML::Any.new(2048),
+        "base"         => YAML::Any.new("."),
+      }
+      analyzer = Analyzer::AI::General.new(options)
+      analyzer.max_tokens.should eq(2048)
+    end
+
+    it "uses LLM.get_max_tokens if ai_max_token is not provided" do
+      LLM.set_mock_max_tokens(512) # Set a specific mock value for this test
+      options = Hash{
+        "ai_provider" => YAML::Any.new("http://localhost:8000"),
+        "ai_model"    => YAML::Any.new("test-model"),
+        "ai_key"      => YAML::Any.new("test-key"),
+        "base"        => YAML::Any.new("."),
+      }
+      analyzer = Analyzer::AI::General.new(options)
+      analyzer.max_tokens.should eq(512)
+    end
+
+    it "uses LLM.get_max_tokens if ai_max_token is nil" do
+      LLM.set_mock_max_tokens(256) # Set a specific mock value for this test
+      options = Hash{
+        "ai_provider"  => YAML::Any.new("http://localhost:8000"),
+        "ai_model"     => YAML::Any.new("test-model"),
+        "ai_key"       => YAML::Any.new("test-key"),
+        "ai_max_token" => YAML::Any.new(nil), # Explicitly nil
+        "base"         => YAML::Any.new("."),
+      }
+      analyzer = Analyzer::AI::General.new(options)
+      analyzer.max_tokens.should eq(256)
+    end
+  end
+end

--- a/spec/unit_test/analyzer/analyzers/llm_analyzers/ollama_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/llm_analyzers/ollama_spec.cr
@@ -1,0 +1,67 @@
+require "../../../../spec_helper"
+require "../../../../../src/analyzer/analyzers/llm_analyzers/ollama"
+# The LLM module mock should be available from general_spec.cr if run together,
+# or ensure it's defined/required if running specs independently.
+# For robustness, we can redefine it or ensure it's in a shared helper.
+# For now, assuming it might be available or let's redefine for clarity if needed.
+
+# If LLM mock isn't automatically shared, redefine or require from a shared spec helper.
+# To be safe, let's ensure the mock is available.
+# This module might already be defined if general_spec.cr ran first.
+unless defined?(LLM)
+  module LLM
+    def self.get_max_tokens(provider_url : String, model_name : String)
+      @@mock_max_tokens_value || 1024
+    end
+
+    def self.set_mock_max_tokens(value : Int32)
+      @@mock_max_tokens_value = value
+    end
+
+    def self.reset_mock_max_tokens
+      @@mock_max_tokens_value = nil
+    end
+  end
+end
+
+describe Analyzer::AI::Ollama do
+  before_each do
+    LLM.reset_mock_max_tokens if defined?(LLM.reset_mock_max_tokens)
+  end
+
+  describe "#initialize" do
+    it "uses ai_max_token from options if provided" do
+      options = Hash{
+        "ollama"       => YAML::Any.new("http://localhost:11434"),
+        "ollama_model" => YAML::Any.new("test-ollama-model"),
+        "ai_max_token" => YAML::Any.new(4096), # Different value for testing
+        "base"         => YAML::Any.new("."),
+      }
+      analyzer = Analyzer::AI::Ollama.new(options)
+      analyzer.max_tokens.should eq(4096)
+    end
+
+    it "uses LLM.get_max_tokens if ai_max_token is not provided" do
+      LLM.set_mock_max_tokens(768) if defined?(LLM.set_mock_max_tokens)
+      options = Hash{
+        "ollama"       => YAML::Any.new("http://localhost:11434"),
+        "ollama_model" => YAML::Any.new("test-ollama-model"),
+        "base"         => YAML::Any.new("."),
+      }
+      analyzer = Analyzer::AI::Ollama.new(options)
+      analyzer.max_tokens.should eq(768)
+    end
+
+    it "uses LLM.get_max_tokens if ai_max_token is nil" do
+      LLM.set_mock_max_tokens(384) if defined?(LLM.set_mock_max_tokens)
+      options = Hash{
+        "ollama"       => YAML::Any.new("http://localhost:11434"),
+        "ollama_model" => YAML::Any.new("test-ollama-model"),
+        "ai_max_token" => YAML::Any.new(nil), # Explicitly nil
+        "base"         => YAML::Any.new("."),
+      }
+      analyzer = Analyzer::AI::Ollama.new(options)
+      analyzer.max_tokens.should eq(384)
+    end
+  end
+end

--- a/src/analyzer/analyzers/llm_analyzers/general.cr
+++ b/src/analyzer/analyzers/llm_analyzers/general.cr
@@ -15,7 +15,11 @@ module Analyzer::AI
       @llm_url = options["ai_provider"].as_s
       @model = options["ai_model"].as_s
       @api_key = options["ai_key"].as_s
-      @max_tokens = LLM.get_max_tokens(@llm_url, @model)
+      if options.has_key?("ai_max_token") && !options["ai_max_token"].nil?
+        @max_tokens = options["ai_max_token"].as_i32
+      else
+        @max_tokens = LLM.get_max_tokens(@llm_url, @model)
+      end
     end
 
     def analyze

--- a/src/analyzer/analyzers/llm_analyzers/ollama.cr
+++ b/src/analyzer/analyzers/llm_analyzers/ollama.cr
@@ -13,7 +13,11 @@ module Analyzer::AI
       super(options)
       @llm_url = options["ollama"].as_s
       @model = options["ollama_model"].as_s
-      @max_tokens = LLM.get_max_tokens("ollama", @model)
+      if options.has_key?("ai_max_token") && !options["ai_max_token"].nil?
+        @max_tokens = options["ai_max_token"].as_i32
+      else
+        @max_tokens = LLM.get_max_tokens("ollama", @model)
+      end
     end
 
     def analyze

--- a/src/completions.cr
+++ b/src/completions.cr
@@ -40,6 +40,7 @@ _arguments \\
   '--ai-provider[Specify the AI (LLM) provider or custom API URL]:provider:' \\
   '--ai-model[Set the model name to use for AI analysis]:model:' \\
   '--ai-key[Provide the API key for the AI provider]:key:' \\
+  '--ai-max-token[Set the maximum number of tokens for AI requests]:value:' \\
   '--ollama[Specify the Ollama server URL (Deprecated)]:URL:_urls' \\
   '--ollama-model[Specify the Ollama model name (Deprecated)]:model:' \\
   '-d[Show debug messages]' \\
@@ -96,6 +97,7 @@ _noir_completions() {
         --ai-provider
         --ai-model
         --ai-key
+        --ai-max-token
         --ollama
         --ollama-model
         -d --debug
@@ -119,7 +121,7 @@ _noir_completions() {
             COMPREPLY=( $(compgen -W "zsh bash fish" -- "${cur}") )
             return 0
             ;;
-        --ai-provider|--ai-model|--ai-key|--ollama|--ollama-model)
+        --ai-provider|--ai-model|--ai-key|--ai-max-token|--ollama|--ollama-model)
             COMPREPLY=( $(compgen -f -- "${cur}") )
             return 0
             ;;
@@ -182,6 +184,7 @@ complete -c noir -n '__fish_noir_needs_command' -a '--generate-completion' -d 'G
 complete -c noir -n '__fish_noir_needs_command' -a '--ai-provider' -d 'Specify the AI (LLM) provider or custom API URL'
 complete -c noir -n '__fish_noir_needs_command' -a '--ai-model' -d 'Set the model name to use for AI analysis'
 complete -c noir -n '__fish_noir_needs_command' -a '--ai-key' -d 'Provide the API key for the AI provider'
+complete -c noir -n '__fish_noir_needs_command' -a '--ai-max-token' -d 'Set the maximum number of tokens for AI requests'
 complete -c noir -n '__fish_noir_needs_command' -a '--ollama' -d 'Specify the Ollama server URL (Deprecated)'
 complete -c noir -n '__fish_noir_needs_command' -a '--ollama-model' -d 'Specify the Ollama model name (Deprecated)'
 complete -c noir -n '__fish_noir_needs_command' -a '-d' -d 'Show debug messages'

--- a/src/options.cr
+++ b/src/options.cr
@@ -126,6 +126,8 @@ def run_options_parser
                                   "  [Example] --ai-model=gpt-4" { |var| noir_options["ai_model"] = YAML::Any.new(var) }
     parser.on "--ai-key KEY", "Provide the API key for authenticating with the AI provider's API. Alternatively, use the NOIR_AI_KEY environment variable.\n" \
                               "  [Example] --ai-key=your-api-key  or  export NOIR_AI_KEY=your-api-key" { |var| noir_options["ai_key"] = YAML::Any.new(var) }
+    parser.on "--ai-max-token INT", "Set the maximum number of tokens for AI requests. This affects the length of generated text and context window for analysis.\n" \
+                                     "  [Example] --ai-max-token=2048" { |var| noir_options["ai_max_token"] = YAML::Any.new(var.to_i) }
     parser.on "--ollama http://localhost:11434", "(Deprecated) Set the Ollama server URL. Use --ai-provider instead." { |var| noir_options["ollama"] = YAML::Any.new(var) }
     parser.on "--ollama-model MODEL", "(Deprecated) Specify the model for the Ollama server. Use --ai-model instead." { |var| noir_options["ollama_model"] = YAML::Any.new(var) }
 


### PR DESCRIPTION
This commit introduces a new command-line flag `--ai-max-token` that allows you to specify the maximum number of tokens for AI requests.

The following changes were made:
- Added the `--ai-max-token` flag to `src/options.cr` under the "AI Integration" section. This flag accepts an integer.
- Modified the `initialize` method in `src/analyzer/analyzers/llm_analyzers/general.cr` to use the value of `ai_max_token` from options if provided, otherwise defaulting to `LLM.get_max_tokens`.
- Modified the `initialize` method in `src/analyzer/analyzers/llm_analyzers/ollama.cr` similarly to use `ai_max_token` if provided.
- Added unit tests for both `Analyzer::AI::General` and `Analyzer::AI::Ollama` to verify the new functionality in `spec/unit_test/analyzer/analyzers/llm_analyzers/`. These tests ensure that `@max_tokens` is correctly set based on the presence or absence of the `ai_max_token` option.