### PR TITLE
feat(java): wire callees through Vert.x

### DIFF
--- a/spec/functional_test/fixtures/java/vertx_callees/src/main/java/com/example/MainVerticle.java
+++ b/spec/functional_test/fixtures/java/vertx_callees/src/main/java/com/example/MainVerticle.java
@@ -1,0 +1,61 @@
+package com.example;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class MainVerticle {
+  private final UserService service = new UserService();
+
+  public void start() {
+    Vertx vertx = Vertx.vertx();
+    Router router = Router.router(vertx);
+
+    router.post("/users/:id").handler(this::createUser);
+    router.route("/orders/:id").get(this::getOrder);
+  }
+
+  private void createUser(RoutingContext ctx) {
+    String id = ctx.pathParam("id");
+    User user = parseUser(ctx);
+    service.save(user, id);
+    AuditLog.write("create");
+    ctx.response().end("ok");
+  }
+
+  private void getOrder(RoutingContext ctx) {
+    String id = ctx.pathParam("id");
+    Order order = findOrder(id);
+    AuditLog.write("get");
+    ctx.response().end(order.id);
+  }
+
+  private User parseUser(RoutingContext ctx) {
+    return new User();
+  }
+
+  private Order findOrder(String id) {
+    return new Order(id);
+  }
+}
+
+class User {
+}
+
+class Order {
+  String id;
+
+  Order(String id) {
+    this.id = id;
+  }
+}
+
+class UserService {
+  void save(User user, String id) {
+  }
+}
+
+class AuditLog {
+  static void write(String event) {
+  }
+}

