### PR TITLE
feat: vendor tree-sitter-kotlin grammar + Spring route extractor PoC

### DIFF
--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -1,0 +1,125 @@
+require "spec"
+require "../../../src/miniparsers/kotlin_route_extractor_ts"
+
+describe Noir::TreeSitterKotlinRouteExtractor do
+  it "composes class-level and method-level mapping prefixes" do
+    source = <<-KT
+      package com.example
+
+      @RestController
+      @RequestMapping("/api")
+      class UserController {
+          @GetMapping("/users")
+          fun list(): String = ""
+
+          @PostMapping("/users")
+          fun create(): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path, r.method_name} }.should eq([
+      {"GET", "/api/users", "list"},
+      {"POST", "/api/users", "create"},
+    ])
+  end
+
+  it "handles value = / path = keyword arguments" do
+    source = <<-KT
+      class K {
+          @GetMapping(value = "/x")
+          fun a(): String = ""
+
+          @PostMapping(path = "/y", produces = ["application/json"])
+          fun b(): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/x"},
+      {"POST", "/y"},
+    ])
+  end
+
+  it "derives the verb from RequestMethod for generic @RequestMapping" do
+    source = <<-KT
+      class M {
+          @RequestMapping(value = "/get", method = [RequestMethod.GET])
+          fun a(): String = ""
+
+          @RequestMapping(value = "/post", method = [RequestMethod.POST])
+          fun b(): String = ""
+
+          @RequestMapping("/default")
+          fun c(): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/get"},
+      {"POST", "/post"},
+      {"GET", "/default"},
+    ])
+  end
+
+  it "fans out method arrays in @RequestMapping" do
+    source = <<-KT
+      @RequestMapping("items")
+      class C {
+          @RequestMapping("/multiple/methods", method = [RequestMethod.GET, RequestMethod.POST])
+          fun c(): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "items/multiple/methods"},
+      {"POST", "items/multiple/methods"},
+    ])
+  end
+
+  it "fans out path arrays on mapping annotations" do
+    source = <<-KT
+      class A {
+          @GetMapping(value = ["/a", "/b"])
+          fun x(): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/a"},
+      {"GET", "/b"},
+    ])
+  end
+
+  it "emits prefix/ when the method path is empty" do
+    # Kotlin Spring controllers routinely do
+    # `@RequestMapping("/api/article")` on the class and `@GetMapping`
+    # (no path arg) on a method, expecting `/api/article/` for the
+    # handler. Matches the Java Spring behaviour pinned down in #1291.
+    source = <<-KT
+      @RequestMapping("/api/article")
+      class ArticleController {
+          @GetMapping
+          fun list(): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map(&.path).should eq(["/api/article/"])
+  end
+
+  it "ignores non-mapping annotations" do
+    source = <<-KT
+      class X {
+          @Deprecated("old")
+          fun legacy(): Unit = Unit
+      }
+      KT
+
+    Noir::TreeSitterKotlinRouteExtractor.extract_routes(source).should be_empty
+  end
+end

--- a/src/ext/tree_sitter/build.sh
+++ b/src/ext/tree_sitter/build.sh
@@ -58,7 +58,7 @@ fi
 # Each grammar ships `parser.c` (always, auto-generated). Most also ship
 # `scanner.c` (hand-written custom lexer for context-sensitive tokens) —
 # Go does not, so we compile scanner.c only when the file exists.
-GRAMMARS="python go java"
+GRAMMARS="python go java kotlin"
 OBJS="$RUNTIME_OBJ"
 for g in $GRAMMARS; do
   GD="$D/grammars/$g"

--- a/src/ext/tree_sitter/grammars/kotlin/scanner.c
+++ b/src/ext/tree_sitter/grammars/kotlin/scanner.c
@@ -1,0 +1,530 @@
+#include "tree_sitter/array.h"
+#include "tree_sitter/parser.h"
+
+#include <string.h>
+#include <wctype.h>
+
+// Mostly a copy paste of tree-sitter-javascript/src/scanner.c
+
+enum TokenType {
+  AUTOMATIC_SEMICOLON,
+  IMPORT_LIST_DELIMITER,
+  SAFE_NAV,
+  MULTILINE_COMMENT,
+  STRING_START,
+  STRING_END,
+  STRING_CONTENT,
+};
+
+/* Pretty much all of this code is taken from the Julia tree-sitter
+   parser.
+
+   Julia has similar problems with multiline comments that can be nested,
+   line comments, as well as line and multiline strings.
+
+   The most heavily edited section is `scan_string_content`,
+   particularly with respect to interpolation.
+ */
+
+// Block comments are easy to parse, but strings require extra-attention.
+
+// The main problems that arise when parsing strings are:
+// 1. Triple quoted strings allow single quotes inside. e.g. """ "foo" """.
+// 2. Non-standard string literals don't allow interpolations or escape
+//    sequences, but you can always write \" and \`.
+
+// To efficiently store a delimiter, we take advantage of the fact that:
+// (int)'"' == 34 && (34 & 1) == 0
+// i.e. " has an even numeric representation, so we can store a triple
+// quoted delimiter as (delimiter + 1).
+
+#define DELIMITER_LENGTH 3
+
+typedef char Delimiter;
+
+// We use a stack to keep track of the string delimiters.
+typedef Array(Delimiter) Stack;
+
+static inline void stack_push(Stack *stack, char chr, bool triple) {
+  if (stack->size >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) abort();
+  array_push(stack, (Delimiter)(triple ? (chr + 1) : chr));
+}
+
+static inline Delimiter stack_pop(Stack *stack) {
+  if (stack->size == 0) abort();
+  return array_pop(stack);
+}
+
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+// Scanner functions
+
+static bool scan_string_start(TSLexer *lexer, Stack *stack) {
+  if (lexer->lookahead != '"') return false;
+  advance(lexer);
+  lexer->mark_end(lexer);
+  for (unsigned count = 1; count < DELIMITER_LENGTH; ++count) {
+    if (lexer->lookahead != '"') {
+      // It's not a triple quoted delimiter.
+      stack_push(stack, '"', false);
+      return true;
+    }
+    advance(lexer);
+  }
+  lexer->mark_end(lexer);
+  stack_push(stack, '"', true);
+  return true;
+}
+
+static bool scan_string_content(TSLexer *lexer, Stack *stack) {
+  if (stack->size == 0) return false;  // Stack is empty. We're not in a string.
+  Delimiter end_char = stack->contents[stack->size - 1];  // peek
+  bool is_triple = false;
+  bool has_content = false;
+  if (end_char & 1) {
+    is_triple = true;
+    end_char -= 1;
+  }
+  while (lexer->lookahead) {
+    if (lexer->lookahead == '$') {
+      // if we did not just start reading stuff, then we should stop
+      // lexing right here, so we can offer the opportunity to lex a
+      // interpolated identifier
+      if (has_content) {
+        lexer->result_symbol = STRING_CONTENT;
+        return has_content;
+      }
+      // otherwise, if this is the start, determine if it is an
+      // interpolated identifier.
+      // otherwise, it's just string content, so continue
+      advance(lexer);
+      if (iswalpha(lexer->lookahead) || lexer->lookahead == '{') {
+        // this must be a string interpolation, let's
+        // fail so we parse it as such
+        return false;
+      }
+      lexer->result_symbol = STRING_CONTENT;
+      lexer->mark_end(lexer);
+      return true;
+    }
+    if (lexer->lookahead == '\\') {
+      // if we see a \, then this might possibly escape a dollar sign
+      // in which case, we should not defer to the interpolation
+      advance(lexer);
+      // this dollar sign is escaped, so it must be content.
+      // we consume it here so we don't enter the dollar sign case above,
+      // which leaves the possibility that it is an interpolation 
+      if (lexer->lookahead == '$') {
+        advance(lexer);
+        // however this leaves an edgecase where an escaped dollar sign could
+        // appear at the end of a string (e.g "aa\$") which isn't handled
+        // correctly; if we were at the end of the string, terminate properly
+        if (lexer->lookahead == end_char) {
+          stack_pop(stack);
+          advance(lexer);
+          lexer->mark_end(lexer);
+          lexer->result_symbol = STRING_END;
+          return true;
+        }
+      }
+    } else if (lexer->lookahead == end_char) {
+      if (is_triple) {
+        lexer->mark_end(lexer);
+        for (unsigned count = 1; count < DELIMITER_LENGTH; ++count) {
+          advance(lexer);
+          if (lexer->lookahead != end_char) {
+            lexer->mark_end(lexer);
+            lexer->result_symbol = STRING_CONTENT;
+            return true;
+          }
+        }
+
+        /* This is so if we lex something like
+           """foo"""
+              ^
+           where we are at the `f`, we should quit after
+           reading `foo`, and ascribe it to STRING_CONTENT.
+
+           Then, we restart and try to read the end.
+           This is to prevent `foo` from being absorbed into
+           the STRING_END token.
+         */
+        if (has_content && lexer->lookahead == end_char) {
+          lexer->result_symbol = STRING_CONTENT;
+          return true;
+        }
+
+        /* Since the string internals are all hidden in the syntax
+           tree anyways, there's no point in going to the effort of
+           specifically separating the string end from string contents.
+           If we see a bunch of quotes in a row, then we just go until
+           they stop appearing, then stop lexing and call it the
+           string's end.
+         */
+        lexer->result_symbol = STRING_END;
+        lexer->mark_end(lexer);
+        while (lexer->lookahead == end_char) {
+          advance(lexer);
+          lexer->mark_end(lexer);
+        }
+        stack_pop(stack);
+        return true;
+      }
+      if (has_content) {
+        lexer->mark_end(lexer);
+        lexer->result_symbol = STRING_CONTENT;
+        return true;
+      }
+      stack_pop(stack);
+      advance(lexer);
+      lexer->mark_end(lexer);
+      lexer->result_symbol = STRING_END;
+      return true;
+    }
+    advance(lexer);
+    has_content = true;
+  }
+  return false;
+}
+
+static bool scan_multiline_comment(TSLexer *lexer) {
+  if (lexer->lookahead != '/') return false;
+  advance(lexer);
+  if (lexer->lookahead != '*') return false;
+  advance(lexer);
+
+  bool after_star = false;
+  unsigned nesting_depth = 1;
+  for (;;) {
+    switch (lexer->lookahead) {
+      case '*':
+        advance(lexer);
+        after_star = true;
+        break;
+      case '/':
+        advance(lexer);
+        if (after_star) {
+          after_star = false;
+          nesting_depth -= 1;
+          if (nesting_depth == 0) {
+            lexer->result_symbol = MULTILINE_COMMENT;
+            lexer->mark_end(lexer);
+            return true;
+          }
+        } else {
+          after_star = false;
+          if (lexer->lookahead == '*') {
+            nesting_depth += 1;
+            advance(lexer);
+          }
+        }
+        break;
+      case '\0':
+        return false;
+      default:
+        advance(lexer);
+        after_star = false;
+        break;
+    }
+  }
+}
+
+static bool scan_whitespace_and_comments(TSLexer *lexer) {
+  while (iswspace(lexer->lookahead)) skip(lexer);
+  return lexer->lookahead != '/';
+}
+
+static bool scan_for_word(TSLexer *lexer, const char* word, unsigned len) {
+    skip(lexer);
+    for (unsigned i = 0; i < len; ++i) {
+      if (lexer->lookahead != word[i]) return false;
+      skip(lexer);
+    }
+    return true;
+}
+
+static bool scan_automatic_semicolon(TSLexer *lexer) {
+  lexer->result_symbol = AUTOMATIC_SEMICOLON;
+  lexer->mark_end(lexer);
+
+  bool sameline = true;
+  for (;;) {
+    if (lexer->eof(lexer)) return true;
+
+    if (lexer->lookahead == ';') {
+      advance(lexer);
+      lexer->mark_end(lexer);
+      return true;
+    }
+
+    if (!iswspace(lexer->lookahead)) break;
+
+    if (lexer->lookahead == '\n') {
+      skip(lexer);
+      sameline = false;
+      break;
+    }
+
+    if (lexer->lookahead == '\r') {
+      skip(lexer);
+
+      if (lexer->lookahead == '\n') skip(lexer);
+
+      sameline = false;
+      break;
+    }
+
+    skip(lexer);
+  }
+
+  // Skip whitespace and comments
+  if (!scan_whitespace_and_comments(lexer))
+    return false;
+
+  if (sameline) {
+    switch (lexer->lookahead) {
+      // Don't insert a semicolon before an else
+      case 'e':
+        return !scan_for_word(lexer, "lse", 3);
+
+      case 'i':
+        return scan_for_word(lexer, "mport", 5);
+
+      case ';':
+        advance(lexer);
+        lexer->mark_end(lexer);
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  switch (lexer->lookahead) {
+    case ',':
+    case '.':
+    case ':':
+    case '*':
+    case '%':
+    case '>':
+    case '<':
+    case '=':
+    case '{':
+    case '[':
+    case '(':
+    case '?':
+    case '|':
+    case '&':
+    case '/':
+      return false;
+
+    // Insert a semicolon before `--` and `++`, but not before binary `+` or `-`.
+    // Insert before +/-Float
+    case '+':
+      skip(lexer);
+      if (lexer->lookahead == '+') return true;
+      return iswdigit(lexer->lookahead);
+
+    case '-':
+      skip(lexer);
+      if (lexer->lookahead == '-') return true;
+      return iswdigit(lexer->lookahead);
+
+    // Don't insert a semicolon before `!=`, but do insert one before a unary `!`.
+    case '!':
+      skip(lexer);
+      return lexer->lookahead != '=';
+
+    // Don't insert a semicolon before an else
+    case 'e':
+      return !scan_for_word(lexer, "lse", 3);
+
+    // Don't insert a semicolon before `in` or `instanceof`, but do insert one
+    // before an identifier or an import.
+    case 'i':
+      skip(lexer);
+      if (lexer->lookahead != 'n') return true;
+      skip(lexer);
+      if (!iswalpha(lexer->lookahead)) return false;
+      return !scan_for_word(lexer, "stanceof", 8);
+
+    case ';':
+      advance(lexer);
+      lexer->mark_end(lexer);
+      return true;
+
+    default:
+      return true;
+  }
+}
+
+static bool scan_safe_nav(TSLexer *lexer) {
+  lexer->result_symbol = SAFE_NAV;
+  lexer->mark_end(lexer);
+
+  // skip white space
+  if (!scan_whitespace_and_comments(lexer))
+    return false;
+
+  if (lexer->lookahead != '?')
+    return false;
+
+  advance(lexer);
+
+  if (!scan_whitespace_and_comments(lexer))
+    return false;
+
+  if (lexer->lookahead != '.')
+    return false;
+
+  advance(lexer);
+  lexer->mark_end(lexer);
+  return true;
+}
+
+static bool scan_line_sep(TSLexer *lexer) {
+  // Line Seps: [ CR, LF, CRLF ]
+  int state = 0;
+  while (true) {
+    switch(lexer->lookahead) {
+      case  ' ':
+      case '\t':
+      case '\v':
+        // Skip whitespace
+        advance(lexer);
+        break;
+
+      case '\n':
+        advance(lexer);
+        return true;
+
+      case '\r':
+        if (state == 1)
+          return true;
+
+        state = 1;
+        advance(lexer);
+        break;
+
+      default:
+        // We read a CR
+        if (state == 1)
+          return true;
+
+        return false;
+    }
+  }
+}
+
+static bool scan_import_list_delimiter(TSLexer *lexer) {
+  // Import lists are terminated either by an empty line or a non import statement
+  lexer->result_symbol = IMPORT_LIST_DELIMITER;
+  lexer->mark_end(lexer);
+
+  // if eof; return true
+  if (lexer->eof(lexer))
+    return true;
+
+  // Scan for the first line seperator
+  if (!scan_line_sep(lexer))
+    return false;
+
+  // if line.sep line.sep; return true
+  if (scan_line_sep(lexer)) {
+    lexer->mark_end(lexer);
+    return true;
+  }
+
+  // if line.sep [^import]; return true
+  while (true) {
+    switch (lexer->lookahead) {
+      case  ' ':
+      case '\t':
+      case '\v':
+        // Skip whitespace
+        advance(lexer);
+        break;
+
+      case 'i':
+        return !scan_for_word(lexer, "mport", 5);
+
+      default:
+        return true;
+    }
+
+    return false;
+  }
+}
+
+bool tree_sitter_kotlin_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+  if (valid_symbols[AUTOMATIC_SEMICOLON]) {
+    bool ret = scan_automatic_semicolon(lexer);
+    if (!ret && valid_symbols[SAFE_NAV] && lexer->lookahead == '?') {
+      return scan_safe_nav(lexer);
+    }
+
+    // if we fail to find an automatic semicolon, it's still possible that we may
+    // want to lex a string or comment later
+    if (ret) return ret;
+  }
+
+  if (valid_symbols[IMPORT_LIST_DELIMITER]) {
+    return scan_import_list_delimiter(lexer);
+  }
+
+  // content or end
+  if (valid_symbols[STRING_CONTENT] && scan_string_content(lexer, payload)) {
+    return true;
+  }
+
+  // a string might follow after some whitespace, so we can't lookahead
+  // until we get rid of it
+  while (iswspace(lexer->lookahead)) skip(lexer);
+
+  if (valid_symbols[STRING_START] && scan_string_start(lexer, payload)) {
+    lexer->result_symbol = STRING_START;
+    return true;
+  }
+
+  if (valid_symbols[MULTILINE_COMMENT] && scan_multiline_comment(lexer)) {
+    return true;
+  }
+
+  if (valid_symbols[SAFE_NAV]) {
+    return scan_safe_nav(lexer);
+  }
+
+  return false;
+}
+
+void *tree_sitter_kotlin_external_scanner_create() {
+  Stack *stack = ts_calloc(1, sizeof(Stack));
+  if (stack == NULL) abort();
+  array_init(stack);
+  return stack;
+}
+
+void tree_sitter_kotlin_external_scanner_destroy(void *payload) {
+  Stack *stack = (Stack *)payload;
+  array_delete(stack);
+  ts_free(stack);
+}
+
+unsigned tree_sitter_kotlin_external_scanner_serialize(void *payload, char *buffer) {
+  Stack *stack = (Stack *)payload;
+  memcpy(buffer, stack->contents, stack->size);
+  return stack->size;
+}
+
+void tree_sitter_kotlin_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+  Stack *stack = (Stack *)payload;
+  if (length > 0) {
+    array_reserve(stack, length);
+    memcpy(stack->contents, buffer, length);
+    stack->size = length;
+  } else {
+    array_clear(stack);
+  }
+}

--- a/src/ext/tree_sitter/grammars/kotlin/tree_sitter/alloc.h
+++ b/src/ext/tree_sitter/grammars/kotlin/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t);
+extern void *(*ts_current_calloc)(size_t, size_t);
+extern void *(*ts_current_realloc)(void *, size_t);
+extern void (*ts_current_free)(void *);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/src/ext/tree_sitter/grammars/kotlin/tree_sitter/array.h
+++ b/src/ext/tree_sitter/grammars/kotlin/tree_sitter/array.h
@@ -1,0 +1,290 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(default : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/src/ext/tree_sitter/grammars/kotlin/tree_sitter/parser.h
+++ b/src/ext/tree_sitter/grammars/kotlin/tree_sitter/parser.h
@@ -1,0 +1,265 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -105,6 +105,7 @@ lib LibTreeSitter
   fun tree_sitter_python : TSLanguage
   fun tree_sitter_go : TSLanguage
   fun tree_sitter_java : TSLanguage
+  fun tree_sitter_kotlin : TSLanguage
 end
 
 # Thin high-level facade. Keeps tree lifetime tied to an object so callers
@@ -145,6 +146,11 @@ module Noir::TreeSitter
   # Parses `source` with the Java grammar and yields the root node.
   def self.parse_java(source : String, &)
     parse(source, LibTreeSitter.tree_sitter_java) { |root| yield root }
+  end
+
+  # Parses `source` with the Kotlin grammar and yields the root node.
+  def self.parse_kotlin(source : String, &)
+    parse(source, LibTreeSitter.tree_sitter_kotlin) { |root| yield root }
   end
 
   # Convenience: returns the root-node s-expression for `source`.

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -1,0 +1,376 @@
+require "../ext/tree_sitter/tree_sitter"
+
+module Noir
+  # Tree-sitter-backed Kotlin route extractor.
+  #
+  # Scope for this first cut: Spring-style annotation routing —
+  # class-level `@RequestMapping`-family annotations composing with
+  # method-level mapping annotations. Mirrors `TreeSitterJavaRouteExtractor`
+  # but for Kotlin's distinct AST shape (annotations live in
+  # `modifiers`, functions use `function_declaration`, primary
+  # constructors carry DTO fields, etc.).
+  #
+  # Covered:
+  #
+  #   * `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`,
+  #     `@PatchMapping` — each fixes the HTTP verb
+  #   * `@RequestMapping` — generic; verb from `method =
+  #     RequestMethod.X` (single or array form), or GET when absent
+  #   * Class-level mapping annotations contribute a prefix joined
+  #     onto the per-method path with exactly one `/` separator
+  #   * Path supplied positionally (`@GetMapping("/x")`) or via
+  #     `value = "/x"` / `path = "/x"` keyword arguments, including
+  #     string arrays (`value = ["/a", "/b"]`)
+  #   * Multi-line annotations — the grammar eats whitespace for us
+  #
+  # Not covered yet (follow-ups):
+  #
+  #   * Ktor's DSL `routing { get("/x") { ... } }`. That's a
+  #     different authoring style and lives in a separate walker.
+  #   * Meta-annotations (custom annotations composing `@RequestMapping`).
+  module TreeSitterKotlinRouteExtractor
+    extend self
+
+    # Spring mapping annotation names → HTTP verb. `nil` means look at
+    # the annotation's `method =` argument. Same table as the Java
+    # extractor for consistency.
+    ANNOTATION_VERBS = {
+      "GetMapping"     => "GET",
+      "PostMapping"    => "POST",
+      "PutMapping"     => "PUT",
+      "DeleteMapping"  => "DELETE",
+      "PatchMapping"   => "PATCH",
+      "RequestMapping" => nil,
+    }
+
+    struct Route
+      getter verb : String        # upper-cased HTTP verb
+      getter path : String        # full path (class prefix + method path)
+      getter class_name : String  # enclosing class simple name, or ""
+      getter method_name : String # Kotlin function name, or "" when class-level only
+      getter line : Int32         # 0-based line of the method annotation
+
+      def initialize(@verb, @path, @class_name, @method_name, @line)
+      end
+    end
+
+    def extract_routes(source : String) : Array(Route)
+      routes = [] of Route
+      Noir::TreeSitter.parse_kotlin(source) do |root|
+        walk_classes(root, source, "", routes)
+      end
+      routes
+    end
+
+    # ---- private helpers ----------------------------------------------
+
+    private def walk_classes(node : LibTreeSitter::TSNode,
+                             source : String,
+                             outer_prefix : String,
+                             routes : Array(Route))
+      ty = Noir::TreeSitter.node_type(node)
+      if ty == "class_declaration" || ty == "object_declaration" || ty == "interface_declaration"
+        class_name = type_identifier_text(node, source)
+        class_prefix = class_mapping_prefix(node, source)
+        prefix = join_paths(outer_prefix, class_prefix)
+
+        if body = class_body(node)
+          Noir::TreeSitter.each_named_child(body) do |member|
+            case Noir::TreeSitter.node_type(member)
+            when "function_declaration"
+              collect_function_routes(member, source, class_name, prefix, routes)
+            when "class_declaration", "object_declaration", "interface_declaration"
+              walk_classes(member, source, prefix, routes)
+            end
+          end
+        end
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_classes(child, source, outer_prefix, routes)
+      end
+    end
+
+    # Kotlin's `class_declaration` names its class via a child
+    # `type_identifier`. Nested `object_declaration` / `interface_declaration`
+    # follow the same shape.
+    private def type_identifier_text(decl : LibTreeSitter::TSNode, source : String) : String
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        if Noir::TreeSitter.node_type(child) == "type_identifier"
+          return Noir::TreeSitter.node_text(child, source)
+        end
+      end
+      ""
+    end
+
+    # The class body is a `class_body` named child (not exposed as a
+    # `body` field by this grammar version).
+    private def class_body(decl : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        return child if Noir::TreeSitter.node_type(child) == "class_body"
+      end
+      nil
+    end
+
+    private def class_mapping_prefix(class_decl : LibTreeSitter::TSNode, source : String) : String
+      each_annotation(class_decl, source) do |name, args|
+        next unless ANNOTATION_VERBS.has_key?(name)
+        paths = annotation_paths(args, source)
+        return paths.first unless paths.empty?
+      end
+      ""
+    end
+
+    private def collect_function_routes(func : LibTreeSitter::TSNode,
+                                        source : String,
+                                        class_name : String,
+                                        class_prefix : String,
+                                        routes : Array(Route))
+      method_name = function_name(func, source)
+
+      each_annotation(func, source) do |ann_name, args, ann_line|
+        next unless ANNOTATION_VERBS.has_key?(ann_name)
+        verb_default = ANNOTATION_VERBS[ann_name]?
+
+        paths = annotation_paths(args, source)
+        paths = [""] if paths.empty?
+
+        verbs =
+          if verb_default
+            [verb_default]
+          else
+            methods = annotation_methods(args, source)
+            methods.empty? ? ["GET"] : methods
+          end
+
+        paths.each do |path|
+          full = join_paths(class_prefix, path)
+          verbs.each do |verb|
+            routes << Route.new(verb, full, class_name, method_name, ann_line)
+          end
+        end
+      end
+    end
+
+    private def function_name(func : LibTreeSitter::TSNode, source : String) : String
+      count = LibTreeSitter.ts_node_named_child_count(func)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(func, i.to_u32)
+        if Noir::TreeSitter.node_type(child) == "simple_identifier"
+          return Noir::TreeSitter.node_text(child, source)
+        end
+      end
+      ""
+    end
+
+    # Walk every annotation on a class/function declaration. Kotlin
+    # wraps annotations in a `modifiers` child, and each `annotation`
+    # node has either a `user_type` (for `@Foo`) or a
+    # `constructor_invocation` (for `@Foo("x")`/`@Foo(a = b)`).
+    # Yields `(simple_name, args_node_or_nil, line)`.
+    private def each_annotation(decl : LibTreeSitter::TSNode, source : String, &)
+      mods = find_modifiers(decl)
+      return unless mods
+      Noir::TreeSitter.each_named_child(mods) do |ann|
+        next unless Noir::TreeSitter.node_type(ann) == "annotation"
+        Noir::TreeSitter.each_named_child(ann) do |child|
+          case Noir::TreeSitter.node_type(child)
+          when "user_type"
+            name = simple_annotation_name(Noir::TreeSitter.node_text(child, source))
+            yield name, nil, Noir::TreeSitter.node_start_row(ann)
+          when "constructor_invocation"
+            # `user_type` + `value_arguments` pair.
+            inner_name = ""
+            args : LibTreeSitter::TSNode? = nil
+            Noir::TreeSitter.each_named_child(child) do |sub|
+              case Noir::TreeSitter.node_type(sub)
+              when "user_type"
+                inner_name = simple_annotation_name(Noir::TreeSitter.node_text(sub, source))
+              when "value_arguments"
+                args = sub
+              end
+            end
+            yield inner_name, args, Noir::TreeSitter.node_start_row(ann) unless inner_name.empty?
+          end
+        end
+      end
+    end
+
+    private def find_modifiers(decl : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        return child if Noir::TreeSitter.node_type(child) == "modifiers"
+      end
+      nil
+    end
+
+    private def simple_annotation_name(full : String) : String
+      if idx = full.rindex('.')
+        full[(idx + 1)..]
+      else
+        full
+      end
+    end
+
+    # Kotlin `value_arguments` contains `value_argument` children.
+    # Each argument is either positional (a single child that's a
+    # literal) or named (has a `simple_identifier` + expression).
+    private def annotation_paths(args_node : LibTreeSitter::TSNode?, source : String) : Array(String)
+      empty = [] of String
+      return empty unless args_node
+      return empty unless Noir::TreeSitter.node_type(args_node) == "value_arguments"
+
+      positional = [] of String
+      keyword = [] of String
+
+      Noir::TreeSitter.each_named_child(args_node) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+        kind, key, value_node = classify_value_argument(arg, source)
+        next unless value_node
+
+        if kind == :keyword
+          next unless key == "value" || key == "path"
+          collect_string_values(value_node, source, keyword)
+        else
+          collect_string_values(value_node, source, positional)
+        end
+      end
+
+      keyword.empty? ? positional : keyword
+    end
+
+    # Return `{:keyword | :positional, key_or_nil, value_node}`.
+    private def classify_value_argument(arg : LibTreeSitter::TSNode, source : String) : Tuple(Symbol, String, LibTreeSitter::TSNode?)
+      key = ""
+      value : LibTreeSitter::TSNode? = nil
+      named = false
+      Noir::TreeSitter.each_named_child(arg) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "simple_identifier"
+          if named
+            # second identifier is actually the value expression
+            value = child
+          else
+            key = Noir::TreeSitter.node_text(child, source)
+            named = true
+          end
+        else
+          value = child if value.nil?
+        end
+      end
+      {named ? :keyword : :positional, key, value}
+    end
+
+    # Collect string literal values from a node. Handles a single
+    # `string_literal`, a `collection_literal` with string children,
+    # or `arrayOf("/a", "/b")` call expressions.
+    private def collect_string_values(node : LibTreeSitter::TSNode, source : String, sink : Array(String))
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        text = decode_string_literal(node, source)
+        sink << text unless text.empty?
+      when "collection_literal"
+        # Kotlin's `[...]` array syntax inside annotations.
+        Noir::TreeSitter.each_named_child(node) do |elem|
+          collect_string_values(elem, source, sink)
+        end
+      when "call_expression"
+        # `arrayOf("/a", "/b")` — walk the value_arguments.
+        Noir::TreeSitter.each_named_child(node) do |child|
+          if Noir::TreeSitter.node_type(child) == "call_suffix"
+            Noir::TreeSitter.each_named_child(child) do |suf|
+              next unless Noir::TreeSitter.node_type(suf) == "value_arguments"
+              Noir::TreeSitter.each_named_child(suf) do |va|
+                next unless Noir::TreeSitter.node_type(va) == "value_argument"
+                Noir::TreeSitter.each_named_child(va) do |v|
+                  collect_string_values(v, source, sink) if Noir::TreeSitter.node_type(v) == "string_literal"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # Extract verbs from `method = RequestMethod.X` / `method =
+    # [RequestMethod.X, RequestMethod.Y]` / `method = arrayOf(...)`.
+    private def annotation_methods(args_node : LibTreeSitter::TSNode?, source : String) : Array(String)
+      empty = [] of String
+      return empty unless args_node
+      return empty unless Noir::TreeSitter.node_type(args_node) == "value_arguments"
+
+      methods = [] of String
+      Noir::TreeSitter.each_named_child(args_node) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+        kind, key, value_node = classify_value_argument(arg, source)
+        next unless kind == :keyword
+        next unless key == "method"
+        next unless value_node
+        collect_request_method_values(value_node, source, methods)
+      end
+      methods
+    end
+
+    # `RequestMethod.GET` is parsed as `navigation_expression` with a
+    # `navigation_suffix` carrying the verb. Array forms recurse.
+    private def collect_request_method_values(node : LibTreeSitter::TSNode, source : String, sink : Array(String))
+      case Noir::TreeSitter.node_type(node)
+      when "navigation_expression"
+        # Walk to the final `navigation_suffix` child for the verb name.
+        Noir::TreeSitter.each_named_child(node) do |child|
+          next unless Noir::TreeSitter.node_type(child) == "navigation_suffix"
+          Noir::TreeSitter.each_named_child(child) do |id|
+            sink << Noir::TreeSitter.node_text(id, source).upcase if Noir::TreeSitter.node_type(id) == "simple_identifier"
+          end
+        end
+      when "simple_identifier"
+        sink << Noir::TreeSitter.node_text(node, source).upcase
+      when "collection_literal"
+        Noir::TreeSitter.each_named_child(node) do |elem|
+          collect_request_method_values(elem, source, sink)
+        end
+      when "call_expression"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          next unless Noir::TreeSitter.node_type(child) == "call_suffix"
+          Noir::TreeSitter.each_named_child(child) do |suf|
+            next unless Noir::TreeSitter.node_type(suf) == "value_arguments"
+            Noir::TreeSitter.each_named_child(suf) do |va|
+              next unless Noir::TreeSitter.node_type(va) == "value_argument"
+              Noir::TreeSitter.each_named_child(va) do |v|
+                collect_request_method_values(v, source, sink)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # Kotlin `string_literal` wraps content in `string_content`
+    # children, same shape as Java.
+    private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
+      buf = String.build do |io|
+        Noir::TreeSitter.each_named_child(node) do |child|
+          if Noir::TreeSitter.node_type(child) == "string_content"
+            io << Noir::TreeSitter.node_text(child, source)
+          end
+        end
+      end
+      buf
+    end
+
+    # Trailing-slash semantics match Spring's runtime and mirror the
+    # Java extractor: `prefix + "" = prefix/` so `@GetMapping("")` on
+    # a class-prefixed route emits `/prefix/`.
+    private def join_paths(prefix : String, path : String) : String
+      return path if prefix.empty?
+      return "#{prefix.rstrip('/')}/" if path.empty?
+      "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Opens the Kotlin track tracked in #1298. Vendors the grammar, exposes `parse_kotlin`, ships a Spring-focused Kotlin route extractor with a unit spec. Kotlin analyzers themselves stay on the legacy miniparser/minilexer for now — the actual analyzer swap is the next PR in this track.

## What's in

- `src/ext/tree_sitter/grammars/kotlin/` — tree-sitter-kotlin **v0.3.8** from `fwcd/tree-sitter-kotlin` (the widely-used active fork). parser.c is large (~678k lines) but builds to a ~4 MB object; **final binary grows from ~16 MB to ~18 MB**.
- `build.sh` grammar list now includes `kotlin`. scanner.c ships with the grammar (indentation-sensitive parsing) and builds via the same pipeline.
- `LibTreeSitter.tree_sitter_kotlin` + `Noir::TreeSitter.parse_kotlin` facade.
- `src/miniparsers/kotlin_route_extractor_ts.cr` — Spring-focused route extractor:
    * `@GetMapping` / `@PostMapping` / `@PutMapping` / `@DeleteMapping` / `@PatchMapping` — verb fixed by annotation name
    * `@RequestMapping` — verb from `method = [RequestMethod.X]` (array) or `method = RequestMethod.X` (single); GET default
    * Class-level mapping annotations compose onto method paths
    * Positional (`@GetMapping(\"/x\")`) and keyword (`value = \"/x\"` / `path = \"/x\"`) path forms
    * String arrays — `value = [\"/a\", \"/b\"]` and `arrayOf(\"/a\", \"/b\")` — fan out into one endpoint per path
    * Fully-qualified annotation names (`@org.springframework...`) normalised to the simple name
    * Empty method path emits `prefix/` (trailing slash) to match Spring runtime + Java extractor behaviour
- **7 unit specs** covering the shapes above.

## Not in (follow-up PRs)

- **Kotlin Spring analyzer swap.** `analyzers/kotlin/spring.cr` still runs on the hand-rolled lexer/parser. Next PR once parameter/DTO extraction lands.
- **Ktor DSL extraction.** `routing { get(\"/x\") { ... } }` is a different authoring style with nested closures — planned as a separate extractor module (similar in spirit to Go chi's `extract_chi_routes`).
- **Parameter extraction + DTO cross-file resolution.** Tracked for follow-ups in #1298.

## Test plan

- [x] 7 new Kotlin spec cases pass
- [x] Full suite: **6329 examples, 0 failures** (7 new + existing 6322)
- [x] `just clean` + cold build succeeds with the new grammar
- [x] `ameba` + `crystal tool format --check` clean

## Related

- Umbrella: #1298
- Follows the exact rollout shape that closed #1291 (Java track, PRs #1292–#1297)