### PR TITLE
perf: route new analyzers + DTO indexes through CodeLocator cache

### DIFF
--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -21,7 +21,7 @@ module Analyzer::Java
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless content.includes?(DROPWIZARD_MARKER)
 
         # Some Dropwizard files (Application, Module classes) won't
@@ -55,7 +55,7 @@ module Analyzer::Java
 
       Noir::ImportGraph.related_files(path, package_name, imports, JAVA_EXTENSION) do |file|
         beans = cache[file] ||= begin
-          body = file == path ? content : File.read(file, encoding: "utf-8", invalid: :skip)
+          body = file == path ? content : read_file_content(file)
           Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
         rescue File::NotFoundError
           {} of String => Array(Param)

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -42,7 +42,7 @@ module Analyzer::Java
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless JAVALIN_MARKERS.any? { |m| content.includes?(m) }
 
         Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(content, CONFIG).each do |route|

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -15,7 +15,7 @@ module Analyzer::Java
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
 
         # Cheap pre-filter: only files that mention JAX-RS bindings
         # carry resource classes. Avoids parsing the entire source
@@ -66,7 +66,7 @@ module Analyzer::Java
 
       Noir::ImportGraph.related_files(path, package_name, imports, JAVA_EXTENSION) do |file|
         beans = cache[file] ||= begin
-          body = file == path ? content : File.read(file, encoding: "utf-8", invalid: :skip)
+          body = file == path ? content : read_file_content(file)
           Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
         rescue File::NotFoundError
           {} of String => Array(Param)

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -14,7 +14,7 @@ module Analyzer::Java
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless MICRONAUT_MARKERS.any? { |marker| content.includes?(marker) }
 
         package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name(content)

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -22,7 +22,7 @@ module Analyzer::Java
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless QUARKUS_MARKERS.any? { |marker| content.includes?(marker) }
 
         package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name(content)
@@ -51,7 +51,7 @@ module Analyzer::Java
 
       Noir::ImportGraph.related_files(path, package_name, imports, JAVA_EXTENSION) do |file|
         beans = cache[file] ||= begin
-          body = file == path ? content : File.read(file, encoding: "utf-8", invalid: :skip)
+          body = file == path ? content : read_file_content(file)
           Noir::TreeSitterJaxRsExtractor.extract_bean_fields(body)
         rescue File::NotFoundError
           {} of String => Array(Param)

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -41,7 +41,7 @@ module Analyzer::Java
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless SPARK_MARKERS.any? { |m| content.includes?(m) }
 
         Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(content, CONFIG).each do |route|

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -51,7 +51,7 @@ module Analyzer::Java
           end
         elsif File.exists?(path) && path.ends_with?(".java")
           webflux_base_path = find_base_path(path, webflux_base_path_map)
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
 
           # Only files that mention Spring MVC / Feign bindings carry
           # annotation-based routes. Reactive `router().route()` files

--- a/src/analyzer/analyzers/javascript/adonisjs.cr
+++ b/src/analyzer/analyzers/javascript/adonisjs.cr
@@ -15,7 +15,7 @@ module Analyzer::Javascript
         next unless File.exists?(path)
         next unless JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless ADONIS_MARKERS.any? { |m| content.includes?(m) }
 
         Noir::TreeSitterAdonisJsExtractor.extract_routes(content).each do |route|

--- a/src/analyzer/analyzers/javascript/astro.cr
+++ b/src/analyzer/analyzers/javascript/astro.cr
@@ -78,7 +78,7 @@ module Analyzer::Javascript
       url = url_for(relative)
 
       content = begin
-        File.read(path, encoding: "utf-8", invalid: :skip)
+        read_file_content(path)
       rescue e
         logger.debug "Error reading #{path}: #{e.message}"
         return

--- a/src/analyzer/analyzers/javascript/elysia.cr
+++ b/src/analyzer/analyzers/javascript/elysia.cr
@@ -12,7 +12,7 @@ module Analyzer::Javascript
         next unless File.exists?(path)
         next unless JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless ELYSIA_MARKERS.any? { |m| content.includes?(m) }
 
         Noir::TreeSitterElysiaExtractor.extract_routes(content).each do |route|

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -69,7 +69,7 @@ module Analyzer::Javascript
         url = url_for(relative)
 
         content = begin
-          File.read(path, encoding: "utf-8", invalid: :skip)
+          read_file_content(path)
         rescue e
           logger.debug "Error reading #{path}: #{e.message}"
           next

--- a/src/analyzer/analyzers/javascript/hapi.cr
+++ b/src/analyzer/analyzers/javascript/hapi.cr
@@ -12,7 +12,7 @@ module Analyzer::Javascript
         next unless File.exists?(path)
         next unless JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless HAPI_MARKERS.any? { |m| content.includes?(m) }
 
         Noir::TreeSitterHapiExtractor.extract_routes(content).each do |route|

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -65,7 +65,7 @@ module Analyzer::Javascript
         url = url_for(leaf)
 
         content = begin
