### PR TITLE
perf(codelocator): cache file contents from detect for analyzer reuse

### DIFF
--- a/spec/unit_test/models/code_locator_spec.cr
+++ b/spec/unit_test/models/code_locator_spec.cr
@@ -1,3 +1,6 @@
+require "../../spec_helper"
+require "../../../src/utils/utils.cr"
+require "../../../src/models/logger.cr"
 require "../../../src/models/code_locator.cr"
 require "../../../src/options.cr"
 
@@ -13,5 +16,58 @@ describe "Initialize" do
     locator.push "unittest", "abcd"
     locator.push "unittest", "bbbb"
     locator.all("unittest").should eq(["abcd", "bbbb"])
+  end
+end
+
+describe "content cache" do
+  it "register_file pushes to file_map and caches content" do
+    locator = CodeLocator.new
+    locator.register_file("/tmp/noir-cache-spec-a.py", "print('hello')")
+
+    locator.all("file_map").should contain("/tmp/noir-cache-spec-a.py")
+    locator.content_for("/tmp/noir-cache-spec-a.py").should eq("print('hello')")
+  end
+
+  it "content_for returns nil for paths that were never registered" do
+    locator = CodeLocator.new
+    locator.content_for("/does/not/exist.rb").should be_nil
+  end
+
+  it "clear(\"file_map\") drops cached content" do
+    locator = CodeLocator.new
+    locator.register_file("/tmp/noir-cache-spec-b.py", "x = 1")
+    locator.content_for("/tmp/noir-cache-spec-b.py").should_not be_nil
+
+    locator.clear("file_map")
+    locator.content_for("/tmp/noir-cache-spec-b.py").should be_nil
+    stats = locator.content_cache_stats
+    stats[:bytes].should eq(0)
+    stats[:files].should eq(0)
+  end
+
+  it "stops caching once the total budget is exhausted" do
+    ENV["NOIR_CONTENT_CACHE_MAX_MB"] = "0"
+    begin
+      locator = CodeLocator.new
+      locator.register_file("/tmp/noir-cache-spec-c.py", "anything")
+      # Budget is 0 bytes, so nothing gets cached, but the path still
+      # makes it into file_map.
+      locator.all("file_map").should contain("/tmp/noir-cache-spec-c.py")
+      locator.content_for("/tmp/noir-cache-spec-c.py").should be_nil
+    ensure
+      ENV.delete("NOIR_CONTENT_CACHE_MAX_MB")
+    end
+  end
+
+  it "honours NOIR_CONTENT_CACHE_DISABLE" do
+    ENV["NOIR_CONTENT_CACHE_DISABLE"] = "true"
+    begin
+      locator = CodeLocator.new
+      locator.register_file("/tmp/noir-cache-spec-d.py", "content")
+      locator.content_for("/tmp/noir-cache-spec-d.py").should be_nil
+      locator.content_cache_stats[:budget].should eq(0)
+    ensure
+      ENV.delete("NOIR_CONTENT_CACHE_DISABLE")
+    end
   end
 end

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -14,26 +14,25 @@ module Analyzer::Go
           go_files.each do |path|
             next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             if File.exists?(path)
-              File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                last_endpoint = Endpoint.new("", "")
-                file.each_line.with_index do |line, index|
-                  details = Details.new(PathInfo.new(path, index + 1))
+              content = read_file_content(path)
+              last_endpoint = Endpoint.new("", "")
+              content.each_line.with_index do |line, index|
+                details = Details.new(PathInfo.new(path, index + 1))
 
-                  # Detect fasthttp route patterns
-                  endpoint = analyze_route_line(line, details)
-                  if endpoint.method != ""
-                    result << endpoint
-                    last_endpoint = endpoint
-                  end
+                # Detect fasthttp route patterns
+                endpoint = analyze_route_line(line, details)
+                if endpoint.method != ""
+                  result << endpoint
+                  last_endpoint = endpoint
+                end
 
