### PR TITLE
Resolve Bottle callee locations to definitions

### DIFF
--- a/spec/functional_test/testers/python/bottle_callees_spec.cr
+++ b/spec/functional_test/testers/python/bottle_callees_spec.cr
@@ -5,12 +5,15 @@ require "../../func_spec.cr"
 # helper call (build_report), and verifies that an attribute *assignment*
 # (response.content_type = "...") does NOT show up as a callee. /ping
 # has zero calls in the body, locking in that empty callees stay empty.
+app_path = "./spec/functional_test/fixtures/python/bottle_callees/app.py"
+helpers_path = "./spec/functional_test/fixtures/python/bottle_callees/helpers.py"
+
 expected_endpoints = [
   Endpoint.new("/report", "GET", [
     Param.new("user_id", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.query.get"))
-    ep.push_callee(Callee.new("build_report"))
+    ep.push_callee(Callee.new("request.query.get", app_path, 7))
+    ep.push_callee(Callee.new("build_report", helpers_path, 1))
   end,
 
   Endpoint.new("/ping", "GET"),

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -49,7 +49,15 @@ module Analyzer::Python
             Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
               methods_literal = deco.methods.map { |m| "'#{m}'" }.join(",")
               extra_params = "methods=[#{methods_literal}]"
-              process_route(path, lines, deco.decorator_line, deco.path, extra_params)
+              process_route(
+                path,
+                lines,
+                line_index: deco.decorator_line,
+                route_path: deco.path,
+                extra_params: extra_params,
+                definition_base_path: current_base_path,
+                source: file_content
+              )
             end
 
             # Form 2 still needs per-line regex — bare `@route("/path")` has
@@ -66,7 +74,15 @@ module Analyzer::Python
                     path_value = orig_match[1]
                   end
                   extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
-                  process_route(path, lines, line_index, path_value, extra)
+                  process_route(
+                    path,
+                    lines,
+                    line_index,
+                    path_value,
+                    extra,
+                    definition_base_path: current_base_path,
+                    source: file_content
+                  )
                 end
               end
             end
@@ -101,7 +117,14 @@ module Analyzer::Python
       methods.uniq
     end
 
-    private def process_route(path : String, lines : Array(String), line_index : Int32, route_path : String, extra_params : String)
+    private def process_route(path : String,
+                              lines : Array(String),
+                              line_index : Int32,
+                              route_path : String,
+                              extra_params : String,
+                              *,
+                              definition_base_path : String,
+                              source : String)
       methods = extract_methods(extra_params)
       methods = ["GET"] if methods.empty?
 
@@ -120,7 +143,13 @@ module Analyzer::Python
 
       # extract_function_body skips the def line, so body row 0 lives
       # at def_index + 1.
-      handler_callees = build_callees_from(function_body, def_index + 1, path)
+      handler_callees = build_callees_from(
+        function_body,
+        def_index + 1,
+        path,
+        definition_base_path: definition_base_path,
+        source: source
+      )
 
       details = Details.new(PathInfo.new(path, line_index + 1))
       methods.each do |method|


### PR DESCRIPTION
## Summary
- pass Bottle handler source/base path into Python callee definition resolution
- resolve imported helper callees to their definition path/line when reachable
- keep unresolved framework calls at call-site locations

Refs #1366

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-bottle-defs crystal spec spec/functional_test/testers/python/bottle_callees_spec.cr --error-trace
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-bottle-defs crystal spec spec/functional_test/testers/python
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-bottle-defs just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-bottle-defs just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-bottle-defs just check
- git diff --check