### PR TITLE
Add Elixir Plug callee extraction

### DIFF
--- a/spec/functional_test/fixtures/elixir/plug_callees/lib/router.ex
+++ b/spec/functional_test/fixtures/elixir/plug_callees/lib/router.ex
@@ -1,0 +1,32 @@
+defmodule ElixirPlugCallees.Router do
+  use Plug.Router
+
+  plug :match
+  plug :dispatch
+
+  get "/users" do
+    page = conn.query_params["page"]
+    users = UserService.list(page)
+    AuditLog.write("users")
+    send_resp(conn, 200, JsonPresenter.render(users))
+  end
+
+  post "/users" do
+    payload = UserPayload.from_conn(conn)
+    created = payload |> UserService.create()
+    send_resp conn, 201, render_user(created)
+  end
+
+  get "/health" do
+    if Health.ready?() do
+      send_resp(conn, 200, "ok")
+    else
+      send_resp(conn, 503, "down")
+    end
+  end
+
+  match "/webhook", via: [:post, :put] do
+    WebhookHandler.dispatch(conn)
+    send_resp(conn, 200, "ok")
+  end
+end

--- a/spec/functional_test/fixtures/elixir/plug_callees/mix.exs
+++ b/spec/functional_test/fixtures/elixir/plug_callees/mix.exs
@@ -1,0 +1,25 @@
+defmodule ElixirPlugCallees.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :elixir_plug_callees,
+      version: "0.1.0",
+      elixir: "~> 1.12",
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:plug, "~> 1.14"},
+      {:plug_cowboy, "~> 2.5"}
+    ]
+  end
+end

