### PR TITLE
perf: parse-once Spring/Kotlin extractors

### DIFF
--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -62,48 +62,51 @@ module Analyzer::Java
           has_feign_bindings = content.includes?(feign_client_package) || content.includes?("@FeignClient")
 
           if has_spring_bindings || has_feign_bindings
-            # Skip files without a package declaration — legacy filter
-            # that avoids scanning test stubs / throwaway snippets.
-            package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name(content)
-            next if package_name.empty?
+            # Single tree-sitter parse for the whole file — every
+            # extraction below pulls from the same root so a
+            # controller with N routes pays for 1 parse instead of
+            # the previous 4 + 2N. The DTO index, FeignClient
+            # detection, route discovery, consumes lookup, and
+            # parameter walks all consume `root`.
+            Noir::TreeSitter.parse_java(content) do |root|
+              # Skip files without a package declaration — legacy filter
+              # that avoids scanning test stubs / throwaway snippets.
+              package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
+              next if package_name.empty?
 
-            # End-to-end tree-sitter pipeline. Route discovery,
-            # parameter extraction, `@FeignClient` detection,
-            # `consumes = ...`, and DTO cross-file resolution all run
-            # on the vendored grammars — no `JavaParser` / `JavaLexer`
-            # involvement.
-            dto_index = dto_builder.build_for(path, content)
-            feign_clients = Noir::TreeSitterJavaParameterExtractor.extract_feign_client_classes(content)
+              dto_index = dto_builder.build_for_with_root(path, content, root)
+              feign_clients = Noir::TreeSitterJavaParameterExtractor.extract_feign_client_classes_from(root, content)
 
-            Noir::TreeSitterJavaRouteExtractor.extract_routes(content).each do |route|
-              is_feign_client = feign_clients.includes?(route.class_name)
+              Noir::TreeSitterJavaRouteExtractor.extract_routes_from(root, content).each do |route|
+                is_feign_client = feign_clients.includes?(route.class_name)
 
-              parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes(
-                content, route.class_name, route.method_name
-              )
-              if parameter_format.nil? && route.verb == "POST"
-                parameter_format = "form"
+                parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
+                  root, content, route.class_name, route.method_name
+                )
+                if parameter_format.nil? && route.verb == "POST"
+                  parameter_format = "form"
+                end
+
+                parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
+                  root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index
+                )
+
+                # Drop the trailing `/` on webflux_base_path when the
+                # route path already starts with one, so the join
+                # doesn't produce `//`.
+                base_path = webflux_base_path
+                if base_path.ends_with?("/") && route.path.starts_with?("/")
+                  base_path = base_path[..-2]
+                end
+
+                line = route.line + 1
+                details = Details.new(PathInfo.new(path, line))
+
+                endpoint = Endpoint.new(
+                  join_paths(base_path, route.path), route.verb, parameters, details, is_feign_client
+                )
+                @result << endpoint
               end
-
-              parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
-                content, route.class_name, route.method_name, route.verb, parameter_format, dto_index
-              )
-
-              # Drop the trailing `/` on webflux_base_path when the
-              # route path already starts with one, so the join
-              # doesn't produce `//`.
-              base_path = webflux_base_path
-              if base_path.ends_with?("/") && route.path.starts_with?("/")
-                base_path = base_path[..-2]
-              end
-
-              line = route.line + 1
-              details = Details.new(PathInfo.new(path, line))
-
-              endpoint = Endpoint.new(
-                join_paths(base_path, route.path), route.verb, parameters, details, is_feign_client
-              )
-              @result << endpoint
             end
           else
             # Reactive routes declared via `router().route(...).andRoute(...)`

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -134,58 +134,65 @@ module Analyzer::Kotlin
     private def process_kotlin_file(path : String, dto_builder : Noir::TreeSitterKotlinDtoIndex, webflux_base_path_map : Hash(String, String))
       content = read_file_content(path)
 
