### PR TITLE
Add Scala Akka and Scalatra callee extraction

### DIFF
--- a/spec/functional_test/fixtures/scala/akka_callees/WebServer.scala
+++ b/spec/functional_test/fixtures/scala/akka_callees/WebServer.scala
@@ -1,0 +1,72 @@
+package com.example.akka
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+
+case class User(name: String, email: String)
+case class Item(id: Int, name: String)
+
+object WebServer {
+  val route =
+    path("users") {
+      concat(
+        get {
+          val literal = "IgnoredService.nope() { }"
+          // CommentedService.nope()
+          val users = UserService.list()
+          complete(renderUsers(users))
+        },
+        post {
+          entity(as[User]) { user =>
+            val created = UserService.create(user)
+            AuditLog.write("create", created.name)
+            complete(renderUser(created))
+          }
+        }
+      )
+    }
+
+  val apiRoute =
+    pathPrefix("api") {
+      pathPrefix("v1") {
+        path("items" / IntNumber) { itemId =>
+          concat(
+            get {
+              val item = ItemService.find(itemId)
+              complete(renderItem(item))
+            },
+            put {
+              entity(as[Item]) { item =>
+                headerValueByName("Authorization") { token =>
+                  val updated = ItemService.update(itemId, item, token)
+                  complete(renderItem(updated))
+                }
+              }
+            },
+            delete {
+              optionalHeaderValueByName("X-API-Key") { apiKey =>
+                ItemService.delete(itemId, apiKey)
+                complete("deleted")
+              }
+            }
+          )
+        }
+      }
+    }
+
+  val compactRoute = path("compact") { get { complete(HealthService.check()) } }
+
+  val repeatedRoute =
+    path("multi") {
+      concat(
+        get {
+          FirstService.call()
+          complete("first")
+        },
+        get {
+          SecondService.call()
+          complete("second")
+        }
+      )
+    }
+}

--- a/spec/functional_test/fixtures/scala/scalatra_callees/MyServlet.scala
+++ b/spec/functional_test/fixtures/scala/scalatra_callees/MyServlet.scala
@@ -1,0 +1,38 @@
+package com.example.scalatra
+
+import org.scalatra._
+import org.json4s.{DefaultFormats, Formats}
+import org.scalatra.json._
+
+case class User(name: String, email: String)
+
+class MyServlet extends ScalatraServlet with JacksonJsonSupport {
+  protected implicit lazy val jsonFormats: Formats = DefaultFormats
+
+  get("/users/:id") {
+    val literal = "IgnoredService.nope()"
+    // CommentedService.nope()
+    val user = UserService.find(params("id"))
+    AuditLog.write("show", user.id)
+    json(serializeUser(user))
+  }
+
+  post("/users") {
+    /*
+     * DangerousService.run()
+     */
+    val payload = UserPayload.from(request.body)
+    val user = UserService.create(payload)
+    json(serializeUser(user))
+  }
+
+  get("/braces") {
+    val template = """
+    }
+    """
+    val rendered = BraceService.render()
+    json(rendered)
+  }
+
+  get("/compact") { json(HealthService.check()) }
+}