-          File.read(path, encoding: "utf-8", invalid: :skip)
+          read_file_content(path)
         rescue e
           logger.debug "Error reading #{path}: #{e.message}"
           next

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -85,7 +85,7 @@ module Analyzer::Javascript
     private def analyze_api_route(path : String, relative : String, result : Array(Endpoint), mutex : Mutex)
       url = url_for(relative)
       content = begin
-        File.read(path, encoding: "utf-8", invalid: :skip)
+        read_file_content(path)
       rescue e
         logger.debug "Error reading #{path}: #{e.message}"
         return

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -12,7 +12,7 @@ module Analyzer::Kotlin
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless content.includes?(HTTP4K_MARKER)
 
         Noir::TreeSitterHttp4kExtractor.extract_routes(content).each do |route|

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -11,7 +11,7 @@ module Analyzer::Kotlin
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
 
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         next unless content.includes?("routing")
 
         Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content).each do |route|

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -132,7 +132,7 @@ module Analyzer::Kotlin
     # `consumes = ...`, and DTO cross-file resolution all run on the
     # vendored Kotlin grammar — no `KotlinParser` / `KotlinLexer`.
     private def process_kotlin_file(path : String, dto_builder : Noir::TreeSitterKotlinDtoIndex, webflux_base_path_map : Hash(String, String))
-      content = File.read(path, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(path)
 
       # Skip files without a package declaration — legacy filter that
       # avoids scanning test stubs / throwaway snippets.

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "../models/code_locator"
 require "./import_graph"
 
 module Noir
@@ -584,7 +585,17 @@ module Noir
 
     private def classes_in(file : String, current_path : String, current_content : String) : Index
       @file_cache[file] ||= begin
-        body = file == current_path ? current_content : File.read(file, encoding: "utf-8", invalid: :skip)
+        body =
+          if file == current_path
+            current_content
+          else
+            # Detector pre-warms a content cache for every scanned
+            # file (size-bounded). Sibling DTO files often live in
+            # that cache already — `nil` falls back to a fresh
+            # `File.read` for files outside the budget.
+            CodeLocator.instance.content_for(file) ||
+            File.read(file, encoding: "utf-8", invalid: :skip)
+          end
         TreeSitterJavaParameterExtractor.extract_class_fields(body)
       rescue File::NotFoundError
         Index.new

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "../models/code_locator"
 require "./import_graph"
 
 module Noir
@@ -719,7 +720,13 @@ module Noir
 
     private def classes_in(file : String, current_path : String, current_content : String) : Index
       @file_cache[file] ||= begin
-        body = file == current_path ? current_content : File.read(file, encoding: "utf-8", invalid: :skip)
+        body =
+          if file == current_path
+            current_content
+          else
+            CodeLocator.instance.content_for(file) ||
+            File.read(file, encoding: "utf-8", invalid: :skip)
+          end
         TreeSitterKotlinParameterExtractor.extract_class_fields(body)
       rescue File::NotFoundError
         Index.new


### PR DESCRIPTION
## Summary

The hotspot survey flagged 26 of 28 analyzers calling `File.read(path, encoding: "utf-8", invalid: :skip)` directly, bypassing the detector-warmed `CodeLocator` content cache. The helper `Analyzer#read_file_content` already exists for exactly this purpose — consults `CodeLocator.instance.content_for(path)` and falls back to `File.read` on cache miss.

This PR routes the new tree-sitter analyzers + the two DTO indexes through that helper:

**Java analyzers:** JAX-RS, Quarkus, Dropwizard, Micronaut, Javalin, Spark Java, Spring (now use it for both the primary file read AND the `bean_index_for` sibling reads).
**Kotlin analyzers:** Spring, Ktor, http4k.
**JavaScript analyzers:** Hapi, Astro, SvelteKit, Remix, Fresh, Elysia, AdonisJS.
**DTO indexes:** `TreeSitterJavaDtoIndex` and `TreeSitterKotlinDtoIndex` — these aren't `Analyzer` subclasses so they consult `CodeLocator.instance.content_for(file)` directly with the same `File.read` fallback for cache misses.

### Performance impact

Bench against the synthetic 5x fixture workload (~2530 files) shows the change within noise — the OS page cache is already hot on repeated runs and the marker pre-filter rejects most files before a second read. The cache benefit shows up on real-world projects where:

1. The detector warms the cache for every scanned file (size-bounded; large files skip the cache).
2. Multiple analyzers run on the same file (Spring + JAX-RS can both fire on a `.java` file with both imports).
3. The DTO index re-reads sibling files that the detector already has cached.

The discipline also matters: future analyzers picking up `read_file_content` from the start get cache parity for free, and a future "marker-coordinated single-pass" optimisation has a cleaner foundation.

## Test plan

- [x] `crystal spec` — 7002 examples, 0 failures
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba` clean