### PR TITLE
feat(spring): swap route-discovery to TreeSitterJavaRouteExtractor

### DIFF
--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../minilexers/java"
 require "../../../miniparsers/java"
+require "../../../miniparsers/java_route_extractor_ts"
 require "../../../utils/parser_limit"
 
 module Analyzer::Java
@@ -87,132 +88,64 @@ module Analyzer::Java
               package_map[package_directory] = package_class_map
             end
 
-            # Extract URL mappings and methods from Spring MVC annotated classes
+            # Extract URL mappings from Spring MVC annotated classes.
+            #
+            # Hybrid approach: tree-sitter (`TreeSitterJavaRouteExtractor`)
+            # handles the pure routing layer — verb, path, class prefix
+            # composition, `@FeignClient` interfaces, method/path arrays
+            # in `@RequestMapping`. The legacy `JavaParser` is still used
+            # for *parameter extraction* (DTO field introspection,
+            # `@RequestParam` / `@RequestBody` / `HttpServletRequest`
+            # body scanning) because that logic is deeply tied to
+            # `MethodModel` and moving it is a separate porting step.
             class_map = package_class_map.merge(import_map)
-            parser.classes.each do |class_model|
-              url = "" # Reset URL for each class
 
-              # Check for @RequestMapping on controllers
-              class_annotation = class_model.annotations["RequestMapping"]?
-              if !class_annotation.nil?
-                next if class_annotation.params.size == 0
-                if class_annotation.params[0].size > 0
-                  class_path_token = class_annotation.params[0][-1]
-                  if class_path_token.type == :STRING_LITERAL
-                    url = class_path_token.value[1..-2]
-                    if url.ends_with? "*"
-                      url = url[0..-2]
-                    end
-                  end
-                end
+            class_models_by_name = Hash(String, ClassModel).new
+            parser.classes.each { |cm| class_models_by_name[cm.name] = cm }
+
+            Noir::TreeSitterJavaRouteExtractor.extract_routes(content).each do |route|
+              class_model = class_models_by_name[route.class_name]?
+              next if class_model.nil?
+
+              is_feign_client = !class_model.annotations["FeignClient"]?.nil?
+              method_model = class_model.methods[route.method_name]?
+              next if method_model.nil?
+
+              # Pick the @*Mapping annotation on this method so we can
+              # still read `consumes = ...` for parameter_format. Method
+              # name collisions across overloads collapse onto the same
+              # MethodModel (pre-existing limitation), which matches
+              # legacy behaviour.
+              mapping_annotation = method_model.annotations.values.find do |a|
+                a.name.ends_with?("Mapping")
+              end
+              parameter_format = consumes_parameter_format(mapping_annotation)
+              if parameter_format.nil? && route.verb == "POST"
+                parameter_format = "form"
               end
 
-              # Check for @FeignClient interface
-              feign_client_annotation = class_model.annotations["FeignClient"]?
-              is_feign_client = !feign_client_annotation.nil?
+              parameters = get_endpoint_parameters(
+                parser, route.verb, method_model, parameter_format, class_map
+              )
 
