### PR TITLE
feat(js): wire callees through Hono

### DIFF
--- a/spec/functional_test/fixtures/javascript/hono_callees/app.ts
+++ b/spec/functional_test/fixtures/javascript/hono_callees/app.ts
@@ -1,0 +1,39 @@
+import { Hono } from 'hono'
+import { getCookie } from 'hono/cookie'
+
+const app = new Hono()
+const service = new UserService()
+
+app.post('/users/:id', async (c) => {
+  const id = c.req.param('id')
+  const user = await parseUser(c)
+  await serviceFactory().save(user, id)
+  ;(AuditLog.write)('create')
+
+  return c.json({ ok: true })
+})
+
+app.get('/profile', (c) => {
+  const sessionId = getCookie(c, 'sessionId')
+  const profile = buildProfile(sessionId)
+
+  return c.json(profile)
+})
+
+app.on('GET', '/health', (c) => {
+  const status = healthService.check()
+
+  return c.json({ status })
+})
+
+async function parseUser(c) {
+  return c.req.json()
+}
+
+function serviceFactory() {
+  return service
+}
+
+function buildProfile(sessionId) {
+  return { sessionId }
+}

--- a/spec/functional_test/testers/javascript/hono_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_callees_spec.cr
@@ -1,0 +1,36 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Hono. The shared JS callee
+# extractor is enabled through JSRouteExtractor and the Hono adapter
+# consumes those parser endpoints directly.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "POST", [
+    Param.new("id", "", "path"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("c.req.param", line: 8))
+    ep.push_callee(Callee.new("parseUser", line: 9))
+    ep.push_callee(Callee.new("serviceFactory().save", line: 10))
+    ep.push_callee(Callee.new("AuditLog.write", line: 11))
+    ep.push_callee(Callee.new("c.json", line: 13))
+  end,
+
+  Endpoint.new("/profile", "GET", [
+    Param.new("sessionId", "", "cookie"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("getCookie", line: 17))
+    ep.push_callee(Callee.new("buildProfile", line: 18))
+    ep.push_callee(Callee.new("c.json", line: 20))
+  end,
+
+  Endpoint.new("/health", "GET").tap do |ep|
+    ep.push_callee(Callee.new("healthService.check", line: 24))
+    ep.push_callee(Callee.new("c.json", line: 26))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/hono_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -1,4 +1,5 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
@@ -10,17 +11,17 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
-          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          include_callee = any_to_bool(@options["include_callee"])
+          callees_by_route = include_callee ? Noir::JSCalleeExtractor.callees_for_routes(content, path) : {} of String => Array(Noir::JSCalleeExtractor::Entry)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
+            include_callees: include_callee, route_callees: callees_by_route)
           parser_endpoints.each do |endpoint|
-            details = Details.new(PathInfo.new(path, 1))
-            endpoint.details = details
-
             extract_path_params(endpoint)
             result << endpoint
           end
 
           # Extract app.on() patterns not handled by JSRouteExtractor
-          extract_on_routes(path, content, result)
+          extract_on_routes(path, content, result, callees_by_route)
 
           Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
             static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
@@ -56,7 +57,10 @@ module Analyzer::Javascript
       end
     end
 
-    private def extract_on_routes(path : String, content : String, result : Array(Endpoint))
+    private def extract_on_routes(path : String,
+                                  content : String,
+                                  result : Array(Endpoint),
+                                  callees_by_route : Hash(String, Array(Noir::JSCalleeExtractor::Entry)))
       http_methods = %w[get post put delete patch options head]
       lines = content.lines
       lines.each_with_index do |line, index|
@@ -69,6 +73,7 @@ module Analyzer::Javascript
               endpoint = Endpoint.new(url, method.upcase)
               details = Details.new(PathInfo.new(path, index + 1))
               endpoint.details = details
+              Noir::JSRouteExtractor.attach_callees(endpoint, callees_by_route, method.upcase, url, index + 1)
 
               # Extract params from subsequent lines in the handler body
               ((index + 1)...lines.size).each do |i|

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -1,0 +1,228 @@
+require "../ext/tree_sitter/tree_sitter"
+
+module Noir::JSCalleeExtractor
+  extend self
+
+  HTTP_VERB_METHODS = {
+    "get"     => "GET",
+    "post"    => "POST",
+    "put"     => "PUT",
+    "delete"  => "DELETE",
+    "del"     => "DELETE",
+    "patch"   => "PATCH",
+    "head"    => "HEAD",
+    "options" => "OPTIONS",
+    "trace"   => "TRACE",
+    "connect" => "CONNECT",
+    "all"     => "ALL",
+  }
+
+  alias Entry = Tuple(String, String, Int32)
+
+  def callees_for_routes(source : String, file_path : String) : Hash(String, Array(Entry))
+    by_route = {} of String => Array(Entry)
+    Noir::TreeSitter.parse_javascript(source) do |root|
+      walk_routes(root, source, file_path, by_route, 0)
+    end
+    by_route
+  rescue
+    {} of String => Array(Entry)
+  end
+
+  def route_key(method : String, path : String, line : Int32) : String
+    "#{method.upcase}::#{path}::#{line}"
+  end
+
+  private def walk_routes(node : LibTreeSitter::TSNode,
+                          source : String,
+                          file_path : String,
+                          by_route : Hash(String, Array(Entry)),
+                          depth : Int32)
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "call_expression"
+      route_info = route_info_for_call(node, source)
+      if route_info
+        method, path, handler = route_info
+        line = Noir::TreeSitter.node_start_row(node) + 1
+        by_route[route_key(method, path, line)] = callees_in_handler(handler, source, file_path)
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk_routes(child, source, file_path, by_route, depth + 1)
+    end
+  end
+
+  private def route_info_for_call(call : LibTreeSitter::TSNode, source : String) : Tuple(String, String, LibTreeSitter::TSNode)?
+    method = call_method_name(call, source)
+    return unless HTTP_VERB_METHODS.has_key?(method) || method == "on"
+
+    args = arguments_node(call)
+    return unless args
+
+    if method == "on"
+      return on_route_info(args, source)
+    end
+
+    path : String? = nil
+    handler : LibTreeSitter::TSNode? = nil
+    Noir::TreeSitter.each_named_child(args) do |arg|
+      case Noir::TreeSitter.node_type(arg)
+      when "string", "template_string"
+        path ||= decode_string(arg, source)
+      when "arrow_function", "function_expression"
+        handler ||= arg
+      end
+    end
+    return unless path && handler
+
+    {HTTP_VERB_METHODS[method], path, handler}
+  end
+
+  private def on_route_info(args : LibTreeSitter::TSNode, source : String) : Tuple(String, String, LibTreeSitter::TSNode)?
+    strings = [] of String
+    handler : LibTreeSitter::TSNode? = nil
+
+    Noir::TreeSitter.each_named_child(args) do |arg|
+      case Noir::TreeSitter.node_type(arg)
+      when "string", "template_string"
+        strings << decode_string(arg, source)
+      when "arrow_function", "function_expression"
+        handler ||= arg
+      end
+    end
+
+    return unless strings.size >= 2 && handler
+    method = strings[0].upcase
+    return unless HTTP_VERB_METHODS.values.includes?(method)
+
+    {method, strings[1], handler}
+  end
+
+  private def callees_in_handler(handler : LibTreeSitter::TSNode, source : String, file_path : String) : Array(Entry)
+    body = Noir::TreeSitter.field(handler, "body") || handler
+    sink = [] of Entry
+    walk_callees(body, source, file_path, sink, 0)
+    sink
+  end
+
+  private def walk_callees(node : LibTreeSitter::TSNode,
+                           source : String,
+                           file_path : String,
+                           sink : Array(Entry),
+                           depth : Int32)
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "call_expression"
+      name = callee_text(node, source)
+      unless name.empty?
+        line = Noir::TreeSitter.node_start_row(node) + 1
+        sink << {name, file_path, line}
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk_callees(child, source, file_path, sink, depth + 1)
+    end
+  end
+
+  private def callee_text(call : LibTreeSitter::TSNode, source : String) : String
+    function = Noir::TreeSitter.field(call, "function") || first_named_child(call)
+    return "" unless function
+
+    expression_text(function, source)
+  end
+
+  private def expression_text(node : LibTreeSitter::TSNode, source : String) : String
+    case Noir::TreeSitter.node_type(node)
+    when "identifier", "property_identifier"
+      Noir::TreeSitter.node_text(node, source)
+    when "member_expression"
+      object = Noir::TreeSitter.field(node, "object")
+      property = Noir::TreeSitter.field(node, "property")
+      return "" unless object && property
+
+      receiver = receiver_text(object, source)
+      return "" if receiver.empty?
+
+      property_name = expression_text(property, source)
+      property_name.empty? ? "" : "#{receiver}.#{property_name}"
+    when "parenthesized_expression"
+      inner = first_named_child(node)
+      inner ? expression_text(inner, source) : ""
+    when "sequence_expression"
+      last = last_named_child(node)
+      last ? expression_text(last, source) : ""
+    else
+      ""
+    end
+  end
+
+  private def receiver_text(node : LibTreeSitter::TSNode, source : String) : String
+    case Noir::TreeSitter.node_type(node)
+    when "identifier", "property_identifier", "this", "super"
+      Noir::TreeSitter.node_text(node, source)
+    when "member_expression"
+      expression_text(node, source)
+    when "call_expression"
+      name = callee_text(node, source)
+      name.empty? ? "" : "#{name}()"
+    when "parenthesized_expression"
+      inner = first_named_child(node)
+      inner ? receiver_text(inner, source) : ""
+    else
+      ""
+    end
+  end
+
+  private def call_method_name(call : LibTreeSitter::TSNode, source : String) : String
+    function = Noir::TreeSitter.field(call, "function") || first_named_child(call)
+    return "" unless function
+    return "" unless Noir::TreeSitter.node_type(function) == "member_expression"
+
+    property = Noir::TreeSitter.field(function, "property")
+    property ? Noir::TreeSitter.node_text(property, source).downcase : ""
+  end
+
+  private def arguments_node(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    Noir::TreeSitter.field(call, "arguments") || begin
+      Noir::TreeSitter.each_named_child(call) do |child|
+        return child if Noir::TreeSitter.node_type(child) == "arguments"
+      end
+      nil
+    end
+  end
+
+  private def first_named_child(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    child_count = LibTreeSitter.ts_node_named_child_count(node)
+    return if child_count == 0
+
+    LibTreeSitter.ts_node_named_child(node, 0)
+  end
+
+  private def last_named_child(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    child_count = LibTreeSitter.ts_node_named_child_count(node)
+    return if child_count == 0
+
+    LibTreeSitter.ts_node_named_child(node, child_count - 1)
+  end
+
+  private def decode_string(node : LibTreeSitter::TSNode, source : String) : String
+    fragments = [] of String
+    Noir::TreeSitter.each_named_child(node) do |child|
+      type = Noir::TreeSitter.node_type(child)
+      if type == "string_fragment" || type == "template_chars"
+        fragments << Noir::TreeSitter.node_text(child, source)
+      end
+    end
+    return fragments.join unless fragments.empty?
+
+    text = Noir::TreeSitter.node_text(node, source)
+    if text.size >= 2
+      text[1..-2]
+    else
+      text
+    end
+  end
+end

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -1,4 +1,5 @@
 require "../models/endpoint"
+require "../miniparsers/js_callee_extractor"
 require "../minilexers/js_lexer"
 require "../miniparsers/js_parser"
 require "../models/code_locator"
@@ -12,13 +13,23 @@ module Noir
     # Import constants for key generation
     ROUTER_PREFIX_KEY = Analyzer::Javascript::ExpressConstants::ROUTER_PREFIX_KEY
 
-    def self.extract_routes(file_path : String, content : String? = nil, debug : Bool = false) : Array(Endpoint)
+    def self.extract_routes(file_path : String,
+                            content : String? = nil,
+                            debug : Bool = false,
+                            *,
+                            include_callees : Bool = false,
+                            route_callees : Hash(String, Array(JSCalleeExtractor::Entry))? = nil) : Array(Endpoint)
       return [] of Endpoint unless File.exists?(file_path)
 
       begin
         content = content || File.read(file_path, encoding: "utf-8", invalid: :skip)
         parser = JSParser.new(content)
         route_patterns = parser.parse_routes
+        callees_by_route = if include_callees
+                             route_callees || JSCalleeExtractor.callees_for_routes(content, file_path)
+                           else
+                             {} of String => Array(JSCalleeExtractor::Entry)
+                           end
 
         if debug && parser.hit_max_iterations?
           STDERR.puts "Warning: Maximum iterations reached in JS parser, parsing may be incomplete"
@@ -178,6 +189,7 @@ module Noir
 
                 # Extract other parameters like body, query, etc. from the content around this route
                 extract_params_from_context(content, pattern, endpoint)
+                attach_callees(endpoint, callees_by_route, normalized_method, pattern.raw_path, line_number)
 
                 endpoints << endpoint
               end
@@ -191,6 +203,7 @@ module Noir
 
               # Extract other parameters like body, query, etc. from the content around this route
               extract_params_from_context(content, pattern, endpoint)
+              attach_callees(endpoint, callees_by_route, normalized_method, pattern.raw_path, line_number)
 
               endpoints << endpoint
             end
@@ -201,6 +214,19 @@ module Noir
       rescue
         # If parser fails, return empty array
         [] of Endpoint
+      end
+    end
+
+    def self.attach_callees(endpoint : Endpoint,
+                            callees_by_route : Hash(String, Array(JSCalleeExtractor::Entry)),
+                            method : String,
+                            path : String,
+                            line : Int32)
+      callees = callees_by_route[JSCalleeExtractor.route_key(method, path, line)]?
+      return unless callees
+
+      callees.each do |name, callee_path, callee_line|
+        endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
       end
     end
 


### PR DESCRIPTION
## Summary
- add a shared Tree-sitter-backed `JSCalleeExtractor` for route handler bodies
- expose optional callee attachment through `JSRouteExtractor`
- enable the shared extractor in the Hono adapter, including `app.on()` fallback routes
- add a Hono callee fixture and functional regression spec

## Verification
- `crystal spec spec/functional_test/testers/javascript/hono_callees_spec.cr spec/functional_test/testers/javascript/hono_spec.cr spec/unit_test/miniparser/js_route_extractor_spec.cr`
- `just test`
- `just build`
- `just check`
- `./bin/noir -b spec/functional_test/fixtures/javascript/hono_callees --include-callee`

Refs #1366