### PR TITLE
Add Amber callee extraction

### DIFF
--- a/spec/functional_test/fixtures/crystal/amber_callees/shard.yml
+++ b/spec/functional_test/fixtures/crystal/amber_callees/shard.yml
@@ -1,0 +1,12 @@
+name: amber_callees
+version: 0.1.0
+
+targets:
+  amber_callees:
+    main: src/testapp.cr
+
+dependencies:
+  amber:
+    github: amberframework/amber
+
+crystal: 1.8.2

--- a/spec/functional_test/fixtures/crystal/amber_callees/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/amber_callees/src/testapp.cr
@@ -1,0 +1,45 @@
+require "amber"
+
+class ApplicationController < Amber::Controller::Base
+  def index
+    payload = HomeService.build; json payload
+  end
+
+  def create_user
+    username = params.json["username"]
+    user = UserService.create(username)
+    AuditTrail.record(user)
+  end
+
+  def show_post
+    id = params["id"]
+    post = PostLookup.find(id)
+    render_post(post)
+  end
+
+  def upload
+    file = params.body["file"]
+    UploadService.store(file)
+    context.request.headers["content-type"]
+  end
+end
+
+class WebSocketController < Amber::Controller::Base
+  def handle
+    SocketTracker.connected
+    socket.send "ok"
+  end
+end
+
+Amber::Server.configure do
+  routes :web do
+    get "/", ApplicationController, :index
+    post "/users", ApplicationController, :create_user
+    get "/posts/:id", ApplicationController, :show_post
+    post "/upload", ApplicationController, :upload
+    ws "/socket", WebSocketController, :handle
+    get "/health"
+  end
+end
+
+Amber::Server.start

