### PR TITLE
Fix Chi parameter extraction in mounted router functions

### DIFF
--- a/spec/functional_test/fixtures/go/chi_crossfile/api_routes.go
+++ b/spec/functional_test/fixtures/go/chi_crossfile/api_routes.go
@@ -9,7 +9,8 @@ import (
 func apiRouter() http.Handler {
 	r := chi.NewRouter()
 	r.Get("/users", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("users list"))
+		page := r.URL.Query().Get("page")
+		_ = page
 	})
 	r.Post("/users", func(w http.ResponseWriter, r *http.Request) {
 		name := r.FormValue("name")
@@ -17,10 +18,12 @@ func apiRouter() http.Handler {
 	})
 	r.Route("/settings", func(r chi.Router) {
 		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("settings"))
+			token := r.Header.Get("Authorization")
+			_ = token
 		})
 		r.Put("/", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("update settings"))
+			theme := r.FormValue("theme")
+			_ = theme
 		})
 	})
 	return r

--- a/spec/functional_test/testers/go/chi_crossfile_spec.cr
+++ b/spec/functional_test/testers/go/chi_crossfile_spec.cr
@@ -2,10 +2,10 @@ require "../../func_spec.cr"
 
 expected_endpoints = [
   Endpoint.new("/", "GET"),
-  Endpoint.new("/api/users", "GET"),
-  Endpoint.new("/api/users", "POST"),
-  Endpoint.new("/api/settings/", "GET"),
-  Endpoint.new("/api/settings/", "PUT"),
+  Endpoint.new("/api/users", "GET", [Param.new("page", "", "query")]),
+  Endpoint.new("/api/users", "POST", [Param.new("name", "", "form")]),
+  Endpoint.new("/api/settings/", "GET", [Param.new("Authorization", "", "header")]),
+  Endpoint.new("/api/settings/", "PUT", [Param.new("theme", "", "form")]),
 ]
 
 FunctionalTester.new("fixtures/go/chi_crossfile/", {

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -112,51 +112,7 @@ module Analyzer::Go
                       last_endpoint = endpoint
                     end
 
-                    # Parameter extraction patterns (order matters - check more specific patterns first)
-                    # Extract chi.URLParam only in inline handler or in ArticleCtx-like middleware
-                    # Other parameters only in inline handler context
-                    if line.includes?("chi.URLParam(")
-                      # Only extract URLParam if in inline handler, or it's part of a middleware function
-                      if state.in_inline_handler?
-                        get_param(line, "URLParam").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
-                      end
-                    elsif state.in_inline_handler?
-                      if line.includes?("Query().Get(")
-                        get_param(line, "Query").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
-                      elsif line.includes?("PostFormValue(")
-                        get_param(line, "PostFormValue").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
-                      elsif line.includes?("FormValue(")
-                        get_param(line, "FormValue").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
-                      elsif line.includes?("Header.Get(")
-                        get_param(line, "Header").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
-                      elsif line.includes?("Cookie(")
-                        get_param(line, "Cookie").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
-                      end
-                    end
+                    extract_params(line, state, last_endpoint)
                   end
                 end
               rescue File::NotFoundError
@@ -236,6 +192,50 @@ module Analyzer::Go
       end
 
       {endpoint, handled}
+    end
+
+    private def extract_params(line : String, state : ChiRouteState, last_endpoint : Endpoint)
+      if line.includes?("chi.URLParam(")
+        if state.in_inline_handler?
+          get_param(line, "URLParam").tap do |param|
+            if param.name.size > 0 && last_endpoint.url != ""
+              last_endpoint.params << param
+            end
+          end
+        end
+      elsif state.in_inline_handler?
+        if line.includes?("Query().Get(")
+          get_param(line, "Query").tap do |param|
+            if param.name.size > 0 && last_endpoint.url != ""
+              last_endpoint.params << param
+            end
+          end
+        elsif line.includes?("PostFormValue(")
+          get_param(line, "PostFormValue").tap do |param|
+            if param.name.size > 0 && last_endpoint.url != ""
+              last_endpoint.params << param
+            end
+          end
+        elsif line.includes?("FormValue(")
+          get_param(line, "FormValue").tap do |param|
+            if param.name.size > 0 && last_endpoint.url != ""
+              last_endpoint.params << param
+            end
+          end
+        elsif line.includes?("Header.Get(")
+          get_param(line, "Header").tap do |param|
+            if param.name.size > 0 && last_endpoint.url != ""
+              last_endpoint.params << param
+            end
+          end
+        elsif line.includes?("Cookie(")
+          get_param(line, "Cookie").tap do |param|
+            if param.name.size > 0 && last_endpoint.url != ""
+              last_endpoint.params << param
+            end
+          end
+        end
+      end
     end
 
     def get_param(line : String, pattern : String) : Param
@@ -336,6 +336,7 @@ module Analyzer::Go
       brace_count = 0
       state = ChiRouteState.new
       started = false
+      last_endpoint = Endpoint.new("", "")
 
       (func_start...lines.size).each do |index|
         line = lines[index]
@@ -351,8 +352,14 @@ module Analyzer::Go
 
         next_line = index + 1 < lines.size ? lines[index + 1] : nil
         details = Details.new(PathInfo.new(actual_file))
-        endpoint, _ = process_route_line(line, next_line, state, details)
-        endpoints << endpoint if endpoint
+        endpoint, handled = process_route_line(line, next_line, state, details)
+
+        if endpoint
+          endpoints << endpoint
+          last_endpoint = endpoint
+        end
+
+        extract_params(line, state, last_endpoint) unless handled
 
         break if brace_count <= 0
       end

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -195,46 +195,27 @@ module Analyzer::Go
     end
 
     private def extract_params(line : String, state : ChiRouteState, last_endpoint : Endpoint)
-      if line.includes?("chi.URLParam(")
-        if state.in_inline_handler?
-          get_param(line, "URLParam").tap do |param|
-            if param.name.size > 0 && last_endpoint.url != ""
-              last_endpoint.params << param
-            end
-          end
-        end
-      elsif state.in_inline_handler?
-        if line.includes?("Query().Get(")
-          get_param(line, "Query").tap do |param|
-            if param.name.size > 0 && last_endpoint.url != ""
-              last_endpoint.params << param
-            end
-          end
-        elsif line.includes?("PostFormValue(")
-          get_param(line, "PostFormValue").tap do |param|
-            if param.name.size > 0 && last_endpoint.url != ""
-              last_endpoint.params << param
-            end
-          end
-        elsif line.includes?("FormValue(")
-          get_param(line, "FormValue").tap do |param|
-            if param.name.size > 0 && last_endpoint.url != ""
-              last_endpoint.params << param
-            end
-          end
-        elsif line.includes?("Header.Get(")
-          get_param(line, "Header").tap do |param|
-            if param.name.size > 0 && last_endpoint.url != ""
-              last_endpoint.params << param
-            end
-          end
-        elsif line.includes?("Cookie(")
-          get_param(line, "Cookie").tap do |param|
-            if param.name.size > 0 && last_endpoint.url != ""
-              last_endpoint.params << param
-            end
-          end
-        end
+      return if last_endpoint.url.empty?
+      return unless state.in_inline_handler?
+
+      # Parameter extraction patterns (order matters - check more specific patterns first)
+      pattern = if line.includes?("chi.URLParam(")
+                  "URLParam"
+                elsif line.includes?("Query().Get(")
+                  "Query"
+                elsif line.includes?("PostFormValue(")
+                  "PostFormValue"
+                elsif line.includes?("FormValue(")
+                  "FormValue"
+                elsif line.includes?("Header.Get(")
+                  "Header"
+                elsif line.includes?("Cookie(")
+                  "Cookie"
+                end
+
+      if pattern
+        param = get_param(line, pattern)
+        last_endpoint.params << param unless param.name.empty?
       end
     end
 


### PR DESCRIPTION
## Summary

- Extract inline parameter detection logic into a reusable `extract_params` method on the Chi analyzer
- Call `extract_params` from `analyze_router_function` so that parameters (`FormValue`, `Query().Get`, `Header.Get`, etc.) are detected inside mounted router inline handlers
- Track `last_endpoint` in `analyze_router_function` to associate extracted params with the correct endpoint
- Update cross-file test fixtures and expectations to cover query, form, and header parameters

Closes #1108