### PR TITLE
perf(analyzer): migrate fasthttp + phoenix analyzers to file_map

### DIFF
--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -43,10 +43,10 @@ module Analyzer::Elixir
       # Find all controller files and extract parameters. Pulls from the
       # detector-built file_map so subtree pruning and --exclude-path
       # apply to this pass too.
-      base_dir_prefix = @base_path.ends_with?("/") ? @base_path : "#{@base_path}/"
+      base_dir_prefixes = base_paths.map { |bp| bp.ends_with?("/") ? bp : "#{bp}/" }
       controller_files = get_files_by_extension(".ex").select do |path|
-        (path.starts_with?(base_dir_prefix) || path == @base_path) &&
-          File.basename(path).ends_with?("_controller.ex")
+        next false unless path.ends_with?("_controller.ex")
+        base_paths.includes?(path) || base_dir_prefixes.any? { |p| path.starts_with?(p) }
       end
 
       controller_files.each do |controller_path|

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -40,8 +40,14 @@ module Analyzer::Elixir
     end
 
     def extract_controller_params
-      # Find all controller files and extract parameters
-      controller_files = Dir.glob(File.join(escape_glob_path(@base_path), "**", "*_controller.ex"))
+      # Find all controller files and extract parameters. Pulls from the
+      # detector-built file_map so subtree pruning and --exclude-path
+      # apply to this pass too.
+      base_dir_prefix = @base_path.ends_with?("/") ? @base_path : "#{@base_path}/"
+      controller_files = get_files_by_extension(".ex").select do |path|
+        (path.starts_with?(base_dir_prefix) || path == @base_path) &&
+          File.basename(path).ends_with?("_controller.ex")
+      end
 
       controller_files.each do |controller_path|
         next unless File.exists?(controller_path)

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -6,9 +6,13 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       begin
+        # Pulls from the detector-built file_map so subtree pruning and
+        # --exclude-path apply to this pass too.
+        go_files = get_files_by_extension(".go")
         base_paths.each do |current_base_path|
-          Dir.glob("#{escape_glob_path(current_base_path)}/**/*.go") do |path|
-            next if File.directory?(path)
+          base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+          go_files.each do |path|
+            next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             if File.exists?(path)
               File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
                 last_endpoint = Endpoint.new("", "")


### PR DESCRIPTION
Part 2/3 of #1254 item **#5**. Migrates the two non-Python analyzers whose `Dir.glob` was a blanket extension scan: fasthttp (`**/*.go`) and elixir_phoenix's `extract_controller_params` (`**/*_controller.ex`).

## Summary
- `go/fasthttp.cr`: `Dir.glob("**/*.go")` → `get_files_by_extension(".go")` + `base_dir_prefix` filter (same pattern as #1255's Python family).
- `elixir/elixir_phoenix.cr` `extract_controller_params`: `Dir.glob("**/*_controller.ex")` → `get_files_by_extension(".ex")` + basename filter.

## Why
Same motivation as #1255: these analyzers re-walked the base path the detector had already walked, and in the process sidestepped both the subtree pruning from #1253 and the `--exclude-path` filter from #1252.

## Notes
- Named the base-path filter variable `base_dir_prefix` from the start, to avoid the shadowing trap Gemini flagged in #1255 (Crystal treats `prefix = …` deeper in the same scope as a rebind of the enclosing variable, which can silently clobber the filter).
- Depends on: nothing — this PR is independent of #1255 and can merge in either order.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/fasthttp_spec.cr spec/functional_test/testers/elixir/` — 322 examples, 0 failures.
- [x] `crystal spec spec/functional_test/` — 4263 examples, 0 failures.
- [x] `ameba` clean on touched files.