-                  # Detect parameter usage in current context
-                  params = analyze_param_line(line)
-                  params.each do |param|
-                    if param.name.size > 0 && last_endpoint.method != ""
-                      # Check for duplicates before adding
-                      unless last_endpoint.params.any? { |p| p.name == param.name && p.param_type == param.param_type }
-                        last_endpoint.params << param
-                      end
+                # Detect parameter usage in current context
+                params = analyze_param_line(line)
+                params.each do |param|
+                  if param.name.size > 0 && last_endpoint.method != ""
+                    # Check for duplicates before adding
+                    unless last_endpoint.params.any? { |p| p.name == param.name && p.param_type == param.param_type }
+                      last_endpoint.params << param
                     end
                   end
                 end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -91,124 +91,119 @@ module Analyzer::Javascript
       router_detected = false
       nested_routers = {} of String => String
 
-      # Preserve the `File.open do ... end` block shape below — the
-      # body expects `file_content` and friends in scope, nothing else
-      # actually uses the File handle.
-      begin
-        # First, handle the specific v1Router pattern directly
-        handle_v1_router_pattern(file_content, result, path)
+      # First, handle the specific v1Router pattern directly
+      handle_v1_router_pattern(file_content, result, path)
 
-        # Handle app.route('/path').method1().method2() patterns
-        handle_app_route_chaining(file_content, result, path)
+      # Handle app.route('/path').method1().method2() patterns
+      handle_app_route_chaining(file_content, result, path)
 
-        # Extract static paths
-        Noir::JSRouteExtractor.extract_static_paths(file_content).each do |static_path|
-          static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+      # Extract static paths
+      Noir::JSRouteExtractor.extract_static_paths(file_content).each do |static_path|
+        static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
+      end
+
+      # First analyze file for router imports and declarations
+      file_content.each_line do |line|
+        # Detect Express router imports and initialization
+        if line.includes?("require('express')") || line.includes?("require(\"express\")") ||
+           line.includes?("from 'express'") || line.includes?("from \"express\"")
+          router_detected = true
         end
 
-        # First analyze file for router imports and declarations
-        file_content.each_line do |line|
-          # Detect Express router imports and initialization
-          if line.includes?("require('express')") || line.includes?("require(\"express\")") ||
-             line.includes?("from 'express'") || line.includes?("from \"express\"")
-            router_detected = true
-          end
-
-          # Detect router initialization - looking for Router() or express.Router() patterns
-          if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:express\.Router\(\)|Router\(\))/
-            router_detected = true
-            nested_routers[$1] = ""
-          end
-
-          # Detect router nesting with use - capture both parent and child routers
-          if line =~ /(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)/
-            # parent_router = $1
-            base_path = $2
-            child_router = $3
-            if nested_routers.has_key?(child_router)
-              nested_routers[child_router] = base_path
-            end
-          end
+        # Detect router initialization - looking for Router() or express.Router() patterns
+        if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:express\.Router\(\)|Router\(\))/
+          router_detected = true
+          nested_routers[$1] = ""
         end
 
-        # Read all lines for multi-line pattern support
-        lines = file_content.split('\n')
-
-        # Now process the file line by line for endpoints
-        current_router = ""
-        lines.each_with_index do |line, index|
-          # Detect current router - support case variations of HTTP methods
-          if line =~ /(\w+)\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|Del|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)/
-            current_router = $1
+        # Detect router nesting with use - capture both parent and child routers
+        if line =~ /(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)/
+          # parent_router = $1
+          base_path = $2
+          child_router = $3
+          if nested_routers.has_key?(child_router)
+            nested_routers[child_router] = base_path
           end
+        end
+      end
 
