### PR TITLE
Remove empty Details initializer

### DIFF
--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -122,13 +122,10 @@ struct Details
   property status_code : Int32?
   property technology : String?
 
-  # + New details types to be added in the future..
+  # New details types can be added in the future.
 
-  def initialize
-  end
-
-  def initialize(code_path : PathInfo)
-    @code_paths << code_path
+  def initialize(code_path : PathInfo? = nil)
+    @code_paths << code_path if code_path
   end
 
   def add_path(code_path : PathInfo)


### PR DESCRIPTION
## Summary
- remove the redundant empty `Details#initialize` overload
- clean up the nearby future-details comment
- keep `Details.new` working by making the `PathInfo` initializer optional

Closes #1151

## Testing
- `crystal tool format src/models/endpoint.cr`
- `crystal tool format --check src/models/endpoint.cr`
- `crystal build src/models/endpoint.cr --no-codegen`
- `crystal eval` smoke check for `Details.new` and `Details.new(PathInfo.new(...))`