### PR TITLE
Resolve Django callee locations to definitions

### DIFF
--- a/spec/functional_test/testers/python/django_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_callees_spec.cr
@@ -19,6 +19,8 @@ require "../../func_spec.cr"
 #
 # Line assertions verify that body_start_line conversion (char-offset
 # → 0-based line) lands correctly for both paths.
+helpers_path = "./spec/functional_test/fixtures/python/django_callees/helpers.py"
+
 expected_endpoints = [
   # Django's `request.POST.get(...)` registers as a form param, and
   # `form` type accepts GET as well (existing REQUEST_PARAM_TYPE_MAP
@@ -27,8 +29,8 @@ expected_endpoints = [
     Param.new("name", "", "form"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("request.POST.get", line: 8))
-    ep.push_callee(Callee.new("save_user", line: 9))
-    ep.push_callee(Callee.new("audit_log", line: 10))
+    ep.push_callee(Callee.new("save_user", helpers_path, 1))
+    ep.push_callee(Callee.new("audit_log", helpers_path, 5))
     ep.push_callee(Callee.new("JsonResponse", line: 11))
   end,
 
@@ -36,20 +38,20 @@ expected_endpoints = [
     Param.new("name", "", "form"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("request.POST.get", line: 8))
-    ep.push_callee(Callee.new("save_user", line: 9))
-    ep.push_callee(Callee.new("audit_log", line: 10))
+    ep.push_callee(Callee.new("save_user", helpers_path, 1))
+    ep.push_callee(Callee.new("audit_log", helpers_path, 5))
     ep.push_callee(Callee.new("JsonResponse", line: 11))
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("build_profile", line: 16))
-    ep.push_callee(Callee.new("audit_log", line: 17))
+    ep.push_callee(Callee.new("build_profile", helpers_path, 9))
+    ep.push_callee(Callee.new("audit_log", helpers_path, 5))
     ep.push_callee(Callee.new("JsonResponse", line: 18))
   end,
 
   Endpoint.new("/profile", "POST").tap do |ep|
-    ep.push_callee(Callee.new("save_user", line: 21))
-    ep.push_callee(Callee.new("audit_log", line: 22))
+    ep.push_callee(Callee.new("save_user", helpers_path, 1))
+    ep.push_callee(Callee.new("audit_log", helpers_path, 5))
     ep.push_callee(Callee.new("JsonResponse", line: 23))
   end,
 ]

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -242,7 +242,13 @@ module Analyzer::Python
           # codeblock starts at the `def` line, so `body_start_line` is
           # that line's 0-based index — derived from the char offset.
           body_start_line = content[0, function_start_index].count('\n')
-          handler_callees = build_callees_from(function_codeblock, body_start_line, filepath)
+          handler_callees = build_callees_from(
+            function_codeblock,
+            body_start_line,
+            filepath,
+            definition_base_path: @django_base_path,
+            source: content
+          )
 
           suspicious_http_methods.uniq.each do |http_method_name|
             endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params))
@@ -288,7 +294,13 @@ module Analyzer::Python
               suspicious_http_methods << method_name
 
               if codeblock = parse_code_block(lines[offset..])
-                method_callees[method_name] = build_callees_from(codeblock, body_start_line + offset + 1, filepath)
+                method_callees[method_name] = build_callees_from(
+                  codeblock,
+                  body_start_line + offset + 1,
+                  filepath,
+                  definition_base_path: @django_base_path,
+                  source: content
+                )
               end
             end
 


### PR DESCRIPTION
## Summary
- enable Python definition resolution for Django function-based views and class-based view methods
- resolve imported helper callees to their definition path/line when reachable
- keep unresolved framework calls such as JsonResponse/request.POST.get at their call-site locations

Refs #1366

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-defs crystal spec spec/functional_test/testers/python/django_callees_spec.cr --error-trace
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-defs crystal spec spec/functional_test/testers/python
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-defs just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-defs just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-django-defs just check
- git diff --check