### PR TITLE
feat: unify Java/Kotlin cross-file resolution via shared ImportGraph (#1107)

### DIFF
--- a/spec/unit_test/miniparser/import_graph_spec.cr
+++ b/spec/unit_test/miniparser/import_graph_spec.cr
@@ -1,0 +1,120 @@
+require "spec"
+require "file_utils"
+require "../../../src/miniparsers/import_graph"
+
+private def collect(path, package_name, imports, extension)
+  visited = [] of String
+  Noir::ImportGraph.related_files(path, package_name, imports, extension) do |file|
+    visited << file
+  end
+  visited
+end
+
+private def with_tmpdir(&)
+  root = File.join(Dir.tempdir, "noir-importgraph-#{Random::Secure.hex(8)}")
+  Dir.mkdir_p(root)
+  begin
+    yield root
+  ensure
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+describe Noir::ImportGraph do
+  describe "#source_root_for" do
+    it "infers the root by stripping the package path from the directory" do
+      Noir::ImportGraph.source_root_for(
+        "/work/proj/src/main/java/com/foo/Bar.java", "com.foo"
+      ).should eq("/work/proj/src/main/java")
+    end
+
+    it "returns '.' when the package consumes the whole directory" do
+      Noir::ImportGraph.source_root_for("com/foo/Bar.kt", "com.foo").should eq(".")
+    end
+
+    it "returns nil when the package path doesn't trail the directory" do
+      Noir::ImportGraph.source_root_for(
+        "/work/proj/src/com/foo/Bar.java", "com.example"
+      ).should be_nil
+    end
+
+    it "returns nil when the directory is shorter than the package" do
+      Noir::ImportGraph.source_root_for("Bar.java", "com.foo").should be_nil
+    end
+  end
+
+  describe "#related_files" do
+    it "yields the file itself, then same-directory siblings, then resolved imports" do
+      with_tmpdir do |root|
+        java_root = File.join(root, "src", "main", "java")
+        Dir.mkdir_p(File.join(java_root, "com", "example", "controller"))
+        Dir.mkdir_p(File.join(java_root, "com", "example", "model"))
+
+        controller = File.join(java_root, "com", "example", "controller", "UserController.java")
+        sibling = File.join(java_root, "com", "example", "controller", "Helper.java")
+        single_import = File.join(java_root, "com", "example", "model", "User.java")
+        wildcard_neighbour = File.join(java_root, "com", "example", "model", "Profile.java")
+        unrelated = File.join(java_root, "com", "example", "model", "Profile.kt")
+
+        [controller, sibling, single_import, wildcard_neighbour, unrelated].each do |f|
+          File.write(f, "")
+        end
+
+        imports = [
+          Noir::ImportGraph::ImportRef.new("com.example.model.User", false),
+          Noir::ImportGraph::ImportRef.new("com.example.model", true),
+        ]
+
+        visited = collect(controller, "com.example.controller", imports, "java")
+        visited.should contain(controller)
+        visited.should contain(sibling)
+        visited.should contain(single_import)
+        visited.should contain(wildcard_neighbour)
+        visited.should_not contain(unrelated)
+        visited.size.should eq(visited.uniq.size) # no duplicates
+      end
+    end
+
+    it "still yields siblings when the package declaration is empty" do
+      with_tmpdir do |root|
+        a = File.join(root, "A.java")
+        b = File.join(root, "B.java")
+        File.write(a, "")
+        File.write(b, "")
+
+        visited = collect(a, "", [] of Noir::ImportGraph::ImportRef, "java")
+        visited.should contain(a)
+        visited.should contain(b)
+      end
+    end
+
+    it "skips imports that don't resolve to existing files" do
+      with_tmpdir do |root|
+        java_root = File.join(root, "src")
+        Dir.mkdir_p(File.join(java_root, "com", "example"))
+        file = File.join(java_root, "com", "example", "Foo.java")
+        File.write(file, "")
+
+        imports = [Noir::ImportGraph::ImportRef.new("com.example.Missing", false)]
+        visited = collect(file, "com.example", imports, "java")
+        visited.should eq([file])
+      end
+    end
+
+    it "deduplicates files reachable through multiple paths" do
+      with_tmpdir do |root|
+        java_root = File.join(root, "src")
+        Dir.mkdir_p(File.join(java_root, "com", "example"))
+        a = File.join(java_root, "com", "example", "A.java")
+        b = File.join(java_root, "com", "example", "B.java")
+        [a, b].each { |f| File.write(f, "") }
+
+        # B is both a same-package sibling and an explicit import.
+        imports = [Noir::ImportGraph::ImportRef.new("com.example.B", false)]
+        visited = collect(a, "com.example", imports, "java")
+        visited.size.should eq(visited.uniq.size)
+        visited.count(b).should eq(1)
+      end
+    end
+  end
+end

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -1,0 +1,112 @@
+module Noir
+  # Shared file-level import-graph traversal for cross-file route /
+  # DTO resolution.
+  #
+  # Today the JVM-style flavour is implemented (Java, Kotlin): a file
+  # belongs to a package whose dotted path is reflected in its
+  # directory layout (`src/main/java/com/foo/Bar.java` ↔
+  # `package com.foo`), and imports map to file paths under the
+  # inferred source root. This is the pattern called out as
+  # duplication in #1107 for `TreeSitterJavaDtoIndex` and
+  # `TreeSitterKotlinDtoIndex`.
+  #
+  # Caveats / non-goals:
+  #
+  #   * Python / Ruby / JS-style cross-file resolution doesn't share
+  #     this exact source-root inference. When those frameworks
+  #     migrate, expect a sibling helper (or a `mode:` parameter) on
+  #     this module rather than forcing them through this code path.
+  #   * The traversal is one level deep — we yield the directly
+  #     visible files, not files reachable through their imports.
+  #     Recursive resolution is the caller's job (and usually
+  #     unnecessary; one level covers the controller-→-DTO case).
+  module ImportGraph
+    # An import declaration extracted from a source file.
+    #
+    #   - `path`     dotted path written in the source
+    #                (`com.example.foo.Bar`, or `com.example.foo`
+    #                for wildcard imports).
+    #   - `wildcard` whether the import is a `.*` form (Java/Kotlin)
+    #                or equivalent `from x import *` style.
+    struct ImportRef
+      getter path : String
+      getter? wildcard : Bool
+
+      def initialize(@path, @wildcard)
+      end
+    end
+
+    # Yields every file path that should be considered when resolving
+    # symbols visible to `path`:
+    #
+    #   1. `path` itself.
+    #   2. Same-directory siblings ending in `.{extension}` (same
+    #      package).
+    #   3. Files reachable through `imports`, resolved against a
+    #      source root inferred from `package_name`.
+    #
+    # Wildcard imports expand to every matching file in the imported
+    # directory. Each file is yielded at most once. When
+    # `package_name` is empty, the source-root step is skipped (no
+    # safe inference possible) — same-directory siblings are still
+    # yielded.
+    def self.related_files(path : String,
+                           package_name : String,
+                           imports : Indexable(ImportRef),
+                           extension : String,
+                           &block : String ->) : Nil
+      seen = Set(String).new
+      visit = ->(file : String) do
+        block.call(file) if seen.add?(file)
+      end
+
+      visit.call(path)
+
+      package_dir = File.dirname(path)
+      safe_glob("#{package_dir}/*.#{extension}") do |sibling|
+        next if sibling == path
+        visit.call(sibling)
+      end
+
+      return if package_name.empty?
+      source_root = source_root_for(path, package_name)
+      return unless source_root
+
+      imports.each do |imp|
+        relative = imp.path.gsub(".", "/")
+        if imp.wildcard?
+          dir = File.join(source_root, relative)
+          next unless Dir.exists?(dir)
+          safe_glob("#{dir}/*.#{extension}") { |match| visit.call(match) }
+        else
+          file = File.join(source_root, "#{relative}.#{extension}")
+          visit.call(file) if File.exists?(file)
+        end
+      end
+    end
+
+    # Infer the source root by stripping the package path from the
+    # file's directory. `src/main/java/com/foo/Bar.java` with package
+    # `com.foo` returns `src/main/java`. Returns nil when the package
+    # path doesn't actually trail the file's directory (the source
+    # tree is laid out differently and we can't safely resolve
+    # imports).
+    def self.source_root_for(file_path : String, package_name : String) : String?
+      package_segments = package_name.split('.')
+      dir = File.dirname(file_path)
+      dir_segments = dir.split('/')
+      return if dir_segments.size < package_segments.size
+      tail = dir_segments[(dir_segments.size - package_segments.size)..]
+      return unless tail == package_segments
+      root = dir_segments[0, dir_segments.size - package_segments.size].join('/')
+      root.empty? ? "." : root
+    end
+
+    # `Dir.glob` raises on unreadable entries in some edge cases;
+    # swallow those so one bad sibling doesn't sink the whole walk.
+    private def self.safe_glob(pattern : String, &block : String ->) : Nil
+      Dir.glob(pattern) { |p| block.call(p) }
+    rescue
+    end
+  end
+end

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./import_graph"
 
 module Noir
   # Tree-sitter-backed parameter extractor for Java/Spring.
@@ -41,13 +42,10 @@ module Noir
     # A Java `import` declaration. `wildcard` is true for star imports
     # (`import com.foo.*;`) which fan out to every `.java` in the
     # resolved directory.
-    struct ImportDecl
-      getter path : String
-      getter? wildcard : Bool
-
-      def initialize(@path, @wildcard)
-      end
-    end
+    # Alias the shared import-graph type so existing call sites stay
+    # ergonomic while the cross-file traversal logic lives in
+    # `Noir::ImportGraph` (#1107).
+    alias ImportDecl = Noir::ImportGraph::ImportRef
 
     struct FieldInfo
       getter name : String
@@ -569,73 +567,28 @@ module Noir
 
     # Build the DTO index visible to the Spring controller at `path`.
     # Callers pass `content` (already read once) to avoid a redundant
-    # disk read for the current file.
+    # disk read for the current file. Cross-file traversal is
+    # delegated to `Noir::ImportGraph` so this stays a thin
+    # language-specific cache.
     def build_for(path : String, content : String) : Index
       result = Index.new
-      merge!(result, classes_in_current(path, content))
-
-      package_dir = File.dirname(path)
-      safe_glob("#{package_dir}/*.java") do |sibling|
-        next if sibling == path
-        merge!(result, classes_in(sibling))
-      end
-
       package_name = TreeSitterJavaParameterExtractor.extract_package_name(content)
-      source_root = source_root_for(path, package_name) unless package_name.empty?
-      return result unless source_root
+      imports = TreeSitterJavaParameterExtractor.extract_imports(content)
 
-      TreeSitterJavaParameterExtractor.extract_imports(content).each do |imp|
-        relative = imp.path.gsub(".", "/")
-        if imp.wildcard?
-          dir = File.join(source_root, relative)
-          next unless Dir.exists?(dir)
-          safe_glob("#{dir}/*.java") do |match|
-            merge!(result, classes_in(match))
-          end
-        else
-          file = File.join(source_root, "#{relative}.java")
-          next unless File.exists?(file)
-          merge!(result, classes_in(file))
-        end
+      Noir::ImportGraph.related_files(path, package_name, imports, "java") do |file|
+        merge!(result, classes_in(file, path, content))
       end
 
       result
     end
 
-    private def classes_in_current(path : String, content : String) : Index
-      @file_cache[path] ||= TreeSitterJavaParameterExtractor.extract_class_fields(content)
-    end
-
-    private def classes_in(path : String) : Index
-      @file_cache[path] ||= begin
-        TreeSitterJavaParameterExtractor.extract_class_fields(File.read(path, encoding: "utf-8", invalid: :skip))
+    private def classes_in(file : String, current_path : String, current_content : String) : Index
+      @file_cache[file] ||= begin
+        body = file == current_path ? current_content : File.read(file, encoding: "utf-8", invalid: :skip)
+        TreeSitterJavaParameterExtractor.extract_class_fields(body)
       rescue File::NotFoundError
         Index.new
       end
-    end
-
-    # Infer the source root by stripping the package path from the
-    # file's directory. `src/main/java/com/foo/Bar.java` with package
-    # `com.foo` gives `src/main/java`. Returns nil when the package
-    # path doesn't actually trail the file's directory (which means
-    # the source tree is laid out differently and we can't safely
-    # resolve imports).
-    private def source_root_for(file_path : String, package_name : String) : String?
-      package_segments = package_name.split('.')
-      dir = File.dirname(file_path)
-      dir_segments = dir.split('/')
-      return if dir_segments.size < package_segments.size
-      tail = dir_segments[(dir_segments.size - package_segments.size)..]
-      return unless tail == package_segments
-      root = dir_segments[0, dir_segments.size - package_segments.size].join('/')
-      root.empty? ? "." : root
-    end
-
-    # `Dir.glob` raises on unreadable entries in some edge cases;
-    # swallow those so one bad sibling doesn't sink the whole index.
-    private def safe_glob(pattern : String, &)
-      Dir.glob(pattern) { |p| yield p }
-    rescue
     end
 
     private def merge!(into : Index, src : Index)

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./import_graph"
 
 module Noir
   # Tree-sitter-backed parameter extractor for Kotlin Spring.
@@ -53,13 +54,10 @@ module Noir
       "X-Frame-Options"  => "X-Frame-Options",
     }
 
