### PR TITLE
feat(go): wire callees through Echo, Fiber, Hertz

### DIFF
--- a/spec/functional_test/fixtures/go/echo_callees/go.mod
+++ b/spec/functional_test/fixtures/go/echo_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/echo-callees-fixture
+
+go 1.23.0
+
+require github.com/labstack/echo/v4 v4.13.4

--- a/spec/functional_test/fixtures/go/echo_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/echo_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func createUser(c echo.Context) error {
+	name := c.FormValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	return c.JSON(200, map[string]string{"id": user})
+}
+
+func listProfile(c echo.Context) error {
+	data := buildProfile()
+	auditLog(data)
+	return c.JSON(200, data)
+}

--- a/spec/functional_test/fixtures/go/echo_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/echo_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/echo_callees/main.go
+++ b/spec/functional_test/fixtures/go/echo_callees/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	e := echo.New()
+	e.POST("/users", createUser)
+	e.GET("/healthz", func(c echo.Context) error {
+		return c.JSON(200, map[string]bool{"ok": true})
+	})
+	e.GET("/profile", listProfile)
+	e.Start(":8080")
+}

--- a/spec/functional_test/fixtures/go/fiber_callees/go.mod
+++ b/spec/functional_test/fixtures/go/fiber_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/fiber-callees-fixture
+
+go 1.23.0
+
+require github.com/gofiber/fiber/v2 v2.52.5

--- a/spec/functional_test/fixtures/go/fiber_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/fiber_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func createUser(c *fiber.Ctx) error {
+	name := c.FormValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	return c.JSON(map[string]string{"id": user})
+}
+
+func listProfile(c *fiber.Ctx) error {
+	data := buildProfile()
+	auditLog(data)
+	return c.JSON(data)
+}

--- a/spec/functional_test/fixtures/go/fiber_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/fiber_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/fiber_callees/main.go
+++ b/spec/functional_test/fixtures/go/fiber_callees/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func main() {
+	app := fiber.New()
+	app.Post("/users", createUser)
+	app.Get("/healthz", func(c *fiber.Ctx) error {
+		return c.JSON(map[string]bool{"ok": true})
+	})
+	app.Get("/profile", listProfile)
+	app.Listen(":8080")
+}

--- a/spec/functional_test/fixtures/go/hertz_callees/go.mod
+++ b/spec/functional_test/fixtures/go/hertz_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/hertz-callees-fixture
+
+go 1.23.0
+
+require github.com/cloudwego/hertz v0.9.5

--- a/spec/functional_test/fixtures/go/hertz_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/hertz_callees/handlers.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+)
+
+func createUser(c context.Context, ctx *app.RequestContext) {
+	name := ctx.PostForm("name")
+	user := saveUser(string(name))
+	auditLog(user)
+	ctx.JSON(200, map[string]string{"id": user})
+}
+
+func listProfile(c context.Context, ctx *app.RequestContext) {
+	data := buildProfile()
+	auditLog(data)
+	ctx.JSON(200, data)
+}

--- a/spec/functional_test/fixtures/go/hertz_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/hertz_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/hertz_callees/main.go
+++ b/spec/functional_test/fixtures/go/hertz_callees/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
+)
+
+func main() {
+	h := server.Default()
+	h.POST("/users", createUser)
+	h.GET("/healthz", func(c context.Context, ctx *app.RequestContext) {
+		ctx.JSON(200, map[string]bool{"ok": true})
+	})
+	h.GET("/profile", listProfile)
+	h.Spin()
+}

--- a/spec/functional_test/testers/go/echo_callees_spec.cr
+++ b/spec/functional_test/testers/go/echo_callees_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Echo (#1366). Same shape as
+# the Gin coverage:
+#
+#   - POST /users   — named handler `createUser` in sibling
+#                     `handlers.go`; exercises the cross-file lookup.
+#   - GET /healthz  — inline closure handler in main.go.
+#   - GET /profile  — second named handler in handlers.go to confirm
+#                     per-handler scoping.
+#
+# Echo's existing file-local param extraction (FormValue/QueryParam/
+# Header.Get) does not follow into sibling files, so the form param
+# for POST /users isn't surfaced — params and callees stay orthogonal.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("c.FormValue", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("c.JSON", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("c.JSON", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("c.JSON", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/echo_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/fiber_callees_spec.cr
+++ b/spec/functional_test/testers/go/fiber_callees_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Fiber (#1366). Mirrors the
+# Gin/Echo coverage. Notable Fiber-specific shape: lowercase verb
+# methods (`app.Get` / `app.Post`) and `*fiber.Ctx` receiver — the
+# extractor handles both transparently because it keys off the verb
+# field text without case-sensitive matching.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("c.FormValue", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("c.JSON", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("c.JSON", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("c.JSON", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/fiber_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/hertz_callees_spec.cr
+++ b/spec/functional_test/testers/go/hertz_callees_spec.cr
@@ -1,0 +1,39 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Hertz (#1366). Mirrors
+# Gin/Echo/Fiber. Hertz's handler signature takes `(c context.Context,
+# ctx *app.RequestContext)`, so callees on the request context come
+# back as `ctx.PostForm` / `ctx.JSON` rather than `c.JSON`.
+#
+# Note: this fixture does NOT exercise the `.Any("/path", ...)` verb
+# expansion path on purpose — that's covered by the existing
+# `hertz_spec.cr` route-extraction tests. Here we only need to confirm
+# that the per-emit-endpoint callee push runs in both the ANY and the
+# single-verb branches of `hertz.cr`. Adding an Any route would just
+# re-state the same assertion N times.
+#
+# Also note `string(name)` in handlers.go is filtered by `BUILTINS` —
+# Go primitive type-conversions don't surface as callees.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("ctx.PostForm", line: 10))
+    ep.push_callee(Callee.new("saveUser", line: 11))
+    ep.push_callee(Callee.new("auditLog", line: 12))
+    ep.push_callee(Callee.new("ctx.JSON", line: 13))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("ctx.JSON", line: 14))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 17))
+    ep.push_callee(Callee.new("auditLog", line: 18))
+    ep.push_callee(Callee.new("ctx.JSON", line: 19))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/hertz_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -6,6 +6,11 @@ module Analyzer::Go
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
       package_groups, file_contents = collect_package_groups_ts
