### PR TITLE
feat(go): wire callees through Chi and GoFrame

### DIFF
--- a/spec/functional_test/fixtures/go/chi_callees/go.mod
+++ b/spec/functional_test/fixtures/go/chi_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/chi-callees-fixture
+
+go 1.23.0
+
+require github.com/go-chi/chi/v5 v5.1.0

--- a/spec/functional_test/fixtures/go/chi_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/chi_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+)
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	name := r.FormValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	w.Write([]byte(user))
+}
+
+func listProfile(w http.ResponseWriter, r *http.Request) {
+	data := buildProfile()
+	auditLog(data)
+	w.Write([]byte(data))
+}

--- a/spec/functional_test/fixtures/go/chi_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/chi_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/chi_callees/main.go
+++ b/spec/functional_test/fixtures/go/chi_callees/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	r := chi.NewRouter()
+	r.Post("/users", createUser)
+	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	r.Route("/profile", func(r chi.Router) {
+		r.Get("/", listProfile)
+	})
+	http.ListenAndServe(":8080", r)
+}

--- a/spec/functional_test/fixtures/go/gf_callees/go.mod
+++ b/spec/functional_test/fixtures/go/gf_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/gf-callees-fixture
+
+go 1.23.0
+
+require github.com/gogf/gf/v2 v2.7.4

--- a/spec/functional_test/fixtures/go/gf_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/gf_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gogf/gf/v2/net/ghttp"
+)
+
+func createUser(r *ghttp.Request) {
+	name := r.GetQuery("name")
+	user := saveUser(name.String())
+	auditLog(user)
+	r.Response.Write(user)
+}
+
+func listProfile(r *ghttp.Request) {
+	data := buildProfile()
+	auditLog(data)
+	r.Response.Write(data)
+}

--- a/spec/functional_test/fixtures/go/gf_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/gf_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/gf_callees/main.go
+++ b/spec/functional_test/fixtures/go/gf_callees/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/net/ghttp"
+)
+
+func main() {
+	s := g.Server()
+	s.BindHandler("/users", createUser)
+	s.BindHandler("/healthz", func(r *ghttp.Request) {
+		r.Response.Write("ok")
+	})
+	s.Group("/api", func(group *ghttp.RouterGroup) {
+		group.GET("/profile", listProfile)
+	})
+	s.Run()
+}

