### PR TITLE
feat(go): wire callees through Mux and httprouter

### DIFF
--- a/spec/functional_test/fixtures/go/httprouter_callees/go.mod
+++ b/spec/functional_test/fixtures/go/httprouter_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/httprouter-callees-fixture
+
+go 1.23.0
+
+require github.com/julienschmidt/httprouter v1.3.0

--- a/spec/functional_test/fixtures/go/httprouter_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/httprouter_callees/handlers.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func createUser(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	name := r.FormValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	w.Write([]byte(user))
+}
+
+func listProfile(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	data := buildProfile()
+	auditLog(data)
+	w.Write([]byte(data))
+}

--- a/spec/functional_test/fixtures/go/httprouter_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/httprouter_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/httprouter_callees/main.go
+++ b/spec/functional_test/fixtures/go/httprouter_callees/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func main() {
+	r := httprouter.New()
+	r.POST("/users", createUser)
+	r.GET("/healthz", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		w.Write([]byte("ok"))
+	})
+	r.Handle("GET", "/profile", listProfile)
+	http.ListenAndServe(":8080", r)
+}

--- a/spec/functional_test/fixtures/go/mux_callees/go.mod
+++ b/spec/functional_test/fixtures/go/mux_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/mux-callees-fixture
+
+go 1.23.0
+
+require github.com/gorilla/mux v1.8.1

--- a/spec/functional_test/fixtures/go/mux_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/mux_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+)
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	name := r.FormValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	w.Write([]byte(user))
+}
+
+func listProfile(w http.ResponseWriter, r *http.Request) {
+	data := buildProfile()
+	auditLog(data)
+	w.Write([]byte(data))
+}

--- a/spec/functional_test/fixtures/go/mux_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/mux_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/mux_callees/main.go
+++ b/spec/functional_test/fixtures/go/mux_callees/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/users", createUser).Methods("POST")
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("ok"))
+	}).Methods("GET")
+	r.HandleFunc("/profile", listProfile).Methods("GET")
+	http.ListenAndServe(":8080", r)
+}

--- a/spec/functional_test/testers/go/httprouter_callees_spec.cr
+++ b/spec/functional_test/testers/go/httprouter_callees_spec.cr
@@ -1,0 +1,48 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on httprouter (#1366).
+# Httprouter has two route shapes that the analyzer threads through
+# `extract_routes(handle_method: "Handle")`:
+#
+#   1. Verb-method form: `r.GET("/x", h)` / `r.POST("/x", h)` etc.
+#   2. Method-first form: `r.Handle("METHOD", "/x", h)`.
+#
+# `find_handler_arg` in `GoCalleeExtractor` picks the first non-string
+# positional arg after the path string, which works for both shapes
+# transparently (Handle has two leading strings, then the handler).
+#
+# httprouter extends `Analyzer` directly (not `GoEngine`), so the
+# analyzer builds `file_contents` inline and uses the module-level
+# twins on `GoCalleeExtractor` — this spec confirms that path
+# resolves cross-file handlers correctly.
+#
+# Coverage:
+#   - POST /users   — verb-method form, named handler in sibling
+#                     `handlers.go`.
+#   - GET /healthz  — verb-method form with inline closure handler.
+#   - GET /profile  — method-first form `r.Handle("GET", "/profile",
+#                     listProfile)`, second named handler in sibling
+#                     file.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("r.FormValue", line: 10))
+    ep.push_callee(Callee.new("saveUser", line: 11))
+    ep.push_callee(Callee.new("auditLog", line: 12))
+    ep.push_callee(Callee.new("w.Write", line: 13))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("w.Write", line: 13))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 17))
+    ep.push_callee(Callee.new("auditLog", line: 18))
+    ep.push_callee(Callee.new("w.Write", line: 19))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/httprouter_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/mux_callees_spec.cr
+++ b/spec/functional_test/testers/go/mux_callees_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Gorilla Mux (#1366). Mux uses
+# the `r.HandleFunc("/x", h).Methods("GET")` chain — verb comes from
+# the outer `.Methods(...)` call. The route extractor records
+# `route.line` on the inner HandleFunc call_expression, so the
+# row-keyed callee lookup matches it. Both inline-closure and named
+# handler resolutions go through the same path.
+#
+# Coverage:
+#   - POST /users   — `r.HandleFunc("/users", createUser).Methods("POST")`
+#                     with named handler in sibling `handlers.go`.
+#   - GET /healthz  — same chain shape with an inline closure handler
+#                     in main.go.
+#   - GET /profile  — second named handler in handlers.go.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("r.FormValue", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("w.Write", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("w.Write", line: 13))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("w.Write", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/mux_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/go_callee_extractor"
 require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
@@ -13,6 +14,21 @@ module Analyzer::Go
 
     def analyze
       # Source Analysis
+      # Pre-pass for cross-file identifier-handler resolution.
+      # Httprouter extends `Analyzer` directly (not `GoEngine`), so we
+      # build the file_contents hash inline and use the module-level
+      # twins on `GoCalleeExtractor`.
+      file_contents = Hash(String, String).new
+      get_files_by_extension(".go").each do |fp|
+        next if File.directory?(fp)
+        begin
+          file_contents[fp] = File.read(fp, encoding: "utf-8", invalid: :skip)
+        rescue File::NotFoundError
+          # skip
+        end
+      end
+      package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies(file_contents)
+
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, ".go")
@@ -44,12 +60,29 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route. `find_handler_arg`
+                    # in `GoCalleeExtractor` picks the first non-string
+                    # positional arg after the path string, which works
+                    # for httprouter's both shapes: `r.GET("/x", h)` (path
+                    # then handler) and `r.Handle("METHOD", "/x", h)` (two
+                    # leading strings then handler).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))
 
                       if ts_hits = routes_by_line[index]?
                         ts_hits.each do |route|
                           last_endpoint = add_endpoint(route.path, route.verb, details)
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              last_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                         end
                       end
 

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -10,6 +10,11 @@ module Analyzer::Go
       # treats "Subrouter" as the grouping method and peeks through the
       # chain to read the PathPrefix argument.
       package_groups, file_contents = collect_package_groups_ts("Subrouter")
