### PR TITLE
fix(groovy): tighten Grails analyzer edge cases

### DIFF
--- a/spec/functional_test/fixtures/groovy/grails/grails-app/conf/PluginUrlMappings.groovy
+++ b/spec/functional_test/fixtures/groovy/grails/grails-app/conf/PluginUrlMappings.groovy
@@ -1,0 +1,5 @@
+class PluginUrlMappings {
+    static mappings = {
+        get "/plugin/status"(controller: "plugin", action: "status")
+    }
+}

--- a/spec/functional_test/fixtures/groovy/grails/grails-app/conf/UrlMappings.groovy
+++ b/spec/functional_test/fixtures/groovy/grails/grails-app/conf/UrlMappings.groovy
@@ -2,5 +2,8 @@ class UrlMappings {
     static mappings = {
         get "/api/health"(controller: "health", action: "ping")
         post "/api/login"(controller: "auth", action: "login")
+        // `method:` argument on a verbless mapping should win over the
+        // default GET fallback.
+        "/api/users"(controller: "user", action: "create", method: "POST")
     }
 }

--- a/spec/functional_test/fixtures/groovy/grails/grails-app/controllers/BaseController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails/grails-app/controllers/BaseController.groovy
@@ -1,0 +1,9 @@
+package demo
+
+// Abstract base controller used as a template for subclasses; its
+// actions are not directly addressable.
+abstract class BaseController {
+    def shared() {
+        render 'shared'
+    }
+}

--- a/spec/functional_test/fixtures/groovy/grails/grails-app/controllers/BookController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails/grails-app/controllers/BookController.groovy
@@ -7,6 +7,13 @@ class BookController {
         delete: 'DELETE'
     ]
 
+    // Field-style declarations and dependency-injected services share the
+    // `def name = ...` syntax with closure-style actions; only the latter
+    // should be surfaced as endpoints.
+    def cache = [:]
+    def messages = ['hi', 'bye']
+    def bookService = new BookService()
+
     def index() {
         render 'list of books'
     }

