### PR TITLE
feat: port Blueprint extraction to tree-sitter Query API

### DIFF
--- a/spec/unit_test/miniparser/python_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/python_route_extractor_ts_spec.cr
@@ -33,13 +33,17 @@ describe Noir::TreeSitterPythonRouteExtractor do
 
       bare_bp = Blueprint("bare", __name__, url_prefix="/bare")
       prefixed = flask.Blueprint("pref", __name__, url_prefix="/api/v1")
+      dotted = my_pkg.flask.Blueprint("d", __name__, url_prefix="/dot")
       ignored = other.Blueprint("x", __name__, url_prefix="/nope")
       PY
 
-    bps = Noir::TreeSitterPythonRouteExtractor.extract_blueprints(source, ["flask"])
+    # `my_pkg.flask` is accepted because the full dotted text is in
+    # the allowlist, preserving the legacy procedural behaviour.
+    bps = Noir::TreeSitterPythonRouteExtractor.extract_blueprints(source, ["flask", "my_pkg.flask"])
     bps.map { |b| {b.name, b.prefix} }.should eq([
       {"bare_bp", "/bare"},
       {"prefixed", "/api/v1"},
+      {"dotted", "/dot"},
     ])
   end
 

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -107,6 +107,11 @@ module Noir
       if q = @@blueprint_query
         return q
       end
