### PR TITLE
Resolve Flask callees to imported helper definitions

### DIFF
--- a/spec/functional_test/testers/python/flask_callees_spec.cr
+++ b/spec/functional_test/testers/python/flask_callees_spec.cr
@@ -5,6 +5,13 @@ require "../../func_spec.cr"
 # Builtins (print/len/range/...) and Python dunder methods are filtered;
 # framework calls like `jsonify` are kept on purpose because they tell a
 # reviewer how the endpoint shapes its output.
+#
+# Imported helper callees (build_user_query, run_sql_query, log_audit,
+# notify_admin) resolve to their definitions in helpers.py; framework
+# calls like `jsonify` stay unresolved (no Python definition reachable
+# from the project root) and keep their call-site location.
+helpers_path = "./spec/functional_test/fixtures/python/flask_callees/helpers.py"
+
 expected_endpoints = [
   # POST /users — exercises every callee in the handler plus dedup
   # (`run_sql_query` is only called once but `request.form[...]` is a
@@ -12,18 +19,18 @@ expected_endpoints = [
   Endpoint.new("/users", "POST", [
     Param.new("name", "", "form"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("build_user_query"))
-    ep.push_callee(Callee.new("run_sql_query"))
-    ep.push_callee(Callee.new("log_audit"))
-    ep.push_callee(Callee.new("notify_admin"))
+    ep.push_callee(Callee.new("build_user_query", helpers_path, 1))
+    ep.push_callee(Callee.new("run_sql_query", helpers_path, 5))
+    ep.push_callee(Callee.new("log_audit", helpers_path, 14))
+    ep.push_callee(Callee.new("notify_admin", helpers_path, 10))
     ep.push_callee(Callee.new("jsonify"))
   end,
 
   # GET /orders/<order_id> — same helpers as POST /users (verifies the
   # callee list is per-handler, not deduped across endpoints).
   Endpoint.new("/orders/<order_id>", "GET").tap do |ep|
-    ep.push_callee(Callee.new("build_user_query"))
-    ep.push_callee(Callee.new("run_sql_query"))
+    ep.push_callee(Callee.new("build_user_query", helpers_path, 1))
+    ep.push_callee(Callee.new("run_sql_query", helpers_path, 5))
     ep.push_callee(Callee.new("jsonify"))
   end,
 

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -416,7 +416,14 @@ module Analyzer::Python
               details = Details.new(PathInfo.new(path, line_index + 1))
               endpoint.details = details
 
-              push_callees_from(endpoint, codeblock, _class_def_index, path)
+              push_callees_from(
+                endpoint,
+                codeblock,
+                _class_def_index,
+                path,
+                definition_base_path: base_path_for(path),
+                source: fetch_file_content(path),
+              )
 
               # Add expect params as endpoint params
               if expect_params.size > 0
@@ -535,7 +542,14 @@ module Analyzer::Python
             endpoint = Endpoint.new(route_url, http_method, params)
             endpoint.details = details
 
-            push_callees_from(endpoint, codeblock, method_def_index, class_file)
+            push_callees_from(
+              endpoint,
+              codeblock,
+              method_def_index,
+              class_file,
+              definition_base_path: base_path_for(class_file),
+              source: fetch_file_content(class_file),
+            )
 
             result << endpoint
           end
@@ -554,6 +568,12 @@ module Analyzer::Python
     # `File.read` calls per file.
     private def fetch_file_content(path : ::String) : ::String
       @file_content_cache[path] ||= read_file_content(path)
+    end
+
+    # Pick the base path that owns this file so the engine's definition
+    # resolver can locate imported modules relative to the right root.
+    private def base_path_for(file_path : ::String) : ::String
+      base_paths.find { |bp| file_path.starts_with?(bp) } || base_paths[0]? || ""
     end
 
     # Create a Python parser for a given path and content. The


### PR DESCRIPTION
## Summary
- Thread `definition_base_path` + `source` through Flask's two `push_callees_from` call sites — function-based routes use the route file, class-based views use `class_file` (the class can live in a different file from the `add_url_rule` registration).
- Adds a small `base_path_for` helper mirroring Tornado's so the engine's resolver locates imports relative to the right root.
- Updates `flask_callees_spec` to lock the resolved positions of imported helpers (`build_user_query` L1, `run_sql_query` L5, `log_audit` L14, `notify_admin` L10 in `helpers.py`). `jsonify` stays unresolved at the call site.

Follow-up to #1461 — Python/Flask track.

## Test plan
- [x] \`crystal spec spec/functional_test/testers/python/flask_callees_spec.cr\`
- [x] \`crystal spec spec/functional_test/testers/python/flask_spec.cr\`
- [x] \`crystal spec spec/functional_test/testers/python/flask_advanced_spec.cr\`
- [x] \`crystal spec spec/functional_test/testers/python/flask_crossfile_spec.cr\`