### PR TITLE
refactor(analyzer): 3-layer architecture + PHP/Ruby/Rust engines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,28 @@ spec/
 - `.ameba.yml` - Linting configuration
 - `.github/workflows/ci.yml` - CI configuration
 
+## Analyzer Layering
+
+An analyzer is composed of three layers. Keep them separate — a framework adapter should not open files or re-implement parsing.
+
+1. **Language Engine** — shared per-language base (`src/analyzer/analyzers/{lang}/common.cr` or equivalent). Owns file walking, concurrency, worker pool, file-content caching. One per language.
+2. **Route Extractor** — shared per-language parser layer (`src/miniparsers/{lang}_route_extractor.cr`). Takes source content, yields route declarations (method, path, location). No file I/O, no framework-specific rules.
+3. **Framework Adapter** — thin per-framework class (`src/analyzer/analyzers/{lang}/{framework}.cr`). Consumes routes from the extractor and applies framework-specific param mappings, filters, and special cases.
+
+**Rule**: the framework adapter receives routes; it does not walk the filesystem or parse tokens itself.
+
+**Reference implementation**: `src/analyzer/analyzers/javascript/hono.cr` on top of `src/miniparsers/js_route_extractor.cr`. Hono is ~205 lines because it follows this split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
+
+**Current coverage**:
+- Language engines: Go, Python. Missing for PHP, Ruby, Rust (tracked as separate work).
+- Route extractors: JavaScript only. Python/Kotlin/Java have parsers but not dedicated extractors.
+
+When adding a new framework in a language that already has an extractor, extend the extractor rather than re-parsing inline.
+
 ## Adding New Components
 
 ### Analyzers
-1. Create `src/analyzer/analyzers/{language}/{framework}.cr`
+1. Create `src/analyzer/analyzers/{language}/{framework}.cr` — framework adapter only. Delegate parsing to the language's route extractor (see **Analyzer Layering** above).
 2. Add functional test: `spec/functional_test/testers/{language}/{framework}_spec.cr`
 3. Add fixtures: `spec/functional_test/fixtures/{language}/{framework}/`
 4. Register in `src/analyzer/analyzer.cr` if needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ spec/
 
 An analyzer is composed of three layers. Keep them separate — a framework adapter should not open files or re-implement parsing.
 
-1. **Language Engine** — shared per-language base (`src/analyzer/analyzers/{lang}/common.cr` or equivalent). Owns file walking, concurrency, worker pool, file-content caching. One per language.
+1. **Language Engine** — shared per-language base. PHP/Ruby/Rust live in `src/analyzer/engines/{lang}_engine.cr`; Go and Python still use `src/analyzer/analyzers/{lang}/common.cr` (will migrate alongside the later engine-vs-extractor split). Owns file walking, concurrency, worker pool, file-content caching.
 2. **Route Extractor** — shared per-language parser layer (`src/miniparsers/{lang}_route_extractor.cr`). Takes source content, yields route declarations (method, path, location). No file I/O, no framework-specific rules.
 3. **Framework Adapter** — thin per-framework class (`src/analyzer/analyzers/{lang}/{framework}.cr`). Consumes routes from the extractor and applies framework-specific param mappings, filters, and special cases.
 
@@ -88,7 +88,7 @@ An analyzer is composed of three layers. Keep them separate — a framework adap
 **Reference implementation**: `src/analyzer/analyzers/javascript/hono.cr` on top of `src/miniparsers/js_route_extractor.cr`. Hono is ~205 lines because it follows this split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
 
 **Current coverage**:
-- Language engines: Go, Python. Missing for PHP, Ruby, Rust (tracked as separate work).
+- Language engines: Go, Python, PHP, Ruby, Rust. Go/Python bases mix engine and route-extraction helpers; splitting them is future work.
 - Route extractors: JavaScript only. Python/Kotlin/Java have parsers but not dedicated extractors.
 
 When adding a new framework in a language that already has an extractor, extend the extractor rather than re-parsing inline.

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -1,45 +1,8 @@
-require "../../../models/analyzer"
-require "../../../utils/utils.cr"
+require "../../engines/php_engine"
 
 module Analyzer::Php
-  class CakePHP < Analyzer
-    def analyze
-      result = [] of Endpoint
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-
-                  if File.exists?(path)
-                    result.concat(analyze_file(path))
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                rescue e
-                  logger.debug "Error analyzing #{path}: #{e}"
-                end
-              end
-            end
-          end
-        end
-      rescue e
-        logger.debug e
-      end
-
-      Fiber.yield
-      result
-    end
-
-    private def analyze_file(path : String) : Array(Endpoint)
+  class CakePHP < PhpEngine
+    def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       # Analyze CakePHP routes file
@@ -136,29 +99,13 @@ module Analyzer::Php
       endpoints
     end
 
-    private def build_full_path(prefix : String, path : String) : String
-      return prefix if path == "/" && !prefix.empty?
-      return path if prefix.empty?
-
-      full_path = "/#{prefix.strip('/')}/#{path.strip('/')}"
-      full_path = full_path.gsub(/\/+/, "/")
-      full_path = full_path.chomp('/') if full_path.size > 1
-      full_path
-    end
-
+    # CakePHP supports both `{id}` and `:id` route params; the latter is not
+    # covered by the engine helper.
     private def extract_route_params(route_path : String) : Array(Param)
