### PR TITLE
Log send request delivery errors

### DIFF
--- a/src/deliver/send_req.cr
+++ b/src/deliver/send_req.cr
@@ -41,7 +41,9 @@ class SendReq < Deliver
               user_agent: "Noir/#{Noir::VERSION}"
             )
           end
-        rescue
+        rescue e
+          @logger.debug "Exception during request delivery"
+          @logger.debug_sub e
         ensure
           wg.done
         end


### PR DESCRIPTION
## Summary
- log request delivery exceptions at debug level before swallowing them
- include the exception details through `debug_sub`, matching the existing Elasticsearch delivery pattern

Closes #1122

## Testing
- `crystal tool format src/deliver/send_req.cr`
- `crystal tool format --check src/deliver/send_req.cr`
- `git diff --check`

Build note: `shards install` completed locally, but `crystal build src/noir.cr --no-codegen` is blocked in this Windows environment by the `http_proxy` shard invoking `shards version` from `lib/http_proxy/src`.