### PR TITLE
Add Salvo callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/salvo_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/salvo_callees/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "salvo-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+salvo = { version = "0.68", features = ["oapi"] }
+tokio = { version = "1", features = ["macros"] }
+serde_json = "1"

--- a/spec/functional_test/fixtures/rust/salvo_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/salvo_callees/src/main.rs
@@ -1,0 +1,43 @@
+use salvo::prelude::*;
+
+#[handler]
+async fn hello() -> String {
+    let status = HealthCheck::ready();
+    render_home(status)
+}
+
+#[handler]
+async fn get_user(req: &mut Request) -> String {
+    let token = req.header("X-Token").unwrap_or_default();
+    let session = req.cookie("session_id").unwrap_or_default();
+    let user = UserService::load(req.param::<String>("id").unwrap());
+    AuditLog::read_user(&token, &session);
+    UserPresenter::render(user)
+}
+
+#[handler]
+async fn create_user(req: &mut Request) -> String {
+    let body: JsonBody<serde_json::Value> = req.extract();
+    let user = UserService::create(body);
+    UserPresenter::render(user)
+}
+
+#[endpoint(method = Post, path = "/api/submit/<id>")]
+#[handler]
+async fn submit_form(req: &mut Request) -> &'static str {
+    let form: FormBody<serde_json::Value> = req.extract();
+    let auth = req.header("Authorization").unwrap_or_default();
+    SubmitService::save(form, auth);
+    "Submitted"
+}
+
+#[tokio::main]
+async fn main() {
+    let router = Router::new()
+        .push(Router::with_path("hello").get(hello))
+        .push(Router::with_path("users/<id>").get(get_user))
+        .push(Router::with_path("users").post(create_user));
+
+    let acceptor = TcpListener::new("127.0.0.1:5800").bind().await;
+    Server::new(acceptor).serve(router).await;
+}

