### PR TITLE
Add Perl Mojolicious callee extraction

### DIFF
--- a/spec/functional_test/fixtures/perl/mojolicious_callees/cpanfile
+++ b/spec/functional_test/fixtures/perl/mojolicious_callees/cpanfile
@@ -1,0 +1,1 @@
+requires 'Mojolicious', '>= 9.0';

--- a/spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp.pm
+++ b/spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp.pm
@@ -1,0 +1,13 @@
+package MyApp;
+use Mojo::Base 'Mojolicious', -signatures;
+
+sub startup ($self) {
+  my $r = $self->routes;
+
+  $r->get('/api/status')->to('api#status');
+  $r->post('/api/login')->to('api#login');
+  $r->get('/admin/users/:id')->to('admin/users#show');
+  $r->post('/admin/users')->to(controller => 'admin/users', action => 'create');
+}
+
+1;

--- a/spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp/Controller/Admin/Users.pm
+++ b/spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp/Controller/Admin/Users.pm
@@ -1,0 +1,14 @@
+package MyApp::Controller::Admin::Users;
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+sub show ($c) {
+  my $user = Admin::UserService->find($c->param('id'));
+  return $c->render(json => $user);
+}
+
+sub create ($c) {
+  my $user = Admin::UserService->create($c->param('name'));
+  return $c->render(json => $user);
+}
+
+1;

--- a/spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp/Controller/Api.pm
+++ b/spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp/Controller/Api.pm
@@ -1,0 +1,14 @@
+package MyApp::Controller::Api;
+use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+sub status ($c) {
+  my $status = StatusService->current;
+  return $c->render(json => $status);
+}
+
+sub login ($c) {
+  my $payload = LoginService::authenticate($c->param('username'));
+  return $c->render(json => $payload);
+}
+
+1;

--- a/spec/functional_test/fixtures/perl/mojolicious_callees/script/myapp.pl
+++ b/spec/functional_test/fixtures/perl/mojolicious_callees/script/myapp.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+use Mojolicious::Lite -signatures;
+
+get '/hello' => sub ($c) {
+  my $message = GreetingService::build($c->param('name'));
+  Audit->log('hello');
+  $c->render(text => $message);
+};
+
+get '/inline' => sub ($c) { InlineService::call(); $c->render(text => 'ok') };
+
+any [qw(GET POST)] => '/multi' => sub ($c) {
+  my $data = MultiService->load();
+  return $c->render(json => $data);
+};
+
+websocket '/echo' => sub ($c) {
+  $c->on(message => sub ($c, $msg) { HiddenService::nested($msg); $c->send($msg) });
+  EchoService::accepted();
+};
+
+app->start;

