### PR TITLE
feat(jvm): wire callees through Spring (Kotlin) and Ktor

### DIFF
--- a/spec/functional_test/fixtures/kotlin/ktor_callees/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor_callees/Application.kt
@@ -1,0 +1,34 @@
+package com.example.ktor
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+fun Application.configureRouting() {
+    routing {
+        post("/users") {
+            val name = call.parameters["name"]
+            val saved = service.save(name)
+            AuditLog.write(saved)
+            call.respondText(saved)
+        }
+
+        get("/profile") {
+            val built = this.buildProfile()
+            AuditLog.write(built)
+            call.respondText(built)
+        }
+
+        get("/legacy") {
+            AuditLog.write("legacy")
+            call.respondText(getLegacy().toString())
+        }
+
+        route("/admin") {
+            get("/dashboard") {
+                renderDashboard()
+            }
+        }
+    }
+}

--- a/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/AuditLog.kt
+++ b/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/AuditLog.kt
@@ -1,0 +1,6 @@
+package com.example
+
+object AuditLog {
+    fun write(message: String) {
+    }
+}

--- a/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/OrderController.kt
+++ b/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/OrderController.kt
@@ -1,0 +1,20 @@
+package com.example
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/orders")
+class OrderController {
+
+    @GetMapping("/legacy")
+    fun legacy(): String {
+        AuditLog.write("legacy")
+        return getLegacy().toString()
+    }
+
+    private fun getLegacy(): String {
+        return "legacy"
+    }
+}

--- a/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/UserController.kt
+++ b/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/UserController.kt
@@ -1,0 +1,29 @@
+package com.example
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/users")
+class UserController(private val service: UserService) {
+
+    @PostMapping("/")
+    fun createUser(): String {
+        val saved = service.save("hahwul")
+        AuditLog.write(saved)
+        return saved
+    }
+
+    @GetMapping("/profile")
+    fun profile(): String {
+        val built = this.buildProfile()
+        AuditLog.write(built)
+        return built
+    }
+
+    private fun buildProfile(): String {
+        return "profile"
+    }
+}

--- a/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/UserService.kt
+++ b/spec/functional_test/fixtures/kotlin/spring_callees/src/main/kotlin/com/example/UserService.kt
@@ -1,0 +1,7 @@
+package com.example
+
+class UserService {
+    fun save(name: String): String {
+        return name
+    }
+}

