### PR TITLE
Add Swift Vapor callee extraction

### DIFF
--- a/spec/functional_test/fixtures/swift/vapor_callees/Package.swift
+++ b/spec/functional_test/fixtures/swift/vapor_callees/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "VaporCalleesFixture",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+    ],
+    targets: [
+        .target(name: "App", dependencies: [
+            .product(name: "Vapor", package: "vapor"),
+        ]),
+    ]
+)

--- a/spec/functional_test/fixtures/swift/vapor_callees/routes.swift
+++ b/spec/functional_test/fixtures/swift/vapor_callees/routes.swift
@@ -1,0 +1,20 @@
+import Vapor
+
+func routes(_ app: Application) throws {
+    app.post("users", ":id") { req -> EventLoopFuture<Response> in
+        let id = req.parameters.get("id")
+        let payload = try req.content.decode(CreateUser.self)
+        let user = try UserService.build(payload)
+        AuditLog.write("create", id: id)
+        return user.save(on: req.db).map { saved in
+            try ResponseBuilder.created(saved)
+        }
+    }
+
+    app.get("health") { req -> String in
+        HealthService.check()
+        return "ok"
+    }
+
+    app.get("ping") { req in PingService.pong() }
+}

--- a/spec/functional_test/fixtures/swift/vapor_callees/routes.swift
+++ b/spec/functional_test/fixtures/swift/vapor_callees/routes.swift
@@ -12,6 +12,10 @@ func routes(_ app: Application) throws {
     }
 
     app.get("health") { req -> String in
+        let template = """
+        }
+        """
+        // }
         HealthService.check()
         return "ok"
     }

--- a/spec/functional_test/testers/swift/vapor_callees_spec.cr
+++ b/spec/functional_test/testers/swift/vapor_callees_spec.cr
@@ -11,10 +11,10 @@ create_endpoint.push_callee(Callee.new("user.save", line: 9))
 create_endpoint.push_callee(Callee.new("ResponseBuilder.created", line: 10))
 
 health_endpoint = Endpoint.new("/health", "GET")
-health_endpoint.push_callee(Callee.new("HealthService.check", line: 15))
+health_endpoint.push_callee(Callee.new("HealthService.check", line: 19))
 
 ping_endpoint = Endpoint.new("/ping", "GET")
-ping_endpoint.push_callee(Callee.new("PingService.pong", line: 19))
+ping_endpoint.push_callee(Callee.new("PingService.pong", line: 23))
 
 expected_endpoints = [
   create_endpoint,

--- a/spec/functional_test/testers/swift/vapor_callees_spec.cr
+++ b/spec/functional_test/testers/swift/vapor_callees_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+create_endpoint = Endpoint.new("/users/:id", "POST")
+create_endpoint.push_param(Param.new("id", "", "path"))
+create_endpoint.push_param(Param.new("body", "", "json"))
+create_endpoint.push_callee(Callee.new("req.parameters.get", line: 5))
+create_endpoint.push_callee(Callee.new("req.content.decode", line: 6))
+create_endpoint.push_callee(Callee.new("UserService.build", line: 7))
+create_endpoint.push_callee(Callee.new("AuditLog.write", line: 8))
+create_endpoint.push_callee(Callee.new("user.save", line: 9))
+create_endpoint.push_callee(Callee.new("ResponseBuilder.created", line: 10))
+
+health_endpoint = Endpoint.new("/health", "GET")
+health_endpoint.push_callee(Callee.new("HealthService.check", line: 15))
+
+ping_endpoint = Endpoint.new("/ping", "GET")
+ping_endpoint.push_callee(Callee.new("PingService.pong", line: 19))
+
+expected_endpoints = [
+  create_endpoint,
+  health_endpoint,
+  ping_endpoint,
+]
+
+FunctionalTester.new("fixtures/swift/vapor_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/swift_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/swift_callee_extractor_spec.cr
@@ -39,4 +39,28 @@ describe Noir::SwiftCalleeExtractor do
       {"SafeService.run", 26},
     ])
   end
