### PR TITLE
feat: extend ImportGraph with relative-import resolution (#1107)

### DIFF
--- a/spec/unit_test/miniparser/import_graph_spec.cr
+++ b/spec/unit_test/miniparser/import_graph_spec.cr
@@ -117,4 +117,100 @@ describe Noir::ImportGraph do
       end
     end
   end
+
+  describe "#resolve_relative_import" do
+    it "resolves a sibling file by adding a candidate extension" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "src"))
+        from_file = File.join(root, "src", "index.ts")
+        target = File.join(root, "src", "users.ts")
+        File.write(from_file, "")
+        File.write(target, "")
+
+        Noir::ImportGraph.resolve_relative_import(from_file, "./users").should eq(target)
+      end
+    end
+
+    it "honours an explicit extension on the specifier" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "src"))
+        from_file = File.join(root, "src", "index.ts")
+        target = File.join(root, "src", "users.ts")
+        # A `.js` sibling exists but the specifier requests `.ts`.
+        File.write(from_file, "")
+        File.write(target, "")
+        File.write(File.join(root, "src", "users.js"), "")
+
+        Noir::ImportGraph.resolve_relative_import(from_file, "./users.ts").should eq(target)
+      end
+    end
+
+    it "falls back to <dir>/index.<ext> for directory specifiers" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "src", "routes"))
+        from_file = File.join(root, "src", "index.ts")
+        target = File.join(root, "src", "routes", "index.ts")
+        File.write(from_file, "")
+        File.write(target, "")
+
+        Noir::ImportGraph.resolve_relative_import(from_file, "./routes").should eq(target)
+      end
+    end
+
+    it "walks up parent directories with `..`" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "src", "deep"))
+        from_file = File.join(root, "src", "deep", "child.ts")
+        target = File.join(root, "src", "shared.ts")
+        File.write(from_file, "")
+        File.write(target, "")
+
+        Noir::ImportGraph.resolve_relative_import(from_file, "../shared").should eq(target)
+      end
+    end
+
+    it "tries extensions in priority order" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "src"))
+        from_file = File.join(root, "src", "index.ts")
+        ts_target = File.join(root, "src", "users.ts")
+        js_target = File.join(root, "src", "users.js")
+        File.write(from_file, "")
+        File.write(ts_target, "")
+        File.write(js_target, "")
+
+        # `.ts` precedes `.js` in `JS_RESOLVE_EXTENSIONS`, so the
+        # TypeScript file wins.
+        Noir::ImportGraph.resolve_relative_import(from_file, "./users").should eq(ts_target)
+      end
+    end
+
+    it "returns nil for bare specifiers (node_modules)" do
+      with_tmpdir do |root|
+        from_file = File.join(root, "index.ts")
+        File.write(from_file, "")
+        Noir::ImportGraph.resolve_relative_import(from_file, "lodash").should be_nil
+        Noir::ImportGraph.resolve_relative_import(from_file, "@hapi/hapi").should be_nil
+      end
+    end
+
+    it "returns nil when nothing on disk matches" do
+      with_tmpdir do |root|
+        from_file = File.join(root, "index.ts")
+        File.write(from_file, "")
+        Noir::ImportGraph.resolve_relative_import(from_file, "./missing").should be_nil
+      end
+    end
+
+    it "accepts a custom extension list" do
+      with_tmpdir do |root|
+        from_file = File.join(root, "index.rb")
+        target = File.join(root, "users.rb")
+        File.write(from_file, "")
+        File.write(target, "")
+
+        Noir::ImportGraph.resolve_relative_import(from_file, "./users", extensions: ["rb"]).should eq(target)
+      end
+    end
+  end
 end

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -108,5 +108,79 @@ module Noir
       Dir.glob(pattern) { |p| block.call(p) }
     rescue
     end