-              class_model.methods.values.each do |method|
-                method.annotations.values.each do |method_annotation|
-                  url_paths = Array(String).new
-
-                  # Spring MVC method mappings
-                  request_methods = Array(String).new
-                  if method_annotation.name.ends_with? "Mapping"
-                    parameter_format = nil
-                    annotation_parameters = method_annotation.params
-                    annotation_parameters.each do |annotation_parameter_tokens|
-                      if annotation_parameter_tokens.size > 2
-                        annotation_parameter_key = annotation_parameter_tokens[0].value
-                        annotation_parameter_value = annotation_parameter_tokens[-1].value
-                        if annotation_parameter_key == "method"
-                          if annotation_parameter_value.in?("}", "]")
-                            # Handle methods declared with multiple HTTP verbs
-                            annotation_parameter_tokens.reverse_each do |token|
-                              break if token.value == "method"
-                              next if token.type.in?(:LBRACE, :RBRACE, :LBRACK, :RBRACK, :COMMA, :DOT)
-                              http_methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
-                              if http_methods.includes?(token.value)
-                                request_methods.push(token.value)
-                              end
-                            end
-                          else
-                            request_methods.push(annotation_parameter_value)
-                          end
-                        elsif annotation_parameter_key == "consumes"
-                          # Set parameter format based on the 'consumes' attribute of the annotation.
-                          if annotation_parameter_value.ends_with? "APPLICATION_FORM_URLENCODED_VALUE"
-                            parameter_format = "form"
-                          elsif annotation_parameter_value.ends_with? "APPLICATION_JSON_VALUE"
-                            parameter_format = "json"
-                          end
-                        end
-                      end
-                    end
-
-                    if webflux_base_path.ends_with?("/") && url.starts_with?("/")
-                      webflux_base_path = webflux_base_path[..-2]
-                    end
-
-                    # Parse and construct endpoints for methods annotated with 'RequestMapping' or specific HTTP methods
-                    if method_annotation.name == "RequestMapping"
-                      url_paths = [""]
-                      if method_annotation.params.size > 0
-                        url_paths = get_mapping_path(parser, tokens, method_annotation.params)
-                        url_paths = ["/"] if url_paths.empty?
-                      end
-
-                      line = method_annotation.tokens[0].line
-                      details = Details.new(PathInfo.new(path, line))
-
-                      if request_methods.empty?
-                        # Handle default HTTP methods if no specific method is annotated
-                        ["GET", "POST", "PUT", "DELETE", "PATCH"].each do |_request_method|
-                          parameters = get_endpoint_parameters(parser, _request_method, method, parameter_format, class_map)
-                          url_paths.each do |url_path|
-                            endpoint = Endpoint.new(join_paths(webflux_base_path, url, url_path), _request_method, parameters, details, is_feign_client)
-                            @result << endpoint
-                          end
-                        end
-                      else
-                        # Create endpoints for annotated HTTP methods
-                        url_paths.each do |url_path|
-                          request_methods.each do |request_method|
-                            parameters = get_endpoint_parameters(parser, request_method, method, parameter_format, class_map)
-                            endpoint = Endpoint.new(join_paths(webflux_base_path, url, url_path), request_method, parameters, details, is_feign_client)
-                            @result << endpoint
-                          end
-                        end
-                      end
-                      break
-                    else
-                      # Handle other specific mapping annotations like 'GetMapping', 'PostMapping', etc
-                      mapping_annotations = ["GetMapping", "PostMapping", "PutMapping", "DeleteMapping", "PatchMapping"]
-                      mapping_index = mapping_annotations.index(method_annotation.name)
-                      if !mapping_index.nil?
-                        line = method_annotation.tokens[0].line
-                        request_method = mapping_annotations[mapping_index][0..-8].upcase
-                        if parameter_format.nil? && request_method == "POST"
-                          parameter_format = "form"
-                        end
-                        parameters = get_endpoint_parameters(parser, request_method, method, parameter_format, class_map)
-
-                        url_paths = [""]
-                        if method_annotation.params.size > 0
-                          url_paths = get_mapping_path(parser, tokens, method_annotation.params)
-                          url_paths = ["/"] if url_paths.empty?
-                        end
-
-                        details = Details.new(PathInfo.new(path, line))
-                        url_paths.each do |url_path|
-                          endpoint = Endpoint.new(join_paths(webflux_base_path, url, url_path), request_method, parameters, details, is_feign_client)
-                          @result << endpoint
-                        end
-                        break
-                      end
-                    end
-                  end
-                end
+              # webflux base-path normalisation — drop the trailing `/`
+              # when the route path already starts with one so the join
+              # doesn't produce `//`.
+              base_path = webflux_base_path
+              if base_path.ends_with?("/") && route.path.starts_with?("/")
+                base_path = base_path[..-2]
               end
