### PR TITLE
Feat: add NOIR_PARSER_MAX_DEPTH to limit parser import depth

### DIFF
--- a/spec/unit_test/utils/parser_limit_spec.cr
+++ b/spec/unit_test/utils/parser_limit_spec.cr
@@ -1,0 +1,80 @@
+require "../../spec_helper"
+require "../../../src/utils/parser_limit"
+
+describe "ParserLimit" do
+  # Reset state before each test so ENV changes take effect.
+  before_each { ParserLimit.reset }
+  after_all { ENV.delete("NOIR_PARSER_MAX_DEPTH"); ParserLimit.reset }
+
+  describe ".max_depth" do
+    it "returns nil when NOIR_PARSER_MAX_DEPTH is not set" do
+      ENV.delete("NOIR_PARSER_MAX_DEPTH")
+      ParserLimit.max_depth.should be_nil
+    end
+
+    it "returns 0 when set to 0" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "0"
+      ParserLimit.max_depth.should eq(0)
+    end
+
+    it "returns the integer value when set to a positive number" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "3"
+      ParserLimit.max_depth.should eq(3)
+    end
+
+    it "returns nil when set to a negative number (no limit)" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "-1"
+      ParserLimit.max_depth.should be_nil
+    end
+
+    it "returns nil when set to a non-integer string" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "abc"
+      ParserLimit.max_depth.should be_nil
+    end
+  end
+
+  describe ".allow_depth?" do
+    it "returns true for any depth when NOIR_PARSER_MAX_DEPTH is not set" do
+      ENV.delete("NOIR_PARSER_MAX_DEPTH")
+      ParserLimit.allow_depth?(0).should be_true
+      ParserLimit.allow_depth?(100).should be_true
+    end
+
+    it "returns false for depth 0 when max depth is 0 (entry file only)" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "0"
+      ParserLimit.allow_depth?(0).should be_false
+    end
+
+    it "returns true for depth 0 and false for depth 1 when max depth is 1" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "1"
+      ParserLimit.allow_depth?(0).should be_true
+      ParserLimit.allow_depth?(1).should be_false
+    end
+
+    it "allows depths below max and blocks depths at or above max" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "3"
+      ParserLimit.allow_depth?(0).should be_true
+      ParserLimit.allow_depth?(1).should be_true
+      ParserLimit.allow_depth?(2).should be_true
+      ParserLimit.allow_depth?(3).should be_false
+      ParserLimit.allow_depth?(4).should be_false
+    end
+
+    it "returns true for any depth when set to negative (no limit)" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "-5"
+      ParserLimit.allow_depth?(0).should be_true
+      ParserLimit.allow_depth?(999).should be_true
+    end
+  end
+
+  describe ".reset" do
+    it "allows re-reading the environment variable" do
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "2"
+      ParserLimit.max_depth.should eq(2)
+
+      ENV["NOIR_PARSER_MAX_DEPTH"] = "5"
+      ParserLimit.reset
+      ParserLimit.max_depth.should eq(5)
+    end
+  end
+end

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -88,6 +88,7 @@ module Analyzer::Java
                   Dir.glob("#{escape_glob_path(import_directory.to_s)}/*.java") do |_path|
                     next if path == _path
                     if !parser_map.has_key?(_path)
+                      # Java Spring only resolves one level of imports, so depth is always 0.
                       next unless ParserLimit.allow_depth?(0)
                       _parser = create_parser(Path.new(_path))
                       parser_map[_path] = _parser
@@ -104,6 +105,7 @@ module Analyzer::Java
                 source_path = root_source_directory.join(import_path + ".java")
                 next if source_path.dirname == package_directory || !File.exists?(source_path)
                 if !parser_map.has_key?(source_path.to_s)
+                  # Java Spring only resolves one level of imports, so depth is always 0.
                   next unless ParserLimit.allow_depth?(0)
                   _parser = create_parser(source_path)
                   parser_map[source_path.to_s] = _parser
@@ -126,6 +128,7 @@ module Analyzer::Java
               Dir.glob("#{escape_glob_path(package_directory)}/*.java") do |_path|
                 next if path == _path
                 if !parser_map.has_key?(_path)
