### PR TITLE
Add pure PHP callee extraction

### DIFF
--- a/spec/functional_test/fixtures/php/php_callees/create.php
+++ b/spec/functional_test/fixtures/php/php_callees/create.php
@@ -1,0 +1,10 @@
+<?
+    function sanitize_name($value) {
+        return trim($value);
+    }
+
+    $name = sanitize_name($_POST['name']);
+    $created = UserRepository::create($name);
+    AuditLog::write('create');
+    render_json($created);
+?>

--- a/spec/functional_test/fixtures/php/php_callees/search.php
+++ b/spec/functional_test/fixtures/php/php_callees/search.php
@@ -1,0 +1,5 @@
+<?
+    $q = $_GET['q'];
+    $users = UserRepository::search($q);
+    render_json($users);
+?>

--- a/spec/functional_test/testers/php/php_callees_spec.cr
+++ b/spec/functional_test/testers/php/php_callees_spec.cr
@@ -1,0 +1,54 @@
+require "../../func_spec.cr"
+
+search = Endpoint.new("/search.php", "GET", [
+  Param.new("q", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserRepository::search", line: 3))
+  ep.push_callee(Callee.new("render_json", line: 4))
+end
+
+create = Endpoint.new("/create.php", "POST", [
+  Param.new("name", "", "form"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("sanitize_name", line: 6))
+  ep.push_callee(Callee.new("UserRepository::create", line: 7))
+  ep.push_callee(Callee.new("AuditLog::write", line: 8))
+  ep.push_callee(Callee.new("render_json", line: 9))
+end
+
+create_get = Endpoint.new("/create.php", "GET").tap do |ep|
+  ep.push_callee(Callee.new("sanitize_name", line: 6))
+  ep.push_callee(Callee.new("UserRepository::create", line: 7))
+  ep.push_callee(Callee.new("AuditLog::write", line: 8))
+  ep.push_callee(Callee.new("render_json", line: 9))
+end
+
+expected_endpoints = [
+  search,
+  create,
+  create_get,
+]
+
+tester = FunctionalTester.new("fixtures/php/php_callees/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+describe "Pure PHP callee extraction" do
+  it "keeps file-level callees to top-level calls" do
+    endpoint = tester.app.endpoints.find { |e| e.method == "POST" && e.url == "/create.php" }
+    endpoint.should_not be_nil
+
+    if endpoint
+      endpoint.callees.map { |callee| {callee.name, callee.line} }.should eq([
+        {"sanitize_name", 6},
+        {"UserRepository::create", 7},
+        {"AuditLog::write", 8},
+        {"render_json", 9},
+      ])
+    end
+  end
+end

--- a/spec/unit_test/miniparser/php_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/php_callee_extractor_spec.cr
@@ -63,4 +63,32 @@ describe Noir::PhpCalleeExtractor do
       {"\\App\\Container::$request->headers->get", 41},
     ])
   end
+
+  it "handles namespaced type hints in closure declarations" do
+    body = <<-'PHP'
+      $app->group('/api', static function (\Slim\Routing\RouteCollectorProxy $group) use ($app): void {
+        Yii::$app->request->get('page');
+      });
+      PHP
+
+    callees = Noir::PhpCalleeExtractor.callees_for_body(body, "index.php", 50)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"$app->group", 50},
+      {"Yii::$app->request->get", 51},
+    ])
+  end
+
+  it "skips named function declarations" do
+    body = <<-PHP
+      function sanitize_name($value) {
+      }
+
+      sanitize_name($payload);
+      PHP
+
+    callees = Noir::PhpCalleeExtractor.callees_for_body(body, "index.php", 60)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"sanitize_name", 63},
+    ])
+  end
 end

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -7,13 +7,15 @@ module Analyzer::Php
 
       endpoints = [] of Endpoint
       relative_path = get_relative_path(base_path, path)
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        content = file.gets_to_end
         params_query = [] of Param
         params_body = [] of Param
         methods = [] of String
 
-        file.each_line do |line|
+        content.each_line do |line|
           if allow_patterns.any? { |pattern| line.includes? pattern }
             match = line.strip.match(/\$_(.*?)\['(.*?)'\]/)
 
@@ -48,9 +50,62 @@ module Analyzer::Php
           endpoints << Endpoint.new("/#{relative_path}", method, params_body, details)
         end
         endpoints << Endpoint.new("/#{relative_path}", "GET", params_query, details)
+        attach_file_callees(endpoints, content, path) if include_callee
       end
 
       endpoints
