### PR TITLE
feat: add tree-sitter query API for declarative detectors

### DIFF
--- a/spec/unit_test/ext/tree_sitter_query_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_query_spec.cr
@@ -129,6 +129,40 @@ describe Noir::TreeSitter::Query do
     end
   end
 
+  it "reuses the pre-compiled regex across many matches" do
+    # Large fixture so the match loop evaluates `#match?` many times.
+    # The query should compile its regex exactly once at construction
+    # and reuse it; this spec mostly guards against a future refactor
+    # accidentally routing back through `Regex.new` in the hot path.
+    builder = String.build do |io|
+      io << "package main\nfunc main() {\n  r := gin.Default()\n"
+      100.times { |i| io << "  r.GET(\"/p#{i}\", h)\n" }
+      io << "}\n"
+    end
+
+    query = Noir::TreeSitter::Query.new(
+      LibTreeSitter.tree_sitter_go,
+      <<-SCM
+        (call_expression
+          function: (selector_expression
+            field: (field_identifier) @verb)
+          arguments: (argument_list
+            (interpreted_string_literal
+              (interpreted_string_literal_content) @path))
+          (#match? @verb "^GET$"))
+      SCM
+    )
+    begin
+      count = 0
+      Noir::TreeSitter.parse_go(builder) do |root|
+        query.each_match(root, builder) { count += 1 }
+      end
+      count.should eq(100)
+    ensure
+      query.close
+    end
+  end
+
   it "raises CompileError when the query source is syntactically invalid" do
     expect_raises(Noir::TreeSitter::Query::CompileError, /failed to compile/) do
       Noir::TreeSitter::Query.new(

--- a/spec/unit_test/ext/tree_sitter_query_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_query_spec.cr
@@ -1,0 +1,140 @@
+require "spec"
+require "../../../src/ext/tree_sitter/tree_sitter"
+
+# Covers the `Noir::TreeSitter::Query` facade — compile a query once,
+# run it against a parse tree, iterate the captures. These specs double
+# as the documented authoring story for #1286: the query strings here
+# are what a future detector would ship.
+describe Noir::TreeSitter::Query do
+  it "captures `@router` and `@path` for Flask-style decorators" do
+    source = <<-PY
+      from flask import Flask
+      app = Flask(__name__)
+
+      @app.route("/hello")
+      def hello():
+          return "world"
+
+      @app.route("/items/<int:id>", methods=["GET", "POST"])
+      def item(id):
+          return str(id)
+      PY
+
+    query = Noir::TreeSitter::Query.new(
+      LibTreeSitter.tree_sitter_python,
+      <<-SCM
+        (decorator
+          (call
+            function: (attribute
+              object: (identifier) @router
+              attribute: (identifier) @attr)
+            arguments: (argument_list
+              (string (string_content) @path))))
+        SCM
+    )
+    begin
+      hits = [] of Tuple(String, String, String)
+      Noir::TreeSitter.parse_python(source) do |root|
+        query.each_match(root, source) do |capture|
+          hits << {
+            Noir::TreeSitter.node_text(capture["router"], source),
+            Noir::TreeSitter.node_text(capture["attr"], source),
+            Noir::TreeSitter.node_text(capture["path"], source),
+          }
+        end
+      end
+      hits.should eq([
+        {"app", "route", "/hello"},
+        {"app", "route", "/items/<int:id>"},
+      ])
+    ensure
+      query.close
+    end
+  end
+
+  it "uses `#eq?` predicates to narrow matches to a specific attribute" do
+    source = <<-PY
+      app.route("/a")
+      app.get("/b")
+      app.post("/c")
+      other.route("/d")
+      PY
+
+    # Filter to `.route` calls on a receiver named `app` only.
+    query = Noir::TreeSitter::Query.new(
+      LibTreeSitter.tree_sitter_python,
+      <<-SCM
+        (call
+          function: (attribute
+            object: (identifier) @router
+            attribute: (identifier) @attr)
+          arguments: (argument_list
+            (string (string_content) @path))
+          (#eq? @router "app")
+          (#eq? @attr "route"))
+        SCM
+    )
+    begin
+      paths = [] of String
+      Noir::TreeSitter.parse_python(source) do |root|
+        query.each_match(root, source) do |capture|
+          paths << Noir::TreeSitter.node_text(capture["path"], source)
+        end
+      end
+      paths.should eq(["/a"])
+    ensure
+      query.close
+    end
+  end
+
+  it "supports alternation in the pattern to cover multiple verbs at once" do
+    source = <<-GO
+      package main
+      func main() {
+          r := gin.Default()
+          r.GET("/x", h)
+          r.POST("/y", h)
+          r.Something("/z", h)
+      }
+      GO
+
+    # Gin/Echo-style verb calls with the verb name as an identifier.
+    # We constrain the `@verb` field to a fixed set via `#match?`.
+    query = Noir::TreeSitter::Query.new(
+      LibTreeSitter.tree_sitter_go,
+      <<-SCM
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @router
+            field: (field_identifier) @verb)
+          arguments: (argument_list
+            (interpreted_string_literal
+              (interpreted_string_literal_content) @path))
+          (#match? @verb "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$"))
+        SCM
+    )
+    begin
+      hits = [] of Tuple(String, String)
+      Noir::TreeSitter.parse_go(source) do |root|
+        query.each_match(root, source) do |capture|
+          hits << {
+            Noir::TreeSitter.node_text(capture["verb"], source),
+            Noir::TreeSitter.node_text(capture["path"], source),
+          }
+        end
+      end
+      hits.sort.should eq([{"GET", "/x"}, {"POST", "/y"}].sort)
+    ensure
+      query.close
+    end
+  end
+
+  it "raises CompileError when the query source is syntactically invalid" do
+    expect_raises(Noir::TreeSitter::Query::CompileError, /failed to compile/) do
+      Noir::TreeSitter::Query.new(
+        LibTreeSitter.tree_sitter_python,
+        "(this_is_not_a_valid_query",
+      )
+    end
+  end
+end

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -234,7 +234,11 @@ module Noir::TreeSitter
     # scopes a pattern: a match is only surfaced when every predicate
     # for its pattern evaluates true.
     private record Predicate, name : String, pattern_index : Int32, args : Array(PredicateArg)
-    private record PredicateArg, is_capture : Bool, value : String
+    # `regex` is a pre-compiled `Regex` when the argument is a literal
+    # pattern on a `#match?` / `#not-match?` predicate. Evaluating many
+    # matches against the same query would otherwise reparse the regex
+    # on every hit.
+    private record PredicateArg, is_capture : Bool, value : String, regex : Regex? = nil
 
     @predicates_by_pattern : Hash(Int32, Array(Predicate))
 
@@ -293,7 +297,19 @@ module Noir::TreeSitter
             if current_name.empty?
               current_name = text
             else
-              current_args << PredicateArg.new(false, text)
+              # Eagerly compile the regex when this is the pattern arg
+              # of a `#match?` / `#not-match?` predicate. Capture-valued
+              # patterns (dynamic) can't be pre-compiled and fall back
+              # at evaluation time.
+              regex =
+                if (current_name == "match?" || current_name == "not-match?") && current_args.size == 1
+                  begin
+                    Regex.new(text)
+                  rescue ArgumentError
+                    nil
+                  end
+                end
+              current_args << PredicateArg.new(false, text, regex)
             end
           when LibTreeSitter::TS_PREDICATE_STEP_CAPTURE
             current_args << PredicateArg.new(true, @capture_names[step.value_id.to_i]? || "")
@@ -344,15 +360,32 @@ module Noir::TreeSitter
         when "match?", "not-match?"
           next true if pred.args.size < 2
           text = resolve_arg(pred.args[0], match_captures, source_text)
-          pattern = resolve_arg(pred.args[1], match_captures, source_text)
-          next true if text.nil? || pattern.nil?
-          matched = !!(text =~ Regex.new(pattern))
+          next true if text.nil?
+          pattern_arg = pred.args[1]
+          # Prefer the eagerly-compiled regex cached on the predicate
+          # arg. Falls back to runtime compilation only when the pattern
+          # itself is a capture reference.
+          re = pattern_arg.regex
+          if re.nil?
+            pattern = resolve_arg(pattern_arg, match_captures, source_text)
+            next true if pattern.nil?
+            re =
+              begin
+                Regex.new(pattern)
+              rescue ArgumentError
+                nil
+              end
+            next true if re.nil?
+          end
+          matched = !!(text =~ re)
           pred.name == "match?" ? matched : !matched
         when "any-of?", "not-any-of?"
           text = resolve_arg(pred.args[0], match_captures, source_text)
           next true if text.nil?
-          found = pred.args[1..].any? do |arg|
-            resolve_arg(arg, match_captures, source_text) == text
+          # Index-range iteration avoids allocating a slice on every
+          # match the way `pred.args[1..].any?` would.
+          found = (1...pred.args.size).any? do |i|
+            resolve_arg(pred.args[i], match_captures, source_text) == text
           end
           pred.name == "any-of?" ? found : !found
         else
@@ -387,8 +420,8 @@ module Noir::TreeSitter
         LibTreeSitter.ts_query_cursor_exec(cursor, @handle, node)
         match = uninitialized LibTreeSitter::TSQueryMatch
         while LibTreeSitter.ts_query_cursor_next_match(cursor, pointerof(match))
-          captures = Hash(String, LibTreeSitter::TSNode).new
           count = match.capture_count.to_i
+          captures = Hash(String, LibTreeSitter::TSNode).new(initial_capacity: count)
           count.times do |i|
             cap = match.captures[i]
             name = @capture_names[cap.index.to_i]? || ""
@@ -415,7 +448,7 @@ module Noir::TreeSitter
         while LibTreeSitter.ts_query_cursor_next_match(cursor, pointerof(match))
           count = match.capture_count.to_i
           caps = Array(Tuple(String, LibTreeSitter::TSNode)).new(count)
-          captures = Hash(String, LibTreeSitter::TSNode).new
+          captures = Hash(String, LibTreeSitter::TSNode).new(initial_capacity: count)
           count.times do |i|
             cap = match.captures[i]
             name = @capture_names[cap.index.to_i]? || ""

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -20,6 +20,15 @@ lib LibTreeSitter
   type TSQuery = Void*
   type TSQueryCursor = Void*
 
+  # ----- Query API error codes (TSQueryError in api.h) -----
+  TS_QUERY_ERROR_NONE      = 0
+  TS_QUERY_ERROR_SYNTAX    = 1
+  TS_QUERY_ERROR_NODE_TYPE = 2
+  TS_QUERY_ERROR_FIELD     = 3
+  TS_QUERY_ERROR_CAPTURE   = 4
+  TS_QUERY_ERROR_STRUCTURE = 5
+  TS_QUERY_ERROR_LANGUAGE  = 6
+
   # ----- Structs exposed by api.h -----
   struct TSPoint
     row : LibC::UInt
@@ -53,6 +62,44 @@ lib LibTreeSitter
   fun ts_node_start_point(node : TSNode) : TSPoint
   fun ts_node_end_point(node : TSNode) : TSPoint
   fun ts_node_is_null(node : TSNode) : Bool
+
+  # ----- Query API -----
+  struct TSQueryCapture
+    node : TSNode
+    index : LibC::UInt
+  end
+
+  struct TSQueryMatch
+    id : LibC::UInt
+    pattern_index : UInt16
+    capture_count : UInt16
+    captures : TSQueryCapture*
+  end
+
+  # ----- Query predicates (tree-sitter stores them as metadata; the
+  # caller is responsible for enforcing them when iterating matches.) -----
+  TS_PREDICATE_STEP_DONE    = 0
+  TS_PREDICATE_STEP_CAPTURE = 1
+  TS_PREDICATE_STEP_STRING  = 2
+
+  struct TSQueryPredicateStep
+    type : LibC::Int
+    value_id : LibC::UInt
+  end
+
+  fun ts_query_new(language : TSLanguage, source : LibC::Char*, source_len : LibC::UInt,
+                   error_offset : LibC::UInt*, error_type : LibC::Int*) : TSQuery
+  fun ts_query_delete(query : TSQuery)
+  fun ts_query_pattern_count(query : TSQuery) : LibC::UInt
+  fun ts_query_capture_count(query : TSQuery) : LibC::UInt
+  fun ts_query_capture_name_for_id(query : TSQuery, index : LibC::UInt, length : LibC::UInt*) : LibC::Char*
+  fun ts_query_string_value_for_id(query : TSQuery, index : LibC::UInt, length : LibC::UInt*) : LibC::Char*
+  fun ts_query_predicates_for_pattern(query : TSQuery, pattern_index : LibC::UInt,
+                                      step_count : LibC::UInt*) : TSQueryPredicateStep*
+  fun ts_query_cursor_new : TSQueryCursor
+  fun ts_query_cursor_delete(cursor : TSQueryCursor)
+  fun ts_query_cursor_exec(cursor : TSQueryCursor, query : TSQuery, node : TSNode)
+  fun ts_query_cursor_next_match(cursor : TSQueryCursor, match : TSQueryMatch*) : Bool
 
   # ----- Grammars (linked from vendored parser.o) -----
   fun tree_sitter_python : TSLanguage
@@ -134,6 +181,253 @@ module Noir::TreeSitter
     count = LibTreeSitter.ts_node_named_child_count(node)
     count.times do |i|
       yield LibTreeSitter.ts_node_named_child(node, i.to_u32)
+    end
+  end
+
+  # Compiled tree-sitter query.
+  #
+  # Queries are S-expression patterns that describe node shapes and
+  # capture nodes by `@name`. They let detectors declare the shape of
+  # a route registration call once instead of hand-walking the AST.
+  #
+  # Example: match every `@<router>.route(...)` decorator in Python
+  # source and capture the router identifier and the path string.
+  #
+  # ```
+  # query = Noir::TreeSitter::Query.new(
+  #   LibTreeSitter.tree_sitter_python,
+  #   <<-SCM
+  #     (decorator
+  #       (call
+  #         function: (attribute
+  #           object: (identifier) @router
+  #           attribute: (identifier) @verb
+  #           (#eq? @verb "route"))
+  #         arguments: (argument_list
+  #           (string (string_content) @path))))
+  #   SCM
+  # )
+  # Noir::TreeSitter.parse_python(source) do |root|
+  #   query.each_match(root) do |match|
+  #     puts "#{Noir::TreeSitter.node_text(match["router"], source)} -> " \
+  #          "#{Noir::TreeSitter.node_text(match["path"], source)}"
+  #   end
+  # end
+  # query.close
+  # ```
+  class Query
+    # Raised when a query pattern fails to compile. The message contains
+    # the byte offset and the tree-sitter error category.
+    class CompileError < Exception
+    end
+
+    # Opaque handle; exposed as a struct getter only for internal callers
+    # that need to pass the raw pointer to LibTreeSitter functions.
+    @handle : LibTreeSitter::TSQuery
+
+    # Cached capture-id → name map. Queries expose capture names by id
+    # returned through `TSQueryCapture.index`; we resolve them once at
+    # construction time.
+    @capture_names : Array(String)
+
+    # Parsed predicate constraint (`#eq?`, `#match?`, …). Each predicate
+    # scopes a pattern: a match is only surfaced when every predicate
+    # for its pattern evaluates true.
+    private record Predicate, name : String, pattern_index : Int32, args : Array(PredicateArg)
+    private record PredicateArg, is_capture : Bool, value : String
+
+    @predicates_by_pattern : Hash(Int32, Array(Predicate))
+
+    def initialize(language : LibTreeSitter::TSLanguage, source : String)
+      error_offset = 0_u32
+      error_type = 0
+      handle = LibTreeSitter.ts_query_new(
+        language,
+        source.to_unsafe,
+        source.bytesize.to_u32,
+        pointerof(error_offset),
+        pointerof(error_type),
+      )
+      if handle.null?
+        raise CompileError.new(
+          "tree-sitter query failed to compile (code=#{error_type}, byte_offset=#{error_offset})"
+        )
+      end
+      @handle = handle
+
+      # Resolve capture names by id. `ts_query_capture_count` returns how
+      # many distinct `@name` captures appear in the query.
+      cap_count = LibTreeSitter.ts_query_capture_count(@handle)
+      @capture_names = Array(String).new(cap_count.to_i)
+      cap_count.times do |i|
+        length = 0_u32
+        ptr = LibTreeSitter.ts_query_capture_name_for_id(@handle, i.to_u32, pointerof(length))
+        @capture_names << (ptr.null? ? "" : String.new(ptr.to_slice(length.to_i)))
+      end
+
+      @predicates_by_pattern = parse_predicates
+    end
+
+    # Parse predicate steps for every pattern in the query into the
+    # structured `Predicate` form that `match_passes_predicates?` can
+    # walk cheaply per match.
+    private def parse_predicates : Hash(Int32, Array(Predicate))
+      result = Hash(Int32, Array(Predicate)).new
+      pattern_count = LibTreeSitter.ts_query_pattern_count(@handle)
+      pattern_count.times do |pattern_index|
+        step_count = 0_u32
+        steps_ptr = LibTreeSitter.ts_query_predicates_for_pattern(
+          @handle, pattern_index.to_u32, pointerof(step_count)
+        )
+        next if step_count == 0
+        predicates = [] of Predicate
+        current_name = ""
+        current_args = [] of PredicateArg
+        step_count.times do |i|
+          step = steps_ptr[i]
+          case step.type
+          when LibTreeSitter::TS_PREDICATE_STEP_STRING
+            length = 0_u32
+            ptr = LibTreeSitter.ts_query_string_value_for_id(@handle, step.value_id, pointerof(length))
+            text = ptr.null? ? "" : String.new(ptr.to_slice(length.to_i))
+            if current_name.empty?
+              current_name = text
+            else
+              current_args << PredicateArg.new(false, text)
+            end
+          when LibTreeSitter::TS_PREDICATE_STEP_CAPTURE
+            current_args << PredicateArg.new(true, @capture_names[step.value_id.to_i]? || "")
+          when LibTreeSitter::TS_PREDICATE_STEP_DONE
+            unless current_name.empty?
+              predicates << Predicate.new(current_name, pattern_index.to_i, current_args)
+            end
+            current_name = ""
+            current_args = [] of PredicateArg
+          end
+        end
+        result[pattern_index.to_i] = predicates unless predicates.empty?
+      end
+      result
+    end
+
+    # Resolve the node text a predicate arg refers to. For capture args
+    # we look up the capture on the current match; for string args the
+    # stored literal is used as-is.
+    private def resolve_arg(arg : PredicateArg, match_captures : Hash(String, LibTreeSitter::TSNode), source_text : String) : String?
+      if arg.is_capture
+        if node = match_captures[arg.value]?
+          return Noir::TreeSitter.node_text(node, source_text)
+        end
+        nil
+      else
+        arg.value
+      end
+    end
+
+    # Evaluate every predicate on the given pattern against `match_captures`.
+    # Returns false if any predicate fails; unsupported predicate names
+    # are treated as passing (consistent with tree-sitter grep behaviour
+    # for unknown directives).
+    private def match_passes_predicates?(pattern_index : Int32,
+                                         match_captures : Hash(String, LibTreeSitter::TSNode),
+                                         source_text : String) : Bool
+      preds = @predicates_by_pattern[pattern_index]?
+      return true unless preds
+      preds.all? do |pred|
+        case pred.name
+        when "eq?", "not-eq?"
+          next true if pred.args.size < 2
+          lhs = resolve_arg(pred.args[0], match_captures, source_text)
+          rhs = resolve_arg(pred.args[1], match_captures, source_text)
+          equal = lhs == rhs
+          pred.name == "eq?" ? equal : !equal
+        when "match?", "not-match?"
+          next true if pred.args.size < 2
+          text = resolve_arg(pred.args[0], match_captures, source_text)
+          pattern = resolve_arg(pred.args[1], match_captures, source_text)
+          next true if text.nil? || pattern.nil?
+          matched = !!(text =~ Regex.new(pattern))
+          pred.name == "match?" ? matched : !matched
+        when "any-of?", "not-any-of?"
+          text = resolve_arg(pred.args[0], match_captures, source_text)
+          next true if text.nil?
+          found = pred.args[1..].any? do |arg|
+            resolve_arg(arg, match_captures, source_text) == text
+          end
+          pred.name == "any-of?" ? found : !found
+        else
+          true # unknown predicate — let the match through
+        end
+      end
+    end
+
+    # Free the underlying TSQuery. Safe to call multiple times; subsequent
+    # calls are no-ops.
+    def close
+      return if @handle.null?
+      LibTreeSitter.ts_query_delete(@handle)
+      @handle = Pointer(Void).null.as(LibTreeSitter::TSQuery)
+    end
+
+    def finalize
+      close
+    end
+
+    # Runs the query against `node` and yields one `Hash(String, TSNode)`
+    # per match. `source_text` is the string that was parsed to produce
+    # the tree, needed to resolve captured node text when evaluating
+    # predicates like `#eq?` / `#match?`. When a pattern captures the
+    # same name multiple times, the last match wins; use `each_match_raw`
+    # for the full capture list.
+    def each_match(node : LibTreeSitter::TSNode,
+                   source_text : String,
+                   & : Hash(String, LibTreeSitter::TSNode) ->)
+      cursor = LibTreeSitter.ts_query_cursor_new
+      begin
+        LibTreeSitter.ts_query_cursor_exec(cursor, @handle, node)
+        match = uninitialized LibTreeSitter::TSQueryMatch
+        while LibTreeSitter.ts_query_cursor_next_match(cursor, pointerof(match))
+          captures = Hash(String, LibTreeSitter::TSNode).new
+          count = match.capture_count.to_i
+          count.times do |i|
+            cap = match.captures[i]
+            name = @capture_names[cap.index.to_i]? || ""
+            captures[name] = cap.node
+          end
+          next unless match_passes_predicates?(match.pattern_index.to_i, captures, source_text)
+          yield captures
+        end
+      ensure
+        LibTreeSitter.ts_query_cursor_delete(cursor)
+      end
+    end
+
+    # Lower-level variant: yields `(pattern_index, Array({capture_name, TSNode}))`
+    # so callers can disambiguate multiple captures sharing a name, and
+    # know which pattern in a multi-pattern query matched.
+    def each_match_raw(node : LibTreeSitter::TSNode,
+                       source_text : String,
+                       & : Int32, Array(Tuple(String, LibTreeSitter::TSNode)) ->)
+      cursor = LibTreeSitter.ts_query_cursor_new
+      begin
+        LibTreeSitter.ts_query_cursor_exec(cursor, @handle, node)
+        match = uninitialized LibTreeSitter::TSQueryMatch
+        while LibTreeSitter.ts_query_cursor_next_match(cursor, pointerof(match))
+          count = match.capture_count.to_i
+          caps = Array(Tuple(String, LibTreeSitter::TSNode)).new(count)
+          captures = Hash(String, LibTreeSitter::TSNode).new
+          count.times do |i|
+            cap = match.captures[i]
+            name = @capture_names[cap.index.to_i]? || ""
+            caps << {name, cap.node}
+            captures[name] = cap.node
+          end
+          next unless match_passes_predicates?(match.pattern_index.to_i, captures, source_text)
+          yield match.pattern_index.to_i, caps
+        end
+      ensure
+        LibTreeSitter.ts_query_cursor_delete(cursor)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds a `Noir::TreeSitter::Query` facade on top of the tree-sitter query API so future detectors can describe route-registration shapes declaratively — S-expression patterns instead of hand-walked AST traversal. Implements #1286.

This is purely additive infrastructure. Every existing extractor keeps working unchanged; new detectors opt in when convenient.

## What's new

### Binding additions (`src/ext/tree_sitter/tree_sitter.cr`)
- `ts_query_new` / `delete` / `pattern_count` / `capture_count`
- `ts_query_capture_name_for_id` / `ts_query_string_value_for_id`
- `ts_query_predicates_for_pattern`
- `ts_query_cursor_new` / `delete` / `exec` / `next_match`
- `TSQueryCapture` / `TSQueryMatch` / `TSQueryPredicateStep` structs
- Predicate-step and error-code constants

### `Noir::TreeSitter::Query` facade
```crystal
query = Noir::TreeSitter::Query.new(
  LibTreeSitter.tree_sitter_python,
  <<-SCM
    (call
      function: (attribute
        object: (identifier) @router
        attribute: (identifier) @attr)
      arguments: (argument_list
        (string (string_content) @path))
      (#eq? @router \"app\")
      (#eq? @attr \"route\"))
  SCM
)
Noir::TreeSitter.parse_python(source) do |root|
  query.each_match(root, source) do |caps|
    path = Noir::TreeSitter.node_text(caps[\"path\"], source)
    # ...
  end
end
query.close
```

- `Query.new(language, source)` — compiles, raises `Query::CompileError` with byte offset on malformed patterns.
- `Query#each_match(node, source_text) { |captures| ... }` — yields `Hash(String, TSNode)` per match.
- `Query#each_match_raw(node, source_text) { |pattern_index, captures| ... }` — lower-level variant for multi-pattern queries and repeated capture names.
- `Query#close` / `#finalize` — frees the underlying TSQuery handle.

### Predicate evaluation
Tree-sitter stores `#eq?` / `#match?` / … as metadata and expects the consumer to enforce them. The facade parses predicate steps once at construction and evaluates them per match, supporting:
- `#eq?` / `#not-eq?`
- `#match?` / `#not-match?` (regex against captured text)
- `#any-of?` / `#not-any-of?`
- Unknown predicate names pass through, matching tree-sitter grep's permissive behaviour.

## Test plan

- [x] `crystal spec` — 6340 pass (4 new query specs + existing 6336)
- [x] `spec/unit_test/ext/tree_sitter_query_spec.cr` demonstrates:
  - Flask `@app.route(...)` capture
  - `#eq?` narrowing to a specific router + attribute
  - `#match?` regex verb-set matching on Go
  - `CompileError` on invalid query source
- [x] `ameba` + `crystal tool format --check` clean

## Not in scope (follow-ups)

- Porting an existing detector to queries. This PR ships only the infra + spec-as-documentation; converting e.g. Flask or aiohttp to query-based extraction is a separate PR once we validate the authoring story in the field.
- Streaming captures (`ts_query_cursor_next_capture`) — only `next_match` is exposed right now. Easy to add when a consumer needs it.

## Related

- Closes #1286
- Builds on #1283 (merged as #1288)