### PR TITLE
refactor: extract hardcoded error truncation length to constant

### DIFF
--- a/src/llm/general/client.cr
+++ b/src/llm/general/client.cr
@@ -7,6 +7,7 @@ module LLM
   class General
     @@tools_cache = {} of String => JSON::Any
     @@tools_cache_mutex = Mutex.new
+    MAX_ERROR_SNIPPET_SIZE = 1024
 
     def initialize(url : String, model : String, api_key : String?)
       @url = url
@@ -77,7 +78,7 @@ module LLM
 
       response = HTTP::Client.post(@api, headers: headers, body: body)
       unless response.success?
-        snippet = response.body.size > 1024 ? "#{response.body[0, 1024]}..." : response.body
+        snippet = response.body.size > MAX_ERROR_SNIPPET_SIZE ? "#{response.body[0, MAX_ERROR_SNIPPET_SIZE]}..." : response.body
         STDERR.puts "WARNING: AI API error (HTTP #{response.status_code}): #{snippet}"
         return ""
       end
@@ -108,7 +109,7 @@ module LLM
 
       response = HTTP::Client.post(@api, headers: headers, body: body)
       unless response.success?
-        snippet = response.body.size > 1024 ? "#{response.body[0, 1024]}..." : response.body
+        snippet = response.body.size > MAX_ERROR_SNIPPET_SIZE ? "#{response.body[0, MAX_ERROR_SNIPPET_SIZE]}..." : response.body
         STDERR.puts "WARNING: AI API error (HTTP #{response.status_code}): #{snippet}"
         return ""
       end

--- a/src/llm/general/client.cr
+++ b/src/llm/general/client.cr
@@ -9,6 +9,10 @@ module LLM
     @@tools_cache_mutex = Mutex.new
     MAX_ERROR_SNIPPET_SIZE = 1024
 
+    private def truncate_error_snippet(body : String)
+      body.size > MAX_ERROR_SNIPPET_SIZE ? "#{body[0, MAX_ERROR_SNIPPET_SIZE]}..." : body
+    end
+
     def initialize(url : String, model : String, api_key : String?)
       @url = url
       @api = if url.includes?("://")
@@ -78,7 +82,7 @@ module LLM
 
       response = HTTP::Client.post(@api, headers: headers, body: body)
       unless response.success?
-        snippet = response.body.size > MAX_ERROR_SNIPPET_SIZE ? "#{response.body[0, MAX_ERROR_SNIPPET_SIZE]}..." : response.body
+        snippet = truncate_error_snippet(response.body)
         STDERR.puts "WARNING: AI API error (HTTP #{response.status_code}): #{snippet}"
         return ""
       end
@@ -109,7 +113,7 @@ module LLM
 
       response = HTTP::Client.post(@api, headers: headers, body: body)
       unless response.success?
-        snippet = response.body.size > MAX_ERROR_SNIPPET_SIZE ? "#{response.body[0, MAX_ERROR_SNIPPET_SIZE]}..." : response.body
+        snippet = truncate_error_snippet(response.body)
         STDERR.puts "WARNING: AI API error (HTTP #{response.status_code}): #{snippet}"
         return ""
       end


### PR DESCRIPTION
Resolves #1102.

Extracts the magic number `1024` used for error-snippet truncation in `src/llm/general/client.cr` into a named constant `MAX_ERROR_SNIPPET_SIZE`, so the limit lives in one place.

## Change

- Added `MAX_ERROR_SNIPPET_SIZE = 1024` on the `LLM::General` class
- Replaced the two magic-number occurrences on lines 80 and 111 with the constant

No behavior change.


[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)