### PR TITLE
Add F# Giraffe callee extraction

### DIFF
--- a/spec/functional_test/fixtures/fsharp/giraffe_callees/Program.fs
+++ b/spec/functional_test/fixtures/fsharp/giraffe_callees/Program.fs
@@ -1,0 +1,36 @@
+module Program
+
+open Giraffe
+
+// Offset-preserving comments should not move callee line numbers.
+(*
+   Ignored.beforeRoute()
+*)
+
+let webApp =
+    choose [
+        GET >=> route "/" >=> text "home"
+        POST >=> route "/login" >=> handleLogin
+        routef "/users/%i" handleUser
+        GET
+            >=> route "/profile"
+            >=> fun next ctx ->
+                task {
+                    let! user = UserService.load ctx
+                    AuditLog.write "profile" user
+                    // Ignored.comment()
+                    let ignored = "Ignored.string()"
+                    return! json (serializeUser user) next ctx
+                }
+        subRoute "/api"
+            (choose [
+                PUT >=> route "/items" >=> ItemController.update
+            ])
+        PATCH >=> route "/pipeline" >=> fun next ctx ->
+            let names = [
+                "alpha"
+                "beta"
+            ]
+            let response = loadPipeline ctx |> enrich |> renderPipeline
+            json response next ctx
+    ]

--- a/spec/functional_test/fixtures/fsharp/giraffe_callees/paket.dependencies
+++ b/spec/functional_test/fixtures/fsharp/giraffe_callees/paket.dependencies
@@ -1,0 +1,4 @@
+source https://api.nuget.org/v3/index.json
+
+nuget Giraffe
+nuget FSharp.Core

--- a/spec/functional_test/testers/fsharp/giraffe_callees_spec.cr
+++ b/spec/functional_test/testers/fsharp/giraffe_callees_spec.cr
@@ -1,0 +1,92 @@
+require "../../func_spec.cr"
+
+def giraffe_endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+fallback_methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+
+profile_callees = [
+  Callee.new("UserService.load", line: 19),
+  Callee.new("AuditLog.write", line: 20),
+  Callee.new("json", line: 23),
+  Callee.new("serializeUser", line: 23),
+]
+
+pipeline_callees = [
+  Callee.new("loadPipeline", line: 34),
+  Callee.new("enrich", line: 34),
+  Callee.new("renderPipeline", line: 34),
+  Callee.new("json", line: 35),
+]
+
+expected_endpoints = [
+  giraffe_endpoint_with_callees("/", "GET", [] of Param, [
+    Callee.new("text", line: 12),
+  ]),
+  giraffe_endpoint_with_callees("/login", "POST", [] of Param, [
+    Callee.new("handleLogin", line: 13),
+  ]),
+]
+
+fallback_methods.each do |method|
+  expected_endpoints << giraffe_endpoint_with_callees("/users/:int", method, [
+    Param.new("int", "int", "path"),
+  ], [
+    Callee.new("handleUser", line: 14),
+  ])
+end
+
+expected_endpoints << giraffe_endpoint_with_callees("/profile", "GET", [] of Param, profile_callees)
+expected_endpoints << giraffe_endpoint_with_callees("/api/items", "PUT", [] of Param, [
+  Callee.new("ItemController.update", line: 27),
+])
+expected_endpoints << giraffe_endpoint_with_callees("/pipeline", "PATCH", [] of Param, pipeline_callees)
+
+tester = FunctionalTester.new("fixtures/fsharp/giraffe_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports exact Giraffe callees for multiline inline handlers" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/profile" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(profile_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "does not leak sibling Giraffe route callees into routef handlers" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/users/:int" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq([
+      {"handleUser", 14},
+    ])
+  end
+end
+
+it "populates Giraffe callee source paths" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/profile" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    paths = actual.callees.map(&.path)
+    paths.uniq!
+    paths.should eq([
+      "./spec/functional_test/fixtures/fsharp/giraffe_callees/Program.fs",
+    ])
+  end
+end
+
+it "does not stop multiline Giraffe handlers at inner list delimiters" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/pipeline" && found.method == "PATCH" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(pipeline_callees.map { |callee| {callee.name, callee.line} })
+  end
+end

--- a/spec/unit_test/miniparser/fsharp_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/fsharp_callee_extractor_spec.cr
@@ -1,0 +1,81 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/fsharp_callee_extractor"
+
+describe Noir::FsharpCalleeExtractor do
+  it "extracts Giraffe chain handlers, applications, returns, and pipelines" do
+    body = <<-FSHARP
+      >=> handleLogin
+      >=> fun next ctx ->
+          task {
+              let! user = UserService.load ctx
+              AuditLog.write "show" user
+              return! json (serializeUser user) next ctx
+          }
+      let response = loadPipeline ctx |> enrich |> renderPipeline
+      json response next ctx
+      FSHARP
+
+    callees = Noir::FsharpCalleeExtractor.callees_for_body(body, "Program.fs", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"handleLogin", 10},
+      {"UserService.load", 13},
+      {"AuditLog.write", 14},
+      {"json", 15},
+      {"serializeUser", 15},
+      {"loadPipeline", 17},
+      {"enrich", 17},
+      {"renderPipeline", 17},
+      {"json", 18},
+    ])
+  end
+
+  it "extracts generic dotted calls and routef-style bare handlers" do
+    body = <<-FSHARP
+      ctx.BindJsonAsync<Order>()
+      handleUser
+      ItemController.update
+      FSHARP
+
+    callees = Noir::FsharpCalleeExtractor.callees_for_body(body, "Program.fs", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"ctx.BindJsonAsync", 30},
+      {"handleUser", 31},
+      {"ItemController.update", 32},
+    ])
+  end
+
+  it "skips comments, nested block comments, strings, triple strings, and reserved words" do
+    body = <<-FSHARP
+      let ignored = "Ignored.string()"
+      let verbatim = @"Ignored.verbatim()"
+      let triple = """
+        Ignored.triple()
+      """
+      (* Ignored.block()
+         (* Nested.block() *)
+      *)
+      // Ignored.line()
+      Real.call "ok"
+      FSHARP
+
+    callees = Noir::FsharpCalleeExtractor.callees_for_body(body, "Program.fs", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"Real.call", 49},
+    ])
+  end
+
+  it "does not report plain dotted property access as calls" do
+    body = <<-FSHARP
+      let path = ctx.Request.Path
+      let name = ctx.User.Identity.Name
+      let loaded = UserService.load ctx
+      ctx.BindJsonAsync<Order>()
+      FSHARP
+
+    callees = Noir::FsharpCalleeExtractor.callees_for_body(body, "Program.fs", 60)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService.load", 62},
+      {"ctx.BindJsonAsync", 63},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/fsharp_callee_extractor"
 
 module Analyzer::Fsharp
   # Giraffe is a functional web framework on top of ASP.NET Core. Routes