--- a/spec/functional_test/testers/perl/mojolicious_callees_spec.cr
+++ b/spec/functional_test/testers/perl/mojolicious_callees_spec.cr
@@ -1,0 +1,154 @@
+require "../../func_spec.cr"
+
+def mojolicious_endpoint_with_callees(url, method, params = [] of Param, callees = [] of Callee, protocol = "http")
+  endpoint = Endpoint.new(url, method, params)
+  endpoint.protocol = protocol
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+hello_callees = [
+  Callee.new("GreetingService::build", line: 5),
+  Callee.new("c.param", line: 5),
+  Callee.new("Audit.log", line: 6),
+  Callee.new("c.render", line: 7),
+]
+
+inline_callees = [
+  Callee.new("InlineService::call", line: 10),
+  Callee.new("c.render", line: 10),
+]
+
+multi_callees = [
+  Callee.new("MultiService.load", line: 13),
+  Callee.new("c.render", line: 14),
+]
+
+echo_callees = [
+  Callee.new("c.on", line: 18),
+  Callee.new("EchoService::accepted", line: 19),
+]
+
+status_callees = [
+  Callee.new("StatusService.current", line: 5),
+  Callee.new("c.render", line: 6),
+]
+
+login_callees = [
+  Callee.new("LoginService::authenticate", line: 10),
+  Callee.new("c.param", line: 10),
+  Callee.new("c.render", line: 11),
+]
+
+admin_show_callees = [
+  Callee.new("Admin.UserService.find", line: 5),
+  Callee.new("c.param", line: 5),
+  Callee.new("c.render", line: 6),
+]
+
+admin_create_callees = [
+  Callee.new("Admin.UserService.create", line: 10),
+  Callee.new("c.param", line: 10),
+  Callee.new("c.render", line: 11),
+]
+
+expected_endpoints = [
+  mojolicious_endpoint_with_callees("/hello", "GET", [
+    Param.new("name", "", "query"),
+  ], hello_callees),
+  mojolicious_endpoint_with_callees("/inline", "GET", [] of Param, inline_callees),
+  mojolicious_endpoint_with_callees("/multi", "GET", [] of Param, multi_callees),
+  mojolicious_endpoint_with_callees("/multi", "POST", [] of Param, multi_callees),
+  mojolicious_endpoint_with_callees("/echo", "GET", [] of Param, echo_callees, "ws"),
+  mojolicious_endpoint_with_callees("/api/status", "GET", [] of Param, status_callees),
+  mojolicious_endpoint_with_callees("/api/login", "POST", [] of Param, login_callees),
+  mojolicious_endpoint_with_callees("/admin/users/:id", "GET", [
+    Param.new("id", "", "path"),
+  ], admin_show_callees),
+  mojolicious_endpoint_with_callees("/admin/users", "POST", [] of Param, admin_create_callees),
+]
+
+tester = FunctionalTester.new("fixtures/perl/mojolicious_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "reports exact Mojolicious::Lite callees for inline handlers" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/hello" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(hello_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "reuses Mojolicious any-handler callees for every emitted method" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/multi" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(multi_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "keeps nested websocket callback callees out of the route body" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/echo" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(echo_callees.map { |callee| {callee.name, callee.line} })
+    actual.callees.map(&.name).should_not contain("HiddenService::nested")
+    actual.callees.map(&.name).should_not contain("c.send")
+  end
+end
+
+it "attaches Mojolicious full-app controller action callees" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/api/login" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(login_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "attaches nested Mojolicious controller action callees" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/admin/users/:id" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(admin_show_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "attaches named Mojolicious controller/action callees" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/admin/users" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map { |callee| {callee.name, callee.line} }.should eq(admin_create_callees.map { |callee| {callee.name, callee.line} })
+  end
+end
+
+it "populates Mojolicious callee source paths" do
+  endpoint = tester.app.endpoints.find { |found| found.url == "/api/status" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    paths = actual.callees.map(&.path)
+    paths.uniq!
+    paths.should eq([
+      "./spec/functional_test/fixtures/perl/mojolicious_callees/lib/MyApp/Controller/Api.pm",
+    ])
+  end
+end
+
+it "does not populate Mojolicious callees by default" do
+  config_init = ConfigInitializer.new
+  noir_options = config_init.default_options
+  noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/perl/mojolicious_callees/")])
+  noir_options["nolog"] = YAML::Any.new(true)
+
+  app = NoirRunner.new(noir_options)
+  app.detect
+  app.analyze
+  app.endpoints.should_not be_empty
+  app.endpoints.each do |endpoint|
+    endpoint.callees.should be_empty
+  end
+end

--- a/spec/unit_test/miniparser/perl_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/perl_callee_extractor_spec.cr
@@ -1,0 +1,101 @@
+require "spec"
+require "../../../src/miniparsers/perl_callee_extractor"
+
+describe Noir::PerlCalleeExtractor do
+  it "extracts Perl bare, qualified, and method callees" do
+    body = <<-PERL
+      my $user = UserService::load($c->param('id'));
+      Audit->write('users');
+      $c->render(json => $user);
+      print "debug";
+      PERL
+
+    callees = Noir::PerlCalleeExtractor.callees_for_body(body, "app.pl", 10)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"UserService::load", 10},
+      {"c.param", 10},
+      {"Audit.write", 11},
+      {"c.render", 12},
+    ])
+  end
+
+  it "extracts sub bodies and skips nested anonymous sub bodies" do
+    source = <<-PERL
+      get '/echo' => sub ($c) {
+        $c->on(message => sub ($c, $msg) {
+          HiddenService::nested($msg);
+          $c->send($msg);
+        });
+        EchoService::accepted();
+      };
+      PERL
+
+    sub_start = source.index!("sub")
+    body = Noir::PerlCalleeExtractor.extract_sub_after(source, sub_start)
+    body.should_not be_nil
+
+    body.try do |body_text, start_line|
+      start_line.should eq(1)
+      Noir::PerlCalleeExtractor.callees_for_body(body_text, "app.pl", start_line).map { |name, _, line| {name, line} }.should eq([
+        {"c.on", 2},
+        {"EchoService::accepted", 6},
+      ])
+    end
+  end
+
+  it "does not index fake subs from comments or quoted strings" do
+    source = <<-PERL
+      # sub ghost { Ghost.call() }
+      my $text = q{sub hidden { Hidden.call() }};
+
+      sub status ($c) {
+        return StatusService->current;
+      }
+      PERL
+
+    bodies = Noir::PerlCalleeExtractor.named_sub_bodies(source, "Api.pm")
+    bodies.keys.sort!.should eq(["status"])
+    status = bodies["status"]
+    Noir::PerlCalleeExtractor.callees_for_body(status[:body], status[:path], status[:start_line]).map(&.[0]).should eq([
+      "StatusService.current",
+    ])
+  end
+
+  it "indexes Mojolicious controller action callees" do
+    source = <<-PERL
+      package MyApp::Controller::Api;
+      use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+      sub status ($c) {
+        my $status = StatusService->current;
+        return $c->render(json => $status);
+      }
+      PERL
+
+    callees = Noir::PerlCalleeExtractor.controller_action_callees(source, "Api.pm")
+    callees.keys.sort!.should eq(["api#status"])
+    callees["api#status"].map { |name, _, line| {name, line} }.should eq([
+      {"StatusService.current", 5},
+      {"c.render", 6},
+    ])
+  end
+
+  it "indexes nested Mojolicious controller namespaces without collapsing them" do
+    source = <<-PERL
+      package MyApp::Controller::Admin::Users;
+      use Mojo::Base 'Mojolicious::Controller', -signatures;
+
+      sub show ($c) {
+        return Admin::UserService->find($c->param('id'));
+      }
+      PERL
+
+    callees = Noir::PerlCalleeExtractor.controller_action_callees(source, "Admin/Users.pm")
+    callees.keys.sort!.should eq(["admin/users#show"])
+    callees["admin/users#show"].map { |name, _, line| {name, line} }.should eq([
+      {"Admin.UserService.find", 5},
+      {"c.param", 5},
+    ])
+    callees.has_key?("users#show").should be_false
+  end
+end

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -1,4 +1,5 @@
 require "../../engines/perl_engine"
+require "../../../miniparsers/perl_callee_extractor"
 
 module Analyzer::Perl
   class Mojolicious < PerlEngine
@@ -9,7 +10,23 @@ module Analyzer::Perl
     FULL_ANY_RE   = /->\s*any\s*\(\s*(?:\[([^\]]+)\]\s*,?\s*=?>?\s*)?['"]([^'"]+)['"]/
     FULL_ROUTE_RE = /->\s*route\s*\(\s*['"]([^'"]+)['"]\s*\)(?:\s*->\s*via\s*\(\s*([^)]+)\))?/
 
