### PR TITLE
Add Poem callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/poem_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/poem_callees/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "poem-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+poem = "3"
+poem-openapi = "5"
+tokio = { version = "1", features = ["macros"] }
+serde_json = "1"

--- a/spec/functional_test/fixtures/rust/poem_callees/src/api.rs
+++ b/spec/functional_test/fixtures/rust/poem_callees/src/api.rs
@@ -1,0 +1,14 @@
+use poem_openapi::{payload::Json, OpenApi};
+
+pub struct Api;
+
+#[OpenApi]
+impl Api {
+    #[oai(path = "/api/items/:id", method = "post")]
+    async fn create_item(&self, body: Json<serde_json::Value>) -> Json<String> {
+        let item = ItemService::create(body);
+        AuditLog::write(&item);
+        let rendered = ItemPresenter::render(item);
+        Json(rendered)
+    }
+}

--- a/spec/functional_test/fixtures/rust/poem_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/poem_callees/src/main.rs
@@ -1,0 +1,36 @@
+use poem::listener::TcpListener;
+use poem::web::{Json, Path};
+use poem::{get, handler, post, Route, Server};
+
+#[handler]
+async fn hello() -> String {
+    let status = HealthCheck::ready();
+    render_home(status)
+}
+
+#[handler]
+async fn get_user(Path(id): Path<u64>, req: &poem::Request) -> String {
+    let token = req.header("X-Token").unwrap_or_default();
+    let session = req.cookie().get("session_id");
+    let user = UserService::load(id);
+    AuditLog::read_user(&token, session);
+    UserPresenter::render(user)
+}
+
+#[handler]
+async fn create_user(Json(body): Json<serde_json::Value>) -> String {
+    let user = UserService::create(body);
+    UserPresenter::render(user)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), std::io::Error> {
+    let app = Route::new()
+        .at("/hello", get(hello))
+        .at("/users/:id", get(get_user))
+        .at("/users", post(create_user));
+
+    Server::new(TcpListener::bind("127.0.0.1:3000"))
+        .run(app)
+        .await
+}

