### PR TITLE
fix(security): add boundary check to ImportGraph.resolve_relative_import

### DIFF
--- a/spec/unit_test/miniparser/import_graph_spec.cr
+++ b/spec/unit_test/miniparser/import_graph_spec.cr
@@ -212,5 +212,73 @@ describe Noir::ImportGraph do
         Noir::ImportGraph.resolve_relative_import(from_file, "./users", extensions: ["rb"]).should eq(target)
       end
     end
+
+    describe "with boundary" do
+      it "allows specifiers that resolve inside the boundary" do
+        with_tmpdir do |root|
+          Dir.mkdir_p(File.join(root, "src", "sub"))
+          from_file = File.join(root, "src", "sub", "index.ts")
+          target = File.join(root, "src", "shared.ts")
+          File.write(from_file, "")
+          File.write(target, "")
+
+          Noir::ImportGraph.resolve_relative_import(
+            from_file, "../shared", boundary: root
+          ).should eq(target)
+        end
+      end
+
+      it "rejects specifiers that escape outside the boundary" do
+        with_tmpdir do |outside|
+          File.write(File.join(outside, "secret.ts"), "")
+          with_tmpdir do |project|
+            Dir.mkdir_p(File.join(project, "src"))
+            from_file = File.join(project, "src", "index.ts")
+            File.write(from_file, "")
+
+            # Compute the relative-traversal specifier from
+            # `from_file` (deep inside `project`) up to the
+            # `secret.ts` file sitting in a sibling tmpdir.
+            specifier = Path[outside, "secret"].relative_to(File.dirname(from_file)).to_s
+            Noir::ImportGraph.resolve_relative_import(
+              from_file, specifier, boundary: project
+            ).should be_nil
+          end
+        end
+      end
+
+      it "treats boundary as inclusive of itself" do
+        with_tmpdir do |root|
+          # `from_file` sits at the boundary root, importing a
+          # sibling that is also at the root — should resolve.
+          from_file = File.join(root, "index.ts")
+          target = File.join(root, "users.ts")
+          File.write(from_file, "")
+          File.write(target, "")
+
+          Noir::ImportGraph.resolve_relative_import(
+            from_file, "./users", boundary: root
+          ).should eq(target)
+        end
+      end
+
+      it "rejects when the from_file itself sits outside the boundary" do
+        # Defence-in-depth: even if the specifier is harmless,
+        # passing a `from_file` that's outside `boundary` shouldn't
+        # let the resolver leak files reachable relative to it.
+        with_tmpdir do |project|
+          with_tmpdir do |elsewhere|
+            from_file = File.join(elsewhere, "index.ts")
+            target = File.join(elsewhere, "neighbour.ts")
+            File.write(from_file, "")
+            File.write(target, "")
+
+            Noir::ImportGraph.resolve_relative_import(
+              from_file, "./neighbour", boundary: project
+            ).should be_nil
+          end
+        end
+      end
+    end
   end
 end

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -134,16 +134,35 @@ module Noir
     #      extension in priority order.
     #   3. Finally, `<base>/<specifier>/index.<ext>` for each
     #      candidate extension — the directory-with-index form.
+    #
+    # **Boundary enforcement.** Source files are untrusted input —
+    # an attacker-controlled repo can ship `import x from
+    # '../../../../etc/passwd'`, which would otherwise resolve into
+    # arbitrary paths on the scanner's disk and trigger
+    # `File.exists?` probes outside the scan root. Pass the project
+    # root (or a parent of `from_file` you want to constrain to)
+    # via `boundary:` so the helper rejects any specifier that
+    # resolves outside that subtree. Callers should always pass it
+    # in production; the parameter is optional only because the
+    # legacy spec helpers exercise the resolver against scratch
+    # tmpdirs that aren't worth boundary-wrapping.
 
     JS_RESOLVE_EXTENSIONS = ["ts", "tsx", "js", "jsx", "mjs", "cjs"]
 
     def self.resolve_relative_import(from_file : String,
                                      import_specifier : String,
-                                     extensions : Array(String) = JS_RESOLVE_EXTENSIONS) : String?
+                                     extensions : Array(String) = JS_RESOLVE_EXTENSIONS,
+                                     boundary : String? = nil) : String?
       return unless import_specifier.starts_with?("./") || import_specifier.starts_with?("../")
 
       base_dir = File.dirname(from_file)
       combined = File.expand_path(File.join(base_dir, import_specifier))
+
+      # Boundary check — drop the resolution before any disk I/O so
+      # we don't even fingerprint files outside the scan root.
+      if boundary
+        return unless under_boundary?(combined, boundary)
+      end
 
       # Specifier with an explicit extension — that exact path or
       # nothing. Mirrors Node's behaviour for fully-qualified
@@ -165,6 +184,23 @@ module Noir
       end
 
       nil
+    end
+
+    # `combined` is already an absolute, lexically-normalised path
+    # (post `File.expand_path`). Boundary likewise gets expanded so
+    # the comparison works even when callers hand over a relative
+    # `./project` form.
+    #
+    # The check is purely lexical — symlinks aren't followed. A
+    # `<boundary>/foo -> /etc` symlink could still leak; defense in
+    # depth on top of this would call `File.realpath` after a
+    # successful `File.exists?` and compare the realpath. Skipped
+    # for now because the symlink scenario requires both an
+    # attacker-controlled checkout and pre-existing symlinks on the
+    # scanner's disk pointing at sensitive paths.
+    private def self.under_boundary?(combined : String, boundary : String) : Bool
+      boundary_abs = File.expand_path(boundary)
+      combined == boundary_abs || combined.starts_with?(boundary_abs + File::SEPARATOR)
     end
 
     # ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

A security audit on the new tree-sitter analyzers flagged `Noir::ImportGraph.resolve_relative_import` (added in #1322) as a path-traversal foothold:

> An attacker-controlled source file in the scanned codebase can ship `import x from '../../../../etc/passwd'`. The resolver `File.expand_path`-s it past the project root, then probes the path via `File.exists?`. That leaks file-existence information about the scanner's host and, worse, could surface bogus "endpoints" pointing at unrelated files when callers chain into `File.read`.

The fix adds an optional `boundary:` parameter — typically the project's scan root. When passed, the helper drops any specifier that resolves outside the boundary tree **before any disk I/O** so we don't even fingerprint files outside scope.

The check is purely lexical (post `File.expand_path`). A doc comment records that a `File.realpath`-based symlink check is a defence-in-depth follow-up — only relevant if both an attacker controls the checkout AND pre-existing symlinks on the scanner's disk point at sensitive paths.

`boundary` is optional only because the existing unit specs use scratch tmpdirs; **production callers should always pass it**. No production callers exist today (the helper was only added in #1322), so this is a non-breaking API extension.

## Test plan

Four new specs covering:

- [x] Resolution allowed inside the boundary
- [x] Rejected when the specifier resolves outside the boundary
- [x] Boundary inclusive of itself (`from_file == boundary` case)
- [x] `from_file` sitting outside the boundary also rejected (defence-in-depth so a misconfigured caller still doesn't leak via the helper)

`crystal spec spec/unit_test/miniparser/import_graph_spec.cr` — 20 examples, all green. Full suite at 6996. `crystal tool format --check` and `./lib/ameba/bin/ameba` clean.