-      params = [] of Param
-
-      # {id}
-      route_path.scan(/\{(\w+)\}/).each do |match|
-        params << Param.new(match[1], "", "path")
-      end
-
-      # :id
+      params = extract_brace_path_params(route_path)
       route_path.scan(/:(\w+)/).each do |match|
         params << Param.new(match[1], "", "path")
       end
-
       params
     end
 

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -1,45 +1,8 @@
-require "../../../models/analyzer"
-require "../../../utils/utils.cr"
+require "../../engines/php_engine"
 
 module Analyzer::Php
-  class Laravel < Analyzer
-    def analyze
-      result = [] of Endpoint
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-
-                  if File.exists?(path)
-                    result.concat(analyze_file(path))
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                rescue e
-                  logger.debug "Error analyzing #{path}: #{e}"
-                end
-              end
-            end
-          end
-        end
-      rescue e
-        logger.debug e
-      end
-
-      Fiber.yield
-      result
-    end
-
-    private def analyze_file(path : String) : Array(Endpoint)
+  class Laravel < PhpEngine
+    def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       # Analyze Laravel routes files
@@ -84,7 +47,7 @@ module Analyzer::Php
           next unless path_match
 
           route_path = path_match[1]
-          params = extract_route_params(route_path)
+          params = extract_brace_path_params(route_path)
           details = Details.new(PathInfo.new(path))
 
           methods = [] of String
@@ -144,7 +107,7 @@ module Analyzer::Php
             full_path = build_full_path(prefix, route_path)
           end
 
-          params = extract_route_params(full_path)
+          params = extract_brace_path_params(full_path)
           methods.each do |http_method|
             endpoints << Endpoint.new(full_path, http_method, params, details.dup)
           end
@@ -200,16 +163,6 @@ module Analyzer::Php
       endpoints
     end
 
