### PR TITLE
Add Dart Frog and Serverpod callee extraction

### DIFF
--- a/spec/functional_test/fixtures/dart/dart_frog_callees/pubspec.yaml
+++ b/spec/functional_test/fixtures/dart/dart_frog_callees/pubspec.yaml
@@ -1,0 +1,10 @@
+name: dart_frog_callees
+description: Dart Frog callee fixture.
+version: 1.0.0+1
+publish_to: none
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  dart_frog: ^1.0.0

--- a/spec/functional_test/fixtures/dart/dart_frog_callees/routes/_middleware.dart
+++ b/spec/functional_test/fixtures/dart/dart_frog_callees/routes/_middleware.dart
@@ -1,0 +1,5 @@
+import 'package:dart_frog/dart_frog.dart';
+
+Handler middleware(Handler handler) {
+  return handler.use(Noise.shouldNotBeEndpoint());
+}

--- a/spec/functional_test/fixtures/dart/dart_frog_callees/routes/status.dart
+++ b/spec/functional_test/fixtures/dart/dart_frog_callees/routes/status.dart
@@ -1,0 +1,4 @@
+import 'package:dart_frog/dart_frog.dart';
+
+Response onRequest(RequestContext context) =>
+    Response.json(body: HealthService.status());

--- a/spec/functional_test/fixtures/dart/dart_frog_callees/routes/users/[id].dart
+++ b/spec/functional_test/fixtures/dart/dart_frog_callees/routes/users/[id].dart
@@ -1,0 +1,17 @@
+import 'package:dart_frog/dart_frog.dart';
+
+Future<Response> onRequest(RequestContext context, String id) async {
+  final service = context.read<UserService>();
+  switch (context.request.method) {
+    case HttpMethod.get:
+      final user = await service.find(id);
+      AuditLog.write('show', user);
+      return Response.json(body: serializeUser(user));
+    case HttpMethod.put:
+      final body = await context.request.json<Map<String, dynamic>>();
+      final updated = await service.save(id, UserDto.fromJson(body));
+      return Response.json(body: renderUser(updated));
+    default:
+      return Response(statusCode: 405);
+  }
+}

--- a/spec/functional_test/fixtures/dart/serverpod_callees/lib/src/endpoints/example_endpoint.dart
+++ b/spec/functional_test/fixtures/dart/serverpod_callees/lib/src/endpoints/example_endpoint.dart
@@ -1,0 +1,35 @@
+import 'package:serverpod/serverpod.dart';
+// Long comment before endpoint classes keeps source offsets honest when comments are stripped.
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    final user = await UserService.find(name);
+    final normalized = _normalize(user);
+    return GreetingBuilder.build(normalized);
+  }
+
+  Future<bool> ping(Session session) async => Health.check();
+
+  Future<String> _normalize(Session session, String value) async {
+    return value.trim();
+  }
+}
+
+class OrderEndpoint extends Endpoint {
+  Future<OrderDto> create(Session session, {required Order order}) async {
+    final saved = await session.db.insertRow(order);
+    AuditLog.write('order.create', saved);
+    return OrderDto.fromModel(saved);
+  }
+}
+
+class ChatEndpoint extends StreamingEndpoint {
+  Future<void> subscribe(Session session, String channel) async {
+    await Streams.open(channel);
+  }
+}
+
+class Order {}
+class OrderDto {
+  static OrderDto fromModel(Order order) => OrderDto();
+}

--- a/spec/functional_test/fixtures/dart/serverpod_callees/pubspec.yaml
+++ b/spec/functional_test/fixtures/dart/serverpod_callees/pubspec.yaml
@@ -1,0 +1,6 @@
+name: serverpod_callees
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  serverpod: ^2.0.0
+  serverpod_server: ^2.0.0

