### PR TITLE
feat: add Crow C++ web framework detector and analyzer

### DIFF
--- a/spec/functional_test/fixtures/cpp/crow/app.cpp
+++ b/spec/functional_test/fixtures/cpp/crow/app.cpp
@@ -1,0 +1,30 @@
+#include "crow.h"
+
+int main() {
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/")([]() {
+        return "Hello World";
+    });
+
+    CROW_ROUTE(app, "/update").methods("POST"_method)
+    ([](const crow::request& req) {
+        auto name = req.url_params.get("name");
+        auto token = req.get_header_value("X-Token");
+        return crow::response(200, req.body);
+    });
+
+    CROW_ROUTE(app, "/user/<int>/<string>")
+    ([](int id, std::string name) {
+        return crow::response(200);
+    });
+
+    CROW_ROUTE(app, "/search")
+    ([](const crow::request& req) {
+        auto q = req.url_params.get("q");
+        return crow::response(200);
+    });
+
+    app.port(18080).multithreaded().run();
+    return 0;
+}

--- a/spec/functional_test/testers/cpp/crow_spec.cr
+++ b/spec/functional_test/testers/cpp/crow_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/update", "POST", [
+    Param.new("name", "", "query"),
+    Param.new("X-Token", "", "header"),
+    Param.new("body", "", "json"),
+  ]),
+  Endpoint.new("/user/{param1}/{param2}", "GET", [
+    Param.new("param1", "", "path"),
+    Param.new("param2", "", "path"),
+  ]),
+  Endpoint.new("/search", "GET", [
+    Param.new("q", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/crow/", {
+  :techs     => 1,
+  :endpoints => 4,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/cpp/crow_detector_spec.cr
+++ b/spec/unit_test/detector/cpp/crow_detector_spec.cr
@@ -1,0 +1,35 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/cpp/*"
+
+describe "Detect C++ Crow" do
+  options = create_test_options
+  instance = Detector::Cpp::Crow.new options
+
+  it "include crow.h quoted" do
+    instance.detect("app.cpp", %(#include "crow.h")).should be_true
+  end
+
+  it "include <crow.h>" do
+    instance.detect("app.cpp", "#include <crow.h>").should be_true
+  end
+
+  it "include <crow/app.h>" do
+    instance.detect("server.cc", "#include <crow/app.h>").should be_true
+  end
+
+  it "CROW_ROUTE macro" do
+    instance.detect("main.cxx", "CROW_ROUTE(app, \"/\")([](){ return \"ok\"; });").should be_true
+  end
+
+  it "crow::SimpleApp reference" do
+    instance.detect("main.hpp", "crow::SimpleApp app;").should be_true
+  end
+
+  it "unrelated cpp file" do
+    instance.detect("main.cpp", "#include <iostream>\nint main(){return 0;}").should be_false
+  end
+
+  it "non-cpp extension" do
+    instance.detect("app.py", %(#include "crow.h")).should be_false
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -16,6 +16,7 @@ def initialize_analyzers(logger : NoirLogger)
 
   # Mapping analyzers to their respective functions
   define_analyzers([
+    {"cpp_crow", Cpp::Crow},
     {"cs_aspnet_mvc", CSharp::AspNetMvc},
     {"cs_aspnet_core_mvc", CSharp::AspNetCoreMvc},
     {"crystal_amber", Crystal::Amber},

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -13,9 +13,9 @@ module Analyzer::Cpp
     # Path placeholder: <int>, <string>, <uint>, <double>, <path> — and the
     # non-standard but occasionally seen <type:name> form.
     PATH_PARAM_REGEX = /<([^<>:]+)(?::([^<>]+))?>/
-    URL_PARAM_GET    = /url_params\s*\.\s*get\s*\(\s*"([^"]+)"/
+    URL_PARAM_GET    = /url_params\s*\.\s*get(?:\s*<[^>]+>)?\s*\(\s*"([^"]+)"/
     HEADER_VALUE     = /get_header_value\s*\(\s*"([^"]+)"/
-    BODY_ACCESS      = /\breq\s*\.\s*body\b/
+    BODY_ACCESS      = /\b(req|request)\s*\.\s*body\b/
 
     def analyze
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
@@ -43,6 +43,7 @@ module Analyzer::Cpp
       last_endpoints = [] of Endpoint
 
       lines.each_with_index do |line, index|
+        next if line.lstrip.starts_with?("//")
         route_match = line.match(ROUTE_REGEX) || line.match(BP_ROUTE_REGEX)
         if route_match
           route_path = route_match[1]

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -1,0 +1,122 @@
+require "../../../models/analyzer"
+
+module Analyzer::Cpp
+  class Crow < Analyzer
+    CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
+    # CROW_ROUTE(app, "/path") — the app identifier and route literal.
+    ROUTE_REGEX = /CROW_ROUTE\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]*)"\s*\)/
+    # CROW_BP_ROUTE(bp, "/path") — blueprint-scoped route registration.
+    BP_ROUTE_REGEX = /CROW_BP_ROUTE\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]*)"\s*\)/
+    # .methods("POST"_method, "GET"_method) clause.
+    METHODS_REGEX = /\.methods\s*\(([^)]*)\)/
+    METHOD_TOKEN  = /"([A-Za-z]+)"_method/
+    # Path placeholder: <int>, <string>, <uint>, <double>, <path> — and the
+    # non-standard but occasionally seen <type:name> form.
+    PATH_PARAM_REGEX = /<([^<>:]+)(?::([^<>]+))?>/
+    URL_PARAM_GET    = /url_params\s*\.\s*get\s*\(\s*"([^"]+)"/
+    HEADER_VALUE     = /get_header_value\s*\(\s*"([^"]+)"/
+    BODY_ACCESS      = /\breq\s*\.\s*body\b/
+
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_filtered_files(channel, CPP_EXTENSIONS)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+          analyze_file(path)
+        end
+      rescue e
+        logger.debug "Crow analyzer failed: #{e.message}"
+      end
+
+      result
+    end
+
+    private def analyze_file(path : String)
+      source = read_file_content(path)
+      return unless source.includes?("CROW_ROUTE") || source.includes?("CROW_BP_ROUTE")
+
+      lines = source.split("\n")
+      last_endpoints = [] of Endpoint
+
+      lines.each_with_index do |line, index|
+        route_match = line.match(ROUTE_REGEX) || line.match(BP_ROUTE_REGEX)
+        if route_match
+          route_path = route_match[1]
+
+          # `.methods(...)` may sit on the same line as CROW_ROUTE or on one
+          # of the following continuation lines before the handler lambda.
+          search_window = line
+          (1..3).each do |offset|
+            break if index + offset >= lines.size
+            next_line = lines[index + offset]
+            break if next_line.match(ROUTE_REGEX) || next_line.match(BP_ROUTE_REGEX)
+            search_window += " " + next_line
+          end
+
+          methods = [] of String
+          if methods_match = search_window.match(METHODS_REGEX)
+            methods_match[1].scan(METHOD_TOKEN) do |m|
+              methods << m[1].upcase
+            end
+          end
+          methods << "GET" if methods.empty?
+
+          normalized_path, path_params = normalize_path(route_path)
+          details = Details.new(PathInfo.new(path, index + 1))
+
+          last_endpoints.clear
+          methods.uniq.each do |method|
+            endpoint = Endpoint.new(normalized_path, method, path_params.dup, details)
+            result << endpoint
+            last_endpoints << endpoint
+          end
+        else
+          next if last_endpoints.empty?
+          collect_params(line).each do |param|
+            last_endpoints.each { |ep| push_unique(ep, param) }
+          end
+        end
+      end
+    end
+
+    private def normalize_path(route_path : String) : Tuple(String, Array(Param))
+      params = [] of Param
+      counter = 0
+      normalized = route_path.gsub(PATH_PARAM_REGEX) do |_|
+        maybe_name = $~[2]?
+        name = if maybe_name && !maybe_name.empty?
+                 maybe_name
+               else
+                 counter += 1
+                 "param#{counter}"
+               end
+        params << Param.new(name, "", "path")
+        "{#{name}}"
+      end
+      {normalized, params}
+    end
+
+    private def collect_params(line : String) : Array(Param)
+      params = [] of Param
+      line.scan(URL_PARAM_GET) do |m|
+        params << Param.new(m[1], "", "query")
+      end
+      line.scan(HEADER_VALUE) do |m|
+        params << Param.new(m[1], "", "header")
+      end
+      if line.match(BODY_ACCESS)
+        params << Param.new("body", "", "json")
+      end
+      params
+    end
+
+    private def push_unique(endpoint : Endpoint, param : Param)
+      return if endpoint.params.any? { |p| p.name == param.name && p.param_type == param.param_type }
+      endpoint.push_param(param)
+    end
+  end
+end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -23,6 +23,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
 
   # Define detectors
   define_detectors([
+    Cpp::Crow,
     CSharp::AspNetMvc,
     CSharp::AspNetCoreMvc,
     Crystal::Amber,

--- a/src/detector/detectors/cpp/crow.cr
+++ b/src/detector/detectors/cpp/crow.cr
@@ -1,0 +1,26 @@
+require "../../../models/detector"
+
+module Detector::Cpp
+  class Crow < Detector
+    CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
+
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless CPP_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
+
+      return true if file_contents.includes?(%(#include "crow.h"))
+      return true if file_contents.includes?("#include <crow.h>")
+      return true if file_contents.includes?(%(#include "crow/crow.h"))
+      return true if file_contents.includes?("#include <crow/crow.h>")
+      return true if file_contents.includes?("#include <crow/app.h>")
+      return true if file_contents.includes?(%(#include "crow/app.h"))
+      return true if file_contents.includes?("crow::SimpleApp")
+      return true if file_contents.includes?("CROW_ROUTE(")
+
+      false
+    end
+
+    def set_name
+      @name = "cpp_crow"
+    end
+  end
+end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -110,6 +110,24 @@ module NoirTechs
         :websocket   => true,
       },
     },
+    :cpp_crow => {
+      :framework => "Crow",
+      :language  => "C++",
+      :similar   => ["crow", "crowcpp", "crow-cpp", "cpp-crow", "cpp_crow", "c++-crow", "c++_crow"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => true,
+      },
+    },
     :cs_aspnet_mvc => {
       :framework => "ASP.NET MVC",
       :language  => "C#",


### PR DESCRIPTION
Closes #1217

## Summary
- Add detector for Crow C++ micro web framework
- Add analyzer supporting CROW_ROUTE macros, path params, query/body/header params
- Add fixtures and tests