### PR TITLE
Add Clojure Compojure callee extraction

### DIFF
--- a/spec/functional_test/fixtures/clojure/compojure_callees/project.clj
+++ b/spec/functional_test/fixtures/clojure/compojure_callees/project.clj
@@ -1,0 +1,3 @@
+(defproject compojure-callees "0.1.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [compojure "1.7.1"]])

--- a/spec/functional_test/fixtures/clojure/compojure_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure_callees/src/demo/core.clj
@@ -1,0 +1,26 @@
+(ns demo.core
+  (:require [compojure.core :refer [defroutes GET POST DELETE context]]
+            [ring.util.response :as response]))
+
+(defroutes app-routes
+  (GET "/users/:id" [id]
+    (let [user (user.service/find-user id)]
+      (audit.log/write! "show" user)
+      (response/ok (present-user user))))
+
+  (POST "/users" request
+    (let [payload (payload/from-request request)
+          user (user.service/create! payload)]
+      (response/created (str "/users/" (:id user)) (present-user user))))
+
+  (context "/api" []
+    (DELETE "/users/:id" [id force]
+      (audit.log/write! "delete" id)
+      (response/ok (user.service/delete! id force))))
+
+  (GET "/quoted" []
+    ; (ignored/comment)
+    "(ignored/string)"
+    '(ignored/quoted)
+    (quote (ignored/again))
+    (response/ok (safe.service/run!))))

--- a/spec/functional_test/testers/clojure/compojure_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_callees_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+show_endpoint = Endpoint.new("/users/:id", "GET", [
+  Param.new("id", "", "path"),
+])
+show_endpoint.push_callee(Callee.new("user.service/find-user", line: 7))
+show_endpoint.push_callee(Callee.new("audit.log/write!", line: 8))
+show_endpoint.push_callee(Callee.new("response/ok", line: 9))
+show_endpoint.push_callee(Callee.new("present-user", line: 9))
+
+create_endpoint = Endpoint.new("/users", "POST")
+create_endpoint.push_callee(Callee.new("payload/from-request", line: 12))
+create_endpoint.push_callee(Callee.new("user.service/create!", line: 13))
+create_endpoint.push_callee(Callee.new("response/created", line: 14))
+create_endpoint.push_callee(Callee.new("present-user", line: 14))
+
+delete_endpoint = Endpoint.new("/api/users/:id", "DELETE", [
+  Param.new("id", "", "path"),
+  Param.new("force", "", "query"),
+])
+delete_endpoint.push_callee(Callee.new("audit.log/write!", line: 18))
+delete_endpoint.push_callee(Callee.new("response/ok", line: 19))
+delete_endpoint.push_callee(Callee.new("user.service/delete!", line: 19))
+
+quoted_endpoint = Endpoint.new("/quoted", "GET")
+quoted_endpoint.push_callee(Callee.new("response/ok", line: 26))
+quoted_endpoint.push_callee(Callee.new("safe.service/run!", line: 26))
+
+expected_endpoints = [
+  show_endpoint,
+  create_endpoint,
+  delete_endpoint,
+  quoted_endpoint,
+]
+
+FunctionalTester.new("fixtures/clojure/compojure_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -33,4 +33,18 @@ describe Noir::ClojureCalleeExtractor do
       {"safe.service/run!", 25},
     ])
   end
+
+  it "keeps namespaced callees that share reserved base names" do
+    body = <<-CLJ
+      (let [items (db/filter params)]
+        (my-service/map items)
+        (clojure.core/map identity items))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"db/filter", 30},
+      {"my-service/map", 31},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -1,0 +1,36 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/clojure_callee_extractor"
+
+describe Noir::ClojureCalleeExtractor do
+  it "extracts nested Clojure calls from handler bodies" do
+    body = <<-CLJ
+      (let [user (user.service/find-user id)]
+        (audit.log/write! "show" user)
+        (response/ok (present-user user)))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"user.service/find-user", 10},
+      {"audit.log/write!", 11},
+      {"response/ok", 12},
+      {"present-user", 12},
+    ])
+  end
+
+  it "skips comments, strings, quoted forms, and common special forms" do
+    body = <<-CLJ
+      ; (ignored/comment)
+      "(ignored/string)"
+      '(ignored/quoted)
+      (quote (ignored/again))
+      #_(ignored/discarded)
+      (safe.service/run!)
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"safe.service/run!", 25},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
 
 module Analyzer::Clojure
@@ -16,13 +17,14 @@ module Analyzer::Clojure
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       all_files.each do |path|
         next unless clojure_file?(path)
 
         content = read_file_content(path)
         next unless compojure_source?(content)
 
-        scan_forms(content, 0, content.bytesize, "", path)
+        scan_forms(content, 0, content.bytesize, "", path, include_callee)
       end
 
       Fiber.yield
@@ -37,7 +39,7 @@ module Analyzer::Clojure
       content.includes?("compojure.core") || content.includes?("defroutes") || content.includes?("(context")
     end
 
