### PR TITLE
Resolve Litestar callee locations to definitions

### DIFF
--- a/spec/functional_test/testers/python/litestar_callees_spec.cr
+++ b/spec/functional_test/testers/python/litestar_callees_spec.cr
@@ -6,12 +6,14 @@ require "../../func_spec.cr"
 # stops at the decorator. Verifies bare-identifier calls surface with
 # correct line numbers and the per-handler `build_callees_from` hoist
 # stays scoped to each emitted endpoint.
+db_path = "./spec/functional_test/fixtures/python/litestar_callees/db.py"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST", [
     Param.new("name", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("save_user", line: 7))
-    ep.push_callee(Callee.new("audit_log", line: 8))
+    ep.push_callee(Callee.new("save_user", db_path, 1))
+    ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 
   Endpoint.new("/healthz", "GET"),

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -30,7 +30,7 @@ module Analyzer::Python
           source = read_file_content(path)
           next unless source.includes?("litestar")
 
-          analyze_file(path, source)
+          analyze_file(path, source, current_base_path)
         end
       end
 
@@ -38,7 +38,7 @@ module Analyzer::Python
       result
     end
 
-    private def analyze_file(path : ::String, source : ::String)
+    private def analyze_file(path : ::String, source : ::String, definition_base_path : ::String)
       lines = source.split("\n")
       router_prefixes = collect_router_prefixes(source)
       handler_routers = collect_handler_to_router(source, router_prefixes)
@@ -89,7 +89,13 @@ module Analyzer::Python
           # Build once per handler — a decorator can emit multiple
           # endpoints when @route(http_method=[...]) lists several verbs.
           handler_callees = if handler_body && (hl = handler_line)
-                              build_callees_from(handler_body, hl, path)
+                              build_callees_from(
+                                handler_body,
+                                hl,
+                                path,
+                                definition_base_path: definition_base_path,
+                                source: source
+                              )
                             else
                               [] of Callee
                             end


### PR DESCRIPTION
## Summary
- pass Litestar handler source/base path into Python callee definition resolution
- resolve imported helper callees to their definition path/line when reachable
- keep unresolved calls on existing call-site fallback behavior

Refs #1366

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-litestar-defs crystal spec spec/functional_test/testers/python/litestar_callees_spec.cr --error-trace
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-litestar-defs crystal spec spec/functional_test/testers/python
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-litestar-defs just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-litestar-defs just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-litestar-defs just check
- git diff --check