### PR TITLE
Update ameba path from bin/ to lib/ameba/bin/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ crystal spec -v
 ### Lint
 ```bash
 crystal tool format
-bin/ameba.cr --fix
+lib/ameba/bin/ameba.cr --fix
 
 # Ameba installation
 # https://github.com/crystal-ameba/ameba#installation

--- a/docs/content/development/how_to_build/index.ko.md
+++ b/docs/content/development/how_to_build/index.ko.md
@@ -74,13 +74,13 @@ crystal spec -v
 Noir는 Crystal용 정적 분석 도구인 [Ameba](https://github.com/crystal-ameba/ameba)로 코드 스타일을 검사합니다.
 
 ```sh
-bin/ameba.cr
+lib/ameba/bin/ameba.cr
 ```
 
 자동 수정도 가능합니다.
 
 ```sh
-bin/ameba.cr --fix
+lib/ameba/bin/ameba.cr --fix
 ```
 
 또는 `just`를 사용합니다.

--- a/docs/content/development/how_to_build/index.md
+++ b/docs/content/development/how_to_build/index.md
@@ -74,13 +74,13 @@ crystal spec -v
 Noir uses [Ameba](https://github.com/crystal-ameba/ameba), a static analysis tool for Crystal.
 
 ```sh
-bin/ameba.cr
+lib/ameba/bin/ameba.cr
 ```
 
 Auto-fix issues.
 
 ```sh
-bin/ameba.cr --fix
+lib/ameba/bin/ameba.cr --fix
 ```
 
 Or use `just`.

--- a/justfile
+++ b/justfile
@@ -46,13 +46,13 @@ docs-dependencies:
 [group('development')]
 fix:
     crystal tool format
-    bin/ameba.cr --fix
+    lib/ameba/bin/ameba.cr --fix
 
 # Check code format and lint without changes.
 [group('development')]
 check:
     crystal tool format --check
-    bin/ameba.cr
+    lib/ameba/bin/ameba.cr
 
 # Run all tests.
 [group('development')]


### PR DESCRIPTION
## Summary
- Update all `bin/ameba.cr` references to `lib/ameba/bin/ameba.cr`
- Affected files: `justfile`, `CONTRIBUTING.md`, and build docs (EN/KO)

## Why
Ameba removed the `executables` entry from `shard.yml` in https://github.com/crystal-ameba/ameba/pull/807, so `bin/ameba.cr` is no longer auto-installed by `shards install/update`. The library-bundled entry point at `lib/ameba/bin/ameba.cr` should be used instead.

## Test plan
- [x] `shards install` no longer creates `bin/ameba.cr`
- [x] `just fix` and `just check` work with the new path

----

cc @ksg97031 