### PR TITLE
Add Yii callee extraction

### DIFF
--- a/spec/functional_test/testers/php/yii_callees_spec.cr
+++ b/spec/functional_test/testers/php/yii_callees_spec.cr
@@ -1,0 +1,86 @@
+require "../../func_spec.cr"
+
+post_index = Endpoint.new("/post/index", "GET", [
+  Param.new("page", "", "query"),
+  Param.new("limit", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("Yii::$app->request->get", line: 13))
+  ep.push_callee(Callee.new("$this->render", line: 15))
+end
+
+post_view = Endpoint.new("/post/view", "GET", [
+  Param.new("id", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$this->render", line: 20))
+end
+
+post_create_callees = [
+  Callee.new("Yii::$app->request->post", line: 25),
+  Callee.new("Yii::$app->request->headers->get", line: 27),
+  Callee.new("$this->render", line: 28),
+]
+
+post_create_post = Endpoint.new("/post/create", "POST", [
+  Param.new("title", "", "form"),
+  Param.new("body", "", "form"),
+  Param.new("X-CSRF-Token", "", "header"),
+]).tap do |ep|
+  post_create_callees.each { |callee| ep.push_callee(callee) }
+end
+
+post_create_get = Endpoint.new("/post/create", "GET", [
+  Param.new("title", "", "form"),
+  Param.new("body", "", "form"),
+]).tap do |ep|
+  post_create_callees.each { |callee| ep.push_callee(callee) }
+end
+
+user_profile = Endpoint.new("/user/profile", "GET", [
+  Param.new("id", "", "query"),
+  Param.new("session_id", "", "cookie"),
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("Yii::$app->request->cookies->get", line: 14))
+  ep.push_callee(Callee.new("Yii::$app->request->headers->get", line: 15))
+end
+
+user_search = Endpoint.new("/user/search", "GET", [
+  Param.new("q", "", "query"),
+  Param.new("tag", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$request->get", line: 22))
+end
+
+expected_endpoints = [
+  post_index,
+  post_view,
+  post_create_post,
+  post_create_get,
+  user_profile,
+  user_search,
+]
+
+FunctionalTester.new("fixtures/php/yii/", {
+  :techs     => 2,
+  :endpoints => 23,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests
+
+describe "Yii config route callees" do
+  it "keeps urlManager-only routes callee-empty" do
+    config_init = ConfigInitializer.new
+    noir_options = config_init.default_options
+    noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/php/yii/")])
+    noir_options["nolog"] = YAML::Any.new(true)
+    noir_options["include_callee"] = YAML::Any.new(true)
+
+    app = NoirRunner.new noir_options
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find { |e| e.method == "GET" && e.url == "/health" }
+    endpoint.should_not be_nil
+    endpoint.callees.should be_empty if endpoint
+  end
+end

--- a/spec/unit_test/miniparser/php_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/php_callee_extractor_spec.cr
@@ -50,4 +50,17 @@ describe Noir::PhpCalleeExtractor do
       {"\\Vendor\\Package\\notify", 35},
     ])
   end
+
+  it "preserves static property object chains" do
+    body = <<-'PHP'
+      $page = Yii::$app->request->get('page');
+      $token = \App\Container::$request->headers->get('Authorization');
+      PHP
+
+    callees = Noir::PhpCalleeExtractor.callees_for_body(body, "index.php", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"Yii::$app->request->get", 40},
+      {"\\App\\Container::$request->headers->get", 41},
+    ])
+  end
 end

--- a/src/analyzer/analyzers/php/yii.cr
+++ b/src/analyzer/analyzers/php/yii.cr
@@ -16,6 +16,7 @@ module Analyzer::Php
       endpoints = [] of Endpoint
 
       return endpoints unless path.ends_with?(".php")
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         content = file.gets_to_end
@@ -25,7 +26,7 @@ module Analyzer::Php
         end
 
         if path.ends_with?("Controller.php") || content.match(/class\s+\w+Controller\s+extends/)
-          endpoints.concat(analyze_controller(path, content))
+          endpoints.concat(analyze_controller(path, content, include_callee))
         end
       end
 
@@ -110,7 +111,7 @@ module Analyzer::Php
       normalized
     end
 
-    private def analyze_controller(path : String, content : String) : Array(Endpoint)
+    private def analyze_controller(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       controller_name = extract_controller_name(path, content)
@@ -147,7 +148,8 @@ module Analyzer::Php
 
         params = extract_action_signature_params(param_sig)
 
-        method_body = extract_method_body(content, method_start + full_match.size - 1)
+        method_body_info = extract_php_method_body_after(content, method_start)
+        method_body = method_body_info ? method_body_info[0] : ""
         body_params = extract_request_params(method_body)
 
         seen = Set(String).new(params.map(&.name))
@@ -161,7 +163,9 @@ module Analyzer::Php
         methods = infer_methods_from_body(method_body)
 
         methods.each do |method|
-          endpoints << Endpoint.new(route_path, method, params, details)
+          endpoint = Endpoint.new(route_path, method, params, details)
+          attach_action_callees(endpoint, method_body_info, path) if include_callee
+          endpoints << endpoint
         end
       end
 
@@ -196,28 +200,12 @@ module Analyzer::Php
       result
     end
 
-    # Brace-count from an opening `{` to isolate the matching method body;
-    # prevents param/method leakage across adjacent action methods.
-    # Note: brace counting may be inaccurate if braces appear inside strings or comments.
-    # A full PHP parser is out of scope; this is a best-effort implementation.
-    private def extract_method_body(content : String, brace_start : Int32) : String
-      return "" unless brace_start < content.size && content[brace_start] == '{'
+    private def attach_action_callees(endpoint : Endpoint, method_body : Tuple(String, Int32)?, path : String)
+      return unless method_body
 
-      depth = 1
-      pos = brace_start + 1
-      while pos < content.size && depth > 0
-        case content[pos]
-        when '{'
-          depth += 1
-        when '}'
-          depth -= 1
-          break if depth == 0
-        end
-        pos += 1
-      end
-
-      return "" if depth != 0 || pos <= brace_start + 1
-      content[(brace_start + 1)...pos]
+      body, start_line = method_body
+      callees = Noir::PhpCalleeExtractor.callees_for_body(body, path, start_line)
+      attach_php_callees(endpoint, callees)
     end
 
     private def extract_action_signature_params(signature : String) : Array(Param)

--- a/src/miniparsers/php_callee_extractor.cr
+++ b/src/miniparsers/php_callee_extractor.cr
@@ -13,9 +13,10 @@ module Noir::PhpCalleeExtractor
     "static", "switch", "throw", "trait", "try", "unset", "while",
   }
 
-  OBJECT_CALL_REGEX = /(\$[A-Za-z_]\w*(?:\s*->\s*[A-Za-z_]\w*\s*(?:\(\s*\))?)*\s*->\s*[A-Za-z_]\w*)\s*\(/
-  STATIC_CALL_REGEX = /((?:\\?[A-Za-z_]\w*\\?)*[A-Za-z_]\w*(?:::[A-Za-z_]\w*)+)\s*\(/
-  BARE_CALL_REGEX   = /(?<![>\w:$\\])((?:\\?[A-Za-z_]\w*\\)*\\?[A-Za-z_]\w*)\s*\(/
+  CLASS_PROPERTY_CALL_REGEX = /((?:\\?[A-Za-z_]\w*\\?)*[A-Za-z_]\w*::\$\w+(?:\s*->\s*[A-Za-z_]\w*\s*(?:\(\s*\))?)*\s*->\s*[A-Za-z_]\w*)\s*\(/
+  OBJECT_CALL_REGEX         = /(?<!:)(\$[A-Za-z_]\w*(?:\s*->\s*[A-Za-z_]\w*\s*(?:\(\s*\))?)*\s*->\s*[A-Za-z_]\w*)\s*\(/
+  STATIC_CALL_REGEX         = /((?:\\?[A-Za-z_]\w*\\?)*[A-Za-z_]\w*(?:::[A-Za-z_]\w*)+)\s*\(/
+  BARE_CALL_REGEX           = /(?<![>\w:$\\])((?:\\?[A-Za-z_]\w*\\)*\\?[A-Za-z_]\w*)\s*\(/
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
@@ -37,6 +38,13 @@ module Noir::PhpCalleeExtractor
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    line.scan(CLASS_PROPERTY_CALL_REGEX) do |match|
+      name = normalize_object_call(match[1])
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
     line.scan(OBJECT_CALL_REGEX) do |match|
       name = normalize_object_call(match[1])
       next if skip_callee?(name)


### PR DESCRIPTION
## Summary
- attach 1-hop callees from Yii action method bodies when `--include-callee` is enabled
- reuse the shared PHP method-body extraction added for Symfony
- preserve `Yii::$app->...` static-property object chains in the PHP callee extractor
- keep urlManager-only and ActiveController auto-REST endpoints callee-empty

Part of #1366

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-yii crystal spec spec/unit_test/miniparser/php_callee_extractor_spec.cr spec/functional_test/testers/php/yii_spec.cr spec/functional_test/testers/php/yii_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-yii-check just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-yii-build just build`
- `./bin/noir -b spec/functional_test/fixtures/php/yii --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-yii-test just test`