### PR TITLE
feat(go): wire callees through go-zero

### DIFF
--- a/spec/functional_test/fixtures/go/gozero_callees/go.mod
+++ b/spec/functional_test/fixtures/go/gozero_callees/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/gozero-callees-fixture
+
+go 1.23.0
+
+require github.com/zeromicro/go-zero v1.7.4

--- a/spec/functional_test/fixtures/go/gozero_callees/handlers.go
+++ b/spec/functional_test/fixtures/go/gozero_callees/handlers.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func createUser(w http.ResponseWriter, r *http.Request) {
+	name := r.FormValue("name")
+	user := saveUser(name)
+	auditLog(user)
+	httpx.OkJson(w, map[string]string{"id": user})
+}
+
+func listProfile(w http.ResponseWriter, r *http.Request) {
+	data := buildProfile()
+	auditLog(data)
+	httpx.OkJson(w, map[string]string{"profile": data})
+}

--- a/spec/functional_test/fixtures/go/gozero_callees/helpers.go
+++ b/spec/functional_test/fixtures/go/gozero_callees/helpers.go
@@ -1,0 +1,12 @@
+package main
+
+func saveUser(name string) string {
+	return name
+}
+
+func auditLog(s string) {
+}
+
+func buildProfile() string {
+	return ""
+}

--- a/spec/functional_test/fixtures/go/gozero_callees/legacy.api
+++ b/spec/functional_test/fixtures/go/gozero_callees/legacy.api
@@ -1,0 +1,6 @@
+syntax = "v1"
+
+service legacy-api {
+    @handler GetLegacy
+    get /legacy
+}

--- a/spec/functional_test/fixtures/go/gozero_callees/main.go
+++ b/spec/functional_test/fixtures/go/gozero_callees/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func main() {
+	server := rest.MustNewServer(rest.RestConf{
+		Host: "localhost",
+		Port: 8888,
+	})
+	defer server.Stop()
+
+	server.Post("/users", createUser)
+	server.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		httpx.OkJson(w, map[string]bool{"ok": true})
+	})
+	server.Get("/profile", listProfile)
+
+	server.Start()
+}

--- a/spec/functional_test/testers/go/gozero_callees_spec.cr
+++ b/spec/functional_test/testers/go/gozero_callees_spec.cr
@@ -1,0 +1,47 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on go-zero (#1366). Gozero
+# handles two route declaration styles, and only one of them gets
+# callees:
+#
+#   - `.go` verb routes (`server.Get("/x", h)`) — picked up by
+#     `extract_routes`, callee extraction wires identically to
+#     Gin/Beego/etc.
+#   - `.api` DSL routes (`get /x (Request)` inside `service` blocks)
+#     — gozero's own templating language, NOT Go. There's no Go
+#     call_expression to extract a 1-hop graph from, so the spec
+#     locks in that `.api`-declared routes emit with an EMPTY callee
+#     list rather than failing or surfacing junk.
+#
+# Coverage:
+#   - POST /users   — named handler `createUser` in sibling
+#                     `handlers.go`.
+#   - GET /healthz  — inline closure in main.go.
+#   - GET /profile  — second named handler in handlers.go.
+#   - GET /legacy   — declared in `legacy.api` (DSL); zero callees.
+expected_endpoints = [
+  Endpoint.new("/users", "POST").tap do |ep|
+    ep.push_callee(Callee.new("r.FormValue", line: 10))
+    ep.push_callee(Callee.new("saveUser", line: 11))
+    ep.push_callee(Callee.new("auditLog", line: 12))
+    ep.push_callee(Callee.new("httpx.OkJson", line: 13))
+  end,
+
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("httpx.OkJson", line: 19))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 17))
+    ep.push_callee(Callee.new("auditLog", line: 18))
+    ep.push_callee(Callee.new("httpx.OkJson", line: 19))
+  end,
+
+  # No callees expected — `.api` files are a non-Go DSL, callees stay empty.
+  Endpoint.new("/legacy", "GET"),
+]
+
+FunctionalTester.new("fixtures/go/gozero_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -6,6 +6,15 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
+      # Pre-pass for cross-file identifier-handler resolution. Only
+      # `.go` routes (`server.Get("/x", h)` shape) get callees —
+      # gozero's `.api` files are a non-Go DSL that declares routes as
+      # `get /path (Request)` with an `@handler Name` directive; there's
+      # no Go call_expression to extract a 1-hop graph from.
+      # `read_package_file_contents` already filters to `.go`, so the
+      # function-body map naturally skips `.api`.
+      file_contents = read_package_file_contents
+      package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         populate_channel_with_filtered_files(channel, [".go", ".api"])
@@ -29,6 +38,7 @@ module Analyzer::Go
                     # pattern Gin uses, no groups in gozero's common idioms).
                     # .api files use a non-Go DSL — keep the legacy regex.
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
+                    callees_by_route = Hash(Int32, Array(Tuple(String, String, Int32))).new
                     if File.extname(path) == ".go"
                       Noir::TreeSitterGoRouteExtractor.extract_routes(content).each do |r|
                         next unless r.raw_path.starts_with?("/")
@@ -38,6 +48,12 @@ module Analyzer::Go
                       Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
                         public_dirs << {"static_path" => sp.url_prefix, "file_path" => sp.disk_path}
                       end
+
+                      # Resolve 1-hop callees for every .go route.
+                      route_rows = Set(Int32).new
+                      routes_by_line.each_key { |row| route_rows << row }
+                      external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                      callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
                     end
 
                     lines.each_with_index do |line, index|
@@ -59,6 +75,12 @@ module Analyzer::Go
                         if ts_hits = routes_by_line[index]?
                           ts_hits.each do |route|
                             new_endpoint = Endpoint.new(route.path, route.verb, details)
+                            if entries = callees_by_route[route.line]?
+                              entries.each do |entry|
+                                name, callee_path, callee_line = entry
+                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                              end
+                            end
                             result << new_endpoint
                             last_endpoint = new_endpoint
                           end


### PR DESCRIPTION
Continuation of #1366 — last Go analyzer joins the callee coverage (13/13).

Gozero handles two route declaration styles:
- **`.go` verb routes** (`server.Get("/x", h)`) — picked up by `extract_routes`. Callee wiring is identical to Beego/Goyave: GoEngine helpers (`read_package_file_contents` + `collect_package_function_bodies`).
- **`.api` DSL routes** (`get /x (Request)` inside `service` blocks) — gozero's own templating language, NOT Go. There's no Go call_expression to extract a 1-hop graph from, so `.api`-declared routes emit with an empty callee list. The dedicated spec locks that behaviour in alongside the `.go`-path assertions.

`read_package_file_contents` already filters to `.go`, so the function-body map naturally skips `.api`; no extra filtering needed inside the callee extractor.

## Coverage
`gozero_callees/` exercises all four handler shapes:
- Inline closure (`server.Get("/healthz", func(...){...})` in main.go).
- Named handler in sibling `handlers.go` resolved via the package map.
- Second named handler in the same sibling file.
- `.api`-only route (`get /legacy`) — emits with **zero callees**, locking in the "DSL has no Go calls" honest scope.

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/gozero_callees_spec.cr` — 26 assertions, 0 failures.
- [x] `crystal spec spec/functional_test/testers/go/gozero_spec.cr` — existing 26 examples unchanged.
- [x] `just test` — 6821 examples, 0 failures.
- [x] `just check` — 761 files, format + ameba clean.
- [x] `just build` — green.

Refs #1366.