### PR TITLE
feat: add PythonRouteExtractor; migrate Flask and Sanic

### DIFF
--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1,5 +1,6 @@
 require "../../../minilexers/python"
 require "../../../miniparsers/python"
+require "../../../miniparsers/python_route_extractor"
 require "../../engines/python_engine"
 
 module Analyzer::Python
@@ -64,16 +65,8 @@ module Analyzer::Python
               end
 
               # Identify Blueprint instance assignments
-              blueprint_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:flask\.)?Blueprint\(/
-              if blueprint_match
-                prefix = ""
-                blueprint_instance_name = blueprint_match[1]
-                param_codes = original_line.split("Blueprint", 2)[1]
-                prefix_match = param_codes.match /url_prefix\s*=\s*[rf]?['"]([^'"]*)['"]/
-                if !prefix_match.nil? && prefix_match.size == 2
-                  prefix = prefix_match[1]
-                end
-
+              if bp = Noir::PythonRouteExtractor.scan_blueprint(line, ["flask"], original_line)
+                blueprint_instance_name, prefix = bp
                 blueprint_prefixes[blueprint_instance_name] ||= prefix
                 api_instances[blueprint_instance_name] ||= prefix
               end
@@ -172,34 +165,12 @@ module Analyzer::Python
                 end
               end
 
-              # Identify Flask route decorators
-              line.scan(/@(#{PYTHON_VAR_NAME_REGEX})\.route\([rf]?['"]([^'"]*)['"](.*)/) do |_match|
-                if _match.size > 0
-                  router_name = _match[1]
-                  extra_params = _match[3]
-                  # Extract route path from original line to preserve spaces in paths
-                  original_route_match = original_line.match /@#{_match[1]}\.route\(\s*[rf]?['"]([^'"]*)['"]/
-                  route_path = original_route_match ? original_route_match[1] : _match[2]
-                  router_info = Tuple(Int32, ::String, ::String, ::String).new(line_index, path, route_path, extra_params)
-                  @routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
-                  @routes[router_name] << router_info
-                end
-              end
-
-              # Also detect method-specific decorators like @app.get, @app.post, etc.
-              HTTP_METHODS.each do |method|
-                line.scan(/@(#{PYTHON_VAR_NAME_REGEX})\.#{method.downcase}\([rf]?['"]([^'"]*)['"](.*)/) do |_match|
-                  if _match.size > 0
-                    router_name = _match[1]
-                    extra_params = "methods=['#{method.upcase}']"
-                    # Extract route path from original line to preserve spaces in paths
-                    original_route_match = original_line.match /@#{_match[1]}\.#{method.downcase}\(\s*[rf]?['"]([^'"]*)['"]/
-                    route_path = original_route_match ? original_route_match[1] : _match[2]
-                    router_info = Tuple(Int32, ::String, ::String, ::String).new(line_index, path, route_path, extra_params)
-                    @routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
-                    @routes[router_name] << router_info
-                  end
-                end
+              # Identify Flask route decorators (both @app.route and @app.<method>).
+              # Pass original_line so paths with spaces survive the earlier gsub.
+              Noir::PythonRouteExtractor.scan_decorators(line, original_line).each do |decoration|
+                router_info = Tuple(Int32, ::String, ::String, ::String).new(line_index, path, decoration.path, decoration.extra_params)
+                @routes[decoration.router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
+                @routes[decoration.router_name] << router_info
               end
 
               # Identify view assignments: view_var = ClassName.as_view('name')

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -1,5 +1,6 @@
 require "../../../minilexers/python"
 require "../../../miniparsers/python"
+require "../../../miniparsers/python_route_extractor"
 require "../../engines/python_engine"
 
 module Analyzer::Python
@@ -57,44 +58,17 @@ module Analyzer::Python
               end
 
               # Identify Blueprint instance assignments
-              blueprint_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:sanic\.)?Blueprint\(/
-              if blueprint_match
-                prefix = ""
-                blueprint_instance_name = blueprint_match[1]
-                param_codes = line.split("Blueprint", 2)[1]
-                prefix_match = param_codes.match /url_prefix=[rf]?['"]([^'"]*)['"]/
-                if !prefix_match.nil? && prefix_match.size == 2
-                  prefix = prefix_match[1]
-                end
-
+              if bp = Noir::PythonRouteExtractor.scan_blueprint(line, ["sanic"])
+                blueprint_instance_name, prefix = bp
                 blueprint_prefixes[blueprint_instance_name] ||= prefix
                 api_instances[blueprint_instance_name] ||= prefix
               end
 
-              # Identify Sanic route decorators
-              line.scan(/@(#{PYTHON_VAR_NAME_REGEX})\.route\([rf]?['"]([^'"]*)['"](.*)/) do |_match|
-                if _match.size > 0
-                  router_name = _match[1]
-                  route_path = _match[2]
-                  extra_params = _match[3]
-                  router_info = Tuple(Int32, ::String, ::String, ::String).new(line_index, path, route_path, extra_params)
-                  @routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
-                  @routes[router_name] << router_info
-                end
-              end
-
-              # Also detect method-specific decorators like @app.get, @app.post, etc.
-              HTTP_METHODS.each do |method|
-                line.scan(/@(#{PYTHON_VAR_NAME_REGEX})\.#{method.downcase}\([rf]?['"]([^'"]*)['"](.*)/) do |_match|
-                  if _match.size > 0
-                    router_name = _match[1]
-                    route_path = _match[2]
-                    extra_params = "methods=['#{method.upcase}']"
-                    router_info = Tuple(Int32, ::String, ::String, ::String).new(line_index, path, route_path, extra_params)
-                    @routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
-                    @routes[router_name] << router_info
-                  end
-                end
+              # Identify Sanic route decorators (both @app.route and @app.<method>)
+              Noir::PythonRouteExtractor.scan_decorators(line).each do |decoration|
+                router_info = Tuple(Int32, ::String, ::String, ::String).new(line_index, path, decoration.path, decoration.extra_params)
+                @routes[decoration.router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
+                @routes[decoration.router_name] << router_info
               end
             end
           end
@@ -190,39 +164,9 @@ module Analyzer::Python
     end
 
     private def extract_params_from_decorator(path : ::String, lines : Array(::String), line_index : Int32, direction : Symbol = :down) : Tuple(Array(Param), Int32)
-      params = [] of Param
-      found_def_index = line_index
-
-      # Find the function definition based on direction
-      if direction == :down
-        i = line_index + 1
-        while i < lines.size
-          line_content = lines[i]
-          # Skip additional decorators and empty lines
-          if line_content.strip.starts_with?("@") || line_content.strip.empty?
-            i += 1
-            next
-          end
-          # Found function or class definition
-          if line_content.lstrip.starts_with?("def ") || line_content.lstrip.starts_with?("async def ") || line_content.lstrip.starts_with?("class ")
-            found_def_index = i
-            break
-          end
-          # If we hit something else (not a decorator or function), stop
-          break
-        end
-      else
-        i = line_index - 1
-        while i >= 0
-          if lines[i].lstrip.starts_with?("def ") || lines[i].lstrip.starts_with?("async def ") || lines[i].lstrip.starts_with?("class ")
-            found_def_index = i
-            break
-          end
-          i -= 1
-        end
-      end
-
-      {params, found_def_index}
+      # params stays empty for Sanic (unlike Flask which does decorator-level
+      # param extraction). The adapter pulls params from the function body later.
+      {[] of Param, Noir::PythonRouteExtractor.find_def_line(lines, line_index, direction)}
     end
 
     private def get_endpoints(method : String, route_path : String, extra_params : String, codeblock_lines : Array(String), prefix : String = "")

--- a/src/miniparsers/python_route_extractor.cr
+++ b/src/miniparsers/python_route_extractor.cr
@@ -1,0 +1,146 @@
+module Noir
+  # Pure parsing helpers for Python framework route idioms.
+  #
+  # Framework adapters (Flask, Sanic, …) iterate source files and call
+  # these helpers per line. The extractor has no file I/O, no `Analyzer`
+  # dependency, and no framework-specific state — it just recognizes
+  # the three most common Python route-related idioms so adapters stop
+  # duplicating the regexes:
+  #
+  #   1. `@<var>.route("/path", methods=[...])`
+  #   2. `@<var>.<method>("/path")`     # method in {get, post, …}
+  #   3. `<var> = Blueprint(url_prefix="…")`
+  #
+  # Plus a helper to locate the `def`/`class` that a decorator applies to.
+  #
+  # This is the Python analogue of `js_route_extractor.cr` / `go_route_extractor.cr`.
+  # Framework-specific behaviour (flask_restx, Sanic's class views, cross-file
+  # `register_blueprint`, etc.) stays in the adapters.
+  module PythonRouteExtractor
+    extend self
+
+    PYTHON_VAR_NAME = /[a-zA-Z_][a-zA-Z0-9_]*/
+    HTTP_METHODS    = %w[get post put patch delete head options trace]
+
+    # One match from `scan_decorators`.
+    #
+    # `router_name` is the variable before `.route` / `.get` / …. `path` is
+    # the string literal argument. `extra_params` is the raw tail of the
+    # decorator call (everything after the path and its closing quote) so
+    # callers can parse `methods=[...]` out of it; for method-specific
+    # decorators the extractor fills it with `methods=['METHOD']` so the
+    # adapter can treat both idioms uniformly.
+    struct Decoration
+      getter router_name : String
+      getter path : String
+      getter extra_params : String
+
+      def initialize(@router_name, @path, @extra_params)
+      end
+    end
+
+    # Scan one line for `@<var>.route(...)` and `@<var>.<method>(...)` and
+    # return every decorator found. Typically 0 or 1 per line.
+    #
+    # `original_line` defaults to `line`. Callers that have space-stripped
+    # `line` for regex-matching convenience should pass the original here
+    # so paths that contain spaces survive (Flask does this; Sanic doesn't
+    # need to because its fixtures never have space-bearing paths).
+    def scan_decorators(line : String, original_line : String? = nil) : Array(Decoration)
+      results = [] of Decoration
+      source = original_line || line
+
+      line.scan(/@(#{PYTHON_VAR_NAME})\.route\([rf]?['"]([^'"]*)['"](.*)/) do |match|
+        next unless match.size > 0
+        router_name = match[1]
+        path = match[2]
+        if original_line
+          if source_match = source.match(/@#{router_name}\.route\(\s*[rf]?['"]([^'"]*)['"]/)
+            path = source_match[1]
+          end
+        end
+        results << Decoration.new(router_name, path, match[3])
+      end
+
+      HTTP_METHODS.each do |method|
+        line.scan(/@(#{PYTHON_VAR_NAME})\.#{method}\([rf]?['"]([^'"]*)['"](.*)/) do |match|
+          next unless match.size > 0
+          router_name = match[1]
+          path = match[2]
+          if original_line
+            if source_match = source.match(/@#{router_name}\.#{method}\(\s*[rf]?['"]([^'"]*)['"]/)
+              path = source_match[1]
+            end
+          end
+          results << Decoration.new(router_name, path, "methods=['#{method.upcase}']")
+        end
+      end
+
+      results
+    end
+
+    # Detect a `<name> = (module.)?Blueprint(url_prefix="...")` assignment.
+    # Returns `{name, prefix}` if matched, `nil` otherwise.
+    #
+    # `module_names` is the list of optional module prefixes a framework
+    # allows — Flask accepts `flask.Blueprint`, Sanic accepts `sanic.Blueprint`,
+    # or a bare `Blueprint` after an `import`.
+    #
+    # `original_line` is used to read `url_prefix`, so if the caller
+    # space-stripped `line`, spaces inside the prefix value still survive.
+    def scan_blueprint(line : String, module_names : Array(String), original_line : String? = nil) : Tuple(String, String)?
+      mod_alt = module_names.map { |m| Regex.escape(m) }.join("|")
+      re = Regex.new("(#{PYTHON_VAR_NAME.source})(?::#{PYTHON_VAR_NAME.source})?=(?:(?:#{mod_alt})\\.)?Blueprint\\(")
+      match = line.match(re)
+      return unless match
+
+      name = match[1]
+      prefix = ""
+      source = original_line || line
+      if param_codes = source.split("Blueprint", 2)[1]?
+        if prefix_match = param_codes.match(/url_prefix\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          prefix = prefix_match[1]
+        end
+      end
+      {name, prefix}
+    end
+
+    # Locate the `def`/`async def`/`class` that a decorator applies to.
+    #
+    # `direction: :down` walks forward past additional decorators and blank
+    # lines, stopping at the first non-decorator line (the one we want, or
+    # something that breaks the decorator chain). `direction: :up` walks
+    # backward, used when the decorator sits on a method whose enclosing
+    # class was found elsewhere.
+    #
+    # Returns the index of the def/class line, or the original `line_index`
+    # when nothing matches.
+    def find_def_line(lines : Array(String), line_index : Int32, direction : Symbol = :down) : Int32
+      case direction
+      when :down
+        i = line_index + 1
+        while i < lines.size
+          stripped = lines[i].lstrip
+          if stripped.starts_with?("def ") || stripped.starts_with?("async def ") || stripped.starts_with?("class ")
+            return i
+          end
+          if stripped.starts_with?("@") || stripped.empty?
+            i += 1
+            next
+          end
+          break
+        end
+      when :up
+        i = line_index - 1
+        while i >= 0
+          stripped = lines[i].lstrip
+          if stripped.starts_with?("def ") || stripped.starts_with?("async def ") || stripped.starts_with?("class ")
+            return i
+          end
+          i -= 1
+        end
+      end
+      line_index
+    end
+  end
+end

--- a/src/miniparsers/python_route_extractor.cr
+++ b/src/miniparsers/python_route_extractor.cr
@@ -55,7 +55,10 @@ module Noir
         router_name = match[1]
         path = match[2]
         if original_line
-          if source_match = source.match(/@#{router_name}\.route\(\s*[rf]?['"]([^'"]*)['"]/)
+          # Python permits spaces around the dot and before the paren
+          # (e.g. `@app . route ("/path")`); match those too when
+          # recovering the unstripped path.
+          if source_match = source.match(/@#{router_name}\s*\.\s*route\s*\(\s*[rf]?['"]([^'"]*)['"]/)
             path = source_match[1]
           end
         end
@@ -68,7 +71,7 @@ module Noir
           router_name = match[1]
           path = match[2]
           if original_line
-            if source_match = source.match(/@#{router_name}\.#{method}\(\s*[rf]?['"]([^'"]*)['"]/)
+            if source_match = source.match(/@#{router_name}\s*\.\s*#{method}\s*\(\s*[rf]?['"]([^'"]*)['"]/)
               path = source_match[1]
             end
           end
@@ -124,7 +127,9 @@ module Noir
           if stripped.starts_with?("def ") || stripped.starts_with?("async def ") || stripped.starts_with?("class ")
             return i
           end
-          if stripped.starts_with?("@") || stripped.empty?
+          # A comment between the decorator and the def is legal Python;
+          # skip it along with blank lines and chained decorators.
+          if stripped.starts_with?("@") || stripped.starts_with?("#") || stripped.empty?
             i += 1
             next
           end


### PR DESCRIPTION
## Summary

Add \`src/miniparsers/python_route_extractor.cr\` — the Python analogue of \`js_route_extractor\` / \`go_route_extractor\`. Migrate **Flask** and **Sanic** to use it. FastAPI/Django/Tornado untouched in this PR.

This closes the Python gap in the Layer 2 coverage listed in \`AGENTS.md\`.

## Why

Flask and Sanic each re-implemented:

1. \`@<var>.route("/path", methods=[...])\` + \`@<var>.<method>("/path")\` decorator scanning
2. \`<name> = (module.)?Blueprint(url_prefix="…")\` assignment matching
3. "Find the def/class this decorator applies to" line walking

None of those have framework-specific bits — they're all Python idioms. Factoring them out makes new Python analyzers (Bottle #1198, Litestar #1200, Pyramid #1199, …) thin adapters rather than ~400-line blobs.

## API

\`\`\`crystal
module Noir::PythonRouteExtractor
  struct Decoration
    getter router_name : String
    getter path : String
    getter extra_params : String   # raw tail (contains methods=[...])
  end

  def scan_decorators(line, original_line = nil) : Array(Decoration)
  def scan_blueprint(line, module_names, original_line = nil) : Tuple(String, String)?
  def find_def_line(lines, line_index, direction = :down) : Int32
end
\`\`\`

\`original_line\` preserves spaces in paths that callers stripped for regex-matching convenience. \`module_names\` lets Flask accept \`flask.Blueprint\` and Sanic accept \`sanic.Blueprint\` from the same helper.

Per-method decorators (\`@app.get\`) are normalized to carry \`methods=['GET']\` in \`extra_params\` so adapters treat \`@app.route(..., methods=[...])\` and \`@app.get(...)\` uniformly.

## Migration footprint

| Analyzer | Δ |
|---|---|
| Flask | **−29 LOC** (decorator scan + Blueprint regex). Keeps its own \`extract_params_from_decorator\` because it also reads flask_restx \`@.expect(Namespace.model)\` along the way — that's framework-specific. |
| Sanic | **−56 LOC** (decorator scan + Blueprint regex + collapses \`extract_params_from_decorator\` body to a one-line \`find_def_line\` delegation). |

Net analyzer code: **−85 LOC**. Extractor adds 146 LOC — reusable by every future Python framework adapter.

## Deliberately out of scope

- **FastAPI** has \`@app.get/post/...\` and \`@router.get/...\` decorators that would fit \`scan_decorators\`, but it also parses \`app.include_router(router, prefix="…")\` and Pydantic-typed function signatures that need framework-specific logic. A follow-up can migrate the decorator portion and keep the rest.
- **Django** uses \`urls.py\` with \`path()\` / \`re_path()\` — a different shape entirely.
- **Tornado** uses \`Application(handlers=[...])\` list-based routing — also different.

Those three stay on their current logic. The extractor is the Layer 2 home when we're ready to bring them in.

## Test plan

- [x] \`just build\` — clean
- [x] \`just test\` — 1255 unit + 4177 functional, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`ameba\` — clean (6 files, 0 failures)