--- a/spec/functional_test/testers/scala/akka_callees_spec.cr
+++ b/spec/functional_test/testers/scala/akka_callees_spec.cr
@@ -1,0 +1,62 @@
+require "../../func_spec.cr"
+
+list_endpoint = Endpoint.new("/users", "GET")
+list_endpoint.push_callee(Callee.new("UserService.list", line: 16))
+list_endpoint.push_callee(Callee.new("complete", line: 17))
+list_endpoint.push_callee(Callee.new("renderUsers", line: 17))
+
+create_endpoint = Endpoint.new("/users", "POST", [Param.new("body", "User", "json")])
+create_endpoint.push_callee(Callee.new("entity", line: 20))
+create_endpoint.push_callee(Callee.new("UserService.create", line: 21))
+create_endpoint.push_callee(Callee.new("AuditLog.write", line: 22))
+create_endpoint.push_callee(Callee.new("complete", line: 23))
+create_endpoint.push_callee(Callee.new("renderUser", line: 23))
+
+show_item_endpoint = Endpoint.new("/api/v1/items/{itemId}", "GET", [Param.new("itemId", "", "path")])
+show_item_endpoint.push_callee(Callee.new("ItemService.find", line: 35))
+show_item_endpoint.push_callee(Callee.new("complete", line: 36))
+show_item_endpoint.push_callee(Callee.new("renderItem", line: 36))
+
+update_item_endpoint = Endpoint.new("/api/v1/items/{itemId}", "PUT", [
+  Param.new("itemId", "", "path"),
+  Param.new("body", "Item", "json"),
+  Param.new("Authorization", "", "header"),
+])
+update_item_endpoint.push_callee(Callee.new("entity", line: 39))
+update_item_endpoint.push_callee(Callee.new("headerValueByName", line: 40))
+update_item_endpoint.push_callee(Callee.new("ItemService.update", line: 41))
+update_item_endpoint.push_callee(Callee.new("complete", line: 42))
+update_item_endpoint.push_callee(Callee.new("renderItem", line: 42))
+
+delete_item_endpoint = Endpoint.new("/api/v1/items/{itemId}", "DELETE", [
+  Param.new("itemId", "", "path"),
+  Param.new("X-API-Key", "", "header"),
+])
+delete_item_endpoint.push_callee(Callee.new("optionalHeaderValueByName", line: 47))
+delete_item_endpoint.push_callee(Callee.new("ItemService.delete", line: 48))
+delete_item_endpoint.push_callee(Callee.new("complete", line: 49))
+
+compact_endpoint = Endpoint.new("/compact", "GET")
+compact_endpoint.push_callee(Callee.new("complete", line: 57))
+compact_endpoint.push_callee(Callee.new("HealthService.check", line: 57))
+
+multi_endpoint = Endpoint.new("/multi", "GET")
+multi_endpoint.push_callee(Callee.new("FirstService.call", line: 63))
+multi_endpoint.push_callee(Callee.new("SecondService.call", line: 67))
+
+expected_endpoints = [
+  list_endpoint,
+  create_endpoint,
+  show_item_endpoint,
+  update_item_endpoint,
+  delete_item_endpoint,
+  compact_endpoint,
+  multi_endpoint,
+]
+
+FunctionalTester.new("fixtures/scala/akka_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/scala/scalatra_callees_spec.cr
+++ b/spec/functional_test/testers/scala/scalatra_callees_spec.cr
@@ -1,0 +1,36 @@
+require "../../func_spec.cr"
+
+show_endpoint = Endpoint.new("/users/:id", "GET", [Param.new("id", "", "path")])
+show_endpoint.push_callee(Callee.new("UserService.find", line: 15))
+show_endpoint.push_callee(Callee.new("params", line: 15))
+show_endpoint.push_callee(Callee.new("AuditLog.write", line: 16))
+show_endpoint.push_callee(Callee.new("json", line: 17))
+show_endpoint.push_callee(Callee.new("serializeUser", line: 17))
+
+create_endpoint = Endpoint.new("/users", "POST", [Param.new("body", "", "json")])
+create_endpoint.push_callee(Callee.new("UserPayload.from", line: 24))
+create_endpoint.push_callee(Callee.new("UserService.create", line: 25))
+create_endpoint.push_callee(Callee.new("json", line: 26))
+create_endpoint.push_callee(Callee.new("serializeUser", line: 26))
+
+braces_endpoint = Endpoint.new("/braces", "GET")
+braces_endpoint.push_callee(Callee.new("BraceService.render", line: 33))
+braces_endpoint.push_callee(Callee.new("json", line: 34))
+
+compact_endpoint = Endpoint.new("/compact", "GET")
+compact_endpoint.push_callee(Callee.new("json", line: 37))
+compact_endpoint.push_callee(Callee.new("HealthService.check", line: 37))
+
+expected_endpoints = [
+  show_endpoint,
+  create_endpoint,
+  braces_endpoint,
+  compact_endpoint,
+]
+
+FunctionalTester.new("fixtures/scala/scalatra_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/analyzer/analyzer_scala_akka_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_scala_akka_spec.cr
@@ -1,0 +1,52 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/scala/akka.cr"
+
+describe "scala akka callee extraction" do
+  it "keeps callees scoped to the matched HTTP method block" do
+    options = create_test_options
+    options["include_callee"] = YAML::Any.new(true)
+    instance = Analyzer::Scala::Akka.new(options)
+
+    temp_dir = File.tempname("scala_akka_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "Routes.scala")
+
+    File.write(temp_file, <<-SCALA)
+      import akka.http.scaladsl.server.Directives._
+
+      object Routes {
+        val route =
+          path("users") {
+            concat(
+              get {
+                UserService.list()
+              },
+              post {
+                UserService.create()
+              }
+            )
+          }
+      }
+      SCALA
+
+    endpoints = instance.analyze_file(temp_file)
+    get_endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/users" }
+    post_endpoint = endpoints.find { |e| e.method == "POST" && e.url == "/users" }
+
+    get_endpoint.should_not be_nil
+    post_endpoint.should_not be_nil
+
+    if get_endpoint && post_endpoint
+      get_names = get_endpoint.callees.map(&.name)
+      post_names = post_endpoint.callees.map(&.name)
+
+      get_names.should contain("UserService.list")
+      get_names.should_not contain("UserService.create")
+      post_names.should contain("UserService.create")
+      post_names.should_not contain("UserService.list")
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/spec/unit_test/miniparser/scala_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/scala_callee_extractor_spec.cr
@@ -1,0 +1,67 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/scala_callee_extractor"
+
+describe Noir::ScalaCalleeExtractor do
+  it "extracts receiver and bare calls from Scala handler bodies" do
+    body = <<-SCALA
+      val user = UserService.find(params("id"))
+      AuditLog.write("show", user.id)
+      json(serializeUser(user))
+      SCALA
+
+    callees = Noir::ScalaCalleeExtractor.callees_for_body(body, "Routes.scala", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService.find", 10},
+      {"params", 10},
+      {"AuditLog.write", 11},
+      {"json", 12},
+      {"serializeUser", 12},
+    ])
+  end
+
+  it "normalizes spaced receiver calls and multiline receiver chains" do
+    body = <<-SCALA
+      val users = UserService
+        .list()
+      val profile = ProfileService . load(user.id)
+      SCALA
+
+    callees = Noir::ScalaCalleeExtractor.callees_for_body(body, "Routes.scala", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService.list", 41},
+      {"ProfileService.load", 42},
+    ])
+  end
+
+  it "skips comments, strings, multiline strings, and common Scala keywords" do
+    body = <<-SCALA
+      // IgnoredService.run()
+      val literal = "UserService.create()"
+      val template = """
+        AuditLog.write()
+      """
+      if (enabled) {
+        SafeService.run()
+      }
+      SCALA
+
+    callees = Noir::ScalaCalleeExtractor.callees_for_body(body, "Routes.scala", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"SafeService.run", 26},
+    ])
+  end
+
+  it "skips block comments across lines" do
+    body = <<-SCALA
+      /*
+       * DangerousService.run()
+       */
+      SafeService.run()
+      SCALA
+
+    callees = Noir::ScalaCalleeExtractor.callees_for_body(body, "Routes.scala", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"SafeService.run", 33},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -6,11 +6,11 @@ module Analyzer::Scala
 
     def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