-    private def build_full_path(prefix : String, path : String) : String
-      return prefix if path == "/" && !prefix.empty?
-      return path if prefix.empty?
-
-      full_path = "/#{prefix.strip('/')}/#{path.strip('/')}"
-      full_path = full_path.gsub(/\/+/, "/")
-      full_path = full_path.chomp('/') if full_path.size > 1
-      full_path
-    end
-
     private def create_resource_endpoints(resource : String, file_path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       details = Details.new(PathInfo.new(file_path))
@@ -228,7 +181,7 @@ module Analyzer::Php
 
       resource_routes.each do |route_info|
         path, method = route_info
-        params = extract_route_params(path)
+        params = extract_brace_path_params(path)
         endpoints << Endpoint.new(path, method, params, details)
       end
 
@@ -251,7 +204,7 @@ module Analyzer::Php
 
       api_resource_routes.each do |route_info|
         path, method = route_info
-        params = extract_route_params(path)
+        params = extract_brace_path_params(path)
         endpoints << Endpoint.new(path, method, params, details)
       end
 
@@ -265,26 +218,6 @@ module Analyzer::Php
         methods << match[1].upcase
       end
       methods
-    end
-
-    private def extract_route_params(route_path : String) : Array(Param)
-      params = [] of Param
-
-      # Extract Laravel route parameters like {id}, {slug}, etc.
-      param_matches = route_path.scan(/\{(\w+)\}/)
-      param_matches.each do |match|
-        param_name = match[1]
-        params << Param.new(param_name, "", "path")
-      end
-
-      # Extract optional parameters like {id?}
-      optional_matches = route_path.scan(/\{(\w+)\?\}/)
-      optional_matches.each do |match|
-        param_name = match[1]
-        params << Param.new(param_name, "", "path")
-      end
-
-      params
     end
   end
 end

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -1,82 +1,56 @@
-require "../../../utils/utils.cr"
-require "../../../models/analyzer"
+require "../../engines/php_engine"
 
 module Analyzer::Php
-  class Php < Analyzer
-    def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+  class Php < PhpEngine
+    def analyze_file(path : String) : Array(Endpoint)
+      return [] of Endpoint unless File.extname(path) == ".php"
 
-      begin
-        populate_channel_with_files(channel)
+      endpoints = [] of Endpoint
+      relative_path = get_relative_path(base_path, path)
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        params_query = [] of Param
+        params_body = [] of Param
+        methods = [] of String
 
-                  relative_path = get_relative_path(base_path, path)
+        file.each_line do |line|
+          if allow_patterns.any? { |pattern| line.includes? pattern }
+            match = line.strip.match(/\$_(.*?)\['(.*?)'\]/)
 
-                  if File.exists?(path) && File.extname(path) == ".php"
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      params_query = [] of Param
-                      params_body = [] of Param
-                      methods = [] of String
+            if match
+              method = match[1]
+              param_name = match[2]
 
-                      file.each_line do |line|
-                        if allow_patterns.any? { |pattern| line.includes? pattern }
-                          match = line.strip.match(/\$_(.*?)\['(.*?)'\]/)
-
-                          if match
-                            method = match[1]
-                            param_name = match[2]
-
-                            if method == "GET"
-                              params_query << Param.new(param_name, "", "query")
-                            elsif method == "POST"
-                              params_body << Param.new(param_name, "", "form")
-                              methods << "POST"
-                            elsif method == "REQUEST"
-                              params_query << Param.new(param_name, "", "query")
-                              params_body << Param.new(param_name, "", "form")
-                              methods << "POST"
-                            elsif method == "SERVER"
-                              if param_name.includes? "HTTP_"
-                                param_name = param_name.sub("HTTP_", "").gsub("_", "-")
-                                params_query << Param.new(param_name, "", "header")
-                                params_body << Param.new(param_name, "", "header")
-                              end
-                            end
-                          end
-                        end
-                      rescue
-                        next
-                      end
-
-                      details = Details.new(PathInfo.new(path))
-                      methods.each do |method|
-                        result << Endpoint.new("/#{relative_path}", method, params_body, details)
-                      end
-                      result << Endpoint.new("/#{relative_path}", "GET", params_query, details)
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+              if method == "GET"
+                params_query << Param.new(param_name, "", "query")
+              elsif method == "POST"
+                params_body << Param.new(param_name, "", "form")
+                methods << "POST"
+              elsif method == "REQUEST"
+                params_query << Param.new(param_name, "", "query")
+                params_body << Param.new(param_name, "", "form")
+                methods << "POST"
+              elsif method == "SERVER"
+                if param_name.includes? "HTTP_"
+                  param_name = param_name.sub("HTTP_", "").gsub("_", "-")
+                  params_query << Param.new(param_name, "", "header")
+                  params_body << Param.new(param_name, "", "header")
                 end
               end
             end
           end
+        rescue
+          next
         end
-      rescue e
-        logger.debug e
-      end
-      Fiber.yield
 
-      result
+        details = Details.new(PathInfo.new(path))
+        methods.each do |method|
+          endpoints << Endpoint.new("/#{relative_path}", method, params_body, details)
+        end
+        endpoints << Endpoint.new("/#{relative_path}", "GET", params_query, details)
+      end
+
+      endpoints
     end
 
     def allow_patterns

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -1,45 +1,8 @@
-require "../../../models/analyzer"
-require "../../../utils/utils.cr"
+require "../../engines/php_engine"
 
 module Analyzer::Php
-  class Symfony < Analyzer
-    def analyze
-      result = [] of Endpoint
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-
-                  if File.exists?(path)
-                    result.concat(analyze_file(path))
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                rescue e
-                  logger.debug "Error analyzing #{path}: #{e}"
-                end
-              end
-            end
-          end
-        end
-      rescue e
-        logger.debug e
-      end
-
-      Fiber.yield
-      result
-    end
-
-    private def analyze_file(path : String) : Array(Endpoint)
+  class Symfony < PhpEngine
+    def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       # Analyze PHP controller files
@@ -83,7 +46,7 @@ module Analyzer::Php
             context_end = [route_start + 1000, content.size].min
             method_context = content[route_start..context_end]
 
-            params = extract_route_params(route_path)
+            params = extract_brace_path_params(route_path)
             # Extract additional parameters from method body
             params.concat(extract_method_params(method_context))
 
@@ -115,7 +78,7 @@ module Analyzer::Php
             context_end = [route_start + 1000, content.size].min
             method_context = content[route_start..context_end]
 
-            params = extract_route_params(route_path)
+            params = extract_brace_path_params(route_path)
             # Extract additional parameters from method body
             params.concat(extract_method_params(method_context))
 
@@ -185,7 +148,7 @@ module Analyzer::Php
               methods = ["GET"]
             end
 
-            params = extract_route_params(route_path)
+            params = extract_brace_path_params(route_path)
             details = Details.new(PathInfo.new(path))
 
             methods.each do |method|
@@ -198,19 +161,6 @@ module Analyzer::Php
       end
 
       endpoints
-    end
-
-    private def extract_route_params(route_path : String) : Array(Param)
-      params = [] of Param
-
-      # Extract path parameters like {id}, {slug}, etc.
-      param_matches = route_path.scan(/\{(\w+)\}/)
-      param_matches.each do |match|
-        param_name = match[1]
-        params << Param.new(param_name, "", "path")
-      end
-
-      params
     end
 
     private def extract_method_params(context : String) : Array(Param)

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -7,7 +7,6 @@ module Analyzer::Ruby
       path = "#{@base_path}/config/routes.rb"
       if File.exists?(path)
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          last_endpoint = Endpoint.new("", "")
           file.each_line.with_index do |line, index|
             details = Details.new(PathInfo.new(path, index + 1))
             endpoint = line_to_endpoint(line, details)
@@ -20,8 +19,6 @@ module Analyzer::Ruby
               end
 
               @result << endpoint
-              last_endpoint = endpoint
-              _ = last_endpoint
             end
           end
         end

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/ruby_engine"
 
 module Analyzer::Ruby
-  class Hanami < Analyzer
+  class Hanami < RubyEngine
     def analyze
       # Config Analysis
       path = "#{@base_path}/config/routes.rb"
@@ -139,52 +139,6 @@ module Analyzer::Ruby
           end
         end
       end
-    end
-
-    def line_to_endpoint(content : String, details : Details) : Endpoint
-      content.scan(/get\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "GET", details)
-        end
-      end
-
-      content.scan(/post\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "POST", details)
-        end
-      end
-
-      content.scan(/put\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "PUT", details)
-        end
-      end
-
-      content.scan(/delete\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "DELETE", details)
-        end
-      end
-
-      content.scan(/patch\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "PATCH", details)
-        end
-      end
-
-      content.scan(/head\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "HEAD", details)
-        end
-      end
-
-      content.scan(/options\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "OPTIONS", details)
-        end
-      end
-
-      Endpoint.new("", "")
     end
   end
 end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/ruby_engine"
 
 module Analyzer::Ruby
-  class Rails < Analyzer
+  class Rails < RubyEngine
     def analyze
       # Public Dir Analysis
       begin

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -1,53 +1,29 @@
-require "../../../models/analyzer"
+require "../../engines/ruby_engine"
 
 module Analyzer::Ruby
-  class Sinatra < Analyzer
+  class Sinatra < RubyEngine
     def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      parallel_file_scan do |path|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+          last_endpoint = Endpoint.new("", "")
+          file.each_line.with_index do |line, index|
+            next unless line.valid_encoding?
+            endpoint = line_to_endpoint(line)
+            if endpoint.method != ""
+              details = Details.new(PathInfo.new(path, index + 1))
+              endpoint.details = details
+              @result << endpoint
+              last_endpoint = endpoint
+            end
 
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path)
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      last_endpoint = Endpoint.new("", "")
-                      file.each_line.with_index do |line, index|
-                        next unless line.valid_encoding?
-                        endpoint = line_to_endpoint(line)
-                        if endpoint.method != ""
-                          details = Details.new(PathInfo.new(path, index + 1))
-                          endpoint.details = details
-                          @result << endpoint
-                          last_endpoint = endpoint
-                        end
-
-                        param = line_to_param(line)
-                        if param.name != ""
-                          if last_endpoint.method != ""
-                            last_endpoint.push_param(param)
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
+            param = line_to_param(line)
+            if param.name != ""
+              if last_endpoint.method != ""
+                last_endpoint.push_param(param)
               end
             end
           end
         end
