### PR TITLE
feat(js): wire callees through Nitro and Nuxt

### DIFF
--- a/spec/functional_test/fixtures/javascript/nitro_callees/nitro.config.ts
+++ b/spec/functional_test/fixtures/javascript/nitro_callees/nitro.config.ts
@@ -1,0 +1,3 @@
+export default defineNitroConfig({
+  compatibilityDate: "2025-01-01",
+})

--- a/spec/functional_test/fixtures/javascript/nitro_callees/routes/users.post.ts
+++ b/spec/functional_test/fixtures/javascript/nitro_callees/routes/users.post.ts
@@ -1,0 +1,9 @@
+const handler = async (event) => {
+  const body = await readBody(event)
+  const user = await serviceFactory().create(body)
+  AuditLog.write("nitro:create")
+
+  return sendUser(user)
+}
+
+export default defineEventHandler(handler)

--- a/spec/functional_test/fixtures/javascript/nitro_callees/routes/users.ts
+++ b/spec/functional_test/fixtures/javascript/nitro_callees/routes/users.ts
@@ -1,0 +1,7 @@
+export default defineEventHandler(async (event: H3Event): Promise<any> => {
+  const query = getQuery(event)
+  const users = await listUsers(query.page)
+  AuditLog.write("nitro:list")
+
+  return sendUsers(serializeUsers(users))
+})

--- a/spec/functional_test/fixtures/javascript/nuxtjs_callees/nuxt.config.ts
+++ b/spec/functional_test/fixtures/javascript/nuxtjs_callees/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  devtools: { enabled: true },
+})

--- a/spec/functional_test/fixtures/javascript/nuxtjs_callees/server/api/orders.get.ts
+++ b/spec/functional_test/fixtures/javascript/nuxtjs_callees/server/api/orders.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler as h } from "h3"
+
+export default h((event) => {
+  const query = getQuery(event)
+  const orders = listOrders(query.status)
+  return sendOrders(serializeOrders(orders))
+})

--- a/spec/functional_test/fixtures/javascript/nuxtjs_callees/server/routes/auth.ts
+++ b/spec/functional_test/fixtures/javascript/nuxtjs_callees/server/routes/auth.ts
@@ -1,0 +1,6 @@
+const wrap = defineEventHandler
+
+export default wrap((event) => {
+  const token = getCookie(event, "session")
+  return authorizeUser(token)
+})

--- a/spec/functional_test/testers/javascript/nitro_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/nitro_callees_spec.cr
@@ -1,0 +1,35 @@
+require "../../func_spec.cr"
+
+list_callees = [
+  Callee.new("getQuery", line: 2),
+  Callee.new("listUsers", line: 3),
+  Callee.new("AuditLog.write", line: 4),
+  Callee.new("sendUsers", line: 6),
+  Callee.new("serializeUsers", line: 6),
+]
+
+create_callees = [
+  Callee.new("readBody", line: 2),
+  Callee.new("serviceFactory().create", line: 3),
+  Callee.new("AuditLog.write", line: 4),
+  Callee.new("sendUser", line: 6),
+]
+
+expected_endpoints = ["GET", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].map do |method|
+  Endpoint.new("/users", method, [
+    Param.new("page", "", "query"),
+  ]).tap do |ep|
+    list_callees.each { |callee| ep.push_callee(callee) }
+  end
+end
+
+expected_endpoints << Endpoint.new("/users", "POST").tap do |ep|
+  create_callees.each { |callee| ep.push_callee(callee) }
+end
+
+FunctionalTester.new("fixtures/javascript/nitro_callees/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/nuxtjs_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/nuxtjs_callees_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+orders_endpoint = Endpoint.new("/api/orders", "GET", [
+  Param.new("status", "", "query"),
+])
+orders_endpoint.push_callee(Callee.new("getQuery", line: 4))
+orders_endpoint.push_callee(Callee.new("listOrders", line: 5))
+orders_endpoint.push_callee(Callee.new("sendOrders", line: 6))
+orders_endpoint.push_callee(Callee.new("serializeOrders", line: 6))
+
+auth_callees = [
+  Callee.new("getCookie", line: 4),
+  Callee.new("authorizeUser", line: 5),
+]
+
+expected_endpoints = [orders_endpoint] + ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].map do |method|
+  Endpoint.new("/auth", method, [
+    Param.new("session", "", "cookie"),
+  ]).tap do |ep|
+    auth_callees.each { |callee| ep.push_callee(callee) }
+  end
+end
+
+FunctionalTester.new("fixtures/javascript/nuxtjs_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/js_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_callee_extractor_spec.cr
@@ -89,4 +89,98 @@ describe Noir::JSCalleeExtractor do
       {"serviceFactory().create", 5},
     ])
   end
