### PR TITLE
Add C++ Crow and Drogon callee extraction

### DIFF
--- a/spec/functional_test/fixtures/cpp/crow_callees/app.cpp
+++ b/spec/functional_test/fixtures/cpp/crow_callees/app.cpp
@@ -1,0 +1,36 @@
+#include "crow.h"
+
+int main() {
+    crow::SimpleApp app;
+
+    CROW_ROUTE(app, "/users/<int>")
+    ([](const crow::request& req, int id) {
+        auto user = UserService::load(id);
+        AuditLog::write("show", user);
+        return crow::response(serializeUser(user));
+    });
+
+    CROW_ROUTE(app, "/users").methods("POST"_method, "PUT"_method)
+    ([](const crow::request& req) {
+        auto payload = parseJson(req.body);
+        UserService service;
+        auto user = service.save(payload);
+        return crow::response(201, renderUser(user));
+    });
+
+    CROW_BP_ROUTE(api, "/search")
+    .methods("GET"_method)
+    ([](const crow::request& request) {
+        auto q = request.url_params.get("q");
+        auto token = request.get_header_value("X-Token");
+        // Ignored::comment();
+        auto text = "Ignored::string()";
+        if (FeatureFlags::enabled("search")) {
+            return crow::response(SearchService::run(q, token));
+        }
+        return crow::response(404);
+    });
+
+    app.port(18080).multithreaded().run();
+    return 0;
+}

--- a/spec/functional_test/fixtures/cpp/drogon_callees/main.cpp
+++ b/spec/functional_test/fixtures/cpp/drogon_callees/main.cpp
@@ -1,0 +1,57 @@
+#include <drogon/drogon.h>
+#include <drogon/HttpController.h>
+
+using namespace drogon;
+
+class ApiController : public drogon::HttpController<ApiController> {
+public:
+    METHOD_LIST_BEGIN
+    ADD_METHOD_TO(ApiController::listUsers, "/api/users", Get);
+    ADD_METHOD_TO(ApiController::createUser, "/api/users", Post);
+    METHOD_LIST_END
+
+    void warmup(const HttpRequestPtr &req) {
+        if (listUsers(req)) {
+            Noise::wrong();
+        }
+    }
+
+    void listUsers(const HttpRequestPtr &req,
+                   std::function<void(const HttpResponsePtr &)> &&callback) {
+        auto users = UserService::list();
+        auto resp = HttpResponse::newHttpJsonResponse(renderUsers(users));
+        callback(resp);
+    }
+
+    void createUser(const HttpRequestPtr &req,
+                    std::function<void(const HttpResponsePtr &)> &&callback) {
+        auto body = req->getJsonObject();
+        auto user = UserService::create(body);
+        callback(makeCreatedResponse(user));
+    }
+};
+
+int main() {
+    app().registerHandler(
+        "/ping",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            auto name = req->getParameter("name");
+            auto resp = HttpResponse::newHttpResponse();
+            callback(resp);
+        },
+        {Get});
+
+    app().registerHandler(
+        "/items/{id:int}",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback,
+           int id) {
+            auto item = ItemService::load(id);
+            callback(HttpResponse::newHttpJsonResponse(renderItem(item)));
+        },
+        {Get, drogon::Delete});
+
+    app().run();
+    return 0;
+}