-      rescue e
-        logger.debug e
       end
 
       @result
@@ -80,52 +56,6 @@ module Analyzer::Ruby
       end
 
       Param.new("", "", "")
-    end
-
-    def line_to_endpoint(content : String) : Endpoint
-      content.scan(/get\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "GET")
-        end
-      end
-
-      content.scan(/post\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "POST")
-        end
-      end
-
-      content.scan(/put\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "PUT")
-        end
-      end
-
-      content.scan(/delete\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "DELETE")
-        end
-      end
-
-      content.scan(/patch\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "PATCH")
-        end
-      end
-
-      content.scan(/head\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "HEAD")
-        end
-      end
-
-      content.scan(/options\s+['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new("#{match[1]}", "OPTIONS")
-        end
-      end
-
-      Endpoint.new("", "")
     end
   end
 end

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -1,61 +1,34 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class ActixWeb < Analyzer
-    def analyze
-      # Source Analysis
-      pattern = /#\[(get|post|put|delete|patch)\("([^"]+)"\)\]/
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+  class ActixWeb < RustEngine
+    ROUTE_PATTERN = /#\[(get|post|put|delete|patch)\("([^"]+)"\)\]/
 
-      begin
-        populate_channel_with_files(channel)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+      lines.each_with_index do |line, index|
+        next unless line.to_s.includes? "#["
+        match = line.match(ROUTE_PATTERN)
+        next unless match
 
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
-                    lines.each_with_index do |line, index|
-                      if line.to_s.includes? "#["
-                        match = line.match(pattern)
-                        if match
-                          begin
-                            route_argument = match[2]
-                            callback_argument = match[1]
-                            details = Details.new(PathInfo.new(path, index + 1))
-                            endpoint = Endpoint.new("#{route_argument}", callback_to_method(callback_argument), details)
+        begin
+          route_argument = match[2]
+          callback_argument = match[1]
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint = Endpoint.new(route_argument, callback_to_method(callback_argument), details)
 
-                            # Extract path parameters from route pattern
-                            extract_path_params(route_argument, endpoint)
+          extract_path_params(route_argument, endpoint)
+          extract_function_params(lines, index + 1, endpoint)
 
-                            # Look ahead to extract parameters from function signature and body
-                            extract_function_params(lines, index + 1, endpoint)
-
-                            result << endpoint
-                          rescue e
-                            logger.debug "Error processing endpoint: #{e.message}"
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
+          endpoints << endpoint
+        rescue e
+          logger.debug "Error processing endpoint: #{e.message}"
         end
-      rescue
       end
 
-      result
+      endpoints
     end
 
     def callback_to_method(str)

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -1,53 +1,29 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Axum < Analyzer
-    def analyze
-      # Source Analysis
-      pattern = /\.route\("([^"]+)",\s*([^)]+)\)/
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+  class Axum < RustEngine
+    ROUTE_PATTERN = /\.route\("([^"]+)",\s*([^)]+)\)/
 
-      begin
-        populate_channel_with_files(channel)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        file.each_line.with_index do |line, index|
+          next unless line.includes? ".route("
+          match = line.match(ROUTE_PATTERN)
+          next unless match
 
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      file.each_line.with_index do |line, index|
-                        if line.includes? ".route("
-                          match = line.match(pattern)
-                          if match
-                            begin
-                              route_argument = match[1]
-                              callback_argument = match[2]
-                              details = Details.new(PathInfo.new(path, index + 1))
-                              result << Endpoint.new("#{route_argument}", callback_to_method(callback_argument), details)
-                            rescue
-                            end
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
+          begin
+            route_argument = match[1]
+            callback_argument = match[2]
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoints << Endpoint.new(route_argument, callback_to_method(callback_argument), details)
+          rescue
           end
         end
-      rescue
       end
 
