### PR TITLE
refactor(analyzer/js,ts): introduce JavascriptEngine shared helper

### DIFF
--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -1,4 +1,4 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 require "../../../utils/url_path"
 require "../../../utils/js_literal_scanner"
@@ -6,7 +6,7 @@ require "./express_constants"
 require "./express/router_mount_scanner"
 
 module Analyzer::Javascript
-  class Express < Analyzer
+  class Express < JavascriptEngine
     include ExpressConstants
 
     # Constants for method chaining detection
@@ -14,60 +14,45 @@ module Analyzer::Javascript
     MAX_CHAIN_SEARCH_DISTANCE = 5000
 
     def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        # Phase 1: Pre-scan to build router mount map
-        scan_for_router_mounts
+      # Phase 1: Pre-scan to build router mount map
+      scan_for_router_mounts
 
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          # Use any? with an array of extensions
-          next unless [".js", ".ts", ".jsx", ".tsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            # First try to use the JS parser for more robust analysis
-            begin
-              content = File.read(path, encoding: "utf-8", invalid: :skip)
-              parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
-              parser_endpoints.each do |endpoint|
-                # Use the line number already set by the extractor; fall back to path-only if missing
-                if endpoint.details.code_paths.empty?
-                  endpoint.details = Details.new(PathInfo.new(path))
-                end
-
-                # Parse path parameters from the URL path itself
-                if endpoint.url.includes?(":")
-                  endpoint.url.scan(/:(\w+)/) do |m|
-                    if m.size > 0
-                      param = Param.new(m[1], "", "path")
-                      endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
-                    end
-                  end
-                end
-
-                result << endpoint
-              end
-
-              # Extract static path declarations
-              Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
-                static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
-              end
-            rescue e
-              logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
-
-              # Fallback to the original regex-based approach if parser fails
-              analyze_with_regex(path, result, static_dirs)
+      parallel_js_scan do |path|
+        begin
+          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints.each do |endpoint|
+            # Use the line number already set by the extractor; fall back to path-only if missing
+            if endpoint.details.code_paths.empty?
+              endpoint.details = Details.new(PathInfo.new(path))
             end
+
+            # Parse path parameters from the URL path itself
+            if endpoint.url.includes?(":")
+              endpoint.url.scan(/:(\w+)/) do |m|
+                if m.size > 0
+                  param = Param.new(m[1], "", "path")
+                  endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
+                end
+              end
+            end
+
+            result << endpoint
           end
+
+          # Extract static path declarations
+          Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
+            static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+          end
+        rescue e
+          logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
+
+          # Fallback to the original regex-based approach if parser fails
+          analyze_with_regex(path, result, static_dirs)
         end
-      rescue e
-        logger.debug "Error in Express analyzer: #{e.message}"
       end
 
       # Process static directories to create endpoints for static files

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -1,59 +1,44 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
-  class Fastify < Analyzer
+  class Fastify < JavascriptEngine
     def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        populate_channel_with_files(channel)
+      parallel_js_scan do |path|
+        begin
+          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints.each do |endpoint|
+            # Add file location details
+            details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
+            endpoint.details = details
 
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          # Use any? with an array of extensions
-          next unless [".js", ".ts", ".jsx", ".tsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            # First try to use the JS parser for more robust analysis
-            begin
-              content = File.read(path, encoding: "utf-8", invalid: :skip)
-              parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
-              parser_endpoints.each do |endpoint|
-                # Add file location details
-                details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-                endpoint.details = details
-
-                # Parse path parameters from the URL path itself
-                if endpoint.url.includes?(":")
-                  endpoint.url.scan(/:(\w+)/) do |m|
-                    if m.size > 0
-                      param = Param.new(m[1], "", "path")
-                      endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
-                    end
-                  end
+            # Parse path parameters from the URL path itself
+            if endpoint.url.includes?(":")
+              endpoint.url.scan(/:(\w+)/) do |m|
+                if m.size > 0
+                  param = Param.new(m[1], "", "path")
+                  endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
                 end
-
-                result << endpoint
               end
-
-              # Extract static path declarations
-              Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
-                static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
-              end
-            rescue e
-              logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
-
-              # Fallback to the original regex-based approach if parser fails
-              analyze_with_regex(path, result, static_dirs)
             end
+
+            result << endpoint
           end
+
+          # Extract static path declarations
+          Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
+            static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+          end
+        rescue e
+          logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
+
+          # Fallback to the original regex-based approach if parser fails
+          analyze_with_regex(path, result, static_dirs)
         end
-      rescue e
-        logger.debug "Error in Fastify analyzer: #{e.message}"
       end
 
       # Process static directories to create endpoints for static files

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -1,47 +1,34 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
-  class Hono < Analyzer
+  class Hono < JavascriptEngine
     def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        populate_channel_with_files(channel)
+      parallel_js_scan do |path|
+        begin
+          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints.each do |endpoint|
+            details = Details.new(PathInfo.new(path, 1))
+            endpoint.details = details
 
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".js", ".ts", ".jsx", ".tsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            begin
-              content = File.read(path, encoding: "utf-8", invalid: :skip)
-              parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
-              parser_endpoints.each do |endpoint|
-                details = Details.new(PathInfo.new(path, 1))
-                endpoint.details = details
-
-                extract_path_params(endpoint)
-                result << endpoint
-              end
-
-              # Extract app.on() patterns not handled by JSRouteExtractor
-              extract_on_routes(path, content, result)
-
-              Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
-                static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
-              end
-            rescue e
-              logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
-              analyze_with_regex(path, result)
-            end
+            extract_path_params(endpoint)
+            result << endpoint
           end
+
+          # Extract app.on() patterns not handled by JSRouteExtractor
+          extract_on_routes(path, content, result)
+
+          Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
+            static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+          end
+        rescue e
+          logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
+          analyze_with_regex(path, result)
         end
-      rescue e
-        logger.debug "Error in Hono analyzer: #{e.message}"
       end
 
       process_static_dirs(static_dirs, result)

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -1,51 +1,39 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
-  class Koa < Analyzer
+  class Koa < JavascriptEngine
     def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        populate_channel_with_files(channel)
+      parallel_js_scan([".js", ".ts", ".mjs"]) do |path|
+        begin
+          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints.each do |endpoint|
+            details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
+            endpoint.details = details
 
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".js", ".ts", ".mjs"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            begin
-              content = File.read(path, encoding: "utf-8", invalid: :skip)
-              parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
-              parser_endpoints.each do |endpoint|
-                details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-                endpoint.details = details
-
-                if endpoint.url.includes?(":")
-                  endpoint.url.scan(/:(\w+)/) do |m|
-                    if m.size > 0
-                      param = Param.new(m[1], "", "path")
-                      endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
-                    end
-                  end
+            if endpoint.url.includes?(":")
+              endpoint.url.scan(/:(\w+)/) do |m|
+                if m.size > 0
+                  param = Param.new(m[1], "", "path")
+                  endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
                 end
-                result << endpoint
               end
-
-              # Extract static path declarations
-              Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
-                static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
-              end
-            rescue e
-              logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
-              analyze_with_regex(path, result, static_dirs)
             end
+            result << endpoint
           end
+
+          # Extract static path declarations
+          Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
+            static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+          end
+        rescue e
+          logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
+          analyze_with_regex(path, result, static_dirs)
         end
-      rescue e
-        logger.debug "Error in Koa analyzer: #{e.message}"
       end
 
       # Process static directories to create endpoints for static files

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -1,26 +1,14 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
-  class Nestjs < Analyzer
+  class Nestjs < JavascriptEngine
     def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".js", ".jsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            analyze_nestjs_file(path, result, static_dirs)
-          end
-        end
-      rescue e : Exception
-        logger.debug "Channel or wait group error: #{e.message}"
+      parallel_js_scan([".js", ".jsx"]) do |path|
+        analyze_nestjs_file(path, result, static_dirs)
       end
 
       # Process static directories to create endpoints for static files

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -1,28 +1,15 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 
 module Analyzer::Javascript
-  class Nitro < Analyzer
+  class Nitro < JavascriptEngine
     def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       mutex = Mutex.new
 
-      begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".js", ".ts", ".mjs", ".mts"].any? { |ext| path.ends_with?(ext) }
-
-          # Focus on routes/ directory for Nitro
-          if path.includes?("/routes/")
-            if File.exists?(path)
-              analyze_nitro_file(path, result, mutex)
-            end
-          end
-        end
-      rescue e : Exception
-        logger.debug "Channel or wait group error: #{e.message}"
+      parallel_js_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
+        # Focus on routes/ directory for Nitro
+        next unless path.includes?("/routes/")
+        analyze_nitro_file(path, result, mutex)
       end
 
       result

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -1,28 +1,15 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 
 module Analyzer::Javascript
-  class Nuxtjs < Analyzer
+  class Nuxtjs < JavascriptEngine
     def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       mutex = Mutex.new
 
-      begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".js", ".ts", ".mjs", ".mts"].any? { |ext| path.ends_with?(ext) }
-
-          # Focus on server/api and server/routes directories for Nuxt 3
-          if path.includes?("/server/api/") || path.includes?("/server/routes/")
-            if File.exists?(path)
-              analyze_nuxt_file(path, result, mutex)
-            end
-          end
-        end
-      rescue e : Exception
-        logger.debug "Channel or wait group error: #{e.message}"
+      parallel_js_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
+        # Focus on server/api and server/routes directories for Nuxt 3
+        next unless path.includes?("/server/api/") || path.includes?("/server/routes/")
+        analyze_nuxt_file(path, result, mutex)
       end
 
       result

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -1,58 +1,44 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
-  class Restify < Analyzer
+  class Restify < JavascriptEngine
     def analyze
