### PR TITLE
feat(analyzer/js): resolve Express config-array mount pattern

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_config_array/app.js
+++ b/spec/functional_test/fixtures/javascript/express_config_array/app.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const routes = require('./routes/v1');
+
+const app = express();
+
+// Top-level mount: everything under /v1.
+app.use('/v1', routes);
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/express_config_array/package.json
+++ b/spec/functional_test/fixtures/javascript/express_config_array/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "express-config-array-fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "^4.18.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/auth.route.js
+++ b/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/auth.route.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.post('/register', (req, res) => res.json({ ok: true }));
+router.post('/login', (req, res) => res.json({ ok: true }));
+router.post('/logout', (req, res) => res.json({ ok: true }));
+
+module.exports = router;

--- a/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/index.js
+++ b/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/index.js
@@ -10,7 +10,8 @@ const router = express.Router();
 // resolve the entries to recover the real mount paths.
 const defaultRoutes = [
   { path: '/auth', route: authRoute },
-  { path: '/users', route: userRoute },
+  // Reversed property order — the extractor must still match.
+  { route: userRoute, path: '/users' },
 ];
 
 defaultRoutes.forEach((r) => {

--- a/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/index.js
+++ b/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/index.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const authRoute = require('./auth.route');
+const userRoute = require('./user.route');
+
+const router = express.Router();
+
+// Mimics the hagopj13/node-express-boilerplate idiom: a config array
+// driven through forEach. `router.use(r.path, r.route)` takes expressions,
+// not string literals, so the mount-scanner's config-array handler has to
+// resolve the entries to recover the real mount paths.
+const defaultRoutes = [
+  { path: '/auth', route: authRoute },
+  { path: '/users', route: userRoute },
+];
+
+defaultRoutes.forEach((r) => {
+  router.use(r.path, r.route);
+});
+
+module.exports = router;

--- a/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/user.route.js
+++ b/spec/functional_test/fixtures/javascript/express_config_array/routes/v1/user.route.js
@@ -1,0 +1,14 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.route('/')
+  .get((req, res) => res.json([]))
+  .post((req, res) => res.json({ created: true }));
+
+router.route('/:userId')
+  .get((req, res) => res.json({}))
+  .patch((req, res) => res.json({ updated: true }))
+  .delete((req, res) => res.status(204).end());
+
+module.exports = router;

--- a/spec/functional_test/testers/javascript/express_config_array_spec.cr
+++ b/spec/functional_test/testers/javascript/express_config_array_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+# Regression guard for two-level Express mount resolution through a
+# route-config array iterated with forEach. The layout mirrors
+# hagopj13/node-express-boilerplate, where it was originally found:
+#
+#   app.js                   app.use('/v1', routes)
+#   routes/v1/index.js       defaultRoutes.forEach((r) =>
+#                              router.use(r.path, r.route))
+#                            defaultRoutes: [
+#                              { path: '/auth',  route: authRoute },
+#                              { path: '/users', route: userRoute },
+#                            ]
+#   routes/v1/auth.route.js  router.post('/register', …)
+#   routes/v1/user.route.js  router.route('/').get(...).post(...)
+#                            router.route('/:userId').get().patch().delete()
+#
+# Every leaf endpoint must be resolved with the full `/v1/{auth,users}`
+# prefix. Pre-fix, noir only had `/register`, `/login`, `/`, `/:userId`
+# because the mount scanner's regex required a string literal and could
+# not see through `router.use(r.path, r.route)`. This spec fails if
+# that regression comes back.
+
+expected_endpoints = [
+  Endpoint.new("/v1/auth/register", "POST"),
+  Endpoint.new("/v1/auth/login", "POST"),
+  Endpoint.new("/v1/auth/logout", "POST"),
+  Endpoint.new("/v1/users/", "GET"),
+  Endpoint.new("/v1/users/", "POST"),
+  Endpoint.new("/v1/users/:userId", "GET", [Param.new("userId", "", "path")]),
+  Endpoint.new("/v1/users/:userId", "PATCH", [Param.new("userId", "", "path")]),
+  Endpoint.new("/v1/users/:userId", "DELETE", [Param.new("userId", "", "path")]),
+]
+
+FunctionalTester.new("fixtures/javascript/express_config_array/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -188,7 +188,17 @@ module Analyzer::Javascript
           prefix, router_identifier = entry
           next if prefix.empty? || router_identifier.empty?
 
-          router_var : String? = require_map.has_key?(router_identifier) ? router_identifier : nil
+          # Identifiers can arrive via three different import/assignment
+          # shapes; match the lookup set `extract_router_reference` uses
+          # for literal `.use(…)` calls so destructured imports
+          # (`const { foo } = require('./bar')`) and factory-returned
+          # routers (`const router = makeRouter()`) also resolve.
+          router_var : String? = nil
+          if require_map.has_key?(router_identifier) ||
+             function_map.has_key?(router_identifier) ||
+             var_to_function.has_key?(router_identifier)
+            router_var = router_identifier
+          end
           router_file_direct : String? = nil
           next unless router_var || router_file_direct
 
@@ -207,8 +217,17 @@ module Analyzer::Javascript
       end
     end
 
-    # Extract `{ path: '…', route: <identifier> }` entries from an array
-    # literal bound to `array_name`. Non-conforming entries are skipped.
+    # Extract `{ path: '…', route: <identifier>, … }` entries from an
+    # array literal bound to `array_name`. Non-conforming entries are
+    # skipped. The property order inside each entry doesn't matter
+    # (`{ path: '/a', route: x }` and `{ route: x, path: '/a' }` both
+    # work), and extra keys beyond `path`/`route` are tolerated.
+    #
+    # The inner-object regex requires flat objects — a nested option bag
+    # like `{ path: '/a', route: x, options: { strict: true } }` would
+    # not match. In practice Express route configs are flat; if a real
+    # project needs nested options, we'll revisit with a brace-balanced
+    # scan.
     private def extract_route_config_array(content : String, array_name : String) : Array(Tuple(String, String))
       entries = [] of Tuple(String, String)
 
@@ -217,8 +236,13 @@ module Analyzer::Javascript
       return entries unless match
 
       body = match[1]
-      body.scan(/\{\s*path\s*:\s*['"]([^'"]+)['"]\s*,\s*route\s*:\s*(\w+)/) do |entry_match|
-        entries << {entry_match[1], entry_match[2]}
+      body.scan(/\{([^{}]+)\}/) do |obj_match|
+        obj_body = obj_match[1]
+        path_match = obj_body.match(/\bpath\s*:\s*['"]([^'"]+)['"]/)
+        route_match = obj_body.match(/\broute\s*:\s*(\w+)/)
+        if path_match && route_match
+          entries << {path_match[1], route_match[1]}
+        end
       end
 
       entries

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -90,6 +90,18 @@ module Analyzer::Javascript
           require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
       end
 
+      # Scan for route-config-array + forEach iteration:
+      #   const defaultRoutes = [
+      #     { path: '/auth', route: authRoute },
+      #     { path: '/users', route: userRoute },
+      #   ];
+      #   defaultRoutes.forEach((r) => router.use(r.path, r.route));
+      #
+      # Each array entry acts like a literal `router.use('/path', routeVar)`
+      # call, so feed them through the same store_*_mount machinery.
+      scan_config_array_mounts(content, main_file, locator,
+        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+
       # Store file context for second pass
       file_contexts[main_file] = {
         require_map:     require_map,
@@ -140,6 +152,76 @@ module Analyzer::Javascript
           global_deferred_mounts << {main_file, caller, prefix, deferred_key} unless deferred_key.empty?
         end
       end
+    end
+
+    # Detect mounts synthesized from a config array iterated via forEach/map,
+    # e.g.
+    #   const defaultRoutes = [
+    #     { path: '/auth', route: authRoute },
+    #     { path: '/users', route: userRoute },
+    #   ];
+    #   defaultRoutes.forEach((r) => router.use(r.path, r.route));
+    #
+    # Resolves the array declaration locally (same file), then yields each
+    # entry into the same store_top_level_mount / store_nested_mount path
+    # the explicit scans use.
+    private def scan_config_array_mounts(
+      content : String,
+      main_file : String,
+      locator : CodeLocator,
+      require_map : Hash(String, String),
+      function_map : Hash(String, String),
+      var_to_function : Hash(String, String),
+      var_prefix : Hash(String, Array(String)),
+      global_deferred_mounts : Array(Tuple(String, String, String, String)),
+    )
+      # ARRAY.forEach(...=> CALLER.use(<param>.path, <param>.route) ...)
+      # Also matches `.map(...)` for the rare case someone uses it for side effects.
+      pattern = /(\w+)\s*\.\s*(?:forEach|map)\s*\(\s*(?:async\s+)?(?:\(\s*\w+(?:\s*,\s*\w+)?\s*\)|\w+)\s*=>\s*\{?\s*(\w+)\s*\.\s*use\s*\(\s*\w+\s*\.\s*path\s*,\s*\w+\s*\.\s*route\s*\)/
+
+      content.scan(pattern) do |m|
+        next unless m.size >= 3
+        array_name = m[1]
+        caller = m[2]
+
+        extract_route_config_array(content, array_name).each do |entry|
+          prefix, router_identifier = entry
+          next if prefix.empty? || router_identifier.empty?
+
+          router_var : String? = require_map.has_key?(router_identifier) ? router_identifier : nil
+          router_file_direct : String? = nil
+          next unless router_var || router_file_direct
+
+          if caller == "app"
+            store_top_level_mount(locator, router_var, router_file_direct, prefix, main_file,
+              require_map, function_map, var_to_function, var_prefix)
+          else
+            processed = store_nested_mount(locator, router_var, router_file_direct, prefix, caller, main_file,
+              require_map, function_map, var_to_function, var_prefix)
+            unless processed
+              deferred_key = router_file_direct || router_var || ""
+              global_deferred_mounts << {main_file, caller, prefix, deferred_key} unless deferred_key.empty?
+            end
+          end
+        end
+      end
+    end
+
+    # Extract `{ path: '…', route: <identifier> }` entries from an array
+    # literal bound to `array_name`. Non-conforming entries are skipped.
+    private def extract_route_config_array(content : String, array_name : String) : Array(Tuple(String, String))
+      entries = [] of Tuple(String, String)
+
+      array_re = /(?:const|let|var)\s+#{Regex.escape(array_name)}\s*=\s*\[([\s\S]*?)\]/
+      match = content.match(array_re)
+      return entries unless match
+
+      body = match[1]
+      body.scan(/\{\s*path\s*:\s*['"]([^'"]+)['"]\s*,\s*route\s*:\s*(\w+)/) do |entry_match|
+        entries << {entry_match[1], entry_match[2]}
+      end
+
+      entries
     end
 
     # Collect all JavaScript/TypeScript files to scan
@@ -805,8 +887,16 @@ module Analyzer::Javascript
       # Case 1: The resolved path is a file that exists
       return resolved if File.file?(resolved)
 
-      # Case 2: The path has no extension, try adding common JS/TS extensions
-      if File.extname(require_path).empty?
+      # Case 2: Try adding common JS/TS extensions.
+      # Using `File.extname(require_path).empty?` is wrong because files
+      # like `./auth.route` have `File.extname` = `.route`, which is not
+      # empty but also not a runnable JS extension. That incorrectly
+      # short-circuits the extension search and leaves common Express
+      # naming idioms (`foo.route`, `bar.controller`, `baz.service`)
+      # unresolvable. Instead, skip the extension search only when the
+      # path already ends with a recognized JS/TS extension.
+      known_js_exts = [".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]
+      unless known_js_exts.any? { |ext| require_path.ends_with?(ext) }
         [".js", ".ts", ".jsx", ".tsx"].each do |ext|
           with_ext = "#{resolved}#{ext}"
           return with_ext if File.file?(with_ext)


### PR DESCRIPTION
## Summary

Running noir on [hagopj13/node-express-boilerplate](https://github.com/hagopj13/node-express-boilerplate) surfaced a very common Express idiom the router-mount scanner didn't understand:

\`\`\`js
const defaultRoutes = [
  { path: '/auth',  route: authRoute  },
  { path: '/users', route: userRoute  },
];
defaultRoutes.forEach((r) => router.use(r.path, r.route));
\`\`\`

\`router.use(r.path, r.route)\` passes expressions, not string literals. The existing regex-based scans all require a string literal in the first argument, so this whole pattern was invisible. The downstream effect: every leaf route inside \`auth.route.js\` / \`user.route.js\` appeared unprefixed (\`/register\`, \`/login\`, \`/:userId\`, …) instead of under \`/v1/auth\` or \`/v1/users\`.

## Changes

**1. \`scan_config_array_mounts\`** in \`router_mount_scanner.cr\` detects:

\`\`\`
<array>.forEach|map((…) => <caller>.use(<cb>.path, <cb>.route))
\`\`\`

then resolves the array declaration in the same file (\`const <array> = [{ path: 'LIT', route: IDENT }, …]\`) and feeds each \`(prefix, identifier)\` pair through the same \`store_top_level_mount\` / \`store_nested_mount\` path as explicit calls. All downstream prefix-chain machinery (multi-level mounts, deferred resolution in pass 2) just works.

**2. \`resolve_require_path\` extension-search fix.** The existing guard \`File.extname(require_path).empty?\` is false for paths like \`./auth.route\` (extname = \`.route\`). Idioms like \`foo.route\`, \`bar.controller\`, \`baz.service\` — **standard Express layout** — were silently unresolvable, so \`authRoute\` never mapped to a file and the new config-array handler had nothing to match against. Swap the guard for an allowlist: only skip extension search when the path already ends with a recognized JS/TS extension.

## Regression fixture

\`spec/functional_test/fixtures/javascript/express_config_array/\` mirrors the OSS layout:

\`\`\`
app.js                     app.use('/v1', routes)
routes/v1/index.js         defaultRoutes.forEach((r) => router.use(r.path, r.route))
routes/v1/auth.route.js    router.post('/register', …)
routes/v1/user.route.js    router.route('/').get().post()
                           router.route('/:userId').get().patch().delete()
\`\`\`

Spec asserts all 8 endpoints with the full \`/v1/{auth,users}\` prefix chain, including path params.

## Before / after

On the real OSS project:

| Endpoint | Before | After |
|---|---|---|
| \`POST /v1/auth/register\` | came only from test file literal | resolved via mount chain |
| \`GET /v1/users\` | missing | present |
| \`GET /v1/users/:userId\` | missing (shown as \`/:userId\`) | present |

## Test plan

- [x] \`just build\`
- [x] \`just test\` — 1256 unit + 4255 functional (+24 from the new config_array spec), 0 failures
- [x] \`crystal tool format\`, \`ameba\` — clean
- [x] Manual: noir against hagopj13/node-express-boilerplate now produces \`/v1/users\` and \`/v1/users/:userId\` via real mount resolution, not just test-file literals.