### PR TITLE
refactor(analyzer): unify engine helper + add architecture docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,11 @@ An analyzer is composed of three layers. Keep them separate — a framework adap
 
 When adding a new framework in a language that already has an extractor, extend the extractor rather than re-parsing inline.
 
+**Two engine shapes** — every engine exposes `parallel_file_scan(&block)` as a protected helper. Subclasses pick one of:
+
+- **Simple per-file**: override `abstract def analyze_file(path) : Array(Endpoint)`. The engine's default `analyze` drives the walk and concats the returned endpoints. Used by Php/Rust/Swift/Crystal/Elixir/Scala analyzers.
+- **Custom `analyze`**: override `analyze` directly and call `parallel_file_scan` when you need closure state, a pre-phase (e.g., Express's `scan_for_router_mounts`), or post-processing (e.g., Hono's `process_static_dirs`, Amber/Kemal's public-dir pass). Used by Ruby/JavaScript/TypeScript analyzers and by the handful of Crystal/Elixir analyzers that override.
+
 ## Adding New Components
 
 ### Analyzers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,14 @@ just fix
   - models: Contains everything related to models, such as classes and structures.
 - noir.cr: Main file and command-line parser.
 
+### Adding a new detector or analyzer
+
+Noir's analyzer stack is a three-layer design (language engine → route extractor → framework adapter). Before adding a new detector/analyzer, read:
+
+**📖 [Analyzer Architecture](https://owasp-noir.github.io/noir/development/analyzer_architecture/)**
+
+The doc covers how the layers fit together, which engines and extractors already exist, the two supported engine shapes, and a step-by-step walkthrough of adding a new framework (Hertz as the worked example).
+
 Feel free to reach out to us if you have any questions or need further assistance!
 
 ## Document Contributing

--- a/docs/content/development/_index.ko.md
+++ b/docs/content/development/_index.ko.md
@@ -9,6 +9,7 @@ sort_by = "weight"
 이 섹션은 OWASP Noir 프로젝트에 기여하고자 하는 개발자를 위한 리소스를 제공합니다. 소스에서 빌드하거나, 개발 환경을 설정하거나, 릴리스를 준비하는 경우 여기에서 필요한 정보를 찾을 수 있습니다.
 
 *   **[빌드 방법](how_to_build/)**: 개발 환경 설정, 프로젝트 빌드, 테스트 실행 방법을 알아보세요.
+*   **[분석기 아키텍처](analyzer_architecture/)**: 3-layer 구조(engine → route extractor → framework adapter) 와 새 detector/analyzer 를 추가하는 단계별 가이드.
 *   **[Nix 환경으로 빌드](nix_environment/)**: Nix와 Docker를 사용하여 재현 가능한 개발 환경을 설정하세요.
 *   **[숨겨진 플래그로 디버그](debug_flags/)**: 고급 디버깅과 실험을 위한 개발자 전용 플래그를 알아보세요.
 *   **[릴리스 방법](how_to_release/)**: Noir의 새로운 릴리스 생성 및 게시를 위한 관리자 가이드입니다.

--- a/docs/content/development/_index.md
+++ b/docs/content/development/_index.md
@@ -9,6 +9,7 @@ sort_by = "weight"
 This section provides resources for developers who want to contribute to the OWASP Noir project. Whether you're building from source, setting up your development environment, or preparing a release, you'll find the information you need here.
 
 *   **[How to Build](how_to_build/)**: Learn how to set up your development environment, build the project, and run tests.
+*   **[Analyzer Architecture](analyzer_architecture/)**: The 3-layer design (engine → route extractor → framework adapter), and a step-by-step guide for adding a new detector/analyzer.
 *   **[Build with Nix Env](nix_environment/)**: Set up a reproducible development environment using Nix and Docker.
 *   **[Debug with hidden flags](debug_flags/)**: Discover developer-only flags for advanced debugging and experimentation.
 *   **[How to Release](how_to_release/)**: Maintainer guide for creating and publishing new releases of Noir.

--- a/docs/content/development/analyzer_architecture/index.ko.md
+++ b/docs/content/development/analyzer_architecture/index.ko.md
@@ -1,0 +1,323 @@
++++
+title = "분석기 아키텍처"
+description = "Noir의 detector, language engine, route extractor, framework adapter 가 어떻게 맞물리는지, 그리고 새 분석기를 어떻게 추가하는지."
+weight = 5
+sort_by = "weight"
+
++++
+
+Noir 는 프로젝트를 두 단계로 스캔합니다. **Detector** 가 어떤 프레임워크가 존재하는지 판단하고, **Analyzer** 가 감지된 프레임워크별로 엔드포인트를 추출합니다. 이 페이지는 분석기 쪽 구조와 새 프레임워크 추가 방법을 설명합니다.
+
+## 파이프라인 개요
+
+```
+프로젝트 파일
+      │
+      ▼
+  Detector         ──►  "이 프로젝트는 go_gin, go_hertz, ... 를 사용"
+      │
+      ▼
+  Analyzer         ──►  Endpoint 리스트 (url, method, params, details)
+      │
+      ▼
+  Optimizer, Taggers, Passive scan, Output formatter
+```
+
+Detector 는 manifest 파일(`go.mod`, `package.json`, `Gemfile` 등) 에 대한 간단한 매칭으로 boolean 을 반환합니다. Analyzer 는 본격 작업(소스 트리 순회, 라우트 선언 파싱, 파라미터 추출) 을 담당합니다.
+
+## 3-layer 분석기
+
+모든 분석기는 세 레이어로 구성됩니다. **Framework adapter 는 파일을 열거나 파싱을 재구현하지 않는다** 는 것이 엄격한 규칙입니다.
+
+| Layer | 위치 | 책임 |
+|---|---|---|
+| **L0 Language Engine** | `src/analyzer/engines/{lang}_engine.cr` | 파일 순회, 동시성(`parallel_analyze`), 채널 설정, 경로별 에러 핸들링. 언어당 하나. |
+| **L1 Route Extractor** | `src/miniparsers/{lang}_route_extractor.cr` | 소스 내용을 파싱. 문자열(파일 내용) 을 받아 라우트 선언(method, path, location) 을 yield. 파일 I/O 없음, 프레임워크 특화 로직 없음. |
+| **L2 Framework Adapter** | `src/analyzer/analyzers/{lang}/{framework}.cr` | 프레임워크별 얇은 클래스. Extractor 에서 받은 라우트에 프레임워크별 파라미터 매핑, 필터, 특수 케이스를 적용. |
+
+**Reference implementation**: [`src/analyzer/analyzers/javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr) + [`src/miniparsers/js_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/js_route_extractor.cr). Hono 는 이 분리를 따르기 때문에 ~205줄입니다. 세 책임을 한 클래스에 섞은 분석기는 500–800줄로 커집니다.
+
+## 현재 커버리지
+
+- **Language engines** (`engines/`): PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala, JavaScript/TypeScript, Python, Go.
+- **Route extractors** (`miniparsers/`): JavaScript (Hono, Express, Fastify, Koa, NestJS, Restify, TypeScript NestJS 에서 사용) + Go (8개 분석기에서 사용).
+- **의도적으로 엔진 밖**: CSharp 의 두 orchestrator, Scala Play (multi-phase 흐름이라 per-file 스캔 안 맞음), Go 의 Chi/Httprouter/Fasthttp (자체 완결 추출). `Analyzer` 를 직접 상속.
+- Python, Kotlin, Java 는 parser 는 있지만 route extractor 층이 아직 없음 — 후속 작업.
+
+## 두 가지 엔진 shape
+
+모든 엔진이 `parallel_file_scan(&block)` 를 protected helper 로 노출합니다. 어댑터는 다음 중 하나를 선택합니다.
+
+**Shape A — `analyze_file`** (단순, 순수 per-file):
+
+```crystal
+class MyFramework < PhpEngine
+  def analyze_file(path : String) : Array(Endpoint)
+    return [] of Endpoint unless path.ends_with?(".php")
+    # 파싱하고 엔드포인트 만들어 반환
+  end
+end
+```
+
+엔진의 기본 `analyze` 가 파일 순회를 돌리고 반환된 엔드포인트를 concat 합니다. 대부분의 Php / Rust / Swift / Crystal / Elixir / Scala 분석기가 이 shape.
+
+**Shape B — `analyze` 직접 오버라이드** (클로저 상태, pre/post-phase 필요):
+
+```crystal
+class MyFramework < JavascriptEngine
+  def analyze
+    result = [] of Endpoint
+    static_dirs = [] of Hash(String, String)
+
+    parallel_file_scan do |path|
+      # ... result 에 엔드포인트 추가, static_dirs 수집
+    end
+
+    process_static_dirs(static_dirs, result)  # post-pass
+    result
+  end
+end
+```
+
+스캔 중 로컬 상태(뮤텍스, dedup set) 가 필요하거나 후처리 단계가 필요할 때 사용. Express, Hono, Rails, Amber 가 예시.
+
+## Detector shape
+
+Detector 는 대체로 한 줄짜리 매칭입니다.
+
+```crystal
+# src/detector/detectors/go/hertz.cr
+module Detector::Go
+  class Hertz < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
+    end
+
+    def set_name
+      @name = "go_hertz"
+    end
+  end
+end
+```
+
+Detector 는 프로젝트의 후보 파일별로 한 번씩 실행됩니다. `true` 를 반환하면 해당 프레임워크가 존재한다고 표시되고 파이프라인이 매칭되는 분석기를 실행합니다.
+
+## 새 프레임워크 추가하기
+
+**Hertz (Go)** 를 예시로 단계별 안내. 실제 PR: [#1244](https://github.com/owasp-noir/noir/pull/1244).
+
+### 1. Detector
+
+`src/detector/detectors/{언어}/{프레임워크}.cr` 생성:
+
+```crystal
+require "../../../models/detector"
+
+module Detector::Go
+  class Hertz < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
+    end
+
+    def set_name
+      @name = "go_hertz"
+    end
+  end
+end
+```
+
+### 2. Analyzer
+
+`src/analyzer/analyzers/{언어}/{프레임워크}.cr` 생성. 언어 엔진을 상속:
+
+```crystal
+require "../../engines/go_engine"
+
+module Analyzer::Go
+  class Hertz < GoEngine
+    HTTP_METHODS_EXPANDED = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
+
+    def analyze
+      public_dirs = [] of Hash(String, String)
+      package_groups, file_lines_cache = collect_package_groups
+
+      parallel_file_scan do |path|
+        lines = file_lines_cache[path]? || File.read_lines(path, encoding: "utf-8", invalid: :skip)
+        groups = groups_for_directory(package_groups, File.dirname(path))
+        # ... 라인별 라우트 + 파라미터 추출. 엔진을 거쳐 GoRouteExtractor 로 위임.
+      end
+
+      resolve_public_dirs(public_dirs)
+      result
+    end
+  end
+end
+```
+
+핵심 포인트:
+
+- **언어 엔진을 상속**. `get_route_path`, `add_param_to_endpoint`, `collect_package_groups`, `resolve_public_dirs` 등을 무료로 사용 가능.
+- **재정의 가능한 메서드 오버라이드**. 프레임워크 파싱이 다르면 `get_static_path`, `get_route_path` 등 재정의 (Mux, GoZero 참조).
+- **`parallel_file_scan` 사용**. 채널 + worker pool 을 재구현하지 말 것.
+
+### 3. 세 곳에 등록
+
+```crystal
+# src/analyzer/analyzer.cr
+{"go_hertz", Go::Hertz},
+
+# src/detector/detector.cr
+Go::Hertz,
+
+# src/techs/techs.cr
+:go_hertz => {
+  :framework => "Hertz",
+  :language  => "Go",
+  :similar   => ["hertz", "go-hertz", "cloudwego"],
+  :supported => {
+    :endpoint => true,
+    :method   => true,
+    :params   => { :query => true, :path => true, :body => true, :header => true, :cookie => true },
+  },
+},
+```
+
+### 4. Fixture
+
+`spec/functional_test/fixtures/{언어}/{프레임워크}/` 에 최소 앱 생성:
+
+```
+spec/functional_test/fixtures/go/hertz/
+├── go.mod            # detector 가 매칭할 import 라인
+├── main.go           # 중요한 라우트/파라미터 패턴 커버
+└── public/           # (옵션) static 파일 감지 테스트용
+    └── index.html
+```
+
+Fixture 는 현실적 패턴(path param, query/form/header/cookie, 라우트 그룹, static, 프레임워크 특화 관용구) 을 커버해야 합니다. Hertz 의 `.Any` 가 모든 HTTP 메서드로 확장되는 것, Flask 의 blueprint 같은 것들. 모두 다 넣으려 하지 말고 실제 버그가 나타날 때 케이스 추가.
+
+### 5. Spec
+
+`spec/functional_test/testers/{언어}/{프레임워크}_spec.cr` 생성:
+
+```crystal
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/ping", "GET", [
+    Param.new("name", "", "query"),
+    Param.new("age", "", "query"),
+  ]),
+  Endpoint.new("/submit", "POST", [
+    Param.new("username", "", "form"),
+    Param.new("password", "", "form"),
+    Param.new("User-Agent", "", "header"),
+  ]),
+  # ... 등등
+]
+
+FunctionalTester.new("fixtures/go/hertz/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+```
+
+테스터가 검증하는 것:
+
+- Detector 가 정확히 1개의 tech 를 찾는지.
+- Analyzer 가 정확히 N개의 엔드포인트를 생성하는지 (`expected_endpoints.size` 와 일치).
+- 각 expected 엔드포인트에 대해 URL + method 매칭되는 엔드포인트가 출력에 존재하는지.
+- 각 expected 파라미터에 대해 `name + param_type` 매칭이 해당 엔드포인트에 붙어있는지.
+
+### 6. 검증
+
+```bash
+just build                 # 깔끔하게 컴파일
+just test                  # unit + functional spec 통과
+crystal tool format --check
+crystal run lib/ameba/bin/ameba.cr
+
+# 수동 확인
+./bin/noir -b spec/functional_test/fixtures/{언어}/{프레임워크}
+```
+
+## 새 언어 엔진 추가하기
+
+같은 언어에서 2개 이상의 분석기가 파일 순회 패턴을 공유할 때 엔진을 추출합니다. `SwiftEngine` 이 템플릿:
+
+```crystal
+# src/analyzer/engines/swift_engine.cr
+require "../../models/analyzer"
+
+module Analyzer::Swift
+  abstract class SwiftEngine < Analyzer
+    def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path) && File.extname(path) == ".swift"
+
+          begin
+            block.call(path)
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+    end
+  end
+end
+```
+
+엔진을 추가할 때는 같은 PR 에서 기존 분석기를 상속하도록 마이그레이션하세요. 예시 PR: [#1236](https://github.com/owasp-noir/noir/pull/1236) (Elixir), [#1237](https://github.com/owasp-noir/noir/pull/1237) (Swift), [#1238](https://github.com/owasp-noir/noir/pull/1238) (Crystal).
+
+## Route extractor (L1) 추가하기
+
+같은 언어에서 2개 이상의 분석기가 단순 파일 순회가 아닌 **실제 파싱 로직** 을 공유할 때 route extractor 모듈을 `src/miniparsers/{lang}_route_extractor.cr` 에 추출합니다. 순수 함수, `Analyzer` 의존성 없음:
+
+```crystal
+module Noir::MyLangRouteExtractor
+  extend self
+
+  def extract_route_path(line : String, groups : Array(...)) : String
+    # 순수 파싱
+  end
+end
+```
+
+엔진은 얇은 인스턴스 메서드 위임을 노출해 어댑터가 프레임워크별 파싱이 다를 때 오버라이드할 수 있게 합니다:
+
+```crystal
+class MyLangEngine < Analyzer
+  def get_route_path(line, groups)
+    Noir::MyLangRouteExtractor.extract_route_path(line, groups)
+  end
+end
+```
+
+정식 예시: [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split).
+
+## 실행 모델 참고
+
+Noir 는 **single-threaded** 로 빌드됩니다 (`preview_mt` 미사용). `parallel_analyze` 는 OS 스레드가 아니라 cooperative Crystal fiber 를 spawn 합니다. 따라서 여러 fiber 에서 `result << endpoint`, `result.concat(...)` 은 안전합니다 — `Array#<<` 와 `#concat` 에 yield 지점이 없기 때문. 모든 per-file 분석기가 result 배열에 Mutex 를 쓰지 않는 것이 그 이유이며, 코드베이스 전반이 그렇게 일관됩니다. 나중에 MT 모드를 켜게 되면 동기화는 `parallel_analyze` 레이어에 한 번 추가해야 하는 일이지, 분석기마다 흩어져 있을 일이 아닙니다.
+
+## 다음에 볼 것
+
+- Reference analyzer: [`javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr)
+- Engine + extractor 쌍: [`engines/go_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/go_engine.cr) + [`miniparsers/go_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/go_route_extractor.cr)
+- Custom shape 예시: [`javascript/express.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/express.cr) (pre-phase + closure state)
+- Framework-adapter-only 예시: [`go/hertz.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/go/hertz.cr) (엔진 리팩터링 이후 첫 프레임워크)

--- a/docs/content/development/analyzer_architecture/index.md
+++ b/docs/content/development/analyzer_architecture/index.md
@@ -1,0 +1,322 @@
++++
+title = "Analyzer Architecture"
+description = "How Noir's detectors, language engines, route extractors, and framework adapters fit together, and how to add a new analyzer."
+weight = 5
+sort_by = "weight"
+
++++
+
+Noir scans a project in two phases: a **detector** decides which frameworks are present, and an **analyzer** extracts endpoints for each detected framework. This page explains how the analyzer side is laid out and how to add a new framework.
+
+## Pipeline overview
+
+```
+project files
+      │
+      ▼
+  Detector         ──►  "this project uses go_gin, go_hertz, …"
+      │
+      ▼
+  Analyzer         ──►  list of Endpoint (url, method, params, details)
+      │
+      ▼
+  Optimizer, Taggers, Passive scan, Output formatter
+```
+
+A detector does a cheap match (usually on a manifest file like `go.mod`, `package.json`, `Gemfile`) and returns a boolean. An analyzer does the heavy work: walks the source tree, parses route declarations, extracts parameters.
+
+## The 3-layer analyzer
+
+Every analyzer is composed of three layers. Keeping them separate is a hard rule — a framework adapter should not open files or re-implement parsing.
+
+| Layer | Lives in | Responsibility |
+|---|---|---|
+| **L0 Language Engine** | `src/analyzer/engines/{lang}_engine.cr` | File walking, concurrency (`parallel_analyze`), channel setup, per-path error handling. One per language. |
+| **L1 Route Extractor** | `src/miniparsers/{lang}_route_extractor.cr` | Parses source content. Takes a string (file contents), yields route declarations (method, path, location). No file I/O, no framework-specific rules. |
+| **L2 Framework Adapter** | `src/analyzer/analyzers/{lang}/{framework}.cr` | Thin per-framework class. Consumes routes from the extractor and applies framework-specific param mappings, filters, and special cases. |
+
+**Reference implementation**: [`src/analyzer/analyzers/javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr) on top of [`src/miniparsers/js_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/js_route_extractor.cr). Hono is ~205 lines because it follows the split; contrast with analyzers that inline all three responsibilities and grow to 500–800 lines.
+
+## Current coverage
+
+- **Language engines** (in `engines/`): PHP, Ruby, Rust, Elixir, Swift, Crystal, Scala, JavaScript/TypeScript, Python, Go.
+- **Route extractors** (in `miniparsers/`): JavaScript (used by Hono, Express, Fastify, Koa, NestJS, Restify, TypeScript NestJS) and Go (used by eight analyzers).
+- **Deliberately outside the engine stack**: CSharp's two orchestrators and Scala Play (multi-phase flows that don't fit a per-file scan), plus Go's Chi/Httprouter/Fasthttp (self-contained extraction). These inherit from `Analyzer` directly.
+- Python, Kotlin, Java have full parsers (in `miniparsers/`) but no dedicated route extractor yet — it's a known follow-up.
+
+## Two engine shapes
+
+Every engine exposes `parallel_file_scan(&block)` as a protected helper. A framework adapter picks one of two shapes:
+
+**Shape A — `analyze_file`** (simpler, pure per-file):
+
+```crystal
+class MyFramework < PhpEngine
+  def analyze_file(path : String) : Array(Endpoint)
+    return [] of Endpoint unless path.ends_with?(".php")
+    # parse, build endpoints, return them
+  end
+end
+```
+
+The engine's default `analyze` drives the walk and concats returned endpoints. Used by most Php / Rust / Swift / Crystal / Elixir / Scala analyzers.
+
+**Shape B — custom `analyze`** (for closure state, pre-/post-phases):
+
+```crystal
+class MyFramework < JavascriptEngine
+  def analyze
+    result = [] of Endpoint
+    static_dirs = [] of Hash(String, String)
+
+    parallel_file_scan do |path|
+      # ... build endpoints into result, collect static_dirs
+    end
+
+    process_static_dirs(static_dirs, result)  # post-pass
+    result
+  end
+end
+```
+
+Used when the analyzer needs local state during the scan (mutexes, dedup sets) or a post-processing pass. Express, Hono, Rails, and Amber are examples.
+
+## Detector shape
+
+Detectors are almost always a one-line match:
+
+```crystal
+# src/detector/detectors/go/hertz.cr
+module Detector::Go
+  class Hertz < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
+    end
+
+    def set_name
+      @name = "go_hertz"
+    end
+  end
+end
+```
+
+The detector runs once per candidate file in the project. Returning `true` marks the framework as present and tells the pipeline to run the matching analyzer.
+
+## Adding a new framework
+
+Walkthrough using **Hertz (Go)** as the concrete example. Real PR: [#1244](https://github.com/owasp-noir/noir/pull/1244).
+
+### 1. Detector
+
+Create `src/detector/detectors/{language}/{framework}.cr`:
+
+```crystal
+require "../../../models/detector"
+
+module Detector::Go
+  class Hertz < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      filename.includes?("go.mod") && file_contents.includes?("github.com/cloudwego/hertz")
+    end
+
+    def set_name
+      @name = "go_hertz"
+    end
+  end
+end
+```
+
+### 2. Analyzer
+
+Create `src/analyzer/analyzers/{language}/{framework}.cr`. Inherit from the language engine. For Hertz (Gin-like), much of the structure is shared with Gin:
+
+```crystal
+require "../../engines/go_engine"
+
+module Analyzer::Go
+  class Hertz < GoEngine
+    HTTP_METHODS_EXPANDED = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
+
+    def analyze
+      public_dirs = [] of Hash(String, String)
+      package_groups, file_lines_cache = collect_package_groups
+
+      parallel_file_scan do |path|
+        lines = file_lines_cache[path]? || File.read_lines(path, encoding: "utf-8", invalid: :skip)
+        groups = groups_for_directory(package_groups, File.dirname(path))
+        # ... per-line route + param extraction, delegates to GoRouteExtractor via engine
+      end
+
+      resolve_public_dirs(public_dirs)
+      result
+    end
+  end
+end
+```
+
+Key points:
+
+- **Inherit from the language engine** (`GoEngine` here). You get `get_route_path`, `add_param_to_endpoint`, `collect_package_groups`, `resolve_public_dirs` for free.
+- **Override overridable methods** if your framework's parsing differs (`get_static_path`, `get_route_path` — see Mux or GoZero for examples).
+- **Use `parallel_file_scan`** for the file walk; don't re-implement the channel + worker pool.
+
+### 3. Register in three places
+
+```crystal
+# src/analyzer/analyzer.cr
+{"go_hertz", Go::Hertz},
+
+# src/detector/detector.cr
+Go::Hertz,
+
+# src/techs/techs.cr
+:go_hertz => {
+  :framework => "Hertz",
+  :language  => "Go",
+  :similar   => ["hertz", "go-hertz", "cloudwego"],
+  :supported => {
+    :endpoint => true,
+    :method   => true,
+    :params   => { :query => true, :path => true, :body => true, :header => true, :cookie => true },
+  },
+},
+```
+
+### 4. Fixture
+
+Create `spec/functional_test/fixtures/{language}/{framework}/` with a minimal app:
+
+```
+spec/functional_test/fixtures/go/hertz/
+├── go.mod            # import line the detector will match
+├── main.go           # exercise every route/param pattern you care about
+└── public/           # optional: for static-file detection
+    └── index.html
+```
+
+The fixture should exercise realistic patterns: path params, query/form/header/cookie, route groups, static serving, and any framework-specific idioms (Hertz's `.Any` expands to all HTTP methods, Flask's blueprints, etc.). Don't try to be exhaustive — add cases as real-world bugs surface.
+
+### 5. Spec
+
+Create `spec/functional_test/testers/{language}/{framework}_spec.cr`:
+
+```crystal
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/ping", "GET", [
+    Param.new("name", "", "query"),
+    Param.new("age", "", "query"),
+  ]),
+  Endpoint.new("/submit", "POST", [
+    Param.new("username", "", "form"),
+    Param.new("password", "", "form"),
+    Param.new("User-Agent", "", "header"),
+  ]),
+  # ... etc
+]
+
+FunctionalTester.new("fixtures/go/hertz/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+```
+
+The tester asserts:
+- The detector finds exactly 1 tech (your framework).
+- The analyzer produces exactly N endpoints (matches `expected_endpoints.size`).
+- For each expected endpoint, an endpoint with matching URL + method exists in the output.
+- For each expected param, a matching `name + param_type` is attached to that endpoint.
+
+### 6. Verify
+
+```bash
+just build                 # compiles cleanly
+just test                  # unit + functional spec pass
+crystal tool format --check
+crystal run lib/ameba/bin/ameba.cr
+
+# Manual smoke test
+./bin/noir -b spec/functional_test/fixtures/{lang}/{framework}
+```
+
+## Adding a new language engine
+
+When a language has 2+ analyzers that share a file-walk pattern, extract an engine. Template, using `SwiftEngine` as the model:
+
+```crystal
+# src/analyzer/engines/swift_engine.cr
+require "../../models/analyzer"
+
+module Analyzer::Swift
+  abstract class SwiftEngine < Analyzer
+    def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_files(channel)
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path) && File.extname(path) == ".swift"
+
+          begin
+            block.call(path)
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      rescue e
+        logger.debug e
+      end
+    end
+  end
+end
+```
+
+When adding the engine, migrate existing analyzers to inherit from it in the same PR. See [#1236](https://github.com/owasp-noir/noir/pull/1236) (Elixir), [#1237](https://github.com/owasp-noir/noir/pull/1237) (Swift), [#1238](https://github.com/owasp-noir/noir/pull/1238) (Crystal) for worked examples.
+
+## Adding a route extractor (L1)
+
+When 2+ analyzers in a language share real parsing logic (not just file walking), extract a route extractor module under `src/miniparsers/{lang}_route_extractor.cr`. Pure functions, no `Analyzer` dependency:
+
+```crystal
+module Noir::MyLangRouteExtractor
+  extend self
+
+  def extract_route_path(line : String, groups : Array(...)) : String
+    # pure parsing
+  end
+end
+```
+
+The engine then exposes thin instance-method delegations so adapter subclasses can override if their framework parses differently:
+
+```crystal
+class MyLangEngine < Analyzer
+  def get_route_path(line, groups)
+    Noir::MyLangRouteExtractor.extract_route_path(line, groups)
+  end
+end
+```
+
+See [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split) for the canonical example.
+
+## Execution model note
+
+Noir is built **single-threaded** (no `preview_mt`). `parallel_analyze` spawns cooperative Crystal fibers, not OS threads — so `result << endpoint` and `result.concat(...)` from multiple fibers are safe because `Array#<<` and `#concat` have no yield points. You'll notice that no per-file analyzer uses a `Mutex` around the result array; that's by design and matches the whole codebase. If noir ever enables MT mode, synchronization belongs at the `parallel_analyze` layer, not scattered across analyzers.
+
+## Where to look next
+
+- Reference analyzer: [`javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr)
+- Reference engine + extractor pair: [`engines/go_engine.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/engines/go_engine.cr) + [`miniparsers/go_route_extractor.cr`](https://github.com/owasp-noir/noir/blob/main/src/miniparsers/go_route_extractor.cr)
+- Custom-shape example: [`javascript/express.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/express.cr) (pre-phase + closure state)
+- Framework-adapter-only example: [`go/hertz.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/go/hertz.cr) (first framework added after the engine refactor)

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -20,7 +20,7 @@ module Analyzer::Javascript
       # Phase 1: Pre-scan to build router mount map
       scan_for_router_mounts
 
-      parallel_js_scan do |path|
+      parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -7,7 +7,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      parallel_js_scan do |path|
+      parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -7,7 +7,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      parallel_js_scan do |path|
+      parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -7,7 +7,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      parallel_js_scan([".js", ".ts", ".mjs"]) do |path|
+      parallel_file_scan([".js", ".ts", ".mjs"]) do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -7,7 +7,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      parallel_js_scan([".js", ".jsx"]) do |path|
+      parallel_file_scan([".js", ".jsx"]) do |path|
         analyze_nestjs_file(path, result, static_dirs)
       end
 

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -6,7 +6,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       mutex = Mutex.new
 
-      parallel_js_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
+      parallel_file_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
         # Focus on routes/ directory for Nitro
         next unless path.includes?("/routes/")
         analyze_nitro_file(path, result, mutex)

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -6,7 +6,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       mutex = Mutex.new
 
-      parallel_js_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
+      parallel_file_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
         # Focus on server/api and server/routes directories for Nuxt 3
         next unless path.includes?("/server/api/") || path.includes?("/server/routes/")
         analyze_nuxt_file(path, result, mutex)

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -7,7 +7,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      parallel_js_scan do |path|
+      parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)

--- a/src/analyzer/analyzers/typescript/nestjs.cr
+++ b/src/analyzer/analyzers/typescript/nestjs.cr
@@ -7,7 +7,7 @@ module Analyzer::Typescript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
 
-      parallel_js_scan([".ts", ".tsx"]) do |path|
+      parallel_file_scan([".ts", ".tsx"]) do |path|
         analyze_nestjs_file(path, result, static_dirs)
       end
 

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -5,7 +5,7 @@ module Analyzer::Typescript
     def analyze
       result = [] of Endpoint
 
-      parallel_js_scan([".ts", ".tsx"]) do |path|
+      parallel_file_scan([".ts", ".tsx"]) do |path|
         analyze_tanstack_file(path, result)
       end
 

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -3,6 +3,19 @@ require "../../models/analyzer"
 module Analyzer::Crystal
   abstract class CrystalEngine < Analyzer
     def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # `.cr` extension filter plus `lib/` exclusion baked in (shards puts
+    # dependencies under `lib/` and we don't want to analyze them).
+    # Subclasses that need a custom scan shape can override `analyze`
+    # (e.g. Amber/Kemal run a public-dir post-pass after the file walk).
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -14,7 +27,7 @@ module Analyzer::Crystal
           next if path.includes?("lib")
 
           begin
-            result.concat(analyze_file(path))
+            block.call(path)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
           end
@@ -22,10 +35,6 @@ module Analyzer::Crystal
       rescue e
         logger.debug e
       end
-
-      result
     end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
   end
 end

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -4,9 +4,9 @@ module Analyzer::Elixir
   abstract class ElixirEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        @result.concat(analyze_file(path))
+        result.concat(analyze_file(path))
       end
-      @result
+      result
     end
 
     abstract def analyze_file(path : String) : Array(Endpoint)

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -3,6 +3,17 @@ require "../../models/analyzer"
 module Analyzer::Elixir
   abstract class ElixirEngine < Analyzer
     def analyze
+      parallel_file_scan do |path|
+        @result.concat(analyze_file(path))
+      end
+      @result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # No extension filter: Phoenix uses `.ex` only, Plug also accepts
+    # `.exs`, so each analyzer filters inside `analyze_file`.
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -13,7 +24,7 @@ module Analyzer::Elixir
           next unless File.exists?(path)
 
           begin
-            @result.concat(analyze_file(path))
+            block.call(path)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
           end
@@ -21,10 +32,6 @@ module Analyzer::Elixir
       rescue e
         logger.debug e
       end
-
-      @result
     end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
   end
 end

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -4,14 +4,16 @@ module Analyzer::Javascript
   abstract class JavascriptEngine < Analyzer
     # Default extension set for JavaScript/TypeScript source files.
     # Analyzers with a different filter (e.g. Nitro adds `.mts`, NestJS JS
-    # only uses `.js`/`.jsx`) pass their own list to `parallel_js_scan`.
+    # only uses `.js`/`.jsx`) pass their own list to `parallel_file_scan`.
     DEFAULT_EXTENSIONS = [".js", ".ts", ".jsx", ".tsx"]
 
     # Walk the project tree concurrently, invoking the block for each
     # readable source file whose extension matches. JS/TS analyzers vary
     # in the exact filter (plain JS vs TS vs .mjs vs .tsx), so the filter
     # is an argument with a sensible default.
-    protected def parallel_js_scan(extensions : Array(String) = DEFAULT_EXTENSIONS, &block : String -> Nil) : Nil
+    #
+    # Name-consistent with the other engines' `parallel_file_scan` helpers.
+    protected def parallel_file_scan(extensions : Array(String) = DEFAULT_EXTENSIONS, &block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -3,21 +3,14 @@ require "../../utils/utils.cr"
 
 module Analyzer::Php
   abstract class PhpEngine < Analyzer
-    # Engine ships two shapes; analyzers pick one:
-    #
-    # - Override `analyze_file(path) -> Array(Endpoint)` for pure per-file
-    #   extraction. `analyze` below drives the worker loop and concats the
-    #   returned endpoints. This is the simpler, default path.
-    #
-    # - Override `analyze` and call `parallel_file_scan(&block)` directly
-    #   when the analyzer needs closure state, pre-phase work, or
-    #   post-processing after the file walk.
+    # See AGENTS.md §"Two engine shapes" (and
+    # docs/content/development/analyzer_architecture/) for when to override
+    # `analyze_file` vs. `analyze` + `parallel_file_scan`.
 
     def analyze
       parallel_file_scan do |path|
         result.concat(analyze_file(path))
       end
-      Fiber.yield
       result
     end
 

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -3,7 +3,31 @@ require "../../utils/utils.cr"
 
 module Analyzer::Php
   abstract class PhpEngine < Analyzer
+    # Engine ships two shapes; analyzers pick one:
+    #
+    # - Override `analyze_file(path) -> Array(Endpoint)` for pure per-file
+    #   extraction. `analyze` below drives the worker loop and concats the
+    #   returned endpoints. This is the simpler, default path.
+    #
+    # - Override `analyze` and call `parallel_file_scan(&block)` directly
+    #   when the analyzer needs closure state, pre-phase work, or
+    #   post-processing after the file walk.
+
     def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      Fiber.yield
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # Walk the project tree concurrently and invoke the block for each
+    # readable, non-directory file. PHP analyzers apply their own
+    # extension/pathname filters inside the block because Symfony matches
+    # `.php` *and* YAML route files, Laravel checks `routes/*.php`, etc.
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -14,7 +38,7 @@ module Analyzer::Php
           next unless File.exists?(path)
 
           begin
-            result.concat(analyze_file(path))
+            block.call(path)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
           end
@@ -22,12 +46,7 @@ module Analyzer::Php
       rescue e
         logger.debug e
       end
-
-      Fiber.yield
-      result
     end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
 
     # Route composition helper. Will migrate to a PHP route extractor when that
     # layer is introduced; kept here for now so Laravel/CakePHP/Symfony stop

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -25,7 +25,9 @@ module Analyzer::Ruby
     # Walk the project file tree in parallel, invoking the block for each
     # readable non-directory file. Used by analyzers that scan the whole
     # tree (Sinatra); Rails/Hanami target specific config files directly.
-    def parallel_file_scan(&block : String -> Nil) : Nil
+    #
+    # Name-consistent with the other engines' `parallel_file_scan` helpers.
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -3,6 +3,19 @@ require "../../models/analyzer"
 module Analyzer::Rust
   abstract class RustEngine < Analyzer
     def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # `.rs` extension filter baked in. Subclasses that want a different scan
+    # shape (e.g. a post-pass after the file walk) can override `analyze`
+    # and call this helper directly; the default `analyze` above is the
+    # simpler path.
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -13,7 +26,7 @@ module Analyzer::Rust
           next unless File.exists?(path) && File.extname(path) == ".rs"
 
           begin
-            result.concat(analyze_file(path))
+            block.call(path)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
           end
@@ -21,10 +34,6 @@ module Analyzer::Rust
       rescue e
         logger.debug e
       end
-
-      result
     end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
   end
 end

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -3,6 +3,18 @@ require "../../models/analyzer"
 module Analyzer::Scala
   abstract class ScalaEngine < Analyzer
     def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      Fiber.yield
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # `.scala` extension filter baked in. Subclasses that need a custom
+    # scan shape can override `analyze` and call this helper directly.
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -13,7 +25,7 @@ module Analyzer::Scala
           next unless File.exists?(path) && File.extname(path) == ".scala"
 
           begin
-            result.concat(analyze_file(path))
+            block.call(path)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
           end
@@ -21,11 +33,6 @@ module Analyzer::Scala
       rescue e
         logger.debug e
       end
-
-      Fiber.yield
-      result
     end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
   end
 end

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -6,7 +6,6 @@ module Analyzer::Scala
       parallel_file_scan do |path|
         result.concat(analyze_file(path))
       end
-      Fiber.yield
       result
     end
 

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -3,6 +3,17 @@ require "../../models/analyzer"
 module Analyzer::Swift
   abstract class SwiftEngine < Analyzer
     def analyze
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      result
+    end
+
+    abstract def analyze_file(path : String) : Array(Endpoint)
+
+    # `.swift` extension filter baked in. Subclasses that need a custom
+    # scan shape can override `analyze` and call this helper directly.
+    protected def parallel_file_scan(&block : String -> Nil) : Nil
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -13,7 +24,7 @@ module Analyzer::Swift
           next unless File.exists?(path) && File.extname(path) == ".swift"
 
           begin
-            result.concat(analyze_file(path))
+            block.call(path)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
           end
@@ -21,10 +32,6 @@ module Analyzer::Swift
       rescue e
         logger.debug e
       end
-
-      result
     end
-
-    abstract def analyze_file(path : String) : Array(Endpoint)
   end
 end


### PR DESCRIPTION
## Summary

Two changes shipped together, because they reinforce each other:

1. **Unify the engine-layer contract.** Every language engine now exposes `parallel_file_scan(&block)` as a protected helper. The engine's own \`analyze\` is a thin wrapper over it. Abstract \`analyze_file\` contract preserved where it existed.
2. **Add a dedicated architecture docs page** so new contributors land on a real reference when they sit down to add a detector/analyzer.

Zero analyzer behavior changes. All 5433 tests pass (1262 unit + 4171 functional + Hertz's 40).

## Engine unification

Before, two engine flavors coexisted:
- **Flavor A** (Php/Rust/Swift/Crystal/Elixir/Scala): abstract \`analyze_file → Array(Endpoint)\`. Engine drives the loop.
- **Flavor B** (Ruby, JavaScript): exposed a scan helper. Analyzer writes own \`analyze\`.

These reflected real shape differences in analyzers (closure state, pre/post-phases), so forcing one flavor would regress the other. Instead:

- All engines now expose **`parallel_file_scan(&block)`** as a protected helper (consistent name, engine-specific extension filter baked in).
- Flavor A engines also keep their existing abstract \`analyze_file\` — their default \`analyze\` now calls the new helper internally.
- Flavor B engines unchanged except for the rename (\`parallel_js_scan\` → \`parallel_file_scan\`).

Net: contributors see the same API surface on every engine. They pick the shape based on their analyzer's needs.

## New docs page

\`docs/content/development/analyzer_architecture/\` (EN + KO) covers:

- 3-layer design (engine → route extractor → framework adapter) with responsibilities and current coverage.
- Two engine shapes and when to pick which.
- Detector shape (one-line manifest match).
- **Step-by-step walkthrough** for adding a new framework, using Hertz (#1202 / #1244) as the worked example.
- How to add a new language engine or route extractor.
- Execution model note (single-threaded Crystal, fibers not threads).

Linked from:
- \`docs/content/development/_index.md\` (and \`.ko.md\`)
- \`CONTRIBUTING.md\` under a new "Adding a new detector or analyzer" section pointing to the published URL.
- \`AGENTS.md\` \`Analyzer Layering\` gets a matching paragraph on the two shapes.

## Files touched

| Bucket | Files |
|---|---|
| Engines (add helper, refactor analyze) | 8 engines |
| JS/TS analyzers (rename call site) | 10 analyzers |
| Docs | new architecture page (EN + KO), \`_index\` updates, AGENTS.md, CONTRIBUTING.md |

## Test plan

- [x] \`just build\`
- [x] \`just test\` — 1262 unit + 4171 functional, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`ameba\` — 22 files, 0 failures
- [x] Each engine's \`analyze\` path verified by existing framework specs (Php/Ruby/Rust/Elixir/Swift/Crystal/Scala/JS all pass unchanged)