### PR TITLE
Add RWF callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/rwf_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rwf_callees/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rwf-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rwf = "0.2"
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"

--- a/spec/functional_test/fixtures/rust/rwf_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rwf_callees/src/main.rs
@@ -1,0 +1,63 @@
+use rwf::http::Server;
+use rwf::prelude::*;
+
+#[derive(Default)]
+struct UsersController;
+
+#[async_trait]
+impl Controller for UsersController {
+    async fn handle(&self, request: &Request) -> Result<Response, Error> {
+        match request.method() {
+            Method::GET => {
+                let users = UserService::list();
+                AuditLog::list_users();
+                Ok(Response::new().json(&UserPresenter::render(users)))
+            }
+            Method::POST => {
+                let body = request.body()?;
+                let user = UserService::create(body);
+                AuditLog::write();
+                Ok(Response::new().json(&UserPresenter::render(user)))
+            }
+            _ => Ok(Response::new().status(405).text("Method not allowed")),
+        }
+    }
+}
+
+#[derive(Default)]
+struct UserController;
+
+#[async_trait]
+impl Controller for UserController {
+    async fn handle(&self, request: &Request) -> Result<Response, Error> {
+        let id = request.path_parameter("id")?;
+        let auth = /* request.header("X-Debug") */ request.header("Authorization");
+        let user = UserService::load(id, auth);
+        AuditLog::read_user();
+        Ok(Response::new().json(&UserPresenter::render(user)))
+    }
+}
+
+#[derive(Default)]
+struct SessionController;
+
+#[async_trait]
+impl Controller for SessionController {
+    async fn handle(&self, request: &Request) -> Result<Response, Error> {
+        let session = request.cookie("session_id");
+        let query = request.query_parameter("redirect");
+        AuthService::session(session, query);
+        Ok(Response::new().text("OK"))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    Server::new(vec![
+        route!("/users" => UsersController),
+        route!("/users/:id" => UserController),
+        route!("/session" => SessionController),
+    ])
+    .launch("0.0.0.0:8000")
+    .await
+}

--- a/spec/functional_test/testers/rust/rwf_callees_spec.cr
+++ b/spec/functional_test/testers/rust/rwf_callees_spec.cr
@@ -1,0 +1,52 @@
+require "../../func_spec.cr"
+
+users_get = Endpoint.new("/users", "GET").tap do |ep|
+  ep.push_callee(Callee.new("UserService::list", line: 12))
+  ep.push_callee(Callee.new("AuditLog::list_users", line: 13))
+  ep.push_callee(Callee.new("Response::new", line: 14))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 14))
+end
+
+users_post = Endpoint.new("/users", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("request.body", line: 17))
+  ep.push_callee(Callee.new("UserService::create", line: 18))
+  ep.push_callee(Callee.new("AuditLog::write", line: 19))
+end
+
+user_show = Endpoint.new("/users/:id", "GET", [
+  Param.new("id", "", "path"),
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("request.path_parameter", line: 33))
+  ep.push_callee(Callee.new("request.header", line: 34))
+  ep.push_callee(Callee.new("UserService::load", line: 35))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 36))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 37))
+end
+
+session = Endpoint.new("/session", "GET", [
+  Param.new("redirect", "", "query"),
+  Param.new("session_id", "", "cookie"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("request.cookie", line: 47))
+  ep.push_callee(Callee.new("request.query_parameter", line: 48))
+  ep.push_callee(Callee.new("AuthService::session", line: 49))
+  ep.push_callee(Callee.new("Response::new", line: 50))
+end
+
+expected_endpoints = [
+  users_get,
+  users_post,
+  user_show,
+  session,
+]
+
+FunctionalTester.new("fixtures/rust/rwf_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_rwf"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -97,7 +97,7 @@ module Analyzer::Rust
       in_block_comment = false
 
       body.each_line do |raw_line|
-        line, in_block_comment = strip_comments_preserving_strings(raw_line, in_block_comment)
+        line, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(raw_line, in_block_comment, preserve_strings: true)
         next unless line.includes?("Method::")
 
         ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].each do |method|
@@ -113,7 +113,7 @@ module Analyzer::Rust
       in_block_comment = false
 
       body.each_line do |raw_line|
-        line, in_block_comment = strip_comments_preserving_strings(raw_line, in_block_comment)
+        line, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(raw_line, in_block_comment, preserve_strings: true)
 
         if line.includes?("request.path_parameter")
           extract_typed_params(line, /request\.path_parameter/, endpoint, "path", existing_path_params)
@@ -131,16 +131,12 @@ module Analyzer::Rust
           endpoint.push_param(Param.new("form", "", "form"))
         end
 
-        if line.includes?("request.header(")
-          line.scan(/request\.header\("([^"]+)"\)/) do |match|
-            endpoint.push_param(Param.new(match[1], "", "header"))
-          end
+        if line.includes?("request.header")
+          extract_typed_params(line, /request\.header/, endpoint, "header")
         end
 
-        if line.includes?("request.cookie(")
-          line.scan(/request\.cookie\("([^"]+)"\)/) do |match|
-            endpoint.push_param(Param.new(match[1], "", "cookie"))
-          end
+        if line.includes?("request.cookie")
+          extract_typed_params(line, /request\.cookie/, endpoint, "cookie")
         end
       end
     end
@@ -256,19 +252,13 @@ module Analyzer::Rust
           end
 
           # Extract headers from request.header()
-          if line.includes?("request.header(")
-            line.scan(/request\.header\("([^"]+)"\)/) do |match|
-              header_name = match[1]
-              endpoint.push_param(Param.new(header_name, "", "header"))
-            end
+          if line.includes?("request.header")
+            extract_typed_params(line, /request\.header/, endpoint, "header")
           end
 
           # Extract cookies from request.cookie()
-          if line.includes?("request.cookie(")
-            line.scan(/request\.cookie\("([^"]+)"\)/) do |match|
-              cookie_name = match[1]
-              endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-            end
+          if line.includes?("request.cookie")
+            extract_typed_params(line, /request\.cookie/, endpoint, "cookie")
           end
 
           # Stop if we've moved past the method (brace count is back to 0 after we've seen an opening brace)
@@ -297,47 +287,6 @@ module Analyzer::Rust
         next if existing_params && existing_params.includes?(param_name)
         endpoint.push_param(Param.new(param_name, "", param_type))
       end
-    end
-
-    private def strip_comments_preserving_strings(line : String, in_block_comment : Bool) : Tuple(String, Bool)
-      in_string = false
-      escaped = false
-      index = 0
-      stripped = String::Builder.new
-
-      while index < line.size
-        char = line[index]
-
-        if in_block_comment
-          if char == '*' && line[index + 1]? == '/'
-            in_block_comment = false
-            index += 1
-          end
-        elsif in_string
-          stripped << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == '"'
-            in_string = false
-          end
-        elsif char == '"'
-          in_string = true
-          stripped << char
-        elsif char == '/' && line[index + 1]? == '/'
-          return {stripped.to_s, in_block_comment}
-        elsif char == '/' && line[index + 1]? == '*'
-          in_block_comment = true
-          index += 1
-        else
-          stripped << char
-        end
-
-        index += 1
-      end
-
-      {stripped.to_s, in_block_comment}
     end
   end
 end

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -7,7 +7,9 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
+      include_callee = any_to_bool(@options["include_callee"]?)
+      controller_bodies = collect_controller_handle_bodies(lines)
 
       lines.each_with_index do |line, index|
         # Look for route! macro definitions
@@ -21,7 +23,8 @@ module Analyzer::Rust
           details = Details.new(PathInfo.new(path, index + 1))
 
           # Extract HTTP methods supported by the controller
-          methods = extract_controller_methods(lines, controller_name)
+          controller_body = controller_bodies[controller_name]?
+          methods = controller_body ? extract_controller_methods_from_body(controller_body[0]) : extract_controller_methods(lines, controller_name)
 
           # If no specific methods found, default to GET
           if methods.empty?
@@ -36,7 +39,13 @@ module Analyzer::Rust
             extract_path_params(route_path, endpoint)
 
             # Look for controller implementation to extract more parameters
-            extract_controller_params(lines, controller_name, endpoint)
+            if controller_body
+              body, body_start_line = controller_body
+              extract_controller_params_from_body(body, endpoint)
+              attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)) if include_callee
+            else
+              extract_controller_params(lines, controller_name, endpoint)
+            end
 
             endpoints << endpoint
           end