+
+  it "tracks nested comments, multiline strings, and trailing closure calls" do
+    body = <<-SWIFT
+      /*
+       OuterService.call()
+       /*
+        InnerService.call()
+        */
+       StillHidden.call()
+       */
+      let template = """
+        HiddenService.call()
+      """
+      dispatch {
+        Worker.run()
+      }
+      SWIFT
+
+    callees = Noir::SwiftCalleeExtractor.callees_for_body(body, "routes.swift", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"dispatch", 40},
+      {"Worker.run", 41},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/swift_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/swift_callee_extractor_spec.cr
@@ -1,0 +1,42 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/swift_callee_extractor"
+
+describe Noir::SwiftCalleeExtractor do
+  it "extracts receiver and bare calls from Swift handler bodies" do
+    body = <<-SWIFT
+      let payload = try req.content.decode(CreateUser.self)
+      let user = try UserService.build(payload)
+      AuditLog.write("create")
+      return user.save(on: req.db).map { saved in
+          ResponseBuilder.created(saved)
+      }
+      SWIFT
+
+    callees = Noir::SwiftCalleeExtractor.callees_for_body(body, "routes.swift", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"req.content.decode", 10},
+      {"UserService.build", 11},
+      {"AuditLog.write", 12},
+      {"user.save", 13},
+      {"ResponseBuilder.created", 14},
+    ])
+  end
+
+  it "skips comments, strings, and Swift control-flow noise" do
+    body = <<-SWIFT
+      // DangerousService.run()
+      let message = "AuditLog.write()"
+      /*
+       HiddenService.call()
+       */
+      if shouldAudit {
+          SafeService.run()
+      }
+      SWIFT
+
+    callees = Noir::SwiftCalleeExtractor.callees_for_body(body, "routes.swift", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"SafeService.run", 26},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -185,28 +185,33 @@ module Analyzer::Swift
       return {"", route_index + 2} unless opening_brace
 
       first_fragment = route_line[(opening_brace + 1)..]? || ""
+      clean_fragment, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
       body_lines = [] of String
-      brace_count = 1 + first_fragment.count('{') - first_fragment.count('}')
+      brace_count = 1 + clean_fragment.count('{') - clean_fragment.count('}')
 
       if brace_count <= 0
-        closing_brace = first_fragment.rindex('}')
+        closing_brace = clean_fragment.rindex('}')
         first_fragment = first_fragment[0...closing_brace] if closing_brace
         return {first_fragment, route_index + 1}
       end
 
-      body_lines << first_fragment unless first_fragment.strip.empty?
+      body_lines << first_fragment
       index = route_index + 1
 
       while index < lines.size && brace_count > 0
         line = lines[index]
-        opens = line.count('{')
-        closes = line.count('}')
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        opens = stripped.count('{')
+        closes = stripped.count('}')
         next_brace_count = brace_count + opens - closes
 
         if next_brace_count <= 0
           if line.strip != "}"
-            closing_brace = line.rindex('}')
-            body_lines << (closing_brace ? line[0...closing_brace] : line)
+            body_lines << line
           end
           break
         end

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -1,4 +1,5 @@
 require "../../engines/swift_engine"
+require "../../../miniparsers/swift_callee_extractor"
 
 module Analyzer::Swift
   class Vapor < SwiftEngine
@@ -14,6 +15,7 @@ module Analyzer::Swift
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       lines.each_with_index do |line, index|
         next unless route_definition_line?(line)
@@ -30,6 +32,7 @@ module Analyzer::Swift
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
+          attach_route_callees(lines, index, path, endpoint) if include_callee
 
           endpoints << endpoint
         rescue e
@@ -166,6 +169,55 @@ module Analyzer::Swift
       route_definition?(line) &&
         !line.includes?("req.parameters") &&
         !line.includes?("req.query")