-      result
+      endpoints
     end
 
     def callback_to_method(str)

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -1,82 +1,58 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Gotham < Analyzer
+  class Gotham < RustEngine
     # Maximum lines to look ahead for handler name
     MAX_HANDLER_LOOKUP_LINES = 5
 
-    def analyze
-      # Source Analysis for Gotham web framework
-      # Gotham uses builder pattern: Router::builder().get("/path").to(handler)
-      # Route paths must start with /
-      pattern = /\.(get|post|put|delete|patch|head|options)\s*\(\s*"(\/[^"]*)"\s*\)/
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+    # Gotham uses builder pattern: Router::builder().get("/path").to(handler)
+    # Route paths must start with /
+    ROUTE_PATTERN = /\.(get|post|put|delete|patch|head|options)\s*\(\s*"(\/[^"]*)"\s*\)/
 
-      begin
-        populate_channel_with_files(channel)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+      lines.each_with_index do |line, index|
+        # Look for Gotham routing patterns like .get("/path")
+        next unless line.includes?(".") && (line.includes?("get") || line.includes?("post") ||
+                    line.includes?("put") || line.includes?("delete") ||
+                    line.includes?("patch") || line.includes?("head") ||
+                    line.includes?("options"))
+        match = line.match(ROUTE_PATTERN)
+        next unless match
 
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
-                    lines.each_with_index do |line, index|
-                      # Look for Gotham routing patterns like .get("/path")
-                      if line.includes?(".") && (line.includes?("get") || line.includes?("post") ||
-                         line.includes?("put") || line.includes?("delete") ||
-                         line.includes?("patch") || line.includes?("head") ||
-                         line.includes?("options"))
-                        match = line.match(pattern)
-                        if match
-                          begin
-                            method = match[1]
-                            route_path = match[2]
+        begin
+          method = match[1]
+          route_path = match[2]
 
-                            # Parse path parameters (Gotham uses :param syntax)
-                            params = [] of Param
-                            final_path = route_path.gsub(/:(\w+)/) do |param_match|
-                              param_name = param_match[1..-1] # Remove the ':'
-                              params << Param.new(param_name, "", "path")
-                              ":#{param_name}"
-                            end
-
-                            details = Details.new(PathInfo.new(path, index + 1))
-                            endpoint = Endpoint.new(final_path, method.upcase, details)
-                            params.each do |param|
-                              endpoint.push_param(param)
-                            end
-
-                            # Try to find the handler function and extract cookies/headers
-                            # Look for .to(handler_name) in nearby lines
-                            handler_name = find_handler_name(lines, index)
-                            if handler_name
-                              extract_handler_params(lines, handler_name, endpoint)
-                            end
-
-                            result << endpoint
-                          rescue
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
+          # Parse path parameters (Gotham uses :param syntax)
+          params = [] of Param
+          final_path = route_path.gsub(/:(\w+)/) do |param_match|
+            param_name = param_match[1..-1] # Remove the ':'
+            params << Param.new(param_name, "", "path")
+            ":#{param_name}"
           end
+
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint = Endpoint.new(final_path, method.upcase, details)
+          params.each do |param|
+            endpoint.push_param(param)
+          end
+
+          # Try to find the handler function and extract cookies/headers
+          # Look for .to(handler_name) in nearby lines
+          handler_name = find_handler_name(lines, index)
+          if handler_name
+            extract_handler_params(lines, handler_name, endpoint)
+          end
+
+          endpoints << endpoint
+        rescue
         end
-      rescue
       end
 
-      result
+      endpoints
     end
 
     # Find the handler function name from .to(handler) pattern

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -1,74 +1,46 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Loco < Analyzer
-    def analyze
-      # Source Analysis for Loco framework routes
-      # Loco follows Rails conventions with controllers and actions
-      # Loco uses Axum under the hood, so we extract parameters using Axum patterns
+  class Loco < RustEngine
+    # Loco follows Rails conventions with controllers and actions.
+    # Loco uses Axum under the hood, so parameters are extracted using Axum patterns.
 
-      # Simple pattern to match function definitions
-      pattern = /pub\s+async\s+fn\s+(\w+)/
+    # Simple pattern to match function definitions
+    FN_PATTERN = /pub\s+async\s+fn\s+(\w+)/
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
 
-      begin
-        populate_channel_with_files(channel)
+      lines.each_with_index do |line, index|
+        next unless line.to_s.includes? "pub async fn"
+        match = line.match(FN_PATTERN)
+        next unless match
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+        begin
+          method_name = match[1]
+          # Convert Rails-style action names to route paths
+          endpoint_path = action_to_path(method_name, path)
+          details = Details.new(PathInfo.new(path, index + 1))
+          # Infer HTTP method from action name and context
+          http_method = infer_http_method(method_name, line)
 
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
-                    lines.each_with_index do |line, index|
-                      if line.to_s.includes? "pub async fn"
-                        match = line.match(pattern)
-                        if match
-                          begin
-                            method_name = match[1]
-                            # Convert Rails-style action names to route paths
-                            endpoint_path = action_to_path(method_name, path)
-                            details = Details.new(PathInfo.new(path, index + 1))
-                            # Infer HTTP method from action name and context
-                            http_method = infer_http_method(method_name, line)
+          endpoint = Endpoint.new(endpoint_path, http_method, details)
 
-                            endpoint = Endpoint.new(endpoint_path, http_method, details)
+          # Extract path parameters from the endpoint path
+          extract_path_params(endpoint_path, endpoint)
 