-      extract_routes_from_content(path, content)
+      extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?))
     end
 
     # Extract routes from Akka HTTP DSL
-    private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
+    private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
       prefix_stack = [] of String
@@ -18,7 +18,8 @@ module Analyzer::Scala
       prefix_depths = [] of Int32 # Track at which depth each prefix was added
 
       lines.each_with_index do |line, index|
-        stripped_line = line.strip
+        stripped_line = scala_code_line(line).strip
+        structural_line = scala_structural_line(line).strip
 
         # Handle pathPrefix: pathPrefix("api") { ... }
         if path_prefix_match = stripped_line.match(/pathPrefix\s*\(\s*"([^"]+)"\s*\)/)
@@ -51,7 +52,11 @@ module Analyzer::Scala
           full_path = prefix_stack.empty? ? route_path : "#{prefix_stack.join("")}#{route_path}"
 
           # Find HTTP methods in the following lines within the same block
-          block_content = extract_block_from_index(lines, index)
+          block = extract_block_from_index(lines, index)
+          next unless block
+
+          block_content = block[0]
+          block_end = block[2]
 
           HTTP_METHODS.each do |method|
             if block_content =~ /\b#{method}\s*\{/
@@ -64,6 +69,7 @@ module Analyzer::Scala
 
               # Extract additional parameters from the block
               extract_params_from_block(endpoint, block_content)
