### PR TITLE
Surface callees in custom serializers

### DIFF
--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -14,7 +14,9 @@ plain 출력에서 callee를 보려면 `--include-callee`를 사용하세요:
 noir -b . --include-callee
 ```
 
-JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는 엔드포인트 모델을 통해 `callees` 필드를 포함합니다. 현재 `path`와 `line`은 callee 정의 위치가 아니라 호출 위치를 가리킵니다.
+JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는 엔드포인트 모델을 통해 `callees` 필드를 포함합니다. OpenAPI 2.0/3.0은 operation 레벨의 `x-noir-callees` extension으로, SARIF는 `result.properties.noir.callees`로, Postman collection은 item description의 사람이 읽을 수 있는 목록으로 callee를 제공합니다. cURL, HTTPie, PowerShell, only-url, only-param 같은 명령/필터 목적 출력은 주 출력 형태를 안정적으로 유지하기 위해 callee를 생략합니다.
+
+현재 `path`와 `line`은 callee 정의 위치가 아니라 호출 위치를 가리킵니다.
 
 ## 커버리지 매트릭스
 

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -14,7 +14,9 @@ Use `--include-callee` to show callees in plain output:
 noir -b . --include-callee
 ```
 
-Model-based formats such as JSON, JSONL, YAML, TOML, and plain model serialization include the `callees` field through the endpoint model. The `path` and `line` values currently point to the call site, not the callee definition.
+Model-based formats such as JSON, JSONL, YAML, TOML, and plain model serialization include the `callees` field through the endpoint model. OpenAPI 2.0 and 3.0 expose callees as the operation-level `x-noir-callees` extension, SARIF stores them in `result.properties.noir.callees`, and Postman collections add a human-readable list to the item description. Purpose-specific command and filter outputs such as cURL, HTTPie, PowerShell, only-url, and only-param omit callees to keep their primary output stable.
+
+The `path` and `line` values currently point to the call site, not the callee definition.
 
 ## Coverage Matrix
 

--- a/spec/unit_test/output_builder/oas2_spec.cr
+++ b/spec/unit_test/output_builder/oas2_spec.cr
@@ -20,6 +20,8 @@ describe "OutputBuilderOas2" do
     endpoint1 = Endpoint.new("/pets/{petId}", "GET")
     endpoint1.push_param(Param.new("petId", "123", "path"))
     endpoint1.push_param(Param.new("api_key", "key123", "header"))
+    endpoint1.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
+    endpoint1.push_callee(Callee.new("AuditLog.record", line: 13))
 
     endpoint2 = Endpoint.new("/pets", "POST")
     endpoint2.push_param(Param.new("name", "Fluffy", "json"))
@@ -74,6 +76,16 @@ describe "OutputBuilderOas2" do
     header_param = header_param.should_not be_nil
     header_param["name"].as_s.should eq("api_key")
     header_param["type"].as_s.should eq("string")
+
+    # Check Noir callee extension
+    callees = get_op["x-noir-callees"].as_a
+    callees.size.should eq(2)
+    callees[0]["name"].as_s.should eq("PetService.find")
+    callees[0]["path"].as_s.should eq("app/controllers/pets.cr")
+    callees[0]["line"].as_i.should eq(12)
+    callees[1]["name"].as_s.should eq("AuditLog.record")
+    callees[1].as_h.has_key?("path").should be_false
+    callees[1]["line"].as_i.should eq(13)
 
     # Check POST endpoint with JSON body
     post_json_op = paths["/pets"]["post"]

--- a/spec/unit_test/output_builder/oas3_spec.cr
+++ b/spec/unit_test/output_builder/oas3_spec.cr
@@ -21,6 +21,8 @@ describe "OutputBuilderOas3" do
     endpoint1 = Endpoint.new("/pets/{petId}", "GET")
     endpoint1.push_param(Param.new("petId", "123", "path"))
     endpoint1.push_param(Param.new("api_key", "key123", "header"))
+    endpoint1.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
+    endpoint1.push_callee(Callee.new("AuditLog.record", line: 13))
 
     endpoint2 = Endpoint.new("/pets", "POST")
     endpoint2.push_param(Param.new("name", "Fluffy", "json"))