-                            # Extract path parameters from the endpoint path
-                            extract_path_params(endpoint_path, endpoint)
+          # Extract parameters from function signature and body
+          extract_function_params(lines, index, endpoint)
 
-                            # Extract parameters from function signature and body
-                            extract_function_params(lines, index, endpoint)
-
-                            result << endpoint
-                          rescue e
-                            # Log the exception for debugging
-                            logger.debug "Error parsing Loco endpoint: #{e.message}"
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                rescue e
-                  logger.debug "Error in Loco analyzer: #{e.message}"
-                end
-              end
-            end
-          end
+          endpoints << endpoint
+        rescue e
+          # Log the exception for debugging
+          logger.debug "Error parsing Loco endpoint: #{e.message}"
         end
-      rescue e
-        logger.debug "Error in Loco analyzer setup: #{e.message}"
       end
 
-      result
+      endpoints
     end
 
     private def action_to_path(action_name : String, file_path : String) : String

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -1,66 +1,42 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Rocket < Analyzer
+  class Rocket < RustEngine
     # Maximum lines to scan ahead for function body analysis
     MAX_FUNCTION_SCAN_LINES = 30
 
-    def analyze
-      # Source Analysis
-      # Enhanced pattern to capture path, query parameters, and data parameters
-      pattern = /#\[(get|post|delete|put|patch)\("([^"]+)"(?:, data = "<([^>]+)>")?\)\]/
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+    # Enhanced pattern to capture path, query parameters, and data parameters
+    ROUTE_PATTERN = /#\[(get|post|delete|put|patch)\("([^"]+)"(?:, data = "<([^>]+)>")?\)\]/
 
-      begin
-        populate_channel_with_files(channel)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+      lines.each_with_index do |line, index|
+        next unless line.includes?("#[") && line.includes?(")]")
+        match = line.match(ROUTE_PATTERN)
+        next unless match
 
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
-                    lines.each_with_index do |line, index|
-                      if line.includes?("#[") && line.includes?(")]")
-                        match = line.match(pattern)
-                        if match
-                          begin
-                            callback_argument = match[1]
-                            route_argument = match[2]
-                            data_argument = match[3]?
+        begin
+          callback_argument = match[1]
+          route_argument = match[2]
+          data_argument = match[3]?
 
-                            # Extract parameters from the route
-                            params = extract_params(route_argument, data_argument)
+          # Extract parameters from the route
+          params = extract_params(route_argument, data_argument)
 
-                            details = Details.new(PathInfo.new(path, index + 1))
-                            endpoint = Endpoint.new("#{route_argument}", callback_to_method(callback_argument), params, details)
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint = Endpoint.new(route_argument, callback_to_method(callback_argument), params, details)
 
-                            # Look ahead to extract cookies and headers from function signature/body
-                            extract_function_params(lines, index + 1, endpoint)
+          # Look ahead to extract cookies and headers from function signature/body
+          extract_function_params(lines, index + 1, endpoint)
 
-                            result << endpoint
-                          rescue
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
+          endpoints << endpoint
+        rescue
         end
-      rescue
       end
 
-      result
+      endpoints
     end
 
     def callback_to_method(str)

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -1,74 +1,50 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Rwf < Analyzer
-    def analyze
-      # Source Analysis
-      # Look for route! macro calls and Controller implementations
-      route_pattern = /route!\("([^"]+)"\s*=>\s*(\w+)\)/
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+  class Rwf < RustEngine
+    # Look for route! macro calls and Controller implementations
+    ROUTE_PATTERN = /route!\("([^"]+)"\s*=>\s*(\w+)\)/
 
-      begin
-        populate_channel_with_files(channel)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
+      lines.each_with_index do |line, index|
+        # Look for route! macro definitions
+        next unless line.includes? "route!("
+        match = line.match(ROUTE_PATTERN)
+        next unless match
 
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
-                    lines.each_with_index do |line, index|
-                      # Look for route! macro definitions
-                      if line.includes? "route!("
-                        match = line.match(route_pattern)
-                        if match
-                          begin
-                            route_path = match[1]
-                            controller_name = match[2]
-                            details = Details.new(PathInfo.new(path, index + 1))
+        begin
+          route_path = match[1]
+          controller_name = match[2]
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                            # Extract HTTP methods supported by the controller
-                            methods = extract_controller_methods(lines, controller_name)
+          # Extract HTTP methods supported by the controller
+          methods = extract_controller_methods(lines, controller_name)
 
-                            # If no specific methods found, default to GET
-                            if methods.empty?
-                              methods = ["GET"]
-                            end
-
-                            # Create an endpoint for each HTTP method
-                            methods.each do |http_method|
-                              endpoint = Endpoint.new(route_path, http_method, details)
-
-                              # Extract path parameters from route pattern (e.g., /users/:id)
-                              extract_path_params(route_path, endpoint)
-
-                              # Look for controller implementation to extract more parameters
-                              extract_controller_params(lines, controller_name, endpoint)
-
-                              result << endpoint
-                            end
-                          rescue
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
+          # If no specific methods found, default to GET
+          if methods.empty?
+            methods = ["GET"]
           end
+
+          # Create an endpoint for each HTTP method
+          methods.each do |http_method|
+            endpoint = Endpoint.new(route_path, http_method, details)
+
+            # Extract path parameters from route pattern (e.g., /users/:id)
+            extract_path_params(route_path, endpoint)
+
+            # Look for controller implementation to extract more parameters
+            extract_controller_params(lines, controller_name, endpoint)
+
+            endpoints << endpoint
+          end
+        rescue
         end
