### PR TITLE
Add framework tagger (+auth tagger)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ src/
 ├── llm/                    # AI/LLM integration (general/, ollama/)
 ├── optimizer/              # Endpoint normalization/dedup and LLM optimizer
 ├── tagger/taggers/         # Endpoint tagging implementations
+├── tagger/framework_taggers/ # Framework-specific auth taggers (by language)
 ├── deliver/                # Results delivery (proxy, elasticsearch)
 ├── minilexers/             # Custom lexers
 ├── miniparsers/            # Custom parsers
@@ -98,7 +99,25 @@ spec/
 ### Taggers
 1. Create `src/tagger/taggers/{tagger_name}.cr`
 2. Add unit test: `spec/unit_test/tagger/{tagger_name}_spec.cr`
-3. Register in tagger registry
+3. Register in `HasTaggers` in `src/tagger/tagger.cr`
+
+### Framework Taggers (Auth Taggers)
+Framework taggers detect framework-specific patterns (e.g., auth decorators, middleware, guards) and tag endpoints accordingly. They extend `FrameworkTagger < Tagger` which provides file caching and `read_source_context()`.
+
+1. Create `src/tagger/framework_taggers/{language}/{tagger_name}.cr`
+   - Inherit from `FrameworkTagger`
+   - Override `self.target_techs` to return matching technology strings (e.g., `["python_django"]`)
+   - Override `perform(endpoints)` to check and tag endpoints
+   - Use `read_file(path)` (cached) and `read_source_context(endpoint)` helpers
+2. Add unit test: `spec/unit_test/tagger/framework_taggers/{tagger_name}_spec.cr`
+3. Add fixtures: `spec/functional_test/fixtures/{language}/{framework}_auth/`
+4. Register in `HasFrameworkTaggers` in `src/tagger/tagger.cr`
+
+Key design notes:
+- `FrameworkTagger` inherits from `Tagger` — shares `@logger`, `@options`, `@name`, `perform()` interface
+- `@file_cache` prevents redundant reads within a tagger run (pre-scan + per-endpoint checks)
+- Framework taggers are dispatched only when endpoints matching their `target_techs` exist
+- Scope tracking (Go groups, Ktor authenticate blocks, Express app.use) uses heuristic brace counting — not AST-level, so edge cases with braces in strings/comments may occur
 
 **After any new component: run `just test` to validate.**
 

--- a/spec/functional_test/fixtures/csharp/aspnet_auth/Controllers/PostsController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_auth/Controllers/PostsController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MyApp.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PostsController : ControllerBase
+    {
+        [AllowAnonymous]
+        [HttpGet]
+        public IActionResult Index()
+        {
+            return Ok(new { message = "public" });
+        }
+
+        [HttpGet("{id}")]
+        public IActionResult Show(int id)
+        {
+            return Ok(new { id = id });
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPost]
+        public IActionResult Create()
+        {
+            return Ok(new { created = true });
+        }
+    }
+}

--- a/spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/post_controller.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/post_controller.ex
@@ -1,0 +1,15 @@
+defmodule MyappWeb.PostController do
+  use MyappWeb, :controller
+
+  plug :require_authenticated_user
+
+  def index(conn, _params) do
+    posts = Blog.list_posts()
+    json(conn, posts)
+  end
+
+  def show(conn, %{"id" => id}) do
+    post = Blog.get_post!(id)
+    json(conn, post)
+  end
+end

--- a/spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/public_controller.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/public_controller.ex
@@ -1,0 +1,7 @@
+defmodule MyappWeb.PublicController do
+  use MyappWeb, :controller
+
+  def index(conn, _params) do
+    json(conn, %{message: "public"})
+  end
+end

--- a/spec/functional_test/fixtures/go/gin_auth/main.go
+++ b/spec/functional_test/fixtures/go/gin_auth/main.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/golang-jwt/jwt/v5"
 )
 
 func main() {
@@ -39,6 +38,8 @@ func main() {
 	r.Run(":8080")
 }
 
+// AuthMiddleware validates JWT tokens from the Authorization header.
+// Simplified for fixture purposes — production code should verify token signature.
 func AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token := c.GetHeader("Authorization")
@@ -46,6 +47,7 @@ func AuthMiddleware() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
+		// TODO: validate token signature in production
 		c.Next()
 	}
 }