+                  # Java Spring only resolves one level of imports, so depth is always 0.
                   next unless ParserLimit.allow_depth?(0)
                   _parser = create_parser(Path.new(_path))
                   parser_map[_path] = _parser

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../minilexers/java"
 require "../../../miniparsers/java"
+require "../../../utils/parser_limit"
 
 module Analyzer::Java
   class Spring < Analyzer
@@ -87,6 +88,7 @@ module Analyzer::Java
                   Dir.glob("#{escape_glob_path(import_directory.to_s)}/*.java") do |_path|
                     next if path == _path
                     if !parser_map.has_key?(_path)
+                      next unless ParserLimit.allow_depth?(0)
                       _parser = create_parser(Path.new(_path))
                       parser_map[_path] = _parser
                     else
@@ -102,6 +104,7 @@ module Analyzer::Java
                 source_path = root_source_directory.join(import_path + ".java")
                 next if source_path.dirname == package_directory || !File.exists?(source_path)
                 if !parser_map.has_key?(source_path.to_s)
+                  next unless ParserLimit.allow_depth?(0)
                   _parser = create_parser(source_path)
                   parser_map[source_path.to_s] = _parser
                   _parser.classes.each do |package_class|
@@ -123,6 +126,7 @@ module Analyzer::Java
               Dir.glob("#{escape_glob_path(package_directory)}/*.java") do |_path|
                 next if path == _path
                 if !parser_map.has_key?(_path)
+                  next unless ParserLimit.allow_depth?(0)
                   _parser = create_parser(Path.new(_path))
                   parser_map[_path] = _parser
                 else

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -193,6 +193,7 @@ module Analyzer::Kotlin
       # TODO: Be aware that the import file location might differ from the actual file system path.
       Dir.glob("#{escape_glob_path(import_directory.to_s)}/*.#{KOTLIN_EXTENSION}") do |path|
         next if path == current_path
+        # Kotlin Spring only resolves one level of imports, so depth is always 0.
         next unless ParserLimit.allow_depth?(0)
         parser = parser_map[path]? || create_parser(Path.new(path))
         parser_map[path] ||= parser
@@ -204,6 +205,7 @@ module Analyzer::Kotlin
     private def process_single_import(root_source_directory : Path, import_path : String, package_directory : Path, parser_map : Hash(String, KotlinParser), import_map : Hash(String, KotlinParser::ClassModel))
       source_path = root_source_directory.join("#{import_path}.#{KOTLIN_EXTENSION}")
       return if source_path.dirname == package_directory || !File.exists?(source_path)
+      # Kotlin Spring only resolves one level of imports, so depth is always 0.
       return unless ParserLimit.allow_depth?(0)
       # TODO: Be aware that the import file location might differ from the actual file system path.
       parser = parser_map[source_path.to_s]? || create_parser(source_path)
@@ -216,6 +218,7 @@ module Analyzer::Kotlin
       package_class_map = Hash(String, KotlinParser::ClassModel).new
       Dir.glob("#{escape_glob_path(package_directory.to_s)}/*.#{KOTLIN_EXTENSION}") do |path|
         next if path == current_path
+        # Kotlin Spring only resolves one level of imports, so depth is always 0.
         next unless ParserLimit.allow_depth?(0)
         parser = parser_map[path]? || create_parser(Path.new(path))
         parser_map[path] ||= parser

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../minilexers/kotlin"
 require "../../../miniparsers/kotlin"
+require "../../../utils/parser_limit"
 require "../../../utils/utils.cr"
 
 module Analyzer::Kotlin
@@ -192,6 +193,7 @@ module Analyzer::Kotlin
       # TODO: Be aware that the import file location might differ from the actual file system path.
       Dir.glob("#{escape_glob_path(import_directory.to_s)}/*.#{KOTLIN_EXTENSION}") do |path|
         next if path == current_path
+        next unless ParserLimit.allow_depth?(0)
         parser = parser_map[path]? || create_parser(Path.new(path))
         parser_map[path] ||= parser
         parser.classes.each { |package_class| import_map[package_class.name] = package_class }