-      rescue
       end
 
-      result
+      endpoints
     end
 
     # Extract path parameters from the route pattern like /users/:id

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -1,53 +1,24 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Salvo < Analyzer
-    def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    analyze_file(path)
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
-        end
-      rescue e
-        logger.debug "Error during Salvo analysis: #{e.message}"
-      end
-
-      result
-    end
-
-    def analyze_file(path : String)
+  class Salvo < RustEngine
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
 
       # Strategy 1: Parse Router chain patterns
       # e.g., Router::with_path("users/<id>").get(get_user)
       # e.g., Router::new().push(Router::with_path("items").get(list_items))
-      parse_router_chains(lines, path)
+      parse_router_chains(lines, path, endpoints)
 
       # Strategy 2: Parse #[endpoint] macro patterns
       # e.g., #[endpoint(method = Get, path = "/api/users")]
-      parse_endpoint_macros(lines, path)
+      parse_endpoint_macros(lines, path, endpoints)
+
+      endpoints
     end
 
-    def parse_router_chains(lines : Array(String), path : String)
+    def parse_router_chains(lines : Array(String), path : String, endpoints : Array(Endpoint))
       lines.each_with_index do |line, index|
         # Match Router::with_path("...").method(handler) or .path("...").method(handler)
         # Pattern: with_path("path") followed by .method(handler)
@@ -76,7 +47,7 @@ module Analyzer::Rust
                   extract_handler_params(lines, handler_name, endpoint)
                 end
 
-                result << endpoint
+                endpoints << endpoint
                 break
               end
             end
@@ -85,7 +56,7 @@ module Analyzer::Rust
       end
     end
 
-    def parse_endpoint_macros(lines : Array(String), path : String)
+    def parse_endpoint_macros(lines : Array(String), path : String, endpoints : Array(Endpoint))
       lines.each_with_index do |line, index|
         # Match #[endpoint(method = Get, path = "/path")]
         if line.strip.starts_with?("#[endpoint(")
@@ -103,12 +74,12 @@ module Analyzer::Rust
           end
 
           details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new("#{route_path}", method, details)
+          endpoint = Endpoint.new(route_path, method, details)
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
 
-          result << endpoint
+          endpoints << endpoint
         end
       end
     end

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -1,44 +1,16 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Tide < Analyzer
-    def analyze
-      # Tide routing patterns: app.at("/path").get(handler), app.at("/path").post(handler), etc.
+  class Tide < RustEngine
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      content = file.gets_to_end
-                      endpoints = parse_tide_routes(content, path)
-                      endpoints.each do |endpoint|
-                        result << endpoint
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
-        end
-      rescue
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        content = file.gets_to_end
+        endpoints = parse_tide_routes(content, path)
       end
 
-      result
+      endpoints
     end
 
     private def parse_tide_routes(content : String, file_path : String) : Array(Endpoint)

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -1,51 +1,26 @@
-require "../../../models/analyzer"
+require "../../engines/rust_engine"
 
 module Analyzer::Rust
-  class Warp < Analyzer
-    def analyze
-      # Pattern for GET endpoints with warp::get()
+  class Warp < RustEngine
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        content = file.gets_to_end
 
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-
-                  if File.exists?(path) && File.extname(path) == ".rs"
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      content = file.gets_to_end
-
-                      # Simple approach: split by let statements and analyze each
-                      statements = content.split(/(?=let\s+\w+\s*=)/)
-                      statements.each do |statement|
-                        if statement.includes?("warp::") && (statement.includes?("get()") || statement.includes?("post()") || statement.includes?("put()") || statement.includes?("delete()"))
-                          endpoint = parse_warp_statement(statement, path)
-                          if endpoint
-                            result << endpoint
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
+        # Simple approach: split by let statements and analyze each
+        statements = content.split(/(?=let\s+\w+\s*=)/)
+        statements.each do |statement|
+          if statement.includes?("warp::") && (statement.includes?("get()") || statement.includes?("post()") || statement.includes?("put()") || statement.includes?("delete()"))
+            endpoint = parse_warp_statement(statement, path)
+            if endpoint
+              endpoints << endpoint
             end
           end
         end
-      rescue
       end
 
-      result
+      endpoints
     end
 
     private def parse_warp_statement(statement : String, file_path : String) : Endpoint?

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -1,0 +1,53 @@
+require "../../models/analyzer"
+require "../../utils/utils.cr"
+
+module Analyzer::Php
+  abstract class PhpEngine < Analyzer
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+
+          begin
+            result.concat(analyze_file(path))
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+
+      Fiber.yield
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # Route composition helper. Will migrate to a PHP route extractor when that
+    # layer is introduced; kept here for now so Laravel/CakePHP/Symfony stop
+    # duplicating it.
+    protected def build_full_path(prefix : String, path : String) : String
+      return prefix if path == "/" && !prefix.empty?
+      return path if prefix.empty?
+
+      full_path = "/#{prefix.strip('/')}/#{path.strip('/')}"
+      full_path = full_path.gsub(/\/+/, "/")
+      full_path = full_path.chomp('/') if full_path.size > 1
+      full_path
+    end
+
+    protected def extract_brace_path_params(route_path : String) : Array(Param)
+      params = [] of Param
+      route_path.scan(/\{(\w+)\??\}/).each do |match|
+        params << Param.new(match[1], "", "path")
+      end
+      params
+    end
+  end
+end

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -1,7 +1,7 @@
 require "../../models/analyzer"
 
 module Analyzer::Ruby
