### PR TITLE
Add Tide callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/tide_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/tide_callees/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tide-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tide = "0.16"
+async-std = { version = "1", features = ["attributes"] }
+serde = { version = "1", features = ["derive"] }

--- a/spec/functional_test/fixtures/rust/tide_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/tide_callees/src/main.rs
@@ -1,0 +1,71 @@
+use serde::Deserialize;
+use tide::{Request, Result};
+
+#[derive(Debug, Deserialize)]
+struct SearchQuery {
+    q: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UserData {
+    name: String,
+}
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    let mut app = tide::new();
+
+    app.at("/").get(home);
+    app.at("/users/:id").get(get_user);
+    app.at("/api/users").post(create_user);
+
+    let account_route = app.at("/accounts/:id");
+    account_route.put(update_account);
+
+    app.at("/auth").get(auth_handler);
+    app.at("/complex/:id").post(complex_handler);
+
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
+
+async fn home(_req: Request<()>) -> Result {
+    let status = HealthCheck::ready();
+    Ok(render_home(status).into())
+}
+
+async fn get_user(req: Request<()>) -> Result {
+    let id = req.param("id")?;
+    let user = UserService::load(id);
+    AuditLog::read_user();
+    Ok(UserPresenter::render(user).into())
+}
+
+async fn create_user(mut req: Request<()>) -> Result {
+    let user: UserData = req.body_json().await?;
+    let created = UserService::create(user);
+    Ok(UserPresenter::render(created).into())
+}
+
+async fn update_account(req: Request<()>) -> Result {
+    let query: SearchQuery = req.query()?;
+    let account = AccountService::update(query);
+    Ok(AccountPresenter::render(account).into())
+}
+
+async fn auth_handler(req: Request<()>) -> Result {
+    let token = req.header("Authorization");
+    let session = req.cookie("session_id");
+    AuthService::validate(token, session);
+    Ok("authenticated".into())
+}
+
+async fn complex_handler(mut req: Request<()>) -> Result {
+    let id = req.param("id")?;
+    let query: SearchQuery = req.query()?;
+    let user: UserData = req.body_json().await?;
+    let token = req.header("Authorization");
+    let session = req.cookie("session_id");
+    ComplexService::process(id, query, user, token, session);
+    Ok("complex".into())
+}

--- a/spec/functional_test/fixtures/rust/tide_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/tide_callees/src/main.rs
@@ -69,3 +69,11 @@ async fn complex_handler(mut req: Request<()>) -> Result {
     ComplexService::process(id, query, user, token, session);
     Ok("complex".into())
 }
+
+/*
+async fn complex_handler(mut req: Request<()>) -> Result {
+    let shadow: ShadowPayload = req.body_json().await?;
+    ShadowService::hidden(shadow);
+    Ok("shadow".into())
+}
+*/

--- a/spec/functional_test/testers/rust/tide_callees_spec.cr
+++ b/spec/functional_test/testers/rust/tide_callees_spec.cr
@@ -1,0 +1,73 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 33))
+  ep.push_callee(Callee.new("render_home", line: 34))
+end
+
+get_user = Endpoint.new("/users/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.param", line: 38))
+  ep.push_callee(Callee.new("UserService::load", line: 39))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 40))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 41))
+end
+
+create_user = Endpoint.new("/api/users", "POST", [
+  Param.new("UserData", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.body_json", line: 45))
+  ep.push_callee(Callee.new("UserService::create", line: 46))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 47))
+end
+
+update_account = Endpoint.new("/accounts/:id", "PUT", [
+  Param.new("id", "", "path"),
+  Param.new("SearchQuery", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.query", line: 51))
+  ep.push_callee(Callee.new("AccountService::update", line: 52))
+  ep.push_callee(Callee.new("AccountPresenter::render", line: 53))
+end
+
+auth_handler = Endpoint.new("/auth", "GET", [
+  Param.new("Authorization", "", "header"),
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.header", line: 57))
+  ep.push_callee(Callee.new("req.cookie", line: 58))
+  ep.push_callee(Callee.new("AuthService::validate", line: 59))
+end
+
+complex_handler = Endpoint.new("/complex/:id", "POST", [
+  Param.new("id", "", "path"),
+  Param.new("SearchQuery", "", "query"),
+  Param.new("UserData", "", "json"),
+  Param.new("Authorization", "", "header"),
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.param", line: 64))
+  ep.push_callee(Callee.new("req.query", line: 65))
+  ep.push_callee(Callee.new("req.body_json", line: 66))
+  ep.push_callee(Callee.new("req.header", line: 67))
+  ep.push_callee(Callee.new("req.cookie", line: 68))
+  ep.push_callee(Callee.new("ComplexService::process", line: 69))
+end
+
+expected_endpoints = [
+  home,
+  get_user,
+  create_user,
+  update_account,
+  auth_handler,
+  complex_handler,
+]
+
+FunctionalTester.new("fixtures/rust/tide_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_tide"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -10,9 +10,8 @@ module Analyzer::Rust
     private def parse_tide_routes(content : String, file_path : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
-      # Map function names to their content for parameter extraction
-      functions_map = extract_functions(content)
-      function_callees = include_callee ? collect_function_callees(content.lines, file_path) : Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
+      # Map function names to their content and callees for route handlers.
+      functions_map, function_callees = extract_functions(content, file_path, include_callee)
 
       # Find .at() method calls with chained HTTP methods
       # Pattern: .at("/path").get(handler) or .at("/path").get(|_| async { ... })
@@ -124,71 +123,34 @@ module Analyzer::Rust
     end
 
     # Extract function definitions and their bodies
-    private def extract_functions(content : String) : Hash(String, String)
+    private def extract_functions(content : String, file_path : String, include_callee : Bool) : Tuple(Hash(String, String), Hash(String, Array(Noir::RustCalleeExtractor::Entry)))
       functions = {} of String => String
-
-      # Pattern to match async function definitions - simplified to handle all cases
-      # async fn function_name(...) -> ... {
-      fn_pattern = /async\s+fn\s+(\w+)[^{]*\{/
-
-      content.scan(fn_pattern) do |match|
-        if match.size >= 2
-          fn_name = match[1]
-          # Find the full function body by tracking braces
-          start_pos = match.begin
-          if start_pos
-            fn_body = extract_function_body(content, start_pos)
-            functions[fn_name] = fn_body if fn_body
-          end
-        end
-      end
-
-      functions
-    end
-
-    # Extract function body by tracking brace matching
-    private def extract_function_body(content : String, start_pos : Int32) : String?
-      brace_count = 0
-      in_body = false
-      body_start = 0
-
-      (start_pos...content.size).each do |i|
-        char = content[i]
-
-        if char == '{'
-          if brace_count == 0
-            body_start = i
-            in_body = true
-          end
-          brace_count += 1
-        elsif char == '}'
-          brace_count -= 1
-          if brace_count == 0 && in_body
-            return content[body_start..i]
-          end
-        end
-      end
-
-      nil
-    rescue
-      nil
-    end
-
-    private def collect_function_callees(lines : Array(String), file_path : String) : Hash(String, Array(Noir::RustCalleeExtractor::Entry))
       function_callees = Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
+      lines = content.lines
+      in_block_comment = false
+      index = 0
 
-      lines.each_with_index do |line, index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
-        next unless match = stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?async\s+fn\s+([A-Za-z_]\w*)\b/)
+      while index < lines.size
+        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(lines[index], in_block_comment)
+        match = stripped.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?async\s+fn\s+([A-Za-z_]\w*)\b/)
 
-        function_body = extract_rust_function_body(lines, index)
-        next unless function_body
+        if match
+          fn_name = match[1]
+          function_body = extract_rust_function_body_with_end(lines, index)
 
-        body, body_start_line = function_body
-        function_callees[match[1]] = Noir::RustCalleeExtractor.callees_for_body(body, file_path, body_start_line)
+          if function_body
+            body, body_start_line, end_index = function_body
+            functions[fn_name] = body
+            function_callees[fn_name] = Noir::RustCalleeExtractor.callees_for_body(body, file_path, body_start_line) if include_callee
+            index = end_index
+            in_block_comment = false
+          end
+        end
+
+        index += 1
       end
 
-      function_callees
+      {functions, function_callees}
     end
 
     private def attach_handler_callees(handler : String,
@@ -206,7 +168,7 @@ module Analyzer::Rust
       stripped = handler.strip
       return if stripped.starts_with?("|")
 
-      match = stripped.match(/^(?:[A-Za-z_]\w*::)*([A-Za-z_]\w*)\b/)
+      match = stripped.match(/^(?:[A-Za-z_]\w*::)*([A-Za-z_]\w*)$/)
       match[1] if match
     end
 

--- a/src/analyzer/analyzers/rust/tide.cr
+++ b/src/analyzer/analyzers/rust/tide.cr
@@ -3,21 +3,16 @@ require "../../engines/rust_engine"
 module Analyzer::Rust
   class Tide < RustEngine
     def analyze_file(path : String) : Array(Endpoint)
-      endpoints = [] of Endpoint
-
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        endpoints = parse_tide_routes(content, path)
-      end
-
-      endpoints
+      content = read_file_content(path)
+      parse_tide_routes(content, path, any_to_bool(@options["include_callee"]?))
     end
 
-    private def parse_tide_routes(content : String, file_path : String) : Array(Endpoint)
+    private def parse_tide_routes(content : String, file_path : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       # Map function names to their content for parameter extraction
       functions_map = extract_functions(content)
+      function_callees = include_callee ? collect_function_callees(content.lines, file_path) : Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
 
       # Find .at() method calls with chained HTTP methods
       # Pattern: .at("/path").get(handler) or .at("/path").get(|_| async { ... })
@@ -45,7 +40,9 @@ module Analyzer::Rust
             extract_handler_params(handler, functions_map, params)
 
             details = Details.new(PathInfo.new(file_path, 1))
-            endpoints << Endpoint.new(final_path, method, params, details)
+            endpoint = Endpoint.new(final_path, method, params, details)
+            attach_handler_callees(handler, function_callees, endpoint) if include_callee
+            endpoints << endpoint
           end
         end
       end
@@ -94,7 +91,9 @@ module Analyzer::Rust
             extract_handler_params(handler, functions_map, params)
 
             details = Details.new(PathInfo.new(file_path, 1))
-            endpoints << Endpoint.new(final_path, method, params, details)
+            endpoint = Endpoint.new(final_path, method, params, details)
+            attach_handler_callees(handler, function_callees, endpoint) if include_callee
+            endpoints << endpoint
           end
         end
       end
@@ -173,6 +172,42 @@ module Analyzer::Rust
       nil
     rescue
       nil
+    end
+
+    private def collect_function_callees(lines : Array(String), file_path : String) : Hash(String, Array(Noir::RustCalleeExtractor::Entry))
+      function_callees = Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
+
+      lines.each_with_index do |line, index|
+        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
+        next unless match = stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?async\s+fn\s+([A-Za-z_]\w*)\b/)
+
+        function_body = extract_rust_function_body(lines, index)
+        next unless function_body
+
+        body, body_start_line = function_body
+        function_callees[match[1]] = Noir::RustCalleeExtractor.callees_for_body(body, file_path, body_start_line)
+      end
+
+      function_callees
+    end
+
+    private def attach_handler_callees(handler : String,
+                                       function_callees : Hash(String, Array(Noir::RustCalleeExtractor::Entry)),
+                                       endpoint : Endpoint)
+      handler_name = extract_handler_name(handler)
+      return unless handler_name
+
+      if callees = function_callees[handler_name]?
+        attach_rust_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_handler_name(handler : String) : String?
+      stripped = handler.strip
+      return if stripped.starts_with?("|")
+
+      match = stripped.match(/^(?:[A-Za-z_]\w*::)*([A-Za-z_]\w*)\b/)
+      match[1] if match
     end
 
     # Extract parameters from handler function

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -42,6 +42,14 @@ module Analyzer::Rust
     end
 
     protected def extract_rust_function_body(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      function_body = extract_rust_function_body_with_end(lines, start_index)
+      return unless function_body
+
+      body, body_start_line, _ = function_body
+      {body, body_start_line}
+    end
+
+    protected def extract_rust_function_body_with_end(lines : Array(String), start_index : Int32) : Tuple(String, Int32, Int32)?
       return if start_index >= lines.size
       return if Noir::RustCalleeExtractor.strip_comment(lines[start_index]).includes?(";")
 
@@ -49,10 +57,11 @@ module Analyzer::Rust
       body_start_line = start_index + 2
       found_opening_brace = false
       depth = 0
+      in_block_comment = false
 
       (start_index...lines.size).each do |index|
         raw_line = lines[index]
-        line = Noir::RustCalleeExtractor.strip_comment(raw_line)
+        line, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(raw_line, in_block_comment)
 
         unless found_opening_brace
           return if index > start_index && line.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
@@ -70,7 +79,7 @@ module Analyzer::Rust
             close_count = tail.count('}')
             if depth + open_count - close_count <= 0
               close_index = tail.rindex('}') || close_index
-              return {tail[0, close_index].strip, body_start_line}
+              return {tail[0, close_index].strip, body_start_line, index}
             end
           end
 
@@ -93,7 +102,7 @@ module Analyzer::Rust
             before_close = line[0, close_index].strip
             body_lines << before_close unless before_close.empty?
           end
-          break
+          return {body_lines.join("\n"), body_start_line, index}
         end
 
         body_lines << raw_line
@@ -102,7 +111,7 @@ module Analyzer::Rust
 
       return unless found_opening_brace
 
-      {body_lines.join("\n"), body_start_line}
+      {body_lines.join("\n"), body_start_line, lines.size - 1}
     end
   end
 end

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -42,7 +42,7 @@ module Noir::RustCalleeExtractor
     stripped
   end
 
-  private def strip_comment_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+  def strip_comment_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
     in_string = false
     escaped = false
     quote = '\0'


### PR DESCRIPTION
## Summary
- wire Tide named route handlers to attach Rust callees when include_callee is enabled
- reuse shared Rust function-body slicing and RustCalleeExtractor for same-file async fn handlers
- preserve existing Tide path/query/json/form/header/cookie param extraction
- add a focused Tide callee fixture covering direct app.at routes, route variable assignment, and path/query/json/header/cookie params

## Scope notes
- Supports same-file named async fn handlers referenced by Tide route registrations.
- Inline closure handlers keep existing endpoint behavior but are out of callee scope for this pass.
- Existing Tide route location metadata remains unchanged.

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-tide-target crystal spec spec/functional_test/testers/rust/tide_spec.cr spec/functional_test/testers/rust/tide_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-tide-build just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-tide-check just check
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-tide-test just test
- ./bin/noir -b spec/functional_test/fixtures/rust/tide_callees -f json --include-callee

Part of #1366.