### PR TITLE
Consolidate duplicate Endpoint initializers using default parameters

### DIFF
--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -6,12 +6,10 @@ struct Endpoint
   include YAML::Serializable
   property url, method, params, protocol, details, tags, internal
 
-  def initialize(@url : String, @method : String)
-    @params = [] of Param
-    @details = Details.new
+  def initialize(@url : String, @method : String, @params : Array(Param) = [] of Param,
+                 @details : Details = Details.new, @internal : Bool = false)
     @protocol = "http"
     @tags = [] of Tag
-    @internal = false
   end
 
   def initialize(@url : String, @method : String, @details : Details)
@@ -19,24 +17,6 @@ struct Endpoint
     @protocol = "http"
     @tags = [] of Tag
     @internal = false
-  end
-
-  def initialize(@url : String, @method : String, @params : Array(Param))
-    @details = Details.new
-    @protocol = "http"
-    @tags = [] of Tag
-    @internal = false
-  end
-
-  def initialize(@url : String, @method : String, @params : Array(Param), @details : Details)
-    @protocol = "http"
-    @tags = [] of Tag
-    @internal = false
-  end
-
-  def initialize(@url : String, @method : String, @params : Array(Param), @details : Details, @internal : Bool)
-    @protocol = "http"
-    @tags = [] of Tag
   end
 
   def details=(details : Details)


### PR DESCRIPTION
## Summary

The `Endpoint` struct had 5 separate initializers (lines 9-40) that repeated the same default assignments (`@protocol = "http"`, `@tags = [] of Tag`, etc.) across each one. This consolidates them into 2 using Crystal's default parameter values:

1. A primary initializer with defaults for `params`, `details`, and `internal`
2. A convenience overload for the `(url, method, details)` call pattern, which is widely used across analyzers

Fixes #1148

## Changes

- `src/models/endpoint.cr`: 5 initializers reduced to 2 (-22 lines, +2 lines)

No caller changes required. All existing call patterns continue to resolve correctly through Crystal's overload resolution:
- `Endpoint.new(url, method)` matches the primary initializer with all defaults
- `Endpoint.new(url, method, details)` matches the Details overload
- `Endpoint.new(url, method, params)` matches the primary initializer
- `Endpoint.new(url, method, params, details)` matches the primary initializer
- `Endpoint.new(url, method, params, details, internal)` matches the primary initializer

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)