### PR TITLE
Fix broken alert_info shortcode on installation page

### DIFF
--- a/docs/content/get_started/installation/index.ko.md
+++ b/docs/content/get_started/installation/index.ko.md
@@ -47,11 +47,12 @@ nix profile add github:owasp-noir/noir
 ```
 
 {% alert_info() %}
-**팁:** Docker 또는 제한된 환경에서는 실험적 기능을 활성화해야 할 수 있습니다:
+**팁:** Docker 또는 제한된 환경에서는 실험적 기능을 활성화해야 할 수 있습니다. 아래 명령어를 사용하세요.
+{% end %}
+
 ```bash
 nix --extra-experimental-features "nix-command flakes" profile add github:owasp-noir/noir
 ```
-{% end %}
 
 설치 없이 직접 실행:
 

--- a/docs/content/get_started/installation/index.md
+++ b/docs/content/get_started/installation/index.md
@@ -47,11 +47,12 @@ nix profile add github:owasp-noir/noir
 ```
 
 {% alert_info() %}
-**Tip:** In Docker or restricted environments, you may need to enable experimental features:
+**Tip:** In Docker or restricted environments, you may need to enable experimental features. Use the command below.
+{% end %}
+
 ```bash
 nix --extra-experimental-features "nix-command flakes" profile add github:owasp-noir/noir
 ```
-{% end %}
 
 Or run directly without installing:
 


### PR DESCRIPTION
## Summary
- Fix broken `{% alert_info() %}` shortcode in the Nix section of the installation page (EN & KO)
- The shortcode body contained a fenced code block (triple backticks), which caused the Hwaro parser to fail — rendering the shortcode as plain text
- Moved the code block outside the shortcode so both the alert and code block render correctly

## Test plan
- [ ] Verify the installation page renders the Nix tip alert correctly: https://owasp-noir.github.io/noir/get_started/installation/
- [ ] Verify the Korean installation page as well: https://owasp-noir.github.io/noir/ko/get_started/installation/