### PR TITLE
Fix/cache error logging

### DIFF
--- a/src/llm/cache.cr
+++ b/src/llm/cache.cr
@@ -73,7 +73,8 @@ module LLM
       path = path_for(key)
       return unless File.exists?(path)
       File.read(path)
-    rescue
+    rescue e
+      Log.debug { "Cache fetch failed for #{key}: #{e.message}" }
       nil
     end
 
@@ -82,7 +83,8 @@ module LLM
       ensure_dir
       File.write(path_for(key), content)
       true
-    rescue
+    rescue e
+      Log.debug { "Cache store failed for #{key}: #{e.message}" }
       false
     end
 
@@ -91,7 +93,8 @@ module LLM
       return false unless File.exists?(path)
       File.delete(path)
       true
-    rescue
+    rescue e
+      Log.debug { "Cache delete failed for #{key}: #{e.message}" }
       false
     end
 
@@ -104,7 +107,8 @@ module LLM
         begin
           File.delete(fp)
           count += 1
-        rescue
+        rescue e
+          Log.debug { "Cache clear: failed to delete #{fp}: #{e.message}" }
         end
       end
       count
@@ -123,7 +127,8 @@ module LLM
             File.delete(fp)
             count += 1
           end
-        rescue
+        rescue e
+          Log.debug { "Cache purge: failed to process #{fp}: #{e.message}" }
         end
       end
       count
@@ -139,7 +144,8 @@ module LLM
           begin
             entries += 1
             bytes += File.size(fp)
-          rescue
+          rescue e
+            Log.debug { "Cache stats: failed to read #{fp}: #{e.message}" }
           end
         end
       end

--- a/src/llm/cache.cr
+++ b/src/llm/cache.cr
@@ -13,6 +13,7 @@ require "digest/sha256"
 require "file_utils"
 require "time"
 require "../utils/home"
+require "log"
 
 module LLM
   module Cache


### PR DESCRIPTION
Right now, the LLM cache module has bare rescue blocks that just swallow exceptions and return nil or false without telling anyone what went wrong. That makes it hard to debug when cache reads or writes fail, and can lead to unnecessary API calls or lost cache entries.

What I changed
Replaced every bare rescue with rescue e so we can actually see the error.
Added Log.debug messages to give us visibility into what failed.
Kept all the existing return values (nil, false, etc.) – so the behavior is exactly the same, just with logging.

Why it’s helpful
No functional changes, but now if something goes wrong with the cache, we’ll see a clear debug log instead of just silence. That’ll make it way easier to figure out issues when they happen.

