### PR TITLE
chore(python): drop dead legacy parser references in sanic/tornado

### DIFF
--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -1,5 +1,3 @@
-require "../../../minilexers/python"
-require "../../../miniparsers/python"
 require "../../../miniparsers/python_route_extractor"
 require "../../../miniparsers/python_route_extractor_ts"
 require "../../engines/python_engine"
@@ -25,7 +23,6 @@ module Analyzer::Python
     }
 
     @file_content_cache = Hash(::String, ::String).new
-    @parsers = Hash(::String, PythonParser).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String))).new
 
     def analyze

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -1,5 +1,3 @@
-require "../../../minilexers/python"
-require "../../../miniparsers/python"
 require "../../engines/python_engine"
 
 module Analyzer::Python
@@ -26,7 +24,6 @@ module Analyzer::Python
     CLASS_DEF_REGEX = /^class\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*[\(:]/
 
     @file_content_cache = Hash(::String, ::String).new
-    @parsers = Hash(::String, PythonParser).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String))).new
     @import_modules_cache = Hash(::String, Hash(::String, Tuple(::String, Int32))).new
 


### PR DESCRIPTION
## Summary

Both Sanic and Tornado declared `@parsers = Hash(::String, PythonParser).new` but never invoked the field — leftover scaffolding from when those analyzers were sketched against the legacy parser. They also pulled `minilexers/python` and `miniparsers/python` only to make that one field's type resolve.

This PR drops both:

- `sanic.cr` — removes `@parsers` field + the two unused legacy requires. Keeps `python_route_extractor` (still used for `find_def_line`).
- `tornado.cr` — removes `@parsers` field + all three legacy requires. Tornado doesn't use `find_def_line` either.

Flask still uses `PythonParser` heavily for variable resolution and namespace prefix extraction, so the heavyweight legacy parser stays in tree until that migration lands separately.

## Test plan

- [x] `crystal spec spec/functional_test/testers/python/` — 652 examples, all green
- [x] `crystal spec` — full suite, 6647 examples, 0 failures
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba`