### PR TITLE
Resolve Pyramid callees to definitions

### DIFF
--- a/spec/functional_test/testers/python/pyramid_callees_spec.cr
+++ b/spec/functional_test/testers/python/pyramid_callees_spec.cr
@@ -1,17 +1,14 @@
 require "../../func_spec.cr"
 
 # Regression test for --include-callee on Pyramid. The fixture exercises
-# the @view_config + config.add_route pattern; the spec confirms the
-# handler def line is threaded through emit_endpoints, so callee line
-# numbers point at the call site inside the view body (not the route
-# declaration line).
+# the @view_config + config.add_route pattern; the spec confirms that
+# callees with reachable same-file or imported Python definitions resolve
+# to the definition location instead of the call site inside the view.
+db_path = "./spec/functional_test/fixtures/python/pyramid_callees/db.py"
+
 expected_endpoints = [
   Endpoint.new("/users/{uid}", "GET").tap do |ep|
-    # `fetch_user(uid)` lives on line 9 of fixtures/python/pyramid_callees/app.py.
-    # Line assertion locks the def-line-threading change that emit_endpoints
-    # picked up — without it, callee.line would point at the route
-    # declaration in `main()` instead of the view body.
-    ep.push_callee(Callee.new("fetch_user", line: 9))
+    ep.push_callee(Callee.new("fetch_user", db_path, 1))
   end,
 ]
 

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -79,7 +79,8 @@ module Analyzer::Python
               next if def_index.nil?
 
               body = extract_function_body(lines, def_index)
-              emit_endpoints(path, line_index, route_path, methods, body, def_index)
+              emit_endpoints(path, line_index, route_path, methods, body, def_index,
+                definition_base_path: current_base_path, source: content)
             end
 
             # config.add_view(view_func, route_name="name", request_method="POST")
@@ -102,7 +103,8 @@ module Analyzer::Python
                 body = extract_function_body(lines, view_def_index) unless view_def_index.nil?
               end
 
-              emit_endpoints(path, line_index, route_path, methods, body, view_def_index)
+              emit_endpoints(path, line_index, route_path, methods, body, view_def_index,
+                definition_base_path: current_base_path, source: content)
             end
           end
         end
@@ -228,13 +230,22 @@ module Analyzer::Python
     # 0-based line of the handler `def` (when known), used to translate
     # tree-sitter rows into absolute callee call-site lines.
     private def emit_endpoints(path : String, line_index : Int32, route_path : String,
-                               methods : Array(String), body : String, def_index : Int32?)
+                               methods : Array(String), body : String, def_index : Int32?,
+                               *,
+                               definition_base_path : String,
+                               source : String)
       path_params = extract_path_params(route_path)
       request_params = extract_request_params(body)
 
       # extract_function_body skips the def line, so body row 0 lives
       # at def_index + 1.
-      handler_callees = def_index ? build_callees_from(body, def_index + 1, path) : [] of Callee
+      handler_callees = def_index ? build_callees_from(
+        body,
+        def_index + 1,
+        path,
+        definition_base_path: definition_base_path,
+        source: source
+      ) : [] of Callee
 
       details = Details.new(PathInfo.new(path, line_index + 1))
       methods.each do |method|


### PR DESCRIPTION
## Summary
- Thread `definition_base_path` and `source` through `emit_endpoints` in the Pyramid analyzer so `build_callees_from` can rewrite imported callees to their definition locations, matching the rollout already done for FastAPI/Django/Bottle/Litestar/Aiohttp/Sanic/Falcon.
- Same-file and unresolved calls continue to fall back to the call-site location.
- Update `pyramid_callees` fixture spec to assert the resolved location in `db.py`.

Part of #1461.

## Test plan
- [x] `crystal spec spec/functional_test/testers/python/pyramid_callees_spec.cr`
- [x] `crystal spec spec/functional_test/testers/python/pyramid_spec.cr`
- [x] `crystal spec spec/functional_test/testers/python/` (931 examples, 0 failures)
- [x] Manual run: `noir -b fixtures/python/pyramid_callees --include-callee -f json` resolves `fetch_user` to `db.py:1`.