### PR TITLE
Add Swift Hummingbird callee extraction

### DIFF
--- a/spec/functional_test/fixtures/swift/hummingbird_callees/Package.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_callees/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "HummingbirdExample",
+    platforms: [
+       .macOS(.v14)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird")
+            ]
+        ),
+    ]
+)

--- a/spec/functional_test/fixtures/swift/hummingbird_callees/routes.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_callees/routes.swift
@@ -1,0 +1,23 @@
+import Hummingbird
+
+func routes(_ router: Router<some RequestContext>) {
+    router.post("users/:id") { request, context -> User in
+        let id = try context.parameters.require("id")
+        let payload = try await request.decode(as: CreateUser.self, context: context)
+        let user = try UserService.build(payload)
+        AuditLog.write("create", id: id)
+        return try await user.save()
+    }
+
+    router.get("search") { request, context -> String in
+        let template = """
+        }
+        """
+        // }
+        let query = request.uri.queryParameters.get("q")
+        SearchMetrics.record(query)
+        return SearchService.render(query)
+    }
+
+    router.get("ping") { request, context in PingService.pong() }
+}

--- a/spec/functional_test/fixtures/swift/hummingbird_callees/routes.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_callees/routes.swift
@@ -20,4 +20,9 @@ func routes(_ router: Router<some RequestContext>) {
     }
 
     router.get("ping") { request, context in PingService.pong() }
+
+    router.get("delayed")
+    { request, context in
+        DelayService.wait()
+    } ; OutsideService.noise()
 }

--- a/spec/functional_test/testers/swift/hummingbird_callees_spec.cr
+++ b/spec/functional_test/testers/swift/hummingbird_callees_spec.cr
@@ -18,10 +18,14 @@ search_endpoint.push_callee(Callee.new("SearchService.render", line: 19))
 ping_endpoint = Endpoint.new("/ping", "GET")
 ping_endpoint.push_callee(Callee.new("PingService.pong", line: 22))
 
