### PR TITLE
Use String#matches? for boolean regex checks

### DIFF
--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -171,11 +171,11 @@ module Analyzer::Groovy
     end
 
     private def extends_restful_controller?(clause : String) : Bool
-      !!clause.match(/extends\s+RestfulController\b/)
+      clause.matches?(/extends\s+RestfulController\b/)
     end
 
     private def has_scaffold?(body : String) : Bool
-      !!body.match(/static\s+scaffold\s*=/)
+      body.matches?(/static\s+scaffold\s*=/)
     end
 
     private def emit_inherited_action(path : String, content : String,

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -155,7 +155,7 @@ module Analyzer::Javascript
     end
 
     private def has_default_export?(content : String) : Bool
-      !!content.match(/export\s+default\b/)
+      content.matches?(/export\s+default\b/)
     end
 
     # Carve the `{...}` object literal out of `export const handler =
@@ -173,8 +173,8 @@ module Analyzer::Javascript
     end
 
     private def handler_function?(content : String) : Bool
-      !!(content.match(/export\s+(?:async\s+)?function\s+handler\b/) ||
-        content.match(/export\s+(?:const|let|var)\s+handler\b\s*(?::[^=]+)?=\s*(?:async\s*)?(?:function\b|\()/))
+      content.matches?(/export\s+(?:async\s+)?function\s+handler\b/) ||
+        content.matches?(/export\s+(?:const|let|var)\s+handler\b\s*(?::[^=]+)?=\s*(?:async\s*)?(?:function\b|\()/)
     end
 
     # Extract the verb names appearing as object keys inside the

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -166,9 +166,9 @@ module Analyzer::Javascript
     end
 
     private def export_named?(content : String, name : String) : Bool
-      !!(content.match(/export\s+(?:async\s+)?function\s+#{name}\b/) ||
-        content.match(/export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/) ||
-        content.match(/export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/))
+      content.matches?(/export\s+(?:async\s+)?function\s+#{name}\b/) ||
+        content.matches?(/export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/) ||
+        content.matches?(/export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/)
     end
   end
 end

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -248,16 +248,16 @@ module Analyzer::Python
 
     # Infers the type of the parameter based on its default value or type annotation
     def infer_parameter_type(data : ::String, is_param_type = false) : ::String?
-      if data.match(/(\b)*Cookie(\b)*/)
+      if data.matches?(/Cookie/)
         "cookie"
-      elsif data.match(/(\b)*Header(\b)*/)
+      elsif data.matches?(/Header/)
         "header"
-      elsif data.match(/(\b)*Body(\b)*/) || data.match(/(\b)*Form(\b)*/) ||
-            data.match(/(\b)*File(\b)*/) || data.match(/(\b)*UploadFile(\b)*/)
+      elsif data.matches?(/Body/) || data.matches?(/Form/) ||
+            data.matches?(/File/) || data.matches?(/UploadFile/)
         "form"
-      elsif data.match(/(\b)*Query(\b)*/)
+      elsif data.matches?(/Query/)
         "query"
-      elsif data.match(/(\b)*WebSocket(\b)*/)
+      elsif data.matches?(/WebSocket/)
         "websocket"
       elsif is_param_type
         # default variable type


### PR DESCRIPTION
## Summary
- Follow up on the Gemini review feedback on #1419 — convert `!!str.match(regex)` to `str.matches?(regex)` in Grails, Fresh, Remix, and FastAPI analyzers so the boolean checks no longer allocate `MatchData`.
- Simplify FastAPI `infer_parameter_type` regexes: `/(\b)*Name(\b)*/` is equivalent to `/Name/` (the `(\b)*` group is zero-width and matches everywhere), so drop the redundant groups.

## Testing
- `crystal tool format --check src/analyzer/analyzers/groovy/grails.cr src/analyzer/analyzers/javascript/fresh.cr src/analyzer/analyzers/javascript/remix.cr src/analyzer/analyzers/python/fastapi.cr`
- `crystal build src/analyzer/analyzers/groovy/grails.cr --no-codegen`
- `crystal build src/analyzer/analyzers/javascript/fresh.cr --no-codegen`
- `crystal build src/analyzer/analyzers/javascript/remix.cr --no-codegen`
- `crystal build src/analyzer/analyzers/python/fastapi.cr --no-codegen`
- `crystal spec spec/functional_test/testers/python/fastapi_spec.cr spec/functional_test/testers/groovy/grails_spec.cr spec/functional_test/testers/javascript/fresh_spec.cr spec/functional_test/testers/javascript/remix_spec.cr` → 190 examples, 0 failures