+
+    # ----------------------------------------------------------------
+    # Relative-import resolution (JS / Ruby flavour).
+    #
+    # JS / Node / Ruby imports are filesystem-relative — neither the
+    # JVM-style package-trailing-the-directory inference nor a
+    # source-root model applies. The caller hands over the importing
+    # file and the import specifier (`./foo`, `../bar/baz`,
+    # `./users.js`) and we return the resolved absolute path or
+    # `nil` when nothing on disk matches.
+    #
+    # Intended for JS analyzers (Express / Hono / Hapi cross-file
+    # route discovery in particular) and any future Ruby / Lua / Lua
+    # analyzer that uses `require './foo'` style paths. Bare
+    # specifiers (`lodash`, `@hapi/hapi`) aren't filesystem-relative
+    # — those need a `node_modules` walk that's deliberately out of
+    # scope for noir today.
+    #
+    # Resolution order, mirroring Node's CJS algorithm:
+    #
+    #   1. If the specifier already carries a known extension, only
+    #      that exact file is tried.
+    #   2. Otherwise, `<base>/<specifier>.<ext>` for each candidate
+    #      extension in priority order.
+    #   3. Finally, `<base>/<specifier>/index.<ext>` for each
+    #      candidate extension — the directory-with-index form.
+
+    JS_RESOLVE_EXTENSIONS = ["ts", "tsx", "js", "jsx", "mjs", "cjs"]
+
+    def self.resolve_relative_import(from_file : String,
+                                     import_specifier : String,
+                                     extensions : Array(String) = JS_RESOLVE_EXTENSIONS) : String?
+      return unless import_specifier.starts_with?("./") || import_specifier.starts_with?("../")
+
+      base_dir = File.dirname(from_file)
+      combined = File.expand_path(File.join(base_dir, import_specifier))
+
+      # Specifier with an explicit extension — that exact path or
+      # nothing. Mirrors Node's behaviour for fully-qualified
+      # `./foo.ts` imports.
+      if extensions.any? { |ext| import_specifier.ends_with?(".#{ext}") }
+        return File.exists?(combined) ? combined : nil
+      end
+
+      extensions.each do |ext|
+        candidate = "#{combined}.#{ext}"
+        return candidate if File.exists?(candidate)
+      end
+
+      if Dir.exists?(combined)
+        extensions.each do |ext|
+          candidate = File.join(combined, "index.#{ext}")
+          return candidate if File.exists?(candidate)
+        end
+      end
+
+      nil
+    end
+
+    # ----------------------------------------------------------------
+    # Python flavour (placeholder).
+    #
+    # Python frameworks (Flask, FastAPI, Sanic, Tornado) currently
+    # use the regex-driven `find_imported_modules` helper inside
+    # `src/analyzer/engines/python_engine.cr`. It already handles
+    # the common shapes — `from foo.bar import baz`, relative `from
+    # . import x` and `from .. import x`, plus parenthesised
+    # multi-line imports.
+    #
+    # When we migrate Python analyzers off the legacy parser this
+    # logic should move into a `Noir::ImportGraph` Python helper so
+    # FastAPI / Sanic / Tornado cross-file route discovery can share
+    # it instead of each analyzer rolling its own. Tracking that
+    # under the same #1107 umbrella as the JS half above.
   end
 end


### PR DESCRIPTION
## Summary

The JVM half of #1107 (PR #1306) covered Java / Kotlin's package-trailing-the-directory layout. This PR adds the JS / Node flavour: a `Noir::ImportGraph.resolve_relative_import` helper that resolves `./foo`, `../bar/baz`, `./users.ts`-style specifiers to absolute file paths.

Resolution mirrors Node's CJS algorithm:

1. Specifiers carrying a known extension resolve to that exact file or fail
2. Otherwise `<base>/<specifier>.<ext>` is tried for each candidate extension in priority order (`.ts` → `.tsx` → `.js` → `.jsx` → `.mjs` → `.cjs`)
3. Finally the directory-with-index form `<base>/<specifier>/index.<ext>` is tried

Bare specifiers (`lodash`, `@hapi/hapi`) return nil — those need a `node_modules` walk that's deliberately out of scope. The helper accepts a custom extension list so Ruby / Lua analyzers can call it with their own lookup order (`.rb`, `.lua`, etc.).

This is the foundation for upcoming JS analyzer migrations — Express / Hono / Hapi can use it to follow split-route imports without each rolling its own filesystem-resolution helper.

The **Python half of #1107 stays open**: Flask / FastAPI / Sanic / Tornado already share `find_imported_modules` inside `python_engine.cr`, so that logic should move into `Noir::ImportGraph` as part of the eventual Python TS migration (separate effort). A doc-comment in the module records that as the next step.

## Test plan

- [x] Eight new unit specs cover sibling resolution, explicit extensions, directory/index fallback, parent traversal (`../`), extension priority, bare-specifier rejection, missing-file nil, and the custom-extension hook for non-JS callers
- [x] `crystal spec spec/unit_test/miniparser/import_graph_spec.cr` — 16 examples, all green (8 new + the 8 JVM ones from #1306)
- [x] `crystal spec` — full suite, 6992 examples, 0 failures
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba`