### PR TITLE
perf: skip already-matched detectors in the per-file detect loop

### DIFF
--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -15,6 +15,23 @@ macro define_detectors(detectors)
   {% end %}
 end
 
+# Reference-typed atomic Boolean. Wrapping `Atomic(Int8)` in a
+# class keeps the underlying byte addressable through an Array
+# index (`Atomic` itself is a struct and would copy on `[]`).
+class AtomicFlag
+  def initialize
+    @value = Atomic(Int8).new(0_i8)
+  end
+
+  def get : Bool
+    @value.get != 0_i8
+  end
+
+  def set
+    @value.set(1_i8)
+  end
+end
+
 def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), passive_scans : Array(PassiveScan), logger : NoirLogger)
   techs = [] of String
   passive_result = [] of PassiveScanResult
@@ -304,6 +321,16 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # Threads for receiving and processing the contents from the channel
   concurrency = options["concurrency"].to_s.to_i
 
+  # One reference-typed atomic flag per detector — set true once
+  # `detect` matches on any file. Workers consult these flags
+  # before invoking `detect()` so already-matched detectors are
+  # skipped on the remaining files (techs are existence-only
+  # signals). The wrapper class is necessary because `Atomic(T)`
+  # is a struct: storing it directly in an `Array` would value-
+  # copy on read, so `.set` would mutate a transient copy and
+  # never persist.
+  detected_flags = Array(AtomicFlag).new(detector_list.size) { AtomicFlag.new }
+
   concurrency.times do
     wg.add(1)
     spawn do
@@ -315,8 +342,14 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
             file, content = file_content
             logger.debug "Detecting: #{file}"
 
-            detector_list.each do |detector|
+            detector_list.each_with_index do |detector, idx|
+              # Skip detectors that have already matched, unless
+              # the detector signals it has side effects in
+              # `detect` (`idempotent? == false`) — see
+              # `Detector#idempotent?` for the contract.
+              next if detector.idempotent? && detected_flags[idx].get
               if detector.detect(file, content)
+                detected_flags[idx].set
                 newly_added = false
                 mutex.synchronize do
                   unless techs.includes?(detector.name)

--- a/src/detector/detectors/csharp/aspnet_core_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_core_mvc.cr
@@ -36,5 +36,12 @@ module Detector::CSharp
     def set_name
       @name = "cs_aspnet_core_mvc"
     end
+
+    # Side effect: registers `Program.cs` / similar paths in
+    # `CodeLocator` for the analyzer. Must keep running after first
+    # match.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/csharp/aspnet_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_mvc.cr
@@ -21,5 +21,13 @@ module Detector::CSharp
     def set_name
       @name = "cs_aspnet_mvc"
     end
+
+    # `check_routeconfig` records every `RouteConfig.cs` path it
+    # sees into `CodeLocator` for the analyzer to consume. Skipping
+    # this detector after its first match would lose the
+    # registration on subsequent files.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/grpc.cr
+++ b/src/detector/detectors/specification/grpc.cr
@@ -18,5 +18,12 @@ module Detector::Specification
     def set_name
       @name = "grpc"
     end
+
+    # Records every matching `.proto` path in `CodeLocator` for the
+    # analyzer pass. Must keep running after the first match so all
+    # service files get registered.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -27,5 +27,10 @@ module Detector::Specification
     def set_name
       @name = "har"
     end
+
+    # Registers HAR file paths in `CodeLocator`.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -35,5 +35,11 @@ module Detector::Specification
     def set_name
       @name = "oas2"
     end
+
+    # Registers every OAS2 spec path in `CodeLocator` for the
+    # analyzer pass. Must keep running after first match.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -35,5 +35,11 @@ module Detector::Specification
     def set_name
       @name = "oas3"
     end
+
+    # Registers every OAS3 spec path in `CodeLocator` for the
+    # analyzer pass. Must keep running after first match.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -28,5 +28,10 @@ module Detector::Specification
     def set_name
       @name = "postman"
     end
+
+    # Registers Postman collection paths in `CodeLocator`.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -26,5 +26,10 @@ module Detector::Specification
     def set_name
       @name = "raml"
     end
+
+    # Registers RAML spec paths in `CodeLocator`.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -25,5 +25,10 @@ module Detector::Specification
     def set_name
       @name = "zap_sites_tree"
     end
+
+    # Registers ZAP sites-tree paths in `CodeLocator`.
+    def idempotent? : Bool
+      false
+    end
   end
 end

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -29,6 +29,17 @@ class Detector
     false
   end
 
+  # Whether the detector can be skipped on subsequent files once it
+  # has matched. Defaults to `true` (idempotent — the detector only
+  # signals tech presence). Detectors that perform side effects in
+  # `detect` (e.g., the C# ASP.NET ones populate the `CodeLocator`
+  # with route-config paths, the OAS/RAML detectors register spec
+  # paths) must override to `false` so the detector pass keeps
+  # invoking them on every file.
+  def idempotent? : Bool
+    true
+  end
+
   macro define_getter_methods(names)
     {% for name, index in names %}
       def {{ name.id }}


### PR DESCRIPTION
## Summary

The detect phase ran `detect()` for every detector × every file, even after the detector had already added its tech to the result set. With ~80 detectors × thousands of files, that's hundreds of thousands of redundant existence-only invocations.

This PR makes the dispatcher skip detectors that have already matched. Each detector index gets a reference-typed `AtomicFlag` (an `Atomic(Int8)` wrapped in a class so the array storage doesn't value-copy the atomic struct on `[]` — `Atomic` is a struct, that's the gotcha). Workers consult the flag before calling `detect()`; on first match the flag is set and remaining workers skip the detector for the rest of the run.

### `idempotent?` opt-out

A subset of detectors carry `CodeLocator`-population **side effects** in `detect()`:

- C# ASP.NET MVC / ASP.NET Core MVC — record `RouteConfig.cs` / similar paths
- OAS3 / OAS2 / RAML / HAR / Postman / gRPC / ZAP spec detectors — register every matching spec file for the analyzer pass

Skipping these after first match would drop the registrations. New `Detector#idempotent? : Bool` (default `true`) lets the nine side-effect detectors opt out:

```crystal
next if detector.idempotent? && detected_flags[idx].get
```

### Concrete numbers

5x synthetic workload (~2,530 files, 101 detectors):

| | Before | After | Reduction |
|---|---:|---:|---:|
| `detect()` calls | 254,520 | 48,716 | **81%** |
| Detect-phase wall clock | ~200 ms | ~143 ms | **~28%** |

Whole-suite wall clock is dominated by analyzer time so the headline shift is small (~3 %), but the saving compounds on detector-heavy workloads (CI runs scanning hundreds of thousands of files where every detector currently re-scans every file). The architecture is also cleaner — `idempotent?` makes the side-effect-vs-pure split explicit, which we'll need anyway when per-extension routing lands later.

## Test plan

- [x] `crystal spec` — 7002 examples, 0 failures (including the C# ASP.NET MVC functional spec which exercises the `RouteConfig.cs` side-effect path through the new `idempotent? = false` opt-out)
- [x] Manual debug-mode run on the 5x synthetic confirms identical tech list (103 techs detected before/after)
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba` clean