### PR TITLE
Add Haskell Yesod callee extraction

### DIFF
--- a/spec/functional_test/fixtures/haskell/yesod_callees/package.yaml
+++ b/spec/functional_test/fixtures/haskell/yesod_callees/package.yaml
@@ -1,0 +1,6 @@
+name: yesod-callees-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - yesod
+  - warp

--- a/spec/functional_test/fixtures/haskell/yesod_callees/src/Foundation.hs
+++ b/spec/functional_test/fixtures/haskell/yesod_callees/src/Foundation.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Foundation where
+
+import Yesod
+
+data App = App
+
+mkYesodData "App" [parseRoutes|
+/ HomeR GET
+/blog/#Text BlogPostR GET POST
+/faq FaqR
+/api ApiR:
+    /health HealthR GET
+|]

--- a/spec/functional_test/fixtures/haskell/yesod_callees/src/Handler/Home.hs
+++ b/spec/functional_test/fixtures/haskell/yesod_callees/src/Handler/Home.hs
@@ -1,0 +1,44 @@
+module Handler.Home where
+
+import Foundation
+import Yesod
+
+getHomeR :: Handler Html
+getHomeR = do
+  users <- loadUsers
+  defaultLayout $ do
+    setTitle "Home"
+    toWidget [lucius|
+      .ignored { color: red; }
+      Ignored.template()
+    |]
+    renderHome users
+
+getBlogPostR :: Text -> Handler Value
+getBlogPostR slug = do
+  post <- Blog.Service.fetch slug
+  returnJson post
+
+postBlogPostR :: Text -> Handler Value
+postBlogPostR slug = do
+  payload <- requireCheckJsonBody
+  saved <- savePost slug payload
+  sendResponseStatus status201 saved
+
+handleFaqR :: Handler Value
+handleFaqR = do
+  item :: FaqItem
+  item <- loadFaq
+  case item of
+    FaqFound value -> returnJson value
+    FaqMissing -> notFound
+
+getHealthR :: Handler Value
+getHealthR = do
+  stats <- healthService
+  returnJson stats
+
+helperOnly :: Handler Value
+helperOnly = do
+  hiddenCall
+  returnJson ()