--- a/spec/functional_test/testers/dart/dart_frog_callees_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_callees_spec.cr
@@ -1,0 +1,55 @@
+require "../../func_spec.cr"
+
+def dart_frog_endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+user_callees = [
+  Callee.new("context.read", line: 4),
+  Callee.new("service.find", line: 7),
+  Callee.new("AuditLog.write", line: 8),
+  Callee.new("Response.json", line: 9),
+  Callee.new("serializeUser", line: 9),
+  Callee.new("context.request.json", line: 11),
+  Callee.new("service.save", line: 12),
+  Callee.new("UserDto.fromJson", line: 12),
+  Callee.new("renderUser", line: 13),
+  Callee.new("Response", line: 15),
+]
+
+status_callees = [
+  Callee.new("Response.json", line: 4),
+  Callee.new("HealthService.status", line: 4),
+]
+
+expected_endpoints = [
+  dart_frog_endpoint_with_callees("/users/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ], user_callees),
+  dart_frog_endpoint_with_callees("/users/{id}", "PUT", [
+    Param.new("id", "", "path"),
+  ], user_callees),
+  dart_frog_endpoint_with_callees("/status", "GET", [] of Param, status_callees),
+  dart_frog_endpoint_with_callees("/status", "POST", [] of Param, status_callees),
+  dart_frog_endpoint_with_callees("/status", "PUT", [] of Param, status_callees),
+  dart_frog_endpoint_with_callees("/status", "DELETE", [] of Param, status_callees),
+  dart_frog_endpoint_with_callees("/status", "PATCH", [] of Param, status_callees),
+]
+
+tester = FunctionalTester.new("fixtures/dart/dart_frog_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports the exact Dart Frog callee list for method-routed files" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/users/{id}" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(user_callees.map { |callee| {callee.name, callee.line} })
+  end
+end

--- a/spec/functional_test/testers/dart/serverpod_callees_spec.cr
+++ b/spec/functional_test/testers/dart/serverpod_callees_spec.cr
@@ -1,0 +1,49 @@
+require "../../func_spec.cr"
+
+def serverpod_endpoint_with_callees(url, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, "POST", params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [
+  serverpod_endpoint_with_callees("/example/hello", [
+    Param.new("name", "String", "json"),
+  ], [
+    Callee.new("UserService.find", line: 6),
+    Callee.new("_normalize", line: 7),
+    Callee.new("GreetingBuilder.build", line: 8),
+  ]),
+  serverpod_endpoint_with_callees("/example/ping", [] of Param, [
+    Callee.new("Health.check", line: 11),
+  ]),
+  serverpod_endpoint_with_callees("/order/create", [
+    Param.new("order", "Order", "json"),
+  ], [
+    Callee.new("session.db.insertRow", line: 20),
+    Callee.new("AuditLog.write", line: 21),
+    Callee.new("OrderDto.fromModel", line: 22),
+  ]),
+  serverpod_endpoint_with_callees("/chat/subscribe", [
+    Param.new("channel", "String", "json"),
+  ], [
+    Callee.new("Streams.open", line: 28),
+  ]),
+]
+
+tester = FunctionalTester.new("fixtures/dart/serverpod_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports the exact Serverpod callees after comments before endpoint classes" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/example/hello" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    expected = expected_endpoints[0].callees.map { |callee| {callee.name, callee.line} }
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(expected)
+  end
+end

--- a/spec/unit_test/miniparser/dart_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/dart_callee_extractor_spec.cr
@@ -1,0 +1,106 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/dart_callee_extractor"
+
+describe Noir::DartCalleeExtractor do
+  it "extracts Dart receiver, static, null-aware, and bare calls" do
+    body = <<-DART
+      final service = context.read<UserService>();
+      final user = await service.find(id);
+      repo?.cache(user);
+      repo!.save(UserDto.fromJson(user));
+      final payload = request.json<Map<String, dynamic>>();
+      return Response.json(body: serialize(user));
+      DART
+
+    callees = Noir::DartCalleeExtractor.callees_for_body(body, "route.dart", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"context.read", 10},
+      {"service.find", 11},
+      {"repo?.cache", 12},
+      {"repo!.save", 13},
+      {"UserDto.fromJson", 13},
+      {"request.json", 14},
+      {"Response.json", 15},
+      {"serialize", 15},
+    ])
+  end
+
+  it "skips comments, strings, raw strings, triple strings, and reserved words" do
+    body = <<-DART
+      if (ready()) {
+        final text = "Ignored.string()";
+        final raw = r"Ignored.raw()";
+        final block = '''
+          Ignored.triple()
+        ''';
+        /* Ignored.block(); */
+        // Ignored.line();
+        assert(true);
+        Real.call();
+      }
+      DART
+
+    callees = Noir::DartCalleeExtractor.callees_for_body(body, "route.dart", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"ready", 20},
+      {"Real.call", 29},
+    ])
+  end
+
+  it "does not report local function declarations as calls" do
+    body = <<-DART
+      String normalize(String input) => input.trim();
+      final value = normalize(name);
+      return Response.json(body: value);
+      DART
+
+    callees = Noir::DartCalleeExtractor.callees_for_body(body, "route.dart", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"input.trim", 40},
+      {"normalize", 41},
+      {"Response.json", 42},
+    ])
+  end
+
+  it "extracts braced and expression bodies" do
+    braced = <<-DART
+      Response onRequest(RequestContext context) {
+        return Response.json(body: Health.status());
+      }
+      DART
+
+    open_paren = braced.index('(') || -1
+    open_paren.should be >= 0
+    close_paren = Noir::DartCalleeExtractor.find_matching_delimiter(braced, open_paren, '(', ')')
+    close_paren.should_not be_nil
+    close_paren.try do |found_close|
+      body_info = Noir::DartCalleeExtractor.extract_body_after(braced, found_close + 1)
+      body_info.should_not be_nil
+      body_info.try do |found_body|
+        body, body_start, _ = found_body
+        start_line = Noir::DartCalleeExtractor.line_number_for(braced, body_start)
+        Noir::DartCalleeExtractor.callees_for_body(body, "route.dart", start_line).map { |name, _, line| {name, line} }.should eq([
+          {"Response.json", 2},
+          {"Health.status", 2},
+        ])
+      end
+    end
+
+    expression = "Future<String> ping(Session session) async => Health.check();"
+    open_paren = expression.index('(') || -1
+    open_paren.should be >= 0
+    close_paren = Noir::DartCalleeExtractor.find_matching_delimiter(expression, open_paren, '(', ')')
+    close_paren.should_not be_nil
+    close_paren.try do |found_close|
+      body_info = Noir::DartCalleeExtractor.extract_body_after(expression, found_close + 1)
+      body_info.should_not be_nil
+      body_info.try do |found_body|
+        body, body_start, _ = found_body
+        start_line = Noir::DartCalleeExtractor.line_number_for(expression, body_start)
+        Noir::DartCalleeExtractor.callees_for_body(body, "endpoint.dart", start_line).map { |name, _, line| {name, line} }.should eq([
+          {"Health.check", 1},
+        ])
+      end
+    end
+  end
+end

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/dart_callee_extractor"
 
 module Analyzer::Dart
   # Dart Frog is a filesystem-routed framework. Routes live under