+      # Pre-pass for cross-file identifier-handler resolution (see Gin).
+      # Mux's HandleFunc/Methods chain stores `route.line` on the
+      # HandleFunc call_expression itself, so the row-keyed callee
+      # lookup matches it cleanly.
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, ".go")
@@ -39,6 +44,12 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     # Mux static-file: `r.PathPrefix("/x/").Handler(... http.Dir("./x/") ...)`
                     Noir::TreeSitterGoRouteExtractor.extract_mux_statics(content).each do |sp|
                       public_dirs << {"static_path" => sp.url_prefix, "file_path" => sp.disk_path}
@@ -54,6 +65,12 @@ module Analyzer::Go
                           # required query params; bind them to the endpoint.
                           route.query_params.each do |qp|
                             new_endpoint.params << Param.new(qp, "", "query")
+                          end
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
                           end
                           result << new_endpoint
                           last_endpoint = new_endpoint


### PR DESCRIPTION
Continuation of #1366 — method-first/chain Go routers join the callee coverage. Both analyzers thread their non-trivial routing shapes through `TreeSitterGoRouteExtractor.extract_routes(...)` (with `handlefunc_methods: true` for Mux, `handle_method: "Handle"` for httprouter); `route.line` still points at the verb-bearing call_expression, so `GoCalleeExtractor.callees_for_routes` matches them by row exactly like the simpler analyzers.

## Per-analyzer

- **`mux.cr`** — extends `GoEngine`, already calls `collect_package_groups_ts("Subrouter")` so the existing `file_contents` map feeds directly into `collect_package_function_bodies`. Mux's `r.HandleFunc("/x", h).Methods("POST")` chain stores `route.line` on the inner HandleFunc call_expression, and `find_handler_arg` correctly picks `h` as the first non-string positional arg after the path. The outer `.Methods("...")` call has only string args so it contributes nothing to the callee map — by design.
- **`httprouter.cr`** — extends `Analyzer` directly (not `GoEngine`), so the analyzer builds `file_contents` inline and uses the module-level twins on `GoCalleeExtractor` (`package_function_bodies` / `function_bodies_for_directory`). `find_handler_arg` handles both httprouter shapes transparently: for `r.GET("/x", h)` it skips one path string then returns h; for `r.Handle("METHOD", "/x", h)` it skips two leading strings then returns h.

## Coverage
- `mux_callees/` exercises the HandleFunc/Methods chain with both named and inline-closure handlers.
- `httprouter_callees/` exercises both the verb-method (`r.POST("/users", h)`) and method-first (`r.Handle("GET", "/profile", h)`) shapes.
- Line assertions verify the row arithmetic for both.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/{mux,httprouter}_callees_spec.cr` — 48 assertions, 0 failures.
- [x] `just test` — 6747 examples, 0 failures.
- [x] `just check` — 758 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.