### PR TITLE
refactor(analyzer/crystal): introduce CrystalEngine

### DIFF
--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -1,75 +1,103 @@
-require "../../../models/analyzer"
+require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
-  class Amber < Analyzer
+  class Amber < CrystalEngine
+    @is_public : Bool = true
+    @public_folders : Array(String) = [] of String
+
     def analyze
-      # Variables
-      is_public = true
-      public_folders = [] of String
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+      super
+      collect_public_dir_endpoints
+      @result
+    end
 
-      # Source Analysis
-      begin
-        populate_channel_with_files(channel)
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      last_endpoint = Endpoint.new("", "")
-                      file.each_line.with_index do |line, index|
-                        endpoint = line_to_endpoint(line)
-                        if endpoint.method != ""
-                          details = Details.new(PathInfo.new(path, index + 1))
-                          endpoint.details = details
-                          result << endpoint
-                          last_endpoint = endpoint
-                        end
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        last_endpoint = Endpoint.new("", "")
+        file.each_line.with_index do |line, index|
+          endpoint = line_to_endpoint(line)
+          if endpoint.method != ""
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint.details = details
+            endpoints << endpoint
+            last_endpoint = endpoint
+          end
 
-                        param = line_to_param(line)
-                        if param.name != ""
-                          if last_endpoint.method != ""
-                            last_endpoint.push_param(param)
-                          end
-                        end
+          param = line_to_param(line)
+          if param.name != ""
+            if last_endpoint.method != ""
+              last_endpoint.push_param(param)
+            end
+          end
 
-                        if line.includes?("serve_static false") || line.includes?("serve_static(false)")
-                          is_public = false
-                        end
+          if line.includes?("serve_static false") || line.includes?("serve_static(false)")
+            @is_public = false
+          end
 
-                        if line.includes?("public_folder")
-                          begin
-                            split = line.split("public_folder")
+          if line.includes?("public_folder")
+            begin
+              split = line.split("public_folder")
 
