### PR TITLE
feat(js): wire callees through Express

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_callees/app.js
+++ b/spec/functional_test/fixtures/javascript/express_callees/app.js
@@ -1,0 +1,39 @@
+const express = require('express')
+
+const app = express()
+const router = express.Router()
+
+app.post('/users/:id', async (req, res) => {
+  const id = req.params.id
+  const include = req.query.include
+  const user = await parseUser(req)
+  await serviceFactory().save(user, id, include)
+  AuditLog.write('express:create')
+
+  return res.json(serializeUser(user))
+})
+
+router.get('/profile', (req, res) => {
+  const sessionId = req.cookies.sessionId
+  const profile = loadProfile(sessionId)
+
+  return res.send(profile)
+})
+
+app.use('/api', router)
+
+function parseUser(req) {
+  return req.body
+}
+
+function serviceFactory() {
+  return userService
+}
+
+function serializeUser(user) {
+  return { data: user }
+}
+
+function loadProfile(sessionId) {
+  return { sessionId }
+}

--- a/spec/functional_test/testers/javascript/express_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/express_callees_spec.cr
@@ -1,0 +1,31 @@
+require "../../func_spec.cr"
+
+# Regression test for --include-callee on Express. Express consumes
+# JSRouteExtractor after its router-mount pre-scan, so parser-covered
+# handlers can reuse the shared JS callee extractor.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("include", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("parseUser", line: 9))
+    ep.push_callee(Callee.new("serviceFactory().save", line: 10))
+    ep.push_callee(Callee.new("AuditLog.write", line: 11))
+    ep.push_callee(Callee.new("res.json", line: 13))
+    ep.push_callee(Callee.new("serializeUser", line: 13))
+  end,
+
+  Endpoint.new("/api/profile", "GET", [
+    Param.new("sessionId", "", "cookie"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("loadProfile", line: 18))
+    ep.push_callee(Callee.new("res.send", line: 20))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/express_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -16,6 +16,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Phase 1: Pre-scan to build router mount map
       scan_for_router_mounts
@@ -23,7 +24,8 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
-          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug)
+          parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
+            include_callees: include_callee)
           parser_endpoints.each do |endpoint|
             # Use the line number already set by the extractor; fall back to path-only if missing
             if endpoint.details.code_paths.empty?


### PR DESCRIPTION
## Summary

- enable shared JS callee extraction for Express when include_callee is set
- add an Express callee fixture covering direct routes and a mounted router route
- keep legacy regex fallback behavior unchanged; this wires parser-covered routes through JSRouteExtractor

## Verification

- crystal spec spec/functional_test/testers/javascript/express_callees_spec.cr spec/functional_test/testers/javascript/express_spec.cr spec/functional_test/testers/javascript/express_deep_nesting_spec.cr spec/unit_test/miniparser/js_callee_extractor_spec.cr spec/unit_test/miniparser/js_route_extractor_spec.cr
- ./bin/noir -b spec/functional_test/fixtures/javascript/express_callees --include-callee
- just build
- just check
- just test