--- a/spec/functional_test/testers/haskell/yesod_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/yesod_callees_spec.cr
@@ -1,0 +1,99 @@
+require "../../func_spec.cr"
+
+def yesod_endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+home_callees = [
+  Callee.new("loadUsers", line: 8),
+  Callee.new("defaultLayout", line: 9),
+  Callee.new("setTitle", line: 10),
+  Callee.new("toWidget", line: 11),
+  Callee.new("renderHome", line: 15),
+]
+
+blog_get_callees = [
+  Callee.new("Blog.Service.fetch", line: 19),
+  Callee.new("returnJson", line: 20),
+]
+
+blog_post_callees = [
+  Callee.new("requireCheckJsonBody", line: 24),
+  Callee.new("savePost", line: 25),
+  Callee.new("sendResponseStatus", line: 26),
+]
+
+health_callees = [
+  Callee.new("healthService", line: 38),
+  Callee.new("returnJson", line: 39),
+]
+
+faq_callees = [
+  Callee.new("loadFaq", line: 31),
+  Callee.new("returnJson", line: 33),
+  Callee.new("notFound", line: 34),
+]
+
+expected_endpoints = [
+  yesod_endpoint_with_callees("/", "GET", [] of Param, home_callees),
+  yesod_endpoint_with_callees("/blog/:text", "GET", [
+    Param.new("text", "Text", "path"),
+  ], blog_get_callees),
+  yesod_endpoint_with_callees("/blog/:text", "POST", [
+    Param.new("text", "Text", "path"),
+  ], blog_post_callees),
+  yesod_endpoint_with_callees("/faq", "GET", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/faq", "POST", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/faq", "PUT", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/faq", "DELETE", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/faq", "PATCH", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/faq", "OPTIONS", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/faq", "HEAD", [] of Param, faq_callees),
+  yesod_endpoint_with_callees("/api/health", "GET", [] of Param, health_callees),
+]
+
+tester = FunctionalTester.new("fixtures/haskell/yesod_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports exact Yesod callees by handler convention" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(home_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "uses handle-prefixed Yesod handlers for methodless routes" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/faq" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(faq_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "does not attach unrelated top-level functions to Yesod endpoints" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/api/health" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map(&.name).should_not contain("hiddenCall")
+  end
+end
+
+it "populates Yesod callee source paths" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/blog/:text" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    paths = actual.callees.map(&.path)
+    paths.uniq!
+    paths.should eq([
+      "./spec/functional_test/fixtures/haskell/yesod_callees/src/Handler/Home.hs",
+    ])
+  end
+end

--- a/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
@@ -1,0 +1,86 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/haskell_callee_extractor"
+
+describe Noir::HaskellCalleeExtractor do
+  it "extracts top-level Haskell function bodies" do
+    source = <<-HASKELL
+      module Handler.Home where
+
+      getHomeR :: Handler Html
+      getHomeR = do
+        users <- loadUsers
+        defaultLayout $ renderUsers users
+
+      helper = do
+        pure ()
+      HASKELL
+
+    bodies = Noir::HaskellCalleeExtractor.function_bodies(source, "Handler/Home.hs")
+    bodies.map { |body| {body[:name], body[:start_line]} }.should eq([
+      {"getHomeR", 4},
+      {"helper", 8},
+    ])
+  end
+
+  it "extracts direct calls from Haskell handler bodies" do
+    body = <<-HASKELL
+      do
+        users <- loadUsers
+        account <- Account.Service.fetch userId
+        defaultLayout $ do
+          setTitle "Ignored.call()"
+          toWidget [lucius|
+            .ignored { color: red; }
+          |]
+          renderUsers users
+        sendResponseStatus status201 account
+      HASKELL
+
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(body, "Handler/Home.hs", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"loadUsers", 21},
+      {"Account.Service.fetch", 22},
+      {"defaultLayout", 23},
+      {"setTitle", 24},
+      {"toWidget", 25},
+      {"renderUsers", 28},
+      {"sendResponseStatus", 29},
+    ])
+  end
+
+  it "skips comments, strings, chars, quasiquotes, and common builtins" do
+    body = <<-HASKELL
+      do
+        -- Ignored.line()
+        {- Ignored.block() -}
+        _ <- pure "Ignored.string()"
+        _ <- pure 'x'
+        html <- [whamlet|Ignored.template()|]
+        realCall html
+      HASKELL
+
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(body, "Handler/Home.hs", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"realCall", 46},
+    ])
+  end
+
+  it "extracts inline branch calls and skips local type signatures" do
+    body = <<-HASKELL
+      do
+        query :: SqlQuery
+        case found of
+          Just user -> returnJson user
+          Nothing -> notFound
+        if ok then redirect HomeR else invalidArgs ["bad"]
+      HASKELL
+
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(body, "Handler/Home.hs", 60)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"returnJson", 63},
+      {"notFound", 64},
+      {"redirect", 65},
+      {"invalidArgs", 65},
+    ])
+  end
+end

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -1,12 +1,16 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/haskell_callee_extractor"
 require "set"
 
 module Analyzer::Haskell
   class Yesod < Analyzer
     HTTP_METHODS = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
+    alias HandlerBody = Noir::HaskellCalleeExtractor::FunctionBody
 
     def analyze
       processed_route_files = Set(String).new
+      include_callee = any_to_bool(@options["include_callee"]?)
+      handler_bodies = include_callee ? build_handler_bodies : {} of String => HandlerBody
 
       all_files.each do |path|
         next if File.directory?(path)
@@ -15,7 +19,7 @@ module Analyzer::Haskell
           expanded_path = File.expand_path(path)
           next if processed_route_files.includes?(expanded_path)
 
-          process_route_content(expanded_path, read_file_content(path))
+          process_route_content(expanded_path, read_file_content(path), include_callee, handler_bodies)
           processed_route_files << expanded_path
           next
         end
@@ -24,7 +28,7 @@ module Analyzer::Haskell
 
         content = read_file_content(path)
         extract_inline_route_blocks(content).each do |block|
-          process_route_content(path, block)
+          process_route_content(path, block, include_callee, handler_bodies)
         end
 
         extract_external_route_paths(content).each do |relative_path|