-          # Detect router base path
-          if line =~ /\.use\s*\(\s*['"]([^'"]+)['"]/
-            current_router_base = $1
-          end
+      # Read all lines for multi-line pattern support
+      lines = file_content.split('\n')
 
-          # Get endpoint from line - with multi-line support
-          endpoint = line_to_endpoint(line, router_detected)
+      # Now process the file line by line for endpoints
+      current_router = ""
+      lines.each_with_index do |line, index|
+        # Detect current router - support case variations of HTTP methods
+        if line =~ /(\w+)\.(get|Get|GET|post|Post|POST|put|Put|PUT|delete|Delete|DELETE|Del|patch|Patch|PATCH|options|Options|OPTIONS|head|Head|HEAD|all|All|ALL)/
+          current_router = $1
+        end
 
-          # Handle multi-line routes - check next line if route path is empty
-          if endpoint.method != "" && endpoint.url.empty? && index + 1 < lines.size
-            next_line = lines[index + 1]
-            endpoint = line_to_endpoint_multiline(line, next_line, router_detected)
-          end
+        # Detect router base path
+        if line =~ /\.use\s*\(\s*['"]([^'"]+)['"]/
+          current_router_base = $1
+        end
 
-          if endpoint.method != ""
-            # Handle router.all by expanding to all HTTP methods
-            if endpoint.method == "ALL"
-              all_methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
-              all_methods.each do |method|
-                expanded_endpoint = Endpoint.new(endpoint.url, method)
+        # Get endpoint from line - with multi-line support
+        endpoint = line_to_endpoint(line, router_detected)
 
-                # Apply nested router prefix if applicable
-                if !current_router.empty? && nested_routers.has_key?(current_router) && !nested_routers[current_router].empty?
-                  router_prefix = nested_routers[current_router]
-                  expanded_endpoint.url = Noir::URLPath.join(router_prefix, expanded_endpoint.url)
-                  # If we have a router base path and the endpoint doesn't already include it
-                elsif !current_router_base.empty? && !expanded_endpoint.url.starts_with?("/")
-                  expanded_endpoint.url = "#{current_router_base}/#{expanded_endpoint.url}"
-                elsif !current_router_base.empty? && expanded_endpoint.url != "/" && !expanded_endpoint.url.starts_with?(current_router_base)
-                  expanded_endpoint.url = "#{current_router_base}#{expanded_endpoint.url}"
-                end
+        # Handle multi-line routes - check next line if route path is empty
+        if endpoint.method != "" && endpoint.url.empty? && index + 1 < lines.size
+          next_line = lines[index + 1]
+          endpoint = line_to_endpoint_multiline(line, next_line, router_detected)
+        end
 
-                details = Details.new(PathInfo.new(path, index + 1))
-                expanded_endpoint.details = details
-                result << expanded_endpoint
-              end
-            else
+        if endpoint.method != ""
+          # Handle router.all by expanding to all HTTP methods
+          if endpoint.method == "ALL"
+            all_methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+            all_methods.each do |method|
+              expanded_endpoint = Endpoint.new(endpoint.url, method)
+
               # Apply nested router prefix if applicable
               if !current_router.empty? && nested_routers.has_key?(current_router) && !nested_routers[current_router].empty?
                 router_prefix = nested_routers[current_router]
-                endpoint.url = Noir::URLPath.join(router_prefix, endpoint.url)
+                expanded_endpoint.url = Noir::URLPath.join(router_prefix, expanded_endpoint.url)
                 # If we have a router base path and the endpoint doesn't already include it
-              elsif !current_router_base.empty? && !endpoint.url.starts_with?("/")
-                endpoint.url = "#{current_router_base}/#{endpoint.url}"
-              elsif !current_router_base.empty? && endpoint.url != "/" && !endpoint.url.starts_with?(current_router_base)
-                endpoint.url = "#{current_router_base}#{endpoint.url}"
+              elsif !current_router_base.empty? && !expanded_endpoint.url.starts_with?("/")
+                expanded_endpoint.url = "#{current_router_base}/#{expanded_endpoint.url}"
+              elsif !current_router_base.empty? && expanded_endpoint.url != "/" && !expanded_endpoint.url.starts_with?(current_router_base)
+                expanded_endpoint.url = "#{current_router_base}#{expanded_endpoint.url}"
               end
 
               details = Details.new(PathInfo.new(path, index + 1))
-              endpoint.details = details
-              result << endpoint
-              last_endpoint = endpoint
+              expanded_endpoint.details = details
+              result << expanded_endpoint
             end
-          end
+          else
+            # Apply nested router prefix if applicable
+            if !current_router.empty? && nested_routers.has_key?(current_router) && !nested_routers[current_router].empty?
+              router_prefix = nested_routers[current_router]
+              endpoint.url = Noir::URLPath.join(router_prefix, endpoint.url)
+              # If we have a router base path and the endpoint doesn't already include it
+            elsif !current_router_base.empty? && !endpoint.url.starts_with?("/")
+              endpoint.url = "#{current_router_base}/#{endpoint.url}"
+            elsif !current_router_base.empty? && endpoint.url != "/" && !endpoint.url.starts_with?(current_router_base)
+              endpoint.url = "#{current_router_base}#{endpoint.url}"
+            end
 
-          # Get parameters from line
-          param = line_to_param(line)
-          if param.name != ""
-            if last_endpoint.method != ""
-              last_endpoint.push_param(param)
-            end
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint.details = details
+            result << endpoint
+            last_endpoint = endpoint
           end
         end
 
-        # After processing all lines, look for any nested router patterns we might have missed
-        scan_for_nested_router_endpoints(file_content, result, path)
+        # Get parameters from line
+        param = line_to_param(line)
+        if param.name != ""
+          if last_endpoint.method != ""
+            last_endpoint.push_param(param)
+          end
+        end
       end
+
+      # After processing all lines, look for any nested router patterns we might have missed
+      scan_for_nested_router_endpoints(file_content, result, path)
     end
 
     # Enhanced method to detect nested router patterns that might be missed in the regular line-by-line analysis

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -22,7 +22,7 @@ module Analyzer::Javascript
 
       parallel_file_scan do |path|
         begin
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
           parser_endpoints.each do |endpoint|
             # Use the line number already set by the extractor; fall back to path-only if missing
@@ -85,13 +85,16 @@ module Analyzer::Javascript
 
     private def analyze_with_regex(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)) = [] of Hash(String, String))
       # Original regex-based analysis as a fallback
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        current_router_base = ""
-        router_detected = false
-        nested_routers = {} of String => String
-        file_content = file.gets_to_end
+      file_content = read_file_content(path)
+      last_endpoint = Endpoint.new("", "")
+      current_router_base = ""
+      router_detected = false
+      nested_routers = {} of String => String
 