+
+  it "extracts callees from default Nitro/Nuxt event handlers" do
+    source = <<-TS
+      export default defineEventHandler((event: { foo: string, bar: number }): { ok: boolean, user: unknown } => {
+        const body = await readBody(event)
+        AuditLog.write(body)
+        return serializeUser(body)
+      })
+      TS
+
+    callees = Noir::JSCalleeExtractor.callees_for_default_event_handler(source, "server/api/users.post.ts", language: :typescript)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"readBody", 2},
+      {"AuditLog.write", 3},
+      {"serializeUser", 4},
+    ])
+  end
+
+  it "extracts default event handlers through wrapper and handler aliases" do
+    source = <<-JS
+      import { defineEventHandler as h } from 'h3'
+
+      const load = (event) => send(loadUser(event))
+      const wrapped = h(load)
+      export default wrapped
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_default_event_handler(source, "server/api/users.get.ts")
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"send", 3},
+      {"loadUser", 3},
+    ])
+  end
+
+  it "extracts default event handlers from default export clauses" do
+    source = <<-JS
+      export const ignored = defineEventHandler(() => ignoredCall())
+
+      const handler = defineEventHandler((event) => {
+        return send(loadUser(event))
+      })
+
+      export { handler as default }
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_default_event_handler(source, "server/api/users.get.ts")
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"send", 4},
+      {"loadUser", 4},
+    ])
+  end
+
+  it "extracts concise default event handler arrows" do
+    source = <<-JS
+      export default defineEventHandler(event => send(loadUser(event)))
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_default_event_handler(source, "server/api/users.get.ts")
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"send", 1},
+      {"loadUser", 1},
+    ])
+  end
+
+  it "detects event handler aliases from property assignments" do
+    source = <<-JS
+      const wrap = h3.defineEventHandler
+      export default wrap((event) => send(loadUser(event)))
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_default_event_handler(source, "server/api/users.get.ts")
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"send", 2},
+      {"loadUser", 2},
+    ])
+  end
+
+  it "extracts cached default event handlers but skips unrelated default exports" do
+    source = <<-JS
+      function handler(event) {
+        return send(loadUser(event))
+      }
+
+      export default defineCachedEventHandler(handler, { maxAge: 60 })
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_default_event_handler(source, "server/api/users.get.ts")
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"send", 2},
+      {"loadUser", 2},
+    ])
+
+    Noir::JSCalleeExtractor.callees_for_default_event_handler("export default { setup() { track() } }", "server/api/users.get.ts").should be_empty
+  end
 end

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -5,17 +5,18 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       parallel_file_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
         # Focus on routes/ directory for Nitro
         next unless path.includes?("/routes/")
-        analyze_nitro_file(path, result, mutex)
+        analyze_nitro_file(path, result, mutex, include_callee)
       end
 
       result
     end
 
-    private def analyze_nitro_file(path : String, result : Array(Endpoint), mutex : Mutex)
+    private def analyze_nitro_file(path : String, result : Array(Endpoint), mutex : Mutex, include_callee : Bool)
       # Extract endpoint from file path
       # routes/hello.ts -> /hello
       # routes/users/[id].ts -> /users/:id
@@ -65,6 +66,7 @@ module Analyzer::Javascript
       # Read file content to extract parameters
       begin
         content = File.read(path, encoding: "utf-8", invalid: :skip)
+        callees = include_callee ? Noir::JSCalleeExtractor.callees_for_default_event_handler(content, path, language: javascript_source_language(path)) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |method|
           endpoint = Endpoint.new(url, method)
@@ -120,6 +122,8 @@ module Analyzer::Javascript
             param = Param.new(cookie_name, "", "cookie")
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
           end
