### PR TITLE
Remove empty `Details#initialize` method in endpoint.cr

### DIFF
--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -127,9 +127,6 @@ struct Details
 
   # + New details types to be added in the future..
 
-  def initialize
-  end
-
   def initialize(code_path : PathInfo)
     @code_paths << code_path
   end


### PR DESCRIPTION
Crystal structs auto-generate a default initializer when all properties have default values. The explicit empty `initialize` in `Details` is redundant since `code_paths` defaults to an empty array and `status_code`/`technology` are nilable. The parameterized `initialize(code_path)` overload is kept.

This contribution was developed with AI assistance (Claude Code).

Fixes #1151