### PR TITLE
Resolve Sanic callee locations to definitions

### DIFF
--- a/spec/functional_test/testers/python/sanic_callees_spec.cr
+++ b/spec/functional_test/testers/python/sanic_callees_spec.cr
@@ -4,18 +4,21 @@ require "../../func_spec.cr"
 # async handlers populate Endpoint.callees with both bare identifiers
 # (save_user, audit_log, json) and dotted-attribute calls
 # (request.form.get) — same shape as the Flask coverage.
+app_path = "./spec/functional_test/fixtures/python/sanic_callees/app.py"
+db_path = "./spec/functional_test/fixtures/python/sanic_callees/db.py"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST", [
     Param.new("name", "", "form"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.form.get"))
-    ep.push_callee(Callee.new("save_user"))
-    ep.push_callee(Callee.new("audit_log"))
-    ep.push_callee(Callee.new("json"))
+    ep.push_callee(Callee.new("request.form.get", app_path, 10))
+    ep.push_callee(Callee.new("save_user", db_path, 1))
+    ep.push_callee(Callee.new("audit_log", db_path, 5))
+    ep.push_callee(Callee.new("json", app_path, 13))
   end,
 
   Endpoint.new("/healthz", "GET").tap do |ep|
-    ep.push_callee(Callee.new("json"))
+    ep.push_callee(Callee.new("json", app_path, 18))
   end,
 ]
 

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -86,7 +86,9 @@ module Analyzer::Python
       @routes.each do |router_name, router_info_list|
         router_info_list.each do |router_info|
           line_index, path, route_path, extra_params = router_info
-          lines = fetch_file_content(path).lines
+          source = fetch_file_content(path)
+          lines = source.lines
+          definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @base_path
           expect_params, class_def_index = extract_params_from_decorator(path, lines, line_index)
           api_instances = path_api_instances[path]
           if api_instances.has_key?(router_name)
@@ -146,7 +148,13 @@ module Analyzer::Python
             # Hoisted out of the per-endpoint loop: one route declaration
             # can emit multiple endpoints (e.g. `methods=["POST","PUT"]`),
             # and they all share the same handler body, so parse once.
-            handler_callees = build_callees_from(codeblock, _class_def_index, path)
+            handler_callees = build_callees_from(
+              codeblock,
+              _class_def_index,
+              path,
+              definition_base_path: definition_base_path,
+              source: source
+            )
 
             # Get the HTTP method from the function name when it is not specified in the route decorator
             method = HTTP_METHODS.find { |http_method| _function_name.downcase == http_method.downcase } || "GET"


### PR DESCRIPTION
## Summary
- pass Sanic handler source/base path into Python callee definition resolution during route emit
- resolve imported helper callees to their definition path/line when reachable
- assert framework/unresolved calls keep call-site path/line fallback

Refs #1366

## Tests
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sanic-defs crystal spec spec/functional_test/testers/python/sanic_callees_spec.cr --error-trace
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sanic-defs crystal spec spec/functional_test/testers/python
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sanic-defs just build
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sanic-defs just test
- CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-sanic-defs just check
- git diff --check