-    private def scan_forms(source : String, start_index : Int32, end_index : Int32, prefix : String, path : String)
+    private def scan_forms(source : String, start_index : Int32, end_index : Int32, prefix : String, path : String, include_callee : Bool)
       i = start_index
       while i < end_index
         case source.byte_at(i).unsafe_chr
@@ -58,14 +60,14 @@ module Analyzer::Clojure
           when "context"
             context_path, _ = first_string_literal(source, after_symbol, form_end)
             next_prefix = context_path ? join_path(prefix, context_path) : prefix
-            scan_forms(source, after_symbol, form_end, next_prefix, path)
+            scan_forms(source, after_symbol, form_end, next_prefix, path, include_callee)
           when "defroutes", "routes"
-            scan_forms(source, after_symbol, form_end, prefix, path)
+            scan_forms(source, after_symbol, form_end, prefix, path, include_callee)
           else
             if route_method = ROUTE_METHODS[base]?
-              add_route(source, i, after_symbol, form_end, prefix, path, route_method)
+              add_route(source, i, after_symbol, form_end, prefix, path, route_method, include_callee)
             else
-              scan_forms(source, after_symbol, form_end, prefix, path)
+              scan_forms(source, after_symbol, form_end, prefix, path, include_callee)
             end
           end
 
@@ -77,7 +79,7 @@ module Analyzer::Clojure
     end
 
     private def add_route(source : String, form_start : Int32, args_start : Int32, form_end : Int32,
-                          prefix : String, path : String, method : String)
+                          prefix : String, path : String, method : String, include_callee : Bool)
       route_path, path_end = first_string_literal(source, args_start, form_end)
       return unless route_path
 
@@ -95,7 +97,38 @@ module Analyzer::Clojure
         end
       end
 
+      attach_route_callees(endpoint, source, path_end + 1, form_end, path) if include_callee
+
       @result << endpoint
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, source : String, args_start : Int32, form_end : Int32, path : String)
+      body_start = route_body_start(source, args_start, form_end)
+      return if body_start >= form_end
+
+      body = source[body_start...form_end]
+      start_line = line_number_for(source, body_start)
+      callees = Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line)
+      Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    private def route_body_start(source : String, index : Int32, limit : Int32) : Int32
+      i = skip_ws_and_comments(source, index, limit)
+      return i if i >= limit
+
+      case source.byte_at(i).unsafe_chr
+      when '['
+        binding_end = find_matching_delimiter(source, i, '[', ']', limit)
+        binding_end > i ? binding_end + 1 : i
+      when '{'
+        binding_end = find_matching_delimiter(source, i, '{', '}', limit)
+        binding_end > i ? binding_end + 1 : i
+      when '('
+        i
+      else
+        _, after_symbol = read_symbol(source, i, limit)
+        after_symbol
+      end
     end
 
     private def extract_path_param_names(route_path : String) : Array(String)

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -69,20 +69,38 @@ module Noir::ClojureCalleeExtractor
   end
 
   private def quoted_form?(symbol : String) : Bool
-    base_symbol(symbol) == "quote"
+    reserved_symbol?(symbol, "quote")
   end
 
   private def skip_callee?(symbol : String) : Bool
     return true if symbol.empty?
     return true if symbol.starts_with?(':')
 
-    base = base_symbol(symbol)
-    RESERVED.includes?(base)
+    reserved_symbol?(symbol)
+  end
+
+  private def reserved_symbol?(symbol : String, expected : String? = nil) : Bool
+    if symbol.includes?('/')
+      return false unless symbol.starts_with?("clojure.core/")
+
+      base = base_symbol(symbol)
+    else
+      base = symbol
+    end
+
+    if expected
+      base == expected
+    else
+      RESERVED.includes?(base)
+    end
   end
 
   private def base_symbol(symbol : String) : String
-    parts = symbol.split('/')
-    parts.last? || symbol
+    if index = symbol.rindex('/')
+      symbol[(index + 1)..]
+    else
+      symbol
+    end
   end
 
   private def skip_quoted_form(source : String, index : Int32, limit : Int32) : Int32
@@ -182,7 +200,7 @@ module Noir::ClojureCalleeExtractor
   end
 
   private def line_number_for(source : String, index : Int32, start_line : Int32) : Int32
-    start_line + source[0...index].count('\n')
+    start_line + source.to_slice[0, index].count('\n'.ord.to_u8)
   end
 
   private def whitespace?(char : Char) : Bool
@@ -190,15 +208,7 @@ module Noir::ClojureCalleeExtractor
   end
 
   private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -1,0 +1,204 @@
