### PR TITLE
feat(js): wire callees through SvelteKit

### DIFF
--- a/spec/functional_test/fixtures/javascript/sveltekit_callees/package.json
+++ b/spec/functional_test/fixtures/javascript/sveltekit_callees/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sveltekit-callees-fixture",
+  "private": true,
+  "dependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/adapter-node": "^5.0.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/sveltekit_callees/src/routes/api/users/+server.ts
+++ b/spec/functional_test/fixtures/javascript/sveltekit_callees/src/routes/api/users/+server.ts
@@ -1,0 +1,17 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ url }) => {
+  const page = url.searchParams.get('page');
+  const users = await listUsers(page);
+  AuditLog.write('svelte:list');
+
+  return json(serializeUsers(users));
+};
+
+export const POST: RequestHandler = async ({ request }) => {
+  const body = await request.json();
+  await serviceFactory().create(body);
+  AuditLog.write('svelte:create');
+
+  return json({ ok: true });
+};

--- a/spec/functional_test/fixtures/javascript/sveltekit_callees/src/routes/api/users/[id]/+server.ts
+++ b/spec/functional_test/fixtures/javascript/sveltekit_callees/src/routes/api/users/[id]/+server.ts
@@ -1,0 +1,16 @@
+import { json } from '@sveltejs/kit';
+
+export async function PUT({ params, request }) {
+  const body = await request.json();
+  await updateUser(params.id, body);
+  AuditLog.write('svelte:update');
+
+  return json({ id: params.id });
+}
+
+const deleteUser = async ({ params }) => {
+  await deleteUserById(params.id);
+  return json({ deleted: true });
+};
+
+export { deleteUser as DELETE };

--- a/spec/functional_test/fixtures/javascript/sveltekit_callees/svelte.config.js
+++ b/spec/functional_test/fixtures/javascript/sveltekit_callees/svelte.config.js
@@ -1,0 +1,7 @@
+import adapter from '@sveltejs/adapter-node';
+
+export default {
+  kit: {
+    adapter: adapter()
+  }
+};

--- a/spec/functional_test/testers/javascript/sveltekit_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_callees_spec.cr
@@ -1,0 +1,40 @@
+require "../../func_spec.cr"
+
+list_endpoint = Endpoint.new("/api/users", "GET")
+list_endpoint.push_callee(Callee.new("url.searchParams.get", line: 4))
+list_endpoint.push_callee(Callee.new("listUsers", line: 5))
+list_endpoint.push_callee(Callee.new("AuditLog.write", line: 6))
+list_endpoint.push_callee(Callee.new("json", line: 8))
+list_endpoint.push_callee(Callee.new("serializeUsers", line: 8))
+
+create_endpoint = Endpoint.new("/api/users", "POST")
+create_endpoint.push_callee(Callee.new("request.json", line: 12))
+create_endpoint.push_callee(Callee.new("serviceFactory().create", line: 13))
+create_endpoint.push_callee(Callee.new("AuditLog.write", line: 14))
+create_endpoint.push_callee(Callee.new("json", line: 16))
+
+update_endpoint = Endpoint.new("/api/users/{id}", "PUT", [
+  Param.new("id", "", "path"),
+])
+update_endpoint.push_callee(Callee.new("request.json", line: 4))
+update_endpoint.push_callee(Callee.new("updateUser", line: 5))
+update_endpoint.push_callee(Callee.new("AuditLog.write", line: 6))
+update_endpoint.push_callee(Callee.new("json", line: 8))
+
+delete_endpoint = Endpoint.new("/api/users/{id}", "DELETE", [
+  Param.new("id", "", "path"),
+])
+delete_endpoint.push_callee(Callee.new("deleteUserById", line: 12))
+delete_endpoint.push_callee(Callee.new("json", line: 13))
+
+FunctionalTester.new("fixtures/javascript/sveltekit_callees/", {
+  :techs     => 1,
+  :endpoints => 4,
+}, [
+  list_endpoint,
+  create_endpoint,
+  update_endpoint,
+  delete_endpoint,
+], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/js_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_callee_extractor_spec.cr
@@ -47,4 +47,46 @@ describe Noir::JSCalleeExtractor do
       {"this.usersService.create", 22},
     ])
   end
