### PR TITLE
Scope Django CBV callees per HTTP method

### DIFF
--- a/spec/functional_test/fixtures/python/django_callees/djangoproj/views.py
+++ b/spec/functional_test/fixtures/python/django_callees/djangoproj/views.py
@@ -16,3 +16,8 @@ class ProfileView(View):
         data = build_profile()
         audit_log(data)
         return JsonResponse(data)
+
+    def post(self, request):
+        user = save_user('profile')
+        audit_log(user)
+        return JsonResponse({'id': user})

--- a/spec/functional_test/testers/python/django_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_callees_spec.cr
@@ -12,11 +12,10 @@ require "../../func_spec.cr"
 #                                    `request.POST.get`); both
 #                                    endpoints must carry the same
 #                                    callee list.
-#   - `views.ProfileView.as_view` → class-based view that calls
-#                                    `build_profile`, `audit_log`,
-#                                    `JsonResponse` inside `def get`.
-#                                    Locks in the class-codeblock
-#                                    handler-body path.
+#   - `views.ProfileView.as_view` → class-based view with distinct
+#                                    callees inside `def get` and
+#                                    `def post`. This locks in
+#                                    per-method callee scoping.
 #
 # Line assertions verify that body_start_line conversion (char-offset
 # → 0-based line) lands correctly for both paths.
@@ -47,9 +46,32 @@ expected_endpoints = [
     ep.push_callee(Callee.new("audit_log", line: 17))
     ep.push_callee(Callee.new("JsonResponse", line: 18))
   end,
+
+  Endpoint.new("/profile", "POST").tap do |ep|
+    ep.push_callee(Callee.new("save_user", line: 21))
+    ep.push_callee(Callee.new("audit_log", line: 22))
+    ep.push_callee(Callee.new("JsonResponse", line: 23))
+  end,
 ]
 
-FunctionalTester.new("fixtures/python/django_callees/", {
+tester = FunctionalTester.new("fixtures/python/django_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "keeps Django class-based view callees scoped to each HTTP method" do
+  get_endpoint = tester.app.endpoints.find { |endpoint| endpoint.url == "/profile" && endpoint.method == "GET" }
+  post_endpoint = tester.app.endpoints.find { |endpoint| endpoint.url == "/profile" && endpoint.method == "POST" }
+
+  get_endpoint.should_not be_nil
+  post_endpoint.should_not be_nil
+
+  get_endpoint.try do |endpoint|
+    endpoint.callees.map(&.name).should eq(["build_profile", "audit_log", "JsonResponse"])
+  end
+
+  post_endpoint.try do |endpoint|
+    endpoint.callees.map(&.name).should eq(["save_user", "audit_log", "JsonResponse"])
+  end
+end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -277,11 +277,19 @@ module Analyzer::Python
             suspicious_http_methods << "POST"
           end
 
+          body_start_line = content[0, class_start_index].count('\n')
+          method_callees = Hash(String, Array(Callee)).new
+
           # Check HTTP methods in class methods
-          lines.each do |line|
-            method_function_match = line.match(/\s+def\s+(#{regext_http_methods})\s*\(/)
+          lines.each_with_index do |line, offset|
+            method_function_match = line.match(/\s+(?:async\s+)?def\s+(#{regext_http_methods})\s*\(/)
             if !method_function_match.nil?
-              suspicious_http_methods << method_function_match[1].upcase
+              method_name = method_function_match[1].upcase
+              suspicious_http_methods << method_name
+
+              if codeblock = parse_code_block(lines[offset..])
+                method_callees[method_name] = build_callees_from(codeblock, body_start_line + offset + 1, filepath)
+              end
             end
 
             extract_params_from_line(line, suspicious_http_methods).each do |param|
@@ -289,17 +297,11 @@ module Analyzer::Python
             end
           end
 
-          # The class codeblock spans every responder method (get/post/...)
-          # plus any helpers, and we emit one endpoint per detected HTTP
-          # method. Class-level callees go onto every emitted endpoint —
-          # finer per-method scoping would require a second AST pass and
-          # is out of scope for this 1-hop extractor.
-          body_start_line = content[0, class_start_index].count('\n')
-          handler_callees = build_callees_from(class_codeblock, body_start_line, filepath)
-
           suspicious_http_methods.uniq.each do |http_method_name|
             endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params))
-            handler_callees.each { |c| endpoint.push_callee(c) }
+            if callees = method_callees[http_method_name]?
+              callees.each { |c| endpoint.push_callee(c) }
+            end
             endpoints << endpoint
           end
 


### PR DESCRIPTION
## Summary
- scope Django class-based view callees to the matching `get`/`post`/HTTP method body
- keep function-based view callee behavior unchanged
- extend the Django callee fixture with distinct GET and POST class methods and exact callee assertions

Part of #1366.

## Verification
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-cbv crystal spec spec/functional_test/testers/python/django_callees_spec.cr
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-cbv just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-cbv just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-cbv just check
- git diff --check
- ./bin/noir -b spec/functional_test/fixtures/python/django_callees -f json --include-callee