### PR TITLE
Remove LLVM 21 overlay from flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770169770,
-        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "lastModified": 1775639890,
+        "narHash": "sha256-9O9gNidrdzcb7vgKGtff7QiLtr0IsVaCi0pAXm8anhQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "rev": "456e8a9468b9d46bd8c9524425026c00745bc4d2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,27 +9,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [
-            (final: prev: {
-              # Crystal(1.19.x)가 LLVM 22.1을 끌고 오고 있음. 다만 현재 LLVM 22.1은 빌드가 깨짐.
-              # 그래서 devShell 진입이 불가하고 우선 이를 대응하기 위해 LLVM 21로 고정합니다. (깨짐은 macOS 기준)
-              crystal =
-                let
-                  llvmPackages =
-                    prev.llvmPackages_21
-                      or (throw "llvmPackages_21 not found in this nixpkgs; update/pin nixpkgs to a revision that provides LLVM 21");
-                in
-                # `pkgs.crystal`이 makeOverridable이 아니라 `override`가 없어서(callPackage로) 재정의
-                (prev.callPackage (prev.path + "/pkgs/development/compilers/crystal") {
-                  # crystal 1.19.1은 기본적으로 llvmPackages_22(LLVM 22.1)를 사용
-                  # 여기서는 llvmPackages_22를 llvmPackages_21로 치환해 LLVM 21을 강제로 사용하게 합니다.
-                  llvmPackages_22 = llvmPackages;
-                }).crystal;
-            })
-          ];
-        };
+        pkgs = import nixpkgs { inherit system; };
 
         noir = pkgs.crystal.buildCrystalPackage rec {
           pname = "noir";


### PR DESCRIPTION
## Summary
- LLVM 22.1 builds are now fixed in nixpkgs-unstable (LLVM 22.1.2), so the workaround that pinned Crystal to LLVM 21 is no longer needed
- Updated `flake.lock` to latest nixpkgs-unstable (2026-04-08)
- Simplifies `flake.nix` by removing the overlay entirely

## Test
Tested on macOS aarch64:
- `nix develop` — Crystal 1.19.1 with LLVM 22.1.2 loads successfully
- `nix build` — package builds without errors