### PR TITLE
Add initial Korean language support to Hugo docs

### DIFF
--- a/docs/config/_default/menu.ko.toml
+++ b/docs/config/_default/menu.ko.toml
@@ -1,0 +1,39 @@
+[[main]]
+  name = "개요"
+  pageRef = "/docs/overview"
+  weight = 10
+
+[[main]]
+  name = "설치"
+  pageRef = "/docs/installation"
+  weight = 20
+
+[[main]]
+  name = "사용법"
+  pageRef = "/docs/usage"
+  weight = 30
+
+[[main]]
+  name = "특징"
+  pageRef = "/docs/features"
+  weight = 40
+
+[[main]]
+  name = "AI 통합"
+  pageRef = "/docs/ai_integration"
+  weight = 50
+
+[[main]]
+  name = "개발자"
+  pageRef = "/docs/developers"
+  weight = 60
+
+[[main]]
+  name = "커뮤니티"
+  pageRef = "/docs/community"
+  weight = 70
+
+[[main]]
+  name = "기여" # Assuming contribitions.md is meant to be contributions
+  pageRef = "/docs/contribitions" # Path should match the actual file
+  weight = 80

--- a/docs/content/ko/docs/overview.md
+++ b/docs/content/ko/docs/overview.md
@@ -1,0 +1,90 @@
++++
+title = '개요'
+weight = 1
+icon = "circle"
+aliases = ['/introdution/index.html']
++++
+
+OWASP 느와르는 화이트박스 보안 테스트 및 보안 파이프라인 강화를 위해 공격 표면을 식별하는 데 특화된 오픈 소스 프로젝트입니다.
+
+[Github](https://github.com/owasp-noir/noir)
+[OWASP](https://owasp.org/www-project-noir)
+
+## 느와르란 무엇인가?
+
+느와르는 공격 표면 식별, 화이트박스 보안 테스트 강화, 보안 파이프라인 최적화에 전념하는 오픈 소스 프로젝트입니다. 포괄적인 보안 분석을 위해 소스 코드 내에서 API 엔드포인트, 웹 엔드포인트 및 기타 잠재적인 진입점을 찾는 데 탁월합니다.
+
+![](images/noir-usage.jpg)
+
+이 도구는 [Crystal](https://crystal-lang.org)을 사용하여 개발되었습니다. 2023년 8월 hahwul의 개인 프로젝트[^1]로 시작하여 2024년 6월 [hahwul](https://github.com/hahwul)과 [ksg](https://github.com/ksg97031)가 공동으로 이끄는 OWASP 프로젝트[^2]가 되었습니다.
+
+[^1]: [안녕하세요 느와르 👋🏼](https://www.hahwul.com/2023/08/03/hello-noir/)
+[^2]: [OWASP 느와르에 오신 것을 환영합니다](https://github.com/orgs/owasp-noir/discussions/336)
+
+## 작동 방식
+
+느와르는 탐지기, 분석기, 전달기, 미니렉서/미니파서[^3], 출력 빌더, 수동 스캔 및 태거[^4] 등 여러 주요 구성 요소로 구성됩니다. 이러한 구성 요소는 상호 작용하고 함께 작동하여 소스 코드를 효과적으로 분석합니다. 이 프로세스를 통해 소스 코드 내에서 엔드포인트, 매개변수, 헤더 등을 식별하는 데 도움이 됩니다.
+
+[^3]: 미니렉서와 미니파서는 소스 코드 내의 다양한 요소를 식별하기 위해 코드 분석에 사용되는 파서 및 토크나이저입니다.
+[^4]: 태거는 식별된 문제에 관련 태그를 할당하여 쉽게 분류하고 관리할 수 있도록 합니다.
+
+```mermaid
+flowchart LR
+    SourceCode:::highlight --> Detectors
+
+    subgraph Detectors
+        direction LR
+        Detector1 & Detector2 & Detector3 --> |Condition| PassiveScan
+    end
+
+    PassiveScan --> |Results| OutputBuilder
+
+    Detectors --> |Techs| Analyzers
+
+    subgraph Analyzers
+        direction LR
+        CodeAnalyzers & FileAnalyzer & LLMAnalyzer
+        CodeAnalyzers --> |Condition| Minilexer
+        CodeAnalyzers --> |Condition| Miniparser
+    end
+
+    Analyzers --> |Condition| Deliver
+    Analyzers --> |Condition| Tagger
+    Deliver --> 3rdParty
+    Tagger --> |Tags| OutputBuilder
+    Analyzers --> |Endpoints| OutputBuilder
+    OutputBuilder --> Report:::highlight
+
+    classDef highlight fill:#f9f,stroke:#333,stroke-width:4px;
+```
+
+## 프로젝트 정보
+### 라이선스
+OWASP 느와르는 [MIT 라이선스](https://github.com/owasp-noir/noir/blob/main/LICENSE)로 배포됩니다.
+
+### 기여
+
+오픈 소스 프로젝트는 커뮤니티의 힘으로 번창합니다. 작은 기여에서부터 주요 기여에 이르기까지 모든 기여자에게 감사를 표하고 싶습니다. 기여에 관심이 있으시면 이 문서를 확인하십시오.
+
+모든 기여가 중요하다고 생각하며 이 프로젝트를 더 좋게 만드는 데 들이는 시간과 노력에 감사드립니다. 오타 수정, 새로운 기능 추가 또는 문서 개선 등 귀하의 도움은 매우 중요합니다. 커뮤니티의 일원이 되어 주셔서 감사합니다!
+
+시작하려면 [기여 가이드](https://github.com/owasp-noir/noir/blob/main/CONTRIBUTING.md)의 지침을 따르기만 하면 됩니다. 첫 기여를 원활하고 즐겁게 만드는 데 도움이 되는 유용한 팁과 지침으로 가득 차 있습니다.
+
+즐거운 기여 되세요!
+
+#### 느와르의 기여자분들께 감사드립니다 ♥️
+
+![](https://raw.githubusercontent.com/owasp-noir/noir/refs/heads/main/CONTRIBUTORS.svg)
+
+*수동 스캔 규칙 기여자*
+
+[![](https://raw.githubusercontent.com/owasp-noir/noir-passive-rules/refs/heads/main/CONTRIBUTORS.svg)](https://github.com/owasp-noir/noir-passive-rules/graphs/contributors)
+
+### 행동 강령
+OWASP 느와르는 환영하는 커뮤니티를 조성하기 위해 최선을 다하고 있습니다.
+
+GitHub 리포지토리에서 [행동 강령](https://github.com/owasp-noir/noir/blob/main/CODE_OF_CONDUCT.md)을 확인하십시오.
+
+## 도움말 및 피드백
+
+항상 피드백을 환영합니다. GitHub [토론](https://github.com/orgs/owasp-noir/discussions) 또는 [문제](https://github.com/owasp-noir/noir/issues) 페이지를 통해 생각, 제안 또는 문제를 보고해 주십시오.

--- a/docs/data/landing.ko.yaml
+++ b/docs/data/landing.ko.yaml
@@ -1,0 +1,101 @@
+hero:
+  enable: true
+  weight: 10
+  template: hero
+
+  backgroundImage:
+    path: "images"
+    filename:
+      desktop: "b.jpg"
+      mobile: "b.jpg"
+
+  badge:
+    text: v0.21.1
+    color: primary
+    pill: false
+    soft: true
+
+  title: ""
+  subtitle: "정적 분석을 통해 엔드포인트를 식별하는 공격 표면 탐지기입니다."
+
+  titleLogo:
+    path: "images"
+    filename: "owasp-noir-black.png"
+    alt: "OWASP 느와르 로고"
+    height: 80px
+
+  image:
+    path: "images"
+    filename: "capture.png"
+    alt: "OWASP 느와르 로고"
+    boxShadow: true
+    rounded: true
+
+  ctaButton:
+    icon: rocket_launch
+    btnText: "시작하기"
+    url: "/noir/docs/installation/"
+  cta2Button:
+    icon: code
+    btnText: "GitHub에서 보기"
+    url: "https://github.com/owasp-noir/noir"
+
+  info: "**오픈 소스** MIT 라이선스입니다."
+
+# Feature Grid
+featureGrid:
+  enable: true
+  weight: 20
+  template: feature grid
+
+  title: "OWASP 느와르를 선택해야 하는 이유"
+  subtitle: "OWASP 느와르는 정적 분석을 통해 엔드포인트와 취약점을 발견하여 보안 팀에 고급 공격 표면 탐지 기능을 제공합니다. 핵심 기능은 다음과 같습니다."
+
+  items:
+    - title: "엔드포인트 추출"
+      icon: api
+      description: "포괄적인 보안 분석을 위해 소스 코드에서 직접 API 및 웹 엔드포인트와 매개변수를 추출합니다."
+
+    - title: "다국어 지원"
+      icon: code
+      description: "다양한 프로그래밍 언어와 프레임워크를 지원하여 다양한 프로젝트에 대한 광범위한 호환성을 보장합니다."
+
+    - title: "보안 문제 탐지"
+      icon: security
+      description: "규칙 기반 수동 스캔을 수행하여 잠재적인 보안 취약점을 상세한 통찰력과 함께 식별합니다."
+
+    - title: "DevOps 통합"
+      icon: code
+      description: "curl, ZAP, Caido와 같은 DevOps 도구와 원활하게 통합하여 보안 파이프라인을 강화합니다."
+
+    - title: "유연한 출력 형식"
+      icon: file_download
+      description: "JSON, YAML, OAS 형식으로 명확하고 실행 가능한 결과를 생성하여 쉽게 사용할 수 있도록 합니다."
+
+    - title: "AI 강화 검색"
+      icon: auto_awesome
+      description: "AI를 활용하여 익숙하지 않은 프레임워크에서 숨겨진 API와 엔드포인트를 찾아냅니다."
+
+# Image Compare
+imageCompare:
+  enable: true
+  weight: 30
+  template: image compare
+
+  title: "OWASP 느와르 분석 시각화"
+  subtitle: "OWASP 느와르는 애플리케이션의 공격 표면에 대한 상세한 통찰력을 제공합니다. CLI 사용과 JSON 출력을 비교하여 느와르가 실행 가능한 결과를 제공하는 방법을 확인하십시오."
+
+  items:
+    - title: "CLI 대 JSON 출력"
+      config:
+        startingPoint: 50
+        addCircle: true
+        addCircleBlur: false
+        showLabels: true
+        labelOptions:
+          before: "CLI 사용"
+          after: "JSON 출력"
+          onHover: false
+      imagePath: "images/screenshots"
+      imageBefore: "plain.png" # Placeholder for CLI screenshot (e.g., from /docs/images/get_started/basic.png)
+      imageAfter: "json.png" # Placeholder for JSON output screenshot

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -1,6 +1,12 @@
 baseURL = 'https://owasp-noir.github.io/noir/'
+defaultContentLanguage = "en"
 languageCode = 'en-us'
 title = 'OWASP Noir'
+
+[languages.ko]
+  languageName = "한국어"
+  contentDir = "content/ko"
+  weight = 2
 
 [params.flexsearch]
   enabled = true


### PR DESCRIPTION
This commit introduces the basic framework for Korean (ko) localization in the Hugo documentation site.

Key changes include:

- Updated `hugo.toml` to define the 'ko' language, setting its `languageName`, `contentDir`, and `weight`. English (`en`) is set as the default content language.
- Created the `docs/content/ko/` directory to house Korean content.
- Added a Korean version of the landing page data (`docs/data/landing.ko.yaml`) with placeholder translations.
- Added a sample translated content page (`docs/content/ko/docs/overview.md`) with placeholder Korean text.
- Created a Korean menu configuration file (`docs/config/_default/menu.ko.toml`) with placeholder translations for menu items.

This provides the foundational structure for translating the documentation into Korean. Further work will involve translating all content pages and refining the placeholder translations.