### PR TITLE
feat(java): wire callees through JAX-RS analyzers

### DIFF
--- a/spec/functional_test/fixtures/java/dropwizard_callees/src/main/java/com/example/api/HelloResource.java
+++ b/spec/functional_test/fixtures/java/dropwizard_callees/src/main/java/com/example/api/HelloResource.java
@@ -1,0 +1,46 @@
+package com.example.api;
+
+import io.dropwizard.core.Application;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+@Path("/hello")
+public class HelloResource {
+    private final HelloService service = new HelloService();
+
+    @POST
+    @Path("/{id}")
+    public Response create(@PathParam("id") long id,
+                           @QueryParam("dry_run") boolean dryRun) {
+        validate(id);
+        service.save(id, dryRun);
+        AuditLog.write("create");
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/profile")
+    public Response profile() {
+        String profile = this.buildProfile();
+        AuditLog.write(profile);
+        return Response.ok(profile).build();
+    }
+
+    private void validate(long id) {}
+
+    private String buildProfile() {
+        return "profile";
+    }
+}
+
+class HelloService {
+    void save(long id, boolean dryRun) {}
+}
+
+class AuditLog {
+    static void write(String event) {}
+}

--- a/spec/functional_test/fixtures/java/jaxrs_callees/src/main/java/com/example/api/UserResource.java
+++ b/spec/functional_test/fixtures/java/jaxrs_callees/src/main/java/com/example/api/UserResource.java
@@ -1,0 +1,45 @@
+package com.example.api;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+
+@Path("/users")
+public class UserResource {
+    private final UserService service = new UserService();
+
+    @POST
+    @Path("/{id}")
+    public Response create(@PathParam("id") long id,
+                           @QueryParam("dry_run") boolean dryRun) {
+        validate(id);
+        service.save(id, dryRun);
+        AuditLog.write("create");
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/profile")
+    public Response profile() {
+        String profile = this.buildProfile();
+        AuditLog.write(profile);
+        return Response.ok(profile).build();
+    }
+
+    private void validate(long id) {}
+
+    private String buildProfile() {
+        return "profile";
+    }
+}
+
+class UserService {
+    void save(long id, boolean dryRun) {}
+}
+
+class AuditLog {
+    static void write(String event) {}
+}

--- a/spec/functional_test/fixtures/java/quarkus_callees/src/main/java/com/example/api/GreetingResource.java
+++ b/spec/functional_test/fixtures/java/quarkus_callees/src/main/java/com/example/api/GreetingResource.java
@@ -1,0 +1,47 @@
+package com.example.api;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestPath;
+import org.jboss.resteasy.reactive.RestQuery;
+
+@Path("/greetings")
+@RegisterForReflection
+public class GreetingResource {
+    private final GreetingService service = new GreetingService();
+
+    @POST
+    @Path("/{id}")
+    public Response create(@RestPath long id,
+                           @RestQuery("dry_run") boolean dryRun) {
+        validate(id);
+        service.save(id, dryRun);
+        AuditLog.write("create");
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/profile")
+    public Response profile() {
+        String profile = this.buildProfile();
+        AuditLog.write(profile);
+        return Response.ok(profile).build();
+    }
+
+    private void validate(long id) {}
+
+    private String buildProfile() {
+        return "profile";
+    }
+}
+
+class GreetingService {
+    void save(long id, boolean dryRun) {}
+}
+
+class AuditLog {
+    static void write(String event) {}
+}

--- a/spec/functional_test/testers/java/dropwizard_callees_spec.cr
+++ b/spec/functional_test/testers/java/dropwizard_callees_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Dropwizard resource classes.
+# Dropwizard rides on the shared JAX-RS extractor, so its analyzer only
+# needs to push the extractor-provided callees onto emitted endpoints.
+expected_endpoints = [
+  Endpoint.new("/hello/{id}", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("dry_run", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("validate", line: 19))
+    ep.push_callee(Callee.new("service.save", line: 20))
+    ep.push_callee(Callee.new("AuditLog.write", line: 21))
+    ep.push_callee(Callee.new("Response.ok", line: 22))
+  end,
+
+  Endpoint.new("/hello/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 28))
+    ep.push_callee(Callee.new("AuditLog.write", line: 29))
+    ep.push_callee(Callee.new("Response.ok", line: 30))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/dropwizard_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/java/jaxrs_callees_spec.cr
+++ b/spec/functional_test/testers/java/jaxrs_callees_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on vanilla JAX-RS resources.
+# The shared JAX-RS extractor already walks each resource method, so
+# it now returns 1-hop method invocations alongside route metadata.
+expected_endpoints = [
+  Endpoint.new("/users/{id}", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("dry_run", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("validate", line: 18))
+    ep.push_callee(Callee.new("service.save", line: 19))
+    ep.push_callee(Callee.new("AuditLog.write", line: 20))
+    ep.push_callee(Callee.new("Response.ok", line: 21))
+  end,
+
+  Endpoint.new("/users/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 27))
+    ep.push_callee(Callee.new("AuditLog.write", line: 28))
+    ep.push_callee(Callee.new("Response.ok", line: 29))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/jaxrs_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/java/quarkus_callees_spec.cr
+++ b/spec/functional_test/testers/java/quarkus_callees_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Quarkus's JAX-RS-flavoured
+# analyzer. Quarkus shares the JAX-RS extractor and should receive the
+# same method-body callee coverage.
+expected_endpoints = [
+  Endpoint.new("/greetings/{id}", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("dry_run", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("validate", line: 20))
+    ep.push_callee(Callee.new("service.save", line: 21))
+    ep.push_callee(Callee.new("AuditLog.write", line: 22))
+    ep.push_callee(Callee.new("Response.ok", line: 23))
+  end,
+
+  Endpoint.new("/greetings/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 29))
+    ep.push_callee(Callee.new("AuditLog.write", line: 30))
+    ep.push_callee(Callee.new("Response.ok", line: 31))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/quarkus_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -38,7 +38,11 @@ module Analyzer::Java
         Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          @result << Endpoint.new(route.path, route.verb, route.params, details)
+          endpoint = Endpoint.new(route.path, route.verb, route.params, details)
+          route.callees.each do |name, callee_line|
+            endpoint.push_callee(Callee.new(name, path: path, line: callee_line))
+          end
+          @result << endpoint
         end
       end
 

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -36,7 +36,11 @@ module Analyzer::Java
         Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          @result << Endpoint.new(route.path, route.verb, route.params, details)
+          endpoint = Endpoint.new(route.path, route.verb, route.params, details)
+          route.callees.each do |name, callee_line|
+            endpoint.push_callee(Callee.new(name, path: path, line: callee_line))
+          end
+          @result << endpoint
         end
       end
 

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -34,7 +34,11 @@ module Analyzer::Java
         Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          @result << Endpoint.new(route.path, route.verb, route.params, details)
+          endpoint = Endpoint.new(route.path, route.verb, route.params, details)
+          route.callees.each do |name, callee_line|
+            endpoint.push_callee(Callee.new(name, path: path, line: callee_line))
+          end
+          @result << endpoint
         end
       end
 

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -69,6 +69,15 @@ module Noir::JavaCalleeExtractor
   def callees_in_lambda(body : LibTreeSitter::TSNode,
                         source : String,
                         file_path : String) : Array(Tuple(String, String, Int32))
+    callees_in_body(body, source, file_path)
+  end
+
+  # Generic body walker for analyzers/extractors that already have the
+  # handler method/lambda body node. Returns every 1-hop
+  # `method_invocation` callee inside that body.
+  def callees_in_body(body : LibTreeSitter::TSNode,
+                      source : String,
+                      file_path : String) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
     walk(body) do |n|
       next unless Noir::TreeSitter.node_type(n) == "method_invocation"

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./java_callee_extractor"
 require "./java_parameter_extractor_ts"
 require "./import_graph"
 
@@ -80,9 +81,10 @@ module Noir
       getter line : Int32
       getter parameter_format : String?
       getter params : Array(Param)
+      getter callees : Array(Tuple(String, Int32))
 
       def initialize(@verb, @path, @class_name, @method_name, @line,
-                     @parameter_format, @params)
+                     @parameter_format, @params, @callees)
       end
     end
 
@@ -95,9 +97,21 @@ module Noir
                        bean_index : Hash(String, Array(Param)) = {} of String => Array(Param)) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
-        walk_classes(root) do |decl|
-          collect_class_routes(decl, source, dto_index, bean_index, routes)
-        end
+        routes.concat(extract_routes_from(root, source, dto_index, bean_index))
+      end
+      routes
+    end
+
+    # Same as `extract_routes`, but reuses a Java tree-sitter root the
+    # caller already parsed. Analyzer adapters use this when they also
+    # need to attach method-body callees without reparsing the file.
+    def extract_routes_from(root : LibTreeSitter::TSNode,
+                            source : String,
+                            dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)) = {} of String => Array(TreeSitterJavaParameterExtractor::FieldInfo),
+                            bean_index : Hash(String, Array(Param)) = {} of String => Array(Param)) : Array(Route)
+      routes = [] of Route
+      walk_classes(root) do |decl|
+        collect_class_routes(decl, source, dto_index, bean_index, routes)
       end
       routes
     end
@@ -174,8 +188,19 @@ module Noir
           dto_index, bean_index)
 
         line = Noir::TreeSitter.node_start_row(verb_node)
+        callees = collect_method_callees(member, source)
         routes << Route.new(verb, full_path, class_name, method_name, line,
-          method_consumes, params)
+          method_consumes, params, callees)
+      end
+    end
+
+    private def collect_method_callees(method : LibTreeSitter::TSNode,
+                                       source : String) : Array(Tuple(String, Int32))
+      body = Noir::TreeSitter.field(method, "body")
+      return [] of Tuple(String, Int32) unless body
+
+      Noir::JavaCalleeExtractor.callees_in_body(body, source, "").map do |name, _path, line|
+        {name, line}
       end
     end
 


### PR DESCRIPTION
## Summary
- add method-body callee collection to the shared `TreeSitterJaxRsExtractor`
- wire extracted callees through Java JAX-RS, Quarkus, and Dropwizard analyzers
- add dedicated callee fixtures/specs for all three analyzers

## Tests
- `crystal spec spec/functional_test/testers/java/jaxrs_callees_spec.cr spec/functional_test/testers/java/quarkus_callees_spec.cr spec/functional_test/testers/java/dropwizard_callees_spec.cr spec/functional_test/testers/java/jaxrs_spec.cr spec/functional_test/testers/java/quarkus_spec.cr spec/functional_test/testers/java/dropwizard_spec.cr`
- `just test`
- `just build`
- `./bin/noir -b spec/functional_test/fixtures/java/jaxrs_callees --include-callee`
- `./bin/noir -b spec/functional_test/fixtures/java/quarkus_callees --include-callee`
- `./bin/noir -b spec/functional_test/fixtures/java/dropwizard_callees --include-callee`

Refs #1366