-    struct ImportDecl
-      getter path : String
-      getter? wildcard : Bool
-
-      def initialize(@path, @wildcard)
-      end
-    end
+    # Alias the shared import-graph type so existing call sites stay
+    # ergonomic while the cross-file traversal logic lives in
+    # `Noir::ImportGraph` (#1107).
+    alias ImportDecl = Noir::ImportGraph::ImportRef
 
     struct FieldInfo
       getter name : String
@@ -709,62 +707,23 @@ module Noir
 
     def build_for(path : String, content : String) : Index
       result = Index.new
-      merge!(result, classes_in_current(path, content))
-
-      package_dir = File.dirname(path)
-      safe_glob("#{package_dir}/*.kt") do |sibling|
-        next if sibling == path
-        merge!(result, classes_in(sibling))
-      end
-
       package_name = TreeSitterKotlinParameterExtractor.extract_package_name(content)
-      source_root = source_root_for(path, package_name) unless package_name.empty?
-      return result unless source_root
+      imports = TreeSitterKotlinParameterExtractor.extract_imports(content)
 
-      TreeSitterKotlinParameterExtractor.extract_imports(content).each do |imp|
-        relative = imp.path.gsub(".", "/")
-        if imp.wildcard?
-          dir = File.join(source_root, relative)
-          next unless Dir.exists?(dir)
-          safe_glob("#{dir}/*.kt") do |match|
-            merge!(result, classes_in(match))
-          end
-        else
-          file = File.join(source_root, "#{relative}.kt")
-          next unless File.exists?(file)
-          merge!(result, classes_in(file))
-        end
+      Noir::ImportGraph.related_files(path, package_name, imports, "kt") do |file|
+        merge!(result, classes_in(file, path, content))
       end
 
       result
     end
 
