### PR TITLE
Add Lua Lapis callee extraction

### DIFF
--- a/spec/functional_test/fixtures/lua/lapis_callees/admin.lua
+++ b/spec/functional_test/fixtures/lua/lapis_callees/admin.lua
@@ -1,0 +1,15 @@
+local lapis = require("lapis")
+
+return lapis.Application:extend({
+  ["/admin/dashboard"] = "dashboard",
+
+  dashboard = function(self)
+    local stats = AdminService:stats()
+    return render_admin(stats)
+  end,
+
+  ["/admin/users/:id"] = function(self)
+    local user = AdminUsers.find(self.params.id)
+    return json_response(user)
+  end,
+})

--- a/spec/functional_test/fixtures/lua/lapis_callees/app.lua
+++ b/spec/functional_test/fixtures/lua/lapis_callees/app.lua
@@ -1,0 +1,39 @@
+local lapis = require("lapis")
+local app = lapis.Application()
+
+local named_profile = function(self)
+  local profile = Profiles.find(self.params.id)
+  return render_json(profile)
+end
+
+app:get("/users", function(self)
+  local users = UserService:list(self.params.page)
+  Audit.write("users")
+  return render_json(users)
+end)
+
+app:post("/users/:id", function(self)
+  local user = Users.update(self.params.id)
+  return respond({ json = user })
+end)
+
+app:match("/health", function(self)
+  health_check()
+  return respond_ok()
+end)
+
+app:get("/named", "named_profile")
+
+-- app:get("/ignored", function(self) Fake.call() end)
+app:get("/string-noise", function(self)
+  local text = "Fake.call()"
+  return clean_text(text)
+end)
+
+local identifier_profile = function(self)
+  return IdentifierService.show(self.params.id)
+end
+
+app:get("/identifier", identifier_profile)
+
+return app

--- a/spec/functional_test/fixtures/lua/lapis_callees/app.moon
+++ b/spec/functional_test/fixtures/lua/lapis_callees/app.moon
@@ -1,0 +1,9 @@
+lapis = require "lapis"
+
+class extends lapis.Application
+  "/moon": =>
+    moon_service.load @params
+    render_moon "home"
+  [show: "/moon/users/:id"]: =>
+    user = Users\find @params.id
+    json_response user

--- a/spec/functional_test/fixtures/lua/lapis_callees/lapis-fixture-1.0-1.rockspec
+++ b/spec/functional_test/fixtures/lua/lapis_callees/lapis-fixture-1.0-1.rockspec
@@ -1,0 +1,8 @@
+package = "lapis-callee-fixture"
+version = "1.0-1"
+source = { url = "git+https://example.com/lapis-callee-fixture.git" }
+description = { summary = "Lapis callee fixture" }
+dependencies = {
+  "lua >= 5.1",
+  "lapis",
+}

