### PR TITLE
feat(jvm): wire callees through Javalin, Spark, and http4k

### DIFF
--- a/spec/functional_test/fixtures/java/javalin_callees/src/Application.java
+++ b/spec/functional_test/fixtures/java/javalin_callees/src/Application.java
@@ -1,0 +1,37 @@
+package com.example;
+
+import io.javalin.Javalin;
+
+public class Application {
+    public static void main(String[] args) {
+        Javalin app = Javalin.create();
+
+        app.post("/users", ctx -> {
+            String name = ctx.queryParam("name");
+            String saved = UserService.save(name);
+            AuditLog.write(saved);
+            ctx.result(saved);
+        });
+
+        app.get("/profile", ctx -> {
+            String built = buildProfile();
+            AuditLog.write(built);
+            ctx.result(built);
+        });
+
+        app.get("/legacy", ctx -> {
+            AuditLog.write("legacy");
+            ctx.result(getLegacy().toString());
+        });
+
+        app.start();
+    }
+
+    static String buildProfile() {
+        return "profile";
+    }
+
+    static String getLegacy() {
+        return "legacy";
+    }
+}

--- a/spec/functional_test/fixtures/java/spark_callees/src/Application.java
+++ b/spec/functional_test/fixtures/java/spark_callees/src/Application.java
@@ -1,0 +1,34 @@
+package com.example;
+
+import static spark.Spark.*;
+
+public class Application {
+    public static void main(String[] args) {
+        post("/users", (req, res) -> {
+            String name = req.queryParams("name");
+            String saved = UserService.save(name);
+            AuditLog.write(saved);
+            res.status(201);
+            return saved;
+        });
+
+        get("/profile", (req, res) -> {
+            String built = buildProfile();
+            AuditLog.write(built);
+            return built;
+        });
+
+        get("/legacy", (req, res) -> {
+            AuditLog.write("legacy");
+            return getLegacy().toString();
+        });
+    }
+
+    static String buildProfile() {
+        return "profile";
+    }
+
+    static String getLegacy() {
+        return "legacy";
+    }
+}

--- a/spec/functional_test/fixtures/kotlin/http4k_callees/src/main/kotlin/com/example/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/http4k_callees/src/main/kotlin/com/example/Application.kt
@@ -1,0 +1,33 @@
+package com.example
+
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+
+val app = routes(
+    "/users" bind POST to { req: Request ->
+        val name = req.query("name")
+        val saved = UserService.save(name)
+        AuditLog.write(saved)
+        Response(OK)
+    },
+
+    "/profile" bind GET to { _: Request ->
+        val built = buildProfile()
+        AuditLog.write(built)
+        Response(OK)
+    },
+
+    "/legacy" bind GET to { _: Request ->
+        AuditLog.write("legacy")
+        val out = getLegacy().toString()
+        Response(OK)
+    }
+)
+
+fun buildProfile(): String = "profile"
+fun getLegacy(): String = "legacy"