@@ -33,7 +37,7 @@ module Analyzer::Haskell
           next if File.directory?(referenced_path)
           next if processed_route_files.includes?(referenced_path)
 
-          process_route_content(referenced_path, read_file_content(referenced_path))
+          process_route_content(referenced_path, read_file_content(referenced_path), include_callee, handler_bodies)
           processed_route_files << referenced_path
         end
       end
@@ -49,6 +53,21 @@ module Analyzer::Haskell
       return true if path.ends_with?(".yesodroutes")
 
       File.basename(path) == "routes" && File.dirname(path).ends_with?("/config")
+    end
+
+    private def build_handler_bodies : Hash(String, HandlerBody)
+      handlers = {} of String => HandlerBody
+
+      all_files.each do |path|
+        next if File.directory?(path)
+        next unless haskell_source?(path)
+
+        Noir::HaskellCalleeExtractor.function_bodies(read_file_content(path), path).each do |body|
+          handlers[body[:name]] = body
+        end
+      end
+
+      handlers
     end
 
     private def extract_inline_route_blocks(content : String) : Array(String)
@@ -73,7 +92,10 @@ module Analyzer::Haskell
       paths.uniq
     end
 
-    private def process_route_content(source_path : String, content : String)
+    private def process_route_content(source_path : String,
+                                      content : String,
+                                      include_callee : Bool,
+                                      handler_bodies : Hash(String, HandlerBody))
       scope_stack = [{indent: -1, raw_segments: [] of String}]
 
       logical_route_lines(content).each do |entry|
@@ -82,6 +104,7 @@ module Analyzer::Haskell
 
         tokens = split_route_tokens(stripped_line)
         next if tokens.size < 2
+        route_name = tokens[1]
 
         indent = entry[:indent]
         while scope_stack.size > 1 && indent <= scope_stack.last[:indent]
@@ -99,15 +122,41 @@ module Analyzer::Haskell
 
         methods = extract_methods(tokens)
         next if methods.empty?
+        methodless_route = methodless_route?(tokens)
 
         url, params = build_url_and_params(scope_stack.last[:raw_segments] + raw_segments)
         details = Details.new(PathInfo.new(source_path, entry[:line]))
 
         methods.each do |method|
           endpoint_params = params.map { |param| Param.new(param.name, param.value, param.param_type) }
-          @result << Endpoint.new(url, method, endpoint_params, details)
+          endpoint = Endpoint.new(url, method, endpoint_params, details)
+          attach_handler_callees(endpoint, method, route_name, methodless_route, handler_bodies) if include_callee
+          @result << endpoint
         end
       end
+    end
+
+    private def attach_handler_callees(endpoint : Endpoint,
+                                       method : String,
+                                       route_name : String,
+                                       methodless_route : Bool,
+                                       handler_bodies : Hash(String, HandlerBody))
+      handler_name = handler_name_for(method, route_name, methodless_route)
+      handler_body = handler_bodies[handler_name]?
+      return unless handler_body
+
+      callees = Noir::HaskellCalleeExtractor.callees_for_body(
+        handler_body[:body],
+        handler_body[:path],
+        handler_body[:start_line]
+      )
+      Noir::HaskellCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    private def handler_name_for(method : String, route_name : String, methodless_route : Bool) : String
+      return "handle#{route_name}" if methodless_route
+
+      method.downcase + route_name
     end
 
     private def logical_route_lines(content : String) : Array(NamedTuple(text: String, line: Int32, indent: Int32))
@@ -222,6 +271,12 @@ module Analyzer::Haskell
       return HTTP_METHODS.dup if non_attrs.empty?
 
       [] of String
