### PR TITLE
feat(go): wire callees through Iris and Goyave

### DIFF
--- a/spec/functional_test/fixtures/go/goyave_callees/go.mod
+++ b/spec/functional_test/fixtures/go/goyave_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/goyave-callees-fixture
+
+go 1.23.0
+
+require goyave.dev/goyave/v5 v5.5.0

--- a/spec/functional_test/fixtures/go/goyave_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/goyave_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"goyave.dev/goyave/v5"
+)
+
+func createUser(response *goyave.Response, request *goyave.Request) {
+	name := request.QueryParams.Get("name")
+	user := saveUser(name)
+	auditLog(user)
+	response.JSON(200, map[string]string{"id": user})
+}
+
+func listProfile(response *goyave.Response, request *goyave.Request) {
+	data := buildProfile()
+	auditLog(data)
+	response.JSON(200, data)
+}

--- a/spec/functional_test/fixtures/go/goyave_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/goyave_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/goyave_callees/main.go
+++ b/spec/functional_test/fixtures/go/goyave_callees/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	"goyave.dev/goyave/v5"
+)
+
+func main() {
+	server, err := goyave.New(goyave.Options{})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	server.RegisterRoutes(func(server *goyave.Server, router *goyave.Router) {
+		router.Post("/users", createUser)
+		router.Get("/healthz", func(response *goyave.Response, request *goyave.Request) {
+			response.JSON(200, map[string]bool{"ok": true})
+		})
+		router.Get("/profile", listProfile)
+	})
+
+	if err := server.Start(); err != nil {
+		fmt.Println(err)
+	}
+}

--- a/spec/functional_test/fixtures/go/iris_callees/go.mod
+++ b/spec/functional_test/fixtures/go/iris_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/iris-callees-fixture
+
+go 1.23.0
+
+require github.com/kataras/iris/v12 v12.2.11

--- a/spec/functional_test/fixtures/go/iris_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/iris_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/kataras/iris/v12"
+)
+
+func createUser(ctx iris.Context) {
+	name := ctx.PostValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	ctx.JSON(map[string]string{"id": user})
+}
+
+func listProfile(ctx iris.Context) {
+	data := buildProfile()
+	auditLog(data)
+	ctx.JSON(data)
+}

--- a/spec/functional_test/fixtures/go/iris_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/iris_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/iris_callees/main.go
+++ b/spec/functional_test/fixtures/go/iris_callees/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/kataras/iris/v12"
+)
+
+func main() {
+	app := iris.New()
+	app.Post("/users", createUser)
+	app.Get("/healthz", func(ctx iris.Context) {
+		ctx.JSON(map[string]bool{"ok": true})
+	})
+	app.Get("/profile", listProfile)
+	app.Listen(":8080")
+}

--- a/spec/functional_test/testers/go/goyave_callees_spec.cr
+++ b/spec/functional_test/testers/go/goyave_callees_spec.cr
@@ -1,0 +1,44 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Goyave (#1366). Goyave
+# doesn't use the route extractor's cross-file group fixpoint, so the
+# analyzer builds `file_contents` for the callee map via the dedicated
+# `read_package_file_contents` helper in GoEngine — this spec confirms
+# that path resolves cross-file handlers correctly.
+#
+# Coverage:
+#   - POST /users   — named handler `createUser` in sibling
+#                     `handlers.go`; the call `request.QueryParams.Get`
+#                     exercises a 2-level selector chain (identifier
+#                     → attribute → attribute), proving the dotted
+#                     callee name is reconstructed cleanly.
+#   - GET /healthz  — inline closure inside the `RegisterRoutes`
+#                     closure (Goyave's idiom). Routes live inside a
+#                     `func` closure on `server.RegisterRoutes(...)`,
+#                     and the callee `response.JSON` shows up at the
+#                     real line in main.go (line 19, not the
+#                     RegisterRoutes wrapper line).
+#   - GET /profile  — second named handler in handlers.go.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("request.QueryParams.Get", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("response.JSON", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("response.JSON", line: 19))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("response.JSON", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/goyave_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/iris_callees_spec.cr
+++ b/spec/functional_test/testers/go/iris_callees_spec.cr
@@ -1,0 +1,39 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Iris (#1366). Iris uses
+# `.Party(...)` for route groups; the route extractor handles that via
+# `group_method: "Party"`, and callee wiring is identical to Gin/Hertz
+# (with the same ANY-verb fan-out branch).
+#
+# Coverage:
+#   - POST /users   — named handler `createUser` in sibling
+#                     `handlers.go`; cross-file lookup.
+#   - GET /healthz  — inline closure in main.go.
+#   - GET /profile  — second named handler in handlers.go.
+#
+# This fixture does not exercise the ANY-route fan-out path; the
+# callee push lives in both branches of iris.cr, but adding an
+# `.Any("/x", h)` here would just re-state the same assertion N times.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("ctx.PostValue", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("ctx.JSON", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("ctx.JSON", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("ctx.JSON", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/iris_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -6,6 +6,12 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
+      # Pre-pass for cross-file identifier-handler resolution. Goyave
+      # doesn't use the route extractor's cross-file group fixpoint, so
+      # we build the file_contents hash via a dedicated helper rather
+      # than piggy-backing on `collect_package_groups_ts`.
+      file_contents = read_package_file_contents
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -41,6 +47,12 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     # `router.Static(&fs, "/prefix", false)` — the first
                     # `/`-prefixed string arg is both URL prefix and (with
                     # leading slash stripped) disk path.
@@ -63,6 +75,12 @@ module Analyzer::Go
                           clean_path = route.path.gsub(/\{([a-zA-Z0-9_]+):[^}]+\}/, "{\\1}")
 
                           new_endpoint = Endpoint.new(clean_path, verb, details)
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                           result << new_endpoint
                           last_endpoint = new_endpoint
 

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -8,6 +8,8 @@ module Analyzer::Go
       # Iris uses `.Party(...)` for route groups; pass that into both the
       # engine's fixpoint group collection and the per-file extractor.
       package_groups, file_contents = collect_package_groups_ts("Party")
+      # Pre-pass for cross-file identifier-handler resolution (see Gin).
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -36,20 +38,35 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))
 
                       if ts_hits = routes_by_line[index]?
                         ts_hits.each do |route|
                           normalized = normalize_iris_path(route.path)
