### PR TITLE
Add CodeIgniter callee extraction

### DIFF
--- a/spec/functional_test/fixtures/php/codeigniter_callees/app/Config/Routes.php
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/app/Config/Routes.php
@@ -1,0 +1,17 @@
+<?php
+
+use CodeIgniter\Router\RouteCollection;
+
+/**
+ * @var RouteCollection $routes
+ */
+$routes->get('/', 'Home::index');
+$routes->get('array-home', [Home::class, 'arrayIndex']);
+$routes->get('users/(:num)', 'UserController::show/$1');
+$routes->match(['get', 'post'], 'contact', 'ContactController::handle');
+$routes->add('webhook', 'WebhookController::any');
+$routes->resource('photos');
+
+$routes->group('api', ['namespace' => 'App\Controllers\Api'], function ($routes) {
+    $routes->get('status', 'StatusController::index');
+});

--- a/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/Api/StatusController.php
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/Api/StatusController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Controllers\Api;
+
+use App\Controllers\BaseController;
+
+class StatusController extends BaseController
+{
+    public function index()
+    {
+        $status = StatusProbe::check();
+        return $this->response->setJSON(['status' => $status]);
+    }
+}

--- a/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/ContactController.php
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/ContactController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Controllers;
+
+class ContactController extends BaseController
+{
+    public function handle()
+    {
+        ContactNotifier::deliver();
+        return view('contact');
+    }
+}

--- a/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/Home.php
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/Home.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controllers;
+
+class Home extends BaseController
+{
+    public function index()
+    {
+        $payload = WelcomeService::build();
+        return view('welcome_message', $payload);
+    }
+
+    public function arrayIndex()
+    {
+        $payload = ArrayHomeService::build();
+        return view('array_home', $payload);
+    }
+}

--- a/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/UserController.php
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/UserController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Controllers;
+
+class UserController extends BaseController
+{
+    public function show($id)
+    {
+        $user = UserRepository::find($id);
+        return $this->response->setJSON($user);
+    }
+}

--- a/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/WebhookController.php
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/app/Controllers/WebhookController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Controllers;
+
+class WebhookController extends BaseController
+{
+    public function any()
+    {
+        WebhookHandler::dispatch();
+        return $this->response->setJSON(['ok' => true]);
+    }
+}

--- a/spec/functional_test/fixtures/php/codeigniter_callees/composer.json
+++ b/spec/functional_test/fixtures/php/codeigniter_callees/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "codeigniter4/framework": "^4.5"
+  }
+}

--- a/spec/functional_test/testers/php/codeigniter_callees_spec.cr
+++ b/spec/functional_test/testers/php/codeigniter_callees_spec.cr
@@ -1,0 +1,71 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("WelcomeService::build", line: 9))
+  ep.push_callee(Callee.new("view", line: 10))
+end
+
+array_home = Endpoint.new("/array-home", "GET").tap do |ep|
+  ep.push_callee(Callee.new("ArrayHomeService::build", line: 15))
+  ep.push_callee(Callee.new("view", line: 16))
+end
+
+user_show = Endpoint.new("/users/{num}", "GET", [
+  Param.new("num", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserRepository::find", line: 9))
+  ep.push_callee(Callee.new("$this->response->setJSON", line: 10))
+end
+
+contact_callees = [
+  Callee.new("ContactNotifier::deliver", line: 9),
+  Callee.new("view", line: 10),
+]
+
+contact_get = Endpoint.new("/contact", "GET").tap do |ep|
+  contact_callees.each { |callee| ep.push_callee(callee) }
+end
+
+contact_post = Endpoint.new("/contact", "POST").tap do |ep|
+  contact_callees.each { |callee| ep.push_callee(callee) }
+end
+
+webhook_delete = Endpoint.new("/webhook", "DELETE").tap do |ep|
+  ep.push_callee(Callee.new("WebhookHandler::dispatch", line: 9))
+  ep.push_callee(Callee.new("$this->response->setJSON", line: 10))
+end
+
+photos_index = Endpoint.new("/photos", "GET")
+
+api_status = Endpoint.new("/api/status", "GET").tap do |ep|
+  ep.push_callee(Callee.new("StatusProbe::check", line: 11))
+  ep.push_callee(Callee.new("$this->response->setJSON", line: 12))
+end
+
+expected_endpoints = [
+  home,
+  array_home,
+  user_show,
+  contact_get,
+  contact_post,
+  webhook_delete,
+  photos_index,
+  api_status,
+]
+
+tester = FunctionalTester.new("fixtures/php/codeigniter_callees/", {
+  :techs     => 1,
+  :endpoints => 21,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("php_codeigniter"),
+})
+tester.perform_tests
+
+describe "CodeIgniter callee extraction" do
+  it "keeps resource convention routes callee-empty in the first pass" do
+    photos = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/photos" }
+    photos.should_not be_nil
+    photos.callees.should be_empty if photos
+  end
+end

--- a/src/analyzer/analyzers/php/codeigniter.cr
+++ b/src/analyzer/analyzers/php/codeigniter.cr
@@ -30,10 +30,11 @@ module Analyzer::Php
 
     private def analyze_routes_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      include_callee = any_to_bool(@options["include_callee"]?)
       begin
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           content = file.gets_to_end
-          endpoints.concat(analyze_routes_content(content, "", path))
+          endpoints.concat(analyze_routes_content(content, "", path, include_callee, "App\\Controllers"))
           endpoints.concat(analyze_ci3_routes(content, path))
         end
       rescue e
@@ -42,19 +43,25 @@ module Analyzer::Php
       endpoints
     end
 
-    private def analyze_routes_content(content : String, prefix : String, file_path : String) : Array(Endpoint)
+    private def analyze_routes_content(content : String,
+                                       prefix : String,
+                                       file_path : String,
+                                       include_callee : Bool,
+                                       controller_namespace : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       details = Details.new(PathInfo.new(file_path))
 
       working_content = content
 
       # 1. Group routes: $routes->group('prefix', [opts]?, function($routes) { ... })
-      group_pattern = /\$routes->group\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*\[(?:[^\[\]]|\[[^\[\]]*\])*\])?\s*,\s*(?:static\s+)?function\s*\([^)]*\)\s*(?:use\s*\([^)]*\)\s*)?\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}/mi
+      group_pattern = /\$routes->group\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*(\[(?:[^\[\]]|\[[^\[\]]*\])*\]))?\s*,\s*(?:static\s+)?function\s*\([^)]*\)\s*(?:use\s*\([^)]*\)\s*)?\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}/mi
       working_content.scan(group_pattern).each do |match|
         group_prefix = normalize_route(match[1])
