### PR TITLE
fix(security): bound recursion depth in tree-walker extractors

### DIFF
--- a/spec/unit_test/miniparser/extractor_recursion_depth_spec.cr
+++ b/spec/unit_test/miniparser/extractor_recursion_depth_spec.cr
@@ -1,0 +1,91 @@
+require "spec"
+
+# Each extractor defines its own deep walk over the AST. A
+# malicious source file with thousands of nested syntactic
+# constructs (e.g., `((((((...))))))` in Kotlin or chained
+# `.get(...).get(...)` in TS) would otherwise blow the Crystal
+# stack mid-walk and crash the scanner. These specs exercise the
+# `Noir::TreeSitter::MAX_AST_DEPTH` guard added to each new
+# extractor — the assertion is simply "doesn't raise" since the
+# extractor's job is to produce results without crashing on
+# adversarial input. Real route shapes never nest beyond ~30
+# levels.
+require "../../../src/miniparsers/elysia_extractor_ts"
+require "../../../src/miniparsers/hapi_extractor_ts"
+require "../../../src/miniparsers/http4k_extractor_ts"
+require "../../../src/miniparsers/adonisjs_extractor_ts"
+require "../../../src/miniparsers/jvm_lambda_dsl_extractor_ts"
+require "../../../src/miniparsers/kotlin_ktor_route_extractor_ts"
+
+private NEST = 3000
+
+describe "extractor recursion depth bounds" do
+  it "Elysia tolerates a 3000-link chained DSL without crashing" do
+    chain = String.build do |io|
+      io << "import { Elysia } from 'elysia'\n"
+      io << "const app = new Elysia()"
+      NEST.times { |i| io << ".get('/r#{i}', () => '#{i}')" }
+      io << "\n"
+    end
+    Noir::TreeSitterElysiaExtractor.extract_routes(chain)
+  end
+
+  it "Hapi tolerates 3000 nested object/array configs without crashing" do
+    body = String.build do |io|
+      io << "server.route("
+      NEST.times { io << "[" }
+      io << "{ method: 'GET', path: '/x', handler: (r) => r }"
+      NEST.times { io << "]" }
+      io << ");\n"
+    end
+    Noir::TreeSitterHapiExtractor.extract_routes(body)
+  end
+
+  it "http4k tolerates a 3000-deep nested routes() chain without crashing" do
+    body = String.build do |io|
+      io << "val app = "
+      NEST.times { |i| io << "\"/p#{i}\" bind routes(" }
+      io << "\"/leaf\" bind GET to handler"
+      NEST.times { io << ")" }
+      io << "\n"
+    end
+    Noir::TreeSitterHttp4kExtractor.extract_routes(body)
+  end
+
+  it "AdonisJS tolerates a 3000-link prefix/group chain without crashing" do
+    body = String.build do |io|
+      io << "import Route from '@ioc:Adonis/Core/Route'\n"
+      io << "Route.group(() => { Route.get('/x', 'C.h') })"
+      NEST.times { |i| io << ".prefix('/p#{i}')" }
+      io << "\n"
+    end
+    Noir::TreeSitterAdonisJsExtractor.extract_routes(body)
+  end
+
+  it "JvmLambdaDsl extractor tolerates 3000 nested path() blocks without crashing" do
+    body = String.build do |io|
+      io << "class A {\n  void m() {\n"
+      NEST.times { |i| io << "    path(\"/p#{i}\", () -> {\n" }
+      io << "      get(\"/leaf\", (req, res) -> \"ok\");\n"
+      NEST.times { io << "    });\n" }
+      io << "  }\n}\n"
+    end
+
+    config = Noir::TreeSitterJvmLambdaDslExtractor::Config.new(
+      verb_methods: {"get" => "GET"},
+      nest_methods: Set{"path"},
+    )
+    Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(body, config)
+  end
+
+  it "Ktor route extractor tolerates 3000 nested route() blocks without crashing" do
+    body = String.build do |io|
+      io << "fun App.cfg() { routing {\n"
+      NEST.times { |i| io << "  route(\"/p#{i}\") {\n" }
+      io << "    get(\"/leaf\") { call.respondText(\"ok\") }\n"
+      NEST.times { io << "  }\n" }
+      io << "} }\n"
+    end
+    Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(body)
+  end
+end

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -112,6 +112,16 @@ end
 # Thin high-level facade. Keeps tree lifetime tied to an object so callers
 # don't have to think about `ts_tree_delete`.
 module Noir::TreeSitter
