### PR TITLE
detector(java): refine JSP XML detection and expand unit tests

### DIFF
--- a/spec/unit_test/detector/java/jsp_spec.cr
+++ b/spec/unit_test/detector/java/jsp_spec.cr
@@ -69,6 +69,16 @@ describe "Detect Java JSP" do
     instance.detect("config.xml", content).should be_false
   end
 
+  it "does not detect commented out JspServlet in web.xml" do
+    content = <<-XML
+      <servlet>
+        <servlet-name>jsp</servlet-name>
+        <!-- <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class> -->
+      </servlet>
+      XML
+    instance.detect("WEB-INF/web.xml", content).should be_false
+  end
+
   it "does not detect non-JSP files" do
     instance.detect("index.html", "<html></html>").should be_false
     instance.detect("app.js", "console.log('hello')").should be_false

--- a/spec/unit_test/detector/java/jsp_spec.cr
+++ b/spec/unit_test/detector/java/jsp_spec.cr
@@ -5,7 +5,63 @@ describe "Detect Java JSP" do
   options = create_test_options
   instance = Detector::Java::Jsp.new options
 
-  it "case1" do
+  it "detects .jsp file" do
     instance.detect("1.jsp", "<% info(); %>").should be_true
+  end
+
+  it "detects web.xml with <jsp-file>" do
+    content = <<-XML
+      <servlet>
+        <servlet-name>index</servlet-name>
+        <jsp-file>/index.jsp</jsp-file>
+      </servlet>
+      XML
+    instance.detect("WEB-INF/web.xml", content).should be_true
+  end
+
+  it "detects web.xml with JspServlet" do
+    content = <<-XML
+      <servlet>
+        <servlet-name>jsp</servlet-name>
+        <servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>
+      </servlet>
+      XML
+    instance.detect("WEB-INF/web.xml", content).should be_true
+  end
+
+  it "detects .java with javax.servlet.jsp" do
+    content = "import javax.servlet.jsp.JspWriter;"
+    instance.detect("MyServlet.java", content).should be_true
+  end
+
+  it "detects .java with jakarta.servlet.jsp" do
+    content = "import jakarta.servlet.jsp.JspWriter;"
+    instance.detect("MyServlet.java", content).should be_true
+  end
+
+  it "does not detect pom.xml with javax.servlet.jsp dependency" do
+    content = <<-XML
+      <dependency>
+        <groupId>javax.servlet.jsp</groupId>
+        <artifactId>javax.servlet.jsp-api</artifactId>
+        <version>2.3.3</version>
+      </dependency>
+      XML
+    instance.detect("pom.xml", content).should be_false
+  end
+
+  it "does not detect generic xml with servlet and .jsp strings" do
+    content = <<-XML
+      <config>
+        <servlet-api>javax.servlet.jsp-api</servlet-api>
+        <description>Handles .jsp pages</description>
+      </config>
+      XML
+    instance.detect("config.xml", content).should be_false
+  end
+
+  it "does not detect non-JSP files" do
+    instance.detect("index.html", "<html></html>").should be_false
+    instance.detect("app.js", "console.log('hello')").should be_false
   end
 end

--- a/spec/unit_test/detector/java/jsp_spec.cr
+++ b/spec/unit_test/detector/java/jsp_spec.cr
@@ -60,6 +60,15 @@ describe "Detect Java JSP" do
     instance.detect("config.xml", content).should be_false
   end
 
+  it "does not detect xml with JspServlet outside servlet-class tag" do
+    content = <<-XML
+      <config>
+        <description>Uses JspServlet for docs</description>
+      </config>
+      XML
+    instance.detect("config.xml", content).should be_false
+  end
+
   it "does not detect non-JSP files" do
     instance.detect("index.html", "<html></html>").should be_false
     instance.detect("app.js", "console.log('hello')").should be_false

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -12,12 +12,7 @@ module Detector::Java
           file_contents.includes?("jakarta.servlet.jsp")
       end
 
-      # web.xml often contains servlet mappings; allow broader heuristic there
-      if filename.ends_with?("web.xml")
-        return file_contents.includes?("<jsp-file>") ||
-          file_contents.includes?("JspServlet") ||
-          (file_contents.includes?(".jsp") && file_contents.includes?("servlet"))
-      elsif filename.ends_with?(".xml")
+      if filename.ends_with?(".xml")
         return file_contents.includes?("<jsp-file>") ||
           file_contents.includes?("JspServlet")
       end

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -14,7 +14,7 @@ module Detector::Java
 
       if filename.ends_with?(".xml")
         return file_contents.includes?("<jsp-file>") ||
-          file_contents.includes?("JspServlet")
+          !!file_contents.match(/<servlet-class>\s*[^<]*\bJspServlet\b[^<]*<\/servlet-class>/)
       end
 
       false

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -13,8 +13,9 @@ module Detector::Java
       end
 
       if filename.ends_with?(".xml")
-        return file_contents.includes?("<jsp-file>") ||
-          !!file_contents.match(/<servlet-class>\s*[^<]*\bJspServlet\b[^<]*<\/servlet-class>/)
+        xml_without_comments = file_contents.gsub(/<!--.*?-->/m, "")
+        return xml_without_comments.includes?("<jsp-file>") ||
+          !!xml_without_comments.match(/<servlet-class>\s*[^<]*\bJspServlet\b[^<]*<\/servlet-class>/)
       end
 
       false


### PR DESCRIPTION
Hi team, this PR aims to refine Java JSP detection in XML files to reduce false positives

## Why
The previous XML heuristic could match broad `JspServlet` occurrences in non-servlet XML contexts.

## Changes
- Updated `Detector::Java::Jsp` XML detection:
  - Keep `<jsp-file>` detection.
  - Scope `JspServlet` detection to `<servlet-class>...</servlet-class>` only.
- Expanded JSP detector unit tests:
  - Positive coverage for `.jsp`, Java imports, and `web.xml` servlet-class usage.
  - Negative coverage for generic XML, Maven dependency-only XML, and non-JSP files.
  - Added explicit negative test where `JspServlet` appears outside `<servlet-class>`.