+              attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
 
               endpoints << endpoint
             end
@@ -71,8 +77,8 @@ module Analyzer::Scala
         end
 
         # Track brace depth to manage prefix stack
-        opening_braces = stripped_line.count('{')
-        closing_braces = stripped_line.count('}')
+        opening_braces = structural_line.count('{')
+        closing_braces = structural_line.count('}')
 
         brace_depth += opening_braces
         brace_depth -= closing_braces
@@ -88,27 +94,48 @@ module Analyzer::Scala
     end
 
     # Extract block content starting from a given index
-    private def extract_block_from_index(lines : Array(String), start_index : Int32) : String
-      block_lines = [] of String
-      brace_count = 0
-      started = false
+    private def extract_block_from_index(lines : Array(String), start_index : Int32) : Tuple(String, Int32, Int32)?
+      extract_scala_brace_block_with_end(lines, start_index)
+    end
 
-      (start_index...lines.size).each do |i|
-        line = lines[i]
+    private def attach_method_callees(endpoint : Endpoint,
+                                      lines : Array(String),
+                                      route_start : Int32,
+                                      route_end : Int32,
+                                      method : String,
+                                      path : String)
+      extract_method_blocks(lines, route_start, route_end, method).each do |body, start_line|
+        callees = Noir::ScalaCalleeExtractor.callees_for_body(body, path, start_line)
+        attach_scala_callees(endpoint, callees)
+      end
+    end
 
-        brace_count += line.count('{')
+    private def extract_method_blocks(lines : Array(String),
+                                      route_start : Int32,
+                                      route_end : Int32,
+                                      method : String) : Array(Tuple(String, Int32))
+      blocks = [] of Tuple(String, Int32)
+      index = route_start
 
-        if brace_count > 0
-          started = true
-          block_lines << line
+      while index <= route_end
+        stripped = scala_structural_line(lines[index])
+        match = stripped.match(/(?<![.\w])#{Regex.escape(method)}\s*\{/)
+        unless match
+          index += 1
+          next
         end
 
-        brace_count -= line.count('}')
+        opening_brace = (match.end(0) || 1) - 1
+        if block = extract_scala_brace_block_with_end_at(lines, index, opening_brace)
+          blocks << {block[0], block[1]}
+          index = block[2] + 1
+          next
+        end
 
-        break if started && brace_count <= 0
+        index += 1
       end
 
-      block_lines.join(" ")
+      blocks
     end
 
     # Extract parameters from a code block

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -6,16 +6,16 @@ module Analyzer::Scala
 
     def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
-      extract_routes_from_content(path, content)
+      extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?))
     end
 
     # Extract routes from Scalatra DSL
-    private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
+    private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
 
       lines.each_with_index do |line, index|
-        stripped_line = line.strip
+        stripped_line = scala_code_line(line).strip
 
         # Match Scalatra route definitions: get("/path") { ... }
         HTTP_METHODS.each do |method|
@@ -32,8 +32,10 @@ module Analyzer::Scala
             extract_path_params(endpoint, route_path)
 
             # Extract parameters from the route block
