### PR TITLE
Refactor duplicate code across Go framework analyzers

### DIFF
--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -1,8 +1,7 @@
-require "../../../models/analyzer"
-require "../../../minilexers/golang"
+require "./common"
 
 module Analyzer::Go
-  class Beego < Analyzer
+  class Beego < Common
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -27,36 +26,7 @@ module Analyzer::Go
                         details = Details.new(PathInfo.new(path, index + 1))
                         lexer = GolangLexer.new
 
-                        if line.includes?(".Group(")
-                          map = lexer.tokenize(line)
-                          before = Token.new(:unknown, "", 0)
-                          group_name = ""
-                          group_path = ""
-                          map.each do |token|
-                            if token.type == :assign
-                              group_name = before.value.to_s.gsub(":", "").gsub(/\s/, "")
-                            end
-
-                            if token.type == :string
-                              group_path = token.value.to_s
-                              groups.each do |group|
-                                group.each do |key, value|
-                                  if before.value.to_s.includes? key
-                                    group_path = value + group_path
-                                  end
-                                end
-                              end
-                            end
-
-                            before = token
-                          end
-
-                          if group_name.size > 0 && group_path.size > 0
-                            groups << {
-                              group_name => group_path,
-                            }
-                          end
-                        end
+                        analyze_group(line, lexer, groups)
 
                         if line.includes?(".Get(") || line.includes?(".Post(") || line.includes?(".Put(") || line.includes?(".Delete(")
                           get_route_path(line, groups).tap do |route_path|
@@ -116,48 +86,9 @@ module Analyzer::Go
         logger.debug e
       end
 
-      public_dirs.each do |p_dir|
-        full_path = (base_path + "/" + p_dir["file_path"]).gsub_repeatedly("//", "/")
-        Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
-          next if File.directory?(path)
-          if File.exists?(path)
-            if p_dir["static_path"].ends_with?("/")
-              p_dir["static_path"] = p_dir["static_path"][0..-2]
-            end
-
-            details = Details.new(PathInfo.new(path))
-            result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET", details)
-          end
-        end
-      end
+      resolve_public_dirs_with_glob(public_dirs)
 
       result
-    end
-
-    def get_route_path(line : String, groups : Array(Hash(String, String))) : String
-      lexer = GolangLexer.new
-      map = lexer.tokenize(line)
-      before = Token.new(:unknown, "", 0)
-      map.each do |token|
-        if token.type == :string
-          final_path = token.value.to_s
-          # Route path must start with "/" to be a valid HTTP endpoint
-          next unless final_path.starts_with?("/")
-          groups.each do |group|
-            group.each do |key, value|
-              if before.value.to_s.includes? key
-                final_path = value + final_path
-              end
-            end
-          end
-
-          return final_path
-        end
-
-        before = token
-      end
-
-      ""
     end
   end
 end

--- a/src/analyzer/analyzers/go/common.cr
+++ b/src/analyzer/analyzers/go/common.cr
@@ -160,7 +160,8 @@ module Analyzer::Go
     def resolve_public_dirs_with_glob(public_dirs : Array(Hash(String, String)))
       public_dirs.each do |p_dir|
         next if p_dir["file_path"].size == 0
-        full_path = (base_path + "/" + p_dir["file_path"]).gsub_repeatedly("//", "/")
+        full_path = File.expand_path(p_dir["file_path"], base_path)
+        next unless File.directory?(full_path)
         Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
           next if File.directory?(path)
           if File.exists?(path)

--- a/src/analyzer/analyzers/go/common.cr
+++ b/src/analyzer/analyzers/go/common.cr
@@ -160,7 +160,15 @@ module Analyzer::Go
     def resolve_public_dirs_with_glob(public_dirs : Array(Hash(String, String)))
       public_dirs.each do |p_dir|
         next if p_dir["file_path"].size == 0
-        full_path = File.expand_path(p_dir["file_path"], base_path)
+        raw_full_path = (base_path + "/" + p_dir["file_path"]).gsub_repeatedly("//", "/")
+        normalized_full_path = Path[raw_full_path].normalize.to_s
+
+        if base_path.starts_with?("./") && !normalized_full_path.starts_with?("./") && !normalized_full_path.starts_with?("/")
+          full_path = "./#{normalized_full_path}"
+        else
+          full_path = normalized_full_path
+        end
+
         next unless File.directory?(full_path)
         Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
           next if File.directory?(path)

--- a/src/analyzer/analyzers/go/common.cr
+++ b/src/analyzer/analyzers/go/common.cr
@@ -145,6 +145,37 @@ module Analyzer::Go
       groups
     end
 