--- a/spec/functional_test/testers/lua/lapis_callees_spec.cr
+++ b/spec/functional_test/testers/lua/lapis_callees_spec.cr
@@ -1,0 +1,148 @@
+require "../../func_spec.cr"
+
+def lapis_endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+fallback_methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+
+users_callees = [
+  Callee.new("UserService.list", line: 10),
+  Callee.new("Audit.write", line: 11),
+  Callee.new("render_json", line: 12),
+]
+
+update_callees = [
+  Callee.new("Users.update", line: 16),
+  Callee.new("respond", line: 17),
+]
+
+health_callees = [
+  Callee.new("health_check", line: 21),
+  Callee.new("respond_ok", line: 22),
+]
+
+named_callees = [
+  Callee.new("Profiles.find", line: 5),
+  Callee.new("render_json", line: 6),
+]
+
+noise_callees = [
+  Callee.new("clean_text", line: 30),
+]
+
+identifier_callees = [
+  Callee.new("IdentifierService.show", line: 34),
+]
+
+dashboard_callees = [
+  Callee.new("AdminService.stats", line: 7),
+  Callee.new("render_admin", line: 8),
+]
+
+admin_user_callees = [
+  Callee.new("AdminUsers.find", line: 12),
+  Callee.new("json_response", line: 13),
+]
+
+moon_callees = [
+  Callee.new("moon_service.load", line: 5),
+  Callee.new("render_moon", line: 6),
+]
+
+moon_user_callees = [
+  Callee.new("Users.find", line: 8),
+  Callee.new("json_response", line: 9),
+]
+
+expected_endpoints = [
+  lapis_endpoint_with_callees("/users", "GET", [] of Param, users_callees),
+  lapis_endpoint_with_callees("/users/:id", "POST", [
+    Param.new("id", "", "path"),
+  ], update_callees),
+  lapis_endpoint_with_callees("/named", "GET", [] of Param, named_callees),
+  lapis_endpoint_with_callees("/string-noise", "GET", [] of Param, noise_callees),
+  lapis_endpoint_with_callees("/identifier", "GET", [] of Param, identifier_callees),
+]
+
+fallback_methods.each do |method|
+  expected_endpoints << lapis_endpoint_with_callees("/health", method, [] of Param, health_callees)
+  expected_endpoints << lapis_endpoint_with_callees("/admin/dashboard", method, [] of Param, dashboard_callees)
+  expected_endpoints << lapis_endpoint_with_callees("/admin/users/:id", method, [
+    Param.new("id", "", "path"),
+  ], admin_user_callees)
+  expected_endpoints << lapis_endpoint_with_callees("/moon", method, [] of Param, moon_callees)
+  expected_endpoints << lapis_endpoint_with_callees("/moon/users/:id", method, [
+    Param.new("id", "", "path"),
+  ], moon_user_callees)
+end
+
+tester = FunctionalTester.new("fixtures/lua/lapis_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports exact Lapis callees for inline Lua handlers" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/users" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(users_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "reuses same Lapis callees for app:match fallback methods" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/health" && found.method == "PATCH" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(health_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "resolves same-file string action handlers for Lapis table routes" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/admin/dashboard" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(dashboard_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "extracts MoonScript action callees without leaking adjacent routes" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/moon/users/:id" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(moon_user_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "ignores fake calls in Lua strings and comments" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/string-noise" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(noise_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "resolves identifier handler variables for Lapis routes" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/identifier" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(identifier_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "populates Lapis callee source paths" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/named" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    paths = actual.callees.map(&.path)
+    paths.uniq!
+    paths.should eq([
+      "./spec/functional_test/fixtures/lua/lapis_callees/app.lua",
+    ])
+  end
+end

--- a/spec/unit_test/miniparser/lua_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/lua_callee_extractor_spec.cr
@@ -1,0 +1,137 @@
+require "spec"
+require "../../../src/miniparsers/lua_callee_extractor"
+
+describe Noir::LuaCalleeExtractor do
+  it "extracts Lua receiver, method, bare, and command-style callees" do
+    body = <<-LUA
+      local users = UserService:list(self.params.page)
+      Audit.write("users")
+      render_json(users)
+      ngx.say "ok"
+      local ignored = "Fake.call()"
+      -- Commented.call()
+      print("debug")
+      LUA
+
+    callees = Noir::LuaCalleeExtractor.callees_for_body(body, "app.lua", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService.list", 10},
+      {"Audit.write", 11},
+      {"render_json", 12},
+      {"ngx.say", 13},
+    ])
+  end
+
+  it "skips nested local function bodies in handler callees" do
+    body = <<-LUA
+      local helper = function()
+        Hidden.call()
+      end
+      return Visible.call()
+      LUA
+
+    callees = Noir::LuaCalleeExtractor.callees_for_body(body, "app.lua", 20)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"Visible.call", 23},
+    ])
+  end
+
+  it "extracts inline function bodies with nested Lua blocks" do
+    source = <<-LUA
+      app:get("/users", function(self)
+        if self.params.id then
+          return Users.find(self.params.id)
+        end
+
+        return Users.list()
+      end)
+      LUA
+
+    start = source.index!("function")
+    body = Noir::LuaCalleeExtractor.extract_function_after(source, start)
+    body.should_not be_nil
+
+    body.try do |body_text, start_line|
+      start_line.should eq(1)
+      Noir::LuaCalleeExtractor.callees_for_body(body_text, "app.lua", start_line).map { |name, _, line| {name, line} }.should eq([
+        {"Users.find", 3},
+        {"Users.list", 6},
+      ])
+    end
+  end
+
+  it "indexes named function and function-valued table bodies" do
+    source = <<-LUA
+      local named_profile = function(self)
+        return Profiles.find(self.params.id)
+      end
+
+      function app:dashboard(self)
+        return Dashboard.load()
+      end
+      LUA
+
+    bodies = Noir::LuaCalleeExtractor.function_bodies(source, "app.lua")
+    bodies.keys.sort!.should eq(["app:dashboard", "dashboard", "named_profile"])
+
+    profile = bodies["named_profile"]
+    Noir::LuaCalleeExtractor.callees_for_body(profile[:body], profile[:path], profile[:start_line]).map(&.[0]).should eq([
+      "Profiles.find",
+    ])
+
+    dashboard = bodies["dashboard"]
+    Noir::LuaCalleeExtractor.callees_for_body(dashboard[:body], dashboard[:path], dashboard[:start_line]).map(&.[0]).should eq([
+      "Dashboard.load",
+    ])
+  end
+
+  it "does not index fake functions from Lua comments or long strings" do
+    source = <<-LUA
+      --[[ dashboard = function(self)
+        Ghost.call()
+      end ]]
+
+      local text = [[
+        named_profile = function(self)
+          Hidden.call()
+        end
+      ]]
+
+      local dashboard = function(self)
+        return Dashboard.load()
+      end
+      LUA
+
+    bodies = Noir::LuaCalleeExtractor.function_bodies(source, "app.lua")
+    bodies.keys.sort!.should eq(["dashboard"])
+    dashboard = bodies["dashboard"]
+    Noir::LuaCalleeExtractor.callees_for_body(dashboard[:body], dashboard[:path], dashboard[:start_line]).map(&.[0]).should eq([
+      "Dashboard.load",
+    ])
+  end
+
+  it "extracts MoonScript indented route bodies" do
+    source = <<-MOON
+      class extends lapis.Application
+        "/moon": =>
+          moon_service.load @params
+          @render "profile"
+          render_moon "home"
+        "/next": =>
+          next_call()
+      MOON
+
+    arrow_end = source.index!("=>") + 2
+    body = Noir::LuaCalleeExtractor.extract_moonscript_block_after(source, arrow_end)
+    body.should_not be_nil
+
+    body.try do |body_text, start_line|
+      start_line.should eq(3)
+      Noir::LuaCalleeExtractor.callees_for_body(body_text, "app.moon", start_line).map { |name, _, line| {name, line} }.should eq([
+        {"moon_service.load", 3},
+        {"self.render", 4},
+        {"render_moon", 5},
+      ])
+    end
+  end
+end

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/lua_callee_extractor"
 
 module Analyzer::Lua
   # Lapis is a Lua/MoonScript web framework on top of OpenResty. Routes
