### PR TITLE
Remove unnecessary `require "regex"` in graphql_analyzer.cr

### DIFF
--- a/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
+++ b/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
@@ -1,7 +1,6 @@
 require "../../../models/analyzer"
 require "../../../models/endpoint"
 require "json"
-require "regex" # Explicitly require Regex
 
 # Define the regex as a top-level constant in this file
 OPERATION_REGEX = Regex.new("(query|mutation|subscription)\\s+([_A-Za-z][_0-9A-Za-z]*)")


### PR DESCRIPTION
Crystal's `Regex` class is part of the standard library prelude and available without explicit `require`. No other file in the codebase requires it explicitly. Removes the redundant line from `src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr`.

This contribution was developed with AI assistance (Claude Code).

Fixes #1147