+    def add_param_to_endpoint(param : Param, endpoint : Endpoint)
+      if param.name.size > 0 && endpoint.method != "" && endpoint.url != ""
+        endpoint.params << param
+      end
+    end
+
+    def add_static_path_if_valid(static_path : Hash(String, String), public_dirs : Array(Hash(String, String)))
+      if static_path["static_path"].size > 0 && static_path["file_path"].size > 0
+        public_dirs << static_path
+      end
+    end
+
+    def resolve_public_dirs_with_glob(public_dirs : Array(Hash(String, String)))
+      public_dirs.each do |p_dir|
+        next if p_dir["file_path"].size == 0
+        full_path = (base_path + "/" + p_dir["file_path"]).gsub_repeatedly("//", "/")
+        Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
+          next if File.directory?(path)
+          if File.exists?(path)
+            static_url = p_dir["static_path"]
+            if static_url.ends_with?("/")
+              static_url = static_url[0..-2]
+            end
+
+            details = Details.new(PathInfo.new(path))
+            result << Endpoint.new("#{static_url}#{path.gsub(full_path, "")}", "GET", details)
+          end
+        end
+      end
+    end
+
     def resolve_public_dirs(public_dirs : Array(Hash(String, String)))
       public_dirs.each do |p_dir|
         # Join path manually first to handle concatenation

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -51,19 +51,11 @@ module Analyzer::Go
                       end
 
                       if line.includes?("Param(") || line.includes?("FormValue(")
-                        get_param(line).tap do |param|
-                          if param.name.size > 0 && last_endpoint.method != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line), last_endpoint)
                       end
 
                       if line.includes?("Static(")
-                        get_static_path(line).tap do |static_path|
-                          if static_path["static_path"].size > 0 && static_path["file_path"].size > 0
-                            public_dirs << static_path
-                          end
-                        end
+                        add_static_path_if_valid(get_static_path(line), public_dirs)
                       end
 
                       if line.includes?("Request().Header.Get(")

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -55,19 +55,11 @@ module Analyzer::Go
                       end
 
                       if line.includes?(".Query(") || line.includes?(".FormValue(")
-                        get_param(line).tap do |param|
-                          if param.name.size > 0 && last_endpoint.method != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line), last_endpoint)
                       end
 
                       if line.includes?("Static(")
-                        get_static_path(line).tap do |static_path|
-                          if static_path["static_path"].size > 0 && static_path["file_path"].size > 0
-                            public_dirs << static_path
-                          end
-                        end
+                        add_static_path_if_valid(get_static_path(line), public_dirs)
                       end
 
                       if line.includes?("GetRespHeader(")

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -109,20 +109,12 @@ module Analyzer::Go
 
                       ["Get", "GetQuery", "GetForm", "GetHeader", "GetUploadFile"].each do |pattern|
                         if line.includes?("#{pattern}(") && !line.includes?("Cookie.Get")
-                          get_param(line).tap do |param|
-                            if param.name.size > 0 && last_endpoint.method != ""
-                              last_endpoint.params << param
-                            end
-                          end
+                          add_param_to_endpoint(get_param(line), last_endpoint)
                         end
                       end
 
                       if line.includes?("Static(")
-                        get_static_path(line).tap do |static_path|
-                          if static_path["static_path"].size > 0 && static_path["file_path"].size > 0
-                            public_dirs << static_path
-                          end
-                        end
+                        add_static_path_if_valid(get_static_path(line), public_dirs)
                       end
 
                       if line.includes?("Cookie.Get(")

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -50,20 +50,12 @@ module Analyzer::Go
 
                       ["Query", "PostForm", "GetHeader"].each do |pattern|
                         if line.includes?("#{pattern}(")
-                          get_param(line).tap do |param|
-                            if param.name.size > 0 && last_endpoint.method != ""
-                              last_endpoint.params << param
-                            end
-                          end
+                          add_param_to_endpoint(get_param(line), last_endpoint)
                         end
                       end
 
                       if line.includes?("Static(")
-                        get_static_path(line).tap do |static_path|
-                          if static_path["static_path"].size > 0 && static_path["file_path"].size > 0
-                            public_dirs << static_path
-                          end
-                        end
+                        add_static_path_if_valid(get_static_path(line), public_dirs)
                       end
 
                       if line.includes?("Cookie(")

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -1,8 +1,7 @@
-require "../../../models/analyzer"
-require "../../../minilexers/golang"
+require "./common"
 
 module Analyzer::Go
