### PR TITLE
perf(detector): prune ignored dirs at walk time + dedup media stats

### DIFF
--- a/spec/functional_test/fixtures/javascript/base_in_node_modules/node_modules/myproj/app.js
+++ b/spec/functional_test/fixtures/javascript/base_in_node_modules/node_modules/myproj/app.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const app = express();
+
+// Regression for issue #912: users sometimes run noir with -b pointed at a
+// directory that itself lives under a path component named node_modules.
+// When noir is pointed *here*, the base-relative filter must NOT treat
+// the parent path component as grounds for skipping the base itself.
+app.get('/health', (req, res) => res.json({ ok: true }));
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/base_in_node_modules/node_modules/myproj/node_modules/somepkg/index.js
+++ b/spec/functional_test/fixtures/javascript/base_in_node_modules/node_modules/myproj/node_modules/somepkg/index.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const app = express();
+
+// This file lives inside a nested node_modules subtree BELOW the base.
+// It must NOT be scanned — a dependency route would become a phantom
+// endpoint on the scanned project.
+app.get('/from-nested-node-modules', (req, res) => res.json({ nope: true }));
+
+module.exports = app;

--- a/spec/functional_test/testers/javascript/base_in_node_modules_spec.cr
+++ b/spec/functional_test/testers/javascript/base_in_node_modules_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+# Regression test for issue #912.
+#
+# A user may legitimately point -b at a directory whose absolute path happens
+# to contain a "node_modules" component (e.g. noir is unpacked under some
+# other tool's node_modules). The base-relative ignore filter must:
+#
+#   1. Scan files under the base even when the base path itself contains
+#      "/node_modules/" as a component.
+#   2. Still skip a nested node_modules/ directory BELOW the base (those
+#      are vendored dependencies, not project code).
+#
+# The fixture embeds the fake "project" two levels inside node_modules
+# (…/base_in_node_modules/node_modules/myproj/) and places a nested
+# node_modules inside it. Only the top-level /health route should appear.
+
+expected_endpoints = [
+  Endpoint.new("/health", "GET"),
+]
+
+FunctionalTester.new(
+  "fixtures/javascript/base_in_node_modules/node_modules/myproj/",
+  {
+    :techs     => 1,
+    :endpoints => expected_endpoints.size,
+  },
+  expected_endpoints,
+).perform_tests

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -147,12 +147,20 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       total_files = 0
       skipped_ignored_dirs = 0
 
-      # Common heavy/irrelevant directories to skip early
-      ignored_dir_patterns = [
-        "/node_modules/", "/.git/", "/dist/", "/build/", "/target/",
-        "/__pycache__/", "/.venv/", "/venv/", "/.idea/", "/.vscode/",
-        "/tmp/", "/.next/", "/out/", "/vendor/",
-      ]
+      # Directory names that are pruned at the walker level: once the
+      # walker meets a subdirectory with one of these names, that whole
+      # subtree is skipped without being enumerated.
+      #
+      # Critical invariant for issue #912: the base path itself is never
+      # matched against this set — we *start* the walk at the base, so a
+      # user pointing `-b` at e.g. `/projects/node_modules/my-app` will
+      # still have their project scanned. Only descendants of the base
+      # are subject to pruning.
+      ignored_dir_names = Set{
+        "node_modules", ".git", "dist", "build", "target",
+        "__pycache__", ".venv", "venv", ".idea", ".vscode",
+        "tmp", ".next", "out", "vendor",
+      }
 
       # User-supplied --exclude-path patterns (comma-separated globs).
       # Patterns containing "/" are matched against the relative path;
@@ -169,44 +177,63 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
         # Pre-compute base path prefix for fast relative path calculation
         base_prefix = base_path.ends_with?("/") ? base_path : base_path + "/"
 
-        Dir.glob("#{escape_glob_path(base_path)}/**/**") do |file|
-          next if File.directory?(file)
-          total_files += 1
+        # Iterative DFS. Avoids `Dir.glob("**/**")`, which enumerates every
+        # file under ignored subtrees before any filter runs; on a Node
+        # monorepo with a 100k-entry node_modules this was the dominant
+        # cost of the detect phase.
+        stack = [base_path]
+        until stack.empty?
+          dir = stack.pop
+          begin
+            Dir.each_child(dir) do |entry|
+              full_path = File.join(dir, entry)
+              info = File.info?(full_path, follow_symlinks: false)
+              next if info.nil?
 
