### PR TITLE
Add Grip callee extraction

### DIFF
--- a/spec/functional_test/fixtures/crystal/grip_callees/shard.yml
+++ b/spec/functional_test/fixtures/crystal/grip_callees/shard.yml
@@ -1,0 +1,12 @@
+name: grip_callees
+version: 0.1.0
+
+targets:
+  grip_callees:
+    main: src/testapp.cr
+
+dependencies:
+  grip:
+    github: grip-framework/grip
+
+crystal: 1.8.2

--- a/spec/functional_test/fixtures/crystal/grip_callees/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/grip_callees/src/testapp.cr
@@ -1,0 +1,61 @@
+require "grip"
+
+class IndexController
+  include Grip::Controllers::HTTP
+
+  def get(context : Context) : Context
+    payload = HomeService.build
+    context.json({"home" => payload}).halt
+  end
+
+  def show(context : Context) : Context
+    id = context.fetch_path_params["id"]
+    user = UserLookup.find(id)
+    context.json({"user" => UserPresenter.render(user)}).halt
+  end
+
+  def create(context : Context) : Context
+    payload = PayloadBuilder.from(context.fetch_json_params["content"])
+    ItemService.create(payload)
+    context.put_status(201).json({"ok" => true}).halt
+  end
+end
+
+class ChatController
+  include Grip::Controllers::WebSocket
+
+  def on_message(context : Context, message : String) : Nil
+    SocketTracker.connected
+    context.send(message)
+  end
+end
+
+module Api
+  class StatusController
+    include Grip::Controllers::HTTP
+
+    def get(context : Context) : Context
+      status = ApiStatus.check
+      context.json({"status" => status}).halt
+    end
+  end
+end
+
+class Application
+  include Grip::Application
+
+  def initialize
+    scope "/api" do
+      get "/", IndexController
+      get "/:id", IndexController, as: :show
+      post "/items", IndexController, as: :create
+      get "/status", Api::StatusController
+    end
+
+    get "/health", IndexController
+    ws "/chat", ChatController
+  end
+end
+
+app = Application.new
+app.run

--- a/spec/functional_test/testers/crystal/grip_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/grip_callees_spec.cr
@@ -1,0 +1,54 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/api/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 7))
+  ep.push_callee(Callee.new("context.json", line: 8))
+end
+
+show = Endpoint.new("/api/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("context.fetch_path_params", line: 12))
+  ep.push_callee(Callee.new("UserLookup.find", line: 13))
+  ep.push_callee(Callee.new("UserPresenter.render", line: 14))
+  ep.push_callee(Callee.new("context.json", line: 14))
+end
+
+create = Endpoint.new("/api/items", "POST").tap do |ep|
+  ep.push_callee(Callee.new("PayloadBuilder.from", line: 18))
+  ep.push_callee(Callee.new("context.fetch_json_params", line: 18))
+  ep.push_callee(Callee.new("ItemService.create", line: 19))
+  ep.push_callee(Callee.new("context.put_status", line: 20))
+end
+
+status = Endpoint.new("/api/status", "GET").tap do |ep|
+  ep.push_callee(Callee.new("ApiStatus.check", line: 38))
+  ep.push_callee(Callee.new("context.json", line: 39))
+end
+
+health = Endpoint.new("/health", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 7))
+  ep.push_callee(Callee.new("context.json", line: 8))
+end
+
+chat = Endpoint.new("/chat", "GET").tap do |ep|
+  ep.push_callee(Callee.new("SocketTracker.connected", line: 28))
+  ep.push_callee(Callee.new("context.send", line: 29))
+end
+
+expected_endpoints = [
+  home,
+  show,
+  create,
+  status,
+  health,
+  chat,
+]
+
+FunctionalTester.new("fixtures/crystal/grip_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("crystal_grip"),
+}).perform_tests

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -4,53 +4,168 @@ module Analyzer::Crystal
   class Grip < CrystalEngine
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      lines = [] of String
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        current_scopes = [] of String
+        file.each_line do |line|
+          lines << line
+        end
+      end
 
-        file.each_line.with_index do |line, index|
-          details = Details.new(PathInfo.new(path, index + 1))
+      include_callee = any_to_bool(@options["include_callee"]?)
+      actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+      last_endpoint = Endpoint.new("", "")
+      current_scopes = [] of String
 