@@ -52,6 +61,87 @@ module Analyzer::Rust
       route.scan(/:(\w+)/) do |match|
         param_name = match[1]
         endpoint.push_param(Param.new(param_name, "", "path"))
+      end
+    end
+
+    private def collect_controller_handle_bodies(lines : Array(String)) : Hash(String, Tuple(String, Int32))
+      controller_bodies = {} of String => Tuple(String, Int32)
+      current_controller = nil
+      in_block_comment = false
+      index = 0
+
+      while index < lines.size
+        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(lines[index], in_block_comment)
+
+        if match = stripped.match(/impl\s+Controller\s+for\s+([A-Za-z_]\w*)/)
+          current_controller = match[1]
+        elsif current_controller && stripped.strip.match(/^(?:async\s+)?fn\s+handle\b/)
+          function_body = extract_rust_function_body_with_end(lines, index)
+          if function_body
+            body, body_start_line, end_index = function_body
+            controller_bodies[current_controller] = {body, body_start_line}
+            current_controller = nil
+            index = end_index
+            in_block_comment = false
+          end
+        end
+
+        index += 1
+      end
+
+      controller_bodies
+    end
+
+    private def extract_controller_methods_from_body(body : String) : Array(String)
+      methods = [] of String
+      in_block_comment = false
+
+      body.each_line do |raw_line|
+        line, in_block_comment = strip_comments_preserving_strings(raw_line, in_block_comment)
+        next unless line.includes?("Method::")
+
+        ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].each do |method|
+          methods << method if line.includes?("Method::#{method}") && !methods.includes?(method)
+        end
+      end
+
+      methods
+    end
+
+    private def extract_controller_params_from_body(body : String, endpoint : Endpoint)
+      existing_path_params = endpoint.params.select { |p| p.param_type == "path" }.map(&.name).to_set
+      in_block_comment = false
+
+      body.each_line do |raw_line|
+        line, in_block_comment = strip_comments_preserving_strings(raw_line, in_block_comment)
+
+        if line.includes?("request.path_parameter")
+          extract_typed_params(line, /request\.path_parameter/, endpoint, "path", existing_path_params)
+        end
+
+        if line.includes?("request.query_parameter")
+          extract_typed_params(line, /request\.query_parameter/, endpoint, "query")
+        end
+
+        if line.includes?("request.body()")
+          endpoint.push_param(Param.new("body", "", "json"))
+        end
+
+        if line.includes?("request.form_data()")
+          endpoint.push_param(Param.new("form", "", "form"))
+        end
+
+        if line.includes?("request.header(")
+          line.scan(/request\.header\("([^"]+)"\)/) do |match|
+            endpoint.push_param(Param.new(match[1], "", "header"))
+          end
+        end
+
+        if line.includes?("request.cookie(")
+          line.scan(/request\.cookie\("([^"]+)"\)/) do |match|
+            endpoint.push_param(Param.new(match[1], "", "cookie"))
+          end
+        end
       end
     end
 
