### PR TITLE
docs(sidebar): expose Analyzer Architecture under Development

### DIFF
--- a/docs/templates/sidebar.html
+++ b/docs/templates/sidebar.html
@@ -404,6 +404,11 @@
                     >
                 </li>
                 <li>
+                    <a href="{{ base_url }}/development/analyzer_architecture/"
+                        >Analyzer Architecture</a
+                    >
+                </li>
+                <li>
                     <a href="{{ base_url }}/development/how_to_release/"
                         >How to Release</a
                     >


### PR DESCRIPTION
Small follow-up to #1245: add the new *Analyzer Architecture* page to the Development sidebar group so contributors can find it from any doc page. Positioned between *How to Build* and *How to Release*, matching the order contributors would encounter them (get running → understand the analyzer stack → ship).