+
+              # Prefer the MethodModel's annotation line (1-based,
+              # matches legacy) when available. Fall back to the
+              # tree-sitter row (0-based) + 1.
+              line = mapping_annotation ? mapping_annotation.tokens[0].line : route.line + 1
+              details = Details.new(PathInfo.new(path, line))
+
+              endpoint = Endpoint.new(
+                join_paths(base_path, route.path), route.verb, parameters, details, is_feign_client
+              )
+              @result << endpoint
             end
           else
             # Extract and construct endpoints from reactive route configurations
@@ -325,6 +258,22 @@ module Analyzer::Java
       end
 
       ""
+    end
+
+    # Return "form" / "json" when the `@*Mapping` annotation declares
+    # a `consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE` or
+    # `APPLICATION_JSON_VALUE`. nil otherwise (callers supply their
+    # own default — POST, for example, falls back to "form").
+    private def consumes_parameter_format(mapping_annotation) : String?
+      return if mapping_annotation.nil?
+      mapping_annotation.params.each do |param_tokens|
+        next unless param_tokens.size > 2
+        next unless param_tokens[0].value == "consumes"
+        value = param_tokens[-1].value
+        return "form" if value.ends_with?("APPLICATION_FORM_URLENCODED_VALUE")
+        return "json" if value.ends_with?("APPLICATION_JSON_VALUE")
+      end
+      nil
     end
 
     def get_mapping_path(parser : JavaParser, tokens : Array(Token), method_params : Array(Array(Token)))

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -303,7 +303,7 @@ module Noir
       # nodes. The legacy analyzer tolerated this because its lenient
       # lexer didn't care. Only run this recovery when we already
       # confirmed a `method = ...` pair existed to minimise false
-      # positives from unrelated ERRORs.
+      # positives from unrelated ERROR nodes.
       if saw_method_pair
         Noir::TreeSitter.each_named_child(args_node) do |arg|
           next unless Noir::TreeSitter.node_type(arg) == "ERROR"

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -253,6 +253,11 @@ module Noir
       keyword.empty? ? positional : keyword
     end
 
+    # Known HTTP-verb identifiers we consider valid `method = ...` values.
+    # Used when reconstructing verbs from ERROR nodes around the
+    # invalid `[...]` bracket syntax.
+    VERB_IDENTIFIERS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+
     # Extract verbs from an annotation's `method = ...` argument.
     # Supports the single form (`method = RequestMethod.GET`) and the
     # array form (`method = {RequestMethod.GET, RequestMethod.POST}`).
@@ -263,12 +268,14 @@ module Noir
       return empty unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
 
       methods = [] of String
+      saw_method_pair = false
       Noir::TreeSitter.each_named_child(args_node) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "element_value_pair"
         key = Noir::TreeSitter.field(arg, "key")
         val = Noir::TreeSitter.field(arg, "value")
         next unless key && val
         next unless Noir::TreeSitter.node_text(key, source) == "method"
+        saw_method_pair = true
         case Noir::TreeSitter.node_type(val)
         when "field_access"
           if f = Noir::TreeSitter.field(val, "field")
@@ -289,7 +296,26 @@ module Noir
           end
         end
       end
-      methods
+
+      # Recover `method = [RequestMethod.GET, RequestMethod.POST]` — the
+      # `[...]` bracket form is invalid Java (only `{...}` is legal) and
+      # tree-sitter scatters the trailing entries into sibling ERROR
+      # nodes. The legacy analyzer tolerated this because its lenient
+      # lexer didn't care. Only run this recovery when we already
+      # confirmed a `method = ...` pair existed to minimise false
+      # positives from unrelated ERRORs.
+      if saw_method_pair
+        Noir::TreeSitter.each_named_child(args_node) do |arg|
+          next unless Noir::TreeSitter.node_type(arg) == "ERROR"
+          Noir::TreeSitter.each_named_child(arg) do |inner|
+            next unless Noir::TreeSitter.node_type(inner) == "identifier"
+            text = Noir::TreeSitter.node_text(inner, source).upcase
+            methods << text if VERB_IDENTIFIERS.includes?(text)
+          end
+        end
+      end
+
+      methods.uniq
     end
 
     private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
