### PR TITLE
Refactor: merge duplicate form/formData branches in OAS2 analyzer

### DIFF
--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -32,18 +32,13 @@ module Analyzer::Specification
                   if method_obj.as_h.has_key?("parameters")
                     method_obj["parameters"].as_a.each do |param_obj|
                       param_name = param_obj["name"].to_s
-                      if param_obj["in"] == "query"
-                        param = Param.new(param_name, "", "query")
-                        params << param
-                      elsif param_obj["in"] == "form"
-                        param = Param.new(param_name, "", "form")
-                        params << param
-                      elsif param_obj["in"] == "formData"
-                        param = Param.new(param_name, "", "form")
-                        params << param
-                      elsif param_obj["in"] == "header"
-                        param = Param.new(param_name, "", "header")
-                        params << param
+                      case param_obj["in"].to_s
+                      when "query"
+                        params << Param.new(param_name, "", "query")
+                      when "form", "formData"
+                        params << Param.new(param_name, "", "form")
+                      when "header"
+                        params << Param.new(param_name, "", "header")
                       end
                     end
                     @result << Endpoint.new(base_path + path, method.upcase, params, details)
@@ -91,18 +86,13 @@ module Analyzer::Specification
                   if method_obj.as_h.has_key?("parameters")
                     method_obj["parameters"].as_a.each do |param_obj|
                       param_name = param_obj["name"].to_s
-                      if param_obj["in"] == "query"
-                        param = Param.new(param_name, "", "query")
-                        params << param
-                      elsif param_obj["in"] == "form"
-                        param = Param.new(param_name, "", "form")
-                        params << param
-                      elsif param_obj["in"] == "formData"
-                        param = Param.new(param_name, "", "form")
-                        params << param
-                      elsif param_obj["in"] == "header"
-                        param = Param.new(param_name, "", "header")
-                        params << param
+                      case param_obj["in"].to_s
+                      when "query"
+                        params << Param.new(param_name, "", "query")
+                      when "form", "formData"
+                        params << Param.new(param_name, "", "form")
+                      when "header"
+                        params << Param.new(param_name, "", "header")
                       end
                     end
                     @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)


### PR DESCRIPTION
## Summary
- Replace `if/elsif` chains with `case/when` blocks in both JSON and YAML parsers
- Merge the identical `"form"` and `"formData"` branches into a single `when "form", "formData"` condition
- Remove intermediate `param` variable assignments — push `Param.new(...)` directly
- Net change: 24 lines removed, 14 lines added

## Acceptance criteria
- [x] `form` and `formData` branches merged in the JSON parser
- [x] `form` and `formData` branches merged in the YAML parser
- [x] Existing OAS2 functional tests still pass (30/30)
- [x] `crystal tool format` and `ameba` clean

## Test plan
- [x] `crystal spec spec/functional_test/testers/specification/oas2_spec.cr` — 30/30 pass
- [x] `crystal tool format --check` — no formatting issues
- [x] `ameba` — 0 failures

Closes #1228