+    def analyze
+      include_callee = any_to_bool(@options["include_callee"]?)
+      controller_callees = include_callee ? index_controller_callees : {} of String => Array(Noir::PerlCalleeExtractor::Entry)
+
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path, include_callee, controller_callees))
+      end
+      result
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
+      analyze_file(path, any_to_bool(@options["include_callee"]?), {} of String => Array(Noir::PerlCalleeExtractor::Entry))
+    end
+
+    private def analyze_file(path : String,
+                             include_callee : Bool,
+                             controller_callees : Hash(String, Array(Noir::PerlCalleeExtractor::Entry))) : Array(Endpoint)
       ext = File.extname(path)
       return [] of Endpoint unless ext == ".pl" || ext == ".pm" ||
                                    ext == ".psgi" || ext == ".t"
@@ -17,14 +34,18 @@ module Analyzer::Perl
       endpoints = [] of Endpoint
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         content = file.gets_to_end
-        endpoints.concat(analyze_content(content, path))
+        endpoints.concat(analyze_content(content, path, include_callee, controller_callees))
       end
       endpoints
     end
 
-    def analyze_content(content : String, file_path : String) : Array(Endpoint)
+    def analyze_content(content : String,
+                        file_path : String,
+                        include_callee : Bool = false,
+                        controller_callees : Hash(String, Array(Noir::PerlCalleeExtractor::Entry)) = {} of String => Array(Noir::PerlCalleeExtractor::Entry)) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.lines
+      offsets = line_offsets(content)
       last_endpoint : Endpoint? = nil
 
       lines.each_with_index do |line, index|