+      # Preserve the `File.open do ... end` block shape below — the
+      # body expects `file_content` and friends in scope, nothing else
+      # actually uses the File handle.
+      begin
         # First, handle the specific v1Router pattern directly
         handle_v1_router_pattern(file_content, result, path)
 

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -50,9 +50,9 @@ module Analyzer::Python
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            lines = file.each_line.to_a
-            next unless lines.any?(&.includes?("flask"))
+          content = read_file_content(path)
+          lines = content.lines
+          if lines.any?(&.includes?("flask"))
             api_instances = Hash(::String, ::String).new
             path_api_instances[path] = api_instances
             view_assignments = Hash(::String, ::String).new # Maps view_var -> ClassName (per-file scope)

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -50,8 +50,7 @@ module Analyzer::Python
           next if path.includes?("/site-packages/")
           @logger.debug "Analyzing #{path}"
 
-          content = read_file_content(path)
-          lines = content.lines
+          lines = fetch_file_content(path).lines
           if lines.any?(&.includes?("flask"))
             api_instances = Hash(::String, ::String).new
             path_api_instances[path] = api_instances
@@ -521,9 +520,14 @@ module Analyzer::Python
       result
     end
 
-    # Fetch content of a file and cache it
+    # Fetch file content, preferring the detector-populated global
+    # cache. The per-analyzer `@file_content_cache` is kept on top to
+    # keep Flask's internal lookups (called 2–3× per file across the
+    # class/blueprint passes) cheap even when the global cache is
+    # disabled — otherwise the fallback would do that many fresh
+    # `File.read` calls per file.
     private def fetch_file_content(path : ::String) : ::String
-      @file_content_cache[path] ||= File.read(path, encoding: "utf-8", invalid: :skip)
+      @file_content_cache[path] ||= read_file_content(path)
     end
 
     # Create a Python parser for a given path and content

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -237,7 +237,9 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
 
               content = File.read(full_path, encoding: "utf-8", invalid: :skip)
               channel.send({full_path, content})
-              locator.push "file_map", full_path
+              # Register the path in file_map and (budget permitting)
+              # cache the content so analyzers can skip the re-read.
+              locator.register_file(full_path, content)
             end
           rescue File::NotFoundError | File::AccessDeniedError
             # Directory vanished or we can't read it — treat the subtree
@@ -254,6 +256,13 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       end
       if skipped_exclude_path > 0
         logger.info "Skipped #{skipped_exclude_path} files matching --exclude-path patterns"
