### PR TITLE
feat(java-extractor): cover array paths, array methods, interfaces

### DIFF
--- a/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
@@ -134,4 +134,119 @@ describe Noir::TreeSitterJavaRouteExtractor do
 
     Noir::TreeSitterJavaRouteExtractor.extract_routes(source).should be_empty
   end
+
+  it "fans out path arrays on @RequestMapping" do
+    # `@RequestMapping({"/a", "/b"})` and the keyword form both emit
+    # one endpoint per path literal.
+    source = <<-JAVA
+      public class A {
+          @GetMapping({"/a", "/b"})
+          public void x() {}
+
+          @RequestMapping(value = {"/c", "/d"}, method = RequestMethod.POST)
+          public void y() {}
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/a"},
+      {"GET", "/b"},
+      {"POST", "/c"},
+      {"POST", "/d"},
+    ])
+  end
+
+  it "fans out method arrays in @RequestMapping" do
+    # Matches fixtures/java/spring/src/ItemController.java: both the
+    # single-method and array-method forms.
+    source = <<-JAVA
+      @RequestMapping("items")
+      public class C {
+          @RequestMapping("/requestmap/put", method = RequestMethod.PUT)
+          public void a() {}
+
+          @RequestMapping("/requestmap/delete", method = {RequestMethod.DELETE})
+          public void b() {}
+
+          @RequestMapping("/multiple/methods", method = {RequestMethod.GET, RequestMethod.POST})
+          public void c() {}
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"PUT", "items/requestmap/put"},
+      {"DELETE", "items/requestmap/delete"},
+      {"GET", "items/multiple/methods"},
+      {"POST", "items/multiple/methods"},
+    ])
+  end
+
+  it "walks `interface_declaration` bodies for @FeignClient" do
+    # Spring Cloud Feign interfaces are routes too; tree-sitter
+    # emits `interface_declaration` for `public interface Foo { ... }`
+    # rather than `class_declaration`.
+    source = <<-JAVA
+      @FeignClient(name = "inventory-service", url = "...")
+      public interface InventoryClient {
+          @PatchMapping("/api/v2/items/{id}/stock")
+          void updateStock(@PathVariable Long id);
+
+          @GetMapping("/api/v2/items")
+          List<Item> list(@RequestParam String category);
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"PATCH", "/api/v2/items/{id}/stock"},
+      {"GET", "/api/v2/items"},
+    ])
+  end
+
+  it "reaches parity with the annotation-based portion of the Spring functional fixture" do
+    # Sanity sweep: run the extractor over every .java file in the
+    # bundled Spring fixture and confirm every annotation-based
+    # endpoint the functional tester expects shows up in the
+    # extracted set. Reactive `router().route()` endpoints are out of
+    # scope for this extractor and are excluded from the check.
+    fixture_dir = File.expand_path("../../../functional_test/fixtures/java/spring/src", __FILE__)
+
+    found = Set(Tuple(String, String)).new
+    Dir.glob("#{fixture_dir}/*.java") do |path|
+      content = File.read(path)
+      Noir::TreeSitterJavaRouteExtractor.extract_routes(content).each do |r|
+        found << {r.verb, r.path}
+      end
+    end
+
+    # Every annotation-based endpoint in `spring_spec.cr` should be
+    # present. Paths match the class prefix exactly as declared in
+    # each fixture — e.g. ItemController.java uses
+    # `@RequestMapping("/items")`, so its routes come out with a
+    # leading slash.
+    expected = [
+      # ItemController.java — class @RequestMapping("/items")
+      {"GET", "/items/{id}"},
+      {"PUT", "/items/update/{id}"},
+      {"DELETE", "/items/delete/{id}"},
+      {"PUT", "/items/requestmap/put"},
+      {"DELETE", "/items/requestmap/delete"},
+      {"GET", "/items/multiple/methods"},
+      {"POST", "/items/multiple/methods"},
+      # ItemController2.java — class @RequestMapping("items2")
+      {"GET", "items2/{id}"},
+      {"POST", "items2/create"},
+      {"PUT", "items2/edit/"},
+      {"GET", "items2/{id}/thePath"},
+      # InventoryClient.java — @FeignClient interface, no class prefix
+      {"PATCH", "/api/v2/items/{id}/stock"},
+      {"GET", "/api/v2/items"},
+      {"POST", "/api/v2/items"},
+      {"DELETE", "/api/v2/items/{id}"},
+    ]
+    missing = expected.reject { |e| found.includes?(e) }
+    missing.should be_empty
+  end
 end

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -68,13 +68,16 @@ module Noir
 
     # ---- private helpers ----------------------------------------------
 
