### PR TITLE
Resolve Starlette callees to imported helper definitions

### DIFF
--- a/spec/functional_test/fixtures/python/starlette_callees/app.py
+++ b/spec/functional_test/fixtures/python/starlette_callees/app.py
@@ -1,6 +1,7 @@
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
 from starlette.responses import JSONResponse, Response
+from helpers import save_user
 
 
 async def create_user(request):

--- a/spec/functional_test/fixtures/python/starlette_callees/helpers.py
+++ b/spec/functional_test/fixtures/python/starlette_callees/helpers.py
@@ -1,0 +1,2 @@
+def save_user(data, user_id):
+    return {"id": user_id, **data}

--- a/spec/functional_test/testers/python/starlette_callees_spec.cr
+++ b/spec/functional_test/testers/python/starlette_callees_spec.cr
@@ -3,6 +3,12 @@ require "../../func_spec.cr"
 # Regression test for --include-callee on Starlette. The analyzer uses
 # a Route()/Mount() scan, then resolves the referenced handler function
 # to attach 1-hop callees to every emitted endpoint/method.
+#
+# Imported helper callees (save_user) resolve to their definition in
+# helpers.py; unresolved bare names stay at the call site.
+app_path = "./spec/functional_test/fixtures/python/starlette_callees/app.py"
+helpers_path = "./spec/functional_test/fixtures/python/starlette_callees/helpers.py"
+
 search_params = [
   Param.new("q", "", "query"),
   Param.new("X-Token", "", "header"),
@@ -13,37 +19,37 @@ expected_endpoints = [
     Param.new("user_id", "", "path"),
     Param.new("body", "", "json"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.json", line: 7))
-    ep.push_callee(Callee.new("save_user", line: 9))
-    ep.push_callee(Callee.new("audit_log", line: 10))
-    ep.push_callee(Callee.new("JSONResponse", line: 11))
+    ep.push_callee(Callee.new("request.json", app_path, 8))
+    ep.push_callee(Callee.new("save_user", helpers_path, 1))
+    ep.push_callee(Callee.new("audit_log", app_path, 11))
+    ep.push_callee(Callee.new("JSONResponse", app_path, 12))
   end,
 
   Endpoint.new("/health", "GET").tap do |ep|
-    ep.push_callee(Callee.new("Response", line: 15))
+    ep.push_callee(Callee.new("Response", app_path, 16))
   end,
 
   Endpoint.new("/search", "GET", search_params).tap do |ep|
-    ep.push_callee(Callee.new("request.query_params.get", line: 19))
-    ep.push_callee(Callee.new("request.headers.get", line: 20))
-    ep.push_callee(Callee.new("run_search", line: 21))
-    ep.push_callee(Callee.new("JSONResponse", line: 22))
+    ep.push_callee(Callee.new("request.query_params.get", app_path, 20))
+    ep.push_callee(Callee.new("request.headers.get", app_path, 21))
+    ep.push_callee(Callee.new("run_search", app_path, 22))
+    ep.push_callee(Callee.new("JSONResponse", app_path, 23))
   end,
 
   Endpoint.new("/search", "POST", search_params).tap do |ep|
-    ep.push_callee(Callee.new("request.query_params.get", line: 19))
-    ep.push_callee(Callee.new("request.headers.get", line: 20))
-    ep.push_callee(Callee.new("run_search", line: 21))
-    ep.push_callee(Callee.new("JSONResponse", line: 22))
+    ep.push_callee(Callee.new("request.query_params.get", app_path, 20))
+    ep.push_callee(Callee.new("request.headers.get", app_path, 21))
+    ep.push_callee(Callee.new("run_search", app_path, 22))
+    ep.push_callee(Callee.new("JSONResponse", app_path, 23))
   end,
 
   Endpoint.new("/api/items", "GET", [
     Param.new("session", "", "cookie"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.cookies.get", line: 26))
-    ep.push_callee(Callee.new("fetch_items", line: 27))
-    ep.push_callee(Callee.new("audit_log", line: 28))
-    ep.push_callee(Callee.new("JSONResponse", line: 29))
+    ep.push_callee(Callee.new("request.cookies.get", app_path, 27))
+    ep.push_callee(Callee.new("fetch_items", app_path, 28))
+    ep.push_callee(Callee.new("audit_log", app_path, 29))
+    ep.push_callee(Callee.new("JSONResponse", app_path, 30))
   end,
 ]
 

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -29,7 +29,7 @@ module Analyzer::Python
           source = read_file_content(path)
           next unless source.includes?("starlette")
 
-          analyze_file(path, source)
+          analyze_file(path, source, current_base_path)
         end
       end
 
@@ -37,7 +37,7 @@ module Analyzer::Python
       result
     end
 
-    private def analyze_file(path : ::String, source : ::String)
+    private def analyze_file(path : ::String, source : ::String, definition_base_path : ::String)
       lines = source.split("\n")
       function_index = build_function_index(lines)
       handler_cache = {} of ::String => Tuple(Array(Param), Array(Callee))
@@ -83,7 +83,8 @@ module Analyzer::Python
             handler_name = positional_match[1]
           end
           if handler_name
-            handler_params, handler_callees = handler_context_for(lines, function_index, handler_name, path, handler_cache)
+            handler_params, handler_callees = handler_context_for(lines, function_index, handler_name, path, handler_cache,
+              definition_base_path: definition_base_path, source: source)
           end
 
           methods.uniq.each do |method|
@@ -135,7 +136,10 @@ module Analyzer::Python
                                     function_index : Hash(::String, Tuple(Int32, ::String)),
                                     handler_name : ::String,
                                     path : ::String,
-                                    cache : Hash(::String, Tuple(Array(Param), Array(Callee)))) : Tuple(Array(Param), Array(Callee))
+                                    cache : Hash(::String, Tuple(Array(Param), Array(Callee))),
+                                    *,
+                                    definition_base_path : ::String,
+                                    source : ::String) : Tuple(Array(Param), Array(Callee))
       cached = cache[handler_name]?
       return cached if cached
 
@@ -169,7 +173,8 @@ module Analyzer::Python
         end
       end
 
-      callees = build_callees_from(codeblock, idx, path)
+      callees = build_callees_from(codeblock, idx, path,
+        definition_base_path: definition_base_path, source: source)
       cache[handler_name] = {params, callees}
       cache[handler_name]
     end


### PR DESCRIPTION
## Summary
- Thread `definition_base_path` and `source` from `analyze` → `analyze_file` → `handler_context_for` → `build_callees_from` so imported helpers resolve to their definition lines.
- Adds a small `helpers.py` to the `starlette_callees` fixture and imports `save_user` from it, locking the new resolved location in the spec.

Follow-up to #1461 — Python/Starlette track. Mirrors Pyramid (#1463), Tornado (#1465), Falcon (#1460), Flask (#1468).

## Test plan
- [x] \`crystal spec spec/functional_test/testers/python/starlette_callees_spec.cr\`
- [x] \`crystal spec spec/functional_test/testers/python/starlette_spec.cr\`