### PR TITLE
feat(go): wire callees through Gin

### DIFF
--- a/spec/functional_test/fixtures/go/gin_callees/go.mod
+++ b/spec/functional_test/fixtures/go/gin_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/gin-callees-fixture
+
+go 1.23.0
+
+require github.com/gin-gonic/gin v1.10.1

--- a/spec/functional_test/fixtures/go/gin_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/gin_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func createUser(c *gin.Context) {
+	name := c.PostForm("name")
+	user := saveUser(name)
+	auditLog(user)
+	c.JSON(200, gin.H{"id": user})
+}
+
+func listProfile(c *gin.Context) {
+	data := buildProfile()
+	auditLog(data)
+	c.JSON(200, data)
+}

--- a/spec/functional_test/fixtures/go/gin_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/gin_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/gin_callees/main.go
+++ b/spec/functional_test/fixtures/go/gin_callees/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.POST("/users", createUser)
+	r.GET("/healthz", func(c *gin.Context) {
+		c.JSON(200, gin.H{"ok": true})
+	})
+	r.GET("/profile", listProfile)
+	r.Run()
+}

--- a/spec/functional_test/testers/go/gin_callees_spec.cr
+++ b/spec/functional_test/testers/go/gin_callees_spec.cr
@@ -1,0 +1,51 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Gin (first cross-language
+# wiring of #1366). Covers the three handler-resolution paths:
+#
+#   - POST /users          — named handler `createUser` defined in a
+#                            sibling file (`handlers.go`). Exercises
+#                            the cross-file lookup via
+#                            `GoCalleeExtractor.collect_function_bodies`
+#                            and confirms callee lines/paths point at
+#                            the sibling, not main.go.
+#   - GET /healthz         — inline `func(c *gin.Context) { … }`
+#                            closure handler in main.go. Walks the
+#                            func_literal body in place; no cross-file
+#                            resolution needed.
+#   - GET /profile         — named handler `listProfile` also in
+#                            handlers.go; locks in that multiple named
+#                            handlers in the same sibling file each
+#                            scope to their own body.
+#
+# Line assertions verify that `start_row` arithmetic from the wrapped
+# external parse maps back to the original file's lines.
+expected_endpoints = [
+  # Note: Gin's existing PostForm/Query/GetHeader param extraction is
+  # file-local — it scans the same file as the route declaration. Since
+  # this endpoint's handler lives in handlers.go, the `c.PostForm("name")`
+  # call there is invisible to the param extractor. The callee list IS
+  # still populated because callee resolution follows the cross-file
+  # handler binding; the two features are intentionally orthogonal.
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("c.PostForm", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("c.JSON", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("c.JSON", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("c.JSON", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/gin_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -6,6 +6,11 @@ module Analyzer::Go
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
       package_groups, file_contents = collect_package_groups_ts
+      # Pre-pass for cross-file identifier-handler resolution. Built
+      # once per analyze() so each per-file callee pass only does an
+      # O(1) lookup into `package_function_bodies` rather than re-
+      # walking every sibling source file.
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, ".go")
@@ -36,6 +41,15 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route in this file.
+                    # Inline-closure handlers walk in place; bare
+                    # identifier handlers fall through to sibling-file
+                    # function bodies via the per-directory map.
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     # Gin uses `r.Static("/url", "./dir")`. Pick these up
                     # in a single tree-sitter pass up front; downstream
                     # `resolve_public_dirs` still expects the legacy hash
@@ -54,6 +68,12 @@ module Analyzer::Go
                       if ts_hits = routes_by_line[index]?
                         ts_hits.each do |route|
                           new_endpoint = Endpoint.new(route.path, route.verb, details)
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                           result << new_endpoint
                           last_endpoint = new_endpoint
                         end

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/go_callee_extractor"
 require "../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
@@ -63,6 +64,33 @@ module Analyzer::Go
     # empty map when the directory has no registered groups.
     def ts_groups_for_directory(package_groups : Hash(String, Hash(String, String)), dir : String) : Hash(String, String)
       package_groups[dir]? || Hash(String, String).new
+    end
+
+    # --- Cross-file function body pre-pass --------------------------------
+    #
+    # Walks every cached `.go` source in `file_contents` and collects
+    # top-level `function_declaration` nodes into a per-directory map
+    # so cross-file identifier-handler resolution in
+    # `Noir::GoCalleeExtractor` is O(1) at lookup time. The map is
+    # keyed by directory because Go's name resolution rules are scoped
+    # to a single package (== single directory), so we never have to
+    # worry about cross-package leakage.
+    def collect_package_function_bodies(file_contents : Hash(String, String)) : Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody))
+      result = Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody)).new
+      file_contents.each do |path, content|
+        dir = File.dirname(path)
+        fns = Noir::GoCalleeExtractor.collect_function_bodies(content, path)
+        next if fns.empty?
+        result[dir] ||= Hash(String, Noir::GoCalleeExtractor::FunctionBody).new
+        fns.each { |name, fb| result[dir][name] ||= fb }
+      end
+      result
+    end
+
+    # Returns the cross-file function-body map for the given directory,
+    # or an empty map when the directory has no captured functions.
+    def ts_function_bodies_for_directory(package_function_bodies : Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody)), dir : String) : Hash(String, Noir::GoCalleeExtractor::FunctionBody)
+      package_function_bodies[dir]? || Hash(String, Noir::GoCalleeExtractor::FunctionBody).new
     end
 
     # --- Adapter helpers (shared across Go framework adapters) ----------

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -1,0 +1,232 @@
+require "../ext/tree_sitter/tree_sitter"
+
+# Tree-sitter-backed Go 1-hop callee extractor. Parallels
+# `Noir::PythonCalleeExtractor` but works at the AST level — Go can't
+# share the Python convention of "give me a body string", because
+# tree-sitter Go needs a complete `source_file` and a bare function body
+# isn't one.
+#
+# The extractor receives a full Go file plus the set of route call
+# expression rows the analyzer cares about. For each match it locates
+# the handler argument and walks the appropriate body:
+#
+#   * `func_literal` (inline closure handler) — walk the closure's body
+#     in place; `path`/`line` on emitted callees point at the original
+#     file.
+#   * `identifier` (named handler) — look the name up in the file's
+#     top-level `function_declaration`s first, then in
+#     `external_functions` (sibling files in the same Go package). The
+#     external map is built once per directory by
+#     `GoEngine#collect_package_function_bodies` so cross-file lookups
+#     are cheap.
+#   * `selector_expression` / other shapes — skipped for the first cut.
+#     Real-world examples include `pkg.Foo` (cross-package) and bound
+#     method values (`handler.Get`); resolving those needs full import
+#     resolution and is left as a follow-up.
+#
+# Builtins (`len`, `make`, `append`, …) and Go's primitive type
+# constructors (`int`, `string`, `byte`, …) are filtered to keep the
+# per-endpoint list focused on signal that's actually useful to an AI
+# reviewer.
+module Noir::GoCalleeExtractor
+  extend self
+
+  # Top-level function definition captured for cross-file identifier
+  # handler resolution. `source` is the full text of the
+  # `function_declaration` node, so re-parsing it yields the same body.
+  # `start_row` is the 0-based row of the `func` keyword in `file_path`,
+  # used to translate tree-sitter rows back to absolute file lines when
+  # the body is walked from a re-parse.
+  struct FunctionBody
+    getter source : String
+    getter file_path : String
+    getter start_row : Int32
+
+    def initialize(@source, @file_path, @start_row)
+    end
+  end
+
+  # Go builtins and primitive type-conversions that carry no useful
+  # signal. Anything framework-specific (`c.JSON`, `c.Query`,
+  # `gin.H{...}`, etc.) is kept on purpose — those tell a reviewer how
+  # the endpoint shapes input/output.
+  BUILTINS = Set{
+    "len", "cap", "make", "new", "append", "copy", "delete",
+    "close", "panic", "recover", "print", "println",
+    "string", "int", "int8", "int16", "int32", "int64",
+    "uint", "uint8", "uint16", "uint32", "uint64", "uintptr", "byte", "rune",
+    "float32", "float64", "complex64", "complex128", "complex",
+    "bool", "error",
+  }
+
+  # Returns top-level function declarations in `source`, keyed by name.
+  # `file_path` is recorded on each `FunctionBody` so callees emitted by
+  # later re-parsing can report a useful path.
+  def collect_function_bodies(source : String, file_path : String) : Hash(String, FunctionBody)
+    bodies = Hash(String, FunctionBody).new
+    Noir::TreeSitter.parse_go(source) do |root|
+      Noir::TreeSitter.each_named_child(root) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "function_declaration"
+        name_node = Noir::TreeSitter.field(child, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        bodies[name] ||= FunctionBody.new(
+          Noir::TreeSitter.node_text(child, source),
+          file_path,
+          Noir::TreeSitter.node_start_row(child),
+        )
+      end
+    end
+    bodies
+  end
+
+  # For each call_expression at a row in `route_rows`, find the handler
+  # argument, walk its body, and return the 1-hop callees keyed by row.
+  # Each entry is a tuple `{name, callee_file_path, file_line_1_based}`.
+  def callees_for_routes(source : String,
+                         file_path : String,
+                         route_rows : Set(Int32),
+                         external_functions : Hash(String, FunctionBody))
+    by_route = Hash(Int32, Array(Tuple(String, String, Int32))).new
+    return by_route if route_rows.empty?
+
+    Noir::TreeSitter.parse_go(source) do |root|
+      local_functions = Hash(String, LibTreeSitter::TSNode).new
+      Noir::TreeSitter.each_named_child(root) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "function_declaration"
+        name_node = Noir::TreeSitter.field(child, "name")
+        next unless name_node
+        local_functions[Noir::TreeSitter.node_text(name_node, source)] = child
+      end
+
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "call_expression"
+        row = Noir::TreeSitter.node_start_row(node)
+        next unless route_rows.includes?(row)
+
+        handler_arg = find_handler_arg(node, source)
+        next unless handler_arg
+
+        callees = [] of Tuple(String, String, Int32)
+        case Noir::TreeSitter.node_type(handler_arg)
+        when "func_literal"
+          if body = Noir::TreeSitter.field(handler_arg, "body")
+            walk_calls_in_node(body, source, file_path, callees, 0)
+          end
+        when "identifier"
+          name = Noir::TreeSitter.node_text(handler_arg, source)
+          if fn_node = local_functions[name]?
+            if body = Noir::TreeSitter.field(fn_node, "body")
+              walk_calls_in_node(body, source, file_path, callees, 0)
+            end
+          elsif extern = external_functions[name]?
+            callees.concat(calls_in_external(extern))
+          end
+        else
+          # selector_expression / method values — out of scope for now.
+        end
+
+        by_route[row] = callees unless callees.empty?
+      end
+    end
+
+    by_route
+  end
+
+  # First non-string positional argument after a string-literal arg in a
+  # verb-route call. Mirrors the convention used by
+  # `TreeSitterGoRouteExtractor#decode_verb_call`.
+  private def find_handler_arg(call_node : LibTreeSitter::TSNode, source : String) : LibTreeSitter::TSNode?
+    args = Noir::TreeSitter.field(call_node, "arguments")
+    return unless args
+    seen_path = false
+    Noir::TreeSitter.each_named_child(args) do |arg|
+      ty = Noir::TreeSitter.node_type(arg)
+      if ty == "interpreted_string_literal" || ty == "raw_string_literal"
+        seen_path = true
+        next
+      end
+      return arg if seen_path
+    end
+    nil
+  end
+
+  # Walk `body_node` for call expressions and append `(name, file_path,
+  # file_line)` tuples. `line_offset` lets callers translate
+  # tree-sitter rows (already absolute when the parse covers the whole
+  # file; offset by FunctionBody#start_row - 1 for re-parsed external
+  # bodies wrapped with a `package` line).
+  private def walk_calls_in_node(body_node : LibTreeSitter::TSNode,
+                                 source : String,
+                                 file_path : String,
+                                 sink : Array(Tuple(String, String, Int32)),
+                                 line_offset : Int32)
+    walk(body_node) do |n|
+      next unless Noir::TreeSitter.node_type(n) == "call_expression"
+      func = Noir::TreeSitter.field(n, "function")
+      next unless func
+      name = callee_text(func, source)
+      next if name.empty?
+      next if BUILTINS.includes?(name)
+      next if name.starts_with?("_")
+      row = Noir::TreeSitter.node_start_row(func) + line_offset
+      sink << {name, file_path, row + 1}
+    end
+  end
+
+  # Re-parse a sibling-file function body for cross-file identifier
+  # handler resolution. Wraps the captured `function_declaration` text
+  # in a `package` line so tree-sitter Go can parse it as a complete
+  # `source_file`; the wrap adds exactly one row, which we subtract via
+  # `start_row - 1` to map walked rows back to the original file.
+  private def calls_in_external(fn : FunctionBody) : Array(Tuple(String, String, Int32))
+    sink = [] of Tuple(String, String, Int32)
+    wrapped = "package _noir_callee_wrap\n#{fn.source}\n"
+    line_offset = fn.start_row - 1
+    Noir::TreeSitter.parse_go(wrapped) do |root|
+      Noir::TreeSitter.each_named_child(root) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "function_declaration"
+        if body = Noir::TreeSitter.field(child, "body")
+          walk_calls_in_node(body, wrapped, fn.file_path, sink, line_offset)
+          break
+        end
+      end
+    end
+    sink
+  end
+
+  # Render a callee's textual name. Identifiers come back verbatim;
+  # `selector_expression` chains rebuild into dotted names, but only
+  # when every link is an identifier — chains rooted on another call
+  # (`foo(x).Bar`) are dropped to keep the list signal-rich. This
+  # mirrors the chained-call-noise filter in PythonCalleeExtractor.
+  private def callee_text(node : LibTreeSitter::TSNode, source : String) : String
+    case Noir::TreeSitter.node_type(node)
+    when "identifier"
+      Noir::TreeSitter.node_text(node, source)
+    when "selector_expression"
+      operand = Noir::TreeSitter.field(node, "operand")
+      field = Noir::TreeSitter.field(node, "field")
+      return "" unless operand && field
+      case Noir::TreeSitter.node_type(operand)
+      when "identifier"
+        "#{Noir::TreeSitter.node_text(operand, source)}.#{Noir::TreeSitter.node_text(field, source)}"
+      when "selector_expression"
+        inner = callee_text(operand, source)
+        inner.empty? ? "" : "#{inner}.#{Noir::TreeSitter.node_text(field, source)}"
+      else
+        # operand is a call/index/literal — chained on a result, skip.
+        ""
+      end
+    else
+      ""
+    end
+  end
+
+  private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    block.call(node)
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk(child, &block)
+    end
+  end
+end


### PR DESCRIPTION
First cross-language wiring for #1366 — Go joins the Python frameworks (Flask, Sanic, Aiohttp, Bottle, Falcon, Pyramid, FastAPI, Litestar, Django, Tornado) that already populate `Endpoint.callees`. Unlike Python, Go can't share the "give me a body string" convention because tree-sitter Go needs a complete `source_file` and a bare function body isn't one; the new `GoCalleeExtractor` works at the AST level instead.

## Changes

- **`src/miniparsers/go_callee_extractor.cr`** (new) — tree-sitter Go body walker:
  - `collect_function_bodies(source, file_path)` captures every top-level `function_declaration` as a `FunctionBody {source, file_path, start_row}` so cross-file identifier-handler lookups are O(1).
  - `callees_for_routes(source, file_path, route_rows, external_functions)` — for each verb-route call_expression at one of the given rows, finds the handler argument and walks the appropriate body. Inline `func_literal` handlers walk in place; bare identifiers fall through to local file functions first, then to the package-wide map. Selectors and method values are out of scope for the first cut.
  - Filters builtins (`len`, `make`, `append`, `panic`, …) and Go primitive type-conversions (`int`, `string`, `byte`, …) so the per-endpoint list stays signal-rich. Chained-call noise (`foo(x).Bar`) is dropped, mirroring `PythonCalleeExtractor`.

- **`src/analyzer/engines/go_engine.cr`** — adds `collect_package_function_bodies(file_contents)` + `ts_function_bodies_for_directory(...)` accessor. Built once per `analyze()` so each per-file callee pass is an O(1) hash lookup rather than re-walking every sibling source file.

- **`src/analyzer/analyzers/go/gin.cr`** — calls `GoCalleeExtractor.callees_for_routes` per file, indexed by route row, and pushes `Callee` entries onto each emitted endpoint. The existing PostForm/Query/GetHeader file-local param extraction stays untouched — params and callees are intentionally orthogonal.

## Honest scope (consistent with #1366)
- **Selector/method-value handlers skipped** — `r.GET("/x", pkg.Foo)` and `r.GET("/x", handler.Get)` patterns return empty callees. Cross-package import resolution would be needed and is left as follow-up.
- **Gin only in this PR** — Echo, Fiber, Chi, Mux, Hertz, etc. all use the same `TreeSitterGoRouteExtractor` shape; wiring them up is a near-identical small change per analyzer.
- **1-hop, dynamic-dispatch-blind** — same caveats as Python: Gin middleware chains, route groups via closures, `r.Use(...)` interceptors don't flow through `call_expression` in the handler body.

## Coverage

`gin_callees/` fixture with three distinct handler-resolution paths:
- `POST /users` → named handler `createUser` defined in a sibling file (`handlers.go`). Exercises the cross-file lookup via `collect_function_bodies` and confirms callee `line`/`path` point at the sibling, not main.go.
- `GET /healthz` → inline `func(c *gin.Context) { … }` closure handler in main.go. Walks the `func_literal` body in place; no cross-file resolution needed.
- `GET /profile` → second named handler also in `handlers.go`; locks in that multiple named handlers in the same sibling file each scope to their own body.

Spec asserts both names and lines, locking the `start_row` arithmetic that maps wrapped-external-parse rows back to original file lines.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/` — 732 examples pass (existing 708 unchanged + 24 new).
- [x] `just test` — 1500 unit + 6529 functional, 0 failures.
- [x] `just check` — 749 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.