-                            if split.size > 1
-                              # Extract path more carefully handling quotes and spaces
-                              match_data = split[1].match(/[=\(]\s*['"]?(.*?)['"]?\s*[\),]/)
-                              public_folder = if match_data && match_data[1]?
-                                                match_data[1].strip
-                                              else
-                                                # Fallback to the previous approach
-                                                split[1].gsub("(", "").gsub(")", "").gsub(" ", "").gsub("\"", "").gsub("'", "")
-                                              end
+              if split.size > 1
+                # Extract path more carefully handling quotes and spaces
+                match_data = split[1].match(/[=\(]\s*['"]?(.*?)['"]?\s*[\),]/)
+                public_folder = if match_data && match_data[1]?
+                                  match_data[1].strip
+                                else
+                                  # Fallback to the previous approach
+                                  split[1].gsub("(", "").gsub(")", "").gsub(" ", "").gsub("\"", "").gsub("'", "")
+                                end
 
-                              if public_folder != ""
-                                public_folders << public_folder
-                              end
-                            end
-                          rescue
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
+                if public_folder != ""
+                  @public_folders << public_folder
                 end
+              end
+            rescue
+            end
+          end
+        end
+      end
+
+      endpoints
+    end
+
+    private def collect_public_dir_endpoints
+      return unless @is_public
+      begin
+        # Process public folder files
+        get_public_files(@base_path).each do |file|
+          # Extract the path after "/public/" regardless of depth
+          if file =~ /\/public\/(.*)/
+            relative_path = $1
+            @result << Endpoint.new("/#{relative_path}", "GET")
+          end
+        end
+
+        # Process other public folders
+        @public_folders.each do |folder|
+          get_public_dir_files(@base_path, folder).each do |file|
+            # Extract relative path from the custom folder
+            if folder.includes?("/")
+              # For absolute paths or paths with directories
+              folder_path = folder.ends_with?("/") ? folder : "#{folder}/"
+              if file.starts_with?(folder_path)
+                relative_path = file.sub(folder_path, "")
+                @result << Endpoint.new("/#{relative_path}", "GET")
+              else
+                # Try to find the folder component in the path
+                folder_name = folder.split("/").last
+                if file =~ /\/#{folder_name}\/(.*)/
+                  relative_path = $1
+                  @result << Endpoint.new("/#{relative_path}", "GET")
+                end
+              end
+            else
+              # For simple folder names (no slashes)
+              if file =~ /\/#{folder}\/(.*)/
+                relative_path = $1
+                @result << Endpoint.new("/#{relative_path}", "GET")
               end
             end
           end
@@ -77,52 +105,6 @@ module Analyzer::Crystal
       rescue e
         logger.debug e
       end
-
-      # Public Dir Analysis
-      if is_public
-        begin
-          # Process public folder files
-          get_public_files(@base_path).each do |file|
-            # Extract the path after "/public/" regardless of depth
-            if file =~ /\/public\/(.*)/
-              relative_path = $1
-              @result << Endpoint.new("/#{relative_path}", "GET")
-            end
-          end
-
-          # Process other public folders
-          public_folders.each do |folder|
-            get_public_dir_files(@base_path, folder).each do |file|
-              # Extract relative path from the custom folder
-              if folder.includes?("/")
-                # For absolute paths or paths with directories
-                folder_path = folder.ends_with?("/") ? folder : "#{folder}/"
-                if file.starts_with?(folder_path)
-                  relative_path = file.sub(folder_path, "")
-                  @result << Endpoint.new("/#{relative_path}", "GET")
-                else
-                  # Try to find the folder component in the path
-                  folder_name = folder.split("/").last
-                  if file =~ /\/#{folder_name}\/(.*)/
-                    relative_path = $1
-                    @result << Endpoint.new("/#{relative_path}", "GET")
-                  end
-                end
-              else
-                # For simple folder names (no slashes)
-                if file =~ /\/#{folder}\/(.*)/
-                  relative_path = $1
-                  @result << Endpoint.new("/#{relative_path}", "GET")
-                end
-              end
-            end
-          end
-        rescue e
-          logger.debug e
-        end
-      end
-
-      result
     end
 
     def line_to_param(content : String) : Param

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -1,80 +1,56 @@
-require "../../../models/analyzer"
+require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
-  class Grip < Analyzer
-    def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+  class Grip < CrystalEngine
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
 
-      # Source Analysis
-      begin
-        populate_channel_with_files(channel)
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        last_endpoint = Endpoint.new("", "")
+        current_scopes = [] of String
 
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      last_endpoint = Endpoint.new("", "")
-                      current_scopes = [] of String
+        file.each_line.with_index do |line, index|
+          details = Details.new(PathInfo.new(path, index + 1))
 
-                      file.each_line.with_index do |line, index|
-                        details = Details.new(PathInfo.new(path, index + 1))
-
-                        # Handle scope statements
-                        if line.includes?("scope ") && line.includes?(" do")
-                          scope_match = line.match(/scope\s+['"](.+?)['"]/)
-                          if scope_match && scope_match[1]?
-                            current_scopes << scope_match[1]
-                          end
-                        end
-
-                        # Handle end statements (basic detection)
-                        if line.strip == "end" && current_scopes.size > 0
-                          current_scopes.pop
-                        end
-
-                        # Parse HTTP method calls
-                        endpoint = line_to_endpoint(line, current_scopes)
-                        if endpoint.method != ""
-                          endpoint.details = details
-                          result << endpoint
-                          last_endpoint = endpoint
-                        end
-
-                        # Parse parameters
-                        param = line_to_param(line)
-                        if param.name != ""
-                          if last_endpoint.method != ""
-                            last_endpoint.push_param(param)
-                          end
-                        end
-
-                        # Parse WebSocket routes
-                        ws_endpoint = line_to_websocket(line, current_scopes)
-                        if ws_endpoint.url != ""
-                          ws_endpoint.details = details
-                          result << ws_endpoint
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
+          # Handle scope statements
+          if line.includes?("scope ") && line.includes?(" do")
+            scope_match = line.match(/scope\s+['"](.+?)['"]/)
+            if scope_match && scope_match[1]?
+              current_scopes << scope_match[1]
             end
           end
+
+          # Handle end statements (basic detection)
+          if line.strip == "end" && current_scopes.size > 0
+            current_scopes.pop
+          end
+
+          # Parse HTTP method calls
+          endpoint = line_to_endpoint(line, current_scopes)
+          if endpoint.method != ""
+            endpoint.details = details
+            endpoints << endpoint
+            last_endpoint = endpoint
+          end
+
+          # Parse parameters
+          param = line_to_param(line)
+          if param.name != ""
+            if last_endpoint.method != ""
+              last_endpoint.push_param(param)
+            end
+          end
+
+          # Parse WebSocket routes
+          ws_endpoint = line_to_websocket(line, current_scopes)
+          if ws_endpoint.url != ""
+            ws_endpoint.details = details
+            endpoints << ws_endpoint
+          end
         end
-      rescue e
-        logger.debug e
       end
 
-      result
+      endpoints
     end
 
     def line_to_param(content : String) : Param

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -1,113 +1,19 @@
-require "../../../models/analyzer"
+require "../../engines/crystal_engine"
 require "../../../utils/url_path"
 
 module Analyzer::Crystal
-  class Kemal < Analyzer
+  class Kemal < CrystalEngine
     NAMESPACE_PATTERN = /^(\s*)(?:(\w+)\.)?namespace\s+["'](.+?)["']/
     MOUNT_PATTERN     = /^\s*mount\s+["'](.+?)["']\s*,\s*(\w+)/
     ROUTER_PATTERN    = /^\s*(\w+)\s*=\s*Kemal::Router\.new/
 
+    @is_public : Bool = true
+    @public_folders : Array(String) = [] of String
+
     def analyze
-      # Variables
-      is_public = true
-      public_folders = [] of String
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
-      # Source Analysis
-      begin
-        populate_channel_with_files(channel)
-
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
-                    analyze_file(path).each do |endpoint|
-                      result << endpoint
-                    end
-
-                    # Extract public folder and serve_static info
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      file.each_line do |line|
-                        if line.includes?("serve_static false") || line.includes?("serve_static(false)")
-                          is_public = false
-                        end
-
-                        if line.includes?("public_folder")
-                          begin
-                            split = line.split("public_folder")
-
-                            if split.size > 1
-                              match_data = split[1].match(/[=\(]\s*['"]?(.*?)['"]?\s*[\),]/)
-                              public_folder = if match_data && match_data[1]?
-                                                match_data[1].strip
-                                              else
-                                                split[1].gsub("(", "").gsub(")", "").gsub(" ", "").gsub("\"", "").gsub("'", "")
-                                              end
-
-                              if public_folder != ""
-                                public_folders << public_folder
-                              end
-                            end
-                          rescue
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
-            end
-          end
-        end
-      rescue e
-        logger.debug e
-      end
-
-      # Public Dir Analysis
-      if is_public
-        begin
-          get_public_files(@base_path).each do |file|
-            if file =~ /\/public\/(.*)/
-              relative_path = $1
-              @result << Endpoint.new("/#{relative_path}", "GET")
-            end
-          end
-
-          public_folders.each do |folder|
-            get_public_dir_files(@base_path, folder).each do |file|
-              if folder.includes?("/")
-                folder_path = folder.ends_with?("/") ? folder : "#{folder}/"
-                if file.starts_with?(folder_path)
-                  relative_path = file.sub(folder_path, "")
-                  @result << Endpoint.new("/#{relative_path}", "GET")
-                else
-                  folder_name = folder.split("/").last
-                  if file =~ /\/#{folder_name}\/(.*)/
-                    relative_path = $1
-                    @result << Endpoint.new("/#{relative_path}", "GET")
-                  end
-                end
-              else
-                if file =~ /\/#{folder}\/(.*)/
-                  relative_path = $1
-                  @result << Endpoint.new("/#{relative_path}", "GET")
-                end
-              end
-            end
-          end
-        rescue e
-          logger.debug e
-        end
-      end
-
-      result
+      super
+      collect_public_dir_endpoints
+      @result
     end
 
     def analyze_file(path : String) : Array(Endpoint)
@@ -132,6 +38,31 @@ module Analyzer::Crystal
       last_endpoint : Endpoint? = nil
 
       lines.each_with_index do |line, index|
+        # Collect public folder / serve_static info (used by post-pass)
+        if line.includes?("serve_static false") || line.includes?("serve_static(false)")
+          @is_public = false
+        end
+
+        if line.includes?("public_folder")
+          begin
+            split = line.split("public_folder")
+
+            if split.size > 1
+              match_data = split[1].match(/[=\(]\s*['"]?(.*?)['"]?\s*[\),]/)
+              public_folder = if match_data && match_data[1]?
+                                match_data[1].strip
+                              else
+                                split[1].gsub("(", "").gsub(")", "").gsub(" ", "").gsub("\"", "").gsub("'", "")
+                              end
+
+              if public_folder != ""
+                @public_folders << public_folder
+              end
+            end
+          rescue
+          end
+        end
+
         # Check for namespace open
         if match = line.match(NAMESPACE_PATTERN)
           indent = match[1].size
@@ -193,6 +124,43 @@ module Analyzer::Crystal
       end
 
       endpoints
+    end
+
+    private def collect_public_dir_endpoints
+      return unless @is_public
+      begin
+        get_public_files(@base_path).each do |file|
+          if file =~ /\/public\/(.*)/
+            relative_path = $1
+            @result << Endpoint.new("/#{relative_path}", "GET")
+          end
+        end
+
+        @public_folders.each do |folder|
+          get_public_dir_files(@base_path, folder).each do |file|
+            if folder.includes?("/")
+              folder_path = folder.ends_with?("/") ? folder : "#{folder}/"
+              if file.starts_with?(folder_path)
+                relative_path = file.sub(folder_path, "")
+                @result << Endpoint.new("/#{relative_path}", "GET")
+              else
+                folder_name = folder.split("/").last
+                if file =~ /\/#{folder_name}\/(.*)/
+                  relative_path = $1
+                  @result << Endpoint.new("/#{relative_path}", "GET")
+                end
+              end
+            else
+              if file =~ /\/#{folder}\/(.*)/
+                relative_path = $1
+                @result << Endpoint.new("/#{relative_path}", "GET")
+              end
+            end
+          end
+        end
+      rescue e
+        logger.debug e
+      end
     end
 
     def line_to_param(content : String) : Param

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -1,67 +1,48 @@
-require "../../../models/analyzer"
+require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
-  class Lucky < Analyzer
+  class Lucky < CrystalEngine
     def analyze
-      # Public Dir Analysis
-      begin
-        get_public_files(@base_path).each do |file|
-          # Extract the path after "/public/" regardless of depth
-          if file =~ /\/public\/(.*)/
-            relative_path = $1
-            @result << Endpoint.new("/#{relative_path}", "GET")
+      collect_public_dir_endpoints
+      super
+    end
+
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        last_endpoint = Endpoint.new("", "")
+        file.each_line.with_index do |line, index|
+          endpoint = line_to_endpoint(line)
+          if endpoint.method != ""
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint.details = details
+            endpoints << endpoint
+            last_endpoint = endpoint
           end
-        end
-      rescue e
-        logger.debug e
-      end
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      populate_channel_with_files(channel)
-
-      # Source Analysis
-      begin
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      last_endpoint = Endpoint.new("", "")
-                      file.each_line.with_index do |line, index|
-                        endpoint = line_to_endpoint(line)
-                        if endpoint.method != ""
-                          details = Details.new(PathInfo.new(path, index + 1))
-                          endpoint.details = details
-                          result << endpoint
-                          last_endpoint = endpoint
-                        end
-
-                        param = line_to_param(line)
-                        if param.name != ""
-                          if last_endpoint.method != ""
-                            last_endpoint.push_param(param)
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
+          param = line_to_param(line)
+          if param.name != ""
+            if last_endpoint.method != ""
+              last_endpoint.push_param(param)
             end
           end
         end
-      rescue e
-        logger.debug e
       end
 
-      result
+      endpoints
+    end
+
+    private def collect_public_dir_endpoints
+      get_public_files(@base_path).each do |file|
+        # Extract the path after "/public/" regardless of depth
+        if file =~ /\/public\/(.*)/
+          relative_path = $1
+          @result << Endpoint.new("/#{relative_path}", "GET")
+        end
+      end
+    rescue e
+      logger.debug e
     end
 
     def line_to_param(content : String) : Param

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -1,69 +1,50 @@
-require "../../../models/analyzer"
+require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
-  class Marten < Analyzer
+  class Marten < CrystalEngine
     def analyze
-      # Public Dir Analysis - static files
-      begin
-        get_public_files(@base_path).each do |file|
-          # Extract the path after "/public/" regardless of depth
-          if file =~ /\/public\/(.*)/
-            relative_path = $1
-            @result << Endpoint.new("/#{relative_path}", "GET")
+      collect_public_dir_endpoints
+      super
+    end
+
+    def analyze_file(path : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        last_endpoint = Endpoint.new("", "")
+        file.each_line.with_index do |line, index|
+          # Parse route definitions
+          endpoint = line_to_endpoint(line)
+          if endpoint.method != ""
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint.details = details
+            endpoints << endpoint
+            last_endpoint = endpoint
           end
-        end
-      rescue e
-        logger.debug e
-      end
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-      populate_channel_with_files(channel)
-
-      # Source Analysis
-      begin
-        WaitGroup.wait do |wg|
-          @options["concurrency"].to_s.to_i.times do
-            wg.spawn do
-              loop do
-                begin
-                  path = channel.receive?
-                  break if path.nil?
-                  next if File.directory?(path)
-                  if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("lib")
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      last_endpoint = Endpoint.new("", "")
-                      file.each_line.with_index do |line, index|
-                        # Parse route definitions
-                        endpoint = line_to_endpoint(line)
-                        if endpoint.method != ""
-                          details = Details.new(PathInfo.new(path, index + 1))
-                          endpoint.details = details
-                          result << endpoint
-                          last_endpoint = endpoint
-                        end
-
-                        # Parse parameter usage
-                        param = line_to_param(line)
-                        if param.name != ""
-                          if last_endpoint.method != ""
-                            last_endpoint.push_param(param)
-                          end
-                        end
-                      end
-                    end
-                  end
-                rescue File::NotFoundError
-                  logger.debug "File not found: #{path}"
-                end
-              end
+          # Parse parameter usage
+          param = line_to_param(line)
+          if param.name != ""
+            if last_endpoint.method != ""
+              last_endpoint.push_param(param)
             end
           end
         end
-      rescue e
-        logger.debug e
       end
 
-      result
+      endpoints
+    end
+
+    private def collect_public_dir_endpoints
+      get_public_files(@base_path).each do |file|
+        # Extract the path after "/public/" regardless of depth
+        if file =~ /\/public\/(.*)/
+          relative_path = $1
+          @result << Endpoint.new("/#{relative_path}", "GET")
+        end
+      end
+    rescue e
+      logger.debug e
     end
 
     def line_to_param(content : String) : Param

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -1,0 +1,31 @@
+require "../../models/analyzer"
+
+module Analyzer::Crystal
+  abstract class CrystalEngine < Analyzer
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path) && File.extname(path) == ".cr"
+          next if path.includes?("lib")
+
+          begin
+            result.concat(analyze_file(path))
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+  end
+end


### PR DESCRIPTION
## Summary

- All five Crystal analyzers (Amber, Grip, Kemal, Lucky, Marten) duplicated the same channel + WaitGroup worker-loop skeleton with a \`.cr\` extension filter and \`lib\`-directory exclusion. Extract into \`Analyzer::Crystal::CrystalEngine\`, mirroring \`PhpEngine\` / \`RustEngine\` / \`SwiftEngine\` (filter baked into the engine).
- Net **−112 LOC across five analyzers** (+31 LOC engine). No behavior change (all 5392 existing spec examples pass).

## Three post-pass shapes

The five analyzers split into three patterns around public-dir handling:

| Analyzer | Shape | \`analyze\` override |
|---|---|---|
| Grip | worker only | none (uses engine's \`analyze\` directly) |
| Lucky, Marten | public-dir **pre-pass** → worker | \`collect_public_dir_endpoints\` then \`super\` |
| Amber, Kemal | worker collects \`@is_public\`/\`@public_folders\` as side effects → **post-pass** | \`super\` then \`collect_public_dir_endpoints\`; explicit \`@result\` return |

For Amber and Kemal, the worker loop mutates instance-variable state (\`@is_public\`, \`@public_folders\`) from spawned fibers. This matches the pattern used across the rest of the codebase (single-threaded Crystal, cooperative fibers; no \`preview_mt\`).

## Notes

- Kemal's previous two-pass file read (routes, then a second \`File.open\` for \`public_folder\` config) is collapsed into a single \`lines.each_with_index\` iteration in \`analyze_file\`. Same semantics, one less read per file.
- \`next unless … && !…\` replaced with split \`next unless … / next if …\` to satisfy ameba's \`Style/NegatedConditionsInUnless\`.

## Test plan

- [x] \`just build\` — clean compile
- [x] \`just test\` — 1261 unit + 4131 functional examples, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`ameba\` — clean (6 files, 0 failures)