+  # Recursion guard for AST walkers. Crystal's default fiber stack
+  # is generous (~8 MB) but a malicious source file with deeply
+  # nested syntax — `(((((((...)))))))` chains, deeply nested
+  # object literals, recursive template expressions — could
+  # cascade through a custom walker until the stack runs out. Real
+  # production code rarely nests beyond ~100 levels, so 1024 is
+  # comfortably above legitimate input and well below the stack
+  # ceiling.
+  MAX_AST_DEPTH = 1024
+
   # Parses `source` with the given `language` and yields the root
   # `LibTreeSitter::TSNode`. The parser and tree are freed when the
   # block returns.

--- a/src/miniparsers/adonisjs_extractor_ts.cr
+++ b/src/miniparsers/adonisjs_extractor_ts.cr
@@ -91,14 +91,16 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_javascript(source) do |root|
-        walk(root, source, "", routes)
+        walk(root, source, "", routes, 0)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "call_expression"
         method = chain_method_name(node, source)
 
@@ -110,13 +112,13 @@ module Noir
           ANY_VERBS.each { |verb| emit_verb(node, source, verb, prefix, routes) }
           return
         when method == GROUP_METHOD
-          walk_group(node, source, prefix, routes)
+          walk_group(node, source, prefix, routes, depth)
           return
         when method == "resource"
           emit_resource(node, source, prefix, ANY_VERBS_ALL, routes)
           return
         when method == "prefix"
-          handle_prefix(node, source, prefix, routes)
+          handle_prefix(node, source, prefix, routes, depth)
           return
         when method == "only"
           handle_resource_filter(node, source, prefix, :only, routes)
@@ -125,13 +127,13 @@ module Noir
           handle_resource_filter(node, source, prefix, :except, routes)
           return
         when TRANSPARENT_MODIFIERS.includes?(method)
-          handle_transparent(node, source, prefix, routes)
+          handle_transparent(node, source, prefix, routes, depth)
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes)
+        walk(child, source, prefix, routes, depth + 1)
       end
     end
 
@@ -142,19 +144,19 @@ module Noir
 
     # `Route.group(cb).prefix('/x')` — capture '/x' and walk the
     # inner call's group with the joined prefix.
