### PR TITLE
feat(go): wire callees through Beego

### DIFF
--- a/spec/functional_test/fixtures/go/beego_callees/go.mod
+++ b/spec/functional_test/fixtures/go/beego_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/beego-callees-fixture
+
+go 1.23.0
+
+require github.com/beego/beego/v2 v2.3.4

--- a/spec/functional_test/fixtures/go/beego_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/beego_callees/handlers.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	beegoctx "github.com/beego/beego/v2/server/web/context"
+)
+
+func createUser(ctx *beegoctx.Context) {
+	name := ctx.Input.Query("name")
+	user := saveUser(name)
+	auditLog(user)
+	ctx.Output.Body([]byte(user))
+}
+
+func listProfile(ctx *beegoctx.Context) {
+	data := buildProfile()
+	auditLog(data)
+	ctx.Output.Body([]byte(data))
+}

--- a/spec/functional_test/fixtures/go/beego_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/beego_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/beego_callees/main.go
+++ b/spec/functional_test/fixtures/go/beego_callees/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/beego/beego/v2/server/web"
+	beegoctx "github.com/beego/beego/v2/server/web/context"
+)
+
+func main() {
+	web.Post("/users", createUser)
+	web.Get("/healthz", func(ctx *beegoctx.Context) {
+		ctx.Output.Body([]byte("ok"))
+	})
+	web.Get("/profile", listProfile)
+	web.Run()
+}

--- a/spec/functional_test/testers/go/beego_callees_spec.cr
+++ b/spec/functional_test/testers/go/beego_callees_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Beego (#1366). Beego uses
+# the verb-method shape (`web.Get("/x", h)` / `web.Post("/x", h)`)
+# that `extract_routes` already recognises; only the wiring on the
+# analyzer side was missing. Beego inherits from `GoEngine`, so it
+# uses the engine helpers (`read_package_file_contents` +
+# `collect_package_function_bodies`) — the same pattern as Goyave.
+#
+# Coverage:
+#   - POST /users   — named handler `createUser` in sibling
+#                     `handlers.go`; exercises a 2-level selector
+#                     chain on the receiver (`ctx.Input.Query`,
+#                     `ctx.Output.Body`), locking in that dotted
+#                     callee names are reconstructed cleanly.
+#   - GET /healthz  — inline `func(ctx *context.Context)` closure in
+#                     main.go.
+#   - GET /profile  — second named handler in handlers.go.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("ctx.Input.Query", line: 8))
+    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("ctx.Output.Body", line: 11))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("ctx.Output.Body", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 15))
+    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("ctx.Output.Body", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/beego_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -6,6 +6,12 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
+      # Pre-pass for cross-file identifier-handler resolution. Beego's
+      # `web.Get("/x", h)` shape is picked up by `extract_routes`, and
+      # callee resolution wires identical to Gin/Echo/etc. Beego doesn't
+      # use group routes, so we just need file_contents — no fixpoint.
+      file_contents = read_package_file_contents
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -31,12 +37,24 @@ module Analyzer::Go
                       routes_by_line[r.line] << r
                     end
 
+                    # Resolve 1-hop callees for every route (see Gin).
+                    route_rows = Set(Int32).new
+                    routes_by_line.each_key { |row| route_rows << row }
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))
 
                       if ts_hits = routes_by_line[index]?
                         ts_hits.each do |route|
                           new_endpoint = Endpoint.new(route.path, route.verb, details)
+                          if entries = callees_by_route[route.line]?
+                            entries.each do |entry|
+                              name, callee_path, callee_line = entry
+                              new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                            end
+                          end
                           result << new_endpoint
                           last_endpoint = new_endpoint
                         end


### PR DESCRIPTION
Continuation of #1366. Beego turns out to be the simple verb-method shape (`web.Get("/x", h)` / `web.Post("/x", h)`) that `extract_routes` already recognises — only the wiring on the analyzer side was missing. Beego inherits from `GoEngine`, so it uses the engine helpers (`read_package_file_contents` + `collect_package_function_bodies`), the same pattern as Goyave.

## Coverage
`beego_callees/` exercises all three handler-resolution paths:
- Inline `func(ctx *context.Context)` closure (in main.go).
- Named handler in sibling `handlers.go` resolved via the package map.
- Second named handler in the same sibling file, scoped to its own body.

The createUser body uses 2-level selector chains on the context (`ctx.Input.Query`, `ctx.Output.Body`), locking in that dotted callee names are reconstructed cleanly through nested `selector_expression` nodes.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/beego_callees_spec.cr` — 24 assertions, 0 failures.
- [x] `crystal spec spec/functional_test/testers/go/beego_spec.cr` — existing 10 examples unchanged.
- [x] `just test` — 6795 examples, 0 failures.
- [x] `just check` — 760 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.