### PR TITLE
perf: share DTO sibling cache across concurrent Java/Kotlin analyzers

### DIFF
--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -607,8 +607,28 @@ module Noir
   class TreeSitterJavaDtoIndex
     alias Index = Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo))
 
+    # Process-wide shared cache of DTO field extractions, keyed by
+    # absolute file path. Multiple Java analyzers (Spring, JAX-RS,
+    # Quarkus, Dropwizard, Micronaut) typically scan the same
+    # codebase concurrently — without sharing, each builds its own
+    # `DtoIndex` and re-parses every DTO file independently.
+    # Promoting the cache to class scope means the Nth analyzer
+    # picks up the previously-extracted fields for free.
+    #
+    # File contents don't change during a noir run, so this is
+    # safe in production. Tests inside the same Crystal process
+    # use unique fixture paths per scenario, so cross-test
+    # contamination doesn't occur in practice; `clear_cache!` is
+    # exposed anyway for any test setup that wants explicit
+    # determinism.
+    @@shared_cache = Hash(String, Index).new
+    @@shared_cache_mutex = Mutex.new
+
+    def self.clear_cache!
+      @@shared_cache_mutex.synchronize { @@shared_cache.clear }
+    end
+
     def initialize
-      @file_cache = Hash(String, Index).new
     end
 
     # Build the DTO index visible to the Spring controller at `path`.
@@ -627,16 +647,20 @@ module Noir
     # `build_for` but uses a pre-parsed root for the current file's
     # extractions (`extract_package_name`, `extract_imports`, the
     # current file's `extract_class_fields`). Sibling files still
-    # parse independently (each via the per-file cache).
+    # parse independently — but sibling parses go through the
+    # process-wide cache so concurrent analyzers don't double-up.
     def build_for_with_root(path : String, content : String, root : LibTreeSitter::TSNode) : Index
       result = Index.new
       package_name = TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
       imports = TreeSitterJavaParameterExtractor.extract_imports_from(root, content)
 
-      # Seed the per-file cache for the current file from the
-      # already-parsed root so the upcoming `related_files` loop
-      # doesn't re-parse it.
-      @file_cache[path] = TreeSitterJavaParameterExtractor.extract_class_fields_from(root, content)
+      # Seed the shared cache for the current file from the
+      # already-parsed root so this and any concurrent analyzer's
+      # `related_files` loop reuses it.
+      current_fields = TreeSitterJavaParameterExtractor.extract_class_fields_from(root, content)
+      @@shared_cache_mutex.synchronize do
+        @@shared_cache[path] ||= current_fields
+      end
 
       Noir::ImportGraph.related_files(path, package_name, imports, "java") do |file|
         merge!(result, classes_in(file, path, content))
@@ -646,22 +670,36 @@ module Noir
     end
 
     private def classes_in(file : String, current_path : String, current_content : String) : Index
-      @file_cache[file] ||= begin
-        body =
-          if file == current_path
-            current_content
-          else
-            # Detector pre-warms a content cache for every scanned
-            # file (size-bounded). Sibling DTO files often live in
-            # that cache already — `nil` falls back to a fresh
-            # `File.read` for files outside the budget.
-            CodeLocator.instance.content_for(file) ||
-            File.read(file, encoding: "utf-8", invalid: :skip)
-          end
-        TreeSitterJavaParameterExtractor.extract_class_fields(body)
-      rescue File::NotFoundError
-        Index.new
+      cached = @@shared_cache_mutex.synchronize { @@shared_cache[file]? }
+      return cached if cached
+
+      fields = parse_classes_for(file, current_path, current_content)
+
+      # Multiple analyzers may race here on a cache miss — the
+      # `||=` keeps whichever wrote first; the loser silently
+      # discards its parse. Acceptable cost vs the per-file lock
+      # complexity that strict single-parse would require.
+      @@shared_cache_mutex.synchronize do
+        @@shared_cache[file] ||= fields
+        @@shared_cache[file]
       end
+    end
+
+    private def parse_classes_for(file : String, current_path : String, current_content : String) : Index
+      body =
+        if file == current_path
+          current_content
+        else
+          # Detector pre-warms a content cache for every scanned
+          # file (size-bounded). Sibling DTO files often live in
+          # that cache already — `nil` falls back to a fresh
+          # `File.read` for files outside the budget.
+          CodeLocator.instance.content_for(file) ||
+            File.read(file, encoding: "utf-8", invalid: :skip)
+        end
+      TreeSitterJavaParameterExtractor.extract_class_fields(body)
+    rescue File::NotFoundError
+      Index.new
     end
 
     private def merge!(into : Index, src : Index)

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -738,8 +738,18 @@ module Noir
   class TreeSitterKotlinDtoIndex
     alias Index = Hash(String, Array(TreeSitterKotlinParameterExtractor::FieldInfo))
 