-  class Goyave < Analyzer
+  class Goyave < Common
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -103,10 +102,9 @@ module Analyzer::Go
 
                       # Static
                       if line.includes?(".Static(")
-                        get_static_path(line).tap do |static_path|
-                          if static_path["static_path"].size > 0
-                            public_dirs << static_path
-                          end
+                        static_path = get_static_path(line)
+                        if static_path["static_path"].size > 0
+                          public_dirs << static_path
                         end
                       end
                     end
@@ -122,22 +120,7 @@ module Analyzer::Go
         logger.debug e
       end
 
-      public_dirs.each do |p_dir|
-        if p_dir["file_path"].size > 0
-          full_path = (base_path + "/" + p_dir["file_path"]).gsub_repeatedly("//", "/")
-          Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
-            next if File.directory?(path)
-            if File.exists?(path)
-              if p_dir["static_path"].ends_with?("/")
-                p_dir["static_path"] = p_dir["static_path"][0..-2]
-              end
-
-              details = Details.new(PathInfo.new(path))
-              result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET", details)
-            end
-          end
-        end
-      end
+      resolve_public_dirs_with_glob(public_dirs)
 
       result
     end

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -1,8 +1,7 @@
-require "../../../models/analyzer"
-require "../../../minilexers/golang"
+require "./common"
 
 module Analyzer::Go
-  class GoZero < Analyzer
+  class GoZero < Common
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -47,36 +46,7 @@ module Analyzer::Go
                           lexer = GolangLexer.new
 
                           # Handle group routing (similar to Gin)
-                          if line.includes?(".Group(")
-                            map = lexer.tokenize(line)
-                            before = Token.new(:unknown, "", 0)
-                            group_name = ""
-                            group_path = ""
-                            map.each do |token|
-                              if token.type == :assign
-                                group_name = before.value.to_s.gsub(":", "").gsub(/\s/, "")
-                              end
-
-                              if token.type == :string
-                                group_path = token.value.to_s
-                                groups.each do |group|
-                                  group.each do |key, value|
-                                    if before.value.to_s.includes? key
-                                      group_path = value + group_path
-                                    end
-                                  end
-                                end
-                              end
-
-                              before = token
-                            end
-
-                            if group_name.size > 0 && group_path.size > 0
-                              groups << {
-                                group_name => group_path,
-                              }
-                            end
-                          end
+                          analyze_group(line, lexer, groups)
 
                           # Handle HTTP method routing
                           # go-zero typically uses patterns like: server.Get("/path", handler)
@@ -102,21 +72,13 @@ module Analyzer::Go
                           # Handle parameter extraction patterns common in go-zero
                           ["Query", "PostForm", "GetHeader", "PathParam", "FormValue"].each do |pattern|
                             if line.includes?("#{pattern}(")
-                              get_param(line).tap do |param|
-                                if param.name.size > 0 && last_endpoint.method != ""
-                                  last_endpoint.params << param
-                                end
-                              end
+                              add_param_to_endpoint(get_param(line), last_endpoint)
                             end
                           end
 
                           # Handle static file serving
                           if line.includes?("Static(")
-                            get_static_path(line).tap do |p_dir|
-                              if p_dir["static_path"].size > 0 && p_dir["file_path"].size > 0
-                                public_dirs << p_dir
-                              end
-                            end
+                            add_static_path_if_valid(get_static_path(line), public_dirs)
                           end
                         end
                       end
@@ -141,44 +103,19 @@ module Analyzer::Go
           Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
             next if File.directory?(path)
             if File.exists?(path)
-              if p_dir["static_path"].ends_with?("/")
-                p_dir["static_path"] = p_dir["static_path"][0..-2]
+              static_url = p_dir["static_path"]
+              if static_url.ends_with?("/")
+                static_url = static_url[0..-2]
               end
 
               details = Details.new(PathInfo.new(path))
-              result << Endpoint.new("#{p_dir["static_path"]}#{path.gsub(full_path, "")}", "GET", details)
+              result << Endpoint.new("#{static_url}#{path.gsub(full_path, "")}", "GET", details)
             end
           end
         end
       end
 
       result
-    end
-
-    def get_route_path(line : String, groups : Array(Hash(String, String))) : String
-      lexer = GolangLexer.new
-      map = lexer.tokenize(line)
-      before = Token.new(:unknown, "", 0)
-      map.each do |token|
-        if token.type == :string
-          final_path = token.value.to_s
-          # Route path must start with "/" to be a valid HTTP endpoint
-          next unless final_path.starts_with?("/")
-          groups.each do |group|
-            group.each do |key, value|
-              if before.value.to_s.includes? key
-                final_path = value + final_path
-              end
-            end
-          end
-
-          return final_path
-        end
-
-        before = token
-      end
-
-      ""
     end
 
     def get_param(line : String) : Param

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -96,24 +96,7 @@ module Analyzer::Go
         # Handle channel errors
       end
 