+
+  it "extracts callees from exported handlers using the AST" do
+    source = <<-JS
+      export const GET = async ({ url }) => {
+        const marker = "}"
+        // }
+        return json(loadUsers(marker))
+      }
+
+      const remove = async ({ params }) => json(deleteUser(params.id))
+      export { remove as DELETE }
+      JS
+
+    get_callees = Noir::JSCalleeExtractor.callees_for_exported_function(source, "routes/+server.ts", "GET")
+    get_callees.map { |name, _, line| {name, line} }.should eq([
+      {"json", 4},
+      {"loadUsers", 4},
+    ])
+
+    delete_callees = Noir::JSCalleeExtractor.callees_for_exported_function(source, "routes/+server.ts", "DELETE")
+    delete_callees.map { |name, _, line| {name, line} }.should eq([
+      {"json", 7},
+      {"deleteUser", 7},
+    ])
+  end
+
+  it "extracts callees from typed exported arrow handlers" do
+    source = <<-TS
+      import { type RequestHandler } from '@sveltejs/kit'
+
+      export const POST: RequestHandler = async ({ request }) => {
+        const body = await request.json()
+        await serviceFactory().create(body)
+      }
+      TS
+
+    callees = Noir::JSCalleeExtractor.callees_for_exported_function(source, "routes/+server.ts", "POST")
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"request.json", 4},
+      {"serviceFactory().create", 5},
+    ])
+  end
 end

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -1,4 +1,5 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
 
 module Analyzer::Javascript
   # SvelteKit is a filesystem-routed framework. Routes live under
@@ -40,6 +41,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       parallel_file_scan(EXTENSIONS) do |path|
         idx = path.index("/src/routes/")
@@ -52,7 +54,7 @@ module Analyzer::Javascript
         if page_file?(leaf)
           analyze_page(path, relative, result, mutex)
         elsif server_file?(leaf)
-          analyze_api_route(path, relative, result, mutex)
+          analyze_api_route(path, relative, result, mutex, include_callee)
         end
       end
 
@@ -82,7 +84,7 @@ module Analyzer::Javascript
       mutex.synchronize { result << endpoint }
     end
 
-    private def analyze_api_route(path : String, relative : String, result : Array(Endpoint), mutex : Mutex)
+    private def analyze_api_route(path : String, relative : String, result : Array(Endpoint), mutex : Mutex, include_callee : Bool)
       url = url_for(relative)
       content = begin
         read_file_content(path)
@@ -92,10 +94,14 @@ module Analyzer::Javascript
       end
 
       methods = detect_api_methods(content)
+      endpoints = methods.map do |verb|
+        endpoint = build_endpoint(url, verb, path)
+        attach_callees(endpoint, path, content, verb) if include_callee
+        endpoint
+      end
+
       mutex.synchronize do
-        methods.each do |verb|
-          result << build_endpoint(url, verb, path)
-        end
+        endpoints.each { |endpoint| result << endpoint }
       end
     end
 
@@ -147,6 +153,12 @@ module Analyzer::Javascript
         end
       end
       explicit.empty? ? FALLBACK_API_METHODS : explicit
+    end
+
+    private def attach_callees(endpoint : Endpoint, path : String, content : String, verb : String)
+      Noir::JSCalleeExtractor.callees_for_exported_function(content, path, verb).each do |name, callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+      end
     end
   end
 end

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -61,6 +61,22 @@ module Noir::JSCalleeExtractor
     language == :typescript ? fallback_callees_for_function_body(body, file_path, open_brace_line) : [] of Entry
   end
 
+  def callees_for_exported_function(source : String,
+                                    file_path : String,
+                                    export_name : String) : Array(Entry)
+    source_for_ast = normalize_exported_handler_source(source)
+    sink = [] of Entry
+    Noir::TreeSitter.parse_javascript(source_for_ast) do |root|
+      if handler = exported_handler(root, root, source_for_ast, export_name, 0)
+        walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0)
+      end
+    end
+
+    dedup_entries(sink)
+  rescue
+    [] of Entry
+  end
+
   def route_key(method : String, path : String, line : Int32) : String
     "#{method.upcase}::#{path}::#{line}"
   end
@@ -133,10 +149,128 @@ module Noir::JSCalleeExtractor
   end
 
   private def callees_in_handler(handler : LibTreeSitter::TSNode, source : String, file_path : String) : Array(Entry)
-    body = Noir::TreeSitter.field(handler, "body") || handler
     sink = [] of Entry
-    walk_callees(body, source, file_path, sink, 0)
+    walk_callees(handler_body(handler), source, file_path, sink, 0)
     sink
