### PR TITLE
Add Marten callee extraction

### DIFF
--- a/spec/functional_test/fixtures/crystal/marten_callees/shard.yml
+++ b/spec/functional_test/fixtures/crystal/marten_callees/shard.yml
@@ -1,0 +1,18 @@
+name: testmarten
+version: 0.1.0
+
+authors:
+  - example <example@gmail.com>
+
+targets:
+  testmarten:
+    main: src/testmarten.cr
+
+dependencies:
+  marten:
+    github: martenframework/marten
+    version: ~> 0.4.0
+
+crystal: 1.8.2
+
+license: MIT

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/admin/reports_handler.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/admin/reports_handler.cr
@@ -1,0 +1,8 @@
+module Admin
+  class ReportsHandler < Marten::Handler
+    def get
+      report = ReportService.latest
+      respond ReportSerializer.render(report)
+    end
+  end
+end

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/home_handler.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/home_handler.cr
@@ -1,0 +1,11 @@
+module Placeholder; end
+
+class PlaceholderHandler; end
+
+class HomeHandler < Marten::Handler
+  def get
+    payload = HomeService.build
+    message = HomePresenter.render(payload)
+    respond message
+  end
+end

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/macro_handler.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/macro_handler.cr
@@ -1,0 +1,8 @@
+class MacroWrappedHandler < Marten::Handler
+  route_definition do
+    def get
+      value = MacroService.call
+      respond MacroPresenter.render(value)
+    end
+  end
+end

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/user_detail_handler.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/user_detail_handler.cr
@@ -1,0 +1,7 @@
+class UserDetailHandler < Marten::Handler
+  def get
+    user_id = params["id"]
+    user = UserLookup.find(user_id)
+    respond UserPresenter.render(user)
+  end
+end

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/users_handler.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/handlers/users_handler.cr
@@ -1,0 +1,12 @@
+class UsersHandler < Marten::Handler
+  def get
+    records = UserSearch.list
+    UserPresenter.render(records)
+    respond "Users"
+  end
+
+  def post
+    UserCreator.create
+    respond "Created"
+  end
+end

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/routes.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/routes.cr
@@ -1,0 +1,8 @@
+Marten.routes.draw do
+  path "/", HomeHandler, name: "home"
+  path "/api/users", UsersHandler, name: "users"
+  path "/api/users/<int:id>", UserDetailHandler, name: "user_detail"
+  path "/admin/reports", Admin::ReportsHandler, name: "admin_reports"
+  path "/absolute/reports", ::Admin::ReportsHandler, name: "absolute_reports"
+  path "/macro", MacroWrappedHandler, name: "macro"
+end

--- a/spec/functional_test/fixtures/crystal/marten_callees/src/testmarten.cr
+++ b/spec/functional_test/fixtures/crystal/marten_callees/src/testmarten.cr
@@ -1,0 +1,10 @@
+require "marten"
+
+Marten.configure do |config|
+  config.secret_key = "insecure-key-for-dev"
+  config.debug = true
+end
+
+require "./routes"
+
+Marten.run

--- a/spec/functional_test/testers/crystal/marten_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/marten_callees_spec.cr
@@ -1,0 +1,56 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 7))
+  ep.push_callee(Callee.new("HomePresenter.render", line: 8))
+  ep.push_callee(Callee.new("respond", line: 9))
+end
+
+users = Endpoint.new("/api/users", "GET").tap do |ep|
+  ep.push_callee(Callee.new("UserSearch.list", line: 3))
+  ep.push_callee(Callee.new("UserPresenter.render", line: 4))
+  ep.push_callee(Callee.new("respond", line: 5))
+end
+
+user_detail = Endpoint.new("/api/users/<int:id>", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserLookup.find", line: 4))
+  ep.push_callee(Callee.new("UserPresenter.render", line: 5))
+  ep.push_callee(Callee.new("respond", line: 5))
+end
+
+admin_reports = Endpoint.new("/admin/reports", "GET").tap do |ep|
+  ep.push_callee(Callee.new("ReportService.latest", line: 4))
+  ep.push_callee(Callee.new("ReportSerializer.render", line: 5))
+  ep.push_callee(Callee.new("respond", line: 5))
+end
+
+absolute_reports = Endpoint.new("/absolute/reports", "GET").tap do |ep|
+  ep.push_callee(Callee.new("ReportService.latest", line: 4))
+  ep.push_callee(Callee.new("ReportSerializer.render", line: 5))
+  ep.push_callee(Callee.new("respond", line: 5))
+end
+
+macro_route = Endpoint.new("/macro", "GET").tap do |ep|
+  ep.push_callee(Callee.new("MacroService.call", line: 4))
+  ep.push_callee(Callee.new("MacroPresenter.render", line: 5))
+  ep.push_callee(Callee.new("respond", line: 5))
+end
+
+expected_endpoints = [
+  home,
+  users,
+  user_detail,
+  admin_reports,
+  absolute_reports,
+  macro_route,
+]
+
+FunctionalTester.new("fixtures/crystal/marten_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("crystal_marten"),
+}).perform_tests

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -2,32 +2,40 @@ require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
   class Marten < CrystalEngine
+    @handler_callees = Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+
     def analyze
       collect_public_dir_endpoints