+    # Process-wide shared cache, mirroring `TreeSitterJavaDtoIndex`.
+    # See that class for the rationale; the same applies for
+    # Kotlin Spring + Ktor + http4k analyzers running concurrently
+    # on the same codebase.
+    @@shared_cache = Hash(String, Index).new
+    @@shared_cache_mutex = Mutex.new
+
+    def self.clear_cache!
+      @@shared_cache_mutex.synchronize { @@shared_cache.clear }
+    end
+
     def initialize
-      @file_cache = Hash(String, Index).new
     end
 
     def build_for(path : String, content : String) : Index
@@ -751,17 +761,21 @@ module Noir
 
     # Variant taking a pre-parsed root so the Kotlin Spring analyzer
     # can share the parse across the route + parameter walks.
-    # Sibling files still parse independently (each via the per-file
-    # cache).
+    # Sibling files still parse independently — but sibling parses
+    # go through the process-wide cache so concurrent analyzers
+    # don't double-up.
     def build_for_with_root(path : String, content : String, root : LibTreeSitter::TSNode) : Index
       result = Index.new
       package_name = TreeSitterKotlinParameterExtractor.extract_package_name_from(root, content)
       imports = TreeSitterKotlinParameterExtractor.extract_imports_from(root, content)
 
-      # Seed the per-file cache for the current file from the
-      # already-parsed root so the upcoming `related_files` loop
-      # doesn't re-parse it.
-      @file_cache[path] = TreeSitterKotlinParameterExtractor.extract_class_fields_from(root, content)
+      # Seed the shared cache for the current file from the
+      # already-parsed root so this and any concurrent analyzer's
+      # `related_files` loop reuses it.
+      current_fields = TreeSitterKotlinParameterExtractor.extract_class_fields_from(root, content)
+      @@shared_cache_mutex.synchronize do
+        @@shared_cache[path] ||= current_fields
+      end
 
       Noir::ImportGraph.related_files(path, package_name, imports, "kt") do |file|
         merge!(result, classes_in(file, path, content))
@@ -771,18 +785,28 @@ module Noir
     end
 
     private def classes_in(file : String, current_path : String, current_content : String) : Index
-      @file_cache[file] ||= begin
-        body =
-          if file == current_path
-            current_content
-          else
-            CodeLocator.instance.content_for(file) ||
-            File.read(file, encoding: "utf-8", invalid: :skip)
-          end
-        TreeSitterKotlinParameterExtractor.extract_class_fields(body)
-      rescue File::NotFoundError
-        Index.new
+      cached = @@shared_cache_mutex.synchronize { @@shared_cache[file]? }
+      return cached if cached
+
+      fields = parse_classes_for(file, current_path, current_content)
+
+      @@shared_cache_mutex.synchronize do
+        @@shared_cache[file] ||= fields
+        @@shared_cache[file]
       end
+    end
+
+    private def parse_classes_for(file : String, current_path : String, current_content : String) : Index
+      body =
+        if file == current_path
+          current_content
+        else
+          CodeLocator.instance.content_for(file) ||
+            File.read(file, encoding: "utf-8", invalid: :skip)
+        end
+      TreeSitterKotlinParameterExtractor.extract_class_fields(body)
+    rescue File::NotFoundError
+      Index.new
     end
 
     private def merge!(into : Index, src : Index)


### PR DESCRIPTION
## Summary

The DTO indexes (`TreeSitterJavaDtoIndex`, `TreeSitterKotlinDtoIndex`) memoised cross-file class-field extractions in a per-instance `@file_cache`. That worked for single-analyzer runs but broke down when multiple analyzers fire concurrently on the same codebase: Spring, JAX-RS, Quarkus, Dropwizard, and Micronaut each create their own `DtoIndex.new` and re-parse every shared DTO file independently. With five JVM analyzers active, a `User.java` referenced by all five controllers gets parsed five times.

This PR promotes the cache to a class-level `@@shared_cache` guarded by a `Mutex`. The mutex is acquired only on the read-then-fill path (cache miss) — the hit path is a single synchronized hash lookup. Concurrent analyzers may still race into a parse on first miss; the loser's result is discarded via `||=`. Acceptable cost vs the per-file lock complexity that strict single-parse would require.

`TreeSitterJavaDtoIndex.clear_cache!` (and the Kotlin equivalent) is exposed for any test setup that wants explicit determinism; production code never calls it.

### Performance impact

Bench impact on the 5x synthetic workload is within noise — the synthetic copies fixtures into independent subtrees, so the cross-analyzer overlap that this PR targets simply doesn't exist in that setup. The win shows up on **real-world projects where the same DTO file gets pulled in by multiple JVM frameworks at once** (e.g., a Spring monolith that's gradually adopting Quarkus services in the same repo, or a Java Spring + Kotlin Ktor mixed codebase sharing model classes).

## Test plan

- [x] `crystal spec` — 7002 examples, 0 failures (Spring + JAX-RS + Quarkus + Dropwizard + Micronaut + Kotlin Spring functional specs all unchanged)
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba` clean