--- a/spec/functional_test/testers/go/chi_callees_spec.cr
+++ b/spec/functional_test/testers/go/chi_callees_spec.cr
@@ -1,0 +1,46 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Chi (#1366). Chi uses
+# closure-scoped routing (`r.Route("/prefix", func(r chi.Router){...})`)
+# so a verb call's `route.line` lives inside a nested closure body.
+# `GoCalleeExtractor.callees_for_routes` walks the full file's AST and
+# filters by row, so nested call_expressions resolve normally.
+#
+# Coverage:
+#   - POST /users    — named handler `createUser` in sibling
+#                      `handlers.go`; cross-file lookup.
+#   - GET /healthz   — inline `func(w http.ResponseWriter, ...)` in
+#                      main.go.
+#   - GET /profile/  — `r.Route("/profile", func(r chi.Router){
+#                      r.Get("/", listProfile) })`; locks in that
+#                      callees attach to the inner verb call inside a
+#                      Chi closure-scoped group. Trailing slash matches
+#                      Chi extractor's path joining.
+#
+# Mount-expanded routes (`r.Mount("/admin", adminRouter())`) do NOT
+# get callees in this first cut — `analyze_router_function` runs its
+# own isolated route walk and would need separate wiring. Tracking
+# that as a follow-up in #1366.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("r.FormValue", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("w.Write", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("w.Write", line: 13))
+  end,
+
+  Endpoint.new("/profile/", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("w.Write", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/chi_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/gf_callees_spec.cr
+++ b/spec/functional_test/testers/go/gf_callees_spec.cr
@@ -1,0 +1,45 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on GoFrame (Gf, #1366). Gf
+# uses three route shapes; this fixture exercises two of them plus
+# the closure-scoped group flavor:
+#
+#   - GET /users         — `s.BindHandler("/users", createUser)`. Gf's
+#                          BindHandler accepts any HTTP method and
+#                          gf.cr folds the resulting "ALL" verb down to
+#                          GET. Callees come from `createUser` in
+#                          sibling `handlers.go`. The body also
+#                          contains `name.String()` nested inside
+#                          `saveUser(...)`, so we get a 5-callee list —
+#                          locks in that nested-call expressions still
+#                          surface their 1-hop callees.
+#   - GET /healthz       — `s.BindHandler("/healthz", func(r ...){...})`,
+#                          inline closure in main.go.
+#   - GET /api/profile   — `s.Group("/api", func(group ...){
+#                          group.GET("/profile", listProfile) })`.
+#                          Locks in the closure-scoped group prefix
+#                          (`/api`) + named handler from sibling file.
+expected_endpoints = [
+  Endpoint.new("/users", "GET").tap do |ep|
+    ep.push_callee(Callee.new("r.GetQuery", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("name.String", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("r.Response.Write", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("r.Response.Write", line: 12))
+  end,
+
+  Endpoint.new("/api/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("r.Response.Write", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/gf_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/go_callee_extractor"
 require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
@@ -47,6 +48,16 @@ module Analyzer::Go
         end
       end
 
+      # Pre-pass for cross-file identifier-handler resolution (see Gin).
+      # Chi extends `Analyzer` directly (not `GoEngine`), so we use the
+      # module-level twins on `GoCalleeExtractor` instead of the engine
+      # instance methods. Mount-expanded routes don't pick up callees
+      # in this first cut — `analyze_router_function` runs its own
+      # isolated route walk and would need separate wiring. Tracking
+      # that as a follow-up; for now Mount endpoints keep an empty
+      # callees list.
+      package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies(file_contents_cache)
+
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, ".go")
@@ -76,6 +87,16 @@ module Analyzer::Go
                     routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
                     routes_by_line[r.line] << r
                   end
+
+                  # Resolve 1-hop callees for every route in this file.
+                  # Inline-closure handlers (the common Chi shape inside
+                  # `r.Route("/x", func(r chi.Router){ r.Get(...) })`)
+                  # walk in place; bare identifier handlers fall through
+                  # to sibling-file function bodies via the per-directory map.
+                  route_rows = Set(Int32).new
+                  routes_by_line.each_key { |row| route_rows << row }
+                  external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, dir)
+                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
 
                   state = ChiRouteState.new
                   last_endpoint = Endpoint.new("", "")
@@ -129,6 +150,12 @@ module Analyzer::Go
                     if ts_hits = routes_by_line[index]?
                       ts_hits.each do |route|
                         endpoint = Endpoint.new(route.path, route.verb, details)
+                        if entries = callees_by_route[route.line]?
+                          entries.each do |entry|
+                            name, callee_path, callee_line = entry
+                            endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                          end
+                        end
                         result << endpoint
                         last_endpoint = endpoint
                       end

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -6,6 +6,12 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
+      # Pre-pass for cross-file identifier-handler resolution. Gf
+      # doesn't use the route extractor's cross-file group fixpoint
+      # (its closure-scoped walker handles groups directly), so we
+      # build the file_contents hash via a dedicated helper.
+      file_contents = read_package_file_contents
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, ".go")
@@ -34,6 +40,12 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))
 
@@ -43,6 +55,12 @@ module Analyzer::Go
                           # fixtures expect GET, so fold "ALL" down.
                           verb = route.verb == "ALL" ? "GET" : route.verb
                           new_endpoint = Endpoint.new(route.path, verb, details)
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                           result << new_endpoint
                           last_endpoint = new_endpoint
                         end

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -59,6 +59,31 @@ module Noir::GoCalleeExtractor
     "bool", "error",
   }
 
+  # Walk every cached `.go` source in `file_contents` and collect
+  # top-level `function_declaration` nodes into a per-directory map
+  # so cross-file identifier-handler resolution is O(1) at lookup
+  # time. Keyed by directory because Go's name resolution is scoped
+  # to a single package (== single directory). Module-level twin of
+  # `GoEngine#collect_package_function_bodies` for analyzers (Chi)
+  # that don't inherit from `GoEngine`.
+  def package_function_bodies(file_contents : Hash(String, String)) : Hash(String, Hash(String, FunctionBody))
+    bodies = Hash(String, Hash(String, FunctionBody)).new
+    file_contents.each do |path, content|
+      dir = File.dirname(path)
+      fns = collect_function_bodies(content, path)
+      next if fns.empty?
+      bodies[dir] ||= Hash(String, FunctionBody).new
+      fns.each { |name, fb| bodies[dir][name] ||= fb }
+    end
+    bodies
+  end
+
+  # Returns the cross-file function-body map for the given directory,
+  # or an empty map. Mirrors `GoEngine#ts_function_bodies_for_directory`.
+  def function_bodies_for_directory(package_bodies : Hash(String, Hash(String, FunctionBody)), dir : String) : Hash(String, FunctionBody)
+    package_bodies[dir]? || Hash(String, FunctionBody).new
+  end
+
   # Returns top-level function declarations in `source`, keyed by name.
   # `file_path` is recorded on each `FunctionBody` so callees emitted by
   # later re-parsing can report a useful path.


### PR DESCRIPTION
Continuation of #1366 — closure-scoped Go frameworks join the callee coverage. Chi and Gf use a different route extractor (`extract_chi_routes` / `extract_gf_routes`) that walks closure bodies with a prefix stack rather than the flat verb-call shape used by Gin/Echo/etc. The good news: `route.line` still points at the inner verb call_expression, so `GoCalleeExtractor.callees_for_routes` matches them by row exactly like the simpler analyzers.

## Per-analyzer

- **`chi.cr`** — Chi extends `Analyzer` directly (not `GoEngine`), so it can't call the engine's `collect_package_function_bodies` / `ts_function_bodies_for_directory` helpers. Added module-level twins on `GoCalleeExtractor` (`package_function_bodies` / `function_bodies_for_directory`) so Chi (and any future non-GoEngine analyzer) gets the same shape via the module without inheritance restructuring. Existing pre-scan already builds `file_contents_cache`; we feed that directly into the module helper. **Mount-expanded routes** (`r.Mount("/admin", adminRouter())`) are intentionally out of scope for this first cut — `analyze_router_function` runs its own isolated route walk and would need separate wiring; tracking as a follow-up.
- **`gf.cr`** — Goyave-style wiring: use the existing `read_package_file_contents` helper on `GoEngine` to build `file_contents`, then `collect_package_function_bodies`. All three Gf route shapes (`BindHandler`, closure groups, chained groups) pick up callees because the extractor's `route.line` already points at the verb call regardless of shape.

## Coverage
- `chi_callees/` exercises a Chi `r.Route("/profile", func(r chi.Router){ r.Get("/", listProfile) })` block plus plain verb call plus inline closure handler.
- `gf_callees/` exercises `s.BindHandler(...)` with named handler, BindHandler with inline closure, and `s.Group("/api", func(group ...){ group.GET(...) })` closure-scoped group with named handler.
- The Gf spec also locks in that a nested call expression (`saveUser(name.String())`) emits both `saveUser` and `name.String` as 1-hop callees.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/{chi,gf}_callees_spec.cr` — 50 assertions, 0 failures.
- [x] `just test` — 6699 examples, 0 failures.
- [x] `just check` — 756 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.