-          # Skip files in ignored directories early
-          # Use simple string slicing instead of Path objects
-          relative_path = if file.starts_with?(base_prefix)
-                            "/" + file[base_prefix.size..]
-                          else
-                            "/" + file
-                          end
+              if info.directory?
+                # Subtree prune happens here. Entry name (not full path)
+                # so the base-as-node_modules case from #912 is safe.
+                skipped_ignored_dirs += 1 if ignored_dir_names.includes?(entry)
+                next if ignored_dir_names.includes?(entry)
+                stack << full_path
+                next
+              end
 
-          if ignored_dir_patterns.any? { |pat| relative_path.includes?(pat) }
-            skipped_ignored_dirs += 1
-            next
-          end
+              # Skip symlinks (cycle guard; matches Dir.glob's default).
+              next unless info.file?
 
-          if exclude_path_active
-            basename = File.basename(file)
-            matched = basename_patterns.any? { |pat| File.match?(pat, basename) } ||
-                      path_patterns.any? { |pat| File.match?(pat, relative_path.lchop('/')) }
-            if matched
-              skipped_exclude_path += 1
-              next
+              total_files += 1
+
+              relative_path = if full_path.starts_with?(base_prefix)
+                                "/" + full_path[base_prefix.size..]
+                              else
+                                "/" + full_path
+                              end
+
+              if exclude_path_active
+                basename = entry
+                matched = basename_patterns.any? { |pat| File.match?(pat, basename) } ||
+                          path_patterns.any? { |pat| File.match?(pat, relative_path.lchop('/')) }
+                if matched
+                  skipped_exclude_path += 1
+                  next
+                end
+              end
+
+              if skip_reason = MediaFilter.skip_check(full_path)
+                logger.debug "Skipping #{full_path}: #{skip_reason}"
+                skipped_files += 1
+                next
+              end
+
+              content = File.read(full_path, encoding: "utf-8", invalid: :skip)
+              channel.send({full_path, content})
+              locator.push "file_map", full_path
             end
+          rescue File::NotFoundError | File::AccessDeniedError
+            # Directory vanished or we can't read it — treat the subtree
+            # as empty and move on.
           end
-
-          # Check if file should be skipped due to media type or size
-          if MediaFilter.should_skip_file?(file)
-            reason = MediaFilter.skip_reason(file)
-            logger.debug "Skipping #{file}: #{reason}"
-            skipped_files += 1
-            next
-          end
-
-          content = File.read(file, encoding: "utf-8", invalid: :skip)
-          channel.send({file, content})
-          locator.push "file_map", file
         end
       end
 
@@ -214,7 +241,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
         logger.info "Skipped #{skipped_files} media/large files out of #{total_files} total files"
       end
       if skipped_ignored_dirs > 0
-        logger.debug "Skipped #{skipped_ignored_dirs} files in ignored directories"
+        logger.debug "Pruned #{skipped_ignored_dirs} ignored directory tree(s)"
       end
       if skipped_exclude_path > 0
         logger.info "Skipped #{skipped_exclude_path} files matching --exclude-path patterns"

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -193,8 +193,10 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               if info.directory?
                 # Subtree prune happens here. Entry name (not full path)
                 # so the base-as-node_modules case from #912 is safe.
-                skipped_ignored_dirs += 1 if ignored_dir_names.includes?(entry)
-                next if ignored_dir_names.includes?(entry)
+                if ignored_dir_names.includes?(entry)
+                  skipped_ignored_dirs += 1
+                  next
+                end
                 stack << full_path
                 next
               end
@@ -204,23 +206,21 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
 
               total_files += 1
 
-              relative_path = if full_path.starts_with?(base_prefix)
-                                "/" + full_path[base_prefix.size..]
-                              else
-                                "/" + full_path
-                              end
-
               if exclude_path_active
-                basename = entry
-                matched = basename_patterns.any? { |pat| File.match?(pat, basename) } ||
-                          path_patterns.any? { |pat| File.match?(pat, relative_path.lchop('/')) }
-                if matched
+                if basename_patterns.any? { |pat| File.match?(pat, entry) }
                   skipped_exclude_path += 1
                   next
                 end
+                if !path_patterns.empty?
+                  rel_path = full_path.starts_with?(base_prefix) ? full_path[base_prefix.size..] : full_path
+                  if path_patterns.any? { |pat| File.match?(pat, rel_path) }
+                    skipped_exclude_path += 1
+                    next
+                  end
+                end
               end
 
