### PR TITLE
feat(java): wire callees through Micronaut

### DIFF
--- a/spec/functional_test/fixtures/java/micronaut_callees/src/main/java/com/example/api/BookController.java
+++ b/spec/functional_test/fixtures/java/micronaut_callees/src/main/java/com/example/api/BookController.java
@@ -1,0 +1,43 @@
+package com.example.api;
+
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
+
+@Controller("/books")
+public class BookController {
+    private final BookService service = new BookService();
+
+    @Post("/{id}")
+    public HttpResponse<?> create(@PathVariable long id,
+                                  @QueryValue("dry_run") boolean dryRun) {
+        validate(id);
+        service.save(id, dryRun);
+        AuditLog.write("create");
+        return HttpResponse.ok();
+    }
+
+    @Get(uris = {"/popular", "/featured"})
+    public HttpResponse<?> highlights() {
+        String profile = this.buildProfile();
+        AuditLog.write(profile);
+        return HttpResponse.ok(profile);
+    }
+
+    private void validate(long id) {}
+
+    private String buildProfile() {
+        return "profile";
+    }
+}
+
+class BookService {
+    void save(long id, boolean dryRun) {}
+}
+
+class AuditLog {
+    static void write(String event) {}
+}

--- a/spec/functional_test/testers/java/micronaut_callees_spec.cr
+++ b/spec/functional_test/testers/java/micronaut_callees_spec.cr
@@ -1,0 +1,35 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Micronaut. The extractor
+# fans out `uris = {...}` into multiple endpoints, and each emitted
+# endpoint should receive the same method-body callees.
+highlight_callees = [
+  Callee.new("this.buildProfile", line: 25),
+  Callee.new("AuditLog.write", line: 26),
+  Callee.new("HttpResponse.ok", line: 27),
+]
+
+expected_endpoints = [
+  Endpoint.new("/books/{id}", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("dry_run", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("validate", line: 17))
+    ep.push_callee(Callee.new("service.save", line: 18))
+    ep.push_callee(Callee.new("AuditLog.write", line: 19))
+    ep.push_callee(Callee.new("HttpResponse.ok", line: 20))
+  end,
+
+  Endpoint.new("/books/popular", "GET").tap do |ep|
+    highlight_callees.each { |callee| ep.push_callee(callee) }
+  end,
+
+  Endpoint.new("/books/featured", "GET").tap do |ep|
+    highlight_callees.each { |callee| ep.push_callee(callee) }
+  end,
+]
+
+FunctionalTester.new("fixtures/java/micronaut_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -25,7 +25,11 @@ module Analyzer::Java
         Noir::TreeSitterMicronautExtractor.extract_routes(content, dto_index).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          @result << Endpoint.new(route.path, route.verb, route.params, details)
+          endpoint = Endpoint.new(route.path, route.verb, route.params, details)
+          route.callees.each do |(name, callee_line)|
+            endpoint.push_callee(Callee.new(name, path: path, line: callee_line))
+          end
+          @result << endpoint
         end
       end
 

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./java_callee_extractor"
 require "./java_parameter_extractor_ts"
 
 module Noir
@@ -65,8 +66,9 @@ module Noir
       getter method_name : String
       getter line : Int32
       getter params : Array(Param)
+      getter callees : Array(Tuple(String, Int32))
 
-      def initialize(@verb, @path, @class_name, @method_name, @line, @params)
+      def initialize(@verb, @path, @class_name, @method_name, @line, @params, @callees)
       end
     end
 
@@ -153,14 +155,25 @@ module Noir
         method_consumes = consumes_format(member, source) || class_consumes
 
         params = collect_method_params(member, source, method_consumes, dto_index)
+        callees = collect_method_callees(member, source)
         line = Noir::TreeSitter.node_start_row(verb_node)
 
         controller_paths.each do |class_path|
           method_paths.each do |method_path|
             full_path = join_paths(class_path, method_path)
-            routes << Route.new(verb, full_path, class_name, method_name, line, params.dup)
+            routes << Route.new(verb, full_path, class_name, method_name, line, params.dup, callees)
           end
         end
+      end
+    end
+
+    private def collect_method_callees(method : LibTreeSitter::TSNode,
+                                       source : String) : Array(Tuple(String, Int32))
+      body = Noir::TreeSitter.field(method, "body")
+      return [] of Tuple(String, Int32) unless body
+
+      Noir::JavaCalleeExtractor.callees_in_body(body, source, "").map do |(name, _path, line)|
+        {name, line}
       end
     end
 


### PR DESCRIPTION
## Summary
- collect 1-hop method-body callees in `TreeSitterMicronautExtractor`
- push Micronaut route callees onto emitted endpoints
- add a Micronaut callee fixture/spec covering normal routes and `uris` fan-out

## Tests
- `crystal spec spec/functional_test/testers/java/micronaut_callees_spec.cr spec/functional_test/testers/java/micronaut_spec.cr`
- `just test`
- `just build`
- `./bin/noir -b spec/functional_test/fixtures/java/micronaut_callees --include-callee`

Refs #1366