--- a/spec/functional_test/testers/rust/poem_callees_spec.cr
+++ b/spec/functional_test/testers/rust/poem_callees_spec.cr
@@ -1,0 +1,50 @@
+require "../../func_spec.cr"
+
+hello = Endpoint.new("/hello", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 7))
+  ep.push_callee(Callee.new("render_home", line: 8))
+end
+
+get_user = Endpoint.new("/users/{id}", "GET", [
+  Param.new("id", "", "path"),
+  Param.new("X-Token", "", "header"),
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.header", line: 13))
+  ep.push_callee(Callee.new("req.cookie", line: 14))
+  ep.push_callee(Callee.new("UserService::load", line: 15))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 16))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 17))
+end
+
+create_user = Endpoint.new("/users", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 22))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 23))
+end
+
+create_item = Endpoint.new("/api/items/{id}", "POST", [
+  Param.new("id", "", "path"),
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ItemService::create", line: 9))
+  ep.push_callee(Callee.new("AuditLog::write", line: 10))
+  ep.push_callee(Callee.new("ItemPresenter::render", line: 11))
+  ep.push_callee(Callee.new("Json", line: 12))
+end
+
+expected_endpoints = [
+  hello,
+  get_user,
+  create_user,
+  create_item,
+]
+
+FunctionalTester.new("fixtures/rust/poem_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_poem"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/poem.cr
+++ b/src/analyzer/analyzers/rust/poem.cr
@@ -6,18 +6,19 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Strategy 1: Parse Route::new().at("/path", get(handler).post(...)) chains
-      parse_at_routes(lines, path, endpoints)
+      parse_at_routes(lines, path, endpoints, include_callee)
 
       # Strategy 2: Parse #[oai(path = "...", method = "...")] poem-openapi attributes
-      parse_oai_attributes(lines, path, endpoints)
+      parse_oai_attributes(lines, path, endpoints, include_callee)
 
       endpoints
     end
 
-    def parse_at_routes(lines : Array(String), path : String, endpoints : Array(Endpoint))
+    def parse_at_routes(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
       lines.each_with_index do |line, index|
         next unless line.includes?(".at(")
 
@@ -41,13 +42,14 @@ module Analyzer::Rust
 
           extract_path_params(route_path, endpoint)
           extract_handler_params(lines, handler_name, endpoint)
+          attach_handler_callees(lines, handler_name, path, endpoint) if include_callee
 
           endpoints << endpoint
         end
       end
     end
 
-    def parse_oai_attributes(lines : Array(String), path : String, endpoints : Array(Endpoint))
+    def parse_oai_attributes(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
       lines.each_with_index do |line, index|
         stripped = line.strip
         next unless stripped.starts_with?("#[oai(")
@@ -65,6 +67,7 @@ module Analyzer::Rust
 
         extract_path_params(route_path, endpoint)
         scan_function(lines, index + 1, endpoint)
+        attach_next_function_callees(lines, index + 1, path, endpoint) if include_callee
 
         endpoints << endpoint
       end
@@ -83,22 +86,21 @@ module Analyzer::Rust
     end
 
     def extract_handler_params(lines : Array(String), handler_name : String, endpoint : Endpoint)
-      lines.each_with_index do |line, index|
-        if line.includes?("fn #{handler_name}")
-          scan_function(lines, index, endpoint)
-          break
-        end
-      end
+      function_index = find_handler_function_index(lines, handler_name)
+      scan_function(lines, function_index, endpoint) if function_index
     end
 
     # Walks a function starting at start_index: first extracts typed/destructured
     # extractors from the signature, then scans the body for header/cookie access.
     def scan_function(lines : Array(String), start_index : Int32, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      return unless function_index
+
       in_signature = true
       brace_count = 0
       seen_opening_brace = false
 
-      (start_index...[start_index + 40, lines.size].min).each do |i|
+      (function_index...[function_index + 40, lines.size].min).each do |i|
         line = lines[i]
 
         if in_signature
@@ -116,11 +118,7 @@ module Analyzer::Rust
           extract_body_params(line, endpoint)
         end
 
-        if seen_opening_brace && brace_count == 0 && i > start_index
-          break
-        end
-
-        if i > start_index && line.strip.starts_with?("#[")
+        if seen_opening_brace && brace_count == 0 && i > function_index
           break
         end
       end
@@ -154,6 +152,40 @@ module Analyzer::Rust
         if match
           endpoint.push_param(Param.new(match[1], "", "cookie"))
         end
+      end
+    end
+
+    private def attach_handler_callees(lines : Array(String), handler_name : String, path : String, endpoint : Endpoint)
+      function_index = find_handler_function_index(lines, handler_name)
+      attach_function_callees(lines, function_index, path, endpoint) if function_index
+    end
+
+    private def attach_next_function_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
+      function_index = find_next_function_index(lines, start_index)
+      attach_function_callees(lines, function_index, path, endpoint) if function_index
+    end
+
+    private def attach_function_callees(lines : Array(String), function_index : Int32, path : String, endpoint : Endpoint)
+      function_body = extract_rust_function_body(lines, function_index)
+      return unless function_body
+
+      body, body_start_line = function_body
+      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
+      attach_rust_callees(endpoint, callees)
+    end
+
+    private def find_handler_function_index(lines : Array(String), handler_name : String) : Int32?
+      local_name = handler_name.split("::").last
+      lines.each_with_index do |line, index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
+        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+#{local_name}\b/)
+      end
+    end
+
+    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
+      (start_index...[start_index + 40, lines.size].min).each do |index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
+        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
       end
     end
   end


### PR DESCRIPTION
## Summary
- wire Poem Route::at handlers and poem-openapi #[oai] methods to attach Rust callees when include_callee is enabled
- reuse shared Rust function-body slicing and RustCalleeExtractor
- make Poem parameter scanning start from the resolved handler function for cleaner stacked attribute handling
- add a focused Poem callee fixture covering route handlers, OpenAPI handlers, path/json/header/cookie params, and framework response builders

## Scope notes
- Supports same-file named handlers referenced by Route::new().at(..., get(handler)).
- Supports same-file #[oai(...)] methods where the function body is adjacent to the attribute.
- Does not expand the existing route parser to cross-file handlers, generated routes, or complex router composition beyond the current analyzer surface.

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-poem-target crystal spec spec/functional_test/testers/rust/poem_spec.cr spec/functional_test/testers/rust/poem_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-poem-build just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-poem-check just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-poem-test just test
- ./bin/noir -b spec/functional_test/fixtures/rust/poem_callees -f json --include-callee

Part of #1366.