### PR TITLE
Fix non-deterministic endpoint dedup in Nitro and Nuxtjs analyzers

### DIFF
--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -5,6 +5,7 @@ module Analyzer::Javascript
     def analyze
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
+      mutex = Mutex.new
 
       begin
         populate_channel_with_files(channel)
@@ -16,7 +17,7 @@ module Analyzer::Javascript
           # Focus on routes/ directory for Nitro
           if path.includes?("/routes/")
             if File.exists?(path)
-              analyze_nitro_file(path, result)
+              analyze_nitro_file(path, result, mutex)
             end
           end
         end
@@ -27,7 +28,7 @@ module Analyzer::Javascript
       result
     end
 
-    private def analyze_nitro_file(path : String, result : Array(Endpoint))
+    private def analyze_nitro_file(path : String, result : Array(Endpoint), mutex : Mutex)
       # Extract endpoint from file path
       # routes/hello.ts -> /hello
       # routes/users/[id].ts -> /users/:id
@@ -133,14 +134,16 @@ module Analyzer::Javascript
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
           end
 
-          existing_idx = result.index { |e| e.url == url && e.method == method }
-          if existing_idx
-            # Method-specific files take precedence over generic handlers
-            if specific_method
-              result[existing_idx] = endpoint
+          mutex.synchronize do
+            existing_idx = result.index { |e| e.url == url && e.method == method }
+            if existing_idx
+              # Method-specific files take precedence over generic handlers
+              if specific_method
+                result[existing_idx] = endpoint
+              end
+            else
+              result << endpoint
             end
-          else
-            result << endpoint
           end
         end
       rescue e : Exception

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -133,7 +133,15 @@ module Analyzer::Javascript
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
           end
 
-          result << endpoint unless result.any? { |e| e.url == url && e.method == method }
+          existing_idx = result.index { |e| e.url == url && e.method == method }
+          if existing_idx
+            # Method-specific files take precedence over generic handlers
+            if specific_method
+              result[existing_idx] = endpoint
+            end
+          else
+            result << endpoint
+          end
         end
       rescue e : Exception
         logger.debug "Error reading file #{path}: #{e.message}"

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -5,6 +5,7 @@ module Analyzer::Javascript
     def analyze
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
+      mutex = Mutex.new
 
       begin
         populate_channel_with_files(channel)
@@ -16,7 +17,7 @@ module Analyzer::Javascript
           # Focus on server/api and server/routes directories for Nuxt 3
           if path.includes?("/server/api/") || path.includes?("/server/routes/")
             if File.exists?(path)
-              analyze_nuxt_file(path, result)
+              analyze_nuxt_file(path, result, mutex)
             end
           end
         end
@@ -27,7 +28,7 @@ module Analyzer::Javascript
       result
     end
 
-    private def analyze_nuxt_file(path : String, result : Array(Endpoint))
+    private def analyze_nuxt_file(path : String, result : Array(Endpoint), mutex : Mutex)
       # Extract endpoint from file path
       # server/api/hello.ts -> /api/hello
       # server/api/users/[id].ts -> /api/users/:id
@@ -148,14 +149,16 @@ module Analyzer::Javascript
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
           end
 
-          existing_idx = result.index { |e| e.url == url && e.method == method }
-          if existing_idx
-            # Method-specific files take precedence over generic handlers
-            if specific_method
-              result[existing_idx] = endpoint
+          mutex.synchronize do
+            existing_idx = result.index { |e| e.url == url && e.method == method }
+            if existing_idx
+              # Method-specific files take precedence over generic handlers
+              if specific_method
+                result[existing_idx] = endpoint
+              end
+            else
+              result << endpoint
             end
-          else
-            result << endpoint
           end
         end
       rescue e : Exception

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -148,7 +148,15 @@ module Analyzer::Javascript
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
           end
 
-          result << endpoint unless result.any? { |e| e.url == url && e.method == method }
+          existing_idx = result.index { |e| e.url == url && e.method == method }
+          if existing_idx
+            # Method-specific files take precedence over generic handlers
+            if specific_method
+              result[existing_idx] = endpoint
+            end
+          else
+            result << endpoint
+          end
         end
       rescue e : Exception
         logger.debug "Error reading file #{path}: #{e.message}"


### PR DESCRIPTION
## Summary
- Fix a race condition in Nitro and Nuxtjs analyzers where `parallel_analyze` processes files in non-deterministic order, causing CI flakes
- When both a generic handler (`[id].ts`) and a method-specific handler (`[id].delete.ts`) exist for the same route, the previous first-wins dedup logic could silently drop method-specific endpoints (with extra params like `authorization`)
- Method-specific files now always take precedence over generic handlers regardless of processing order

## Root Cause
The dedup logic `result << endpoint unless result.any? { |e| e.url == url && e.method == method }` only checked URL + method, ignoring parameters. In CI, `[id].ts` could be processed before `[id].delete.ts`, registering a DELETE endpoint without `authorization` — then the specific handler's endpoint was skipped as a duplicate.

## Test plan
- [x] `crystal spec spec/functional_test/testers/javascript/nitro_spec.cr` — 62 examples, 0 failures
- [x] `crystal spec spec/functional_test/testers/javascript/nuxtjs_spec.cr` — 90 examples, 0 failures
- [x] `crystal spec spec/functional_test/` — 4115 examples, 0 failures