### PR TITLE
Add Hanami callee extraction

### DIFF
--- a/spec/functional_test/fixtures/ruby/hanami_callees/Gemfile
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "hanami", "~> 2.0"

--- a/spec/functional_test/fixtures/ruby/hanami_callees/app/action.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/app/action.rb
@@ -1,0 +1,6 @@
+require "hanami/action"
+
+module Testapp
+  class Action < Hanami::Action
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/health/ready.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/health/ready.rb
@@ -1,0 +1,9 @@
+module Testapp
+  module Actions
+    module Health
+      class Ready < Testapp::Action
+        def handle(request, response) = response.render(HealthCheck.ready)
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/create.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/create.rb
@@ -1,0 +1,18 @@
+module Testapp
+  module Actions
+    module Users
+      class Create < Testapp::Action
+        params do
+          required(:name).filled(:string)
+          optional(:email).filled(:string)
+        end
+
+        def handle(request, response)
+          payload = BuildUser.call(request.params[:source])
+          created = UserService.create(payload)
+          response.render serialize_user(created)
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/destroy.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/destroy.rb
@@ -1,0 +1,9 @@
+module Testapp
+  module Actions
+    module Users
+      class Destroy < Testapp::Action
+        def handle(request, response); UserService.delete(id); response.status = 204; end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/index.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/index.rb
@@ -1,0 +1,14 @@
+module Testapp
+  module Actions
+    module Users
+      class Index < Testapp::Action
+        def handle(request, response)
+          page = request.params[:page]
+          users = UserService.list(page)
+          AuditLog.write("list")
+          response.render serialize_users(users)
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/show.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/app/actions/users/show.rb
@@ -1,0 +1,16 @@
+module Testapp
+  module Actions
+    module Users
+      class Show < Testapp::Action
+        def handle(request, response)
+          user = if Feature.enabled?
+            UserService.find(id)
+          else
+            UserFallback.find(id)
+          end
+          response.render serialize_user(user)
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_callees/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_callees/config/routes.rb
@@ -1,0 +1,10 @@
+module Testapp
+  class Routes < Hanami::Routes
+    get "/users", to: "users.index"
+    post "/users", to: "users.create"
+    get "/users/:id", to: "users.show"
+    delete "/users/:id", to: "users.destroy"
+    get "/ready", to: "health.ready"
+    get "/missing", to: "missing.index"
+  end
+end

