### PR TITLE
Add URL normalization tests for LLM::General client

### DIFF
--- a/spec/unit_test/llm/general_client_spec.cr
+++ b/spec/unit_test/llm/general_client_spec.cr
@@ -115,14 +115,14 @@ describe LLM::General do
       client.__test_api.should eq("http://localhost:11434/v1/chat/completions")
     end
 
-    it "appends /chat/completions to bare server URL" do
+    it "appends /v1/chat/completions to bare server URL" do
       client = LLM::General.new("http://host.docker.internal:11434/", "test-model", nil)
-      client.__test_api.should eq("http://host.docker.internal:11434/chat/completions")
+      client.__test_api.should eq("http://host.docker.internal:11434/v1/chat/completions")
     end
 
-    it "appends /chat/completions to bare server URL without trailing slash" do
+    it "appends /v1/chat/completions to bare server URL without trailing slash" do
       client = LLM::General.new("http://host.docker.internal:11434", "test-model", nil)
-      client.__test_api.should eq("http://host.docker.internal:11434/chat/completions")
+      client.__test_api.should eq("http://host.docker.internal:11434/v1/chat/completions")
     end
 
     it "preserves URL that already ends with /chat/completions" do

--- a/spec/unit_test/llm/general_client_spec.cr
+++ b/spec/unit_test/llm/general_client_spec.cr
@@ -10,6 +10,10 @@ class LLM::General
   def self.__test_tools_cache_size : Int32
     @@tools_cache.size
   end
+
+  def __test_api : String
+    @api
+  end
 end
 
 private def build_tool_response(action : String, arguments_raw : String) : JSON::Any
@@ -102,6 +106,43 @@ describe LLM::General do
       second.as_a[0]["function"]["name"].as_s.should eq("cache_probe_tool")
       size_after_first.should eq(size_before + 1)
       size_after_second.should eq(size_after_first)
+    end
+  end
+
+  describe "URL normalization" do
+    it "appends /chat/completions to base URL with /v1 path" do
+      client = LLM::General.new("http://localhost:11434/v1", "test-model", nil)
+      client.__test_api.should eq("http://localhost:11434/v1/chat/completions")
+    end
+
+    it "appends /chat/completions to bare server URL" do
+      client = LLM::General.new("http://host.docker.internal:11434/", "test-model", nil)
+      client.__test_api.should eq("http://host.docker.internal:11434/chat/completions")
+    end
+
+    it "appends /chat/completions to bare server URL without trailing slash" do
+      client = LLM::General.new("http://host.docker.internal:11434", "test-model", nil)
+      client.__test_api.should eq("http://host.docker.internal:11434/chat/completions")
+    end
+
+    it "preserves URL that already ends with /chat/completions" do
+      client = LLM::General.new("http://localhost:9999/v1/chat/completions", "test-model", nil)
+      client.__test_api.should eq("http://localhost:9999/v1/chat/completions")
+    end
+
+    it "appends /chat/completions to custom path" do
+      client = LLM::General.new("http://custom-server.com/api/v1", "test-model", nil)
+      client.__test_api.should eq("http://custom-server.com/api/v1/chat/completions")
+    end
+
+    it "resolves prefix 'openai' to full endpoint URL" do
+      client = LLM::General.new("openai", "test-model", "test-key")
+      client.__test_api.should eq("https://api.openai.com/v1/chat/completions")
+    end
+
+    it "resolves prefix 'ollama' to full endpoint URL" do
+      client = LLM::General.new("ollama", "test-model", nil)
+      client.__test_api.should eq("http://localhost:11434/v1/chat/completions")
     end
   end
 end

--- a/src/llm/general/client.cr
+++ b/src/llm/general/client.cr
@@ -1,4 +1,5 @@
 require "json"
+require "uri"
 require "http/client"
 
 module LLM
@@ -151,7 +152,14 @@ module LLM
     private def ensure_chat_completions_path(url : String) : String
       normalized = url.chomp("/")
       return normalized if normalized.ends_with?("/chat/completions")
-      "#{normalized}/chat/completions"
+
+      uri = URI.parse(normalized)
+      path = uri.path || ""
+      if path.empty? || path == "/"
+        "#{normalized}/v1/chat/completions"
+      else
+        "#{normalized}/chat/completions"
+      end
     end
 
     def self.parse_tools_cached(tools : String) : JSON::Any

--- a/src/llm/general/client.cr
+++ b/src/llm/general/client.cr
@@ -10,7 +10,7 @@ module LLM
     def initialize(url : String, model : String, api_key : String?)
       @url = url
       @api = if url.includes?("://")
-               url
+               ensure_chat_completions_path(url)
              else
                case url.downcase
                when "openai"
@@ -146,6 +146,12 @@ module LLM
 
     private def self.clean_content(text : String) : String
       text.gsub("```json", "").gsub("```", "").strip
+    end
+
+    private def ensure_chat_completions_path(url : String) : String
+      normalized = url.chomp("/")
+      return normalized if normalized.ends_with?("/chat/completions")
+      "#{normalized}/chat/completions"
     end
 
     def self.parse_tools_cached(tools : String) : JSON::Any


### PR DESCRIPTION
Test various URL inputs to ensure /chat/completions is appended correctly and special prefixes are resolved to full endpoint URLs. Add ensure_chat_completions_path helper to client implementation.