+
+          attach_js_callees(endpoint, callees) if include_callee
 
           mutex.synchronize do
             existing_idx = result.index { |e| e.url == url && e.method == method }

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -5,17 +5,18 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       parallel_file_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
         # Focus on server/api and server/routes directories for Nuxt 3
         next unless path.includes?("/server/api/") || path.includes?("/server/routes/")
-        analyze_nuxt_file(path, result, mutex)
+        analyze_nuxt_file(path, result, mutex, include_callee)
       end
 
       result
     end
 
-    private def analyze_nuxt_file(path : String, result : Array(Endpoint), mutex : Mutex)
+    private def analyze_nuxt_file(path : String, result : Array(Endpoint), mutex : Mutex, include_callee : Bool)
       # Extract endpoint from file path
       # server/api/hello.ts -> /api/hello
       # server/api/users/[id].ts -> /api/users/:id
@@ -78,6 +79,7 @@ module Analyzer::Javascript
       # Read file content to extract parameters
       begin
         content = File.read(path, encoding: "utf-8", invalid: :skip)
+        callees = include_callee ? Noir::JSCalleeExtractor.callees_for_default_event_handler(content, path, language: javascript_source_language(path)) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |method|
           endpoint = Endpoint.new(url, method)
@@ -135,6 +137,8 @@ module Analyzer::Javascript
             param = Param.new(cookie_name, "", "cookie")
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
           end
+
+          attach_js_callees(endpoint, callees) if include_callee
 
           mutex.synchronize do
             existing_idx = result.index { |e| e.url == url && e.method == method }

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/js_callee_extractor"
 
 module Analyzer::Javascript
   abstract class JavascriptEngine < Analyzer
@@ -33,6 +34,16 @@ module Analyzer::Javascript
       rescue e
         logger.debug e
       end
+    end
+
+    protected def attach_js_callees(endpoint : Endpoint, callees : Array(Noir::JSCalleeExtractor::Entry))
+      callees.each do |name, callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+      end
+    end
+
+    protected def javascript_source_language(path : String) : Symbol
+      path.ends_with?(".ts") || path.ends_with?(".mts") || path.ends_with?(".tsx") ? :typescript : :javascript
     end
   end
 end

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -25,6 +25,12 @@ module Noir::JSCalleeExtractor
     "switch",
     "while",
   }
+  EVENT_HANDLER_CALLS = Set{
+    "defineEventHandler",
+    "eventHandler",
+    "defineCachedEventHandler",
+    "cachedEventHandler",
+  }
 
   alias Entry = Tuple(String, String, Int32)
 
@@ -64,10 +70,28 @@ module Noir::JSCalleeExtractor
   def callees_for_exported_function(source : String,
                                     file_path : String,
                                     export_name : String) : Array(Entry)
-    source_for_ast = normalize_exported_handler_source(source)
+    source_for_ast = normalize_handler_source(source)
     sink = [] of Entry
     Noir::TreeSitter.parse_javascript(source_for_ast) do |root|
       if handler = exported_handler(root, root, source_for_ast, export_name, 0)
+        walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0)
+      end
+    end
+
+    dedup_entries(sink)
+  rescue
+    [] of Entry
+  end
+
+  def callees_for_default_event_handler(source : String,
+                                        file_path : String,
+                                        *,
+                                        language : Symbol = :javascript) : Array(Entry)
+    source_for_ast = normalize_handler_source(source)
+    event_handler_calls = event_handler_call_names(source_for_ast)
+    sink = [] of Entry
+    Noir::TreeSitter.parse_javascript(source_for_ast) do |root|
+      if handler = exported_event_handler(root, root, source_for_ast, event_handler_calls, 0)
         walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0)
       end
     end
@@ -154,12 +178,16 @@ module Noir::JSCalleeExtractor
     sink
   end
 
-  private def normalize_exported_handler_source(source : String) : String
+  private def normalize_handler_source(source : String) : String
     # The vendored JavaScript grammar still exposes useful nodes for many
     # TypeScript files, but `const GET: RequestHandler = ...` makes the
     # variable name parse as the type. Strip same-line annotations while
     # preserving line numbers so AST row-based callee locations stay valid.