@@ -80,6 +82,16 @@ describe "OutputBuilderOas3" do
     get_response = get_op["responses"]["200"]
     get_response["description"].as_s.should eq("Successful response")
     get_response["content"]["application/json"]["schema"]["type"].as_s.should eq("object")
+
+    # Check Noir callee extension
+    callees = get_op["x-noir-callees"].as_a
+    callees.size.should eq(2)
+    callees[0]["name"].as_s.should eq("PetService.find")
+    callees[0]["path"].as_s.should eq("app/controllers/pets.cr")
+    callees[0]["line"].as_i.should eq(12)
+    callees[1]["name"].as_s.should eq("AuditLog.record")
+    callees[1].as_h.has_key?("path").should be_false
+    callees[1]["line"].as_i.should eq(13)
 
     # Check POST endpoint with JSON body
     post_json_op = paths["/pets"]["post"]

--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -21,6 +21,8 @@ describe "OutputBuilderPostman" do
     endpoint1 = Endpoint.new("/pets/:petId", "GET")
     endpoint1.push_param(Param.new("petId", "123", "path"))
     endpoint1.push_param(Param.new("api_key", "key123", "header"))
+    endpoint1.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
+    endpoint1.push_callee(Callee.new("AuditLog.record", line: 13))
 
     endpoint2 = Endpoint.new("/pets", "POST")
     endpoint2.push_param(Param.new("name", "Fluffy", "json"))
@@ -60,6 +62,9 @@ describe "OutputBuilderPostman" do
     item1["request"]["url"]["variable"][0]["key"].as_s.should eq("petId")
     item1["request"]["header"].as_a.size.should eq(1)
     item1["request"]["header"][0]["key"].as_s.should eq("api_key")
+    item1["description"].as_s.should contain("Noir callees:")
+    item1["description"].as_s.should contain("PetService.find (app/controllers/pets.cr:12)")
+    item1["description"].as_s.should contain("AuditLog.record (line 13)")
 
     # Check second item (POST with JSON body)
     item2 = items[1]

--- a/spec/unit_test/output_builder/sarif_spec.cr
+++ b/spec/unit_test/output_builder/sarif_spec.cr
@@ -19,6 +19,8 @@ describe "OutputBuilderSarif" do
 
     endpoint = Endpoint.new("/test", "GET")
     endpoint.push_param(Param.new("id", "1", "query"))
+    endpoint.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
+    endpoint.push_callee(Callee.new("AuditLog.record", line: 13))
     endpoints = [endpoint]
 
     builder.print(endpoints)
@@ -43,6 +45,14 @@ describe "OutputBuilderSarif" do
     results[0]["message"]["text"].as_s.should contain("GET")
     results[0]["message"]["text"].as_s.should contain("/test")
     results[0]["message"]["text"].as_s.should contain("query: id")
+    callees = results[0]["properties"]["noir"]["callees"].as_a
+    callees.size.should eq(2)
+    callees[0]["name"].as_s.should eq("PetService.find")
+    callees[0]["path"].as_s.should eq("app/controllers/pets.cr")
+    callees[0]["line"].as_i.should eq(12)
+    callees[1]["name"].as_s.should eq("AuditLog.record")
+    callees[1].as_h.has_key?("path").should be_false
+    callees[1]["line"].as_i.should eq(13)
   end
 
   it "print with endpoints and passive results" do

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -1,4 +1,5 @@
 require "./logger"
+require "./endpoint"
 
 class OutputBuilder
   @logger : NoirLogger
@@ -128,6 +129,58 @@ class OutputBuilder
       tags:       final_tags.uniq,
       body_type:  is_json ? "json" : "form",
     }
