### PR TITLE
Add Lucky callee extraction

### DIFF
--- a/spec/functional_test/fixtures/crystal/lucky_callees/shard.yml
+++ b/spec/functional_test/fixtures/crystal/lucky_callees/shard.yml
@@ -1,0 +1,12 @@
+name: lucky_callees
+version: 0.1.0
+
+targets:
+  lucky_callees:
+    main: src/app.cr
+
+dependencies:
+  lucky:
+    github: luckyframework/lucky
+
+crystal: 1.8.2

--- a/spec/functional_test/fixtures/crystal/lucky_callees/src/actions/api/callees.cr
+++ b/spec/functional_test/fixtures/crystal/lucky_callees/src/actions/api/callees.cr
@@ -1,0 +1,35 @@
+class Api::Callees < Lucky::Action
+  get "/lucky/home" do
+    data = HomeService.build
+    json({home: data})
+  end
+
+  post "/lucky/users" do
+    payload = params.from_json["user"]
+    SaveUser.run(payload) do |_operation, user|
+      AuditTrail.record(user)
+      json({id: UserPresenter.id(user)})
+    end
+  end
+
+  put "/lucky/users/:id" do
+    id = params.get(:id)
+    UserUpdater.call(id)
+    json({ok: true})
+  end
+
+  delete "/lucky/users/:id" do
+    UserDestroyer.call(params.get(:id))
+    head 204
+  end
+
+  patch "/lucky/users/:id" do
+    UserPatch.apply(params.from_query["mode"])
+    json({ok: true})
+  end
+
+  trace "/lucky/trace" do
+    TraceReporter.capture(request.headers["X-Trace"])
+    plain_text "ok"
+  end
+end

--- a/spec/functional_test/fixtures/crystal/lucky_callees/src/actions/socket/show.cr
+++ b/spec/functional_test/fixtures/crystal/lucky_callees/src/actions/socket/show.cr
@@ -1,0 +1,6 @@
+class Socket::Show < Lucky::Action
+  ws "/lucky/socket" do |socket|
+    SocketTracker.connected
+    socket.send "ok"
+  end
+end

--- a/spec/functional_test/testers/crystal/lucky_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/lucky_callees_spec.cr
@@ -1,0 +1,61 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/lucky/home", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 3))
+end
+
+users_create = Endpoint.new("/lucky/users", "POST", [
+  Param.new("user", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("params.from_json", line: 8))
+  ep.push_callee(Callee.new("SaveUser.run", line: 9))
+  ep.push_callee(Callee.new("AuditTrail.record", line: 10))
+  ep.push_callee(Callee.new("UserPresenter.id", line: 11))
+end
+
+users_update = Endpoint.new("/lucky/users/:id", "PUT", [
+  Param.new("id", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("params.get", line: 16))
+  ep.push_callee(Callee.new("UserUpdater.call", line: 17))
+end
+
+users_delete = Endpoint.new("/lucky/users/:id", "DELETE").tap do |ep|
+  ep.push_callee(Callee.new("UserDestroyer.call", line: 22))
+end
+
+users_patch = Endpoint.new("/lucky/users/:id", "PATCH", [
+  Param.new("mode", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserPatch.apply", line: 27))
+end
+
+trace = Endpoint.new("/lucky/trace", "TRACE", [
+  Param.new("X-Trace", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("TraceReporter.capture", line: 32))
+  ep.push_callee(Callee.new("request.headers", line: 32))
+end
+
+socket = Endpoint.new("/lucky/socket", "GET").tap do |ep|
+  ep.push_callee(Callee.new("SocketTracker.connected", line: 3))
+  ep.push_callee(Callee.new("socket.send", line: 4))
+end
+
+expected_endpoints = [
+  home,
+  users_create,
+  users_update,
+  users_delete,
+  users_patch,
+  trace,
+  socket,
+]
+
+FunctionalTester.new("fixtures/crystal/lucky_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("crystal_lucky"),
+}).perform_tests

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -9,28 +9,45 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      lines = [] of String
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        file.each_line.with_index do |line, index|
-          endpoint = line_to_endpoint(line)
-          if endpoint.method != ""
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint.details = details
-            endpoints << endpoint
-            last_endpoint = endpoint
-          end
+        file.each_line do |line|
+          lines << line
+        end
+      end
 
-          param = line_to_param(line)
-          if param.name != ""
-            if last_endpoint.method != ""
-              last_endpoint.push_param(param)
-            end
+      include_callee = any_to_bool(@options["include_callee"]?)
+      last_endpoint = Endpoint.new("", "")
+
+      lines.each_with_index do |line, index|
+        endpoint = line_to_endpoint(line)
+        if endpoint.method != ""
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          attach_route_callees(endpoint, lines, index, path) if include_callee
+          endpoints << endpoint
+          last_endpoint = endpoint
+        end
+
+        param = line_to_param(line)
+        if param.name != ""
+          if last_endpoint.method != ""
+            last_endpoint.push_param(param)
           end
         end
       end
 
       endpoints
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
+      route_body = extract_crystal_do_block(lines, index)
+      return unless route_body
+
+      body, body_start_line = route_body
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+      attach_crystal_callees(endpoint, callees)
     end
 
     private def collect_public_dir_endpoints


### PR DESCRIPTION
## Summary
- wire Lucky route handlers to attach 1-hop Crystal callees when `--include-callee` is enabled
- reuse the shared Crystal `do ... end` block slicing and `CrystalCalleeExtractor` added for Kemal
- cover Lucky `get/post/put/delete/patch/trace/ws` route blocks, including nested block callees and params

## Scope notes
- This PR covers Lucky inline route blocks only.
- Controller-style Crystal framework resolution remains separate work for Amber, Grip, and Marten.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lucky-target-b crystal spec spec/functional_test/testers/crystal/lucky_spec.cr spec/functional_test/testers/crystal/lucky_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lucky-build just build`
- `./bin/noir -b spec/functional_test/fixtures/crystal/lucky_callees --only-techs crystal_lucky --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lucky-check2 just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lucky-test2 just test`

Part of #1366.