-      # Source Analysis
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        populate_channel_with_files(channel)
+      parallel_js_scan do |path|
+        begin
+          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints.each do |endpoint|
+            # Add file location details
+            details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
+            endpoint.details = details
 
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".js", ".ts", ".jsx", ".tsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            # First try to use the JS parser for more robust analysis
-            begin
-              content = File.read(path, encoding: "utf-8", invalid: :skip)
-              parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
-              parser_endpoints.each do |endpoint|
-                # Add file location details
-                details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-                endpoint.details = details
-
-                # Parse path parameters from the URL path itself
-                if endpoint.url.includes?(":")
-                  endpoint.url.scan(/:(\w+)/) do |m|
-                    if m.size > 0
-                      param = Param.new(m[1], "", "path")
-                      endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
-                    end
-                  end
+            # Parse path parameters from the URL path itself
+            if endpoint.url.includes?(":")
+              endpoint.url.scan(/:(\w+)/) do |m|
+                if m.size > 0
+                  param = Param.new(m[1], "", "path")
+                  endpoint.push_param(param) if !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
                 end
-
-                result << endpoint
               end
-
-              # Extract static path declarations
-              Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
-                static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
-              end
-            rescue e
-              logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
-
-              # Fallback to the original regex-based approach if parser fails
-              analyze_with_regex(path, result, static_dirs)
             end
