### PR TITLE
refactor(ruby): tighten Rails controller scan after #1362 review

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/admin/monitor_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/admin/monitor_controller.rb
@@ -1,0 +1,6 @@
+class Admin::MonitorController < ApplicationController
+  def heartbeat
+    request.headers['X-Heartbeat']
+    params["id"]
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/admin/refunds_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/admin/refunds_controller.rb
@@ -7,4 +7,13 @@ class Admin::RefundsController < ApplicationController
   def new_list
     request.headers['X-Page']
   end
+
+  def purge
+    request.headers['X-Confirm']
+    params["id"]
+  end
+
+  def update_metadata
+    params.require(:refund).permit("note", "kind")
+  end
 end

--- a/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/rails/health_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/rails/health_controller.rb
@@ -1,0 +1,5 @@
+class Rails::HealthController < ApplicationController
+  def show
+    request.headers['X-Health']
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -6,11 +6,15 @@ Rails.application.routes.draw do
     resources :refunds do
       member do
         post :change_status
+        delete :purge
+        post :update_metadata
       end
       collection do
         get :new_list
       end
     end
+
+    get "monitor/heartbeat", to: "monitor#heartbeat"
   end
 
   scope :api do

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -23,9 +23,26 @@ expected_endpoints = [
     Param.new("X-Refund-Reason", "", "header"),
     Param.new("status", "", "form"),
   ]),
+  # DELETE custom action — no shared body params, only the action's headers.
+  Endpoint.new("/admin/refunds/1/purge", "DELETE", [
+    Param.new("X-Confirm", "", "header"),
+  ]),
+  # `permit("note", "kind")` (string form) and member POST verb.
+  Endpoint.new("/admin/refunds/1/update_metadata", "POST", [
+    Param.new("note", "", "form"),
+    Param.new("kind", "", "form"),
+  ]),
   Endpoint.new("/admin/refunds/new_list", "GET", [
     Param.new("X-Page", "", "header"),
     Param.new("status", "", "query"),
+  ]),
+
+  # Namespaced `to: "ctrl#action"` resolves against `admin/monitor_controller.rb`,
+  # not the root-level `monitor_controller.rb`. Also exercises `params["id"]`
+  # (string-key form).
+  Endpoint.new("/admin/monitor/heartbeat", "GET", [
+    Param.new("X-Heartbeat", "", "header"),
+    Param.new("id", "", "query"),
   ]),
 
   # scope :api do resources :items, only: [:index, :show] end