@@ -32,12 +33,13 @@ module Analyzer::Fsharp
     }
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".fs") || path.ends_with?(".fsx")
 
         content = read_file_content(path)
-        process_file(path, content)
+        process_file(path, content, include_callee)
       end
 
       @result
@@ -45,7 +47,7 @@ module Analyzer::Fsharp
 
     alias SubRouteScope = NamedTuple(prefix: String, end_pos: Int32, params: Array(Param))
 
-    private def process_file(path : String, content : String)
+    private def process_file(path : String, content : String, include_callee : Bool)
       cleaned = strip_fsharp_comments(content)
       scope_stack = [] of SubRouteScope
 
@@ -89,7 +91,7 @@ module Analyzer::Fsharp
         if routef_match
           path_pattern = routef_match[1]
           match_end_local = routef_match.end(0)
-          emit_route(path, content, cleaned, i, scope_stack, path_pattern, routef: true)
+          emit_route(path, content, cleaned, i, scope_stack, path_pattern, routef: true, include_callee: include_callee)
           i += match_end_local || 1
           next
         end
@@ -99,7 +101,7 @@ module Analyzer::Fsharp
         if route_match
           path_pattern = route_match[1]
           match_end_local = route_match.end(0)
-          emit_route(path, content, cleaned, i, scope_stack, path_pattern, routef: false)
+          emit_route(path, content, cleaned, i, scope_stack, path_pattern, routef: false, include_callee: include_callee)
           i += match_end_local || 1
           next
         end
@@ -120,7 +122,7 @@ module Analyzer::Fsharp
 
     private def emit_route(path : String, content : String, cleaned : String,
                            offset : Int32, scope_stack : Array(SubRouteScope),
-                           path_pattern : String, routef : Bool)
+                           path_pattern : String, routef : Bool, include_callee : Bool)
       url, params = if routef
                       translate_routef(path_pattern)
                     else
