### PR TITLE
Log Elasticsearch delivery outer rescue errors

### DIFF
--- a/src/deliver/send_elasticsearch.cr
+++ b/src/deliver/send_elasticsearch.cr
@@ -18,20 +18,17 @@ class SendElasticSearch < Deliver
     es_headers["Content-Type"] = "application/json"
     es_headers["Accept"] = "application/json"
 
-    begin
-      Crest::Request.execute(
-        method: :post,
-        url: uri.to_s,
-        tls: OpenSSL::SSL::Context::Client.insecure,
-        user_agent: "Noir/#{Noir::VERSION}",
-        form: body,
-        headers: @headers,
-        json: true
-      )
-    rescue e
-      @logger.debug "Exception of ES Delivery"
-      @logger.debug_sub e
-    end
-  rescue
+    Crest::Request.execute(
+      method: :post,
+      url: uri.to_s,
+      tls: OpenSSL::SSL::Context::Client.insecure,
+      user_agent: "Noir/#{Noir::VERSION}",
+      form: body,
+      headers: @headers,
+      json: true
+    )
+  rescue e
+    @logger.debug "Exception of ES Delivery"
+    @logger.debug_sub e
   end
 end


### PR DESCRIPTION
## Summary
- consolidate the nested Elasticsearch delivery rescue blocks into one method-level `rescue e`
- log delivery exceptions and details instead of silently swallowing them

Closes #1088

## Testing
- `crystal tool format src/deliver/send_elasticsearch.cr`
- `crystal tool format --check src/deliver/send_elasticsearch.cr`
- `shards install`
- `git diff --check`

Build note: `crystal build src/noir.cr --no-codegen` is blocked in this Windows environment by the existing `http_proxy` shard invoking `shards version` from `lib/http_proxy/src`. GitHub Actions runs the full Linux build/test matrix.