### PR TITLE
Resolve Tornado callees to definitions

### DIFF
--- a/spec/functional_test/testers/python/tornado_callees_spec.cr
+++ b/spec/functional_test/testers/python/tornado_callees_spec.cr
@@ -12,23 +12,27 @@ require "../../func_spec.cr"
 #                      `async def get` shape so callee extraction
 #                      handles both sync and async handler methods.
 #
-# Line assertions lock the `parse_code_block(lines[def..])` body-start
-# convention used by the helper — body row 0 is the def line, callee
-# line = def_line + tree-sitter-row + 1.
+# Imported helper callees (save_user, audit_log, build_profile) resolve
+# to their definitions in helpers.py; `self.*` calls stay at the
+# call-site because they aren't bare module-level names.
+app_path = "./spec/functional_test/fixtures/python/tornado_callees/app.py"
+handlers_path = "./spec/functional_test/fixtures/python/tornado_callees/handlers.py"
+helpers_path = "./spec/functional_test/fixtures/python/tornado_callees/helpers.py"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST", [
     Param.new("name", "", "form"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("self.get_body_argument", line: 9))
-    ep.push_callee(Callee.new("save_user", line: 10))
-    ep.push_callee(Callee.new("audit_log", line: 11))
-    ep.push_callee(Callee.new("self.write", line: 12))
+    ep.push_callee(Callee.new("self.get_body_argument", app_path, 9))
+    ep.push_callee(Callee.new("save_user", helpers_path, 1))
+    ep.push_callee(Callee.new("audit_log", helpers_path, 5))
+    ep.push_callee(Callee.new("self.write", app_path, 12))
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("build_profile", line: 8))
-    ep.push_callee(Callee.new("audit_log", line: 9))
-    ep.push_callee(Callee.new("self.write", line: 10))
+    ep.push_callee(Callee.new("build_profile", helpers_path, 9))
+    ep.push_callee(Callee.new("audit_log", helpers_path, 5))
+    ep.push_callee(Callee.new("self.write", handlers_path, 10))
   end,
 ]
 

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -349,7 +349,14 @@ module Analyzer::Python
             # line, so `body_start_line = line_index` matches the
             # helper's contract.
             if codeblock = parse_code_block(lines[line_index..])
-              push_callees_from(endpoint, codeblock, line_index, file_path)
+              push_callees_from(
+                endpoint,
+                codeblock,
+                line_index,
+                file_path,
+                definition_base_path: base_path_for(file_path),
+                source: read_file_content(file_path),
+              )
             end
 
             endpoints << endpoint
@@ -368,9 +375,14 @@ module Analyzer::Python
     private def resolve_imports(file_path : ::String) : Hash(::String, Tuple(::String, Int32))
       @import_modules_cache[file_path] ||= begin
         content = read_file_content(file_path)
-        base_path = base_paths.find { |bp| file_path.starts_with?(bp) } || base_paths[0]? || ""
-        find_imported_modules(base_path, file_path, content)
+        find_imported_modules(base_path_for(file_path), file_path, content)
       end
+    end
+
+    # Pick the base path that owns this file so the engine's definition
+    # resolver can locate imported modules relative to the right root.
+    private def base_path_for(file_path : ::String) : ::String
+      base_paths.find { |bp| file_path.starts_with?(bp) } || base_paths[0]? || ""
     end
 
     private def read_file_lines(file_path : ::String) : Array(::String)


### PR DESCRIPTION
## Summary
- Thread the analyzer base path and handler file source through Tornado's `push_callees_from` call so imported helpers (e.g. `save_user`, `audit_log`, `build_profile`) resolve to their definitions in `helpers.py`.
- `self.*` calls stay at the call site because they aren't bare module-level names — preserves the conservative-only rule.
- Factor the base-path lookup `resolve_imports` already used into `base_path_for` so the new caller reuses it.

Follow-up to #1461 — Python/Tornado track.

## Test plan
- [x] \`crystal spec spec/functional_test/testers/python/tornado_callees_spec.cr\`
- [x] \`crystal spec spec/functional_test/testers/python/tornado_spec.cr\`
- [x] \`crystal spec spec/unit_test/detector/python/tornado_spec.cr\`