### PR TITLE
Add Gotham callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/gotham_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/gotham_callees/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "gotham-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gotham = "0.7"
+hyper = "0.14"
+tokio = { version = "1", features = ["full"] }

--- a/spec/functional_test/fixtures/rust/gotham_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/gotham_callees/src/main.rs
@@ -24,13 +24,13 @@ fn create_user_handler(state: State) -> (State, Response<Body>) {
 }
 
 fn session_handler(state: State) -> (State, Response<Body>) {
-    let session_id = state.cookie("session_id");
+    let session_id = /* state.cookie("debug_session") */ state.cookie("session_id");
     AuthService::session(session_id);
     respond(state, "session".to_string(), StatusCode::OK)
 }
 
 fn auth_handler(state: State) -> (State, Response<Body>) {
-    let auth = state.headers().get("Authorization");
+    let auth = /* state.headers().get("X-Debug") */ state.headers().get("Authorization");
     let api_key = state.headers().get("X-API-Key");
     AuthService::validate(auth, api_key);
     respond(state, "auth".to_string(), StatusCode::OK)

--- a/spec/functional_test/fixtures/rust/gotham_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/gotham_callees/src/main.rs
@@ -1,0 +1,65 @@
+use gotham::router::builder::*;
+use gotham::router::Router;
+use gotham::state::State;
+use hyper::{Body, Response, StatusCode};
+
+fn home_handler(state: State) -> (State, Response<Body>) {
+    let status = HealthCheck::ready();
+    let body = render_home(status);
+    respond(state, body, StatusCode::OK)
+}
+
+fn user_handler(state: State) -> (State, Response<Body>) {
+    let user = UserService::load();
+    AuditLog::read_user();
+    let body = UserPresenter::render(user);
+    respond(state, body, StatusCode::OK)
+}
+
+fn create_user_handler(state: State) -> (State, Response<Body>) {
+    let user = UserService::create();
+    AuditLog::write();
+    let body = UserPresenter::render(user);
+    respond(state, body, StatusCode::CREATED)
+}
+
+fn session_handler(state: State) -> (State, Response<Body>) {
+    let session_id = state.cookie("session_id");
+    AuthService::session(session_id);
+    respond(state, "session".to_string(), StatusCode::OK)
+}
+
+fn auth_handler(state: State) -> (State, Response<Body>) {
+    let auth = state.headers().get("Authorization");
+    let api_key = state.headers().get("X-API-Key");
+    AuthService::validate(auth, api_key);
+    respond(state, "auth".to_string(), StatusCode::OK)
+}
+
+fn respond(state: State, body: String, status: StatusCode) -> (State, Response<Body>) {
+    let res = Response::builder()
+        .status(status)
+        .body(body.into())
+        .unwrap();
+    (state, res)
+}
+
+fn router() -> Router {
+    Router::builder()
+        .get("/")
+        .to(home_handler)
+        .get("/users/:id")
+        .to(user_handler)
+        .post("/users")
+        .to(create_user_handler)
+        .get("/session")
+        .to(session_handler)
+        .get("/auth")
+        .to(auth_handler)
+        .build()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    gotham::start("127.0.0.1:3000", router()).await
+}

--- a/spec/functional_test/testers/rust/gotham_callees_spec.cr
+++ b/spec/functional_test/testers/rust/gotham_callees_spec.cr
@@ -1,0 +1,56 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 7))
+  ep.push_callee(Callee.new("render_home", line: 8))
+  ep.push_callee(Callee.new("respond", line: 9))
+end
+
+user = Endpoint.new("/users/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::load", line: 13))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 14))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 15))
+  ep.push_callee(Callee.new("respond", line: 16))
+end
+
+create_user = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 20))
+  ep.push_callee(Callee.new("AuditLog::write", line: 21))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 22))
+  ep.push_callee(Callee.new("respond", line: 23))
+end
+
+session = Endpoint.new("/session", "GET", [
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("state.cookie", line: 27))
+  ep.push_callee(Callee.new("AuthService::session", line: 28))
+  ep.push_callee(Callee.new("respond", line: 29))
+end
+
+auth = Endpoint.new("/auth", "GET", [
+  Param.new("Authorization", "", "header"),
+  Param.new("X-API-Key", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("state.headers", line: 33))
+  ep.push_callee(Callee.new("AuthService::validate", line: 35))
+  ep.push_callee(Callee.new("respond", line: 36))
+end
+
+expected_endpoints = [
+  home,
+  user,
+  create_user,
+  session,
+  auth,
+]
+
+FunctionalTester.new("fixtures/rust/gotham_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_gotham"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -11,7 +11,8 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       lines.each_with_index do |line, index|
         # Look for Gotham routing patterns like .get("/path")
@@ -44,7 +45,12 @@ module Analyzer::Rust
           # Look for .to(handler_name) in nearby lines
           handler_name = find_handler_name(lines, index)
           if handler_name
-            extract_handler_params(lines, handler_name, endpoint)
+            function_body = find_handler_body(lines, handler_name)
+            if function_body
+              body, body_start_line = function_body
+              extract_handler_params(body, endpoint)
+              attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)) if include_callee
+            end
           end
 
           endpoints << endpoint
@@ -59,7 +65,7 @@ module Analyzer::Rust
     private def find_handler_name(lines : Array(String), start_index : Int32) : String?
       (start_index...[start_index + MAX_HANDLER_LOOKUP_LINES, lines.size].min).each do |i|
         line = lines[i]
-        match = line.match(/\.to\s*\(\s*(\w+)\s*\)/)
+        match = line.match(/\.to\s*\(\s*(?:[A-Za-z_]\w*::)*([A-Za-z_]\w*)\s*\)/)
         if match
           return match[1]
         end
@@ -67,30 +73,33 @@ module Analyzer::Rust
       nil
     end
 
+    private def find_handler_body(lines : Array(String), handler_name : String) : Tuple(String, Int32)?
+      function_index = find_handler_function_index(lines, handler_name)
+      return unless function_index
+
+      extract_rust_function_body(lines, function_index)
+    end
+
+    private def find_handler_function_index(lines : Array(String), handler_name : String) : Int32?
+      in_block_comment = false
+
+      lines.each_with_index do |line, index|
+        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(line, in_block_comment)
+        match = stripped.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\b/)
+        return index if match && match[1] == handler_name
+      end
+    end
+
     # Extract cookies and headers from the handler function body
-    private def extract_handler_params(lines : Array(String), handler_name : String, endpoint : Endpoint)
-      in_function = false
-      brace_count = 0
-      seen_opening_brace = false
+    private def extract_handler_params(body : String, endpoint : Endpoint)
+      in_block_comment = false
 
-      lines.each do |line|
-        # Find the handler function definition
-        if !in_function && line.includes?("fn #{handler_name}")
-          in_function = true
-        end
-
-        next unless in_function
-
-        # Track braces
-        brace_count += line.count('{')
-        if brace_count > 0
-          seen_opening_brace = true
-        end
-        brace_count -= line.count('}')
+      body.each_line do |raw_line|
+        line, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(raw_line, in_block_comment)
 
         # Extract cookies from .cookie() or cookies().get() patterns
         if line.includes?(".cookie(")
-          match = line.match(/\.cookie\s*\(\s*"([^"]+)"\s*\)/)
+          match = raw_line.match(/\.cookie\s*\(\s*"([^"]+)"\s*\)/)
           if match
             cookie_name = match[1]
             unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
@@ -101,7 +110,7 @@ module Analyzer::Rust
 
         # Extract headers from .headers().get() or HeaderMap access
         if line.includes?(".headers()") && line.includes?(".get(")
-          match = line.match(/\.headers\(\)\s*\.get\s*\(\s*"([^"]+)"\s*\)/)
+          match = raw_line.match(/\.headers\(\)\s*\.get\s*\(\s*"([^"]+)"\s*\)/)
           if match
             header_name = match[1]
             unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
@@ -119,11 +128,6 @@ module Analyzer::Rust
               endpoint.push_param(Param.new(header_name, "", "header"))
             end
           end
-        end
-
-        # Stop if we've moved past the function
-        if seen_opening_brace && brace_count == 0
-          break
         end
       end
     end

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -13,6 +13,7 @@ module Analyzer::Rust
       endpoints = [] of Endpoint
       lines = read_file_content(path).lines
       include_callee = any_to_bool(@options["include_callee"]?)
+      function_bodies = collect_function_bodies(lines)
 
       lines.each_with_index do |line, index|
         # Look for Gotham routing patterns like .get("/path")
@@ -45,8 +46,7 @@ module Analyzer::Rust
           # Look for .to(handler_name) in nearby lines
           handler_name = find_handler_name(lines, index)
           if handler_name
-            function_body = find_handler_body(lines, handler_name)
-            if function_body
+            if function_body = function_bodies[handler_name]?
               body, body_start_line = function_body
               extract_handler_params(body, endpoint)
               attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)) if include_callee