@@ -202,6 +204,7 @@ module Analyzer::Kotlin
     private def process_single_import(root_source_directory : Path, import_path : String, package_directory : Path, parser_map : Hash(String, KotlinParser), import_map : Hash(String, KotlinParser::ClassModel))
       source_path = root_source_directory.join("#{import_path}.#{KOTLIN_EXTENSION}")
       return if source_path.dirname == package_directory || !File.exists?(source_path)
+      return unless ParserLimit.allow_depth?(0)
       # TODO: Be aware that the import file location might differ from the actual file system path.
       parser = parser_map[source_path.to_s]? || create_parser(source_path)
       parser_map[source_path.to_s] ||= parser
@@ -213,6 +216,7 @@ module Analyzer::Kotlin
       package_class_map = Hash(String, KotlinParser::ClassModel).new
       Dir.glob("#{escape_glob_path(package_directory.to_s)}/*.#{KOTLIN_EXTENSION}") do |path|
         next if path == current_path
+        next unless ParserLimit.allow_depth?(0)
         parser = parser_map[path]? || create_parser(Path.new(path))
         parser_map[path] ||= parser
         parser.classes.each { |package_class| package_class_map[package_class.name] = package_class }

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -543,7 +543,7 @@ module Analyzer::Python
       @logger.debug "Tokenizing #{path}"
       tokens = lexer.tokenize(content)
       @logger.debug "Parsing #{path}"
-      parser = PythonParser.new(path, tokens, @parsers)
+      parser = PythonParser.new(path, tokens, @parsers, depth: 0)
       @logger.debug "Parsed #{path}"
       parser
     end

--- a/src/miniparsers/python.cr
+++ b/src/miniparsers/python.cr
@@ -1,11 +1,13 @@
 require "../minilexers/python"
 require "../models/minilexer/token"
+require "../utils/parser_limit"
 
 class PythonParser
   property tokens : Array(Token)
   property path : String
 
-  def initialize(@path : String, @tokens : Array(Token), @parsers : Hash(String, PythonParser), @visited : Array(String) = Array(String).new)
+  # depth: import depth (0 = entry file). Used with NOIR_PARSER_MAX_DEPTH to cap how deep we follow imports.
+  def initialize(@path : String, @tokens : Array(Token), @parsers : Hash(String, PythonParser), @visited : Array(String) = Array(String).new, depth : Int32 = 0)
     @import_statements = Hash(String, ImportModel).new
     @global_variables = Hash(String, GlobalVariables).new
     @basedir = File.dirname(@path)
@@ -15,6 +17,7 @@ class PythonParser
     end
 
     @debug = false
+    @depth = depth
     @visited << path
     parse
   end
@@ -32,7 +35,7 @@ class PythonParser
 
     lexer = PythonLexer.new
     tokens = lexer.tokenize(content)
-    parser = PythonParser.new(path.to_s, tokens, @parsers, @visited.dup)
+    parser = PythonParser.new(path.to_s, tokens, @parsers, @visited.dup, depth: @depth + 1)
     parser
   end
 
@@ -185,6 +188,7 @@ class PythonParser
         if @visited.includes?(pypath)
           next
         end
+        next unless ParserLimit.allow_depth?(@depth)
         if name == "*"
           parser = get_parser(Path.new(pypath))
           @global_variables.merge!(parser.@global_variables)

--- a/src/options.cr
+++ b/src/options.cr
@@ -95,9 +95,10 @@ private def full_examples_and_env : String
         $ noir -b . -t rails --exclude-techs php
 
     #{"ENVIRONMENT VARIABLES:".colorize(:green)}
-      NOIR_HOME          Path to directory containing config file
-      NOIR_AI_KEY        API key for AI providers (OpenAI, xAI, etc.)
-      NOIR_MAX_FILE_SIZE Maximum file size for analysis (e.g. 5MB or 1048576)
+      NOIR_HOME                    Path to directory containing config file
+      NOIR_AI_KEY                  API key for AI providers (OpenAI, xAI, etc.)
+      NOIR_MAX_FILE_SIZE           Maximum file size for analysis (e.g. 5MB or 1048576)
+      NOIR_PARSER_MAX_DEPTH        Max import depth for parsers (0=entry only; 1=+direct imports; unset=no limit)
     EXTRA
 end
 