--- a/spec/functional_test/testers/java/javalin_callees_spec.cr
+++ b/spec/functional_test/testers/java/javalin_callees_spec.cr
@@ -1,0 +1,43 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Javalin (#1366). Javalin
+# runs on the lambda-DSL shape — `app.get("/x", ctx -> { ... })` —
+# so callees come out of a Java `lambda_expression`'s body, not a
+# `method_declaration`. The shared JVM lambda DSL extractor already
+# locates that body for parameter scanning; callee extraction reuses
+# it via `JavaCalleeExtractor.callees_in_lambda`.
+#
+# Coverage:
+#   - POST /users    — selector-on-identifier (`ctx.queryParam`,
+#                      `ctx.result`) and bare-static
+#                      (`UserService.save`, `AuditLog.write`)
+#                      receivers.
+#   - GET  /profile  — bare unqualified call (`buildProfile`).
+#   - GET  /legacy   — chained-on-call (`getLegacy().toString()`)
+#                      drops the outer `toString` and keeps only
+#                      the inner `getLegacy`.
+expected_endpoints = [
+  Endpoint.new("/users", "POST", [Param.new("name", "", "query")]).tap do |ep|
+    ep.push_callee(Callee.new("ctx.queryParam", line: 10))
+    ep.push_callee(Callee.new("UserService.save", line: 11))
+    ep.push_callee(Callee.new("AuditLog.write", line: 12))
+    ep.push_callee(Callee.new("ctx.result", line: 13))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 17))
+    ep.push_callee(Callee.new("AuditLog.write", line: 18))
+    ep.push_callee(Callee.new("ctx.result", line: 19))
+  end,
+
+  Endpoint.new("/legacy", "GET").tap do |ep|
+    ep.push_callee(Callee.new("AuditLog.write", line: 23))
+    ep.push_callee(Callee.new("ctx.result", line: 24))
+    ep.push_callee(Callee.new("getLegacy", line: 24))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/javalin_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/java/spark_callees_spec.cr
+++ b/spec/functional_test/testers/java/spark_callees_spec.cr
@@ -1,0 +1,39 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Spark Java (#1366). Spark
+# shares the JVM lambda-DSL extractor with Javalin — the handler
+# body is a Java `lambda_expression`'s body, parsed once and walked
+# for both parameters and callees.
+#
+# Coverage:
+#   - POST /users    — selector-on-identifier (`req.queryParams`,
+#                      `res.status`) and bare-static
+#                      (`UserService.save`, `AuditLog.write`)
+#                      receivers.
+#   - GET  /profile  — bare unqualified call (`buildProfile`).
+#   - GET  /legacy   — chained-on-call (`getLegacy().toString()`)
+#                      drops the outer `toString` and keeps only
+#                      the inner `getLegacy`.
+expected_endpoints = [
+  Endpoint.new("/users", "POST", [Param.new("name", "", "query")]).tap do |ep|
+    ep.push_callee(Callee.new("req.queryParams", line: 8))
+    ep.push_callee(Callee.new("UserService.save", line: 9))
+    ep.push_callee(Callee.new("AuditLog.write", line: 10))
+    ep.push_callee(Callee.new("res.status", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 16))
+    ep.push_callee(Callee.new("AuditLog.write", line: 17))
+  end,
+
+  Endpoint.new("/legacy", "GET").tap do |ep|
+    ep.push_callee(Callee.new("AuditLog.write", line: 22))
+    ep.push_callee(Callee.new("getLegacy", line: 23))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/spark_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/kotlin/http4k_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/http4k_callees_spec.cr
@@ -1,0 +1,46 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on http4k (#1366). http4k's
+# routing idiom is `"/x" bind GET to handler` (Kotlin infix), so
+# the handler "body" is whatever expression sits on the RHS of `to`
+# — usually a lambda, occasionally a function reference. The route
+# extractor already passes that RHS into a handler scanner for
+# parameter signals; callee extraction reuses the same RHS via
+# `KotlinCalleeExtractor.callees_in_lambda` with `skip_routing: false`
+# (http4k doesn't have Ktor-style nested routing DSL inside a
+# handler body, so the skip filter would only cause false negatives).
+#
+# Coverage:
+#   - POST /users    — selector-on-identifier (`req.query`),
+#                      bare-static (`UserService.save`,
+#                      `AuditLog.write`), and bare constructor-like
+#                      (`Response`) call shapes.
+#   - GET  /profile  — bare unqualified call (`buildProfile`).
+#   - GET  /legacy   — chained-on-call (`getLegacy().toString()`)
+#                      drops the outer `toString` and keeps only
+#                      the inner `getLegacy`.
+expected_endpoints = [
+  Endpoint.new("/users", "POST", [Param.new("name", "", "query")]).tap do |ep|
+    ep.push_callee(Callee.new("req.query", line: 13))
+    ep.push_callee(Callee.new("UserService.save", line: 14))
+    ep.push_callee(Callee.new("AuditLog.write", line: 15))
+    ep.push_callee(Callee.new("Response", line: 16))
+  end,
+
+  Endpoint.new("/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("buildProfile", line: 20))
+    ep.push_callee(Callee.new("AuditLog.write", line: 21))
+    ep.push_callee(Callee.new("Response", line: 22))
+  end,
+
+  Endpoint.new("/legacy", "GET").tap do |ep|
+    ep.push_callee(Callee.new("AuditLog.write", line: 26))
+    ep.push_callee(Callee.new("getLegacy", line: 27))
+    ep.push_callee(Callee.new("Response", line: 28))
+  end,
+]
+
+FunctionalTester.new("fixtures/kotlin/http4k_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -65,7 +65,16 @@ module Analyzer::Java
       end
 
       details = Details.new(PathInfo.new(path, route.line + 1))
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+
+      # 1-hop callees out of the handler lambda body. The Route
+      # extractor doesn't carry the file path, so attach it here.
+      route.callees.each do |entry|
+        name, line = entry
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
+
+      endpoint
     end
   end
 end

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -61,7 +61,16 @@ module Analyzer::Java
       params << Param.new("body", "", "json") if route.has_body?
 
       details = Details.new(PathInfo.new(path, route.line + 1))
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+
+      # 1-hop callees out of the handler lambda body. The Route
+      # extractor doesn't carry the file path, so attach it here.
+      route.callees.each do |entry|
+        name, line = entry
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
+
+      endpoint
     end
   end
 end

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -32,7 +32,16 @@ module Analyzer::Kotlin
       params << Param.new("body", "", "json") if route.has_body?
 
       details = Details.new(PathInfo.new(path, route.line + 1))
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+
+      # 1-hop callees out of the handler expression. The Route
+      # extractor doesn't carry the file path, so attach it here.
+      route.callees.each do |entry|
+        name, line = entry
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
+
+      endpoint
     end
   end
 end

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./kotlin_callee_extractor"
 
 module Noir
   # Tree-sitter-backed http4k extractor.
@@ -60,9 +61,14 @@ module Noir
       getter query_params : Array(String)
       getter header_params : Array(String)
       getter form_params : Array(String)
+      # 1-hop callees out of the handler expression. `path` is filled
+      # in by the analyzer (the route extractor doesn't carry the
+      # file path); each tuple is (callee_name, line_1_based).
+      getter callees : Array(Tuple(String, Int32))
 
       def initialize(@verb, @path, @line, @has_body,
-                     @query_params, @header_params, @form_params)
+                     @query_params, @header_params, @form_params,
+                     @callees)
       end
     end
 
@@ -133,7 +139,18 @@ module Noir
           end
         end
 
-        routes << Route.new(verb, full, line, has_body, query, header, form)
+        # http4k's routing idiom is `"/x" bind GET to handler`, not
+        # `get { ... }` — there's no Ktor-style nested routing DSL
+        # inside a handler body, so the routing-skip filter is off
+        # to avoid silently dropping real handler calls named `get`,
+        # `post`, etc.
+        callees = [] of Tuple(String, Int32)
+        Noir::KotlinCalleeExtractor.callees_in_lambda(rhs, source, "", skip_routing: false).each do |entry|
+          name, _path, line_no = entry
+          callees << {name, line_no}
+        end
+
+        routes << Route.new(verb, full, line, has_body, query, header, form, callees)
         true
       when "bind"
         return false unless Noir::TreeSitter.node_type(lhs) == "string_literal"

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -59,6 +59,27 @@ module Noir::JavaCalleeExtractor
     sink
   end
 
+  # Lambda/handler entry point used by DSL analyzers (Javalin, Spark,
+  # …) where the handler body is a `lambda_expression`'s body — a
+  # `block` or a single expression — not a `method_declaration`.
+  # Caller is responsible for locating the body (the JVM lambda DSL
+  # extractor already does this for parameter scanning) and passing
+  # it in. Walks the body and returns every 1-hop `method_invocation`
+  # callee.
+  def callees_in_lambda(body : LibTreeSitter::TSNode,
+                        source : String,
+                        file_path : String) : Array(Tuple(String, String, Int32))
+    sink = [] of Tuple(String, String, Int32)
+    walk(body) do |n|
+      next unless Noir::TreeSitter.node_type(n) == "method_invocation"
+      name = callee_text(n, source)
+      next if name.empty?
+      row = Noir::TreeSitter.node_start_row(n)
+      sink << {name, file_path, row + 1}
+    end
+    sink
+  end
+
   # ---- private helpers -----------------------------------------------
 
   private def callee_text(call : LibTreeSitter::TSNode, source : String) : String

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../ext/tree_sitter/tree_sitter"
+require "./java_callee_extractor"
 require "../models/endpoint"
 
 module Noir
@@ -71,9 +72,14 @@ module Noir
       getter form_params : Array(String)
       getter header_params : Array(String)
       getter cookie_params : Array(String)
+      # 1-hop callees out of the handler lambda body. `path` is filled
+      # in by the analyzer (the route extractor doesn't carry the file
+      # path itself); each tuple is (callee_name, line_1_based).
+      getter callees : Array(Tuple(String, Int32))
 
       def initialize(@verb, @path, @line, @body_type, @has_body,
-                     @query_params, @form_params, @header_params, @cookie_params)
+                     @query_params, @form_params, @header_params, @cookie_params,
+                     @callees)
       end
     end
 
@@ -136,6 +142,7 @@ module Noir
       cookie_params = [] of String
       body_type : String? = nil
       has_body = false
+      callees = [] of Tuple(String, Int32)
 
       if body = lambda_body_in_args(call)
         scan_handler(body, source, config, 0) do |kind, value|
@@ -150,10 +157,18 @@ module Noir
             has_body = true
           end
         end
+        # JavaCalleeExtractor takes (name, file_path, line); the route
+        # extractor doesn't carry the file path, so drop the placeholder
+        # here and let the analyzer attach the real path when it builds
+        # the endpoint.
+        Noir::JavaCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+          name, _path, line_no = entry
+          callees << {name, line_no}
+        end
       end
 
       routes << Route.new(verb, full_path, line, body_type, has_body,
-        query_params, form_params, header_params, cookie_params)
+        query_params, form_params, header_params, cookie_params, callees)
     end
 
     private def scan_handler(node : LibTreeSitter::TSNode, source : String, config : Config, depth : Int32, &block : Symbol, String ->)

--- a/src/miniparsers/kotlin_callee_extractor.cr
+++ b/src/miniparsers/kotlin_callee_extractor.cr
@@ -62,15 +62,20 @@ module Noir::KotlinCalleeExtractor
     sink
   end
 
-  # Ktor entry: given a verb DSL call's lambda body (the `statements`
-  # node), return every 1-hop callee inside it. Nested routing DSL
-  # calls are skipped wholesale so their bodies' callees stay
-  # attributed to their own routes.
+  # Ktor / http4k entry: given a handler body node, return every
+  # 1-hop callee inside it. `skip_routing` controls whether Ktor's
+  # routing DSL (`route { ... }`, sibling verb calls, etc.) is
+  # treated as a NESTED ROUTE boundary — Ktor needs this on so a
+  # nested route's callees don't leak into the parent; http4k uses
+  # an entirely different routing idiom (`"/x" bind GET to h`) and
+  # turns the skip off so a real handler call named `get` isn't
+  # silently dropped.
   def callees_in_lambda(body : LibTreeSitter::TSNode,
                         source : String,
-                        file_path : String) : Array(Tuple(String, String, Int32))
+                        file_path : String,
+                        skip_routing : Bool = true) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
-    walk_callees(body, source, file_path, sink, skip_routing: true)
+    walk_callees(body, source, file_path, sink, skip_routing: skip_routing)
     sink
   end
 


### PR DESCRIPTION
## Summary
Threads `--include-callee` through the three remaining JVM DSL-style analyzers — Javalin, Spark Java, and http4k — in one bundle. All three share the same shape: routes are declared with a lambda/handler expression rather than an annotated method, so callee extraction walks a body node directly.

- **Java DSL (Javalin / Spark)**: shared `TreeSitterJvmLambdaDslExtractor` already locates the lambda body for parameter scanning; callee extraction reuses it via a new `JavaCalleeExtractor.callees_in_lambda(body, source, file_path)` entry point. Thin wrapper over the same `walk` + `callee_text` core used by the annotation-driven Spring path.
- **http4k**: routes via Kotlin infix (`\"/x\" bind GET to handler`). The handler RHS is passed to `KotlinCalleeExtractor.callees_in_lambda` with `skip_routing: false` — http4k has no Ktor-style nested verb DSL inside a handler, so the default Ktor-flavoured skip would only cause false negatives by silently dropping real handler calls named `get`/`post`/etc.

`Route` structs in both extractors gain a `callees : Array(Tuple(String, Int32))` field, populated while still inside the parse scope. Analyzers attach the file path when building the endpoint, mirroring the Ktor pattern from #1384.

Receiver shapes covered (same vocabulary as #1383 / #1384):
- bare `foo()` → `foo`
- selector-on-identifier (`ctx.queryParam`, `req.query`, `UserService.save`, `AuditLog.write`, `res.status`, `Response`)
- chained-on-call (`getLegacy().toString()`) → outer dropped, inner `getLegacy` still emitted

Honest scope unchanged: `Callee#path` points at the call site, not the definition. Cross-file resolution stays out of scope for this first cut.

## Test plan
- [x] `crystal spec spec/functional_test/testers/java/` — Java suite still green.
- [x] `crystal spec spec/functional_test/testers/kotlin/` — Kotlin suite still green.
- [x] Combined: 996 examples, 0 failures.
- [x] New \`javalin_callees_spec.cr\` (\`fixtures/java/javalin_callees/\`).
- [x] New \`spark_callees_spec.cr\` (\`fixtures/java/spark_callees/\`).
- [x] New \`http4k_callees_spec.cr\` (\`fixtures/kotlin/http4k_callees/\`).
- [x] \`just check\` clean. \`just build\` clean.
- [x] Local \`typos\` run on changed files — clean.

Refs #1366