-    private def classes_in_current(path : String, content : String) : Index
-      @file_cache[path] ||= TreeSitterKotlinParameterExtractor.extract_class_fields(content)
-    end
-
-    private def classes_in(path : String) : Index
-      @file_cache[path] ||= begin
-        TreeSitterKotlinParameterExtractor.extract_class_fields(File.read(path, encoding: "utf-8", invalid: :skip))
+    private def classes_in(file : String, current_path : String, current_content : String) : Index
+      @file_cache[file] ||= begin
+        body = file == current_path ? current_content : File.read(file, encoding: "utf-8", invalid: :skip)
+        TreeSitterKotlinParameterExtractor.extract_class_fields(body)
       rescue File::NotFoundError
         Index.new
       end
-    end
-
-    private def source_root_for(file_path : String, package_name : String) : String?
-      package_segments = package_name.split('.')
-      dir = File.dirname(file_path)
-      dir_segments = dir.split('/')
-      return if dir_segments.size < package_segments.size
-      tail = dir_segments[(dir_segments.size - package_segments.size)..]
-      return unless tail == package_segments
-      root = dir_segments[0, dir_segments.size - package_segments.size].join('/')
-      root.empty? ? "." : root
-    end
-
-    private def safe_glob(pattern : String, &)
-      Dir.glob(pattern) { |p| yield p }
-    rescue
     end
 
     private def merge!(into : Index, src : Index)


