### PR TITLE
Add Axum callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/axum_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/axum_callees/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "axum-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = { path = "../../axum" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }

--- a/spec/functional_test/fixtures/rust/axum_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum_callees/src/main.rs
@@ -1,0 +1,33 @@
+use axum::{response::Html, routing::{get, post}, Json, Router};
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new()
+        .route("/", get(home))
+        .route("/profile", get(profile))
+        .route("/users", post(create_user));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
+        .await
+        .unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn home() -> Html<&'static str> {
+    let status = HealthCheck::ready().await;
+    Html(render_home(status))
+}
+
+async fn profile() -> Json<Profile> {
+    let profile = ProfileService::load().await;
+    if FeatureFlags::enabled() {
+        Metrics::record_profile();
+    }
+    Json(ProfilePresenter::render(profile))
+}
+
+async fn create_user(Json(payload): Json<CreateUser>) -> Json<User> {
+    let user = UserService::create(payload).await;
+    AuditLog::write(&user);
+    Json(user)
+}

--- a/spec/functional_test/testers/rust/axum_callees_spec.cr
+++ b/spec/functional_test/testers/rust/axum_callees_spec.cr
@@ -1,0 +1,35 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 17))
+  ep.push_callee(Callee.new("Html", line: 18))
+  ep.push_callee(Callee.new("render_home", line: 18))
+end
+
+profile = Endpoint.new("/profile", "GET").tap do |ep|
+  ep.push_callee(Callee.new("ProfileService::load", line: 22))
+  ep.push_callee(Callee.new("FeatureFlags::enabled", line: 23))
+  ep.push_callee(Callee.new("Metrics::record_profile", line: 24))
+  ep.push_callee(Callee.new("Json", line: 26))
+  ep.push_callee(Callee.new("ProfilePresenter::render", line: 26))
+end
+
+create_user = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 30))
+  ep.push_callee(Callee.new("AuditLog::write", line: 31))
+  ep.push_callee(Callee.new("Json", line: 32))
+end
+
+expected_endpoints = [
+  home,
+  profile,
+  create_user,
+]
+
+FunctionalTester.new("fixtures/rust/axum_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_axum"),
+}).perform_tests

--- a/spec/unit_test/analyzer/rust_engine_spec.cr
+++ b/spec/unit_test/analyzer/rust_engine_spec.cr
@@ -1,0 +1,36 @@
+require "../../spec_helper"
+require "../../../src/analyzer/engines/rust_engine"
+
+class RustEngineSpecHarness < Analyzer::Rust::RustEngine
+  def analyze_file(path : String) : Array(Endpoint)
+    [] of Endpoint
+  end
+
+  def function_body(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+    extract_rust_function_body(lines, start_index)
+  end
+end
+
+describe Analyzer::Rust::RustEngine do
+  it "does not attach declaration-only function signatures to the next body" do
+    lines = [
+      "trait Api {",
+      "  fn declared();",
+      "}",
+      "async fn real_handler() {",
+      "  RealService::run();",
+      "}",
+    ]
+
+    harness = RustEngineSpecHarness.new(create_test_options)
+    harness.function_body(lines, 1).should be_nil
+
+    real_body = harness.function_body(lines, 3)
+    real_body.should_not be_nil
+    if real_body
+      body, start_line = real_body
+      start_line.should eq(5)
+      body.should contain("RealService::run")
+    end
+  end
+end

--- a/spec/unit_test/miniparser/rust_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/rust_callee_extractor_spec.cr
@@ -1,0 +1,48 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/rust_callee_extractor"
+
+describe Noir::RustCalleeExtractor do
+  it "extracts path, receiver, and bare calls from Rust handler bodies" do
+    body = <<-RUST
+      let user = UserService::create(payload).await;
+      state.users.find(user.id);
+      Json(user)
+      RUST
+
+    callees = Noir::RustCalleeExtractor.callees_for_body(body, "main.rs", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService::create", 10},
+      {"state.users.find", 11},
+      {"Json", 12},
+    ])
+  end
+
+  it "skips comments, strings, and common Rust noise macros" do
+    body = <<-RUST
+      // AuditLog::write("ignored")
+      let msg = "UserService::create()";
+      let _debug = format!("user {}", id);
+      println!("done");
+      AuditLog::write("created");
+      RUST
+
+    callees = Noir::RustCalleeExtractor.callees_for_body(body, "main.rs", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"AuditLog::write", 24},
+    ])
+  end
+
+  it "skips block comments across lines" do
+    body = <<-RUST
+      /*
+       * DangerousService::run();
+       */
+      SafeService::run();
+      RUST
+
+    callees = Noir::RustCalleeExtractor.callees_for_body(body, "main.rs", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"SafeService::run", 33},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -6,28 +6,65 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
+      functions = include_callee ? collect_function_callees(lines, path) : Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line.with_index do |line, index|
-          next unless line.includes? ".route("
-          match = line.match(ROUTE_PATTERN)
-          next unless match
+      lines.each_with_index do |line, index|
+        next unless line.includes? ".route("
+        match = line.match(ROUTE_PATTERN)
+        next unless match
 