+                          callee_entries = callees_by_route[route.line]?
                           if route.verb == "ANY"
                             HTTP_METHODS.each do |m|
                               new_endpoint = Endpoint.new(normalized, m, details)
+                              callee_entries.try &.each do |entry|
+                                name, callee_path, callee_line = entry
+                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                              end
                               result << new_endpoint
                               last_endpoint = new_endpoint
                             end
                           else
                             new_endpoint = Endpoint.new(normalized, route.verb, details)
+                            callee_entries.try &.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
                             result << new_endpoint
                             last_endpoint = new_endpoint
                           end

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -93,6 +93,23 @@ module Analyzer::Go
       package_function_bodies[dir]? || Hash(String, Noir::GoCalleeExtractor::FunctionBody).new
     end
 
+    # Read every `.go` file once into a `{path => source}` hash. Used by
+    # analyzers (Goyave) that don't otherwise call
+    # `collect_package_groups_ts` but still need the file_contents hash
+    # as input to `collect_package_function_bodies`.
+    def read_package_file_contents : Hash(String, String)
+      file_contents = Hash(String, String).new
+      get_files_by_extension(".go").each do |path|
+        next if File.directory?(path)
+        begin
+          file_contents[path] = File.read(path, encoding: "utf-8", invalid: :skip)
+        rescue File::NotFoundError
+          # skip
+        end
+      end
+      file_contents
+    end
+
     # --- Adapter helpers (shared across Go framework adapters) ----------
 
     def add_param_to_endpoint(param : Param, endpoint : Endpoint)


### PR DESCRIPTION
Continuation of #1366. Two more Go frameworks join the callee coverage. Both use `TreeSitterGoRouteExtractor.extract_routes` with framework-specific group methods (`Party` for Iris, `Subrouter` + `group_aliases: ["Group"]` for Goyave), so the wiring is the same 3-step change as Gin/Echo/Fiber/Hertz with one supporting helper added to `GoEngine`.

## Per-analyzer
- **`iris.cr`** — wires callees in both branches of the emit loop (`route.verb == "ANY"` fan-out and the single-verb default), same shape as Hertz so `.Any("/x", h)` routes also carry callees.
- **`goyave.cr`** — Goyave doesn't use the route extractor's cross-file group fixpoint, so its existing `analyze()` builds no `file_contents` map. Added a small `GoEngine#read_package_file_contents` helper that just reads every `.go` file once into a hash, then fed that into `collect_package_function_bodies`. Goyave's existing per-file group resolution semantics stay unchanged.
- **`go_engine.cr`** — adds the `read_package_file_contents` helper. Future analyzers that need the file_contents hash without going through the group fixpoint can use it directly.

## Coverage
- `iris_callees/` and `goyave_callees/` fixtures, each with `main.go` + sibling `handlers.go` + `helpers.go`. Three handler-resolution paths per framework: inline closure, named local handler, named sibling handler.
- The Goyave spec also covers a 2-level selector chain callee (`request.QueryParams.Get`), confirming that dotted callee names are reconstructed cleanly through nested `selector_expression` nodes.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/{iris,goyave}_callees_spec.cr` — 48 assertions, 0 failures.
- [x] `just test` — 6649 examples, 0 failures.
- [x] `just check` — 754 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.