@@ -50,9 +67,11 @@ expected_endpoints = [
   Endpoint.new("/posts/1/comments", "GET"),
   Endpoint.new("/posts/1/comments/1", "GET"),
 
-  # hash-rocket and to: forms. #1359: `to: "ctrl#action"` resolves the
-  # controller and attaches the action's params.
-  Endpoint.new("/up", "GET"),
+  # hash-rocket and to: forms. #1359: `=> "ctrl#action"` / `to: "ctrl#action"`
+  # resolves the controller and attaches the action's params.
+  Endpoint.new("/up", "GET", [
+    Param.new("X-Health", "", "header"),
+  ]),
   Endpoint.new("/ping", "GET", [
     Param.new("X-Ping", "", "header"),
   ]),
@@ -74,7 +93,8 @@ expected_endpoints = [
 # /scans/1) and devise_for emits its full route set.
 total_endpoints = 1 +  # root
                   5 +  # admin/reports
-                  2 +  # admin/refunds member+collection
+                  4 +  # admin/refunds member (change_status, purge, update_metadata) + collection (new_list)
+                  1 +  # admin/monitor/heartbeat (namespaced `to:`)
                   2 +  # api/items only:[index,show]
                   4 +  # internal/statements except:[destroy]
                   1 +  # /scans only:[index] via controller override

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -39,6 +39,15 @@ module Analyzer::Ruby
       end
     end
 
+    record ControllerData,
+      param_type : String,
+      params_method : Hash(String, Array(Param)),
+      permit_body_params : Array(Param),
+      permit_query_params : Array(Param),
+      defined_actions : Set(String)
+
+    @controller_data_cache = Hash(String, ControllerData).new
+
     def analyze
       framework_roots = discover_framework_roots("config/routes.rb")
       framework_roots = [@base_path] if framework_roots.empty?
@@ -236,7 +245,7 @@ module Analyzer::Ruby
               action_params = [] of Param
               if ctrl_action
                 ctrl_name, action = ctrl_action
-                ctrl_path = find_controller_file(framework_root, ctrl_name)
+                ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
                 action_params = params_for_action(ctrl_path, action, verb)
               end
 
@@ -360,10 +369,10 @@ module Analyzer::Ruby
       return @result unless File.exists?(path)
 
       data = extract_controller_data(path)
-      defined_actions = data[:defined_actions]
-      params_method = data[:params_method]
-      params_body = data[:permit_body_params]
-      deduplication_params_query = dedup_by_name(data[:permit_query_params])
+      defined_actions = data.defined_actions
+      params_method = data.params_method
+      params_body = data.permit_body_params
+      deduplication_params_query = dedup_by_name(data.permit_query_params)
 
       methods = [] of String
       {"index", "show", "create", "update", "destroy"}.each do |name|
@@ -411,25 +420,26 @@ module Analyzer::Ruby
     end
 
     # Scans a controller file once, collecting per-method params (headers/cookies)
-    # plus shared params (params[:x], params.require...permit) and the names of
-    # every `def`. Shared because the existing heuristic associates params[:x]
-    # with the whole controller, not a specific action.
-    private def extract_controller_data(path : String)
-      param_type = "form"
+    # plus shared params (params[:x] / params["x"], params.require...permit) and
+    # the names of every `def`. Shared because the existing heuristic associates
+    # params[:x] with the whole controller, not a specific action. Results are
+    # memoized per path so re-resolution (resources + member/collection + `to:`)
+    # only reads each controller once.
+    private def extract_controller_data(path : String) : ControllerData
+      cached = @controller_data_cache[path]?
+      return cached if cached
+
       params_method = Hash(String, Array(Param)).new
       permit_body_params = [] of Param
       permit_query_params = [] of Param
       defined_actions = Set(String).new
+      param_type = "form"
 
-      empty_result = {
-        param_type:          param_type,
-        params_method:       params_method,
-        permit_body_params:  permit_body_params,
-        permit_query_params: permit_query_params,
-        defined_actions:     defined_actions,
-      }
-
-      return empty_result unless File.exists?(path)
+      unless File.exists?(path)
+        empty = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params, defined_actions)
+        @controller_data_cache[path] = empty
+        return empty
+      end
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |controller_file|
         controller_content = controller_file.gets_to_end
@@ -438,69 +448,54 @@ module Analyzer::Ruby
         controller_file.rewind
         this_method = ""
 
-        controller_file.each_line do |controller_line|
-          if controller_line.includes?("def ")
-            stripped = strip_inline_comment(controller_line)
-            if stripped.includes?("def ")
-              func_name = stripped.split("def ", 2)[1].split("(")[0].split(";")[0].strip
-              func_name = func_name.lchop("self.").strip
-              unless func_name.empty?
-                this_method = func_name
-                defined_actions << func_name
-              end
+        controller_file.each_line do |raw_line|
+          line = strip_inline_comment(raw_line)
+
+          if line.includes?("def ")
+            func_name = line.split("def ", 2)[1].split("(")[0].split(";")[0].strip
+            func_name = func_name.lchop("self.").strip
+            unless func_name.empty?
+              this_method = func_name
+              defined_actions << func_name
             end
           end
 
-          if controller_line.includes?("params.require")
-            split_param = controller_line.strip.split("permit")
-            if split_param.size > 1
-              tparam = split_param[1].gsub("(", "").gsub(")", "").gsub("s", "").gsub(":", "")
-              tparam.split(",").each do |param|
-                permit_body_params << Param.new(param.strip, "", param_type)
-                permit_query_params << Param.new(param.strip, "", "query")
-              end
+          if pm = line.match(/permit\s*\(([^)]*)\)/)
+            pm[1].split(',').each do |raw|
+              name = raw.gsub(/[:\s'"]/, "")
+              next if name.empty?
+              permit_body_params << Param.new(name, "", param_type)
+              permit_query_params << Param.new(name, "", "query")
             end
           end
 
-          if controller_line.includes?("params[:")
-            split_param = controller_line.strip.split("params[:")[1]
-            if split_param
-              param = split_param.split("]")[0]
-              permit_body_params << Param.new(param.strip, "", param_type)
-              permit_query_params << Param.new(param.strip, "", "query")
+          line.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+            name = (m[1]? || m[2]?).to_s.strip
+            next if name.empty?
+            permit_body_params << Param.new(name, "", param_type)
+            permit_query_params << Param.new(name, "", "query")
+          end
+
+          if hm = line.match(/request\.headers\[\s*['"]([^'"]+)['"]\s*\]/)
+            name = hm[1].strip
+            if !name.empty? && this_method != ""
+              params_method[this_method] ||= [] of Param
+              params_method[this_method] << Param.new(name, "", "header")
             end
           end
 
-          if controller_line.includes?("request.headers[")
-            split_param = controller_line.strip.split("request.headers[")[1]
-            if split_param
-              param = split_param.split("]")[0].gsub("'", "").gsub("\"", "")
-              if this_method != ""
-                params_method[this_method] ||= [] of Param
-                params_method[this_method] << Param.new(param.strip, "", "header")
-              end
-            end
-          end
-
-          {"cookies[:", "cookies.signed[:", "cookies.encrypted[:"}.each do |prefix|
-            next unless controller_line.includes?(prefix)
-            split_param = controller_line.strip.split(prefix)[1]
-            next unless split_param
-            param = split_param.split("]")[0].gsub("'", "").gsub("\"", "")
-            next if this_method == ""
+          line.scan(/cookies(?:\.(?:signed|encrypted))?\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |cm|
+            name = (cm[1]? || cm[2]?).to_s.strip
+            next if name.empty? || this_method == ""
             params_method[this_method] ||= [] of Param
-            params_method[this_method] << Param.new(param.strip, "", "cookie")
+            params_method[this_method] << Param.new(name, "", "cookie")
           end
         end
       end
 
-      {
-        param_type:          param_type,
-        params_method:       params_method,
-        permit_body_params:  permit_body_params,
-        permit_query_params: permit_query_params,
-        defined_actions:     defined_actions,
-      }
+      data = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params, defined_actions)
+      @controller_data_cache[path] = data
+      data
     end
 
     private def dedup_by_name(params : Array(Param)) : Array(Param)
@@ -518,18 +513,18 @@ module Analyzer::Ruby
     private def params_for_action(controller_path : String?, action : String, verb : String) : Array(Param)
       return [] of Param if controller_path.nil?
       data = extract_controller_data(controller_path)
-      return [] of Param unless data[:defined_actions].includes?(action)
+      return [] of Param unless data.defined_actions.includes?(action)
 
       result = [] of Param
-      data[:params_method][action]?.try &.each { |p| result << p }
+      data.params_method[action]?.try &.each { |p| result << p }
 
       case verb
       when "GET", "HEAD", "OPTIONS"
-        result.concat(dedup_by_name(data[:permit_query_params]))
+        result.concat(dedup_by_name(data.permit_query_params))
       when "DELETE"
         # No shared body params for delete, matching the resources flow.
       else
-        result.concat(data[:permit_body_params])
+        result.concat(data.permit_body_params)
       end
 
       result
@@ -553,10 +548,21 @@ module Analyzer::Ruby
       nil
     end
 
-    private def find_controller_file(framework_root : String, ctrl_name : String) : String?
+    # Resolve `ctrl#action` to a controller file. When the route lives inside a
+    # `namespace :admin` block, Rails resolves "monitor#ping" to
+    # `Admin::MonitorController` — try the subdir-prefixed path first, then fall
+    # back to a bare lookup so absolute-style references ("api/v1/users") still
+    # work regardless of where they're declared.
+    private def find_controller_file(framework_root : String, ctrl_name : String,
+                                     stack : Array(Frame) = [] of Frame) : String?
       return if ctrl_name.empty?
-      path = "#{framework_root}/app/controllers/#{ctrl_name}_controller.rb"
-      File.exists?(path) ? path : nil
+      candidates = [] of String
+      subdir = current_controller_subdir(stack)
+      if !subdir.empty? && !ctrl_name.includes?('/')
+        candidates << "#{framework_root}/app/controllers/#{subdir}/#{ctrl_name}_controller.rb"
+      end
+      candidates << "#{framework_root}/app/controllers/#{ctrl_name}_controller.rb"
+      candidates.find { |c| File.exists?(c) }
     end
 
     private def action_allowed?(name : String, only : Array(String), except : Array(String)) : Bool


### PR DESCRIPTION
Follow-ups from the [#1362 review](https://github.com/owasp-noir/noir/pull/1362).

## Summary
- **Cache controller scans** — `extract_controller_data` is memoized per path, so resources + member/collection + `to:` resolution only reads each controller file once.
- **Comment-strip once per line** — all param/header/cookie scans now run on the cleaned line, so commented-out code no longer produces phantom params.
- **Replace fragile gsub chain** — the long-standing `gsub(\"s\", \"\")` that mangled `status` → `tatu` is gone; `permit(...)` is parsed by anchored regex.
- **Accept Rails idioms the scan was missing** — `params[\"id\"]` / `params['id']` and `permit(\"a\", \"b\")` (string form) now work alongside the symbol forms.
- **Namespace-aware `find_controller_file`** — walks `current_controller_subdir(stack)` first, so `to: \"monitor#ping\"` inside `namespace :admin` correctly resolves to `admin/monitor_controller.rb`.

## Test plan
Fixture coverage in `rails_advanced` now exercises every new path:
- [x] `delete :purge` (member DELETE) — verifies DELETE custom action emits with the action's header but no shared body params.
- [x] `permit(\"note\", \"kind\")` string form on `post :update_metadata`.
- [x] `params[\"id\"]` (string key) in `def heartbeat`.
- [x] `get \"monitor/heartbeat\", to: \"monitor#heartbeat\"` inside `namespace :admin` resolves to `admin/monitor_controller.rb`.
- [x] Hash-rocket `=> \"rails/health#show\"` resolves to a real controller and pulls `X-Health` header.
- [x] `crystal spec spec/functional_test/testers/ruby/` — 308 specs pass.
- [x] `ameba src/analyzer/analyzers/ruby/rails.cr` — clean.