--- a/spec/functional_test/testers/cpp/crow_callees_spec.cr
+++ b/spec/functional_test/testers/cpp/crow_callees_spec.cr
@@ -1,0 +1,47 @@
+require "../../func_spec.cr"
+
+def endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [
+  endpoint_with_callees("/users/{param1}", "GET", [
+    Param.new("param1", "", "path"),
+  ], [
+    Callee.new("UserService::load", line: 8),
+    Callee.new("AuditLog::write", line: 9),
+    Callee.new("crow::response", line: 10),
+    Callee.new("serializeUser", line: 10),
+  ]),
+  endpoint_with_callees("/users", "POST", [] of Param, [
+    Callee.new("parseJson", line: 15),
+    Callee.new("service.save", line: 17),
+    Callee.new("crow::response", line: 18),
+    Callee.new("renderUser", line: 18),
+  ]),
+  endpoint_with_callees("/users", "PUT", [] of Param, [
+    Callee.new("parseJson", line: 15),
+    Callee.new("service.save", line: 17),
+    Callee.new("crow::response", line: 18),
+    Callee.new("renderUser", line: 18),
+  ]),
+  endpoint_with_callees("/search", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("X-Token", "", "header"),
+  ], [
+    Callee.new("request.url_params.get", line: 24),
+    Callee.new("request.get_header_value", line: 25),
+    Callee.new("FeatureFlags::enabled", line: 28),
+    Callee.new("crow::response", line: 29),
+    Callee.new("SearchService::run", line: 29),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/crow_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/cpp/drogon_callees_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_callees_spec.cr
@@ -1,0 +1,46 @@
+require "../../func_spec.cr"
+
+def drogon_endpoint_with_callees(url, method, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [
+  drogon_endpoint_with_callees("/ping", "GET", [
+    Callee.new("req->getParameter", line: 39),
+    Callee.new("HttpResponse::newHttpResponse", line: 40),
+    Callee.new("callback", line: 41),
+  ]),
+  drogon_endpoint_with_callees("/items/{id}", "GET", [
+    Callee.new("ItemService::load", line: 50),
+    Callee.new("callback", line: 51),
+    Callee.new("HttpResponse::newHttpJsonResponse", line: 51),
+    Callee.new("renderItem", line: 51),
+  ]),
+  drogon_endpoint_with_callees("/items/{id}", "DELETE", [
+    Callee.new("ItemService::load", line: 50),
+    Callee.new("callback", line: 51),
+    Callee.new("HttpResponse::newHttpJsonResponse", line: 51),
+    Callee.new("renderItem", line: 51),
+  ]),
+  drogon_endpoint_with_callees("/api/users", "GET", [
+    Callee.new("UserService::list", line: 21),
+    Callee.new("HttpResponse::newHttpJsonResponse", line: 22),
+    Callee.new("renderUsers", line: 22),
+    Callee.new("callback", line: 23),
+  ]),
+  drogon_endpoint_with_callees("/api/users", "POST", [
+    Callee.new("req->getJsonObject", line: 28),
+    Callee.new("UserService::create", line: 29),
+    Callee.new("callback", line: 30),
+    Callee.new("makeCreatedResponse", line: 30),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/drogon_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/cpp_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/cpp_callee_extractor_spec.cr
@@ -1,0 +1,77 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/cpp_callee_extractor"
+
+describe Noir::CppCalleeExtractor do
+  it "extracts scoped, member, and bare C++ calls from handler bodies" do
+    body = <<-CPP
+      auto user = UserService::load(id);
+      auto token = req->getParameter("token");
+      audit.write(user);
+      callback(makeResponse(user));
+      auto payload = Parser::decode<std::map<std::string, std::vector<int>>>(req->body());
+      CPP
+
+    callees = Noir::CppCalleeExtractor.callees_for_body(body, "handler.cpp", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService::load", 10},
+      {"req->getParameter", 11},
+      {"audit.write", 12},
+      {"callback", 13},
+      {"makeResponse", 13},
+      {"Parser::decode", 14},
+      {"req->body", 14},
+    ])
+  end
+
+  it "skips control keywords, comments, strings, and char literals" do
+    body = <<-CPP
+      if (ready()) {
+        auto text = "Ignored::string() { }";
+        char brace = '}';
+        /* Ignored::block(); */
+        // Ignored::line();
+        auto casted = const_cast<User*>(user);
+        Real::call();
+      }
+      CPP
+
+    callees = Noir::CppCalleeExtractor.callees_for_body(body, "handler.cpp", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"ready", 20},
+      {"Real::call", 26},
+    ])
+  end
+
+  it "extracts blocks while ignoring braces in comments and strings" do
+    source = <<-CPP
+      app.route([] {
+        auto text = "}";
+        /* } */
+        Result::send();
+      });
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_block_after(source, 0)
+    block.should_not be_nil
+    block.try do |found_block|
+      body, start_line = found_block
+      callees = Noir::CppCalleeExtractor.callees_for_body(body, "handler.cpp", start_line)
+      callees.map { |name, _, line| {name, line} }.should eq([
+        {"Result::send", 4},
+      ])
+    end
+  end
+
+  it "does not extract a later block as a lambda body after a named handler route" do
+    source = <<-CPP
+      CROW_ROUTE(app, "/named")(&show_user);
+
+      auto unrelated = [] {
+        Wrong::call();
+      };
+      CPP
+
+    block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, 0)
+    block.should be_nil
+  end
+end

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/cpp_callee_extractor"
 
 module Analyzer::Cpp
   class Crow < Analyzer
@@ -18,6 +19,7 @@ module Analyzer::Cpp
     BODY_ACCESS      = /\b(req|request)\s*\.\s*body\b/
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -26,7 +28,7 @@ module Analyzer::Cpp
         parallel_analyze(channel) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
-          analyze_file(path)
+          analyze_file(path, include_callee)
         end
       rescue e
         logger.debug "Crow analyzer failed: #{e.message}"
@@ -35,11 +37,12 @@ module Analyzer::Cpp
       result
     end
 
-    private def analyze_file(path : String)
+    private def analyze_file(path : String, include_callee : Bool)
       source = read_file_content(path)
       return unless source.includes?("CROW_ROUTE") || source.includes?("CROW_BP_ROUTE")
 
       lines = source.split("\n")
+      line_offsets = line_start_offsets(source)
       last_endpoints = [] of Endpoint
 
       lines.each_with_index do |line, index|
@@ -68,10 +71,13 @@ module Analyzer::Cpp
 
           normalized_path, path_params = normalize_path(route_path)
           details = Details.new(PathInfo.new(path, index + 1))
+          route_offset = line_offsets[index] + (route_match.begin(0) || 0)
+          route_callees = include_callee ? callees_for_route(source, path, route_offset + route_match[0].bytesize) : [] of Noir::CppCalleeExtractor::Entry
 
           last_endpoints.clear
           methods.uniq.each do |method|
             endpoint = Endpoint.new(normalized_path, method, path_params.dup, details)
+            Noir::CppCalleeExtractor.attach_to(endpoint, route_callees) if include_callee
             result << endpoint
             last_endpoints << endpoint
           end
@@ -82,6 +88,32 @@ module Analyzer::Cpp
           end
         end
       end
+    end
+
+    private def callees_for_route(source : String, path : String, search_start : Int32) : Array(Noir::CppCalleeExtractor::Entry)
+      block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, search_start, next_route_offset(source, search_start))
+      return [] of Noir::CppCalleeExtractor::Entry unless block
+
+      body, start_line = block
+      Noir::CppCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def next_route_offset(source : String, search_start : Int32) : Int32
+      offsets = [
+        source.index("CROW_ROUTE", search_start),
+        source.index("CROW_BP_ROUTE", search_start),
+      ].compact
+      offsets.min? || source.bytesize
+    end
+
+    private def line_start_offsets(source : String) : Array(Int32)
+      offsets = [0]
+      index = 0
+      while index < source.bytesize
+        offsets << index + 1 if source.byte_at(index) == '\n'.ord
+        index += 1
+      end
+      offsets
     end
 
     private def normalize_path(route_path : String) : Tuple(String, Array(Param))

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -1,9 +1,12 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/cpp_callee_extractor"
 require "wait_group"
 
 module Analyzer::Cpp
   class Drogon < Analyzer
     CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp"]
+    alias HandlerTarget = Tuple(String?, String)
+    alias SourceRange = Tuple(Int32, Int32)
 
     HTTP_METHODS = {
       "Get"     => "GET",
@@ -20,9 +23,10 @@ module Analyzer::Cpp
 
     REGEX_REGISTER_HANDLER = /app\(\)\s*\.?\s*registerHandler\s*\(\s*"([^"]+)"/
     REGEX_PATH_ADD         = /PATH_ADD\s*\(\s*"([^"]+)"\s*,\s*([^)]+)\)/
