### PR TITLE
perf(analyzer/python): use file_map instead of re-walking base path

### DIFF
--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -32,9 +32,9 @@ module Analyzer::Python
       # --exclude-path apply to this pass too.
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
         python_files.each do |path|
-          next unless path.starts_with?(prefix) || path == current_base_path
+          next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -28,9 +28,13 @@ module Analyzer::Python
     BARE_DECORATORS = %w[route get post put delete patch head options]
 
     def analyze
+      # Pulls from the detector-built file_map so subtree pruning and
+      # --exclude-path apply to this pass too.
+      python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        Dir.glob("#{escape_glob_path(current_base_path)}/**/*.py") do |path|
-          next if File.directory?(path)
+        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        python_files.each do |path|
+          next unless path.starts_with?(prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -9,10 +9,14 @@ module Analyzer::Python
       fastapi_base_file : ::String = ""
 
       begin
-        # Iterate through all Python files in all base paths
+        # Iterate through all Python files in all base paths. Pulls from
+        # the detector-built file_map so subtree pruning and
+        # --exclude-path apply to this pass too.
+        python_files = get_files_by_extension(".py")
         base_paths.each do |current_base_path|
-          Dir.glob("#{escape_glob_path(current_base_path)}/**/*.py") do |path|
-            next if File.directory?(path)
+          prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+          python_files.each do |path|
+            next unless path.starts_with?(prefix) || path == current_base_path
             next if path.includes?("/site-packages/")
             source = File.read(path, encoding: "utf-8", invalid: :skip)
 

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -14,9 +14,9 @@ module Analyzer::Python
         # --exclude-path apply to this pass too.
         python_files = get_files_by_extension(".py")
         base_paths.each do |current_base_path|
-          prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+          base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
           python_files.each do |path|
-            next unless path.starts_with?(prefix) || path == current_base_path
+            next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             next if path.includes?("/site-packages/")
             source = File.read(path, encoding: "utf-8", invalid: :skip)
 

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -44,9 +44,9 @@ module Analyzer::Python
       # resolution, so keep the outer loop and filter by prefix.
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
         python_files.each do |path|
-          next unless path.starts_with?(prefix) || path == current_base_path
+          next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -38,10 +38,15 @@ module Analyzer::Python
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
       register_blueprint = Hash(::String, Hash(::String, ::String)).new
 
-      # Iterate through all Python files in all base paths
+      # Iterate through all Python files in all base paths. Pulls from
+      # the detector-built file_map so subtree pruning and --exclude-path
+      # apply; current_base_path is still needed further down for import
+      # resolution, so keep the outer loop and filter by prefix.
+      python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        Dir.glob("#{escape_glob_path(current_base_path)}/**/*.py") do |path|
-          next if File.directory?(path)
+        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        python_files.each do |path|
+          next unless path.starts_with?(prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -33,10 +33,14 @@ module Analyzer::Python
       blueprint_prefixes = Hash(::String, ::String).new
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
 
-      # Iterate through all Python files in all base paths
+      # Iterate through all Python files in all base paths. Pulls from
+      # the detector-built file_map so subtree pruning and --exclude-path
+      # apply to this pass too.
+      python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        Dir.glob("#{escape_glob_path(current_base_path)}/**/*.py") do |path|
-          next if File.directory?(path)
+        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        python_files.each do |path|
+          next unless path.starts_with?(prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -38,9 +38,9 @@ module Analyzer::Python
       # apply to this pass too.
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
         python_files.each do |path|
-          next unless path.starts_with?(prefix) || path == current_base_path
+          next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -40,9 +40,9 @@ module Analyzer::Python
       # apply to this pass too.
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
         python_files.each do |path|
-          next unless path.starts_with?(prefix) || path == current_base_path
+          next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -35,10 +35,14 @@ module Analyzer::Python
       tornado_app_instances["app"] ||= "" # Common tornado app instance name
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
 
-      # Iterate through all Python files in all base paths
+      # Iterate through all Python files in all base paths. Pulls from
+      # the detector-built file_map so subtree pruning and --exclude-path
+      # apply to this pass too.
+      python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
-        Dir.glob("#{escape_glob_path(current_base_path)}/**/*.py") do |path|
-          next if File.directory?(path)
+        prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        python_files.each do |path|
+          next unless path.starts_with?(prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 


### PR DESCRIPTION
Part 1/3 of #1254's item **#5 — analyzers that `Dir.glob` bypass `file_map` and therefore bypass `--exclude-path` / subtree pruning**. This PR migrates the Python family.

## Summary
- `flask.cr`, `tornado.cr`, `sanic.cr`, `bottle.cr`, `fastapi.cr` each replaced their `Dir.glob("base/**/*.py")` with `get_files_by_extension(".py")` from `FileHelper`, which reads the `CodeLocator` `file_map` the detector built once.
- `site-packages` post-filter and Flask's `current_base_path` usage for import resolution are preserved.

## Why
After #1253, the detector prunes `node_modules`/`.git`/… at walk time; after #1252, it honours `--exclude-path`. But these analyzers re-walked the tree themselves, so test files, vendored code, and anything matching the user's exclusion patterns still surfaced through them.

## Confirmed behavior
Manual test with a Flask fixture:
```
$ noir -b . --exclude-path 'test_*.py'
```
Previously surfaced `GET /test/fake-route` from `test_app.py`. Now filtered out — only the real `/api/users` remains.

## Not in this PR
- `django.cr` uses a different glob pattern (`**/#{relative_path}` where `relative_path` is derived from the parsed URLConf). It's a targeted module-file search, not a blanket extension scan — left alone by design.

## Split strategy
This is the first of three split PRs for #1254's item #5:
1. **This PR:** Python family (5 analyzers).
2. Next: Go + Elixir (fasthttp, elixir_phoenix).
3. Last: unified_ai + example (cleanup).

The remaining ⚠️ CONDITIONAL cases (Kotlin/Java single-directory scans) were audited and left for a potential `FileHelper#get_files_in_directory_with_extension` follow-up.

## Test plan
- [x] `crystal spec spec/functional_test/` — 4263 examples, 0 failures.
- [x] Manual `--exclude-path` verification (see above).
- [x] `ameba` clean on touched files.
- [ ] CI green.