### PR TITLE
docs(agents): refresh analyzer engine coverage after Phase 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ spec/
 
 An analyzer is composed of three layers. Keep them separate — a framework adapter should not open files or re-implement parsing.
 
-1. **Language Engine** — shared per-language base. PHP/Ruby/Rust live in `src/analyzer/engines/{lang}_engine.cr`; Go and Python still use `src/analyzer/analyzers/{lang}/common.cr` (will migrate alongside the later engine-vs-extractor split). Owns file walking, concurrency, worker pool, file-content caching.
+1. **Language Engine** — shared per-language base in `src/analyzer/engines/{lang}_engine.cr`. Owns file walking, concurrency, worker pool, file-content caching. Go and Python still use legacy `src/analyzer/analyzers/{lang}/common.cr` bases (engine and route-extraction mixed); they will migrate alongside the later engine-vs-extractor split.
 2. **Route Extractor** — shared per-language parser layer (`src/miniparsers/{lang}_route_extractor.cr`). Takes source content, yields route declarations (method, path, location). No file I/O, no framework-specific rules.
 3. **Framework Adapter** — thin per-framework class (`src/analyzer/analyzers/{lang}/{framework}.cr`). Consumes routes from the extractor and applies framework-specific param mappings, filters, and special cases.
 
@@ -88,8 +88,8 @@ An analyzer is composed of three layers. Keep them separate — a framework adap
 **Reference implementation**: `src/analyzer/analyzers/javascript/hono.cr` on top of `src/miniparsers/js_route_extractor.cr`. Hono is ~205 lines because it follows this split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
 
 **Current coverage**:
-- Language engines: Go, Python, PHP, Ruby, Rust. Go/Python bases mix engine and route-extraction helpers; splitting them is future work.
-- Route extractors: JavaScript only. Python/Kotlin/Java have parsers but not dedicated extractors.
+- Language engines: PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala (Akka + Scalatra), JavaScript/TypeScript. Go and Python still use legacy `analyzers/{lang}/common.cr` bases pending the engine-vs-extractor split. CSharp and Scala Play stay on the `Analyzer` base because their analyze flows orchestrate multiple phases rather than a per-file scan.
+- Route extractors: JavaScript only (`js_route_extractor.cr`, used by Hono, Express, Fastify, Koa, NestJS, Restify, and TypeScript NestJS). Python/Kotlin/Java have parsers but no dedicated route extractor yet.
 
 When adding a new framework in a language that already has an extractor, extend the extractor rather than re-parsing inline.
 


### PR DESCRIPTION
## Summary

Update \`AGENTS.md\` to reflect the current engine coverage after the Phase 1 refactor cycle.

## Changes

- Layer 1 description: engines live in \`src/analyzer/engines/{lang}_engine.cr\`; Go/Python bases noted as legacy pending the later engine-vs-extractor split.
- **Current coverage** bullet rewritten:
  - **Language engines** (8): PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala (Akka + Scalatra), JavaScript/TypeScript.
  - Deliberately on Analyzer base: CSharp (two multi-phase orchestrators), Scala Play (two-phase flow).
  - **Route extractors**: JavaScript only; names the six JS + one TS analyzer that wire into it so the Layer 2 gap for other languages is concrete.

Doc-only; no code changes.