### PR TITLE
feat(java): wire callees through Armeria

### DIFF
--- a/spec/functional_test/fixtures/java/armeria_callees/pom.xml
+++ b/spec/functional_test/fixtures/java/armeria_callees/pom.xml
@@ -1,0 +1,9 @@
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>com.linecorp.armeria</groupId>
+      <artifactId>armeria</artifactId>
+      <version>1.30.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/spec/functional_test/fixtures/java/armeria_callees/src/AnnotatedService.java
+++ b/spec/functional_test/fixtures/java/armeria_callees/src/AnnotatedService.java
@@ -1,0 +1,48 @@
+package org.example.armeria;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Header;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.RequestObject;
+
+public class AnnotatedService {
+    private final UserService service = new UserService();
+
+    @Post("/annotated/users/{userId}")
+    public HttpResponse createUser(@Param String userId,
+                                   @RequestObject User user,
+                                   @Header("Content-Type") String contentType) {
+        validate(userId);
+        service.save(user);
+        AuditLog.write("create");
+        return HttpResponse.of("created");
+    }
+
+    @Get("/annotated/users/profile")
+    public HttpResponse profile() {
+        String profile = this.buildProfile();
+        AuditLog.write(profile);
+        return HttpResponse.of(profile);
+    }
+
+    private void validate(String userId) {}
+
+    private String buildProfile() {
+        return "profile";
+    }
+
+    public static class User {
+        public String name;
+        public String email;
+    }
+}
+
+class UserService {
+    void save(AnnotatedService.User user) {}
+}
+
+class AuditLog {
+    static void write(String event) {}
+}

--- a/spec/functional_test/testers/java/armeria_callees_spec.cr
+++ b/spec/functional_test/testers/java/armeria_callees_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Armeria annotated services.
+# Builder-chain routes are regex-only and have no handler body here;
+# annotated services already expose the method node and can provide
+# 1-hop callees.
+expected_endpoints = [
+  Endpoint.new("/annotated/users/{userId}", "POST", [
+    Param.new("user", "", "json"),
+    Param.new("Content-Type", "", "header"),
+    Param.new("userId", "", "path"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("validate", line: 17))
+    ep.push_callee(Callee.new("service.save", line: 18))
+    ep.push_callee(Callee.new("AuditLog.write", line: 19))
+    ep.push_callee(Callee.new("HttpResponse.of", line: 20))
+  end,
+
+  Endpoint.new("/annotated/users/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 25))
+    ep.push_callee(Callee.new("AuditLog.write", line: 26))
+    ep.push_callee(Callee.new("HttpResponse.of", line: 27))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/armeria_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/java_callee_extractor"
 
 module Analyzer::Java
   class Armeria < Analyzer
@@ -134,9 +135,21 @@ module Analyzer::Java
 
         parameters = collect_method_params(method, content, url_path)
         endpoint = Endpoint.new(url_path, http_method, parameters, details)
+        collect_method_callees(method, content, path).each do |(name, callee_path, callee_line)|
+          endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+        end
         extract_path_parameters(url_path, endpoint)
         @result << endpoint
       end
+    end
+
+    private def collect_method_callees(method : LibTreeSitter::TSNode,
+                                       content : String,
+                                       path : String) : Array(Tuple(String, String, Int32))
+      body = Noir::TreeSitter.field(method, "body")
+      return [] of Tuple(String, String, Int32) unless body
+
+      Noir::JavaCalleeExtractor.callees_in_body(body, content, path)
     end
 
     private def find_modifiers(decl : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?


### PR DESCRIPTION
## Summary
- attach 1-hop method-body callees to Armeria annotated service endpoints
- reuse `JavaCalleeExtractor.callees_in_body` for annotation-based service methods
- add an `armeria_callees` fixture/spec covering params and callees

## Scope
- Builder-chain regex routes still do not get callees because this analyzer has no handler body for those routes. Annotated services do.

## Tests
- `crystal spec spec/functional_test/testers/java/armeria_callees_spec.cr spec/functional_test/testers/java/armeria_spec.cr`
- `just test`
- `just build`
- `./bin/noir -b spec/functional_test/fixtures/java/armeria_callees --include-callee`

Refs #1366