### PR TITLE
feat(detector): add --exclude-path to filter files by glob

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_exclude_path/app.js
+++ b/spec/functional_test/fixtures/javascript/express_exclude_path/app.js
@@ -1,0 +1,6 @@
+const express = require('express');
+const app = express();
+
+app.get('/api/users', (req, res) => res.json([]));
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/express_exclude_path/app.test.js
+++ b/spec/functional_test/fixtures/javascript/express_exclude_path/app.test.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+
+// Test-only route — should be excluded via --exclude-path "*.test.js"
+app.get('/test/should-not-appear', (req, res) => res.json({ ok: true }));
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/express_exclude_path/tests/integration.js
+++ b/spec/functional_test/fixtures/javascript/express_exclude_path/tests/integration.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+
+// Path-scoped test route — should be excluded via --exclude-path "tests/*"
+app.get('/integration/should-not-appear', (req, res) => res.json({ ok: true }));
+
+module.exports = app;

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -18,11 +18,12 @@ class FunctionalTester
   @app : NoirRunner
   @path : String
 
-  def initialize(@path, expected_count, expected_endpoints)
+  def initialize(@path, expected_count, expected_endpoints, option_overrides : Hash(String, YAML::Any)? = nil)
     config_init = ConfigInitializer.new
     noir_options = config_init.default_options
     noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{@path}")])
     noir_options["nolog"] = YAML::Any.new(true)
+    option_overrides.try &.each { |k, v| noir_options[k] = v }
 
     if !expected_count.nil?
       @expected_count = expected_count

--- a/spec/functional_test/testers/javascript/express_exclude_path_spec.cr
+++ b/spec/functional_test/testers/javascript/express_exclude_path_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Regression test for --exclude-path.
+#
+# The fixture ships three Express files:
+#   - app.js                 → real route, must survive
+#   - app.test.js            → excluded by basename glob "*.test.js"
+#   - tests/integration.js   → excluded by path glob "tests/*"
+#
+# With both patterns active only the /api/users route should appear.
+
+expected_endpoints = [
+  Endpoint.new("/api/users", "GET"),
+]
+
+overrides = Hash(String, YAML::Any).new
+overrides["exclude_path"] = YAML::Any.new("*.test.js,tests/*")
+
+FunctionalTester.new(
+  "fixtures/javascript/express_exclude_path/",
+  {
+    :techs     => 1,
+    :endpoints => expected_endpoints.size,
+  },
+  expected_endpoints,
+  overrides,
+).perform_tests

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -83,6 +83,7 @@ class ConfigInitializer
       "debug"                        => YAML::Any.new(false),
       "verbose"                      => YAML::Any.new(false),
       "exclude_codes"                => YAML::Any.new(""),
+      "exclude_path"                 => YAML::Any.new(""),
       "exclude_techs"                => YAML::Any.new(""),
       "only_techs"                   => YAML::Any.new(""),
       "format"                       => YAML::Any.new("plain"),
@@ -165,6 +166,9 @@ class ConfigInitializer
 
       # Technologies to exclude
       exclude_techs: "#{options["exclude_techs"]}"
+
+      # File paths to exclude (comma-separated glob patterns, e.g. "*.test.js,*_test.go")
+      exclude_path: "#{options["exclude_path"]}"
 
       # The format to use for the output
       format: "#{options["format"]}"

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -157,8 +157,12 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       # User-supplied --exclude-path patterns (comma-separated globs).
       # Patterns containing "/" are matched against the relative path;
       # patterns without "/" are matched against the basename.
-      exclude_path_patterns = options["exclude_path"]?.to_s
+      # Partition once up front so the per-file loop only walks the two
+      # already-classified lists — no substring check per file.
+      exclude_path_raw = options["exclude_path"]?.to_s
         .split(",").map(&.strip).reject(&.empty?)
+      path_patterns, basename_patterns = exclude_path_raw.partition(&.includes?('/'))
+      exclude_path_active = !exclude_path_raw.empty?
       skipped_exclude_path = 0
 
       base_paths.each do |base_path|
@@ -182,13 +186,10 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
             next
           end
 
-          if !exclude_path_patterns.empty?
-            rel_no_slash = relative_path.lchop('/')
+          if exclude_path_active
             basename = File.basename(file)