-  class RubyEngine < Analyzer
+  abstract class RubyEngine < Analyzer
     HTTP_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
     # Match the `<verb> "<path>"` idiom on a single line and return the first

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -1,0 +1,49 @@
+require "../../models/analyzer"
+
+module Analyzer::Ruby
+  class RubyEngine < Analyzer
+    HTTP_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
+
+    # Match the `<verb> "<path>"` idiom on a single line and return the first
+    # endpoint found, or an empty endpoint if none match. Shared by Hanami
+    # and Sinatra (Rails uses a different per-line-multi-match shape).
+    def line_to_endpoint(content : String, details : Details? = nil) : Endpoint
+      HTTP_VERBS.each do |verb|
+        content.scan(/#{verb}\s+['"](.+?)['"]/) do |match|
+          if match.size > 1
+            if details
+              return Endpoint.new(match[1], verb.upcase, details)
+            else
+              return Endpoint.new(match[1], verb.upcase)
+            end
+          end
+        end
+      end
+      Endpoint.new("", "")
+    end
+
+    # Walk the project file tree in parallel, invoking the block for each
+    # readable non-directory file. Used by analyzers that scan the whole
+    # tree (Sinatra); Rails/Hanami target specific config files directly.
+    def parallel_file_scan(&block : String -> Nil) : Nil
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+
+          begin
+            block.call(path)
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+    end
+  end
+end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -1,0 +1,30 @@
+require "../../models/analyzer"
+
+module Analyzer::Rust
+  abstract class RustEngine < Analyzer
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path) && File.extname(path) == ".rs"
+
+          begin
+            result.concat(analyze_file(path))
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+  end
+end


### PR DESCRIPTION
## Summary

- Document the analyzer 3-layer model (Language Engine → Route Extractor → Framework Adapter) in `AGENTS.md`, naming Hono as the reference implementation.
- Introduce `PhpEngine`, `RubyEngine`, `RustEngine` under `src/analyzer/engines/` so the 16 analyzers in those languages (previously with no shared base) now inherit worker-pool, file filtering, and error-handling boilerplate from a single place.
- Net **−395 LOC across 16 analyzers** with no material behavior change (see **Notes on behavior** below).

## Layer breakdown

| Layer | Responsibility | New / existing |
|---|---|---|
| Language Engine | file walking, concurrency, per-path error handling | `engines/php_engine.cr`, `ruby_engine.cr`, `rust_engine.cr` (new); Go/Python already had per-language commons |
| Route Extractor | parse source, yield routes | unchanged (JS only; future work) |
| Framework Adapter | apply framework-specific param rules | the analyzers themselves |

## Engine designs

- **PhpEngine** — abstract `analyze_file(path) : Array(Endpoint)`; engine owns channel + `parallel_analyze` + error catch. Shared helpers: `build_full_path`, `extract_brace_path_params`.
- **RubyEngine** — opt-in helpers: `line_to_endpoint(content, details?)` (replaces ~42 duplicated lines between Hanami and Sinatra) and `parallel_file_scan(&block)` for whole-tree scanners. Rails keeps its internal logic; only the superclass changed.
- **RustEngine** — same abstract-`analyze_file` shape as PhpEngine with a `.rs` extension filter baked in. All 9 Rust analyzers had an identical 20-line worker-pool skeleton that now lives in one place.

## Notes on behavior

Two intentional normalizations; neither changes output on real-world inputs but they deviate from the pre-refactor behavior and are worth calling out explicitly:

1. **Concurrency clamp.** Migrated analyzers now go through `Analyzer#parallel_analyze`, which clamps `--concurrency` at `MAX_ANALYZER_WORKERS = 64`. Previously PHP/Ruby/Rust analyzers spawned exactly as many workers as requested. This aligns PHP/Ruby/Rust with Go/JS and is a safety bound, not a throttle anyone will hit in practice (default concurrency is well below 64).
2. **`{id?}` now matches in Symfony.** `extract_brace_path_params` uses `/\{(\w+)\??\}/`, where the original Symfony regex was `/\{(\w+)\}/`. `{id?}` is a Laravel idiom and shouldn't appear in Symfony sources, so the expansion is theoretical. If it ever appears, Symfony will now emit the path param rather than silently dropping it.

Errors that were previously swallowed by bare `rescue` blocks in some Rust analyzers (axum, rocket, rwf) are now logged at debug level via the engine's uniform `rescue e / logger.debug` — strict debuggability improvement.

## Out of scope

- Go/Python commons stay in `analyzers/{lang}/common.cr` since they currently mix engine and route-extraction helpers; they migrate when the engine-vs-extractor split lands.
- No param-extraction unification: semantics differ per framework (Rails emits query+body, Hanami query only, Flask-RESTx differs again). Regex-level consolidation would conflate them.
- Engine-level unit tests are not added in this PR; existing functional tests exercise the engines end-to-end via all 16 migrated analyzers.

## Test plan

- [x] `just build` — clean compile
- [x] `just test` — 1261 unit + 4131 functional examples, 0 failures, 0 errors
- [x] `crystal tool format --check` — all touched files clean