+
+            result << endpoint
           end
+
+          # Extract static path declarations
+          Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
+            static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+          end
+        rescue e
+          logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
+
+          # Fallback to the original regex-based approach if parser fails
+          analyze_with_regex(path, result, static_dirs)
         end
-      rescue e
-        logger.debug "Error in Restify analyzer: #{e.message}"
       end
 
       # Process static directories to create endpoints for static files

--- a/src/analyzer/analyzers/typescript/nestjs.cr
+++ b/src/analyzer/analyzers/typescript/nestjs.cr
@@ -1,26 +1,14 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Typescript
-  class Nestjs < Analyzer
+  class Nestjs < Analyzer::Javascript::JavascriptEngine
     def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".ts", ".tsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            analyze_nestjs_file(path, result, static_dirs)
-          end
-        end
-      rescue e : Exception
-        logger.debug "Channel or wait group error: #{e.message}"
+      parallel_js_scan([".ts", ".tsx"]) do |path|
+        analyze_nestjs_file(path, result, static_dirs)
       end
 
       # Process static directories to create endpoints for static files

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -1,24 +1,12 @@
-require "../../../models/analyzer"
+require "../../engines/javascript_engine"
 
 module Analyzer::Typescript
-  class TanstackRouter < Analyzer
+  class TanstackRouter < Analyzer::Javascript::JavascriptEngine
     def analyze
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       result = [] of Endpoint
 