-            block_content = extract_block_from_index(lines, index)
+            block = extract_block_from_index(lines, index)
+            block_content = block ? block[0] : ""
             extract_params_from_block(endpoint, block_content)
+            attach_route_callees(endpoint, block_content, path, block[1]) if include_callee && block
 
             endpoints << endpoint
           end
@@ -59,27 +61,13 @@ module Analyzer::Scala
     end
 
     # Extract block content starting from a given index
-    private def extract_block_from_index(lines : Array(String), start_index : Int32) : String
-      block_lines = [] of String
-      brace_count = 0
-      started = false
+    private def extract_block_from_index(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      extract_scala_brace_block(lines, start_index)
+    end
 
-      (start_index...lines.size).each do |i|
-        line = lines[i]
-
-        brace_count += line.count('{')
-
-        if brace_count > 0
-          started = true
-          block_lines << line
-        end
-
-        brace_count -= line.count('}')
-
-        break if started && brace_count <= 0
-      end
-
-      block_lines.join("\n")
+    private def attach_route_callees(endpoint : Endpoint, body : String, path : String, start_line : Int32)
+      callees = Noir::ScalaCalleeExtractor.callees_for_body(body, path, start_line)
+      attach_scala_callees(endpoint, callees)
     end
 
     # Extract parameters from a code block

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -1,4 +1,5 @@
 require "../../models/analyzer"
+require "../../miniparsers/scala_callee_extractor"
 
 module Analyzer::Scala
   abstract class ScalaEngine < Analyzer
@@ -32,6 +33,99 @@ module Analyzer::Scala
       rescue e
         logger.debug e
       end
+    end
+
+    protected def attach_scala_callees(endpoint : Endpoint, callees : Array(Noir::ScalaCalleeExtractor::Entry))
+      Noir::ScalaCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    protected def extract_scala_brace_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+      block = extract_scala_brace_block_with_end(lines, start_index)
+      return unless block
+
+      {block[0], block[1]}
+    end
+
+    protected def extract_scala_brace_block_with_end(lines : Array(String), start_index : Int32) : Tuple(String, Int32, Int32)?
+      return if start_index >= lines.size
+
+      opening_brace = scala_structural_opening_brace(lines[start_index])
+      return unless opening_brace
+
+      extract_scala_brace_block_with_end_at(lines, start_index, opening_brace)
+    end
+
+    protected def extract_scala_brace_block_at(lines : Array(String),
+                                               start_index : Int32,
+                                               opening_brace : Int32) : Tuple(String, Int32)?
+      block = extract_scala_brace_block_with_end_at(lines, start_index, opening_brace)
+      return unless block
+
+      {block[0], block[1]}
+    end
+
+    protected def extract_scala_brace_block_with_end_at(lines : Array(String),
+                                                        start_index : Int32,
+                                                        opening_brace : Int32) : Tuple(String, Int32, Int32)?
+      return if start_index >= lines.size
+
+      body_after_scala_opening_brace(lines, start_index, opening_brace)
+    end
+
+    protected def scala_structural_line(line : String) : String
+      stripped, _, _ = Noir::ScalaCalleeExtractor.strip_non_code_with_state(line, 0, false)
+      stripped
+    end
+
+    protected def scala_code_line(line : String) : String
+      Noir::ScalaCalleeExtractor.strip_comment_preserving_strings(line)
+    end
+
+    private def scala_structural_opening_brace(line : String) : Int32?
+      scala_structural_line(line).index('{')
+    end
+
+    private def body_after_scala_opening_brace(lines : Array(String),
+                                               opening_index : Int32,
+                                               opening_brace : Int32) : Tuple(String, Int32, Int32)
+      opening_line = lines[opening_index]
+      first_fragment = opening_line[(opening_brace + 1)..]? || ""
+      clean_fragment, block_comment_depth, in_multiline_string = Noir::ScalaCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
+      body_lines = [] of String
+      brace_count = 1 + clean_fragment.count('{') - clean_fragment.count('}')
+
+      if brace_count <= 0
+        closing_brace = clean_fragment.rindex('}')
+        first_fragment = first_fragment[0...closing_brace] if closing_brace
+        return {first_fragment, opening_index + 1, opening_index}
+      end
+
+      body_lines << first_fragment
+      index = opening_index + 1
+
+      while index < lines.size && brace_count > 0
+        line = lines[index]
+        stripped, block_comment_depth, in_multiline_string = Noir::ScalaCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        next_brace_count = brace_count + stripped.count('{') - stripped.count('}')
+
+        if next_brace_count <= 0
+          if line.strip != "}"
+            closing_brace = stripped.rindex('}')
+            body_lines << (closing_brace ? line[0...closing_brace] : line)
+          end
+          return {body_lines.join("\n"), opening_index + 1, index}
+        end
+
+        body_lines << line
+        brace_count = next_brace_count
+        index += 1
+      end
+
+      {body_lines.join("\n"), opening_index + 1, index}
     end
   end
 end

--- a/src/miniparsers/scala_callee_extractor.cr
+++ b/src/miniparsers/scala_callee_extractor.cr
@@ -1,0 +1,206 @@
+require "../models/endpoint"
+
+module Noir::ScalaCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "abstract", "case", "catch", "class", "def", "do", "else",
+    "extends", "false", "final", "finally", "for", "forSome",
+    "if", "implicit", "import", "lazy", "match", "new", "null",
+    "object", "override", "package", "private", "protected",
+    "return", "sealed", "super", "this", "throw", "trait", "try",
+    "true", "type", "val", "var", "while", "with", "yield",
+    "println", "Some", "None", "Nil",
+  }
+
+  RECEIVER_CALL_REGEX = /([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)+)\s*(?:\(|\{)/
+  BARE_CALL_REGEX     = /(?<![.\w])([A-Za-z_]\w*)\s*(?:\(|\{)/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Tuple(Int32, Entry)
+    block_comment_depth = 0
+    in_multiline_string = false
+    code = String::Builder.new
+    line_offsets = [] of Int32
+    offset = 0
+    body_lines = body.lines
+
+    body_lines.each_with_index do |line, index|
+      stripped, block_comment_depth, in_multiline_string = strip_non_code_with_state(
+        line,
+        block_comment_depth,
+        in_multiline_string
+      )
+      line_offsets << offset
+      code << stripped
+
+      unless index == body_lines.size - 1
+        code << '\n'
+        offset += stripped.size + 1
+      end
+    end
+
+    scan_code(code.to_s, file_path, start_line, line_offsets, entries)
+    dedup_entries(entries.sort_by(&.[0]).map(&.[1]))
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def strip_comment(line : String, block_comment_depth : Int32 = 0, in_multiline_string : Bool = false) : String
+    stripped, _, _ = strip_non_code_with_state(line, block_comment_depth, in_multiline_string)
+    stripped
+  end
+
+  def strip_comment_preserving_strings(line : String) : String
+    stripped, _, _ = strip_non_code_with_state(line, 0, false, preserve_strings: true)
+    stripped
+  end
+
+  def strip_non_code_with_state(line : String,
+                                block_comment_depth : Int32,
+                                in_multiline_string : Bool,
+                                preserve_strings : Bool = false) : Tuple(String, Int32, Bool)
+    in_string = false
+    escaped = false
+    index = 0
+    stripped = String::Builder.new
+
+    while index < line.size
+      char = line[index]
+      next_char = line[index + 1]?
+      third_char = line[index + 2]?
+
+      if block_comment_depth > 0
+        if char == '/' && next_char == '*'
+          block_comment_depth += 1
+          append_spaces(stripped, 2)
+          index += 2
+          next
+        elsif char == '*' && next_char == '/'
+          block_comment_depth -= 1
+          append_spaces(stripped, 2)
+          index += 2
+          next
+        end
+        stripped << ' '
+      elsif in_multiline_string
+        if char == '"' && next_char == '"' && third_char == '"'
+          in_multiline_string = false
+          append_spaces(stripped, 3)
+          index += 3
+          next
+        end
+        stripped << ' '
+      elsif in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == '"'
+          in_string = false
+        end
+        stripped << (preserve_strings ? char : ' ')
+      elsif char == '"'
+        if next_char == '"' && third_char == '"'
+          in_multiline_string = true
+          append_spaces(stripped, 3)
+          index += 3
+          next
+        else
+          in_string = true
+        end
+        stripped << (preserve_strings ? char : ' ')
+      elsif char == '/' && next_char == '/'
+        append_spaces(stripped, line.size - index)
+        return {stripped.to_s, block_comment_depth, in_multiline_string}
+      elsif char == '/' && next_char == '*'
+        block_comment_depth += 1
+        append_spaces(stripped, 2)
+        index += 2
+        next
+      else
+        stripped << char
+      end
+      index += 1
+    end
+
+    {stripped.to_s, block_comment_depth, in_multiline_string}
+  end
+
+  private def append_spaces(stripped : String::Builder, count : Int32)
+    count.times { stripped << ' ' }
+  end
+
+  private def scan_code(code : String,
+                        file_path : String,
+                        start_line : Int32,
+                        line_offsets : Array(Int32),
+                        entries : Array(Tuple(Int32, Entry)))
+    code.scan(RECEIVER_CALL_REGEX) do |match|
+      name = normalized_name(match[1])
+      next if skip_callee?(name)
+
+      offset = call_offset(match)
+      entries << {offset, {name, file_path, line_for_offset(offset, start_line, line_offsets)}}
+    end
+
+    code.scan(BARE_CALL_REGEX) do |match|
+      name = match[1]
+      name_start = match.begin(1) || 0
+      next if dotted_receiver_continuation?(code, name_start)
+      next if skip_callee?(name)
+
+      offset = call_offset(match)
+      entries << {offset, {name, file_path, line_for_offset(offset, start_line, line_offsets)}}
+    end
+  end
+
+  private def call_offset(match : Regex::MatchData) : Int32
+    (match.end(0) || match.begin(0) || 1) - 1
+  end
+
+  private def line_for_offset(offset : Int32, start_line : Int32, line_offsets : Array(Int32)) : Int32
+    line_index = 0
+    line_offsets.each_with_index do |line_offset, index|
+      break if line_offset > offset
+
+      line_index = index
+    end
+
+    start_line + line_index
+  end
+
+  private def dotted_receiver_continuation?(code : String, name_start : Int32) : Bool
+    code[0...name_start].strip.ends_with?(".")
+  end
+
+  private def normalized_name(name : String) : String
+    name.gsub(/\s+/, "")
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared lightweight Scala callee extractor for receiver and bare calls
- wire Akka HTTP method-block callees behind `--include-callee`
- wire Scalatra route-block callees behind `--include-callee`
- add fixtures/specs covering comments, strings, multiline strings, compact handlers, Akka sibling verbs, and nested path prefixes

## Scope
- Akka callees are sliced from the matched HTTP method block to avoid sibling verb leakage
- Scalatra callees are sliced from the route block using the shared comment/string-aware Scala brace helper
- existing Akka parameter behavior is preserved; this PR only narrows callee extraction to method bodies

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-scala-target4 crystal spec spec/unit_test/miniparser/scala_callee_extractor_spec.cr spec/unit_test/analyzer/analyzer_scala_akka_spec.cr spec/functional_test/testers/scala/akka_spec.cr spec/functional_test/testers/scala/akka_callees_spec.cr spec/functional_test/testers/scala/scalatra_spec.cr spec/functional_test/testers/scala/scalatra_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-scala-build3 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-scala-test2 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-scala-check3 just check`
- `./bin/noir -b spec/functional_test/fixtures/scala/akka_callees -f json --include-callee`
- `./bin/noir -b spec/functional_test/fixtures/scala/scalatra_callees -f json --include-callee`

Part of #1366.