### PR DESCRIPTION
## Summary

Closes the "make it systematic" half of #1107 for the JVM-side analyzers.

`TreeSitterJavaDtoIndex` and `TreeSitterKotlinDtoIndex` have been carrying near-identical cross-file traversal logic — `safe_glob`, `source_root_for`, package-relative import resolution, dedup. This PR pulls that into a shared `Noir::ImportGraph` module:

- New `Noir::ImportGraph::ImportRef` is the single import-statement value type both extractors use (the language-local `ImportDecl` becomes a thin alias).
- `Noir::ImportGraph.related_files(path, package_name, imports, extension) { |file| ... }` yields the file itself, same-directory siblings, and resolved imports — deduped, with wildcard-import directory expansion.
- `Noir::ImportGraph.source_root_for(file_path, package_name)` infers the source root by stripping the package path from the file's directory.

Each language extractor's index now just memoises per-file class-field extraction and asks the graph for files. ~140 LOC of duplicated traversal collapse into 1 shared module.

The graph currently models the JVM-style flavour (package path trailing the directory layout). When Python / Ruby / JS-style cross-file resolution lands (FastAPI, Sanic, etc., as outlined in #1107), expect a sibling helper or a `mode:` parameter rather than forcing those through this path.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/import_graph_spec.cr` — 8 examples covering the source-root inference + the `related_files` traversal (siblings, single + wildcard imports, dedup, missing files, empty package fallback)
- [x] `crystal spec` — full suite, 6334 examples, 0 failures (Java + Kotlin Spring functional specs unchanged)
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba`