### PR TITLE
refactor(analyzer/go): split common.cr into engine + route extractor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ spec/
 
 An analyzer is composed of three layers. Keep them separate — a framework adapter should not open files or re-implement parsing.
 
-1. **Language Engine** — shared per-language base in `src/analyzer/engines/{lang}_engine.cr`. Owns file walking, concurrency, worker pool, file-content caching. Go and Python still use legacy `src/analyzer/analyzers/{lang}/common.cr` bases (engine and route-extraction mixed); they will migrate alongside the later engine-vs-extractor split.
+1. **Language Engine** — shared per-language base in `src/analyzer/engines/{lang}_engine.cr`. Owns file walking, concurrency, worker pool, file-content caching.
 2. **Route Extractor** — shared per-language parser layer (`src/miniparsers/{lang}_route_extractor.cr`). Takes source content, yields route declarations (method, path, location). No file I/O, no framework-specific rules.
 3. **Framework Adapter** — thin per-framework class (`src/analyzer/analyzers/{lang}/{framework}.cr`). Consumes routes from the extractor and applies framework-specific param mappings, filters, and special cases.
 
@@ -88,8 +88,8 @@ An analyzer is composed of three layers. Keep them separate — a framework adap
 **Reference implementation**: `src/analyzer/analyzers/javascript/hono.cr` on top of `src/miniparsers/js_route_extractor.cr`. Hono is ~205 lines because it follows this split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
 
 **Current coverage**:
-- Language engines: PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala (Akka + Scalatra), JavaScript/TypeScript. Go and Python still use legacy `analyzers/{lang}/common.cr` bases pending the engine-vs-extractor split. CSharp and Scala Play stay on the `Analyzer` base because their analyze flows orchestrate multiple phases rather than a per-file scan.
-- Route extractors: JavaScript only (`js_route_extractor.cr`, used by Hono, Express, Fastify, Koa, NestJS, Restify, and TypeScript NestJS). Python/Kotlin/Java have parsers but no dedicated route extractor yet.
+- Language engines: PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala (Akka + Scalatra), JavaScript/TypeScript, Python, Go. CSharp, Scala Play, Chi/Httprouter/Fasthttp (Go) stay on the `Analyzer` base because their flows orchestrate multiple phases or carry self-contained extraction that doesn't share with other analyzers.
+- Route extractors: JavaScript (`js_route_extractor.cr`, used by Hono, Express, Fastify, Koa, NestJS, Restify, and TypeScript NestJS) and Go (`go_route_extractor.cr`, wrapped by `GoEngine` and delegated to from eight analyzers). Python/Kotlin/Java have parsers but no dedicated route extractor yet.
 
 When adding a new framework in a language that already has an extractor, extend the extractor rather than re-parsing inline.
 

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Beego < Common
+  class Beego < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Echo < Common
+  class Echo < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Fiber < Common
+  class Fiber < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Gf < Common
+  class Gf < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Gin < Common
+  class Gin < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Goyave < Common
+  class Goyave < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class GoZero < Common
+  class GoZero < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -1,7 +1,7 @@
-require "./common"
+require "../../engines/go_engine"
 
 module Analyzer::Go
-  class Mux < Common
+  class Mux < GoEngine
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -1,91 +1,28 @@
-require "../../../models/analyzer"
-require "../../../minilexers/golang"
+require "../../models/analyzer"
+require "../../minilexers/golang"
+require "../../miniparsers/go_route_extractor"
 
 module Analyzer::Go
-  class Common < Analyzer
+  class GoEngine < Analyzer
+    # --- Route-extractor delegations -------------------------------------
+    #
+    # Kept as instance methods so per-framework analyzers (Mux, Goyave,
+    # GoZero) can override them. The default implementations live in
+    # `Noir::GoRouteExtractor` as pure functions.
+
     def analyze_group(line : String, lexer : GolangLexer, groups : Array(Hash(String, String)))
