### PR TITLE
Resolve FastAPI callees to definitions

### DIFF
--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -16,7 +16,7 @@ noir -b . --include-callee
 
 JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는 엔드포인트 모델을 통해 `callees` 필드를 포함합니다. OpenAPI 2.0/3.0은 operation 레벨의 `x-noir-callees` extension으로, SARIF는 `result.properties.noir.callees`로, Postman collection은 item description의 사람이 읽을 수 있는 목록으로 callee를 제공합니다. cURL, HTTPie, PowerShell, only-url, only-param 같은 명령/필터 목적 출력은 주 출력 형태를 안정적으로 유지하기 위해 callee를 생략합니다.
 
-현재 `path`와 `line`은 callee 정의 위치가 아니라 호출 위치를 가리킵니다.
+`path`와 `line`은 best-effort 위치 정보입니다. 대부분의 analyzer는 호출 위치를 보고하고, definition resolution을 지원하는 analyzer는 도달 가능한 경우 callee 정의 위치를 보고하며 그렇지 않으면 호출 위치를 유지합니다.
 
 ## 커버리지 매트릭스
 
@@ -52,5 +52,6 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 - Callee는 1-hop만 제공합니다. Noir는 transitive call graph를 만들지 않습니다.
 - Dynamic dispatch, middleware chain, decorator, macro expansion, generated code, reflection은 정적 추출에서 누락될 수 있습니다.
 - Named handler 기반 프레임워크는 동적이거나 inline callback이 많은 프레임워크보다 callee 커버리지가 좋은 편입니다.
+- Definition resolution은 점진적으로 적용되며 현재 analyzer별로 지원됩니다.
 - downstream 도구가 쓰기 쉽도록 callee는 엔드포인트별로 dedup되고 개수가 제한됩니다.
 - renderer나 request accessor 같은 프레임워크 helper는 엔드포인트가 입력과 출력을 어떻게 다루는지 보여주므로 의도적으로 유지합니다.

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -16,7 +16,7 @@ noir -b . --include-callee
 
 Model-based formats such as JSON, JSONL, YAML, TOML, and plain model serialization include the `callees` field through the endpoint model. OpenAPI 2.0 and 3.0 expose callees as the operation-level `x-noir-callees` extension, SARIF stores them in `result.properties.noir.callees`, and Postman collections add a human-readable list to the item description. Purpose-specific command and filter outputs such as cURL, HTTPie, PowerShell, only-url, and only-param omit callees to keep their primary output stable.
 
-The `path` and `line` values currently point to the call site, not the callee definition.
+The `path` and `line` values are best-effort locations. Most analyzers report the call site; analyzers with definition resolution report the callee definition when reachable, and keep the call-site location otherwise.
 
 ## Coverage Matrix
 
@@ -52,5 +52,6 @@ This matrix lists frameworks with functional test coverage for callee extraction
 - Callees are 1-hop only. Noir does not build a transitive call graph.
 - Dynamic dispatch, middleware chains, decorators, macro expansion, generated code, and reflection can hide calls from static extraction.
 - Named handler frameworks usually have better callee coverage than heavily dynamic or inline callback-heavy frameworks.
+- Definition resolution is incremental and currently analyzer-specific.
 - Calls are deduplicated and capped per endpoint to keep output compact for downstream tools.
 - Framework helpers such as renderers and request accessors are intentionally kept because they describe how the endpoint handles input and output.

--- a/spec/functional_test/fixtures/python/fastapi_callees/api.py
+++ b/spec/functional_test/fixtures/python/fastapi_callees/api.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter
-from db import fetch_report
+import db
 
 api = APIRouter()
 
 
 @api.get("/reports")
 def list_reports():
-    rows = fetch_report()
+    rows = db.fetch_report()
     return rows

--- a/spec/functional_test/fixtures/python/fastapi_callees/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_callees/main.py
@@ -13,6 +13,10 @@ def rate_limit(_n):
     return deco
 
 