+    end
+
+    private def attach_route_callees(lines : Array(String), route_index : Int32, path : String, endpoint : Endpoint)
+      body, start_line = route_body(lines, route_index)
+      return if body.empty?
+
+      callees = Noir::SwiftCalleeExtractor.callees_for_body(body, path, start_line)
+      Noir::SwiftCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    private def route_body(lines : Array(String), route_index : Int32) : Tuple(String, Int32)
+      route_line = lines[route_index]
+      opening_brace = route_line.index('{')
+      return {"", route_index + 2} unless opening_brace
+
+      first_fragment = route_line[(opening_brace + 1)..]? || ""
+      body_lines = [] of String
+      brace_count = 1 + first_fragment.count('{') - first_fragment.count('}')
+
+      if brace_count <= 0
+        closing_brace = first_fragment.rindex('}')
+        first_fragment = first_fragment[0...closing_brace] if closing_brace
+        return {first_fragment, route_index + 1}
+      end
+
+      body_lines << first_fragment unless first_fragment.strip.empty?
+      index = route_index + 1
+
+      while index < lines.size && brace_count > 0
+        line = lines[index]
+        opens = line.count('{')
+        closes = line.count('}')
+        next_brace_count = brace_count + opens - closes
+
+        if next_brace_count <= 0
+          if line.strip != "}"
+            closing_brace = line.rindex('}')
+            body_lines << (closing_brace ? line[0...closing_brace] : line)
+          end
+          break
+        end
+
+        body_lines << line
+        brace_count = next_brace_count
+
+        index += 1
+      end
+
+      {body_lines.join("\n"), route_index + 1}
     end
   end
 end

