### PR TITLE
chore(deps): exclude spec fixtures from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,32 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  # Test fixtures under spec/ are intentionally pinned for reproducible
+  # functional tests. Suppress both version and security updates for them.
+  - package-ecosystem: bundler
+    directories:
+      - "/spec/functional_test/fixtures/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: pip
+    directories:
+      - "/spec/functional_test/fixtures/python/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: npm
+    directories:
+      - "/spec/functional_test/fixtures/javascript/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Summary
- Test fixtures under `spec/functional_test/fixtures/` are intentionally pinned for reproducible functional tests, but Dependabot security updates keep opening patch PRs against them (e.g. #1369 aiohttp, #1370 litestar).
- Add explicit `pip` / `bundler` / `npm` entries scoped to the fixture directories with `open-pull-requests-limit: 0` and `ignore: "*"` so both version and security updates are suppressed there.
- Production ecosystems (`github-actions`, `docker`, `bundler` at `/`) are unchanged.

## Test plan
- [ ] After merge, confirm no new Dependabot PRs touch `spec/functional_test/fixtures/**`.
- [ ] Existing open Dependabot PRs against fixtures can be closed manually.