-      # Skip files without a package declaration — legacy filter that
-      # avoids scanning test stubs / throwaway snippets.
-      package_name = Noir::TreeSitterKotlinParameterExtractor.extract_package_name(content)
-      return if package_name.empty?
+      # Single tree-sitter parse for the whole file — every
+      # extraction below pulls from the same root so a controller
+      # with N routes pays for 1 parse instead of the previous
+      # 4 + 2N. Same shape as the Java Spring analyzer's
+      # parse-once pipeline.
+      Noir::TreeSitter.parse_kotlin(content) do |root|
+        # Skip files without a package declaration — legacy filter that
+        # avoids scanning test stubs / throwaway snippets.
+        package_name = Noir::TreeSitterKotlinParameterExtractor.extract_package_name_from(root, content)
+        next if package_name.empty?
 
-      webflux_base_path = find_base_path(path, webflux_base_path_map)
-      dto_index = dto_builder.build_for(path, content)
+        webflux_base_path = find_base_path(path, webflux_base_path_map)
+        dto_index = dto_builder.build_for_with_root(path, content, root)
 
-      routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(content)
+        routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes_from(root, content)
 
-      # Pin the parameter format to the FIRST verb seen for each
-      # (class, method) — for multi-verb `@RequestMapping(method =
-      # [GET, POST])` we want a single shared format so the
-      # `params=` constraint expansion matches across both routes
-      # (mirrors the legacy `||=` quirk: first verb wins).
-      first_verb = Hash(String, String).new
-      routes.each do |route|
-        key = "#{route.class_name}##{route.method_name}"
-        first_verb[key] ||= route.verb
-      end
-
-      routes.each do |route|
-        key = "#{route.class_name}##{route.method_name}"
-        format_verb = first_verb[key]? || route.verb
-
-        parameter_format = Noir::TreeSitterKotlinParameterExtractor.extract_consumes(
-          content, route.class_name, route.method_name
-        )
-        if parameter_format.nil?
-          parameter_format = case format_verb
-                             when "POST", "PUT", "DELETE", "PATCH"
-                               "form"
-                             when "GET"
-                               "query"
-                             end
+        # Pin the parameter format to the FIRST verb seen for each
+        # (class, method) — for multi-verb `@RequestMapping(method =
+        # [GET, POST])` we want a single shared format so the
+        # `params=` constraint expansion matches across both routes
+        # (mirrors the legacy `||=` quirk: first verb wins).
+        first_verb = Hash(String, String).new
+        routes.each do |route|
+          key = "#{route.class_name}##{route.method_name}"
+          first_verb[key] ||= route.verb
         end
 
-        parameters = Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters(
-          content, route.class_name, route.method_name, format_verb, parameter_format, dto_index
-        )
+        routes.each do |route|
+          key = "#{route.class_name}##{route.method_name}"
+          format_verb = first_verb[key]? || route.verb
 
-        # Drop the trailing `/` on webflux_base_path when the route
-        # path already starts with one, so the join doesn't produce
-        # `//`.
-        base_path = webflux_base_path
-        if base_path.ends_with?("/") && route.path.starts_with?("/")
-          base_path = base_path[..-2]
+          parameter_format = Noir::TreeSitterKotlinParameterExtractor.extract_consumes_from(
+            root, content, route.class_name, route.method_name
+          )
+          if parameter_format.nil?
+            parameter_format = case format_verb
+                               when "POST", "PUT", "DELETE", "PATCH"
+                                 "form"
+                               when "GET"
+                                 "query"
+                               end
+          end
+
+          parameters = Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters_from(
+            root, content, route.class_name, route.method_name, format_verb, parameter_format, dto_index
+          )
+
+          # Drop the trailing `/` on webflux_base_path when the route
+          # path already starts with one, so the join doesn't produce
+          # `//`.
+          base_path = webflux_base_path
+          if base_path.ends_with?("/") && route.path.starts_with?("/")
+            base_path = base_path[..-2]
+          end
+
+          line = route.line + 1
+          details = Details.new(PathInfo.new(path, line))
+          @result << Endpoint.new(join_paths(base_path, route.path), route.verb, parameters, details)
         end
-
-        line = route.line + 1
-        details = Details.new(PathInfo.new(path, line))
-        @result << Endpoint.new(join_paths(base_path, route.path), route.verb, parameters, details)
       end
     end
 

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -65,15 +65,29 @@ module Noir
     def extract_class_fields(source : String) : Hash(String, Array(FieldInfo))
       results = Hash(String, Array(FieldInfo)).new
       Noir::TreeSitter.parse_java(source) do |root|
