### PR TITLE
Refactor analyzer regex match checks

### DIFF
--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -157,11 +157,11 @@ module Analyzer::Groovy
     end
 
     private def extends_restful_controller?(clause : String) : Bool
-      clause.match(/extends\s+RestfulController\b/) != nil
+      !!clause.match(/extends\s+RestfulController\b/)
     end
 
     private def has_scaffold?(body : String) : Bool
-      body.match(/static\s+scaffold\s*=/) != nil
+      !!body.match(/static\s+scaffold\s*=/)
     end
 
     private def emit_inherited_action(path : String, content : String,

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -155,7 +155,7 @@ module Analyzer::Javascript
     end
 
     private def has_default_export?(content : String) : Bool
-      content.match(/export\s+default\b/) != nil
+      !!content.match(/export\s+default\b/)
     end
 
     # Carve the `{...}` object literal out of `export const handler =
@@ -173,8 +173,8 @@ module Analyzer::Javascript
     end
 
     private def handler_function?(content : String) : Bool
-      content.match(/export\s+(?:async\s+)?function\s+handler\b/) != nil ||
-        content.match(/export\s+(?:const|let|var)\s+handler\b\s*(?::[^=]+)?=\s*(?:async\s*)?(?:function\b|\()/) != nil
+      !!(content.match(/export\s+(?:async\s+)?function\s+handler\b/) ||
+        content.match(/export\s+(?:const|let|var)\s+handler\b\s*(?::[^=]+)?=\s*(?:async\s*)?(?:function\b|\()/))
     end
 
     # Extract the verb names appearing as object keys inside the

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -166,9 +166,9 @@ module Analyzer::Javascript
     end
 
     private def export_named?(content : String, name : String) : Bool
-      content.match(/export\s+(?:async\s+)?function\s+#{name}\b/) != nil ||
-        content.match(/export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/) != nil ||
-        content.match(/export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/) != nil
+      !!(content.match(/export\s+(?:async\s+)?function\s+#{name}\b/) ||
+        content.match(/export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/) ||
+        content.match(/export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/))
     end
   end
 end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -142,7 +142,7 @@ module Analyzer::Python
             end
           end
         end
-        next if new_django_urls != nil
+        next if new_django_urls
 
         details = Details.new(PathInfo.new(django_urls.filepath))
         if view == ""

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -242,7 +242,7 @@ module Analyzer::Python
     def infer_parameter_type(data : ::String, is_param_type = false) : ::String?
       if data.match(/(\b)*Cookie(\b)*/)
         "cookie"
-      elsif data.match(/(\b)*Header(\b)*/) != nil
+      elsif data.match(/(\b)*Header(\b)*/)
         "header"
       elsif data.match(/(\b)*Body(\b)*/) || data.match(/(\b)*Form(\b)*/) ||
             data.match(/(\b)*File(\b)*/) || data.match(/(\b)*UploadFile(\b)*/)


### PR DESCRIPTION
## Summary
- replace explicit `match(...) != nil` checks with Crystal truthiness or `!!` where a `Bool` return is required
- simplify the Django include guard with `next if new_django_urls`
- cover the same pattern in the Grails analyzer while touching the issue area

Closes #1341

## Testing
- `crystal tool format --check src/analyzer/analyzers/javascript/remix.cr src/analyzer/analyzers/javascript/fresh.cr src/analyzer/analyzers/python/fastapi.cr src/analyzer/analyzers/python/django.cr src/analyzer/analyzers/groovy/grails.cr`
- `crystal build src/analyzer/analyzers/javascript/remix.cr --no-codegen`
- `crystal build src/analyzer/analyzers/javascript/fresh.cr --no-codegen`
- `crystal build src/analyzer/analyzers/python/fastapi.cr --no-codegen`
- `crystal build src/analyzer/analyzers/python/django.cr --no-codegen`
- `crystal build src/analyzer/analyzers/groovy/grails.cr --no-codegen`
- `git diff --check`
- `rg -n match\\([^\\n]*\\)\\s*!=\\s*nil|new_django_urls\\s*!=\\s*nil src`