### PR TITLE
fix(perl): satisfy ameba in mojolicious analyzer

### DIFF
--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -2,7 +2,7 @@ require "../../engines/perl_engine"
 
 module Analyzer::Perl
   class Mojolicious < PerlEngine
-    HTTP_VERBS    = %w(get post put delete patch options head)
+    HTTP_VERBS    = %w[get post put delete patch options head]
     LITE_VERB_RE  = /^\s*(get|post|put|patch|delete|del|options|head|websocket)\s+['"]([^'"]+)['"]/
     LITE_ANY_RE   = /^\s*any\s+(?:\[([^\]]+)\]\s*=>\s*)?['"]([^'"]+)['"]/
     FULL_VERB_RE  = /->\s*(get|post|put|patch|delete|del|options|head|websocket)\s*\(\s*['"]([^'"]+)['"]/
@@ -38,7 +38,16 @@ module Analyzer::Perl
           endpoints << endpoint
         end
 
-        targets = line_endpoints.empty? ? (last_endpoint ? [last_endpoint.not_nil!] : [] of Endpoint) : line_endpoints
+        targets = if line_endpoints.empty?
+                    if le = last_endpoint
+                      [le]
+                    else
+                      [] of Endpoint
+                    end
+                  else
+                    line_endpoints
+                  end
+
         targets.each do |target|
           extract_params_from_line(line, target.method).each do |param|
             push_unique_param(target, param)


### PR DESCRIPTION
## Summary
- Fixes the two Ameba violations introduced by #1345 that left lint red on main
- \`Style/PercentLiteralDelimiters\`: \`%w(...)\` → \`%w[...]\` for HTTP_VERBS
- \`Lint/NotNil\`: replace the ternary \`last_endpoint.not_nil!\` with an explicit branch

## Test plan
- [x] \`crystal lib/ameba/bin/ameba.cr src/analyzer/analyzers/perl/ src/analyzer/engines/perl_engine.cr src/detector/detectors/perl/\` (3 inspected, 0 failures)
- [x] \`crystal spec spec/unit_test/detector/perl/mojolicious_spec.cr spec/functional_test/testers/perl/mojolicious_spec.cr\` (76 examples, 0 failures)