+      # Pre-pass for cross-file identifier-handler resolution. Built
+      # once per analyze() so each per-file callee pass only does an
+      # O(1) lookup into `package_function_bodies` rather than re-
+      # walking every sibling source file.
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -34,6 +39,15 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route in this file.
+                    # Inline-closure handlers walk in place; bare
+                    # identifier handlers fall through to sibling-file
+                    # function bodies via the per-directory map.
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     # `e.Static("/url", "./dir")` — same shape as Gin/Fiber/etc.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
                       public_dirs << {"static_path" => sp.url_prefix, "file_path" => sp.disk_path}
@@ -45,6 +59,12 @@ module Analyzer::Go
                       if ts_hits = routes_by_line[index]?
                         ts_hits.each do |route|
                           new_endpoint = Endpoint.new(route.path, route.verb, details)
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                           result << new_endpoint
                           last_endpoint = new_endpoint
                         end

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -6,6 +6,8 @@ module Analyzer::Go
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
       package_groups, file_contents = collect_package_groups_ts
+      # Pre-pass for cross-file identifier-handler resolution (see Gin).
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -36,6 +38,12 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     # `app.Static("/url", "./dir")`.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
                       public_dirs << {"static_path" => sp.url_prefix, "file_path" => sp.disk_path}
@@ -48,6 +56,12 @@ module Analyzer::Go
                         ts_hits.each do |route|
                           new_endpoint = Endpoint.new(route.path, route.verb, details)
                           new_endpoint.protocol = "ws" if route.handler.includes?("websocket.New(")
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                           result << new_endpoint
                           last_endpoint = new_endpoint
                         end

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -14,6 +14,8 @@ module Analyzer::Go
     def analyze
       public_dirs = [] of (Hash(String, String))
       package_groups, file_contents = collect_package_groups_ts
+      # Pre-pass for cross-file identifier-handler resolution (see Gin).
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, ".go")
@@ -43,6 +45,12 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     # `h.Static("/url", "./dir")`.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
                       public_dirs << {"static_path" => sp.url_prefix, "file_path" => sp.disk_path}
@@ -53,14 +61,23 @@ module Analyzer::Go
 
                       if ts_hits = routes_by_line[index]?
                         ts_hits.each do |route|
+                          callee_entries = callees_by_route[route.line]?
                           if route.verb == "ANY"
                             HTTP_METHODS_EXPANDED.each do |m|
                               new_endpoint = Endpoint.new(route.path, m, details)
+                              callee_entries.try &.each do |entry|
+                                name, callee_path, callee_line = entry
+                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                              end
                               result << new_endpoint
                               last_endpoint = new_endpoint
                             end
                           else
                             new_endpoint = Endpoint.new(route.path, route.verb, details)
+                            callee_entries.try &.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
                             result << new_endpoint
                             last_endpoint = new_endpoint
                           end


### PR DESCRIPTION
Continuation of #1366. The three Go frameworks that share Gin's `TreeSitterGoRouteExtractor` shape now also populate `Endpoint.callees`. Each wiring is the same 3-step change as `gin.cr`: add `collect_package_function_bodies` to the analyze() entry, build `route_rows` after the route harvest, push callees onto each emitted endpoint.

## Per-analyzer
- **`echo.cr`** — verbatim Gin pattern. The existing FormValue/QueryParam/Header.Get/Cookie param extraction is file-local, so sibling-file handlers don't surface params; the spec acknowledges that.
- **`fiber.cr`** — same pattern; preserves the existing `protocol = "ws"` flip when the handler text contains `websocket.New(`.
- **`hertz.cr`** — handles two emit branches because `r.Any("/path", h)` expands into one endpoint per HTTP method. Callees attach in both branches so an Any-route also carries them, matching its fan-out.

## Coverage
Three new `*_callees` fixtures, each with `main.go` + sibling `handlers.go` + `helpers.go` (mirroring `gin_callees/`). Specs assert names plus line numbers across all three handler-resolution paths: inline closure (in main.go), named handler in sibling file, and a second sibling handler.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/{echo,fiber,hertz}_callees_spec.cr` — 72 assertions, 0 failures.
- [x] `just test` — 6601 examples, 0 failures (full functional suite).
- [x] `just check` — 752 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.