-    REGEX_ADD_METHOD       = /ADD_METHOD_TO\s*\(\s*[^,]+\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)/
+    REGEX_ADD_METHOD       = /ADD_METHOD_TO\s*\(\s*([^,]+)\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)/
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -41,7 +45,7 @@ module Analyzer::Cpp
                       content.includes?("METHOD_LIST_BEGIN") ||
                       content.includes?("ADD_METHOD_TO")
 
-          analyze_file(path, content)
+          analyze_file(path, content, include_callee)
         end
       rescue e
         logger.debug "Drogon analyzer failed: #{e.message}"
@@ -50,11 +54,11 @@ module Analyzer::Cpp
       @result
     end
 
-    def analyze_file(path : String, content : String)
+    def analyze_file(path : String, content : String, include_callee : Bool = false)
       lines = content.split("\n")
       file_params = extract_params(lines)
 
-      extract_register_handler_endpoints(path, content, lines, file_params).each do |endpoint|
+      extract_register_handler_endpoints(path, content, lines, file_params, include_callee).each do |endpoint|
         @result << endpoint
       end
 
@@ -62,12 +66,12 @@ module Analyzer::Cpp
         @result << endpoint
       end
 
-      extract_block_endpoints(path, lines, "METHOD_LIST_BEGIN", "METHOD_LIST_END", REGEX_ADD_METHOD, file_params).each do |endpoint|
+      extract_add_method_endpoints(path, content, lines, file_params, include_callee).each do |endpoint|
         @result << endpoint
       end
     end
 
