### PR TITLE
Add MCP endpoint tagger

### DIFF
--- a/spec/unit_test/tagger/tagger_spec.cr
+++ b/spec/unit_test/tagger/tagger_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "../../../src/utils/*"
 require "../../../src/tagger/tagger"
 
 describe "Tagger" do
@@ -137,6 +138,20 @@ describe "Tagger" do
       endpoint.tags.empty?.should be_false
       endpoint.tags.each do |tag|
         tag.name.should eq("graphql")
+      end
+    end
+  end
+
+  it "mcp_tagger" do
+    noir_options = create_test_options
+    expected_endpoints = [
+      Endpoint.new("/mcp", "POST"),
+    ]
+    NoirTaggers.run_tagger(expected_endpoints, noir_options, "mcp")
+    expected_endpoints.each do |endpoint|
+      endpoint.tags.empty?.should be_false
+      endpoint.tags.each do |tag|
+        tag.name.should eq("mcp")
       end
     end
   end

--- a/spec/unit_test/tagger/taggers/mcp_spec.cr
+++ b/spec/unit_test/tagger/taggers/mcp_spec.cr
@@ -1,0 +1,95 @@
+require "../../../spec_helper"
+require "../../../../src/utils/*"
+require "../../../../src/models/endpoint.cr"
+require "../../../../src/models/logger.cr"
+require "../../../../src/models/tagger.cr"
+require "../../../../src/tagger/taggers/mcp.cr"
+require "yaml"
+
+def default_tagger_options
+  {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+  }
+end
+
+describe "McpTagger" do
+  describe "initialization" do
+    it "creates tagger with name" do
+      tagger = McpTagger.new(default_tagger_options)
+      tagger.should_not be_nil
+    end
+  end
+
+  describe "perform" do
+    it "tags Streamable HTTP MCP endpoint" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/mcp", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("mcp")
+      endpoint.tags[0].tagger.should eq("MCP")
+    end
+
+    it "tags nested MCP endpoint path segments" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/mcp/tools", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("mcp")
+    end
+
+    it "tags model-context-protocol paths" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("https://example.com/model-context-protocol", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("mcp")
+    end
+
+    it "tags legacy SSE transport pairs" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      sse_endpoint = Endpoint.new("/api/sse", "GET")
+      message_endpoint = Endpoint.new("/api/messages", "POST")
+
+      tagger.perform([sse_endpoint, message_endpoint])
+
+      sse_endpoint.tags.size.should eq(1)
+      sse_endpoint.tags[0].name.should eq("mcp")
+      message_endpoint.tags.size.should eq(1)
+      message_endpoint.tags[0].name.should eq("mcp")
+    end
+
+    it "does not tag standalone SSE endpoint" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/events/sse", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag MCP management URLs without an MCP path segment" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/mcp-servers", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -36,6 +36,11 @@ module NoirTaggers
       desc:   "Identifies GraphQL endpoints",
       runner: GraphqlTagger,
     },
+    mcp: {
+      name:   "MCP Tagger",
+      desc:   "Identifies Model Context Protocol endpoints",
+      runner: McpTagger,
+    },
     jwt: {
       name:   "JWT Tagger",
       desc:   "Identifies JWT authentication endpoints",

--- a/src/tagger/taggers/mcp.cr
+++ b/src/tagger/taggers/mcp.cr
@@ -1,0 +1,96 @@
+require "../../models/tagger"
+require "../../models/endpoint"
+
+class McpTagger < Tagger
+  LEGACY_SSE_SEGMENT      = "sse"
+  LEGACY_MESSAGE_SEGMENTS = ["message", "messages"]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "mcp"
+  end
+
+  def perform(endpoints : Array(Endpoint))
+    legacy_prefixes = legacy_mcp_prefixes(endpoints)
+
+    endpoints.each do |endpoint|
+      next unless mcp_endpoint?(endpoint, legacy_prefixes)
+
+      tag = Tag.new("mcp", "Model Context Protocol endpoint for tool and resource communication, often using Streamable HTTP or legacy SSE transports.", "MCP")
+      endpoint.add_tag(tag)
+    end
+  end
+
+  private def mcp_endpoint?(endpoint : Endpoint, legacy_prefixes : Set(String)) : Bool
+    path = normalized_path(endpoint.url)
+    segments = path_segments(path)
+
+    return true if segments.includes?("mcp")
+    return true if path.includes?("model-context-protocol")
+
+    legacy_mcp_endpoint?(endpoint, segments, legacy_prefixes)
+  end
+
+  private def legacy_mcp_prefixes(endpoints : Array(Endpoint)) : Set(String)
+    sse_prefixes = Set(String).new
+    message_prefixes = Set(String).new
+
+    endpoints.each do |endpoint|
+      segments = path_segments(normalized_path(endpoint.url))
+      next if segments.empty?
+
+      prefix = legacy_prefix(segments)
+      last_segment = segments[-1]
+      method = endpoint.method.upcase
+
+      if method == "GET" && last_segment == LEGACY_SSE_SEGMENT
+        sse_prefixes.add(prefix)
+      elsif method == "POST" && LEGACY_MESSAGE_SEGMENTS.includes?(last_segment)
+        message_prefixes.add(prefix)
+      end
+    end
+
+    sse_prefixes & message_prefixes
+  end
+
+  private def legacy_mcp_endpoint?(endpoint : Endpoint, segments : Array(String), legacy_prefixes : Set(String)) : Bool
+    return false if segments.empty?
+
+    last_segment = segments[-1]
+    prefix = legacy_prefix(segments)
+    method = endpoint.method.upcase
+
+    return true if method == "GET" && last_segment == LEGACY_SSE_SEGMENT && legacy_prefixes.includes?(prefix)
+    return true if method == "POST" && LEGACY_MESSAGE_SEGMENTS.includes?(last_segment) && legacy_prefixes.includes?(prefix)
+
+    false
+  end
+
+  private def normalized_path(url : String) : String
+    path = url.strip
+
+    if scheme_index = path.index("://")
+      remainder = path[(scheme_index + 3)..]
+      if slash_index = remainder.index("/")
+        path = remainder[slash_index..]
+      else
+        path = "/"
+      end
+    end
+
+    path = path.split("?", 2)[0]
+    path = path.split("#", 2)[0]
+    path = "/" if path.empty?
+    path.downcase
+  end
+
+  private def path_segments(path : String) : Array(String)
+    path.split("/").reject(&.empty?)
+  end
+
+  private def legacy_prefix(segments : Array(String)) : String
+    return "" if segments.size <= 1
+
+    segments[0...-1].join("/")
+  end
+end


### PR DESCRIPTION
Add a generic MCP endpoint tagger for /mcp paths and legacy SSE transport pairs. Tests: just test, just check, just build.