### PR TITLE
Add Symfony callee extraction

### DIFF
--- a/spec/functional_test/testers/php/symfony_callees_spec.cr
+++ b/spec/functional_test/testers/php/symfony_callees_spec.cr
@@ -1,0 +1,95 @@
+require "../../func_spec.cr"
+
+users_index = Endpoint.new("/api/users", "GET", [
+  Param.new("page", "", "query"),
+  Param.new("limit", "", "query"),
+  Param.new("search", "", "query"),
+  Param.new("X-API-Key", "", "header"),
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$request->query->get", line: 17))
+  ep.push_callee(Callee.new("$request->get", line: 19))
+  ep.push_callee(Callee.new("$request->headers->get", line: 20))
+  ep.push_callee(Callee.new("$request->cookies->get", line: 21))
+  ep.push_callee(Callee.new("$this->json", line: 23))
+end
+
+users_create = Endpoint.new("/api/users", "POST", [
+  Param.new("name", "", "form"),
+  Param.new("email", "", "form"),
+  Param.new("Authorization", "", "header"),
+  Param.new("avatar", "", "file"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$request->request->get", line: 39))
+  ep.push_callee(Callee.new("$request->headers->get", line: 41))
+  ep.push_callee(Callee.new("$request->files->get", line: 42))
+  ep.push_callee(Callee.new("$this->json", line: 43))
+end
+
+users_update = Endpoint.new("/api/users/{id}", "PUT", [
+  Param.new("id", "", "path"),
+  Param.new("Content-Type", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$request->getContent", line: 51))
+  ep.push_callee(Callee.new("json_decode", line: 51))
+  ep.push_callee(Callee.new("$request->headers->get", line: 52))
+  ep.push_callee(Callee.new("$this->json", line: 53))
+end
+
+products_create = Endpoint.new("/api/products", "POST", [
+  Param.new("name", "", "form"),
+  Param.new("price", "", "form"),
+  Param.new("category", "", "query"),
+  Param.new("User-Agent", "", "header"),
+  Param.new("image", "", "file"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$request->request->get", line: 27))
+  ep.push_callee(Callee.new("$request->get", line: 29))
+  ep.push_callee(Callee.new("$request->headers->get", line: 30))
+  ep.push_callee(Callee.new("$request->files->get", line: 31))
+  ep.push_callee(Callee.new("$this->json", line: 32))
+end
+
+products_update = Endpoint.new("/api/products/{slug}", "PATCH", [
+  Param.new("slug", "", "path"),
+  Param.new("X-CSRF-Token", "", "header"),
+  Param.new("preferences", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$request->getContent", line: 38))
+  ep.push_callee(Callee.new("$request->headers->get", line: 39))
+  ep.push_callee(Callee.new("$request->cookies->get", line: 40))
+  ep.push_callee(Callee.new("$this->json", line: 41))
+end
+
+expected_endpoints = [
+  users_index,
+  users_create,
+  users_update,
+  products_create,
+  products_update,
+]
+
+FunctionalTester.new("fixtures/php/symfony/", {
+  :techs     => 2,
+  :endpoints => 20,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests
+
+describe "Symfony YAML route callees" do
+  it "keeps YAML-only routes callee-empty" do
+    config_init = ConfigInitializer.new
+    noir_options = config_init.default_options
+    noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/php/symfony/")])
+    noir_options["nolog"] = YAML::Any.new(true)
+    noir_options["include_callee"] = YAML::Any.new(true)
+
+    app = NoirRunner.new noir_options
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find { |e| e.method == "GET" && e.url == "/api/health" }
+    endpoint.should_not be_nil
+    endpoint.callees.should be_empty if endpoint
+  end
+end

--- a/spec/unit_test/analyzer/php_engine_spec.cr
+++ b/spec/unit_test/analyzer/php_engine_spec.cr
@@ -1,0 +1,43 @@
+require "../../spec_helper"
+require "../../../src/analyzer/engines/php_engine"
+
+class PhpEngineSpecHarness < Analyzer::Php::PhpEngine
+  def analyze_file(path : String) : Array(Endpoint)
+    [] of Endpoint
+  end
+
+  def method_body_after(content : String, start_pos : Int32) : Tuple(String, Int32)?
+    extract_php_method_body_after(content, start_pos)
+  end
+end
+
+describe Analyzer::Php::PhpEngine do
+  it "extracts method bodies without treating strings or comments as braces" do
+    content = <<-PHP
+      <?php
+      class DemoController {
+          #[Route('/demo')]
+          public function show(): JsonResponse
+          {
+              $literal = "{";
+              /* } */
+              if ($literal) {
+                  return $this->json($literal);
+              }
+          }
+      }
+      PHP
+
+    route_start = content.index("#[Route")
+    route_start.should_not be_nil
+
+    method_body = route_start ? PhpEngineSpecHarness.new(create_test_options).method_body_after(content, route_start) : nil
+    method_body.should_not be_nil
+    if method_body
+      body, start_line = method_body
+      start_line.should eq(5)
+      body.should contain("$this->json")
+      body.should_not contain("class DemoController")
+    end
+  end
+end

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -4,10 +4,11 @@ module Analyzer::Php
   class Symfony < PhpEngine
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Analyze PHP controller files
       if path.ends_with?(".php")
-        endpoints.concat(analyze_php_routes(path))
+        endpoints.concat(analyze_php_routes(path, include_callee))
       end
 
       # Analyze YAML route files
@@ -20,7 +21,7 @@ module Analyzer::Php
       endpoints
     end
 
-    private def analyze_php_routes(path : String) : Array(Endpoint)
+    private def analyze_php_routes(path : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
@@ -42,18 +43,18 @@ module Analyzer::Php
             methods = extract_methods_from_annotation_context(full_match)
             methods = ["GET"] if methods.empty?
 
-            # Get context for method body parameter extraction (starts from annotation)
-            context_end = [route_start + 1000, content.size].min
-            method_context = content[route_start..context_end]
+            method_body = extract_php_method_body_after(content, route_start)
 
             params = extract_brace_path_params(route_path)
             # Extract additional parameters from method body
-            params.concat(extract_method_params(method_context))
+            params.concat(extract_method_params(method_body[0])) if method_body
 
             details = Details.new(PathInfo.new(path))
 
             methods.each do |method|
-              endpoints << Endpoint.new(route_path, method.upcase, params, details)
+              endpoint = Endpoint.new(route_path, method.upcase, params, details)
+              attach_method_callees(endpoint, method_body, path) if include_callee
+              endpoints << endpoint
             end
           end
         end
@@ -74,18 +75,18 @@ module Analyzer::Php
             methods = extract_methods_from_attribute_context(full_match)
             methods = ["GET"] if methods.empty?
 
-            # Get context for method body parameter extraction (starts from attribute)
-            context_end = [route_start + 1000, content.size].min
-            method_context = content[route_start..context_end]
+            method_body = extract_php_method_body_after(content, route_start)
 
             params = extract_brace_path_params(route_path)
             # Extract additional parameters from method body
-            params.concat(extract_method_params(method_context))
+            params.concat(extract_method_params(method_body[0])) if method_body
 
             details = Details.new(PathInfo.new(path))
 
             methods.each do |method|
-              endpoints << Endpoint.new(route_path, method.upcase, params, details)
+              endpoint = Endpoint.new(route_path, method.upcase, params, details)
+              attach_method_callees(endpoint, method_body, path) if include_callee
+              endpoints << endpoint
             end
           end
         end
@@ -163,39 +164,17 @@ module Analyzer::Php
       endpoints
     end
 
-    private def extract_method_params(context : String) : Array(Param)
+    private def attach_method_callees(endpoint : Endpoint, method_body : Tuple(String, Int32)?, path : String)
+      return unless method_body
+
+      body, start_line = method_body
+      callees = Noir::PhpCalleeExtractor.callees_for_body(body, path, start_line)
+      attach_php_callees(endpoint, callees)
+    end
+
+    private def extract_method_params(method_body : String) : Array(Param)
       params = [] of Param
       seen_params = Set(String).new
-
-      # Improved method body extraction using brace counting
-      # Find the start of the method function
-      func_match = context.match(/public\s+function\s+\w+[^{]*\{/)
-      return params unless func_match
-
-      # Find the opening brace position
-      start_pos = context.index(func_match[0])
-      return params unless start_pos
-
-      brace_start = start_pos + func_match[0].size - 1 # Position of the opening '{'
-
-      # Count braces to find the matching closing brace
-      brace_count = 1
-      pos = brace_start + 1
-      method_end = pos
-
-      while pos < context.size && brace_count > 0
-        if context[pos] == '{'
-          brace_count += 1
-        elsif context[pos] == '}'
-          brace_count -= 1
-          method_end = pos if brace_count == 0
-        end
-        pos += 1
-      end
-
-      # Extract the method body (between the opening and closing braces)
-      return params if method_end <= brace_start + 1
-      method_body = context[(brace_start + 1)...method_end]
 
       # Extract query parameters: $request->query->get('param')
       query_matches = method_body.scan(/\$request->query->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -66,5 +66,84 @@ module Analyzer::Php
     protected def attach_php_callees(endpoint : Endpoint, callees : Array(Noir::PhpCalleeExtractor::Entry))
       Noir::PhpCalleeExtractor.attach_to(endpoint, callees)
     end
+
+    protected def extract_php_method_body_after(content : String, start_pos : Int32) : Tuple(String, Int32)?
+      return unless start_pos < content.size
+
+      context = content[start_pos..]
+      func_match = context.match(/(?:public|protected|private)\s+function\s+\w+[^{]*\{/m)
+      return unless func_match
+
+      func_start = context.index(func_match[0])
+      return unless func_start
+
+      brace_start = start_pos + func_start + func_match[0].size - 1
+      method_end = find_matching_php_close_brace(content, brace_start)
+      return unless method_end
+      return if method_end <= brace_start + 1
+
+      body_start_line = php_line_number_for_index(content, brace_start)
+      {content[(brace_start + 1)...method_end], body_start_line}
+    end
+
+    protected def php_line_number_for_index(content : String, index : Int32) : Int32
+      return 1 if index <= 0
+
+      content[0...index].count('\n') + 1
+    end
+
+    protected def find_matching_php_close_brace(content : String, open_pos : Int32) : Int32?
+      return unless open_pos < content.size && content[open_pos] == '{'
+
+      depth = 0
+      in_string = false
+      in_line_comment = false
+      in_block_comment = false
+      escaped = false
+      quote = '\0'
+      pos = open_pos
+
+      while pos < content.size
+        char = content[pos]
+        next_char = content[pos + 1]?
+
+        if in_line_comment
+          in_line_comment = false if char == '\n'
+        elsif in_block_comment
+          if char == '*' && next_char == '/'
+            in_block_comment = false
+            pos += 1
+          end
+        elsif in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '/' && next_char == '/'
+          in_line_comment = true
+          pos += 1
+        elsif char == '/' && next_char == '*'
+          in_block_comment = true
+          pos += 1
+        elsif char == '#'
+          in_line_comment = true
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '{'
+          depth += 1
+        elsif char == '}'
+          depth -= 1
+          return pos if depth == 0
+        end
+
+        pos += 1
+      end
+
+      nil
+    end
   end
 end


### PR DESCRIPTION
## Summary
- reuse shared PHP method-body extraction for Symfony controller annotations and attributes
- attach Symfony controller method callees when `--include-callee` is enabled
- keep YAML-only Symfony routes callee-empty and add regression coverage

Part of #1366

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-symfony crystal spec spec/unit_test/analyzer/php_engine_spec.cr spec/functional_test/testers/php/symfony_spec.cr spec/functional_test/testers/php/symfony_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-symfony-check2 just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-symfony-build2 just build`
- `./bin/noir -b spec/functional_test/fixtures/php/symfony --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-symfony-test just test`