### PR TITLE
Add Haskell Servant callee extraction

### DIFF
--- a/spec/functional_test/fixtures/haskell/servant_callees/package.yaml
+++ b/spec/functional_test/fixtures/haskell/servant_callees/package.yaml
@@ -1,0 +1,6 @@
+name: servant-callees-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - servant
+  - text

--- a/spec/functional_test/fixtures/haskell/servant_callees/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees/src/Api.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Api where
+
+import Data.Text (Text)
+import Servant
+
+data User
+data Health
+
+type UserAPI =
+       "users" :> Get '[JSON] [User]
+  :<|> "users" :> Capture "userId" Integer :> Get '[JSON] User
+
+type API =
+       "v1" :> UserAPI
+  :<|> "health" :> Get '[JSON] Health
+
+server :: Server API
+server =
+       userServer
+  :<|> healthServer
+
+userServer :: Server UserAPI
+userServer =
+       listUsers
+  :<|> getUser
+
+healthServer :: Server ("health" :> Get '[JSON] Health)
+healthServer = healthHandler
+
+listUsers :: Handler [User]
+listUsers = do
+  users <- loadUsers
+  audit "list"
+  return users
+
+getUser :: Integer -> Handler User
+getUser userId = do
+  user <- UserRepo.find userId
+  case user of
+    Just found -> return found
+    Nothing -> throwError err404
+
+healthHandler :: Handler Health
+healthHandler = do
+  status <- healthCheck
+  return status

--- a/spec/functional_test/fixtures/haskell/servant_callees_cross_alias/package.yaml
+++ b/spec/functional_test/fixtures/haskell/servant_callees_cross_alias/package.yaml
@@ -1,0 +1,5 @@
+name: servant-callees-cross-alias-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - servant

--- a/spec/functional_test/fixtures/haskell/servant_callees_cross_alias/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_cross_alias/src/Api.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Api where
+
+import Servant
+
+data Thing
+
+type API =
+       "users" :> Get '[JSON] Thing
+  :<|> "health" :> Get '[JSON] Thing
+
+server :: Server API
+server =
+       usersServer
+  :<|> healthHandler
+
+healthHandler :: Handler Thing
+healthHandler = do
+  healthCheck

--- a/spec/functional_test/fixtures/haskell/servant_callees_cross_alias/src/Other.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_cross_alias/src/Other.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Other where
+
+import Servant
+
+data Thing
+
+usersServer :: Server OtherAPI
+usersServer = otherHandler
+
+otherHandler :: Handler Thing
+otherHandler = do
+  loadOtherUsers

--- a/spec/functional_test/fixtures/haskell/servant_callees_mismatch/package.yaml
+++ b/spec/functional_test/fixtures/haskell/servant_callees_mismatch/package.yaml
@@ -1,0 +1,5 @@
+name: servant-callees-mismatch-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - servant

--- a/spec/functional_test/fixtures/haskell/servant_callees_mismatch/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_mismatch/src/Api.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Api where
+
+import Servant
+
+data Thing
+
+type API =
+       "one" :> Get '[JSON] Thing
+  :<|> "two" :> Get '[JSON] Thing
+
+server :: Server API
+server = onlyHandler
+
+onlyHandler :: Handler Thing
+onlyHandler = do
+  value <- loadThing
+  return value

--- a/spec/functional_test/fixtures/haskell/servant_callees_mismatch/src/ZOther.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_mismatch/src/ZOther.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module ZOther where
+
+import Servant
+
+data Thing
+
+server :: Server OtherAPI
+server =
+       wrongOne
+  :<|> wrongTwo
+
+wrongOne :: Handler Thing
+wrongOne = do
+  loadWrongOne
+
+wrongTwo :: Handler Thing
+wrongTwo = do
+  loadWrongTwo

--- a/spec/functional_test/fixtures/haskell/servant_callees_multi_api/package.yaml
+++ b/spec/functional_test/fixtures/haskell/servant_callees_multi_api/package.yaml
@@ -1,0 +1,5 @@
+name: servant-callees-multi-api-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - servant

--- a/spec/functional_test/fixtures/haskell/servant_callees_multi_api/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_multi_api/src/Api.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Api where
+
+import Servant
+
+data Thing
+
+type PublicAPI = "public" :> Get '[JSON] Thing
+
+type AdminAPI = "admin" :> Get '[JSON] Thing
+
+server :: Server PublicAPI
+server = publicHandler
+
+publicHandler :: Handler Thing
+publicHandler = do
+  loadPublic
+
+adminHandler :: Handler Thing
+adminHandler = do
+  loadAdmin

--- a/spec/functional_test/testers/haskell/servant_callees_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_callees_spec.cr
@@ -1,0 +1,131 @@
+require "../../func_spec.cr"
+
+def servant_endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+list_users_callees = [
+  Callee.new("loadUsers", line: 35),
+  Callee.new("audit", line: 36),
+]
+
+get_user_callees = [
+  Callee.new("UserRepo.find", line: 41),
+  Callee.new("throwError", line: 44),
+]
+
+health_callees = [
+  Callee.new("healthCheck", line: 48),
+]
+
+expected_endpoints = [
+  servant_endpoint_with_callees("/v1/users", "GET", [] of Param, list_users_callees),
+  servant_endpoint_with_callees("/v1/users/:userId", "GET", [
+    Param.new("userId", "Integer", "path"),
+  ], get_user_callees),
+  servant_endpoint_with_callees("/health", "GET", [] of Param, health_callees),
+]
+
+tester = FunctionalTester.new("fixtures/haskell/servant_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports exact Servant callees by flattened server order" do
+  list_endpoint = tester.app.endpoints.find { |found| found.url == "/v1/users" && found.method == "GET" }
+  list_endpoint.should_not be_nil
+  list_endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(list_users_callees.map { |callee| {callee.name, callee.line} })
+  end
+
+  endpoint = tester.app.endpoints.find { |found| found.url == "/v1/users/:userId" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(get_user_callees.map { |callee| {callee.name, callee.line} })
+  end
+
+  health_endpoint = tester.app.endpoints.find { |found| found.url == "/health" && found.method == "GET" }
+  health_endpoint.should_not be_nil
+  health_endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(health_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "populates Servant callee source paths" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/health" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    paths = actual.callees.map(&.path)
+    paths.uniq!
+    paths.should eq([
+      "./spec/functional_test/fixtures/haskell/servant_callees/src/Api.hs",
+    ])
+  end
+end
+
+mismatch_expected = [
+  Endpoint.new("/one", "GET"),
+  Endpoint.new("/two", "GET"),
+]
+
+mismatch_tester = FunctionalTester.new("fixtures/haskell/servant_callees_mismatch/", {
+  :techs     => 1,
+  :endpoints => mismatch_expected.size,
+}, mismatch_expected, {
+  "include_callee" => YAML::Any.new(true),
+})
+mismatch_tester.perform_tests
+
+it "leaves Servant callees empty when server leaf count mismatches endpoint count" do
+  mismatch_tester.app.endpoints.each do |endpoint|
+    endpoint.callees.should be_empty
+  end
+end
+
+multi_api_public = Endpoint.new("/public", "GET")
+multi_api_public.push_callee(Callee.new("loadPublic", line: 19))
+
+multi_api_expected = [
+  multi_api_public,
+  Endpoint.new("/admin", "GET"),
+]
+
+multi_api_tester = FunctionalTester.new("fixtures/haskell/servant_callees_multi_api/", {
+  :techs     => 1,
+  :endpoints => multi_api_expected.size,
+}, multi_api_expected, {
+  "include_callee" => YAML::Any.new(true),
+})
+multi_api_tester.perform_tests
+
+it "does not reuse a same-file generic Servant server for a different API alias" do
+  admin = multi_api_tester.app.endpoints.find { |found| found.url == "/admin" && found.method == "GET" }
+  admin.should_not be_nil
+  admin.try do |endpoint|
+    endpoint.callees.should be_empty
+  end
+end
+
+cross_alias_expected = [
+  Endpoint.new("/users", "GET"),
+  Endpoint.new("/health", "GET"),
+]
+
+cross_alias_tester = FunctionalTester.new("fixtures/haskell/servant_callees_cross_alias/", {
+  :techs     => 1,
+  :endpoints => cross_alias_expected.size,
+}, cross_alias_expected, {
+  "include_callee" => YAML::Any.new(true),
+})
+cross_alias_tester.perform_tests
+
+it "does not expand nested Servant server aliases from another file" do
+  cross_alias_tester.app.endpoints.each do |endpoint|
+    endpoint.callees.should be_empty
+  end
+end

--- a/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
@@ -22,6 +22,24 @@ describe Noir::HaskellCalleeExtractor do
     ])
   end
 
+  it "keeps scanning after Servant promoted type lists" do
+    source = <<-HASKELL
+      type API = "users" :> Get '[JSON] User
+
+      server = handler
+
+      handler = do
+        value <- loadValue
+        return value
+      HASKELL
+
+    bodies = Noir::HaskellCalleeExtractor.function_bodies(source, "Api.hs")
+    bodies.map { |body| {body[:name], body[:start_line]} }.should eq([
+      {"server", 3},
+      {"handler", 5},
+    ])
+  end
+
   it "extracts direct calls from Haskell handler bodies" do
     body = <<-HASKELL
       do

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/haskell_callee_extractor"
 require "set"
 
 module Analyzer::Haskell
@@ -6,9 +7,15 @@ module Analyzer::Haskell
     HTTP_METHOD_VERBS = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
 
     alias TypeAlias = NamedTuple(body: String, source: String, line: Int32)
+    alias HandlerBody = Noir::HaskellCalleeExtractor::FunctionBody
+    alias HandlerBodies = Hash(String, Array(HandlerBody))
+    alias ServerBindings = Hash(Tuple(String, String), String)
 
     def analyze
       type_aliases = {} of String => TypeAlias
+      include_callee = any_to_bool(@options["include_callee"]?)
+      handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
+      server_bindings = include_callee ? build_server_bindings : ServerBindings.new
 
       all_files.each do |path|
         next if File.directory?(path)
@@ -37,10 +44,61 @@ module Analyzer::Haskell
         expanded = expand_references(entry[:body], type_aliases)
         next unless contains_servant_signature?(expanded)
 
-        process_api_body(entry[:source], entry[:line], expanded)
+        endpoints = process_api_body(entry[:source], entry[:line], expanded)
+        attach_servant_callees(name, entry[:source], endpoints, handler_bodies, server_bindings) if include_callee
+        @result.concat(endpoints)
       end
 
       @result
+    end
+
+    private def build_handler_bodies : HandlerBodies
+      handlers = HandlerBodies.new
+
+      all_files.each do |path|
+        next if File.directory?(path)
+        next unless haskell_source?(path)
+
+        Noir::HaskellCalleeExtractor.function_bodies(read_file_content(path), path).each do |body|
+          handlers[body[:name]] ||= [] of HandlerBody
+          handlers[body[:name]] << body
+        end
+      end
+
+      handlers
+    end
+
+    private def build_server_bindings : ServerBindings
+      bindings = ServerBindings.new
+
+      all_files.each do |path|
+        next if File.directory?(path)
+        next unless haskell_source?(path)
+
+        extract_server_binding_targets(read_file_content(path)).each do |entry|
+          bindings[{path, entry[:name]}] = entry[:target]
+        end
+      end
+
+      bindings
+    end
+
+    private def extract_server_binding_targets(content : String) : Array(NamedTuple(name: String, target: String))
+      targets = [] of NamedTuple(name: String, target: String)
+      cleaned = strip_haskell_comments(content)
+
+      cleaned.each_line do |line|
+        match = line.match(/^\s*([a-z_][A-Za-z0-9_']*)\s*::.*\bServer(?:T)?\b\s*(.*)$/)
+        next unless match
+
+        target_match = match[2].strip.match(/\A([A-Z][A-Za-z0-9_']*)\b/)
+        targets << {
+          name:   match[1],
+          target: target_match ? target_match[1] : "",
+        }
+      end
+
+      targets.uniq
     end
 
     private def haskell_source?(path : String) : Bool
@@ -190,12 +248,154 @@ module Analyzer::Haskell
       false
     end
 
-    private def process_api_body(source : String, line_number : Int32, body : String)
+    private def process_api_body(source : String, line_number : Int32, body : String) : Array(Endpoint)
+      endpoints = [] of Endpoint
       flat = flatten_alternatives(body)
       routes = split_top_level(flat, ":<|>")
       routes.each do |route|
-        process_route(source, line_number, route)
+        if endpoint = process_route(source, line_number, route)
+          endpoints << endpoint
+        end
       end
+      endpoints
+    end
+
+    private def attach_servant_callees(api_name : String,
+                                       api_source : String,
+                                       endpoints : Array(Endpoint),
+                                       handler_bodies : HandlerBodies,
+                                       server_bindings : ServerBindings)
+      leaf_names = server_leaf_names_for(api_name, api_source, endpoints.size, handler_bodies, server_bindings)
+      return unless leaf_names
+
+      endpoints.zip(leaf_names).each do |endpoint, handler_name|
+        handler_body = unique_handler_body(handler_name, handler_bodies)
+        next unless handler_body
+
+        callees = Noir::HaskellCalleeExtractor.callees_for_body(
+          handler_body[:body],
+          handler_body[:path],
+          handler_body[:start_line]
+        )
+        Noir::HaskellCalleeExtractor.attach_to(endpoint, callees)
+      end
+    end
+
+    private def server_leaf_names_for(api_name : String,
+                                      api_source : String,
+                                      endpoint_count : Int32,
+                                      handler_bodies : HandlerBodies,
+                                      server_bindings : ServerBindings) : Array(String)?
+      server_candidate_names(api_name).each do |server_name|
+        binding = body_for_path(server_name, api_source, handler_bodies)
+        next unless binding
+        next unless root_server_matches_api?(server_name, api_source, api_name, server_bindings)
+
+        visited = Set(Tuple(String, String)).new
+        visited << {binding[:path], server_name}
+        leaves = flatten_server_expression(binding[:body], handler_bodies, server_bindings, binding[:path], visited)
+        next unless leaves
+        next unless leaves.size == endpoint_count
+        next unless leaves.all? { |leaf| !unique_handler_body(leaf, handler_bodies).nil? }
+
+        return leaves
+      end
+
+      nil
+    end
+
+    private def server_candidate_names(api_name : String) : Array(String)
+      candidates = ["server", "#{lower_camel(api_name)}Server"]
+
+      if api_name.ends_with?("API")
+        prefix = api_name[0...(api_name.size - "API".size)]
+        candidates << "#{lower_camel(prefix)}Server" unless prefix.empty?
+      end
+
+      candidates.uniq
+    end
+
+    private def lower_camel(name : String) : String
+      return name if name.empty?
+
+      name[0].downcase.to_s + name[1..]
+    end
+
+    private def flatten_server_expression(expression : String,
+                                          handler_bodies : HandlerBodies,
+                                          server_bindings : ServerBindings,
+                                          current_path : String,
+                                          visited : Set(Tuple(String, String))) : Array(String)?
+      parts = split_top_level(expression, ":<|>")
+      leaves = [] of String
+
+      parts.each do |part|
+        part_leaves = flatten_server_part(part, handler_bodies, server_bindings, current_path, visited)
+        return unless part_leaves
+
+        leaves.concat(part_leaves)
+      end
+
+      leaves
+    end
+
+    private def flatten_server_part(part : String,
+                                    handler_bodies : HandlerBodies,
+                                    server_bindings : ServerBindings,
+                                    current_path : String,
+                                    visited : Set(Tuple(String, String))) : Array(String)?
+      name = unwrap_parens(part.strip)
+      return unless simple_value_name?(name)
+
+      binding = body_for_path(name, current_path, handler_bodies)
+      if binding
+        key = {current_path, name}
+        server_binding = server_bindings.has_key?(key) || server_like_name?(name)
+        if (server_binding || binding[:body].includes?(":<|>")) && !visited.includes?(key)
+          visited << key
+          expanded = flatten_server_expression(binding[:body], handler_bodies, server_bindings, binding[:path], visited)
+          visited.delete(key)
+          return expanded if expanded && expanded.size > 0
+          return if server_binding
+        end
+      end
+
+      return if server_like_name?(name) || server_binding_name?(name, server_bindings)
+
+      [name]
+    end
+
+    private def root_server_matches_api?(server_name : String,
+                                         api_source : String,
+                                         api_name : String,
+                                         server_bindings : ServerBindings) : Bool
+      server_bindings[{api_source, server_name}]? == api_name
+    end
+
+    private def body_for_path(name : String, path : String, handler_bodies : HandlerBodies) : HandlerBody?
+      bodies = handler_bodies[name]?
+      return unless bodies
+
+      bodies.find { |body| body[:path] == path }
+    end
+
+    private def unique_handler_body(name : String, handler_bodies : HandlerBodies) : HandlerBody?
+      bodies = handler_bodies[name]?
+      return unless bodies && bodies.size == 1
+
+      bodies.first
+    end
+
+    private def server_like_name?(name : String) : Bool
+      name == "server" || name.ends_with?("Server")
+    end
+
+    private def server_binding_name?(name : String, server_bindings : ServerBindings) : Bool
+      server_bindings.keys.any? { |key| key[1] == name }
+    end
+
+    private def simple_value_name?(name : String) : Bool
+      !!name.match(/\A[a-z_][A-Za-z0-9_']*\z/)
     end
 
     private def flatten_alternatives(body : String) : String
@@ -238,7 +438,7 @@ module Analyzer::Haskell
       [route]
     end
 
-    private def process_route(source : String, line_number : Int32, route : String)
+    private def process_route(source : String, line_number : Int32, route : String) : Endpoint?
       raw = unwrap_parens(route.strip)
       return if raw.empty?
 
@@ -306,7 +506,7 @@ module Analyzer::Haskell
       url = url_parts.empty? ? "/" : "/#{url_parts.join("/")}"
       details = Details.new(PathInfo.new(source, line_number))
       endpoint_params = params.map { |p| Param.new(p.name, p.value, p.param_type) }
-      @result << Endpoint.new(url, resolved_method, endpoint_params, details)
+      Endpoint.new(url, resolved_method, endpoint_params, details)
     end
 
     private def http_method_for(token : String) : String?

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -175,7 +175,7 @@ module Noir::HaskellCalleeExtractor
         next
       end
 
-      if char == '\''
+      if char == '\'' && char_literal_start?(source, index)
         finish = skip_char(source, index)
         append_blanks(stripped, source, index, finish)
         index = finish
@@ -194,6 +194,15 @@ module Noir::HaskellCalleeExtractor
     end
 
     stripped.to_s
+  end
+
+  private def char_literal_start?(source : String, start : Int32) : Bool
+    return false if start + 2 >= source.size
+    return false if source[start + 1] == '['
+
+    finish = skip_char(source, start)
+    return false if finish >= source.size
+    finish - start <= 8
   end
 
   private def append_blanks_until_line_end(stripped : String::Builder, source : String, start : Int32) : Int32


### PR DESCRIPTION
## Summary
- wire Haskell Servant to attach handler callees when `--include-callee` is enabled
- conservatively map flattened Servant API endpoints to flattened server handler leaves only when counts and root `Server <API>` signatures match
- reuse the Haskell callee extractor and fix promoted type list handling for Servant signatures

## Scope
- supports simple top-level `server = handler1 :<|> handler2` and same-file nested server aliases such as `userServer` / `healthServer`
- leaves callees empty when server leaf count mismatches, root server signature does not match the API alias, nested server aliases resolve only from another file, or handler names are ambiguous
- intentionally avoids inline lambdas, generated servers, generic records, `hoistServer`, import graph resolution, and other cases that could false-pair handlers

## Verification
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-servant-target7 crystal spec spec/unit_test/miniparser/haskell_callee_extractor_spec.cr spec/functional_test/testers/haskell/servant_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-servant-build4 just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-servant-test4 just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-servant-check4 just check`
- `git diff --check`
- CLI smoke for matching, count-mismatch, same-file multi-API, and cross-file nested alias fixtures

Part of #1366.