### PR TITLE
fix(perl): escape heredoc in mojolicious detector spec

### DIFF
--- a/spec/unit_test/detector/perl/mojolicious_spec.cr
+++ b/spec/unit_test/detector/perl/mojolicious_spec.cr
@@ -57,11 +57,11 @@ describe "Detect Perl Mojolicious" do
   end
 
   it "does not detect plain Perl files" do
-    plain = <<-PERL
+    plain = <<-'PERL'
       use strict;
       use warnings;
 
-      sub hello { print "hi\\n" }
+      sub hello { print "hi\n" }
       hello();
       PERL
 


### PR DESCRIPTION
## Summary
- ameba's new `Style/HeredocEscape` rule flagged the plain-perl heredoc in `mojolicious_spec.cr` because it contained `\n`
- Switch the marker to `<<-'PERL'` and store the literal escape sequence — the test only checks for the absence of Mojolicious markers, so the surrounding string content is unaffected

## Test plan
- [x] `crystal lib/ameba/bin/ameba.cr` (706 inspected, 0 failures)
- [x] `crystal spec spec/unit_test/detector/perl/mojolicious_spec.cr` (6 examples, 0 failures)