### PR TITLE
Resolve Pyramid callees to imported helper definitions

### DIFF
--- a/spec/functional_test/testers/python/pyramid_callees_spec.cr
+++ b/spec/functional_test/testers/python/pyramid_callees_spec.cr
@@ -2,16 +2,17 @@ require "../../func_spec.cr"
 
 # Regression test for --include-callee on Pyramid. The fixture exercises
 # the @view_config + config.add_route pattern; the spec confirms the
-# handler def line is threaded through emit_endpoints, so callee line
-# numbers point at the call site inside the view body (not the route
-# declaration line).
+# handler def line is threaded through emit_endpoints AND that imported
+# helpers are resolved to their definition location (db.py) rather than
+# left at the view call site.
+db_path = "./spec/functional_test/fixtures/python/pyramid_callees/db.py"
+
 expected_endpoints = [
   Endpoint.new("/users/{uid}", "GET").tap do |ep|
-    # `fetch_user(uid)` lives on line 9 of fixtures/python/pyramid_callees/app.py.
-    # Line assertion locks the def-line-threading change that emit_endpoints
-    # picked up — without it, callee.line would point at the route
-    # declaration in `main()` instead of the view body.
-    ep.push_callee(Callee.new("fetch_user", line: 9))
+    # `fetch_user` is imported from db.py where it's defined at line 1.
+    # Without definition resolution the callee would point at line 9 of
+    # app.py (the call site inside `user_detail`).
+    ep.push_callee(Callee.new("fetch_user", db_path, 1))
   end,
 ]
 

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -79,7 +79,8 @@ module Analyzer::Python
               next if def_index.nil?
 
               body = extract_function_body(lines, def_index)
-              emit_endpoints(path, line_index, route_path, methods, body, def_index)
+              emit_endpoints(path, line_index, route_path, methods, body, def_index,
+                definition_base_path: current_base_path, source: content)
             end
 
             # config.add_view(view_func, route_name="name", request_method="POST")
@@ -102,7 +103,8 @@ module Analyzer::Python
                 body = extract_function_body(lines, view_def_index) unless view_def_index.nil?
               end
 
-              emit_endpoints(path, line_index, route_path, methods, body, view_def_index)
+              emit_endpoints(path, line_index, route_path, methods, body, view_def_index,
+                definition_base_path: current_base_path, source: content)
             end
           end
         end
@@ -228,13 +230,20 @@ module Analyzer::Python
     # 0-based line of the handler `def` (when known), used to translate
     # tree-sitter rows into absolute callee call-site lines.
     private def emit_endpoints(path : String, line_index : Int32, route_path : String,
-                               methods : Array(String), body : String, def_index : Int32?)
+                               methods : Array(String), body : String, def_index : Int32?,
+                               *, definition_base_path : String, source : String)
       path_params = extract_path_params(route_path)
       request_params = extract_request_params(body)
 
       # extract_function_body skips the def line, so body row 0 lives
       # at def_index + 1.
-      handler_callees = def_index ? build_callees_from(body, def_index + 1, path) : [] of Callee
+      handler_callees = def_index ? build_callees_from(
+        body,
+        def_index + 1,
+        path,
+        definition_base_path: definition_base_path,
+        source: source,
+      ) : [] of Callee
 
       details = Details.new(PathInfo.new(path, line_index + 1))
       methods.each do |method|


### PR DESCRIPTION
## Summary
- Threads `definition_base_path` and the file `source` through Pyramid's `emit_endpoints` so `build_callees_from` can resolve callees imported from sibling modules to their definition locations, matching the Falcon rollout (#1460).
- Updates the `pyramid_callees` spec to assert `fetch_user` lands in `db.py` line 1 instead of the call site inside the `@view_config` handler.

Follow-up to #1461 — Python/Pyramid track.

## Test plan
- [x] \`crystal spec spec/functional_test/testers/python/pyramid_callees_spec.cr\`
- [x] \`crystal spec spec/functional_test/testers/python/pyramid_spec.cr\`