-    # Walk every class_declaration (including nested). `outer_prefix` is
-    # the path prefix accumulated from enclosing classes.
+    # Walk every class/interface declaration (including nested). Interfaces
+    # are relevant for Spring Cloud Feign (`@FeignClient` + method
+    # `@*Mapping` annotations). `outer_prefix` is the path prefix
+    # accumulated from enclosing scopes.
     private def walk_classes(node : LibTreeSitter::TSNode,
                              source : String,
                              outer_prefix : String,
                              routes : Array(Route))
-      if Noir::TreeSitter.node_type(node) == "class_declaration"
+      ty = Noir::TreeSitter.node_type(node)
+      if ty == "class_declaration" || ty == "interface_declaration"
         class_name = class_simple_name(node, source)
         class_prefix = class_mapping_prefix(node, source)
         prefix = join_paths(outer_prefix, class_prefix)
@@ -84,7 +87,7 @@ module Noir
             case Noir::TreeSitter.node_type(member)
             when "method_declaration"
               collect_method_routes(member, source, class_name, prefix, routes)
-            when "class_declaration"
+            when "class_declaration", "interface_declaration"
               walk_classes(member, source, prefix, routes)
             end
           end
@@ -105,13 +108,14 @@ module Noir
     end
 
     # Pull a class-level `@RequestMapping(...)` / `@GetMapping(...)`
-    # path contribution. Returns "" if no mapping annotation is on
-    # the class.
+    # path contribution. Returns the first path if the annotation lists
+    # multiple (`{"/a", "/b"}`) — Spring treats the class prefix as a
+    # single value, so picking one is fine. `""` when absent.
     private def class_mapping_prefix(class_decl : LibTreeSitter::TSNode, source : String) : String
       each_annotation(class_decl, source) do |name, args_node|
         next unless ANNOTATION_VERBS.has_key?(name)
-        path = annotation_path(args_node, source)
-        return path if path
+        paths = annotation_paths(args_node, source)
+        return paths.first if !paths.empty?
       end
       ""
     end
@@ -130,11 +134,26 @@ module Noir
         verb_default = ANNOTATION_VERBS[ann_name]?
         next unless ANNOTATION_VERBS.has_key?(ann_name)
 
-        path = annotation_path(args_node, source) || ""
-        verb = verb_default || annotation_method(args_node, source) || "GET"
+        paths = annotation_paths(args_node, source)
+        paths = [""] if paths.empty?
 
-        full = join_paths(class_prefix, path)
-        routes << Route.new(verb, full, class_name, method_name, ann_line)
+        verbs =
+          if verb_default
+            [verb_default]
+          else
+            methods = annotation_methods(args_node, source)
+            methods.empty? ? ["GET"] : methods
+          end
+
+        # Fan out into every (path × verb) combination. Spring's
+        # `@RequestMapping({"/a", "/b"}, method = {GET, POST})` emits
+        # four routes.
+        paths.each do |path|
+          full = join_paths(class_prefix, path)
+          verbs.each do |verb|
+            routes << Route.new(verb, full, class_name, method_name, ann_line)
+          end
+        end
       end
     end
 
@@ -176,45 +195,74 @@ module Noir
       end
     end
 
