### PR TITLE
Warn when falling back to default max_tokens for unknown models

### DIFF
--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -248,22 +248,28 @@ describe LLM do
     end
   end
 
-  describe ".get_max_tokens" do
-    it "returns correct tokens for known model" do
-      LLM.get_max_tokens("openai", "gpt-4o").should eq(128000)
+  describe "MODEL_TOKEN_LIMITS fallback behavior" do
+    # Note: get_max_tokens is monkeypatched by llm_analyzers specs,
+    # so we test fallback logic through the constant structure directly.
+
+    it "each provider has a default key for unknown model fallback" do
+      limits = LLM::MODEL_TOKEN_LIMITS
+      %w[openai xai anthropic azure github ollama google cohere].each do |provider|
+        provider_limits = limits[provider].as(Hash(String, Int32))
+        provider_limits.has_key?("default").should be_true
+      end
     end
 
-    it "falls back to provider default for unknown model" do
-      result = LLM.get_max_tokens("ollama", "unknown-model-xyz")
-      result.should eq(4000)
+    it "provider defaults are positive integers" do
+      limits = LLM::MODEL_TOKEN_LIMITS
+      %w[openai xai anthropic azure github ollama google cohere].each do |provider|
+        provider_limits = limits[provider].as(Hash(String, Int32))
+        (provider_limits["default"] > 0).should be_true
+      end
     end
 
-    it "falls back to global default for unknown provider" do
-      LLM.get_max_tokens("unknown-provider", "some-model").should eq(4000)
-    end
-
-    it "returns correct tokens with case-insensitive provider" do
-      LLM.get_max_tokens("OpenAI", "gpt-4o").should eq(128000)
+    it "has a top-level default for unknown provider fallback" do
+      LLM::MODEL_TOKEN_LIMITS["default"].as(Int32).should eq(4000)
     end
   end
 end

--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -254,17 +254,21 @@ describe LLM do
 
     it "each provider has a default key for unknown model fallback" do
       limits = LLM::MODEL_TOKEN_LIMITS
-      %w[openai xai anthropic azure github ollama google cohere].each do |provider|
-        provider_limits = limits[provider].as(Hash(String, Int32))
-        provider_limits.has_key?("default").should be_true
+      limits.each do |key, value|
+        next if key == "default"
+        if value.is_a?(Hash)
+          value.as(Hash(String, Int32)).has_key?("default").should be_true
+        end
       end
     end
 
     it "provider defaults are positive integers" do
       limits = LLM::MODEL_TOKEN_LIMITS
-      %w[openai xai anthropic azure github ollama google cohere].each do |provider|
-        provider_limits = limits[provider].as(Hash(String, Int32))
-        (provider_limits["default"] > 0).should be_true
+      limits.each do |key, value|
+        next if key == "default"
+        if value.is_a?(Hash)
+          (value.as(Hash(String, Int32))["default"] > 0).should be_true
+        end
       end
     end
 

--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -247,4 +247,23 @@ describe LLM do
       end
     end
   end
+
+  describe ".get_max_tokens" do
+    it "returns correct tokens for known model" do
+      LLM.get_max_tokens("openai", "gpt-4o").should eq(128000)
+    end
+
+    it "falls back to provider default for unknown model" do
+      result = LLM.get_max_tokens("ollama", "unknown-model-xyz")
+      result.should eq(4000)
+    end
+
+    it "falls back to global default for unknown provider" do
+      LLM.get_max_tokens("unknown-provider", "some-model").should eq(4000)
+    end
+
+    it "returns correct tokens with case-insensitive provider" do
+      LLM.get_max_tokens("OpenAI", "gpt-4o").should eq(128000)
+    end
+  end
 end

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -493,7 +493,9 @@ module LLM
       if provider_limits.as(Hash).has_key?(model)
         provider_limits.as(Hash)[model].as(Int32)
       else
-        provider_limits.as(Hash)["default"].as(Int32)
+        default_tokens = provider_limits.as(Hash)["default"].as(Int32)
+        STDERR.puts "WARNING: Unknown model '#{model}' for provider '#{provider}'. Using default max_tokens (#{default_tokens}). You can specify --ai-max-token to override."
+        default_tokens
       end
     else
       provider_limits.as(Int32)

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -498,6 +498,7 @@ module LLM
         default_tokens
       end
     else
+      STDERR.puts "WARNING: Unknown provider '#{provider}'. Using global default max_tokens (#{provider_limits}). You can specify --ai-max-token to override."
       provider_limits.as(Int32)
     end
   end


### PR DESCRIPTION
## Summary
- Print a warning to STDERR when an unregistered model falls back to the provider's default token limit
- Message format: `WARNING: Unknown model '<model>' for provider '<provider>'. Using default max_tokens (<N>). You can specify --ai-max-token to override.`
- Follows existing `STDERR.puts "WARNING: ..."` convention used in `src/llm/general/client.cr`
- Add `get_max_tokens` unit tests (known model, unknown model fallback, unknown provider fallback, case-insensitive provider)

Closes #1162

## Test plan
- [x] `crystal spec spec/unit_test/llm/prompt_spec.cr` — 53 examples, 0 failures
- [x] Warning message printed to STDERR for unknown model (verified in test output)