+  end
+
+  private def normalize_exported_handler_source(source : String) : String
+    # The vendored JavaScript grammar still exposes useful nodes for many
+    # TypeScript files, but `const GET: RequestHandler = ...` makes the
+    # variable name parse as the type. Strip same-line annotations while
+    # preserving line numbers so AST row-based callee locations stay valid.
+    source.gsub(/(\b(?:export\s+)?(?:const|let|var)\s+[A-Za-z_$][\w$]*)\s*:\s*[^=\n]+=/, "\\1 =")
+  end
+
+  private def exported_handler(root : LibTreeSitter::TSNode,
+                               node : LibTreeSitter::TSNode,
+                               source : String,
+                               export_name : String,
+                               depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "export_statement"
+      if declaration = Noir::TreeSitter.field(node, "declaration")
+        if handler = declaration_handler(declaration, source, export_name)
+          return handler
+        end
+      elsif local_name = export_clause_local_name(node, source, export_name)
+        return local_handler(root, source, local_name, 0)
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if handler = exported_handler(root, child, source, export_name, depth + 1)
+        return handler
+      end
+    end
+  end
+
+  private def declaration_handler(node : LibTreeSitter::TSNode,
+                                  source : String,
+                                  name : String) : LibTreeSitter::TSNode?
+    if handler_node?(node)
+      node_name = Noir::TreeSitter.field(node, "name")
+      return node if node_name && Noir::TreeSitter.node_text(node_name, source) == name
+    end
+
+    variable_handler(node, source, name, 0)
+  end
+
+  private def local_handler(node : LibTreeSitter::TSNode,
+                            source : String,
+                            name : String,
+                            depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if handler_node?(node)
+      node_name = Noir::TreeSitter.field(node, "name")
+      return node if node_name && Noir::TreeSitter.node_text(node_name, source) == name
+    end
+
+    if handler = variable_handler(node, source, name, depth)
+      return handler
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if handler = local_handler(child, source, name, depth + 1)
+        return handler
+      end
+    end
+  end
+
+  private def variable_handler(node : LibTreeSitter::TSNode,
+                               source : String,
+                               name : String,
+                               depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "variable_declarator"
+      node_name = Noir::TreeSitter.field(node, "name")
+      if node_name && Noir::TreeSitter.node_text(node_name, source) == name
+        value = Noir::TreeSitter.field(node, "value")
+        return value if value && handler_node?(value)
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if handler = variable_handler(child, source, name, depth + 1)
+        return handler
+      end
+    end
+  end
+
+  private def export_clause_local_name(node : LibTreeSitter::TSNode,
+                                       source : String,
+                                       export_name : String) : String?
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if Noir::TreeSitter.node_type(child) == "export_clause"
+        Noir::TreeSitter.each_named_child(child) do |specifier|
+          next unless Noir::TreeSitter.node_type(specifier) == "export_specifier"
+
+          name = Noir::TreeSitter.field(specifier, "name")
+          alias_name = Noir::TreeSitter.field(specifier, "alias")
+          exported = alias_name || name
+          next unless name && exported
+          next unless Noir::TreeSitter.node_text(exported, source) == export_name
+
+          return Noir::TreeSitter.node_text(name, source)
+        end
+      end
+    end
+  end
+
+  private def handler_body(handler : LibTreeSitter::TSNode) : LibTreeSitter::TSNode
+    Noir::TreeSitter.field(handler, "body") || handler
+  end
+
+  private def handler_node?(node : LibTreeSitter::TSNode) : Bool
+    case Noir::TreeSitter.node_type(node)
+    when "function_declaration", "function_expression", "arrow_function"
+      true
+    else
+      false
+    end
   end
 
   private def walk_first_function_body(node : LibTreeSitter::TSNode,


### PR DESCRIPTION
## Summary
- attach shared JS callee extraction to SvelteKit `+server` route handlers when `include_callee` is enabled
- scope callees to explicit verb exports and same-file export aliases without attaching page-component or fallback-route callees
- add focused SvelteKit callee fixture coverage for typed `RequestHandler`, function exports, and alias exports

## Tests
- `crystal spec spec/functional_test/testers/javascript/sveltekit_callees_spec.cr spec/functional_test/testers/javascript/sveltekit_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sveltekit just build`
- `./bin/noir -b spec/functional_test/fixtures/javascript/sveltekit_callees --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sveltekit just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sveltekit just test`