-              if skip_reason = MediaFilter.skip_check(full_path)
+              if skip_reason = MediaFilter.skip_check(full_path, info: info)
                 logger.debug "Skipping #{full_path}: #{skip_reason}"
                 skipped_files += 1
                 next

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -201,7 +201,16 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 next
               end
 
-              # Skip symlinks (cycle guard; matches Dir.glob's default).
+              # `info` was obtained with follow_symlinks: false, so symlinks
+              # land here as type=symlink and `info.file?` is false — they
+              # are skipped entirely. This is a minor behavior change from
+              # the previous `Dir.glob` implementation, which would have
+              # yielded symlinked regular files for scanning. Skipping them
+              # trades coverage of unusual monorepo layouts for a simpler
+              # cycle guard; revisit if a real project needs the old
+              # behavior. Non-regular files (FIFOs, sockets, devices) are
+              # also dropped here — previously they would reach `File.read`
+              # and either hang or error out.
               next unless info.file?
 
               total_files += 1

--- a/src/utils/media_filter.cr
+++ b/src/utils/media_filter.cr
@@ -107,15 +107,23 @@ module MediaFilter
   # readable reason in a single pass — avoids re-stat'ing the file just
   # to compose the log message. Returns `nil` when the file should be
   # processed.
-  def self.skip_check(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : String?
+  #
+  # When the caller has already obtained a `File::Info` (e.g. the
+  # detector walker stats each entry with `follow_symlinks: false`), it
+  # can be passed as `info` to skip the size stat entirely.
+  def self.skip_check(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil) : String?
     extension = File.extname(file_path).downcase
     return "media file (#{extension})" if MEDIA_EXTENSION_SET.includes?(extension)
 
-    size = begin
-      File.size(file_path)
-    rescue
-      nil
-    end
+    size = if info
+             info.size
+           else
+             begin
+               File.size(file_path)
+             rescue
+               nil
+             end
+           end
 
     if size && size > max_size
       size_mb = (size / (1024.0 * 1024.0)).round(2)
@@ -129,13 +137,13 @@ module MediaFilter
   # Combined check - returns true if file should be skipped. Prefer
   # {skip_check} on hot paths: it returns the reason in the same call
   # so the caller does not re-stat to log.
-  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : Bool
-    !skip_check(file_path, max_size).nil?
+  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil) : Bool
+    !skip_check(file_path, max_size, info).nil?
   end
 
   # Get a human-readable reason why a file was skipped. Kept for
   # backwards compatibility; new callers should use {skip_check}.
-  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : String?
-    skip_check(file_path, max_size)
+  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil) : String?
+    skip_check(file_path, max_size, info)
   end
 end

--- a/src/utils/media_filter.cr
+++ b/src/utils/media_filter.cr
@@ -48,6 +48,10 @@ module MediaFilter
     ".ttf", ".otf", ".woff", ".woff2", ".eot",
   ]
 
+  # O(1) lookup set materialized from MEDIA_EXTENSIONS. Used on the hot
+  # path — every file in the project is checked once.
+  MEDIA_EXTENSION_SET = MEDIA_EXTENSIONS.to_set
+
   # Cache for parsed size strings
   @@size_cache : Hash(String, Int32) = Hash(String, Int32).new
 
@@ -83,7 +87,7 @@ module MediaFilter
   # Check if a file should be skipped based on extension
   def self.media_file?(file_path : String) : Bool
     extension = File.extname(file_path).downcase
-    MEDIA_EXTENSIONS.includes?(extension)
+    MEDIA_EXTENSION_SET.includes?(extension)
   end
 
   # Check if a file is too large to process
@@ -99,23 +103,39 @@ module MediaFilter
     end
   end
 
