### PR TITLE
Add Rails callee extraction

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_callees/Gemfile
+++ b/spec/functional_test/fixtures/ruby/rails_callees/Gemfile
@@ -1,0 +1,1 @@
+gem "rails"

--- a/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/monitor_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/monitor_controller.rb
@@ -1,0 +1,6 @@
+class MonitorController < ApplicationController
+  def status
+    status = Health.check()
+    render(json: status_payload(status))
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/monitor_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/monitor_controller.rb
@@ -1,6 +1,12 @@
 class MonitorController < ApplicationController
   def status
     status = Health.check()
-    render(json: status_payload(status))
+    render json: status_payload(status)
+  end
+
+  def ping; render plain: Health.check; end
+
+  def ready
+    render plain: Ready.check
   end
 end

--- a/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
@@ -2,23 +2,23 @@ class PostsController < ApplicationController
   def index
     posts = PostQuery.list(params[:page])
     AuditLog.write("index")
-    render(json: serialize_posts(posts))
+    render json: serialize_posts(posts)
   end
 
   def show
     post = Post.find(params[:id])
-    render(json: serialize_post(post))
+    render json: serialize_post(post)
   end
 
   def create
     post = PostCreator.create(post_params)
     AuditLog.write("create")
-    render(json: serialize_post(post), status: :created)
+    render json: serialize_post(post), status: :created
   end
 
   def preview
     preview = PreviewBuilder.build(params[:draft])
-    render(json: serialize_preview(preview))
+    render json: serialize_preview(preview)
   end
 
   private

--- a/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
@@ -1,0 +1,29 @@
+class PostsController < ApplicationController
+  def index
+    posts = PostQuery.list(params[:page])
+    AuditLog.write("index")
+    render(json: serialize_posts(posts))
+  end
+
+  def show
+    post = Post.find(params[:id])
+    render(json: serialize_post(post))
+  end
+
+  def create
+    post = PostCreator.create(post_params)
+    AuditLog.write("create")
+    render(json: serialize_post(post), status: :created)
+  end
+
+  def preview
+    preview = PreviewBuilder.build(params[:draft])
+    render(json: serialize_preview(preview))
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title)
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   end
 
   get "status", to: "monitor#status"
+  get "ping", to: "monitor#ping"
+  get "ready", to: "monitor#ready"
 end

--- a/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
@@ -1,0 +1,9 @@
+Rails.application.routes.draw do
+  resources :posts, only: [:index, :show, :create] do
+    collection do
+      get :preview
+    end
+  end
+
+  get "status", to: "monitor#status"
+end

