### PR TITLE
feat: move Python import resolver into ImportGraph (#1107 Python half)

### DIFF
--- a/spec/unit_test/miniparser/import_graph_spec.cr
+++ b/spec/unit_test/miniparser/import_graph_spec.cr
@@ -282,3 +282,115 @@ describe Noir::ImportGraph do
     end
   end
 end
+
+describe Noir::ImportGraph::Python do
+  describe "#find_imported_modules" do
+    it "resolves `from package.module import name` to a file path" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "models"))
+        target = File.join(root, "models", "user.py")
+        from_file = File.join(root, "app.py")
+        File.write(target, "def get_user(): pass\n")
+        # `get_user` chosen instead of `User` so the case-insensitive
+        # macOS filesystem doesn't collapse `User.py` and `user.py`
+        # into the same `File.exists?` truthy result inside the
+        # PackageType::FILE / CODE classifier.
+        content = "from models.user import get_user\n"
+        File.write(from_file, content)
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file, content)
+        result.should eq({"get_user" => {target, Noir::ImportGraph::Python::PackageType::CODE}})
+      end
+    end
+
+    it "honours `as` aliases in the imported-name key" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "lib"))
+        target = File.join(root, "lib", "helpers.py")
+        from_file = File.join(root, "main.py")
+        File.write(target, "")
+        content = "from lib.helpers import format as fmt\n"
+        File.write(from_file, content)
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file, content)
+        result.has_key?("fmt").should be_true
+        result.has_key?("format").should be_false
+      end
+    end
+
+    it "resolves relative imports `from . import x` against the file's directory" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "pkg"))
+        sibling = File.join(root, "pkg", "sibling.py")
+        from_file = File.join(root, "pkg", "main.py")
+        File.write(sibling, "")
+        content = "from . import sibling\n"
+        File.write(from_file, content)
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file, content)
+        # The dotted-walk maps the bare module name to the package
+        # path — `py_path` is empty (no leaf-module hit) when we
+        # land on a directory, but the entry exists.
+        result.has_key?("sibling").should be_true
+      end
+    end
+
+    it "handles parenthesised multi-line imports" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "models"))
+        a = File.join(root, "models", "a.py")
+        b = File.join(root, "models", "b.py")
+        from_file = File.join(root, "app.py")
+        [a, b].each { |f| File.write(f, "") }
+        content = "from models import (\n  a,\n  b,\n)\n"
+        File.write(from_file, content)
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file, content)
+        result.has_key?("a").should be_true
+        result.has_key?("b").should be_true
+      end
+    end
+
+    it "returns an empty map when no imports resolve to files" do
+      with_tmpdir do |root|
+        from_file = File.join(root, "app.py")
+        content = "from missing.package import nothing\n"
+        File.write(from_file, content)
+
+        Noir::ImportGraph::Python.find_imported_modules(root, from_file, content).should be_empty
+      end
+    end
+
+    it "reads from disk when content is omitted" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "lib"))
+        target = File.join(root, "lib", "x.py")
+        File.write(target, "")
+        from_file = File.join(root, "app.py")
+        File.write(from_file, "from lib.x import x\n")
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file)
+        result.has_key?("x").should be_true
+      end
+    end
+  end
+
+  describe "#find_imported_package" do
+    it "marks leaf modules as PackageType::FILE" do
+      with_tmpdir do |root|
+        target = File.join(root, "user.py")
+        File.write(target, "")
+        result = Noir::ImportGraph::Python.find_imported_package(root, "user")
+        result.size.should eq(1)
+        _, _, package_type = result.first
+        package_type.should eq(Noir::ImportGraph::Python::PackageType::FILE)
+      end
+    end
+
+    it "returns an empty array for unresolvable dotted paths" do
+      with_tmpdir do |root|
+        Noir::ImportGraph::Python.find_imported_package(root, "no.such.module").should be_empty
+      end
+    end
+  end
+end

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/import_graph"
 require "json"
 
 module Analyzer::Python
@@ -97,126 +98,18 @@ module Analyzer::Python
       FunctionDefinition.new(name, parameters)
     end
 
-    # Finds all the modules imported in a given Python file
+    # Resolve every `import` and `from … import …` in the file to
+    # `{name => {filepath, package_type}}`. Thin delegator over
+    # `Noir::ImportGraph::Python.find_imported_modules` so future
+    # Python analyzers (or new tagger logic) can call the resolver
+    # directly without going through `PythonEngine`.
     def find_imported_modules(app_base_path : ::String, file_path : ::String, content : ::String? = nil) : Hash(::String, Tuple(::String, Int32))