--- a/spec/functional_test/testers/rust/salvo_callees_spec.cr
+++ b/spec/functional_test/testers/rust/salvo_callees_spec.cr
@@ -1,0 +1,51 @@
+require "../../func_spec.cr"
+
+hello = Endpoint.new("/hello", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 5))
+  ep.push_callee(Callee.new("render_home", line: 6))
+end
+
+get_user = Endpoint.new("/users/<id>", "GET", [
+  Param.new("id", "", "path"),
+  Param.new("X-Token", "", "header"),
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.header", line: 11))
+  ep.push_callee(Callee.new("req.cookie", line: 12))
+  ep.push_callee(Callee.new("UserService::load", line: 13))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 14))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 15))
+end
+
+create_user = Endpoint.new("/users", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.extract", line: 20))
+  ep.push_callee(Callee.new("UserService::create", line: 21))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 22))
+end
+
+submit_form = Endpoint.new("/api/submit/<id>", "POST", [
+  Param.new("id", "", "path"),
+  Param.new("form", "", "form"),
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.extract", line: 28))
+  ep.push_callee(Callee.new("req.header", line: 29))
+  ep.push_callee(Callee.new("SubmitService::save", line: 30))
+end
+
+expected_endpoints = [
+  hello,
+  get_user,
+  create_user,
+  submit_form,
+]
+
+FunctionalTester.new("fixtures/rust/salvo_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_salvo"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -4,21 +4,22 @@ module Analyzer::Rust
   class Salvo < RustEngine
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Strategy 1: Parse Router chain patterns
       # e.g., Router::with_path("users/<id>").get(get_user)
       # e.g., Router::new().push(Router::with_path("items").get(list_items))
-      parse_router_chains(lines, path, endpoints)
+      parse_router_chains(lines, path, endpoints, include_callee)
 
       # Strategy 2: Parse #[endpoint] macro patterns
       # e.g., #[endpoint(method = Get, path = "/api/users")]
-      parse_endpoint_macros(lines, path, endpoints)
+      parse_endpoint_macros(lines, path, endpoints, include_callee)
 
       endpoints
     end
 
-    def parse_router_chains(lines : Array(String), path : String, endpoints : Array(Endpoint))
+    def parse_router_chains(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
       lines.each_with_index do |line, index|
         # Match Router::with_path("...").method(handler) or .path("...").method(handler)
         # Pattern: with_path("path") followed by .method(handler)
@@ -45,6 +46,7 @@ module Analyzer::Rust
                 if handler_match
                   handler_name = handler_match[2]
                   extract_handler_params(lines, handler_name, endpoint)
+                  attach_handler_callees(lines, handler_name, path, endpoint) if include_callee
                 end
 
                 endpoints << endpoint
@@ -56,7 +58,7 @@ module Analyzer::Rust
       end
     end
 
-    def parse_endpoint_macros(lines : Array(String), path : String, endpoints : Array(Endpoint))
+    def parse_endpoint_macros(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
       lines.each_with_index do |line, index|
         # Match #[endpoint(method = Get, path = "/path")]
         if line.strip.starts_with?("#[endpoint(")
@@ -78,6 +80,7 @@ module Analyzer::Rust
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
+          attach_next_function_callees(lines, index + 1, path, endpoint) if include_callee
 
           endpoints << endpoint
         end
@@ -94,20 +97,19 @@ module Analyzer::Rust
 
     # Look for handler function definition and extract params from its signature/body
     def extract_handler_params(lines : Array(String), handler_name : String, endpoint : Endpoint)
-      lines.each_with_index do |line, index|
-        if line.includes?("fn #{handler_name}")
-          extract_function_params(lines, index, endpoint)
-          break
-        end
-      end
+      function_index = find_handler_function_index(lines, handler_name)
+      extract_function_params(lines, function_index, endpoint) if function_index
     end
 
     # Extract parameters from function signature and body
     def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      return unless function_index
+
       brace_count = 0
       seen_opening_brace = false
 
-      (start_index...[start_index + 30, lines.size].min).each do |i|
+      (function_index...[function_index + 30, lines.size].min).each do |i|
         line = lines[i]
 
         brace_count += line.count('{')
@@ -149,13 +151,42 @@ module Analyzer::Rust
           end
         end
 
-        if seen_opening_brace && brace_count == 0 && i > start_index
+        if seen_opening_brace && brace_count == 0 && i > function_index
           break
         end
+      end
+    end
 
-        if i > start_index && line.strip.starts_with?("#[")
-          break
-        end
+    private def attach_handler_callees(lines : Array(String), handler_name : String, path : String, endpoint : Endpoint)
+      function_index = find_handler_function_index(lines, handler_name)
+      attach_function_callees(lines, function_index, path, endpoint) if function_index
+    end
+
+    private def attach_next_function_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      attach_function_callees(lines, function_index, path, endpoint) if function_index
+    end
+
+    private def attach_function_callees(lines : Array(String), function_index : Int32, path : String, endpoint : Endpoint)
+      function_body = extract_rust_function_body(lines, function_index)
+      return unless function_body
+
+      body, body_start_line = function_body
+      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
+      attach_rust_callees(endpoint, callees)
+    end
+
+    private def find_handler_function_index(lines : Array(String), handler_name : String) : Int32?
+      lines.each_with_index do |line, index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
+        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+#{handler_name}\b/)
+      end
+    end
+
+    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
+      (start_index...[start_index + 30, lines.size].min).each do |index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
+        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
       end
     end
   end


### PR DESCRIPTION
## Summary
- wire Salvo router chains and endpoint macros to attach Rust callees when include_callee is enabled
- reuse shared Rust function-body slicing and RustCalleeExtractor
- make Salvo parameter scanning start from the resolved handler function for cleaner stacked attribute handling
- add a focused Salvo callee fixture covering router-chain handlers, endpoint macros, path/json/form/header/cookie params, and call-site noise handling

## Scope notes
- Supports same-file named handlers referenced by Router::with_path(...).method(handler).
- Supports #[endpoint(...)] macros followed by a same-file handler function.
- Does not expand the existing route parser to cross-file handlers, generated routes, or complex router composition beyond the current analyzer surface.

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-salvo-target crystal spec spec/functional_test/testers/rust/salvo_spec.cr spec/functional_test/testers/rust/salvo_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-salvo-build just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-salvo-check just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-salvo-test just test
- ./bin/noir -b spec/functional_test/fixtures/rust/salvo_callees -f json --include-callee

Part of #1366.