@@ -33,6 +34,7 @@ module Analyzer::Dart
     FALLBACK_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       result = [] of Endpoint
       mutex = Mutex.new
 
@@ -61,9 +63,10 @@ module Analyzer::Dart
           end
 
           methods = detect_methods(content)
+          callees = include_callee ? callees_for_on_request(content, path) : [] of Noir::DartCalleeExtractor::Entry
           mutex.synchronize do
             methods.each do |verb|
-              result << build_endpoint(url, verb, path)
+              result << build_endpoint(url, verb, path, callees)
             end
           end
         end
@@ -74,13 +77,37 @@ module Analyzer::Dart
       result
     end
 
-    private def build_endpoint(url : String, verb : String, path : String) : Endpoint
+    private def build_endpoint(url : String,
+                               verb : String,
+                               path : String,
+                               callees : Array(Noir::DartCalleeExtractor::Entry) = [] of Noir::DartCalleeExtractor::Entry) : Endpoint
       endpoint = Endpoint.new(url, verb)
       endpoint.details = Details.new(PathInfo.new(path, 1))
       url.scan(/\{(\w+)\}/) do |match|
         endpoint.push_param(Param.new(match[1], "", "path"))
       end
+      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
       endpoint
+    end
+
+    private def callees_for_on_request(content : String, path : String) : Array(Noir::DartCalleeExtractor::Entry)
+      content.scan(/\bonRequest\s*\(/) do |match|
+        match_start = match.begin(0) || 0
+        open_paren = Noir::DartCalleeExtractor.find_next_code_char(content, '(', match_start)
+        next unless open_paren
+
+        close_paren = Noir::DartCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
+        next unless close_paren
+
+        body_info = Noir::DartCalleeExtractor.extract_body_after(content, close_paren + 1)
+        next unless body_info
+
+        body, body_start, _ = body_info
+        start_line = Noir::DartCalleeExtractor.line_number_for(content, body_start)
+        return Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
+      end
+
+      [] of Noir::DartCalleeExtractor::Entry
     end
 
     # Filesystem path → URL pattern. Drops the `.dart` extension,

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/dart_callee_extractor"
 
 module Analyzer::Dart
   # Serverpod is an RPC-style backend framework. Server endpoints are
@@ -16,20 +17,22 @@ module Analyzer::Dart
   class Serverpod < Analyzer
     HTTP_METHOD         = "POST"
     RESERVED_DART_NAMES = %w[if else for while switch case return try catch finally throw new const final var late void await async assert]
+    alias MethodParam = NamedTuple(name: String, type: String)
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".dart")
 
         content = read_file_content(path)
