### PR TITLE
Add Loco callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/loco_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/loco_callees/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "loco-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+loco-rs = { version = "0.2" }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+axum = "0.7"

--- a/spec/functional_test/fixtures/rust/loco_callees/src/controllers/posts_controller.rs
+++ b/spec/functional_test/fixtures/rust/loco_callees/src/controllers/posts_controller.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::{Form, Json, Path},
+    http::HeaderMap,
+};
+use loco_rs::prelude::*;
+
+pub struct PostsController;
+
+impl PostsController {
+    pub async fn index() -> Result<impl IntoResponse> {
+        let posts = PostService::list();
+        let payload = PostPresenter::render(posts);
+        Ok(Json(payload))
+    }
+
+    pub async fn show(Path(id): Path<i64>) -> Result<impl IntoResponse> {
+        let post = PostService::load(id);
+        AuditLog::read_post();
+        let payload = PostPresenter::render(post);
+        Ok(Json(payload))
+    }
+
+    pub async fn create(Json(data): Json<CreatePostData>) -> Result<impl IntoResponse> {
+        let post = PostService::create(data);
+        AuditLog::write();
+        let payload = PostPresenter::render(post);
+        Ok(Json(payload))
+    }
+
+    pub async fn users(headers: HeaderMap) -> Result<impl IntoResponse> {
+        let auth = headers.get("Authorization");
+        AuthService::validate(auth);
+        Ok(Json(UserPresenter::list()))
+    }
+
+    pub async fn login(Form(form): Form<LoginForm>) -> Result<impl IntoResponse> {
+        let session = AuthService::login(form);
+        AuditLog::write();
+        Ok(Json(SessionPresenter::render(session)))
+    }
+}

--- a/spec/functional_test/testers/rust/loco_callees_spec.cr
+++ b/spec/functional_test/testers/rust/loco_callees_spec.cr
@@ -1,0 +1,59 @@
+require "../../func_spec.cr"
+
+index = Endpoint.new("/posts", "GET").tap do |ep|
+  ep.push_callee(Callee.new("PostService::list", line: 11))
+  ep.push_callee(Callee.new("PostPresenter::render", line: 12))
+  ep.push_callee(Callee.new("Json", line: 13))
+end
+
+show = Endpoint.new("/posts/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PostService::load", line: 17))
+  ep.push_callee(Callee.new("AuditLog::read_post", line: 18))
+  ep.push_callee(Callee.new("PostPresenter::render", line: 19))
+  ep.push_callee(Callee.new("Json", line: 20))
+end
+
+create = Endpoint.new("/posts", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PostService::create", line: 24))
+  ep.push_callee(Callee.new("AuditLog::write", line: 25))
+  ep.push_callee(Callee.new("PostPresenter::render", line: 26))
+  ep.push_callee(Callee.new("Json", line: 27))
+end
+
+users = Endpoint.new("/posts/users", "GET", [
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("headers.get", line: 31))
+  ep.push_callee(Callee.new("AuthService::validate", line: 32))
+  ep.push_callee(Callee.new("Json", line: 33))
+  ep.push_callee(Callee.new("UserPresenter::list", line: 33))
+end
+
+login = Endpoint.new("/posts/login", "POST", [
+  Param.new("form", "", "form"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("AuthService::login", line: 37))
+  ep.push_callee(Callee.new("AuditLog::write", line: 38))
+  ep.push_callee(Callee.new("Json", line: 39))
+  ep.push_callee(Callee.new("SessionPresenter::render", line: 39))
+end
+
+expected_endpoints = [
+  index,
+  show,
+  create,
+  users,
+  login,
+]
+
+FunctionalTester.new("fixtures/rust/loco_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_loco"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -10,7 +10,8 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       lines.each_with_index do |line, index|
         next unless line.to_s.includes? "pub async fn"
@@ -32,6 +33,7 @@ module Analyzer::Rust
 
           # Extract parameters from function signature and body
           extract_function_params(lines, index, endpoint)
+          attach_handler_callees(lines, index, path, endpoint) if include_callee
 
           endpoints << endpoint
         rescue e
@@ -41,6 +43,14 @@ module Analyzer::Rust
       end
 
       endpoints
+    end
+
+    private def attach_handler_callees(lines : Array(String), function_index : Int32, path : String, endpoint : Endpoint)
+      function_body = extract_rust_function_body(lines, function_index)
+      return unless function_body
+
+      body, body_start_line = function_body
+      attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line))
     end
 
     private def action_to_path(action_name : String, file_path : String) : String

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -27,13 +27,17 @@ module Analyzer::Rust
           http_method = infer_http_method(method_name, line)
 
           endpoint = Endpoint.new(endpoint_path, http_method, details)
+          function_body = extract_rust_function_body(lines, index)
 
           # Extract path parameters from the endpoint path
           extract_path_params(endpoint_path, endpoint)
 
           # Extract parameters from function signature and body
-          extract_function_params(lines, index, endpoint)
-          attach_handler_callees(lines, index, path, endpoint) if include_callee
+          extract_function_params(lines, index, endpoint, function_body.try(&.[0]))
+          if include_callee && function_body
+            body, body_start_line = function_body
+            attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line))
+          end
 
           endpoints << endpoint
         rescue e
@@ -43,14 +47,6 @@ module Analyzer::Rust
       end
 
       endpoints
-    end
-
-    private def attach_handler_callees(lines : Array(String), function_index : Int32, path : String, endpoint : Endpoint)
-      function_body = extract_rust_function_body(lines, function_index)
-      return unless function_body
-
-      body, body_start_line = function_body
-      attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line))
     end
 
     private def action_to_path(action_name : String, file_path : String) : String
