### PR TITLE
Add Actix Web callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/actix_web_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/actix_web_callees/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "actix-web-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4.9"
+serde = { version = "1", features = ["derive"] }

--- a/spec/functional_test/fixtures/rust/actix_web_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_web_callees/src/main.rs
@@ -36,3 +36,12 @@ async fn protected(req: HttpRequest) -> impl Responder {
     AuthService::validate(auth);
     HttpResponse::Ok().body(marker)
 }
+
+#[get("/multi-a")]
+#[post("/multi-b")]
+#[put("/multi-c")]
+#[allow(dead_code)]
+async fn multi_route() -> impl Responder {
+    MultiService::serve();
+    HttpResponse::Ok().finish()
+}

--- a/spec/functional_test/fixtures/rust/actix_web_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_web_callees/src/main.rs
@@ -1,0 +1,38 @@
+use actix_web::{get, post, web, HttpRequest, HttpResponse, Responder};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct UserInfo {
+    id: u32,
+}
+
+#[get("/")]
+async fn hello() -> impl Responder {
+    let status = HealthCheck::ready().await;
+    HttpResponse::Ok().body(render_home(status))
+}
+
+#[get("/users/{id}")]
+async fn get_user(path: web::Path<u32>) -> impl Responder {
+    let user = UserService::load(path.into_inner()).await;
+    AuditLog::read_user();
+    HttpResponse::Ok().json(UserPresenter::render(user))
+}
+
+#[post("/api/users")]
+async fn create_user(body: web::Json<UserInfo>) -> impl Responder {
+    let user = UserService::create(body.into_inner()).await;
+    AuditLog::write(&user);
+    HttpResponse::Created().json(UserPresenter::render(user))
+}
+
+#[get("/protected")]
+#[allow(dead_code)]
+#[allow(unused_variables)]
+async fn protected(req: HttpRequest) -> impl Responder {
+    let marker = "DangerService::run()";
+    // Ignored::call();
+    let auth = req.headers().get("Authorization");
+    AuthService::validate(auth);
+    HttpResponse::Ok().body(marker)
+}

--- a/spec/functional_test/testers/rust/actix_web_callees_spec.cr
+++ b/spec/functional_test/testers/rust/actix_web_callees_spec.cr
@@ -1,0 +1,50 @@
+require "../../func_spec.cr"
+
+hello = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 11))
+  ep.push_callee(Callee.new("HttpResponse::Ok", line: 12))
+  ep.push_callee(Callee.new("render_home", line: 12))
+end
+
+get_user = Endpoint.new("/users/{id}", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::load", line: 17))
+  ep.push_callee(Callee.new("path.into_inner", line: 17))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 18))
+  ep.push_callee(Callee.new("HttpResponse::Ok", line: 19))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 19))
+end
+
+create_user = Endpoint.new("/api/users", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 24))
+  ep.push_callee(Callee.new("body.into_inner", line: 24))
+  ep.push_callee(Callee.new("AuditLog::write", line: 25))
+  ep.push_callee(Callee.new("HttpResponse::Created", line: 26))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 26))
+end
+
+protected_endpoint = Endpoint.new("/protected", "GET", [
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.headers", line: 35))
+  ep.push_callee(Callee.new("AuthService::validate", line: 36))
+  ep.push_callee(Callee.new("HttpResponse::Ok", line: 37))
+end
+
+expected_endpoints = [
+  hello,
+  get_user,
+  create_user,
+  protected_endpoint,
+]
+
+FunctionalTester.new("fixtures/rust/actix_web_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_actix_web"),
+}).perform_tests

