### PR TITLE
[WIP] Improve javascript analyzers

### DIFF
--- a/spec/functional_test/fixtures/javascript/express/app.js
+++ b/spec/functional_test/fixtures/javascript/express/app.js
@@ -96,3 +96,9 @@ router.get('/admin/dashboard', (req, res) => {
 
 // Export the router
 module.exports = router;
+
+// Dynamic routes for testing
+const API_PREFIX = '/api/v2';
+router.get(`${API_PREFIX}/users`, (req, res) => res.json({}));
+router.post(API_PREFIX + '/login', (req, res) => res.json({}));
+router.all(`${API_PREFIX}/catchall`, (req, res) => res.json({}));

--- a/spec/functional_test/testers/javascript/express_spec.cr
+++ b/spec/functional_test/testers/javascript/express_spec.cr
@@ -47,6 +47,10 @@ extected_endpoints = [
     Param.new("view", "", "query"),
     Param.new("Admin-Token", "", "header"),
   ]),
+  # Dynamic routes
+  Endpoint.new("/api/v2/users", "GET"),
+  Endpoint.new("/api/v2/login", "POST"),
+  Endpoint.new("/api/v2/catchall", "ALL"),
 ]
 
 FunctionalTester.new("fixtures/javascript/express/", {

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -169,7 +169,7 @@ module Analyzer::Javascript
           prefix = m[2]
 
           # Now find all endpoints defined on this router
-          http_methods = %w(get post put delete patch options head)
+          http_methods = %w(get post put delete patch options head all)
 
           http_methods.each do |http_method|
             endpoint_pattern = /#{router_var}\.#{http_method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
@@ -311,7 +311,7 @@ module Analyzer::Javascript
         next if router_prefix.empty?
 
         # Look for route handlers on this router
-        http_methods = %w(get post put delete patch options head)
+        http_methods = %w(get post put delete patch options head all)
 
         http_methods.each do |method|
           # Enhanced pattern to catch more route handler formats
@@ -361,7 +361,7 @@ module Analyzer::Javascript
 
     # Special method to process versioned routers like v1Router
     private def process_versioned_router(content : String, result : Array(Endpoint), path : String, router_name : String, prefix : String)
-      http_methods = %w(get post put delete patch options head)
+      http_methods = %w(get post put delete patch options head all)
 
       http_methods.each do |method|
         pattern = /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"](?:[^{]*)\{([^}]*(?:\{[^}]*\})*[^}]*)\}/m
@@ -602,7 +602,7 @@ module Analyzer::Javascript
     end
 
     def line_to_endpoint(line : String, router_detected : Bool = false) : Endpoint
-      http_methods = %w(get post put delete patch options head)
+      http_methods = %w(get post put delete patch options head all)
 
       http_methods.each do |method|
         # Match both app.method and router.method patterns with improved regex

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -47,7 +47,7 @@ module Noir
         return "DELETE"
       when "OPTIONS"
         return "OPTIONS"
-      when "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"
+      when "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "ALL"
         return method
       end
 


### PR DESCRIPTION
The changes include:
- **JSLexer:** Updated to recognize the `all` HTTP method, the `+` operator, and to tokenize template literals (backticked strings).
- **JSParser:** Implemented a symbol table to track string constants. A new `resolve_path_expression` method was added to evaluate route paths constructed from variables, template literals, or string concatenation. The main route parsing functions were updated to use this new resolver. Several bugs in this logic were found and fixed.
- **Analyzer:** The Express analyzer and route extractor were updated to recognize the `ALL` HTTP method.
- **Tests:** Added new test fixtures and expectations for dynamic routes as described in the issue.

**Known Issues & Next Steps:**
The implementation is currently incomplete and the tests are still failing. The new parsing logic appears to have a subtle bug that causes it to fail silently, making the analyzer fall back to the old regex-based method. My debugging attempts (forcing crashes, logging) were hampered by nested exception handling that suppressed the stack trace.

The root cause is likely a subtle logic error in `JSParser#resolve_path_expression` that was not revealed by my logging. Further, more granular logging or a different debugging approach is needed to solve this issue.