### PR TITLE
feat(jvm): wire callees through Spring

### DIFF
--- a/spec/functional_test/fixtures/java/spring_callees/src/AuditLog.java
+++ b/spec/functional_test/fixtures/java/spring_callees/src/AuditLog.java
@@ -1,0 +1,6 @@
+package com.test;
+
+public class AuditLog {
+    public static void write(String message) {
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_callees/src/OrderController.java
+++ b/spec/functional_test/fixtures/java/spring_callees/src/OrderController.java
@@ -1,0 +1,20 @@
+package com.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    @GetMapping("/legacy")
+    public String legacy() {
+        AuditLog.write("legacy");
+        return getLegacy().toString();
+    }
+
+    private String getLegacy() {
+        return "legacy";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_callees/src/UserController.java
+++ b/spec/functional_test/fixtures/java/spring_callees/src/UserController.java
@@ -1,0 +1,35 @@
+package com.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService service;
+
+    public UserController(UserService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/")
+    public String createUser() {
+        String saved = service.save("hahwul");
+        AuditLog.write(saved);
+        return saved;
+    }
+
+    @GetMapping("/profile")
+    public String profile() {
+        String built = this.buildProfile();
+        AuditLog.write(built);
+        return built;
+    }
+
+    private String buildProfile() {
+        return "profile";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_callees/src/UserService.java
+++ b/spec/functional_test/fixtures/java/spring_callees/src/UserService.java
@@ -1,0 +1,7 @@
+package com.test;
+
+public class UserService {
+    public String save(String name) {
+        return name;
+    }
+}

--- a/spec/functional_test/testers/java/spring_callees_spec.cr
+++ b/spec/functional_test/testers/java/spring_callees_spec.cr
@@ -1,0 +1,43 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Spring (#1366). Spring is
+# the first JVM analyzer to grow callees, and the shape mirrors the
+# Python/Go path: a tree-sitter parse already produced for route and
+# parameter extraction is reused to walk the matching
+# `method_declaration` body for 1-hop `method_invocation` nodes.
+#
+# Cross-file definition resolution (e.g. `service.save` →
+# `UserServiceImpl.save`) is intentionally out of scope for this
+# first cut; `Callee#path` therefore points at the call site, matching
+# the honest scope on every other analyzer.
+#
+# Coverage:
+#   - POST /api/users/        — bare static (`AuditLog.write`) and
+#                               selector-on-identifier
+#                               (`service.save`) receivers.
+#   - GET  /api/users/profile — `this.foo` receiver shape.
+#   - GET  /api/orders/legacy — chained-on-call (`getLegacy().toString()`)
+#                               drops the outer `toString` and keeps
+#                               only the inner `getLegacy`, matching
+#                               the Python/Go chained-call noise filter.
+expected_endpoints = [
+  Endpoint.new("/api/users/", "POST").tap do |ep|
+    ep.push_callee(Callee.new("service.save", line: 20))
+    ep.push_callee(Callee.new("AuditLog.write", line: 21))
+  end,
+
+  Endpoint.new("/api/users/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 27))
+    ep.push_callee(Callee.new("AuditLog.write", line: 28))
+  end,
+
+  Endpoint.new("/api/orders/legacy", "GET").tap do |ep|
+    ep.push_callee(Callee.new("AuditLog.write", line: 13))
+    ep.push_callee(Callee.new("getLegacy", line: 14))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/spring_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/java_route_extractor_ts"
 require "../../../miniparsers/java_parameter_extractor_ts"
+require "../../../miniparsers/java_callee_extractor"
 
 module Analyzer::Java
   class Spring < Analyzer
@@ -105,6 +106,20 @@ module Analyzer::Java
                 endpoint = Endpoint.new(
                   join_paths(base_path, route.path), route.verb, parameters, details, is_feign_client
                 )
+
+                # 1-hop callees out of the handler method body. Cross-file
+                # definition resolution is intentionally out of scope —
+                # `Callee#path` points at the call site, matching every
+                # other analyzer's first-cut honest scope.
+                unless route.class_name.empty? || route.method_name.empty?
+                  Noir::JavaCalleeExtractor.callees_in_method(
+                    root, content, path, route.class_name, route.method_name
+                  ).each do |entry|
+                    name, callee_path, callee_line = entry
+                    endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                  end
+                end
+
                 @result << endpoint
               end
             end

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -1,0 +1,135 @@
+require "../ext/tree_sitter/tree_sitter"
+
+# Tree-sitter-backed Java 1-hop callee extractor. Parallels
+# `Noir::PythonCalleeExtractor` / `Noir::GoCalleeExtractor` for JVM
+# analyzers (Spring + framework-adapter siblings). Java's
+# `method_invocation` node carries the receiver in an `object` field
+# and the method name in a `name` field, so 1-hop extraction reduces
+# to:
+#
+#   1. Find the (class_name, method_name) `method_declaration` in the
+#      already-parsed root.
+#   2. Walk its body for `method_invocation` nodes.
+#   3. For each, reconstruct a textual callee:
+#        * `foo()`              → `foo`
+#        * `service.save(x)`    → `service.save`
+#        * `this.foo()`         → `this.foo`
+#        * `Foo.bar()` (static) → `Foo.bar`
+#        * `getFoo().bar()`     → "" (chained on a call — dropped as
+#                                 noise, mirroring the Python/Go
+#                                 chained-call filter)
+#
+# Cross-file definition resolution (e.g. `userService.save` →
+# `UserServiceImpl.save` in another file) is intentionally out of
+# scope for this first cut. `Callee#path` therefore points at the
+# call site, matching the honest scope on every other analyzer.
+module Noir::JavaCalleeExtractor
+  extend self
+
+  # Java keywords that show up as receivers but carry no useful
+  # callee signal on their own when stripped of the method name.
+  # Currently empty — `this`/`super` *do* surface (as
+  # `this.foo`/`super.foo`) and that's a useful prior; the receiver
+  # walker handles them explicitly.
+
+  # Find the matching method_declaration in `root` and return every
+  # 1-hop method_invocation callee inside its body as
+  # `{name, file_path, file_line_1_based}`. Empty array when the
+  # method can't be located or its body is missing.
+  def callees_in_method(root : LibTreeSitter::TSNode,
+                        source : String,
+                        file_path : String,
+                        class_name : String,
+                        method_name : String) : Array(Tuple(String, String, Int32))
+    sink = [] of Tuple(String, String, Int32)
+    return sink if class_name.empty? || method_name.empty?
+
+    method_node = find_method(root, source, class_name, method_name)
+    return sink unless method_node
+    body = Noir::TreeSitter.field(method_node, "body")
+    return sink unless body
+
+    walk(body) do |n|
+      next unless Noir::TreeSitter.node_type(n) == "method_invocation"
+      name = callee_text(n, source)
+      next if name.empty?
+      row = Noir::TreeSitter.node_start_row(n)
+      sink << {name, file_path, row + 1}
+    end
+    sink
+  end
+
+  # ---- private helpers -----------------------------------------------
+
+  private def callee_text(call : LibTreeSitter::TSNode, source : String) : String
+    name_node = Noir::TreeSitter.field(call, "name")
+    return "" unless name_node
+    name = Noir::TreeSitter.node_text(name_node, source)
+    return "" if name.empty?
+
+    object = Noir::TreeSitter.field(call, "object")
+    return name if object.nil?
+
+    receiver = receiver_text(object, source)
+    return "" if receiver.empty? # chained-on-call or unsupported receiver
+    "#{receiver}.#{name}"
+  end
+
+  # Reconstruct a dotted receiver text from `identifier` / `field_access`
+  # / `this` / `super` nodes. Drops receivers rooted on another
+  # call_expression (`foo().bar`) or other non-identifier shapes,
+  # mirroring the chained-call-noise filter used by the Python and
+  # Go extractors.
+  private def receiver_text(node : LibTreeSitter::TSNode, source : String) : String
+    case Noir::TreeSitter.node_type(node)
+    when "identifier", "this", "super"
+      Noir::TreeSitter.node_text(node, source)
+    when "field_access"
+      object = Noir::TreeSitter.field(node, "object")
+      field = Noir::TreeSitter.field(node, "field")
+      return "" unless object && field
+      inner = receiver_text(object, source)
+      inner.empty? ? "" : "#{inner}.#{Noir::TreeSitter.node_text(field, source)}"
+    else
+      ""
+    end
+  end
+
+  private def find_method(root : LibTreeSitter::TSNode,
+                          source : String,
+                          class_name : String,
+                          method_name : String) : LibTreeSitter::TSNode?
+    result : LibTreeSitter::TSNode? = nil
+    walk_class_decls(root) do |decl|
+      next if result
+      name_node = Noir::TreeSitter.field(decl, "name")
+      next unless name_node
+      next unless Noir::TreeSitter.node_text(name_node, source) == class_name
+      body = Noir::TreeSitter.field(decl, "body")
+      next unless body
+      Noir::TreeSitter.each_named_child(body) do |member|
+        next if result
+        next unless Noir::TreeSitter.node_type(member) == "method_declaration"
+        mn = Noir::TreeSitter.field(member, "name")
+        next unless mn
+        result = member if Noir::TreeSitter.node_text(mn, source) == method_name
+      end
+    end
+    result
+  end
+
+  private def walk_class_decls(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    ty = Noir::TreeSitter.node_type(node)
+    block.call(node) if ty == "class_declaration" || ty == "interface_declaration"
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk_class_decls(child, &block)
+    end
+  end
+
+  private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    block.call(node)
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk(child, &block)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `JavaCalleeExtractor` — tree-sitter walker that, given an already-parsed root + `(class_name, method_name)`, returns every 1-hop `method_invocation` callee inside the matching `method_declaration` body. Mirrors the Python/Go extractor module API so JVM siblings (Kotlin/Ktor, Micronaut, …) can hook in the same way.
- Wires it into the Spring analyzer at the endpoint-emit point so `@GetMapping`/`@PostMapping`/etc. endpoints surface 1-hop callees. The Spring analyzer already parses each Java file once for route + parameter + DTO + FeignClient extraction; callee resolution reuses that root.
- Honest scope on `Callee#path` (call site, not definition) — cross-file definition resolution stays out of scope for this first cut, same as every other framework that has callees today.
- Reactive `router().route(...).andRoute(...)` routes are unchanged; that branch is regex-scoped and not worth a dedicated walker yet.

Receiver shapes handled:
- `foo()` → `foo`
- `service.save(x)` → `service.save`
- `this.foo()` → `this.foo`, `super.foo()` → `super.foo`
- `Foo.bar()` (static) → `Foo.bar`
- `getFoo().bar()` → outer dropped as chained-call noise; the inner `getFoo` is still emitted (same filter Python/Go use).

## Test plan
- [x] `crystal spec spec/functional_test/testers/java/spring_spec.cr` — existing Spring spec still green (136 examples).
- [x] `crystal spec spec/functional_test/testers/java/` — full Java suite green (638 examples).
- [x] New `spring_callees_spec.cr` (`fixtures/java/spring_callees/`) covers bare-static, selector-on-identifier, `this.foo`, and chained-on-call receivers; asserts callee names AND line numbers.
- [x] `just check` clean. `just build` clean.

Refs #1366