-          # Handle scope statements
-          if line.includes?("scope ") && line.includes?(" do")
-            scope_match = line.match(/scope\s+['"](.+?)['"]/)
-            if scope_match && scope_match[1]?
-              current_scopes << scope_match[1]
-            end
+      lines.each_with_index do |line, index|
+        details = Details.new(PathInfo.new(path, index + 1))
+
+        # Handle scope statements
+        if line.includes?("scope ") && line.includes?(" do")
+          scope_match = line.match(/scope\s+['"](.+?)['"]/)
+          if scope_match && scope_match[1]?
+            current_scopes << scope_match[1]
           end
+        end
 
-          # Handle end statements (basic detection)
-          if line.strip == "end" && current_scopes.size > 0
-            current_scopes.pop
-          end
+        # Handle end statements (basic detection)
+        if line.strip == "end" && current_scopes.size > 0
+          current_scopes.pop
+        end
 
-          # Parse HTTP method calls
-          endpoint = line_to_endpoint(line, current_scopes)
-          if endpoint.method != ""
-            endpoint.details = details
-            endpoints << endpoint
-            last_endpoint = endpoint
-          end
+        # Parse HTTP method calls
+        endpoint = line_to_endpoint(line, current_scopes)
+        if endpoint.method != ""
+          endpoint.details = details
+          attach_route_callees(endpoint, line, actions) if include_callee
+          endpoints << endpoint
+          last_endpoint = endpoint
+        end
 
-          # Parse parameters
-          param = line_to_param(line)
-          if param.name != ""
-            if last_endpoint.method != ""
-              last_endpoint.push_param(param)
-            end
+        # Parse parameters
+        param = line_to_param(line)
+        if param.name != ""
+          if last_endpoint.method != ""
+            last_endpoint.push_param(param)
           end
+        end
 
-          # Parse WebSocket routes
-          ws_endpoint = line_to_websocket(line, current_scopes)
-          if ws_endpoint.url != ""
-            ws_endpoint.details = details
-            endpoints << ws_endpoint
-          end
+        # Parse WebSocket routes
+        ws_endpoint = line_to_websocket(line, current_scopes)
+        if ws_endpoint.url != ""
+          ws_endpoint.details = details
+          attach_websocket_callees(ws_endpoint, line, actions) if include_callee
+          endpoints << ws_endpoint
         end
       end
 
       endpoints
+    end
+
+    private def collect_controller_actions(lines : Array(String), path : String) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry))
+      actions = Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+      scope_stack = [] of Tuple(String, String)
+
+      lines.each_with_index do |line, index|
+        stripped = Noir::CrystalCalleeExtractor.strip_comment(line).strip
+
+        if stripped == "end" || stripped.starts_with?("end ")
+          scope_stack.pop? unless scope_stack.empty?
+          next
+        end
+
+        if module_match = stripped.match(/^module\s+([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\b/)
+          scope_stack << {"module", qualified_crystal_const(module_match[1], scope_stack)}
+          next
+        end
+
+        if class_match = stripped.match(/^class\s+([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\b/)
+          scope_stack << {"class", qualified_crystal_const(class_match[1], scope_stack)}
+          next
+        end
+
+        if (current_class = current_direct_crystal_class(scope_stack)) &&
+           (def_match = stripped.match(/^(?:(?:private|protected)\s+)?def\s+([A-Za-z_]\w*[!?=]?)/))
+          method_body = extract_crystal_def_block(lines, index)
+          if method_body
+            body, body_start_line = method_body
+            callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+            actions[controller_action_key(current_class, def_match[1])] = callees
+          end
+          scope_stack << {"block", ""} unless stripped.match(/\bend\b/)
+          next
+        end
+
+        crystal_do_block_open_delta(stripped).times do
+          scope_stack << {"block", ""}
+        end
+      end
+
+      actions
+    end
+
+    private def qualified_crystal_const(name : String, scope_stack : Array(Tuple(String, String))) : String
+      return name if name.includes?("::")
+
+      prefix = current_crystal_const_scope(scope_stack)
+      prefix.empty? ? name : "#{prefix}::#{name}"
+    end
+
+    private def current_crystal_const_scope(scope_stack : Array(Tuple(String, String))) : String
+      scope_stack.reverse_each do |kind, name|
+        return name if kind == "module" || kind == "class"
+      end
+
+      ""
+    end
+
+    private def current_direct_crystal_class(scope_stack : Array(Tuple(String, String))) : String?
+      return if scope_stack.empty?
+      kind, name = scope_stack.last
+      return unless kind == "class"
+
+      name
+    end
+
+    private def attach_route_callees(endpoint : Endpoint,
+                                     line : String,
+                                     actions : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)))
+      route_target = extract_route_target(line)
+      return unless route_target
+
+      controller, action = route_target
+      if callees = actions[controller_action_key(controller, action)]?
+        attach_crystal_callees(endpoint, callees)
+      end
+    end
+
+    private def attach_websocket_callees(endpoint : Endpoint,
+                                         line : String,
+                                         actions : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)))
+      route_target = extract_websocket_target(line)
+      return unless route_target
+
+      controller, action = route_target
+      if callees = actions[controller_action_key(controller, action)]?
+        attach_crystal_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_route_target(line : String) : Tuple(String, String)?
+      if match = line.match(/\b(get|post|put|patch|delete|options|head)\s+['"][^'"]+['"]\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)(?:\s*,\s*as:\s*:(\w+))?/)
+        action = match[3]? || match[1]
+        {match[2], action}
+      end
+    end
+
+    private def extract_websocket_target(line : String) : Tuple(String, String)?
+      if match = line.match(/\bws\s+['"][^'"]+['"]\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)(?:\s*,\s*as:\s*:(\w+))?/)
+        {match[1], match[2]? || "on_message"}
+      end
+    end
+
+    private def controller_action_key(controller : String, action : String) : String
+      "#{controller}##{action}"
     end
 
     def line_to_param(content : String) : Param


### PR DESCRIPTION
## Summary
- wire Grip controller routes to attach 1-hop Crystal callees when `--include-callee` is enabled
- resolve `as: :action` route targets and default HTTP verb method targets
- resolve websocket routes to `on_message` by default
- preserve existing endpoint/param semantics while adding a focused callee fixture

## Scope notes
- This resolves same-file Grip controller methods only.
- Handler inference is intentionally limited to existing Grip route forms and websocket `on_message`.
- Marten remains separate because its current analyzer emits one `GET` per `path` and needs careful handler mapping.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grip-target-a crystal spec spec/functional_test/testers/crystal/grip_spec.cr spec/functional_test/testers/crystal/grip_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grip-build just build`
- `./bin/noir -b spec/functional_test/fixtures/crystal/grip_callees --only-techs crystal_grip --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grip-check just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-grip-test just test`

Part of #1366.