-      # Process static files
-      public_dirs.each do |p_dir|
-        full_path = File.expand_path(p_dir["file_path"], @base_path)
-        if File.directory?(full_path)
-          Dir.glob("#{escape_glob_path(full_path)}/**/*") do |path|
-            next if File.directory?(path)
-            if File.exists?(path)
-              static_url = p_dir["static_path"]
-              if static_url.ends_with?("/")
-                static_url = static_url[0..-2]
-              end
-
-              details = Details.new(PathInfo.new(path))
-              result << Endpoint.new("#{static_url}#{path.gsub(full_path, "")}", "GET", details)
-            end
-          end
-        end
-      end
+      resolve_public_dirs_with_glob(public_dirs)
 
       result
     end

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -1,8 +1,7 @@
-require "../../../models/analyzer"
-require "../../../minilexers/golang"
+require "./common"
 
 module Analyzer::Go
-  class Mux < Analyzer
+  class Mux < Common
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -87,50 +86,22 @@ module Analyzer::Go
 
                       # Handle parameter extraction patterns in Go (order matters - check more specific patterns first)
                       if line.includes?("Vars(")
-                        get_param(line, "Vars").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line, "Vars"), last_endpoint)
                       elsif line.includes?("Query().Get(")
-                        get_param(line, "Query").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line, "Query"), last_endpoint)
                       elsif line.includes?("PostFormValue(")
-                        get_param(line, "PostFormValue").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line, "PostFormValue"), last_endpoint)
                       elsif line.includes?("FormValue(")
-                        get_param(line, "FormValue").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line, "FormValue"), last_endpoint)
                       elsif line.includes?("Header.Get(")
-                        get_param(line, "Header").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line, "Header"), last_endpoint)
                       elsif line.includes?("Cookie(")
-                        get_param(line, "Cookie").tap do |param|
-                          if param.name.size > 0 && last_endpoint.url != ""
-                            last_endpoint.params << param
-                          end
-                        end
+                        add_param_to_endpoint(get_param(line, "Cookie"), last_endpoint)
                       end
 
                       # Handle static file serving (e.g., r.PathPrefix("/static/").Handler(...))
                       if line.includes?(".PathPrefix(") && line.includes?(".Handler(") && !line.includes?(".Subrouter(")
-                        get_static_path(line).tap do |static_path|
-                          if static_path["static_path"].size > 0 && static_path["file_path"].size > 0
-                            public_dirs << static_path
-                          end
-                        end
+                        add_static_path_if_valid(get_static_path(line), public_dirs)
                       end
                     end
                   end
@@ -168,32 +139,6 @@ module Analyzer::Go
       end
 
       result
-    end
-
-    def get_route_path(line : String, subrouters : Array(Hash(String, String))) : String
-      lexer = GolangLexer.new
-      map = lexer.tokenize(line)
-      before = Token.new(:unknown, "", 0)
-      map.each do |token|
-        if token.type == :string
-          final_path = token.value.to_s
-          # Route path must start with "/" to be a valid HTTP endpoint
-          next unless final_path.starts_with?("/")
-          subrouters.each do |sub|
-            sub.each do |key, value|
-              if before.value.to_s.includes? key
-                final_path = value + final_path
-              end
-            end
-          end
-
-          return final_path
-        end
-
-        before = token
-      end
-
-      ""
     end
 
     def get_method_from_line(line : String) : String


### PR DESCRIPTION
## Summary
- Extract shared helpers into `Common` class: `add_param_to_endpoint`, `add_static_path_if_valid`, `resolve_public_dirs_with_glob`
- Migrate `beego`, `gozero`, `mux`, `goyave` to extend `Common` instead of `Analyzer`, removing duplicated `get_route_path` and `analyze_group` implementations
- Use shared helpers across all Go analyzers (`echo`, `fiber`, `gin`, `gf`, `mux`, `beego`, `goyave`, `gozero`) to replace repeated param/static-path validation patterns
- Net reduction: **-205 lines** across 9 files

## Test plan
- [x] Full test suite passes (5205 examples, 0 failures)
- [x] All Go analyzer functional tests pass (637 examples)
- [x] Compilation check passes (`crystal build --no-codegen`)

Closes #1125