--- a/spec/functional_test/fixtures/go/gin_auth/main.go
+++ b/spec/functional_test/fixtures/go/gin_auth/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func main() {
+	r := gin.Default()
+
+	// Public routes
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	r.GET("/public", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "public"})
+	})
+
+	// Auth middleware protected group
+	api := r.Group("/api")
+	api.Use(AuthMiddleware())
+	api.GET("/profile", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"user": "profile"})
+	})
+
+	// Inline auth middleware
+	r.GET("/dashboard", AuthRequired, func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"dashboard": true})
+	})
+
+	// Admin route with role check
+	r.DELETE("/admin/users/:id", AdminOnly, func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"deleted": true})
+	})
+
+	r.Run(":8080")
+}
+
+func AuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token := c.GetHeader("Authorization")
+		if token == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		c.Next()
+	}
+}
+
+func AuthRequired(c *gin.Context) {
+	token := c.GetHeader("Authorization")
+	if token == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	c.Next()
+}
+
+func AdminOnly(c *gin.Context) {
+	role := c.GetString("role")
+	if role != "admin" {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	c.Next()
+}

--- a/spec/functional_test/fixtures/java/spring_auth/src/main/java/com/example/Controller.java
+++ b/spec/functional_test/fixtures/java/spring_auth/src/main/java/com/example/Controller.java
@@ -1,0 +1,29 @@
+package com.example;
+
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
+import javax.annotation.security.RolesAllowed;
+import org.springframework.security.access.annotation.Secured;
+
+@RestController
+@RequestMapping("/api")
+public class Controller {
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/users")
+    public String getUsers() {
+        return "users";
+    }
+
+    @Secured("ROLE_USER")
+    @PostMapping("/posts")
+    public String createPost() {
+        return "created";
+    }
+
+    @RolesAllowed({"ROLE_ADMIN", "ROLE_MANAGER"})
+    @DeleteMapping("/posts/{id}")
+    public String deletePost(@PathVariable Long id) {
+        return "deleted";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_auth/src/main/java/com/example/OpenController.java
+++ b/spec/functional_test/fixtures/java/spring_auth/src/main/java/com/example/OpenController.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/public")
+public class OpenController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "ok";
+    }
+
+    @GetMapping("/info")
+    public String info() {
+        return "info";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_auth/src/main/java/com/example/SecurityConfig.java
+++ b/spec/functional_test/fixtures/java/spring_auth/src/main/java/com/example/SecurityConfig.java
@@ -1,0 +1,22 @@
+package com.example;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/public/**").permitAll()
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                .requestMatchers("/api/user/**").authenticated()
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/spec/functional_test/fixtures/javascript/express_auth/app.js
+++ b/spec/functional_test/fixtures/javascript/express_auth/app.js
@@ -17,8 +17,8 @@ app.get('/profile', passport.authenticate('jwt', { session: false }), (req, res)
   res.json({ user: req.user });
 });
 
-// JWT middleware protected route
-app.post('/api/data', expressjwt({ secret: 'secret', algorithms: ['HS256'] }), (req, res) => {
+// JWT middleware protected route (secret is a fixture placeholder, not production code)
+app.post('/api/data', expressjwt({ secret: process.env.JWT_SECRET || 'fixture-placeholder', algorithms: ['HS256'] }), (req, res) => {
   res.json({ data: [] });
 });
 

--- a/spec/functional_test/fixtures/javascript/express_auth/app.js
+++ b/spec/functional_test/fixtures/javascript/express_auth/app.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const passport = require('passport');
+const { expressjwt } = require('express-jwt');
+
+const app = express();
+
+// Global auth middleware for /admin routes
+app.use('/admin', passport.authenticate('jwt', { session: false }));
+
+// Public route - no auth
+app.get('/public', (req, res) => {
+  res.json({ message: 'Public content' });
+});
+
+// Passport-protected route
+app.get('/profile', passport.authenticate('jwt', { session: false }), (req, res) => {
+  res.json({ user: req.user });
+});
+
+// JWT middleware protected route
+app.post('/api/data', expressjwt({ secret: 'secret', algorithms: ['HS256'] }), (req, res) => {
+  res.json({ data: [] });
+});
+
+// Generic auth middleware
+app.get('/dashboard', requireAuth, (req, res) => {
+  res.json({ dashboard: true });
+});
+
+// Unprotected API route
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+function requireAuth(req, res, next) {
+  if (!req.user) return res.status(401).json({ error: 'Unauthorized' });
+  next();
+}
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/express_auth/package.json
+++ b/spec/functional_test/fixtures/javascript/express_auth/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "express-auth-test",
+  "dependencies": {
+    "express": "^4.18.0",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.0",
+    "express-jwt": "^7.0.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/nestjs_auth/src/posts.controller.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_auth/src/posts.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { Roles } from './decorators/roles.decorator';
+import { Public } from './decorators/public.decorator';
+
+@Controller('posts')
+@UseGuards(JwtAuthGuard)
+export class PostsController {
+
+  @Public()
+  @Get()
+  findAll() {
+    return [];
+  }
+
+  @Get(':id')
+  findOne() {
+    return {};
+  }
+
+  @Roles('admin')
+  @Post()
+  create() {
+    return {};
+  }
+}

--- a/spec/functional_test/fixtures/kotlin/ktor_auth/src/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor_auth/src/Application.kt
@@ -1,0 +1,29 @@
+package com.example
+
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+fun Application.configureRouting() {
+    routing {
+        get("/public") {
+            call.respondText("public")
+        }
+
+        authenticate("auth-jwt") {
+            get("/profile") {
+                val principal = call.principal<JWTPrincipal>()
+                call.respondText("Hello, ${principal}")
+            }
+
+            post("/api/data") {
+                call.respondText("created")
+            }
+        }
+
+        get("/health") {
+            call.respondText("ok")
+        }
+    }
+}

--- a/spec/functional_test/fixtures/kotlin/ktor_auth/src/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor_auth/src/Application.kt
@@ -22,6 +22,14 @@ fun Application.configureRouting() {
             }
         }
 
+        authenticate("auth-session") {
+            route("/admin") {
+                get("/dashboard") {
+                    call.respondText("admin dashboard")
+                }
+            }
+        }
+
         get("/health") {
             call.respondText("ok")
         }

--- a/spec/functional_test/fixtures/php/laravel_auth/app/Http/Controllers/PostController.php
+++ b/spec/functional_test/fixtures/php/laravel_auth/app/Http/Controllers/PostController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index()
+    {
+        return response()->json(Post::all());
+    }
+
+    public function store(Request $request)
+    {
+        $this->authorize('create', Post::class);
+        return response()->json(Post::create($request->all()));
+    }
+}

--- a/spec/functional_test/fixtures/php/laravel_auth/app/Http/Controllers/PublicController.php
+++ b/spec/functional_test/fixtures/php/laravel_auth/app/Http/Controllers/PublicController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class PublicController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['message' => 'public']);
+    }
+}

--- a/spec/functional_test/fixtures/python/django_auth/blog/views.py
+++ b/spec/functional_test/fixtures/python/django_auth/blog/views.py
@@ -1,0 +1,33 @@
+from django.contrib.auth.decorators import login_required, permission_required, user_passes_test
+from django.contrib.admin.views.decorators import staff_member_required
+from django.views.generic import DetailView
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+from django.http import HttpResponse
+
+
+def public_page(request):
+    return HttpResponse("Public content")
+
+
+@login_required
+def post_list(request):
+    return HttpResponse("Post list")
+
+
+@permission_required('blog.add_post')
+def post_create(request):
+    return HttpResponse("Create post")
+
+
+class PostDetailView(LoginRequiredMixin, DetailView):
+    model = None
+    template_name = 'blog/post_detail.html'
+
+
+class PostAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({"posts": []})

--- a/spec/functional_test/fixtures/python/django_auth/blog/views.py
+++ b/spec/functional_test/fixtures/python/django_auth/blog/views.py
@@ -1,8 +1,8 @@
-from django.contrib.auth.decorators import login_required, permission_required, user_passes_test
-from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.decorators import login_required, permission_required
 from django.views.generic import DetailView
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from rest_framework.views import APIView
+from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from django.http import HttpResponse
 

--- a/spec/functional_test/fixtures/python/django_auth/djangoproject/settings.py
+++ b/spec/functional_test/fixtures/python/django_auth/djangoproject/settings.py
@@ -1,0 +1,14 @@
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'rest_framework',
+    'blog',
+]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+    ],
+}

--- a/spec/functional_test/fixtures/python/django_auth/djangoproject/urls.py
+++ b/spec/functional_test/fixtures/python/django_auth/djangoproject/urls.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+from django.urls import path
+from blog import views
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('posts/', views.post_list, name='post_list'),
+    path('posts/create/', views.post_create, name='post_create'),
+    path('posts/<int:pk>/', views.PostDetailView.as_view(), name='post_detail'),
+    path('api/posts/', views.PostAPIView.as_view(), name='post_api'),
+    path('public/', views.public_page, name='public_page'),
+]

--- a/spec/functional_test/fixtures/python/fastapi_auth/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_auth/main.py
@@ -1,8 +1,18 @@
 from fastapi import FastAPI, Depends, Security
 from fastapi.security import OAuth2PasswordBearer
+from pydantic import BaseModel
 
 app = FastAPI()
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+class User(BaseModel):
+    username: str
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)) -> User:
+    # Mock: decode token and return user
+    return User(username="testuser")
 
 
 @app.get("/public")

--- a/spec/functional_test/fixtures/python/fastapi_auth/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_auth/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI, Depends, Security
+from fastapi.security import OAuth2PasswordBearer
+
+app = FastAPI()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+@app.get("/public")
+async def public_page():
+    return {"message": "public"}
+
+
+@app.get("/profile")
+async def profile(current_user: User = Depends(get_current_user)):
+    return {"user": current_user}
+
+
+@app.get("/admin")
+async def admin(token: str = Security(oauth2_scheme)):
+    return {"admin": True}
+
+
+@app.get("/open")
+async def open_page():
+    return {"message": "open"}

--- a/spec/functional_test/fixtures/python/flask_auth/app.py
+++ b/spec/functional_test/fixtures/python/flask_auth/app.py
@@ -1,0 +1,27 @@
+from flask import Flask, jsonify
+from flask_login import login_required
+from flask_jwt_extended import jwt_required
+
+app = Flask(__name__)
+
+
+@app.route('/public')
+def public_page():
+    return jsonify(message="public")
+
+
+@login_required
+@app.route('/profile')
+def profile():
+    return jsonify(user="profile")
+
+
+@jwt_required()
+@app.route('/api/data')
+def api_data():
+    return jsonify(data=[])
+
+
+@app.route('/open')
+def open_page():
+    return jsonify(message="open")

--- a/spec/functional_test/fixtures/ruby/rails_auth/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_auth/app/controllers/posts_controller.rb
@@ -11,8 +11,9 @@ class PostsController < ApplicationController
   end
 
   def create
-    authorize @post
-    render json: Post.create(post_params)
+    post = Post.new(params.permit(:title, :body))
+    authorize post
+    render json: post.save
   end
 
   def destroy

--- a/spec/functional_test/fixtures/ruby/rails_auth/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_auth/app/controllers/posts_controller.rb
@@ -1,0 +1,21 @@
+class PostsController < ApplicationController
+  before_action :authenticate_user!
+  skip_before_action :authenticate_user!, only: [:index]
+
+  def index
+    render json: Post.all
+  end
+
+  def show
+    render json: Post.find(params[:id])
+  end
+
+  def create
+    authorize @post
+    render json: Post.create(post_params)
+  end
+
+  def destroy
+    render json: Post.find(params[:id]).destroy
+  end
+end

--- a/spec/functional_test/fixtures/rust/actix_auth/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_auth/src/main.rs
@@ -64,9 +64,12 @@ struct PostData {
 
 struct AdminGuard;
 
+// Validator for HttpAuthentication middleware.
+// Simplified for fixture — production code should verify the bearer token.
 async fn validator(
     req: actix_web::dev::ServiceRequest,
     credentials: BearerAuth,
 ) -> Result<actix_web::dev::ServiceRequest, actix_web::Error> {
+    // TODO: validate credentials.token() against auth provider
     Ok(req)
 }

--- a/spec/functional_test/fixtures/rust/actix_auth/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_auth/src/main.rs
@@ -1,0 +1,72 @@
+use actix_web::{web, App, HttpServer, HttpRequest, HttpResponse, get, post};
+use actix_web_httpauth::middleware::HttpAuthentication;
+use actix_web_httpauth::extractors::bearer::BearerAuth;
+
+// Public endpoint - no auth
+#[get("/health")]
+async fn health() -> HttpResponse {
+    HttpResponse::Ok().body("ok")
+}
+
+// Public endpoint
+#[get("/public")]
+async fn public_page() -> HttpResponse {
+    HttpResponse::Ok().body("public content")
+}
+
+// Protected by BearerAuth extractor
+#[get("/profile")]
+async fn profile(auth: BearerAuth) -> HttpResponse {
+    HttpResponse::Ok().body(format!("User: {}", auth.token()))
+}
+
+// Protected by custom auth guard
+#[guard = "AdminGuard"]
+#[get("/admin/users")]
+async fn admin_users() -> HttpResponse {
+    HttpResponse::Ok().body("admin users list")
+}
+
+// Protected by AuthUser request guard in signature
+#[post("/api/posts")]
+async fn create_post(user: AuthUser, body: web::Json<PostData>) -> HttpResponse {
+    HttpResponse::Ok().body("created")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .service(health)
+            .service(public_page)
+            .service(profile)
+            .service(admin_users)
+            .service(
+                web::scope("/api")
+                    .wrap(HttpAuthentication::bearer(validator))
+                    .service(create_post)
+            )
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+
+struct AuthUser {
+    id: u64,
+    name: String,
+}
+
+struct PostData {
+    title: String,
+    content: String,
+}
+
+struct AdminGuard;
+
+async fn validator(
+    req: actix_web::dev::ServiceRequest,
+    credentials: BearerAuth,
+) -> Result<actix_web::dev::ServiceRequest, actix_web::Error> {
+    Ok(req)
+}

--- a/spec/functional_test/fixtures/swift/vapor_auth/Sources/routes.swift
+++ b/spec/functional_test/fixtures/swift/vapor_auth/Sources/routes.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+func routes(_ app: Application) throws {
+    app.get("public") { req in
+        return "public"
+    }
+
+    let protected = app.grouped(UserAuthenticator())
+    protected.get("profile") { req in
+        let user = try req.auth.require(User.self)
+        return "Hello, \(user.name)"
+    }
+
+    protected.post("api", "data") { req in
+        return "created"
+    }
+
+    app.get("health") { req in
+        return "ok"
+    }
+}

--- a/spec/unit_test/tagger/framework_taggers/aspnet_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/aspnet_auth_spec.cr
@@ -1,0 +1,68 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "AspnetAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/csharp/aspnet_auth"
+  controller_path = "#{fixture_base}/Controllers/PostsController.cs"
+
+  # PostsController.cs line reference:
+  #  6: [Authorize]
+  #  7: [ApiController]
+  #  8: [Route("api/[controller]")]
+  #  9: public class PostsController : ControllerBase
+  # 11:     [AllowAnonymous]
+  # 12:     [HttpGet]
+  # 13:     public IActionResult Index()
+  # 18:     [HttpGet("{id}")]
+  # 19:     public IActionResult Show(int id)
+  # 24:     [Authorize(Roles = "Admin")]
+  # 25:     [HttpPost]
+  # 26:     public IActionResult Create()
+
+  it "detects class-level [Authorize] on actions" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 19))
+    details.technology = "cs_aspnet_core_mvc"
+    endpoint = Endpoint.new("/api/posts/1", "GET", [] of Param, details)
+
+    tagger = AspnetAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("aspnet_auth")
+    endpoint.tags[0].description.should contain("[Authorize]")
+  end
+
+  it "respects [AllowAnonymous]" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 13))
+    details.technology = "cs_aspnet_core_mvc"
+    endpoint = Endpoint.new("/api/posts", "GET", [] of Param, details)
+
+    tagger = AspnetAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "detects method-level [Authorize(Roles)]" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 26))
+    details.technology = "cs_aspnet_core_mvc"
+    endpoint = Endpoint.new("/api/posts", "POST", [] of Param, details)
+
+    tagger = AspnetAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("Roles")
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/django_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/django_auth_spec.cr
@@ -1,0 +1,112 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "DjangoAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/python/django_auth"
+  views_path = "#{fixture_base}/blog/views.py"
+
+  # views.py line reference:
+  # 10: def public_page(request):
+  # 14: @login_required
+  # 15: def post_list(request):
+  # 19: @permission_required('blog.add_post')
+  # 20: def post_create(request):
+  # 24: class PostDetailView(LoginRequiredMixin, DetailView):
+  # 25:     model = None
+  # 29: class PostAPIView(APIView):
+  # 30:     permission_classes = [IsAuthenticated]
+  # 32:     def get(self, request):
+
+  it "detects @login_required decorator" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(views_path, 15))
+    details.technology = "python_django"
+    endpoint = Endpoint.new("/posts/", "GET", [] of Param, details)
+
+    tagger = DjangoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("django_auth")
+    endpoint.tags[0].description.should contain("login_required")
+  end
+
+  it "detects @permission_required decorator" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(views_path, 20))
+    details.technology = "python_django"
+    endpoint = Endpoint.new("/posts/create/", "POST", [] of Param, details)
+
+    tagger = DjangoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("permission_required")
+  end
+
+  it "detects LoginRequiredMixin in class" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(views_path, 25))
+    details.technology = "python_django"
+    endpoint = Endpoint.new("/posts/1/", "GET", [] of Param, details)
+
+    tagger = DjangoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("LoginRequiredMixin")
+  end
+
+  it "detects DRF permission_classes" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(views_path, 32))
+    details.technology = "python_django"
+    endpoint = Endpoint.new("/api/posts/", "GET", [] of Param, details)
+
+    tagger = DjangoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("DRF permission_classes")
+  end
+
+  it "does not tag unprotected views" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(views_path, 10))
+    details.technology = "python_django"
+    endpoint = Endpoint.new("/public/", "GET", [] of Param, details)
+
+    tagger = DjangoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "handles empty code_paths gracefully" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new
+    details.technology = "python_django"
+    endpoint = Endpoint.new("/unknown/", "GET", [] of Param, details)
+
+    tagger = DjangoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/elixir_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/elixir_auth_spec.cr
@@ -1,0 +1,60 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "ElixirAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/elixir/phoenix_auth"
+  controller_path = "#{fixture_base}/lib/myapp_web/controllers/post_controller.ex"
+  public_path = "#{fixture_base}/lib/myapp_web/controllers/public_controller.ex"
+
+  # post_controller.ex line reference:
+  #  3: plug :require_authenticated_user
+  #  5: def index(conn, _params) do
+  # 10: def show(conn, %{"id" => id}) do
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects plug :require_authenticated_user" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(controller_path, 5))
+    details.technology = "elixir_phoenix"
+    endpoint = Endpoint.new("/posts", "GET", [] of Param, details)
+
+    tagger = ElixirAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("elixir_auth")
+    endpoint.tags[0].description.should contain("require_authenticated_user")
+  end
+
+  it "does not tag public controller" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(public_path, 4))
+    details.technology = "elixir_phoenix"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = ElixirAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/express_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/express_auth_spec.cr
@@ -1,0 +1,144 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "ExpressAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/javascript/express_auth"
+  app_path = "#{fixture_base}/app.js"
+
+  # app.js line reference:
+  #  8: app.use('/admin', passport.authenticate('jwt', { session: false }));
+  # 11: app.get('/public', (req, res) => {
+  # 16: app.get('/profile', passport.authenticate('jwt', { session: false }), (req, res) => {
+  # 21: app.post('/api/data', expressjwt({ secret: 'secret', algorithms: ['HS256'] }), (req, res) => {
+  # 26: app.get('/dashboard', requireAuth, (req, res) => {
+  # 31: app.get('/api/health', (req, res) => {
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects passport.authenticate in route" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 16))
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = ExpressAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("express_auth")
+    endpoint.tags[0].description.should contain("Passport")
+  end
+
+  it "detects expressjwt middleware" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 21))
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/api/data", "POST", [] of Param, details)
+
+    tagger = ExpressAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("JWT")
+  end
+
+  it "detects generic auth middleware (requireAuth)" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 26))
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/dashboard", "GET", [] of Param, details)
+
+    tagger = ExpressAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("requireAuth")
+  end
+
+  it "does not tag unprotected routes" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 31))
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/api/health", "GET", [] of Param, details)
+
+    tagger = ExpressAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "detects app.use level auth for matching prefix" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    # This endpoint has no auth on its own route definition,
+    # but /admin prefix has app.use() level auth
+    details = Details.new(PathInfo.new(app_path, 31))
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/admin/settings", "GET", [] of Param, details)
+
+    tagger = ExpressAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("app.use()")
+  end
+
+  it "handles empty code_paths gracefully" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new
+    details.technology = "js_express"
+    endpoint = Endpoint.new("/unknown/", "GET", [] of Param, details)
+
+    tagger = ExpressAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/fastapi_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/fastapi_auth_spec.cr
@@ -6,20 +6,20 @@ describe "FastAPIAuthTagger" do
   main_path = "#{fixture_base}/main.py"
 
   # main.py line reference:
-  # 10: @app.get("/public")
-  # 11: async def public_page():
-  # 15: @app.get("/profile")
-  # 16: async def profile(current_user: User = Depends(get_current_user)):
-  # 20: @app.get("/admin")
-  # 21: async def admin(token: str = Security(oauth2_scheme)):
-  # 25: @app.get("/open")
-  # 26: async def open_page():
+  # 18: @app.get("/public")
+  # 19: async def public_page():
+  # 23: @app.get("/profile")
+  # 24: async def profile(current_user: User = Depends(get_current_user)):
+  # 28: @app.get("/admin")
+  # 29: async def admin(token: str = Security(oauth2_scheme)):
+  # 33: @app.get("/open")
+  # 34: async def open_page():
 
   it "detects Depends(get_current_user)" do
     noir_options = create_test_options
     noir_options["base"] = YAML::Any.new(fixture_base)
 
-    details = Details.new(PathInfo.new(main_path, 15))
+    details = Details.new(PathInfo.new(main_path, 24))
     details.technology = "python_fastapi"
     endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
 
@@ -36,7 +36,7 @@ describe "FastAPIAuthTagger" do
     noir_options = create_test_options
     noir_options["base"] = YAML::Any.new(fixture_base)
 
-    details = Details.new(PathInfo.new(main_path, 20))
+    details = Details.new(PathInfo.new(main_path, 29))
     details.technology = "python_fastapi"
     endpoint = Endpoint.new("/admin", "GET", [] of Param, details)
 
@@ -52,7 +52,7 @@ describe "FastAPIAuthTagger" do
     noir_options = create_test_options
     noir_options["base"] = YAML::Any.new(fixture_base)
 
-    details = Details.new(PathInfo.new(main_path, 10))
+    details = Details.new(PathInfo.new(main_path, 19))
     details.technology = "python_fastapi"
     endpoint = Endpoint.new("/public", "GET", [] of Param, details)
 

--- a/spec/unit_test/tagger/framework_taggers/fastapi_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/fastapi_auth_spec.cr
@@ -1,0 +1,64 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "FastAPIAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/python/fastapi_auth"
+  main_path = "#{fixture_base}/main.py"
+
+  # main.py line reference:
+  # 10: @app.get("/public")
+  # 11: async def public_page():
+  # 15: @app.get("/profile")
+  # 16: async def profile(current_user: User = Depends(get_current_user)):
+  # 20: @app.get("/admin")
+  # 21: async def admin(token: str = Security(oauth2_scheme)):
+  # 25: @app.get("/open")
+  # 26: async def open_page():
+
+  it "detects Depends(get_current_user)" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(main_path, 15))
+    details.technology = "python_fastapi"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = FastAPIAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("fastapi_auth")
+    endpoint.tags[0].description.should contain("get_current_user")
+  end
+
+  it "detects Security(oauth2_scheme)" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(main_path, 20))
+    details.technology = "python_fastapi"
+    endpoint = Endpoint.new("/admin", "GET", [] of Param, details)
+
+    tagger = FastAPIAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("oauth2_scheme")
+  end
+
+  it "does not tag unprotected routes" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(main_path, 10))
+    details.technology = "python_fastapi"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = FastAPIAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/flask_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/flask_auth_spec.cr
@@ -1,0 +1,64 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "FlaskAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/python/flask_auth"
+  app_path = "#{fixture_base}/app.py"
+
+  # app.py line reference:
+  #  9: @app.route('/public')
+  # 10: def public_page():
+  # 14: @login_required
+  # 15: @app.route('/profile')
+  # 16: def profile():
+  # 20: @jwt_required()
+  # 21: @app.route('/api/data')
+  # 22: def api_data():
+
+  it "detects @login_required decorator" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(app_path, 16))
+    details.technology = "python_flask"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = FlaskAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("flask_auth")
+    endpoint.tags[0].description.should contain("login_required")
+  end
+
+  it "detects @jwt_required decorator" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(app_path, 22))
+    details.technology = "python_flask"
+    endpoint = Endpoint.new("/api/data", "GET", [] of Param, details)
+
+    tagger = FlaskAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("jwt_required")
+  end
+
+  it "does not tag unprotected routes" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(app_path, 10))
+    details.technology = "python_flask"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = FlaskAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
@@ -6,13 +6,13 @@ describe "GoAuthTagger" do
   main_path = "#{fixture_base}/main.go"
 
   # main.go line reference:
-  # 14: r.GET("/health", func(c *gin.Context) {
-  # 18: r.GET("/public", func(c *gin.Context) {
-  # 23: api := r.Group("/api")
-  # 24: api.Use(AuthMiddleware())
-  # 25: api.GET("/profile", func(c *gin.Context) {
-  # 30: r.GET("/dashboard", AuthRequired, func(c *gin.Context) {
-  # 35: r.DELETE("/admin/users/:id", AdminOnly, func(c *gin.Context) {
+  # 13: r.GET("/health", func(c *gin.Context) {
+  # 17: r.GET("/public", func(c *gin.Context) {
+  # 22: api := r.Group("/api")
+  # 23: api.Use(AuthMiddleware())
+  # 24: api.GET("/profile", func(c *gin.Context) {
+  # 29: r.GET("/dashboard", AuthRequired, func(c *gin.Context) {
+  # 34: r.DELETE("/admin/users/:id", AdminOnly, func(c *gin.Context) {
 
   before_each do
     CodeLocator.instance.clear_all
@@ -28,7 +28,7 @@ describe "GoAuthTagger" do
       locator.push("file_map", file)
     end
 
-    details = Details.new(PathInfo.new(main_path, 30))
+    details = Details.new(PathInfo.new(main_path, 29))
     details.technology = "go_gin"
     endpoint = Endpoint.new("/dashboard", "GET", [] of Param, details)
 
@@ -51,7 +51,7 @@ describe "GoAuthTagger" do
       locator.push("file_map", file)
     end
 
-    details = Details.new(PathInfo.new(main_path, 35))
+    details = Details.new(PathInfo.new(main_path, 34))
     details.technology = "go_gin"
     endpoint = Endpoint.new("/admin/users/1", "DELETE", [] of Param, details)
 
@@ -73,7 +73,7 @@ describe "GoAuthTagger" do
       locator.push("file_map", file)
     end
 
-    details = Details.new(PathInfo.new(main_path, 25))
+    details = Details.new(PathInfo.new(main_path, 24))
     details.technology = "go_gin"
     endpoint = Endpoint.new("/api/profile", "GET", [] of Param, details)
 
@@ -95,7 +95,7 @@ describe "GoAuthTagger" do
       locator.push("file_map", file)
     end
 
-    details = Details.new(PathInfo.new(main_path, 14))
+    details = Details.new(PathInfo.new(main_path, 13))
     details.technology = "go_gin"
     endpoint = Endpoint.new("/health", "GET", [] of Param, details)
 

--- a/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
@@ -1,0 +1,121 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "GoAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/go/gin_auth"
+  main_path = "#{fixture_base}/main.go"
+
+  # main.go line reference:
+  # 14: r.GET("/health", func(c *gin.Context) {
+  # 18: r.GET("/public", func(c *gin.Context) {
+  # 23: api := r.Group("/api")
+  # 24: api.Use(AuthMiddleware())
+  # 25: api.GET("/profile", func(c *gin.Context) {
+  # 30: r.GET("/dashboard", AuthRequired, func(c *gin.Context) {
+  # 35: r.DELETE("/admin/users/:id", AdminOnly, func(c *gin.Context) {
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects inline auth middleware (AuthRequired)" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 30))
+    details.technology = "go_gin"
+    endpoint = Endpoint.new("/dashboard", "GET", [] of Param, details)
+
+    tagger = GoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("go_auth")
+    endpoint.tags[0].description.should contain("AuthRequired")
+  end
+
+  it "detects inline AdminOnly middleware" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 35))
+    details.technology = "go_gin"
+    endpoint = Endpoint.new("/admin/users/1", "DELETE", [] of Param, details)
+
+    tagger = GoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("AdminOnly")
+  end
+
+  it "detects group-level Use(AuthMiddleware)" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 25))
+    details.technology = "go_gin"
+    endpoint = Endpoint.new("/api/profile", "GET", [] of Param, details)
+
+    tagger = GoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("AuthMiddleware")
+  end
+
+  it "does not tag public endpoints" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 14))
+    details.technology = "go_gin"
+    endpoint = Endpoint.new("/health", "GET", [] of Param, details)
+
+    tagger = GoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "handles empty code_paths gracefully" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new
+    details.technology = "go_gin"
+    endpoint = Endpoint.new("/unknown/", "GET", [] of Param, details)
+
+    tagger = GoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
@@ -10,7 +10,10 @@ describe "KtorAuthTagger" do
   # 14:     authenticate("auth-jwt") {
   # 15:       get("/profile") {
   # 20:       post("/api/data") {
-  # 24:     get("/health") {
+  # 25:     authenticate("auth-session") {
+  # 26:       route("/admin") {
+  # 27:         get("/dashboard") {
+  # 33:     get("/health") {
 
   before_each do
     CodeLocator.instance.clear_all
@@ -90,7 +93,7 @@ describe "KtorAuthTagger" do
       locator.push("file_map", file)
     end
 
-    details = Details.new(PathInfo.new(app_path, 24))
+    details = Details.new(PathInfo.new(app_path, 33))
     details.technology = "kotlin_ktor"
     endpoint = Endpoint.new("/health", "GET", [] of Param, details)
 
@@ -98,5 +101,28 @@ describe "KtorAuthTagger" do
     tagger.perform([endpoint])
 
     endpoint.tags.empty?.should be_true
+  end
+
+  it "detects authenticate block with nested route() block" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 27))
+    details.technology = "kotlin_ktor"
+    endpoint = Endpoint.new("/admin/dashboard", "GET", [] of Param, details)
+
+    tagger = KtorAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("ktor_auth")
+    endpoint.tags[0].description.should contain("auth-session")
   end
 end

--- a/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ktor_auth_spec.cr
@@ -1,0 +1,102 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "KtorAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/kotlin/ktor_auth"
+  app_path = "#{fixture_base}/src/Application.kt"
+
+  # Application.kt line reference:
+  # 10:     get("/public") {
+  # 14:     authenticate("auth-jwt") {
+  # 15:       get("/profile") {
+  # 20:       post("/api/data") {
+  # 24:     get("/health") {
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects authenticate block wrapping route" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 15))
+    details.technology = "kotlin_ktor"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = KtorAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("ktor_auth")
+    endpoint.tags[0].description.should contain("authenticate")
+  end
+
+  it "detects principal access in handler" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 15))
+    details.technology = "kotlin_ktor"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = KtorAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+  end
+
+  it "does not tag public routes" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 10))
+    details.technology = "kotlin_ktor"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = KtorAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "does not tag health route outside authenticate block" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 24))
+    details.technology = "kotlin_ktor"
+    endpoint = Endpoint.new("/health", "GET", [] of Param, details)
+
+    tagger = KtorAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/nestjs_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/nestjs_auth_spec.cr
@@ -1,0 +1,70 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "NestjsAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/javascript/nestjs_auth"
+  controller_path = "#{fixture_base}/src/posts.controller.ts"
+
+  # posts.controller.ts line reference:
+  #  8: @Controller('posts')
+  #  9: @UseGuards(JwtAuthGuard)
+  # 10: export class PostsController {
+  # 12:   @Public()
+  # 13:   @Get()
+  # 14:   findAll() {
+  # 18:   @Get(':id')
+  # 19:   findOne() {
+  # 23:   @Roles('admin')
+  # 24:   @Post()
+  # 25:   create() {
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects class-level @UseGuards(JwtAuthGuard) on non-public action" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 19))
+    details.technology = "ts_nestjs"
+    endpoint = Endpoint.new("/posts/1", "GET", [] of Param, details)
+
+    tagger = NestjsAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("nestjs_auth")
+    endpoint.tags[0].description.should contain("JwtAuthGuard")
+  end
+
+  it "respects @Public() decorator" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 14))
+    details.technology = "ts_nestjs"
+    endpoint = Endpoint.new("/posts", "GET", [] of Param, details)
+
+    tagger = NestjsAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "detects @Roles decorator" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 25))
+    details.technology = "ts_nestjs"
+    endpoint = Endpoint.new("/posts", "POST", [] of Param, details)
+
+    tagger = NestjsAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/php_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/php_auth_spec.cr
@@ -1,0 +1,60 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "PhpAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/php/laravel_auth"
+  controller_path = "#{fixture_base}/app/Http/Controllers/PostController.php"
+  public_path = "#{fixture_base}/app/Http/Controllers/PublicController.php"
+
+  # PostController.php line reference:
+  # 10:     $this->middleware('auth');
+  # 14:   public function index()
+  # 19:   public function store(Request $request)
+  # 21:     $this->authorize('create', Post::class);
+
+  it "detects $this->middleware('auth') in constructor" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 14))
+    details.technology = "php_laravel"
+    endpoint = Endpoint.new("/posts", "GET", [] of Param, details)
+
+    tagger = PhpAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("php_auth")
+    endpoint.tags[0].description.should contain("auth")
+  end
+
+  it "detects $this->authorize in action body" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 19))
+    details.technology = "php_laravel"
+    endpoint = Endpoint.new("/posts", "POST", [] of Param, details)
+
+    tagger = PhpAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+  end
+
+  it "does not tag public controller" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(public_path, 8))
+    details.technology = "php_laravel"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = PhpAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/ruby_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ruby_auth_spec.cr
@@ -1,0 +1,62 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "RubyAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/ruby/rails_auth"
+  controller_path = "#{fixture_base}/app/controllers/posts_controller.rb"
+
+  # posts_controller.rb line reference:
+  #  1: class PostsController < ApplicationController
+  #  2:   before_action :authenticate_user!
+  #  3:   skip_before_action :authenticate_user!, only: [:index]
+  #  5:   def index
+  #  9:   def show
+  # 13:   def create
+  # 18:   def destroy
+
+  it "detects before_action :authenticate_user! on protected action" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 9))
+    details.technology = "ruby_rails"
+    endpoint = Endpoint.new("/posts/1", "GET", [] of Param, details)
+
+    tagger = RubyAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("ruby_auth")
+    endpoint.tags[0].description.should contain("authenticate_user")
+  end
+
+  it "detects Pundit authorize in action body" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 13))
+    details.technology = "ruby_rails"
+    endpoint = Endpoint.new("/posts", "POST", [] of Param, details)
+
+    tagger = RubyAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+  end
+
+  it "respects skip_before_action for :index" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(controller_path, 5))
+    details.technology = "ruby_rails"
+    endpoint = Endpoint.new("/posts", "GET", [] of Param, details)
+
+    tagger = RubyAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/rust_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/rust_auth_spec.cr
@@ -1,0 +1,145 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "RustAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/rust/actix_auth"
+  main_path = "#{fixture_base}/src/main.rs"
+
+  # main.rs line reference:
+  #  6: #[get("/health")]
+  #  7: async fn health() -> HttpResponse {
+  # 12: #[get("/public")]
+  # 13: async fn public_page() -> HttpResponse {
+  # 18: #[get("/profile")]
+  # 19: async fn profile(auth: BearerAuth) -> HttpResponse {
+  # 24: #[guard = "AdminGuard"]
+  # 25: #[get("/admin/users")]
+  # 26: async fn admin_users() -> HttpResponse {
+  # 31: #[post("/api/posts")]
+  # 32: async fn create_post(user: AuthUser, body: web::Json<PostData>) -> HttpResponse {
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects BearerAuth extractor in function signature" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 18))
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = RustAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("rust_auth")
+    endpoint.tags[0].description.should contain("BearerAuth")
+  end
+
+  it "detects #[guard] attribute" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 25))
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/admin/users", "GET", [] of Param, details)
+
+    tagger = RustAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("guard")
+  end
+
+  it "detects AuthUser guard type in function signature" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 31))
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/api/posts", "POST", [] of Param, details)
+
+    tagger = RustAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("AuthUser")
+  end
+
+  it "does not tag public endpoints" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 6))
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/health", "GET", [] of Param, details)
+
+    tagger = RustAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "does not tag public_page endpoint" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(main_path, 12))
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = RustAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "handles empty code_paths gracefully" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/unknown/", "GET", [] of Param, details)
+
+    tagger = RustAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/spring_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/spring_auth_spec.cr
@@ -1,0 +1,124 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "SpringAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/java/spring_auth"
+  controller_path = "#{fixture_base}/src/main/java/com/example/Controller.java"
+  open_controller_path = "#{fixture_base}/src/main/java/com/example/OpenController.java"
+
+  # Controller.java line reference:
+  # 12: @PreAuthorize("hasRole('ADMIN')")
+  # 13: @GetMapping("/admin/users")
+  # 14: public String getUsers() {
+  # 18: @Secured("ROLE_USER")
+  # 19: @PostMapping("/posts")
+  # 20: public String createPost() {
+  # 24: @RolesAllowed({"ROLE_ADMIN", "ROLE_MANAGER"})
+  # 25: @DeleteMapping("/posts/{id}")
+  # 26: public String deletePost(@PathVariable Long id) {
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects @PreAuthorize annotation" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(controller_path, 14))
+    details.technology = "java_spring"
+    endpoint = Endpoint.new("/api/admin/users", "GET", [] of Param, details)
+
+    tagger = SpringAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("spring_auth")
+    endpoint.tags[0].description.should contain("@PreAuthorize")
+  end
+
+  it "detects @Secured annotation" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(controller_path, 20))
+    details.technology = "java_spring"
+    endpoint = Endpoint.new("/api/posts", "POST", [] of Param, details)
+
+    tagger = SpringAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("@Secured")
+  end
+
+  it "detects @RolesAllowed annotation" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(controller_path, 26))
+    details.technology = "java_spring"
+    endpoint = Endpoint.new("/api/posts/1", "DELETE", [] of Param, details)
+
+    tagger = SpringAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("@RolesAllowed")
+  end
+
+  it "does not tag open controller endpoints (no annotations)" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(open_controller_path, 9))
+    details.technology = "java_spring"
+    endpoint = Endpoint.new("/api/public/health", "GET", [] of Param, details)
+
+    tagger = SpringAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "handles empty code_paths gracefully" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new
+    details.technology = "java_spring"
+    endpoint = Endpoint.new("/unknown/", "GET", [] of Param, details)
+
+    tagger = SpringAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/swift_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/swift_auth_spec.cr
@@ -1,0 +1,75 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "SwiftAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/swift/vapor_auth"
+  routes_path = "#{fixture_base}/Sources/routes.swift"
+
+  # routes.swift line reference:
+  #  4: app.get("public") { req in
+  #  8: let protected = app.grouped(UserAuthenticator())
+  #  9: protected.get("profile") { req in
+  # 10:     let user = try req.auth.require(User.self)
+  # 14: protected.post("api", "data") { req in
+  # 18: app.get("health") { req in
+
+  it "detects .grouped(UserAuthenticator()) middleware" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(routes_path, 9))
+    details.technology = "swift_vapor"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = SwiftAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("swift_auth")
+    endpoint.tags[0].description.should contain("Vapor")
+  end
+
+  it "detects req.auth.require in handler body" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(routes_path, 9))
+    details.technology = "swift_vapor"
+    endpoint = Endpoint.new("/profile", "GET", [] of Param, details)
+
+    tagger = SwiftAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+  end
+
+  it "does not tag public routes" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(routes_path, 4))
+    details.technology = "swift_vapor"
+    endpoint = Endpoint.new("/public", "GET", [] of Param, details)
+
+    tagger = SwiftAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+
+  it "does not tag health route" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(routes_path, 18))
+    details.technology = "swift_vapor"
+    endpoint = Endpoint.new("/health", "GET", [] of Param, details)
+
+    tagger = SwiftAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -60,6 +60,8 @@ class FrameworkTagger
       line = path_info.line
 
       if line
+        # Note: `line` is 1-indexed (from PathInfo), but `context` is a 0-indexed array slice.
+        # To map back: context[line - start_line - 1] is the endpoint's line.
         start_line = [line - context_lines, 0].max
         end_line = [line + context_lines, lines.size - 1].min
         context = lines[start_line..end_line]

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -1,0 +1,87 @@
+require "./logger"
+require "./endpoint"
+require "./code_locator"
+require "./file_helper"
+
+struct SourceContext
+  property path : String
+  property line : Int32?
+  property context : Array(String)
+  property full_content : String
+
+  def initialize(@path : String, @line : Int32?, @context : Array(String), @full_content : String)
+  end
+end
+
+class FrameworkTagger
+  include FileHelper
+
+  @logger : NoirLogger
+  @options : Hash(String, YAML::Any)
+  @is_debug : Bool
+  @is_verbose : Bool
+  @is_color : Bool
+  @is_log : Bool
+  @name : String
+  @base_path : String
+
+  def initialize(options : Hash(String, YAML::Any))
+    @is_debug = any_to_bool(options["debug"])
+    @is_verbose = any_to_bool(options["verbose"])
+    @options = options
+    @is_color = any_to_bool(options["color"])
+    @is_log = any_to_bool(options["nolog"])
+    @name = ""
+    @base_path = options["base"].to_s
+
+    @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
+  end
+
+  def name
+    @name
+  end
+
+  def self.target_techs : Array(String)
+    [] of String
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints
+  end
+
+  def read_source_context(endpoint : Endpoint, context_lines : Int32 = 30) : Array(SourceContext)
+    results = [] of SourceContext
+
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line = path_info.line
+
+      if line
+        start_line = [line - context_lines, 0].max
+        end_line = [line + context_lines, lines.size - 1].min
+        context = lines[start_line..end_line]
+      else
+        context = lines
+      end
+
+      results << SourceContext.new(
+        path: path_info.path,
+        line: line,
+        context: context,
+        full_content: content
+      )
+    end
+
+    results
+  end
+
+  def read_file(path : String) : String?
+    File.read(path)
+  rescue ex
+    @logger.debug "FrameworkTagger: Failed to read file #{path}: #{ex.message}"
+    nil
+  end
+end

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -1,4 +1,4 @@
-require "./logger"
+require "./tagger"
 require "./endpoint"
 require "./code_locator"
 require "./file_helper"
@@ -6,73 +6,38 @@ require "./file_helper"
 struct SourceContext
   property path : String
   property line : Int32?
-  property context : Array(String)
   property full_content : String
 
-  def initialize(@path : String, @line : Int32?, @context : Array(String), @full_content : String)
+  def initialize(@path : String, @line : Int32?, @full_content : String)
   end
 end
 
-class FrameworkTagger
+class FrameworkTagger < Tagger
   include FileHelper
 
-  @logger : NoirLogger
-  @options : Hash(String, YAML::Any)
-  @is_debug : Bool
-  @is_verbose : Bool
-  @is_color : Bool
-  @is_log : Bool
-  @name : String
   @base_path : String
+  @file_cache : Hash(String, String)
 
   def initialize(options : Hash(String, YAML::Any))
-    @is_debug = any_to_bool(options["debug"])
-    @is_verbose = any_to_bool(options["verbose"])
-    @options = options
-    @is_color = any_to_bool(options["color"])
-    @is_log = any_to_bool(options["nolog"])
-    @name = ""
+    super
     @base_path = options["base"].to_s
-
-    @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
-  end
-
-  def name
-    @name
+    @file_cache = Hash(String, String).new
   end
 
   def self.target_techs : Array(String)
     [] of String
   end
 
-  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    endpoints
-  end
-
-  def read_source_context(endpoint : Endpoint, context_lines : Int32 = 30) : Array(SourceContext)
+  def read_source_context(endpoint : Endpoint) : Array(SourceContext)
     results = [] of SourceContext
 
     endpoint.details.code_paths.each do |path_info|
       content = read_file(path_info.path)
       next if content.nil?
 
-      lines = content.split("\n")
-      line = path_info.line
-
-      if line
-        # Note: `line` is 1-indexed (from PathInfo), but `context` is a 0-indexed array slice.
-        # To map back: context[line - start_line - 1] is the endpoint's line.
-        start_line = [line - context_lines, 0].max
-        end_line = [line + context_lines, lines.size - 1].min
-        context = lines[start_line..end_line]
-      else
-        context = lines
-      end
-
       results << SourceContext.new(
         path: path_info.path,
-        line: line,
-        context: context,
+        line: path_info.line,
         full_content: content
       )
     end
@@ -81,7 +46,13 @@ class FrameworkTagger
   end
 
   def read_file(path : String) : String?
-    File.read(path)
+    if cached = @file_cache[path]?
+      return cached
+    end
+
+    content = File.read(path)
+    @file_cache[path] = content
+    content
   rescue ex
     @logger.debug "FrameworkTagger: Failed to read file #{path}: #{ex.message}"
     nil

--- a/src/options.cr
+++ b/src/options.cr
@@ -225,12 +225,12 @@ def run_options_parser
       puts "Available taggers:"
       NoirTaggers.taggers.each do |tagger, info|
         puts " #{tagger.to_s.colorize(:green)}"
-        info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" }
+        info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
       end
       puts "\nFramework-specific taggers:"
       NoirTaggers.framework_taggers.each do |tagger, info|
         puts " #{tagger.to_s.colorize(:green)}"
-        info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" }
+        info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
       end
       exit
     end

--- a/src/options.cr
+++ b/src/options.cr
@@ -227,6 +227,11 @@ def run_options_parser
         puts " #{tagger.to_s.colorize(:green)}"
         info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" }
       end
+      puts "\nFramework-specific taggers:"
+      NoirTaggers.framework_taggers.each do |tagger, info|
+        puts " #{tagger.to_s.colorize(:green)}"
+        info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" }
+      end
       exit
     end
 

--- a/src/tagger/framework_taggers/crystal/crystal_auth.cr
+++ b/src/tagger/framework_taggers/crystal/crystal_auth.cr
@@ -1,0 +1,111 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class CrystalAuthTagger < FrameworkTagger
+  # Amber auth pipe patterns
+  AMBER_AUTH_PATTERNS = [
+    {/pipeline\s+:auth/, "Amber :auth pipeline"},
+    {/plug\s+Authenticate/, "Amber Authenticate plug"},
+    {/plug\s+\w*[Aa]uth\w*/, "Amber auth plug"},
+  ]
+
+  # Kemal auth patterns
+  KEMAL_AUTH_PATTERNS = [
+    {/before_all.*do.*auth/i, "Kemal before_all auth filter"},
+    {/env\.session\.string\s*\(\s*"user/, "Kemal session user check"},
+    {/env\.get\s*\(\s*"auth/, "Kemal auth context"},
+    {/basic_auth/, "Kemal basic_auth"},
+  ]
+
+  # Lucky auth patterns
+  LUCKY_AUTH_PATTERNS = [
+    {/include Auth::RequireSignIn/, "Lucky Auth::RequireSignIn"},
+    {/include Auth::AllowGuests/, "Lucky Auth::AllowGuests"},
+    {/before require_sign_in/, "Lucky require_sign_in before action"},
+    {/current_user/, "Lucky current_user check"},
+  ]
+
+  # Grip/Marten auth patterns
+  GENERIC_CRYSTAL_AUTH = [
+    {/before_action.*auth/i, "Crystal before_action auth"},
+    {/context\.session/, "Crystal session check"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "crystal_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["crystal_kemal", "crystal_amber", "crystal_lucky", "crystal_grip", "crystal_marten"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check for auth patterns in enclosing scope
+      description = check_enclosing_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "crystal_auth"))
+        return
+      end
+
+      # Check route handler body
+      description = check_handler_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "crystal_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_enclosing_auth(lines : Array(String), route_line : Int32) : String?
+    idx = route_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      all_patterns = AMBER_AUTH_PATTERNS + KEMAL_AUTH_PATTERNS + LUCKY_AUTH_PATTERNS + GENERIC_CRYSTAL_AUTH
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      # Stop at module/class definition
+      break if current.starts_with?("module ") || current.starts_with?("class ")
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_handler_auth(lines : Array(String), route_line : Int32) : String?
+    idx = route_line + 1
+    end_idx = [route_line + 10, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx].strip
+
+      all_patterns = KEMAL_AUTH_PATTERNS + LUCKY_AUTH_PATTERNS + GENERIC_CRYSTAL_AUTH
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/csharp/aspnet_auth.cr
+++ b/src/tagger/framework_taggers/csharp/aspnet_auth.cr
@@ -1,0 +1,148 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class AspnetAuthTagger < FrameworkTagger
+  # ASP.NET [Authorize] attribute patterns
+  AUTHORIZE_PATTERNS = [
+    {/\[Authorize\]/, "ASP.NET [Authorize]"},
+    {/\[Authorize\s*\(\s*Roles\s*=/, "ASP.NET [Authorize(Roles)]"},
+    {/\[Authorize\s*\(\s*Policy\s*=/, "ASP.NET [Authorize(Policy)]"},
+    {/\[Authorize\s*\(\s*AuthenticationSchemes\s*=/, "ASP.NET [Authorize(AuthenticationSchemes)]"},
+    {/\[RequireAuthorization/, "ASP.NET [RequireAuthorization]"},
+  ]
+
+  # Public override markers
+  ALLOW_ANONYMOUS_PATTERN = /\[AllowAnonymous\]/
+
+  # ASP.NET Core middleware auth in action body
+  ACTION_AUTH_PATTERNS = [
+    {/User\.Identity\.IsAuthenticated/, "ASP.NET User.Identity.IsAuthenticated"},
+    {/User\.IsInRole\s*\(/, "ASP.NET User.IsInRole check"},
+    {/HttpContext\.User/, "ASP.NET HttpContext.User check"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "aspnet_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["cs_aspnet_mvc", "cs_aspnet_core_mvc"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check for [AllowAnonymous] on this action
+      if has_allow_anonymous?(lines, line_idx)
+        return
+      end
+
+      # Check method-level [Authorize]
+      description = check_method_attributes(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "aspnet_auth"))
+        return
+      end
+
+      # Check class-level [Authorize] (applies to all actions)
+      description = check_class_attributes(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description} (class-level)", "aspnet_auth"))
+        return
+      end
+
+      # Check action body for auth checks
+      description = check_action_body(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "aspnet_auth"))
+        return
+      end
+    end
+  end
+
+  private def has_allow_anonymous?(lines : Array(String), method_line : Int32) : Bool
+    idx = method_line - 1
+    while idx >= 0 && idx >= method_line - 5
+      current = lines[idx].strip
+      break if current.empty? && idx < method_line - 1
+      return true if current.matches?(ALLOW_ANONYMOUS_PATTERN)
+      idx -= 1
+    end
+    false
+  end
+
+  private def check_method_attributes(lines : Array(String), method_line : Int32) : String?
+    idx = method_line - 1
+    while idx >= 0 && idx >= method_line - 8
+      current = lines[idx].strip
+      break if current.empty? && idx < method_line - 1
+
+      AUTHORIZE_PATTERNS.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_class_attributes(lines : Array(String), method_line : Int32) : String?
+    idx = method_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      if current.includes?("class ") && (current.includes?(":") || current.includes?("{"))
+        # Found class definition, check attributes above
+        attr_idx = idx - 1
+        while attr_idx >= 0 && attr_idx >= idx - 5
+          attr = lines[attr_idx].strip
+          break if attr.empty? && attr_idx < idx - 1
+
+          AUTHORIZE_PATTERNS.each do |pattern, desc|
+            return desc if attr.matches?(pattern)
+          end
+
+          attr_idx -= 1
+        end
+        break
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_action_body(lines : Array(String), method_line : Int32) : String?
+    idx = method_line + 1
+    end_idx = [method_line + 15, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx].strip
+
+      ACTION_AUTH_PATTERNS.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/elixir/elixir_auth.cr
+++ b/src/tagger/framework_taggers/elixir/elixir_auth.cr
@@ -1,0 +1,177 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class ElixirAuthTagger < FrameworkTagger
+  # Phoenix pipeline auth plugs
+  PLUG_AUTH_PATTERNS = [
+    {/plug\s+:require_authenticated_user/, "Phoenix require_authenticated_user plug"},
+    {/plug\s+:authenticate/, "Phoenix authenticate plug"},
+    {/plug\s+:require_auth/, "Phoenix require_auth plug"},
+    {/plug\s+:ensure_authenticated/, "Phoenix ensure_authenticated plug"},
+    {/plug\s+:fetch_current_user/, "Phoenix fetch_current_user plug"},
+    {/plug\s+\w*[Aa]uth\w*/, "Phoenix auth plug"},
+  ]
+
+  # Plug-level auth (in router or controller)
+  PLUG_MODULE_PATTERNS = [
+    {/plug\s+\w+\.Auth/, "Phoenix Auth module plug"},
+    {/plug\s+\w+\.RequireAuth/, "Phoenix RequireAuth module plug"},
+    {/plug\s+\w+\.EnsureAuthenticated/, "Phoenix EnsureAuthenticated plug"},
+    {/plug\s+Guardian\.Plug\.EnsureAuthenticated/, "Guardian EnsureAuthenticated"},
+    {/plug\s+Guardian\.Plug\.VerifyHeader/, "Guardian VerifyHeader"},
+    {/plug\s+Pow\.Plug\.RequireAuthenticated/, "Pow RequireAuthenticated"},
+  ]
+
+  # Action-level auth checks
+  ACTION_AUTH_PATTERNS = [
+    {/conn\.assigns\.\w*current_user/, "Phoenix current_user check"},
+    {/Guardian\.Plug\.current_resource/, "Guardian current_resource"},
+    {/Pow\.Plug\.current_user/, "Pow current_user"},
+    {/get_session\s*\(\s*conn,\s*:user/, "Phoenix session user check"},
+  ]
+
+  # Pipeline references
+  PIPELINE_AUTH_PATTERNS = [
+    {/pipe_through\s+\[.*:authenticated/, "Phoenix :authenticated pipeline"},
+    {/pipe_through\s+:authenticated/, "Phoenix :authenticated pipeline"},
+    {/pipe_through\s+\[.*:auth/, "Phoenix :auth pipeline"},
+    {/pipe_through\s+:auth/, "Phoenix :auth pipeline"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "elixir_auth"
+    @auth_scopes = [] of {prefix: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    ["elixir_phoenix", "elixir_plug"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # Pre-scan routers for pipeline-scope auth
+    @auth_scopes.clear
+    pre_scan_router_pipelines
+
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def pre_scan_router_pipelines
+    files = get_files_by_prefix_and_extension(@base_path, ".ex")
+    files.each do |file|
+      content = read_file(file)
+      next if content.nil?
+      next unless content.includes?("scope") && content.includes?("pipe_through")
+
+      scan_router(content)
+    end
+  end
+
+  private def scan_router(content : String)
+    lines = content.split("\n")
+    current_scope : String? = nil
+    in_auth_scope = false
+
+    lines.each do |line|
+      stripped = line.strip
+
+      # Track scope
+      scope_match = stripped.match(/scope\s+["']([^"']+)["']/)
+      if scope_match
+        current_scope = scope_match[1]
+        in_auth_scope = false
+      end
+
+      # Check for authenticated pipeline
+      PIPELINE_AUTH_PATTERNS.each do |pattern, desc|
+        if stripped.matches?(pattern) && current_scope
+          @auth_scopes << {prefix: current_scope, description: "Protected by #{desc}"}
+          in_auth_scope = true
+        end
+      end
+
+      if stripped == "end"
+        current_scope = nil
+        in_auth_scope = false
+      end
+    end
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check controller-level plugs
+      description = check_controller_plugs(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "elixir_auth"))
+        return
+      end
+
+      # Check action body for auth checks
+      description = check_action_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "elixir_auth"))
+        return
+      end
+    end
+
+    # Check router scope-level auth
+    description = check_scope_auth(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "elixir_auth"))
+    end
+  end
+
+  private def check_controller_plugs(lines : Array(String), action_line : Int32) : String?
+    idx = action_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      all_patterns = PLUG_AUTH_PATTERNS + PLUG_MODULE_PATTERNS
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      break if current.starts_with?("defmodule ")
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_action_auth(lines : Array(String), action_line : Int32) : String?
+    idx = action_line + 1
+    end_idx = [action_line + 15, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx].strip
+      break if current.starts_with?("def ") || current.starts_with?("defp ")
+
+      ACTION_AUTH_PATTERNS.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+
+  private def check_scope_auth(endpoint : Endpoint) : String?
+    url = endpoint.url
+    @auth_scopes.each do |scope|
+      return scope[:description] if url.starts_with?(scope[:prefix])
+    end
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/elixir/elixir_auth.cr
+++ b/src/tagger/framework_taggers/elixir/elixir_auth.cr
@@ -72,32 +72,36 @@ class ElixirAuthTagger < FrameworkTagger
 
   private def scan_router(content : String)
     lines = content.split("\n")
-    current_scope : String? = nil
-    in_auth_scope = false
+    # Stack-based scope tracking for nested Phoenix scopes
+    scope_stack = [] of String
 
     lines.each do |line|
       stripped = line.strip
 
-      # Track scope
+      # Track scope nesting
       scope_match = stripped.match(/scope\s+["']([^"']+)["']/)
       if scope_match
-        current_scope = scope_match[1]
-        in_auth_scope = false
+        scope_stack << scope_match[1]
       end
 
-      # Check for authenticated pipeline
+      # Check for authenticated pipeline within current scope
       PIPELINE_AUTH_PATTERNS.each do |pattern, desc|
-        if stripped.matches?(pattern) && current_scope
-          @auth_scopes << {prefix: current_scope, description: "Protected by #{desc}"}
-          in_auth_scope = true
+        if stripped.matches?(pattern) && !scope_stack.empty?
+          prefix = normalize_scope(scope_stack)
+          @auth_scopes << {prefix: prefix, description: "Protected by #{desc}"}
         end
       end
 
-      if stripped == "end"
-        current_scope = nil
-        in_auth_scope = false
+      if stripped == "end" && !scope_stack.empty?
+        scope_stack.pop
       end
     end
+  end
+
+  private def normalize_scope(segments : Array(String)) : String
+    joined = segments.join("")
+    parts = joined.split("/").reject(&.empty?)
+    parts.empty? ? "/" : "/" + parts.join("/")
   end
 
   private def check_endpoint(endpoint : Endpoint)

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -101,8 +101,8 @@ class GoAuthTagger < FrameworkTagger
         group_stack << group_match[1]
       end
 
-      # Track closing braces (rough scope tracking)
-      if stripped == "})" || stripped == "}"
+      # Track closing braces for scope tracking
+      if stripped.starts_with?("}") || stripped == "})"
         group_stack.pop? unless group_stack.empty?
       end
 
@@ -111,7 +111,7 @@ class GoAuthTagger < FrameworkTagger
         match = stripped.match(pattern)
         if match
           middleware_name = match[1]
-          prefix = group_stack.join("")
+          prefix = normalize_prefix(group_stack)
           prefix = "/" if prefix.empty?
           @middleware_scopes << {
             prefix:      prefix,
@@ -124,7 +124,7 @@ class GoAuthTagger < FrameworkTagger
       # Check for JWT library middleware
       JWT_PATTERNS.each do |pattern|
         if stripped.matches?(pattern) && stripped.includes?(".Use")
-          prefix = group_stack.join("")
+          prefix = normalize_prefix(group_stack)
           prefix = "/" if prefix.empty?
           jwt_match = stripped.match(pattern)
           jwt_name = jwt_match ? jwt_match[0] : "JWT"
@@ -207,5 +207,13 @@ class GoAuthTagger < FrameworkTagger
     end
 
     nil
+  end
+
+  private def normalize_prefix(segments : Array(String)) : String
+    joined = segments.join("")
+    # Ensure segments that lack a leading "/" are joined properly
+    # e.g., ["api", "v1"] → "/api/v1", ["/api", "/v1"] → "/api/v1"
+    parts = joined.split("/").reject(&.empty?)
+    parts.empty? ? "/" : "/" + parts.join("/")
   end
 end

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -38,17 +38,6 @@ class GoAuthTagger < FrameworkTagger
     /\b[Pp]ermission[Cc]heck\b/,
   ]
 
-  # Import patterns for auth packages
-  AUTH_IMPORT_PATTERNS = [
-    /golang-jwt/,
-    /dgrijalva\/jwt-go/,
-    /go-chi\/jwtauth/,
-    /labstack\/echo.*\/middleware/,
-    /gin-contrib\/sessions/,
-    /gorilla\/sessions/,
-    /casbin/,
-  ]
-
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "go_auth"
@@ -164,7 +153,8 @@ class GoAuthTagger < FrameworkTagger
         end
       end
 
-      # Check lines just above for middleware applied to this specific route
+      # Check up to 5 lines above for middleware applied to this specific route
+      # Go middleware is typically chained immediately before the route handler
       check_idx = line_idx - 1
       while check_idx >= 0 && check_idx >= line_idx - 5
         above_line = lines[check_idx].strip

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -1,0 +1,211 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class GoAuthTagger < FrameworkTagger
+  # Middleware usage patterns in route groups
+  USE_AUTH_MIDDLEWARE_PATTERNS = [
+    /\.Use\s*\(\s*(\w*[Aa]uth\w*)/,
+    /\.Use\s*\(\s*(\w*JWT\w*)/i,
+    /\.Use\s*\(\s*(\w*[Tt]oken\w*)/,
+    /\.Use\s*\(\s*(\w*[Ss]ession\w*)/,
+    /\.Use\s*\(\s*(\w*[Pp]ermission\w*)/,
+    /\.Use\s*\(\s*(\w*[Ll]ogin\w*)/,
+    /\.Use\s*\(\s*(\w*RBAC\w*)/i,
+    /\.Use\s*\(\s*(\w*ACL\w*)/i,
+  ]
+
+  # JWT library patterns
+  JWT_PATTERNS = [
+    /echojwt\.\w+/,
+    /jwtauth\.\w+/,
+    /jwt\.New\s*\(/,
+    /jwt\.Auth\s*\(/,
+    /middleware\.JWT\s*\(/,
+    /middleware\.JWTWithConfig\s*\(/,
+  ]
+
+  # Auth middleware in route definition (inline middleware)
+  INLINE_AUTH_MIDDLEWARE = [
+    /\b[Aa]uth(?:enticate|orize|Required|Middleware|Handler|Guard|Check)\b/,
+    /\b[Rr]equire[Aa]uth\b/,
+    /\b[Ii]s[Aa]uth(?:enticated)?\b/,
+    /\b[Ll]ogin[Rr]equired\b/,
+    /\b[Vv]erify[Tt]oken\b/,
+    /\b[Cc]heck[Tt]oken\b/,
+    /\b[Jj][Ww][Tt](?:Auth|Middleware|Verify|Check|Guard)?\b/,
+    /\b[Aa]dmin[Oo]nly\b/,
+    /\b[Rr]ole[Cc]heck\b/,
+    /\b[Pp]ermission[Cc]heck\b/,
+  ]
+
+  # Import patterns for auth packages
+  AUTH_IMPORT_PATTERNS = [
+    /golang-jwt/,
+    /dgrijalva\/jwt-go/,
+    /go-chi\/jwtauth/,
+    /labstack\/echo.*\/middleware/,
+    /gin-contrib\/sessions/,
+    /gorilla\/sessions/,
+    /casbin/,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "go_auth"
+    @middleware_scopes = [] of {prefix: String, middleware: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    [
+      "go_echo", "go_gin", "go_chi", "go_fiber",
+      "go_beego", "go_mux", "go_fasthttp",
+      "go_gozero", "go_goyave",
+    ]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # Phase 1: Pre-scan for group-level middleware
+    pre_scan_middleware_scopes
+
+    # Phase 2: Check each endpoint
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+
+    endpoints
+  end
+
+  private def pre_scan_middleware_scopes
+    @middleware_scopes.clear
+
+    files = get_files_by_prefix_and_extension(@base_path, ".go")
+    files.each do |file|
+      content = read_file(file)
+      next if content.nil?
+
+      scan_group_middleware(content, file)
+    end
+  end
+
+  private def scan_group_middleware(content : String, file : String)
+    lines = content.split("\n")
+    # Track current route group context
+    group_stack = [] of String
+
+    lines.each_with_index do |line, _idx|
+      stripped = line.strip
+
+      # Track Group/Route prefix definitions
+      group_match = stripped.match(/\.(?:Group|Route)\s*\(\s*"([^"]*)"/)
+      if group_match
+        group_stack << group_match[1]
+      end
+
+      # Track closing braces (rough scope tracking)
+      if stripped == "})" || stripped == "}"
+        group_stack.pop? unless group_stack.empty?
+      end
+
+      # Check for .Use() with auth middleware
+      USE_AUTH_MIDDLEWARE_PATTERNS.each do |pattern|
+        match = stripped.match(pattern)
+        if match
+          middleware_name = match[1]
+          prefix = group_stack.join("")
+          prefix = "/" if prefix.empty?
+          @middleware_scopes << {
+            prefix:      prefix,
+            middleware:   middleware_name,
+            description: "Protected by Go middleware #{middleware_name}",
+          }
+        end
+      end
+
+      # Check for JWT library middleware
+      JWT_PATTERNS.each do |pattern|
+        if stripped.matches?(pattern) && stripped.includes?(".Use")
+          prefix = group_stack.join("")
+          prefix = "/" if prefix.empty?
+          jwt_match = stripped.match(pattern)
+          jwt_name = jwt_match ? jwt_match[0] : "JWT"
+          @middleware_scopes << {
+            prefix:      prefix,
+            middleware:   jwt_name,
+            description: "Protected by Go JWT middleware (#{jwt_name})",
+          }
+        end
+      end
+    end
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    # Check route definition for inline middleware
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+
+      # Check the route definition line and surrounding context
+      line_idx = line_num - 1 # 0-indexed
+      next if line_idx < 0 || line_idx >= lines.size
+
+      route_line = lines[line_idx]
+
+      # Check for inline auth middleware in route definition
+      INLINE_AUTH_MIDDLEWARE.each do |pattern|
+        if route_line.matches?(pattern)
+          match = route_line.match(pattern)
+          middleware_name = match ? match[0] : "auth"
+          endpoint.add_tag(Tag.new("auth", "Protected by Go #{middleware_name} middleware", "go_auth"))
+          return
+        end
+      end
+
+      # Check lines just above for middleware applied to this specific route
+      check_idx = line_idx - 1
+      while check_idx >= 0 && check_idx >= line_idx - 5
+        above_line = lines[check_idx].strip
+        break if above_line.empty?
+
+        USE_AUTH_MIDDLEWARE_PATTERNS.each do |pattern|
+          match = above_line.match(pattern)
+          if match
+            middleware_name = match[1]
+            endpoint.add_tag(Tag.new("auth", "Protected by Go #{middleware_name} middleware", "go_auth"))
+            return
+          end
+        end
+
+        JWT_PATTERNS.each do |pattern|
+          if above_line.matches?(pattern) && above_line.includes?(".Use")
+            endpoint.add_tag(Tag.new("auth", "Protected by Go JWT middleware", "go_auth"))
+            return
+          end
+        end
+
+        check_idx -= 1
+      end
+    end
+
+    # Phase 3: Check group-level middleware scope
+    description = check_middleware_scopes(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "go_auth"))
+    end
+  end
+
+  private def check_middleware_scopes(endpoint : Endpoint) : String?
+    url = endpoint.url
+
+    @middleware_scopes.each do |scope|
+      if url.starts_with?(scope[:prefix])
+        return scope[:description]
+      end
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -115,7 +115,7 @@ class GoAuthTagger < FrameworkTagger
           prefix = "/" if prefix.empty?
           @middleware_scopes << {
             prefix:      prefix,
-            middleware:   middleware_name,
+            middleware:  middleware_name,
             description: "Protected by Go middleware #{middleware_name}",
           }
         end
@@ -130,7 +130,7 @@ class GoAuthTagger < FrameworkTagger
           jwt_name = jwt_match ? jwt_match[0] : "JWT"
           @middleware_scopes << {
             prefix:      prefix,
-            middleware:   jwt_name,
+            middleware:  jwt_name,
             description: "Protected by Go JWT middleware (#{jwt_name})",
           }
         end

--- a/src/tagger/framework_taggers/java/java_misc_auth.cr
+++ b/src/tagger/framework_taggers/java/java_misc_auth.cr
@@ -1,0 +1,106 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class JavaMiscAuthTagger < FrameworkTagger
+  # Vert.x auth patterns
+  VERTX_AUTH_PATTERNS = [
+    {/AuthHandler/, "Vert.x AuthHandler"},
+    {/JWTAuth/, "Vert.x JWTAuth"},
+    {/BasicAuthHandler/, "Vert.x BasicAuthHandler"},
+    {/OAuth2AuthHandler/, "Vert.x OAuth2AuthHandler"},
+    {/RedirectAuthHandler/, "Vert.x RedirectAuthHandler"},
+    {/SessionHandler/, "Vert.x SessionHandler"},
+    {/routingContext\.user\(\)/, "Vert.x user() check"},
+  ]
+
+  # Armeria auth patterns
+  ARMERIA_AUTH_PATTERNS = [
+    {/AuthService/, "Armeria AuthService decorator"},
+    {/\.decorator\s*\(\s*AuthService/, "Armeria AuthService"},
+    {/Authorizer/, "Armeria Authorizer"},
+    {/BasicToken/, "Armeria BasicToken auth"},
+    {/OAuth2Token/, "Armeria OAuth2Token auth"},
+  ]
+
+  # JSP/Servlet auth patterns
+  JSP_AUTH_PATTERNS = [
+    {/request\.getUserPrincipal\s*\(\)/, "Servlet getUserPrincipal"},
+    {/request\.isUserInRole\s*\(/, "Servlet isUserInRole"},
+    {/request\.getRemoteUser\s*\(\)/, "Servlet getRemoteUser"},
+    {/HttpServletRequest.*getSession/, "Servlet session check"},
+    {/<security-constraint>/, "web.xml security-constraint"},
+    {/<auth-constraint>/, "web.xml auth-constraint"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "java_misc_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["java_vertx", "java_armeria", "java_jsp"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check route context for auth patterns
+      description = check_route_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "java_misc_auth"))
+        return
+      end
+
+      # Check handler body
+      description = check_handler_body(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "java_misc_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_route_auth(lines : Array(String), line_idx : Int32) : String?
+    start_idx = [line_idx - 10, 0].max
+
+    all_patterns = VERTX_AUTH_PATTERNS + ARMERIA_AUTH_PATTERNS + JSP_AUTH_PATTERNS
+    (start_idx..line_idx).each do |idx|
+      current = lines[idx]
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+    end
+
+    nil
+  end
+
+  private def check_handler_body(lines : Array(String), line_idx : Int32) : String?
+    idx = line_idx + 1
+    end_idx = [line_idx + 15, lines.size - 1].min
+
+    all_patterns = VERTX_AUTH_PATTERNS + ARMERIA_AUTH_PATTERNS + JSP_AUTH_PATTERNS
+    while idx <= end_idx
+      current = lines[idx].strip
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+      idx += 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -85,7 +85,7 @@ class SpringAuthTagger < FrameworkTagger
 
   private def check_annotations(ctx : SourceContext) : String?
     line = ctx.line
-    return nil unless line
+    return unless line
 
     # Walk backwards from endpoint line to find annotations
     lines = ctx.context

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -143,7 +143,8 @@ class SpringAuthTagger < FrameworkTagger
         .gsub("DOUBLE_STAR", ".*")
       url.matches?(/^#{regex_str}/)
     end
-  rescue
+  rescue ex
+    @logger.debug "SpringAuthTagger: Failed to match ant pattern '#{pattern}': #{ex.message}"
     false
   end
 end

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -88,14 +88,22 @@ class SpringAuthTagger < FrameworkTagger
     return unless line
 
     # Walk backwards from endpoint line to find annotations
+    # Note: `line` is 1-indexed (from PathInfo), context array is 0-indexed
     lines = ctx.context
     context_start = [line - 15, 0].max
-    endpoint_idx = line - context_start
+    endpoint_idx = line - 1 - context_start
 
     idx = [endpoint_idx - 1, lines.size - 1].min
     while idx >= 0 && idx < lines.size
       current_line = lines[idx].strip
-      break if current_line.empty? && idx < endpoint_idx - 2
+      # Skip empty lines but stop at method/class boundaries
+      if current_line.empty?
+        idx -= 1
+        next
+      end
+      break if current_line.starts_with?("public ") || current_line.starts_with?("private ") || current_line.starts_with?("protected ")
+      break if current_line.starts_with?("class ") || current_line.starts_with?("}")
+      break if current_line.ends_with?("}")
 
       ANNOTATION_PATTERNS.each do |pattern|
         if current_line.matches?(pattern)

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -1,0 +1,141 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class SpringAuthTagger < FrameworkTagger
+  ANNOTATION_PATTERNS = [
+    /\@PreAuthorize\s*\(/,
+    /\@Secured\s*\(/,
+    /\@RolesAllowed\s*\(/,
+  ]
+
+  # Patterns for security config URL rules
+  ANT_MATCHERS_AUTH = /\.(antMatchers|requestMatchers)\s*\(([^)]+)\)\s*\.\s*(authenticated|hasRole|hasAnyRole|hasAuthority|hasAnyAuthority)\s*\(/
+  MVC_MATCHERS_AUTH = /\.(mvcMatchers)\s*\(([^)]+)\)\s*\.\s*(authenticated|hasRole|hasAnyRole|hasAuthority|hasAnyAuthority)\s*\(/
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "spring_auth"
+    @security_rules = [] of {pattern: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    ["java_spring", "kotlin_spring"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # Phase 1: Pre-scan security config files
+    pre_scan_security_configs
+
+    # Phase 2 & 3: Check each endpoint
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+
+    endpoints
+  end
+
+  private def pre_scan_security_configs
+    @security_rules.clear
+
+    # Find Java and Kotlin security config files
+    extensions = [".java", ".kt"]
+    extensions.each do |ext|
+      files = get_files_by_prefix_and_extension(@base_path, ext)
+      files.each do |file|
+        content = read_file(file)
+        next if content.nil?
+        next unless content.includes?("SecurityFilterChain") || content.includes?("HttpSecurity") || content.includes?("WebSecurityConfigurerAdapter")
+
+        scan_security_config(content)
+      end
+    end
+  end
+
+  private def scan_security_config(content : String)
+    lines = content.split("\n")
+    lines.each do |line|
+      [ANT_MATCHERS_AUTH, MVC_MATCHERS_AUTH].each do |pattern|
+        match = line.match(pattern)
+        if match
+          url_pattern = match[2].gsub("\"", "").strip
+          auth_type = match[3]
+          @security_rules << {pattern: url_pattern, description: "Protected by Spring Security #{auth_type} via #{match[1]}(\"#{url_pattern}\")"}
+        end
+      end
+    end
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    # Phase 2: Check annotations near code_paths
+    contexts = read_source_context(endpoint, 15)
+    contexts.each do |ctx|
+      description = check_annotations(ctx)
+      if description
+        endpoint.add_tag(Tag.new("auth", description, "spring_auth"))
+        return
+      end
+    end
+
+    # Phase 3: Match endpoint URL against security config rules
+    description = check_security_config_rules(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "spring_auth"))
+    end
+  end
+
+  private def check_annotations(ctx : SourceContext) : String?
+    line = ctx.line
+    return nil unless line
+
+    # Walk backwards from endpoint line to find annotations
+    lines = ctx.context
+    context_start = [line - 15, 0].max
+    endpoint_idx = line - context_start
+
+    idx = [endpoint_idx - 1, lines.size - 1].min
+    while idx >= 0 && idx < lines.size
+      current_line = lines[idx].strip
+      break if current_line.empty? && idx < endpoint_idx - 2
+
+      ANNOTATION_PATTERNS.each do |pattern|
+        if current_line.matches?(pattern)
+          annotation_name = current_line.split("(").first.strip
+          return "Protected by Spring #{annotation_name}"
+        end
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_security_config_rules(endpoint : Endpoint) : String?
+    url = endpoint.url
+
+    @security_rules.each do |rule|
+      pattern = rule[:pattern]
+      # Handle ant-style patterns
+      if matches_ant_pattern?(url, pattern)
+        return rule[:description]
+      end
+    end
+
+    nil
+  end
+
+  private def matches_ant_pattern?(url : String, pattern : String) : Bool
+    # Handle comma-separated patterns
+    patterns = pattern.split(",").map(&.strip)
+
+    patterns.any? do |p|
+      # Convert ant pattern to regex
+      regex_str = p.gsub("**", "DOUBLE_STAR")
+        .gsub("*", "[^/]*")
+        .gsub("DOUBLE_STAR", ".*")
+      url.matches?(/^#{regex_str}/)
+    end
+  rescue
+    false
+  end
+end

--- a/src/tagger/framework_taggers/java/spring_auth.cr
+++ b/src/tagger/framework_taggers/java/spring_auth.cr
@@ -67,7 +67,7 @@ class SpringAuthTagger < FrameworkTagger
 
   private def check_endpoint(endpoint : Endpoint)
     # Phase 2: Check annotations near code_paths
-    contexts = read_source_context(endpoint, 15)
+    contexts = read_source_context(endpoint)
     contexts.each do |ctx|
       description = check_annotations(ctx)
       if description
@@ -88,13 +88,12 @@ class SpringAuthTagger < FrameworkTagger
     return unless line
 
     # Walk backwards from endpoint line to find annotations
-    # Note: `line` is 1-indexed (from PathInfo), context array is 0-indexed
-    lines = ctx.context
-    context_start = [line - 15, 0].max
-    endpoint_idx = line - 1 - context_start
+    # `line` is 1-indexed (from PathInfo), array is 0-indexed
+    lines = ctx.full_content.split("\n")
+    endpoint_idx = line - 1
 
     idx = [endpoint_idx - 1, lines.size - 1].min
-    while idx >= 0 && idx < lines.size
+    while idx >= 0 && idx >= endpoint_idx - 15
       current_line = lines[idx].strip
       # Skip empty lines but stop at method/class boundaries
       if current_line.empty?

--- a/src/tagger/framework_taggers/javascript/express_auth.cr
+++ b/src/tagger/framework_taggers/javascript/express_auth.cr
@@ -1,0 +1,186 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class ExpressAuthTagger < FrameworkTagger
+  PASSPORT_PATTERNS = [
+    /passport\.authenticate\s*\(/,
+  ]
+
+  JWT_MIDDLEWARE_PATTERNS = [
+    /expressjwt\s*\(/,
+    /expressJwt\s*\(/,
+  ]
+
+  AUTH_MIDDLEWARE_NAMES = [
+    /\brequireAuth\b/,
+    /\bisAuth\b/,
+    /\bisAuthenticated\b/,
+    /\benchureLoggedIn\b/,
+    /\benchureAuthenticated\b/,
+    /\bauthorize\b/,
+    /\brequireLogin\b/,
+    /\bauthMiddleware\b/,
+    /\bverifyToken\b/,
+    /\bcheckAuth\b/,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "express_auth"
+    @app_use_auth_patterns = [] of {prefix: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    ["js_express"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # Pre-scan: Find app.use() level auth middleware
+    pre_scan_app_use_auth
+
+    # Check each endpoint
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+
+    endpoints
+  end
+
+  private def pre_scan_app_use_auth
+    @app_use_auth_patterns.clear
+
+    extensions = [".js", ".ts", ".mjs", ".cjs"]
+    extensions.each do |ext|
+      files = get_files_by_prefix_and_extension(@base_path, ext)
+      files.each do |file|
+        content = read_file(file)
+        next if content.nil?
+
+        lines = content.split("\n")
+        lines.each do |line|
+          stripped = line.strip
+
+          # Match app.use('/prefix', authMiddleware)
+          match = stripped.match(/(?:app|router)\.use\s*\(\s*['"]([^'"]+)['"]/)
+          if match
+            prefix = match[1]
+            if has_auth_middleware_in_line?(stripped)
+              @app_use_auth_patterns << {prefix: prefix, description: "Protected by Express app.use() auth middleware on #{prefix}"}
+            end
+          end
+
+          # Match app.use(authMiddleware) without prefix (applies to all routes)
+          if stripped.matches?(/(?:app|router)\.use\s*\(/) && !match
+            if has_auth_middleware_in_line?(stripped)
+              @app_use_auth_patterns << {prefix: "/", description: "Protected by Express global auth middleware"}
+            end
+          end
+        end
+      end
+    end
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    # Check route definition line for auth patterns
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+
+      # Check the route definition line and a few lines around it (same statement)
+      route_lines = get_route_statement(lines, line_num - 1) # 0-indexed
+      route_text = route_lines.join(" ")
+
+      # Check for passport.authenticate in route definition
+      PASSPORT_PATTERNS.each do |pattern|
+        if route_text.matches?(pattern)
+          match = route_text.match(/passport\.authenticate\s*\(\s*['"]([^'"]+)['"]/)
+          strategy = match ? match[1] : "unknown"
+          endpoint.add_tag(Tag.new("auth", "Protected by Passport.js #{strategy} strategy", "express_auth"))
+          return
+        end
+      end
+
+      # Check for JWT middleware
+      JWT_MIDDLEWARE_PATTERNS.each do |pattern|
+        if route_text.matches?(pattern)
+          endpoint.add_tag(Tag.new("auth", "Protected by Express JWT middleware", "express_auth"))
+          return
+        end
+      end
+
+      # Check for generic auth middleware names in route definition
+      AUTH_MIDDLEWARE_NAMES.each do |pattern|
+        if route_text.matches?(pattern)
+          match = route_text.match(pattern)
+          middleware_name = match ? match[0] : "auth"
+          endpoint.add_tag(Tag.new("auth", "Protected by Express #{middleware_name} middleware", "express_auth"))
+          return
+        end
+      end
+    end
+
+    # Check app.use() level auth for route prefix matching
+    description = check_app_use_auth(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "express_auth"))
+    end
+  end
+
+  # Get lines that make up a route statement (handles multi-line route definitions)
+  private def get_route_statement(lines : Array(String), line_idx : Int32) : Array(String)
+    return [] of String if line_idx < 0 || line_idx >= lines.size
+
+    result = [lines[line_idx]]
+
+    # Look at preceding lines that might be part of the same statement
+    # (e.g., chained method calls)
+    i = line_idx - 1
+    while i >= 0 && i >= line_idx - 2
+      stripped = lines[i].strip
+      break if stripped.empty? || stripped.ends_with?(";") || stripped.ends_with?(")")
+      # Only include if this looks like part of the route definition
+      if stripped.matches?(/\.(get|post|put|patch|delete|all|use)\s*\(/) ||
+         stripped.includes?("passport") || stripped.includes?("jwt") ||
+         stripped.includes?("Auth") || stripped.includes?("auth")
+        result.unshift(lines[i])
+      else
+        break
+      end
+      i -= 1
+    end
+
+    # Look at following lines that might complete the statement
+    i = line_idx + 1
+    while i < lines.size && i <= line_idx + 3
+      stripped = lines[i].strip
+      break if stripped.empty?
+      result << lines[i]
+      break if stripped.includes?(");") || stripped.ends_with?(")")
+      i += 1
+    end
+
+    result
+  end
+
+  private def check_app_use_auth(endpoint : Endpoint) : String?
+    url = endpoint.url
+
+    @app_use_auth_patterns.each do |rule|
+      if url.starts_with?(rule[:prefix])
+        return rule[:description]
+      end
+    end
+
+    nil
+  end
+
+  private def has_auth_middleware_in_line?(line : String) : Bool
+    PASSPORT_PATTERNS.any? { |p| line.matches?(p) } ||
+      JWT_MIDDLEWARE_PATTERNS.any? { |p| line.matches?(p) } ||
+      AUTH_MIDDLEWARE_NAMES.any? { |p| line.matches?(p) }
+  end
+end

--- a/src/tagger/framework_taggers/javascript/express_auth.cr
+++ b/src/tagger/framework_taggers/javascript/express_auth.cr
@@ -141,11 +141,10 @@ class ExpressAuthTagger < FrameworkTagger
     i = line_idx - 1
     while i >= 0 && i >= line_idx - 2
       stripped = lines[i].strip
-      break if stripped.empty? || stripped.ends_with?(";") || stripped.ends_with?(")")
+      break if stripped.empty? || stripped.ends_with?(";")
       # Only include if this looks like part of the route definition
       if stripped.matches?(/\.(get|post|put|patch|delete|all|use)\s*\(/) ||
-         stripped.includes?("passport") || stripped.includes?("jwt") ||
-         stripped.includes?("Auth") || stripped.includes?("auth")
+         stripped.includes?("passport") || stripped.includes?("expressjwt")
         result.unshift(lines[i])
       else
         break

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -1,0 +1,121 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class JsMiscAuthTagger < FrameworkTagger
+  # Fastify auth patterns
+  FASTIFY_PATTERNS = [
+    {/onRequest.*authenticate/, "Fastify onRequest authenticate hook"},
+    {/preHandler.*authenticate/, "Fastify preHandler authenticate"},
+    {/fastify\.authenticate/, "Fastify authenticate decorator"},
+    {/preValidation.*auth/i, "Fastify preValidation auth"},
+    {/@fastify\/jwt/, "Fastify JWT plugin"},
+    {/fastify-auth/, "Fastify auth plugin"},
+    {/fastify\.auth\s*\(/, "Fastify auth"},
+  ]
+
+  # Koa auth patterns
+  KOA_PATTERNS = [
+    {/koa-passport/, "Koa Passport middleware"},
+    {/koa-jwt/, "Koa JWT middleware"},
+    {/koa-session/, "Koa session middleware"},
+    {/passport\.authenticate\s*\(/, "Koa Passport authenticate"},
+    {/ctx\.state\.user/, "Koa ctx.state.user check"},
+    {/ctx\.isAuthenticated\s*\(\)/, "Koa isAuthenticated check"},
+  ]
+
+  # Restify auth patterns
+  RESTIFY_PATTERNS = [
+    {/authorizationParser/, "Restify authorizationParser"},
+    {/req\.authorization/, "Restify req.authorization check"},
+    {/req\.username/, "Restify req.username check"},
+  ]
+
+  # Generic Node.js auth middleware (shared across frameworks)
+  GENERIC_NODE_AUTH = [
+    {/\brequireAuth\b/, "requireAuth middleware"},
+    {/\bisAuthenticated\b/, "isAuthenticated middleware"},
+    {/\benchureLoggedIn\b/, "ensureLoggedIn middleware"},
+    {/\bverifyToken\b/, "verifyToken middleware"},
+    {/\bcheckAuth\b/, "checkAuth middleware"},
+    {/\bauthMiddleware\b/, "authMiddleware"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "js_misc_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["js_fastify", "js_koa", "js_restify", "js_nuxtjs"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check route definition line for auth middleware
+      description = check_route_line(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "js_misc_auth"))
+        return
+      end
+
+      # Check nearby context (hooks, before handlers)
+      description = check_nearby_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "js_misc_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_route_line(lines : Array(String), line_idx : Int32) : String?
+    return nil if line_idx < 0 || line_idx >= lines.size
+
+    # Check the route definition line and adjacent lines
+    start_idx = [line_idx - 2, 0].max
+    end_idx = [line_idx + 3, lines.size - 1].min
+
+    (start_idx..end_idx).each do |idx|
+      current = lines[idx]
+
+      all_patterns = FASTIFY_PATTERNS + KOA_PATTERNS + RESTIFY_PATTERNS + GENERIC_NODE_AUTH
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+    end
+
+    nil
+  end
+
+  private def check_nearby_auth(lines : Array(String), line_idx : Int32) : String?
+    # Walk backwards to find hooks or middleware applied to this route context
+    idx = line_idx - 1
+    while idx >= 0 && idx >= line_idx - 10
+      current = lines[idx].strip
+      break if current.empty? && idx < line_idx - 3
+
+      all_patterns = FASTIFY_PATTERNS + KOA_PATTERNS + RESTIFY_PATTERNS
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -83,7 +83,7 @@ class JsMiscAuthTagger < FrameworkTagger
   end
 
   private def check_route_line(lines : Array(String), line_idx : Int32) : String?
-    return nil if line_idx < 0 || line_idx >= lines.size
+    return if line_idx < 0 || line_idx >= lines.size
 
     # Check the route definition line and adjacent lines
     start_idx = [line_idx - 2, 0].max

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -65,7 +65,7 @@ class NestjsAuthTagger < FrameworkTagger
       line_idx = line_num - 1
 
       # Check if endpoint is explicitly public
-      if is_public?(lines, line_idx)
+      if public?(lines, line_idx)
         return
       end
 
@@ -85,7 +85,7 @@ class NestjsAuthTagger < FrameworkTagger
     end
   end
 
-  private def is_public?(lines : Array(String), method_line : Int32) : Bool
+  private def public?(lines : Array(String), method_line : Int32) : Bool
     idx = method_line - 1
     while idx >= 0 && idx >= method_line - 5
       current = lines[idx].strip

--- a/src/tagger/framework_taggers/javascript/nestjs_auth.cr
+++ b/src/tagger/framework_taggers/javascript/nestjs_auth.cr
@@ -1,0 +1,150 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class NestjsAuthTagger < FrameworkTagger
+  # NestJS guard decorators
+  GUARD_PATTERNS = [
+    {/\@UseGuards\s*\(\s*AuthGuard/, "NestJS @UseGuards(AuthGuard)"},
+    {/\@UseGuards\s*\(\s*JwtAuthGuard/, "NestJS @UseGuards(JwtAuthGuard)"},
+    {/\@UseGuards\s*\(\s*LocalAuthGuard/, "NestJS @UseGuards(LocalAuthGuard)"},
+    {/\@UseGuards\s*\(\s*RolesGuard/, "NestJS @UseGuards(RolesGuard)"},
+    {/\@UseGuards\s*\(\s*AuthenticationGuard/, "NestJS @UseGuards(AuthenticationGuard)"},
+    {/\@UseGuards\s*\(\s*\w*[Aa]uth\w*Guard/, "NestJS auth guard"},
+    {/\@UseGuards\s*\(\s*GqlAuthGuard/, "NestJS GraphQL auth guard"},
+  ]
+
+  # NestJS role/permission decorators
+  ROLE_PATTERNS = [
+    {/\@Roles\s*\(/, "NestJS @Roles decorator"},
+    {/\@Permissions\s*\(/, "NestJS @Permissions decorator"},
+    {/\@RequirePermissions\s*\(/, "NestJS @RequirePermissions decorator"},
+    {/\@SetMetadata\s*\(\s*['"]roles['"]/, "NestJS role metadata"},
+  ]
+
+  # NestJS auth-related decorators
+  AUTH_DECORATORS = [
+    {/\@ApiBearerAuth\s*\(/, "NestJS @ApiBearerAuth (Swagger)"},
+    {/\@ApiBasicAuth\s*\(/, "NestJS @ApiBasicAuth (Swagger)"},
+    {/\@ApiOAuth2\s*\(/, "NestJS @ApiOAuth2 (Swagger)"},
+    {/\@ApiSecurity\s*\(/, "NestJS @ApiSecurity (Swagger)"},
+  ]
+
+  # Public/skip auth markers (negative signal)
+  PUBLIC_PATTERNS = [
+    /\@Public\s*\(\)/,
+    /\@SkipAuth\s*\(\)/,
+    /\@AllowAnonymous\s*\(\)/,
+    /\@SetMetadata\s*\(\s*['"]isPublic['"]/,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "nestjs_auth"
+    @class_guards = Hash(String, String).new
+  end
+
+  def self.target_techs : Array(String)
+    ["js_nestjs", "ts_nestjs"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check if endpoint is explicitly public
+      if is_public?(lines, line_idx)
+        return
+      end
+
+      # Check method-level guards/decorators
+      description = check_method_decorators(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "nestjs_auth"))
+        return
+      end
+
+      # Check class-level guards (applies to all methods)
+      description = check_class_decorators(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description} (class-level)", "nestjs_auth"))
+        return
+      end
+    end
+  end
+
+  private def is_public?(lines : Array(String), method_line : Int32) : Bool
+    idx = method_line - 1
+    while idx >= 0 && idx >= method_line - 5
+      current = lines[idx].strip
+      break if current.empty? && idx < method_line - 1
+
+      PUBLIC_PATTERNS.each do |pattern|
+        return true if current.matches?(pattern)
+      end
+
+      idx -= 1
+    end
+
+    false
+  end
+
+  private def check_method_decorators(lines : Array(String), method_line : Int32) : String?
+    idx = method_line - 1
+    while idx >= 0 && idx >= method_line - 8
+      current = lines[idx].strip
+      break if current.empty? && idx < method_line - 1
+      # Stop if we hit another method
+      break if current.includes?("async ") && current.includes?("(") && idx < method_line - 1
+
+      all_patterns = GUARD_PATTERNS + ROLE_PATTERNS + AUTH_DECORATORS
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_class_decorators(lines : Array(String), method_line : Int32) : String?
+    # Walk backwards to find the class definition, checking for class-level guards
+    idx = method_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      if current.includes?("class ") && current.includes?("{")
+        # Found class — now check decorators above it
+        class_idx = idx - 1
+        while class_idx >= 0 && class_idx >= idx - 10
+          decorator = lines[class_idx].strip
+          break if decorator.empty? && class_idx < idx - 1
+
+          GUARD_PATTERNS.each do |pattern, desc|
+            return desc if decorator.matches?(pattern)
+          end
+
+          class_idx -= 1
+        end
+        break
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -8,12 +8,6 @@ class KtorAuthTagger < FrameworkTagger
     {/authenticate\s*\(\s*"([^"]+)"/, "Ktor named authenticate"},
   ]
 
-  # Ktor auth configuration install patterns
-  AUTH_INSTALL_PATTERNS = [
-    {/install\s*\(\s*Authentication\s*\)/, "Ktor Authentication plugin"},
-    {/authentication\s*\{/, "Ktor authentication configuration"},
-  ]
-
   # Ktor session/JWT/basic auth in route context
   ROUTE_AUTH_PATTERNS = [
     {/principal</, "Ktor principal extraction"},
@@ -57,33 +51,44 @@ class KtorAuthTagger < FrameworkTagger
 
   private def scan_auth_blocks(content : String)
     lines = content.split("\n")
-    in_authenticate = false
-    current_prefix = ""
+    # Stack-based prefix tracking for nested route() blocks
+    prefix_stack = [] of String
 
     lines.each do |line|
       stripped = line.strip
 
-      # Track route() prefix
+      # Track route() prefix nesting
       route_match = stripped.match(/route\s*\(\s*"([^"]+)"/)
       if route_match
-        current_prefix = route_match[1]
+        prefix_stack << route_match[1]
       end
 
       # Detect authenticate block (only record if route prefix is known)
-      if !current_prefix.empty?
+      if !prefix_stack.empty?
         AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, _desc|
           if stripped.matches?(pattern)
-            in_authenticate = true
             auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
             auth_name = auth_match ? auth_match[1] : "default"
+            prefix = normalize_prefix(prefix_stack)
             @auth_scopes << {
-              prefix:      current_prefix,
+              prefix:      prefix,
               description: "Protected by Ktor authenticate(\"#{auth_name}\") block",
             }
           end
         end
       end
+
+      # Pop prefix on closing brace (end of route block)
+      if (stripped == "}" || stripped == "})") && !prefix_stack.empty?
+        prefix_stack.pop
+      end
     end
+  end
+
+  private def normalize_prefix(segments : Array(String)) : String
+    joined = segments.join("")
+    parts = joined.split("/").reject(&.empty?)
+    parts.empty? ? "/" : "/" + parts.join("/")
   end
 
   private def check_endpoint(endpoint : Endpoint)
@@ -120,6 +125,7 @@ class KtorAuthTagger < FrameworkTagger
 
   private def check_enclosing_authenticate(lines : Array(String), route_line : Int32) : String?
     # Walk backwards to find an enclosing authenticate {} block
+    # 30-line window: Ktor authenticate blocks can wrap multiple route definitions
     idx = route_line - 1
     brace_depth = 0
 
@@ -128,9 +134,9 @@ class KtorAuthTagger < FrameworkTagger
       stripped = current.strip
 
       # Check pattern BEFORE counting braces on this line
-      # brace_depth == 0 means no net block boundaries crossed → we're inside
+      # brace_depth <= 0 means we haven't left the enclosing scope (handles nested route blocks)
       AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, _desc|
-        if stripped.matches?(pattern) && brace_depth == 0
+        if stripped.matches?(pattern) && brace_depth <= 0
           auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
           if auth_match
             return "Ktor authenticate(\"#{auth_match[1]}\") block"

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -1,0 +1,179 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class KtorAuthTagger < FrameworkTagger
+  # Ktor authenticate block patterns
+  AUTHENTICATE_BLOCK_PATTERNS = [
+    {/authenticate\s*\(/, "Ktor authenticate block"},
+    {/authenticate\s*\(\s*"([^"]+)"/, "Ktor named authenticate"},
+  ]
+
+  # Ktor auth configuration install patterns
+  AUTH_INSTALL_PATTERNS = [
+    {/install\s*\(\s*Authentication\s*\)/, "Ktor Authentication plugin"},
+    {/authentication\s*\{/, "Ktor authentication configuration"},
+  ]
+
+  # Ktor session/JWT/basic auth in route context
+  ROUTE_AUTH_PATTERNS = [
+    {/principal</, "Ktor principal extraction"},
+    {/call\.principal/, "Ktor call.principal"},
+    {/call\.authentication/, "Ktor call.authentication"},
+    {/sessions\.get</, "Ktor session check"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "ktor_auth"
+    @auth_scopes = [] of {prefix: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    ["kotlin_ktor"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # Pre-scan for authenticate {} blocks with route prefixes
+    pre_scan_auth_blocks
+
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def pre_scan_auth_blocks
+    @auth_scopes.clear
+
+    files = get_files_by_prefix_and_extension(@base_path, ".kt")
+    files.each do |file|
+      content = read_file(file)
+      next if content.nil?
+      next unless content.includes?("authenticate")
+
+      scan_auth_blocks(content)
+    end
+  end
+
+  private def scan_auth_blocks(content : String)
+    lines = content.split("\n")
+    in_authenticate = false
+    current_prefix = ""
+
+    lines.each do |line|
+      stripped = line.strip
+
+      # Track route() prefix
+      route_match = stripped.match(/route\s*\(\s*"([^"]+)"/)
+      if route_match
+        current_prefix = route_match[1]
+      end
+
+      # Detect authenticate block (only record if route prefix is known)
+      if !current_prefix.empty?
+        AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, desc|
+          if stripped.matches?(pattern)
+            in_authenticate = true
+            auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
+            auth_name = auth_match ? auth_match[1] : "default"
+            @auth_scopes << {
+              prefix:      current_prefix,
+              description: "Protected by Ktor authenticate(\"#{auth_name}\") block",
+            }
+          end
+        end
+      end
+    end
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check for authenticate block wrapping this route
+      description = check_enclosing_authenticate(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ktor_auth"))
+        return
+      end
+
+      # Check route handler body for principal/session access
+      description = check_route_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ktor_auth"))
+        return
+      end
+    end
+
+    # Check scope-level auth
+    description = check_scope_auth(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "ktor_auth"))
+    end
+  end
+
+  private def check_enclosing_authenticate(lines : Array(String), route_line : Int32) : String?
+    # Walk backwards to find an enclosing authenticate {} block
+    idx = route_line - 1
+    brace_depth = 0
+
+    while idx >= 0 && idx >= route_line - 30
+      current = lines[idx]
+      stripped = current.strip
+
+      # Check pattern BEFORE counting braces on this line
+      # brace_depth == 0 means no net block boundaries crossed → we're inside
+      AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, desc|
+        if stripped.matches?(pattern) && brace_depth == 0
+          auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
+          if auth_match
+            return "Ktor authenticate(\"#{auth_match[1]}\") block"
+          end
+          return "Ktor authenticate block"
+        end
+      end
+
+      brace_depth += current.count('}') - current.count('{')
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_route_auth(lines : Array(String), route_line : Int32) : String?
+    idx = route_line + 1
+    end_idx = [route_line + 15, lines.size - 1].min
+    brace_depth = 1 # Inside the route handler's opening {
+
+    while idx <= end_idx
+      current = lines[idx]
+      stripped = current.strip
+
+      ROUTE_AUTH_PATTERNS.each do |pattern, desc|
+        return desc if stripped.matches?(pattern)
+      end
+
+      brace_depth += current.count('{') - current.count('}')
+      break if brace_depth <= 0
+
+      idx += 1
+    end
+
+    nil
+  end
+
+  private def check_scope_auth(endpoint : Endpoint) : String?
+    url = endpoint.url
+    @auth_scopes.each do |scope|
+      return scope[:description] if url.starts_with?(scope[:prefix])
+    end
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/kotlin/ktor_auth.cr
+++ b/src/tagger/framework_taggers/kotlin/ktor_auth.cr
@@ -71,7 +71,7 @@ class KtorAuthTagger < FrameworkTagger
 
       # Detect authenticate block (only record if route prefix is known)
       if !current_prefix.empty?
-        AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, desc|
+        AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, _desc|
           if stripped.matches?(pattern)
             in_authenticate = true
             auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
@@ -129,7 +129,7 @@ class KtorAuthTagger < FrameworkTagger
 
       # Check pattern BEFORE counting braces on this line
       # brace_depth == 0 means no net block boundaries crossed → we're inside
-      AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, desc|
+      AUTHENTICATE_BLOCK_PATTERNS.each do |pattern, _desc|
         if stripped.matches?(pattern) && brace_depth == 0
           auth_match = stripped.match(/authenticate\s*\(\s*"([^"]+)"/)
           if auth_match

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -1,0 +1,183 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class PhpAuthTagger < FrameworkTagger
+  # Laravel middleware patterns
+  LARAVEL_ROUTE_MIDDLEWARE = [
+    {/->middleware\s*\(\s*['"]auth['"]/, "Laravel auth middleware"},
+    {/->middleware\s*\(\s*['"]auth:api['"]/, "Laravel auth:api middleware"},
+    {/->middleware\s*\(\s*['"]auth:sanctum['"]/, "Laravel Sanctum auth"},
+    {/->middleware\s*\(\s*['"]auth:web['"]/, "Laravel web auth"},
+    {/->middleware\s*\(\s*['"]verified['"]/, "Laravel verified middleware"},
+    {/->middleware\s*\(\s*\[.*['"]auth['"]/, "Laravel auth middleware"},
+  ]
+
+  # Laravel controller middleware
+  LARAVEL_CONTROLLER_MIDDLEWARE = [
+    {/\$this->middleware\s*\(\s*['"]auth['"]/, "Laravel controller auth middleware"},
+    {/\$this->middleware\s*\(\s*['"]auth:/, "Laravel controller auth middleware"},
+    {/\$this->authorizeResource\s*\(/, "Laravel authorizeResource"},
+  ]
+
+  # Laravel Gate/Policy checks in action body
+  LARAVEL_AUTH_CHECKS = [
+    {/Gate::allows\s*\(/, "Laravel Gate authorization"},
+    {/Gate::authorize\s*\(/, "Laravel Gate authorization"},
+    {/\$this->authorize\s*\(/, "Laravel Policy authorization"},
+    {/auth\(\)->check\(\)/, "Laravel auth check"},
+    {/Auth::check\(\)/, "Laravel Auth::check"},
+    {/\$request->user\(\)/, "Laravel request user check"},
+  ]
+
+  # Symfony security attributes/annotations
+  SYMFONY_PATTERNS = [
+    {/#\[IsGranted\s*\(/, "Symfony #[IsGranted]"},
+    {/#\[Security\s*\(/, "Symfony #[Security]"},
+    {/@Security\s*\(/, "Symfony @Security annotation"},
+    {/@IsGranted\s*\(/, "Symfony @IsGranted annotation"},
+    {/\$this->denyAccessUnlessGranted\s*\(/, "Symfony denyAccessUnlessGranted"},
+    {/\$this->isGranted\s*\(/, "Symfony isGranted check"},
+  ]
+
+  # CakePHP auth patterns
+  CAKEPHP_PATTERNS = [
+    {/\$this->Authentication->/, "CakePHP Authentication component"},
+    {/\$this->Authorization->authorize/, "CakePHP Authorization"},
+    {/\$this->loadComponent\s*\(\s*['"]Authentication['"]/, "CakePHP Authentication component"},
+  ]
+
+  # Generic PHP auth patterns
+  GENERIC_PATTERNS = [
+    {/session_start\s*\(\).*\$_SESSION\[['"]user/, "PHP session auth"},
+    {/\$_SERVER\[['"]PHP_AUTH_USER['"]/, "PHP HTTP Basic Auth"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "php_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["php_laravel", "php_symfony", "php_cakephp", "php_pure"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check route-level middleware (Laravel)
+      description = check_patterns_near_line(lines, line_idx, LARAVEL_ROUTE_MIDDLEWARE, 3)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "php_auth"))
+        return
+      end
+
+      # Check controller constructor middleware (walk back to find class)
+      description = check_controller_middleware(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "php_auth"))
+        return
+      end
+
+      # Check Symfony attributes/annotations above the method
+      description = check_annotations_above(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "php_auth"))
+        return
+      end
+
+      # Check method body for auth calls
+      description = check_method_body(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "php_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_patterns_near_line(lines : Array(String), line_idx : Int32,
+                                       patterns : Array(Tuple(Regex, String)),
+                                       window : Int32) : String?
+    start_idx = [line_idx - window, 0].max
+    end_idx = [line_idx + window, lines.size - 1].min
+
+    (start_idx..end_idx).each do |idx|
+      line = lines[idx]
+      patterns.each do |pattern, desc|
+        return desc if line.matches?(pattern)
+      end
+    end
+
+    nil
+  end
+
+  private def check_controller_middleware(lines : Array(String), action_line : Int32) : String?
+    # Walk backwards to find __construct or class-level middleware
+    idx = action_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      LARAVEL_CONTROLLER_MIDDLEWARE.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      break if current.starts_with?("class ")
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_annotations_above(lines : Array(String), method_line : Int32) : String?
+    idx = method_line - 1
+    while idx >= 0 && idx >= method_line - 8
+      current = lines[idx].strip
+      break if current.empty? && idx < method_line - 1
+
+      all_patterns = SYMFONY_PATTERNS
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_method_body(lines : Array(String), method_line : Int32) : String?
+    idx = method_line + 1
+    end_idx = [method_line + 15, lines.size - 1].min
+    brace_count = 0
+
+    while idx <= end_idx
+      current = lines[idx]
+      stripped = current.strip
+
+      brace_count += current.count('{') - current.count('}')
+      break if brace_count < 0
+
+      all_patterns = LARAVEL_AUTH_CHECKS + CAKEPHP_PATTERNS + GENERIC_PATTERNS
+      all_patterns.each do |pattern, desc|
+        return desc if stripped.matches?(pattern)
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -1,0 +1,153 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class DjangoAuthTagger < FrameworkTagger
+  DECORATOR_PATTERNS = [
+    /\@login_required/,
+    /\@permission_required\s*\(/,
+    /\@user_passes_test\s*\(/,
+    /\@staff_member_required/,
+  ]
+
+  MIXIN_PATTERNS = [
+    /LoginRequiredMixin/,
+    /PermissionRequiredMixin/,
+    /UserPassesTestMixin/,
+    /StaffMemberRequiredMixin/,
+  ]
+
+  DRF_PATTERNS = [
+    /permission_classes\s*=\s*\[.*IsAuthenticated/,
+    /permission_classes\s*=\s*\[.*IsAdminUser/,
+    /permission_classes\s*=\s*\[.*DjangoModelPermissions/,
+    /permission_classes\s*=\s*\(.*IsAuthenticated/,
+    /permission_classes\s*=\s*\(.*IsAdminUser/,
+    /permission_classes\s*=\s*\(.*DjangoModelPermissions/,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "django_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["python_django"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    contexts = read_source_context(endpoint, 30)
+    return if contexts.empty?
+
+    contexts.each do |ctx|
+      line = ctx.line
+      lines = ctx.full_content.split("\n")
+
+      if line
+        # Check decorators by walking backwards from endpoint line
+        description = check_decorators(lines, line)
+        if description
+          endpoint.add_tag(Tag.new("auth", description, "django_auth"))
+          return
+        end
+
+        # Check enclosing class for mixins
+        description = check_enclosing_class_mixins(lines, line)
+        if description
+          endpoint.add_tag(Tag.new("auth", description, "django_auth"))
+          return
+        end
+
+        # Check enclosing class for DRF permission_classes
+        description = check_enclosing_class_drf(lines, line)
+        if description
+          endpoint.add_tag(Tag.new("auth", description, "django_auth"))
+          return
+        end
+      end
+    end
+  end
+
+  private def check_decorators(lines : Array(String), endpoint_line : Int32) : String?
+    # Walk backwards from the line before the endpoint definition
+    idx = endpoint_line - 2 # 0-indexed, one line before
+    return nil if idx < 0
+
+    while idx >= 0
+      current = lines[idx].strip
+      # Stop at blank lines or other definitions
+      break if current.empty?
+      break if current.starts_with?("class ") || (current.starts_with?("def ") && idx < endpoint_line - 2)
+
+      DECORATOR_PATTERNS.each do |pattern|
+        if current.matches?(pattern)
+          decorator_name = current.split("(").first.lstrip('@')
+          return "Protected by Django #{decorator_name} decorator"
+        end
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_enclosing_class_mixins(lines : Array(String), endpoint_line : Int32) : String?
+    # Walk backwards from endpoint line to find the enclosing class definition
+    idx = endpoint_line - 1 # 0-indexed
+    while idx >= 0
+      current = lines[idx].lstrip
+      if current.starts_with?("class ") && current.includes?("(")
+        # Found the enclosing class — check for mixins
+        MIXIN_PATTERNS.each do |pattern|
+          if current.matches?(pattern)
+            mixin_name = pattern.source.gsub("\\", "")
+            return "Protected by Django #{mixin_name}"
+          end
+        end
+        # Found a class but no mixin — stop searching
+        return nil
+      end
+      # If we hit a top-level def (not indented), we're not in a class
+      if current.starts_with?("def ") && lines[idx] == lines[idx].lstrip
+        return nil
+      end
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_enclosing_class_drf(lines : Array(String), endpoint_line : Int32) : String?
+    # Walk backwards from endpoint line to find permission_classes in same class
+    idx = endpoint_line - 1 # 0-indexed
+    while idx >= 0
+      current = lines[idx].lstrip
+      # If we hit the class definition, stop
+      if current.starts_with?("class ")
+        return nil
+      end
+      # If we hit a top-level def (not indented), we're not in a class
+      if current.starts_with?("def ") && lines[idx] == lines[idx].lstrip
+        return nil
+      end
+
+      DRF_PATTERNS.each do |pattern|
+        if current.matches?(pattern)
+          return "Protected by DRF permission_classes"
+        end
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -78,7 +78,7 @@ class DjangoAuthTagger < FrameworkTagger
   private def check_decorators(lines : Array(String), endpoint_line : Int32) : String?
     # Walk backwards from the line before the endpoint definition
     idx = endpoint_line - 2 # 0-indexed, one line before
-    return nil if idx < 0
+    return if idx < 0
 
     while idx >= 0
       current = lines[idx].strip
@@ -113,11 +113,11 @@ class DjangoAuthTagger < FrameworkTagger
           end
         end
         # Found a class but no mixin — stop searching
-        return nil
+        return
       end
       # If we hit a top-level def (not indented), we're not in a class
       if current.starts_with?("def ") && lines[idx] == lines[idx].lstrip
-        return nil
+        return
       end
       idx -= 1
     end
@@ -132,11 +132,11 @@ class DjangoAuthTagger < FrameworkTagger
       current = lines[idx].lstrip
       # If we hit the class definition, stop
       if current.starts_with?("class ")
-        return nil
+        return
       end
       # If we hit a top-level def (not indented), we're not in a class
       if current.starts_with?("def ") && lines[idx] == lines[idx].lstrip
-        return nil
+        return
       end
 
       DRF_PATTERNS.each do |pattern|

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -76,7 +76,8 @@ class DjangoAuthTagger < FrameworkTagger
   end
 
   private def check_decorators(lines : Array(String), endpoint_line : Int32) : String?
-    # Walk backwards from the line before the endpoint definition
+    # Walk backwards with no fixed limit — Python decorators stack directly above the def,
+    # separated only by other decorators, so we stop at the first blank line or definition.
     idx = endpoint_line - 2 # 0-indexed, one line before
     return if idx < 0
 

--- a/src/tagger/framework_taggers/python/django_auth.cr
+++ b/src/tagger/framework_taggers/python/django_auth.cr
@@ -43,7 +43,7 @@ class DjangoAuthTagger < FrameworkTagger
   end
 
   private def check_endpoint(endpoint : Endpoint)
-    contexts = read_source_context(endpoint, 30)
+    contexts = read_source_context(endpoint)
     return if contexts.empty?
 
     contexts.each do |ctx|

--- a/src/tagger/framework_taggers/python/fastapi_auth.cr
+++ b/src/tagger/framework_taggers/python/fastapi_auth.cr
@@ -1,0 +1,89 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class FastAPIAuthTagger < FrameworkTagger
+  # Depends() with auth-related callables
+  DEPENDS_AUTH_PATTERNS = [
+    {/Depends\s*\(\s*get_current_user/, "FastAPI Depends(get_current_user)"},
+    {/Depends\s*\(\s*get_current_active_user/, "FastAPI Depends(get_current_active_user)"},
+    {/Depends\s*\(\s*oauth2_scheme/, "FastAPI OAuth2 dependency"},
+    {/Depends\s*\(\s*get_token/, "FastAPI token dependency"},
+    {/Depends\s*\(\s*verify_token/, "FastAPI token verification"},
+    {/Depends\s*\(\s*auth/, "FastAPI auth dependency"},
+    {/Depends\s*\(\s*require_auth/, "FastAPI require_auth dependency"},
+    {/Depends\s*\(\s*check_permission/, "FastAPI permission check"},
+    {/Depends\s*\(\s*RoleChecker/, "FastAPI role checker"},
+  ]
+
+  # Security() declarations
+  SECURITY_PATTERNS = [
+    {/Security\s*\(\s*oauth2_scheme/, "FastAPI Security(oauth2_scheme)"},
+    {/Security\s*\(\s*api_key/, "FastAPI Security(api_key)"},
+    {/Security\s*\(\s*http_bearer/, "FastAPI Security(http_bearer)"},
+    {/Security\s*\(\s*http_basic/, "FastAPI Security(http_basic)"},
+  ]
+
+  # Auth-related parameter type annotations
+  AUTH_PARAM_PATTERNS = [
+    {/:\s*User\s*=\s*Depends/, "FastAPI User dependency injection"},
+    {/:\s*TokenData\s*=\s*Depends/, "FastAPI TokenData dependency"},
+    {/:\s*HTTPAuthorizationCredentials\s*=\s*Security/, "FastAPI HTTP authorization"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "fastapi_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["python_fastapi"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+
+      # Check function signature and decorator for Depends/Security
+      # Use tight window to avoid matching adjacent functions
+      start_idx = [line_num - 2, 0].max
+      end_idx = [line_num + 2, lines.size - 1].min
+
+      (start_idx..end_idx).each do |idx|
+        line = lines[idx]
+
+        DEPENDS_AUTH_PATTERNS.each do |pattern, desc|
+          if line.matches?(pattern)
+            endpoint.add_tag(Tag.new("auth", "Protected by #{desc}", "fastapi_auth"))
+            return
+          end
+        end
+
+        SECURITY_PATTERNS.each do |pattern, desc|
+          if line.matches?(pattern)
+            endpoint.add_tag(Tag.new("auth", "Protected by #{desc}", "fastapi_auth"))
+            return
+          end
+        end
+
+        AUTH_PARAM_PATTERNS.each do |pattern, desc|
+          if line.matches?(pattern)
+            endpoint.add_tag(Tag.new("auth", "Protected by #{desc}", "fastapi_auth"))
+            return
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/tagger/framework_taggers/python/fastapi_auth.cr
+++ b/src/tagger/framework_taggers/python/fastapi_auth.cr
@@ -56,7 +56,8 @@ class FastAPIAuthTagger < FrameworkTagger
       next if line_num.nil?
 
       # Check function signature and decorator for Depends/Security
-      # Use tight window to avoid matching adjacent functions
+      # ±2 line window: FastAPI auth deps are in the function signature or @app decorator,
+      # kept tight to avoid matching patterns from adjacent route handlers
       start_idx = [line_num - 2, 0].max
       end_idx = [line_num + 2, lines.size - 1].min
 

--- a/src/tagger/framework_taggers/python/flask_auth.cr
+++ b/src/tagger/framework_taggers/python/flask_auth.cr
@@ -1,0 +1,62 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class FlaskAuthTagger < FrameworkTagger
+  DECORATOR_PATTERNS = [
+    {/\@login_required/, "flask-login login_required"},
+    {/\@roles_required\s*\(/, "flask-security roles_required"},
+    {/\@roles_accepted\s*\(/, "flask-security roles_accepted"},
+    {/\@jwt_required\s*\(/, "flask-jwt-extended jwt_required"},
+    {/\@jwt_optional\s*\(/, "flask-jwt-extended jwt_optional"},
+    {/\@fresh_jwt_required\s*\(/, "flask-jwt-extended fresh_jwt_required"},
+    {/\@auth\.login_required/, "flask-httpauth login_required"},
+    {/\@auth\.verify_password/, "flask-httpauth verify_password"},
+    {/\@token_auth\.login_required/, "flask-httpauth token_auth"},
+    {/\@multi_auth\.login_required/, "flask-httpauth multi_auth"},
+    {/\@requires_auth/, "requires_auth"},
+    {/\@authenticated/, "authenticated"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "flask_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["python_flask"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+
+      # Walk backwards from function definition to find decorators
+      idx = line_num - 2 # 0-indexed, one line before
+      while idx >= 0 && idx >= line_num - 10
+        current = lines[idx].strip
+        break if current.empty? && idx < line_num - 2
+
+        DECORATOR_PATTERNS.each do |pattern, desc|
+          if current.matches?(pattern)
+            endpoint.add_tag(Tag.new("auth", "Protected by #{desc}", "flask_auth"))
+            return
+          end
+        end
+
+        idx -= 1
+      end
+    end
+  end
+end

--- a/src/tagger/framework_taggers/python/flask_auth.cr
+++ b/src/tagger/framework_taggers/python/flask_auth.cr
@@ -43,6 +43,7 @@ class FlaskAuthTagger < FrameworkTagger
       next if line_num.nil?
 
       # Walk backwards from function definition to find decorators
+      # 8-line window: Flask decorators stack above def, typically 1-5 decorators
       idx = line_num - 2 # 0-indexed, one line before
       while idx >= 0 && idx >= line_num - 10
         current = lines[idx].strip

--- a/src/tagger/framework_taggers/python/python_misc_auth.cr
+++ b/src/tagger/framework_taggers/python/python_misc_auth.cr
@@ -1,0 +1,106 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class PythonMiscAuthTagger < FrameworkTagger
+  # Sanic auth patterns
+  SANIC_PATTERNS = [
+    {/\@authorized\s*\(/, "Sanic @authorized decorator"},
+    {/\@protected\s*\(/, "Sanic @protected decorator"},
+    {/\@scoped\s*\(/, "Sanic @scoped decorator"},
+    {/sanic_jwt/, "Sanic JWT"},
+    {/\@auth\.login_required/, "Sanic auth login_required"},
+  ]
+
+  # Tornado auth patterns
+  TORNADO_PATTERNS = [
+    {/\@tornado\.web\.authenticated/, "Tornado @authenticated decorator"},
+    {/\@authenticated/, "Tornado @authenticated"},
+    {/get_current_user\s*\(/, "Tornado get_current_user"},
+    {/current_user/, "Tornado current_user check"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "python_misc_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["python_sanic", "python_tornado"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check decorators above function/method
+      description = check_decorators(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "python_misc_auth"))
+        return
+      end
+
+      # Check class for Tornado auth mixin/method
+      description = check_class_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "python_misc_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_decorators(lines : Array(String), func_line : Int32) : String?
+    idx = func_line - 1
+    while idx >= 0 && idx >= func_line - 5
+      current = lines[idx].strip
+      break if current.empty? && idx < func_line - 1
+
+      all_patterns = SANIC_PATTERNS + TORNADO_PATTERNS
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+
+      idx -= 1
+    end
+    nil
+  end
+
+  private def check_class_auth(lines : Array(String), method_line : Int32) : String?
+    # Walk backwards to find class definition with Tornado's get_current_user override
+    idx = method_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      if current.starts_with?("class ")
+        # Found class — scan class body for get_current_user
+        scan_idx = idx + 1
+        while scan_idx < lines.size && scan_idx < idx + 30
+          scan_line = lines[scan_idx].strip
+          break if scan_line.starts_with?("class ")
+
+          if scan_line.includes?("def get_current_user")
+            return "Tornado get_current_user override"
+          end
+
+          scan_idx += 1
+        end
+        break
+      end
+
+      idx -= 1
+    end
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -97,7 +97,6 @@ class RubyAuthTagger < FrameworkTagger
     # Walk backwards to find the controller class and before_action declarations
     idx = action_line
     action_name = extract_action_name(lines, action_line)
-    found_class = false
 
     while idx >= 0
       current = lines[idx].strip
@@ -108,10 +107,10 @@ class RubyAuthTagger < FrameworkTagger
           # Check if it applies to this specific action via only: []
           if current.includes?("only:")
             if action_name && current.includes?(":#{action_name}")
-              return nil # Explicitly skipped
+              return # Explicitly skipped
             end
           else
-            return nil # Broadly skipped
+            return # Broadly skipped
           end
         end
       end
@@ -142,10 +141,7 @@ class RubyAuthTagger < FrameworkTagger
         end
       end
 
-      if current.starts_with?("class ")
-        found_class = true
-        break
-      end
+      break if current.starts_with?("class ")
 
       idx -= 1
     end
@@ -193,7 +189,7 @@ class RubyAuthTagger < FrameworkTagger
   end
 
   private def extract_action_name(lines : Array(String), line_idx : Int32) : String?
-    return nil if line_idx < 0 || line_idx >= lines.size
+    return if line_idx < 0 || line_idx >= lines.size
     line = lines[line_idx].strip
     match = line.match(/def\s+(\w+)/)
     match ? match[1] : nil

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -1,0 +1,201 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class RubyAuthTagger < FrameworkTagger
+  # Rails before_action patterns
+  BEFORE_ACTION_PATTERNS = [
+    {/before_action\s+:authenticate_user!/, "Devise authenticate_user!"},
+    {/before_action\s+:authenticate_/, "Devise authentication"},
+    {/before_action\s+:require_login/, "require_login"},
+    {/before_action\s+:require_authentication/, "require_authentication"},
+    {/before_action\s+:authorize/, "authorize"},
+    {/before_action\s+:check_auth/, "check_auth"},
+    {/before_action\s+:verify_authenticity_token/, "CSRF verify_authenticity_token"},
+    {/before_action\s+:doorkeeper_authorize!/, "Doorkeeper OAuth authorize"},
+    {/before_action\s+:authenticate_with_token/, "token authentication"},
+  ]
+
+  # Pundit / CanCanCan authorization in action body
+  ACTION_AUTH_PATTERNS = [
+    {/authorize\s+@?\w+/, "Pundit authorize"},
+    {/authorize!\s*/, "CanCanCan authorize!"},
+    {/load_and_authorize_resource/, "CanCanCan load_and_authorize_resource"},
+  ]
+
+  # Sinatra/Rack patterns
+  SINATRA_AUTH_PATTERNS = [
+    {/before\s+do.*auth/, "Sinatra before filter auth"},
+    {/use\s+Rack::Auth/, "Rack::Auth middleware"},
+    {/use\s+Warden/, "Warden middleware"},
+    {/env\['warden'\]\.authenticate/, "Warden authenticate"},
+    {/protected!/, "protected! helper"},
+    {/halt\s+401/, "401 halt guard"},
+  ]
+
+  # Hanami patterns
+  HANAMI_AUTH_PATTERNS = [
+    {/before\s+:authenticate/, "Hanami authenticate"},
+    {/before\s+:authorize/, "Hanami authorize"},
+  ]
+
+  # skip_before_action marks public overrides
+  SKIP_PATTERNS = [
+    /skip_before_action\s+:authenticate/,
+    /skip_before_action\s+:require_login/,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "ruby_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["ruby_rails", "ruby_sinatra", "ruby_hanami"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # For Rails: find enclosing class, check before_action
+      description = check_controller_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ruby_auth"))
+        return
+      end
+
+      # Check action body for authorization calls
+      description = check_action_body_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ruby_auth"))
+        return
+      end
+
+      # Check Sinatra/Rack patterns in context
+      description = check_sinatra_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ruby_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_controller_auth(lines : Array(String), action_line : Int32) : String?
+    # Walk backwards to find the controller class and before_action declarations
+    idx = action_line
+    action_name = extract_action_name(lines, action_line)
+    found_class = false
+
+    while idx >= 0
+      current = lines[idx].strip
+
+      # Check for skip_before_action that applies to this action
+      SKIP_PATTERNS.each do |pattern|
+        if current.matches?(pattern)
+          # Check if it applies to this specific action via only: []
+          if current.includes?("only:")
+            if action_name && current.includes?(":#{action_name}")
+              return nil # Explicitly skipped
+            end
+          else
+            return nil # Broadly skipped
+          end
+        end
+      end
+
+      # Check for before_action with auth
+      BEFORE_ACTION_PATTERNS.each do |pattern, desc|
+        if current.matches?(pattern)
+          # Check if it has only: restriction
+          if current.includes?("only:")
+            if action_name && current.includes?(":#{action_name}")
+              return desc
+            end
+          elsif current.includes?("except:")
+            if action_name && current.includes?(":#{action_name}")
+              next # Excluded
+            end
+            return desc
+          else
+            return desc # Applies to all actions
+          end
+        end
+      end
+
+      # Check Hanami patterns
+      HANAMI_AUTH_PATTERNS.each do |pattern, desc|
+        if current.matches?(pattern)
+          return desc
+        end
+      end
+
+      if current.starts_with?("class ")
+        found_class = true
+        break
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_action_body_auth(lines : Array(String), action_line : Int32) : String?
+    # Scan forward from the action definition for auth calls
+    idx = action_line + 1
+    end_idx = [action_line + 20, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx].strip
+      # Stop at next method definition
+      break if current.starts_with?("def ") && idx > action_line
+
+      ACTION_AUTH_PATTERNS.each do |pattern, desc|
+        if current.matches?(pattern)
+          return desc
+        end
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+
+  private def check_sinatra_auth(lines : Array(String), route_line : Int32) : String?
+    # Check surrounding context for Sinatra auth patterns
+    start_idx = [route_line - 15, 0].max
+
+    (start_idx...route_line).each do |idx|
+      current = lines[idx].strip
+
+      SINATRA_AUTH_PATTERNS.each do |pattern, desc|
+        if current.matches?(pattern)
+          return desc
+        end
+      end
+    end
+
+    nil
+  end
+
+  private def extract_action_name(lines : Array(String), line_idx : Int32) : String?
+    return nil if line_idx < 0 || line_idx >= lines.size
+    line = lines[line_idx].strip
+    match = line.match(/def\s+(\w+)/)
+    match ? match[1] : nil
+  end
+end

--- a/src/tagger/framework_taggers/rust/rust_auth.cr
+++ b/src/tagger/framework_taggers/rust/rust_auth.cr
@@ -117,8 +117,8 @@ class RustAuthTagger < FrameworkTagger
         # If no scope found, skip — don't default to "/" (global)
       end
 
-      # Reset scope context on closing parenthesis/brace
-      if stripped == ")" || stripped == ");" || stripped == "}"
+      # Reset scope context on closing parenthesis/brace that ends a scope block
+      if stripped == ")" || stripped == ");" || stripped == "})" || stripped == "});"
         current_scope = nil
       end
     end
@@ -191,7 +191,12 @@ class RustAuthTagger < FrameworkTagger
     idx = route_line_idx - 1
     while idx >= 0 && idx >= route_line_idx - 5
       current = lines[idx].strip
-      break if current.empty? && idx < route_line_idx - 1
+      # Skip empty lines; stop at non-attribute code boundaries
+      if current.empty?
+        idx -= 1
+        next
+      end
+      break unless current.starts_with?("#[") || current.starts_with?("//")
 
       GUARD_ATTRIBUTE_PATTERNS.each do |pattern|
         match = current.match(pattern)

--- a/src/tagger/framework_taggers/rust/rust_auth.cr
+++ b/src/tagger/framework_taggers/rust/rust_auth.cr
@@ -1,0 +1,287 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class RustAuthTagger < FrameworkTagger
+  # Actix-Web auth middleware/extractor patterns
+  ACTIX_AUTH_PATTERNS = [
+    /HttpAuthentication/,
+    /BearerAuth/,
+    /BasicAuth/,
+    /Identity/,
+  ]
+
+  # Rocket request guard types (in function signatures)
+  GUARD_TYPE_PATTERNS = [
+    /\b(?:Auth|Authenticated|AuthGuard|AuthUser|AuthToken)\b/,
+    /\b(?:ApiKey|ApiToken|BearerToken|AccessToken)\b/,
+    /\b(?:Claims|JwtClaims|TokenClaims|JwtToken)\b/,
+    /\b(?:AdminUser|AdminGuard|Admin)\b/,
+    /\b(?:UserGuard|UserToken|CurrentUser|LoggedInUser)\b/,
+    /\b(?:Session|SessionUser|CookieAuth)\b/,
+    /\b(?:RoleGuard|Permission|Authorized)\b/,
+  ]
+
+  # Axum extractor patterns
+  AXUM_EXTRACTOR_PATTERNS = [
+    /Extension<.*(?:Auth|Claims|Token|User|Session).*>/,
+    /TypedHeader<.*(?:Authorization|Bearer).*>/,
+  ]
+
+  # Middleware layer patterns (in Router/App setup)
+  MIDDLEWARE_LAYER_PATTERNS = [
+    /\.wrap\s*\(\s*(\w*[Aa]uth\w*)/,
+    /\.wrap\s*\(\s*HttpAuthentication/,
+    /\.layer\s*\(\s*(\w*[Aa]uth\w*)/,
+    /\.layer\s*\(\s*middleware::from_fn\s*\(\s*(\w*auth\w*)/i,
+  ]
+
+  # Guard/middleware attribute patterns
+  GUARD_ATTRIBUTE_PATTERNS = [
+    /#\[guard\s*=\s*"(\w+)"\]/,
+    /#\[.*guard.*\]/i,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "rust_auth"
+    @middleware_scopes = [] of {prefix: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    [
+      "rust_axum", "rust_rocket", "rust_actix_web",
+      "rust_loco", "rust_rwf", "rust_tide",
+      "rust_warp", "rust_gotham",
+    ]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # Phase 1: Pre-scan for service/scope-level middleware
+    pre_scan_middleware_scopes
+
+    # Phase 2: Check each endpoint
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+
+    endpoints
+  end
+
+  private def pre_scan_middleware_scopes
+    @middleware_scopes.clear
+
+    files = get_files_by_prefix_and_extension(@base_path, ".rs")
+    files.each do |file|
+      content = read_file(file)
+      next if content.nil?
+
+      scan_scope_middleware(content)
+    end
+  end
+
+  private def scan_scope_middleware(content : String)
+    lines = content.split("\n")
+    current_scope : String? = nil
+
+    lines.each_with_index do |line, idx|
+      stripped = line.strip
+
+      # Track current scope context
+      scope_match = stripped.match(/web::(?:scope|resource)\s*\(\s*"([^"]*)"/)
+      if scope_match
+        current_scope = scope_match[1]
+      end
+
+      # Check if this line has auth middleware
+      has_auth = false
+      middleware_name = "auth"
+
+      MIDDLEWARE_LAYER_PATTERNS.each do |pattern|
+        match = stripped.match(pattern)
+        if match
+          has_auth = true
+          middleware_name = match[1]? || "auth"
+          break
+        end
+      end
+
+      if has_auth
+        # Determine scope: check current line, then walk back to find scope
+        prefix = find_scope_for_line(lines, idx, current_scope)
+        if prefix
+          @middleware_scopes << {
+            prefix:      prefix,
+            description: "Protected by Rust #{middleware_name} middleware on #{prefix}",
+          }
+        end
+        # If no scope found, skip — don't default to "/" (global)
+      end
+
+      # Reset scope context on closing parenthesis/brace
+      if stripped == ")" || stripped == ");" || stripped == "}"
+        current_scope = nil
+      end
+    end
+  end
+
+  private def find_scope_for_line(lines : Array(String), line_idx : Int32, current_scope : String?) : String?
+    # Use tracked scope if available
+    return current_scope if current_scope
+
+    # Walk backwards to find a scope/route definition
+    idx = line_idx - 1
+    while idx >= 0 && idx >= line_idx - 10
+      prev = lines[idx].strip
+
+      scope_match = prev.match(/web::(?:scope|resource)\s*\(\s*"([^"]*)"/)
+      return scope_match[1] if scope_match
+
+      route_match = prev.match(/\.route\s*\(\s*"([^"]*)"/)
+      return route_match[1] if route_match
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+
+      line_idx = line_num - 1 # 0-indexed
+      next if line_idx < 0 || line_idx >= lines.size
+
+      # Check for guard attributes above the route
+      description = check_guard_attributes(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", description, "rust_auth"))
+        return
+      end
+
+      # Check function signature for auth guard types/extractors
+      description = check_function_signature(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", description, "rust_auth"))
+        return
+      end
+
+      # Check for actix-web auth extractors in function body
+      description = check_actix_extractors(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", description, "rust_auth"))
+        return
+      end
+    end
+
+    # Check scope-level middleware
+    description = check_middleware_scopes(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "rust_auth"))
+    end
+  end
+
+  private def check_guard_attributes(lines : Array(String), route_line_idx : Int32) : String?
+    # Walk backwards from route attribute to find guard attributes
+    idx = route_line_idx - 1
+    while idx >= 0 && idx >= route_line_idx - 5
+      current = lines[idx].strip
+      break if current.empty? && idx < route_line_idx - 1
+
+      GUARD_ATTRIBUTE_PATTERNS.each do |pattern|
+        match = current.match(pattern)
+        if match
+          guard_name = match[1]? || "guard"
+          return "Protected by Rust #[guard] attribute (#{guard_name})"
+        end
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_function_signature(lines : Array(String), route_line_idx : Int32) : String?
+    # Look at lines after the route attribute for the function signature
+    # Route attributes like #[get("/path")] are followed by fn handler(...)
+    idx = route_line_idx
+    end_idx = [route_line_idx + 5, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx]
+
+      # Check for auth-related types in function parameters
+      if current.includes?("fn ") || current.includes?("async fn ")
+        # Gather the full function signature (may span multiple lines)
+        sig_lines = [current]
+        sig_idx = idx + 1
+        while sig_idx < lines.size && !current.includes?("{") && !current.includes?("->")
+          sig_lines << lines[sig_idx]
+          current = lines[sig_idx]
+          sig_idx += 1
+        end
+        signature = sig_lines.join(" ")
+
+        GUARD_TYPE_PATTERNS.each do |pattern|
+          if signature.matches?(pattern)
+            match = signature.match(pattern)
+            guard_type = match ? match[0] : "Auth"
+            return "Protected by Rust #{guard_type} request guard"
+          end
+        end
+
+        AXUM_EXTRACTOR_PATTERNS.each do |pattern|
+          if signature.matches?(pattern)
+            return "Protected by Rust auth extractor"
+          end
+        end
+
+        break
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+
+  private def check_actix_extractors(lines : Array(String), route_line_idx : Int32) : String?
+    # Check function signature and body for actix-web auth types
+    idx = route_line_idx
+    end_idx = [route_line_idx + 3, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx]
+
+      ACTIX_AUTH_PATTERNS.each do |pattern|
+        if current.matches?(pattern)
+          match = current.match(pattern)
+          auth_type = match ? match[0] : "auth"
+          return "Protected by Actix-Web #{auth_type}"
+        end
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+
+  private def check_middleware_scopes(endpoint : Endpoint) : String?
+    url = endpoint.url
+
+    @middleware_scopes.each do |scope|
+      if url.starts_with?(scope[:prefix])
+        return scope[:description]
+      end
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/rust/rust_auth.cr
+++ b/src/tagger/framework_taggers/rust/rust_auth.cr
@@ -81,15 +81,16 @@ class RustAuthTagger < FrameworkTagger
 
   private def scan_scope_middleware(content : String)
     lines = content.split("\n")
-    current_scope : String? = nil
+    # Stack-based scope tracking for nested Actix-Web scopes
+    scope_stack = [] of String
 
     lines.each_with_index do |line, idx|
       stripped = line.strip
 
-      # Track current scope context
+      # Track scope nesting
       scope_match = stripped.match(/web::(?:scope|resource)\s*\(\s*"([^"]*)"/)
       if scope_match
-        current_scope = scope_match[1]
+        scope_stack << scope_match[1]
       end
 
       # Check if this line has auth middleware
@@ -106,7 +107,8 @@ class RustAuthTagger < FrameworkTagger
       end
 
       if has_auth
-        # Determine scope: check current line, then walk back to find scope
+        # Determine scope: use stack or walk back to find scope
+        current_scope = scope_stack.empty? ? nil : normalize_scope(scope_stack)
         prefix = find_scope_for_line(lines, idx, current_scope)
         if prefix
           @middleware_scopes << {
@@ -114,14 +116,19 @@ class RustAuthTagger < FrameworkTagger
             description: "Protected by Rust #{middleware_name} middleware on #{prefix}",
           }
         end
-        # If no scope found, skip — don't default to "/" (global)
       end
 
-      # Reset scope context on closing parenthesis/brace that ends a scope block
+      # Pop scope on closing parenthesis/brace that ends a scope block
       if stripped == ")" || stripped == ");" || stripped == "})" || stripped == "});"
-        current_scope = nil
+        scope_stack.pop unless scope_stack.empty?
       end
     end
+  end
+
+  private def normalize_scope(segments : Array(String)) : String
+    joined = segments.join("")
+    parts = joined.split("/").reject(&.empty?)
+    parts.empty? ? "/" : "/" + parts.join("/")
   end
 
   private def find_scope_for_line(lines : Array(String), line_idx : Int32, current_scope : String?) : String?

--- a/src/tagger/framework_taggers/scala/scala_auth.cr
+++ b/src/tagger/framework_taggers/scala/scala_auth.cr
@@ -1,0 +1,113 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class ScalaAuthTagger < FrameworkTagger
+  # Play Framework auth patterns
+  PLAY_AUTH_PATTERNS = [
+    {/Authenticated\s*[\{\(]/, "Play Authenticated action"},
+    {/AuthenticatedAction/, "Play AuthenticatedAction"},
+    {/WithAuthentication/, "Play WithAuthentication"},
+    {/Security\.Authenticated/, "Play Security.Authenticated"},
+    {/deadbolt/, "Play Deadbolt authorization"},
+    {/SubjectPresent/, "Play Deadbolt SubjectPresent"},
+    {/Restrict\s*\(/, "Play Deadbolt Restrict"},
+    {/Dynamic\s*\(/, "Play Deadbolt Dynamic"},
+    {/silhouette\.\w+\.SecuredAction/, "Play Silhouette SecuredAction"},
+    {/silhouette\.\w+\.UserAwareAction/, "Play Silhouette UserAwareAction"},
+  ]
+
+  # Akka HTTP auth directives
+  AKKA_AUTH_PATTERNS = [
+    {/authenticateBasic\s*\(/, "Akka HTTP authenticateBasic"},
+    {/authenticateOAuth2\s*\(/, "Akka HTTP authenticateOAuth2"},
+    {/authorize\s*\(/, "Akka HTTP authorize directive"},
+    {/authenticateOrRejectWithChallenge/, "Akka HTTP authenticateOrRejectWithChallenge"},
+    {/extractCredentials/, "Akka HTTP extractCredentials"},
+  ]
+
+  # Scalatra auth patterns
+  SCALATRA_AUTH_PATTERNS = [
+    {/basicAuth\s*\{/, "Scalatra basicAuth"},
+    {/scentry/, "Scalatra Scentry auth"},
+    {/isAuthenticated/, "Scalatra isAuthenticated check"},
+    {/userOption/, "Scalatra userOption check"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "scala_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["scala_play", "scala_akka", "scala_scalatra", "java_play"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check route definition and surrounding context
+      description = check_auth_patterns(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "scala_auth"))
+        return
+      end
+
+      # Check enclosing scope for auth directives (Akka)
+      description = check_enclosing_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "scala_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_auth_patterns(lines : Array(String), line_idx : Int32) : String?
+    start_idx = [line_idx - 5, 0].max
+    end_idx = [line_idx + 10, lines.size - 1].min
+
+    all_patterns = PLAY_AUTH_PATTERNS + SCALATRA_AUTH_PATTERNS
+    (start_idx..end_idx).each do |idx|
+      current = lines[idx]
+      all_patterns.each do |pattern, desc|
+        return desc if current.matches?(pattern)
+      end
+    end
+
+    nil
+  end
+
+  private def check_enclosing_auth(lines : Array(String), line_idx : Int32) : String?
+    # Walk backwards for Akka HTTP auth directives wrapping this route
+    idx = line_idx - 1
+    brace_depth = 0
+
+    while idx >= 0 && idx >= line_idx - 20
+      current = lines[idx]
+      stripped = current.strip
+
+      brace_depth += current.count('}') - current.count('{')
+
+      AKKA_AUTH_PATTERNS.each do |pattern, desc|
+        return desc if stripped.matches?(pattern) && brace_depth <= 0
+      end
+
+      idx -= 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/swift/swift_auth.cr
+++ b/src/tagger/framework_taggers/swift/swift_auth.cr
@@ -77,13 +77,13 @@ class SwiftAuthTagger < FrameworkTagger
   end
 
   private def check_middleware_group(lines : Array(String), route_line : Int32) : String?
-    return nil if route_line < 0 || route_line >= lines.size
+    return if route_line < 0 || route_line >= lines.size
 
     route_line_text = lines[route_line].strip
 
     # Extract the receiver variable from the route line (e.g., "protected" from "protected.get(...)")
     receiver_match = route_line_text.match(/^(\w+)\.(get|post|put|delete|patch|group)/)
-    return nil unless receiver_match
+    return unless receiver_match
     receiver = receiver_match[1]
 
     # Walk backwards to find if this receiver was assigned from .grouped(AuthMiddleware)

--- a/src/tagger/framework_taggers/swift/swift_auth.cr
+++ b/src/tagger/framework_taggers/swift/swift_auth.cr
@@ -1,0 +1,136 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class SwiftAuthTagger < FrameworkTagger
+  # Vapor middleware patterns
+  VAPOR_MIDDLEWARE_PATTERNS = [
+    {/\.grouped\s*\(\s*\w*[Aa]uth\w*/, "Vapor auth middleware group"},
+    {/\.grouped\s*\(\s*User\.authenticator\(\)/, "Vapor User.authenticator()"},
+    {/\.grouped\s*\(\s*Token\.authenticator\(\)/, "Vapor Token.authenticator()"},
+    {/\.grouped\s*\(\s*User\.guardMiddleware\(\)/, "Vapor User.guardMiddleware()"},
+    {/\.grouped\s*\(\s*\w+\.guardMiddleware\(\)/, "Vapor guardMiddleware"},
+    {/\.grouped\s*\(\s*BearerAuthenticator/, "Vapor BearerAuthenticator"},
+    {/\.grouped\s*\(\s*BasicAuthenticator/, "Vapor BasicAuthenticator"},
+    {/\.grouped\s*\(\s*SessionAuthenticator/, "Vapor SessionAuthenticator"},
+  ]
+
+  # Auth requirement in route handler
+  HANDLER_AUTH_PATTERNS = [
+    {/req\.auth\.require\s*\(/, "Vapor req.auth.require"},
+    {/request\.auth\.require\s*\(/, "Vapor request.auth.require"},
+    {/req\.auth\.get\s*\(/, "Vapor req.auth.get"},
+    {/guard.*req\.auth/, "Vapor auth guard"},
+  ]
+
+  # Kitura patterns
+  KITURA_AUTH_PATTERNS = [
+    {/Credentials/, "Kitura Credentials middleware"},
+    {/TypeSafeMiddleware/, "Kitura TypeSafeMiddleware"},
+  ]
+
+  # Hummingbird patterns
+  HUMMINGBIRD_AUTH_PATTERNS = [
+    {/\.add\s*\(\s*middleware:\s*\w*[Aa]uth\w*/, "Hummingbird auth middleware"},
+    {/HBAuthenticator/, "Hummingbird HBAuthenticator"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "swift_auth"
+  end
+
+  def self.target_techs : Array(String)
+    ["swift_vapor", "swift_kitura", "swift_hummingbird"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check for auth middleware group wrapping this route
+      description = check_middleware_group(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "swift_auth"))
+        return
+      end
+
+      # Check route handler body for auth requirements
+      description = check_handler_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "swift_auth"))
+        return
+      end
+    end
+  end
+
+  private def check_middleware_group(lines : Array(String), route_line : Int32) : String?
+    return nil if route_line < 0 || route_line >= lines.size
+
+    route_line_text = lines[route_line].strip
+
+    # Extract the receiver variable from the route line (e.g., "protected" from "protected.get(...)")
+    receiver_match = route_line_text.match(/^(\w+)\.(get|post|put|delete|patch|group)/)
+    return nil unless receiver_match
+    receiver = receiver_match[1]
+
+    # Walk backwards to find if this receiver was assigned from .grouped(AuthMiddleware)
+    idx = route_line - 1
+    while idx >= 0 && idx >= route_line - 20
+      current = lines[idx]
+      stripped = current.strip
+
+      # Check if this line assigns the receiver variable from a .grouped() call
+      # e.g., "let protected = app.grouped(UserAuthenticator())" — receiver must be "protected"
+      assign_match = stripped.match(/(?:let|var)\s+(\w+)\s*=\s*\w+\.grouped\s*\(/)
+      if assign_match && assign_match[1] == receiver
+        all_patterns = VAPOR_MIDDLEWARE_PATTERNS + KITURA_AUTH_PATTERNS + HUMMINGBIRD_AUTH_PATTERNS
+        all_patterns.each do |pattern, desc|
+          return desc if stripped.matches?(pattern)
+        end
+      end
+
+      # Stop at function/class definition
+      break if stripped.starts_with?("func ") || stripped.starts_with?("class ") || stripped.starts_with?("struct ")
+
+      idx -= 1
+    end
+
+    nil
+  end
+
+  private def check_handler_auth(lines : Array(String), route_line : Int32) : String?
+    idx = route_line + 1
+    end_idx = [route_line + 15, lines.size - 1].min
+    brace_depth = 1 # We start inside the route closure's opening {
+
+    while idx <= end_idx
+      current = lines[idx]
+      stripped = current.strip
+
+      HANDLER_AUTH_PATTERNS.each do |pattern, desc|
+        return desc if stripped.matches?(pattern)
+      end
+
+      # Track braces to stop at end of this route's closure
+      brace_depth += current.count('{') - current.count('}')
+      break if brace_depth <= 0
+
+      idx += 1
+    end
+
+    nil
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -73,6 +73,76 @@ module NoirTaggers
       desc:   "Identifies Rust authentication patterns (guards, extractors, middleware)",
       runner: RustAuthTagger,
     },
+    flask_auth: {
+      name:   "Flask Auth Tagger",
+      desc:   "Identifies Flask authentication patterns (flask-login, flask-jwt, flask-httpauth)",
+      runner: FlaskAuthTagger,
+    },
+    fastapi_auth: {
+      name:   "FastAPI Auth Tagger",
+      desc:   "Identifies FastAPI authentication patterns (Depends, Security, OAuth2)",
+      runner: FastAPIAuthTagger,
+    },
+    python_misc_auth: {
+      name:   "Python Misc Auth Tagger",
+      desc:   "Identifies Sanic/Tornado authentication patterns",
+      runner: PythonMiscAuthTagger,
+    },
+    ruby_auth: {
+      name:   "Ruby Auth Tagger",
+      desc:   "Identifies Ruby authentication patterns (Devise, Pundit, CanCanCan, Warden)",
+      runner: RubyAuthTagger,
+    },
+    php_auth: {
+      name:   "PHP Auth Tagger",
+      desc:   "Identifies PHP authentication patterns (Laravel, Symfony, CakePHP)",
+      runner: PhpAuthTagger,
+    },
+    nestjs_auth: {
+      name:   "NestJS Auth Tagger",
+      desc:   "Identifies NestJS authentication patterns (Guards, decorators)",
+      runner: NestjsAuthTagger,
+    },
+    js_misc_auth: {
+      name:   "JS Misc Auth Tagger",
+      desc:   "Identifies Fastify/Koa/Restify authentication patterns",
+      runner: JsMiscAuthTagger,
+    },
+    aspnet_auth: {
+      name:   "ASP.NET Auth Tagger",
+      desc:   "Identifies ASP.NET authentication patterns ([Authorize], policies)",
+      runner: AspnetAuthTagger,
+    },
+    elixir_auth: {
+      name:   "Elixir Auth Tagger",
+      desc:   "Identifies Phoenix/Plug authentication patterns (plugs, Guardian, Pow)",
+      runner: ElixirAuthTagger,
+    },
+    ktor_auth: {
+      name:   "Ktor Auth Tagger",
+      desc:   "Identifies Ktor authentication patterns (authenticate blocks, principals)",
+      runner: KtorAuthTagger,
+    },
+    java_misc_auth: {
+      name:   "Java Misc Auth Tagger",
+      desc:   "Identifies Vert.x/Armeria/JSP authentication patterns",
+      runner: JavaMiscAuthTagger,
+    },
+    swift_auth: {
+      name:   "Swift Auth Tagger",
+      desc:   "Identifies Vapor/Kitura/Hummingbird authentication patterns",
+      runner: SwiftAuthTagger,
+    },
+    scala_auth: {
+      name:   "Scala Auth Tagger",
+      desc:   "Identifies Play/Akka/Scalatra authentication patterns",
+      runner: ScalaAuthTagger,
+    },
+    crystal_auth: {
+      name:   "Crystal Auth Tagger",
+      desc:   "Identifies Crystal framework authentication patterns (Kemal, Amber, Lucky)",
+      runner: CrystalAuthTagger,
+    },
   }
 
   def self.taggers

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -191,20 +191,23 @@ module NoirTaggers
 
     return if endpoints_by_tech.empty?
 
+    is_all = use_taggers_arr.includes?("all")
+
     HasFrameworkTaggers.each_value do |tagger_info|
-      instance = tagger_info[:runner].new(options)
-
-      next unless use_taggers_arr.includes?(instance.name) || use_taggers_arr.includes?("all")
-
-      # Get endpoints matching this tagger's target technologies
+      # Check if any target tech has endpoints before instantiating
+      target_techs = tagger_info[:runner].target_techs
       matching_endpoints = [] of Endpoint
-      tagger_info[:runner].target_techs.each do |tech|
+      target_techs.each do |tech|
         if endpoints_by_tech.has_key?(tech)
           matching_endpoints.concat(endpoints_by_tech[tech])
         end
       end
 
       next if matching_endpoints.empty?
+
+      # Instantiate only when there are matching endpoints
+      instance = tagger_info[:runner].new(options)
+      next unless is_all || use_taggers_arr.includes?(instance.name)
 
       instance.perform(matching_endpoints)
     end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -1,5 +1,7 @@
 require "./taggers/*"
+require "./framework_taggers/**"
 require "../models/tagger"
+require "../models/framework_tagger"
 
 module NoirTaggers
   HasTaggers = {
@@ -45,8 +47,40 @@ module NoirTaggers
     },
   }
 
+  HasFrameworkTaggers = {
+    django_auth: {
+      name:   "Django Auth Tagger",
+      desc:   "Identifies Django authentication patterns (decorators, mixins, DRF permissions)",
+      runner: DjangoAuthTagger,
+    },
+    spring_auth: {
+      name:   "Spring Auth Tagger",
+      desc:   "Identifies Spring Security patterns (annotations, security config)",
+      runner: SpringAuthTagger,
+    },
+    express_auth: {
+      name:   "Express Auth Tagger",
+      desc:   "Identifies Express.js authentication patterns (Passport, JWT, auth middleware)",
+      runner: ExpressAuthTagger,
+    },
+    go_auth: {
+      name:   "Go Auth Tagger",
+      desc:   "Identifies Go authentication patterns (middleware, JWT, session)",
+      runner: GoAuthTagger,
+    },
+    rust_auth: {
+      name:   "Rust Auth Tagger",
+      desc:   "Identifies Rust authentication patterns (guards, extractors, middleware)",
+      runner: RustAuthTagger,
+    },
+  }
+
   def self.taggers
     HasTaggers
+  end
+
+  def self.framework_taggers
+    HasFrameworkTaggers
   end
 
   def self.run_tagger(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers : String)
@@ -68,6 +102,41 @@ module NoirTaggers
     # Run taggers
     tagger_list.each do |tagger|
       tagger.perform(endpoints) if use_taggers_arr.includes?(tagger.name) || use_taggers_arr.includes?("all")
+    end
+
+    # Run framework taggers
+    run_framework_taggers(endpoints, options, use_taggers_arr)
+  end
+
+  private def self.run_framework_taggers(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers_arr : Array(String))
+    # Group endpoints by technology
+    endpoints_by_tech = Hash(String, Array(Endpoint)).new
+
+    endpoints.each do |endpoint|
+      tech = endpoint.details.technology
+      next if tech.nil?
+      endpoints_by_tech[tech] ||= [] of Endpoint
+      endpoints_by_tech[tech] << endpoint
+    end
+
+    return if endpoints_by_tech.empty?
+
+    HasFrameworkTaggers.each_value do |tagger_info|
+      instance = tagger_info[:runner].new(options)
+
+      next unless use_taggers_arr.includes?(instance.name) || use_taggers_arr.includes?("all")
+
+      # Get endpoints matching this tagger's target technologies
+      matching_endpoints = [] of Endpoint
+      tagger_info[:runner].target_techs.each do |tech|
+        if endpoints_by_tech.has_key?(tech)
+          matching_endpoints.concat(endpoints_by_tech[tech])
+        end
+      end
+
+      next if matching_endpoints.empty?
+
+      instance.perform(matching_endpoints)
     end
   end
 end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -154,10 +154,8 @@ module NoirTaggers
   end
 
   def self.run_tagger(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers : String)
-    tagger_list = [] of Tagger # This will hold instances of taggers
+    tagger_list = [] of Tagger
 
-    # Define taggers by creating instances
-    # Assuming HuntParamTagger is defined and is the only tagger
     HasTaggers.each_value do |tagger|
       if tagger[:runner].class.to_s == "Class"
         instance = tagger[:runner].new(options)
@@ -174,12 +172,12 @@ module NoirTaggers
       tagger.perform(endpoints) if use_taggers_arr.includes?(tagger.name) || use_taggers_arr.includes?("all")
     end
 
-    # Run framework taggers
+    # Run framework taggers (tech-aware, only instantiated when matching endpoints exist)
     run_framework_taggers(endpoints, options, use_taggers_arr)
   end
 
   private def self.run_framework_taggers(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers_arr : Array(String))
-    # Group endpoints by technology
+    # Group endpoints by technology for efficient dispatch
     endpoints_by_tech = Hash(String, Array(Endpoint)).new
 
     endpoints.each do |endpoint|
@@ -194,7 +192,6 @@ module NoirTaggers
     is_all = use_taggers_arr.includes?("all")
 
     HasFrameworkTaggers.each_value do |tagger_info|
-      # Check if any target tech has endpoints before instantiating
       target_techs = tagger_info[:runner].target_techs
       matching_endpoints = [] of Endpoint
       target_techs.each do |tech|
@@ -205,7 +202,6 @@ module NoirTaggers
 
       next if matching_endpoints.empty?
 
-      # Instantiate only when there are matching endpoints
       instance = tagger_info[:runner].new(options)
       next unless is_all || use_taggers_arr.includes?(instance.name)
 

--- a/typos.toml
+++ b/typos.toml
@@ -20,4 +20,6 @@ extend-exclude = [
   "docs/themes/goyo/**",
   # individual files to exclude
   "spec/functional_test/fixtures/python/django/djangoblog/settings.py",
+  # framework taggers contain regex patterns with intentional partial words
+  "src/tagger/framework_taggers/**",
 ]


### PR DESCRIPTION
Introduce FrameworkTagger base and concrete taggers for Go, Spring, Express, Django, and Rust. Add functional fixtures and unit tests for each framework and update CLI help to list framework-specific taggers.