### PR TITLE
fix: preserve accurate line numbers for JS endpoints

### DIFF
--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -36,9 +36,10 @@ module Analyzer::Javascript
               content = File.read(path, encoding: "utf-8", invalid: :skip)
               parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
               parser_endpoints.each do |endpoint|
-                # Add file location details
-                details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-                endpoint.details = details
+                # Use the line number already set by the extractor; fall back to path-only if missing
+                if endpoint.details.code_paths.empty?
+                  endpoint.details = Details.new(PathInfo.new(path))
+                end
 
                 # Parse path parameters from the URL path itself
                 if endpoint.url.includes?(":")

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -154,6 +154,14 @@ module Noir
           # Normalize HTTP method (e.g., DEL -> DELETE)
           normalized_method = normalize_http_method(pattern.method)
 
+          # Convert byte offset to line number
+          line_number = if pattern.start_pos >= 0
+                          content.to_slice[0, pattern.start_pos].count('\n'.ord.to_u8) + 1
+                        else
+                          1
+                        end
+          route_details = Details.new(PathInfo.new(file_path, line_number))
+
           # Handle router.all by expanding to all HTTP methods
           prefixes.each do |prefix|
             path_with_prefix = prefix.empty? ? pattern.path : URLPath.join(prefix, pattern.path)
@@ -161,7 +169,7 @@ module Noir
             if normalized_method == "ALL"
               all_methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
               all_methods.each do |method|
-                endpoint = Endpoint.new(path_with_prefix, method)
+                endpoint = Endpoint.new(path_with_prefix, method, route_details)
 
                 # Add path parameters detected in the URL
                 pattern.params.each do |param|
@@ -174,7 +182,7 @@ module Noir
                 endpoints << endpoint
               end
             else
-              endpoint = Endpoint.new(path_with_prefix, normalized_method)
+              endpoint = Endpoint.new(path_with_prefix, normalized_method, route_details)
 
               # Add path parameters detected in the URL
               pattern.params.each do |param|


### PR DESCRIPTION
## Summary

When scanning JavaScript services, Noir was unconditionally overwriting endpoint details set by `JSRouteExtractor` with hardcoded approximate values (`line 1`), causing all detected endpoints to report the wrong source location regardless of where the route was actually defined in the file.

## Changes

- **`src/miniparsers/js_route_extractor.cr`**: Compute the accurate line number from `pattern.start_pos` by counting newlines in the content before that offset, and attach it to the endpoint when constructing it.
- **`src/analyzer/analyzers/javascript/express.cr`**: Only set `endpoint.details` if `code_paths` is empty, so the accurate line number set by the extractor is preserved instead of being overwritten.

## Testing

Verified that endpoints detected in Express apps now report the correct line number matching the route definition in the source file.

Closes #1141