### PR TITLE
feat(spring): port parameter extraction to tree-sitter

### DIFF
--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../minilexers/java"
 require "../../../miniparsers/java"
 require "../../../miniparsers/java_route_extractor_ts"
+require "../../../miniparsers/java_parameter_extractor_ts"
 require "../../../utils/parser_limit"
 
 module Analyzer::Java
@@ -88,44 +89,56 @@ module Analyzer::Java
               package_map[package_directory] = package_class_map
             end
 
-            # Extract URL mappings from Spring MVC annotated classes.
+            # Extract URL mappings + parameters from Spring MVC annotated classes.
             #
-            # Hybrid approach: tree-sitter (`TreeSitterJavaRouteExtractor`)
-            # handles the pure routing layer — verb, path, class prefix
-            # composition, `@FeignClient` interfaces, method/path arrays
-            # in `@RequestMapping`. The legacy `JavaParser` is still used
-            # for *parameter extraction* (DTO field introspection,
-            # `@RequestParam` / `@RequestBody` / `HttpServletRequest`
-            # body scanning) because that logic is deeply tied to
-            # `MethodModel` and moving it is a separate porting step.
+            # Fully tree-sitter-based: `TreeSitterJavaRouteExtractor`
+            # handles routing (verb, path, class prefix, `@FeignClient`,
+            # path/method arrays) and `TreeSitterJavaParameterExtractor`
+            # handles parameter extraction (@RequestParam / @RequestBody
+            # / @RequestHeader / @PathVariable, primitives, DTO field
+            # expansion, HttpServletRequest body scanning, `consumes = ...`).
+            #
+            # `JavaParser` is still invoked above (for import /
+            # same-package resolution) so that DTO classes imported
+            # from sibling files stay discoverable. The resulting
+            # `class_map` is rebuilt here as a TS-shaped FieldInfo
+            # index.
             class_map = package_class_map.merge(import_map)
 
-            class_models_by_name = Hash(String, ClassModel).new
-            parser.classes.each { |cm| class_models_by_name[cm.name] = cm }
+            # Build a TS-shaped DTO index from the JavaParser class_map
+            # plus an in-file TS sweep so same-file DTOs (the common
+            # case in fixtures) are picked up even when JavaParser's
+            # import/package resolution missed them.
+            dto_index = Hash(String, Array(Noir::TreeSitterJavaParameterExtractor::FieldInfo)).new
+            Noir::TreeSitterJavaParameterExtractor.extract_class_fields(content).each do |k, v|
+              dto_index[k] = v
+            end
+            class_map.each do |class_name, class_model|
+              next if dto_index.has_key?(class_name)
+              dto_index[class_name] = class_model.fields.values.map do |field|
+                Noir::TreeSitterJavaParameterExtractor::FieldInfo.new(
+                  field.name,
+                  field.access_modifier,
+                  field.has_setter?,
+                  field.init_value,
+                )
+              end
+            end
+
+            feign_clients = Noir::TreeSitterJavaParameterExtractor.extract_feign_client_classes(content)
 
             Noir::TreeSitterJavaRouteExtractor.extract_routes(content).each do |route|
-              class_model = class_models_by_name[route.class_name]?
-              next if class_model.nil?
+              is_feign_client = feign_clients.includes?(route.class_name)
 
-              is_feign_client = !class_model.annotations["FeignClient"]?.nil?
-              method_model = class_model.methods[route.method_name]?
-              next if method_model.nil?
-
-              # Pick the @*Mapping annotation on this method so we can
-              # still read `consumes = ...` for parameter_format. Method
-              # name collisions across overloads collapse onto the same
-              # MethodModel (pre-existing limitation), which matches
-              # legacy behaviour.
-              mapping_annotation = method_model.annotations.values.find do |a|
-                a.name.ends_with?("Mapping")
-              end
-              parameter_format = consumes_parameter_format(mapping_annotation)
+              parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes(
+                content, route.class_name, route.method_name
+              )
               if parameter_format.nil? && route.verb == "POST"
                 parameter_format = "form"
               end
 
-              parameters = get_endpoint_parameters(
-                parser, route.verb, method_model, parameter_format, class_map
+              parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+                content, route.class_name, route.method_name, route.verb, parameter_format, dto_index
               )
 
               # webflux base-path normalisation — drop the trailing `/`
@@ -136,10 +149,7 @@ module Analyzer::Java
                 base_path = base_path[..-2]
               end
 
