### PR TITLE
Fix Kotlin Spring flaky test caused by package_map cache bug

### DIFF
--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -146,7 +146,7 @@ module Analyzer::Kotlin
       package_directory = Path.new(path).parent
 
       import_map = process_imports(parser, root_source_directory, package_directory, path, parser_map)
-      package_class_map = package_map[package_directory.to_s]? || process_package_classes(package_directory, path, parser_map)
+      package_class_map = package_map[package_directory.to_s]? || process_package_classes(package_directory, parser_map)
       package_map[package_directory.to_s] ||= package_class_map
 
       class_map = package_class_map.merge(import_map)
@@ -214,7 +214,7 @@ module Analyzer::Kotlin
     end
 
     # Process all classes in the same package directory
-    private def process_package_classes(package_directory : Path, current_path : String, parser_map : Hash(String, KotlinParser)) : Hash(String, KotlinParser::ClassModel)
+    private def process_package_classes(package_directory : Path, parser_map : Hash(String, KotlinParser)) : Hash(String, KotlinParser::ClassModel)
       package_class_map = Hash(String, KotlinParser::ClassModel).new
       Dir.glob("#{escape_glob_path(package_directory.to_s)}/*.#{KOTLIN_EXTENSION}").sort.each do |path|
         # Kotlin Spring only resolves one level of imports, so depth is always 0.

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -217,7 +217,6 @@ module Analyzer::Kotlin
     private def process_package_classes(package_directory : Path, current_path : String, parser_map : Hash(String, KotlinParser)) : Hash(String, KotlinParser::ClassModel)
       package_class_map = Hash(String, KotlinParser::ClassModel).new
       Dir.glob("#{escape_glob_path(package_directory.to_s)}/*.#{KOTLIN_EXTENSION}").sort.each do |path|
-        next if path == current_path
         # Kotlin Spring only resolves one level of imports, so depth is always 0.
         next unless ParserLimit.allow_depth?(0)
         parser = parser_map[path]? || create_parser(Path.new(path))


### PR DESCRIPTION
## Summary
- `process_package_classes` excluded `current_path` when building the class map, but the result was cached in `package_map` keyed by directory
- When another file in the same directory reused the cache, the first file's classes were missing
- On Linux CI, `Entities.kt` was processed before `HtmlController.kt`, so `Article` class was excluded from the cache → `POST /article` params unresolved (8 failures)
- The previous fix (#1132) sorted `Dir.glob` but didn't address the root cause: **the cache itself was incomplete**
- Fix: remove `next if path == current_path` — `parser_map` already caches parsers so there's no redundant parsing

## Test plan
- [x] `crystal spec spec/functional_test/testers/kotlin/spring_spec.cr` passes locally (110 examples, 0 failures)
- [x] CI passes on Linux (the environment where this was failing)