--- a/spec/functional_test/testers/elixir/plug_callees_spec.cr
+++ b/spec/functional_test/testers/elixir/plug_callees_spec.cr
@@ -1,0 +1,47 @@
+require "../../func_spec.cr"
+
+users_index = Endpoint.new("/users", "GET", [
+  Param.new("page", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService.list", line: 9))
+  ep.push_callee(Callee.new("AuditLog.write", line: 10))
+  ep.push_callee(Callee.new("JsonPresenter.render", line: 11))
+  ep.push_callee(Callee.new("send_resp", line: 11))
+end
+
+users_create = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("UserPayload.from_conn", line: 15))
+  ep.push_callee(Callee.new("UserService.create", line: 16))
+  ep.push_callee(Callee.new("send_resp", line: 17))
+  ep.push_callee(Callee.new("render_user", line: 17))
+end
+
+health = Endpoint.new("/health", "GET").tap do |ep|
+  ep.push_callee(Callee.new("Health.ready?", line: 21))
+end
+
+webhook_post = Endpoint.new("/webhook", "POST").tap do |ep|
+  ep.push_callee(Callee.new("WebhookHandler.dispatch", line: 29))
+  ep.push_callee(Callee.new("send_resp", line: 30))
+end
+
+webhook_put = Endpoint.new("/webhook", "PUT").tap do |ep|
+  ep.push_callee(Callee.new("WebhookHandler.dispatch", line: 29))
+  ep.push_callee(Callee.new("send_resp", line: 30))
+end
+
+expected_endpoints = [
+  users_index,
+  users_create,
+  health,
+  webhook_post,
+  webhook_put,
+]
+
+FunctionalTester.new("fixtures/elixir/plug_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("elixir_plug"),
+}).perform_tests

--- a/spec/unit_test/miniparser/elixir_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/elixir_callee_extractor_spec.cr
@@ -1,0 +1,43 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/elixir_callee_extractor"
+
+describe Noir::ElixirCalleeExtractor do
+  it "extracts qualified and local calls from Elixir handler bodies with line numbers" do
+    body = <<-ELIXIR
+      users = UserService.list(conn.query_params["page"])
+      AuditLog.write("list")
+      send_resp(conn, 200, JsonPresenter.render(users))
+      ELIXIR
+
+    callees = Noir::ElixirCalleeExtractor.callees_for_body(body, "router.ex", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService.list", 10},
+      {"AuditLog.write", 11},
+      {"JsonPresenter.render", 12},
+      {"send_resp", 12},
+    ])
+  end
+
+  it "skips comments, strings, and language keywords while keeping pipe calls" do
+    body = <<-ELIXIR
+      # AuditLog.write("ignored")
+      message = "DangerService.run()"
+      created = payload |> UserService.create()
+      Notifier.deliver created
+      send_resp conn, 201, render_user(created)
+      if Health.ready?() do
+        send_resp(conn, 200, "ok")
+      end
+      ELIXIR
+
+    callees = Noir::ElixirCalleeExtractor.callees_for_body(body, "router.ex", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService.create", 22},
+      {"Notifier.deliver", 23},
+      {"send_resp", 24},
+      {"render_user", 24},
+      {"Health.ready?", 25},
+      {"send_resp", 26},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -18,6 +18,7 @@ module Analyzer::Elixir
 
     def analyze_content(content : String, file_path : String) : Array(Endpoint)
       endpoints = Array(Endpoint).new
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Find all route blocks and extract params
       lines = content.lines
@@ -28,9 +29,12 @@ module Analyzer::Elixir
             details = Details.new(PathInfo.new(file_path, index + 1))
             endpoint.details = details
 
-            # Extract parameters from the route block
-            params = extract_params_from_block(lines, index, endpoint.method)
+            block_end = find_block_end(lines, index)
+
+            params = extract_params_from_block(lines, index, endpoint.method, block_end)
             params.each { |param| endpoint.push_param(param) }
+
+            attach_callees_from_block(endpoint, lines, index, block_end, file_path) if include_callee
 
             endpoints << endpoint
           end
@@ -40,16 +44,16 @@ module Analyzer::Elixir
       endpoints
     end
 
-    def extract_params_from_block(lines : Array(String), start_index : Int32, method : String) : Array(Param)
+    def extract_params_from_block(lines : Array(String), start_index : Int32, method : String, block_end : Int32? = nil) : Array(Param)
       params = Array(Param).new
       seen_params = Set(String).new # Track seen params for O(1) lookup
 
       # Find the end of the current route block (find matching "end")
-      block_end = find_block_end(lines, start_index)
-      return params if block_end == -1
+      end_index = block_end || find_block_end(lines, start_index)
+      return params if end_index == -1
 
       # Extract parameters from the block content
-      (start_index..block_end).each do |i|
+      (start_index..end_index).each do |i|
         line = lines[i]
 
         # Extract query parameters (conn.query_params["param"] or conn.params["param"] for GET)
@@ -105,6 +109,21 @@ module Analyzer::Elixir
       end
 
       params
+    end
+
+    private def attach_callees_from_block(endpoint : Endpoint,
+                                          lines : Array(String),
+                                          start_index : Int32,
+                                          block_end : Int32?,
+                                          file_path : String)
+      return unless block_end
+      return if block_end == -1 || block_end <= start_index
+
+      body_lines = lines[(start_index + 1)...block_end]
+      return if body_lines.empty?
+
+      callees = Noir::ElixirCalleeExtractor.callees_for_lines(body_lines, file_path, start_index + 2)
+      attach_elixir_callees(endpoint, callees)
     end
 
     def find_block_end(lines : Array(String), start_index : Int32) : Int32

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/elixir_callee_extractor"
 
 module Analyzer::Elixir
   abstract class ElixirEngine < Analyzer
@@ -10,6 +11,10 @@ module Analyzer::Elixir
     end
 
     abstract def analyze_file(path : String) : Array(Endpoint)
+
+    protected def attach_elixir_callees(endpoint : Endpoint, callees : Array(Noir::ElixirCalleeExtractor::Entry))
+      Noir::ElixirCalleeExtractor.attach_to(endpoint, callees)
+    end
 
     # No extension filter: Phoenix uses `.ex` only, Plug also accepts
     # `.exs`, so each analyzer filters inside `analyze_file`.

--- a/src/miniparsers/elixir_callee_extractor.cr
+++ b/src/miniparsers/elixir_callee_extractor.cr
@@ -1,0 +1,95 @@
+require "../models/endpoint"
+
+module Noir::ElixirCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "after", "alias", "and", "case", "catch", "cond", "def", "defdelegate",
+    "defexception", "defguard", "defguardp", "defimpl", "defmacro",
+    "defmacrop", "defmodule", "defoverridable", "defp", "defprotocol",
+    "defstruct", "do", "else", "end", "false", "fn", "for", "if",
+    "import", "in", "nil", "not", "or", "quote", "raise", "receive",
+    "require", "rescue", "throw", "true", "try", "unless", "unquote",
+    "use", "when", "with",
+  }
+
+  QUALIFIED_CALL_REGEX = /((?:(?:[A-Z]\w*|:[a-z_]\w*)(?:\.[A-Z]\w*)*\.)[a-z_]\w*[!?]?)(?:\s*\(|(?=\s+(?:[A-Za-z_:@%"{\[]|\d)))/
+  BARE_CALL_REGEX      = /(?<![.\w:])([a-z_]\w*[!?]?)(?:\s*\(|(?=\s+(?:[A-Za-z_:@%"{\[]|\d)))/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    callees_for_lines(body.lines, file_path, start_line)
+  end
+
+  def callees_for_lines(lines : Enumerable(String), file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+
+    lines.each_with_index do |line, index|
+      scan_line(strip_comment(line), file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    line.scan(QUALIFIED_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  def strip_comment(line : String) : String
+    in_string = false
+    escaped = false
+    quote = '\0'
+    stripped = String::Builder.new
+
+    line.each_char do |char|
+      if in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == quote
+          in_string = false
+        end
+      elsif char == '"' || char == '\''
+        in_string = true
+        quote = char
+      elsif char == '#'
+        return stripped.to_s
+      else
+        stripped << char
+      end
+    end
+
+    stripped.to_s
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    entries.uniq
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight Elixir callee extractor for qualified and local calls
- wire ElixirEngine with an attach helper and Plug route blocks behind --include-callee
- add unit and functional coverage for Plug callees, including match via routes and existing parameter extraction

## Scope
- covers callees inside block-style Plug routes where the existing analyzer can find the route block end
- does not yet attach Phoenix controller action callees

## Verification
- crystal spec spec/unit_test/miniparser/elixir_callee_extractor_spec.cr spec/functional_test/testers/elixir/plug_spec.cr spec/functional_test/testers/elixir/plug_callees_spec.cr
- crystal spec spec/functional_test/testers/elixir
- just build
- just check
- just test
- ./bin/noir -b spec/functional_test/fixtures/elixir/plug_callees -f json --include-callee

Part of #1366.