### PR TITLE
Add Kemal callee extraction

### DIFF
--- a/spec/functional_test/fixtures/crystal/kemal_callees/shard.yml
+++ b/spec/functional_test/fixtures/crystal/kemal_callees/shard.yml
@@ -1,0 +1,12 @@
+name: kemal_callees
+version: 0.1.0
+
+targets:
+  kemal_callees:
+    main: src/testapp.cr
+
+dependencies:
+  kemal:
+    github: kemalcr/kemal
+
+crystal: 1.8.2

--- a/spec/functional_test/fixtures/crystal/kemal_callees/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_callees/src/testapp.cr
@@ -1,0 +1,32 @@
+require "kemal"
+
+get "/" do |env|
+  payload = HomeService.build
+  env.redirect "/dashboard"
+end
+
+post "/users" do |env|
+  payload = env.params.json["user"]
+  UserService.create(payload)
+end
+
+get "/inline" do
+  InlineService.call; "ok"
+end
+
+ws "/socket" do |socket|
+  SocketTracker.connected
+  socket.send "ok"
+end
+
+api = Kemal::Router.new
+api.namespace "/api" do
+  get "/users/:id" do |env|
+    id = env.params.url["id"]
+    user = UserLookup.find(id)
+    UserPresenter.render(user)
+  end
+end
+mount "/v1", api
+
+Kemal.run

--- a/spec/functional_test/testers/crystal/kemal_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_callees_spec.cr
@@ -1,0 +1,44 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 4))
+  ep.push_callee(Callee.new("env.redirect", line: 5))
+end
+
+users_create = Endpoint.new("/users", "POST", [
+  Param.new("user", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("env.params.json", line: 9))
+  ep.push_callee(Callee.new("UserService.create", line: 10))
+end
+
+inline = Endpoint.new("/inline", "GET").tap do |ep|
+  ep.push_callee(Callee.new("InlineService.call", line: 14))
+end
+
+socket = Endpoint.new("/socket", "GET").tap do |ep|
+  ep.push_callee(Callee.new("SocketTracker.connected", line: 18))
+  ep.push_callee(Callee.new("socket.send", line: 19))
+end
+
+api_user = Endpoint.new("/v1/api/users/:id", "GET").tap do |ep|
+  ep.push_callee(Callee.new("env.params.url", line: 25))
+  ep.push_callee(Callee.new("UserLookup.find", line: 26))
+  ep.push_callee(Callee.new("UserPresenter.render", line: 27))
+end
+
+expected_endpoints = [
+  home,
+  users_create,
+  inline,
+  socket,
+  api_user,
+]
+
+FunctionalTester.new("fixtures/crystal/kemal_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("crystal_kemal"),
+}).perform_tests

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -19,6 +19,7 @@ module Analyzer::Crystal
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path)
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Pre-scan: build mount_map (variable_name => mount_path)
       mount_map = {} of String => String
@@ -108,6 +109,7 @@ module Analyzer::Crystal
           endpoint.url = full_path
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint.details = details
+          attach_route_callees(endpoint, lines, index, path) if include_callee
           endpoints << endpoint
           last_endpoint = endpoint
         end
@@ -124,6 +126,15 @@ module Analyzer::Crystal
       end
 
       endpoints
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
+      route_body = extract_crystal_do_block(lines, index)
+      return unless route_body
+
+      body, body_start_line = route_body
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+      attach_crystal_callees(endpoint, callees)
     end
 
     private def collect_public_dir_endpoints

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/crystal_callee_extractor"
 
 module Analyzer::Crystal
   abstract class CrystalEngine < Analyzer
@@ -35,6 +36,65 @@ module Analyzer::Crystal
       rescue e
         logger.debug e
       end