-      if line.includes?(".Group(")
-        map = lexer.tokenize(line)
-        before = Token.new(:unknown, "", 0)
-        group_name = ""
-        group_path = ""
-        map.each do |token|
-          if token.type == :assign
-            group_name = before.value.to_s.gsub(":", "").gsub(/\s/, "")
-          end
-
-          if token.type == :string
-            group_path = token.value.to_s
-            groups.each do |group|
-              group.each do |key, value|
-                if before.value.to_s.includes? key
-                  group_path = value + group_path
-                end
-              end
-            end
-          end
-
-          before = token
-        end
-
-        if group_name.size > 0 && group_path.size > 0
-          # Skip if a group with this name is already registered
-          unless groups.any?(&.has_key?(group_name))
-            groups << {
-              group_name => group_path,
-            }
-          end
-        end
-      end
+      Noir::GoRouteExtractor.scan_group(line, lexer, groups)
     end
 
     def get_route_path(line : String, groups : Array(Hash(String, String))) : String
-      lexer = GolangLexer.new
-      map = lexer.tokenize(line)
-      before = Token.new(:unknown, "", 0)
-      map.each do |token|
-        if token.type == :string
-          final_path = token.value.to_s
-          # Route path must start with "/" to be a valid HTTP endpoint
-          next unless final_path.starts_with?("/")
-          groups.each do |group|
-            group.each do |key, value|
-              if before.value.to_s.includes? key
-                final_path = value + final_path
-              end
-            end
-          end
-
-          return final_path
-        end
-
-        before = token
-      end
-
-      ""
+      Noir::GoRouteExtractor.extract_route_path(line, groups)
     end
 
     def get_static_path(line : String) : Hash(String, String)
-      first = line.strip.split("(")
-      if first.size > 1
-        second = first[1].split(",")
-        if second.size > 1
-          static_path = second[0].gsub("\"", "")
-          file_path = second[1].gsub("\"", "").gsub(" ", "").gsub(")", "").gsub_repeatedly("//", "/")
-          rtn = {
-            "static_path" => static_path,
-            "file_path"   => file_path,
-          }
-
-          return rtn
-        end
-      end
-
-      {
-        "static_path" => "",
-        "file_path"   => "",
-      }
+      Noir::GoRouteExtractor.extract_static_path(line)
     end
+
+    # --- Engine layer ----------------------------------------------------
 
     # Pre-collect all group definitions across Go files grouped by directory (package).
     # This enables cross-file group resolution since all .go files in the same
@@ -144,6 +81,8 @@ module Analyzer::Go
       end
       groups
     end
+
+    # --- Adapter helpers (shared across Go framework adapters) ----------
 
     def add_param_to_endpoint(param : Param, endpoint : Endpoint)
       if param.name.size > 0 && endpoint.method != "" && endpoint.url != ""

