### PR TITLE
Add CakePHP callee extraction

### DIFF
--- a/spec/functional_test/fixtures/php/cakephp_callees/composer.json
+++ b/spec/functional_test/fixtures/php/cakephp_callees/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "cakephp/cakephp": "^5.0"
+  }
+}

--- a/spec/functional_test/fixtures/php/cakephp_callees/config/routes.php
+++ b/spec/functional_test/fixtures/php/cakephp_callees/config/routes.php
@@ -1,0 +1,14 @@
+<?php
+
+use Cake\Routing\RouteBuilder;
+
+return static function (RouteBuilder $routes) {
+    $routes->scope('/', function (RouteBuilder $builder) {
+        $builder->connect('/', ['controller' => 'Pages', 'action' => 'home']);
+        $builder->get('/articles/:id', ['controller' => 'Articles', 'action' => 'view']);
+        $builder->post('/articles', ['controller' => 'Articles', 'action' => 'add']);
+        $builder->resources('Photos');
+        $builder->get('/legacy', 'Legacy::index');
+        $builder->connect('/computed', ['controller' => $controller, 'action' => 'show']);
+    });
+};

--- a/spec/functional_test/fixtures/php/cakephp_callees/src/Controller/ArticlesController.php
+++ b/spec/functional_test/fixtures/php/cakephp_callees/src/Controller/ArticlesController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Controller;
+
+class ArticlesController extends AppController
+{
+    public function view($id)
+    {
+        $article = ArticleService::find($id);
+        return $this->jsonArticle($article);
+    }
+
+    public function add()
+    {
+        $payload = ArticlePayload::fromRequest($this->request);
+        return ArticleService::create($payload);
+    }
+}

--- a/spec/functional_test/fixtures/php/cakephp_callees/src/Controller/PagesController.php
+++ b/spec/functional_test/fixtures/php/cakephp_callees/src/Controller/PagesController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Controller;
+
+class PagesController extends AppController
+{
+    public function home()
+    {
+        $payload = PageService::home();
+        return $this->renderHome($payload);
+    }
+}

--- a/spec/functional_test/fixtures/php/cakephp_callees/src/Controller/PhotosController.php
+++ b/spec/functional_test/fixtures/php/cakephp_callees/src/Controller/PhotosController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Controller;
+
+class PhotosController extends AppController
+{
+    public function index()
+    {
+        $photos = PhotoService::list();
+        return $this->jsonList($photos);
+    }
+
+    public function add()
+    {
+        $payload = PhotoPayload::fromRequest($this->request);
+        return PhotoService::create($payload);
+    }
+
+    public function view($id)
+    {
+        $photo = PhotoService::find($id);
+        return $this->jsonPhoto($photo);
+    }
+
+    public function edit($id)
+    {
+        $payload = PhotoPayload::fromRequest($this->request);
+        return PhotoService::update($id, $payload);
+    }
+
+    public function delete($id)
+    {
+        PhotoService::delete($id);
+        return $this->emptyResponse();
+    }
+}