-  # Combined check - returns true if file should be skipped
-  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : Bool
-    media_file?(file_path) || file_too_large?(file_path, max_size)
+  # Decide whether a file should be skipped and, if so, return the human
+  # readable reason in a single pass — avoids re-stat'ing the file just
+  # to compose the log message. Returns `nil` when the file should be
+  # processed.
+  def self.skip_check(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : String?
+    extension = File.extname(file_path).downcase
+    return "media file (#{extension})" if MEDIA_EXTENSION_SET.includes?(extension)
+
+    size = begin
+      File.size(file_path)
+    rescue
+      nil
+    end
+
+    if size && size > max_size
+      size_mb = (size / (1024.0 * 1024.0)).round(2)
+      max_mb = (max_size / (1024.0 * 1024.0)).round(2)
+      return "file too large (#{size_mb}MB > #{max_mb}MB)"
+    end
+
+    nil
   end
 
-  # Get a human-readable reason why a file was skipped
-  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : String?
-    return unless should_skip_file?(file_path, max_size)
+  # Combined check - returns true if file should be skipped. Prefer
+  # {skip_check} on hot paths: it returns the reason in the same call
+  # so the caller does not re-stat to log.
+  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : Bool
+    !skip_check(file_path, max_size).nil?
+  end
 
-    if media_file?(file_path)
-      "media file (#{File.extname(file_path).downcase})"
-    elsif file_too_large?(file_path, max_size)
-      size_mb = (File.size(file_path) / (1024.0 * 1024.0)).round(2)
-      max_mb = (max_size / (1024.0 * 1024.0)).round(2)
-      "file too large (#{size_mb}MB > #{max_mb}MB)"
-    else
-      "unknown reason"
-    end
+  # Get a human-readable reason why a file was skipped. Kept for
+  # backwards compatibility; new callers should use {skip_check}.
+  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE) : String?
+    skip_check(file_path, max_size)
   end
 end


### PR DESCRIPTION
## Summary
- Replace `Dir.glob("base/**/**")` + per-file substring filter with an iterative DFS that prunes ignored directories (`node_modules`, `.git`, `target`, …) at walk time — their subtrees are never enumerated.
- Dedupe `MediaFilter` work: add `skip_check/1` that returns the skip reason in one call, and a `MEDIA_EXTENSION_SET` for O(1) extension lookup. `skip_check` now also accepts an optional pre-stat'd `File::Info` so the detector walker doesn't re-stat the same file.

### Why
Profiling with a populated `node_modules` showed the detect phase was dominated by walking trees we immediately throw away — every file gets `File.directory?`-stat'd, relative-path'd, then checked against 14 `String#includes?` patterns. On a synthetic 50k-file `node_modules`, warm-cache detect drops from **178 ms → 25 ms (~7×)**.

### Behavior changes to be aware of
The new walker is stricter about what it reads than the old `Dir.glob` path:

1. **Symlinks to regular files are now skipped.** The old implementation would follow through to `File.read` and scan the target. The new walker uses `File.info?(…, follow_symlinks: false)` + `info.file?` as its cycle guard, so any symlink (to a file *or* a directory) is dropped at the walker level. In practice this affects uncommon monorepo layouts that symlink shared source files into subprojects; if a user reports missed routes we can restore the old behavior with an extra stat.
2. **Non-regular files (FIFOs, sockets, block/char devices) are now skipped.** The old path would have handed them to `File.read`, which either hung or errored. This change is strictly safer.

These are documented in-code at `src/detector/detector.cr` next to the `info.file?` check.

### Preserving issue #912
The closed regression from #912 — *"user runs noir with `-b` pointed into a directory whose absolute path contains a `node_modules` component; the project must still be scanned"* — is preserved by construction. The walker **starts** at the base and only checks entry **names** below it; the base itself is never rejected. A new fixture at `spec/functional_test/fixtures/javascript/base_in_node_modules/` nests a fake project two levels inside `node_modules/` and also places a `node_modules/` directly below it. Only the top-level `/health` route should appear — and does.

### Other correctness notes
- `File::NotFoundError` / `File::AccessDeniedError` on a subtree are swallowed — same fault tolerance as the old glob.
- "Skipped N files in ignored directories" debug log becomes "Pruned N ignored directory tree(s)" — more accurate under the new implementation (we're counting pruned trees, not skipped files).
- `MediaFilter.should_skip_file?` and `skip_reason/1` are kept for backward compatibility; they now both delegate to `skip_check/1`.

### Numbers
Synthetic benchmark: base path with a real Express project + 50k fake files across 500 fake packages in `node_modules/`.

| | warm cache |
|---|---|
| `main` | 178 ms |
| this PR | **25 ms** |

The relative speedup scales with `node_modules` size; projects with larger vendored trees (monorepos) will see a larger absolute win.

## Test plan
- [x] New fixture: `fixtures/javascript/base_in_node_modules/node_modules/myproj/` (base path deep inside `node_modules`, plus a nested `node_modules/` below the base that must be pruned).
- [x] New spec: `testers/javascript/base_in_node_modules_spec.cr` — guardrail for #912.
- [x] `crystal spec spec/functional_test/` — 4263 examples, 0 failures.
- [x] `crystal spec spec/unit_test/` — 1256 examples, 0 failures.
- [x] Manual benchmark on synthetic 50k-file `node_modules` (before: 178 ms, after: 25 ms warm cache).
- [x] `ameba` clean on touched files.