--- a/src/miniparsers/swift_callee_extractor.cr
+++ b/src/miniparsers/swift_callee_extractor.cr
@@ -18,14 +18,19 @@ module Noir::SwiftCalleeExtractor
   }
 
   RECEIVER_CALL_REGEX = /([A-Za-z_]\w*(?:\??\.[A-Za-z_]\w*)+)\s*(?:\(|\{)/
-  BARE_CALL_REGEX     = /(?<![.\w])([A-Za-z_]\w*)\s*\(/
+  BARE_CALL_REGEX     = /(?<![.\w])([A-Za-z_]\w*)\s*(\(|\{)/
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
-    in_block_comment = false
+    block_comment_depth = 0
+    in_multiline_string = false
 
     body.lines.each_with_index do |line, index|
-      stripped, in_block_comment = strip_comment_with_state(line, in_block_comment)
+      stripped, block_comment_depth, in_multiline_string = strip_non_code_with_state(
+        line,
+        block_comment_depth,
+        in_multiline_string
+      )
       scan_line(stripped, file_path, start_line + index, entries)
     end
 
@@ -44,6 +49,13 @@ module Noir::SwiftCalleeExtractor
   end
 
   def strip_comment_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+    stripped, block_comment_depth, _ = strip_non_code_with_state(line, in_block_comment ? 1 : 0, false)
+    {stripped, block_comment_depth > 0}
+  end
+
+  def strip_non_code_with_state(line : String,
+                                block_comment_depth : Int32,
+                                in_multiline_string : Bool) : Tuple(String, Int32, Bool)
     in_string = false
     escaped = false
     index = 0
@@ -51,10 +63,21 @@ module Noir::SwiftCalleeExtractor
 
     while index < line.size
       char = line[index]
-      if in_block_comment
-        if char == '*' && line[index + 1]? == '/'
-          in_block_comment = false
+      next_char = line[index + 1]?
+      third_char = line[index + 2]?
+
+      if block_comment_depth > 0
+        if char == '/' && next_char == '*'
+          block_comment_depth += 1
           index += 1
+        elsif char == '*' && next_char == '/'
+          block_comment_depth -= 1
+          index += 1
+        end
+      elsif in_multiline_string
+        if char == '"' && next_char == '"' && third_char == '"'
+          in_multiline_string = false
+          index += 2
         end
       elsif in_string
         if escaped
@@ -65,11 +88,16 @@ module Noir::SwiftCalleeExtractor
           in_string = false
         end
       elsif char == '"'
-        in_string = true
+        if next_char == '"' && third_char == '"'
+          in_multiline_string = true
+          index += 2
+        else
+          in_string = true
+        end
       elsif char == '/' && line[index + 1]? == '/'
-        return {stripped.to_s, in_block_comment}
+        return {stripped.to_s, block_comment_depth, in_multiline_string}
       elsif char == '/' && line[index + 1]? == '*'
-        in_block_comment = true
+        block_comment_depth += 1
         index += 1
       else
         stripped << char
@@ -77,7 +105,7 @@ module Noir::SwiftCalleeExtractor
       index += 1
     end
 
-    {stripped.to_s, in_block_comment}
+    {stripped.to_s, block_comment_depth, in_multiline_string}
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -90,6 +118,11 @@ module Noir::SwiftCalleeExtractor
 
     line.scan(BARE_CALL_REGEX) do |match|
       name = match[1]
+      delimiter = match[2]
+      if delimiter == "{"
+        name_start = match.begin(1) || 0
+        next if control_flow_condition?(line, name_start)
+      end
       next if skip_callee?(name)
 
       entries << {name, file_path, line_number}
@@ -101,6 +134,11 @@ module Noir::SwiftCalleeExtractor
 
     last = name.split('.').last
     RESERVED.includes?(last)
+  end
+
+  private def control_flow_condition?(line : String, name_start : Int32) : Bool
+    prefix = line[0...name_start].strip
+    !!prefix.match(/\b(if|guard|while|for|switch|catch|else|do)$/)
   end
 
   private def dedup_entries(entries : Array(Entry)) : Array(Entry)

--- a/src/miniparsers/swift_callee_extractor.cr
+++ b/src/miniparsers/swift_callee_extractor.cr
@@ -1,0 +1,118 @@
+require "../models/endpoint"
+
+module Noir::SwiftCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "as", "associatedtype", "break", "case", "catch", "class",
+    "continue", "default", "defer", "deinit", "do", "else",
+    "enum", "extension", "fallthrough", "false", "fileprivate",
+    "for", "func", "guard", "if", "import", "in", "init",
+    "inout", "internal", "is", "let", "nil", "open", "operator",
+    "private", "protocol", "public", "repeat", "return", "self",
+    "Self", "static", "struct", "subscript", "super", "switch",
+    "throw", "throws", "true", "try", "typealias", "var", "where",
+    "while", "await",
+  }
+
+  RECEIVER_CALL_REGEX = /([A-Za-z_]\w*(?:\??\.[A-Za-z_]\w*)+)\s*(?:\(|\{)/
+  BARE_CALL_REGEX     = /(?<![.\w])([A-Za-z_]\w*)\s*\(/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    in_block_comment = false
+
+    body.lines.each_with_index do |line, index|
+      stripped, in_block_comment = strip_comment_with_state(line, in_block_comment)
+      scan_line(stripped, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def strip_comment(line : String, in_block_comment : Bool = false) : String
+    stripped, _ = strip_comment_with_state(line, in_block_comment)
+    stripped
+  end
+
+  def strip_comment_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+    in_string = false
+    escaped = false
+    index = 0
+    stripped = String::Builder.new
+
+    while index < line.size
+      char = line[index]
+      if in_block_comment
+        if char == '*' && line[index + 1]? == '/'
+          in_block_comment = false
+          index += 1
+        end
+      elsif in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == '"'
+          in_string = false
+        end
+      elsif char == '"'
+        in_string = true
+      elsif char == '/' && line[index + 1]? == '/'
+        return {stripped.to_s, in_block_comment}
+      elsif char == '/' && line[index + 1]? == '*'
+        in_block_comment = true
+        index += 1
+      else
+        stripped << char
+      end
+      index += 1
+    end
+
+    {stripped.to_s, in_block_comment}
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    line.scan(RECEIVER_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      name = match[1]
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight shared Swift callee extractor for 1-hop receiver and bare call sites
- attach Vapor route closure callees when `--include-callee` is enabled
- add Vapor callee fixtures and functional coverage for multiline and single-line route closures

## Scope
- covers inline Vapor route closure bodies in the existing Vapor analyzer path
- keeps existing Vapor endpoint and parameter extraction semantics unchanged
- extractor is best-effort regex-based and skips comments/strings, not a full Swift AST call graph

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-vapor-target crystal spec spec/unit_test/miniparser/swift_callee_extractor_spec.cr spec/functional_test/testers/swift/vapor_callees_spec.cr spec/functional_test/testers/swift/vapor_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-vapor-build just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-vapor-check just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-vapor-test just test`
- `./bin/noir -b spec/functional_test/fixtures/swift/vapor_callees -f json --include-callee`

Part of #1366.