+delayed_endpoint = Endpoint.new("/delayed", "GET")
+delayed_endpoint.push_callee(Callee.new("DelayService.wait", line: 26))
+
 expected_endpoints = [
   create_endpoint,
   search_endpoint,
   ping_endpoint,
+  delayed_endpoint,
 ]
 
 FunctionalTester.new("fixtures/swift/hummingbird_callees/", {

--- a/spec/functional_test/testers/swift/hummingbird_callees_spec.cr
+++ b/spec/functional_test/testers/swift/hummingbird_callees_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+create_endpoint = Endpoint.new("/users/:id", "POST")
+create_endpoint.push_param(Param.new("id", "", "path"))
+create_endpoint.push_param(Param.new("body", "", "json"))
+create_endpoint.push_callee(Callee.new("context.parameters.require", line: 5))
+create_endpoint.push_callee(Callee.new("request.decode", line: 6))
+create_endpoint.push_callee(Callee.new("UserService.build", line: 7))
+create_endpoint.push_callee(Callee.new("AuditLog.write", line: 8))
+create_endpoint.push_callee(Callee.new("user.save", line: 9))
+
+search_endpoint = Endpoint.new("/search", "GET")
+search_endpoint.push_param(Param.new("q", "", "query"))
+search_endpoint.push_callee(Callee.new("request.uri.queryParameters.get", line: 17))
+search_endpoint.push_callee(Callee.new("SearchMetrics.record", line: 18))
+search_endpoint.push_callee(Callee.new("SearchService.render", line: 19))
+
+ping_endpoint = Endpoint.new("/ping", "GET")
+ping_endpoint.push_callee(Callee.new("PingService.pong", line: 22))
+
+expected_endpoints = [
+  create_endpoint,
+  search_endpoint,
+  ping_endpoint,
+]
+
+FunctionalTester.new("fixtures/swift/hummingbird_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -1,4 +1,5 @@
 require "../../engines/swift_engine"
+require "../../../miniparsers/swift_callee_extractor"
 
 module Analyzer::Swift
   class Hummingbird < SwiftEngine
@@ -13,6 +14,7 @@ module Analyzer::Swift
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      include_callee = any_to_bool(@options["include_callee"]?)
 
       lines.each_with_index do |line, index|
         next unless route_definition_line?(line)
@@ -29,6 +31,7 @@ module Analyzer::Swift
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
+          attach_route_callees(lines, index, path, endpoint) if include_callee
 
           endpoints << endpoint
         rescue e
@@ -156,6 +159,60 @@ module Analyzer::Swift
       route_definition?(line) &&
         !line.includes?("context.parameters") &&
         !line.includes?("request.uri.queryParameters")
+    end
+
+    private def attach_route_callees(lines : Array(String), route_index : Int32, path : String, endpoint : Endpoint)
+      body, start_line = route_body(lines, route_index)
+      return if body.empty?
+
+      callees = Noir::SwiftCalleeExtractor.callees_for_body(body, path, start_line)
+      Noir::SwiftCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    private def route_body(lines : Array(String), route_index : Int32) : Tuple(String, Int32)
+      route_line = lines[route_index]
+      opening_brace = route_line.index('{')
+      return {"", route_index + 2} unless opening_brace
+
+      first_fragment = route_line[(opening_brace + 1)..]? || ""
+      clean_fragment, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
+      body_lines = [] of String
+      brace_count = 1 + clean_fragment.count('{') - clean_fragment.count('}')
+
+      if brace_count <= 0
+        closing_brace = clean_fragment.rindex('}')
+        first_fragment = first_fragment[0...closing_brace] if closing_brace
+        return {first_fragment, route_index + 1}
+      end
+
+      body_lines << first_fragment
+      index = route_index + 1
+
+      while index < lines.size && brace_count > 0
+        line = lines[index]
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        opens = stripped.count('{')
+        closes = stripped.count('}')
+        next_brace_count = brace_count + opens - closes
+
+        if next_brace_count <= 0
+          if line.strip != "}"
+            body_lines << line
+          end
+          break
+        end
+
+        body_lines << line
+        brace_count = next_brace_count
+
+        index += 1
+      end
+
+      {body_lines.join("\n"), route_index + 1}
     end
   end
 end

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -9,7 +9,8 @@ module Analyzer::Swift
     # Patterns for route definitions in Hummingbird:
     # router.get("path") { ... }
     # router.post("path") { ... }
-    ROUTE_PATTERN = /(\w+)\.(get|post|put|delete|patch)\(([^)]+)\)/
+    ROUTE_PATTERN              = /(\w+)\.(get|post|put|delete|patch)\(([^)]+)\)/
+    ROUTE_BODY_LOOKAHEAD_LIMIT = 5
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
@@ -170,10 +171,22 @@ module Analyzer::Swift
     end
 
     private def route_body(lines : Array(String), route_index : Int32) : Tuple(String, Int32)
-      route_line = lines[route_index]
-      opening_brace = route_line.index('{')
+      opening_index = route_index
+      opening_brace = structural_opening_brace(lines[opening_index])
+      unless opening_brace
+        ((route_index + 1)...[route_index + ROUTE_BODY_LOOKAHEAD_LIMIT, lines.size].min).each do |index|
+          break if route_definition_line?(lines[index])
+
+          if brace_index = structural_opening_brace(lines[index])
+            opening_index = index
+            opening_brace = brace_index
+            break
+          end
+        end
+      end
       return {"", route_index + 2} unless opening_brace
 
+      route_line = lines[opening_index]
       first_fragment = route_line[(opening_brace + 1)..]? || ""
       clean_fragment, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
       body_lines = [] of String
@@ -182,11 +195,11 @@ module Analyzer::Swift
       if brace_count <= 0
         closing_brace = clean_fragment.rindex('}')
         first_fragment = first_fragment[0...closing_brace] if closing_brace
-        return {first_fragment, route_index + 1}
+        return {first_fragment, opening_index + 1}
       end
 
       body_lines << first_fragment
-      index = route_index + 1
+      index = opening_index + 1
 
       while index < lines.size && brace_count > 0
         line = lines[index]
@@ -201,7 +214,8 @@ module Analyzer::Swift
 
         if next_brace_count <= 0
           if line.strip != "}"
-            body_lines << line
+            closing_brace = stripped.rindex('}')
+            body_lines << (closing_brace ? line[0...closing_brace] : line)
           end
           break
         end
@@ -212,7 +226,12 @@ module Analyzer::Swift
         index += 1
       end
 
-      {body_lines.join("\n"), route_index + 1}
+      {body_lines.join("\n"), opening_index + 1}
+    end
+
+    private def structural_opening_brace(line : String) : Int32?
+      stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
+      stripped.index('{')
     end
   end
 end

--- a/src/miniparsers/swift_callee_extractor.cr
+++ b/src/miniparsers/swift_callee_extractor.cr
@@ -69,16 +69,24 @@ module Noir::SwiftCalleeExtractor
       if block_comment_depth > 0
         if char == '/' && next_char == '*'
           block_comment_depth += 1
-          index += 1
+          append_spaces(stripped, 2)
+          index += 2
+          next
         elsif char == '*' && next_char == '/'
           block_comment_depth -= 1
-          index += 1
+          append_spaces(stripped, 2)
+          index += 2
+          next
         end
+        stripped << ' '
       elsif in_multiline_string
         if char == '"' && next_char == '"' && third_char == '"'
           in_multiline_string = false
-          index += 2
+          append_spaces(stripped, 3)
+          index += 3
+          next
         end
+        stripped << ' '
       elsif in_string
         if escaped
           escaped = false
@@ -87,18 +95,25 @@ module Noir::SwiftCalleeExtractor
         elsif char == '"'
           in_string = false
         end
+        stripped << ' '
       elsif char == '"'
         if next_char == '"' && third_char == '"'
           in_multiline_string = true
-          index += 2
+          append_spaces(stripped, 3)
+          index += 3
+          next
         else
           in_string = true
         end
+        stripped << ' '
       elsif char == '/' && line[index + 1]? == '/'
+        append_spaces(stripped, line.size - index)
         return {stripped.to_s, block_comment_depth, in_multiline_string}
       elsif char == '/' && line[index + 1]? == '*'
         block_comment_depth += 1
-        index += 1
+        append_spaces(stripped, 2)
+        index += 2
+        next
       else
         stripped << char
       end
@@ -106,6 +121,10 @@ module Noir::SwiftCalleeExtractor
     end
 
     {stripped.to_s, block_comment_depth, in_multiline_string}
+  end
+
+  private def append_spaces(stripped : String::Builder, count : Int32)
+    count.times { stripped << ' ' }
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))


### PR DESCRIPTION
## Summary
- attach Hummingbird route closure callees when `--include-callee` is enabled
- reuse the shared Swift callee extractor introduced for Vapor
- add Hummingbird callee fixtures and functional coverage for body/path/query params, multiline closures, and single-line closures

## Scope
- covers inline Hummingbird route closure bodies in the existing analyzer path
- keeps existing Hummingbird endpoint and parameter extraction semantics unchanged
- route-body slicing uses the shared Swift non-code stripper so braces inside comments/strings do not end the body early

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-hummingbird-target crystal spec spec/unit_test/miniparser/swift_callee_extractor_spec.cr spec/functional_test/testers/swift/hummingbird_callees_spec.cr spec/functional_test/testers/swift/hummingbird_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-hummingbird-build just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-hummingbird-check just check`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-swift-hummingbird-test just test`
- `./bin/noir -b spec/functional_test/fixtures/swift/hummingbird_callees -f json --include-callee`

Part of #1366.