### PR TITLE
Add Sinatra callee extraction

### DIFF
--- a/spec/functional_test/fixtures/ruby/sinatra_callees/Gemfile
+++ b/spec/functional_test/fixtures/ruby/sinatra_callees/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/spec/functional_test/fixtures/ruby/sinatra_callees/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra_callees/app.rb
@@ -1,0 +1,22 @@
+require 'sinatra'
+
+get '/users' do
+  page = params['page']
+  users = UserService.list(page)
+  AuditLog.write('list')
+  json serialize_users(users)
+end
+
+post '/users' do
+  payload = JSON.parse(request.body.read)
+  user = UserService.create(payload)
+  redirect_to user_url(user)
+end
+
+get '/ping' do; head :ok; end
+
+get '/ready' do
+  if Health.ready?
+    json status_payload(Health.check)
+  end
+end

--- a/spec/functional_test/fixtures/ruby/sinatra_callees/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra_callees/app.rb
@@ -3,7 +3,8 @@ require 'sinatra'
 get '/users' do
   page = params['page']
   users = UserService.list(page)
-  AuditLog.write('list')
+  users.each do |user| AuditLog.write(user)
+  end
   json serialize_users(users)
 end
 
@@ -16,7 +17,10 @@ end
 get '/ping' do; head :ok; end
 
 get '/ready' do
-  if Health.ready?
-    json status_payload(Health.check)
+  status = if Health.ready?
+    Health.check
+  else
+    Health.down
   end
+  json status_payload(status)
 end

--- a/spec/functional_test/testers/ruby/sinatra_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/sinatra_callees_spec.cr
@@ -2,28 +2,30 @@ require "../../func_spec.cr"
 
 users_index = Endpoint.new("/users", "GET").tap do |ep|
   ep.push_callee(Callee.new("UserService.list", line: 5))
+  ep.push_callee(Callee.new("users.each", line: 6))
   ep.push_callee(Callee.new("AuditLog.write", line: 6))
-  ep.push_callee(Callee.new("json", line: 7))
-  ep.push_callee(Callee.new("serialize_users", line: 7))
+  ep.push_callee(Callee.new("json", line: 8))
+  ep.push_callee(Callee.new("serialize_users", line: 8))
 end
 
 users_create = Endpoint.new("/users", "POST").tap do |ep|
-  ep.push_callee(Callee.new("JSON.parse", line: 11))
-  ep.push_callee(Callee.new("request.body.read", line: 11))
-  ep.push_callee(Callee.new("UserService.create", line: 12))
-  ep.push_callee(Callee.new("redirect_to", line: 13))
-  ep.push_callee(Callee.new("user_url", line: 13))
+  ep.push_callee(Callee.new("JSON.parse", line: 12))
+  ep.push_callee(Callee.new("request.body.read", line: 12))
+  ep.push_callee(Callee.new("UserService.create", line: 13))
+  ep.push_callee(Callee.new("redirect_to", line: 14))
+  ep.push_callee(Callee.new("user_url", line: 14))
 end
 
 ping = Endpoint.new("/ping", "GET").tap do |ep|
-  ep.push_callee(Callee.new("head", line: 16))
+  ep.push_callee(Callee.new("head", line: 17))
 end
 
 ready = Endpoint.new("/ready", "GET").tap do |ep|
