### PR TITLE
Add Rocket callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/rocket_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rocket_callees/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rocket-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rocket = { version = "0.5", features = ["json"] }
+serde = { version = "1", features = ["derive"] }

--- a/spec/functional_test/fixtures/rust/rocket_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rocket_callees/src/main.rs
@@ -1,0 +1,50 @@
+#[macro_use]
+extern crate rocket;
+
+use rocket::http::CookieJar;
+use rocket::request::Request;
+use rocket::serde::json::Json;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct UserInput {
+    name: String,
+}
+
+#[get("/")]
+#[allow(dead_code)]
+fn index() -> String {
+    let status = HealthCheck::ready();
+    render_home(status)
+}
+
+#[get("/users/<id>?<verbose>")]
+fn get_user(id: i32, verbose: Option<bool>, request: &Request<'_>) -> String {
+    let trace_id = request.headers().get("x-trace-id").next();
+    let user = UserService::load(id);
+    AuditLog::read_user(trace_id);
+    UserPresenter::render(user, verbose)
+}
+
+#[post("/api/users", data = "<user>")]
+fn create_user(user: Json<UserInput>) -> String {
+    let user = UserService::create(user.into_inner());
+    AuditLog::write(&user);
+    UserPresenter::render(user)
+}
+
+#[get("/session")]
+fn session(cookies: &CookieJar<'_>) -> String {
+    let marker = "IgnoredService::run()";
+    // IgnoredAudit::write();
+    let session_id = cookies.get("session_id");
+    AuthService::session(session_id)
+}
+
+#[get("/multi-a")]
+#[post("/multi-b")]
+#[put("/multi-c")]
+fn multi_route() -> String {
+    MultiService::serve();
+    "ok".to_string()
+}

--- a/spec/functional_test/testers/rust/rocket_callees_spec.cr
+++ b/spec/functional_test/testers/rust/rocket_callees_spec.cr
@@ -1,0 +1,63 @@
+require "../../func_spec.cr"
+
+index = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 17))
+  ep.push_callee(Callee.new("render_home", line: 18))
+end
+
+get_user = Endpoint.new("/users/<id>?<verbose>", "GET", [
+  Param.new("id", "", "path"),
+  Param.new("verbose", "", "query"),
+  Param.new("x-trace-id", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("request.headers", line: 23))
+  ep.push_callee(Callee.new("UserService::load", line: 24))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 25))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 26))
+end
+
+create_user = Endpoint.new("/api/users", "POST", [
+  Param.new("user", "", "body"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 31))
+  ep.push_callee(Callee.new("user.into_inner", line: 31))
+  ep.push_callee(Callee.new("AuditLog::write", line: 32))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 33))
+end
+
+session = Endpoint.new("/session", "GET", [
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("cookies.get", line: 40))
+  ep.push_callee(Callee.new("AuthService::session", line: 41))
+end
+
+multi_route_get = Endpoint.new("/multi-a", "GET").tap do |ep|
+  ep.push_callee(Callee.new("MultiService::serve", line: 48))
+end
+
+multi_route_post = Endpoint.new("/multi-b", "POST").tap do |ep|
+  ep.push_callee(Callee.new("MultiService::serve", line: 48))
+end
+
+multi_route_put = Endpoint.new("/multi-c", "PUT").tap do |ep|
+  ep.push_callee(Callee.new("MultiService::serve", line: 48))
+end
+
+expected_endpoints = [
+  index,
+  get_user,
+  create_user,
+  session,
+  multi_route_get,
+  multi_route_post,
+  multi_route_put,
+]
+
+FunctionalTester.new("fixtures/rust/rocket_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_rocket"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -10,7 +10,8 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       lines.each_with_index do |line, index|
         next unless line.includes?("#[") && line.includes?(")]")
@@ -30,6 +31,7 @@ module Analyzer::Rust
 
           # Look ahead to extract cookies and headers from function signature/body
           extract_function_params(lines, index + 1, endpoint)
+          attach_handler_callees(lines, index + 1, path, endpoint) if include_callee
 
           endpoints << endpoint
         rescue
@@ -46,6 +48,25 @@ module Analyzer::Rust
       end
 
       method.upcase
+    end
+
+    private def attach_handler_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      return unless function_index
+
+      function_body = extract_rust_function_body(lines, function_index)
+      return unless function_body
+
+      body, body_start_line = function_body
+      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
+      attach_rust_callees(endpoint, callees)
+    end
+
+    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
+      (start_index...[start_index + MAX_FUNCTION_SCAN_LINES, lines.size].min).each do |index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
+        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
+      end
     end
 
     private def extract_params(route : String, data_param : String?) : Array(Param)
@@ -87,12 +108,15 @@ module Analyzer::Rust
 
     # Extract parameters from function signature and body (cookies, headers)
     private def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      return unless function_index
+
       in_function = false
       brace_count = 0
       seen_opening_brace = false
       has_cookie_jar = false
 
-      (start_index...[start_index + MAX_FUNCTION_SCAN_LINES, lines.size].min).each do |i|
+      (function_index...[function_index + MAX_FUNCTION_SCAN_LINES, lines.size].min).each do |i|
         line = lines[i]
 
         # Track if we're inside the function
@@ -138,13 +162,6 @@ module Analyzer::Rust
 
         # Stop if we've moved past the function
         if in_function && seen_opening_brace && brace_count == 0 && i > start_index
-          break
-        end
-
-        # Also stop if we hit another route attribute
-        if i > start_index && (line.strip.starts_with?("#[get") || line.strip.starts_with?("#[post") ||
-           line.strip.starts_with?("#[put") || line.strip.starts_with?("#[delete") ||
-           line.strip.starts_with?("#[patch"))
           break
         end
       end


### PR DESCRIPTION
## Summary
- wire Rocket route attributes to attach Rust callees when include_callee is enabled
- reuse shared Rust function-body slicing and RustCalleeExtractor from the Rust callee work
- start Rocket body param scanning at the matched handler function so stacked attributes/routes still resolve cleanly
- add a focused Rocket callee fixture covering path/query/body/header/cookie params, stacked handler attributes, stacked route attributes, and comment/string noise

## Scope notes
- Supports same-file Rocket route attributes like #[get("/...")] and #[post("/...", data = "<body>")] followed by a handler function.
- Does not expand the existing Rocket route parser to multiline route attributes, generated routes, mount resolution, or cross-file handler resolution.
- Existing Rocket query/path param behavior is preserved; this PR only adds callees and narrows handler-body scanning to the located function.

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rocket-target crystal spec spec/functional_test/testers/rust/rocket_spec.cr spec/functional_test/testers/rust/rocket_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rocket-build just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rocket-check just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-rocket-test just test
- ./bin/noir -b spec/functional_test/fixtures/rust/rocket_callees -f json --include-callee

Part of #1366.