### PR TITLE
fix(typos): rename SKIPPED_LEAFS → SKIPPED_LEAVES (Fresh analyzer)

### DIFF
--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -51,7 +51,7 @@ module Analyzer::Javascript
     FALLBACK_HANDLER_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
     # Files that are framework plumbing rather than routes.
-    SKIPPED_LEAFS = ["_app", "_layout", "_404", "_500", "_middleware"]
+    SKIPPED_LEAVES = ["_app", "_layout", "_404", "_500", "_middleware"]
 
     def analyze
       result = [] of Endpoint
@@ -63,7 +63,7 @@ module Analyzer::Javascript
 
         relative = path[(idx + "/routes/".size)..-1]
         leaf = strip_extension(File.basename(relative))
-        next if SKIPPED_LEAFS.includes?(leaf)
+        next if SKIPPED_LEAVES.includes?(leaf)
         next if leaf.starts_with?("_") # other underscore-prefixed plumbing
 
         url = url_for(relative)


### PR DESCRIPTION
## Summary

Unblock main — the crate-ci/typos check from #1319 flagged `LEAFS` as a misspelling of `LEAVES` in the Fresh analyzer's plumbing-leaf skip-list.

```
error: \`LEAFS\` should be \`LEAVES\`
   ╭▸ ./src/analyzer/analyzers/javascript/fresh.cr:54:13
   │
54 │     SKIPPED_LEAFS = ["_app", "_layout", "_404", "_500", "_middleware"]
```

The constant and its single usage site are renamed. No behaviour change.

CI run: [actions/runs/24934114936](https://github.com/owasp-noir/noir/actions/runs/24934114936)

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/fresh_spec.cr` — 36 examples, all green
- [x] `grep -rn LEAFS src/` — no remaining occurrences