-        group_content = match[2]
+        group_options = match[2]?
+        group_content = match[3]
+        group_namespace = extract_group_namespace(group_options) || controller_namespace
         new_prefix = build_full_path(prefix, group_prefix)
-        endpoints.concat(analyze_routes_content(group_content, new_prefix, file_path))
+        endpoints.concat(analyze_routes_content(group_content, new_prefix, file_path, include_callee, group_namespace))
       end
       working_content = working_content.gsub(group_pattern, "")
 
@@ -62,40 +69,49 @@ module Analyzer::Php
       env_pattern = /\$routes->environment\s*\(\s*['"][^'"]+['"]\s*,\s*(?:static\s+)?function\s*\([^)]*\)\s*(?:use\s*\([^)]*\)\s*)?\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\}/mi
       working_content.scan(env_pattern).each do |match|
         env_content = match[1]
-        endpoints.concat(analyze_routes_content(env_content, prefix, file_path))
+        endpoints.concat(analyze_routes_content(env_content, prefix, file_path, include_callee, controller_namespace))
       end
       working_content = working_content.gsub(env_pattern, "")
 
       # 3. HTTP verb routes: $routes->get/post/put/patch/delete/options/head('path', ...)
-      verb_pattern = /\$routes->(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi
+      verb_pattern = /\$routes->(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*(.*?))?\s*\)/mi
       working_content.scan(verb_pattern).each do |match|
         method = match[1].upcase
         route_path = match[2]
+        handler = extract_ci4_handler(match[3]?)
         full_path = build_full_path(prefix, normalize_route(route_path))
         params = extract_ci_path_params(full_path)
-        endpoints << Endpoint.new(full_path, method, params, details.dup)
+        endpoint = Endpoint.new(full_path, method, params, details.dup)
+        attach_route_target_callees(endpoint, handler, file_path, controller_namespace) if include_callee
+        endpoints << endpoint
       end
 
       # 4. $routes->match(['get','post'], 'path', ...)
-      match_pattern = /\$routes->match\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"][^)]*\)/mi
+      match_pattern = /\$routes->match\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"](?:\s*,\s*(.*?))?\s*\)/mi
       working_content.scan(match_pattern).each do |match|
         methods = extract_methods_from_array(match[1])
         route_path = match[2]
+        handler = extract_ci4_handler(match[3]?)
         full_path = build_full_path(prefix, normalize_route(route_path))
         params = extract_ci_path_params(full_path)
         methods.each do |http_method|
-          endpoints << Endpoint.new(full_path, http_method, params, details.dup)
+          endpoint = Endpoint.new(full_path, http_method, params, details.dup)
+          attach_route_target_callees(endpoint, handler, file_path, controller_namespace) if include_callee
+          endpoints << endpoint
         end
       end
 
       # 5. $routes->add('path', ...) — any HTTP verb
-      add_pattern = /\$routes->add\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi
+      add_pattern = /\$routes->add\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*(.*?))?\s*\)/mi
       working_content.scan(add_pattern).each do |match|
         route_path = match[1]
+        handler = extract_ci4_handler(match[2]?)
         full_path = build_full_path(prefix, normalize_route(route_path))
         params = extract_ci_path_params(full_path)
         ALL_HTTP_VERBS.each do |http_method|
