### PR TITLE
Add Groovy Grails callee extraction

### DIFF
--- a/spec/functional_test/fixtures/groovy/grails_callees/build.gradle
+++ b/spec/functional_test/fixtures/groovy/grails_callees/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id "org.grails.grails-web" version "6.1.0"
+}
+
+dependencies {
+    implementation "org.grails:grails-core"
+    implementation "org.grails:grails-web"
+}

--- a/spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/AuthorController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/AuthorController.groovy
@@ -1,0 +1,15 @@
+package demo
+
+class AuthorController {
+    def authorService
+
+    def list = {
+        def authors = authorService.list(params)
+        render authors
+    }
+
+    String profile() {
+        def profile = profileService.show(params.id)
+        render profile
+    }
+}

--- a/spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/BookController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/BookController.groovy
@@ -1,0 +1,46 @@
+package demo
+
+// Long comment before the controller keeps source offsets honest.
+/*
+ * Ignored.beforeController()
+ */
+class BookController {
+    static allowedMethods = [
+        save: 'POST',
+        update: ['PUT', 'PATCH']
+    ]
+
+    def cache = [:]
+    def bookService = new BookService()
+
+    def index() {
+        def books = bookService.list()
+        AuditLog.write('book.index', books)
+        def ignored = "Ignored.string()"
+        render view: 'index', model: [books: books]
+    }
+
+    def save() {
+        def book = bookService.save(request.JSON)
+        respond book
+    }
+
+    def update(Long id) {
+        def book = bookService.update(id, params)
+        withTransaction {
+            AuditLog.write 'book.update', book
+        }
+        redirect(action: 'show', id: id)
+    }
+
+    def show(Long id) {
+        def ignoredSlashy = /Ignored.slashy(})/
+        def ignoredDollar = $/Ignored.dollar({})/$
+        def ignoredTriple = '''Ignored.triple({})'''
+        return render view: 'show', model: [book: bookService?.find(id)]
+    }
+
+    private def helper() {
+        Hidden.call()
+    }
+}

--- a/spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/ProductController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/ProductController.groovy
@@ -1,0 +1,5 @@
+package demo
+
+class ProductController {
+    static scaffold = Product
+}

