### PR TITLE
feat(csharp): wire callees through ASP.NET analyzers

### DIFF
--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees/Controllers/OrdersController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees/Controllers/OrdersController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Demo.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OrdersController : ControllerBase
+    {
+        [HttpGet("{id}")]
+        public IActionResult Show([FromRoute] int id)
+        {
+            var order = orderService.Load(id);
+            AuditLog.Write("core:show");
+            return Ok(SerializeOrder(order));
+        }
+
+        [HttpPost]
+        public IActionResult Create([FromBody] string name)
+        {
+            var order = orderService.Create(name);
+            return Created("", SerializeOrder(order));
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees/Endpoints/OrderEndpoint.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees/Endpoints/OrderEndpoint.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Demo.Endpoints
+{
+    public class OrderEndpoint
+    {
+        public void Register(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder routeBuilder)
+        {
+            routeBuilder.MapPost("/mapped/orders/{id}", async context =>
+            {
+                var query = context.Request.Query["expand"];
+                var saved = await orderService.Save(context);
+                AuditLog.Write("minimal");
+                await context.Response.WriteAsync(SerializeOrder(saved));
+            });
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees/MyApp.csproj
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees/MyApp.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/aspnet_mvc_callees/Controllers/ShopController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_mvc_callees/Controllers/ShopController.cs
@@ -1,0 +1,21 @@
+using System.Web.Mvc;
+
+namespace Demo.Controllers
+{
+    public class ShopController : Controller
+    {
+        public ActionResult Details(int id)
+        {
+            var item = shopService.Load(id);
+            AuditLog.Write("mvc:details");
+            return View(SerializeItem(item));
+        }
+
+        [HttpPost]
+        public ActionResult Create(string name, string email)
+        {
+            var item = shopService.Create(name, email);
+            return Json(SerializeItem(item));
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_mvc_callees/packages.config
+++ b/spec/functional_test/fixtures/csharp/aspnet_mvc_callees/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.2.9" targetFramework="net48" />
+</packages>

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_callees_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_callees_spec.cr
@@ -1,0 +1,36 @@
+require "../../func_spec.cr"
+
+show_endpoint = Endpoint.new("/api/Orders/{id}", "GET", [
+  Param.new("id", "", "path"),
+])
+show_endpoint.push_callee(Callee.new("orderService.Load", line: 12))
+show_endpoint.push_callee(Callee.new("AuditLog.Write", line: 13))
+show_endpoint.push_callee(Callee.new("Ok", line: 14))
+show_endpoint.push_callee(Callee.new("SerializeOrder", line: 14))
+
+create_endpoint = Endpoint.new("/api/Orders", "POST", [
+  Param.new("name", "", "json"),
+])
+create_endpoint.push_callee(Callee.new("orderService.Create", line: 20))
+create_endpoint.push_callee(Callee.new("Created", line: 21))
+create_endpoint.push_callee(Callee.new("SerializeOrder", line: 21))
+
+mapped_endpoint = Endpoint.new("/mapped/orders/{id}", "POST", [
+  Param.new("id", "", "path"),
+  Param.new("expand", "", "query"),
+])
+mapped_endpoint.push_callee(Callee.new("orderService.Save", line: 13))
+mapped_endpoint.push_callee(Callee.new("AuditLog.Write", line: 14))
+mapped_endpoint.push_callee(Callee.new("context.Response.WriteAsync", line: 15))
+mapped_endpoint.push_callee(Callee.new("SerializeOrder", line: 15))
+
+FunctionalTester.new("fixtures/csharp/aspnet_core_mvc_callees/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, [
+  show_endpoint,
+  create_endpoint,
+  mapped_endpoint,
+], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/csharp/aspnet_mvc_callees_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_mvc_callees_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+details_endpoint = Endpoint.new("/Shop/Details", "GET", [
+  Param.new("id", "", "query"),
+])
+details_endpoint.push_callee(Callee.new("shopService.Load", line: 9))
+details_endpoint.push_callee(Callee.new("AuditLog.Write", line: 10))
+details_endpoint.push_callee(Callee.new("View", line: 11))
+details_endpoint.push_callee(Callee.new("SerializeItem", line: 11))
+
+create_endpoint = Endpoint.new("/Shop/Create", "POST", [
+  Param.new("name", "", "form"),
+  Param.new("email", "", "form"),
+])
+create_endpoint.push_callee(Callee.new("shopService.Create", line: 17))
+create_endpoint.push_callee(Callee.new("Json", line: 18))
+create_endpoint.push_callee(Callee.new("SerializeItem", line: 18))
+
+FunctionalTester.new("fixtures/csharp/aspnet_mvc_callees/", {
+  :techs     => 1,
+  :endpoints => 2,
+}, [
+  details_endpoint,
+  create_endpoint,
+], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/csharp_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/csharp_callee_extractor_spec.cr
@@ -1,0 +1,59 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/csharp_callee_extractor"
+
+describe Noir::CSharpCalleeExtractor do
+  it "extracts method calls from C# handler blocks with line numbers" do
+    body = <<-CS
+      public IActionResult Show(int id)
+      {
+        var order = orderService.Load(id);
+        AuditLog.Write("show");
+        return Ok(SerializeOrder(order));
+      }
+      CS
+
+    callees = Noir::CSharpCalleeExtractor.callees_for_block(body, "OrdersController.cs", 10, skip_first_line: true)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"orderService.Load", 12},
+      {"AuditLog.Write", 13},
+      {"Ok", 14},
+      {"SerializeOrder", 14},
+    ])
+  end
+
+  it "skips route builder wrappers and comments in minimal API blocks" do
+    body = <<-CS
+      routeBuilder.MapPost("/orders", async context =>
+      {
+        // ignoredCall()
+        var saved = await orderService.Save(context);
+        await context.Response.WriteAsync(SerializeOrder(saved));
+      });
+      CS
+
+    callees = Noir::CSharpCalleeExtractor.callees_for_block(body, "OrderEndpoint.cs", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"orderService.Save", 23},
+      {"context.Response.WriteAsync", 24},
+      {"SerializeOrder", 24},
+    ])
+  end
+
+  it "skips direct constructor chaining calls while keeping this member calls" do
+    body = <<-CS
+      public OrdersController() : this()
+      {
+        this();
+        this.orderService.Save();
+        base();
+        base.Initialize();
+      }
+      CS
+
+    callees = Noir::CSharpCalleeExtractor.callees_for_block(body, "OrdersController.cs", 30, skip_first_line: true)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"this.orderService.Save", 33},
+      {"base.Initialize", 35},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -1,17 +1,21 @@
 require "../../../models/analyzer"
+require "./common"
 
 module Analyzer::CSharp
   class AspNetCoreMvc < Analyzer
+    include Common
+
     DEFAULT_ROUTE = "{controller=Home}/{action=Index}/{id?}"
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       route_patterns = load_route_patterns
-      analyze_controllers(route_patterns)
-      analyze_route_builder_endpoints
+      analyze_controllers(route_patterns, include_callee)
+      analyze_route_builder_endpoints(include_callee)
       @result
     end
 
-    private def analyze_route_builder_endpoints
+    private def analyze_route_builder_endpoints(include_callee : Bool)
       map_regex = /Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/
       map_methods_block_regex = /MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/
 
@@ -27,7 +31,10 @@ module Analyzer::CSharp
             extra_params = extract_params_from_block(block)
             extra_params.concat(extract_bind_params_from_file(block, lines))
             endpoint = build_endpoint_from_route(route, http_method, file, index + 1, extra_params)
-            @result << endpoint if endpoint
+            if endpoint
+              attach_csharp_callees(endpoint, block, file, index + 1, include_callee)
+              @result << endpoint
+            end
           end
 
           if line.includes?("MapMethods")
@@ -50,7 +57,10 @@ module Analyzer::CSharp
               extra_params.concat(extract_bind_params_from_file(block, lines))
               methods.each do |method|
                 endpoint = build_endpoint_from_route(route, method, file, index + 1, extra_params)
-                @result << endpoint if endpoint
+                if endpoint
+                  attach_csharp_callees(endpoint, block, file, index + 1, include_callee)
+                  @result << endpoint
+                end
               end
             end
           end
@@ -69,6 +79,7 @@ module Analyzer::CSharp
         paren_depth += line.count('(') - line.count(')')
         brace_depth += line.count('{') - line.count('}')
         io << line
+        io << '\n'
 
         if paren_depth <= 0 && brace_depth <= 0 && line.includes?(";")
           break
@@ -185,18 +196,18 @@ module Analyzer::CSharp
       patterns
     end
 
-    private def analyze_controllers(route_patterns : Array(String))
+    private def analyze_controllers(route_patterns : Array(String), include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
         base = File.basename(file)
         base.includes?("Controller") && !base.ends_with?("RouteConfig.cs") && base != "Program.cs" && base != "Startup.cs"
       end
 
       controller_files.each do |file|
-        analyze_controller_file(file, route_patterns)
+        analyze_controller_file(file, route_patterns, include_callee)
       end
     end
 
-    private def analyze_controller_file(file : String, route_patterns : Array(String))
+    private def analyze_controller_file(file : String, route_patterns : Array(String), include_callee : Bool)
       return unless File.exists?(file)
 
       content = File.read(file, encoding: "utf-8", invalid: :skip)
@@ -244,6 +255,7 @@ module Analyzer::CSharp
                   endpoint.params << param
                 end
 
+                attach_csharp_callees(endpoint, body_block, file, end_index + 1, include_callee, skip_first_line: true)
                 @result << endpoint
               end
 
@@ -292,40 +304,6 @@ module Analyzer::CSharp
 
     private def potential_action_signature?(line : String) : Bool
       line.includes?("public") && line.includes?("(") && !line.includes?(" class ")
-    end
-
-    private def build_signature(lines : Array(String), start_index : Int32) : Tuple(String, Int32)
-      signature = lines[start_index]
-      paren_count = signature.count('(') - signature.count(')')
-      index = start_index + 1
-
-      while paren_count > 0 && index < lines.size
-        signature += " " + lines[index]
-        paren_count += lines[index].count('(') - lines[index].count(')')
-        index += 1
-      end
-
-      {signature, index - 1}
-    end
-
-    private def extract_method_block(lines : Array(String), start_index : Int32) : String
-      io = String::Builder.new
-      brace = 0
-      started = false
-      i = start_index
-
-      while i < lines.size
-        line = lines[i]
-        brace += line.count('{') - line.count('}')
-        started ||= brace > 0 || line.includes?("{")
-        io << line
-        if started && brace <= 0 && line.includes?("}")
-          break
-        end
-        i += 1
-      end
-
-      io.to_s
     end
 
     private def action_method?(signature : String) : Bool

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -1,8 +1,12 @@
 require "../../../models/analyzer"
+require "./common"
 
 module Analyzer::CSharp
   class AspNetMvc < Analyzer
+    include Common
+
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       # Static Analysis
       locator = CodeLocator.instance
       route_config_file = locator.get("cs-apinet-mvc-routeconfig")
@@ -44,22 +48,22 @@ module Analyzer::CSharp
       end
 
       # Analyze controller files for action methods and parameters
-      analyze_controllers()
+      analyze_controllers(include_callee)
 
       @result
     end
 
-    private def analyze_controllers
+    private def analyze_controllers(include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
         file.includes?("Controller") && !file.includes?("RouteConfig")
       end
 
       controller_files.each do |file|
-        analyze_controller_file(file)
+        analyze_controller_file(file, include_callee)
       end
     end
 
-    private def analyze_controller_file(file : String)
+    private def analyze_controller_file(file : String, include_callee : Bool)
       return unless File.exists?(file)
 
       content = File.read(file, encoding: "utf-8", invalid: :skip)
@@ -101,25 +105,29 @@ module Analyzer::CSharp
 
         # Check for action method definition
         if line.includes?("public") && line.includes?("ActionResult") && line.includes?("(")
-          action_name = extract_action_name(line)
-          parameters = extract_parameters(line, lines, i, http_method)
+          signature, end_index = build_signature(lines, i)
+          action_name = extract_action_name(signature)
+          parameters = extract_parameters(signature, http_method)
 
           unless action_name.empty?
             # Build URL from controller route, action route, and action name
             url = build_url(controller_route_prefix, action_route, controller_name, action_name)
             details = Details.new(PathInfo.new(file, i + 1))
             endpoint = Endpoint.new(url, http_method, details)
+            body_block = extract_method_block(lines, end_index)
 
             parameters.each do |param|
               endpoint.params << param
             end
 
+            attach_csharp_callees(endpoint, body_block, file, end_index + 1, include_callee, skip_first_line: true)
             @result << endpoint
 
             # Reset to default after processing the method
             http_method = "GET"
             action_route = ""
           end
+          i = end_index
         end
 
         i += 1
@@ -140,20 +148,8 @@ module Analyzer::CSharp
       match[1]
     end
 
-    private def extract_parameters(line : String, lines : Array(String), start_index : Int32, http_method : String) : Array(Param)
+    private def extract_parameters(full_signature : String, http_method : String) : Array(Param)
       parameters = [] of Param
-
-      # Extract parameters from method signature
-      # Handle multi-line method signatures
-      full_signature = line
-      paren_count = line.count('(') - line.count(')')
-
-      current_index = start_index + 1
-      while paren_count > 0 && current_index < lines.size
-        full_signature += " " + lines[current_index]
-        paren_count += lines[current_index].count('(') - lines[current_index].count(')')
-        current_index += 1
-      end
 
       # Extract parameter list from signature
       match = full_signature.match(/\((.*?)\)/)

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -1,0 +1,51 @@
+require "../../../miniparsers/csharp_callee_extractor"
+
+module Analyzer::CSharp::Common
+  protected def build_signature(lines : Array(String), start_index : Int32) : Tuple(String, Int32)
+    signature = lines[start_index]
+    paren_count = signature.count('(') - signature.count(')')
+    index = start_index + 1
+
+    while paren_count > 0 && index < lines.size
+      signature += " " + lines[index]
+      paren_count += lines[index].count('(') - lines[index].count(')')
+      index += 1
+    end
+
+    {signature, index - 1}
+  end
+
+  protected def extract_method_block(lines : Array(String), start_index : Int32) : String
+    io = String::Builder.new
+    brace = 0
+    started = false
+    index = start_index
+
+    while index < lines.size
+      line = lines[index]
+      brace += line.count('{') - line.count('}')
+      started ||= brace > 0 || line.includes?("{")
+      io << line
+      io << '\n'
+      if started && brace <= 0 && line.includes?("}")
+        break
+      end
+      index += 1
+    end
+
+    io.to_s
+  end
+
+  protected def attach_csharp_callees(endpoint : Endpoint,
+                                      block : String,
+                                      file : String,
+                                      start_line : Int32,
+                                      include_callee : Bool,
+                                      *,
+                                      skip_first_line : Bool = false)
+    return unless include_callee
+
+    callees = Noir::CSharpCalleeExtractor.callees_for_block(block, file, start_line, skip_first_line: skip_first_line)
+    Noir::CSharpCalleeExtractor.attach_to(endpoint, callees)
+  end
+end

--- a/src/miniparsers/csharp_callee_extractor.cr
+++ b/src/miniparsers/csharp_callee_extractor.cr
@@ -1,0 +1,108 @@
+require "../models/endpoint"
+
+module Noir::CSharpCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "as", "await", "base", "case", "catch", "checked", "default",
+    "delegate", "do", "else", "event", "explicit", "finally",
+    "fixed", "for", "foreach", "if", "implicit", "is", "lock",
+    "nameof", "new", "operator", "return", "sizeof", "switch",
+    "this", "throw", "typeof", "unchecked", "unsafe", "using", "while",
+  }
+
+  ROUTE_BUILDER_METHODS = Set{
+    "Map", "MapGet", "MapPost", "MapPut", "MapDelete", "MapPatch",
+    "MapHead", "MapOptions", "MapMethods",
+  }
+
+  CALL_REGEX = /((?:[A-Za-z_][\w]*)(?:\s*\.\s*[A-Za-z_][\w]*)*)\s*(?:<[^>\n]+>)?\s*\(/
+
+  def callees_for_block(block : String,
+                        file_path : String,
+                        start_line : Int32,
+                        *,
+                        skip_first_line : Bool = false) : Array(Entry)
+    entries = [] of Entry
+
+    block.lines.each_with_index do |line, index|
+      if skip_first_line && index == 0
+        if brace_index = line.index('{')
+          remainder = line[(brace_index + 1)..]? || ""
+          scan_line(strip_line_comment(remainder), file_path, start_line + index, entries)
+        end
+        next
+      end
+
+      scan_line(strip_line_comment(line), file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    code = line.strip
+    return if code.empty?
+
+    code.scan(CALL_REGEX) do |match|
+      name = match[1].gsub(/\s+/, "")
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    return true if RESERVED.includes?(last)
+    return true if ROUTE_BUILDER_METHODS.includes?(last)
+
+    false
+  end
+
+  private def strip_line_comment(line : String) : String
+    in_string = false
+    escaped = false
+
+    line.each_char_with_index do |char, index|
+      if in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == '"'
+          in_string = false
+        end
+      elsif char == '"'
+        in_string = true
+      elsif char == '/' && line[index + 1]? == '/'
+        return line[0, index]
+      end
+    end
+
+    line
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight C# callee extractor for handler blocks
- attach `--include-callee` results to ASP.NET Core MVC controller actions and Minimal API route builder endpoints
- attach `--include-callee` results to classic ASP.NET MVC controller actions
- add C# extractor unit tests plus dedicated ASP.NET Core MVC / ASP.NET MVC functional callee fixtures

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-csharp crystal spec spec/unit_test/miniparser/csharp_callee_extractor_spec.cr spec/functional_test/testers/csharp/aspnet_core_mvc_callees_spec.cr spec/functional_test/testers/csharp/aspnet_mvc_callees_spec.cr spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr spec/functional_test/testers/csharp/aspnet_mvc_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-csharp just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-csharp just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-csharp just test`
- `./bin/noir -b spec/functional_test/fixtures/csharp/aspnet_core_mvc_callees --include-callee`
- `./bin/noir -b spec/functional_test/fixtures/csharp/aspnet_mvc_callees --include-callee`

Part of #1366.