-      # If content is not provided, read it from the file
-      content = File.read(file_path, encoding: "utf-8", invalid: :skip) if content.nil?
-
-      file_base_path = file_path
-      file_base_path = File.dirname(file_path) if file_path.ends_with? ".py"
-
-      import_map = Hash(::String, Tuple(::String, Int32)).new
-      offset = 0
-      content.each_line do |line|
-        package_path = app_base_path
-        from_import = ""
-        imports = ""
-
-        # Check if the line starts with "from" or "import"
-        if line.starts_with?("from")
-          line.scan(/from\s*([^'"\s\\]*)\s*import\s*(.*)/) do |match|
-            next if match.size != 3
-            from_import = match[1]
-            imports = match[2]
-          end
-        elsif line.starts_with?("import")
-          line.scan(/import\s*([^'"\s\\]*)/) do |match|
-            next if match.size != 2
-            imports = match[1]
-          end
-        end
-
-        unless imports.empty?
-          round_bracket_index = line.index('(')
-          if !round_bracket_index.nil?
-            # Parse 'import (\n a,\n b,\n c)' pattern
-            index = offset + round_bracket_index + 1
-            while index < content.size && content[index] != ')'
-              index += 1
-            end
-            imports = content[(offset + round_bracket_index + 1)..(index - 1)].strip
-          end
-
-          # Handle relative paths
-          if from_import.starts_with?("..")
-            package_path = File.join(file_base_path, "..")
-            from_import = from_import[2..]
-          elsif from_import.starts_with?(".")
-            package_path = file_base_path
-            from_import = from_import[1..]
-          end
-
-          imports.split(",").each do |import|
-            import = import.strip
-            if import.starts_with?("..")
-              package_path = File.join(file_base_path, "..")
-            elsif import.starts_with?(".")
-              package_path = file_base_path
-            end
-
-            dotted_as_names = import
-            dotted_as_names = "#{from_import}.#{import}" unless from_import.empty?
-
-            # Create package map (Hash[name => filepath, ...])
-            import_package_map = find_imported_package(package_path, dotted_as_names)
-            next if import_package_map.empty?
-            import_package_map.each do |name, filepath, package_type|
-              import_map[name] = {filepath, package_type}
-            end
-          end
-        end
-
-        offset += line.size + 1
-      end
-
-      import_map
+      Noir::ImportGraph::Python.find_imported_modules(app_base_path, file_path, content)
     end
 
-    # Finds the package path for imported modules
+    # See `find_imported_modules` — same delegator.
     def find_imported_package(package_path : ::String, dotted_as_names : ::String) : Array(Tuple(::String, ::String, Int32))
-      package_map = Array(Tuple(::String, ::String, Int32)).new
-
-      py_path = ""
-      is_positive_travel = false
-      dotted_as_names_split = dotted_as_names.split(".")
-
-      dotted_as_names_split.each_with_index do |names, index|
-        travel_package_path = File.join(package_path, names)
-
-        py_guess = "#{travel_package_path}.py"
-        if File.directory?(travel_package_path)
-          package_path = travel_package_path
-          is_positive_travel = true
-        elsif dotted_as_names_split.size - 2 <= index && File.exists?(py_guess)
-          py_path = py_guess
-          is_positive_travel = true
-        else
-          break
-        end
-      end
-
-      if is_positive_travel
-        names = dotted_as_names_split[-1]
-        names.split(",").each do |name|
-          import = name.strip
-          next if import.empty?
-
-          alias_name = nil
-          if import.includes?(" as ")
-            import, alias_name = import.split(" as ")
-          end
-
-          package_type = File.exists?(File.join(package_path, "#{import}.py")) ? PackageType::FILE : PackageType::CODE
-
-          if !alias_name.nil?
-            package_map << {alias_name, py_path, package_type}
-          else
-            package_map << {import, py_path, package_type}
-          end
-        end
-      end
-
-      package_map
+      Noir::ImportGraph::Python.find_imported_package(package_path, dotted_as_names)
     end
 
     # Finds all parameters in JSON objects within a given code block
@@ -348,10 +241,11 @@ module Analyzer::Python
       data
     end
 
-    module PackageType
-      FILE = 0
-      CODE = 1
-    end
+    # `PackageType::FILE` / `PackageType::CODE` constants are now
+    # canonical at `Noir::ImportGraph::Python::PackageType`. Aliasing
+    # the inner module keeps `PackageType::FILE`-style references in
+    # subclasses working without a sweeping rename.
+    alias PackageType = Noir::ImportGraph::Python::PackageType
 
     class FunctionParameter
       @name : ::String

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -202,21 +202,173 @@ module Noir
       boundary_abs = File.expand_path(boundary)
       combined == boundary_abs || combined.starts_with?(boundary_abs + File::SEPARATOR)
     end
+  end
+end
 
-    # ----------------------------------------------------------------
-    # Python flavour (placeholder).
-    #
-    # Python frameworks (Flask, FastAPI, Sanic, Tornado) currently
-    # use the regex-driven `find_imported_modules` helper inside
-    # `src/analyzer/engines/python_engine.cr`. It already handles
-    # the common shapes — `from foo.bar import baz`, relative `from
-    # . import x` and `from .. import x`, plus parenthesised
-    # multi-line imports.
-    #
-    # When we migrate Python analyzers off the legacy parser this
-    # logic should move into a `Noir::ImportGraph` Python helper so
-    # FastAPI / Sanic / Tornado cross-file route discovery can share
-    # it instead of each analyzer rolling its own. Tracking that
-    # under the same #1107 umbrella as the JS half above.
+# ----------------------------------------------------------------
+# Python flavour.
+#
+# Python imports are dotted-module paths anchored at one of:
+#
+#   1. `app_base_path` — the project's source root (the `app`
+#      directory passed by the analyzer).
+#   2. The current file's directory, for relative imports
+#      (`from . import x`, `from .. import x`).
+#
+# The resolver walks the dotted path one segment at a time,
+# preferring directories (Python packages) over file siblings
+# (modules) until either a leaf `.py` is found or the path runs
+# out — matching the behaviour expected by the existing
+# Django / FastAPI / Tornado analyzers.
+#
+# Lives under the shared `Noir::ImportGraph` umbrella so a future
+# Python analyzer migration off the legacy `PythonParser` (still
+# used by Flask) can reuse the same resolver. Until that
+# migration lands the JVM / JS / Python flavours all share the
+# top-level module but each operates on its own data shapes —
+# Python's hashes look different from the JVM `ImportRef` form
+# because Python returns import-name → file-path mappings rather
+# than a yield of files.
+module Noir::ImportGraph::Python
+  module PackageType
+    FILE = 0
+    CODE = 1
+  end
+
+  # Find every `import` and `from … import …` line in `content`
+  # and resolve each name to a `{filepath, package_type}` tuple.
+  # Returns an empty hash for files that import nothing
+  # resolvable. The map is keyed on the IMPORTED-IN-LOCAL name —
+  # `from a.b import c as d` keys `d`, not `c`.
+  #
+  # `app_base_path` anchors the dotted path for absolute imports;
+  # `file_path`'s directory anchors relative imports. Pass
+  # `content` when the caller already has the file in hand to
+  # skip the second `File.read`.
+  def self.find_imported_modules(app_base_path : String,
+                                 file_path : String,
+                                 content : String? = nil) : Hash(String, Tuple(String, Int32))
+    content = File.read(file_path, encoding: "utf-8", invalid: :skip) if content.nil?
+
+    file_base_path = file_path
+    file_base_path = File.dirname(file_path) if file_path.ends_with? ".py"
+
+    import_map = Hash(String, Tuple(String, Int32)).new
+    offset = 0
+    content.each_line do |line|
+      package_path = app_base_path
+      from_import = ""
+      imports = ""
+
+      if line.starts_with?("from")
+        line.scan(/from\s*([^'"\s\\]*)\s*import\s*(.*)/) do |match|
+          next if match.size != 3
+          from_import = match[1]
+          imports = match[2]
+        end
+      elsif line.starts_with?("import")
+        line.scan(/import\s*([^'"\s\\]*)/) do |match|
+          next if match.size != 2
+          imports = match[1]
+        end
+      end
+
+      unless imports.empty?
+        round_bracket_index = line.index('(')
+        if !round_bracket_index.nil?
+          # Parse `import (\n a,\n b,\n c)` pattern — track
+          # bytes from the opening `(` to the matching `)`.
+          index = offset + round_bracket_index + 1
+          while index < content.size && content[index] != ')'
+            index += 1
+          end
+          imports = content[(offset + round_bracket_index + 1)..(index - 1)].strip
+        end
+
+        # `..` resolves to file's parent dir; `.` to file's dir.
+        if from_import.starts_with?("..")
+          package_path = File.join(file_base_path, "..")
+          from_import = from_import[2..]
+        elsif from_import.starts_with?(".")
+          package_path = file_base_path
+          from_import = from_import[1..]
+        end
+
+        imports.split(",").each do |import|
+          import = import.strip
+          if import.starts_with?("..")
+            package_path = File.join(file_base_path, "..")
+          elsif import.starts_with?(".")
+            package_path = file_base_path
+          end
+
+          dotted_as_names = import
+          dotted_as_names = "#{from_import}.#{import}" unless from_import.empty?
+
+          import_package_map = find_imported_package(package_path, dotted_as_names)
+          next if import_package_map.empty?
+          import_package_map.each do |name, filepath, package_type|
+            import_map[name] = {filepath, package_type}
+          end
+        end
+      end
+
+      offset += line.size + 1
+    end
+
+    import_map
+  end
+
+  # Resolve a dotted Python identifier (`a.b.c` or
+  # `a.b.c, d.e as f`) under `package_path`. Walks segment by
+  # segment, preferring packages (directories) over modules
+  # (`.py` files). Returns each resolvable name as `{name,
+  # filepath, package_type}` so the caller can keep the alias
+  # mapping intact.
+  def self.find_imported_package(package_path : String,
+                                 dotted_as_names : String) : Array(Tuple(String, String, Int32))
+    package_map = Array(Tuple(String, String, Int32)).new
+
+    py_path = ""
+    is_positive_travel = false
+    dotted_as_names_split = dotted_as_names.split(".")
+
+    dotted_as_names_split.each_with_index do |names, index|
+      travel_package_path = File.join(package_path, names)
+
+      py_guess = "#{travel_package_path}.py"
+      if File.directory?(travel_package_path)
+        package_path = travel_package_path
+        is_positive_travel = true
+      elsif dotted_as_names_split.size - 2 <= index && File.exists?(py_guess)
+        py_path = py_guess
+        is_positive_travel = true
+      else
+        break
+      end
+    end
+
+    if is_positive_travel
+      names = dotted_as_names_split[-1]
+      names.split(",").each do |name|
+        import = name.strip
+        next if import.empty?
+
+        alias_name = nil
+        if import.includes?(" as ")
+          import, alias_name = import.split(" as ")
+        end
+
+        package_type = File.exists?(File.join(package_path, "#{import}.py")) ? PackageType::FILE : PackageType::CODE
+
+        if !alias_name.nil?
+          package_map << {alias_name, py_path, package_type}
+        else
+          package_map << {import, py_path, package_type}
+        end
+      end
+    end
+
+    package_map
   end
 end


### PR DESCRIPTION
## Summary

The third (and last) leg of the #1107 unification. After the JVM half (#1306) and JS half (#1322), Python import resolution still lived inside `Analyzer::Python::PythonEngine` as `find_imported_modules` + `find_imported_package` instance methods — used by Django, FastAPI, and Tornado for cross-file route discovery.

This PR promotes both into the shared `Noir::ImportGraph::Python` module so any future Python analyzer (or new tagger logic) can call them without subclassing the engine.

The resolver behaviour is unchanged. The `PythonEngine` methods become thin delegators, and `PythonEngine::PackageType` aliases to `Noir::ImportGraph::Python::PackageType` so existing `PackageType::FILE` / `PackageType::CODE` references in subclasses keep working without a sweeping rename.

**Out of scope:** the heavyweight `miniparsers/python.cr` (`PythonParser`) is still consumed by Flask and stays in tree until that analyzer's separate migration.

### Macro shape after this PR

`Noir::ImportGraph` now hosts three flavours, one per language family:

| Flavour | Helper | Used by |
|---|---|---|
| **JVM** | `related_files(path, package_name, imports, ext)` | Java + Kotlin DTO indexes (#1306) |
| **JS / Ruby / Lua** | `resolve_relative_import(from_file, specifier, …)` | New JS analyzers (foundation #1322) |
| **Python** | `Python.find_imported_modules(app_base_path, file_path, content)` | Django, FastAPI, Tornado (this PR) |

## Test plan

- [x] Eight new unit specs cover dotted-module resolution, `as` aliasing, relative `from . import x`, parenthesised multi-line imports, unresolvable / missing-file paths, and the `PackageType::FILE` vs `CODE` classifier
- [x] One spec documents the macOS APFS case-insensitivity quirk that bit me halfway through (`User.py` and `user.py` collapse in `File.exists?`)
- [x] `crystal spec` — 7025 examples, 0 failures (Django + FastAPI + Tornado functional specs all unchanged via the delegator path)
- [x] `crystal tool format --check` and `./lib/ameba/bin/ameba` clean