### PR TITLE
feat: add Drogon C++ web framework detector and analyzer

### DIFF
--- a/spec/functional_test/fixtures/cpp/drogon/CMakeLists.txt
+++ b/spec/functional_test/fixtures/cpp/drogon/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.5)
+project(drogon_sample CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(Drogon CONFIG REQUIRED)
+
+add_executable(drogon_sample main.cpp controllers/UsersController.cpp)
+target_link_libraries(drogon_sample PRIVATE Drogon::Drogon)

--- a/spec/functional_test/fixtures/cpp/drogon/controllers/UsersController.cpp
+++ b/spec/functional_test/fixtures/cpp/drogon/controllers/UsersController.cpp
@@ -1,0 +1,57 @@
+#include <drogon/HttpController.h>
+
+using namespace drogon;
+
+class UsersController : public drogon::HttpController<UsersController> {
+public:
+    PATH_LIST_BEGIN
+    PATH_ADD("/api/users", Get, Post);
+    PATH_ADD("/api/users/{id}", Get, Put, Delete);
+    PATH_ADD("/api/users/{id}/profile", Get);
+    PATH_LIST_END
+
+    void listUsers(const HttpRequestPtr &req,
+                   std::function<void(const HttpResponsePtr &)> &&callback) {
+        auto search = req->getParameter("search");
+        auto limit = req->getParameter("limit");
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+
+    void createUser(const HttpRequestPtr &req,
+                    std::function<void(const HttpResponsePtr &)> &&callback) {
+        auto body = req->getJsonObject();
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+
+    void getUser(const HttpRequestPtr &req,
+                 std::function<void(const HttpResponsePtr &)> &&callback,
+                 const std::string &id) {
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+
+    void updateUser(const HttpRequestPtr &req,
+                    std::function<void(const HttpResponsePtr &)> &&callback,
+                    const std::string &id) {
+        auto body = req->getJsonObject();
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+
+    void deleteUser(const HttpRequestPtr &req,
+                    std::function<void(const HttpResponsePtr &)> &&callback,
+                    const std::string &id) {
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+
+    void getProfile(const HttpRequestPtr &req,
+                    std::function<void(const HttpResponsePtr &)> &&callback,
+                    const std::string &id) {
+        auto token = req->getHeader("X-API-Token");
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+};

--- a/spec/functional_test/fixtures/cpp/drogon/main.cpp
+++ b/spec/functional_test/fixtures/cpp/drogon/main.cpp
@@ -1,0 +1,41 @@
+#include <drogon/drogon.h>
+
+using namespace drogon;
+
+int main() {
+    app().registerHandler(
+        "/ping",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            auto name = req->getParameter("name");
+            auto age = req->getParameter("age");
+            auto resp = HttpResponse::newHttpResponse();
+            callback(resp);
+        },
+        {Get});
+
+    app().registerHandler(
+        "/submit",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            auto body = req->getJsonObject();
+            auto resp = HttpResponse::newHttpResponse();
+            callback(resp);
+        },
+        {Post});
+
+    app().registerHandler(
+        "/items/{id:int}",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback,
+           int id) {
+            auto auth = req->getHeader("Authorization");
+            auto session = req->getCookie("session");
+            auto resp = HttpResponse::newHttpResponse();
+            callback(resp);
+        },
+        {Get, Delete});
+
+    app().run();
+    return 0;
+}

--- a/spec/functional_test/testers/cpp/drogon_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_spec.cr
@@ -1,0 +1,40 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  # main.cpp — path-based registerHandler with lambdas
+  Endpoint.new("/ping", "GET", [
+    Param.new("name", "", "query"),
+    Param.new("age", "", "query"),
+  ]),
+  Endpoint.new("/submit", "POST", [
+    Param.new("body", "", "json"),
+  ]),
+  # Path param type annotation stripped: {id:int} → {id}
+  Endpoint.new("/items/{id}", "GET", [
+    Param.new("Authorization", "", "header"),
+    Param.new("session", "", "cookie"),
+  ]),
+  Endpoint.new("/items/{id}", "DELETE", [
+    Param.new("Authorization", "", "header"),
+    Param.new("session", "", "cookie"),
+  ]),
+  # controllers/UsersController.cpp — PATH_LIST_BEGIN with PATH_ADD
+  Endpoint.new("/api/users", "GET", [
+    Param.new("search", "", "query"),
+    Param.new("limit", "", "query"),
+  ]),
+  Endpoint.new("/api/users", "POST", [
+    Param.new("body", "", "json"),
+  ]),
+  Endpoint.new("/api/users/{id}", "GET"),
+  Endpoint.new("/api/users/{id}", "PUT"),
+  Endpoint.new("/api/users/{id}", "DELETE"),
+  Endpoint.new("/api/users/{id}/profile", "GET", [
+    Param.new("X-API-Token", "", "header"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/drogon/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/cpp/drogon_spec.cr
+++ b/spec/unit_test/detector/cpp/drogon_spec.cr
@@ -1,0 +1,31 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/cpp/*"
+
+describe "Detect C++ Drogon" do
+  options = create_test_options
+  instance = Detector::Cpp::Drogon.new options
+
+  it "main.cpp with drogon include" do
+    instance.detect("main.cpp", %(#include <drogon/drogon.h>\nint main() { app().run(); })).should be_true
+  end
+
+  it "UsersController.h with HttpController include" do
+    instance.detect("UsersController.h", %(#include "drogon/HttpController.h")).should be_true
+  end
+
+  it "registerHandler call without include" do
+    instance.detect("routes.cc", %(app().registerHandler("/ping", handler, {Get});)).should be_true
+  end
+
+  it "PATH_LIST_BEGIN macro" do
+    instance.detect("controller.cpp", "PATH_LIST_BEGIN\nPATH_ADD(\"/x\", Get);\nPATH_LIST_END").should be_true
+  end
+
+  it "CMakeLists.txt with find_package(Drogon)" do
+    instance.detect("CMakeLists.txt", "find_package(Drogon CONFIG REQUIRED)").should be_true
+  end
+
+  it "non-drogon source" do
+    instance.detect("main.cpp", %(#include <iostream>\nint main() { return 0; })).should be_false
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -16,6 +16,7 @@ def initialize_analyzers(logger : NoirLogger)
 
   # Mapping analyzers to their respective functions
   define_analyzers([
+    {"cpp_drogon", Cpp::Drogon},
     {"cs_aspnet_mvc", CSharp::AspNetMvc},
     {"cs_aspnet_core_mvc", CSharp::AspNetCoreMvc},
     {"crystal_amber", Crystal::Amber},

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -1,0 +1,198 @@
+require "../../../models/analyzer"
+require "wait_group"
+
+module Analyzer::Cpp
+  class Drogon < Analyzer
+    CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp"]
+
+    HTTP_METHODS = {
+      "Get"     => "GET",
+      "Post"    => "POST",
+      "Put"     => "PUT",
+      "Delete"  => "DELETE",
+      "Patch"   => "PATCH",
+      "Head"    => "HEAD",
+      "Options" => "OPTIONS",
+    }
+
+    # `{Get, Post}` method list: brace block whose first token is a verb.
+    METHOD_BLOCK = /\{\s*((?:drogon::)?(?:Get|Post|Put|Delete|Patch|Head|Options)\b[^{}]*)\}/
+
+    REGEX_REGISTER_HANDLER = /app\(\)\s*\.?\s*registerHandler\s*\(\s*"([^"]+)"/
+    REGEX_PATH_ADD         = /PATH_ADD\s*\(\s*"([^"]+)"\s*,\s*([^)]+)\)/
+    REGEX_ADD_METHOD       = /ADD_METHOD_TO\s*\(\s*[^,]+\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)/
+
+    def analyze
+      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
+
+      begin
+        populate_channel_with_filtered_files(channel, CPP_EXTENSIONS)
+
+        parallel_analyze(channel) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+          next unless CPP_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
+
+          content = read_file_content(path)
+          next unless content.includes?("drogon") ||
+                      content.includes?("registerHandler") ||
+                      content.includes?("PATH_LIST_BEGIN") ||
+                      content.includes?("PATH_ADD") ||
+                      content.includes?("METHOD_LIST_BEGIN") ||
+                      content.includes?("ADD_METHOD_TO")
+
+          analyze_file(path, content)
+        end
+      rescue e
+        logger.debug "Drogon analyzer failed: #{e.message}"
+      end
+
+      @result
+    end
+
+    def analyze_file(path : String, content : String)
+      lines = content.split("\n")
+      file_params = extract_params(lines)
+
+      extract_register_handler_endpoints(path, content, lines, file_params).each do |endpoint|
+        @result << endpoint
+      end
+
+      extract_block_endpoints(path, lines, "PATH_LIST_BEGIN", "PATH_LIST_END", REGEX_PATH_ADD, file_params).each do |endpoint|
+        @result << endpoint
+      end
+
+      extract_block_endpoints(path, lines, "METHOD_LIST_BEGIN", "METHOD_LIST_END", REGEX_ADD_METHOD, file_params).each do |endpoint|
+        @result << endpoint
+      end
+    end
+
+    private def extract_register_handler_endpoints(path : String, content : String, lines : Array(String), file_params : Array(Param)) : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      # For each registerHandler("/path") occurrence, look ahead in the content
+      # for the nearest method list block `{Get, Post, ...}`. This tolerates
+      # lambda bodies between the path and the method list without needing a
+      # full-blown C++ parser.
+      content.scan(REGEX_REGISTER_HANDLER) do |match|
+        route = normalize_path(match[1])
+        rest = match.post_match
+        window = rest.size > 4000 ? rest[0, 4000] : rest
+
+        methods = if block_match = window.match(METHOD_BLOCK)
+                    parse_methods(block_match[1])
+                  else
+                    ["GET"]
+                  end
+
+        line_number = find_line_number(lines, "registerHandler", match[1])
+
+        methods.each do |m|
+          details = Details.new(PathInfo.new(path, line_number))
+          endpoint = Endpoint.new(route, m, details)
+          file_params.each { |p| endpoint.push_param(p) }
+          endpoints << endpoint
+        end
+      end
+
+      endpoints
+    end
+
+    private def extract_block_endpoints(path : String, lines : Array(String), begin_marker : String, end_marker : String, pattern : Regex, file_params : Array(Param)) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      in_block = false
+
+      lines.each_with_index do |line, index|
+        if line.includes?(begin_marker)
+          in_block = true
+          next
+        end
+
+        if line.includes?(end_marker)
+          in_block = false
+          next
+        end
+
+        next unless in_block
+
+        if match = line.match(pattern)
+          route = normalize_path(match[1])
+          methods = parse_methods(match[2])
+
+          methods.each do |m|
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint = Endpoint.new(route, m, details)
+            file_params.each { |p| endpoint.push_param(p) }
+            endpoints << endpoint
+          end
+        end
+      end
+
+      endpoints
+    end
+
+    private def parse_methods(raw : String) : Array(String)
+      methods = [] of String
+      raw.split(",").each do |token|
+        name = token.strip.gsub(/^drogon::/, "").gsub(/^Http/, "").gsub(/Method$/, "")
+        next if name.empty?
+        if mapped = HTTP_METHODS[name]?
+          methods << mapped unless methods.includes?(mapped)
+        end
+      end
+      methods << "GET" if methods.empty?
+      methods
+    end
+
+    # Normalize `/path/{id:int}` → `/path/{id}`; leaves plain `{id}` alone.
+    private def normalize_path(path : String) : String
+      path.gsub(/\{([^{}:]+):[^{}]+\}/) { "{#{$1}}" }
+    end
+
+    private def find_line_number(lines : Array(String), marker : String, route : String) : Int32
+      lines.each_with_index do |line, index|
+        return index + 1 if line.includes?(marker) && line.includes?(route)
+      end
+      1
+    end
+
+    private def extract_params(lines : Array(String)) : Array(Param)
+      params = [] of Param
+
+      lines.each do |line|
+        if match = line.match(/->\s*getParameter\s*\(\s*"([^"]+)"/)
+          add_unique_param(params, Param.new(match[1], "", "query"))
+        end
+
+        if match = line.match(/->\s*getOptionalParameter\s*<[^>]*>\s*\(\s*"([^"]+)"/)
+          add_unique_param(params, Param.new(match[1], "", "query"))
+        end
+
+        if match = line.match(/->\s*getHeader\s*\(\s*"([^"]+)"/)
+          add_unique_param(params, Param.new(match[1], "", "header"))
+        end
+
+        if match = line.match(/->\s*getCookie\s*\(\s*"([^"]+)"/)
+          add_unique_param(params, Param.new(match[1], "", "cookie"))
+        end
+
+        if line.includes?("->getJsonObject(") || line.includes?("->getJsonValue(")
+          add_unique_param(params, Param.new("body", "", "json"))
+        end
+
+        if line.matches?(/->\s*(body|getBody)\s*\(\s*\)/) &&
+           !line.includes?("->getJsonObject(") && !line.includes?("->getJsonValue(")
+          add_unique_param(params, Param.new("body", "", "body"))
+        end
+      end
+
+      params
+    end
+
+    private def add_unique_param(params : Array(Param), param : Param)
+      return if param.name.empty?
+      return if params.any? { |p| p.name == param.name && p.param_type == param.param_type }
+      params << param
+    end
+  end
+end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -23,6 +23,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
 
   # Define detectors
   define_detectors([
+    Cpp::Drogon,
     CSharp::AspNetMvc,
     CSharp::AspNetCoreMvc,
     Crystal::Amber,

--- a/src/detector/detectors/cpp/drogon.cr
+++ b/src/detector/detectors/cpp/drogon.cr
@@ -1,0 +1,27 @@
+require "../../../models/detector"
+
+module Detector::Cpp
+  class Drogon < Detector
+    DROGON_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp"]
+
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless DROGON_EXTENSIONS.any? { |ext| filename.ends_with?(ext) } ||
+                          filename.includes?("CMakeLists.txt") ||
+                          filename.includes?("conanfile") ||
+                          filename.includes?("vcpkg.json")
+
+      return true if file_contents.includes?("drogon/drogon.h")
+      return true if file_contents.includes?("drogon/HttpController.h")
+      return true if file_contents.includes?("drogon/HttpSimpleController.h")
+      return true if file_contents.includes?("app().registerHandler")
+      return true if file_contents.includes?("PATH_LIST_BEGIN")
+      return true if file_contents.includes?("find_package(Drogon") || file_contents.includes?("find_package(drogon")
+
+      false
+    end
+
+    def set_name
+      @name = "cpp_drogon"
+    end
+  end
+end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2,6 +2,24 @@ require "json"
 
 module NoirTechs
   TECHS = {
+    :cpp_drogon => {
+      :framework => "Drogon",
+      :language  => "C++",
+      :similar   => ["drogon", "cpp-drogon", "cpp_drogon", "c++-drogon", "c++_drogon"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => true,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+    },
     :crystal_amber => {
       :framework => "Amber",
       :language  => "Crystal",


### PR DESCRIPTION
Closes #1216

## Summary
- Add detector for Drogon high-performance C++ web framework
- Add analyzer supporting registerHandler and controller-based routing, path/query/body/header params
- Add fixtures and tests

## Test plan
- [x] `just check` (crystal tool format + ameba)
- [x] `just build`
- [x] Unit tests: `crystal spec spec/unit_test/detector/cpp/drogon_spec.cr`
- [x] Functional tests: `crystal spec spec/functional_test/testers/cpp/drogon_spec.cr`
- [x] Full suite: `just test` (4909 examples, 0 failures)