### PR TITLE
feat(js): wire callees through Restify

### DIFF
--- a/spec/functional_test/fixtures/javascript/restify_callees/app.js
+++ b/spec/functional_test/fixtures/javascript/restify_callees/app.js
@@ -1,0 +1,56 @@
+const restify = require('restify')
+const Router = require('restify-router').Router
+
+const server = restify.createServer()
+const router = new Router()
+
+server.post('/users/:id', function (req, res, next) {
+  const id = req.params.id
+  const actor = req.header('X-Actor')
+  const payload = parseUser(req)
+  serviceFactory().save(payload, id, actor)
+  AuditLog.write('restify:create')
+
+  res.send(201, serializeUser(payload))
+  return next()
+})
+
+function setupRoutes(server) {
+  server.get('/health', function (req, res, next) {
+    const status = loadHealth()
+    res.send(status)
+    return next()
+  })
+}
+
+router.get('/profile', function (req, res, next) {
+  const userId = req.query.userId
+  const profile = loadProfile(userId)
+
+  res.send(profile)
+  return next()
+})
+
+function parseUser(req) {
+  return req.body
+}
+
+function serviceFactory() {
+  return userService
+}
+
+function serializeUser(payload) {
+  return { data: payload }
+}
+
+function loadHealth() {
+  return { ok: true }
+}
+
+function loadProfile(userId) {
+  return { userId }
+}
+
+setupRoutes(server)
+router.applyRoutes(server)
+server.listen(3000)

--- a/spec/functional_test/testers/javascript/restify_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/restify_callees_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Restify. Restify consumes
+# JSRouteExtractor, so direct parser-covered routes reuse the shared
+# JS callee extractor. Prefix semantics in applyRoutes(base) stay out
+# of scope for this fixture.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("X-Actor", "", "header"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("req.header", line: 9))
+    ep.push_callee(Callee.new("parseUser", line: 10))
+    ep.push_callee(Callee.new("serviceFactory().save", line: 11))
+    ep.push_callee(Callee.new("AuditLog.write", line: 12))
+    ep.push_callee(Callee.new("res.send", line: 14))
+    ep.push_callee(Callee.new("serializeUser", line: 14))
+  end,
+
+  Endpoint.new("/health", "GET").tap do |ep|
+    ep.push_callee(Callee.new("loadHealth", line: 20))
+    ep.push_callee(Callee.new("res.send", line: 21))
+  end,
+
+  Endpoint.new("/profile", "GET", [
+    Param.new("userId", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("loadProfile", line: 28))
+    ep.push_callee(Callee.new("res.send", line: 30))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/restify_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -6,11 +6,13 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       parallel_file_scan do |path|
         begin
           content = File.read(path, encoding: "utf-8", invalid: :skip)
-          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
+            include_callees: include_callee)
           parser_endpoints.each do |endpoint|
             # Add file location details
             details = Details.new(PathInfo.new(path, 1)) # Line number is approximate


### PR DESCRIPTION
## Summary

- enable shared JS callee extraction for Restify when include_callee is set
- add a Restify callee fixture covering direct, function-scoped, and unprefixed router routes
- keep applyRoutes(base) prefix behavior out of scope for this callee-only pass

## Verification

- crystal spec spec/functional_test/testers/javascript/restify_callees_spec.cr spec/functional_test/testers/javascript/restify_spec.cr spec/unit_test/miniparser/js_callee_extractor_spec.cr spec/unit_test/miniparser/js_route_extractor_spec.cr
- ./bin/noir -b spec/functional_test/fixtures/javascript/restify_callees --include-callee
- just build
- just check
- just test