### PR TITLE
Add Grape callee extraction

### DIFF
--- a/spec/functional_test/fixtures/ruby/grape_callees/Gemfile
+++ b/spec/functional_test/fixtures/ruby/grape_callees/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'grape'

--- a/spec/functional_test/fixtures/ruby/grape_callees/app.rb
+++ b/spec/functional_test/fixtures/ruby/grape_callees/app.rb
@@ -1,0 +1,38 @@
+require "grape"
+
+class API < Grape::API
+  prefix "api"
+
+  resource :users do
+    params do
+      optional :page, type: Integer
+    end
+
+    get do
+      users = UserService.list(params[:page])
+      AuditLog.write("list")
+      present serialize_users(users)
+    end
+
+    params do
+      requires :name, type: String
+    end
+
+    post do
+      payload = BuildUser.call(params[:name])
+      created = UserService.create(payload)
+      present serialize_user(created)
+    end
+
+    get ":id" do
+      status = if Feature.enabled?
+        UserService.find(params[:id])
+      else
+        UserFallback.find(params[:id])
+      end
+      present serialize_user(status)
+    end
+
+    delete ":id" do; UserService.delete(params[:id]); end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/grape_callees/app.rb
+++ b/spec/functional_test/fixtures/ruby/grape_callees/app.rb
@@ -8,7 +8,7 @@ class API < Grape::API
       optional :page, type: Integer
     end
 
-    get do
+    get do # comment mentions end
       users = UserService.list(params[:page])
       AuditLog.write("list")
       present serialize_users(users)

--- a/spec/functional_test/testers/ruby/grape_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/grape_callees_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+users_index = Endpoint.new("/api/users", "GET").tap do |ep|
+  ep.push_callee(Callee.new("UserService.list", line: 12))
+  ep.push_callee(Callee.new("AuditLog.write", line: 13))
+  ep.push_callee(Callee.new("present", line: 14))
+  ep.push_callee(Callee.new("serialize_users", line: 14))
+end
+
+users_create = Endpoint.new("/api/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("BuildUser.call", line: 22))
+  ep.push_callee(Callee.new("UserService.create", line: 23))
+  ep.push_callee(Callee.new("present", line: 24))
+  ep.push_callee(Callee.new("serialize_user", line: 24))
+end
+
+users_show = Endpoint.new("/api/users/{id}", "GET").tap do |ep|
+  ep.push_callee(Callee.new("Feature.enabled?", line: 28))
+  ep.push_callee(Callee.new("UserService.find", line: 29))
+  ep.push_callee(Callee.new("UserFallback.find", line: 31))
+  ep.push_callee(Callee.new("present", line: 33))
+  ep.push_callee(Callee.new("serialize_user", line: 33))
+end
+
+users_delete = Endpoint.new("/api/users/{id}", "DELETE").tap do |ep|
+  ep.push_callee(Callee.new("UserService.delete", line: 36))
+end
+
+expected_endpoints = [
+  users_index,
+  users_create,
+  users_show,
+  users_delete,
+]
+
+FunctionalTester.new("fixtures/ruby/grape_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -5,25 +5,28 @@ module Analyzer::Ruby
     GRAPE_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
+
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")
         content = read_file_content(path)
         next unless content.includes?("Grape::API")
-        process_file(path, content)
+        process_file(path, content, include_callee)
       end
 
       @result
     end
 
-    private def process_file(path : String, content : String) : Nil
+    private def process_file(path : String, content : String, include_callee : Bool) : Nil
       prefix_segments = [] of String
       block_kinds = [] of Symbol
       class_prefix = ""
       pending_params = [] of String
       in_params_block = false
       last_endpoint : Endpoint? = nil
+      lines = content.lines
 
-      content.each_line.with_index do |raw_line, index|
+      lines.each_with_index do |raw_line, index|
         line = raw_line
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?('#')
@@ -73,9 +76,10 @@ module Analyzer::Ruby
             end
             pending_params.clear
 
+            attach_route_callees(endpoint, lines, index, path) if include_callee
             @result << endpoint
             last_endpoint = endpoint
-            block_kinds << :other
+            block_kinds << :other unless stripped.match(/\bend\b/)
             verb_handled = true
             break
           end
@@ -90,9 +94,10 @@ module Analyzer::Ruby
             end
             pending_params.clear
 
+            attach_route_callees(endpoint, lines, index, path) if include_callee
             @result << endpoint
             last_endpoint = endpoint
-            block_kinds << :other
+            block_kinds << :other unless stripped.match(/\bend\b/)
             verb_handled = true
             break
           end
@@ -118,15 +123,7 @@ module Analyzer::Ruby
           end
         end
 
-        if stripped.matches?(/\bdo(\s*\|[^|]*\|)?\s*$/)
-          block_kinds << :other
-        elsif stripped.starts_with?("if ") || stripped == "if" ||
-              stripped.starts_with?("unless ") || stripped == "unless" ||
-              stripped.starts_with?("def ") || stripped == "def" ||
-              stripped.starts_with?("class ") || stripped == "class" ||
-              stripped.starts_with?("module ") || stripped == "module" ||
-              stripped.starts_with?("begin ") || stripped == "begin" ||
-              stripped.starts_with?("case ") || stripped == "case"
+        if ruby_do_block_open_delta(stripped) > 0
           block_kinds << :other
         end
 
@@ -136,6 +133,14 @@ module Analyzer::Ruby
             prefix_segments.pop
           end
         end
+      end
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
+      if block = extract_ruby_do_block(lines, index)
+        body, body_start_line = block
+        callees = Noir::RubyCalleeExtractor.callees_for_body(body, path, body_start_line)
+        attach_ruby_callees(endpoint, callees)
       end
     end
 

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -27,7 +27,7 @@ module Analyzer::Ruby
       lines = content.lines
 
       lines.each_with_index do |raw_line, index|
-        line = raw_line
+        line = Noir::RubyCalleeExtractor.strip_comment(raw_line)
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?('#')
 

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -121,7 +121,7 @@ module Analyzer::Ruby
       {body_lines.join("\n"), body_start_line}
     end
 
-    private def ruby_do_block_open_delta(line : String) : Int32
+    protected def ruby_do_block_open_delta(line : String) : Int32
       return 0 if line.empty?
       return 1 if line.match(/\bdo\b/) && !line.match(/\bend\b/)
       return 1 if line.match(/(?:^|=[^=>])\s*(if|unless|case|begin|while|until|for|class|module|def)\b/) && !line.match(/\bend\b/)


### PR DESCRIPTION
## Summary
- wire Grape route blocks into the shared Ruby callee extractor behind --include-callee
- reuse RubyEngine block-open tracking for Grape's prefix stack so assignment-if and inline route blocks keep route scoping correct
- add Grape callee fixtures covering prefix/resource routes, params blocks, path params, nested assignment-if, and one-line routes

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grape crystal spec spec/unit_test/miniparser/ruby_callee_extractor_spec.cr spec/functional_test/testers/ruby/grape_callees_spec.cr spec/functional_test/testers/ruby/grape_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grape just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grape just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grape just test
- ./bin/noir -b spec/functional_test/fixtures/ruby/grape_callees --include-callee