@@ -35,6 +56,7 @@ module Analyzer::Perl
         line_endpoints.each do |endpoint|
           endpoint.details = Details.new(PathInfo.new(file_path, index + 1))
           extract_path_params(endpoint).each { |p| push_unique_param(endpoint, p) }
+          attach_route_callees(endpoint, content, line, offsets[index], controller_callees) if include_callee
           endpoints << endpoint
         end
 
@@ -58,6 +80,23 @@ module Analyzer::Perl
       end
 
       endpoints
+    end
+
+    private def index_controller_callees : Hash(String, Array(Noir::PerlCalleeExtractor::Entry))
+      callees = {} of String => Array(Noir::PerlCalleeExtractor::Entry)
+
+      all_files.each do |path|
+        next if File.directory?(path)
+        ext = File.extname(path)
+        next unless ext == ".pl" || ext == ".pm" || ext == ".psgi" || ext == ".t"
+
+        content = read_file_content(path)
+        Noir::PerlCalleeExtractor.controller_action_callees(content, path).each do |key, entries|
+          callees[key] ||= entries
+        end
+      end
+
+      callees
     end
 
     def line_to_endpoints(line : String) : Array(Endpoint)
@@ -182,6 +221,62 @@ module Analyzer::Perl
         return if existing.name == param.name && existing.param_type == param.param_type
       end
       endpoint.push_param(param)
