### PR TITLE
refactor(analyzer/elixir): introduce ElixirEngine

### DIFF
--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -1,7 +1,7 @@
-require "../../../models/analyzer"
+require "../../engines/elixir_engine"
 
 module Analyzer::Elixir
-  class Phoenix < Analyzer
+  class Phoenix < ElixirEngine
     # Store mapping of route -> controller/action for parameter extraction
     @route_map : Hash(String, ControllerAction) = Hash(String, ControllerAction).new
 
@@ -14,49 +14,29 @@ module Analyzer::Elixir
     end
 
     def analyze
-      # Source Analysis - First pass: collect routes
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && File.extname(path) == ".ex"
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      file.each_line.with_index do |line, index|
-                        endpoints = line_to_endpoint(line, path)
-                        endpoints.each do |endpoint|
-                          if endpoint.method != ""
-                            details = Details.new(PathInfo.new(path, index + 1))
-                            endpoint.details = details
-                            @result << endpoint
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
-        end
-      rescue e
-        logger.debug e
-      end
+      # First pass: collect routes via the engine's parallel file scan.
+      super
 
       # Second pass: extract parameters from controller files
       extract_controller_params
 
       @result
+    end
+
+    def analyze_file(path : String) : Array(Endpoint)
+      return [] of Endpoint unless File.extname(path) == ".ex"
+
+      endpoints = [] of Endpoint
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        file.each_line.with_index do |line, index|
+          line_to_endpoint(line, path).each do |endpoint|
+            next if endpoint.method == ""
+            endpoint.details = Details.new(PathInfo.new(path, index + 1))
+            endpoints << endpoint
+          end
+        end
+      end
+      endpoints
     end
 
     def extract_controller_params

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -1,45 +1,19 @@
-require "../../../models/analyzer"
+require "../../engines/elixir_engine"
 
 module Analyzer::Elixir
-  class Plug < Analyzer
-    def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+  class Plug < ElixirEngine
+    def analyze_file(path : String) : Array(Endpoint)
+      ext = File.extname(path)
+      return [] of Endpoint unless ext == ".ex" || ext == ".exs"
 
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && (File.extname(path) == ".ex" || File.extname(path) == ".exs")
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      content = file.gets_to_end
-                      endpoints = analyze_content(content, path)
-                      endpoints.each do |endpoint|
-                        if endpoint.method != ""
-                          @result << endpoint
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
+      endpoints = [] of Endpoint
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        content = file.gets_to_end
+        analyze_content(content, path).each do |endpoint|
+          endpoints << endpoint if endpoint.method != ""
         end
-      rescue e
-        logger.debug e
       end
-
-      @result
+      endpoints
     end
 
     def analyze_content(content : String, file_path : String) : Array(Endpoint)

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -1,0 +1,30 @@
+require "../../models/analyzer"
+
+module Analyzer::Elixir
+  abstract class ElixirEngine < Analyzer
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+
+          begin
+            @result.concat(analyze_file(path))
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+
+      @result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+  end
+end


### PR DESCRIPTION
## Summary

- Both Elixir analyzers (Phoenix, Plug) had the same channel + WaitGroup worker-loop skeleton. Extract it into \`Analyzer::Elixir::ElixirEngine\`, mirroring \`PhpEngine\` / \`RustEngine\`.
- Net **−46 LOC across two analyzers** (+30 LOC engine). No behavior change.

## Notes

- Phoenix has a second pass (\`extract_controller_params\`) that runs after route collection; it stays as an \`analyze\` override that calls \`super\` for the worker loop and then runs the second pass.
- Plug and Phoenix filter extensions differently (\`.ex\`/\`.exs\` vs \`.ex\`); each \`analyze_file\` applies its own filter, so the engine stays extension-agnostic like PhpEngine.

## Test plan

- [x] \`just build\` — clean compile
- [x] \`just test\` — 1261 unit + 4131 functional examples, 0 failures
- [x] \`crystal tool format --check\` — clean