-    # Extract the route path from an annotation's argument list. Accepts
-    # a bare string literal or a `value = "..."` / `path = "..."`
-    # element-value pair. Returns nil when no path is present.
-    private def annotation_path(args_node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless args_node
-      return unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
+    # Extract route paths from an annotation's argument list. Accepts
+    # any combination of:
+    #   - bare string literal `@GetMapping("/x")`
+    #   - bare array `@RequestMapping({"/a", "/b"})`
+    #   - `value = "..."` / `path = "..."` keyword forms of either
+    #
+    # Always returns an array. Empty when the annotation has no
+    # path-like argument. Callers fan out into one endpoint per path.
+    private def annotation_paths(args_node : LibTreeSitter::TSNode?, source : String) : Array(String)
+      empty = [] of String
+      return empty unless args_node
+      return empty unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
 
-      positional : String? = nil
-      keyword : String? = nil
+      positional = [] of String
+      keyword = [] of String
       Noir::TreeSitter.each_named_child(args_node) do |arg|
         case Noir::TreeSitter.node_type(arg)
         when "string_literal"
-          positional ||= decode_string_literal(arg, source)
+          positional << decode_string_literal(arg, source)
+        when "element_value_array_initializer"
+          Noir::TreeSitter.each_named_child(arg) do |elem|
+            if Noir::TreeSitter.node_type(elem) == "string_literal"
+              positional << decode_string_literal(elem, source)
+            end
+          end
         when "element_value_pair"
           key = Noir::TreeSitter.field(arg, "key")
           val = Noir::TreeSitter.field(arg, "value")
           next unless key && val
           k = Noir::TreeSitter.node_text(key, source)
           next unless k == "value" || k == "path"
-          if Noir::TreeSitter.node_type(val) == "string_literal"
-            keyword ||= decode_string_literal(val, source)
-          elsif Noir::TreeSitter.node_type(val) == "element_value_array_initializer"
+          case Noir::TreeSitter.node_type(val)
+          when "string_literal"
+            keyword << decode_string_literal(val, source)
+          when "element_value_array_initializer"
             Noir::TreeSitter.each_named_child(val) do |elem|
               if Noir::TreeSitter.node_type(elem) == "string_literal"
-                keyword ||= decode_string_literal(elem, source)
-                break
+                keyword << decode_string_literal(elem, source)
               end
+            end
+          end
+        when "ERROR"
+          # `@RequestMapping("/x", method = RequestMethod.GET)` is a
+          # positional+keyword mix that Java technically disallows, but
+          # the legacy analyzer (and idiomatic Spring code in the wild)
+          # tolerate it. tree-sitter flags it as an `ERROR` node; recover
+          # any string literal inside so we don't regress on fixtures
+          # using this shape.
+          Noir::TreeSitter.each_named_child(arg) do |elem|
+            if Noir::TreeSitter.node_type(elem) == "string_literal"
+              positional << decode_string_literal(elem, source)
             end
           end
         end
       end
-      keyword || positional
+      keyword.empty? ? positional : keyword
     end
 
-    # Return the verb from an annotation's `method = RequestMethod.X`
-    # argument, or nil.
-    private def annotation_method(args_node : LibTreeSitter::TSNode?, source : String) : String?
-      return unless args_node
-      return unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
+    # Extract verbs from an annotation's `method = ...` argument.
+    # Supports the single form (`method = RequestMethod.GET`) and the
+    # array form (`method = {RequestMethod.GET, RequestMethod.POST}`).
+    # Returns an empty array when `method` is absent.
+    private def annotation_methods(args_node : LibTreeSitter::TSNode?, source : String) : Array(String)
+      empty = [] of String
+      return empty unless args_node
+      return empty unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
+
+      methods = [] of String
       Noir::TreeSitter.each_named_child(args_node) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "element_value_pair"
         key = Noir::TreeSitter.field(arg, "key")
@@ -223,13 +271,25 @@ module Noir
         next unless Noir::TreeSitter.node_text(key, source) == "method"
         case Noir::TreeSitter.node_type(val)
         when "field_access"
-          field = Noir::TreeSitter.field(val, "field")
-          return Noir::TreeSitter.node_text(field, source).upcase if field
+          if f = Noir::TreeSitter.field(val, "field")
+            methods << Noir::TreeSitter.node_text(f, source).upcase
+          end
         when "identifier"
-          return Noir::TreeSitter.node_text(val, source).upcase
+          methods << Noir::TreeSitter.node_text(val, source).upcase
+        when "element_value_array_initializer"
+          Noir::TreeSitter.each_named_child(val) do |elem|
+            case Noir::TreeSitter.node_type(elem)
+            when "field_access"
+              if f = Noir::TreeSitter.field(elem, "field")
+                methods << Noir::TreeSitter.node_text(f, source).upcase
+              end
+            when "identifier"
+              methods << Noir::TreeSitter.node_text(elem, source).upcase
+            end
+          end
         end
       end
-      nil
+      methods
     end
 
     private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String


### PR DESCRIPTION
## Summary

Extends `TreeSitterJavaRouteExtractor` to the full Spring route-discovery surface so the Spring analyzer can port to it without regressing on the existing fixture coverage. Analyzer swap remains a separate PR — this one grows the extractor and pins parity in unit specs.

Step 2 of the rollout plan in #1291.

## Shapes added

- **Array paths** — `@RequestMapping({\"/a\", \"/b\"})` and `value = {\"/a\", \"/b\"}` / `path = {\"/a\", \"/b\"}` all fan out to one endpoint per literal.
- **Array methods** — `method = {RequestMethod.GET, RequestMethod.POST}` emits one endpoint per verb. Single-method form still works.
- **Path × method cross product** — `@RequestMapping({\"/a\", \"/b\"}, method = {GET, POST})` emits four endpoints, matching Spring's runtime.
- **`interface_declaration`** — tree-sitter represents `public interface Foo {...}` as a different node type from `class_declaration`. Walking both lets us pick up Spring Cloud Feign clients (`@FeignClient` + method-level `@*Mapping` on interface members).
- **`ERROR` node recovery for positional+keyword mix** — `@RequestMapping(\"/x\", method = ...)` is technically invalid Java (positional has to be alone, or `value =` keyword), but the legacy analyzer and real Spring code in the wild use it freely. tree-sitter flags the positional literal as an `ERROR`; we recover the string_literal inside rather than silently dropping the route.

## Parity spec

`spec/unit_test/miniparser/java_route_extractor_ts_spec.cr` grows a \"reaches parity with the annotation-based portion of the Spring functional fixture\" case. Walks every `.java` file under `spec/functional_test/fixtures/java/spring/src/` and asserts every expected `(verb, path)` annotation-based endpoint from `spring_spec.cr` is produced.

Reactive `router().route()...build()` endpoints are still out of scope for this extractor — QuoteRouter and similar will stay on the legacy path when the Spring analyzer ports, since they don't use annotations.

## Not yet in (follow-ups)

- **Spring analyzer swap.** Route discovery now matches the legacy annotation path, but parameter extraction (`@RequestParam`, `@RequestBody`, DTO field introspection, HttpServletRequest body scanning) and webflux `application.yml` base-path handling still live inside `spring.cr` on top of the old `JavaParser`. Next PR swaps the route source while keeping those layers.
- `[...]` array syntax — `method = [RequestMethod.GET]` is invalid Java (only `{...}` is legal) and tree-sitter flags it with ERRORs that are harder to unwind cleanly. Legacy tolerates it because its custom tokenizer is lenient; extractor support can come as a targeted ERROR-recovery follow-up.

## Test plan

- [x] `crystal spec` — 6352 pass (+4 new Java cases + existing 6348)
- [x] Parity sweep over bundled Spring fixtures
- [x] `ameba` + `crystal tool format --check` clean

## Related

- Umbrella: #1291
- Builds on merged #1292 (vendoring + PoC)