-          endpoints << Endpoint.new(full_path, http_method, params, details.dup)
+          endpoint = Endpoint.new(full_path, http_method, params, details.dup)
+          attach_route_target_callees(endpoint, handler, file_path, controller_namespace) if include_callee
+          endpoints << endpoint
         end
       end
 
@@ -114,6 +130,99 @@ module Analyzer::Php
       end
 
       endpoints
+    end
+
+    private def attach_route_target_callees(endpoint : Endpoint,
+                                            handler : String?,
+                                            routes_file_path : String,
+                                            controller_namespace : String)
+      method_body = extract_handler_method_body(routes_file_path, handler, controller_namespace)
+      return unless method_body
+
+      body, controller_path, start_line = method_body
+      callees = Noir::PhpCalleeExtractor.callees_for_body(body, controller_path, start_line)
+      attach_php_callees(endpoint, callees)
+    end
+
+    private def extract_handler_method_body(routes_file_path : String,
+                                            handler : String?,
+                                            controller_namespace : String) : Tuple(String, String, Int32)?
+      target = parse_ci4_handler(handler)
+      return unless target
+
+      controller_name, action_name = target
+      controller_path = resolve_ci4_controller_path(routes_file_path, controller_name, controller_namespace)
+      return unless controller_path && File.exists?(controller_path)
+
+      content = File.read(controller_path, encoding: "utf-8", invalid: :skip)
+      method_match = content.match(/(?:public|protected|private)\s+function\s+#{action_name}\s*\(/)
+      return unless method_match
+
+      method_body = extract_php_method_body_after(content, method_match.begin(0))
+      return unless method_body
+
+      body, start_line = method_body
+      {body, controller_path, start_line}
+    rescue e
+      logger.debug "Error resolving CodeIgniter handler #{handler}: #{e}"
+      nil
+    end
+
+    private def extract_group_namespace(options : String?) : String?
+      return unless options
+
+      if namespace_match = options.match(/['"]namespace['"]\s*=>\s*['"]([^'"]+)['"]/)
+        namespace_match[1]
+      end
+    end
+
+    private def extract_ci4_handler(argument : String?) : String?
+      return unless argument
+
+      handler = argument.strip
+      if string_match = handler.match(/\A['"]([^'"]+)['"]/)
+        return string_match[1]
+      end
+
+      if array_match = handler.match(/\A\[\s*([^,\]]+)\s*,\s*['"]([^'"]+)['"]/)
+        controller_expr = array_match[1].strip
+        action_name = array_match[2]
+        if class_match = controller_expr.match(/\A((?:\\?[A-Za-z_]\w*\\)*\\?[A-Za-z_]\w*)::class\z/)
+          "#{class_match[1]}::#{action_name}"
+        end
+      end
+    end
+
+    private def parse_ci4_handler(handler : String?) : Tuple(String, String)?
+      return unless handler
+
+      target = handler.split("/", 2)[0].strip
+      parts = target.split("::", 2)
+      return unless parts.size == 2
+
+      controller_name = parts[0].strip
+      action_name = parts[1].strip
+      return if controller_name.empty?
+      return unless action_name.match(/\A[A-Za-z_]\w*\z/)
+
+      {controller_name, action_name}
+    end
+
+    private def resolve_ci4_controller_path(routes_file_path : String,
+                                            controller_name : String,
+                                            controller_namespace : String) : String?
+      marker = "/app/Config/Routes.php"
+      marker_index = routes_file_path.index(marker)
+      return unless marker_index
+
+      controller_root = File.join(routes_file_path[0...marker_index], "app", "Controllers")
+      full_controller = controller_name.includes?("\\") ? controller_name : "#{controller_namespace}\\#{controller_name}"
+      relative = full_controller.gsub("\\", "/")
+      relative = relative.sub(/\A\/+/, "")
+      relative = relative.sub(/\AApp\/Controllers\/?/, "")
+      return if relative.empty? || relative.includes?("..")
+
+      File.join(controller_root, "#{relative}.php")
     end
 
     # CodeIgniter 3 style: $route['products/(:num)'] = 'catalog/lookup/$1';


### PR DESCRIPTION
## Summary
- attach 1-hop PHP callees for CodeIgniter CI4 direct route handlers when `--include-callee` is enabled
- resolve string handlers like `Home::index` and `UserController::show/$1` to `app/Controllers` methods
- support group namespace options and array callable handlers like `[Home::class, 'arrayIndex']`
- keep resource/presenter/CI3 routes callee-empty in this pass

## Scope notes
- Does not resolve CI4 resource/presenter conventions or CI3 route targets yet.
- Namespaced groups are resolved for direct CI4 handlers.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-codeigniter-callees-target3 crystal spec spec/functional_test/testers/php/codeigniter_spec.cr spec/functional_test/testers/php/codeigniter_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-codeigniter-callees-check3 just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-codeigniter-callees-build3 just build`
- `./bin/noir -b spec/functional_test/fixtures/php/codeigniter_callees --only-techs php_codeigniter --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-codeigniter-callees-test2 just test`

Part of #1366.