@@ -134,11 +136,149 @@ module Analyzer::Fsharp
 
       line = line_for_offset(content, offset)
       details = Details.new(PathInfo.new(path, line))
+      callees = include_callee ? callees_for_route(path, content, cleaned, offset) : [] of Noir::FsharpCalleeExtractor::Entry
 
       methods.each do |verb|
         endpoint_params = full_params.map { |p| Param.new(p.name, p.value, p.param_type) }
-        @result << Endpoint.new(full_url, verb, endpoint_params, details)
+        endpoint = Endpoint.new(full_url, verb, endpoint_params, details)
+        Noir::FsharpCalleeExtractor.attach_to(endpoint, callees)
+        @result << endpoint
       end
+    end
+
+    private def callees_for_route(path : String,
+                                  content : String,
+                                  cleaned : String,
+                                  offset : Int32) : Array(Noir::FsharpCalleeExtractor::Entry)
+      body_info = route_handler_body(cleaned, offset)
+      return [] of Noir::FsharpCalleeExtractor::Entry unless body_info
+
+      body, body_start = body_info
+      start_line = line_for_offset(content, body_start)
+      Noir::FsharpCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def route_handler_body(text : String, offset : Int32) : Tuple(String, Int32)?
+      body_start = route_pattern_end(text, offset)
+      return unless body_start
+
+      route_line_start = line_start_for_offset(text, offset)
+      base_indent = indentation_at(text, route_line_start)
+      body_end = route_handler_end(text, body_start, base_indent)
+      return if body_end <= body_start
+
+      {text[body_start...body_end], body_start}
+    end
+
+    private def route_pattern_end(text : String, offset : Int32) : Int32?
+      i = offset
+      while i < text.size && identifier_char?(text[i])
+        i += 1
+      end
+
+      while i < text.size && text[i].whitespace?
+        i += 1
+      end
+
+      return unless i < text.size && text[i] == '"'
+
+      string_end = find_string_end(text, i)
+      return unless string_end
+
+      string_end + 1
+    end
+
+    private def find_string_end(text : String, quote_index : Int32) : Int32?
+      i = quote_index + 1
+      escaping = false
+
+      while i < text.size
+        char = text[i]
+        if escaping
+          escaping = false
+        elsif char == '\\'
+          escaping = true
+        elsif char == '"'
+          return i
+        end
+        i += 1
+      end
+
+      nil
+    end
+
+    private def route_handler_end(text : String, start : Int32, base_indent : Int32) : Int32
+      first_line = true
+      line_start = line_start_for_offset(text, start)
+      cursor = line_start
+
+      while cursor < text.size
+        line_end = text.index('\n', cursor) || text.size
+        line = text[cursor...line_end]
+
+        if !first_line && route_handler_stop_line?(line, base_indent)
+          return cursor
+        end
+
+        first_line = false
+        cursor = line_end + 1
+      end
+
+      text.size
+    end
+
+    private def route_handler_stop_line?(line : String, base_indent : Int32) : Bool
+      stripped = line.strip
+      return false if stripped.empty?
+
+      indent = indentation_of_line(line)
+      return false if indent > base_indent
+      return true if stripped.starts_with?("]") || stripped.starts_with?(")")
+      return true if stripped.match(/\A(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b\s*$/)
+
+      !!stripped.match(/\A(?:(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b.*\broute(?:Ci|f|x)?\b|route(?:Ci|f|x)?\b|subRoute(?:Ci|f)?\b)/)
+    end
+
+    private def line_start_for_offset(text : String, offset : Int32) : Int32
+      return 0 if offset <= 0
+
+      line_start_raw = text.rindex('\n', offset - 1)
+      line_start_raw ? line_start_raw + 1 : 0
+    end
+
+    private def indentation_at(text : String, line_start : Int32) : Int32
+      count = 0
+      i = line_start
+      while i < text.size
+        char = text[i]
+        if char == ' '
+          count += 1
+        elsif char == '\t'
+          count += 2
+        else
+          break
+        end
+        i += 1
+      end
+      count
+    end
+
+    private def indentation_of_line(line : String) : Int32
+      count = 0
+      line.each_char do |char|
+        if char == ' '
+          count += 1
+        elsif char == '\t'
+          count += 2
+        else
+          break
+        end
+      end
+      count
+    end
+
+    private def identifier_char?(char : Char) : Bool
+      char.alphanumeric? || char == '_'
     end
 
     private def translate_routef(pattern : String) : Tuple(String, Array(Param))
@@ -273,7 +413,15 @@ module Analyzer::Fsharp
 
         # Line comments: //
         if i + 1 < chars.size && c == '/' && chars[i + 1] == '/'
+          result << ' '
+          result << ' '
+          i += 2
           while i < chars.size && chars[i] != '\n'
+            result << ' '
+            i += 1
+          end
+          if i < chars.size
+            result << chars[i]
             i += 1
           end
           next
@@ -282,16 +430,22 @@ module Analyzer::Fsharp
         # Block comments: (* ... *) — F# uses these instead of /* */.
         if i + 1 < chars.size && c == '(' && chars[i + 1] == '*'
           depth = 1
+          result << ' '
+          result << ' '
           i += 2
           while i + 1 < chars.size && depth > 0
             if chars[i] == '(' && chars[i + 1] == '*'
               depth += 1
+              result << ' '
+              result << ' '
               i += 2
             elsif chars[i] == '*' && chars[i + 1] == ')'
               depth -= 1
+              result << ' '
+              result << ' '
               i += 2
             else
-              result << '\n' if chars[i] == '\n'
+              result << (chars[i] == '\n' ? '\n' : ' ')
               i += 1
             end
           end

--- a/src/miniparsers/fsharp_callee_extractor.cr
+++ b/src/miniparsers/fsharp_callee_extractor.cr
@@ -1,0 +1,179 @@
+require "../models/endpoint"
+
+module Noir::FsharpCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+  alias StripState = NamedTuple(block_comment_depth: Int32, triple_string: Bool)
+
+  INITIAL_STATE = {
+    block_comment_depth: 0,
+    triple_string:       false,
+  }
+
+  RESERVED = Set{
+    "abstract", "and", "as", "assert", "base", "begin", "class", "default",
+    "delegate", "do", "done", "downcast", "downto", "elif", "else", "end",
+    "exception", "extern", "false", "finally", "for", "fun", "function",
+    "global", "if", "in", "inherit", "inline", "interface", "internal",
+    "lazy", "let", "let!", "match", "member", "module", "mutable",
+    "namespace", "new", "not", "null", "of", "open", "or", "override",
+    "private", "public", "rec", "return", "return!", "select", "static",
+    "struct", "then", "to", "true", "try", "type", "upcast", "use", "use!",
+    "val", "void", "when", "while", "with", "yield", "yield!",
+    "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
+    "choose", "route", "routeCi", "routef", "routex", "subRoute",
+    "subRouteCi", "subRoutef", "task", "async", "next", "ctx", "context",
+  }
+
+  QUALIFIED_CALL_REGEX = /(?<![A-Za-z0-9_'])((?:[A-Za-z_][A-Za-z0-9_']*)(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']+)+)(?:\s*<[^>\n]*>)?\s*(?:\(|(?=\s+(?:[A-Za-z_(@"]|\d)))/
+  CHAIN_CALL_REGEX     = />=>\s*([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']+)*)/
+  PIPE_CALL_REGEX      = /\|>\s*([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']+)*)/
+  ASSIGN_CALL_REGEX    = /\b(?:let!?|use!?)\s+[A-Za-z_][A-Za-z0-9_']*(?:\s*:[^=]+)?\s*=\s*([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']+)*)(?:\s*<[^>\n]*>)?\s*(?:\(|(?=\s+(?:[A-Za-z_(@"]|\d)))/
+  RETURN_CALL_REGEX    = /\breturn!?\s+([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']+)*)(?:\s*<[^>\n]*>)?\s*(?:\(|(?=\s+(?:[A-Za-z_(@"]|\d)))/
+  PAREN_CALL_REGEX     = /[(,]\s*([A-Za-z_][A-Za-z0-9_']*)\s+(?=[A-Za-z_(@"])/
+  STATEMENT_CALL_REGEX = /^\s*([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']+)*)\b(?:\s*<[^>\n]*>)?\s*(?:$|(?=[A-Za-z_(@"]))/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    state = INITIAL_STATE
+
+    body.each_line.with_index do |line, index|
+      stripped, state = strip_non_code_with_state(line, state)
+      scan_line(stripped, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    scan_candidates(line, QUALIFIED_CALL_REGEX, candidates)
+    scan_candidates(line, CHAIN_CALL_REGEX, candidates)
+    scan_candidates(line, PIPE_CALL_REGEX, candidates)
+    scan_candidates(line, ASSIGN_CALL_REGEX, candidates)
+    scan_candidates(line, RETURN_CALL_REGEX, candidates)
+    scan_candidates(line, PAREN_CALL_REGEX, candidates)
+    scan_candidates(line, STATEMENT_CALL_REGEX, candidates)
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |_, name|
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def scan_candidates(line : String, regex : Regex, candidates : Array(Tuple(Int32, String)))
+    line.scan(regex) do |match|
+      candidates << {match.begin(1) || 0, normalize_name(match[1])}
+    end
+  end
+
+  private def normalize_name(name : String) : String
+    name.gsub(/\s+/, "")
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = name.split('.').last
+    RESERVED.includes?(last)
+  end
+
+  private def strip_non_code_with_state(line : String, state : StripState) : Tuple(String, StripState)
+    chars = line.chars
+    block_comment_depth = state[:block_comment_depth]
+    triple_string = state[:triple_string]
+    index = 0
+    stripped = String::Builder.new
+
+    while index < chars.size
+      char = chars[index]
+
+      if block_comment_depth > 0
+        if char == '(' && chars[index + 1]? == '*'
+          block_comment_depth += 1
+          index += 1
+        elsif char == '*' && chars[index + 1]? == ')'
+          block_comment_depth -= 1
+          index += 1
+        end
+      elsif triple_string
+        if triple_string_delimiter?(chars, index)
+          triple_string = false
+          index += 2
+        end
+      elsif triple_string_delimiter?(chars, index)
+        triple_string = true
+        index += 2
+      elsif char == '/' && chars[index + 1]? == '/'
+        break
+      elsif char == '(' && chars[index + 1]? == '*'
+        block_comment_depth += 1
+        index += 1
+      elsif char == '@' && chars[index + 1]? == '"'
+        index = skip_verbatim_string(chars, index + 1)
+      elsif char == '"'
+        index = skip_string(chars, index)
+      else
+        stripped << char
+      end
+
+      index += 1
+    end
+
+    {stripped.to_s, {block_comment_depth: block_comment_depth, triple_string: triple_string}}
+  end
+
+  private def triple_string_delimiter?(chars : Array(Char), index : Int32) : Bool
+    chars[index]? == '"' && chars[index + 1]? == '"' && chars[index + 2]? == '"'
+  end
+
+  private def skip_string(chars : Array(Char), index : Int32) : Int32
+    i = index + 1
+    escaping = false
+
+    while i < chars.size
+      char = chars[i]
+      if escaping
+        escaping = false
+      elsif char == '\\'
+        escaping = true
+      elsif char == '"'
+        return i
+      end
+      i += 1
+    end
+
+    chars.size - 1
+  end
+
+  private def skip_verbatim_string(chars : Array(Char), index : Int32) : Int32
+    i = index + 1
+    while i < chars.size
+      if chars[i] == '"'
+        if chars[i + 1]? == '"'
+          i += 2
+          next
+        end
+        return i
+      end
+      i += 1
+    end
+
+    chars.size - 1
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight F# callee extractor for Giraffe handler chains, function applications, dotted calls, pipelines, and return expressions
- wire the Giraffe analyzer to attach route-handler callees when `--include-callee` is enabled
- preserve existing endpoint, method, subRoute/subRoutef, and routef parameter behavior

## Scope
- callees are extracted from the handler expression after `route` / `routeCi` / `routex` / `routef`
- fallback-method fan-out receives the same route handler callee list
- comment stripping preserves offsets so endpoint and callee line numbers remain source-aligned
- property-style dotted access like `ctx.Request.Path` is filtered unless it appears in a call/application context
- route-body slicing stops at sibling route lines, while nested handler delimiters such as inner `]` lists remain inside the handler body

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-fsharp-target6 crystal spec spec/unit_test/miniparser/fsharp_callee_extractor_spec.cr spec/functional_test/testers/fsharp/giraffe_callees_spec.cr --error-trace`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-fsharp-build3 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-fsharp-test3 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-fsharp-check3 just check`
- `git diff --check`
- CLI smoke check for the Giraffe callee fixture with `--include-callee`

Part of #1366.