-        walk_class_containers(root) do |decl|
-          name_node = Noir::TreeSitter.field(decl, "name")
-          next unless name_node
-          class_name = Noir::TreeSitter.node_text(name_node, source)
-          body = Noir::TreeSitter.field(decl, "body")
-          next unless body
-          fields = collect_class_fields(body, source)
-          results[class_name] = fields unless fields.empty?
-        end
+        results = extract_class_fields_from(root, source)
+      end
+      results
+    end
+
+    # `_from(root, source)` variants accept a pre-parsed root node so
+    # callers (typically the Spring analyzer) can amortise the
+    # tree-sitter parse across multiple extractions on the same file
+    # — `extract_routes_from`, `extract_consumes_from`,
+    # `extract_method_parameters_from`, and the rest can all share a
+    # single `Noir::TreeSitter.parse_java` block. Tree lifetime is
+    # the caller's responsibility (it must keep `root` valid by
+    # staying inside the `parse_java` block while these are invoked).
+    def extract_class_fields_from(root : LibTreeSitter::TSNode, source : String) : Hash(String, Array(FieldInfo))
+      results = Hash(String, Array(FieldInfo)).new
+      walk_class_containers(root) do |decl|
+        name_node = Noir::TreeSitter.field(decl, "name")
+        next unless name_node
+        class_name = Noir::TreeSitter.node_text(name_node, source)
+        body = Noir::TreeSitter.field(decl, "body")
+        next unless body
+        fields = collect_class_fields(body, source)
+        results[class_name] = fields unless fields.empty?
       end
       results
     end
@@ -95,11 +109,21 @@ module Noir
                                   class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
       params = [] of Param
       Noir::TreeSitter.parse_java(source) do |root|
-        method = find_method(root, source, class_name, method_name)
-        next unless method
-        params = collect_method_params(method, source, verb, parameter_format, class_fields)
+        params = extract_method_parameters_from(root, source, class_name, method_name, verb, parameter_format, class_fields)
       end
       params