--- a/spec/functional_test/testers/ruby/rails_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_callees_spec.cr
@@ -1,0 +1,48 @@
+require "../../func_spec.cr"
+
+index_endpoint = Endpoint.new("/posts", "GET").tap do |ep|
+  ep.push_callee(Callee.new("PostQuery.list", line: 3))
+  ep.push_callee(Callee.new("AuditLog.write", line: 4))
+  ep.push_callee(Callee.new("render", line: 5))
+  ep.push_callee(Callee.new("serialize_posts", line: 5))
+end
+
+show_endpoint = Endpoint.new("/posts/1", "GET").tap do |ep|
+  ep.push_callee(Callee.new("Post.find", line: 9))
+  ep.push_callee(Callee.new("render", line: 10))
+  ep.push_callee(Callee.new("serialize_post", line: 10))
+end
+
+create_endpoint = Endpoint.new("/posts", "POST").tap do |ep|
+  ep.push_callee(Callee.new("PostCreator.create", line: 14))
+  ep.push_callee(Callee.new("AuditLog.write", line: 15))
+  ep.push_callee(Callee.new("render", line: 16))
+  ep.push_callee(Callee.new("serialize_post", line: 16))
+end
+
+preview_endpoint = Endpoint.new("/posts/preview", "GET").tap do |ep|
+  ep.push_callee(Callee.new("PreviewBuilder.build", line: 20))
+  ep.push_callee(Callee.new("render", line: 21))
+  ep.push_callee(Callee.new("serialize_preview", line: 21))
+end
+
+status_endpoint = Endpoint.new("/status", "GET").tap do |ep|
+  ep.push_callee(Callee.new("Health.check", line: 3))
+  ep.push_callee(Callee.new("render", line: 4))
+  ep.push_callee(Callee.new("status_payload", line: 4))
+end
+
+expected_endpoints = [
+  index_endpoint,
+  show_endpoint,
+  create_endpoint,
+  preview_endpoint,
+  status_endpoint,
+]
+
+FunctionalTester.new("fixtures/ruby/rails_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/ruby/rails_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_callees_spec.cr
@@ -32,12 +32,24 @@ status_endpoint = Endpoint.new("/status", "GET").tap do |ep|
   ep.push_callee(Callee.new("status_payload", line: 4))
 end
 
+ping_endpoint = Endpoint.new("/ping", "GET").tap do |ep|
+  ep.push_callee(Callee.new("render", line: 7))
+  ep.push_callee(Callee.new("Health.check", line: 7))
+end
+
+ready_endpoint = Endpoint.new("/ready", "GET").tap do |ep|
+  ep.push_callee(Callee.new("render", line: 10))
+  ep.push_callee(Callee.new("Ready.check", line: 10))
+end
+
 expected_endpoints = [
   index_endpoint,
   show_endpoint,
   create_endpoint,
   preview_endpoint,
   status_endpoint,
+  ping_endpoint,
+  ready_endpoint,
 ]
 
 FunctionalTester.new("fixtures/ruby/rails_callees/", {

--- a/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
@@ -1,0 +1,34 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/ruby_callee_extractor"
+
+describe Noir::RubyCalleeExtractor do
+  it "extracts receiver and bare calls from Ruby handler bodies with line numbers" do
+    body = <<-RUBY
+      posts = PostQuery.list(params[:page])
+      AuditLog.write("index")
+      render(json: serialize_posts(posts))
+      RUBY
+
+    callees = Noir::RubyCalleeExtractor.callees_for_body(body, "posts_controller.rb", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"PostQuery.list", 10},
+      {"AuditLog.write", 11},
+      {"render", 12},
+      {"serialize_posts", 12},
+    ])
+  end
+
+  it "skips comments and receiver method duplicates" do
+    body = <<-RUBY
+      # AuditLog.write("ignored")
+      @post.save!
+      Admin::Health.check()
+      RUBY
+
+    callees = Noir::RubyCalleeExtractor.callees_for_body(body, "posts_controller.rb", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"@post.save!", 21},
+      {"Admin::Health.check", 22},
+    ])
+  end
+end

--- a/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
@@ -31,4 +31,21 @@ describe Noir::RubyCalleeExtractor do
       {"Admin::Health.check", 22},
     ])
   end
+
+  it "extracts Ruby command-style calls without parentheses" do
+    body = <<-RUBY
+      render json: serialize_posts(posts)
+      redirect_to post_url(post)
+      head :no_content
+      RUBY
+
+    callees = Noir::RubyCalleeExtractor.callees_for_body(body, "posts_controller.rb", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"render", 30},
+      {"serialize_posts", 30},
+      {"redirect_to", 31},
+      {"post_url", 31},
+      {"head", 32},
+    ])
+  end
 end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -529,26 +529,31 @@ module Analyzer::Ruby
         stripped = strip_inline_comment(lines[index]).strip
         if m = stripped.match(/^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?([A-Za-z_]\w*[!?=]?)\b/)
           action = m[1]
+          inline_body, closed_on_def_line = inline_def_body(stripped, m[0])
           body_lines = [] of String
-          body_start_line = index + 2
-          depth = 1
-          index += 1
+          body_start_line = inline_body ? index + 1 : index + 2
+          body_lines << inline_body if inline_body
 
-          while index < lines.size
-            raw_body_line = lines[index]
-            body_line = strip_inline_comment(raw_body_line).strip
-
-            if closes_ruby_block?(body_line)
-              depth -= 1
-              break if depth == 0
-              body_lines << raw_body_line
-              index += 1
-              next
-            end
-
-            body_lines << raw_body_line
-            depth += ruby_block_open_delta(body_line)
+          unless closed_on_def_line
+            depth = 1
             index += 1
