### PR TITLE
Redirect miniparser debug output from STDOUT to STDERR

### DIFF
--- a/src/miniparsers/java.cr
+++ b/src/miniparsers/java.cr
@@ -572,16 +572,16 @@ class JavaParser
   def print_tokens(tokens : Array(Token), id = "default", trace = false)
     STDERR.puts("\n================ #{id} ===================")
     tokens.each do |token|
-      STDERR.print(token.value)
+      STDERR.print("#{token.value} ")
       if id == "error"
-        STDERR.print("(#{token.type})")
+        STDERR.print("(#{token.type}) ")
       end
     end
 
     if trace
       STDERR.puts ""
       tokens.each do |token|
-        STDERR.print("#{token.value}(#{token.type})")
+        STDERR.print("#{token.value}(#{token.type}) ")
       end
     end
   end

--- a/src/miniparsers/java.cr
+++ b/src/miniparsers/java.cr
@@ -570,18 +570,18 @@ class JavaParser
   end
 
   def print_tokens(tokens : Array(Token), id = "default", trace = false)
-    puts("\n================ #{id} ===================")
+    STDERR.puts("\n================ #{id} ===================")
     tokens.each do |token|
-      print(token.value)
+      STDERR.print(token.value)
       if id == "error"
-        print("(#{token.type})")
+        STDERR.print("(#{token.type})")
       end
     end
 
     if trace
-      puts ""
+      STDERR.puts ""
       tokens.each do |token|
-        print("#{token.value}(#{token.type})")
+        STDERR.print("#{token.value}(#{token.type})")
       end
     end
   end

--- a/src/miniparsers/kotlin.cr
+++ b/src/miniparsers/kotlin.cr
@@ -637,18 +637,18 @@ class KotlinParser
 
   # Print tokens for debugging purposes
   def print_tokens(tokens : Array(Token), id = "default", trace = false)
-    puts("\n================ #{id} ===================")
+    STDERR.puts("\n================ #{id} ===================")
     tokens.each do |token|
-      print("#{token.value} ")
+      STDERR.print("#{token.value} ")
       if id == "error"
-        print("(#{token.type})")
+        STDERR.print("(#{token.type})")
       end
     end
 
     if trace
-      puts ""
+      STDERR.puts ""
       tokens.each do |token|
-        print("#{token.value}(#{token.type})")
+        STDERR.print("#{token.value}(#{token.type})")
       end
     end
   end
@@ -661,10 +661,10 @@ class KotlinParser
         print_tokens annotation_model.tokens, "#{_class.name} annotation"
       end
 
-      puts("\n================ class #{_class.name} ==================")
+      STDERR.puts("\n================ class #{_class.name} ==================")
       _class.fields.each_key do |field_name|
         field = _class.fields[field_name]
-        puts("[Field] #{field.access_modifier} #{field.val_or_var} #{field.name}: #{field.type} = #{field.init_value}")
+        STDERR.puts("[Field] #{field.access_modifier} #{field.val_or_var} #{field.name}: #{field.type} = #{field.init_value}")
       end
 
       _class.methods.each_key do |method_name|

--- a/src/miniparsers/python.cr
+++ b/src/miniparsers/python.cr
@@ -323,15 +323,15 @@ class PythonParser
   def print_line(index)
     while index < @tokens.size
       break if @tokens[index].type == :NEWLINE
-      print(@tokens[index].to_s, " ")
+      STDERR.print(@tokens[index].to_s, " ")
       index += 1
     end
-    puts ""
+    STDERR.puts ""
   end
 
   def debug_print(s)
     if @debug
-      puts s
+      STDERR.puts s
     end
   end
 

--- a/src/miniparsers/python.cr
+++ b/src/miniparsers/python.cr
@@ -323,7 +323,7 @@ class PythonParser
   def print_line(index)
     while index < @tokens.size
       break if @tokens[index].type == :NEWLINE
-      STDERR.print(@tokens[index].to_s, " ")
+      STDERR.print("#{@tokens[index].type} #{@tokens[index].value.inspect}", " ")
       index += 1
     end
     STDERR.puts ""


### PR DESCRIPTION
## Summary

Several miniparser debug methods (`print_tokens` in kotlin.cr and java.cr, `debug_print` and `print_line` in python.cr) write directly to STDOUT via raw `puts`/`print`. This can pollute normal tool output when debug/trace flags are enabled.

This replaces all `puts`/`print` calls in these debug methods with `STDERR.puts`/`STDERR.print` so debug output stays separate from normal STDOUT.

Fixes #1150

## Changes

- `src/miniparsers/kotlin.cr`: `print_tokens` and `trace` methods now write to STDERR
- `src/miniparsers/java.cr`: `print_tokens` method now writes to STDERR
- `src/miniparsers/python.cr`: `print_line` and `debug_print` methods now write to STDERR

No behavioral changes to the parsers themselves. The debug output content is identical, just routed to STDERR instead of STDOUT.