-          begin
-            route_argument = match[1]
-            callback_argument = match[2]
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoints << Endpoint.new(route_argument, callback_to_method(callback_argument), details)
-          rescue
-          end
+        begin
+          route_argument = match[1]
+          callback_argument = match[2]
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint = Endpoint.new(route_argument, callback_to_method(callback_argument), details)
+          attach_route_callees(endpoint, callback_argument, functions) if include_callee
+          endpoints << endpoint
+        rescue
         end
       end
 
       endpoints
     end
 
+    private def collect_function_callees(lines : Array(String), path : String) : Hash(String, Array(Noir::RustCalleeExtractor::Entry))
+      functions = Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
+
+      lines.each_with_index do |line, index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
+        if match = stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\b/)
+          function_body = extract_rust_function_body(lines, index)
+          if function_body
+            body, body_start_line = function_body
+            functions[match[1]] = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
+          end
+        end
+      end
+
+      functions
+    end
+
+    private def attach_route_callees(endpoint : Endpoint,
+                                     callback_argument : String,
+                                     functions : Hash(String, Array(Noir::RustCalleeExtractor::Entry)))
+      handler = extract_route_handler(callback_argument)
+      return unless handler
+
+      if callees = functions[handler]?
+        attach_rust_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_route_handler(callback_argument : String) : String?
+      if match = callback_argument.match(/\b(?:get|post|put|delete|patch|head|options)\s*\(\s*([A-Za-z_]\w*)/)
+        match[1]
+      end
+    end
+
     def callback_to_method(str)
-      method = str.split("(").first
+      method = str.split("(").first.strip
       if !method.in?(%w[get post put delete])
         method = "get"
       end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/rust_callee_extractor"
 
 module Analyzer::Rust
   abstract class RustEngine < Analyzer
@@ -34,6 +35,74 @@ module Analyzer::Rust
       rescue e
         logger.debug e
       end
+    end
+
+    protected def attach_rust_callees(endpoint : Endpoint, callees : Array(Noir::RustCalleeExtractor::Entry))
+      Noir::RustCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    protected def extract_rust_function_body(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      return if start_index >= lines.size
+      return if Noir::RustCalleeExtractor.strip_comment(lines[start_index]).includes?(";")
+
+      body_lines = [] of String
+      body_start_line = start_index + 2
+      found_opening_brace = false
+      depth = 0
+
+      (start_index...lines.size).each do |index|
+        raw_line = lines[index]
+        line = Noir::RustCalleeExtractor.strip_comment(raw_line)
+
+        unless found_opening_brace
+          return if index > start_index && line.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
+
+          brace_index = line.index('{')
+          next unless brace_index
+
+          found_opening_brace = true
+          depth = 1
+          tail = line[(brace_index + 1)..].strip
+          body_start_line = index + 1
+
+          if close_index = tail.index('}')
+            open_count = tail.count('{')
+            close_count = tail.count('}')
+            if depth + open_count - close_count <= 0
+              close_index = tail.rindex('}') || close_index
+              return {tail[0, close_index].strip, body_start_line}
+            end
+          end
+
+          if tail.empty?
+            body_start_line = index + 2
+          else
+            body_lines << tail
+            depth += tail.count('{') - tail.count('}')
+          end
+          next
+        end
+
+        stripped = line.strip
+        open_count = stripped.count('{')
+        close_count = stripped.count('}')
+
+        if close_count > 0 && depth + open_count - close_count <= 0
+          if close_index = line.index('}')
+            close_index = line.rindex('}') || close_index
+            before_close = line[0, close_index].strip
+            body_lines << before_close unless before_close.empty?
+          end
+          break
+        end
+
+        body_lines << raw_line
+        depth += open_count - close_count
+      end
+
+      return unless found_opening_brace
+
+      {body_lines.join("\n"), body_start_line}
     end
   end
 end

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -1,0 +1,126 @@
+require "../models/endpoint"
+
+module Noir::RustCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "as", "async", "await", "break", "const", "continue", "crate",
+    "dyn", "else", "enum", "extern", "false", "fn", "for", "if",
+    "impl", "in", "let", "loop", "match", "mod", "move", "mut",
+    "pub", "ref", "return", "self", "Self", "static", "struct",
+    "super", "trait", "true", "type", "unsafe", "use", "where",
+    "while", "Ok", "Err", "Some", "None", "format", "format!",
+    "vec", "vec!", "println", "println!",
+  }
+
+  PATH_CALL_REGEX     = /((?:[A-Za-z_]\w*::)+[A-Za-z_]\w*[!?]?)\s*(?:\(|!)/
+  RECEIVER_CALL_REGEX = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*[!?]?)+)\s*\(/
+  BARE_CALL_REGEX     = /(?<![.\w:])([A-Za-z_]\w*[!?]?)(?:\s*\(|!)/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    in_block_comment = false
+
+    body.lines.each_with_index do |line, index|
+      stripped, in_block_comment = strip_comment_with_state(line, in_block_comment)
+      scan_line(stripped, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def strip_comment(line : String, in_block_comment : Bool = false) : String
+    stripped, _ = strip_comment_with_state(line, in_block_comment)
+    stripped
+  end
+
+  private def strip_comment_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+    in_string = false
+    escaped = false
+    quote = '\0'
+    index = 0
+    stripped = String::Builder.new
+
+    while index < line.size
+      char = line[index]
+      if in_block_comment
+        if char == '*' && line[index + 1]? == '/'
+          in_block_comment = false
+          index += 1
+        end
+      elsif in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == quote
+          in_string = false
+        end
+      elsif char == '"'
+        in_string = true
+        quote = char
+      elsif char == '/' && line[index + 1]? == '/'
+        return {stripped.to_s, in_block_comment}
+      elsif char == '/' && line[index + 1]? == '*'
+        in_block_comment = true
+        index += 1
+      else
+        stripped << char
+      end
+      index += 1
+    end
+
+    {stripped.to_s, in_block_comment}
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    line.scan(PATH_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
+    line.scan(RECEIVER_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last.split("::").last
+    RESERVED.includes?(last)
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared lightweight Rust callee extractor for 1-hop handler body calls
- add RustEngine helpers for attaching callees and slicing Rust function bodies
- wire Axum `.route("...", get(handler))` / `post(handler)` routes to same-file named handler callees when `--include-callee` is enabled
- add focused Axum callee fixture coverage plus unit coverage for Rust comment stripping and declaration-only `fn` signatures

## Scope notes
- This PR intentionally supports same-file bare handler identifiers only, such as `get(home)` and `post(create_user)`.
- Module-qualified or cross-file handlers like `get(handlers::home)` are left for a follow-up after the first Rust extractor lands.
- Existing Axum endpoint semantics are preserved; callee extraction is gated behind `include_callee`.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-axum-target crystal spec spec/unit_test/miniparser/rust_callee_extractor_spec.cr spec/unit_test/analyzer/rust_engine_spec.cr spec/functional_test/testers/rust/axum_spec.cr spec/functional_test/testers/rust/axum_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-axum-build2 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-axum-check2 just check`
- `./bin/noir -b spec/functional_test/fixtures/rust/axum_callees --only-techs rust_axum --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-axum-test2 just test`

Part of #1366.