-  ep.push_callee(Callee.new("Health.ready?", line: 19))
-  ep.push_callee(Callee.new("Health.check", line: 20))
-  ep.push_callee(Callee.new("json", line: 20))
-  ep.push_callee(Callee.new("status_payload", line: 20))
+  ep.push_callee(Callee.new("Health.ready?", line: 20))
+  ep.push_callee(Callee.new("Health.check", line: 21))
+  ep.push_callee(Callee.new("Health.down", line: 23))
+  ep.push_callee(Callee.new("json", line: 25))
+  ep.push_callee(Callee.new("status_payload", line: 25))
 end
 
 expected_endpoints = [

--- a/spec/functional_test/testers/ruby/sinatra_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/sinatra_callees_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+users_index = Endpoint.new("/users", "GET").tap do |ep|
+  ep.push_callee(Callee.new("UserService.list", line: 5))
+  ep.push_callee(Callee.new("AuditLog.write", line: 6))
+  ep.push_callee(Callee.new("json", line: 7))
+  ep.push_callee(Callee.new("serialize_users", line: 7))
+end
+
+users_create = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("JSON.parse", line: 11))
+  ep.push_callee(Callee.new("request.body.read", line: 11))
+  ep.push_callee(Callee.new("UserService.create", line: 12))
+  ep.push_callee(Callee.new("redirect_to", line: 13))
+  ep.push_callee(Callee.new("user_url", line: 13))
+end
+
+ping = Endpoint.new("/ping", "GET").tap do |ep|
+  ep.push_callee(Callee.new("head", line: 16))
+end
+
+ready = Endpoint.new("/ready", "GET").tap do |ep|
+  ep.push_callee(Callee.new("Health.ready?", line: 19))
+  ep.push_callee(Callee.new("Health.check", line: 20))
+  ep.push_callee(Callee.new("json", line: 20))
+  ep.push_callee(Callee.new("status_payload", line: 20))
+end
+
+expected_endpoints = [
+  users_index,
+  users_create,
+  ping,
+  ready,
+]
+
+FunctionalTester.new("fixtures/ruby/sinatra_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -8,7 +8,7 @@ module Analyzer::Ruby
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          lines = file.gets_to_end.lines
+          lines = file.each_line.to_a
           last_endpoint = Endpoint.new("", "")
           lines.each_with_index do |line, index|
             next unless line.valid_encoding?

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -3,16 +3,20 @@ require "../../engines/ruby_engine"
 module Analyzer::Ruby
   class Sinatra < RubyEngine
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
+
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+          lines = file.gets_to_end.lines
           last_endpoint = Endpoint.new("", "")
-          file.each_line.with_index do |line, index|
+          lines.each_with_index do |line, index|
             next unless line.valid_encoding?
             endpoint = line_to_endpoint(line)
             if endpoint.method != ""
               details = Details.new(PathInfo.new(path, index + 1))
               endpoint.details = details
+              attach_route_callees(endpoint, lines, index, path) if include_callee
               @result << endpoint
               last_endpoint = endpoint
             end
@@ -28,6 +32,14 @@ module Analyzer::Ruby
       end
 
       @result
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
+      if block = extract_ruby_do_block(lines, index)
+        body, body_start_line = block
+        callees = Noir::RubyCalleeExtractor.callees_for_body(body, path, body_start_line)
+        attach_ruby_callees(endpoint, callees)
+      end
     end
 
     def line_to_param(content : String) : Param

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -80,7 +80,7 @@ module Analyzer::Ruby
     protected def extract_ruby_do_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
       return if start_index >= lines.size
 
-      start_line = strip_ruby_inline_comment(lines[start_index]).strip
+      start_line = Noir::RubyCalleeExtractor.strip_comment(lines[start_index]).strip
       match = start_line.match(/\bdo\b(?:\s*\|[^|]*\|)?(.*)$/)
       return unless match
 
@@ -103,7 +103,7 @@ module Analyzer::Ruby
       index = start_index + 1
       while index < lines.size
         raw_body_line = lines[index]
-        body_line = strip_ruby_inline_comment(raw_body_line).strip
+        body_line = Noir::RubyCalleeExtractor.strip_comment(raw_body_line).strip
 
         if ruby_closes_block?(body_line)
           depth -= 1
@@ -123,38 +123,13 @@ module Analyzer::Ruby
 
     private def ruby_do_block_open_delta(line : String) : Int32
       return 0 if line.empty?
-      return 1 if line.match(/\bdo\b\s*(\|[^|]*\|)?\s*\z/)
-      return 1 if line.match(/^(if|unless|case|begin|while|until|for|class|module|def)\b/) && !line.match(/\bend\b/)
+      return 1 if line.match(/\bdo\b/) && !line.match(/\bend\b/)
+      return 1 if line.match(/(?:^|=[^=>])\s*(if|unless|case|begin|while|until|for|class|module|def)\b/) && !line.match(/\bend\b/)
       0
     end
 
     private def ruby_closes_block?(line : String) : Bool
       !!line.match(/^end\b/)
-    end
-
-    private def strip_ruby_inline_comment(line : String) : String
-      in_string = false
-      escaped = false
-      quote = '\0'
-
-      line.each_char_with_index do |char, index|
-        if in_string
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            in_string = false
-          end
-        elsif char == '"' || char == '\''
-          in_string = true
-          quote = char
-        elsif char == '#'
-          return line[0, index]
-        end
-      end
-
-      line
     end
   end
 end

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -76,5 +76,85 @@ module Analyzer::Ruby
     protected def attach_ruby_callees(endpoint : Endpoint, callees : Array(Noir::RubyCalleeExtractor::Entry))
       Noir::RubyCalleeExtractor.attach_to(endpoint, callees)
     end
+
+    protected def extract_ruby_do_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      return if start_index >= lines.size
+
+      start_line = strip_ruby_inline_comment(lines[start_index]).strip
+      match = start_line.match(/\bdo\b(?:\s*\|[^|]*\|)?(.*)$/)
+      return unless match
+
+      body_lines = [] of String
+      body_start_line = start_index + 2
+      depth = 1
+      tail = match[1].strip
+      tail = tail[1, tail.size - 1].strip if tail.starts_with?(";")
+
+      unless tail.empty?
+        body_start_line = start_index + 1
+        if m = tail.match(/^(.*?)(?:;\s*)?end\b/)
+          return {m[1].strip, body_start_line}
+        end
+
+        body_lines << tail
+        depth += ruby_do_block_open_delta(tail)
+      end
+
+      index = start_index + 1
+      while index < lines.size
+        raw_body_line = lines[index]
+        body_line = strip_ruby_inline_comment(raw_body_line).strip
+
+        if ruby_closes_block?(body_line)
+          depth -= 1
+          break if depth == 0
+          body_lines << raw_body_line
+          index += 1
+          next
+        end
+
+        body_lines << raw_body_line
+        depth += ruby_do_block_open_delta(body_line)
+        index += 1
+      end
+
+      {body_lines.join("\n"), body_start_line}
+    end
+
+    private def ruby_do_block_open_delta(line : String) : Int32
+      return 0 if line.empty?
+      return 1 if line.match(/\bdo\b\s*(\|[^|]*\|)?\s*\z/)
+      return 1 if line.match(/^(if|unless|case|begin|while|until|for|class|module|def)\b/) && !line.match(/\bend\b/)
+      0
+    end
+
+    private def ruby_closes_block?(line : String) : Bool
+      !!line.match(/^end\b/)
+    end
+
+    private def strip_ruby_inline_comment(line : String) : String
+      in_string = false
+      escaped = false
+      quote = '\0'
+
+      line.each_char_with_index do |char, index|
+        if in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '#'
+          return line[0, index]
+        end
+      end
+
+      line
+    end
   end
 end

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -55,7 +55,7 @@ module Noir::RubyCalleeExtractor
     RESERVED.includes?(last)
   end
 
-  private def strip_comment(line : String) : String
+  def strip_comment(line : String) : String
     in_string = false
     escaped = false
     quote = '\0'


### PR DESCRIPTION
## Summary
- add a shared Ruby do/end block extraction helper in RubyEngine
- wire Sinatra route blocks into the Ruby callee extractor behind --include-callee
- add Sinatra callee fixtures for multiline routes, one-line routes, nested blocks, and command-style Ruby calls

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sinatra crystal spec spec/unit_test/miniparser/ruby_callee_extractor_spec.cr spec/functional_test/testers/ruby/sinatra_callees_spec.cr spec/functional_test/testers/ruby/sinatra_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sinatra just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sinatra just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sinatra just test
- ./bin/noir -b spec/functional_test/fixtures/ruby/sinatra_callees --include-callee