+    end
+
+    protected def attach_crystal_callees(endpoint : Endpoint, callees : Array(Noir::CrystalCalleeExtractor::Entry))
+      Noir::CrystalCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    protected def extract_crystal_do_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      return if start_index >= lines.size
+
+      start_line = Noir::CrystalCalleeExtractor.strip_comment(lines[start_index]).strip
+      match = start_line.match(/\bdo\b(?:\s*\|[^|]*\|)?(.*)$/)
+      return unless match
+
+      body_lines = [] of String
+      body_start_line = start_index + 2
+      depth = 1
+      tail = match[1].strip
+      tail = tail[1, tail.size - 1].strip if tail.starts_with?(";")
+
+      unless tail.empty?
+        body_start_line = start_index + 1
+        if m = tail.match(/^(.*?)(?:;\s*)?end\b/)
+          return {m[1].strip, body_start_line}
+        end
+
+        body_lines << tail
+        depth += crystal_do_block_open_delta(tail)
+      end
+
+      index = start_index + 1
+      while index < lines.size
+        raw_body_line = lines[index]
+        body_line = Noir::CrystalCalleeExtractor.strip_comment(raw_body_line).strip
+
+        if crystal_closes_block?(body_line)
+          depth -= 1
+          break if depth == 0
+          body_lines << raw_body_line
+          index += 1
+          next
+        end
+
+        body_lines << raw_body_line
+        depth += crystal_do_block_open_delta(body_line)
+        index += 1
+      end
+
+      {body_lines.join("\n"), body_start_line}
+    end
+
+    protected def crystal_do_block_open_delta(line : String) : Int32
+      return 0 if line.empty?
+      return 1 if line.match(/\bdo\b/) && !line.match(/\bend\b/)
+      return 1 if line.match(/(?:^|=[^=>])\s*(if|unless|case|begin|while|until|for|class|module|def|macro)\b/) && !line.match(/\bend\b/)
+      0
+    end
+
+    private def crystal_closes_block?(line : String) : Bool
+      !!line.match(/^end\b/)
     end
   end
 end

--- a/src/miniparsers/crystal_callee_extractor.cr
+++ b/src/miniparsers/crystal_callee_extractor.cr
@@ -1,0 +1,98 @@
+require "../models/endpoint"
+
+module Noir::CrystalCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "abstract", "alias", "annotation", "as", "asm", "begin",
+    "break", "case", "class", "def", "do", "else", "elsif",
+    "end", "ensure", "enum", "extend", "false", "for", "fun",
+    "if", "in", "include", "lib", "macro", "module", "next",
+    "nil", "of", "out", "private", "protected", "require",
+    "rescue", "return", "self", "struct", "super", "then",
+    "true", "type", "union", "unless", "until", "when", "while",
+    "with", "yield",
+  }
+
+  RECEIVER_CALL_REGEX = /((?:@{1,2})?[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*(?:\.[A-Za-z_]\w*[!?=]?)+)\s*(?:\(|\b|$)/
+  BARE_CALL_REGEX     = /(?<![.\w:])([a-z_]\w*[!?=]?)(?:\s*\(|(?=\s+(?:[:'"]|@{1,2}[A-Za-z_]|[A-Za-z_]\w*[!?=]?)))/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+
+    body.lines.each_with_index do |line, index|
+      scan_line(strip_comment(line), file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    line.scan(RECEIVER_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  def strip_comment(line : String) : String
+    in_string = false
+    escaped = false
+    quote = '\0'
+
+    line.each_char_with_index do |char, index|
+      if in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == quote
+          in_string = false
+        end
+      elsif char == '"' || char == '\''
+        in_string = true
+        quote = char
+      elsif char == '#'
+        return line[0, index]
+      end
+    end
+
+    line
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared lightweight `CrystalCalleeExtractor` for 1-hop Crystal call-site extraction
- add Crystal engine helpers for attaching callees and slicing `do ... end` route blocks
- wire Kemal inline route handlers to attach callees when `--include-callee` is enabled
- cover multiline routes, formatted inline routes, websocket routes, and mounted namespace routes

## Scope notes
- This PR covers Kemal inline route blocks only.
- Crystal controller-style frameworks such as Amber/Grip/Marten still need controller/action or handler resolution before callees are useful.
- The extractor is intentionally scanner-based because there is no Crystal tree-sitter grammar wired into Noir yet.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-kemal-target-d crystal spec spec/functional_test/testers/crystal/kemal_spec.cr spec/functional_test/testers/crystal/kemal_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-kemal-build just build`
- `./bin/noir -b spec/functional_test/fixtures/crystal/kemal_callees --only-techs crystal_kemal --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-kemal-test just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-kemal-check2 just check`

Part of #1366.