-              # Prefer the MethodModel's annotation line (1-based,
-              # matches legacy) when available. Fall back to the
-              # tree-sitter row (0-based) + 1.
-              line = mapping_annotation ? mapping_annotation.tokens[0].line : route.line + 1
+              line = route.line + 1
               details = Details.new(PathInfo.new(path, line))
 
               endpoint = Endpoint.new(
@@ -258,210 +268,6 @@ module Analyzer::Java
       end
 
       ""
-    end
-
-    # Return "form" / "json" when the `@*Mapping` annotation declares
-    # a `consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE` or
-    # `APPLICATION_JSON_VALUE`. nil otherwise (callers supply their
-    # own default — POST, for example, falls back to "form").
-    private def consumes_parameter_format(mapping_annotation) : String?
-      return if mapping_annotation.nil?
-      mapping_annotation.params.each do |param_tokens|
-        next unless param_tokens.size > 2
-        next unless param_tokens[0].value == "consumes"
-        value = param_tokens[-1].value
-        return "form" if value.ends_with?("APPLICATION_FORM_URLENCODED_VALUE")
-        return "json" if value.ends_with?("APPLICATION_JSON_VALUE")
-      end
-      nil
-    end
-
-    def get_mapping_path(parser : JavaParser, tokens : Array(Token), method_params : Array(Array(Token)))
-      # 1. Search for the value of the Mapping annotation.
-      # 2. If the value is a string literal, return the literal.
-      # 3. If the value is an array, return each element of the array.
-      # 4. In other cases, return an empty array.
-      url_paths = Array(String).new
-      if method_params[0].size != 0
-        path_argument_index = 0
-        method_params.each_with_index do |mapping_parameter, index|
-          next unless mapping_parameter
-          if mapping_parameter[0].type == :IDENTIFIER && mapping_parameter[0].value == "value"
-            path_argument_index = index
-          end
-        end
-
-        path_parameter_tokens = method_params[path_argument_index]
-        # Extract single and multiple mapping path
-        if path_parameter_tokens[-1].type == :STRING_LITERAL
-          url_paths << path_parameter_tokens[-1].value[1..-2]
-        elsif path_parameter_tokens[-1].type == :RBRACE
-          i = path_parameter_tokens.size - 2
-          while i > 0
-            parameter_token = path_parameter_tokens[i]
-            if parameter_token.type == :LBRACE
-              break
-            elsif parameter_token.type == :COMMA
-              i -= 1
-              next
-            elsif parameter_token.type == :STRING_LITERAL
-              url_paths << parameter_token.value[1..-2]
-            else
-              break
-            end
-
-            i -= 1
-          end
-        end
-      end
-
-      url_paths
-    end
-
-    def get_endpoint_parameters(parser : JavaParser, request_method : String, method : MethodModel, parameter_format : String?, package_class_map : Hash(String, ClassModel)) : Array(Param)
-      endpoint_parameters = Array(Param).new
-      method.params.each do |method_param_tokens|
-        next if method_param_tokens.size == 0
-        if method_param_tokens[-1].type == :IDENTIFIER
-          if method_param_tokens[0].type == :AT
-            if method_param_tokens[1].value == "PathVariable"
-              next
-            elsif method_param_tokens[1].value == "RequestBody"
-              if parameter_format.nil?
-                parameter_format = "json"
-              end
-            elsif method_param_tokens[1].value == "RequestParam"
-              parameter_format = "query"
-            elsif method_param_tokens[1].value == "RequestHeader"
-              parameter_format = "header"
-            end
-          end
-
-          if parameter_format.nil?
-            next
-          end
-
-          default_value = nil
-          # Extract parameter name directly if not an identifier
-          parameter_name = method_param_tokens[-1].value
-          if method_param_tokens.size > 2
-            if method_param_tokens[2].type == :LPAREN
-              request_parameters = parser.parse_formal_parameters(method_param_tokens, 2)
-              request_parameters.each do |request_parameter_tokens|
-                if request_parameter_tokens.size > 2
-                  request_param_name = request_parameter_tokens[0].value
-                  request_param_value = request_parameter_tokens[-1].value
-
-                  # Extract 'name' from @RequestParam(value/defaultValue/name = "name")
-                  if request_param_name == "value"
-                    parameter_name = request_param_value
-                  elsif request_param_name == "name"
-                    parameter_name = request_param_value
-                  elsif request_param_name == "defaultValue"
-                    default_value = request_param_value
-                  end
-
-                  unless parameter_name.nil?
-                    if parameter_name.starts_with?("\"") && parameter_name.ends_with?("\"")
-                      parameter_name = parameter_name[1..-2]
-                    else
-                      idx = 2
-                      while idx < request_parameter_tokens.size
-                        req_param_token = request_parameter_tokens[-idx]
-                        break unless req_param_token.type == :IDENTIFIER || req_param_token.type == :DOT
-                        parameter_name = req_param_token.value + parameter_name
-                        idx += 1
-                      end
-
-                      # https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpHeaders.html
-                      if parameter_name.starts_with?("HttpHeaders.")
-                        header_key = parameter_name["HttpHeaders.".size..-1]
-                        parameter_name = header_key.split('_').map(&.capitalize).join('-')
-                        special_cases = {
-                          "Etag"             => "ETag",
-                          "Te"               => "TE",
-                          "Www-Authenticate" => "WWW-Authenticate",
-                          "X-Frame-Options"  => "X-Frame-Options",
-                        }
-                        if special_cases.has_key?(parameter_name)
-                          parameter_name = special_cases[parameter_name]
-                        end
-                      end
-                    end
-                  end
-
-                  unless default_value.nil?
-                    if default_value.starts_with?("\"") && default_value.ends_with?("\"")
-                      default_value = default_value[1..-2]
-                    end
-                  end
-                end
-              end
-              # Handle direct string literal as parameter name, e.g., @RequestParam("name")
-              if method_param_tokens[3].type == :STRING_LITERAL
-                parameter_name_token = method_param_tokens[3]
-                parameter_name = parameter_name_token.value[1..-2]
-              end
-            end
-          end
-
-          argument_name = method_param_tokens[-1].value
-          parameter_type = method_param_tokens[-2].value
-          if ["long", "int", "integer", "char", "boolean", "string", "multipartfile"].index(parameter_type.downcase)
-            param_default_value = default_value.nil? ? "" : default_value
-            endpoint_parameters << Param.new(parameter_name, param_default_value, parameter_format)
-          elsif parameter_type == "HttpServletRequest"
-            i = 0
-            while i < method.body.size - 6
-              if [:TAB, :NEWLINE].index(method.body[i].type)
-                i += 1
-                next
-              end
-
-              next if method.body[i].type == :NEWLINE
-
-              if method.body[i].type == :IDENTIFIER && method.body[i].value == argument_name
-                if method.body[i + 1].type == :DOT
-                  if method.body[i + 2].type == :IDENTIFIER && method.body[i + 3].type == :LPAREN
-                    servlet_request_method_name = method.body[i + 2].value
-                    if method.body[i + 4].type == :STRING_LITERAL
-                      parameter_name = method.body[i + 4].value[1..-2]
-                      if servlet_request_method_name == "getParameter"
-                        unless endpoint_parameters.any? { |param| param.name == parameter_name }
-                          endpoint_parameters << Param.new(parameter_name, "", parameter_format)
-                        end
-                        i += 6
-                        next
-                      elsif servlet_request_method_name == "getHeader"
-                        unless endpoint_parameters.any? { |param| param.name == parameter_name }
-                          endpoint_parameters << Param.new(parameter_name, "", "header")
-                        end
-                        i += 6
-                        next
-                      end
-                    end
-                  end
-                end
-              end
-
-              i += 1
-            end
-          else
-            # Map fields of user-defined class to parameters.
-            if package_class_map.has_key?(parameter_type)
-              package_class = package_class_map[parameter_type]
-              package_class.fields.values.each do |field|
-                if field.access_modifier == "public" || field.has_setter?
-                  param_default_value = default_value.nil? ? field.init_value : default_value
-                  endpoint_parameters << Param.new(field.name, param_default_value, parameter_format)
-                end
-              end
-            end
-          end
-        end
-      end
-
-      endpoint_parameters
     end
   end
 end

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -1,0 +1,492 @@
+require "../ext/tree_sitter/tree_sitter"
+require "../models/endpoint"
+
+module Noir
+  # Tree-sitter-backed parameter extractor for Java/Spring.
+  #
+  # Pairs with `TreeSitterJavaRouteExtractor`: after the route
+  # discovery pass tells us which methods are routes, this module
+  # walks the matching `method_declaration` to extract request
+  # parameters from `@RequestParam` / `@RequestBody` / `@RequestHeader`
+  # / `@PathVariable` annotations, primitive typed args,
+  # `HttpServletRequest` body scans, and user-defined DTO fields.
+  #
+  # DTO resolution is caller-provided (`class_fields` map) so the same
+  # extractor works whether fields come from a same-file scan, a same-
+  # package Dir.glob, or a cross-file import resolver. Keeping that
+  # concern out of here keeps the extractor source-scoped and testable.
+  module TreeSitterJavaParameterExtractor
+    extend self
+
+    # Primitive / stdlib types whose name we emit directly as a
+    # parameter. Everything else is looked up in `class_fields` for
+    # DTO expansion.
+    PRIMITIVE_TYPES = Set{"long", "int", "integer", "char", "boolean", "string", "multipartfile"}
+
+    # Subset of servlet types whose method body is scanned for
+    # `request.getParameter("x")` / `request.getHeader("x")` calls.
+    SERVLET_REQUEST_TYPES = Set{"HttpServletRequest"}
+
+    # Spring `HttpHeaders` constant → canonical header name. Matches
+    # the table the legacy analyzer maintained; necessary because
+    # tree-sitter reports the constant as a `field_access` node
+    # (e.g. `HttpHeaders.AUTHORIZATION`), not the string value.
+    HTTP_HEADER_SPECIAL_CASES = {
+      "Etag"             => "ETag",
+      "Te"               => "TE",
+      "Www-Authenticate" => "WWW-Authenticate",
+      "X-Frame-Options"  => "X-Frame-Options",
+    }
+
+    struct FieldInfo
+      getter name : String
+      getter access_modifier : String # "public", "private", "protected", ""
+      getter? has_setter : Bool
+      getter init_value : String # "" when no initializer
+
+      def initialize(@name, @access_modifier, @has_setter, @init_value)
+      end
+    end
+
+    # Scan every `class_declaration` / `interface_declaration` in
+    # `source` and return `{class_name => [FieldInfo]}`. Only classes
+    # with at least one field appear; setter detection walks sibling
+    # `method_declaration`s looking for `setFoo(...)`.
+    def extract_class_fields(source : String) : Hash(String, Array(FieldInfo))
+      results = Hash(String, Array(FieldInfo)).new
+      Noir::TreeSitter.parse_java(source) do |root|
+        walk_class_containers(root) do |decl|
+          name_node = Noir::TreeSitter.field(decl, "name")
+          next unless name_node
+          class_name = Noir::TreeSitter.node_text(name_node, source)
+          body = Noir::TreeSitter.field(decl, "body")
+          next unless body
+          fields = collect_class_fields(body, source)
+          results[class_name] = fields unless fields.empty?
+        end
+      end
+      results
+    end
+
+    # Extract parameters for `method_name` on `class_name`. Returns
+    # `[]` when the method isn't found. `parameter_format` is the
+    # method's default-shape hint (e.g. "form" when `@PostMapping` +
+    # no explicit `consumes`); individual parameter annotations
+    # override it.
+    #
+    # `class_fields` is the pre-built DTO index — a parameter whose
+    # type matches a key is expanded into one `Param` per public /
+    # setter-backed field on that class.
+    def extract_method_parameters(source : String,
+                                  class_name : String,
+                                  method_name : String,
+                                  verb : String,
+                                  parameter_format : String?,
+                                  class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
+      params = [] of Param
+      Noir::TreeSitter.parse_java(source) do |root|
+        method = find_method(root, source, class_name, method_name)
+        next unless method
+        params = collect_method_params(method, source, verb, parameter_format, class_fields)
+      end
+      params
+    end
+
+    # Find `@*Mapping` annotation on (class_name, method_name) and
+    # read its `consumes = ...` attribute. Returns "form" / "json" /
+    # nil — matches `spring.cr`'s legacy helper semantics so the
+    # analyzer can swap this in without behaviour drift.
+    def extract_consumes(source : String, class_name : String, method_name : String) : String?
+      result : String? = nil
+      Noir::TreeSitter.parse_java(source) do |root|
+        method = find_method(root, source, class_name, method_name)
+        next unless method
+        ann = mapping_annotation_on(method, source)
+        next unless ann
+        args = Noir::TreeSitter.field(ann, "arguments")
+        next unless args
+        Noir::TreeSitter.each_named_child(args) do |arg|
+          next unless Noir::TreeSitter.node_type(arg) == "element_value_pair"
+          key = Noir::TreeSitter.field(arg, "key")
+          val = Noir::TreeSitter.field(arg, "value")
+          next unless key && val
+          next unless Noir::TreeSitter.node_text(key, source) == "consumes"
+          text = Noir::TreeSitter.node_text(val, source)
+          if text.ends_with?("APPLICATION_FORM_URLENCODED_VALUE")
+            result = "form"
+          elsif text.ends_with?("APPLICATION_JSON_VALUE")
+            result = "json"
+          end
+        end
+      end
+      result
+    end
+
+    # Return the set of class/interface simple names annotated with
+    # `@FeignClient` in `source`. Spring Cloud Feign interfaces are
+    # treated as remote clients in the analyzer's output.
+    def extract_feign_client_classes(source : String) : Set(String)
+      result = Set(String).new
+      Noir::TreeSitter.parse_java(source) do |root|
+        walk_class_containers(root) do |decl|
+          name_node = Noir::TreeSitter.field(decl, "name")
+          next unless name_node
+          each_annotation_on(decl, source) do |ann_name|
+            if ann_name == "FeignClient"
+              result << Noir::TreeSitter.node_text(name_node, source)
+              break
+            end
+          end
+        end
+      end
+      result
+    end
+
+    # ---- private helpers ----------------------------------------------
+
+    # Walk every class/interface declaration in the tree.
+    private def walk_class_containers(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      ty = Noir::TreeSitter.node_type(node)
+      if ty == "class_declaration" || ty == "interface_declaration"
+        block.call(node)
+      end
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_class_containers(child, &block)
+      end
+    end
+
+    # Find the (class_name, method_name) method_declaration in the
+    # tree. Returns nil when absent.
+    private def find_method(root : LibTreeSitter::TSNode,
+                            source : String,
+                            class_name : String,
+                            method_name : String) : LibTreeSitter::TSNode?
+      result : LibTreeSitter::TSNode? = nil
+      walk_class_containers(root) do |decl|
+        next if result
+        name_node = Noir::TreeSitter.field(decl, "name")
+        next unless name_node
+        next unless Noir::TreeSitter.node_text(name_node, source) == class_name
+        body = Noir::TreeSitter.field(decl, "body")
+        next unless body
+        Noir::TreeSitter.each_named_child(body) do |member|
+          next if result
+          next unless Noir::TreeSitter.node_type(member) == "method_declaration"
+          mn = Noir::TreeSitter.field(member, "name")
+          next unless mn
+          if Noir::TreeSitter.node_text(mn, source) == method_name
+            result = member
+          end
+        end
+      end
+      result
+    end
+
+    # Iterate annotation names (marker or full) attached to a
+    # declaration's `modifiers` child. Yields just the simple name
+    # (e.g. `"RequestParam"` even for `@org.springframework.web.bind.
+    # annotation.RequestParam`).
+    private def each_annotation_on(decl : LibTreeSitter::TSNode, source : String, &)
+      mods = find_modifiers(decl)
+      return unless mods
+      Noir::TreeSitter.each_named_child(mods) do |ann|
+        ty = Noir::TreeSitter.node_type(ann)
+        next unless ty == "annotation" || ty == "marker_annotation"
+        n = Noir::TreeSitter.field(ann, "name")
+        next unless n
+        yield simple_name(Noir::TreeSitter.node_text(n, source))
+      end
+    end
+
+    private def find_modifiers(decl : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        return child if Noir::TreeSitter.node_type(child) == "modifiers"
+      end
+      nil
+    end
+
+    private def simple_name(full : String) : String
+      if idx = full.rindex('.')
+        full[(idx + 1)..]
+      else
+        full
+      end
+    end
+
+    # Find the first annotation whose simple name ends with "Mapping".
+    private def mapping_annotation_on(decl : LibTreeSitter::TSNode, source : String) : LibTreeSitter::TSNode?
+      mods = find_modifiers(decl)
+      return unless mods
+      Noir::TreeSitter.each_named_child(mods) do |ann|
+        ty = Noir::TreeSitter.node_type(ann)
+        next unless ty == "annotation" || ty == "marker_annotation"
+        n = Noir::TreeSitter.field(ann, "name")
+        next unless n
+        return ann if simple_name(Noir::TreeSitter.node_text(n, source)).ends_with?("Mapping")
+      end
+      nil
+    end
+
+    # ---- class field introspection ------------------------------------
+
+    private def collect_class_fields(body : LibTreeSitter::TSNode, source : String) : Array(FieldInfo)
+      # First pass: collect field declarations.
+      declared = [] of Tuple(String, String, String) # name, access, init_value
+      setter_targets = Set(String).new
+
+      Noir::TreeSitter.each_named_child(body) do |member|
+        case Noir::TreeSitter.node_type(member)
+        when "field_declaration"
+          access = modifier_access(member, source)
+          type_node = Noir::TreeSitter.field(member, "type")
+          _ = type_node
+          dec = Noir::TreeSitter.field(member, "declarator")
+          next unless dec
+          name_node = Noir::TreeSitter.field(dec, "name")
+          next unless name_node
+          name = Noir::TreeSitter.node_text(name_node, source)
+          init = ""
+          if value_node = Noir::TreeSitter.field(dec, "value")
+            init = Noir::TreeSitter.node_text(value_node, source)
+          end
+          declared << {name, access, init}
+        when "method_declaration"
+          mn = Noir::TreeSitter.field(member, "name")
+          next unless mn
+          name = Noir::TreeSitter.node_text(mn, source)
+          next unless name.starts_with?("set") && name.size > 3
+          # Convert `setFoo` → `foo` for field-name matching.
+          base = name[3].downcase.to_s + name[4..]
+          setter_targets << base
+        end
+      end
+
+      declared.map do |name, access, init|
+        FieldInfo.new(name, access, setter_targets.includes?(name), init)
+      end
+    end
+
+    # Return the first access modifier keyword in `decl`'s modifiers,
+    # or "" when none. Spring's legacy analyzer compared this to
+    # "public" to decide whether a field is externally settable.
+    private def modifier_access(decl : LibTreeSitter::TSNode, source : String) : String
+      mods = find_modifiers(decl)
+      return "" unless mods
+      count = LibTreeSitter.ts_node_child_count(mods)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_child(mods, i.to_u32)
+        text = Noir::TreeSitter.node_text(child, source)
+        case text
+        when "public", "private", "protected"
+          return text
+        end
+      end
+      ""
+    end
+
+    # ---- method parameter walk ----------------------------------------
+
+    private def collect_method_params(method : LibTreeSitter::TSNode,
+                                      source : String,
+                                      verb : String,
+                                      parameter_format : String?,
+                                      class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
+      params = [] of Param
+      fparams = Noir::TreeSitter.field(method, "parameters")
+      return params unless fparams
+
+      # `current_format` carries over between parameters, matching the
+      # legacy analyzer's sticky state: once a `@RequestParam` promotes
+      # the format to "query", a subsequent un-annotated `String name`
+      # argument is still emitted as a query parameter.
+      current_format = parameter_format
+
+      Noir::TreeSitter.each_named_child(fparams) do |fp|
+        next unless Noir::TreeSitter.node_type(fp) == "formal_parameter"
+        current_format = emit_param_for(fp, method, source, verb, current_format, class_fields, params)
+      end
+      params
+    end
+
+    private def emit_param_for(fp : LibTreeSitter::TSNode,
+                               method : LibTreeSitter::TSNode,
+                               source : String,
+                               verb : String,
+                               parameter_format : String?,
+                               class_fields : Hash(String, Array(FieldInfo)),
+                               sink : Array(Param)) : String?
+      type_node = Noir::TreeSitter.field(fp, "type")
+      name_node = Noir::TreeSitter.field(fp, "name")
+      return parameter_format unless type_node && name_node
+
+      type_name = Noir::TreeSitter.node_text(type_node, source)
+      arg_name = Noir::TreeSitter.node_text(name_node, source)
+
+      # Annotation dispatch. A parameter may carry at most one of
+      # `@PathVariable` / `@RequestBody` / `@RequestParam` /
+      # `@RequestHeader`; the first we see wins.
+      ann_kind = nil
+      ann_node : LibTreeSitter::TSNode? = nil
+      if mods = find_modifiers(fp)
+        Noir::TreeSitter.each_named_child(mods) do |ann|
+          ty = Noir::TreeSitter.node_type(ann)
+          next unless ty == "annotation" || ty == "marker_annotation"
+          n = Noir::TreeSitter.field(ann, "name")
+          next unless n
+          sn = simple_name(Noir::TreeSitter.node_text(n, source))
+          case sn
+          when "PathVariable"
+            ann_kind = :path
+            ann_node = ann
+            break
+          when "RequestBody"
+            ann_kind = :body
+            ann_node = ann
+            break
+          when "RequestParam"
+            ann_kind = :query
+            ann_node = ann
+            break
+          when "RequestHeader"
+            ann_kind = :header
+            ann_node = ann
+            break
+          end
+        end
+      end
+
+      return parameter_format if ann_kind == :path # legacy: @PathVariable is not emitted
+
+      effective_format = parameter_format
+      case ann_kind
+      when :body
+        effective_format = effective_format.nil? ? "json" : effective_format
+      when :query
+        effective_format = "query"
+      when :header
+        effective_format = "header"
+      end
+      return effective_format if effective_format.nil?
+
+      default_value : String? = nil
+      parameter_name = arg_name
+
+      # Walk `@RequestParam(value = "x", defaultValue = "y")` / single-arg shorthand.
+      if ann_node
+        if args = Noir::TreeSitter.field(ann_node, "arguments")
+          Noir::TreeSitter.each_named_child(args) do |arg|
+            case Noir::TreeSitter.node_type(arg)
+            when "string_literal"
+              parameter_name = decode_string_literal(arg, source)
+            when "field_access"
+              parameter_name = normalise_http_header_constant(Noir::TreeSitter.node_text(arg, source))
+            when "element_value_pair"
+              key = Noir::TreeSitter.field(arg, "key")
+              val = Noir::TreeSitter.field(arg, "value")
+              next unless key && val
+              k = Noir::TreeSitter.node_text(key, source)
+              case k
+              when "value", "name"
+                parameter_name = resolve_annotation_string_or_const(val, source)
+              when "defaultValue"
+                default_value = decode_string_literal(val, source) if Noir::TreeSitter.node_type(val) == "string_literal"
+              end
+            end
+          end
+        end
+      end
+
+      type_key = type_name.downcase
+      if PRIMITIVE_TYPES.includes?(type_key)
+        sink << Param.new(parameter_name, default_value || "", effective_format)
+      elsif SERVLET_REQUEST_TYPES.includes?(type_name)
+        scan_servlet_body(method, source, arg_name, effective_format, sink)
+      elsif fields = class_fields[type_name]?
+        fields.each do |field|
+          next unless field.access_modifier == "public" || field.has_setter?
+          expanded_default = default_value || field.init_value
+          sink << Param.new(field.name, expanded_default, effective_format)
+        end
+      end
+
+      effective_format
+    end
+
+    # Resolve either a string literal or a qualified-identifier
+    # constant (`HttpHeaders.AUTHORIZATION`) to the final header/param
+    # name. Matches the legacy normalisation.
+    private def resolve_annotation_string_or_const(node : LibTreeSitter::TSNode, source : String) : String
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        decode_string_literal(node, source)
+      when "field_access"
+        normalise_http_header_constant(Noir::TreeSitter.node_text(node, source))
+      else
+        Noir::TreeSitter.node_text(node, source)
+      end
+    end
+
+    # `HttpHeaders.X_FRAME_OPTIONS` → `X-Frame-Options`.
+    private def normalise_http_header_constant(raw : String) : String
+      return raw unless raw.starts_with?("HttpHeaders.")
+      header_key = raw["HttpHeaders.".size..]
+      normalised = header_key.split('_').map(&.capitalize).join('-')
+      HTTP_HEADER_SPECIAL_CASES[normalised]? || normalised
+    end
+
+    # Walk a method body for `<arg>.getParameter("x")` /
+    # `<arg>.getHeader("x")` calls, turning each into a Param on the
+    # endpoint. `arg_name` is the declared `HttpServletRequest`
+    # parameter name.
+    private def scan_servlet_body(method : LibTreeSitter::TSNode,
+                                  source : String,
+                                  arg_name : String,
+                                  parameter_format : String,
+                                  sink : Array(Param))
+      body = Noir::TreeSitter.field(method, "body")
+      return unless body
+      walk_node(body) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "method_invocation"
+        obj = Noir::TreeSitter.field(node, "object")
+        name = Noir::TreeSitter.field(node, "name")
+        next unless obj && name
+        next unless Noir::TreeSitter.node_type(obj) == "identifier"
+        next unless Noir::TreeSitter.node_text(obj, source) == arg_name
+        method_name = Noir::TreeSitter.node_text(name, source)
+        next unless method_name == "getParameter" || method_name == "getHeader"
+
+        args = Noir::TreeSitter.field(node, "arguments")
+        next unless args
+        Noir::TreeSitter.each_named_child(args) do |arg|
+          next unless Noir::TreeSitter.node_type(arg) == "string_literal"
+          param_name = decode_string_literal(arg, source)
+          next if param_name.empty?
+          format = method_name == "getHeader" ? "header" : parameter_format
+          # Match legacy dedupe: same-name params collapse.
+          next if sink.any? { |p| p.name == param_name && p.param_type == format }
+          sink << Param.new(param_name, "", format)
+        end
+      end
+    end
+
+    private def walk_node(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_node(child, &block)
+      end
+    end
+
+    private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
+      buf = String.build do |io|
+        Noir::TreeSitter.each_named_child(node) do |child|
+          if Noir::TreeSitter.node_type(child) == "string_fragment"
+            io << Noir::TreeSitter.node_text(child, source)
+          end
+        end
+      end
+      buf
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Step 4 of #1291. Replaces the 144-line `get_endpoint_parameters` + supporting helpers in `spring.cr` with a new `TreeSitterJavaParameterExtractor` module. The Spring analyzer no longer consults `JavaParser.MethodModel` for parameter introspection — routes, params, `consumes`, and `@FeignClient` detection all run through tree-sitter.

## Shapes covered

- **`@PathVariable`** — skipped (URL already carries path params)
- **`@RequestBody`** — format defaults to `json`; `consumes = ...` on the method's `@*Mapping` overrides
- **`@RequestParam`** — forces `query`; `value=`/`name=`/positional string resolve the param name; `defaultValue=` carries through
- **`@RequestHeader`** — forces `header`; `HttpHeaders.X_FRAME_OPTIONS` constant normalised to `X-Frame-Options`; full special-case table (`Etag`→`ETag`, `Te`→`TE`, `Www-Authenticate`→`WWW-Authenticate`) preserved
- **Primitive / String / MultipartFile** — emitted directly with the declared parameter name
- **HttpServletRequest body scan** — walks `method_invocation` nodes against the declared servlet argument name; recognises `<arg>.getParameter(\"x\")` / `<arg>.getHeader(\"x\")`; dedupes same-name entries
- **User-defined DTO** — looks up the type in a caller-supplied `class_fields` index; each `public` or setter-backed field fans out into its own Param
- **Sticky format** — once a `@RequestParam` promotes the format to `query`, a following un-annotated `String name` argument inherits `query`. Reproduces the legacy analyzer's per-method carry-over so no endpoint params go missing.

## DTO index architecture

`extract_class_fields(source)` scans in-file classes via tree-sitter. The analyzer top-layer additionally merges same-package / import classes that the legacy `JavaParser` resolves cross-file. **That last hop is the sole remaining `JavaParser` usage in `spring.cr`**; killing it in the next PR lets `src/miniparsers/java.cr` (669 LOC) + `src/minilexers/java.cr` (576 LOC) finally be deleted.

## Also removed

- `Spring#consumes_parameter_format` — replaced by `TreeSitterJavaParameterExtractor.extract_consumes`
- `Spring#get_endpoint_parameters` + `Spring#get_mapping_path` — dead code now that TS covers both responsibilities
- `class_model.annotations[\"FeignClient\"]?` lookup — replaced by `TreeSitterJavaParameterExtractor.extract_feign_client_classes`

## Test plan

- [x] `spec/functional_test/testers/java/spring_spec.cr` — every expected endpoint (60+) passes, including FeignClient interfaces, DTO field fan-out, sticky-format params, HttpServletRequest body scanning, `HttpHeaders.AUTHORIZATION` header resolution
- [x] Full suite: **6352 examples, 0 failures**
- [x] `ameba` + `crystal tool format --check` clean

## Not yet

Cross-file DTO resolution (same-package sibling scan, import path resolution) still lives on `JavaParser`. Porting it to tree-sitter removes the last `JavaParser` call in `spring.cr`, at which point `miniparsers/java.cr` + `minilexers/java.cr` can be deleted. Next PR in this track.

## Related

- Umbrella: #1291
- Builds on: #1292 (grammar + PoC), #1293 (extractor parity), #1294 (route-discovery swap)