+def build_status():
+    return {"ok": True}
+
+
 app = FastAPI()
 app.include_router(api, prefix="/internal")
 
@@ -26,7 +30,7 @@ def create_user(name: str):
 
 @app.get("/healthz")
 def healthz():
-    return {"ok": True}
+    return build_status()
 
 
 # Stacked decorators between the route declaration and the def — used

--- a/spec/functional_test/func_spec.cr
+++ b/spec/functional_test/func_spec.cr
@@ -137,6 +137,15 @@ class FunctionalTester
                         found.line.should eq expected_line
                       end
                     end
+                    if expected_path = callee.path
+                      it "check '#{callee.name}' path #{expected_path}" do
+                        actual_path = found.path
+                        actual_path.should_not be_nil
+                        if actual_path
+                          File.expand_path(actual_path).should eq File.expand_path(expected_path)
+                        end
+                      end
+                    end
                   end
                 end
               end

--- a/spec/functional_test/testers/python/fastapi_callees_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_callees_spec.cr
@@ -19,27 +19,32 @@ require "../../func_spec.cr"
 #                              a separate file; locks in that the
 #                              include_router emit branch also pushes
 #                              callees.
+db_path = "./spec/functional_test/fixtures/python/fastapi_callees/db.py"
+main_path = "./spec/functional_test/fixtures/python/fastapi_callees/main.py"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST", [
     Param.new("name", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("save_user", line: 22))
-    ep.push_callee(Callee.new("audit_log", line: 23))
+    ep.push_callee(Callee.new("save_user", db_path, 1))
+    ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 
-  Endpoint.new("/healthz", "GET"),
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("build_status", main_path, 16))
+  end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("save_user", line: 39))
-    ep.push_callee(Callee.new("audit_log", line: 40))
+    ep.push_callee(Callee.new("save_user", db_path, 1))
+    ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 
   Endpoint.new("/orders/{order_id}", "DELETE").tap do |ep|
-    ep.push_callee(Callee.new("audit_log", line: 49))
+    ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 
   Endpoint.new("/reports", "GET").tap do |ep|
-    ep.push_callee(Callee.new("fetch_report", line: 9))
+    ep.push_callee(Callee.new("db.fetch_report", db_path, 9))
   end,
 ]
 

--- a/spec/unit_test/analyzer/python_engine_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_spec.cr
@@ -1,0 +1,43 @@
+require "../../spec_helper"
+require "../../../src/analyzer/engines/python_engine"
+
+class PythonEngineSpecHarness < Analyzer::Python::PythonEngine
+  def callees_from(body : String,
+                   body_start_line : Int32,
+                   path : String,
+                   definition_base_path : String,
+                   source : String) : Array(Callee)
+    build_callees_from(
+      body,
+      body_start_line,
+      path,
+      definition_base_path: definition_base_path,
+      source: source
+    )
+  end
+end
+
+describe Analyzer::Python::PythonEngine do
+  it "keeps call-site coordinates when a Python callee definition is unreachable" do
+    harness = PythonEngineSpecHarness.new(create_test_options)
+    source = <<-PY
+      def handler():
+          unknown_call()
+      PY
+    body = source
+    caller_path = "/tmp/noir-python-engine-spec/app.py"
+
+    callees = harness.callees_from(
+      body,
+      0,
+      caller_path,
+      "/tmp/noir-python-engine-spec",
+      source
+    )
+
+    callees.size.should eq(1)
+    callees[0].name.should eq("unknown_call")
+    callees[0].path.should eq(caller_path)
+    callees[0].line.should eq(2)
+  end
+end

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -64,6 +64,7 @@ module Analyzer::Python
 
         include_router_map.each do |path, router_map|
           source = File.read(path, encoding: "utf-8", invalid: :skip)
+          definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @fastapi_base_path
           import_modules = find_imported_modules(@fastapi_base_path, path, source)
           codelines = source.split("\n")
           router_map.each do |instance_name, router_class|