-    private def extract_register_handler_endpoints(path : String, content : String, lines : Array(String), file_params : Array(Param)) : Array(Endpoint)
+    private def extract_register_handler_endpoints(path : String, content : String, lines : Array(String), file_params : Array(Param), include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       # For each registerHandler("/path") occurrence, look ahead in the content
@@ -86,11 +90,14 @@ module Analyzer::Cpp
                   end
 
         line_number = find_line_number(lines, "registerHandler", match[1])
+        match_start = match.begin(0) || 0
+        callees = include_callee ? callees_for_block_after(content, path, match_start) : [] of Noir::CppCalleeExtractor::Entry
 
         methods.each do |m|
           details = Details.new(PathInfo.new(path, line_number))
           endpoint = Endpoint.new(route, m, details)
           file_params.each { |p| endpoint.push_param(p) }
+          Noir::CppCalleeExtractor.attach_to(endpoint, callees) if include_callee
           endpoints << endpoint
         end
       end
@@ -129,6 +136,154 @@ module Analyzer::Cpp
       end
 
       endpoints
+    end
+
+    private def extract_add_method_endpoints(path : String,
+                                             content : String,
+                                             lines : Array(String),
+                                             file_params : Array(Param),
+                                             include_callee : Bool) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      in_block = false
+
+      lines.each_with_index do |line, index|
+        if line.includes?("METHOD_LIST_BEGIN")
+          in_block = true
+          next
+        end
+
+        if line.includes?("METHOD_LIST_END")
+          in_block = false
+          next
+        end
+
+        next unless in_block
+
+        if match = line.match(REGEX_ADD_METHOD)
+          handler_target = normalize_handler_target(match[1])
+          route = normalize_path(match[2])
+          methods = parse_methods(match[3])
+          callees = include_callee ? callees_for_handler(content, path, handler_target) : [] of Noir::CppCalleeExtractor::Entry
+
+          methods.each do |m|
+            details = Details.new(PathInfo.new(path, index + 1))
+            endpoint = Endpoint.new(route, m, details)
+            file_params.each { |p| endpoint.push_param(p) }
+            Noir::CppCalleeExtractor.attach_to(endpoint, callees) if include_callee
+            endpoints << endpoint
+          end
+        end
+      end
+
+      endpoints
+    end
+
+    private def callees_for_block_after(content : String, path : String, search_start : Int32) : Array(Noir::CppCalleeExtractor::Entry)
+      block = Noir::CppCalleeExtractor.extract_block_after(content, search_start)
+      return [] of Noir::CppCalleeExtractor::Entry unless block
+
+      body, start_line = block
+      Noir::CppCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def callees_for_handler(content : String, path : String, handler_target : HandlerTarget) : Array(Noir::CppCalleeExtractor::Entry)
+      block = extract_method_body(content, handler_target)
+      return [] of Noir::CppCalleeExtractor::Entry unless block
+
+      body, start_line = block
+      Noir::CppCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def extract_method_body(content : String, handler_target : HandlerTarget) : Tuple(String, Int32)?
+      owner, method_name = handler_target
+      return if method_name.empty?
+
+      if owner
+        class_range = class_body_range(content, owner)
+        if class_range
+          body = extract_method_body_in_range(content, Regex.escape(method_name), class_range)
+          return body if body
+        end
+
+        extract_method_body_in_range(content, "#{Regex.escape(owner)}\\s*::\\s*#{Regex.escape(method_name)}", {0, content.bytesize})
+      else
+        extract_method_body_in_range(content, Regex.escape(method_name), {0, content.bytesize})
+      end
+    end
+
+    private def extract_method_body_in_range(content : String, method_pattern : String, range : SourceRange) : Tuple(String, Int32)?
+      range_start, range_end = range
+      content.scan(/\b#{method_pattern}\s*\(/) do |match|
+        match_start = match.begin(0) || 0
+        next if match_start < range_start || match_start >= range_end
+        next if call_context?(content, match_start)
+
+        open_paren = Noir::CppCalleeExtractor.find_next_code_char(content, '(', match_start)
+        next unless open_paren
+
+        close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
+        next unless close_paren
+
+        body_open = Noir::CppCalleeExtractor.find_next_code_char(content, '{', close_paren + 1)
+        next unless body_open
+        next if body_open > range_end
+        next unless method_suffix?(content[(close_paren + 1)...body_open])
+
+        semicolon = Noir::CppCalleeExtractor.find_next_code_char(content, ';', close_paren + 1)
+        next if semicolon && semicolon < body_open
+
+        body_close = Noir::CppCalleeExtractor.find_matching_delimiter(content, body_open, '{', '}')
+        next unless body_close
+
+        return {content[(body_open + 1)...body_close], Noir::CppCalleeExtractor.line_number_for(content, body_open)}
+      end
+
+      nil
+    end
+
+    private def class_body_range(content : String, class_name : String) : SourceRange?
+      content.scan(/\b(?:class|struct)\s+#{Regex.escape(class_name)}\b/) do |match|
+        class_start = match.begin(0) || 0
+        open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', class_start)
+        next unless open_brace
+
+        close_brace = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_brace, '{', '}')
+        next unless close_brace
+
+        return {open_brace + 1, close_brace}
+      end
+
+      nil
+    end
+
+    private def method_suffix?(suffix : String) : Bool
+      normalized = suffix.gsub(/noexcept\s*\([^)]*\)/, "noexcept")
+      normalized.matches?(/\A[\sA-Za-z0-9_:<>,*&\-\[\]]*\z/)
+    end
+
+    private def call_context?(content : String, index : Int32) : Bool
+      previous = previous_code_char(content, index)
+      previous == '(' || previous == '.' || previous == '>' || previous == ':'
+    end
+
+    private def previous_code_char(content : String, index : Int32) : Char?
+      cursor = index - 1
+      while cursor >= 0
+        char = content.byte_at(cursor).unsafe_chr
+        return char unless char.whitespace?
+
+        cursor -= 1
+      end
+
+      nil
+    end
+
+    private def normalize_handler_target(raw : String) : HandlerTarget
+      target = raw.strip.lchop('&').strip
+      parts = target.split("::").map(&.strip).reject(&.empty?)
+      method_name = parts.last? || target
+      owner = parts.size > 1 ? parts[-2] : nil
+      {owner, method_name}
     end
 
     private def parse_methods(raw : String) : Array(String)

--- a/src/miniparsers/cpp_callee_extractor.cr
+++ b/src/miniparsers/cpp_callee_extractor.cr
@@ -1,0 +1,289 @@
+require "../models/endpoint"
+
+module Noir::CppCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
+    "bitor", "bool", "break", "case", "catch", "char", "char8_t",
+    "char16_t", "char32_t", "class", "compl", "concept", "const",
+    "const_cast", "consteval", "constexpr", "constinit", "continue",
+    "co_await", "co_return", "co_yield", "decltype", "default", "delete", "do",
+    "double", "dynamic_cast", "else", "enum", "explicit", "export",
+    "extern", "false", "float", "for", "friend", "goto", "if",
+    "inline", "int", "long", "mutable", "namespace", "new", "noexcept",
+    "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private",
+    "protected", "public", "register", "reinterpret_cast", "requires",
+    "return", "short", "signed", "sizeof", "static", "static_assert",
+    "static_cast", "struct", "switch", "template", "this", "thread_local",
+    "throw", "true", "try", "typedef", "typeid", "typename", "union",
+    "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while",
+    "xor", "xor_eq",
+  }
+
+  ROUTE_MACROS = Set{
+    "CROW_ROUTE", "CROW_BP_ROUTE", "PATH_ADD", "ADD_METHOD_TO",
+    "PATH_LIST_BEGIN", "PATH_LIST_END", "METHOD_LIST_BEGIN", "METHOD_LIST_END",
+  }
+
+  SCOPED_CALL_REGEX = /((?:[A-Za-z_][A-Za-z0-9_]*\s*::\s*)+[A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^;\n{}]*>)?\s*\(/
+  MEMBER_CALL_REGEX = /([A-Za-z_][A-Za-z0-9_]*(?:\s*(?:->|\.)\s*[A-Za-z_][A-Za-z0-9_]*)+)\s*(?:<[^;\n{}]*>)?\s*\(/
+  BARE_CALL_REGEX   = /(?<![A-Za-z0-9_:.>])([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^;\n{}]*>)?\s*\(/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    in_block_comment = false
+
+    body.each_line.with_index do |line, index|
+      stripped, in_block_comment = strip_non_code_with_state(line, in_block_comment)
+      scan_line(stripped, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def extract_block_after(source : String, start_index : Int32, limit : Int32 = source.bytesize) : Tuple(String, Int32)?
+    open_index = find_next_code_char(source, '{', start_index, limit)
+    return unless open_index
+
+    close_index = find_matching_delimiter(source, open_index, '{', '}', limit)
+    return unless close_index
+
+    {source[(open_index + 1)...close_index], line_number_for(source, open_index)}
+  end
+
+  def extract_lambda_block_after(source : String, start_index : Int32, limit : Int32 = source.bytesize) : Tuple(String, Int32)?
+    open_index = find_next_code_char(source, '{', start_index, limit)
+    return unless open_index
+    return if find_next_code_char(source, ';', start_index, open_index)
+    return unless source[start_index...open_index].includes?('[')
+
+    close_index = find_matching_delimiter(source, open_index, '{', '}', limit)
+    return unless close_index
+
+    {source[(open_index + 1)...close_index], line_number_for(source, open_index)}
+  end
+
+  def find_next_code_char(source : String, target : Char, start_index : Int32, limit : Int32 = source.bytesize) : Int32?
+    i = start_index
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      case char
+      when '"'
+        i = skip_string(source, i, limit)
+      when '\''
+        i = skip_char_literal(source, i, limit)
+      when '/'
+        next_char = i + 1 < limit ? source.byte_at(i + 1).unsafe_chr : '\0'
+        if next_char == '/'
+          i = skip_line_comment(source, i, limit)
+        elsif next_char == '*'
+          i = skip_block_comment(source, i, limit)
+        elsif char == target
+          return i
+        end
+      else
+        return i if char == target
+      end
+      i += 1
+    end
+
+    nil
+  end
+
+  def find_matching_delimiter(source : String,
+                              index : Int32,
+                              open_char : Char,
+                              close_char : Char,
+                              limit : Int32 = source.bytesize) : Int32?
+    depth = 0
+    i = index
+
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      case char
+      when '"'
+        i = skip_string(source, i, limit)
+      when '\''
+        i = skip_char_literal(source, i, limit)
+      when '/'
+        next_char = i + 1 < limit ? source.byte_at(i + 1).unsafe_chr : '\0'
+        if next_char == '/'
+          i = skip_line_comment(source, i, limit)
+        elsif next_char == '*'
+          i = skip_block_comment(source, i, limit)
+        end
+      when open_char
+        depth += 1
+      when close_char
+        depth -= 1
+        return i if depth == 0
+      end
+      i += 1
+    end
+
+    nil
+  end
+
+  def line_number_for(source : String, index : Int32) : Int32
+    1 + source.to_slice[0, index].count('\n'.ord.to_u8)
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    line.scan(SCOPED_CALL_REGEX) do |match|
+      candidates << {match.begin(1) || 0, normalize_name(match[1])}
+    end
+
+    line.scan(MEMBER_CALL_REGEX) do |match|
+      candidates << {match.begin(1) || 0, normalize_name(match[1])}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      candidates << {match.begin(1) || 0, match[1]}
+    end
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |_, name|
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def normalize_name(name : String) : String
+    name.gsub(/\s+/, "")
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+    return true if ROUTE_MACROS.includes?(name)
+
+    last = name.split("::").last.split("->").last.split('.').last
+    RESERVED.includes?(last) || ROUTE_MACROS.includes?(last)
+  end
+
+  private def strip_non_code_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
+    chars = line.chars
+    in_string = false
+    in_char = false
+    escaped = false
+    index = 0
+    stripped = String::Builder.new
+
+    while index < chars.size
+      char = chars[index]
+
+      if in_block_comment
+        if char == '*' && chars[index + 1]? == '/'
+          in_block_comment = false
+          index += 1
+        end
+      elsif in_string
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == '"'
+          in_string = false
+        end
+      elsif in_char
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == '\''
+          in_char = false
+        end
+      elsif char == '"'
+        in_string = true
+      elsif char == '\''
+        in_char = true
+      elsif char == '/' && chars[index + 1]? == '/'
+        break
+      elsif char == '/' && chars[index + 1]? == '*'
+        in_block_comment = true
+        index += 1
+      else
+        stripped << char
+      end
+
+      index += 1
+    end
+
+    {stripped.to_s, in_block_comment}
+  end
+
+  private def skip_string(source : String, index : Int32, limit : Int32) : Int32
+    i = index + 1
+    escaping = false
+
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if escaping
+        escaping = false
+      elsif char == '\\'
+        escaping = true
+      elsif char == '"'
+        return i
+      end
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def skip_char_literal(source : String, index : Int32, limit : Int32) : Int32
+    i = index + 1
+    escaping = false
+
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if escaping
+        escaping = false
+      elsif char == '\\'
+        escaping = true
+      elsif char == '\''
+        return i
+      end
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def skip_line_comment(source : String, index : Int32, limit : Int32) : Int32
+    i = index
+    while i < limit && source.byte_at(i).unsafe_chr != '\n'
+      i += 1
+    end
+    i
+  end
+
+  private def skip_block_comment(source : String, index : Int32, limit : Int32) : Int32
+    i = index + 2
+    while i < limit
+      return i + 1 if source.byte_at(i).unsafe_chr == '*' &&
+                      i + 1 < limit &&
+                      source.byte_at(i + 1).unsafe_chr == '/'
+
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared C++ callee extractor for scoped calls, member calls, and bare handler-body calls
- wire Crow inline route lambdas to attach callees when `--include-callee` is enabled
- wire Drogon `registerHandler` lambdas and `ADD_METHOD_TO` member handlers to attach callees when `--include-callee` is enabled

## Scope
- Crow callee extraction is limited to inline lambda route handlers; named handler routes keep existing endpoint extraction without guessing a body
- Drogon `PATH_ADD` routes keep existing endpoint extraction, while `ADD_METHOD_TO` routes resolve same-file handler bodies
- comments, strings, char literals, route macros, C++ keywords, and casts are filtered from callee output

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cpp-target2 crystal spec spec/unit_test/miniparser/cpp_callee_extractor_spec.cr spec/functional_test/testers/cpp/crow_spec.cr spec/functional_test/testers/cpp/drogon_spec.cr spec/functional_test/testers/cpp/crow_callees_spec.cr spec/functional_test/testers/cpp/drogon_callees_spec.cr --error-trace`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cpp-build2 just build`
- `./bin/noir -b spec/functional_test/fixtures/cpp/crow_callees -f json --include-callee`
- `./bin/noir -b spec/functional_test/fixtures/cpp/drogon_callees -f json --include-callee`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cpp-test2 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cpp-check2 just check`
- post-rebase: `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-cpp-postrebase-target crystal spec spec/unit_test/miniparser/cpp_callee_extractor_spec.cr spec/functional_test/testers/cpp/crow_spec.cr spec/functional_test/testers/cpp/drogon_spec.cr spec/functional_test/testers/cpp/crow_callees_spec.cr spec/functional_test/testers/cpp/drogon_callees_spec.cr`

Part of #1366.