+    end
+
+    private def attach_route_callees(endpoint : Endpoint,
+                                     content : String,
+                                     line : String,
+                                     line_offset : Int32,
+                                     controller_callees : Hash(String, Array(Noir::PerlCalleeExtractor::Entry)))
+      line_end = line_offset + line.size
+      if body = Noir::PerlCalleeExtractor.extract_sub_after(content, line_offset, line_end)
+        body_text, start_line = body
+        Noir::PerlCalleeExtractor.attach_to(endpoint, Noir::PerlCalleeExtractor.callees_for_body(body_text, endpoint.details.code_paths.first.path, start_line))
+        return
+      end
+
+      if target = controller_action_target(line)
+        if callees = controller_callees[target]?
+          Noir::PerlCalleeExtractor.attach_to(endpoint, callees)
+        end
+      end
+    end
+
+    private def controller_action_target(line : String) : String?
+      if match = line.match(/->\s*to\s*\(\s*['"]([A-Za-z_][A-Za-z0-9_:\/-]*)#([A-Za-z_][A-Za-z0-9_]*)['"]\s*\)/)
+        return "#{controller_key(match[1])}##{match[2]}"
+      end
+
+      if match = line.match(/->\s*to\s*\(([^)]*)\)/)
+        args = match[1]
+        controller = named_to_arg(args, "controller")
+        action = named_to_arg(args, "action")
+        "#{controller_key(controller)}##{action}" if controller && action
+      end
+    end
+
+    private def named_to_arg(args : String, name : String) : String?
+      if match = args.match(/(?:^|[,\s])#{name}\s*=>\s*['"]([A-Za-z_][A-Za-z0-9_:\/-]*)['"]/)
+        match[1]
+      end
+    end
+
+    private def controller_key(controller : String) : String
+      controller.gsub("::", "/").split('/').reject(&.empty?).map do |segment|
+        underscore(segment.gsub("-", "_"))
+      end.join("/")
+    end
+
+    private def underscore(name : String) : String
+      name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
+    end
+
+    private def line_offsets(content : String) : Array(Int32)
+      offsets = [0]
+      content.each_char_with_index do |char, index|
+        offsets << index + 1 if char == '\n'
+      end
+      offsets
     end
   end
 end

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -1,0 +1,455 @@
+require "../models/endpoint"
+
+module Noir::PerlCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+  alias SubBody = NamedTuple(body: String, path: String, start_line: Int32)
+
+  RESERVED = Set{
+    "and", "cmp", "continue", "do", "else", "elsif", "eq", "eval",
+    "for", "foreach", "ge", "given", "gt", "if", "last", "le", "lt",
+    "my", "ne", "next", "no", "not", "our", "package", "return", "state",
+    "sub", "unless", "until", "use", "when", "while",
+    "bless", "caller", "chomp", "chop", "close", "defined", "delete",
+    "die", "each", "exists", "grep", "join", "keys", "length", "map",
+    "open", "pop", "print", "push", "qw", "q", "qq", "qr", "ref",
+    "scalar", "shift", "sort", "split", "sprintf", "undef", "unshift",
+    "values", "wantarray", "warn",
+  }
+
+  STANDARD_MODULES = Set{
+    "Carp", "Data::Dumper", "Encode", "File::Spec", "JSON", "List::Util",
+    "Mojo::Base", "Mojolicious::Lite", "strict", "warnings",
+  }
+
+  METHOD_CALL_REGEX    = /(\$?[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*)\s*->\s*([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])\s*(?:\(|(?=\s*(?:[A-Za-z_$'"]|\{|\[|;|,|\)|\}|$)))/
+  QUALIFIED_CALL_REGEX = /(?<![A-Za-z0-9_:])([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+)\s*(?:\(|(?=\s+(?:[A-Za-z_$'"]|\{|\[)))/
+  BARE_CALL_REGEX      = /(?<![A-Za-z0-9_:>$])([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|(?=\s+(?:[A-Za-z_$'"]|\{|\[)))/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    stripped = strip_nested_sub_bodies(strip_non_code(body))
+
+    stripped.each_line.with_index do |line, offset|
+      scan_line(line, file_path, start_line + offset, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  def controller_action_callees(source : String, file_path : String) : Hash(String, Array(Entry))
+    package = package_name(source)
+    return {} of String => Array(Entry) unless package
+    return {} of String => Array(Entry) unless package.includes?("::Controller::")
+
+    controller = package.split("::Controller::", 2)[1]?
+    return {} of String => Array(Entry) unless controller
+
+    bodies = named_sub_bodies(source, file_path)
+    actions = {} of String => Array(Entry)
+    controller_keys(controller).each do |controller_key|
+      bodies.each do |action, body|
+        key = "#{controller_key}##{action}"
+        actions[key] = callees_for_body(body[:body], body[:path], body[:start_line])
+      end
+    end
+
+    actions
+  end
+
+  def named_sub_bodies(source : String, file_path : String) : Hash(String, SubBody)
+    bodies = {} of String => SubBody
+    stripped = strip_non_code(source)
+
+    stripped.scan(/\bsub\s+([A-Za-z_][A-Za-z0-9_]*)\b/) do |match|
+      sub_index = match.begin(0) || 0
+      next unless sub_keyword_at?(source, sub_index)
+      next unless body = extract_sub_at(source, sub_index)
+
+      body_text, start_line = body
+      bodies[match[1]] ||= {body: body_text, path: file_path, start_line: start_line}
+    end
+
+    bodies
+  end
+
+  def extract_sub_after(source : String,
+                        start_index : Int32,
+                        search_limit : Int32 = source.size,
+                        body_limit : Int32 = source.size) : Tuple(String, Int32)?
+    sub_index = find_keyword(source, "sub", start_index, search_limit)
+    return unless sub_index
+
+    extract_sub_at(source, sub_index, body_limit)
+  end
+
+  def extract_sub_at(source : String,
+                     sub_index : Int32,
+                     limit : Int32 = source.size) : Tuple(String, Int32)?
+    return unless sub_keyword_at?(source, sub_index)
+
+    open_brace = find_char(source, '{', sub_index, limit)
+    return unless open_brace
+    close_brace = find_matching_delimiter(source, open_brace, '{', '}', limit)
+    return unless close_brace
+
+    {source[(open_brace + 1)...close_brace], line_number_for(source, open_brace + 1)}
+  end
+
+  def find_matching_delimiter(source : String, open_index : Int32, open_char : Char, close_char : Char,
+                              limit : Int32 = source.size) : Int32?
+    depth = 0
+    index = open_index
+
+    while index < limit && index < source.size
+      char = source[index]
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif quote_like_start?(source, index)
+        index = skip_quote_like(source, index, limit)
+        next
+      elsif char == '"' || char == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      elsif char == open_char
+        depth += 1
+      elsif char == close_char
+        depth -= 1
+        return index if depth == 0
+      end
+
+      index += 1
+    end
+
+    nil
+  end
+
+  def strip_non_code(source : String) : String
+    stripped = String::Builder.new
+    index = 0
+
+    while index < source.size
+      char = source[index]
+      if comment_start?(source, index)
+        finish = skip_comment(source, index, source.size)
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      elsif quote_like_start?(source, index)
+        finish = skip_quote_like(source, index, source.size)
+        append_string_placeholder(stripped, source, index, finish)
+        index = finish
+        next
+      elsif char == '"' || char == '\''
+        finish = skip_short_string(source, index, source.size)
+        append_string_placeholder(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      stripped << char
+      index += 1
+    end
+
+    stripped.to_s
+  end
+
+  def line_number_for(source : String, index : Int32) : Int32
+    return 1 if index <= 0
+
+    limit = index > source.size ? source.size : index
+    source[0...limit].count('\n') + 1
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    candidates = [] of Tuple(Int32, String)
+
+    line.scan(METHOD_CALL_REGEX) do |match|
+      candidates << {match.begin(0) || 0, "#{normalize_receiver(match[1])}.#{match[2]}"}
+    end
+    scan_candidates(line, QUALIFIED_CALL_REGEX, candidates)
+    scan_candidates(line, BARE_CALL_REGEX, candidates)
+
+    candidates.sort_by! { |position, _| position }
+    candidates.each do |position, name|
+      next if skip_callee?(name)
+      next if declaration_name?(line, position)
+
+      entries << {name, file_path, line_number}
+    end
+  end
+
+  private def scan_candidates(line : String, regex : Regex, candidates : Array(Tuple(Int32, String)))
+    line.scan(regex) do |match|
+      candidates << {match.begin(1) || 0, match[1]}
+    end
+  end
+
+  private def normalize_receiver(name : String) : String
+    normalized = name.starts_with?("$") ? name[1..] : name
+    normalized.gsub("::", ".")
+  end
+
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+
+    base = name.split('.').last
+    return true if RESERVED.includes?(base)
+    return true if STANDARD_MODULES.includes?(name)
+
+    false
+  end
+
+  private def declaration_name?(line : String, position : Int32) : Bool
+    prefix = line[0...position]
+    !!prefix.match(/\bsub\s+$/)
+  end
+
+  private def strip_nested_sub_bodies(source : String) : String
+    stripped = String::Builder.new
+    index = 0
+
+    while index < source.size
+      if sub_keyword_at?(source, index)
+        finish = find_matching_sub_end(source, index) || index + "sub".size
+        append_blanks(stripped, source, index, finish)
+        index = finish
+        next
+      end
+
+      stripped << source[index]
+      index += 1
+    end
+
+    stripped.to_s
+  end
+
+  private def find_matching_sub_end(source : String, sub_index : Int32) : Int32?
+    open_brace = find_char(source, '{', sub_index, source.size)
+    return unless open_brace
+    close_brace = find_matching_delimiter(source, open_brace, '{', '}', source.size)
+    return unless close_brace
+    close_brace + 1
+  end
+
+  private def package_name(source : String) : String?
+    stripped = strip_non_code(source)
+    if match = stripped.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_:]*)\s*;/m)
+      match[1]
+    end
+  end
+
+  private def controller_keys(controller : String) : Array(String)
+    keys = Set(String).new
+    segments = controller.split("::")
+    keys << segments.map(&.downcase).join("/")
+    keys << segments.map { |segment| underscore(segment) }.join("/")
+    keys.to_a
+  end
+
+  private def underscore(name : String) : String
+    name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
+  end
+
+  private def find_keyword(source : String, keyword : String, start_index : Int32, limit : Int32) : Int32?
+    index = start_index
+
+    while index < limit && index < source.size
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif quote_like_start?(source, index)
+        index = skip_quote_like(source, index, limit)
+        next
+      elsif source[index] == '"' || source[index] == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      elsif identifier_start?(source[index])
+        token_start = index
+        token, index = read_identifier(source, index, limit)
+        return token_start if token == keyword
+        next
+      end
+
+      index += 1
+    end
+
+    nil
+  end
+
+  private def find_char(source : String, target : Char, start_index : Int32, limit : Int32) : Int32?
+    index = start_index
+
+    while index < limit && index < source.size
+      if comment_start?(source, index)
+        index = skip_comment(source, index, limit)
+        next
+      elsif quote_like_start?(source, index)
+        index = skip_quote_like(source, index, limit)
+        next
+      elsif source[index] == '"' || source[index] == '\''
+        index = skip_short_string(source, index, limit)
+        next
+      end
+
+      return index if source[index] == target
+
+      index += 1
+    end
+
+    nil
+  end
+
+  private def sub_keyword_at?(source : String, index : Int32) : Bool
+    return false unless source[index, "sub".size]? == "sub"
+    before = index > 0 ? source[index - 1] : '\0'
+    after_index = index + "sub".size
+    after = after_index < source.size ? source[after_index] : '\0'
+    !identifier_part?(before) && !identifier_part?(after)
+  end
+
+  private def read_identifier(source : String, index : Int32, limit : Int32) : Tuple(String, Int32)
+    cursor = index
+    while cursor < limit && cursor < source.size && identifier_part?(source[cursor])
+      cursor += 1
+    end
+
+    {source[index...cursor], cursor}
+  end
+
+  private def identifier_start?(char : Char) : Bool
+    char.ascii_letter? || char == '_'
+  end
+
+  private def identifier_part?(char : Char) : Bool
+    char.ascii_alphanumeric? || char == '_'
+  end
+
+  private def comment_start?(source : String, index : Int32) : Bool
+    source[index] == '#'
+  end
+
+  private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+    cursor = index
+    while cursor < limit && cursor < source.size && source[cursor] != '\n'
+      cursor += 1
+    end
+    cursor
+  end
+
+  private def quote_like_start?(source : String, index : Int32) : Bool
+    return false unless index < source.size
+    return false unless source[index] == 'q'
+    return false if index > 0 && identifier_part?(source[index - 1])
+
+    cursor = index + 1
+    if cursor < source.size && {'q', 'r', 'w', 'x'}.includes?(source[cursor])
+      cursor += 1
+    elsif cursor < source.size && identifier_part?(source[cursor])
+      return false
+    end
+
+    while cursor < source.size && source[cursor].whitespace?
+      cursor += 1
+    end
+    return false if cursor >= source.size
+
+    !!quote_close_char(source[cursor])
+  end
+
+  private def skip_quote_like(source : String, index : Int32, limit : Int32) : Int32
+    cursor = index + 1
+    cursor += 1 if cursor < limit && cursor < source.size && {'q', 'r', 'w', 'x'}.includes?(source[cursor])
+    while cursor < limit && cursor < source.size && source[cursor].whitespace?
+      cursor += 1
+    end
+    return index + 1 if cursor >= limit || cursor >= source.size
+
+    open_char = source[cursor]
+    close_char = quote_close_char(open_char)
+    return index + 1 unless close_char
+
+    cursor += 1
+    escaped = false
+    while cursor < limit && cursor < source.size
+      char = source[cursor]
+      if escaped
+        escaped = false
+      elsif char == '\\'
+        escaped = true
+      elsif char == close_char
+        return cursor + 1
+      end
+      cursor += 1
+    end
+
+    limit
+  end
+
+  private def quote_close_char(open_char : Char) : Char?
+    case open_char
+    when '('                      then ')'
+    when '['                      then ']'
+    when '{'                      then '}'
+    when '<'                      then '>'
+    when '"', '\'', '/', '|', '!' then open_char
+    end
+  end
+
+  private def skip_short_string(source : String, index : Int32, limit : Int32) : Int32
+    quote = source[index]
+    cursor = index + 1
+    escaped = false
+
+    while cursor < limit && cursor < source.size
+      char = source[cursor]
+      if escaped
+        escaped = false
+      elsif char == '\\'
+        escaped = true
+      elsif char == quote
+        return cursor + 1
+      end
+      cursor += 1
+    end
+
+    limit
+  end
+
+  private def append_blanks(builder : String::Builder, source : String, start_index : Int32, finish_index : Int32)
+    index = start_index
+    while index < finish_index && index < source.size
+      builder << (source[index] == '\n' ? '\n' : ' ')
+      index += 1
+    end
+  end
+
+  private def append_string_placeholder(builder : String::Builder, source : String, start_index : Int32, finish_index : Int32)
+    placeholder_written = false
+    index = start_index
+    while index < finish_index && index < source.size
+      if source[index] == '\n'
+        builder << '\n'
+      elsif !placeholder_written
+        builder << ' '
+        placeholder_written = true
+      else
+        builder << ' '
+      end
+      index += 1
+    end
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(Entry).new
+    entries.select { |entry| seen.add?(entry) }
+  end
+end


### PR DESCRIPTION
## Summary
- add a Perl callee extractor for Mojolicious route handlers
- attach callees for inline route subs and same-project controller actions
- cover nested controller namespaces, named controller/action routes, websocket callbacks, and include_callee gating

Part of #1366.

## Verification
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-perl1 crystal spec spec/unit_test/miniparser/perl_callee_extractor_spec.cr spec/functional_test/testers/perl/mojolicious_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-perl1 just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-perl1 just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-perl1 just check
- git diff --check
- ./bin/noir -b spec/functional_test/fixtures/perl/mojolicious_callees -f json --include-callee