+
+            while index < lines.size
+              raw_body_line = lines[index]
+              body_line = strip_inline_comment(raw_body_line).strip
+
+              if closes_ruby_block?(body_line)
+                depth -= 1
+                break if depth == 0
+                body_lines << raw_body_line
+                index += 1
+                next
+              end
+
+              body_lines << raw_body_line
+              depth += ruby_block_open_delta(body_line)
+              index += 1
+            end
           end
 
           callees = Noir::RubyCalleeExtractor.callees_for_body(body_lines.join("\n"), path, body_start_line)
@@ -561,15 +566,30 @@ module Analyzer::Ruby
       result
     end
 
+    private def inline_def_body(line : String, match_text : String) : Tuple(String?, Bool)
+      return {nil, false} if match_text.size >= line.size
+
+      tail = line[match_text.size, line.size - match_text.size].strip
+      return {nil, false} unless tail.starts_with?(";")
+
+      tail = tail[1, tail.size - 1].strip
+      if m = tail.match(/^(.*?)(?:;\s*)?end\b/)
+        body = m[1].strip
+        return {body.empty? ? nil : body, true}
+      end
+
+      {tail.empty? ? nil : tail, false}
+    end
+
     private def ruby_block_open_delta(line : String) : Int32
       return 0 if line.empty?
       return 1 if line.match(/\bdo\b\s*(\|[^|]*\|)?\s*\z/)
-      return 1 if line.match(/^(if|unless|case|begin|while|until|for|class|module|def)\b/)
+      return 1 if line.match(/^(if|unless|case|begin|while|until|for|class|module|def)\b/) && !line.match(/\bend\b/)
       0
     end
 
     private def closes_ruby_block?(line : String) : Bool
-      line == "end" || line.starts_with?("end ") || line.starts_with?("end;")
+      !!line.match(/^end\b/)
     end
 
     private def dedup_by_name(params : Array(Param)) : Array(Param)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -44,7 +44,8 @@ module Analyzer::Ruby
       params_method : Hash(String, Array(Param)),
       permit_body_params : Array(Param),
       permit_query_params : Array(Param),
-      defined_actions : Set(String)
+      defined_actions : Set(String),
+      callees_by_action : Hash(String, Array(Noir::RubyCalleeExtractor::Entry))
 
     @controller_data_cache = Hash(String, ControllerData).new
 
@@ -229,7 +230,9 @@ module Analyzer::Ruby
               if url
                 parent = parent_resources_frame(stack)
                 action_params = parent ? params_for_action(parent.controller_path, action, verb) : ([] of Param)
-                @result << Endpoint.new(url, verb, action_params, details)
+                endpoint = Endpoint.new(url, verb, action_params, details)
+                attach_callees_for_action(endpoint, parent.try(&.controller_path), action)
+                @result << endpoint
               end
               next
             end
@@ -243,13 +246,18 @@ module Analyzer::Ruby
 
               ctrl_action = parse_controller_action(rest)
               action_params = [] of Param
+              ctrl_path = nil.as(String?)
+              action_name = nil.as(String?)
               if ctrl_action
                 ctrl_name, action = ctrl_action
                 ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
+                action_name = action
                 action_params = params_for_action(ctrl_path, action, verb)
               end
 
-              @result << Endpoint.new(url, verb, action_params, details)
+              endpoint = Endpoint.new(url, verb, action_params, details)
+              attach_callees_for_action(endpoint, ctrl_path, action) if action = action_name
+              @result << endpoint
               next
             end
             next
@@ -400,19 +408,29 @@ module Analyzer::Ruby
         case method
         when "GET/INDEX"
           last_params = (params_method["index"]? || [] of Param) + deduplication_params_query
-          @result << Endpoint.new(index_url, "GET", last_params, details)
+          endpoint = Endpoint.new(index_url, "GET", last_params, details)
+          attach_callees_for_action(endpoint, data, "index")
+          @result << endpoint
         when "GET/SHOW"
           last_params = (params_method["show"]? || [] of Param) + deduplication_params_query
