### PR TITLE
Add Elixir Phoenix callee extraction

### DIFF
--- a/spec/functional_test/fixtures/elixir/phoenix_callees/lib/elixir_phoenix_callees_web/controllers/post_controller.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix_callees/lib/elixir_phoenix_callees_web/controllers/post_controller.ex
@@ -1,0 +1,15 @@
+defmodule ElixirPhoenixCalleesWeb.PostController do
+  use ElixirPhoenixCalleesWeb, :controller
+
+  def index(conn, _params) do
+    category = conn.query_params["category"]
+    posts = PostQuery.list(category)
+    render(conn, :index, posts: PostPresenter.render(posts))
+  end
+
+  def show(conn, %{"id" => id}) do
+    post = PostQuery.find(id)
+    AuditLog.read_post(id)
+    render(conn, :show, post: PostPresenter.render(post))
+  end
+end

--- a/spec/functional_test/fixtures/elixir/phoenix_callees/lib/elixir_phoenix_callees_web/controllers/user_controller.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix_callees/lib/elixir_phoenix_callees_web/controllers/user_controller.ex
@@ -1,0 +1,18 @@
+defmodule ElixirPhoenixCalleesWeb.UserController do
+  use ElixirPhoenixCalleesWeb, :controller
+
+  def index(conn, _params) do
+    page = conn.query_params["page"]
+    users = UserService.list(page)
+    AuditLog.write("users")
+    json(conn, JsonPresenter.render(users))
+  end
+
+  def create(conn, _params) do
+    payload = UserPayload.from_conn(conn)
+    created = UserService.create(payload)
+    conn
+    |> put_status(:created)
+    |> json(render_user(created))
+  end
+end

--- a/spec/functional_test/fixtures/elixir/phoenix_callees/lib/elixir_phoenix_callees_web/router.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix_callees/lib/elixir_phoenix_callees_web/router.ex
@@ -1,0 +1,9 @@
+defmodule ElixirPhoenixCalleesWeb.Router do
+  use ElixirPhoenixCalleesWeb, :router
+
+  scope "/", ElixirPhoenixCalleesWeb do
+    get "/users", UserController, :index
+    post "/users", UserController, :create
+    resources "/posts", PostController, only: [:index, :show]
+  end
+end

--- a/spec/functional_test/fixtures/elixir/phoenix_callees/mix.exs
+++ b/spec/functional_test/fixtures/elixir/phoenix_callees/mix.exs
@@ -1,0 +1,24 @@
+defmodule ElixirPhoenix.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :elixir_phoenix_callees,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7.1"}
+    ]
+  end
+end