-        process_file(path, content)
+        process_file(path, content, include_callee)
       end
 
       @result
     end
 
-    private def process_file(path : String, content : String)
+    private def process_file(path : String, content : String, include_callee : Bool)
       cleaned = strip_dart_comments(content)
 
       cleaned.scan(/class\s+([A-Z][A-Za-z0-9_]*)(?:\s*<[^>]*>)?\s+extends\s+(?:StreamingEndpoint|Endpoint)\b/) do |match|
@@ -44,7 +47,7 @@ module Analyzer::Dart
         body, body_start = body_info
         line_number = line_for_offset(content, match_start)
         endpoint_name = endpoint_name_for(class_name)
-        process_class_body(path, endpoint_name, body, body_start, content, line_number)
+        process_class_body(path, endpoint_name, body, body_start, content, line_number, include_callee)
       end
     end
 
@@ -55,7 +58,13 @@ module Analyzer::Dart
       base[0].downcase.to_s + base[1..]
     end
 
-    private def process_class_body(path : String, endpoint_name : String, body : String, body_start : Int32, file_content : String, fallback_line : Int32)
+    private def process_class_body(path : String,
+                                   endpoint_name : String,
+                                   body : String,
+                                   body_start : Int32,
+                                   file_content : String,
+                                   fallback_line : Int32,
+                                   include_callee : Bool)
       depth = 0
       in_string = false
       string_quote = '\0'
@@ -103,7 +112,8 @@ module Analyzer::Dart
                 params = parse_method_params(params_text)
                 line = line_for_offset(file_content, body_start + i)
                 line = fallback_line if line <= 0
-                emit_endpoint(path, endpoint_name, method_name, params, line)
+                callees = include_callee ? callees_for_method_body(path, body, body_start, close_paren, file_content) : [] of Noir::DartCalleeExtractor::Entry
+                emit_endpoint(path, endpoint_name, method_name, params, line, callees)
                 i = close_paren + 1
                 next
               end