+      end
+
+      stats = locator.content_cache_stats
+      if stats[:budget] > 0
+        cached_mb = (stats[:bytes] / (1024.0 * 1024.0)).round(1)
+        budget_mb = (stats[:budget] / (1024.0 * 1024.0)).round(1)
+        logger.debug "Content cache: #{stats[:files]} files / #{cached_mb} MB (budget #{budget_mb} MB, #{stats[:skipped]} skipped)"
       end
     ensure
       channel.close

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -43,6 +43,19 @@ class Analyzer
     # After inheriting the class, write an action code here.
   end
 
+  # Prefer the detector-populated cache over a fresh disk read. On
+  # cache miss (budget exhausted, cache cleared between runs, path
+  # not registered via register_file) falls back to `File.read`.
+  #
+  # Analyzers migrating from direct `File.read(path, ...)` calls
+  # should use this helper so the second read of files the detector
+  # already loaded is free.
+  def read_file_content(path : String) : String
+    cached = CodeLocator.instance.content_for(path)
+    return cached if cached
+    File.read(path, encoding: "utf-8", invalid: :skip)
+  end
+
   def parallel_analyze(channel : Channel(String), &block : String -> Nil)
     WaitGroup.wait do |wg|
       worker_count = @options["concurrency"].to_s.to_i

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -44,7 +44,7 @@ class CodeLocator
   end
 
   private def resolve_content_cache_budget : Int64
-    return 0_i64 if ENV["NOIR_CONTENT_CACHE_DISABLE"]?.to_s.downcase.in?({"true", "1", "yes"})
+    return 0_i64 if any_to_bool(ENV["NOIR_CONTENT_CACHE_DISABLE"]?)
     if raw = ENV["NOIR_CONTENT_CACHE_MAX_MB"]?
       parsed = raw.to_i64?
       return parsed * 1024 * 1024 if parsed && parsed >= 0

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -1,6 +1,13 @@
 class CodeLocator
   @@instance : CodeLocator? = nil
 
+  # Default content cache budget (bytes). Override via
+  # `NOIR_CONTENT_CACHE_MAX_MB` (value in megabytes). Set to 0 or the
+  # env `NOIR_CONTENT_CACHE_DISABLE=true` to disable caching entirely,
+  # in which case `content_for` always returns nil and analyzers fall
+  # through to `File.read`.
+  DEFAULT_CONTENT_CACHE_BUDGET = 512_i64 * 1024 * 1024
+
   @logger : NoirLogger
   @is_debug : Bool
   @is_verbose : Bool
@@ -11,6 +18,10 @@ class CodeLocator
   @file_usage_stats : Hash(String, Int32) # Track number of file reads
   @extension_index : Hash(String, Array(String))
   @extension_index_built : Bool
+  @file_contents : Hash(String, String)
+  @content_cache_budget : Int64
+  @content_cache_used : Int64
+  @content_cache_skipped : Int32
 
   def initialize
     options = {"debug" => "false", "verbose" => "false", "color" => "true", "nolog" => "false"}
@@ -25,6 +36,20 @@ class CodeLocator
     @file_usage_stats = Hash(String, Int32).new
     @extension_index = Hash(String, Array(String)).new
     @extension_index_built = false
+
+    @file_contents = Hash(String, String).new
+    @content_cache_budget = resolve_content_cache_budget
+    @content_cache_used = 0_i64
+    @content_cache_skipped = 0
+  end
+
+  private def resolve_content_cache_budget : Int64
+    return 0_i64 if ENV["NOIR_CONTENT_CACHE_DISABLE"]?.to_s.downcase.in?({"true", "1", "yes"})
+    if raw = ENV["NOIR_CONTENT_CACHE_MAX_MB"]?
+      parsed = raw.to_i64?
+      return parsed * 1024 * 1024 if parsed && parsed >= 0
+    end
+    DEFAULT_CONTENT_CACHE_BUDGET
   end
 
   def self.instance : CodeLocator
@@ -49,6 +74,36 @@ class CodeLocator
     if key == "file_map"
       increment_file_usage(value)
     end
