### PR TITLE
Improve CI/release build performance: native ARM runners and cache optimization

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -10,39 +10,35 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version to build and tag (e.g., 0.0.13)
+        required: true
+        type: string
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.1
-        with:
-          cosign-release: v2.1.1
-
-      # Using QEME for multiple platforms
-      # https://github.com/docker/build-push-action?tab=readme-ov-file#usage
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v4
 
@@ -64,16 +60,103 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: build-and-push
+      - name: Prepare platform slug
+        id: platform
+        run: |
+          echo "slug=$(echo '${{ matrix.arch }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      # Build and push by digest (no tag yet)
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          file: docker/Dockerfile
+          platforms: ${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64
-          cache-from: type=gha,scope=${{ github.sha }}
-          cache-to: type=gha,mode=max,scope=${{ github.sha }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=ghcr-${{ steps.platform.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=ghcr-${{ steps.platform.outputs.slug }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      # Install the cosign tool
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+        with:
+          cosign-release: v2.1.1
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Normalize version: strip leading 'v' if present
+      - name: Normalize version
+        if: github.event_name == 'workflow_dispatch'
+        id: normalize
+        run: |
+          RAW_VERSION="${{ inputs.version }}"
+          VERSION="${RAW_VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # main push -> :main
+            type=ref,event=branch
+
+            # GitHub Release -> v1.2.3, 1.2, latest
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+            # Manual dispatch -> input version + latest
+            type=raw,value=${{ steps.normalize.outputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -14,16 +14,19 @@ permissions:
 jobs:
   build-deb:
     strategy:
+      fail-fast: false
       matrix:
-        arch: [amd64, arm64]
-    runs-on: ubuntu-latest
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Checkout source code
         uses: actions/checkout@v6
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Get Version
         id: get_version
         run: |
@@ -35,7 +38,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build noir Binary
         run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/noir -w /noir --entrypoint="" 84codes/crystal:latest-debian-12 sh -c "
+          docker run --rm -v $(pwd):/noir -w /noir --entrypoint="" 84codes/crystal:latest-debian-12 sh -c "
             apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
             shards install --production &&
             /usr/bin/crystal build src/noir.cr -o noir --release --no-debug --static


### PR DESCRIPTION
## Summary
- Replace QEMU emulation with native `ubuntu-24.04-arm` runners for arm64 builds in `publish-ghcr.yml` and `release-deb.yml`
- Fix Docker layer cache scope from `github.sha` (never reused) to fixed scope per platform
- Parallelize multi-platform Docker builds with digest-based approach and manifest merge
- Add `workflow_dispatch` version input and proper semver tagging for GHCR publish

## Changes

### `publish-ghcr.yml` — Full rewrite
- **Native ARM runners**: QEMU → `ubuntu-24.04-arm` for arm64
- **Cache fix**: `scope=${{ github.sha }}` → `scope=ghcr-linux-amd64` / `scope=ghcr-linux-arm64`
- **Parallel build + merge**: Split into per-platform matrix jobs pushing by digest, then merge manifests
- **Version tagging**: Added `workflow_dispatch` version input, semver tags for releases, branch tags for pushes

### `release-deb.yml`
- **Native ARM runners**: QEMU → `ubuntu-24.04-arm` for arm64
- Removed QEMU setup step and `--platform` flag

### `ci.yml` — No changes
Already optimized with native ARM runners and proper cache scope.

## Expected Impact
- Native ARM: arm64 builds ~5-10x faster (no QEMU overhead)
- Cache fix: unchanged layers skip rebuild (~2-5x faster)
- Parallelization: total time ≈ max(amd64, arm64) instead of sum

## Test plan
- [ ] Verify `publish-ghcr.yml` builds and pushes multi-arch image correctly
- [ ] Verify `release-deb.yml` builds .deb for both architectures
- [ ] Confirm cache is reused across commits

Closes #1166