--- a/spec/functional_test/testers/kotlin/ktor_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_callees_spec.cr
@@ -1,0 +1,57 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Ktor (#1366). Unlike
+# annotation-driven analyzers, Ktor declares routes via a DSL —
+# `routing { get("/x") { ... } }` — so the handler body is a lambda
+# `statements` node, not a `function_declaration`. The route
+# extractor already locates that lambda for receive/parameter/header
+# scanning; callee extraction reuses the same body via
+# `KotlinCalleeExtractor.callees_in_lambda`.
+#
+# A nested routing DSL call (`route("/admin") { get("/dashboard") { ... } }`)
+# must NOT leak the inner route's callees into the outer route's
+# list — that's what `skip_routing: true` in the callee walker is
+# for, and `/admin/dashboard` here exercises the boundary.
+#
+# Coverage:
+#   - POST /users            — selector-on-identifier (`service.save`),
+#                              bare-static (`AuditLog.write`), and
+#                              chained-identifier (`call.respondText`)
+#                              receivers.
+#   - GET  /profile          — `this.foo` receiver shape.
+#   - GET  /legacy           — chained-on-call (`getLegacy().toString()`)
+#                              drops the outer `toString` and keeps
+#                              only the inner `getLegacy`.
+#   - GET  /admin/dashboard  — nested `route { get { ... } }` block;
+#                              the parent `route("/admin")` lambda
+#                              does NOT pick up `renderDashboard`,
+#                              and the nested route emits it on its
+#                              own.
+expected_endpoints = [
+  Endpoint.new("/users", "POST", [Param.new("name", "", "query")]).tap do |ep|
+    ep.push_callee(Callee.new("service.save", line: 12))
+    ep.push_callee(Callee.new("AuditLog.write", line: 13))
+    ep.push_callee(Callee.new("call.respondText", line: 14))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 18))
+    ep.push_callee(Callee.new("AuditLog.write", line: 19))
+    ep.push_callee(Callee.new("call.respondText", line: 20))
+  end,
+
+  Endpoint.new("/legacy", "GET").tap do |ep|
+    ep.push_callee(Callee.new("AuditLog.write", line: 24))
+    ep.push_callee(Callee.new("call.respondText", line: 25))
+    ep.push_callee(Callee.new("getLegacy", line: 25))
+  end,
+
+  Endpoint.new("/admin/dashboard", "GET").tap do |ep|
+    ep.push_callee(Callee.new("renderDashboard", line: 30))
+  end,
+]
+
+FunctionalTester.new("fixtures/kotlin/ktor_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/kotlin/spring_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_callees_spec.cr
@@ -1,0 +1,42 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Spring (Kotlin) (#1366).
+# Mirrors the Java Spring callees spec — both analyzers reuse a
+# tree-sitter parse already produced for route and parameter
+# extraction to walk the matching `function_declaration` body for
+# 1-hop callees.
+#
+# Cross-file definition resolution is intentionally out of scope for
+# this first cut; `Callee#path` therefore points at the call site,
+# matching the honest scope on every other analyzer.
+#
+# Coverage:
+#   - POST /api/users/        — bare-static (`AuditLog.write`) and
+#                               selector-on-identifier
+#                               (`service.save`) receivers.
+#   - GET  /api/users/profile — `this.foo` receiver shape.
+#   - GET  /api/orders/legacy — chained-on-call
+#                               (`getLegacy().toString()`) drops the
+#                               outer `toString` and keeps only the
+#                               inner `getLegacy`.
+expected_endpoints = [
+  Endpoint.new("/api/users/", "POST").tap do |ep|
+    ep.push_callee(Callee.new("service.save", line: 14))
+    ep.push_callee(Callee.new("AuditLog.write", line: 15))
+  end,
+
+  Endpoint.new("/api/users/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 21))
+    ep.push_callee(Callee.new("AuditLog.write", line: 22))
+  end,
+
+  Endpoint.new("/api/orders/legacy", "GET").tap do |ep|
+    ep.push_callee(Callee.new("AuditLog.write", line: 13))
+    ep.push_callee(Callee.new("getLegacy", line: 14))
+  end,
+]
+
+FunctionalTester.new("fixtures/kotlin/spring_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -47,7 +47,17 @@ module Analyzer::Kotlin
         params << Param.new(name, "", "header")
       end
 
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+
+      # 1-hop callees out of the handler lambda body. The Route
+      # extractor doesn't know the file path it came from, so attach
+      # it here.
+      route.callees.each do |entry|
+        name, line = entry
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
+
+      endpoint
     end
   end
 end

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/kotlin_route_extractor_ts"
 require "../../../miniparsers/kotlin_parameter_extractor_ts"
+require "../../../miniparsers/kotlin_callee_extractor"
 require "../../../utils/utils.cr"
 
 module Analyzer::Kotlin
@@ -206,7 +207,22 @@ module Analyzer::Kotlin
 
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          @result << Endpoint.new(join_paths(base_path, route.path), route.verb, parameters, details)
+          endpoint = Endpoint.new(join_paths(base_path, route.path), route.verb, parameters, details)
+
+          # 1-hop callees out of the handler function body. Cross-file
+          # definition resolution is intentionally out of scope —
+          # `Callee#path` points at the call site, matching every
+          # other analyzer's first-cut honest scope.
+          unless route.class_name.empty? || route.method_name.empty?
+            Noir::KotlinCalleeExtractor.callees_in_method(
+              root, content, path, route.class_name, route.method_name
+            ).each do |entry|
+              name, callee_path, callee_line = entry
+              endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+            end
+          end
+
+          @result << endpoint
         end
       end
     end

--- a/src/miniparsers/kotlin_callee_extractor.cr
+++ b/src/miniparsers/kotlin_callee_extractor.cr
@@ -1,0 +1,255 @@
+require "../ext/tree_sitter/tree_sitter"
+
+# Tree-sitter-backed Kotlin 1-hop callee extractor. Parallels
+# `Noir::JavaCalleeExtractor` for JVM analyzers — both Spring (Kotlin)
+# and Ktor route through this module. Kotlin's `call_expression`
+# wraps either a `simple_identifier` (bare call), a
+# `navigation_expression` (`a.b.c` selector chain, optionally rooted on
+# `this`/`super`), or an inner `call_expression` (the `foo(...) { }`
+# trailing-lambda shape). 1-hop extraction reduces to:
+#
+#   1. For Spring Kotlin: find the (class_name, method_name)
+#      `function_declaration` in the already-parsed root and walk its
+#      `function_body`.
+#   2. For Ktor: walk the verb DSL call's lambda `statements` node.
+#   3. For each `call_expression`, reconstruct a textual callee:
+#        * `foo()`              → `foo`
+#        * `service.save(x)`    → `service.save`
+#        * `this.foo()`         → `this.foo`
+#        * `super.foo()`        → `super.foo`
+#        * `Foo.bar()` (static) → `Foo.bar`
+#        * `getFoo().bar()`     → "" (chained on a call — outer dropped
+#                                 as noise, inner `getFoo` still
+#                                 emitted via the recursive walk)
+#
+# Cross-file definition resolution (e.g. `userService.save` →
+# `UserServiceImpl.save` in another file) is intentionally out of
+# scope for this first cut. `Callee#path` therefore points at the
+# call site, matching the honest scope on every other analyzer.
+module Noir::KotlinCalleeExtractor
+  extend self
+
+  # Routing DSL verbs + scoping helpers. When `skip_routing` is on
+  # (Ktor handler body), a `call_expression` whose root name is in
+  # this set is treated as a NESTED ROUTE — we skip both emitting it
+  # and descending into its trailing lambda so the nested route's
+  # callees don't leak into the parent route's list.
+  ROUTING_DSL_NAMES = Set{
+    "get", "post", "put", "delete", "patch", "head", "options",
+    "route", "routing", "authenticate", "rateLimit", "install",
+    "intercept", "host", "port",
+  }
+
+  # Spring Kotlin entry: find the (class_name, method_name)
+  # `function_declaration` in `root` and return every 1-hop
+  # `call_expression` callee inside its body as
+  # `{name, file_path, file_line_1_based}`. Empty array when the
+  # function can't be located or its body is missing.
+  def callees_in_method(root : LibTreeSitter::TSNode,
+                        source : String,
+                        file_path : String,
+                        class_name : String,
+                        method_name : String) : Array(Tuple(String, String, Int32))
+    sink = [] of Tuple(String, String, Int32)
+    return sink if class_name.empty? || method_name.empty?
+
+    fn = find_function(root, source, class_name, method_name)
+    return sink unless fn
+    body = function_body_node(fn)
+    return sink unless body
+
+    walk_callees(body, source, file_path, sink, skip_routing: false)
+    sink
+  end
+
+  # Ktor entry: given a verb DSL call's lambda body (the `statements`
+  # node), return every 1-hop callee inside it. Nested routing DSL
+  # calls are skipped wholesale so their bodies' callees stay
+  # attributed to their own routes.
+  def callees_in_lambda(body : LibTreeSitter::TSNode,
+                        source : String,
+                        file_path : String) : Array(Tuple(String, String, Int32))
+    sink = [] of Tuple(String, String, Int32)
+    walk_callees(body, source, file_path, sink, skip_routing: true)
+    sink
+  end
+
+  # ---- private helpers ----------------------------------------------
+
+  private def walk_callees(node : LibTreeSitter::TSNode,
+                           source : String,
+                           file_path : String,
+                           sink : Array(Tuple(String, String, Int32)),
+                           skip_routing : Bool)
+    if Noir::TreeSitter.node_type(node) == "call_expression"
+      # Detect nested routing DSL BEFORE emitting/descending — for
+      # the `get("/x") { ... }` shape the outermost call_expression
+      # wraps an inner call_expression carrying the verb name.
+      if skip_routing
+        root = call_root_name(node, source)
+        return if ROUTING_DSL_NAMES.includes?(root)
+      end
+
+      name = callee_text(node, source)
+      unless name.empty?
+        sink << {name, file_path, Noir::TreeSitter.node_start_row(node) + 1}
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk_callees(child, source, file_path, sink, skip_routing)
+    end
+  end
+
+  # Reconstruct the textual callee for a single `call_expression`.
+  # Returns "" when the call's receiver is a chained call or other
+  # non-identifier shape (mirrors the Python/Go/Java chained-call
+  # noise filter).
+  private def callee_text(call : LibTreeSitter::TSNode, source : String) : String
+    callable = first_named_child(call)
+    return "" unless callable
+
+    case Noir::TreeSitter.node_type(callable)
+    when "simple_identifier"
+      Noir::TreeSitter.node_text(callable, source)
+    when "navigation_expression"
+      navigation_text(callable, source)
+    else
+      # `call_expression` (trailing-lambda outer wrapper), `string_literal`,
+      # `parenthesized_expression`, etc. — not a 1-hop callable shape.
+      # The inner call_expression (when present) gets visited separately
+      # by `walk_callees` and emitted on its own merits.
+      ""
+    end
+  end
+
+  # Collapse a `navigation_expression` (`a.b.c`, `this.foo`,
+  # `Foo.bar`, etc.) into the joined dotted string. Returns "" if
+  # any component is a call_expression (chained) or other
+  # non-identifier shape.
+  private def navigation_text(node : LibTreeSitter::TSNode, source : String) : String
+    parts = [] of String
+    Noir::TreeSitter.each_named_child(node) do |child|
+      case Noir::TreeSitter.node_type(child)
+      when "simple_identifier", "type_identifier"
+        parts << Noir::TreeSitter.node_text(child, source)
+      when "this_expression"
+        parts << "this"
+      when "super_expression"
+        parts << "super"
+      when "navigation_expression"
+        inner = navigation_text(child, source)
+        return "" if inner.empty?
+        parts << inner
+      when "navigation_suffix"
+        suf = navigation_suffix_text(child, source)
+        return "" if suf.empty?
+        parts << suf
+      else
+        return ""
+      end
+    end
+    parts.join(".")
+  end
+
+  private def navigation_suffix_text(suffix : LibTreeSitter::TSNode, source : String) : String
+    Noir::TreeSitter.each_named_child(suffix) do |child|
+      if Noir::TreeSitter.node_type(child) == "simple_identifier"
+        return Noir::TreeSitter.node_text(child, source)
+      end
+    end
+    ""
+  end
+
+  # The "root" name of a call for routing-DSL detection. Only bare
+  # calls qualify — `obj.get("x")` returns "" so a method named
+  # `get` on a real object doesn't get mis-classified as nested
+  # routing.
+  private def call_root_name(call : LibTreeSitter::TSNode, source : String) : String
+    callable = first_named_child(call)
+    return "" unless callable
+    case Noir::TreeSitter.node_type(callable)
+    when "simple_identifier"
+      Noir::TreeSitter.node_text(callable, source)
+    when "call_expression"
+      # `foo(...) { ... }` — outer wraps inner with trailing lambda.
+      call_root_name(callable, source)
+    else
+      ""
+    end
+  end
+
+  private def first_named_child(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    count = LibTreeSitter.ts_node_named_child_count(node)
+    return if count == 0
+    LibTreeSitter.ts_node_named_child(node, 0_u32)
+  end
+
+  # Find the (class_name, method_name) `function_declaration` node.
+  # Mirrors the Java extractor's `find_method` shape; Kotlin uses
+  # `class_declaration` / `object_declaration` / `interface_declaration`
+  # as the class container.
+  private def find_function(root : LibTreeSitter::TSNode,
+                            source : String,
+                            class_name : String,
+                            method_name : String) : LibTreeSitter::TSNode?
+    result : LibTreeSitter::TSNode? = nil
+    walk_class_containers(root) do |decl|
+      next if result
+      next unless type_identifier_text(decl, source) == class_name
+      body = class_body_of(decl)
+      next unless body
+      Noir::TreeSitter.each_named_child(body) do |member|
+        next if result
+        next unless Noir::TreeSitter.node_type(member) == "function_declaration"
+        result = member if function_name(member, source) == method_name
+      end
+    end
+    result
+  end
+
+  private def walk_class_containers(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    ty = Noir::TreeSitter.node_type(node)
+    if ty == "class_declaration" || ty == "object_declaration" || ty == "interface_declaration"
+      block.call(node)
+    end
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk_class_containers(child, &block)
+    end
+  end
+
+  private def type_identifier_text(decl : LibTreeSitter::TSNode, source : String) : String
+    Noir::TreeSitter.each_named_child(decl) do |child|
+      if Noir::TreeSitter.node_type(child) == "type_identifier"
+        return Noir::TreeSitter.node_text(child, source)
+      end
+    end
+    ""
+  end
+
+  private def class_body_of(decl : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    Noir::TreeSitter.each_named_child(decl) do |child|
+      return child if Noir::TreeSitter.node_type(child) == "class_body"
+    end
+    nil
+  end
+
+  private def function_name(func : LibTreeSitter::TSNode, source : String) : String
+    Noir::TreeSitter.each_named_child(func) do |child|
+      if Noir::TreeSitter.node_type(child) == "simple_identifier"
+        return Noir::TreeSitter.node_text(child, source)
+      end
+    end
+    ""
+  end
+
+  # `function_declaration`'s body is a `function_body` child holding
+  # either a block (`{ ... }`) or an expression body (`= expr`).
+  # Walking it from `walk_callees` works for both shapes.
+  private def function_body_node(func : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    Noir::TreeSitter.each_named_child(func) do |child|
+      return child if Noir::TreeSitter.node_type(child) == "function_body"
+    end
+    nil
+  end
+end

--- a/src/miniparsers/kotlin_callee_extractor.cr
+++ b/src/miniparsers/kotlin_callee_extractor.cr
@@ -163,8 +163,7 @@ module Noir::KotlinCalleeExtractor
 
   # The "root" name of a call for routing-DSL detection. Only bare
   # calls qualify — `obj.get("x")` returns "" so a method named
-  # `get` on a real object doesn't get mis-classified as nested
-  # routing.
+  # `get` on a real object isn't misclassified as nested routing.
   private def call_root_name(call : LibTreeSitter::TSNode, source : String) : String
     callable = first_named_child(call)
     return "" unless callable

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./kotlin_callee_extractor"
 
 module Noir
   # Tree-sitter-backed Ktor DSL route extractor.
@@ -71,8 +72,12 @@ module Noir
       getter receive_type : String?
       getter query_params : Array(String)
       getter header_params : Array(String)
+      # 1-hop callees out of the handler lambda body. `path` is left
+      # for the caller to fill in (the route extractor doesn't carry
+      # the file path itself); each tuple is (callee_name, line_1_based).
+      getter callees : Array(Tuple(String, Int32))
 
-      def initialize(@verb, @path, @line, @receive_type, @query_params, @header_params)
+      def initialize(@verb, @path, @line, @receive_type, @query_params, @header_params, @callees)
       end
     end
 
@@ -126,14 +131,24 @@ module Noir
       receive_type : String? = nil
       query_params = [] of String
       header_params = [] of String
+      callees = [] of Tuple(String, Int32)
 
       if body = call_lambda_body(node)
         scan_handler_body(body, source, query_params, header_params).tap do |rt|
           receive_type = rt
         end
+        # KotlinCalleeExtractor uses `(name, file_path, line)` so it can
+        # mirror the Java/Python/Go shape, but Ktor's route extractor
+        # doesn't carry the file path — drop the placeholder here and
+        # let the analyzer attach the real path when it builds the
+        # endpoint.
+        Noir::KotlinCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+          name, _path, line_no = entry
+          callees << {name, line_no}
+        end
       end
 
-      routes << Route.new(verb, full_path, line, receive_type, query_params, header_params)
+      routes << Route.new(verb, full_path, line, receive_type, query_params, header_params, callees)
     end
 
     # ---- call shape helpers ------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `KotlinCalleeExtractor` — one tree-sitter walker covering both JVM-Kotlin idioms. `callees_in_method` mirrors the Java extractor (find `function_declaration` by `(class_name, method_name)`, walk its body) for Spring (Kotlin). `callees_in_lambda` takes a Ktor verb-call's lambda `statements` directly and walks it, skipping nested routing DSL calls so a nested route's callees don't leak into the parent route's list.
- Wires Spring (Kotlin) at the same endpoint-emit point as Java Spring — the annotation analyzer already parses each `.kt` once for route/parameter/DTO extraction; callee resolution reuses that root.
- Wires Ktor by extending `TreeSitterKotlinKtorRouteExtractor::Route` with a `callees : Array(Tuple(String, Int32))` field, populated inside `emit_route` while still inside the parse scope. The analyzer drains it and attaches the file path when constructing each endpoint.
- Honest scope: `Callee#path` is the call site, not the definition. Cross-file resolution stays out of scope for this first cut, matching every other framework that has callees today.

Receiver shapes handled (same vocabulary as Java/Python/Go):
- `foo()` → `foo`
- `service.save(x)` → `service.save`
- `this.foo()` / `super.foo()` → `this.foo` / `super.foo`
- `Foo.bar(x)` (static-looking, including Kotlin `object`s like `AuditLog`) → `Foo.bar`
- `call.respondText(s)` and other multi-level selectors → joined dotted form
- `getFoo().bar()` → outer dropped as chained-call noise; inner `getFoo` still emitted

Routing DSL guard (Ktor only): a `call_expression` whose root name is `get` / `post` / `put` / `delete` / `patch` / `head` / `options` / `route` / `routing` / `authenticate` / `rateLimit` / `install` / `intercept` / `host` / `port` is treated as a NESTED ROUTE — neither emitted as a callee nor descended into. The detection is bare-call only, so `obj.get(\"x\")` (a real method call that happens to share a verb name) is not mis-classified.

## Test plan
- [x] `crystal spec spec/functional_test/testers/kotlin/` — full Kotlin suite green (220 → 272 examples after additions).
- [x] `crystal spec spec/functional_test/testers/java/` — Java suite still green (638), confirming the shared `Callee` plumbing didn't drift.
- [x] New `spring_callees_spec.cr` (`fixtures/kotlin/spring_callees/`) covers bare-static, selector-on-identifier, `this.foo`, and chained-on-call receivers.
- [x] New `ktor_callees_spec.cr` (`fixtures/kotlin/ktor_callees/`) covers all of the above plus the nested-route boundary: `/admin/dashboard` lives inside `route(\"/admin\") { ... }` and emits `renderDashboard` only on itself, never leaking up to the parent.
- [x] `just check` clean, `just build` clean.

Refs #1366