--- a/src/utils/parser_limit.cr
+++ b/src/utils/parser_limit.cr
@@ -1,0 +1,42 @@
+# Parser limits from environment (e.g. for large repos).
+#
+# NOIR_PARSER_MAX_DEPTH  When set, miniparsers stop following imports beyond this depth.
+#                        Depth 0 = entry file only; 1 = entry + direct imports; etc.
+#                        Unset or negative = no limit.
+module ParserLimit
+  extend self
+
+  @@max_depth : Int32? = nil
+  @@initialized = false
+  @@mutex = Mutex.new
+
+  private def self.init
+    return if @@initialized
+    @@mutex.synchronize do
+      return if @@initialized
+      if s = ENV["NOIR_PARSER_MAX_DEPTH"]?
+        n = s.to_i?
+        # 0 = entry file only (no import following); 1 = entry + direct imports; etc. Negative/unset = no limit.
+        @@max_depth = (n && n >= 0) ? n : nil
+      end
+      @@initialized = true
+    end
+  end
+
+  # Maximum import depth (0 = entry file only). Nil = no limit.
+  def max_depth : Int32?
+    init
+    @@max_depth
+  end
+
+  # Returns true if parsing at the given depth may follow imports (i.e. depth < max_depth).
+  def allow_depth?(depth : Int32) : Bool
+    init
+    max = @@max_depth
+    if max.nil?
+      true
+    else
+      depth < max
+    end
+  end
+end

--- a/src/utils/parser_limit.cr
+++ b/src/utils/parser_limit.cr
@@ -39,4 +39,13 @@ module ParserLimit
       depth < max
     end
   end
+
+  # Reset cached state so the environment variable is re-read on next access.
+  # Intended for testing only.
+  def reset
+    @@mutex.synchronize do
+      @@max_depth = nil
+      @@initialized = false
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds an optional environment variable **`NOIR_PARSER_MAX_DEPTH`** so that users can cap how deep parsers follow imports. This keeps analysis time predictable on large codebases and in CI (e.g. Python/Flask, Java/Kotlin Spring), where miniparsers recursively resolve imports.

## Problem

On large repos, the Python miniparser (and similar logic in Java/Kotlin analyzers) can follow long import chains and parse a huge number of files. In practice this can mean:

- **Analysis runs for over an hour** or appears to hang.
- One entry file can pull in hundreds of modules (and their imports), so runtime grows quickly with repo size and import depth.

Without a way to cap how deep parsers follow imports, users on large codebases have no way to get a bounded, predictable run time.

## Solution

- **`NOIR_PARSER_MAX_DEPTH`** (integer):
  - **`0`** = only the entry file is parsed (no import following).
  - **`1`** = entry file + direct imports (one level).
  - **`2`** = entry + direct imports + their imports (two levels).
  - **Unset or negative** = no limit (previous behaviour).

Parsers stop following new imports once the current depth reaches the limit. Entry files are always at depth 0.

## Changes

| Area | Change |
|------|--------|
| **`src/utils/parser_limit.cr`** | New module that reads `NOIR_PARSER_MAX_DEPTH` and exposes `allow_depth?(depth)`. |
| **Python miniparser** | Tracks depth per parser instance; skips following imports when `depth >= max_depth`; root parser is created with depth 0 from Flask. |
| **Flask analyzer** | Creates the root Python parser with `depth: 0`. |
| **Java Spring & Kotlin Spring** | Before creating a parser for an imported or same-package file, call `ParserLimit.allow_depth?(0)` so depth-1 parsing respects the limit. |
| **Options / help** | `noir --help-all` documents `NOIR_PARSER_MAX_DEPTH` in the environment variables section. |

## Usage

```
# Entry files only (fastest; may miss endpoints that depend on imports)
NOIR_PARSER_MAX_DEPTH=0 noir -b /path/to/app

# Entry + direct imports (good default for CI)
NOIR_PARSER_MAX_DEPTH=1 noir -b /path/to/app

# No limit (default if unset)
noir -b /path/to/app

```