+  end
+
+  protected def noir_callee_json(callee : Callee) : JSON::Any
+    data = {
+      "name" => JSON::Any.new(callee.name),
+    } of String => JSON::Any
+
+    if path = callee.path
+      data["path"] = JSON::Any.new(path)
+    end
+
+    if line = callee.line
+      data["line"] = JSON::Any.new(line.to_i64)
+    end
+
+    JSON::Any.new(data)
+  end
+
+  protected def noir_callees_json(endpoint : Endpoint) : Array(JSON::Any)
+    endpoint.callees.map { |callee| noir_callee_json(callee) }
+  end
+
+  protected def add_noir_callees_extension(operation : Hash(String, JSON::Any), endpoint : Endpoint)
+    return if endpoint.callees.empty?
+
+    operation["x-noir-callees"] = JSON::Any.new(noir_callees_json(endpoint))
+  end
+
+  protected def noir_callees_description(endpoint : Endpoint) : String?
+    return if endpoint.callees.empty?
+
+    lines = ["Noir callees:"]
+    endpoint.callees.each do |callee|
+      lines << "- #{format_noir_callee(callee)}"
+    end
+    lines.join("\n")
+  end
+
+  private def format_noir_callee(callee : Callee) : String
+    if path = callee.path
+      if line = callee.line
+        return "#{callee.name} (#{path}:#{line})"
+      end
+
+      return "#{callee.name} (#{path})"
+    end
+
+    if line = callee.line
+      return "#{callee.name} (line #{line})"
+    end
+
+    callee.name
   end
 
   macro define_getter_methods(names)

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -98,6 +98,8 @@ class OutputBuilderOas2 < OutputBuilder
         operation["consumes"] = JSON::Any.new(consumes.map { |c| JSON::Any.new(c) })
       end
 
+      add_noir_callees_extension(operation, endpoint)
+
       # Convert path parameters from :param to {param} format for OAS2
       uri = URI.parse(endpoint.url)
       oas_path = uri.path.gsub(/:(\w+)/, "{\\1}")

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -116,6 +116,8 @@ class OutputBuilderOas3 < OutputBuilder
         } of String => JSON::Any)
       end
 
+      add_noir_callees_extension(operation, endpoint)
+
       # Convert path parameters from :param to {param} format for OAS3
       uri = URI.parse(endpoint.url)
       oas_path = uri.path.gsub(/:(\w+)/, "{\\1}")

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -153,6 +153,10 @@ class OutputBuilderPostman < OutputBuilder
         "request" => JSON::Any.new(request),
       } of String => JSON::Any
 
+      if description = noir_callees_description(endpoint)
+        item["description"] = JSON::Any.new(description)
+      end
+
       items << item
     end
 

--- a/src/output_builder/sarif.cr
+++ b/src/output_builder/sarif.cr
@@ -81,7 +81,37 @@ class OutputBuilderSarif < OutputBuilder
       end
     end
 
-    log.to_json
+    attach_noir_callees(log.to_json, endpoints)
+  end
+
+  private def attach_noir_callees(message : String, endpoints : Array(Endpoint)) : String
+    return message unless endpoints.any? { |endpoint| !endpoint.callees.empty? }
+
+    sarif = JSON.parse(message)
+    runs = sarif["runs"].as_a
+    return message if runs.empty?
+
+    results_json = runs[0]["results"]?
+    return message unless results_json
+
+    endpoint_index = 0
+    results_json.as_a.each do |result_json|
+      result = result_json.as_h
+      next unless result["ruleId"]?.try(&.as_s?) == "endpoint-discovery"
+
+      endpoint = endpoints[endpoint_index]?
+      endpoint_index += 1
+      next unless endpoint
+      next if endpoint.callees.empty?
+
+      properties = result["properties"]?.try(&.as_h?) || {} of String => JSON::Any
+      properties["noir"] = JSON::Any.new({
+        "callees" => JSON::Any.new(noir_callees_json(endpoint)),
+      } of String => JSON::Any)
+      result["properties"] = JSON::Any.new(properties)
+    end
+
+    sarif.to_json
   end
 
   private def map_severity_to_sarif_level(severity : String) : Sarif::Level


### PR DESCRIPTION
## Summary
- add shared callee metadata helpers for custom output builders
- expose callees as `x-noir-callees` in OAS2/OAS3 operations
- expose callees in Postman item descriptions and SARIF `result.properties.noir.callees`
- document how non-model serializers surface or intentionally omit callees

Part of #1366.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-serializers crystal spec spec/unit_test/output_builder/oas2_spec.cr spec/unit_test/output_builder/oas3_spec.cr spec/unit_test/output_builder/postman_spec.cr spec/unit_test/output_builder/sarif_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-serializers just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-serializers just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-serializers just check`
- `hwaro build` from `docs/`
- `git diff --check`