### PR TITLE
refactor(analyzer/python): move Python base to engines/python_engine

### DIFF
--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -1,9 +1,8 @@
-require "../../../models/analyzer"
-require "./python"
+require "../../engines/python_engine"
 require "json"
 
 module Analyzer::Python
-  class Django < Python
+  class Django < PythonEngine
     # Base path for the Django project
     @django_base_path : ::String = ""
     @visited_url_paths = Hash(String, Bool).new

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -1,8 +1,7 @@
-require "../../../models/analyzer"
-require "./python"
+require "../../engines/python_engine"
 
 module Analyzer::Python
-  class FastAPI < Python
+  class FastAPI < PythonEngine
     @fastapi_base_path : ::String = ""
 
     def analyze

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1,10 +1,9 @@
-require "../../../models/analyzer"
 require "../../../minilexers/python"
 require "../../../miniparsers/python"
-require "./python"
+require "../../engines/python_engine"
 
 module Analyzer::Python
-  class Flask < Python
+  class Flask < PythonEngine
     # Reference: https://stackoverflow.com/a/16664376
     # Reference: https://tedboy.github.io/flask/generated/generated/flask.Request.html
     REQUEST_PARAM_FIELDS = {

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -1,10 +1,9 @@
-require "../../../models/analyzer"
 require "../../../minilexers/python"
 require "../../../miniparsers/python"
-require "./python"
+require "../../engines/python_engine"
 
 module Analyzer::Python
-  class Sanic < Python
+  class Sanic < PythonEngine
     # Reference: https://sanic.readthedocs.io/en/stable/sanic/request.html
     REQUEST_PARAM_FIELDS = {
       "args"    => {["GET"], "query"},

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -1,10 +1,9 @@
-require "../../../models/analyzer"
 require "../../../minilexers/python"
 require "../../../miniparsers/python"
-require "./python"
+require "../../engines/python_engine"
 
 module Analyzer::Python
-  class Tornado < Python
+  class Tornado < PythonEngine
     # Reference: https://tornadoweb.org/en/stable/web.html
     # Reference: https://tornadoweb.org/en/stable/httputil.html#tornado.httputil.HTTPServerRequest
     REQUEST_PARAM_FIELDS = {

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -1,8 +1,8 @@
-require "../../../models/analyzer"
+require "../../models/analyzer"
 require "json"
 
 module Analyzer::Python
-  class Python < Analyzer
+  class PythonEngine < Analyzer
     # HTTP method names commonly used in REST APIs
     HTTP_METHODS = ["get", "post", "put", "patch", "delete", "head", "options", "trace"]
     # Indentation size in spaces; different sizes can cause analysis issues


### PR DESCRIPTION
## Summary

- Relocate \`src/analyzer/analyzers/python/python.cr\` to \`src/analyzer/engines/python_engine.cr\` and rename the class from \`Python\` to \`PythonEngine\`.
- Update the five Python analyzers (Flask, FastAPI, Django, Sanic, Tornado) to require the new path and inherit from \`PythonEngine\`.
- No logic changes.

## Why

The class's contents (\`parse_function_def\`, \`find_imported_modules\`, \`find_imported_package\`, \`find_json_params\`, \`parse_code_block\`, \`return_literal_value\`, plus the \`FunctionParameter\`/\`FunctionDefinition\`/\`PackageType\` inner types) are all language-level helpers — the same category of code \`engines/\` already houses for the other eight languages. Its location under \`analyzers/python/\` was a historical artifact. Now the 3-layer story in \`AGENTS.md\` matches reality for Python.

## Follow-up

Go (\`analyzers/go/common.cr\`) is the last language still on a legacy mixed engine+extractor base — that's the remaining Phase 2 item.

## Test plan

- [x] \`just build\` — clean compile (Git shows the file as a 99% similarity rename, no content drift)
- [x] \`just test\` — 1261 unit + 4131 functional, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`ameba\` — 6 files, 0 failures