### PR TITLE
feat(js): wire callees through Remix

### DIFF
--- a/spec/functional_test/fixtures/javascript/remix_callees/app/routes/api.users.ts
+++ b/spec/functional_test/fixtures/javascript/remix_callees/app/routes/api.users.ts
@@ -1,0 +1,18 @@
+import { json, type LoaderFunctionArgs, type ActionFunctionArgs } from "@remix-run/node";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const page = url.searchParams.get("page");
+  const users = await listUsers(page);
+  AuditLog.write("remix:list");
+
+  return json(serializeUsers(users));
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const body = await request.json();
+  await serviceFactory().create(body);
+  AuditLog.write("remix:create");
+
+  return json({ ok: true });
+}

--- a/spec/functional_test/fixtures/javascript/remix_callees/app/routes/users.$id.ts
+++ b/spec/functional_test/fixtures/javascript/remix_callees/app/routes/users.$id.ts
@@ -1,0 +1,14 @@
+import { json, type LoaderFunctionArgs, type ActionFunctionArgs } from "@remix-run/node";
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  const user = await loadUser(params.id);
+  return json(serializeUser(user));
+};
+
+const mutateUser = async ({ params, request }: ActionFunctionArgs) => {
+  const body = await request.formData();
+  await updateUser(params.id, body);
+  return json({ ok: true });
+};
+
+export { mutateUser as action };

--- a/spec/functional_test/fixtures/javascript/remix_callees/package.json
+++ b/spec/functional_test/fixtures/javascript/remix_callees/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "remix-callees-fixture",
+  "private": true,
+  "dependencies": {
+    "@remix-run/node": "^2.0.0",
+    "@remix-run/react": "^2.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/spec/functional_test/testers/javascript/remix_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/remix_callees_spec.cr
@@ -1,0 +1,55 @@
+require "../../func_spec.cr"
+
+api_loader = Endpoint.new("/api/users", "GET")
+api_loader.push_callee(Callee.new("url.searchParams.get", line: 5))
+api_loader.push_callee(Callee.new("listUsers", line: 6))
+api_loader.push_callee(Callee.new("AuditLog.write", line: 7))
+api_loader.push_callee(Callee.new("json", line: 9))
+api_loader.push_callee(Callee.new("serializeUsers", line: 9))
+
+api_action_callees = [
+  Callee.new("request.json", line: 13),
+  Callee.new("serviceFactory().create", line: 14),
+  Callee.new("AuditLog.write", line: 15),
+  Callee.new("json", line: 17),
+]
+
+user_loader = Endpoint.new("/users/{id}", "GET", [
+  Param.new("id", "", "path"),
+])
+user_loader.push_callee(Callee.new("loadUser", line: 4))
+user_loader.push_callee(Callee.new("json", line: 5))
+user_loader.push_callee(Callee.new("serializeUser", line: 5))
+
+user_action_callees = [
+  Callee.new("request.formData", line: 9),
+  Callee.new("updateUser", line: 10),
+  Callee.new("json", line: 11),
+]
+
+expected_endpoints = [
+  api_loader,
+]
+
+["POST", "PUT", "PATCH", "DELETE"].each do |verb|
+  endpoint = Endpoint.new("/api/users", verb)
+  api_action_callees.each { |callee| endpoint.push_callee(callee) }
+  expected_endpoints << endpoint
+end
+
+expected_endpoints << user_loader
+
+["POST", "PUT", "PATCH", "DELETE"].each do |verb|
+  endpoint = Endpoint.new("/users/{id}", verb, [
+    Param.new("id", "", "path"),
+  ])
+  user_action_callees.each { |callee| endpoint.push_callee(callee) }
+  expected_endpoints << endpoint
+end
+
+FunctionalTester.new("fixtures/javascript/remix_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -1,4 +1,5 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
 
 module Analyzer::Javascript
   # Remix v2 is filesystem-routed under `app/routes/`. The route URL
@@ -48,6 +49,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       parallel_file_scan(EXTENSIONS) do |path|
         idx = path.index("/app/routes/")
@@ -72,11 +74,27 @@ module Analyzer::Javascript
         end
 
         is_page = PAGE_EXTENSIONS.any? { |ext| relative.ends_with?(ext) }
-        verbs = detect_verbs(content, is_page)
+        has_loader = export_named?(content, "loader")
+        has_action = export_named?(content, "action")
+        verbs = detect_verbs(is_page, has_loader, has_action)
         next if verbs.empty?
 
+        loader_callees = include_callee && has_loader ? Noir::JSCalleeExtractor.callees_for_exported_function(content, path, "loader") : nil
+        action_callees = include_callee && has_action ? Noir::JSCalleeExtractor.callees_for_exported_function(content, path, "action") : nil
+
+        endpoints = verbs.map do |verb|
+          endpoint = build_endpoint(url, verb, path)
+          if include_callee
+            callees = verb == "GET" ? loader_callees : action_callees
+            callees.try &.each do |name, callee_path, line|
+              endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+            end
+          end
+          endpoint
+        end
+
         mutex.synchronize do
-          verbs.each { |verb| result << build_endpoint(url, verb, path) }
+          endpoints.each { |endpoint| result << endpoint }
         end
       end
 
@@ -132,13 +150,10 @@ module Analyzer::Javascript
       url == "/" ? "/" : url.sub(/\/+$/, "")
     end
 
-    # `verbs(content, is_page)` — figure out which verbs the file
+    # `verbs(is_page, has_loader, has_action)` — figure out which verbs the file
     # registers based on the page-vs-resource shape and the
     # exported names.
-    private def detect_verbs(content : String, is_page : Bool) : Array(String)
-      has_loader = export_named?(content, "loader")
-      has_action = export_named?(content, "action")
-
+    private def detect_verbs(is_page : Bool, has_loader : Bool, has_action : Bool) : Array(String)
       verbs = [] of String
       verbs << "GET" if is_page || has_loader
       verbs.concat(NON_GET_VERBS) if has_action


### PR DESCRIPTION
## Summary
- attach shared JS exported-handler callee extraction to Remix loader/action routes when `include_callee` is enabled
- scope GET callees to `loader` exports and non-GET fan-out callees to `action` exports
- add focused Remix callee fixture coverage for function exports, typed const exports, and same-file action aliases

## Tests
- `crystal spec spec/functional_test/testers/javascript/remix_callees_spec.cr spec/functional_test/testers/javascript/remix_spec.cr spec/unit_test/miniparser/js_callee_extractor_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-remix just build`
- `./bin/noir -b spec/functional_test/fixtures/javascript/remix_callees --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-remix just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-remix just test`