--- a/spec/functional_test/testers/php/cakephp_callees_spec.cr
+++ b/spec/functional_test/testers/php/cakephp_callees_spec.cr
@@ -1,0 +1,98 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("PageService::home", line: 9))
+  ep.push_callee(Callee.new("$this->renderHome", line: 10))
+end
+
+article_view = Endpoint.new("/articles/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ArticleService::find", line: 9))
+  ep.push_callee(Callee.new("$this->jsonArticle", line: 10))
+end
+
+article_add = Endpoint.new("/articles", "POST").tap do |ep|
+  ep.push_callee(Callee.new("ArticlePayload::fromRequest", line: 15))
+  ep.push_callee(Callee.new("ArticleService::create", line: 16))
+end
+
+photos_index = Endpoint.new("/Photos", "GET").tap do |ep|
+  ep.push_callee(Callee.new("PhotoService::list", line: 9))
+  ep.push_callee(Callee.new("$this->jsonList", line: 10))
+end
+
+photos_add = Endpoint.new("/Photos", "POST").tap do |ep|
+  ep.push_callee(Callee.new("PhotoPayload::fromRequest", line: 15))
+  ep.push_callee(Callee.new("PhotoService::create", line: 16))
+end
+
+photos_view = Endpoint.new("/Photos/{id}", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PhotoService::find", line: 21))
+  ep.push_callee(Callee.new("$this->jsonPhoto", line: 22))
+end
+
+photos_edit_callees = [
+  Callee.new("PhotoPayload::fromRequest", line: 27),
+  Callee.new("PhotoService::update", line: 28),
+]
+
+photos_edit_put = Endpoint.new("/Photos/{id}", "PUT", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  photos_edit_callees.each { |callee| ep.push_callee(callee) }
+end
+
+photos_edit_patch = Endpoint.new("/Photos/{id}", "PATCH", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  photos_edit_callees.each { |callee| ep.push_callee(callee) }
+end
+
+photos_delete = Endpoint.new("/Photos/{id}", "DELETE", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PhotoService::delete", line: 33))
+  ep.push_callee(Callee.new("$this->emptyResponse", line: 34))
+end
+
+legacy = Endpoint.new("/legacy", "GET")
+computed = Endpoint.new("/computed", "GET")
+
+expected_endpoints = [
+  home,
+  article_view,
+  article_add,
+  photos_index,
+  photos_add,
+  photos_view,
+  photos_edit_put,
+  photos_edit_patch,
+  photos_delete,
+  legacy,
+  computed,
+]
+
+tester = FunctionalTester.new("fixtures/php/cakephp_callees/", {
+  :techs     => 1,
+  :endpoints => 11,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("php_cakephp"),
+})
+tester.perform_tests
+
+describe "CakePHP callee extraction" do
+  it "keeps unsupported route targets callee-empty" do
+    legacy_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/legacy" }
+    computed_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/computed" }
+
+    legacy_endpoint.should_not be_nil
+    computed_endpoint.should_not be_nil
+
+    legacy_endpoint.callees.should be_empty if legacy_endpoint
+    computed_endpoint.callees.should be_empty if computed_endpoint
+  end
+end

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -15,10 +15,11 @@ module Analyzer::Php
 
     private def analyze_routes_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      include_callee = any_to_bool(@options["include_callee"]?)
       begin
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           content = file.gets_to_end
-          endpoints = analyze_routes_content(content, "", path)
+          endpoints = analyze_routes_content(content, "", path, include_callee)
         end
       rescue e
         logger.debug "Error analyzing routes file #{path}: #{e}"
@@ -26,7 +27,10 @@ module Analyzer::Php
       endpoints
     end
 
-    private def analyze_routes_content(content : String, prefix : String, file_path : String) : Array(Endpoint)
+    private def analyze_routes_content(content : String,
+                                       prefix : String,
+                                       file_path : String,
+                                       include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       details = Details.new(PathInfo.new(file_path))
 
@@ -34,8 +38,8 @@ module Analyzer::Php
 
       # 1. Scoped routes
       scope_patterns = [
-        /(\$routes|\$builder)->scope\s*\(\s*['"]([^'"]+)['"]\s*,[^,]*,\s*function\s*\(\s*(?:[^$)]+\s+)?\$[^)]+\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi,
-        /(\$routes|\$builder)->scope\s*\(\s*['"]([^'"]+)['"]\s*,\s*function\s*\(\s*(?:[^$)]+\s+)?\$[^)]+\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi,
+        /(\$routes|\$builder)->scope\s*\(\s*['"]([^'"]+)['"]\s*,[^,]*,\s*(?:static\s+)?function\s*\(\s*(?:[^$)]+\s+)?\$[^)]+\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi,
+        /(\$routes|\$builder)->scope\s*\(\s*['"]([^'"]+)['"]\s*,\s*(?:static\s+)?function\s*\(\s*(?:[^$)]+\s+)?\$[^)]+\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi,
       ]
 
       scope_patterns.each do |pattern|
@@ -45,7 +49,7 @@ module Analyzer::Php
           # match[3] is content
           if match.size >= 4
             new_prefix = build_full_path(prefix, match[2])
-            endpoints.concat(analyze_routes_content(match[3], new_prefix, file_path))
+            endpoints.concat(analyze_routes_content(match[3], new_prefix, file_path, include_callee))
           end
         end
         working_content = working_content.gsub(pattern, "")
@@ -59,24 +63,27 @@ module Analyzer::Php
 
         full_path = build_full_path(prefix, route_path)
         params = extract_route_params(full_path)
+        target = extract_controller_action_target(options_str)
 
         method = "GET"
         if method_match = options_str.match(/['"]_method['"]\s*=>\s*['"]([^'"]+)['"]/)
           method = method_match[1].upcase
         end
 
-        endpoints << Endpoint.new(full_path, method, params, details.dup)
+        endpoint = Endpoint.new(full_path, method, params, details.dup)
+        attach_route_target_callees(endpoint, target, file_path) if include_callee
+        endpoints << endpoint
       end
 
       # 3. HTTP Verb methods
       verb_patterns = {
-        "GET"     => /(\$routes|\$builder)->get\s*\(\s*['"]([^'"]+)['"]/mi,
-        "POST"    => /(\$routes|\$builder)->post\s*\(\s*['"]([^'"]+)['"]/mi,
-        "PUT"     => /(\$routes|\$builder)->put\s*\(\s*['"]([^'"]+)['"]/mi,
-        "PATCH"   => /(\$routes|\$builder)->patch\s*\(\s*['"]([^'"]+)['"]/mi,
-        "DELETE"  => /(\$routes|\$builder)->delete\s*\(\s*['"]([^'"]+)['"]/mi,
-        "OPTIONS" => /(\$routes|\$builder)->options\s*\(\s*['"]([^'"]+)['"]/mi,
-        "HEAD"    => /(\$routes|\$builder)->head\s*\(\s*['"]([^'"]+)['"]/mi,
+        "GET"     => /(\$routes|\$builder)->get\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
+        "POST"    => /(\$routes|\$builder)->post\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
+        "PUT"     => /(\$routes|\$builder)->put\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
+        "PATCH"   => /(\$routes|\$builder)->patch\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
+        "DELETE"  => /(\$routes|\$builder)->delete\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
+        "OPTIONS" => /(\$routes|\$builder)->options\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
+        "HEAD"    => /(\$routes|\$builder)->head\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*\[(.*?)\])?/mi,
       }
 
       verb_patterns.each do |method, pattern|
@@ -84,7 +91,10 @@ module Analyzer::Php
           route_path = match[2]
           full_path = build_full_path(prefix, route_path)
           params = extract_route_params(full_path)
-          endpoints << Endpoint.new(full_path, method, params, details.dup)
+          target = extract_controller_action_target(match[3]?)
+          endpoint = Endpoint.new(full_path, method, params, details.dup)
+          attach_route_target_callees(endpoint, target, file_path) if include_callee
+          endpoints << endpoint
         end
       end
 
@@ -93,7 +103,7 @@ module Analyzer::Php
       working_content.scan(resource_pattern).each do |match|
         resource_name = match[2]
         full_resource_path = build_full_path(prefix, resource_name)
-        endpoints.concat(create_resource_endpoints(full_resource_path, file_path))
+        endpoints.concat(create_resource_endpoints(full_resource_path, file_path, include_callee, resource_name))
       end
 
       endpoints
@@ -109,27 +119,121 @@ module Analyzer::Php
       params
     end
 
-    private def create_resource_endpoints(resource_path : String, file_path : String) : Array(Endpoint)
+    private def create_resource_endpoints(resource_path : String,
+                                          file_path : String,
+                                          include_callee : Bool,
+                                          controller_name : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       details = Details.new(PathInfo.new(file_path))
 
       # Standard REST resource routes
       resource_routes = [
-        {resource_path, "GET"},              # index
-        {resource_path, "POST"},             # add
-        {"#{resource_path}/{id}", "GET"},    # view
-        {"#{resource_path}/{id}", "PUT"},    # edit
-        {"#{resource_path}/{id}", "PATCH"},  # edit
-        {"#{resource_path}/{id}", "DELETE"}, # delete
+        {resource_path, "GET", "index"},
+        {resource_path, "POST", "add"},
+        {"#{resource_path}/{id}", "GET", "view"},
+        {"#{resource_path}/{id}", "PUT", "edit"},
+        {"#{resource_path}/{id}", "PATCH", "edit"},
+        {"#{resource_path}/{id}", "DELETE", "delete"},
       ]
 
       resource_routes.each do |route_info|
-        path, method = route_info
+        path, method, action = route_info
         params = extract_route_params(path)
-        endpoints << Endpoint.new(path, method, params, details)
+        endpoint = Endpoint.new(path, method, params, details.dup)
+        attach_route_target_callees(endpoint, {controller_name, action}, file_path) if include_callee
+        endpoints << endpoint
       end
 
       endpoints
+    end
+
+    private def attach_route_target_callees(endpoint : Endpoint,
+                                            target : Tuple(String, String)?,
+                                            routes_file_path : String)
+      return unless target
+
+      method_body = extract_controller_action_body(routes_file_path, target[0], target[1])
+      return unless method_body
+
+      body, controller_path, start_line = method_body
+      callees = Noir::PhpCalleeExtractor.callees_for_body(body, controller_path, start_line)
+      attach_php_callees(endpoint, callees)
+    end
+
+    private def extract_controller_action_body(routes_file_path : String,
+                                               controller_name : String,
+                                               action_name : String) : Tuple(String, String, Int32)?
+      controller_path = resolve_cakephp_controller_path(routes_file_path, controller_name)
+      return unless controller_path && File.exists?(controller_path)
+
+      content = File.read(controller_path, encoding: "utf-8", invalid: :skip)
+      method_match = content.match(/(?:public|protected|private)\s+function\s+#{action_name}\s*\(/)
+      return unless method_match
+
+      method_body = extract_php_method_body_after(content, method_match.begin(0))
+      return unless method_body
+
+      body, start_line = method_body
+      {body, controller_path, start_line}
+    rescue e
+      logger.debug "Error resolving CakePHP handler #{controller_name}::#{action_name}: #{e}"
+      nil
+    end
+
+    private def extract_controller_action_target(options_str : String?) : Tuple(String, String)?
+      return unless options_str
+
+      controller_match = options_str.match(/['"]controller['"]\s*=>\s*['"]([^'"]+)['"]/)
+      action_match = options_str.match(/['"]action['"]\s*=>\s*['"]([^'"]+)['"]/)
+      return unless controller_match && action_match
+
+      controller_name = controller_match[1].strip
+      action_name = action_match[1].strip
+      return if controller_name.empty? || action_name.empty?
+      return unless action_name.match(/\A[A-Za-z_]\w*\z/)
+
+      {controller_name, action_name}
+    end
+
+    private def resolve_cakephp_controller_path(routes_file_path : String, controller_name : String) : String?
+      marker = "/config/routes.php"
+      marker_index = routes_file_path.index(marker)
+      return unless marker_index
+
+      relative = cakephp_controller_relative_path(controller_name)
+      return unless relative
+
+      File.join(routes_file_path[0...marker_index], "src", "Controller", "#{relative}.php")
+    end
+
+    private def cakephp_controller_relative_path(controller_name : String) : String?
+      normalized = controller_name.gsub("\\", "/").strip
+      segments = normalized.split("/").reject(&.empty?)
+      return if segments.empty?
+      return if segments.any? { |segment| segment == "." || segment == ".." }
+
+      last_index = segments.size - 1
+      last_segment = normalize_controller_segment(segments[last_index])
+      return if last_segment.empty?
+
+      segments[last_index] = last_segment.ends_with?("Controller") ? last_segment : "#{last_segment}Controller"
+      File.join(segments)
+    end
+
+    private def normalize_controller_segment(segment : String) : String
+      base = segment.strip
+      suffix = "Controller"
+      base = base[0...(base.size - suffix.size)] if base.ends_with?(suffix)
+      return base if base.match(/[A-Z]/) && !base.includes?("_") && !base.includes?("-")
+
+      String.build do |io|
+        base.split(/[_-]/).each do |part|
+          next if part.empty?
+
+          io << part[0].upcase
+          io << part[1..] if part.size > 1
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- attach 1-hop PHP callees for CakePHP route targets when `--include-callee` is enabled
- resolve literal controller/action arrays from `connect()` and HTTP verb route declarations to `src/Controller/*Controller.php`
- attach callees for simple `resources()` convention routes using CakePHP's standard `index/add/view/edit/delete` actions
- keep unsupported string and dynamic route targets callee-empty in this pass

## Scope notes
- This is a first pass for direct, statically named CakePHP controller actions.
- Plugin/prefix-specific conventions and dynamic controller/action expressions are intentionally left unresolved.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cakephp-target-a crystal spec spec/functional_test/testers/php/cakephp_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cakephp-target-b crystal spec spec/functional_test/testers/php/cakephp_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cakephp-check just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cakephp-build just build`
- `./bin/noir -b spec/functional_test/fixtures/php/cakephp_callees --only-techs php_cakephp --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cakephp-test just test`

Part of #1366.