@@ -307,9 +333,14 @@ module Noir
     # handles the leading-slash ambiguity Spring is famously relaxed
     # about: `@RequestMapping("items")` + `@GetMapping("{id}")` maps to
     # `/items/{id}` even though neither segment has a leading slash.
+    #
+    # Empty method path (`@PostMapping` with no argument, or
+    # `@GetMapping("")`) emits `prefix/` — matches Spring's runtime
+    # behaviour and the legacy analyzer's `File.join("/prefix", "")`
+    # trailing-slash convention.
     private def join_paths(prefix : String, path : String) : String
       return path if prefix.empty?
-      return prefix if path.empty?
+      return "#{prefix.rstrip('/')}/" if path.empty?
       trimmed_prefix = prefix.rstrip('/')
       trimmed_path = path.lstrip('/')
       "#{trimmed_prefix}/#{trimmed_path}"


### PR DESCRIPTION
## Summary

Step 3 of #1291. Replaces the Spring analyzer's 124-line class-scanning loop — `parser.classes.each` / `method.annotations.values.each` walking `@*Mapping` annotations — with a single `TreeSitterJavaRouteExtractor.extract_routes(content)` call.

Legacy `JavaParser` stays in place for **parameter extraction** (DTO introspection, `@RequestParam` / `@RequestBody` / `@RequestHeader`, HttpServletRequest body scanning) because that logic is deeply tied to `MethodModel`. Porting it is a separate step — tackled in the next PR of this track.

## What the analyzer now does

1. Still invokes `JavaParser` for `ClassModel`s + import/package maps (needed for DTO field introspection).
2. Calls `TreeSitterJavaRouteExtractor.extract_routes(content)` for the list of `(class_name, method_name, verb, path)` routes.
3. For each route, finds the matching `MethodModel` by name, reads the `consumes = ...` attribute off the method's `@*Mapping` annotation for `parameter_format`, hands off to the existing `get_endpoint_parameters`.
4. Joins `webflux_base_path` + `route.path` using the same trailing-/ semantics the legacy `File.join` path produced.

Reactive `router().route()...build()` detection (the `else` branch for files without Spring web bindings) is untouched.

## Extractor adjustments landed here

- `join_paths(prefix, \"\")` now returns `prefix/`. Empty method paths (`@PostMapping` with no argument, or `@GetMapping(\"\")`) need the trailing slash to match Spring's runtime. Fixed 6 formerly-missing endpoints like `/items/` POST, `/empty/` GET.
- `annotation_methods` recovers verbs from ERROR nodes when the annotation uses `[...]` bracket array syntax (`method = [RequestMethod.GET, RequestMethod.POST]`). This is invalid Java — only `{...}` is legal — but the legacy analyzer tolerated it, and the Spring fixture relies on it for `/items/multiple/methods2`. Gated on a real `method = ...` pair existing so unrelated ERRORs don't produce phantom verbs.

## Verification

- **`spec/functional_test/testers/java/spring_spec.cr`** — every expected endpoint (60+) passes, including FeignClient interfaces, multi-method/multi-path annotations, empty paths, params, DTO fields, HttpServletRequest scanning.
- `spec/unit_test/detector/java/spring_spec.cr` — unchanged, passes.
- `spec/functional_test/testers/kotlin/spring_spec.cr` — unchanged, passes.
- Full suite: **6352 examples, 0 failures**.
- `ameba` + `crystal tool format --check` clean.

## Not in this PR

- **Parameter extraction port.** `get_endpoint_parameters` + DTO field introspection still lives on `JavaParser`. `src/miniparsers/java.cr` (669 LOC) + `src/minilexers/java.cr` (576 LOC) stay for now — they get removed when the param side ports too.
- **Other JVM analyzers** (Armeria, Play, JSP, Vert.x). Shared infra is in place; each gets its own swap PR.

## Related

- Umbrella: #1291
- Builds on: #1288 (tree-sitter core), #1292 (Java grammar + PoC), #1293 (extractor parity)