### PR TITLE
feat(go): wire callees through fasthttp

### DIFF
--- a/spec/functional_test/fixtures/go/fasthttp_callees/go.mod
+++ b/spec/functional_test/fixtures/go/fasthttp_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/fasthttp-callees-fixture
+
+go 1.23.0
+
+require github.com/valyala/fasthttp v1.55.0

--- a/spec/functional_test/fixtures/go/fasthttp_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/fasthttp_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/valyala/fasthttp"
+)
+
+func createUser(ctx *fasthttp.RequestCtx) {
+	name := string(ctx.FormValue("name"))
+	user := saveUser(name)
+	auditLog(user)
+	ctx.WriteString(user)
+}
+
+func listProfile(ctx *fasthttp.RequestCtx) {
+	data := buildProfile()
+	auditLog(data)
+	ctx.WriteString(data)
+}

--- a/spec/functional_test/fixtures/go/fasthttp_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/fasthttp_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/fasthttp_callees/main.go
+++ b/spec/functional_test/fixtures/go/fasthttp_callees/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/valyala/fasthttp"
+)
+
+// Minimal router stub mirroring the verb-method shape `extract_routes`
+// recognises for fasthttp (`<router>.GET("/path", handler)` etc.).
+type Router struct{}
+
+func (r *Router) GET(path string, handler func(*fasthttp.RequestCtx))  {}
+func (r *Router) POST(path string, handler func(*fasthttp.RequestCtx)) {}
+
+func main() {
+	router := &Router{}
+	router.POST("/users", createUser)
+	router.GET("/healthz", func(ctx *fasthttp.RequestCtx) {
+		ctx.WriteString("ok")
+	})
+	router.GET("/profile", listProfile)
+	fasthttp.ListenAndServe(":8080", nil)
+}

--- a/spec/functional_test/testers/go/fasthttp_callees_spec.cr
+++ b/spec/functional_test/testers/go/fasthttp_callees_spec.cr
@@ -1,0 +1,40 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on fasthttp (#1366). Fasthttp
+# extends `Analyzer` directly (not `GoEngine`), so the analyzer builds
+# `file_contents` inline at analyze() entry and uses the module-level
+# twins on `GoCalleeExtractor` (same shape as Chi and httprouter).
+#
+# Coverage:
+#   - POST /users   — named handler `createUser` in sibling
+#                     `handlers.go`; the body also contains a
+#                     `string(ctx.FormValue("name"))` type-conversion
+#                     wrap, locking in that the `string` builtin is
+#                     filtered while `ctx.FormValue` still surfaces as
+#                     a callee on its own.
+#   - GET /healthz  — inline `func(ctx *fasthttp.RequestCtx)` closure
+#                     handler in main.go.
+#   - GET /profile  — second named handler in handlers.go.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("ctx.FormValue", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("ctx.WriteString", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("ctx.WriteString", line: 18))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("ctx.WriteString", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/fasthttp_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/go_callee_extractor"
 require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
@@ -9,6 +10,22 @@ module Analyzer::Go
         # Pulls from the detector-built file_map so subtree pruning and
         # --exclude-path apply to this pass too.
         go_files = get_files_by_extension(".go")
+
+        # Pre-pass for cross-file identifier-handler resolution.
+        # Fasthttp extends `Analyzer` directly (not `GoEngine`), so we
+        # build the file_contents hash inline and use the module-level
+        # twins on `GoCalleeExtractor`.
+        file_contents = Hash(String, String).new
+        go_files.each do |fp|
+          next if File.directory?(fp)
+          begin
+            file_contents[fp] = read_file_content(fp)
+          rescue File::NotFoundError
+            # skip
+          end
+        end
+        package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies(file_contents)
+
         base_paths.each do |current_base_path|
           base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
           go_files.each do |path|
@@ -32,12 +49,24 @@ module Analyzer::Go
                 routes_by_line[r.line] << r
               end
 
+              # Resolve 1-hop callees for every route (see Gin).
+              route_rows = Set(Int32).new
+              routes_by_line.each_key { |row| route_rows << row }
+              external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
+              callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
               content.each_line.with_index do |line, index|
                 details = Details.new(PathInfo.new(path, index + 1))
 
                 if ts_hits = routes_by_line[index]?
                   ts_hits.each do |route|
                     endpoint = Endpoint.new(route.path, route.verb, details)
+                    if entries = callees_by_route[route.line]?
+                      entries.each do |entry|
+                        name, callee_path, callee_line = entry
+                        endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                      end
+                    end
                     result << endpoint
                     last_endpoint = endpoint
                   end


### PR DESCRIPTION
Continuation of #1366. Fasthttp uses the verb-method route shape (`<router>.GET("/path", handler)`) that `extract_routes` already recognises; only the wiring on the analyzer side was missing.

Fasthttp extends `Analyzer` directly (not `GoEngine`), so the analyzer builds `file_contents` inline at analyze() entry and uses the module-level twins on `GoCalleeExtractor` — same shape as Chi and httprouter.

## Coverage
`fasthttp_callees/` exercises all three handler-resolution paths:
- Inline `func(ctx *fasthttp.RequestCtx)` closure (in main.go).
- Named handler in sibling `handlers.go` resolved via the package map.
- Second named handler in the same sibling file, scoped to its own body.

The `createUser` body wraps the form value in `string(ctx.FormValue("name"))`, locking in that the `string` builtin gets filtered while `ctx.FormValue` still surfaces as its own callee through the nested call.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/fasthttp_callees_spec.cr` — 24 assertions, 0 failures.
- [x] `crystal spec spec/functional_test/testers/go/fasthttp_spec.cr` — existing 88 examples unchanged.
- [x] `just test` — 6771 examples, 0 failures.
- [x] `just check` — 759 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.