--- a/spec/functional_test/testers/ruby/hanami_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/hanami_callees_spec.cr
@@ -1,0 +1,63 @@
+require "../../func_spec.cr"
+
+users_index = Endpoint.new("/users", "GET", [
+  Param.new("page", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("request.params", line: 6))
+  ep.push_callee(Callee.new("UserService.list", line: 7))
+  ep.push_callee(Callee.new("AuditLog.write", line: 8))
+  ep.push_callee(Callee.new("response.render", line: 9))
+  ep.push_callee(Callee.new("serialize_users", line: 9))
+end
+
+users_create = Endpoint.new("/users", "POST", [
+  Param.new("name", "", "json"),
+  Param.new("email", "", "json"),
+  Param.new("source", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("BuildUser.call", line: 11))
+  ep.push_callee(Callee.new("request.params", line: 11))
+  ep.push_callee(Callee.new("UserService.create", line: 12))
+  ep.push_callee(Callee.new("response.render", line: 13))
+  ep.push_callee(Callee.new("serialize_user", line: 13))
+end
+
+users_show = Endpoint.new("/users/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("Feature.enabled?", line: 6))
+  ep.push_callee(Callee.new("UserService.find", line: 7))
+  ep.push_callee(Callee.new("UserFallback.find", line: 9))
+  ep.push_callee(Callee.new("response.render", line: 11))
+  ep.push_callee(Callee.new("serialize_user", line: 11))
+end
+
+users_destroy = Endpoint.new("/users/:id", "DELETE", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService.delete", line: 5))
+  ep.push_callee(Callee.new("response.status", line: 5))
+end
+
+health_ready = Endpoint.new("/ready", "GET").tap do |ep|
+  ep.push_callee(Callee.new("response.render", line: 5))
+  ep.push_callee(Callee.new("HealthCheck.ready", line: 5))
+end
+
+missing_action = Endpoint.new("/missing", "GET")
+
+expected_endpoints = [
+  users_index,
+  users_create,
+  users_show,
+  users_destroy,
+  health_ready,
+  missing_action,
+]
+
+FunctionalTester.new("fixtures/ruby/hanami_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -3,6 +3,7 @@ require "../../engines/ruby_engine"
 module Analyzer::Ruby
   class Hanami < RubyEngine
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       framework_roots = discover_framework_roots("config/routes.rb")
       framework_roots = [@base_path] if framework_roots.empty?
 
@@ -19,7 +20,7 @@ module Analyzer::Ruby
               action_path = extract_action_path(line, framework_root)
               if action_path != ""
                 # Scan action file for parameters
-                scan_action_file(endpoint, action_path)
+                scan_action_file(endpoint, action_path, include_callee)
               end
 
               @result << endpoint
@@ -43,103 +44,184 @@ module Analyzer::Ruby
       ""
     end
 
-    def scan_action_file(endpoint : Endpoint, action_path : String)
+    def scan_action_file(endpoint : Endpoint, action_path : String, include_callee : Bool = false)
       return unless File.exists?(action_path)
 
+      lines = [] of String
       File.open(action_path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        in_params_block = false
+        lines = file.each_line.to_a
+      end
 
-        file.each_line do |line|
-          # Detect params block
-          if line.strip == "params do"
-            in_params_block = true
-            next
-          elsif line.strip == "end" && in_params_block
-            in_params_block = false
-            next
-          end
+      scan_action_params(endpoint, lines)
+      attach_handle_callees(endpoint, action_path, lines) if include_callee
+    end
 
-          # Extract params from params block
-          # Matches required(:name) or optional(:name) - validation methods like
-          # .filled(), .value(), .maybe() are chained after and don't affect extraction
-          if in_params_block
-            # Match required(:name) or optional(:name) with any validation method
-            line.scan(/(?:required|optional)\(:([\w]+)\)/) do |match|
-              if match.size > 1
-                param_name = match[1]
-                # Determine if it's JSON or form based on content type
-                param_type = "json"
-                endpoint.push_param(Param.new(param_name, "", param_type))
-              end
-            end
-          end
+    private def scan_action_params(endpoint : Endpoint, lines : Array(String))
+      in_params_block = false
 
-          # Extract query parameters from request.params[:name]
-          line.scan(/request\.params\[:([\w]+)\]/) do |match|
+      lines.each do |line|
+        # Detect params block
+        if line.strip == "params do"
+          in_params_block = true
+          next
+        elsif line.strip == "end" && in_params_block
+          in_params_block = false
+          next
+        end
+
+        # Extract params from params block
+        # Matches required(:name) or optional(:name) - validation methods like
+        # .filled(), .value(), .maybe() are chained after and don't affect extraction
+        if in_params_block
+          # Match required(:name) or optional(:name) with any validation method
+          line.scan(/(?:required|optional)\(:([\w]+)\)/) do |match|
             if match.size > 1
               param_name = match[1]
-              endpoint.push_param(Param.new(param_name, "", "query"))
-            end
-          end
-
-          # Extract query parameters from request.params["name"]
-          line.scan(/request\.params\[['"](\w+)['"]\]/) do |match|
-            if match.size > 1
-              param_name = match[1]
-              endpoint.push_param(Param.new(param_name, "", "query"))
-            end
-          end
-
-          # Extract query parameters from params[:name] (without request prefix)
-          # Use word boundary to avoid matching params inside method names or identifiers
-          # Avoid matching inside params do blocks
-          unless in_params_block
-            line.scan(/\bparams\[:([\w]+)\]/) do |match|
-              if match.size > 1
-                param_name = match[1]
-                endpoint.push_param(Param.new(param_name, "", "query"))
-              end
-            end
-          end
-
-          # Extract query parameters from params["name"] (without request prefix)
-          # Use word boundary to avoid matching params inside method names or identifiers
-          # Avoid matching inside params do blocks
-          unless in_params_block
-            line.scan(/\bparams\[['"](\w+)['"]\]/) do |match|
-              if match.size > 1
-                param_name = match[1]
-                endpoint.push_param(Param.new(param_name, "", "query"))
-              end
-            end
-          end
-
-          # Extract header parameters from request.headers['name'] or request.headers["name"]
-          line.scan(/request\.headers\[['"](.+?)['"]\]/) do |match|
-            if match.size > 1
-              param_name = match[1]
-              endpoint.push_param(Param.new(param_name, "", "header"))
-            end
-          end
-
-          # Extract cookie parameters from request.cookies['name'] or request.cookies["name"]
-          line.scan(/request\.cookies\[['"](.+?)['"]\]/) do |match|
-            if match.size > 1
-              param_name = match[1]
-              endpoint.push_param(Param.new(param_name, "", "cookie"))
-            end
-          end
-
-          # Extract environment headers from request.env['HTTP_*']
-          line.scan(/request\.env\[['"]HTTP_(.+?)['"]\]/) do |match|
-            if match.size > 1
-              # Convert HTTP_USER_AGENT to User-Agent format
-              header_name = match[1].split('_').map(&.capitalize).join('-')
-              endpoint.push_param(Param.new(header_name, "", "header"))
+              # Determine if it's JSON or form based on content type
+              param_type = "json"
+              endpoint.push_param(Param.new(param_name, "", param_type))
             end
           end
         end
+
+        # Extract query parameters from request.params[:name]
+        line.scan(/request\.params\[:([\w]+)\]/) do |match|
+          if match.size > 1
+            param_name = match[1]
+            endpoint.push_param(Param.new(param_name, "", "query"))
+          end
+        end
+
+        # Extract query parameters from request.params["name"]
+        line.scan(/request\.params\[['"](\w+)['"]\]/) do |match|
+          if match.size > 1
+            param_name = match[1]
+            endpoint.push_param(Param.new(param_name, "", "query"))
+          end
+        end
+
+        # Extract query parameters from params[:name] (without request prefix)
+        # Use word boundary to avoid matching params inside method names or identifiers
+        # Avoid matching inside params do blocks
+        unless in_params_block
+          line.scan(/(?<!\.)\bparams\[:([\w]+)\]/) do |match|
+            if match.size > 1
+              param_name = match[1]
+              endpoint.push_param(Param.new(param_name, "", "query"))
+            end
+          end
+        end
+
+        # Extract query parameters from params["name"] (without request prefix)
+        # Use word boundary to avoid matching params inside method names or identifiers
+        # Avoid matching inside params do blocks
+        unless in_params_block
+          line.scan(/(?<!\.)\bparams\[['"](\w+)['"]\]/) do |match|
+            if match.size > 1
+              param_name = match[1]
+              endpoint.push_param(Param.new(param_name, "", "query"))
+            end
+          end
+        end
+
+        # Extract header parameters from request.headers['name'] or request.headers["name"]
+        line.scan(/request\.headers\[['"](.+?)['"]\]/) do |match|
+          if match.size > 1
+            param_name = match[1]
+            endpoint.push_param(Param.new(param_name, "", "header"))
+          end
+        end
+
+        # Extract cookie parameters from request.cookies['name'] or request.cookies["name"]
+        line.scan(/request\.cookies\[['"](.+?)['"]\]/) do |match|
+          if match.size > 1
+            param_name = match[1]
+            endpoint.push_param(Param.new(param_name, "", "cookie"))
+          end
+        end
+
+        # Extract environment headers from request.env['HTTP_*']
+        line.scan(/request\.env\[['"]HTTP_(.+?)['"]\]/) do |match|
+          if match.size > 1
+            # Convert HTTP_USER_AGENT to User-Agent format
+            header_name = match[1].split('_').map(&.capitalize).join('-')
+            endpoint.push_param(Param.new(header_name, "", "header"))
+          end
+        end
       end
+    end
+
+    private def attach_handle_callees(endpoint : Endpoint, action_path : String, lines : Array(String))
+      if block = extract_handle_body(lines)
+        body, body_start_line = block
+        callees = Noir::RubyCalleeExtractor.callees_for_body(body, action_path, body_start_line)
+        attach_ruby_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_handle_body(lines : Array(String)) : Tuple(String, Int32)?
+      index = 0
+
+      while index < lines.size
+        stripped = Noir::RubyCalleeExtractor.strip_comment(lines[index]).strip
+        if match = stripped.match(/^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?handle\b/)
+          inline_body, closed_on_def_line = inline_def_body(stripped, match[0])
+          body_lines = [] of String
+          body_start_line = inline_body ? index + 1 : index + 2
+          body_lines << inline_body if inline_body
+
+          unless closed_on_def_line
+            depth = 1
+            index += 1
+
+            while index < lines.size
+              raw_body_line = lines[index]
+              body_line = Noir::RubyCalleeExtractor.strip_comment(raw_body_line).strip
+
+              if closes_ruby_block?(body_line)
+                depth -= 1
+                break if depth == 0
+                body_lines << raw_body_line
+                index += 1
+                next
+              end
+
+              body_lines << raw_body_line
+              depth += ruby_do_block_open_delta(body_line)
+              index += 1
+            end
+          end
+
+          return {body_lines.join("\n"), body_start_line}
+        end
+
+        index += 1
+      end
+    end
+
+    private def inline_def_body(line : String, match_text : String) : Tuple(String?, Bool)
+      return {nil, false} if match_text.size >= line.size
+
+      tail = line[match_text.size, line.size - match_text.size].strip
+      tail = tail.sub(/^\([^)]*\)\s*/, "")
+      if tail.starts_with?("=")
+        body = tail[1, tail.size - 1].strip
+        return {body.empty? ? nil : body, true}
+      end
+
+      return {nil, false} unless tail.starts_with?(";")
+
+      tail = tail[1, tail.size - 1].strip
+      if match = tail.match(/^(.*?)(?:;\s*)?end\b/)
+        body = match[1].strip
+        return {body.empty? ? nil : body, true}
+      end
+
+      {tail.empty? ? nil : tail, false}
+    end
+
+    private def closes_ruby_block?(line : String) : Bool
+      !!line.match(/^end\b/)
     end
   end
 end


### PR DESCRIPTION
## Summary
- attach Ruby callee extraction to Hanami action `handle` bodies when `--include-callee` is enabled
- keep Hanami param extraction behavior while reusing the same action file read for callee extraction
- cover multiline, inline, endless-method, missing-action, params DSL, and nested branch Hanami actions

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-hanami crystal spec spec/unit_test/miniparser/ruby_callee_extractor_spec.cr spec/functional_test/testers/ruby/hanami_spec.cr spec/functional_test/testers/ruby/hanami_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-hanami just build`
- `./bin/noir -b spec/functional_test/fixtures/ruby/hanami_callees --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-hanami just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-hanami just test`

Part of #1366