-    source.gsub(/(\b(?:export\s+)?(?:const|let|var)\s+[A-Za-z_$][\w$]*)\s*:\s*[^=\n]+=/, "\\1 =")
+    source
+      .gsub(/(\b(?:export\s+)?(?:const|let|var)\s+[A-Za-z_$][\w$]*)\s*:\s*[^=\n]+=/, "\\1 =")
+      .gsub(/([,(]\s*[A-Za-z_$][\w$]*)\s*:\s*(?:\{[^}\n]*\}|[^,\)=]+)(?=[,\)])/, "\\1")
+      .gsub(/\)\s*:\s*(?:\{[^}\n]*\}|[^=\n]+)=>/, ") =>")
+      .gsub(/\)\s*:\s*(?:\{[^}\n]*\}|[^{\n]+){/, ") {")
   end
 
   private def exported_handler(root : LibTreeSitter::TSNode,
@@ -258,6 +286,199 @@ module Noir::JSCalleeExtractor
         end
       end
     end
+  end
+
+  private def exported_event_handler(root : LibTreeSitter::TSNode,
+                                     node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     event_handler_calls : Set(String),
+                                     depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "export_statement"
+      if value = Noir::TreeSitter.field(node, "value")
+        if handler = event_handler_from_default_value(root, value, source, event_handler_calls)
+          return handler
+        end
+      elsif default_export?(node, source)
+        if declaration = Noir::TreeSitter.field(node, "declaration")
+          return declaration if handler_node?(declaration)
+        end
+      elsif local_name = export_clause_local_name(node, source, "default")
+        if handler = local_default_event_handler(root, source, local_name, event_handler_calls)
+          return handler
+        end
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if handler = exported_event_handler(root, child, source, event_handler_calls, depth + 1)
+        return handler
+      end
+    end
+  end
+
+  private def event_handler_from_default_value(root : LibTreeSitter::TSNode,
+                                               node : LibTreeSitter::TSNode,
+                                               source : String,
+                                               event_handler_calls : Set(String)) : LibTreeSitter::TSNode?
+    return node if handler_node?(node)
+
+    if Noir::TreeSitter.node_type(node) == "identifier"
+      return local_default_event_handler(root, source, Noir::TreeSitter.node_text(node, source), event_handler_calls)
+    end
+
+    event_handler_from_wrapper_call(root, node, source, event_handler_calls, 0)
+  end
+
+  private def local_default_event_handler(root : LibTreeSitter::TSNode,
+                                          source : String,
+                                          name : String,
+                                          event_handler_calls : Set(String)) : LibTreeSitter::TSNode?
+    local_wrapped_event_handler(root, root, source, name, event_handler_calls, 0) ||
+      local_callable_handler(root, source, name, 0)
+  end
+
+  private def local_wrapped_event_handler(root : LibTreeSitter::TSNode,
+                                          node : LibTreeSitter::TSNode,
+                                          source : String,
+                                          name : String,
+                                          event_handler_calls : Set(String),
+                                          depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "variable_declarator"
+      node_name = Noir::TreeSitter.field(node, "name")
+      if node_name && Noir::TreeSitter.node_text(node_name, source) == name
+        value = Noir::TreeSitter.field(node, "value")
+        return event_handler_from_wrapper_call(root, value, source, event_handler_calls, 0) if value
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if handler = local_wrapped_event_handler(root, child, source, name, event_handler_calls, depth + 1)
+        return handler
+      end
+    end
+  end
+
+  private def event_handler_from_wrapper_call(root : LibTreeSitter::TSNode,
+                                              node : LibTreeSitter::TSNode,
+                                              source : String,
+                                              event_handler_calls : Set(String),
+                                              depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if Noir::TreeSitter.node_type(node) == "call_expression"
+      name = callee_text(node, source)
+      if event_handler_call?(name, event_handler_calls)
+        args = arguments_node(node)
+        if args
+          Noir::TreeSitter.each_named_child(args) do |arg|
+            if handler = event_handler_from_arg(root, arg, source, event_handler_calls, depth + 1)
+              return handler
+            end
+          end
+        end
+      end
+    end
+
+    if Noir::TreeSitter.node_type(node) == "parenthesized_expression" || Noir::TreeSitter.node_type(node) == "sequence_expression"
+      Noir::TreeSitter.each_named_child(node) do |child|
+        if handler = event_handler_from_wrapper_call(root, child, source, event_handler_calls, depth + 1)
+          return handler
+        end
+      end
+    end
+  end
+
+  private def event_handler_from_arg(root : LibTreeSitter::TSNode,
+                                     node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     event_handler_calls : Set(String),
+                                     depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+    return node if handler_node?(node)
+
+    if Noir::TreeSitter.node_type(node) == "identifier"
+      return local_callable_handler(root, source, Noir::TreeSitter.node_text(node, source), 0)
+    end
+
+    if handler = event_handler_from_wrapper_call(root, node, source, event_handler_calls, depth + 1)
+      return handler
+    end
+
+    if Noir::TreeSitter.node_type(node) == "parenthesized_expression" || Noir::TreeSitter.node_type(node) == "sequence_expression"
+      Noir::TreeSitter.each_named_child(node) do |child|
+        if handler = event_handler_from_arg(root, child, source, event_handler_calls, depth + 1)
+          return handler
+        end
+      end
+    end
+  end
+
+  private def local_callable_handler(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     name : String,
+                                     depth : Int32) : LibTreeSitter::TSNode?
+    return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+    if handler_node?(node)
+      node_name = Noir::TreeSitter.field(node, "name")
+      return node if node_name && Noir::TreeSitter.node_text(node_name, source) == name
+    end
+
+    if Noir::TreeSitter.node_type(node) == "variable_declarator"
+      node_name = Noir::TreeSitter.field(node, "name")
+      if node_name && Noir::TreeSitter.node_text(node_name, source) == name
+        value = Noir::TreeSitter.field(node, "value")
+        return value if value && handler_node?(value)
+      end
+    end
+
+    Noir::TreeSitter.each_named_child(node) do |child|
+      if handler = local_callable_handler(child, source, name, depth + 1)
+        return handler
+      end
+    end
+  end
+
+  private def event_handler_call_names(source : String) : Set(String)
+    names = EVENT_HANDLER_CALLS.dup
+
+    source.scan(/import\s*\{([^}]+)\}\s*from\s*['"][^'"]+['"]/) do |match|
+      match[1].split(",").each do |specifier|
+        parts = specifier.strip.split(/\s+as\s+/)
+        imported = parts[0]?.try &.strip
+        local = parts[1]?.try &.strip
+        names.add(local) if imported && local && EVENT_HANDLER_CALLS.includes?(imported)
+      end
+    end
+
+    loop do
+      size = names.size
+      alternation = names.map { |name| Regex.escape(name) }.join("|")
+      source.scan(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:[A-Za-z_$][\w$]*\.)?(?:#{alternation})\b/) do |match|
+        names.add(match[1])
+      end
+      break if names.size == size
+    end
+
+    names
+  end
+
+  private def event_handler_call?(name : String, event_handler_calls : Set(String)) : Bool
+    return true if event_handler_calls.includes?(name)
+
+    if dot = name.rindex('.')
+      event_handler_calls.includes?(name[(dot + 1)..-1])
+    else
+      false
+    end
+  end
+
+  private def default_export?(node : LibTreeSitter::TSNode, source : String) : Bool
+    Noir::TreeSitter.node_text(node, source).matches?(/\Aexport\s+default\b/)
   end
 
   private def handler_body(handler : LibTreeSitter::TSNode) : LibTreeSitter::TSNode


### PR DESCRIPTION
## Summary
- add a shared JS callee extractor API for default-exported Nitro/Nuxt event handlers
- attach `--include-callee` results in the Nitro and Nuxt analyzers, reusing the per-file handler callees across emitted methods
- add unit coverage for default event-handler wrappers, aliases, concise arrows, cached handlers, and negative default exports
- add Nitro/Nuxt functional fixtures that assert callee names and call-site lines

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-nitro-nuxt crystal spec spec/unit_test/miniparser/js_callee_extractor_spec.cr spec/functional_test/testers/javascript/nitro_callees_spec.cr spec/functional_test/testers/javascript/nuxtjs_callees_spec.cr spec/functional_test/testers/javascript/nitro_spec.cr spec/functional_test/testers/javascript/nuxtjs_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-nitro-nuxt just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-nitro-nuxt just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-nitro-nuxt just test`
- `./bin/noir -b spec/functional_test/fixtures/javascript/nitro_callees --include-callee`
- `./bin/noir -b spec/functional_test/fixtures/javascript/nuxtjs_callees --include-callee`

Part of #1366.