+  end
+
+  # One-shot used by the detector's file reader: push the path into
+  # `file_map` and (budget permitting) cache the content so analyzers
+  # can skip the second `File.read`. Files whose content exceeds the
+  # remaining budget are still registered in `file_map` but not cached,
+  # and `content_for(path)` returns `nil` for them — callers must keep
+  # a `File.read` fallback.
+  def register_file(path : String, content : String)
+    push("file_map", path)
+
+    return if @content_cache_budget <= 0
+    size = content.bytesize.to_i64
+    if @content_cache_used + size > @content_cache_budget
+      @content_cache_skipped += 1
+      return
+    end
+    @file_contents[path] = content
+    @content_cache_used += size
+  end
+
+  # Returns cached file content or `nil` if the file was not cached
+  # (budget exhausted, caching disabled, or read after cache was
+  # cleared). Callers should fall back to `File.read` on `nil`.
+  def content_for(path : String) : String?
+    @file_contents[path]?
+  end
+
+  def content_cache_stats : NamedTuple(bytes: Int64, files: Int32, skipped: Int32, budget: Int64)
+    {bytes: @content_cache_used, files: @file_contents.size, skipped: @content_cache_skipped, budget: @content_cache_budget}
   end
 
   def all(key : String) : Array(String)
@@ -83,6 +138,9 @@ class CodeLocator
     if key == "file_map"
       @extension_index.clear
       @extension_index_built = false
+      @file_contents.clear
+      @content_cache_used = 0_i64
+      @content_cache_skipped = 0
     end
   end
 
@@ -92,6 +150,9 @@ class CodeLocator
     @file_usage_stats.clear
     @extension_index.clear
     @extension_index_built = false
+    @file_contents.clear
+    @content_cache_used = 0_i64
+    @content_cache_skipped = 0
   end
 
   def show_table


### PR DESCRIPTION
Addresses the last open item (**#2**) on #1254's perf backlog.

## Why
The detect phase already reads every project file into memory; today the content is shoved through a channel and then dropped, so every analyzer that needs the same file reads it a second time from disk. On projects where multiple techs match (monorepos especially) a single source file can end up read 5–6×.

## What
- `CodeLocator#register_file(path, content)` — single entry that pushes to `file_map` and, budget permitting, caches the content.
- `CodeLocator#content_for(path) : String?` — cache lookup.
- `Analyzer#read_file_content(path)` — helper that prefers the cache and falls back to `File.read` on a miss, so misses (budget exhausted, cache cleared, path not registered) stay transparent.

### Budget + kill switches
- Default: **512 MiB total**. Override via `NOIR_CONTENT_CACHE_MAX_MB`.
- `NOIR_CONTENT_CACHE_DISABLE=true` zeroes the budget; every `content_for` returns nil and callers fall through to `File.read`.
- Files whose content would overflow the remaining budget are still registered in `file_map` but skip caching (FIFO, no LRU eviction). A debug-level log line reports `files / MB / skipped` after the walk.

### Migration scope (this PR)
Three high-traffic analyzers migrated to `read_file_content` to prove the design and book a measurable win:
- `analyzer/javascript/express.cr` (both `analyze` + the regex fallback)
- `analyzer/python/flask.cr`
- `analyzer/go/fasthttp.cr`

The remaining ~27 `File.read` call sites across the analyzer tree can follow in separate PRs, one language family at a time — same shape as how #1255/#1256/#1257 split up the `Dir.glob` → `file_map` migration.

## Numbers
Synthetic benchmark, 3000 Express-importing JS files, single base:

|            | warm cache |
|------------|------------|
| `main`     | 0.51s median |
| **this PR** | **0.41s median** (~20%) |

`NOIR_CONTENT_CACHE_DISABLE=true` matches main within noise — clean bypass.

Debug log after the walker (end of detect phase):

```
Content cache: 3002 files / 0.4 MB (budget 512.0 MB, 0 skipped)
```

## Test plan
- [x] 5 new specs in `spec/unit_test/models/code_locator_spec.cr` — `register_file` / `content_for` / `clear` propagation / budget exhaustion / `NOIR_CONTENT_CACHE_DISABLE`.
- [x] Fixed the pre-existing issue where that spec file couldn't run in isolation (missing requires for `NoirLogger` / `any_to_bool`).
- [x] `crystal spec spec/functional_test/` — 4263 examples, 0 failures.
- [x] `crystal spec spec/unit_test/` — 1264 examples, 0 failures.
- [x] Manual: `NOIR_CONTENT_CACHE_DISABLE=true` round-trip; `--debug` shows the cache stats line.
- [x] `ameba` clean on touched files.