+      # `object: (_) @module` (not `(identifier)`) so dotted prefixes
+      # like `my_pkg.flask.Blueprint(...)` still match — tree-sitter
+      # represents `my_pkg.flask` as an `attribute`, not an identifier,
+      # and the legacy procedural decoder accepted any node by reading
+      # its full text. We keep that parity.
       q = Noir::TreeSitter::Query.new(
         LibTreeSitter.tree_sitter_python,
         <<-SCM
@@ -117,12 +122,12 @@ module Noir
               function: (identifier) @func) @call
             (#eq? @func "Blueprint"))
 
-          ; Pattern 1: qualified `name = module.Blueprint(...)`
+          ; Pattern 1: qualified `name = <module>.Blueprint(...)`
           (assignment
             left: (identifier) @name
             right: (call
               function: (attribute
-                object: (identifier) @module
+                object: (_) @module
                 attribute: (identifier) @attr)) @call
             (#eq? @attr "Blueprint"))
           SCM

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -66,18 +66,87 @@ module Noir
     # `module_names` is the list of module prefixes allowed before
     # `.Blueprint` (e.g. `["flask"]`). A bare `Blueprint` call is always
     # accepted, matching the regex extractor.
+    #
+    # Uses a tree-sitter query to find the two Blueprint assignment
+    # shapes (bare and module-qualified). The `url_prefix` keyword is
+    # still extracted procedurally because a Blueprint may be declared
+    # without one and the query language can't express "this keyword,
+    # if present" cleanly.
     def extract_blueprints(source : String, module_names : Array(String)) : Array(BlueprintDecl)
       results = [] of BlueprintDecl
       allowed = module_names.to_set
+      query = blueprint_query
       Noir::TreeSitter.parse_python(source) do |root|
-        walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "assignment"
-          if bp = decode_blueprint(node, source, allowed)
-            results << bp
+        query.each_match_raw(root, source) do |pattern_index, caps|
+          captures = caps.to_h
+          name_node = captures["name"]?
+          call_node = captures["call"]?
+          next unless name_node && call_node
+
+          # Pattern 1 is the qualified form; enforce the module allowlist.
+          if pattern_index == 1
+            module_node = captures["module"]?
+            next unless module_node
+            next unless allowed.includes?(Noir::TreeSitter.node_text(module_node, source))
           end
+
+          name = Noir::TreeSitter.node_text(name_node, source)
+          prefix = extract_url_prefix(call_node, source)
+          results << BlueprintDecl.new(name, prefix, Noir::TreeSitter.node_start_row(name_node))
         end
       end
       results
+    end
+
+    # Lazily compiled, cached across all calls. Two patterns keep bare
+    # and qualified Blueprint shapes separate so the evaluator can tell
+    # them apart via `pattern_index`.
+    @@blueprint_query : Noir::TreeSitter::Query? = nil
+
+    private def blueprint_query : Noir::TreeSitter::Query
+      if q = @@blueprint_query
+        return q
+      end
+      q = Noir::TreeSitter::Query.new(
+        LibTreeSitter.tree_sitter_python,
+        <<-SCM
+          ; Pattern 0: bare `name = Blueprint(...)`
+          (assignment
+            left: (identifier) @name
+            right: (call
+              function: (identifier) @func) @call
+            (#eq? @func "Blueprint"))
+
+          ; Pattern 1: qualified `name = module.Blueprint(...)`
+          (assignment
+            left: (identifier) @name
+            right: (call
+              function: (attribute
+                object: (identifier) @module
+                attribute: (identifier) @attr)) @call
+            (#eq? @attr "Blueprint"))
+          SCM
+      )
+      @@blueprint_query = q
+      q
+    end
+
+    # Walk the `call` node's arguments and return the string value of
+    # the `url_prefix` keyword if present, `""` otherwise.
+    private def extract_url_prefix(call_node : LibTreeSitter::TSNode, source : String) : String
+      args = Noir::TreeSitter.field(call_node, "arguments")
+      return "" unless args
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "keyword_argument"
+        key = Noir::TreeSitter.field(arg, "name")
+        val = Noir::TreeSitter.field(arg, "value")
+        next unless key && val
+        next unless Noir::TreeSitter.node_text(key, source) == "url_prefix"
+        if Noir::TreeSitter.node_type(val) == "string"
+          return decode_string(val, source)
+        end
+      end
+      ""
     end
 
     # ---- private helpers --------------------------------------------------
@@ -230,54 +299,6 @@ module Noir
         methods << decode_string(value, source).upcase
       end
       methods
-    end
-
-    private def decode_blueprint(assign : LibTreeSitter::TSNode,
-                                 source : String,
-                                 allowed : Set(String)) : BlueprintDecl?
-      left = Noir::TreeSitter.field(assign, "left")
-      right = Noir::TreeSitter.field(assign, "right")
-      return unless left && right
-      return unless Noir::TreeSitter.node_type(right) == "call"
-
-      # The assignment must name a single identifier on the left — dotted
-      # or destructured left-hand sides aren't Blueprint declarations.
-      return unless Noir::TreeSitter.node_type(left) == "identifier"
-      name = Noir::TreeSitter.node_text(left, source)
-
-      function = Noir::TreeSitter.field(right, "function")
-      return unless function
-
-      case Noir::TreeSitter.node_type(function)
-      when "identifier"
-        return unless Noir::TreeSitter.node_text(function, source) == "Blueprint"
-      when "attribute"
-        object = Noir::TreeSitter.field(function, "object")
-        attr = Noir::TreeSitter.field(function, "attribute")
-        return unless object && attr
-        return unless Noir::TreeSitter.node_text(attr, source) == "Blueprint"
-        # Module can be an identifier or a dotted name; take the full text.
-        mod = Noir::TreeSitter.node_text(object, source)
-        return unless allowed.includes?(mod)
-      else
-        return
-      end
-
-      prefix = ""
-      if args = Noir::TreeSitter.field(right, "arguments")
-        Noir::TreeSitter.each_named_child(args) do |arg|
-          next unless Noir::TreeSitter.node_type(arg) == "keyword_argument"
-          key = Noir::TreeSitter.field(arg, "name")
-          val = Noir::TreeSitter.field(arg, "value")
-          next unless key && val
-          next unless Noir::TreeSitter.node_text(key, source) == "url_prefix"
-          if Noir::TreeSitter.node_type(val) == "string"
-            prefix = decode_string(val, source)
-          end
-        end
-      end
-
-      BlueprintDecl.new(name, prefix, Noir::TreeSitter.node_start_row(assign))
     end
   end
 end


### PR DESCRIPTION
## Summary

First consumer of the `Noir::TreeSitter::Query` facade (landed in #1289). Replaces ~40 lines of hand-walked AST navigation in `TreeSitterPythonRouteExtractor#extract_blueprints` with two S-expression patterns. External API is unchanged so Flask / Sanic / Aiohttp / Bottle analyzers pick up the new implementation transparently.

Meant as a reference for future detector migrations — the PR body doubles as a \"what does query-based authoring look like in practice\" walkthrough.

## Query

```scheme
; Pattern 0: bare `name = Blueprint(...)`
(assignment
  left: (identifier) @name
  right: (call
    function: (identifier) @func) @call
  (#eq? @func \"Blueprint\"))

; Pattern 1: qualified `name = module.Blueprint(...)`
(assignment
  left: (identifier) @name
  right: (call
    function: (attribute
      object: (identifier) @module
      attribute: (identifier) @attr)) @call
  (#eq? @attr \"Blueprint\"))
```

- Compiled **once** and cached in a module-level class var. Recompiling per scan would dominate wallclock on hundred-file repositories.
- `each_match_raw` branches on `pattern_index` so the qualified form enforces the caller-supplied module allowlist before emitting.
- `url_prefix=` keyword extraction stays procedural — a Blueprint may be declared without it, and expressing \"keyword if present\" in the query language would require four patterns to cover two shapes.

## What it replaces

`decode_blueprint` helper (procedural) is gone. `each_match_raw` handles both assignment shapes directly; qualified-form module filtering moves from case-branch to explicit `pattern_index == 1` check.

## Test plan

- [x] `crystal spec` — 6341 pass, zero behavioural change
- [x] Flask / Flask-advanced / Flask-crossfile / Sanic specs unchanged
- [x] `crystal tool format --check` + ameba clean

## Not in scope

- `extract_decorations` migration. It normalises `method=` / `methods=` kwargs, dispatches between `.route` / `.get` / `.post` / … attributes, and fills in the HTTP verb from the attribute name — easier to read as Crystal than as chained predicates. Can be revisited once more detectors have moved to queries and we have a feel for what's ergonomic.
- Go / TypeScript detector ports. Same authoring pattern applies; different PR.

## Related

- Closes the \"port one detector\" follow-up from #1289
- Builds on #1283 (tree-sitter core) and #1286 (query API)