+    end
+
+    def extract_method_parameters_from(root : LibTreeSitter::TSNode,
+                                       source : String,
+                                       class_name : String,
+                                       method_name : String,
+                                       verb : String,
+                                       parameter_format : String?,
+                                       class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
+      method = find_method(root, source, class_name, method_name)
+      return [] of Param unless method
+      collect_method_params(method, source, verb, parameter_format, class_fields)
     end
 
     # Find `@*Mapping` annotation on (class_name, method_name) and
@@ -109,24 +133,30 @@ module Noir
     def extract_consumes(source : String, class_name : String, method_name : String) : String?
       result : String? = nil
       Noir::TreeSitter.parse_java(source) do |root|
-        method = find_method(root, source, class_name, method_name)
-        next unless method
-        ann = mapping_annotation_on(method, source)
-        next unless ann
-        args = Noir::TreeSitter.field(ann, "arguments")
-        next unless args
-        Noir::TreeSitter.each_named_child(args) do |arg|
-          next unless Noir::TreeSitter.node_type(arg) == "element_value_pair"
-          key = Noir::TreeSitter.field(arg, "key")
-          val = Noir::TreeSitter.field(arg, "value")
-          next unless key && val
-          next unless Noir::TreeSitter.node_text(key, source) == "consumes"
-          text = Noir::TreeSitter.node_text(val, source)
-          if text.ends_with?("APPLICATION_FORM_URLENCODED_VALUE")
-            result = "form"
-          elsif text.ends_with?("APPLICATION_JSON_VALUE")
-            result = "json"
-          end
+        result = extract_consumes_from(root, source, class_name, method_name)
+      end
+      result
+    end
+
+    def extract_consumes_from(root : LibTreeSitter::TSNode, source : String, class_name : String, method_name : String) : String?
+      method = find_method(root, source, class_name, method_name)
+      return unless method
+      ann = mapping_annotation_on(method, source)
+      return unless ann
+      args = Noir::TreeSitter.field(ann, "arguments")
+      return unless args
+      result : String? = nil
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "element_value_pair"
+        key = Noir::TreeSitter.field(arg, "key")
+        val = Noir::TreeSitter.field(arg, "value")
+        next unless key && val
+        next unless Noir::TreeSitter.node_text(key, source) == "consumes"
+        text = Noir::TreeSitter.node_text(val, source)
+        if text.ends_with?("APPLICATION_FORM_URLENCODED_VALUE")
+          result = "form"
+        elsif text.ends_with?("APPLICATION_JSON_VALUE")
+          result = "json"
         end
       end
       result
@@ -137,19 +167,22 @@ module Noir
     def extract_package_name(source : String) : String
       result = ""
       Noir::TreeSitter.parse_java(source) do |root|
-        Noir::TreeSitter.each_named_child(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "package_declaration"
-          Noir::TreeSitter.each_named_child(node) do |child|
-            ty = Noir::TreeSitter.node_type(child)
-            if ty == "scoped_identifier" || ty == "identifier"
-              result = Noir::TreeSitter.node_text(child, source)
-              break
-            end
-          end
-          break
-        end
+        result = extract_package_name_from(root, source)
       end
       result
+    end
+
+    def extract_package_name_from(root : LibTreeSitter::TSNode, source : String) : String
+      Noir::TreeSitter.each_named_child(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "package_declaration"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          ty = Noir::TreeSitter.node_type(child)
+          if ty == "scoped_identifier" || ty == "identifier"
+            return Noir::TreeSitter.node_text(child, source)
+          end
+        end
+      end
+      ""
     end
 
     # Return every `import` in the source as `ImportDecl`. Static imports
@@ -158,24 +191,30 @@ module Noir
     def extract_imports(source : String) : Array(ImportDecl)
       results = [] of ImportDecl
       Noir::TreeSitter.parse_java(source) do |root|
-        Noir::TreeSitter.each_named_child(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "import_declaration"
-          # Static imports emit `(static)` as a child; skip them.
-          text = Noir::TreeSitter.node_text(node, source)
-          next if text.starts_with?("import static")
+        results = extract_imports_from(root, source)
+      end
+      results
+    end
 
-          path = ""
-          wildcard = false
-          Noir::TreeSitter.each_named_child(node) do |child|
-            case Noir::TreeSitter.node_type(child)
-            when "scoped_identifier", "identifier"
-              path = Noir::TreeSitter.node_text(child, source) if path.empty?
-            when "asterisk"
-              wildcard = true
-            end
+    def extract_imports_from(root : LibTreeSitter::TSNode, source : String) : Array(ImportDecl)
+      results = [] of ImportDecl
+      Noir::TreeSitter.each_named_child(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "import_declaration"
+        # Static imports emit `(static)` as a child; skip them.
+        text = Noir::TreeSitter.node_text(node, source)
+        next if text.starts_with?("import static")
+
+        path = ""
+        wildcard = false
+        Noir::TreeSitter.each_named_child(node) do |child|
+          case Noir::TreeSitter.node_type(child)
+          when "scoped_identifier", "identifier"
+            path = Noir::TreeSitter.node_text(child, source) if path.empty?
+          when "asterisk"
+            wildcard = true
           end
-          results << ImportDecl.new(path, wildcard) unless path.empty?
         end
+        results << ImportDecl.new(path, wildcard) unless path.empty?
       end
       results
     end
@@ -186,14 +225,20 @@ module Noir
     def extract_feign_client_classes(source : String) : Set(String)
       result = Set(String).new
       Noir::TreeSitter.parse_java(source) do |root|
-        walk_class_containers(root) do |decl|
-          name_node = Noir::TreeSitter.field(decl, "name")
-          next unless name_node
-          each_annotation_on(decl, source) do |ann_name|
-            if ann_name == "FeignClient"
-              result << Noir::TreeSitter.node_text(name_node, source)
-              break
-            end
+        result = extract_feign_client_classes_from(root, source)
+      end
+      result
+    end
+
+    def extract_feign_client_classes_from(root : LibTreeSitter::TSNode, source : String) : Set(String)
+      result = Set(String).new
+      walk_class_containers(root) do |decl|
+        name_node = Noir::TreeSitter.field(decl, "name")
+        next unless name_node
+        each_annotation_on(decl, source) do |ann_name|
+          if ann_name == "FeignClient"
+            result << Noir::TreeSitter.node_text(name_node, source)
+            break
           end
         end
       end
@@ -572,9 +617,26 @@ module Noir
     # delegated to `Noir::ImportGraph` so this stays a thin
     # language-specific cache.
     def build_for(path : String, content : String) : Index
+      Noir::TreeSitter.parse_java(content) do |root|
+        return build_for_with_root(path, content, root)
+      end
+      Index.new
+    end
+
+    # `build_for_with_root(path, content, root)` — same as
+    # `build_for` but uses a pre-parsed root for the current file's
+    # extractions (`extract_package_name`, `extract_imports`, the
+    # current file's `extract_class_fields`). Sibling files still
+    # parse independently (each via the per-file cache).
+    def build_for_with_root(path : String, content : String, root : LibTreeSitter::TSNode) : Index
       result = Index.new
-      package_name = TreeSitterJavaParameterExtractor.extract_package_name(content)
-      imports = TreeSitterJavaParameterExtractor.extract_imports(content)
+      package_name = TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
+      imports = TreeSitterJavaParameterExtractor.extract_imports_from(root, content)
+
+      # Seed the per-file cache for the current file from the
+      # already-parsed root so the upcoming `related_files` loop
+      # doesn't re-parse it.
+      @file_cache[path] = TreeSitterJavaParameterExtractor.extract_class_fields_from(root, content)
 
       Noir::ImportGraph.related_files(path, package_name, imports, "java") do |file|
         merge!(result, classes_in(file, path, content))

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -61,8 +61,18 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
-        walk_classes(root, source, "", routes)
+        routes = extract_routes_from(root, source)
       end
+      routes
+    end
+
+    # `_from` variant — accept a pre-parsed `root` so the Spring
+    # analyzer can amortise tree-sitter parses across multiple
+    # extractions on the same file. Tree lifetime is the caller's
+    # responsibility.
+    def extract_routes_from(root : LibTreeSitter::TSNode, source : String) : Array(Route)
+      routes = [] of Route
+      walk_classes(root, source, "", routes)
       routes
     end
 

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -85,12 +85,22 @@ module Noir
     def extract_class_fields(source : String) : Hash(String, Array(FieldInfo))
       results = Hash(String, Array(FieldInfo)).new
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk_class_containers(root) do |decl|
-          name = type_identifier_text(decl, source)
-          next if name.empty?
-          fields = collect_class_fields(decl, source)
-          results[name] = fields unless fields.empty?
-        end
+        results = extract_class_fields_from(root, source)
+      end
+      results
+    end
+
+    # `_from(root, source, ...)` variants accept a pre-parsed root
+    # so the Kotlin Spring analyzer can amortise the tree-sitter
+    # parse across multiple extractions on the same file. Tree
+    # lifetime is the caller's responsibility.
+    def extract_class_fields_from(root : LibTreeSitter::TSNode, source : String) : Hash(String, Array(FieldInfo))
+      results = Hash(String, Array(FieldInfo)).new
+      walk_class_containers(root) do |decl|
+        name = type_identifier_text(decl, source)
+        next if name.empty?
+        fields = collect_class_fields(decl, source)
+        results[name] = fields unless fields.empty?
       end
       results
     end
@@ -108,11 +118,22 @@ module Noir
                                   class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
       params = [] of Param
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        method = find_function(root, source, class_name, method_name)
-        next unless method
-        params = collect_method_params(method, source, verb, parameter_format, class_fields)
-        append_constraint_params(method, source, verb, params)
+        params = extract_method_parameters_from(root, source, class_name, method_name, verb, parameter_format, class_fields)
       end
+      params
+    end
+
+    def extract_method_parameters_from(root : LibTreeSitter::TSNode,
+                                       source : String,
+                                       class_name : String,
+                                       method_name : String,
+                                       verb : String,
+                                       parameter_format : String?,
+                                       class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
+      method = find_function(root, source, class_name, method_name)
+      return [] of Param unless method
+      params = collect_method_params(method, source, verb, parameter_format, class_fields)
+      append_constraint_params(method, source, verb, params)
       params
     end
 
@@ -121,27 +142,33 @@ module Noir
     def extract_consumes(source : String, class_name : String, method_name : String) : String?
       result : String? = nil
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        method = find_function(root, source, class_name, method_name)
-        next unless method
-        ann = mapping_annotation_on(method, source)
-        next unless ann
-        args = annotation_args(ann)
-        next unless args
-        Noir::TreeSitter.each_named_child(args) do |arg|
-          next unless Noir::TreeSitter.node_type(arg) == "value_argument"
-          kind, key, value = classify_value_argument(arg, source)
-          next unless kind == :keyword && key == "consumes"
-          next unless value
-          # Use the raw text so we catch both string literals
-          # ("application/json") and constant references
-          # (MediaType.APPLICATION_JSON_VALUE) in one pass — same
-          # approach as the Java extractor.
-          text = Noir::TreeSitter.node_text(value, source)
-          if text.includes?("application/x-www-form-urlencoded") || text.includes?("APPLICATION_FORM_URLENCODED_VALUE")
-            result = "form"
-          elsif text.includes?("application/json") || text.includes?("APPLICATION_JSON_VALUE")
-            result = "json"
-          end
+        result = extract_consumes_from(root, source, class_name, method_name)
+      end
+      result
+    end
+
+    def extract_consumes_from(root : LibTreeSitter::TSNode, source : String, class_name : String, method_name : String) : String?
+      method = find_function(root, source, class_name, method_name)
+      return unless method
+      ann = mapping_annotation_on(method, source)
+      return unless ann
+      args = annotation_args(ann)
+      return unless args
+      result : String? = nil
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+        kind, key, value = classify_value_argument(arg, source)
+        next unless kind == :keyword && key == "consumes"
+        next unless value
+        # Use the raw text so we catch both string literals
+        # ("application/json") and constant references
+        # (MediaType.APPLICATION_JSON_VALUE) in one pass — same
+        # approach as the Java extractor.
+        text = Noir::TreeSitter.node_text(value, source)
+        if text.includes?("application/x-www-form-urlencoded") || text.includes?("APPLICATION_FORM_URLENCODED_VALUE")
+          result = "form"
+        elsif text.includes?("application/json") || text.includes?("APPLICATION_JSON_VALUE")
+          result = "json"
         end
       end
       result
@@ -150,40 +177,49 @@ module Noir
     def extract_package_name(source : String) : String
       result = ""
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        Noir::TreeSitter.each_named_child(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "package_header"
-          Noir::TreeSitter.each_named_child(node) do |child|
-            ty = Noir::TreeSitter.node_type(child)
-            if ty == "identifier" || ty == "simple_identifier"
-              result = Noir::TreeSitter.node_text(child, source)
-              break
-            end
-          end
-          break
-        end
+        result = extract_package_name_from(root, source)
       end
       result
+    end
+
+    def extract_package_name_from(root : LibTreeSitter::TSNode, source : String) : String
+      Noir::TreeSitter.each_named_child(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "package_header"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          ty = Noir::TreeSitter.node_type(child)
+          if ty == "identifier" || ty == "simple_identifier"
+            return Noir::TreeSitter.node_text(child, source)
+          end
+        end
+      end
+      ""
     end
 
     def extract_imports(source : String) : Array(ImportDecl)
       results = [] of ImportDecl
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        Noir::TreeSitter.each_named_child(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "import_list"
-          Noir::TreeSitter.each_named_child(node) do |header|
-            next unless Noir::TreeSitter.node_type(header) == "import_header"
-            path = ""
-            wildcard = false
-            Noir::TreeSitter.each_named_child(header) do |child|
-              case Noir::TreeSitter.node_type(child)
-              when "identifier", "simple_identifier"
-                path = Noir::TreeSitter.node_text(child, source) if path.empty?
-              when "wildcard_import"
-                wildcard = true
-              end
+        results = extract_imports_from(root, source)
+      end
+      results
+    end
+
+    def extract_imports_from(root : LibTreeSitter::TSNode, source : String) : Array(ImportDecl)
+      results = [] of ImportDecl
+      Noir::TreeSitter.each_named_child(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "import_list"
+        Noir::TreeSitter.each_named_child(node) do |header|
+          next unless Noir::TreeSitter.node_type(header) == "import_header"
+          path = ""
+          wildcard = false
+          Noir::TreeSitter.each_named_child(header) do |child|
+            case Noir::TreeSitter.node_type(child)
+            when "identifier", "simple_identifier"
+              path = Noir::TreeSitter.node_text(child, source) if path.empty?
+            when "wildcard_import"
+              wildcard = true
             end
-            results << ImportDecl.new(path, wildcard) unless path.empty?
           end
+          results << ImportDecl.new(path, wildcard) unless path.empty?
         end
       end
       results
@@ -707,9 +743,25 @@ module Noir
     end
 
     def build_for(path : String, content : String) : Index
+      Noir::TreeSitter.parse_kotlin(content) do |root|
+        return build_for_with_root(path, content, root)
+      end
+      Index.new
+    end
+
+    # Variant taking a pre-parsed root so the Kotlin Spring analyzer
+    # can share the parse across the route + parameter walks.
+    # Sibling files still parse independently (each via the per-file
+    # cache).
+    def build_for_with_root(path : String, content : String, root : LibTreeSitter::TSNode) : Index
       result = Index.new
-      package_name = TreeSitterKotlinParameterExtractor.extract_package_name(content)
-      imports = TreeSitterKotlinParameterExtractor.extract_imports(content)
+      package_name = TreeSitterKotlinParameterExtractor.extract_package_name_from(root, content)
+      imports = TreeSitterKotlinParameterExtractor.extract_imports_from(root, content)
+
+      # Seed the per-file cache for the current file from the
+      # already-parsed root so the upcoming `related_files` loop
+      # doesn't re-parse it.
+      @file_cache[path] = TreeSitterKotlinParameterExtractor.extract_class_fields_from(root, content)
 
       Noir::ImportGraph.related_files(path, package_name, imports, "kt") do |file|
         merge!(result, classes_in(file, path, content))

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -57,8 +57,18 @@ module Noir
     def extract_routes(source : String) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk_classes(root, source, "", routes)
+        routes = extract_routes_from(root, source)
       end
+      routes
+    end
+
+    # `_from(root, source)` — accept a pre-parsed root so the Kotlin
+    # Spring analyzer can amortise the parse across multiple
+    # extractions on the same file. Tree lifetime is the caller's
+    # responsibility.
+    def extract_routes_from(root : LibTreeSitter::TSNode, source : String) : Array(Route)
+      routes = [] of Route
+      walk_classes(root, source, "", routes)
       routes
     end
 


### PR DESCRIPTION
## Summary

The bench instrumentation flagged the Spring analyzers as the heaviest tree-sitter parse hotspot — a Java file with N routes paid for **4 + 2N parses of the same source string**:

- 1 each for `extract_package_name`, `extract_imports`, `extract_class_fields` (DTO index), `extract_feign_client_classes`, `extract_routes`
- 2 per route for `extract_consumes` and `extract_method_parameters`

A modest 5-route controller triggered 14 parses.

This PR adds `_from(root, source, ...)` variants of every public extraction method so callers can amortise the parse:

- `java_route_extractor_ts.cr` — `extract_routes_from`
- `java_parameter_extractor_ts.cr` — `_from` variants for `extract_class_fields`, `extract_method_parameters`, `extract_consumes`, `extract_package_name`, `extract_imports`, `extract_feign_client_classes`
- `TreeSitterJavaDtoIndex#build_for_with_root` — same as `build_for` but uses the pre-parsed root for the current file's package/imports/fields, seeding the per-file cache so the upcoming `related_files` loop doesn't re-parse it
- Mirror set on the Kotlin side

Existing public methods stay (they wrap a single `parse_*` block around the new `_from` variant) so backward compatibility is preserved.

The Spring analyzers wrap per-file extraction in a single `parse_java` / `parse_kotlin` block and feed `root` to every extractor.

### Concrete numbers

| Workload | Before | After | Reduction |
|---|---:|---:|---:|
| Java Spring fixture (23 .java files) | 122 parses | 23 | **5.3×** |
| Kotlin Spring fixture | 80 parses | 15 | **5.3×** |
| Per-file (Spring controller, N routes) | 4 + 2N | 1 | |

Per-file Spring scan time drops ~63% on the fixture (0.024s → 0.009s). Whole-suite synthetic 5x bench is dominated by other analyzers' costs — the Spring saving shows up on real-world projects with many controllers.

### Tree-lifetime contract

The caller must keep `root` valid by staying inside the `parse_java` / `parse_kotlin` block while the `_from` variants are invoked. A doc comment on each `_from` records that contract.

## Test plan

- [x] `crystal spec` — 7002 examples, 0 failures (including the Java + Kotlin Spring functional specs which exercise every code path the parse fold-in touches)
- [x] Per-fixture functional specs unchanged — Spring fixtures emit the same endpoints with the same params
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba` clean