+require "../models/endpoint"
+
+module Noir::ClojureCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "def", "defn", "defmacro", "fn", "let", "letfn", "if", "if-not",
+    "when", "when-not", "when-let", "when-first", "cond", "condp",
+    "case", "do", "doseq", "dotimes", "for", "loop", "recur",
+    "try", "catch", "finally", "throw", "quote", "var", "new",
+    "set!", "and", "or", "not", "->", "->>", "as->", "cond->",
+    "cond->>", "some->", "some->>", "doto", ".", "..", "comment",
+    "str", "println", "print", "prn", "list", "vector", "hash-map",
+    "map", "filter", "reduce", "partial", "comp", "identity",
+  }
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    scan_forms(body, 0, body.bytesize, file_path, start_line, entries)
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_forms(source : String,
+                         start_index : Int32,
+                         end_index : Int32,
+                         file_path : String,
+                         start_line : Int32,
+                         entries : Array(Entry))
+    i = start_index
+    while i < end_index
+      case source.byte_at(i).unsafe_chr
+      when ';'
+        i = skip_comment(source, i, end_index)
+      when '"'
+        i = skip_string(source, i, end_index) + 1
+      when '\'', '`'
+        i = skip_quoted_form(source, i + 1, end_index)
+      when '#'
+        next_char = i + 1 < end_index ? source.byte_at(i + 1).unsafe_chr : '\0'
+        if next_char == '_'
+          i = skip_quoted_form(source, i + 2, end_index)
+        else
+          i += 1
+        end
+      when '('
+        form_end = find_matching_delimiter(source, i, '(', ')', end_index)
+        break if form_end <= i
+
+        symbol_start = skip_ws_and_comments(source, i + 1, form_end)
+        symbol, after_symbol = read_symbol(source, symbol_start, form_end)
+        unless skip_callee?(symbol)
+          entries << {symbol, file_path, line_number_for(source, i, start_line)}
+        end
+
+        scan_forms(source, after_symbol, form_end, file_path, start_line, entries) unless quoted_form?(symbol)
+        i = form_end + 1
+      else
+        i += 1
+      end
+    end
+  end
+
+  private def quoted_form?(symbol : String) : Bool
+    base_symbol(symbol) == "quote"
+  end
+
+  private def skip_callee?(symbol : String) : Bool
+    return true if symbol.empty?
+    return true if symbol.starts_with?(':')
+
+    base = base_symbol(symbol)
+    RESERVED.includes?(base)
+  end
+
+  private def base_symbol(symbol : String) : String
+    parts = symbol.split('/')
+    parts.last? || symbol
+  end
+
+  private def skip_quoted_form(source : String, index : Int32, limit : Int32) : Int32
+    i = skip_ws_and_comments(source, index, limit)
+    return i if i >= limit
+
+    case source.byte_at(i).unsafe_chr
+    when '('
+      find_matching_delimiter(source, i, '(', ')', limit) + 1
+    when '['
+      find_matching_delimiter(source, i, '[', ']', limit) + 1
+    when '{'
+      find_matching_delimiter(source, i, '{', '}', limit) + 1
+    when '"'
+      skip_string(source, i, limit) + 1
+    else
+      _, after_symbol = read_symbol(source, i, limit)
+      after_symbol
+    end
+  end
+
+  private def read_symbol(source : String, index : Int32, limit : Int32) : Tuple(String, Int32)
+    i = index
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      break if whitespace?(char) || {'(', ')', '[', ']', '{', '}', '"', ';'}.includes?(char)
+
+      i += 1
+    end
+
+    {source[index...i], i}
+  end
+
+  private def skip_ws_and_comments(source : String, index : Int32, limit : Int32) : Int32
+    i = index
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if whitespace?(char)
+        i += 1
+      elsif char == ';'
+        i = skip_comment(source, i, limit)
+      else
+        break
+      end
+    end
+    i
+  end
+
+  private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+    i = index
+    while i < limit && source.byte_at(i).unsafe_chr != '\n'
+      i += 1
+    end
+    i
+  end
+
+  private def skip_string(source : String, index : Int32, limit : Int32) : Int32
+    i = index + 1
+    escaping = false
+
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if escaping
+        escaping = false
+      elsif char == '\\'
+        escaping = true
+      elsif char == '"'
+        return i
+      end
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
+    depth = 0
+    i = index
+
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      case char
+      when ';'
+        i = skip_comment(source, i, limit)
+      when '"'
+        i = skip_string(source, i, limit)
+      when open_char
+        depth += 1
+      when close_char
+        depth -= 1
+        return i if depth == 0
+      end
+      i += 1
+    end
+
+    index
+  end
+
+  private def line_number_for(source : String, index : Int32, start_line : Int32) : Int32
+    start_line + source[0...index].count('\n')
+  end
+
+  private def whitespace?(char : Char) : Bool
+    char.whitespace?
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight Clojure callee extractor for first-symbol function calls in handler bodies
- wire Compojure route bodies to attach callees when `--include-callee` is enabled
- add Compojure callee fixtures covering path/query params, nested context routes, request-symbol handlers, quoted forms, strings, comments, and reader discard forms

## Scope
- captures direct Clojure list invocations inside route handler bodies
- skips common special forms, comments, strings, quoted forms, and `#_` discarded forms
- keeps existing route and parameter extraction behavior unchanged

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-clojure-target5 crystal spec spec/unit_test/miniparser/clojure_callee_extractor_spec.cr spec/functional_test/testers/clojure/compojure_spec.cr spec/functional_test/testers/clojure/compojure_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-clojure-build2 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-clojure-test1 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-clojure-check1 just check`
- `./bin/noir -b spec/functional_test/fixtures/clojure/compojure_callees -f json --include-callee`

Part of #1366.