@@ -134,7 +130,7 @@ module Analyzer::Rust
     # - Json<T> for JSON body
     # - Form<T> for form data
     # - HeaderMap or headers for header access
-    private def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
+    private def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint, body : String? = nil)
       # Look ahead up to 30 lines for the function definition and body
       in_function = false
       brace_count = 0
@@ -203,9 +199,7 @@ module Analyzer::Rust
       # Extract headers - look for HeaderMap or headers parameter
       if param_section.includes?("HeaderMap") || param_section.includes?(": HeaderMap")
         # Look in the function body for specific header usage
-        (start_index...[start_index + 30, lines.size].min).each do |i|
-          line = lines[i]
-
+        each_function_body_line(lines, start_index, body) do |line|
           # Extract specific header names from .get("header_name") or headers.get("header_name")
           if line.includes?(".get(\"")
             line.scan(/\.get\("([^"]+)"\)/) do |match|
@@ -220,15 +214,25 @@ module Analyzer::Rust
       end
 
       # Extract cookies from cookie access patterns
-      (start_index...[start_index + 30, lines.size].min).each do |i|
-        line = lines[i]
-
+      each_function_body_line(lines, start_index, body) do |line|
         # Look for .cookie("name") patterns
         if line.includes?(".cookie(\"")
           line.scan(/\.cookie\("([^"]+)"\)/) do |match|
             cookie_name = match[1]
             endpoint.push_param(Param.new(cookie_name, "", "cookie"))
           end
+        end
+      end
+    end
+
+    private def each_function_body_line(lines : Array(String), start_index : Int32, body : String?, &)
+      if body
+        body.each_line do |line|
+          yield line
+        end
+      else
+        (start_index...[start_index + 30, lines.size].min).each do |i|
+          yield lines[i]
         end
       end
     end


### PR DESCRIPTION
## Summary
- attach Rust callees for Loco endpoints when --include-callee is enabled
- reuse the shared Rust function-body and callee extraction helpers for each inferred handler action
- add Loco controller fixture coverage for REST-style actions, headers, form data, and JSON bodies

## Scope
- same-file handler body only; Loco's existing action-name/path inference remains unchanged
- keeps existing Loco parameter extraction behavior

## Tests
- crystal spec spec/functional_test/testers/rust/loco_spec.cr spec/functional_test/testers/rust/loco_callees_spec.cr
- crystal spec spec/functional_test/testers/rust
- just build
- just check
- just test
- ./bin/noir -b spec/functional_test/fixtures/rust/loco_callees -f json --include-callee

Part of #1366.