-          @result << Endpoint.new(member_url, "GET", last_params, details)
+          endpoint = Endpoint.new(member_url, "GET", last_params, details)
+          attach_callees_for_action(endpoint, data, "show")
+          @result << endpoint
         when "POST"
           last_params = (params_method["create"]? || [] of Param) + params_body
-          @result << Endpoint.new(index_url, method, last_params, details)
+          endpoint = Endpoint.new(index_url, method, last_params, details)
+          attach_callees_for_action(endpoint, data, "create")
+          @result << endpoint
         when "DELETE"
           last_params = params_method["destroy"]? || [] of Param
-          @result << Endpoint.new(member_url, method, last_params, details)
+          endpoint = Endpoint.new(member_url, method, last_params, details)
+          attach_callees_for_action(endpoint, data, "destroy")
+          @result << endpoint
         else
           last_params = (params_method["update"]? || [] of Param) + params_body
-          @result << Endpoint.new(member_url, method, last_params, details)
+          endpoint = Endpoint.new(member_url, method, last_params, details)
+          attach_callees_for_action(endpoint, data, "update")
+          @result << endpoint
         end
       end
 
@@ -433,10 +451,12 @@ module Analyzer::Ruby
       permit_body_params = [] of Param
       permit_query_params = [] of Param
       defined_actions = Set(String).new
+      callees_by_action = Hash(String, Array(Noir::RubyCalleeExtractor::Entry)).new
       param_type = "form"
 
       unless File.exists?(path)
-        empty = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params, defined_actions)
+        empty = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params,
+          defined_actions, callees_by_action)
         @controller_data_cache[path] = empty
         return empty
       end
@@ -444,6 +464,7 @@ module Analyzer::Ruby
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |controller_file|
         controller_content = controller_file.gets_to_end
         param_type = "json" if controller_content.includes?("render json:")
+        callees_by_action = extract_action_callees(controller_content, path) if include_callee?
 
         controller_file.rewind
         this_method = ""
@@ -493,9 +514,62 @@ module Analyzer::Ruby
         end
       end
 
-      data = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params, defined_actions)
+      data = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params,
+        defined_actions, callees_by_action)
       @controller_data_cache[path] = data
       data
+    end
+
+    private def extract_action_callees(content : String, path : String) : Hash(String, Array(Noir::RubyCalleeExtractor::Entry))
+      result = Hash(String, Array(Noir::RubyCalleeExtractor::Entry)).new
+      lines = content.lines
+      index = 0
+
+      while index < lines.size
+        stripped = strip_inline_comment(lines[index]).strip
+        if m = stripped.match(/^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?([A-Za-z_]\w*[!?=]?)\b/)
+          action = m[1]
+          body_lines = [] of String
+          body_start_line = index + 2
+          depth = 1
+          index += 1
+
+          while index < lines.size
+            raw_body_line = lines[index]
+            body_line = strip_inline_comment(raw_body_line).strip
+
+            if closes_ruby_block?(body_line)
+              depth -= 1
+              break if depth == 0
+              body_lines << raw_body_line
+              index += 1
+              next
+            end
+
+            body_lines << raw_body_line
+            depth += ruby_block_open_delta(body_line)
+            index += 1
+          end
+
+          callees = Noir::RubyCalleeExtractor.callees_for_body(body_lines.join("\n"), path, body_start_line)
+          result[action] = callees unless callees.empty?
+        end
+
+        index += 1
+      end
+
+      result
+    end
+
+    private def ruby_block_open_delta(line : String) : Int32
+      return 0 if line.empty?
+      return 1 if line.match(/\bdo\b\s*(\|[^|]*\|)?\s*\z/)
+      return 1 if line.match(/^(if|unless|case|begin|while|until|for|class|module|def)\b/)
+      0
+    end
+
+    private def closes_ruby_block?(line : String) : Bool
+      line == "end" || line.starts_with?("end ") || line.starts_with?("end;")
     end
 
     private def dedup_by_name(params : Array(Param)) : Array(Param)
