### PR TITLE
refactor(analyzer/scala): introduce ScalaEngine for Akka and Scalatra

### DIFF
--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -1,32 +1,17 @@
-require "../../../models/analyzer"
+require "../../engines/scala_engine"
 
 module Analyzer::Scala
-  class Akka < Analyzer
-    SCALA_EXTENSION = "scala"
-    HTTP_METHODS    = %w[get post put delete patch head options]
+  class Akka < ScalaEngine
+    HTTP_METHODS = %w[get post put delete patch head options]
 
-    def analyze
-      file_list = all_files()
-      file_list.each do |path|
-        next unless File.exists?(path)
-
-        if path.ends_with?(".#{SCALA_EXTENSION}")
-          process_scala_file(path)
-        end
-      end
-
-      Fiber.yield
-      @result
-    end
-
-    # Process individual Scala files to analyze Akka HTTP routing
-    private def process_scala_file(path : String)
+    def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
       extract_routes_from_content(path, content)
     end
 
     # Extract routes from Akka HTTP DSL
-    private def extract_routes_from_content(path : String, content : String)
+    private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
       lines = content.split('\n')
       prefix_stack = [] of String
       brace_depth = 0
@@ -80,7 +65,7 @@ module Analyzer::Scala
               # Extract additional parameters from the block
               extract_params_from_block(endpoint, block_content)
 
-              @result << endpoint
+              endpoints << endpoint
             end
           end
         end
@@ -98,6 +83,8 @@ module Analyzer::Scala
           prefix_depths.pop
         end
       end
+
+      endpoints
     end
 
     # Extract block content starting from a given index

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -1,32 +1,17 @@
-require "../../../models/analyzer"
+require "../../engines/scala_engine"
 
 module Analyzer::Scala
-  class Scalatra < Analyzer
-    SCALA_EXTENSION = "scala"
-    HTTP_METHODS    = %w[get post put delete patch head options]
+  class Scalatra < ScalaEngine
+    HTTP_METHODS = %w[get post put delete patch head options]
 
-    def analyze
-      file_list = all_files()
-      file_list.each do |path|
-        next unless File.exists?(path)
-
-        if path.ends_with?(".#{SCALA_EXTENSION}")
-          process_scala_file(path)
-        end
-      end
-
-      Fiber.yield
-      @result
-    end
-
-    # Process individual Scala files to analyze Scalatra routing
-    private def process_scala_file(path : String)
+    def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
       extract_routes_from_content(path, content)
     end
 
     # Extract routes from Scalatra DSL
-    private def extract_routes_from_content(path : String, content : String)
+    private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
       lines = content.split('\n')
 
       lines.each_with_index do |line, index|
@@ -50,10 +35,12 @@ module Analyzer::Scala
             block_content = extract_block_from_index(lines, index)
             extract_params_from_block(endpoint, block_content)
 
-            @result << endpoint
+            endpoints << endpoint
           end
         end
       end
+
+      endpoints
     end
 
     # Extract path parameters from the route pattern

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -1,0 +1,31 @@
+require "../../models/analyzer"
+
+module Analyzer::Scala
+  abstract class ScalaEngine < Analyzer
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path) && File.extname(path) == ".scala"
+
+          begin
+            result.concat(analyze_file(path))
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+
+      Fiber.yield
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+  end
+end


### PR DESCRIPTION
## Summary

- Akka and Scalatra shared a synchronous \`all_files().each\` walk with a \`.scala\` extension filter. Extract into \`Analyzer::Scala::ScalaEngine\` (using \`parallel_analyze\`, mirroring the other language engines).
- \`extract_routes_from_content\` now returns \`Array(Endpoint)\` instead of mutating \`@result\`, so \`analyze_file\` can return per-file endpoints for the engine to concat.

## Play stays on the Analyzer base

Play orchestrates a two-phase flow — parse all controller files into a map, then process routes files that reference controllers by name — which doesn't fit the per-file \`analyze_file(path) → Array(Endpoint)\` shape. Left unmodified.

## Behavior note

Akka and Scalatra now process files **concurrently** via \`parallel_analyze\` instead of sequentially. Endpoint equality in functional tests is order-independent, so fixtures still pass.

## Test plan

- [x] \`just build\` — clean compile
- [x] \`just test\` — 1261 unit + 4131 functional examples, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`ameba\` — clean (4 files, 0 failures)

## Net

−26 LOC across the two migrated analyzers; +31 LOC engine. No material behavior change.