### PR TITLE
feat(js): wire callees through Koa

### DIFF
--- a/spec/functional_test/fixtures/javascript/koa_callees/app.js
+++ b/spec/functional_test/fixtures/javascript/koa_callees/app.js
@@ -1,0 +1,41 @@
+const Koa = require('koa')
+const Router = require('@koa/router')
+
+const app = new Koa()
+const router = new Router()
+
+router.post('/users/:id', async ctx => {
+  const id = ctx.params.id
+  const actor = ctx.get('X-Actor')
+  const payload = await parseBody(ctx)
+  await serviceFactory().save(payload, id, actor)
+  ;(AuditLog.write)('koa:create')
+
+  ctx.body = serializeUser(payload)
+})
+
+router.get('/session', async ctx => {
+  const sessionId = ctx.cookies.get('sessionId')
+  const profile = await loadProfile(sessionId)
+
+  ctx.body = profile
+})
+
+function parseBody(ctx) {
+  return ctx.request.body
+}
+
+function serviceFactory() {
+  return userService
+}
+
+function serializeUser(payload) {
+  return { data: payload }
+}
+
+async function loadProfile(sessionId) {
+  return { sessionId }
+}
+
+app.use(router.routes())
+app.listen(3000)

--- a/spec/functional_test/testers/javascript/koa_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_callees_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Koa. Koa consumes
+# JSRouteExtractor, so it can reuse the shared JS callee extractor.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("X-Actor", "", "header"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("ctx.get", line: 9))
+    ep.push_callee(Callee.new("parseBody", line: 10))
+    ep.push_callee(Callee.new("serviceFactory().save", line: 11))
+    ep.push_callee(Callee.new("AuditLog.write", line: 12))
+    ep.push_callee(Callee.new("serializeUser", line: 14))
+  end,
+
+  Endpoint.new("/session", "GET", [
+    Param.new("sessionId", "", "cookie"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("ctx.cookies.get", line: 18))
+    ep.push_callee(Callee.new("loadProfile", line: 19))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/koa_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/js_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_callee_extractor_spec.cr
@@ -1,0 +1,21 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/js_callee_extractor"
+
+describe Noir::JSCalleeExtractor do
+  it "does not duplicate receiver calls for fluent method invocations" do
+    source = <<-JS
+      app.post('/users/:id', async (req, res) => {
+        await serviceFactory().save(req.body)
+        res.send(await loadProfile())
+      })
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_routes(source, "app.js")
+    route_callees = callees[Noir::JSCalleeExtractor.route_key("POST", "/users/:id", 1)]
+    route_callees.map(&.[0]).should eq([
+      "serviceFactory().save",
+      "res.send",
+      "loadProfile",
+    ])
+  end
+end

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -6,11 +6,13 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
+      include_callee = any_to_bool(@options["include_callee"])
 
       parallel_file_scan([".js", ".ts", ".mjs"]) do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
-          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
+            include_callees: include_callee)
           parser_endpoints.each do |endpoint|
             details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
             endpoint.details = details

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -114,15 +114,19 @@ module Noir::JSCalleeExtractor
                            depth : Int32)
     return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
+    skip_function_child : LibTreeSitter::TSNode? = nil
     if Noir::TreeSitter.node_type(node) == "call_expression"
       name = callee_text(node, source)
       unless name.empty?
         line = Noir::TreeSitter.node_start_row(node) + 1
         sink << {name, file_path, line}
+        skip_function_child = Noir::TreeSitter.field(node, "function") || first_named_child(node)
       end
     end
 
     Noir::TreeSitter.each_named_child(node) do |child|
+      next if skip_function_child && same_node?(child, skip_function_child)
+
       walk_callees(child, source, file_path, sink, depth + 1)
     end
   end
@@ -206,6 +210,11 @@ module Noir::JSCalleeExtractor
     return if child_count == 0
 
     LibTreeSitter.ts_node_named_child(node, child_count - 1)
+  end
+
+  private def same_node?(left : LibTreeSitter::TSNode, right : LibTreeSitter::TSNode) : Bool
+    LibTreeSitter.ts_node_start_byte(left) == LibTreeSitter.ts_node_start_byte(right) &&
+      LibTreeSitter.ts_node_end_byte(left) == LibTreeSitter.ts_node_end_byte(right)
   end
 
   private def decode_string(node : LibTreeSitter::TSNode, source : String) : String


### PR DESCRIPTION
## Summary

- enable shared JS callee extraction for Koa when include_callee is set
- add a Koa callee fixture and functional spec
- tighten JS callee extraction so fluent receiver calls like serviceFactory().save do not also emit serviceFactory

## Verification

- crystal spec spec/unit_test/miniparser/js_callee_extractor_spec.cr spec/functional_test/testers/javascript/koa_callees_spec.cr spec/functional_test/testers/javascript/fastify_callees_spec.cr spec/functional_test/testers/javascript/hono_callees_spec.cr
- ./bin/noir -b spec/functional_test/fixtures/javascript/koa_callees --include-callee
- ./bin/noir -b spec/functional_test/fixtures/javascript/fastify_callees --include-callee
- just build
- just check
- just test