+    end
+
+    private def methodless_route?(tokens : Array(String)) : Bool
+      rest = tokens[2..]? || [] of String
+      non_attrs = rest.reject(&.starts_with?("!"))
+      non_attrs.empty?
     end
 
     # Yesod subsite declarations use two non-method tokens after the route

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -1,0 +1,288 @@
+require "../models/endpoint"
+
+module Noir::HaskellCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+  alias FunctionBody = NamedTuple(name: String, body: String, path: String, start_line: Int32)
+
+  RESERVED = Set{
+    "as", "case", "class", "data", "default", "deriving", "do", "else",
+    "family", "forall", "foreign", "hiding", "if", "import", "in",
+    "infix", "infixl", "infixr", "instance", "let", "module", "newtype",
+    "of", "qualified", "then", "type", "where",
+    "return", "pure", "fmap", "map", "filter", "foldl", "foldr", "id",
+    "const", "show", "read", "print", "putStrLn", "length", "null",
+    "not", "and", "or", "maybe", "either", "fst", "snd",
+  }
+
+  QUALIFIED_CALL_REGEX = /(?<![A-Za-z0-9_'.])((?:[A-Z][A-Za-z0-9_']*\.)+[a-z_][A-Za-z0-9_']*)\b/
+  STATEMENT_CALL_REGEX = /^\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
+  BIND_CALL_REGEX      = /(?:<-|=)\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
+  DOLLAR_CALL_REGEX    = /\$\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
+  PAREN_CALL_REGEX     = /[(,]\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
+  BRANCH_CALL_REGEX    = /(?:->|\bthen\b|\belse\b)\s*([a-z_][A-Za-z0-9_']*)\b(?=\s|$|\()/
+
+  def function_bodies(content : String, file_path : String) : Array(FunctionBody)
+    cleaned = strip_non_code(content)
+    lines = cleaned.lines
+    results = [] of FunctionBody
+    index = 0
+
+    while index < lines.size
+      line = lines[index]
+      match = line.match(/^([a-z_][A-Za-z0-9_']*)\b.*=/)
+      unless match
+        index += 1
+        next
+      end
+
+      name = match[1]
+      if skip_callee?(name) || line.includes?("::")
+        index += 1
+        next
+      end
+
+      equals_index = line.index('=')
+      unless equals_index
+        index += 1
+        next
+      end
+
+      body_lines = [line[(equals_index + 1)..]? || ""]
+      start_line = index + 1
+      cursor = index + 1
+
+      while cursor < lines.size
+        next_line = lines[cursor]
+        break if top_level_declaration?(next_line) && !same_function_equation?(next_line, name)
+
+        body_lines << next_line
+        cursor += 1
+      end
+
+      results << {
+        name:       name,
+        body:       body_lines.join("\n"),
+        path:       file_path,
+        start_line: start_line,
+      }
+      index = cursor
+    end
+
+    results
+  end
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    stripped_body = strip_non_code(body)
+
+    stripped_body.each_line.with_index do |line, offset|
+      scan_line(line, file_path, start_line + offset, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    scan_candidates(line, QUALIFIED_CALL_REGEX, candidates)
+    scan_statement_candidates(line, candidates)
+    scan_candidates(line, BIND_CALL_REGEX, candidates)
+    scan_candidates(line, DOLLAR_CALL_REGEX, candidates)
+    scan_candidates(line, PAREN_CALL_REGEX, candidates)
+    scan_candidates(line, BRANCH_CALL_REGEX, candidates)
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |_, name|
+      next if skip_callee?(name)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def scan_statement_candidates(line : String, candidates : Array(Tuple(Int32, String)))
+    line.scan(STATEMENT_CALL_REGEX) do |match|
+      position = match.begin(1) || 0
+      name = match[1]
+      next if assignment_lhs?(line, position, name)
+
+      candidates << {position, name}
+    end
+  end
+
+  private def scan_candidates(line : String, regex : Regex, candidates : Array(Tuple(Int32, String)))
+    line.scan(regex) do |match|
+      candidates << {match.begin(1) || 0, match[1]}
+    end
+  end
+
+  private def assignment_lhs?(line : String, position : Int32, name : String) : Bool
+    rest = line[(position + name.size)..]? || ""
+    !!rest.match(/\A\s*(?:<-|=|::)/)
+  end
+
+  private def top_level_declaration?(line : String) : Bool
+    stripped = line.strip
+    return false if stripped.empty?
+    return false if line[0].whitespace?
+
+    return true if stripped.match(/^(?:module|import|data|newtype|type|class|instance)\b/)
+    !!stripped.match(/^[A-Za-z_][A-Za-z0-9_']*\b.*(?:=|::)/)
+  end
+
+  private def same_function_equation?(line : String, name : String) : Bool
+    !!line.match(/^#{Regex.escape(name)}\b.*=/)
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+    return true if name == "_"
+
+    RESERVED.includes?(name.split('.').last)
+  end
+
+  private def strip_non_code(source : String) : String
+    index = 0
+    stripped = String::Builder.new
+
+    while index < source.size
+      char = source[index]
+
+      if index + 1 < source.size && char == '-' && source[index + 1] == '-'
+        index = append_blanks_until_line_end(stripped, source, index)
+        next
+      end
+
+      if index + 1 < source.size && char == '{' && source[index + 1] == '-'
+        finish = skip_block_comment(source, index)
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      if char == '"'
+        finish = skip_string(source, index)
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      if char == '\''
+        finish = skip_char(source, index)
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      if quasiquote_start?(source, index)
+        finish = skip_quasiquote(source, index)
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      stripped << char
+      index += 1
+    end
+
+    stripped.to_s
+  end
+
+  private def append_blanks_until_line_end(stripped : String::Builder, source : String, start : Int32) : Int32
+    index = start
+    while index < source.size && source[index] != '\n'
+      stripped << ' '
+      index += 1
+    end
+    index
+  end
+
+  private def append_blanks(stripped : String::Builder, source : String, start : Int32, finish : Int32)
+    index = start
+    while index < finish && index < source.size
+      stripped << (source[index] == '\n' ? '\n' : ' ')
+      index += 1
+    end
+  end
+
+  private def skip_block_comment(source : String, start : Int32) : Int32
+    index = start + 2
+    depth = 1
+    while index < source.size && depth > 0
+      if index + 1 < source.size && source[index] == '{' && source[index + 1] == '-'
+        depth += 1
+        index += 2
+      elsif index + 1 < source.size && source[index] == '-' && source[index + 1] == '}'
+        depth -= 1
+        index += 2
+      else
+        index += 1
+      end
+    end
+    index
+  end
+
+  private def skip_string(source : String, start : Int32) : Int32
+    index = start + 1
+    while index < source.size
+      if source[index] == '\\' && index + 1 < source.size
+        index += 2
+        next
+      end
+      return index + 1 if source[index] == '"'
+
+      index += 1
+    end
+    source.size
+  end
+
+  private def skip_char(source : String, start : Int32) : Int32
+    index = start + 1
+    while index < source.size
+      if source[index] == '\\' && index + 1 < source.size
+        index += 2
+        next
+      end
+      return index + 1 if source[index] == '\''
+
+      index += 1
+    end
+    source.size
+  end
+
+  private def quasiquote_start?(source : String, start : Int32) : Bool
+    return false unless source[start] == '['
+
+    index = start + 1
+    return false unless source[index]? && (source[index].ascii_letter? || source[index] == '_')
+
+    while index < source.size && (source[index].alphanumeric? || source[index] == '_' || source[index] == '\'')
+      index += 1
+    end
+
+    index < source.size && source[index] == '|'
+  end
+
+  private def skip_quasiquote(source : String, start : Int32) : Int32
+    index = start + 1
+    while index + 1 < source.size
+      return index + 2 if source[index] == '|' && source[index + 1] == ']'
+
+      index += 1
+    end
+    source.size
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight Haskell callee extractor for top-level handler bodies
- wire Yesod routes to attach handler callees when `--include-callee` is enabled
- derive conventional Yesod handler names such as `getHomeR`, `postBlogPostR`, and methodless `handleFaqR`

## Scope
- Yesod only; Servant is left as a follow-up because its analyzer currently sees type-level API declarations without a safe server handler mapping
- callees are extracted from local top-level Haskell handler bodies and remain 1-hop call-site entries
- quasiquotes, strings, chars, comments, local type signatures, branch expressions, and methodless routes are covered by tests

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-haskell-target3 crystal spec spec/unit_test/miniparser/haskell_callee_extractor_spec.cr spec/functional_test/testers/haskell/yesod_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-haskell-build2 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-haskell-test2 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-haskell-check2 just check`
- `git diff --check`
- CLI smoke: `./bin/noir -b spec/functional_test/fixtures/haskell/yesod_callees -f json --include-callee`

Part of #1366.