### PR TITLE
ci(homebrew): fix Ruby interpolation in formula test block

### DIFF
--- a/.github/workflows/publish-homebrew-tap.yml
+++ b/.github/workflows/publish-homebrew-tap.yml
@@ -24,7 +24,7 @@ jobs:
             system "shards install"
             system "shards build --release --no-debug --production"
             bin.install "bin/noir"
-          test: system "{bin}/noir", "-v"
+          test: system "#{bin}/noir", "-v"
           update_readme_table: false
           ignore_warnings: true
           skip_commit: false


### PR DESCRIPTION
## Summary
- The current homebrew-releaser config emits a formula whose `test` block reads `system "{bin}/noir", "-v"` — a literal path, which breaks `brew test` and `brew audit`.
- Switched to `#{bin}` so Homebrew interpolates the formula's bin path.
- Next published release will regenerate `Formula/noir.rb` correctly.

Same fix as hahwul/hwaro#518 — caught while sweeping siblings for the same pattern.

## Test plan
- [ ] After next release, verify the published formula contains `system "#{bin}/noir", "-v"` and `brew test noir` succeeds