--- a/spec/functional_test/testers/elixir/phoenix_callees_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_callees_spec.cr
@@ -1,0 +1,50 @@
+require "../../func_spec.cr"
+
+users_index = Endpoint.new("/users", "GET", [
+  Param.new("page", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService.list", line: 6))
+  ep.push_callee(Callee.new("AuditLog.write", line: 7))
+  ep.push_callee(Callee.new("JsonPresenter.render", line: 8))
+  ep.push_callee(Callee.new("json", line: 8))
+end
+
+users_create = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("UserPayload.from_conn", line: 12))
+  ep.push_callee(Callee.new("UserService.create", line: 13))
+  ep.push_callee(Callee.new("put_status", line: 15))
+  ep.push_callee(Callee.new("json", line: 16))
+  ep.push_callee(Callee.new("render_user", line: 16))
+end
+
+posts_index = Endpoint.new("/posts", "GET", [
+  Param.new("category", "", "query"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PostQuery.list", line: 6))
+  ep.push_callee(Callee.new("PostPresenter.render", line: 7))
+  ep.push_callee(Callee.new("render", line: 7))
+end
+
+posts_show = Endpoint.new("/posts/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("PostQuery.find", line: 11))
+  ep.push_callee(Callee.new("AuditLog.read_post", line: 12))
+  ep.push_callee(Callee.new("PostPresenter.render", line: 13))
+  ep.push_callee(Callee.new("render", line: 13))
+end
+
+expected_endpoints = [
+  users_index,
+  users_create,
+  posts_index,
+  posts_show,
+]
+
+FunctionalTester.new("fixtures/elixir/phoenix_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("elixir_phoenix"),
+}).perform_tests

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -76,20 +76,23 @@ module Analyzer::Elixir
         if match = line.match(/^\s*def\s+(\w+)\(conn,/)
           action_name = match[1]
 
-          # Find the matching endpoints for this controller and action
-          @result.each do |endpoint|
-            # Match based on route_map if available, or try to match by convention
-            if should_extract_params_for_endpoint?(endpoint, controller_name, action_name)
-              # Find the end of the function block
-              block_end = find_function_end(lines, index)
-              next if block_end == -1
+          matching_endpoints = @result.select do |endpoint|
+            should_extract_params_for_endpoint?(endpoint, controller_name, action_name)
+          end
+          next if matching_endpoints.empty?
 
-              # Extract parameters from the function block
-              params = extract_params_from_function_block(lines, index, block_end, endpoint.method)
-              params.each { |param| endpoint.push_param(param) }
+          # Find the end of the function block once per controller action.
+          block_end = find_function_end(lines, index)
+          next if block_end == -1
 
-              attach_callees_from_function_block(endpoint, lines, index, block_end, controller_path) if include_callee
-            end
+          callees = include_callee ? callees_from_function_block(lines, index, block_end, controller_path) : nil
+
+          matching_endpoints.each do |endpoint|
+            # Extract parameters from the function block
+            params = extract_params_from_function_block(lines, index, block_end, endpoint.method)
+            params.each { |param| endpoint.push_param(param) }
+
+            attach_elixir_callees(endpoint, callees) if callees
           end
         end
       end
@@ -194,18 +197,16 @@ module Analyzer::Elixir
       params
     end
 
-    private def attach_callees_from_function_block(endpoint : Endpoint,
-                                                   lines : Array(String),
-                                                   start_index : Int32,
-                                                   end_index : Int32,
-                                                   controller_path : String)
-      return if end_index <= start_index
+    private def callees_from_function_block(lines : Array(String),
+                                            start_index : Int32,
+                                            end_index : Int32,
+                                            controller_path : String) : Array(Noir::ElixirCalleeExtractor::Entry)
+      return [] of Noir::ElixirCalleeExtractor::Entry if end_index <= start_index
 
       body_lines = lines[(start_index + 1)...end_index]
-      return if body_lines.empty?
+      return [] of Noir::ElixirCalleeExtractor::Entry if body_lines.empty?
 
-      callees = Noir::ElixirCalleeExtractor.callees_for_lines(body_lines, controller_path, start_index + 2)
-      attach_elixir_callees(endpoint, callees)
+      Noir::ElixirCalleeExtractor.callees_for_lines(body_lines, controller_path, start_index + 2)
     end
 
     def line_to_endpoint(line : String, file_path : String) : Array(Endpoint)

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -66,6 +66,7 @@ module Analyzer::Elixir
 
     def extract_params_from_controller(content : String, controller_name : String, controller_path : String)
       lines = content.lines
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       # Find all function definitions and extract parameters
       lines.each_with_index do |line, index|
@@ -86,6 +87,8 @@ module Analyzer::Elixir
               # Extract parameters from the function block
               params = extract_params_from_function_block(lines, index, block_end, endpoint.method)
               params.each { |param| endpoint.push_param(param) }
+
+              attach_callees_from_function_block(endpoint, lines, index, block_end, controller_path) if include_callee
             end
           end
         end
@@ -189,6 +192,20 @@ module Analyzer::Elixir
       end
 
       params
+    end
+
+    private def attach_callees_from_function_block(endpoint : Endpoint,
+                                                   lines : Array(String),
+                                                   start_index : Int32,
+                                                   end_index : Int32,
+                                                   controller_path : String)
+      return if end_index <= start_index
+
+      body_lines = lines[(start_index + 1)...end_index]
+      return if body_lines.empty?
+
+      callees = Noir::ElixirCalleeExtractor.callees_for_lines(body_lines, controller_path, start_index + 2)
+      attach_elixir_callees(endpoint, callees)
     end
 
     def line_to_endpoint(line : String, file_path : String) : Array(Endpoint)


### PR DESCRIPTION
## Summary
- attach Elixir Phoenix controller action callees to route endpoints when `--include-callee` is enabled
- reuse the shared Elixir callee extractor added for Plug
- add Phoenix controller/route fixtures and functional coverage for direct routes and `resources` routes

## Scope
- covers controller action bodies mapped through Phoenix router/controller/action entries
- LiveView/socket routes are still endpoint-only because there is no controller action body to attach

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-phoenix crystal spec spec/unit_test/miniparser/elixir_callee_extractor_spec.cr spec/functional_test/testers/elixir/phoenix_spec.cr spec/functional_test/testers/elixir/phoenix_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-phoenix-check just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-phoenix-build just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-phoenix-test just test`
- `./bin/noir -b spec/functional_test/fixtures/elixir/phoenix_callees -f json --include-callee`

Part of #1366.