### PR TITLE
Remove cyclonedx-cr from development dependencies

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -37,6 +37,3 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
     branch: master
-  cyclonedx-cr:
-    github: hahwul/cyclonedx-cr
-    branch: main


### PR DESCRIPTION
## Summary
- Remove `cyclonedx-cr` from `development_dependencies` in `shard.yml`
- SBOM generation is handled via GitHub Action (`hahwul/cyclonedx-cr@v1.3.0`), not as a shard dependency
- Also fixes `shards update` error: `Could not find executable "cyclonedx-cr" for "cyclonedx-cr"`

## Test plan
- [x] `shards install` completes without errors
- [x] `shards update` completes without errors
- [x] SBOM release workflow still works (uses GitHub Action, unaffected)