@@ -133,8 +143,8 @@ module Analyzer::Dart
       candidate
     end
 
-    private def parse_method_params(params_text : String) : Array(NamedTuple(name: String, type: String))
-      result = [] of NamedTuple(name: String, type: String)
+    private def parse_method_params(params_text : String) : Array(MethodParam)
+      result = [] of MethodParam
       stripped = params_text.gsub(/[\[\]{}]/, " ")
       split_top_level_commas(stripped).each do |raw|
         part = raw.strip
@@ -196,11 +206,31 @@ module Analyzer::Dart
       parts
     end
 
-    private def emit_endpoint(path : String, endpoint_name : String, method_name : String, params : Array(NamedTuple(name: String, type: String)), line : Int32)
+    private def emit_endpoint(path : String,
+                              endpoint_name : String,
+                              method_name : String,
+                              params : Array(MethodParam),
+                              line : Int32,
+                              callees : Array(Noir::DartCalleeExtractor::Entry) = [] of Noir::DartCalleeExtractor::Entry)
       url = "/#{endpoint_name}/#{method_name}"
       details = Details.new(PathInfo.new(path, line))
       endpoint_params = params.map { |p| Param.new(p[:name], p[:type], "json") }
-      @result << Endpoint.new(url, HTTP_METHOD, endpoint_params, details)
+      endpoint = Endpoint.new(url, HTTP_METHOD, endpoint_params, details)
+      Noir::DartCalleeExtractor.attach_to(endpoint, callees)
+      @result << endpoint
+    end
+
+    private def callees_for_method_body(path : String,
+                                        class_body : String,
+                                        class_body_start : Int32,
+                                        close_paren : Int32,
+                                        file_content : String) : Array(Noir::DartCalleeExtractor::Entry)
+      body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, close_paren + 1)
+      return [] of Noir::DartCalleeExtractor::Entry unless body_info
+
+      body, body_start, _ = body_info
+      start_line = line_for_offset(file_content, class_body_start + body_start)
+      Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
@@ -316,19 +346,33 @@ module Analyzer::Dart
         end
 
         if i + 1 < chars.size && c == '/' && chars[i + 1] == '/'
+          result << ' '
+          result << ' '
+          i += 2
           while i < chars.size && chars[i] != '\n'
+            result << ' '
+            i += 1
+          end
+          if i < chars.size
+            result << chars[i]
             i += 1
           end
           next
         end
 
         if i + 1 < chars.size && c == '/' && chars[i + 1] == '*'
+          result << ' '
+          result << ' '
           i += 2
           while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
-            result << '\n' if chars[i] == '\n'
+            result << (chars[i] == '\n' ? '\n' : ' ')
             i += 1
           end
-          i += 2 if i + 1 < chars.size
+          if i + 1 < chars.size
+            result << ' '
+            result << ' '
+            i += 2
+          end
           next
         end
 

