### PR TITLE
chore(typos): allow `paket` (NuGet Paket manifest)

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -13,6 +13,8 @@ Verticle = "Verticle"
 nd = "nd"
 # `deps.edn` is the canonical Clojure dependency file (extensible data notation).
 edn = "edn"
+# `paket` is the .NET dependency manager (paket.dependencies).
+paket = "paket"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Summary
- Giraffe (F#) detector references `paket.dependencies`, the manifest for the Paket .NET dependency manager.
- Add `paket` to `typos.toml` extend-words so CI stops flagging it as a misspelling of `packet`.

## Test plan
- [x] `typos .` passes locally
- [ ] CI typos job is green