### PR TITLE
Fix OAS2 analyzer mapping 'form' param type to 'json'

### DIFF
--- a/spec/functional_test/fixtures/specification/oas2/doc.yml
+++ b/spec/functional_test/fixtures/specification/oas2/doc.yml
@@ -32,6 +32,42 @@ paths:
       responses:
         201:
           description: Pet added successfully
+  /pets/search:
+    get:
+      summary: Search pets by query parameters
+      parameters:
+        - name: name
+          in: query
+          type: string
+        - name: X-Request-Id
+          in: header
+          type: string
+      responses:
+        200:
+          description: Search results
+  /pets/upload:
+    post:
+      summary: Upload pet data using formData
+      parameters:
+        - name: file
+          in: formData
+          type: file
+        - name: description
+          in: formData
+          type: string
+      responses:
+        201:
+          description: Upload successful
+  /pets/submit:
+    post:
+      summary: Submit pet data using form (non-standard)
+      parameters:
+        - name: pet_name
+          in: form
+          type: string
+      responses:
+        201:
+          description: Submit successful
   /pets/{petId}:
     get:
       summary: Get information about a specific pet

--- a/spec/functional_test/testers/specification/oas2_spec.cr
+++ b/spec/functional_test/testers/specification/oas2_spec.cr
@@ -3,6 +3,17 @@ require "../../func_spec.cr"
 expected_endpoints = [
   Endpoint.new("/v1/pets", "GET"),
   Endpoint.new("/v1/pets", "POST"),
+  Endpoint.new("/v1/pets/search", "GET", [
+    Param.new("name", "", "query"),
+    Param.new("X-Request-Id", "", "header"),
+  ]),
+  Endpoint.new("/v1/pets/upload", "POST", [
+    Param.new("file", "", "form"),
+    Param.new("description", "", "form"),
+  ]),
+  Endpoint.new("/v1/pets/submit", "POST", [
+    Param.new("pet_name", "", "form"),
+  ]),
   Endpoint.new("/v1/pets/{petId}", "GET", [Param.new("petId", "", "path")]),
   Endpoint.new("/v1/pets/{petId}", "PUT", [Param.new("petId", "", "path")]),
 ]

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -36,7 +36,7 @@ module Analyzer::Specification
                         param = Param.new(param_name, "", "query")
                         params << param
                       elsif param_obj["in"] == "form"
-                        param = Param.new(param_name, "", "json")
+                        param = Param.new(param_name, "", "form")
                         params << param
                       elsif param_obj["in"] == "formData"
                         param = Param.new(param_name, "", "form")
@@ -95,7 +95,7 @@ module Analyzer::Specification
                         param = Param.new(param_name, "", "query")
                         params << param
                       elsif param_obj["in"] == "form"
-                        param = Param.new(param_name, "", "json")
+                        param = Param.new(param_name, "", "form")
                         params << param
                       elsif param_obj["in"] == "formData"
                         param = Param.new(param_name, "", "form")


### PR DESCRIPTION
## Summary
- Fix `"in": "form"` parameters being incorrectly mapped to param_type `"json"` instead of `"form"` in the OAS2 analyzer (both JSON and YAML parsers)
- While `"form"` is not a standard Swagger 2.0 value (the spec uses `"formData"`), the existing branch handles it as lenient parsing — mapping to `"form"` is consistent with the `"formData"` branch
- Add functional test coverage for `query`, `header`, `formData`, and `form` parameter types

## Test plan
- [x] `crystal spec` — 30/30 OAS2 tests pass
- [x] `crystal tool format` — no formatting issues
- [x] `ameba` lint — 0 failures

Closes #1087