--- a/spec/functional_test/testers/groovy/grails_spec.cr
+++ b/spec/functional_test/testers/groovy/grails_spec.cr
@@ -11,6 +11,11 @@ expected_endpoints = [
   Endpoint.new("/author/profile", "GET"),
   Endpoint.new("/api/health", "GET"),
   Endpoint.new("/api/login", "POST"),
+  # `method:` argument on a verbless URL mapping must override the
+  # default GET — see UrlMappings.groovy.
+  Endpoint.new("/api/users", "POST"),
+  # Plugin-style `<Name>UrlMappings.groovy` should also be processed.
+  Endpoint.new("/plugin/status", "GET"),
 ]
 
 FunctionalTester.new("fixtures/groovy/grails/", {

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -55,17 +55,26 @@ module Analyzer::Groovy
     end
 
     private def url_mappings_path?(path : String) : Bool
-      path.ends_with?("/UrlMappings.groovy") || path.ends_with?("UrlMappings.groovy")
+      # Grails plugins ship their own `<Name>UrlMappings.groovy` files
+      # alongside the canonical `UrlMappings.groovy`, so accept any basename
+      # ending in `UrlMappings.groovy` — but only inside `grails-app/conf/`
+      # so unrelated files with similar names are not picked up.
+      return false unless path.includes?("/grails-app/conf/")
+      File.basename(path).ends_with?("UrlMappings.groovy")
     end
 
     private def process_controller(path : String, content : String)
       cleaned = strip_groovy_comments(content)
 
-      cleaned.scan(/class\s+([A-Z][A-Za-z0-9_]*Controller)\b[^\{]*\{/) do |match|
-        class_name = match[1]
+      cleaned.scan(/((?:(?:public|protected|private|abstract|final|static)\s+)*)class\s+([A-Z][A-Za-z0-9_]*Controller)\b[^\{]*\{/) do |match|
+        modifiers = match[1]
+        class_name = match[2]
         match_end = match.end(0)
         match_start = match.begin(0)
         next unless match_end && match_start
+        # Abstract base controllers are templates for subclasses, not
+        # directly addressable endpoints — skip them.
+        next if modifiers.includes?("abstract")
 
         body_info = extract_braced_block(cleaned, match_end - 1)
         next unless body_info
@@ -135,7 +144,12 @@ module Analyzer::Groovy
 
         if depth == 0
           rest = body[i..]
-          m = rest.match(/\A(public\s+|protected\s+|private\s+)?def\s+([a-z_][A-Za-z0-9_]*)\s*(?:\(|\=)/)
+          # Method form: `def name(...)`
+          # Closure form: `def name = { ... }` — explicitly require the
+          # closure brace via lookahead so plain field assignments like
+          # `def cache = [:]` or `def bookService = new BookService()`
+          # are not mistaken for actions.
+          m = rest.match(/\A(public\s+|protected\s+|private\s+)?def\s+([a-z_][A-Za-z0-9_]*)\s*(?:\(|=\s*(?=\{))/)
           if m
             modifier = m[1]?
             name = m[2]
@@ -252,17 +266,26 @@ module Analyzer::Groovy
           Details.new(PathInfo.new(path, line)))
       end
 
-      # `'/path'(controller: 'foo', action: 'bar')` → defaults to GET.
+      # `'/path'(controller: 'foo', action: 'bar', method: 'POST')`
+      # — defaults to GET when no `method:` argument is supplied.
       simple_pattern = /(?:^|\n)\s*(['"])([^'"]+)\1\s*\(([^)]*?)\)/m
       cleaned.scan(simple_pattern) do |match|
         url_pattern = match[2]
         body_args = match[3]
         next unless body_args.includes?("controller:") || body_args.includes?("action:") || body_args.includes?("view:")
+        verb = extract_method_arg(body_args) || "GET"
         line = line_for_offset(content, match.begin(0) || 0)
-        @result << Endpoint.new(translate_pattern(url_pattern), "GET",
+        @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),
           Details.new(PathInfo.new(path, line)))
       end
+    end
+
+    private def extract_method_arg(body_args : String) : String?
+      m = body_args.match(/method:\s*['"]([A-Za-z]+)['"]/)
+      return unless m
+      verb = m[1].upcase
+      HTTP_METHODS.includes?(verb) ? verb : nil
     end
 
     private def translate_pattern(pattern : String) : String


### PR DESCRIPTION
## Summary
Follow-up to #1350. A review of the just-merged Grails analyzer surfaced four real edge cases:

1. **Closure-form regex over-match** — `def cache = [:]`, `def messages = ['hi', 'bye']`, and `def bookService = new BookService()` were all emitted as endpoints because the closure-form pattern only checked for `=`. The regex now requires \`{\` after \`=\` via lookahead, so plain field assignments and DI fields are filtered out.
2. **\`method:\` arg in UrlMappings ignored** — \`\"/api/users\"(controller: 'user', action: 'create', method: 'POST')\` defaulted to GET. The argument is now parsed and used as the HTTP verb.
3. **Abstract base controllers** — \`abstract class BaseController\` was surfaced even though such classes are templates, not addressable endpoints. The class regex now captures leading modifiers and skips abstract declarations.
4. **\`url_mappings_path?\` over-broad** — any path ending in \`UrlMappings.groovy\` was matched. It now requires \`grails-app/conf/\` in the path while preserving the \`<Name>UrlMappings.groovy\` plugin convention.

The fixture is extended with a \`BaseController.groovy\`, a \`PluginUrlMappings.groovy\`, field-style assignments inside \`BookController\`, and a \`method:\`-tagged mapping in \`UrlMappings.groovy\` to lock these behaviors in.

## Test plan
- [x] \`crystal spec spec/unit_test/detector/groovy/ spec/functional_test/testers/groovy/\` (33 examples, 0 failures)
- [x] \`crystal run bin/ameba.cr -- src/analyzer/analyzers/groovy/grails.cr\`
- [x] \`crystal build src/noir.cr --no-codegen\`