### PR TITLE
Resolve Aiohttp callee locations to definitions

### DIFF
--- a/spec/functional_test/testers/python/aiohttp_callees_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_callees_spec.cr
@@ -5,15 +5,18 @@ require "../../func_spec.cr"
 # body in hand at emit time, so wiring is a one-liner — this spec
 # locks the per-endpoint scope (web.json_response shows up on both
 # routes, save_order only on /orders).
+app_path = "./spec/functional_test/fixtures/python/aiohttp_callees/app.py"
+db_path = "./spec/functional_test/fixtures/python/aiohttp_callees/db.py"
+
 expected_endpoints = [
   Endpoint.new("/orders", "POST").tap do |ep|
-    ep.push_callee(Callee.new("request.json"))
-    ep.push_callee(Callee.new("save_order"))
-    ep.push_callee(Callee.new("web.json_response"))
+    ep.push_callee(Callee.new("request.json", app_path, 9))
+    ep.push_callee(Callee.new("save_order", db_path, 1))
+    ep.push_callee(Callee.new("web.json_response", app_path, 11))
   end,
 
   Endpoint.new("/healthz", "GET").tap do |ep|
-    ep.push_callee(Callee.new("web.json_response"))
+    ep.push_callee(Callee.new("web.json_response", app_path, 16))
   end,
 ]
 

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -58,7 +58,16 @@ module Analyzer::Python
               deco.methods.uniq.each do |deco_method|
                 def_line = deco.def_line >= 0 ? deco.def_line : deco.decorator_line
                 next if def_line == deco.decorator_line
-                emit_endpoint(path, lines, def_line, deco.path, deco_method, deco.decorator_line)
+                emit_endpoint(
+                  path,
+                  lines,
+                  def_line,
+                  deco.path,
+                  deco_method,
+                  deco.decorator_line,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
               end
             end
 
@@ -75,7 +84,15 @@ module Analyzer::Python
                 if orig_match = line.match(/@#{aiohttp_route_deco[1]}\s*\.\s*route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
                   route_path = orig_match[1]
                 end
-                process_decorator_route(path, lines, line_index, route_path, method)
+                process_decorator_route(
+                  path,
+                  lines,
+                  line_index,
+                  route_path,
+                  method,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
               end
 
               # Style A: app.router.add_<method>("/path", handler)
@@ -107,7 +124,16 @@ module Analyzer::Python
             handler_routes[path].each do |route_path, method, line_index, handler_name|
               def_index = find_handler_def(lines, handler_name)
               next if def_index.nil?
-              emit_endpoint(path, lines, def_index, route_path, method, line_index)
+              emit_endpoint(
+                path,
+                lines,
+                def_index,
+                route_path,
+                method,
+                line_index,
+                definition_base_path: current_base_path,
+                source: file_content
+              )
             end
           end
         end
@@ -116,13 +142,37 @@ module Analyzer::Python
       result
     end
 
-    private def process_decorator_route(path : ::String, lines : Array(::String), line_index : Int32, route_path : ::String, method : ::String)
+    private def process_decorator_route(path : ::String,
+                                        lines : Array(::String),
+                                        line_index : Int32,
+                                        route_path : ::String,
+                                        method : ::String,
+                                        *,
+                                        definition_base_path : ::String,
+                                        source : ::String)
       def_index = Noir::PythonRouteExtractor.find_def_line(lines, line_index)
       return if def_index == line_index
-      emit_endpoint(path, lines, def_index, route_path, method, line_index)
+      emit_endpoint(
+        path,
+        lines,
+        def_index,
+        route_path,
+        method,
+        line_index,
+        definition_base_path: definition_base_path,
+        source: source
+      )
     end
 
-    private def emit_endpoint(path : ::String, lines : Array(::String), def_index : Int32, route_path : ::String, method : ::String, report_line : Int32)
+    private def emit_endpoint(path : ::String,
+                              lines : Array(::String),
+                              def_index : Int32,
+                              route_path : ::String,
+                              method : ::String,
+                              report_line : Int32,
+                              *,
+                              definition_base_path : ::String,
+                              source : ::String)
       function_body = extract_function_body(lines, def_index)
       request_params = extract_request_params(function_body, method)
 
@@ -151,7 +201,14 @@ module Analyzer::Python
 
       # extract_function_body skips the def line, so body row 0 lives
       # at def_index + 1.
-      push_callees_from(endpoint, function_body, def_index + 1, path)
+      push_callees_from(
+        endpoint,
+        function_body,
+        def_index + 1,
+        path,
+        definition_base_path: definition_base_path,
+        source: source
+      )
 
       result << endpoint
     end


### PR DESCRIPTION
## Summary
- pass Aiohttp handler source/base path through decorator and imperative route emit paths
- resolve imported helper callees to their definition path/line when reachable
- assert framework/unresolved calls keep call-site path/line fallback

Refs #1366

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-aiohttp-defs crystal spec spec/functional_test/testers/python/aiohttp_callees_spec.cr --error-trace
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-aiohttp-defs crystal spec spec/functional_test/testers/python
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-aiohttp-defs just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-aiohttp-defs just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-aiohttp-defs just check
- git diff --check