--- a/src/miniparsers/go_route_extractor.cr
+++ b/src/miniparsers/go_route_extractor.cr
@@ -1,0 +1,103 @@
+require "../minilexers/golang"
+
+module Noir
+  # Pure parsing helpers for Go route-like source lines.
+  #
+  # No file I/O and no dependency on the Analyzer base — the engine
+  # (`Analyzer::Go::GoEngine`) wraps these for analyzer instances.
+  # Per-framework analyzers may still override their own `get_route_path`
+  # / `get_static_path` to customize extraction; this module is the
+  # default implementation they delegate to.
+  module GoRouteExtractor
+    extend self
+
+    # Scan one line for a `.Group(...)` definition and append the
+    # resolved `{name => path}` entry to `groups` if found.
+    def scan_group(line : String, lexer : GolangLexer, groups : Array(Hash(String, String))) : Nil
+      return unless line.includes?(".Group(")
+
+      map = lexer.tokenize(line)
+      before = Token.new(:unknown, "", 0)
+      group_name = ""
+      group_path = ""
+      map.each do |token|
+        if token.type == :assign
+          group_name = before.value.to_s.gsub(":", "").gsub(/\s/, "")
+        end
+
+        if token.type == :string
+          group_path = token.value.to_s
+          groups.each do |group|
+            group.each do |key, value|
+              if before.value.to_s.includes? key
+                group_path = value + group_path
+              end
+            end
+          end
+        end
+
+        before = token
+      end
+
+      if group_name.size > 0 && group_path.size > 0
+        # Skip if a group with this name is already registered
+        unless groups.any?(&.has_key?(group_name))
+          groups << {
+            group_name => group_path,
+          }
+        end
+      end
+    end
+
+    # Parse one line, return the route path with group prefix applied.
+    # Returns "" if no route string is found.
+    def extract_route_path(line : String, groups : Array(Hash(String, String))) : String
+      lexer = GolangLexer.new
+      map = lexer.tokenize(line)
+      before = Token.new(:unknown, "", 0)
+      map.each do |token|
+        if token.type == :string
+          final_path = token.value.to_s
+          # Route path must start with "/" to be a valid HTTP endpoint
+          next unless final_path.starts_with?("/")
+          groups.each do |group|
+            group.each do |key, value|
+              if before.value.to_s.includes? key
+                final_path = value + final_path
+              end
+            end
+          end
+
+          return final_path
+        end
+
+        before = token
+      end
+
+      ""
+    end
+
+    # Parse one line for a `Static(route, dir)`-style call and return
+    # `{"static_path" => …, "file_path" => …}`. Both entries are ""
+    # when the line does not match.
+    def extract_static_path(line : String) : Hash(String, String)
+      first = line.strip.split("(")
+      if first.size > 1
+        second = first[1].split(",")
+        if second.size > 1
+          static_path = second[0].gsub("\"", "")
+          file_path = second[1].gsub("\"", "").gsub(" ", "").gsub(")", "").gsub_repeatedly("//", "/")
+          return {
+            "static_path" => static_path,
+            "file_path"   => file_path,
+          }
+        end
+      end
+
+      {
+        "static_path" => "",
+        "file_path"   => "",
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The legacy \`Analyzer::Go::Common\` base mixed three layers in one class. Split along the 3-layer boundary documented in \`AGENTS.md\`:

- **New** \`src/miniparsers/go_route_extractor.cr\` — \`Noir::GoRouteExtractor\` module with pure parsing functions: \`scan_group\`, \`extract_route_path\`, \`extract_static_path\`. No file I/O, no \`Analyzer\` dependency.
- **New** \`src/analyzer/engines/go_engine.cr\` — \`Analyzer::Go::GoEngine\` wrapping:
  - Instance-method delegations (\`analyze_group\` / \`get_route_path\` / \`get_static_path\`) so Mux, Goyave, and GoZero keep their per-framework overrides.
  - Engine orchestration (\`collect_package_groups\`, \`groups_for_directory\`) and adapter helpers (\`add_param_to_endpoint\`, \`add_static_path_if_valid\`, \`resolve_public_dirs*\`).
- **Deleted** \`src/analyzer/analyzers/go/common.cr\`.

## Migrations

| Inherited from Common → GoEngine | Stays on Analyzer (self-contained) |
|---|---|
| beego, echo, fiber, gf, gin, gozero, goyave, mux | chi, httprouter, fasthttp |

## Why keep instance methods on the engine

Mux, Goyave, and GoZero override \`get_route_path\` / \`get_static_path\` with framework-specific parsing. Keeping the engine's instance methods as thin delegations to \`Noir::GoRouteExtractor\` preserves those overrides without change.

## Result

This closes the last Phase 2 item in \`AGENTS.md\`: no language is on a legacy mixed-layer base anymore.

## Test plan

- [x] \`just build\` — clean compile
- [x] \`just test\` — 1261 unit + 4131 functional, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`ameba\` — 13 files, 0 failures