@@ -172,7 +173,14 @@ module Analyzer::Python
                   # `parse_code_block(codelines[def_line..])` keeps the
                   # def line, so body row 0 lives at file line `def_line`.
                   if handler_codeblock = parse_code_block(codelines[def_line..])
-                    push_callees_from(endpoint, handler_codeblock, def_line, path)
+                    push_callees_from(
+                      endpoint,
+                      handler_codeblock,
+                      def_line,
+                      path,
+                      definition_base_path: definition_base_path,
+                      source: source
+                    )
                   end
 
                   result << endpoint

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -288,19 +288,145 @@ module Analyzer::Python
     # pass `def_idx` because that helper keeps the def line. Callers
     # using `extract_function_body(lines, def_idx)` should pass
     # `def_idx + 1` because that helper skips the def line.
-    def build_callees_from(body : ::String, body_start_line : Int32, path : ::String) : Array(Callee)
+    # When `definition_base_path` is provided, callees with reachable
+    # same-file or imported Python definitions are rewritten to that
+    # definition location; unresolved callees keep their call-site
+    # `path`/`line`.
+    def build_callees_from(body : ::String,
+                           body_start_line : Int32,
+                           path : ::String,
+                           *,
+                           definition_base_path : ::String? = nil,
+                           source : ::String? = nil) : Array(Callee)
       return [] of Callee if body.empty?
-      Noir::PythonCalleeExtractor.calls_in(body).map do |entry|
+      callees = Noir::PythonCalleeExtractor.calls_in(body).map do |entry|
         name, row = entry
         Callee.new(name, path: path, line: body_start_line + row + 1)
       end
+
+      return callees unless base_path = definition_base_path
+
+      resolve_python_callee_definitions(callees, base_path, path, source)
     end
 
     # Convenience wrapper around `build_callees_from`: parse + push in
     # one call when one body maps to exactly one endpoint.
     # `Endpoint#push_callee` enforces dedup and the per-endpoint cap.