@@ -73,21 +73,29 @@ module Analyzer::Rust
       nil
     end
 
-    private def find_handler_body(lines : Array(String), handler_name : String) : Tuple(String, Int32)?
-      function_index = find_handler_function_index(lines, handler_name)
-      return unless function_index
-
-      extract_rust_function_body(lines, function_index)
-    end
-
-    private def find_handler_function_index(lines : Array(String), handler_name : String) : Int32?
+    private def collect_function_bodies(lines : Array(String)) : Hash(String, Tuple(String, Int32))
+      function_bodies = {} of String => Tuple(String, Int32)
       in_block_comment = false
+      index = 0
 
-      lines.each_with_index do |line, index|
-        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(line, in_block_comment)
+      while index < lines.size
+        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(lines[index], in_block_comment)
         match = stripped.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\b/)
-        return index if match && match[1] == handler_name
+
+        if match
+          function_body = extract_rust_function_body_with_end(lines, index)
+          if function_body
+            body, body_start_line, end_index = function_body
+            function_bodies[match[1]] = {body, body_start_line}
+            index = end_index
+            in_block_comment = false
+          end
+        end
+
+        index += 1
       end
+
+      function_bodies
     end
 
     # Extract cookies and headers from the handler function body
@@ -95,11 +103,11 @@ module Analyzer::Rust
       in_block_comment = false
 
       body.each_line do |raw_line|