--- a/spec/functional_test/testers/groovy/grails_callees_spec.cr
+++ b/spec/functional_test/testers/groovy/grails_callees_spec.cr
@@ -1,0 +1,101 @@
+require "../../func_spec.cr"
+
+def grails_endpoint_with_callees(url, method, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+index_callees = [
+  Callee.new("bookService.list", line: 17),
+  Callee.new("AuditLog.write", line: 18),
+  Callee.new("render", line: 20),
+]
+
+save_callees = [
+  Callee.new("bookService.save", line: 24),
+  Callee.new("respond", line: 25),
+]
+
+update_callees = [
+  Callee.new("bookService.update", line: 29),
+  Callee.new("withTransaction", line: 30),
+  Callee.new("AuditLog.write", line: 31),
+  Callee.new("redirect", line: 33),
+]
+
+show_callees = [
+  Callee.new("render", line: 40),
+  Callee.new("bookService.find", line: 40),
+]
+
+list_callees = [
+  Callee.new("authorService.list", line: 7),
+  Callee.new("render", line: 8),
+]
+
+profile_callees = [
+  Callee.new("profileService.show", line: 12),
+  Callee.new("render", line: 13),
+]
+
+expected_endpoints = [
+  grails_endpoint_with_callees("/book/index", "GET", index_callees),
+  grails_endpoint_with_callees("/book/save", "POST", save_callees),
+  grails_endpoint_with_callees("/book/update", "PUT", update_callees),
+  grails_endpoint_with_callees("/book/update", "PATCH", update_callees),
+  grails_endpoint_with_callees("/book/show", "GET", show_callees),
+  grails_endpoint_with_callees("/author/list", "GET", list_callees),
+  grails_endpoint_with_callees("/author/profile", "GET", profile_callees),
+  Endpoint.new("/product/index", "GET"),
+  Endpoint.new("/product/show", "GET"),
+  Endpoint.new("/product/create", "GET"),
+  Endpoint.new("/product/save", "POST"),
+  Endpoint.new("/product/edit", "GET"),
+  Endpoint.new("/product/update", "PUT"),
+  Endpoint.new("/product/delete", "DELETE"),
+]
+
+tester = FunctionalTester.new("fixtures/groovy/grails_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports exact Grails callees for allowedMethods fan-out" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/book/update" && found.method == "PUT" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(update_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "handles Groovy literals and safe navigation in Grails action bodies" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/book/show" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(show_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "does not attach callees to scaffold-generated Grails actions" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/product/save" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.should be_empty
+  end
+end
+
+it "populates Grails callee source paths" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/book/index" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    paths = actual.callees.map(&.path)
+    paths.uniq!
+    paths.should eq([
+      "./spec/functional_test/fixtures/groovy/grails_callees/grails-app/controllers/BookController.groovy",
+    ])
+  end
+end

--- a/spec/unit_test/miniparser/groovy_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/groovy_callee_extractor_spec.cr
@@ -1,0 +1,91 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/groovy_callee_extractor"
+
+describe Noir::GroovyCalleeExtractor do
+  it "extracts receiver, framework command, and bare calls" do
+    body = <<-GROOVY
+      def books = bookService.list()
+      AuditLog.write('book.index', books)
+      render view: 'index', model: [books: books]
+      respond bookService.create(params)
+      redirect(action: 'show', id: book.id)
+      getBook().toString()
+      GROOVY
+
+    callees = Noir::GroovyCalleeExtractor.callees_for_body(body, "BookController.groovy", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"bookService.list", 10},
+      {"AuditLog.write", 11},
+      {"render", 12},
+      {"respond", 13},
+      {"bookService.create", 13},
+      {"redirect", 14},
+      {"getBook", 15},
+    ])
+  end
+
+  it "skips comments, strings, constructors, and declarations" do
+    body = <<-GROOVY
+      def ignored = "Ignored.string()"
+      def triple = '''
+        Ignored.triple()
+      '''
+      def escapedTriple = """Ignored.escapedTriple(\\""")"""
+      def slashy = /Ignored.slashy({})/
+      def dollarSlashy = $/Ignored.dollar({}) $/$ Still.ignored()/$
+      /* Ignored.block() */
+      // Ignored.line()
+      def book = new Book()
+      def helper()
+      Real.call()
+      GROOVY
+
+    callees = Noir::GroovyCalleeExtractor.callees_for_body(body, "BookController.groovy", 30)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"Real.call", 41},
+    ])
+  end
+
+  it "keeps Groovy with calls" do
+    body = <<-GROOVY
+      with {
+        service.call()
+      }
+      GROOVY
+
+    callees = Noir::GroovyCalleeExtractor.callees_for_body(body, "BookController.groovy", 45)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"with", 45},
+      {"service.call", 46},
+    ])
+  end
+
+  it "extracts safe navigation, spread, and keyword command calls" do
+    body = <<-GROOVY
+      return render view: 'show', model: [book: bookService?.find(id)]
+      books*.save()
+      throw notFound params.id
+      GROOVY
+
+    callees = Noir::GroovyCalleeExtractor.callees_for_body(body, "BookController.groovy", 55)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"render", 55},
+      {"bookService.find", 55},
+      {"books.save", 56},
+      {"notFound", 57},
+    ])
+  end
+
+  it "extracts command-style dotted calls" do
+    body = <<-GROOVY
+      AuditLog.write 'book.update', book
+      def saved = BookService.save params
+      GROOVY
+
+    callees = Noir::GroovyCalleeExtractor.callees_for_body(body, "BookController.groovy", 60)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"AuditLog.write", 60},
+      {"BookService.save", 61},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -1,4 +1,6 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/groovy_callee_extractor"
+require "../../../utils/groovy_literal_scanner"
 
 module Analyzer::Groovy
   # Grails follows a convention-over-configuration layout where each
@@ -67,6 +69,7 @@ module Analyzer::Groovy
     ]
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".groovy")
@@ -74,7 +77,7 @@ module Analyzer::Groovy
         content = read_file_content(path)
 
         if controller_path?(path)
-          process_controller(path, content)
+          process_controller(path, content, include_callee)
         end
 
         if url_mappings_path?(path)
@@ -98,7 +101,7 @@ module Analyzer::Groovy
       File.basename(path).ends_with?("UrlMappings.groovy")
     end
 
-    private def process_controller(path : String, content : String)
+    private def process_controller(path : String, content : String, include_callee : Bool)
       cleaned = strip_groovy_comments(content)
 
       cleaned.scan(/((?:(?:public|protected|private|abstract|final|static)\s+)*)class\s+([A-Z][A-Za-z0-9_]*Controller)\b([^\{]*)\{/) do |match|
@@ -147,13 +150,24 @@ module Analyzer::Groovy
           methods = allowed_methods[action[:name]]? || DEFAULT_METHODS
           line = line_for_offset(content, body_start + action[:offset])
           line = line_for_offset(content, match_start) if line <= 0
+          callees = include_callee ? callees_for_action(path, content, body_start, action) : [] of Noir::GroovyCalleeExtractor::Entry
           methods.each do |verb|
             url = "/#{controller_name}/#{action[:name]}"
             details = Details.new(PathInfo.new(path, line))
-            @result << Endpoint.new(url, verb, [] of Param, details)
+            endpoint = Endpoint.new(url, verb, [] of Param, details)
+            Noir::GroovyCalleeExtractor.attach_to(endpoint, callees)
+            @result << endpoint
           end
         end
       end
+    end
+
+    private def callees_for_action(path : String,
+                                   content : String,
+                                   class_body_start : Int32,
+                                   action : Action) : Array(Noir::GroovyCalleeExtractor::Entry)
+      start_line = line_for_offset(content, class_body_start + action[:body_start])
+      Noir::GroovyCalleeExtractor.callees_for_body(action[:body], path, start_line)
     end
 
     private def extends_restful_controller?(clause : String) : Bool
@@ -185,32 +199,22 @@ module Analyzer::Groovy
       base[0].downcase.to_s + base[1..]
     end
 
-    private def extract_actions(body : String) : Array(NamedTuple(name: String, offset: Int32))
-      actions = [] of NamedTuple(name: String, offset: Int32)
+    alias Action = NamedTuple(name: String, offset: Int32, body: String, body_start: Int32)
+
+    private def extract_actions(body : String) : Array(Action)
+      actions = [] of Action
       depth = 0
-      in_string = false
-      string_quote = '\0'
       i = 0
 
       while i < body.size
         c = body[i]
 
-        if in_string
-          if c == '\\' && i + 1 < body.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(body, i)
+          i = literal_end
           next
         end
 
         case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
-          i += 1
-          next
         when '{'
           depth += 1
           i += 1
@@ -236,7 +240,10 @@ module Analyzer::Groovy
             name = m[2]
             is_private = modifier && modifier.lstrip.starts_with?("private")
             unless is_private || SKIP_ACTION_NAMES.includes?(name)
-              actions << {name: name, offset: i}
+              if action_body = extract_braced_block(body, i + (m.end(0) || 0))
+                action_body_text, action_body_start = action_body
+                actions << {name: name, offset: i, body: action_body_text, body_start: action_body_start}
+              end
             end
             match_end = m.end(0)
             i = match_end ? i + match_end : i + 1
@@ -251,7 +258,11 @@ module Analyzer::Groovy
           if m2
             name = m2[3]
             unless SKIP_ACTION_NAMES.includes?(name)
-              actions << {name: name, offset: i}
+              open_brace = i + (m2.end(0) || 1) - 1
+              if action_body = extract_braced_block(body, open_brace)
+                action_body_text, action_body_start = action_body
+                actions << {name: name, offset: i, body: action_body_text, body_start: action_body_start}
+              end
             end
             match_end = m2.end(0)
             i = match_end ? i + match_end : i + 1
@@ -444,23 +455,14 @@ module Analyzer::Groovy
       return unless open_idx < text.size && text[open_idx] == '{'
       depth = 1
       i = open_idx + 1
-      in_string = false
-      string_quote = '\0'
       while i < text.size && depth > 0
-        c = text[i]
-        if in_string
-          if c == '\\' && i + 1 < text.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(text, i)
+          i = literal_end
           next
         end
+
+        c = text[i]
         case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
         when '{'
           depth += 1
         when '}'
@@ -510,25 +512,15 @@ module Analyzer::Groovy
       body_start = i + 1
       depth = 1
       i += 1
-      in_string = false
-      string_quote = '\0'
 
       while i < text.size && depth > 0
-        c = text[i]
-        if in_string
-          if c == '\\' && i + 1 < text.size
-            i += 2
-            next
-          end
-          in_string = false if c == string_quote
-          i += 1
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(text, i)
+          i = literal_end
           next
         end
 
+        c = text[i]
         case c
-        when '"', '\''
-          in_string = true
-          string_quote = c
         when '{'
           depth += 1
         when '}'
@@ -547,49 +539,44 @@ module Analyzer::Groovy
     private def strip_groovy_comments(text : String) : String
       result = String::Builder.new
       i = 0
-      chars = text.chars
-      in_string = false
-      string_quote = '\0'
 
-      while i < chars.size
-        c = chars[i]
+      while i < text.size
+        c = text[i]
 
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            result << c
-            result << chars[i + 1]
-            i += 2
-            next
-          elsif c == string_quote
-            in_string = false
-          end
-          result << c
-          i += 1
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(text, i)
+          append_source_range(result, text, i, literal_end)
+          i = literal_end
           next
         end
 
-        if c == '"' || c == '\''
-          in_string = true
-          string_quote = c
-          result << c
-          i += 1
-          next
-        end
-
-        if i + 1 < chars.size && c == '/' && chars[i + 1] == '/'
-          while i < chars.size && chars[i] != '\n'
-            i += 1
-          end
-          next
-        end
-
-        if i + 1 < chars.size && c == '/' && chars[i + 1] == '*'
+        if i + 1 < text.size && c == '/' && text[i + 1] == '/'
+          result << ' '
+          result << ' '
           i += 2
-          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
-            result << '\n' if chars[i] == '\n'
+          while i < text.size && text[i] != '\n'
+            result << ' '
             i += 1
           end
-          i += 2 if i + 1 < chars.size
+          if i < text.size
+            result << text[i]
+            i += 1
+          end
+          next
+        end
+
+        if i + 1 < text.size && c == '/' && text[i + 1] == '*'
+          result << ' '
+          result << ' '
+          i += 2
+          while i + 1 < text.size && !(text[i] == '*' && text[i + 1] == '/')
+            result << (text[i] == '\n' ? '\n' : ' ')
+            i += 1
+          end
+          if i + 1 < text.size
+            result << ' '
+            result << ' '
+            i += 2
+          end
           next
         end
 
@@ -598,6 +585,14 @@ module Analyzer::Groovy
       end
 
       result.to_s
+    end
+
+    private def append_source_range(result : String::Builder, text : String, start : Int32, finish : Int32)
+      index = start
+      while index < finish && index < text.size
+        result << text[index]
+        index += 1
+      end
     end
 
     private def line_for_offset(content : String, offset : Int32) : Int32

--- a/src/miniparsers/groovy_callee_extractor.cr
+++ b/src/miniparsers/groovy_callee_extractor.cr
@@ -1,0 +1,148 @@
+require "../models/endpoint"
+require "../utils/groovy_literal_scanner"
+
+module Noir::GroovyCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  RESERVED = Set{
+    "as", "assert", "break", "case", "catch", "class", "const", "continue",
+    "def", "default", "do", "else", "enum", "extends", "false", "final",
+    "finally", "for", "if", "implements", "import", "in", "instanceof",
+    "interface", "new", "null", "package", "private", "protected", "public",
+    "return", "static", "super", "switch", "this", "throw", "throws", "trait",
+    "true", "try", "void", "while",
+  }
+
+  RECEIVER_CALL_REGEX        = /([A-Za-z_$][A-Za-z0-9_$]*(?:(?:\s*(?:\?\.|\*\.|\.))\s*[A-Za-z_$][A-Za-z0-9_$]*)+)\s*(?:<[^;\n{}]*>)?\s*\(/
+  BARE_CALL_REGEX            = /(?<![A-Za-z0-9_$.])([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:<[^;\n{}]*>)?\s*\(/
+  COMMAND_CALL_REGEX         = /(?:^|[;{}])\s*([A-Za-z_$][A-Za-z0-9_$]*(?:(?:\s*(?:\?\.|\*\.|\.))\s*[A-Za-z_$][A-Za-z0-9_$]*)?)\s+(?=(?:['"{\[\w$,]|\d))/
+  KEYWORD_COMMAND_CALL_REGEX = /\b(?:return|throw)\s+([A-Za-z_$][A-Za-z0-9_$]*(?:(?:\s*(?:\?\.|\*\.|\.))\s*[A-Za-z_$][A-Za-z0-9_$]*)?)\s+(?=(?:['"{\[\w$,]|\d))/
+  ASSIGN_CALL_REGEX          = /=\s*([A-Za-z_$][A-Za-z0-9_$]*(?:(?:\s*(?:\?\.|\*\.|\.))\s*[A-Za-z_$][A-Za-z0-9_$]*)?)\s+(?=(?:['"{\[\w$,]|\d))/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    stripped_body = strip_non_code(body)
+
+    stripped_body.each_line.with_index do |line, index|
+      scan_line(line, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    scan_candidates(line, RECEIVER_CALL_REGEX, candidates)
+    line.scan(BARE_CALL_REGEX) do |match|
+      position = match.begin(1) || 0
+      next if declaration_or_constructor?(line, position)
+
+      candidates << {position, match[1]}
+    end
+    scan_candidates(line, COMMAND_CALL_REGEX, candidates)
+    scan_candidates(line, KEYWORD_COMMAND_CALL_REGEX, candidates)
+    scan_candidates(line, ASSIGN_CALL_REGEX, candidates)
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |_, name|
+      next if skip_callee?(name)
+
+      entries << {normalize_name(name), file_path, line_number}
+    end
+  end
+
+  private def scan_candidates(line : String, regex : Regex, candidates : Array(Tuple(Int32, String)))
+    line.scan(regex) do |match|
+      candidates << {match.begin(1) || 0, match[1]}
+    end
+  end
+
+  private def normalize_name(name : String) : String
+    name.gsub(/\s+/, "").gsub("?.", ".").gsub("*.", ".")
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    last = normalize_name(name).split('.').last
+    RESERVED.includes?(last)
+  end
+
+  private def declaration_or_constructor?(line : String, position : Int32) : Bool
+    before = line[0...position]
+    return true if before.match(/\b(?:def|private|protected|public|static|final)\s+$/)
+    return true if before.match(/\bnew\s+$/)
+
+    false
+  end
+
+  private def strip_non_code(body : String) : String
+    index = 0
+    stripped = String::Builder.new
+
+    while index < body.size
+      char = body[index]
+
+      if index + 1 < body.size && char == '/' && body[index + 1] == '/'
+        append_blanks_until_line_end(stripped, body, index)
+        index += 2
+        while index < body.size && body[index] != '\n'
+          index += 1
+        end
+        next
+      end
+
+      if index + 1 < body.size && char == '/' && body[index + 1] == '*'
+        end_index = index + 2
+        while end_index + 1 < body.size && !(body[end_index] == '*' && body[end_index + 1] == '/')
+          end_index += 1
+        end
+        end_index += 2 if end_index + 1 < body.size
+        append_blanks(stripped, body, index, end_index)
+        index = end_index
+        next
+      end
+
+      if literal_end = Noir::GroovyLiteralScanner.skip_literal(body, index)
+        append_blanks(stripped, body, index, literal_end)
+        index = literal_end
+        next
+      end
+
+      stripped << char
+      index += 1
+    end
+
+    stripped.to_s
+  end
+
+  private def append_blanks_until_line_end(stripped : String::Builder, body : String, start : Int32)
+    index = start
+    while index < body.size && body[index] != '\n'
+      stripped << ' '
+      index += 1
+    end
+  end
+
+  private def append_blanks(stripped : String::Builder, body : String, start : Int32, finish : Int32)
+    index = start
+    while index < finish && index < body.size
+      stripped << (body[index] == '\n' ? '\n' : ' ')
+      index += 1
+    end
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end

--- a/src/utils/groovy_literal_scanner.cr
+++ b/src/utils/groovy_literal_scanner.cr
@@ -1,0 +1,155 @@
+module Noir::GroovyLiteralScanner
+  extend self
+
+  SLASHY_PRECEDING_CHARS = [
+    '(', '[', '{', ',', ':', ';', '=', '!', '&', '|', '?',
+    '+', '-', '*', '%', '<', '>', '~',
+  ]
+
+  SLASHY_PRECEDING_KEYWORDS = Set{
+    "assert", "case", "in", "return", "throw",
+  }
+
+  def skip_literal(content : String, pos : Int32) : Int32?
+    return if pos >= content.size
+
+    char = content[pos]
+
+    return skip_dollar_slashy(content, pos) if dollar_slashy_start?(content, pos)
+    return skip_triple_quote(content, pos, char) if triple_quote_start?(content, pos, char)
+    return skip_quoted(content, pos, char) if char == '"' || char == '\''
+    return skip_slashy(content, pos) if slashy_start?(content, pos)
+
+    nil
+  end
+
+  private def dollar_slashy_start?(content : String, pos : Int32) : Bool
+    pos + 1 < content.size && content[pos] == '$' && content[pos + 1] == '/'
+  end
+
+  private def triple_quote_start?(content : String, pos : Int32, quote : Char) : Bool
+    return false unless quote == '"' || quote == '\''
+
+    pos + 2 < content.size &&
+      content[pos] == quote &&
+      content[pos + 1] == quote &&
+      content[pos + 2] == quote
+  end
+
+  private def slashy_start?(content : String, pos : Int32) : Bool
+    return false unless content[pos] == '/'
+    return false if pos + 1 < content.size && {'/', '*', '='}.includes?(content[pos + 1])
+
+    prev = previous_nonspace_index(content, pos)
+    return true unless prev
+
+    prev_char = content[prev]
+    return true if SLASHY_PRECEDING_CHARS.includes?(prev_char)
+
+    word = previous_word(content, prev)
+    SLASHY_PRECEDING_KEYWORDS.includes?(word)
+  end
+
+  private def previous_nonspace_index(content : String, pos : Int32) : Int32?
+    index = pos - 1
+    while index >= 0
+      return index unless content[index].whitespace?
+      index -= 1
+    end
+    nil
+  end
+
+  private def previous_word(content : String, word_end : Int32) : String
+    end_exclusive = word_end + 1
+    index = word_end
+    while index >= 0 && identifier_char?(content[index])
+      index -= 1
+    end
+
+    content[(index + 1)...end_exclusive]
+  end
+
+  private def identifier_char?(char : Char) : Bool
+    char.alphanumeric? || char == '_' || char == '$'
+  end
+
+  private def skip_quoted(content : String, pos : Int32, quote : Char) : Int32
+    index = pos + 1
+    while index < content.size
+      if content[index] == '\\' && index + 1 < content.size
+        index += 2
+        next
+      end
+
+      if content[index] == quote
+        return index + 1
+      end
+
+      index += 1
+    end
+
+    content.size
+  end
+
+  private def skip_triple_quote(content : String, pos : Int32, quote : Char) : Int32
+    index = pos + 3
+    while index + 2 < content.size
+      if content[index] == quote &&
+         content[index + 1] == quote &&
+         content[index + 2] == quote &&
+         !escaped?(content, index)
+        return index + 3
+      end
+
+      index += 1
+    end
+
+    content.size
+  end
+
+  private def skip_dollar_slashy(content : String, pos : Int32) : Int32
+    index = pos + 2
+    while index + 1 < content.size
+      if content[index] == '/' &&
+         content[index + 1] == '$' &&
+         !escaped_dollar_slashy_delimiter?(content, pos, index)
+        return index + 2
+      end
+
+      index += 1
+    end
+
+    content.size
+  end
+
+  private def skip_slashy(content : String, pos : Int32) : Int32
+    index = pos + 1
+    while index < content.size
+      if content[index] == '\\' && index + 1 < content.size
+        index += 2
+        next
+      end
+
+      return index + 1 if content[index] == '/'
+
+      index += 1
+    end
+
+    content.size
+  end
+
+  private def escaped?(content : String, pos : Int32) : Bool
+    backslashes = 0
+    index = pos - 1
+    while index >= 0 && content[index] == '\\'
+      backslashes += 1
+      index -= 1
+    end
+
+    backslashes.odd?
+  end
+
+  private def escaped_dollar_slashy_delimiter?(content : String, start : Int32, slash_pos : Int32) : Bool
+    slash_pos > start + 2 && content[slash_pos - 1] == '$'
+  end
+end


### PR DESCRIPTION
## Summary
- add Groovy literal-aware scanning shared by Grails action body parsing and callee extraction
- attach callees for explicit Grails controller actions when `--include-callee` is enabled
- cover receiver calls, bare calls, command-style calls, keyword-prefixed command calls, safe navigation, spread calls, slashy strings, dollar-slashy strings, and triple-quoted strings

## Scope
- scaffold/RestfulController inherited actions and UrlMappings remain endpoint-only because there is no local handler body to resolve in this pass
- framework calls such as `render`, `respond`, `redirect`, and `withTransaction` are kept as endpoint behavior signals
- comment stripping preserves offsets so action and callee line numbers stay source-aligned

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-groovy-target2 crystal spec spec/unit_test/miniparser/groovy_callee_extractor_spec.cr spec/functional_test/testers/groovy/grails_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-groovy-build2 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-groovy-test2 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-groovy-check2 just check`
- `git diff --check`
- CLI smoke: `./bin/noir -b spec/functional_test/fixtures/groovy/grails_callees -f json --include-callee`

Part of #1366.