@@ -528,6 +602,22 @@ module Analyzer::Ruby
       end
 
       result
+    end
+
+    private def attach_callees_for_action(endpoint : Endpoint, controller_path : String?, action : String)
+      return if controller_path.nil?
+      attach_callees_for_action(endpoint, extract_controller_data(controller_path), action)
+    end
+
+    private def attach_callees_for_action(endpoint : Endpoint, data : ControllerData, action : String)
+      return unless include_callee?
+      if callees = data.callees_by_action[action]?
+        attach_ruby_callees(endpoint, callees)
+      end
+    end
+
+    private def include_callee? : Bool
+      any_to_bool(@options["include_callee"]?)
     end
 
     private def parent_resources_frame(stack : Array(Frame)) : Frame?

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/ruby_callee_extractor"
 
 module Analyzer::Ruby
   abstract class RubyEngine < Analyzer
@@ -70,6 +71,10 @@ module Analyzer::Ruby
       rescue e
         logger.debug e
       end
+    end
+
+    protected def attach_ruby_callees(endpoint : Endpoint, callees : Array(Noir::RubyCalleeExtractor::Entry))
+      Noir::RubyCalleeExtractor.attach_to(endpoint, callees)
     end
   end
 end

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -1,0 +1,95 @@
+require "../models/endpoint"
+
+module Noir::RubyCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "alias", "and", "begin", "break", "case", "class", "def",
+    "defined?", "do", "else", "elsif", "end", "ensure", "false",
+    "for", "if", "in", "module", "next", "nil", "not", "or",
+    "redo", "rescue", "retry", "return", "self", "super", "then",
+    "true", "undef", "unless", "until", "when", "while", "yield",
+  }
+
+  RECEIVER_CALL_REGEX = /((?:@{1,2})?[A-Za-z_][\w]*(?:::[A-Za-z_][\w]*)*(?:\.[A-Za-z_][\w]*[!?=]?)+)\s*(?:\(|\b|$)/
+  BARE_CALL_REGEX     = /(?<![.\w:])([a-z_][\w]*[!?=]?)\s*\(/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+
+    body.lines.each_with_index do |line, index|
+      scan_line(strip_comment(line), file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    line.scan(RECEIVER_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  private def strip_comment(line : String) : String
+    in_string = false
+    escaped = false
+    quote = '\0'
+
+    line.each_char_with_index do |char, index|
+      if in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == quote
+          in_string = false
+        end
+      elsif char == '"' || char == '\''
+        in_string = true
+        quote = char
+      elsif char == '#'
+        return line[0, index]
+      end
+    end
+
+    line
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -14,7 +14,7 @@ module Noir::RubyCalleeExtractor
   }
 
   RECEIVER_CALL_REGEX = /((?:@{1,2})?[A-Za-z_][\w]*(?:::[A-Za-z_][\w]*)*(?:\.[A-Za-z_][\w]*[!?=]?)+)\s*(?:\(|\b|$)/
-  BARE_CALL_REGEX     = /(?<![.\w:])([a-z_][\w]*[!?=]?)\s*\(/
+  BARE_CALL_REGEX     = /(?<![.\w:])([a-z_][\w]*[!?=]?)(?:\s*\(|(?=\s+(?:[:'"]|@{1,2}[A-Za-z_]|[A-Za-z_][\w]*[!?=]?)))/
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry


### PR DESCRIPTION
## Summary
- add a shared lightweight Ruby callee extractor for handler bodies
- wire Rails controller action callees into REST resources, collection/member actions, and explicit controller#action routes
- add Rails callee fixtures plus unit coverage for Ruby callee extraction

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rails crystal spec spec/unit_test/miniparser/ruby_callee_extractor_spec.cr spec/functional_test/testers/ruby/rails_callees_spec.cr spec/functional_test/testers/ruby/rails_spec.cr spec/functional_test/testers/ruby/rails_advanced_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rails just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rails just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rails just test
- ./bin/noir -b spec/functional_test/fixtures/ruby/rails_callees --include-callee