@@ -207,6 +297,47 @@ module Analyzer::Rust
         next if existing_params && existing_params.includes?(param_name)
         endpoint.push_param(Param.new(param_name, "", param_type))
       end
+    end
+
+    private def strip_comments_preserving_strings(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+      in_string = false
+      escaped = false
+      index = 0
+      stripped = String::Builder.new
+
+      while index < line.size
+        char = line[index]
+
+        if in_block_comment
+          if char == '*' && line[index + 1]? == '/'
+            in_block_comment = false
+            index += 1
+          end
+        elsif in_string
+          stripped << char
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == '"'
+            in_string = false
+          end
+        elsif char == '"'
+          in_string = true
+          stripped << char
+        elsif char == '/' && line[index + 1]? == '/'
+          return {stripped.to_s, in_block_comment}
+        elsif char == '/' && line[index + 1]? == '*'
+          in_block_comment = true
+          index += 1
+        else
+          stripped << char
+        end
+
+        index += 1
+      end
+
+      {stripped.to_s, in_block_comment}
     end
   end
 end

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -37,12 +37,12 @@ module Noir::RustCalleeExtractor
     end
   end
 
-  def strip_comment(line : String, in_block_comment : Bool = false) : String
-    stripped, _ = strip_comment_with_state(line, in_block_comment)
+  def strip_comment(line : String, in_block_comment : Bool = false, preserve_strings : Bool = false) : String
+    stripped, _ = strip_comment_with_state(line, in_block_comment, preserve_strings)
     stripped
   end
 
-  def strip_comment_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+  def strip_comment_with_state(line : String, in_block_comment : Bool, preserve_strings : Bool = false) : Tuple(String, Bool)
     in_string = false
     escaped = false
     quote = '\0'
@@ -57,6 +57,7 @@ module Noir::RustCalleeExtractor
           index += 1
         end
       elsif in_string
+        stripped << char if preserve_strings
         if escaped
           escaped = false
         elsif char == '\\'
@@ -67,6 +68,7 @@ module Noir::RustCalleeExtractor
       elsif char == '"'
         in_string = true
         quote = char
+        stripped << char if preserve_strings
       elsif char == '/' && line[index + 1]? == '/'
         return {stripped.to_s, in_block_comment}
       elsif char == '/' && line[index + 1]? == '*'


### PR DESCRIPTION
## Summary
- attach Rust callees for RWF controller handle bodies when --include-callee is enabled
- precompute controller handle bodies once per file and reuse them for method, parameter, and callee extraction
- add RWF callee fixture coverage for method dispatch, path/header/query/cookie/body params, and comment-safe header extraction

## Scope
- callee extraction is scoped to each controller handle body; when one handle dispatches multiple HTTP methods, emitted endpoints share the controller-level 1-hop callees
- preserves existing RWF route! path and method inference behavior

## Tests
- crystal spec spec/functional_test/testers/rust/rwf_spec.cr spec/functional_test/testers/rust/rwf_callees_spec.cr
- crystal spec spec/functional_test/testers/rust
- just build
- just check
- just test
- ./bin/noir -b spec/functional_test/fixtures/rust/rwf_callees -f json --include-callee

Part of #1366.