--- a/spec/functional_test/testers/rust/actix_web_callees_spec.cr
+++ b/spec/functional_test/testers/rust/actix_web_callees_spec.cr
@@ -34,11 +34,29 @@ protected_endpoint = Endpoint.new("/protected", "GET", [
   ep.push_callee(Callee.new("HttpResponse::Ok", line: 37))
 end
 
+multi_route_get = Endpoint.new("/multi-a", "GET").tap do |ep|
+  ep.push_callee(Callee.new("MultiService::serve", line: 45))
+  ep.push_callee(Callee.new("HttpResponse::Ok", line: 46))
+end
+
+multi_route_post = Endpoint.new("/multi-b", "POST").tap do |ep|
+  ep.push_callee(Callee.new("MultiService::serve", line: 45))
+  ep.push_callee(Callee.new("HttpResponse::Ok", line: 46))
+end
+
+multi_route_put = Endpoint.new("/multi-c", "PUT").tap do |ep|
+  ep.push_callee(Callee.new("MultiService::serve", line: 45))
+  ep.push_callee(Callee.new("HttpResponse::Ok", line: 46))
+end
+
 expected_endpoints = [
   hello,
   get_user,
   create_user,
   protected_endpoint,
+  multi_route_get,
+  multi_route_post,
+  multi_route_put,
 ]
 
 FunctionalTester.new("fixtures/rust/actix_web_callees/", {

--- a/spec/unit_test/miniparser/rust_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/rust_callee_extractor_spec.cr
@@ -35,14 +35,15 @@ describe Noir::RustCalleeExtractor do
   it "keeps namespaced calls whose final segment is a common Rust wrapper" do
     body = <<-RUST
       Ok(user)
+      std::format!("user {}", user.id)
       HttpResponse::Ok().json(user)
       HttpResponse::Created().finish()
       RUST
 
     callees = Noir::RustCalleeExtractor.callees_for_body(body, "main.rs", 40)
     callees.map { |name, _, line| {name, line} }.should eq([
-      {"HttpResponse::Ok", 41},
-      {"HttpResponse::Created", 42},
+      {"HttpResponse::Ok", 42},
+      {"HttpResponse::Created", 43},
     ])
   end
 

--- a/spec/unit_test/miniparser/rust_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/rust_callee_extractor_spec.cr
@@ -32,6 +32,20 @@ describe Noir::RustCalleeExtractor do
     ])
   end
 
+  it "keeps namespaced calls whose final segment is a common Rust wrapper" do
+    body = <<-RUST
+      Ok(user)
+      HttpResponse::Ok().json(user)
+      HttpResponse::Created().finish()
+      RUST
+
+    callees = Noir::RustCalleeExtractor.callees_for_body(body, "main.rs", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"HttpResponse::Ok", 41},
+      {"HttpResponse::Created", 42},
+    ])
+  end
+
   it "skips block comments across lines" do
     body = <<-RUST
       /*

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -2,11 +2,13 @@ require "../../engines/rust_engine"
 
 module Analyzer::Rust
   class ActixWeb < RustEngine
-    ROUTE_PATTERN = /#\[(get|post|put|delete|patch)\("([^"]+)"\)\]/
+    ROUTE_PATTERN            = /#\[(get|post|put|delete|patch)\("([^"]+)"\)\]/
+    FUNCTION_LOOKAHEAD_LINES = 20
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       lines.each_with_index do |line, index|
         next unless line.to_s.includes? "#["
@@ -21,6 +23,7 @@ module Analyzer::Rust
 
           extract_path_params(route_argument, endpoint)
           extract_function_params(lines, index + 1, endpoint)
+          attach_handler_callees(lines, index + 1, path, endpoint) if include_callee
 
           endpoints << endpoint
         rescue e
@@ -40,6 +43,26 @@ module Analyzer::Rust
       method.upcase
     end
 
+    private def attach_handler_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      return unless function_index
+
+      function_body = extract_rust_function_body(lines, function_index)
+      return unless function_body
+
+      body, body_start_line = function_body
+      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
+      attach_rust_callees(endpoint, callees)
+    end
+
+    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
+      (start_index...[start_index + FUNCTION_LOOKAHEAD_LINES, lines.size].min).each do |index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
+        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
+        break if index > start_index && stripped.match(ROUTE_PATTERN)
+      end
+    end
+
     # Extract path parameters from the route pattern like /users/{id}
     def extract_path_params(route : String, endpoint : Endpoint)
       route.scan(/\{(\w+)\}/) do |match|
@@ -55,7 +78,7 @@ module Analyzer::Rust
       brace_count = 0
       seen_opening_brace = false
 
-      (start_index...[start_index + 20, lines.size].min).each do |i|
+      (start_index...[start_index + FUNCTION_LOOKAHEAD_LINES, lines.size].min).each do |i|
         line = lines[i]
 
         # Track if we're inside the function
@@ -108,8 +131,8 @@ module Analyzer::Rust
           break
         end
 
-        # Also stop if we hit another attribute
-        if i > start_index && line.strip.starts_with?("#[")
+        # Also stop if we hit another route attribute
+        if i > start_index && line.strip.match(ROUTE_PATTERN)
           break
         end
       end

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -59,7 +59,6 @@ module Analyzer::Rust
       (start_index...[start_index + FUNCTION_LOOKAHEAD_LINES, lines.size].min).each do |index|
         stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
         return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
-        break if index > start_index && stripped.match(ROUTE_PATTERN)
       end
     end
 
@@ -128,11 +127,6 @@ module Analyzer::Rust
 
         # Stop if we've moved past the function (brace count is back to 0 after we've seen an opening brace)
         if in_function && seen_opening_brace && brace_count == 0 && i > start_index
-          break
-        end
-
-        # Also stop if we hit another route attribute
-        if i > start_index && line.strip.match(ROUTE_PATTERN)
           break
         end
       end

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -106,10 +106,9 @@ module Noir::RustCalleeExtractor
 
   private def skip_callee?(name : String) : Bool
     return true if name.empty?
-    return false if name.includes?("::")
 
     last = name.split('.').last.split("::").last
-    RESERVED.includes?(last)
+    RESERVED.includes?(last) && (!name.includes?("::") || last.includes?('!'))
   end
 
   private def dedup_entries(entries : Array(Entry)) : Array(Entry)

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -106,6 +106,7 @@ module Noir::RustCalleeExtractor
 
   private def skip_callee?(name : String) : Bool
     return true if name.empty?
+    return false if name.includes?("::")
 
     last = name.split('.').last.split("::").last
     RESERVED.includes?(last)


### PR DESCRIPTION
## Summary
- wire Actix Web attribute routes to attach Rust callees when include_callee is enabled
- reuse the shared Rust function-body slicing and callee extractor added for Axum
- keep framework response builders such as HttpResponse::Ok as callees while still filtering bare Ok/Err noise
- add a focused Actix Web callee fixture covering path/json/header params, stacked handler attributes, and comment/string noise

## Scope notes
- Supports same-file Actix Web attribute routes like #[get("/...")] and #[post("/...")] followed by a handler function.
- Does not expand the existing route parser to .route(...), .service(...), #[route(...)], scopes, or cross-file handler resolution.

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-actix-target crystal spec spec/unit_test/miniparser/rust_callee_extractor_spec.cr spec/functional_test/testers/rust/actix_web_spec.cr spec/functional_test/testers/rust/actix_web_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-actix-build just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-actix-check just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-actix-test just test
- ./bin/noir -b spec/functional_test/fixtures/rust/actix_web_callees -f json --include-callee

Part of #1366.