### PR TITLE
Add Warp callee extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/warp_callees/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/warp_callees/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "warp-callees-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+warp = "0.3"
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/spec/functional_test/fixtures/rust/warp_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/warp_callees/src/main.rs
@@ -1,0 +1,79 @@
+use serde::Deserialize;
+use warp::{Filter, Rejection, Reply};
+
+#[derive(Deserialize)]
+struct SearchQuery {
+    q: String,
+}
+
+#[derive(Deserialize)]
+struct CreateUser {
+    username: String,
+}
+
+fn home_handler() -> impl Reply {
+    let status = HealthCheck::ready();
+    render_home(status)
+}
+
+async fn get_user(id: u32) -> Result<impl Reply, Rejection> {
+    let user = UserService::load(id);
+    AuditLog::read_user();
+    Ok(UserPresenter::render(user))
+}
+
+async fn create_user(user: CreateUser) -> Result<impl Reply, Rejection> {
+    let created = UserService::create(user);
+    AuditLog::write();
+    Ok(UserPresenter::render(created))
+}
+
+async fn profile_handler(query: SearchQuery) -> impl Reply {
+    let profile = ProfileService::search(query);
+    ProfilePresenter::render(profile)
+}
+
+pub unsafe fn generic_handler<T>() -> impl Reply {
+    let value = GenericService::load();
+    GenericPresenter::render(value)
+}
+
+#[tokio::main]
+async fn main() {
+    let home = warp::path::end()
+        .and(warp::get())
+        .map(home_handler);
+
+    let get_user_route = warp::path("users")
+        .and(warp::path::param::<u32>())
+        .and(warp::path::end())
+        .and(warp::get())
+        .and_then(get_user);
+
+    let create_user_route = warp::path("users")
+        .and(warp::path::end())
+        .and(warp::body::json::<CreateUser>())
+        .and(warp::post())
+        .and_then(create_user);
+
+    let profile_route = warp::path("profile")
+        .and(warp::path::end())
+        .and(warp::query::<SearchQuery>())
+        .and(warp::get())
+        .then(profile_handler);
+
+    let generic_route = warp::path("generic")
+        .and(warp::path::end())
+        .and(warp::get())
+        .map(handlers::generic_handler::<u32>);
+
+    let routes = home
+        .or(get_user_route)
+        .or(create_user_route)
+        .or(profile_route)
+        .or(generic_route);
+
+    warp::serve(routes)
+        .run(([127, 0, 0, 1], 3030))
+        .await;
+}

--- a/spec/functional_test/testers/rust/warp_callees_spec.cr
+++ b/spec/functional_test/testers/rust/warp_callees_spec.cr
@@ -1,0 +1,50 @@
+require "../../func_spec.cr"
+
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 15))
+  ep.push_callee(Callee.new("render_home", line: 16))
+end
+
+get_user = Endpoint.new("/users/:param", "GET", [
+  Param.new("param", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::load", line: 20))
+  ep.push_callee(Callee.new("AuditLog::read_user", line: 21))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 22))
+end
+
+create_user = Endpoint.new("/users", "POST", [
+  Param.new("CreateUser", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 26))
+  ep.push_callee(Callee.new("AuditLog::write", line: 27))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 28))
+end
+
+profile = Endpoint.new("/profile", "GET", [
+  Param.new("SearchQuery", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ProfileService::search", line: 32))
+  ep.push_callee(Callee.new("ProfilePresenter::render", line: 33))
+end
+
+generic = Endpoint.new("/generic", "GET").tap do |ep|
+  ep.push_callee(Callee.new("GenericService::load", line: 37))
+  ep.push_callee(Callee.new("GenericPresenter::render", line: 38))
+end
+
+expected_endpoints = [
+  home,
+  get_user,
+  create_user,
+  profile,
+  generic,
+]
+
+FunctionalTester.new("fixtures/rust/warp_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_warp"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -4,18 +4,18 @@ module Analyzer::Rust
   class Warp < RustEngine
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      content = read_file_content(path)
+      include_callee = any_to_bool(@options["include_callee"]?)
+      function_callees = include_callee ? collect_function_callees(content.lines, path) : Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-
-        # Simple approach: split by let statements and analyze each
-        statements = content.split(/(?=let\s+\w+\s*=)/)
-        statements.each do |statement|
-          if statement.includes?("warp::") && (statement.includes?("get()") || statement.includes?("post()") || statement.includes?("put()") || statement.includes?("delete()"))
-            endpoint = parse_warp_statement(statement, path)
-            if endpoint
-              endpoints << endpoint
-            end
+      # Simple approach: split by let statements and analyze each
+      statements = content.split(/(?=let\s+\w+\s*=)/)
+      statements.each do |statement|
+        if statement.includes?("warp::") && (statement.includes?("get()") || statement.includes?("post()") || statement.includes?("put()") || statement.includes?("delete()"))
+          endpoint = parse_warp_statement(statement, path)
+          if endpoint
+            attach_handler_callees(statement, function_callees, endpoint) if include_callee
+            endpoints << endpoint
           end
         end
       end
@@ -81,6 +81,49 @@ module Analyzer::Rust
       Endpoint.new(route_path, method, params, details)
     rescue
       nil
+    end
+
+    private def collect_function_callees(lines : Array(String), path : String) : Hash(String, Array(Noir::RustCalleeExtractor::Entry))
+      function_callees = Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
+      in_block_comment = false
+      index = 0
+
+      while index < lines.size
+        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(lines[index], in_block_comment)
+        match = stripped.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+|const\s+|unsafe\s+)*fn\s+([A-Za-z_]\w*)\b/)
+
+        if match
+          function_body = extract_rust_function_body_with_end(lines, index)
+          if function_body
+            body, body_start_line, end_index = function_body
+            function_callees[match[1]] = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
+            index = end_index
+            in_block_comment = false
+          end
+        end
+
+        index += 1
+      end
+
+      function_callees
+    end
+
+    private def attach_handler_callees(statement : String,
+                                       function_callees : Hash(String, Array(Noir::RustCalleeExtractor::Entry)),
+                                       endpoint : Endpoint)
+      handler_name = extract_handler_name(statement)
+      return unless handler_name
+
+      if callees = function_callees[handler_name]?
+        attach_rust_callees(endpoint, callees)
+      end
+    end
+
+    private def extract_handler_name(statement : String) : String?
+      match = statement.match(/\.(?:map|and_then|then)\s*\(\s*((?:[A-Za-z_]\w*::)*[A-Za-z_]\w*)(?:::<[^>]+>)?\s*\)/)
+      return unless match
+
+      match[1].split("::").last
     end
 
     private def extract_non_path_params(statement : String, params : Array(Param))


### PR DESCRIPTION
## Summary
- add callee extraction for named Warp handlers passed to .map, .and_then, and .then
- collect same-file Rust handler function callees and attach them to matching endpoints when --include-callee is enabled
- add Warp callee fixtures and functional coverage for GET, POST, path, query, and JSON params

## Scope
- covers named handlers in the same source file
- inline closures keep existing endpoint/parameter behavior but do not emit callees yet

## Verification
- crystal spec spec/functional_test/testers/rust/warp_spec.cr spec/functional_test/testers/rust/warp_callees_spec.cr
- crystal spec spec/functional_test/testers/rust
- just build
- just check
- just test
- ./bin/noir -b spec/functional_test/fixtures/rust/warp_callees -f json --include-callee

Part of #1366.