### PR TITLE
feat(config): log errors from bare rescue blocks in config_initializer

### DIFF
--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -74,7 +74,7 @@ class ConfigInitializer
 
       final_options = default_options.merge(symbolized_hash) { |_, _, new_val| new_val }
       final_options
-    rescue e : Exception
+    rescue e
       # Falling back silently made malformed-YAML bugs hard to track down.
       # Log the cause at debug level and keep the existing default-options
       # fallback so behavior is unchanged.

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -1,4 +1,5 @@
 require "file"
+require "log"
 require "yaml"
 require "./utils/home.cr"
 require "./llm/native_tool_calling"
@@ -26,7 +27,11 @@ class ConfigInitializer
 
     # Create the config file if it doesn't exist
     File.write(@config_file, generate_config_file) unless File.exists?(@config_file)
-  rescue
+  rescue e
+    # Silent failures here made permission/disk-full problems during startup
+    # hard to diagnose. Log at debug level so --debug surfaces the cause
+    # without noising up normal runs.
+    Log.debug { "ConfigInitializer.setup failed: #{e.message} (#{e.class})" }
   end
 
   def read_config
@@ -69,7 +74,11 @@ class ConfigInitializer
 
       final_options = default_options.merge(symbolized_hash) { |_, _, new_val| new_val }
       final_options
-    rescue Exception
+    rescue e : Exception
+      # Falling back silently made malformed-YAML bugs hard to track down.
+      # Log the cause at debug level and keep the existing default-options
+      # fallback so behavior is unchanged.
+      Log.debug { "ConfigInitializer.read_config failed, using defaults: #{e.message} (#{e.class})" }
       default_options
     end
   end


### PR DESCRIPTION
## Summary

Fixes #1123. Adds `Log.debug` output to the two bare `rescue` blocks in `src/config_initializer.cr` so debug logs now surface the actual cause of config-file permission / disk-full / malformed-YAML problems that used to fail silently.

## Why this matters

The `setup` method used a bare `rescue` to swallow any failure during directory creation / config-file writing, and `read_config` used `rescue Exception` to fall back to defaults without explaining why the real config was skipped. Both are legit recovery paths, but the silence makes it hard to see what happened — exactly the debugging complaint in the issue (bad permissions, malformed YAML look like "Noir ignored my config" with no trace).

## Changes

- `rescue` in `setup` → `rescue e` + `Log.debug { "ConfigInitializer.setup failed: #{e.message} (#{e.class})" }`
- `rescue Exception` in `read_config` → `rescue e : Exception` + `Log.debug { "ConfigInitializer.read_config failed, using defaults: #{e.message} (#{e.class})" }`
- `require "log"` added alongside the existing `require "file" / "yaml"`.

## Behavior

- **Normal runs:** unchanged. `Log.debug` is suppressed at the default log level, so users who don't pass `--debug` see the same output as before.
- **`--debug`:** the cause of the fallback is now visible. The `default_options` fallback path is preserved, so the existing error-tolerance behavior is intact.

## Conventions

Follows the existing `Log.debug { "..." }` pattern already in use in `src/llm/cache.cr` (6 sites) and `src/models/passive_scan.cr`. No new dependencies — Crystal's stdlib `Log` module is the project's established logging path. Keeps the include-class-name tail (`#{e.class}`) so debug output is unambiguous when `e.message` is generic.

## Diff

- `src/config_initializer.cr`: +11 / -2

Fixes #1123

---

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