+    end
+
+    private def attach_file_callees(endpoints : Array(Endpoint), content : String, path : String)
+      callees = Noir::PhpCalleeExtractor.callees_for_body(executable_file_content(content), path, 1)
+      endpoints.each do |endpoint|
+        attach_php_callees(endpoint, callees)
+      end
+    end
+
+    private def executable_file_content(content : String) : String
+      declaration_ranges = [] of Tuple(Int32, Int32)
+      declaration_regex = /\b(?:abstract\s+|final\s+)?(?:class|interface|trait|enum)\s+[A-Za-z_]\w*[^{]*\{|\bfunction\s+&?\s*[A-Za-z_]\w*[^{]*\{/m
+      offset = 0
+
+      while offset < content.size
+        match = declaration_regex.match(content, offset)
+        break unless match
+
+        brace_pos = match.end(0) - 1
+        close_pos = find_matching_php_close_brace(content, brace_pos)
+        unless close_pos
+          offset = match.end(0)
+          next
+        end
+
+        declaration_ranges << {match.begin(0), close_pos + 1}
+        offset = close_pos + 1
+      end
+
+      return content if declaration_ranges.empty?
+
+      blank_ranges(content, declaration_ranges)
+    end
+
+    private def blank_ranges(content : String, ranges : Array(Tuple(Int32, Int32))) : String
+      String.build do |io|
+        offset = 0
+        ranges.each do |range_start, range_end|
+          io << content[offset...range_start]
+          io << blank_preserving_newlines(content[range_start...range_end])
+          offset = range_end
+        end
+        io << content[offset..]
+      end
+    end
+
+    private def blank_preserving_newlines(content : String) : String
+      String.build do |io|
+        content.each_char do |char|
+          io << (char == '\n' ? '\n' : ' ')
+        end
+      end
     end
 
     def allow_patterns

--- a/src/miniparsers/php_callee_extractor.cr
+++ b/src/miniparsers/php_callee_extractor.cr
@@ -10,13 +10,13 @@ module Noir::PhpCalleeExtractor
     "elseif", "empty", "eval", "exit", "fn", "for", "foreach",
     "function", "global", "if", "include", "include_once", "isset",
     "list", "match", "print", "require", "require_once", "return",
-    "static", "switch", "throw", "trait", "try", "unset", "while",
+    "static", "switch", "throw", "trait", "try", "unset", "use", "while",
   }
 
-  CLASS_PROPERTY_CALL_REGEX = /((?:\\?[A-Za-z_]\w*\\?)*[A-Za-z_]\w*::\$\w+(?:\s*->\s*[A-Za-z_]\w*\s*(?:\(\s*\))?)*\s*->\s*[A-Za-z_]\w*)\s*\(/
+  CLASS_PROPERTY_CALL_REGEX = /(\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*::\$\w+(?:\s*->\s*[A-Za-z_]\w*\s*(?:\(\s*\))?)*\s*->\s*[A-Za-z_]\w*)\s*\(/
   OBJECT_CALL_REGEX         = /(?<!:)(\$[A-Za-z_]\w*(?:\s*->\s*[A-Za-z_]\w*\s*(?:\(\s*\))?)*\s*->\s*[A-Za-z_]\w*)\s*\(/
-  STATIC_CALL_REGEX         = /((?:\\?[A-Za-z_]\w*\\?)*[A-Za-z_]\w*(?:::[A-Za-z_]\w*)+)\s*\(/
-  BARE_CALL_REGEX           = /(?<![>\w:$\\])((?:\\?[A-Za-z_]\w*\\)*\\?[A-Za-z_]\w*)\s*\(/
+  STATIC_CALL_REGEX         = /(\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*(?:::[A-Za-z_]\w*)+)\s*\(/
+  BARE_CALL_REGEX           = /(?<![>\w:$\\])(\\?[A-Za-z_]\w*(?:\\[A-Za-z_]\w*)*)\s*\(/
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
@@ -61,10 +61,17 @@ module Noir::PhpCalleeExtractor
 
     line.scan(BARE_CALL_REGEX) do |match|
       name = match[1]
+      next if declaration_name?(line, match.begin(1))
       next if skip_callee?(name)
 
       entries << {name, file_path, line_number}
     end
+  end
+
+  private def declaration_name?(line : String, name_start : Int32?) : Bool
+    return false unless name_start
+
+    line[0...name_start].match(/\bfunction\s*&?\s*$/) ? true : false
   end
 
   private def normalize_object_call(name : String) : String


### PR DESCRIPTION
## Summary
- attach PHP callee extraction to pure PHP file endpoints when `--include-callee` is enabled
- keep pure PHP file-level callees focused on top-level calls by blanking named function/class declarations before extraction
- harden PHP callee regexes for namespaced/static-property forms and avoid treating function declarations or `use (...)` as callees

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-pure-target2 crystal spec spec/unit_test/miniparser/php_callee_extractor_spec.cr spec/functional_test/testers/php/php_spec.cr spec/functional_test/testers/php/php_callees_spec.cr spec/functional_test/testers/php/slim_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-pure-check3 just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-pure-build2 just build`
- `./bin/noir -b spec/functional_test/fixtures/php/php_callees --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-php-pure-test just test`

Part of #1366.