@@ -22,41 +23,60 @@ module Analyzer::Lua
     FALLBACK_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
+
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".lua") || path.ends_with?(".moon")
 
         content = read_file_content(path)
-        process_file(path, content)
+        process_file(path, content, include_callee)
       end
 
       @result
     end
 
-    private def process_file(path : String, content : String)
+    private def process_file(path : String, content : String, include_callee : Bool)
       cleaned = strip_lua_comments(content)
+      handler_bodies = if include_callee
+                         Noir::LuaCalleeExtractor.function_bodies(content, path)
+                       else
+                         {} of String => Noir::LuaCalleeExtractor::FunctionBody
+                       end
 
-      emit_method_calls(path, content, cleaned)
-      emit_match_calls(path, content, cleaned)
-      emit_table_routes(path, content, cleaned)
-      emit_moonscript_routes(path, content, cleaned)
+      emit_method_calls(path, content, cleaned, include_callee, handler_bodies)
+      emit_match_calls(path, content, cleaned, include_callee, handler_bodies)
+      emit_table_routes(path, content, cleaned, include_callee, handler_bodies)
+      emit_moonscript_routes(path, content, cleaned, include_callee)
     end
 
     # `app:get "/path"`, `app:post("/path", handler)`, etc.
-    private def emit_method_calls(path : String, content : String, cleaned : String)
+    private def emit_method_calls(path : String,
+                                  content : String,
+                                  cleaned : String,
+                                  include_callee : Bool,
+                                  handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody))
       pattern = /\bapp\s*[:.]\s*(get|post|put|delete|patch|head|options)\s*\(?\s*(['"])([^'"]+)\2/
       cleaned.scan(pattern) do |match|
         verb = match[1].upcase
         next unless HTTP_METHODS.includes?(verb)
         url = match[3]
         next unless url.starts_with?("/")
-        emit_endpoint(path, content, match.begin(0) || 0, url, [verb])
+
+        route_offset = match.begin(0) || 0
+        after_url = match.end(0) || route_offset
+        callees = include_callee ? route_call_callees(path, content, route_offset, after_url, handler_bodies) : [] of Noir::LuaCalleeExtractor::Entry
+        emit_endpoint(path, content, route_offset, url, [verb], callees)
       end
     end
 
     # `app:match("/path", handler)` — any HTTP method.
     # `app:match("name", "/path", handler)` — named route.
-    private def emit_match_calls(path : String, content : String, cleaned : String)
+    private def emit_match_calls(path : String,
+                                 content : String,
+                                 cleaned : String,
+                                 include_callee : Bool,
+                                 handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody))
       pattern = /\bapp\s*[:.]\s*match\s*\(?\s*(['"])([^'"]+)\1(?:\s*,\s*(['"])([^'"]+)\3)?/
       cleaned.scan(pattern) do |match|
         first = match[2]
@@ -68,49 +88,231 @@ module Analyzer::Lua
               else
                 next
               end
-        emit_endpoint(path, content, match.begin(0) || 0, url, FALLBACK_METHODS)
+        route_offset = match.begin(0) || 0
+        url_end = match.end(0) || route_offset
+        callees = include_callee ? route_call_callees(path, content, route_offset, url_end, handler_bodies) : [] of Noir::LuaCalleeExtractor::Entry
+        emit_endpoint(path, content, route_offset, url, FALLBACK_METHODS, callees)
       end
     end
 
     # `["/path"] = "handler"` and `["/path"] = function(self) ... end`
     # — application-table style.
-    private def emit_table_routes(path : String, content : String, cleaned : String)
+    private def emit_table_routes(path : String,
+                                  content : String,
+                                  cleaned : String,
+                                  include_callee : Bool,
+                                  handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody))
       pattern = /\[\s*(['"])([^'"]+)\1\s*\]\s*=/
       cleaned.scan(pattern) do |match|
         url = match[2]
         next unless url.starts_with?("/")
-        emit_endpoint(path, content, match.begin(0) || 0, url, FALLBACK_METHODS)
+
+        route_offset = match.begin(0) || 0
+        after_assignment = match.end(0) || route_offset
+        callees = include_callee ? table_route_callees(path, content, after_assignment, handler_bodies) : [] of Noir::LuaCalleeExtractor::Entry
+        emit_endpoint(path, content, route_offset, url, FALLBACK_METHODS, callees)
       end
     end
 
     # MoonScript class actions:
     #   "/path": =>
     #   [name: "/path"]: =>
-    private def emit_moonscript_routes(path : String, content : String, cleaned : String)
+    private def emit_moonscript_routes(path : String, content : String, cleaned : String, include_callee : Bool)
       simple = /(?:^|\n)\s*(['"])([^'"]+)\1\s*:\s*=>/m
       cleaned.scan(simple) do |match|
         url = match[2]
         next unless url.starts_with?("/")
-        emit_endpoint(path, content, match.begin(0) || 0, url, FALLBACK_METHODS)
+
+        route_offset = match.begin(2) || match.begin(0) || 0
+        arrow_end = match.end(0) || route_offset
+        callees = include_callee ? moonscript_route_callees(path, content, arrow_end) : [] of Noir::LuaCalleeExtractor::Entry
+        emit_endpoint(path, content, route_offset, url, FALLBACK_METHODS, callees)
       end
 
       named = /\[\s*[A-Za-z_]\w*\s*:\s*(['"])([^'"]+)\1\s*\]\s*:\s*=>/
       cleaned.scan(named) do |match|
         url = match[2]
         next unless url.starts_with?("/")
-        emit_endpoint(path, content, match.begin(0) || 0, url, FALLBACK_METHODS)
+
+        route_offset = match.begin(2) || match.begin(0) || 0
+        arrow_end = match.end(0) || route_offset
+        callees = include_callee ? moonscript_route_callees(path, content, arrow_end) : [] of Noir::LuaCalleeExtractor::Entry
+        emit_endpoint(path, content, route_offset, url, FALLBACK_METHODS, callees)
       end
     end
 
     private def emit_endpoint(path : String, content : String, offset : Int32,
-                              url : String, methods : Array(String))
+                              url : String, methods : Array(String),
+                              callees : Array(Noir::LuaCalleeExtractor::Entry) = [] of Noir::LuaCalleeExtractor::Entry)
       params = extract_path_params(url)
       line = line_for_offset(content, offset)
       details = Details.new(PathInfo.new(path, line))
       methods.each do |verb|
         endpoint_params = params.map { |p| Param.new(p.name, p.value, p.param_type) }
-        @result << Endpoint.new(url, verb, endpoint_params, details)
+        endpoint = Endpoint.new(url, verb, endpoint_params, details)
+        Noir::LuaCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+        @result << endpoint
       end
+    end
+
+    private def route_call_callees(path : String,
+                                   content : String,
+                                   route_offset : Int32,
+                                   after_url : Int32,
+                                   handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody)) : Array(Noir::LuaCalleeExtractor::Entry)
+      search_limit, body_limit = route_call_limits(content, route_offset, after_url)
+      if body = Noir::LuaCalleeExtractor.extract_function_after(content, after_url, search_limit, body_limit)
+        body_text, start_line = body
+        return Noir::LuaCalleeExtractor.callees_for_body(body_text, path, start_line)
+      end
+
+      if handler_name = string_handler_after(content, after_url, search_limit)
+        return callees_for_named_handler(handler_name, handler_bodies)
+      end
+
+      if handler_name = identifier_handler_after(content, after_url, search_limit)
+        return callees_for_named_handler(handler_name, handler_bodies)
+      end
+
+      [] of Noir::LuaCalleeExtractor::Entry
+    end
+
+    private def table_route_callees(path : String,
+                                    content : String,
+                                    after_assignment : Int32,
+                                    handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody)) : Array(Noir::LuaCalleeExtractor::Entry)
+      value_start = skip_ws(content, after_assignment)
+      if starts_with_keyword?(content, value_start, "function")
+        if body = Noir::LuaCalleeExtractor.extract_function_at(content, value_start)
+          body_text, start_line = body
+          return Noir::LuaCalleeExtractor.callees_for_body(body_text, path, start_line)
+        end
+      elsif handler_name = string_literal_at(content, value_start)
+        return callees_for_named_handler(handler_name, handler_bodies)
+      end
+
+      [] of Noir::LuaCalleeExtractor::Entry
+    end
+
+    private def moonscript_route_callees(path : String, content : String, arrow_end : Int32) : Array(Noir::LuaCalleeExtractor::Entry)
+      if body = Noir::LuaCalleeExtractor.extract_moonscript_block_after(content, arrow_end)
+        body_text, start_line = body
+        return Noir::LuaCalleeExtractor.callees_for_body(body_text, path, start_line)
+      end
+
+      [] of Noir::LuaCalleeExtractor::Entry
+    end
+
+    private def callees_for_named_handler(handler_name : String,
+                                          handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody)) : Array(Noir::LuaCalleeExtractor::Entry)
+      if body = handler_bodies[handler_name]?
+        return Noir::LuaCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
+      end
+
+      [] of Noir::LuaCalleeExtractor::Entry
+    end
+
+    private def route_call_limits(content : String, route_offset : Int32, after_url : Int32) : Tuple(Int32, Int32)
+      if open_paren = first_open_paren_before(content, route_offset, after_url)
+        if close_paren = Noir::LuaCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
+          return {close_paren, close_paren}
+        end
+      end
+
+      line_end = content.index('\n', after_url) || content.size
+      {line_end, content.size}
+    end
+
+    private def first_open_paren_before(content : String, start_index : Int32, end_index : Int32) : Int32?
+      cursor = start_index
+      while cursor < end_index && cursor < content.size
+        return cursor if content[cursor] == '('
+        cursor += 1
+      end
+
+      nil
+    end
+
+    private def string_handler_after(content : String, start_index : Int32, limit : Int32) : String?
+      cursor = skip_ws_and_commas(content, start_index)
+      return if cursor >= limit
+
+      string_literal_at(content, cursor)
+    end
+
+    private def identifier_handler_after(content : String, start_index : Int32, limit : Int32) : String?
+      cursor = skip_ws_and_commas(content, start_index)
+      return if cursor >= limit
+      return unless identifier_start?(content[cursor])
+
+      ident_start = cursor
+      cursor += 1
+      while cursor < limit && cursor < content.size && identifier_part?(content[cursor])
+        cursor += 1
+      end
+
+      trailing = skip_ws(content, cursor)
+      return if trailing < limit && content[trailing] == '('
+
+      content[ident_start...cursor]
+    end
+
+    private def string_literal_at(content : String, index : Int32) : String?
+      return if index >= content.size
+      quote = content[index]
+      return unless quote == '"' || quote == '\''
+
+      cursor = index + 1
+      escaped = false
+      value = String::Builder.new
+      while cursor < content.size
+        char = content[cursor]
+        if escaped
+          value << char
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == quote
+          return value.to_s
+        else
+          value << char
+        end
+        cursor += 1
+      end
+
+      nil
+    end
+
+    private def skip_ws_and_commas(content : String, index : Int32) : Int32
+      cursor = index
+      while cursor < content.size && (content[cursor].whitespace? || content[cursor] == ',')
+        cursor += 1
+      end
+      cursor
+    end
+
+    private def skip_ws(content : String, index : Int32) : Int32
+      cursor = index
+      while cursor < content.size && content[cursor].whitespace?
+        cursor += 1
+      end
+      cursor
+    end
+
+    private def starts_with_keyword?(content : String, index : Int32, keyword : String) : Bool
+      return false unless content[index, keyword.size]? == keyword
+      before = index > 0 ? content[index - 1] : '\0'
+      after_index = index + keyword.size
+      after = after_index < content.size ? content[after_index] : '\0'
+      !identifier_part?(before) && !identifier_part?(after)
+    end
+
+    private def identifier_start?(char : Char) : Bool
+      char.ascii_letter? || char == '_'
+    end
+
+    private def identifier_part?(char : Char) : Bool
+      char.ascii_alphanumeric? || char == '_'
     end
 
     private def extract_path_params(url : String) : Array(Param)
@@ -158,16 +360,21 @@ module Analyzer::Lua
         if i + 1 < chars.size && c == '-' && chars[i + 1] == '-'
           # Block form: --[[ ... ]]
           if i + 3 < chars.size && chars[i + 2] == '[' && chars[i + 3] == '['
+            4.times { result << ' ' }
             i += 4
             while i + 1 < chars.size && !(chars[i] == ']' && chars[i + 1] == ']')
-              result << '\n' if chars[i] == '\n'
+              result << (chars[i] == '\n' ? '\n' : ' ')
               i += 1
             end
-            i += 2 if i + 1 < chars.size
+            if i + 1 < chars.size
+              2.times { result << ' ' }
+              i += 2
+            end
             next
           end
           # Line form
           while i < chars.size && chars[i] != '\n'
+            result << ' '
             i += 1
           end
           next

--- a/src/miniparsers/lua_callee_extractor.cr
+++ b/src/miniparsers/lua_callee_extractor.cr
@@ -1,0 +1,542 @@
+require "../models/endpoint"
+
+module Noir::LuaCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+  alias FunctionBody = NamedTuple(body: String, path: String, start_line: Int32)
+
+  RESERVED = Set{
+    "and", "break", "do", "else", "elseif", "end", "false", "for",
+    "function", "goto", "if", "in", "local", "nil", "not", "or",
+    "repeat", "return", "then", "true", "until", "while",
+    "assert", "collectgarbage", "dofile", "error", "getmetatable",
+    "ipairs", "load", "loadfile", "next", "pairs", "pcall", "print",
+    "rawequal", "rawget", "rawlen", "rawset", "require", "select",
+    "setmetatable", "tonumber", "tostring", "type", "xpcall",
+  }
+
+  STANDARD_LIB_ROOTS = Set{
+    "coroutine", "debug", "io", "math", "os", "package", "string",
+    "table", "utf8",
+  }
+
+  RECEIVER_CALL_REGEX = /(?<![A-Za-z0-9_@])(@?[A-Za-z_][A-Za-z0-9_]*(?:(?:\s*[.:\\]\s*)[A-Za-z_][A-Za-z0-9_]*)+)\s*(?:\(|(?=\s+(?:["'{]|\[\[|@)))/
+  SELF_CALL_REGEX     = /(?<![A-Za-z0-9_])(@[A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|(?=\s+(?:["'{]|\[\[|[A-Za-z_@])))/
+  BARE_CALL_REGEX     = /(?<![A-Za-z0-9_.:\\@])([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|(?=\s*(?:["'{]|\[\[)))/
+  COMMAND_CALL_REGEX  = /(?:^\s*|[=,;]\s*|\breturn\s+)([A-Za-z_][A-Za-z0-9_]*)\s+(?=["'{A-Za-z_@\[])/
+
+  def function_bodies(source : String, file_path : String) : Hash(String, FunctionBody)
+    bodies = {} of String => FunctionBody
+    stripped = strip_non_code(source)
+
+    stripped.scan(/\bfunction\s+([A-Za-z_][A-Za-z0-9_]*(?:(?:[:.])[A-Za-z_][A-Za-z0-9_]*)*)\s*\(/) do |match|
+      function_index = match.begin(0) || 0
+      next unless function_keyword_at?(source, function_index)
+
+      if body = extract_function_at(source, function_index)
+        name = match[1]
+        add_function_body(bodies, name, body, file_path)
+      end
+    end
+
+    stripped.scan(/(?:^|[\n,{])\s*(?:local\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\b/) do |match|
+      function_index = (match.begin(0) || 0) + match[0].rindex!("function")
+      next unless function_keyword_at?(source, function_index)
+
+      if body = extract_function_at(source, function_index)
+        add_function_body(bodies, match[1], body, file_path)
+      end
+    end
+
+    bodies
+  end
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    stripped = strip_nested_function_bodies(strip_non_code(body))
+
+    stripped.each_line.with_index do |line, offset|
+      scan_line(line, file_path, start_line + offset, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def extract_function_after(source : String,
+                             start_index : Int32,
+                             search_limit : Int32 = source.size,
+                             body_limit : Int32 = source.size) : Tuple(String, Int32)?
+    function_index = find_keyword(source, "function", start_index, search_limit)
+    return unless function_index
+
+    extract_function_at(source, function_index, body_limit)
+  end
+
+  def extract_function_at(source : String,
+                          function_index : Int32,
+                          limit : Int32 = source.size) : Tuple(String, Int32)?
+    return unless function_keyword_at?(source, function_index)
+
+    body_start = function_body_start(source, function_index, limit)
+    body_end = matching_function_end(source, function_index, limit)
+    return unless body_end
+    return if body_end < body_start
+
+    {source[body_start...body_end], line_number_for(source, body_start)}
+  end
+
+  def extract_moonscript_block_after(source : String, arrow_end_index : Int32) : Tuple(String, Int32)?
+    route_line_start = line_start_for(source, arrow_end_index)
+    route_indent = indentation_at(source, route_line_start)
+    route_line_end = line_end_for(source, arrow_end_index)
+    tail = source[arrow_end_index...route_line_end].strip
+    unless tail.empty?
+      return {tail, line_number_for(source, arrow_end_index)}
+    end
+
+    body_lines = [] of String
+    body_start_line = nil
+    index = route_line_end < source.size ? route_line_end + 1 : source.size
+
+    while index < source.size
+      current_end = line_end_for(source, index)
+      line = source[index...current_end]
+      stripped = line.strip
+
+      if stripped.empty?
+        body_lines << line if body_start_line
+        index = current_end < source.size ? current_end + 1 : source.size
+        next
+      end
+
+      indent = indentation_at(source, index)
+      break if indent <= route_indent
+
+      body_start_line ||= line_number_for(source, index)
+      body_lines << line
+      index = current_end < source.size ? current_end + 1 : source.size
+    end
+
+    return unless body_start_line
+
+    {body_lines.join("\n"), body_start_line}
+  end
+
+  def find_matching_delimiter(source : String, open_index : Int32, open_char : Char, close_char : Char,
+                              limit : Int32 = source.size) : Int32?
+    depth = 0
+    index = open_index
+
+    while index < limit && index < source.size
+      char = source[index]
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif long_bracket_start?(source, index)
+        index = skip_long_bracket(source, index, limit)
+        next
+      elsif char == '"' || char == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      elsif char == open_char
+        depth += 1
+      elsif char == close_char
+        depth -= 1
+        return index if depth == 0
+      end
+
+      index += 1
+    end
+
+    nil
+  end
+
+  def line_number_for(source : String, index : Int32) : Int32
+    return 1 if index <= 0
+
+    limit = index > source.size ? source.size : index
+    source[0...limit].count('\n') + 1
+  end
+
+  def strip_non_code(source : String) : String
+    stripped = String::Builder.new
+    index = 0
+
+    while index < source.size
+      char = source[index]
+      if comment_start?(source, index)
+        finish = skip_comment(source, index, source.size)
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      elsif long_bracket_start?(source, index)
+        finish = skip_long_bracket(source, index, source.size)
+        append_string_placeholder(stripped, source, index, finish, "[[]]")
+        index = finish
+        next
+      elsif char == '"' || char == '\''
+        finish = skip_short_string(source, index, source.size)
+        append_string_placeholder(stripped, source, index, finish, "#{char}#{char}")
+        index = finish
+        next
+      end
+
+      stripped << char
+      index += 1
+    end
+
+    stripped.to_s
+  end
+
+  private def add_function_body(bodies : Hash(String, FunctionBody),
+                                name : String,
+                                body : Tuple(String, Int32),
+                                file_path : String)
+    body_text, start_line = body
+    body_info = {body: body_text, path: file_path, start_line: start_line}
+    bodies[name] ||= body_info
+    short_name = name.split(/[.:]/).last
+    bodies[short_name] ||= body_info
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    scan_candidates(line, RECEIVER_CALL_REGEX, candidates)
+    scan_candidates(line, SELF_CALL_REGEX, candidates)
+    scan_candidates(line, BARE_CALL_REGEX, candidates)
+    scan_candidates(line, COMMAND_CALL_REGEX, candidates)
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |position, name|
+      next if skip_callee?(name)
+      next if declaration_name?(line, position)
+
+      entries << {normalize_name(name), file_path, line_number}
+    end
+  end
+
+  private def scan_candidates(line : String, regex : Regex, candidates : Array(Tuple(Int32, String)))
+    line.scan(regex) do |match|
+      candidates << {match.begin(1) || 0, match[1]}
+    end
+  end
+
+  private def normalize_name(name : String) : String
+    normalized = name.gsub(/\s+/, "").gsub('\\', '.').gsub(':', '.')
+    normalized = "self.#{normalized[1..]}" if normalized.starts_with?("@")
+    normalized
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    normalized = normalize_name(name)
+    parts = normalized.split('.')
+    return STANDARD_LIB_ROOTS.includes?(parts.first) if parts.size > 1
+
+    RESERVED.includes?(normalized)
+  end
+
+  private def declaration_name?(line : String, position : Int32) : Bool
+    prefix = line[0...position]
+    !!prefix.match(/\bfunction\s+$/)
+  end
+
+  private def strip_nested_function_bodies(source : String) : String
+    stripped = String::Builder.new
+    index = 0
+
+    while index < source.size
+      if function_keyword_at?(source, index)
+        finish = if function_end = matching_function_end(source, index, source.size)
+                   function_end + "end".size
+                 else
+                   index + "function".size
+                 end
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      stripped << source[index]
+      index += 1
+    end
+
+    stripped.to_s
+  end
+
+  private def function_body_start(source : String, function_index : Int32, limit : Int32) : Int32
+    paren_index = find_char(source, '(', function_index, limit)
+    return function_index + "function".size unless paren_index
+
+    close_index = find_matching_delimiter(source, paren_index, '(', ')', limit)
+    return close_index + 1 if close_index
+
+    function_index + "function".size
+  end
+
+  private def matching_function_end(source : String, function_index : Int32, limit : Int32) : Int32?
+    depth = 0
+    pending_do = 0
+    index = function_index
+
+    while index < limit && index < source.size
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif long_bracket_start?(source, index)
+        index = skip_long_bracket(source, index, limit)
+        next
+      elsif source[index] == '"' || source[index] == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      elsif identifier_start?(source[index])
+        token_start = index
+        token, index = read_identifier(source, index, limit)
+        case token
+        when "function", "if", "repeat"
+          depth += 1
+        when "for", "while"
+          depth += 1
+          pending_do += 1
+        when "do"
+          if pending_do > 0
+            pending_do -= 1
+          else
+            depth += 1
+          end
+        when "end"
+          depth -= 1
+          return token_start if depth == 0
+        when "until"
+          depth -= 1 if depth > 1
+        end
+        next
+      end
+
+      index += 1
+    end
+
+    nil
+  end
+
+  private def find_keyword(source : String, keyword : String, start_index : Int32, limit : Int32) : Int32?
+    index = start_index
+
+    while index < limit && index < source.size
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif long_bracket_start?(source, index)
+        index = skip_long_bracket(source, index, limit)
+        next
+      elsif source[index] == '"' || source[index] == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      elsif identifier_start?(source[index])
+        token_start = index
+        token, index = read_identifier(source, index, limit)
+        return token_start if token == keyword
+        next
+      end
+
+      index += 1
+    end
+
+    nil
+  end
+
+  private def find_char(source : String, target : Char, start_index : Int32, limit : Int32) : Int32?
+    index = start_index
+
+    while index < limit && index < source.size
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif long_bracket_start?(source, index)
+        index = skip_long_bracket(source, index, limit)
+        next
+      elsif source[index] == '"' || source[index] == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      end
+
+      return index if source[index] == target
+
+      index += 1
+    end
+
+    nil
+  end
+
+  private def function_keyword_at?(source : String, index : Int32) : Bool
+    return false unless source[index, "function".size]? == "function"
+    before = index > 0 ? source[index - 1] : '\0'
+    after_index = index + "function".size
+    after = after_index < source.size ? source[after_index] : '\0'
+    !identifier_part?(before) && !identifier_part?(after)
+  end
+
+  private def read_identifier(source : String, index : Int32, limit : Int32) : Tuple(String, Int32)
+    cursor = index
+    while cursor < limit && cursor < source.size && identifier_part?(source[cursor])
+      cursor += 1
+    end
+
+    {source[index...cursor], cursor}
+  end
+
+  private def identifier_start?(char : Char) : Bool
+    char.ascii_letter? || char == '_'
+  end
+
+  private def identifier_part?(char : Char) : Bool
+    char.ascii_alphanumeric? || char == '_'
+  end
+
+  private def comment_start?(source : String, index : Int32) : Bool
+    index + 1 < source.size && source[index] == '-' && source[index + 1] == '-'
+  end
+
+  private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+    if index + 2 < limit && long_bracket_start?(source, index + 2)
+      skip_long_bracket(source, index + 2, limit)
+    else
+      cursor = index
+      while cursor < limit && cursor < source.size && source[cursor] != '\n'
+        cursor += 1
+      end
+      cursor
+    end
+  end
+
+  private def long_bracket_start?(source : String, index : Int32) : Bool
+    !!long_bracket_equals(source, index)
+  end
+
+  private def long_bracket_equals(source : String, index : Int32) : Int32?
+    return unless index < source.size && source[index] == '['
+
+    cursor = index + 1
+    equals = 0
+    while cursor < source.size && source[cursor] == '='
+      equals += 1
+      cursor += 1
+    end
+
+    return equals if cursor < source.size && source[cursor] == '['
+    nil
+  end
+
+  private def skip_long_bracket(source : String, index : Int32, limit : Int32) : Int32
+    equals = long_bracket_equals(source, index)
+    return index + 1 unless equals
+
+    cursor = index + equals + 2
+    while cursor < limit && cursor < source.size
+      if source[cursor] == ']'
+        close_cursor = cursor + 1
+        seen_equals = 0
+        while close_cursor < source.size && source[close_cursor] == '='
+          seen_equals += 1
+          close_cursor += 1
+        end
+        return close_cursor + 1 if seen_equals == equals && close_cursor < source.size && source[close_cursor] == ']'
+      end
+      cursor += 1
+    end
+
+    limit
+  end
+
+  private def skip_short_string(source : String, index : Int32, limit : Int32) : Int32
+    quote = source[index]
+    cursor = index + 1
+    escaped = false
+
+    while cursor < limit && cursor < source.size
+      char = source[cursor]
+      if escaped
+        escaped = false
+      elsif char == '\\'
+        escaped = true
+      elsif char == quote
+        return cursor + 1
+      end
+      cursor += 1
+    end
+
+    limit
+  end
+
+  private def append_blanks(builder : String::Builder, source : String, start_index : Int32, finish_index : Int32)
+    index = start_index
+    while index < finish_index && index < source.size
+      builder << (source[index] == '\n' ? '\n' : ' ')
+      index += 1
+    end
+  end
+
+  private def append_string_placeholder(builder : String::Builder, source : String,
+                                        start_index : Int32, finish_index : Int32, placeholder : String)
+    placeholder_index = 0
+    index = start_index
+    while index < finish_index && index < source.size
+      if source[index] == '\n'
+        builder << '\n'
+      elsif placeholder_index < placeholder.size
+        builder << placeholder[placeholder_index]
+        placeholder_index += 1
+      else
+        builder << ' '
+      end
+      index += 1
+    end
+  end
+
+  private def line_start_for(source : String, index : Int32) : Int32
+    cursor = index
+    while cursor > 0 && source[cursor - 1] != '\n'
+      cursor -= 1
+    end
+    cursor
+  end
+
+  private def line_end_for(source : String, index : Int32) : Int32
+    cursor = index
+    while cursor < source.size && source[cursor] != '\n'
+      cursor += 1
+    end
+    cursor
+  end
+
+  private def indentation_at(source : String, line_start : Int32) : Int32
+    cursor = line_start
+    indent = 0
+    while cursor < source.size
+      case source[cursor]
+      when ' '
+        indent += 1
+      when '\t'
+        indent += 2
+      else
+        break
+      end
+      cursor += 1
+    end
+    indent
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end


### PR DESCRIPTION
## Summary
- add a lightweight Lua/MoonScript callee extractor for Lapis handler bodies
- attach callees for inline Lua handlers, app:match fallback methods, same-file string/identifier handlers, table-style routes, and MoonScript actions
- add Lapis callee fixtures plus unit coverage for comment/string noise, nested function false positives, identifier handlers, and MoonScript self calls

Part of #1366.

## Verification
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lua-full2 just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lua-full2 just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-lua-full2 just check
- git diff --check
- ./bin/noir -b spec/functional_test/fixtures/lua/lapis_callees -f json --include-callee