--- a/src/miniparsers/dart_callee_extractor.cr
+++ b/src/miniparsers/dart_callee_extractor.cr
@@ -1,0 +1,380 @@
+require "../models/endpoint"
+
+module Noir::DartCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+  alias BodyInfo = Tuple(String, Int32, Int32)
+  alias StripState = NamedTuple(block_comment: Bool, triple_quote: Char)
+
+  INITIAL_STATE = {
+    block_comment: false,
+    triple_quote:  '\0',
+  }
+
+  RESERVED = Set{
+    "abstract", "as", "assert", "async", "await", "break", "case",
+    "catch", "class", "const", "continue", "covariant", "default",
+    "deferred", "do", "dynamic", "else", "enum", "export", "extends",
+    "extension", "external", "factory", "false", "final", "finally",
+    "for", "Function", "get", "hide", "if", "implements", "import",
+    "in", "interface", "is", "late", "library", "mixin", "new", "null",
+    "on", "operator", "part", "required", "rethrow", "return", "set",
+    "show", "static", "super", "switch", "sync", "this", "throw",
+    "true", "try", "typedef", "var", "void", "when", "while", "with",
+    "yield", "print", "identical",
+  }
+
+  RECEIVER_CALL_REGEX       = /([A-Za-z_][A-Za-z0-9_]*(?:\s*(?:\?\.|!\.|\.)\s*[A-Za-z_][A-Za-z0-9_]*)+)\s*(?:<[^;\n{}]*>)?\s*\(/
+  BARE_CALL_REGEX           = /(?<![A-Za-z0-9_.!?<])([A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^;\n{}]*>)?\s*\(/
+  DECLARATION_CONTEXT_REGEX = /(?:^|[;{}])\s*((?:[A-Z][A-Za-z0-9_]*|void|int|double|num|bool|String|Future|Stream|Map|List|Set|Iterable|Object|dynamic)(?:\s*<[^;{}()=]*>)?\??)\s+$/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    state = INITIAL_STATE
+
+    body.each_line.with_index do |line, index|
+      stripped, state = strip_non_code_with_state(line, state)
+      scan_line(stripped, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def extract_body_after(source : String, start_index : Int32, limit : Int32 = source.bytesize) : BodyInfo?
+    arrow_index = find_next_arrow(source, start_index, limit)
+    open_brace = find_next_code_char(source, '{', start_index, limit)
+    semicolon = find_next_code_char(source, ';', start_index, limit)
+
+    if arrow_index && (!semicolon || arrow_index < semicolon) && (!open_brace || arrow_index < open_brace)
+      body_start = arrow_index + 2
+      body_end = semicolon || limit
+      return {source[body_start...body_end], body_start, body_end}
+    end
+
+    if open_brace && (!semicolon || open_brace < semicolon)
+      close_brace = find_matching_delimiter(source, open_brace, '{', '}', limit)
+      return unless close_brace
+
+      body_start = open_brace + 1
+      return {source[body_start...close_brace], body_start, close_brace + 1}
+    end
+
+    nil
+  end
+
+  def find_next_code_char(source : String, target : Char, start_index : Int32, limit : Int32 = source.bytesize) : Int32?
+    i = start_index
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if raw_string_prefix?(source, i, limit)
+        i = skip_string(source, i + 1, limit, raw: true)
+      else
+        case char
+        when '"', '\''
+          i = skip_string(source, i, limit)
+        when '/'
+          next_char = i + 1 < limit ? source.byte_at(i + 1).unsafe_chr : '\0'
+          if next_char == '/'
+            i = skip_line_comment(source, i, limit)
+          elsif next_char == '*'
+            i = skip_block_comment(source, i, limit)
+          elsif char == target
+            return i
+          end
+        else
+          return i if char == target
+        end
+      end
+      i += 1
+    end
+
+    nil
+  end
+
+  def find_matching_delimiter(source : String,
+                              index : Int32,
+                              open_char : Char,
+                              close_char : Char,
+                              limit : Int32 = source.bytesize) : Int32?
+    depth = 0
+    i = index
+
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if raw_string_prefix?(source, i, limit)
+        i = skip_string(source, i + 1, limit, raw: true)
+      else
+        case char
+        when '"', '\''
+          i = skip_string(source, i, limit)
+        when '/'
+          next_char = i + 1 < limit ? source.byte_at(i + 1).unsafe_chr : '\0'
+          if next_char == '/'
+            i = skip_line_comment(source, i, limit)
+          elsif next_char == '*'
+            i = skip_block_comment(source, i, limit)
+          end
+        when open_char
+          depth += 1
+        when close_char
+          depth -= 1
+          return i if depth == 0
+        end
+      end
+      i += 1
+    end
+
+    nil
+  end
+
+  def line_number_for(source : String, index : Int32) : Int32
+    1 + source.to_slice[0, index].count('\n'.ord.to_u8)
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    line.scan(RECEIVER_CALL_REGEX) do |match|
+      candidates << {match.begin(1) || 0, normalize_name(match[1])}
+    end
+
+    line.scan(BARE_CALL_REGEX) do |match|
+      position = match.begin(1) || 0
+      next if declaration_callee?(line, position)
+
+      candidates << {position, match[1]}
+    end
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |_, name|
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def normalize_name(name : String) : String
+    name.gsub(/\s+/, "")
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split("?.").last.split("!.").last.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  private def declaration_callee?(line : String, position : Int32) : Bool
+    return false if position <= 0
+
+    before = line[0...position]
+    return false if before.strip.empty?
+
+    !!before.match(DECLARATION_CONTEXT_REGEX)
+  end
+
+  private def find_next_arrow(source : String, start_index : Int32, limit : Int32) : Int32?
+    i = start_index
+    while i + 1 < limit
+      char = source.byte_at(i).unsafe_chr
+      if raw_string_prefix?(source, i, limit)
+        i = skip_string(source, i + 1, limit, raw: true)
+      else
+        case char
+        when '"', '\''
+          i = skip_string(source, i, limit)
+        when '/'
+          next_char = source.byte_at(i + 1).unsafe_chr
+          if next_char == '/'
+            i = skip_line_comment(source, i, limit)
+          elsif next_char == '*'
+            i = skip_block_comment(source, i, limit)
+          end
+        when '='
+          return i if source.byte_at(i + 1).unsafe_chr == '>'
+        end
+      end
+      i += 1
+    end
+
+    nil
+  end
+
+  private def strip_non_code_with_state(line : String, state : StripState) : Tuple(String, StripState)
+    chars = line.chars
+    block_comment = state[:block_comment]
+    triple_quote = state[:triple_quote]
+    index = 0
+    stripped = String::Builder.new
+
+    while index < chars.size
+      char = chars[index]
+
+      if block_comment
+        if char == '*' && chars[index + 1]? == '/'
+          block_comment = false
+          index += 1
+        end
+      elsif triple_quote != '\0'
+        if triple_delimiter?(chars, index, triple_quote)
+          triple_quote = '\0'
+          index += 2
+        end
+      elsif raw_string_prefix?(chars, index)
+        quote = chars[index + 1]
+        if triple_delimiter?(chars, index + 1, quote)
+          index = skip_triple_string(chars, index + 1, quote)
+        else
+          index = skip_quoted_string(chars, index + 1, quote, raw: true)
+        end
+      elsif char == '"' || char == '\''
+        if triple_delimiter?(chars, index, char)
+          triple_quote = char
+          index += 2
+        else
+          index = skip_quoted_string(chars, index, char)
+        end
+      elsif char == '/' && chars[index + 1]? == '/'
+        break
+      elsif char == '/' && chars[index + 1]? == '*'
+        block_comment = true
+        index += 1
+      else
+        stripped << char
+      end
+
+      index += 1
+    end
+
+    {stripped.to_s, {block_comment: block_comment, triple_quote: triple_quote}}
+  end
+
+  private def raw_string_prefix?(chars : Array(Char), index : Int32) : Bool
+    return false unless chars[index]? == 'r'
+    quote = chars[index + 1]?
+    return false unless quote == '"' || quote == '\''
+    return true if index == 0
+
+    !identifier_char?(chars[index - 1])
+  end
+
+  private def raw_string_prefix?(source : String, index : Int32, limit : Int32) : Bool
+    return false unless source.byte_at(index).unsafe_chr == 'r'
+    return false unless index + 1 < limit
+
+    quote = source.byte_at(index + 1).unsafe_chr
+    return false unless quote == '"' || quote == '\''
+    return true if index == 0
+
+    !identifier_char?(source.byte_at(index - 1).unsafe_chr)
+  end
+
+  private def identifier_char?(char : Char) : Bool
+    char.alphanumeric? || char == '_'
+  end
+
+  private def triple_delimiter?(chars : Array(Char), index : Int32, quote : Char) : Bool
+    chars[index]? == quote && chars[index + 1]? == quote && chars[index + 2]? == quote
+  end
+
+  private def skip_quoted_string(chars : Array(Char), index : Int32, quote : Char, raw : Bool = false) : Int32
+    i = index + 1
+    escaping = false
+
+    while i < chars.size
+      char = chars[i]
+      if !raw && escaping
+        escaping = false
+      elsif !raw && char == '\\'
+        escaping = true
+      elsif char == quote
+        return i
+      end
+      i += 1
+    end
+
+    chars.size - 1
+  end
+
+  private def skip_triple_string(chars : Array(Char), index : Int32, quote : Char) : Int32
+    i = index + 3
+    while i < chars.size
+      return i + 2 if triple_delimiter?(chars, i, quote)
+
+      i += 1
+    end
+
+    chars.size - 1
+  end
+
+  private def skip_string(source : String, index : Int32, limit : Int32, raw : Bool = false) : Int32
+    quote = source.byte_at(index).unsafe_chr
+    if index + 2 < limit &&
+       source.byte_at(index + 1).unsafe_chr == quote &&
+       source.byte_at(index + 2).unsafe_chr == quote
+      return skip_triple_string(source, index, quote, limit)
+    end
+
+    i = index + 1
+    escaping = false
+    while i < limit
+      char = source.byte_at(i).unsafe_chr
+      if !raw && escaping
+        escaping = false
+      elsif !raw && char == '\\'
+        escaping = true
+      elsif char == quote
+        return i
+      end
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def skip_triple_string(source : String, index : Int32, quote : Char, limit : Int32) : Int32
+    i = index + 3
+    while i + 2 < limit
+      if source.byte_at(i).unsafe_chr == quote &&
+         source.byte_at(i + 1).unsafe_chr == quote &&
+         source.byte_at(i + 2).unsafe_chr == quote
+        return i + 2
+      end
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def skip_line_comment(source : String, index : Int32, limit : Int32) : Int32
+    i = index
+    while i < limit && source.byte_at(i).unsafe_chr != '\n'
+      i += 1
+    end
+    i
+  end
+
+  private def skip_block_comment(source : String, index : Int32, limit : Int32) : Int32
+    i = index + 2
+    while i + 1 < limit
+      return i + 1 if source.byte_at(i).unsafe_chr == '*' &&
+                      source.byte_at(i + 1).unsafe_chr == '/'
+
+      i += 1
+    end
+
+    limit - 1
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end


### PR DESCRIPTION
## Summary
- add a shared Dart callee extractor for bare, receiver/static, null-aware, non-null, and generic call sites
- wire Dart Frog `onRequest` handlers to attach callees when `--include-callee` is enabled
- wire Serverpod endpoint methods, including expression-bodied methods, to attach callees when `--include-callee` is enabled

## Scope
- Dart Frog attaches the full `onRequest` body to each emitted method for that route; it does not attempt branch-level method scoping yet
- Serverpod private methods remain non-endpoints but may appear as callees when public endpoint methods call them
- comments, raw strings, triple strings, normal strings, reserved words, generic type arguments, and local function declarations are filtered
- chained calls on call results such as `clientFactory().get()` remain best-effort and may report the factory/constructor call rather than the final method

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-dart-target6 crystal spec spec/unit_test/miniparser/dart_callee_extractor_spec.cr spec/functional_test/testers/dart/dart_frog_spec.cr spec/functional_test/testers/dart/serverpod_spec.cr spec/functional_test/testers/dart/dart_frog_callees_spec.cr spec/functional_test/testers/dart/serverpod_callees_spec.cr --error-trace`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-dart-build3 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-dart-test2 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-dart-check2 just check`
- `git diff --check`
- CLI smoke checks for Dart Frog and Serverpod fixtures with `--include-callee`

Part of #1366.
