### PR TITLE
Use .matches? instead of =~ for regex checks

### DIFF
--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -86,9 +86,9 @@ class LLMEndpointOptimizer < EndpointOptimizer
     return true if url.includes?("__") || url.includes?("--") # Double separators
 
     # Check for complex parameter patterns
-    params_text = endpoint.params.map(&.name).join(" ")
-    return true if params_text.includes?("_id_") # Complex ID patterns
-    return true if params_text.matches?(/[A-Z]{2,}/) # Unusual naming patterns
+    return true if endpoint.params.any? do |p|
+      p.name.includes?("_id_") || p.name.matches?(/[A-Z]{2,}/)
+    end
 
     false
   end

--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -80,15 +80,15 @@ class LLMEndpointOptimizer < EndpointOptimizer
     # Look for unusual parameter patterns, complex paths, or non-standard naming
     return true if url.includes?("*")                         # Wildcard patterns
     return true if url.includes?("...")                       # Spread/rest patterns
-    return true if url.matches?(/\{[^}]*\|[^}]*\}/)            # Union types in parameters
+    return true if url.matches?(/\{[^}]*\|[^}]*\}/)           # Union types in parameters
     return true if url.matches?(/[A-Z]{2,}/)                  # Unusual uppercase segments
     return true if url.matches?(/\d{3,}/)                     # Long numeric segments
     return true if url.includes?("__") || url.includes?("--") # Double separators
 
     # Check for complex parameter patterns
     return true if endpoint.params.any? do |p|
-      p.name.includes?("_id_") || p.name.matches?(/[A-Z]{2,}/)
-    end
+                     p.name.includes?("_id_") || p.name.matches?(/[A-Z]{2,}/)
+                   end
 
     false
   end

--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -80,15 +80,15 @@ class LLMEndpointOptimizer < EndpointOptimizer
     # Look for unusual parameter patterns, complex paths, or non-standard naming
     return true if url.includes?("*")                         # Wildcard patterns
     return true if url.includes?("...")                       # Spread/rest patterns
-    return true if url =~ /\{[^}]*\|[^}]*\}/                  # Union types in parameters
-    return true if url =~ /[A-Z]{2,}/                         # Unusual uppercase segments
-    return true if url =~ /\d{3,}/                            # Long numeric segments
+    return true if url.matches?(/\{[^}]*\|[^}]*\}/)            # Union types in parameters
+    return true if url.matches?(/[A-Z]{2,}/)                  # Unusual uppercase segments
+    return true if url.matches?(/\d{3,}/)                     # Long numeric segments
     return true if url.includes?("__") || url.includes?("--") # Double separators
 
     # Check for complex parameter patterns
     params_text = endpoint.params.map(&.name).join(" ")
     return true if params_text.includes?("_id_") # Complex ID patterns
-    return true if params_text =~ /[A-Z]{2,}/    # Unusual naming patterns
+    return true if params_text.matches?(/[A-Z]{2,}/) # Unusual naming patterns
 
     false
   end


### PR DESCRIPTION
## Summary
- Follow-up from #1180 review feedback by @Sija
- Replace `=~` operator with `.matches?` for regex pattern checks in `llm_optimizer.cr`
- `.matches?` is more efficient as it avoids creating `MatchData` objects for simple existence checks

## Test plan
- [x] Existing tests should pass without changes (no behavioral difference)