-      super
+      @handler_callees = include_callee? ? collect_handler_callees : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+
+      result
     end
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      lines = read_source_lines(path)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        file.each_line.with_index do |line, index|
-          # Parse route definitions
-          endpoint = line_to_endpoint(line)
-          if endpoint.method != ""
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint.details = details
-            endpoints << endpoint
-            last_endpoint = endpoint
-          end
+      last_endpoint = Endpoint.new("", "")
+      lines.each_with_index do |line, index|
+        # Parse route definitions
+        endpoint = line_to_endpoint(line)
+        if endpoint.method != ""
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          attach_route_callees(endpoint, line) if include_callee?
+          endpoints << endpoint
+          last_endpoint = endpoint
+        end
 
-          # Parse parameter usage
-          param = line_to_param(line)
-          if param.name != ""
-            if last_endpoint.method != ""
-              last_endpoint.push_param(param)
-            end
+        # Parse parameter usage
+        param = line_to_param(line)
+        if param.name != ""
+          if last_endpoint.method != ""
+            last_endpoint.push_param(param)
           end
         end
       end
@@ -45,6 +53,117 @@ module Analyzer::Crystal
       end
     rescue e
       logger.debug e
+    end
+
+    private def include_callee? : Bool
+      any_to_bool(@options["include_callee"]?)
+    end
+
+    private def read_source_lines(path : String) : Array(String)
+      read_file_content(path).lines
+    end
+
+    private def collect_handler_callees : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry))
+      actions = Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
+
+      get_files_by_extension(".cr").each do |path|
+        next if File.directory?(path)
+        next unless File.exists?(path)
+        next if path.includes?("lib")
+
+        collect_handler_callees_from_lines(read_source_lines(path), path, actions)
+      rescue e
+        logger.debug "Error collecting Marten handler callees from #{path}: #{e}"
+      end
+
+      actions
+    end
+
+    private def collect_handler_callees_from_lines(lines : Array(String),
+                                                   path : String,
+                                                   actions : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)))
+      scope_stack = [] of Tuple(String, String)
+
+      lines.each_with_index do |line, index|
+        stripped = Noir::CrystalCalleeExtractor.strip_comment(line).strip
+
+        if stripped == "end" || stripped.starts_with?("end ")
+          scope_stack.pop? unless scope_stack.empty?
+          next
+        end
+
+        if module_match = stripped.match(/^module\s+((?:::)?[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\b/)
+          scope_stack << {"module", qualified_crystal_const(module_match[1], scope_stack)} unless stripped.match(/\bend\b/)
+          next
+        end
+
+        if class_match = stripped.match(/^class\s+((?:::)?[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\b/)
+          scope_stack << {"class", qualified_crystal_const(class_match[1], scope_stack)} unless stripped.match(/\bend\b/)
+          next
+        end
+
+        if (current_class = current_direct_crystal_class(scope_stack)) &&
+           (def_match = stripped.match(/^(?:(?:private|protected)\s+)?def\s+(get)\b/))
+          method_body = extract_crystal_def_block(lines, index)
+          if method_body
+            body, body_start_line = method_body
+            callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+            actions[handler_action_key(current_class, def_match[1])] = callees
+          end
+          scope_stack << {"block", ""} unless stripped.match(/\bend\b/)
+          next
+        end
+
+        crystal_do_block_open_delta(stripped).times do
+          scope_stack << {"block", ""}
+        end
+      end
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, line : String)
+      handler = extract_route_target(line)
+      return unless handler
+
+      if callees = @handler_callees[handler_action_key(handler, "get")]?
+        attach_crystal_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_route_target(line : String) : String?
+      if match = line.match(/\bpath\s+['"][^'"]+['"]\s*,\s*((?:::)?[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)/)
+        normalize_absolute_crystal_const(match[1])
+      end
+    end
+
+    private def qualified_crystal_const(name : String, scope_stack : Array(Tuple(String, String))) : String
+      return normalize_absolute_crystal_const(name) if name.starts_with?("::")
+
+      prefix = current_crystal_const_scope(scope_stack)
+      prefix.empty? ? name : "#{prefix}::#{name}"
+    end
+
+    private def current_crystal_const_scope(scope_stack : Array(Tuple(String, String))) : String
+      scope_stack.reverse_each do |kind, name|
+        return name if kind == "module" || kind == "class"
+      end
+
+      ""
+    end
+
+    private def current_direct_crystal_class(scope_stack : Array(Tuple(String, String))) : String?
+      scope_stack.reverse_each do |kind, name|
+        return name if kind == "class"
+      end
+
+      nil
+    end
+
+    private def normalize_absolute_crystal_const(name : String) : String
+      name.starts_with?("::") ? name[2, name.size - 2] : name
+    end
+
+    private def handler_action_key(handler : String, action : String) : String
+      "#{handler}##{action}"
     end
 
     def line_to_param(content : String) : Param


### PR DESCRIPTION
## Summary
- add `--include-callee` support for Marten `path "...", Handler` routes
- resolve handler classes across project files and attach 1-hop callees from the matched handler `def get` body
- support namespaced handlers such as `Admin::ReportsHandler`
- add focused Marten callee fixture coverage, including a `post` method that must not bleed into the emitted GET route

## Scope notes
- Existing Marten endpoint semantics are preserved: each `path` declaration still emits a GET endpoint only.
- This PR does not fan out POST/PUT/DELETE endpoints from handler methods.
- Existing raw empty-url handler-method detections are left unchanged; optimizer still reduces the fixture to the expected final route endpoints.
- Callee resolution is static and keyed by handler class name plus `get`.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-marten-target crystal spec spec/functional_test/testers/crystal/marten_spec.cr spec/functional_test/testers/crystal/marten_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-marten-build just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-marten-check just check`
- `./bin/noir -b spec/functional_test/fixtures/crystal/marten_callees --only-techs crystal_marten --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-marten-test just test`

Part of #1366.