-      begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
-          next if File.directory?(path)
-          next unless [".ts", ".tsx"].any? { |ext| path.ends_with?(ext) }
-
-          if File.exists?(path)
-            analyze_tanstack_file(path, result)
-          end
-        end
-      rescue e : Exception
-        logger.debug "Channel or wait group error: #{e.message}"
+      parallel_js_scan([".ts", ".tsx"]) do |path|
+        analyze_tanstack_file(path, result)
       end
 
       result

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -1,0 +1,36 @@
+require "../../models/analyzer"
+
+module Analyzer::Javascript
+  abstract class JavascriptEngine < Analyzer
+    # Default extension set for JavaScript/TypeScript source files.
+    # Analyzers with a different filter (e.g. Nitro adds `.mts`, NestJS JS
+    # only uses `.js`/`.jsx`) pass their own list to `parallel_js_scan`.
+    DEFAULT_EXTENSIONS = [".js", ".ts", ".jsx", ".tsx"]
+
+    # Walk the project tree concurrently, invoking the block for each
+    # readable source file whose extension matches. JS/TS analyzers vary
+    # in the exact filter (plain JS vs TS vs .mjs vs .tsx), so the filter
+    # is an argument with a sensible default.
+    protected def parallel_js_scan(extensions : Array(String) = DEFAULT_EXTENSIONS, &block : String -> Nil) : Nil
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+          next unless extensions.any? { |ext| path.ends_with?(ext) }
+
+          begin
+            block.call(path)
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

All ten JS/TS analyzers already used \`parallel_analyze\` (the pattern other engines converged on), but each one re-declared the channel setup, extension filter, \`File.exists?\` guard, and outer \`begin/rescue\`. Extract into \`Analyzer::Javascript::JavascriptEngine\` with a protected \`parallel_js_scan(extensions, &block)\` helper.

Net **−131 LOC across 10 analyzers** (+36 LOC engine). No behavior change.

## Why helper, not abstract \`analyze_file\`

JS analyzers carry closure state (local \`result\` array, \`static_dirs\`, per-analyzer \`Mutex\`) and have varied post-processing (\`process_static_dirs\`, Express's router-mount pre-phase). Forcing them into the \`PhpEngine\`-style \`analyze_file(path) : Array(Endpoint)\` shape would require reshaping every analyzer; a helper in the spirit of \`RubyEngine#parallel_file_scan\` is a much smaller intervention.

## Per-analyzer extension filters

Default is \`.js/.ts/.jsx/.tsx\` (Express, Fastify, Hono, Restify). The rest pass their own:

| Analyzer | Extensions |
|---|---|
| Koa | \`.js, .ts, .mjs\` |
| Nestjs (JS) | \`.js, .jsx\` |
| Nitro / Nuxtjs | \`.js, .ts, .mjs, .mts\` |
| Nestjs (TS), TanstackRouter | \`.ts, .tsx\` |

## Cross-module inheritance

TypeScript analyzers inherit from the JS-module engine:
\`\`\`crystal
class Analyzer::Typescript::Nestjs < Analyzer::Javascript::JavascriptEngine
\`\`\`

## Test plan

- [x] \`just build\` — clean compile
- [x] \`just test\` — 1261 unit + 4131 functional, 0 failures
- [x] \`crystal tool format --check\` — clean (format applied)
- [x] \`ameba\` — 13 files, 0 failures