### PR TITLE
fix(miniparsers/go): accept grouped routes without leading slash

### DIFF
--- a/spec/functional_test/fixtures/go/gin/server.go
+++ b/spec/functional_test/fixtures/go/gin/server.go
@@ -37,6 +37,14 @@ func main() {
 		c.JSON(http.StatusOK, "users")
 	})
 
+	// Gin accepts route paths without a leading "/" — the group prefix
+	// supplies the separator. Real-world fixture: gin-gonic/examples/basic
+	// uses `authorized.POST("admin", …)` under a `r.Group("/", …)`.
+	authorized := r.Group("/")
+	authorized.POST("admin", func(c *gin.Context) {
+		c.JSON(http.StatusOK, "admin")
+	})
+
 	// Test various coding styles
 	// Mixed case methods (Go convention)
 	r.Get("/mixed-get", func(c *gin.Context) {

--- a/spec/functional_test/testers/go/gin_spec.cr
+++ b/spec/functional_test/testers/go/gin_spec.cr
@@ -16,6 +16,9 @@ expected_endpoints = [
   Endpoint.new("/public/secret.html", "GET"),
   Endpoint.new("/group/users", "GET"),
   Endpoint.new("/group/v1/migration", "GET"),
+  # Route path without leading "/" under a Group("/"). Regression guard
+  # for the gin-gonic/examples/basic pattern.
+  Endpoint.new("/admin", "POST"),
   Endpoint.new("/mixed-get", "GET"),
   Endpoint.new("/mixed-post", "POST", [
     Param.new("field1", "", "form"),

--- a/src/miniparsers/go_route_extractor.cr
+++ b/src/miniparsers/go_route_extractor.cr
@@ -71,14 +71,27 @@ module Noir
           final_path = token.value.to_s
           next if final_path.empty?
 
+          # Walk groups in reverse so the most recently registered (i.e.
+          # most specific) match wins and the loop stops after the first
+          # hit. `includes?` does substring matching — without the break,
+          # group names that share a prefix would stack prefixes (e.g.
+          # registering both `v1` and `v12` and then scanning
+          # `v12.POST(…)` would otherwise produce `/v1/v12/…`).
+          #
+          # The join uses `rstrip('/')` + `/` + `lstrip('/')` so there's
+          # exactly one separator regardless of whether the group value
+          # ended in `/` or the path began with one — otherwise
+          # `Group("/api")` + `admin` would concatenate to `/apiadmin`.
           group_prefix_applied = false
-          groups.each do |group|
+          groups.reverse_each do |group|
             group.each do |key, value|
               if before.value.to_s.includes? key
-                final_path = value + final_path
+                final_path = "#{value.rstrip('/')}/#{final_path.lstrip('/')}"
                 group_prefix_applied = true
+                break
               end
             end
+            break if group_prefix_applied
           end
 
           next unless final_path.starts_with?("/") || group_prefix_applied

--- a/src/miniparsers/go_route_extractor.cr
+++ b/src/miniparsers/go_route_extractor.cr
@@ -51,6 +51,17 @@ module Noir
 
     # Parse one line, return the route path with group prefix applied.
     # Returns "" if no route string is found.
+    #
+    # Accepts a string literal as a route path when *either*:
+    #   - it starts with "/" (the common Gin/Echo idiom), or
+    #   - a known group prefix applies (i.e., the identifier preceding the
+    #     literal matches a registered group name, like
+    #     `authorized.POST("admin", …)` under `authorized := r.Group("/")`).
+    #
+    # The second case fixes the gin-gonic/examples pattern where route
+    # paths under a Group lack a leading "/". Other string literals in the
+    # line (e.g. `c.Cookie.Get("abcd_token")`, `r.Get("password")`) still
+    # get filtered because their preceding identifier isn't a group name.
     def extract_route_path(line : String, groups : Array(Hash(String, String))) : String
       lexer = GolangLexer.new
       map = lexer.tokenize(line)
@@ -58,16 +69,19 @@ module Noir
       map.each do |token|
         if token.type == :string
           final_path = token.value.to_s
-          # Route path must start with "/" to be a valid HTTP endpoint
-          next unless final_path.starts_with?("/")
+          next if final_path.empty?
+
+          group_prefix_applied = false
           groups.each do |group|
             group.each do |key, value|
               if before.value.to_s.includes? key
                 final_path = value + final_path
+                group_prefix_applied = true
               end
             end
           end
 
+          next unless final_path.starts_with?("/") || group_prefix_applied
           return final_path
         end
 


### PR DESCRIPTION
## Summary

Real-world gap found by running noir on `gin-gonic/examples/basic`:

```go
authorized := r.Group(\"/\")
authorized.POST(\"admin\", handler)   // silently dropped
```

The extractor's `next unless final_path.starts_with?(\"/\")` guard filtered the second form before group-prefix resolution ran, so `POST /admin` never appeared in the output even though Gin serves it.

## The fix

Removing the guard outright regressed `gf`'s analyzer: lines like `r.Cookie.Get(\"abcd_token\")` and `r.Get(\"password\")` also match the HTTP-method regex under `/i`, and their string literals turned into phantom routes (`/abcd_token`, `/apipassword`).

Relax the guard to: **accept a non-empty string literal when either it starts with `/` OR a known group prefix applies** (the preceding identifier token references a registered group).

That covers the legitimate Gin idiom while keeping accessor strings out — no group matches identifiers like `r.Cookie.Get(` or `r.Get(`, so those lines still skip.

## Regression guard

Added to the Gin fixture + spec:

```go
authorized := r.Group(\"/\")
authorized.POST(\"admin\", func(c *gin.Context) { … })
```

Asserts `POST /admin` is captured.

## Test plan

- [x] `just build` — clean
- [x] `just test` — 1256 unit + 4215 functional, 0 failures
- [x] `crystal tool format`, `ameba` — clean
- [x] Manual: `./bin/noir -b /tmp/gin-examples/basic -t go_gin` now reports `POST /admin` alongside `GET /ping` and `GET /user/:name`.

## Discovered during

OSS smoke test across `gin-gonic/examples`, `pallets/flask`, `hagopj13/node-express-boilerplate`. Other findings (cross-function group propagation in Gin, JSRouteExtractor false-positive on `Promise.all(Object.values(...).map(...))`, two-level Express router-mount chain) are logged separately for follow-up PRs.