-        line, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(raw_line, in_block_comment)
+        line, in_block_comment = strip_comments_preserving_strings(raw_line, in_block_comment)
 
         # Extract cookies from .cookie() or cookies().get() patterns
         if line.includes?(".cookie(")
-          match = raw_line.match(/\.cookie\s*\(\s*"([^"]+)"\s*\)/)
+          match = line.match(/\.cookie\s*\(\s*"([^"]+)"\s*\)/)
           if match
             cookie_name = match[1]
             unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
@@ -110,7 +118,7 @@ module Analyzer::Rust
 
         # Extract headers from .headers().get() or HeaderMap access
         if line.includes?(".headers()") && line.includes?(".get(")
-          match = raw_line.match(/\.headers\(\)\s*\.get\s*\(\s*"([^"]+)"\s*\)/)
+          match = line.match(/\.headers\(\)\s*\.get\s*\(\s*"([^"]+)"\s*\)/)
           if match
             header_name = match[1]
             unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
@@ -130,6 +138,47 @@ module Analyzer::Rust
           end
         end
       end
+    end
+
+    private def strip_comments_preserving_strings(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+      in_string = false
+      escaped = false
+      index = 0
+      stripped = String::Builder.new
+
+      while index < line.size
+        char = line[index]
+
+        if in_block_comment
+          if char == '*' && line[index + 1]? == '/'
+            in_block_comment = false
+            index += 1
+          end
+        elsif in_string
+          stripped << char
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == '"'
+            in_string = false
+          end
+        elsif char == '"'
+          in_string = true
+          stripped << char
+        elsif char == '/' && line[index + 1]? == '/'
+          return {stripped.to_s, in_block_comment}
+        elsif char == '/' && line[index + 1]? == '*'
+          in_block_comment = true
+          index += 1
+        else
+          stripped << char
+        end
+
+        index += 1
+      end
+
+      {stripped.to_s, in_block_comment}
     end
   end
 end


### PR DESCRIPTION
## Summary
- wire Gotham route handlers to attach Rust callees when --include-callee is enabled
- reuse the shared Rust function-body helper for handler param extraction and callee extraction
- keep existing Gotham cookie/header/path param extraction while adding callee fixture coverage

## Scope
- supports same-file named Gotham handlers passed through .to(handler) or .to(module::handler)
- keeps call-site path/line behavior consistent with the other Rust callee analyzers

## Tests
- crystal spec spec/functional_test/testers/rust/gotham_spec.cr spec/functional_test/testers/rust/gotham_callees_spec.cr
- crystal spec spec/functional_test/testers/rust
- just build
- just check
- just test
- ./bin/noir -b spec/functional_test/fixtures/rust/gotham_callees -f json --include-callee

Part of #1366.