--- a/spec/functional_test/testers/java/vertx_callees_spec.cr
+++ b/spec/functional_test/testers/java/vertx_callees_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Vert.x method-reference
+# handlers. Regex route discovery still owns route matching; the
+# analyzer resolves `this::handler` references to method bodies and
+# attaches the handler's 1-hop callees.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "POST").tap do |ep|
+    ep.push_callee(Callee.new("ctx.pathParam", line: 19))
+    ep.push_callee(Callee.new("parseUser", line: 20))
+    ep.push_callee(Callee.new("service.save", line: 21))
+    ep.push_callee(Callee.new("AuditLog.write", line: 22))
+    ep.push_callee(Callee.new("ctx.response", line: 23))
+  end,
+
+  Endpoint.new("/orders/:id", "GET").tap do |ep|
+    ep.push_callee(Callee.new("ctx.pathParam", line: 27))
+    ep.push_callee(Callee.new("findOrder", line: 28))
+    ep.push_callee(Callee.new("AuditLog.write", line: 29))
+    ep.push_callee(Callee.new("ctx.response", line: 30))
+  end,
+]
+
+FunctionalTester.new("fixtures/java/vertx_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -1,13 +1,16 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/java_callee_extractor"
 require "wait_group"
 
 module Analyzer::Java
   class Vertx < Analyzer
     # Regex patterns for Vert.x route detection
-    REGEX_ROUTER_ROUTE    = /router\.(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*["\']([^"\']*)["\'].*?\)/i
-    REGEX_ROUTE_METHOD    = /\.route\s*\(\s*["\']([^"\']*)["\'].*?\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(/i
-    REGEX_ROUTER_INSTANCE = /Router\s+(\w+)\s*=\s*Router\.router\(\s*[^)]*\s*\)/
-    REGEX_MOUNTSUBPATH    = /router\.mountSubRouter\s*\(\s*["\']([^"\']*)["\'].*?\)/i
+    REGEX_ROUTER_ROUTE         = /router\.(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*["\']([^"\']*)["\'].*?\)/i
+    REGEX_ROUTE_METHOD         = /\.route\s*\(\s*["\']([^"\']*)["\'].*?\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(/i
+    REGEX_ROUTER_ROUTE_HANDLER = /router\.(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
+    REGEX_ROUTE_METHOD_HANDLER = /\.route\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*this::([\w$]+)\s*\)/i
+    REGEX_ROUTER_INSTANCE      = /Router\s+(\w+)\s*=\s*Router\.router\(\s*[^)]*\s*\)/
+    REGEX_MOUNTSUBPATH         = /router\.mountSubRouter\s*\(\s*["\']([^"\']*)["\'].*?\)/i
 
     def analyze
       # Source Analysis
@@ -32,6 +35,8 @@ module Analyzer::Java
                     # Skip if no Vert.x related content
                     next unless content.includes?("Router") || content.includes?("vertx")
 
+                    callees_by_route = extract_method_reference_callees(content, path)
+
                     # Find direct router method calls like router.get("/path", handler)
                     content.scan(REGEX_ROUTER_ROUTE) do |match|
                       next if match.size < 3
@@ -41,7 +46,9 @@ module Analyzer::Java
                       next if !method.in?(%w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE])
                       next if endpoint.empty?
 
-                      @result << Endpoint.new(endpoint, method, details)
+                      found = Endpoint.new(endpoint, method, details)
+                      attach_callees(found, callees_by_route, method, endpoint)
+                      @result << found
                     end
 
                     # Find route().method() pattern calls
@@ -53,7 +60,9 @@ module Analyzer::Java
                       next if !method.in?(%w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE])
                       next if endpoint.empty?
 
-                      @result << Endpoint.new(endpoint, method, details)
+                      found = Endpoint.new(endpoint, method, details)
+                      attach_callees(found, callees_by_route, method, endpoint)
+                      @result << found
                     end
 
                     # Find sub-router mount points for base paths
@@ -79,6 +88,85 @@ module Analyzer::Java
       Fiber.yield
 
       @result
+    end
+
+    private def extract_method_reference_callees(content : String, path : String) : Hash(String, Array(Callee))
+      handlers_by_route = {} of String => String
+
+      content.scan(REGEX_ROUTER_ROUTE_HANDLER) do |match|
+        next if match.size < 4
+        method = match[1].upcase
+        endpoint = match[2]
+        handler_name = match[3]
+        next if endpoint.empty? || handler_name.empty?
+
+        handlers_by_route[route_key(method, endpoint)] = handler_name
+      end
+
+      content.scan(REGEX_ROUTE_METHOD_HANDLER) do |match|
+        next if match.size < 4
+        endpoint = match[1]
+        method = match[2].upcase
+        handler_name = match[3]
+        next if endpoint.empty? || handler_name.empty?
+
+        handlers_by_route[route_key(method, endpoint)] = handler_name
+      end
+
+      return {} of String => Array(Callee) if handlers_by_route.empty?
+
+      wanted_handlers = handlers_by_route.values.uniq!
+      callees_by_handler = {} of String => Array(Callee)
+
+      Noir::TreeSitter.parse_java(content) do |root|
+        walk_method_declarations(root) do |method|
+          name_node = Noir::TreeSitter.field(method, "name")
+          next unless name_node
+
+          method_name = Noir::TreeSitter.node_text(name_node, content)
+          next unless wanted_handlers.includes?(method_name)
+          next if callees_by_handler.has_key?(method_name)
+
+          body = Noir::TreeSitter.field(method, "body")
+          next unless body
+
+          callees_by_handler[method_name] = Noir::JavaCalleeExtractor.callees_in_body(body, content, path).map do |(name, callee_path, callee_line)|
+            Callee.new(name, path: callee_path, line: callee_line)
+          end
+        end
+      end
+
+      callees_by_route = {} of String => Array(Callee)
+      handlers_by_route.each do |key, handler_name|
+        if callees = callees_by_handler[handler_name]?
+          callees_by_route[key] = callees
+        end
+      end
+      callees_by_route
+    end
+
+    private def attach_callees(endpoint : Endpoint, callees_by_route : Hash(String, Array(Callee)), method : String, route : String)
+      callees = callees_by_route[route_key(method, route)]?
+      return unless callees
+
+      callees.each do |callee|
+        endpoint.push_callee(callee)
+      end
+    end
+
+    private def route_key(method : String, route : String) : String
+      "#{method.upcase}::#{route}"
+    end
+
+    private def walk_method_declarations(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      if Noir::TreeSitter.node_type(node) == "method_declaration"
+        block.call(node)
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_method_declarations(child, &block)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- attach Java 1-hop callees to Vert.x routes that use `this::handler` method references
- keep the existing regex route discovery path, then resolve referenced handler method bodies with Tree-sitter
- add a Vert.x callee fixture and functional regression spec

## Verification
- `crystal spec spec/functional_test/testers/java/vertx_callees_spec.cr spec/functional_test/testers/java/vertx_spec.cr`
- `just test`
- `just build`
- `just check`
- `./bin/noir -b spec/functional_test/fixtures/java/vertx_callees --include-callee`

Refs #1366