--- a/spec/functional_test/testers/crystal/amber_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/amber_callees_spec.cr
@@ -1,0 +1,58 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 5))
+  ep.push_callee(Callee.new("json", line: 5))
+end
+
+users_create = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("params.json", line: 9))
+  ep.push_callee(Callee.new("UserService.create", line: 10))
+  ep.push_callee(Callee.new("AuditTrail.record", line: 11))
+end
+
+post_show = Endpoint.new("/posts/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PostLookup.find", line: 16))
+  ep.push_callee(Callee.new("render_post", line: 17))
+end
+
+upload = Endpoint.new("/upload", "POST").tap do |ep|
+  ep.push_callee(Callee.new("params.body", line: 21))
+  ep.push_callee(Callee.new("UploadService.store", line: 22))
+  ep.push_callee(Callee.new("context.request.headers", line: 23))
+end
+
+socket = Endpoint.new("/socket", "GET").tap do |ep|
+  ep.push_callee(Callee.new("SocketTracker.connected", line: 29))
+  ep.push_callee(Callee.new("socket.send", line: 30))
+end
+
+health = Endpoint.new("/health", "GET")
+
+expected_endpoints = [
+  home,
+  users_create,
+  post_show,
+  upload,
+  socket,
+  health,
+]
+
+tester = FunctionalTester.new("fixtures/crystal/amber_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("crystal_amber"),
+})
+tester.perform_tests
+
+describe "Amber callee extraction" do
+  it "keeps controller-less fallback routes callee-empty" do
+    health_endpoint = tester.app.endpoints.find { |e| e.method == "GET" && e.url == "/health" }
+    health_endpoint.should_not be_nil
+    health_endpoint.callees.should be_empty if health_endpoint
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_amber_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_amber_spec.cr
@@ -1,0 +1,39 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/crystal/amber.cr"
+
+describe "amber callee extraction" do
+  it "extracts callees from single-line controller actions" do
+    options = create_test_options
+    options["include_callee"] = YAML::Any.new(true)
+    instance = Analyzer::Crystal::Amber.new(options)
+
+    temp_dir = File.tempname("amber_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "test.cr")
+
+    File.write(temp_file, <<-CRYSTAL)
+      class ApplicationController < Amber::Controller::Base
+        def index; payload = HomeService.build; json payload; end
+      end
+
+      Amber::Server.configure do
+        routes :web do
+          get "/", ApplicationController, :index
+        end
+      end
+      CRYSTAL
+
+    endpoints = instance.analyze_file(temp_file)
+    endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/" }
+    endpoint.should_not be_nil
+    if endpoint
+      endpoint.callees.map(&.name).should contain("HomeService.build")
+      endpoint.callees.map(&.name).should contain("json")
+      endpoint.callees.find { |c| c.name == "HomeService.build" }.try(&.line).should eq(2)
+      endpoint.callees.find { |c| c.name == "json" }.try(&.line).should eq(2)
+    end
+
+    File.delete(temp_file)
+    Dir.delete(temp_dir)
+  end
+end

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -13,54 +13,123 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      lines = [] of String
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        file.each_line.with_index do |line, index|
-          endpoint = line_to_endpoint(line)
-          if endpoint.method != ""
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint.details = details
-            endpoints << endpoint
-            last_endpoint = endpoint
+        file.each_line do |line|
+          lines << line
+        end
+      end
+
+      include_callee = any_to_bool(@options["include_callee"]?)
+      actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+      last_endpoint = Endpoint.new("", "")
+
+      lines.each_with_index do |line, index|
+        endpoint = line_to_endpoint(line)
+        if endpoint.method != ""
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          attach_route_callees(endpoint, line, actions) if include_callee
+          endpoints << endpoint
+          last_endpoint = endpoint
+        end
+
+        param = line_to_param(line)
+        if param.name != ""
+          if last_endpoint.method != ""
+            last_endpoint.push_param(param)
           end
+        end
 
-          param = line_to_param(line)
-          if param.name != ""
-            if last_endpoint.method != ""
-              last_endpoint.push_param(param)
-            end
-          end
+        if line.includes?("serve_static false") || line.includes?("serve_static(false)")
+          @is_public = false
+        end
 
-          if line.includes?("serve_static false") || line.includes?("serve_static(false)")
-            @is_public = false
-          end
+        if line.includes?("public_folder")
+          begin
+            split = line.split("public_folder")
 
-          if line.includes?("public_folder")
-            begin
-              split = line.split("public_folder")
+            if split.size > 1
+              # Extract path more carefully handling quotes and spaces
+              match_data = split[1].match(/[=\(]\s*['"]?(.*?)['"]?\s*[\),]/)
+              public_folder = if match_data && match_data[1]?
+                                match_data[1].strip
+                              else
+                                # Fallback to the previous approach
+                                split[1].gsub("(", "").gsub(")", "").gsub(" ", "").gsub("\"", "").gsub("'", "")
+                              end
 
-              if split.size > 1
-                # Extract path more carefully handling quotes and spaces
-                match_data = split[1].match(/[=\(]\s*['"]?(.*?)['"]?\s*[\),]/)
-                public_folder = if match_data && match_data[1]?
-                                  match_data[1].strip
-                                else
-                                  # Fallback to the previous approach
-                                  split[1].gsub("(", "").gsub(")", "").gsub(" ", "").gsub("\"", "").gsub("'", "")
-                                end
-
-                if public_folder != ""
-                  @public_folders << public_folder
-                end
+              if public_folder != ""
+                @public_folders << public_folder
               end
-            rescue
             end
+          rescue
           end
         end
       end
 
       endpoints
+    end
+
+    private def collect_controller_actions(lines : Array(String), path : String) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry))
+      actions = Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+      current_class = ""
+      class_depth = 0
+
+      lines.each_with_index do |line, index|
+        stripped = Noir::CrystalCalleeExtractor.strip_comment(line).strip
+        if class_match = stripped.match(/^class\s+([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\b/)
+          current_class = class_match[1]
+          class_depth = 1
+          next
+        end
+
+        next if current_class.empty?
+        if stripped == "end" || stripped.starts_with?("end ")
+          class_depth -= 1
+          if class_depth <= 0
+            current_class = ""
+            class_depth = 0
+          end
+          next
+        end
+
+        if class_depth == 1 && (def_match = stripped.match(/^(?:(?:private|protected)\s+)?def\s+([A-Za-z_]\w*[!?=]?)/))
+          method_body = extract_crystal_def_block(lines, index)
+          if method_body
+            body, body_start_line = method_body
+            callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+            actions[controller_action_key(current_class, def_match[1])] = callees
+          end
+        end
+
+        class_depth += crystal_do_block_open_delta(stripped)
+      end
+
+      actions
+    end
+
+    private def attach_route_callees(endpoint : Endpoint,
+                                     line : String,
+                                     actions : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)))
+      route_target = extract_route_target(line)
+      return unless route_target
+
+      controller, action = route_target
+      if callees = actions[controller_action_key(controller, action)]?
+        attach_crystal_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_route_target(line : String) : Tuple(String, String)?
+      if match = line.match(/\b(?:get|post|put|delete|patch|head|options|ws)\s+['"][^'"]+['"]\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*,\s*:(\w+)/)
+        {match[1], match[2]}
+      end
+    end
+
+    private def controller_action_key(controller : String, action : String) : String
+      "#{controller}##{action}"
     end
 
     private def collect_public_dir_endpoints

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -86,6 +86,42 @@ module Analyzer::Crystal
       {body_lines.join("\n"), body_start_line}
     end
 
+    protected def extract_crystal_def_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      return if start_index >= lines.size
+
+      def_line = Noir::CrystalCalleeExtractor.strip_comment(lines[start_index]).strip
+      if semicolon_index = def_line.index(';')
+        tail = def_line[(semicolon_index + 1)..].strip
+        if m = tail.match(/^(.*?)(?:;\s*)?end\b/)
+          return {m[1].strip, start_index + 1}
+        end
+      end
+
+      body_lines = [] of String
+      body_start_line = start_index + 2
+      depth = 1
+      index = start_index + 1
+
+      while index < lines.size
+        raw_body_line = lines[index]
+        body_line = Noir::CrystalCalleeExtractor.strip_comment(raw_body_line).strip
+
+        if crystal_closes_block?(body_line)
+          depth -= 1
+          break if depth == 0
+          body_lines << raw_body_line
+          index += 1
+          next
+        end
+
+        body_lines << raw_body_line
+        depth += crystal_do_block_open_delta(body_line)
+        index += 1
+      end
+
+      {body_lines.join("\n"), body_start_line}
+    end
+
     protected def crystal_do_block_open_delta(line : String) : Int32
       return 0 if line.empty?
       return 1 if line.match(/\bdo\b/) && !line.match(/\bend\b/)


### PR DESCRIPTION
## Summary
- add a Crystal engine helper for slicing controller `def` bodies
- wire Amber `Controller, :action` route declarations to attach 1-hop callees when `--include-callee` is enabled
- preserve existing Amber endpoint and param semantics; controller body params are surfaced only as callees in this pass
- cover controller-backed routes, websocket routes, and controller-less fallback routes that remain callee-empty

## Scope notes
- This resolves same-file Amber controller/action methods only.
- Static public endpoints and controller-less fallback routes stay callee-empty.
- Grip and Marten still need separate handler-resolution passes.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-amber-target-c crystal spec spec/functional_test/testers/crystal/amber_spec.cr spec/functional_test/testers/crystal/amber_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-amber-build just build`
- `./bin/noir -b spec/functional_test/fixtures/crystal/amber_callees --only-techs crystal_amber --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-amber-test just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-amber-check just check`

Part of #1366.