-    private def handle_prefix(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def handle_prefix(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
       arg = first_string_argument(call, source)
       receiver = chain_receiver(call)
       return unless receiver
 
       new_prefix = arg ? join_paths(prefix, arg) : prefix
-      walk(receiver, source, new_prefix, routes)
+      walk(receiver, source, new_prefix, routes, depth + 1)
     end
 
-    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
       receiver = chain_receiver(call)
       return unless receiver
-      walk(receiver, source, prefix, routes)
+      walk(receiver, source, prefix, routes, depth + 1)
     end
 
     # `.only([...])` / `.except([...])` modifiers on `.resource(...)`.
@@ -178,7 +180,7 @@ module Noir
       emit_resource(receiver, source, prefix, effective, routes)
     end
 
-    private def walk_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
       args = arguments_node(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
@@ -186,7 +188,7 @@ module Noir
                     Noir::TreeSitter.node_type(arg) == "function_expression" ||
                     Noir::TreeSitter.node_type(arg) == "function"
         if body = function_body(arg)
-          walk(body, source, prefix, routes)
+          walk(body, source, prefix, routes, depth + 1)
         end
       end
     end

--- a/src/miniparsers/elysia_extractor_ts.cr
+++ b/src/miniparsers/elysia_extractor_ts.cr
@@ -84,38 +84,40 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_javascript(source) do |root|
-        walk(root, source, "", routes)
+        walk(root, source, "", routes, 0)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "call_expression"
         method = chain_method_name(node, source)
         case
         when HTTP_VERB_METHODS.has_key?(method)
           emit_route(node, source, HTTP_VERB_METHODS[method], prefix, routes)
-          walk_chain_predecessor(node, source, prefix, routes)
+          walk_chain_predecessor(node, source, prefix, routes, depth)
           return
         when method == "all"
           ALL_VERBS.each { |verb| emit_route(node, source, verb, prefix, routes) }
-          walk_chain_predecessor(node, source, prefix, routes)
+          walk_chain_predecessor(node, source, prefix, routes, depth)
           return
         when GROUP_METHODS.includes?(method)
-          handle_group(node, source, prefix, routes)
-          walk_chain_predecessor(node, source, prefix, routes)
+          handle_group(node, source, prefix, routes, depth)
+          walk_chain_predecessor(node, source, prefix, routes, depth)
           return
         when TRANSPARENT_METHODS.includes?(method)
-          handle_transparent(node, source, prefix, routes)
-          walk_chain_predecessor(node, source, prefix, routes)
+          handle_transparent(node, source, prefix, routes, depth)
+          walk_chain_predecessor(node, source, prefix, routes, depth)
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes)
+        walk(child, source, prefix, routes, depth + 1)
       end
     end
 
@@ -136,16 +138,16 @@ module Noir
     # Continue down the chain into the prior link's call_expression
     # — `a.get(...).post(...)` outer has the inner `a.get(...)` as
     # the member_expression's first child.
-    private def walk_chain_predecessor(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk_chain_predecessor(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
       callee = first_named_child(call)
       return unless callee
       return unless Noir::TreeSitter.node_type(callee) == "member_expression"
       inner = first_named_child(callee)
       return unless inner
-      walk(inner, source, prefix, routes) if Noir::TreeSitter.node_type(inner) == "call_expression"
+      walk(inner, source, prefix, routes, depth + 1) if Noir::TreeSitter.node_type(inner) == "call_expression"
     end
 
-    private def handle_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def handle_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
       args = arguments_node(call)
       return unless args
 
@@ -162,16 +164,16 @@ module Noir
       return unless group_path && group_body
 
       new_prefix = join_paths(prefix, group_path)
-      walk(group_body, source, new_prefix, routes)
+      walk(group_body, source, new_prefix, routes, depth + 1)
     end
 
-    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
       args = arguments_node(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "arrow_function"
         if body = arrow_body(arg)
-          walk(body, source, prefix, routes)
+          walk(body, source, prefix, routes, depth + 1)
         end
       end
     end
@@ -201,7 +203,7 @@ module Noir
       has_body = false
 
       if handler
-        scan_handler(handler, source) do |kind, value|
+        scan_handler(handler, source, 0) do |kind, value|
           case kind
           when :query  then query_params << value unless query_params.includes?(value)
           when :header then header_params << value unless header_params.includes?(value)
@@ -221,13 +223,14 @@ module Noir
     # signals. Both the destructuring pattern
     # (`({ body, query, headers, cookie })`) and member-expression
     # access (`query.foo`, `ctx.headers['x']`) contribute.
-    private def scan_handler(handler : LibTreeSitter::TSNode, source : String, &block : Symbol, String ->)
+    private def scan_handler(handler : LibTreeSitter::TSNode, source : String, depth : Int32, &block : Symbol, String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       Noir::TreeSitter.each_named_child(handler) do |child|
         case Noir::TreeSitter.node_type(child)
         when "formal_parameters"
           scan_destructured_params(child, source, &block)
         else
-          scan_handler_body(child, source, &block)
+          scan_handler_body(child, source, depth + 1, &block)
         end
       end
     end
@@ -263,7 +266,8 @@ module Noir
       end
     end
 
-    private def scan_handler_body(node : LibTreeSitter::TSNode, source : String, &block : Symbol, String ->)
+    private def scan_handler_body(node : LibTreeSitter::TSNode, source : String, depth : Int32, &block : Symbol, String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       ty = Noir::TreeSitter.node_type(node)
 
       case ty
@@ -305,7 +309,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        scan_handler_body(child, source, &block)
+        scan_handler_body(child, source, depth + 1, &block)
       end
     end
 

--- a/src/miniparsers/hapi_extractor_ts.cr
+++ b/src/miniparsers/hapi_extractor_ts.cr
@@ -64,21 +64,23 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_javascript(source) do |root|
-        walk(root, source, routes)
+        walk(root, source, routes, 0)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, routes : Array(Route))
+    private def walk(node : LibTreeSitter::TSNode, source : String, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "call_expression" && route_call?(node, source)
         emit_routes(node, source, routes)
         return
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, routes)
+        walk(child, source, routes, depth + 1)
       end
     end
 
@@ -141,7 +143,7 @@ module Noir
       has_body = false
 
       if handler
-        scan_handler(handler, source) do |kind, value|
+        scan_handler(handler, source, 0) do |kind, value|
           case kind
           when :query  then query_params << value
           when :header then header_params << value
@@ -199,7 +201,8 @@ module Noir
 
     # ---- handler-body scan ------------------------------------------
 
-    private def scan_handler(node : LibTreeSitter::TSNode, source : String, &block : Symbol, String ->)
+    private def scan_handler(node : LibTreeSitter::TSNode, source : String, depth : Int32, &block : Symbol, String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       ty = Noir::TreeSitter.node_type(node)
 
       case ty
@@ -240,7 +243,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        scan_handler(child, source, &block)
+        scan_handler(child, source, depth + 1, &block)
       end
     end
 

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -69,27 +69,29 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes)
+        walk(root, source, "", routes, 0)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       ty = Noir::TreeSitter.node_type(node)
 
-      if ty == "infix_expression" && handle_bind(node, source, prefix, routes)
+      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, depth)
         return
       end
 
       if ty == "call_expression" && call_function_name(node, source) == "routes"
-        walk_routes_args(node, source, prefix, routes)
+        walk_routes_args(node, source, prefix, routes, depth)
         return
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes)
+        walk(child, source, prefix, routes, depth + 1)
       end
     end
 
@@ -100,7 +102,7 @@ module Noir
     #
     # Returns true when consumed; false otherwise so the caller can
     # fall through to the generic descent.
-    private def handle_bind(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route)) : Bool
+    private def handle_bind(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32) : Bool
       lhs, op, rhs = infix_parts(node, source)
       return false unless lhs && rhs
 
@@ -122,7 +124,7 @@ module Noir
 
         query, header, form = [] of String, [] of String, [] of String
         has_body = false
-        scan_handler(rhs, source) do |kind, value|
+        scan_handler(rhs, source, 0) do |kind, value|
           case kind
           when :query  then query << value
           when :header then header << value
@@ -140,7 +142,7 @@ module Noir
 
         path_text = decode_string_literal(lhs, source)
         new_prefix = join_paths(prefix, path_text)
-        walk_routes_args(rhs, source, new_prefix, routes)
+        walk_routes_args(rhs, source, new_prefix, routes, depth + 1)
         true
       else
         false
@@ -151,13 +153,14 @@ module Noir
     # Each argument is a `value_argument` wrapping an
     # `infix_expression` (the binding) or another nested `routes(...)`
     # call.
-    private def walk_routes_args(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk_routes_args(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       args = call_value_arguments(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "value_argument"
         Noir::TreeSitter.each_named_child(arg) do |child|
-          walk(child, source, prefix, routes)
+          walk(child, source, prefix, routes, depth + 1)
         end
       end
     end
@@ -169,7 +172,8 @@ module Noir
     # about the receiver name — http4k handlers conventionally use
     # `req`, but lambdas with implicit `it` or other names should
     # still surface signals.
-    private def scan_handler(node : LibTreeSitter::TSNode, source : String, &block : Symbol, String ->)
+    private def scan_handler(node : LibTreeSitter::TSNode, source : String, depth : Int32, &block : Symbol, String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       ty = Noir::TreeSitter.node_type(node)
 
       if ty == "call_expression"
@@ -196,7 +200,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        scan_handler(child, source, &block)
+        scan_handler(child, source, depth + 1, &block)
       end
     end
 

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -80,14 +80,16 @@ module Noir
     def extract_routes(source : String, config : Config) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
-        walk(root, source, "", config, routes)
+        walk(root, source, "", config, routes, 0)
       end
       routes
     end
 
     # ---- traversal ---------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, config : Config, routes : Array(Route))
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, config : Config, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       ty = Noir::TreeSitter.node_type(node)
 
       if ty == "method_invocation"
@@ -100,19 +102,19 @@ module Noir
           path_arg = first_string_argument(node, source)
           new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
           if body = lambda_body_in_args(node)
-            walk(body, source, new_prefix, config, routes)
+            walk(body, source, new_prefix, config, routes, depth + 1)
           end
           return
         when config.transparent_methods.includes?(name)
           if body = lambda_body_in_args(node)
-            walk(body, source, prefix, config, routes)
+            walk(body, source, prefix, config, routes, depth + 1)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, config, routes)
+        walk(child, source, prefix, config, routes, depth + 1)
       end
     end
 
@@ -136,7 +138,7 @@ module Noir
       has_body = false
 
       if body = lambda_body_in_args(call)
-        scan_handler(body, source, config) do |kind, value|
+        scan_handler(body, source, config, 0) do |kind, value|
           case kind
           when :query  then query_params << value
           when :form   then form_params << value
@@ -154,7 +156,9 @@ module Noir
         query_params, form_params, header_params, cookie_params)
     end
 
-    private def scan_handler(node : LibTreeSitter::TSNode, source : String, config : Config, &block : Symbol, String ->)
+    private def scan_handler(node : LibTreeSitter::TSNode, source : String, config : Config, depth : Int32, &block : Symbol, String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       ty = Noir::TreeSitter.node_type(node)
 
       if ty == "method_invocation"
@@ -192,7 +196,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        scan_handler(child, source, config, &block)
+        scan_handler(child, source, config, depth + 1, &block)
       end
     end
 

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -79,14 +79,16 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes)
+        walk(root, source, "", routes, 0)
       end
       routes
     end
 
     # ---- traversal ----------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route))
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "call_expression"
         name = call_name(node, source)
         case
@@ -97,19 +99,19 @@ module Noir
           path_arg = call_string_argument(node, source)
           new_prefix = path_arg ? prefix + path_arg : prefix
           if body = call_lambda_body(node)
-            walk(body, source, new_prefix, routes)
+            walk(body, source, new_prefix, routes, depth + 1)
           end
           return
         when PASSTHROUGH_NAMES.includes?(name)
           if body = call_lambda_body(node)
-            walk(body, source, prefix, routes)
+            walk(body, source, prefix, routes, depth + 1)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes)
+        walk(child, source, prefix, routes, depth + 1)
       end
     end
 
@@ -247,7 +249,7 @@ module Noir
                                   query_params : Array(String),
                                   header_params : Array(String)) : String?
       receive_type : String? = nil
-      walk_handler(node, source, query_params, header_params) do |type|
+      walk_handler(node, source, query_params, header_params, 0) do |type|
         receive_type ||= type
       end
       receive_type
@@ -257,7 +259,10 @@ module Noir
                              source : String,
                              query_params : Array(String),
                              header_params : Array(String),
+                             depth : Int32,
                              &block : String ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       ty = Noir::TreeSitter.node_type(node)
 
       case ty
@@ -285,7 +290,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_handler(child, source, query_params, header_params, &block)
+        walk_handler(child, source, query_params, header_params, depth + 1, &block)
       end
     end
 
@@ -314,13 +319,17 @@ module Noir
     end
 
     # Walk down a `type_projection` / `user_type` / `nullable_type`
-    # chain to its `type_identifier` leaf.
-    private def type_leaf(node : LibTreeSitter::TSNode, source : String) : String?
+    # chain to its `type_identifier` leaf. The depth bound here is
+    # defence-in-depth — Kotlin types nesting beyond a few dozen
+    # levels would already break the grammar, but the same recursion
+    # discipline as the route walker keeps the surface uniform.
+    private def type_leaf(node : LibTreeSitter::TSNode, source : String, depth : Int32 = 0) : String?
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       ty = Noir::TreeSitter.node_type(node)
       return Noir::TreeSitter.node_text(node, source) if ty == "type_identifier"
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        if leaf = type_leaf(child, source)
+        if leaf = type_leaf(child, source, depth + 1)
           return leaf
         end
       end


### PR DESCRIPTION
## Summary

Yesterday's security audit flagged the new tree-sitter extractors' custom AST walkers as a stack-overflow DoS vector:

> An attacker-controlled source file with deeply nested syntax — `(((((...)))))` in Kotlin, chained `.get(...).get(...)` in TS, deeply nested object literals in Hapi configs, etc. — would cascade through a walker until the Crystal stack runs out and crashes the scanner.

The fix is a single shared constant `Noir::TreeSitter::MAX_AST_DEPTH = 1024` and a `depth : Int32` parameter threaded through every primary `walk` / `scan_handler` / `walk_handler` recursion in the new extractors. Each guards `return if depth > MAX_AST_DEPTH` at the top and increments depth on each recursive call (both the `each_named_child` descent and the chain / group / transparent helper cross-calls).

Files touched:

- `src/ext/tree_sitter/tree_sitter.cr` — shared constant + doc
- `jvm_lambda_dsl_extractor_ts.cr` (Javalin / Spark) — `walk` + `scan_handler`
- `http4k_extractor_ts.cr` — `walk`, `walk_routes_args`, `handle_bind`, `scan_handler`
- `elysia_extractor_ts.cr` — `walk`, `walk_chain_predecessor`, `handle_group`, `handle_transparent`, `scan_handler`, `scan_handler_body`
- `adonisjs_extractor_ts.cr` — `walk`, `handle_prefix`, `handle_transparent`, `walk_group`
- `hapi_extractor_ts.cr` — `walk`, `scan_handler`
- `kotlin_ktor_route_extractor_ts.cr` — `walk`, `walk_handler`, plus the audit's MEDIUM-severity `type_leaf` (defence-in-depth — generic types nesting beyond a few dozen levels would already break the grammar, but the same recursion discipline keeps the surface uniform)

The constant is comfortably above legitimate input (real code rarely nests beyond ~30 levels) and well below the Crystal fiber stack ceiling.

## Test plan

- [x] New `extractor_recursion_depth_spec.cr` builds a 3000-link-deep adversarial source for each affected extractor and asserts the call returns without raising. Without the bound, every one of these would stack-overflow.
- [x] `crystal spec` — full suite at **7002 examples, 0 failures** (was 6996 before the six new depth-bound specs).
- [x] Per-fixture functional specs unchanged (Javalin 80, Spark 34, http4k 44, Elysia 40, AdonisJS 62, Hapi 50, Ktor 60).
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba` clean.