-            matched = exclude_path_patterns.any? do |pat|
-              target = pat.includes?('/') ? rel_no_slash : basename
-              File.match?(pat, target)
-            end
+            matched = basename_patterns.any? { |pat| File.match?(pat, basename) } ||
+                      path_patterns.any? { |pat| File.match?(pat, relative_path.lchop('/')) }
             if matched
               skipped_exclude_path += 1
               next

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -154,6 +154,13 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
         "/tmp/", "/.next/", "/out/", "/vendor/",
       ]
 
+      # User-supplied --exclude-path patterns (comma-separated globs).
+      # Patterns containing "/" are matched against the relative path;
+      # patterns without "/" are matched against the basename.
+      exclude_path_patterns = options["exclude_path"]?.to_s
+        .split(",").map(&.strip).reject(&.empty?)
+      skipped_exclude_path = 0
+
       base_paths.each do |base_path|
         # Pre-compute base path prefix for fast relative path calculation
         base_prefix = base_path.ends_with?("/") ? base_path : base_path + "/"
@@ -175,6 +182,19 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
             next
           end
 
+          if !exclude_path_patterns.empty?
+            rel_no_slash = relative_path.lchop('/')
+            basename = File.basename(file)
+            matched = exclude_path_patterns.any? do |pat|
+              target = pat.includes?('/') ? rel_no_slash : basename
+              File.match?(pat, target)
+            end
+            if matched
+              skipped_exclude_path += 1
+              next
+            end
+          end
+
           # Check if file should be skipped due to media type or size
           if MediaFilter.should_skip_file?(file)
             reason = MediaFilter.skip_reason(file)
@@ -194,6 +214,9 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       end
       if skipped_ignored_dirs > 0
         logger.debug "Skipped #{skipped_ignored_dirs} files in ignored directories"
+      end
+      if skipped_exclude_path > 0
+        logger.info "Skipped #{skipped_exclude_path} files matching --exclude-path patterns"
       end
     ensure
       channel.close

--- a/src/options.cr
+++ b/src/options.cr
@@ -179,6 +179,9 @@ def run_options_parser
     parser.on "--exclude-codes 404,500", "Exclude HTTP codes (comma-separated)" do |v|
       noir_options["exclude_codes"] = YAML::Any.new(v)
     end
+    parser.on "--exclude-path PATTERN", "Exclude files by glob (e.g. *.test.js,*_test.go)" do |v|
+      noir_options["exclude_path"] = YAML::Any.new(v)
+    end
     parser.on "--include-path", "Include file path in plain output" do
       noir_options["include_path"] = YAML::Any.new(true)
     end


### PR DESCRIPTION
## Summary
- New `--exclude-path PATTERN[,PATTERN...]` flag that skips files during `file_map` population.
- Patterns containing `/` are matched against the relative path, bare patterns against the basename — lets users drop common noise like `*.test.js`, `*_test.go`, `test_*.py`, or `tests/*`.
- Applied once in `detector.cr` so every analyzer driven through `CodeLocator#file_map` inherits the exclusion; no per-analyzer changes needed.

### Motivation
Smoke runs against real OSS projects kept turning test harness files into phantom endpoints (see the `fake-route` kind of output). This gives users a scalpel instead of forcing them to wait on analyzer-side heuristics for every new fixture convention.

### Example
```
noir -b . --exclude-path '*.test.js,*_test.go,test_*.py,tests/*'
```

### Implementation notes
- `File.match?` handles the glob matching. Patterns split on `,` and trimmed; empties are ignored.
- When any exclude-path pattern fires, the file is counted separately (`Skipped N files matching --exclude-path patterns`) so users can confirm their pattern worked.
- `FunctionalTester` gained an optional `option_overrides` hash so functional specs can exercise flags like this without plumbing new constructors.

## Test plan
- [x] `crystal spec spec/functional_test/testers/javascript/express_exclude_path_spec.cr` — new regression fixture (real route + `app.test.js` basename exclusion + `tests/integration.js` path exclusion)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 780 existing cases still pass
- [x] Manual run against a throwaway Express project to confirm CLI + excluded-file log line
- [x] `ameba` clean on touched files