-    def push_callees_from(endpoint : Endpoint, body : ::String, body_start_line : Int32, path : ::String) : Nil
-      build_callees_from(body, body_start_line, path).each { |c| endpoint.push_callee(c) }
+    def push_callees_from(endpoint : Endpoint,
+                          body : ::String,
+                          body_start_line : Int32,
+                          path : ::String,
+                          *,
+                          definition_base_path : ::String? = nil,
+                          source : ::String? = nil) : Nil
+      build_callees_from(
+        body,
+        body_start_line,
+        path,
+        definition_base_path: definition_base_path,
+        source: source
+      ).each { |c| endpoint.push_callee(c) }
+    end
+
+    private def resolve_python_callee_definitions(callees : Array(Callee),
+                                                  app_base_path : ::String,
+                                                  caller_path : ::String,
+                                                  caller_source : ::String?) : Array(Callee)
+      source_cache = Hash(::String, ::String).new
+      source_cache[caller_path] = caller_source || File.read(caller_path, encoding: "utf-8", invalid: :skip)
+      import_map = find_imported_modules(app_base_path, caller_path, source_cache[caller_path])
+
+      callees.map do |callee|
+        if definition = resolve_python_callee_definition(callee.name, caller_path, source_cache, import_map)
+          definition_path, definition_line = definition
+          Callee.new(callee.name, path: definition_path, line: definition_line)
+        else
+          callee
+        end
+      end
+    rescue
+      callees
+    end
+
+    private def resolve_python_callee_definition(name : ::String,
+                                                 caller_path : ::String,
+                                                 source_cache : Hash(::String, ::String),
+                                                 import_map : Hash(::String, Tuple(::String, Int32))) : Tuple(::String, Int32)?
+      parts = name.split(".")
+      return if parts.empty?
+
+      caller_source = source_cache[caller_path]
+      if definition = find_python_definition(caller_path, caller_source, parts)
+        return definition
+      end
+
+      first_part = parts[0]
+      return unless imported = import_map[first_part]?
+
+      imported_path = imported.first
+      return if imported_path.empty? || !File.exists?(imported_path)
+
+      imported_source = source_cache[imported_path] ||= File.read(imported_path, encoding: "utf-8", invalid: :skip)
+      imported_parts = parts.size == 1 ? parts : parts[1..]
+      find_python_definition(imported_path, imported_source, imported_parts) ||
+        find_python_definition(imported_path, imported_source, parts)
+    end
+
+    private def find_python_definition(path : ::String, source : ::String, parts : Array(::String)) : Tuple(::String, Int32)?
+      return if parts.empty?
+
+      if parts.size == 1
+        line = find_python_function_or_class_line(source, parts[0])
+        return {path, line} if line
+        return
+      end
+
+      if line = find_python_class_method_line(source, parts[0], parts[1])
+        return {path, line}
+      end
+    end
+
+    private def find_python_function_or_class_line(source : ::String, name : ::String) : Int32?
+      source.lines.each_with_index do |line, index|
+        stripped = line.lstrip
+        next if stripped.starts_with?("#")
+        if python_def_matches?(stripped, name) || python_class_matches?(stripped, name)
+          return index + 1
+        end
+      end
+    end
+
+    private def find_python_class_method_line(source : ::String, class_name : ::String, method_name : ::String) : Int32?
+      lines = source.lines
+      class_indent : Int32? = nil
+
+      lines.each_with_index do |line, index|
+        stripped = line.lstrip
+        next if stripped.starts_with?("#")
+
+        if class_indent.nil?
+          next unless python_class_matches?(stripped, class_name)
+
+          class_indent = line.size - stripped.size
+          next
+        end
+
+        indent = line.size - stripped.size
+        next if stripped.empty? || stripped.starts_with?("@") || stripped.starts_with?("#")
+        if current_class_indent = class_indent
+          return if indent <= current_class_indent
+        end
+
+        return index + 1 if python_def_matches?(stripped, method_name)
+      end
+    end
+
+    private def python_def_matches?(stripped : ::String, name : ::String) : Bool
+      stripped.starts_with?("def #{name}(") || stripped.starts_with?("async def #{name}(")
+    end
+
+    private def python_class_matches?(stripped : ::String, name : ::String) : Bool
+      stripped.starts_with?("class #{name}:") || stripped.starts_with?("class #{name}(")
     end
 
     class FunctionParameter

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -181,9 +181,9 @@ end
 
 # A function/method invoked directly from an endpoint's handler body
 # (1-hop only). `name` is the textual callee as it appears in source
-# (e.g. `User.create`, `raw_sql_query`). `path` and `line` point at the
-# call site — i.e. where the call appears in the handler — not at the
-# callee's definition; resolving to the definition is future work.
+# (e.g. `User.create`, `raw_sql_query`). `path` and `line` are
+# best-effort location metadata: analyzers with definition resolution use
+# the callee's definition when reachable; the rest keep the call site.
 #
 # The list is intentionally incomplete: dynamic dispatch (Rails
 # `before_action`, JS middleware, Python decorators) bypasses the body


### PR DESCRIPTION
## Summary
- add optional Python callee definition resolution while preserving call-site fallback for unresolved calls
- enable definition locations for FastAPI callees
- extend FastAPI callee fixtures to cover same-file helpers, `from ... import ...`, and dotted module calls
- update callee docs/model wording from call-site-only to best-effort locations

Part of #1366.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-defs crystal spec spec/unit_test/analyzer/python_engine_spec.cr spec/unit_test/miniparser/import_graph_spec.cr spec/functional_test/testers/python/fastapi_callees_spec.cr`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-defs crystal spec spec/functional_test/testers/python`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-defs just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-defs just test`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-defs just check`
- `hwaro build` from `docs/`
- `git diff --check`