### PR TITLE
feat(js): wire callees through Fastify

### DIFF
--- a/spec/functional_test/fixtures/javascript/fastify_callees/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_callees/app.js
@@ -1,0 +1,30 @@
+const fastify = require('fastify')({ logger: true })
+
+const service = new UserService()
+
+fastify.post('/users/:id', async (request, reply) => {
+  const id = request.params.id
+  const user = await parseUser(request)
+  await serviceFactory().save(user, id)
+  ;(AuditLog.write)('create')
+
+  return reply.send(user)
+})
+
+fastify.get('/profile', async (request, reply) => {
+  const profile = await loadProfile(request.query.userId)
+
+  return reply.send(profile)
+})
+
+async function parseUser(request) {
+  return request.body
+}
+
+function serviceFactory() {
+  return service
+}
+
+async function loadProfile(userId) {
+  return { userId }
+}

--- a/spec/functional_test/testers/javascript/fastify_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_callees_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Fastify. Fastify consumes
+# JSRouteExtractor, so it can reuse the shared JS callee extractor
+# introduced for Hono.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "POST", [
+    Param.new("id", "", "path"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("parseUser", line: 7))
+    ep.push_callee(Callee.new("serviceFactory().save", line: 8))
+    ep.push_callee(Callee.new("AuditLog.write", line: 9))
+    ep.push_callee(Callee.new("reply.send", line: 11))
+  end,
+
+  Endpoint.new("/profile", "GET", [
+    Param.new("userId", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("loadProfile", line: 15))
+    ep.push_callee(Callee.new("reply.send", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/fastify_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -6,11 +6,13 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
+      include_callee = any_to_bool(@options["include_callee"])
 
       parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
-          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
+            include_callees: include_callee)
           parser_endpoints.each do |endpoint|
             # Add file location details
             details = Details.new(PathInfo.new(path, 1)) # Line number is approximate


### PR DESCRIPTION
## Summary
- enable shared JS callee extraction in the Fastify analyzer when `include_callee` is set
- add a Fastify callee fixture covering inline handlers, parenthesized calls, and fluent receivers
- add a functional regression spec for Fastify endpoint callees

## Verification
- `crystal spec spec/functional_test/testers/javascript/fastify_callees_spec.cr spec/functional_test/testers/javascript/fastify_spec.cr spec/unit_test/miniparser/js_route_extractor_spec.cr`
- `just test`
- `just build`
- `just check`
- `./bin/noir -b spec/functional_test/fixtures/javascript/fastify_callees --include-callee`

Refs #1366