### PR TITLE
Resolve Java same-file method callees to definitions

### DIFF
--- a/spec/functional_test/testers/java/spring_callees_spec.cr
+++ b/spec/functional_test/testers/java/spring_callees_spec.cr
@@ -15,7 +15,12 @@ require "../../func_spec.cr"
 #   - POST /api/users/        — bare static (`AuditLog.write`) and
 #                               selector-on-identifier
 #                               (`service.save`) receivers.
-#   - GET  /api/users/profile — `this.foo` receiver shape.
+#   - GET  /api/users/profile — `this.foo` receiver shape; the
+#                               unambiguous same-file
+#                               `buildProfile` declaration resolves
+#                               to its definition line, while
+#                               `AuditLog.write` (qualified
+#                               non-`this`) stays at the call site.
 #   - GET  /api/orders/legacy — chained-on-call (`getLegacy().toString()`)
 #                               drops the outer `toString` and keeps
 #                               only the inner `getLegacy`, matching
@@ -27,13 +32,13 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/api/users/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("this.buildProfile", line: 27))
+    ep.push_callee(Callee.new("this.buildProfile", line: 32))
     ep.push_callee(Callee.new("AuditLog.write", line: 28))
   end,
 
   Endpoint.new("/api/orders/legacy", "GET").tap do |ep|
     ep.push_callee(Callee.new("AuditLog.write", line: 13))
-    ep.push_callee(Callee.new("getLegacy", line: 14))
+    ep.push_callee(Callee.new("getLegacy", line: 17))
   end,
 ]
 

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -49,12 +49,15 @@ module Noir::JavaCalleeExtractor
     body = Noir::TreeSitter.field(method_node, "body")
     return sink unless body
 
+    decl_index = build_method_decl_index(root, source)
+
     walk(body) do |n|
       next unless Noir::TreeSitter.node_type(n) == "method_invocation"
       name = callee_text(n, source)
       next if name.empty?
       row = Noir::TreeSitter.node_start_row(n)
-      sink << {name, file_path, row + 1}
+      resolved_line = resolve_same_file_line(n, source, decl_index)
+      sink << {name, file_path, resolved_line || (row + 1)}
     end
     sink
   end
@@ -161,5 +164,56 @@ module Noir::JavaCalleeExtractor
     Noir::TreeSitter.each_named_child(node) do |child|
       walk(child, &block)
     end
+  end
+
+  # Build a same-file method-name -> start row map. `nil` value marks
+  # an ambiguous name (multiple `method_declaration`s share it), so the
+  # caller knows to keep the call site location instead of guessing
+  # which overload to point at. Conservative by design — overloads,
+  # qualified non-`this` calls, and missing declarations all stay at
+  # call site.
+  private def build_method_decl_index(root : LibTreeSitter::TSNode,
+                                      source : String) : Hash(String, Int32?)
+    index = {} of String => Int32?
+    walk(root) do |n|
+      next unless Noir::TreeSitter.node_type(n) == "method_declaration"
+      name_node = Noir::TreeSitter.field(n, "name")
+      next unless name_node
+      name = Noir::TreeSitter.node_text(name_node, source)
+      next if name.empty?
+      if index.has_key?(name)
+        index[name] = nil # ambiguous: skip resolution for this name
+      else
+        index[name] = Noir::TreeSitter.node_start_row(n)
+      end
+    end
+    index
+  end
+
+  # Resolve a `method_invocation` to a same-file `method_declaration`
+  # line (1-based) only when the call is unambiguous:
+  #   - unqualified `foo(...)` (no `object` field), or
+  #   - `this.foo(...)` (object is the literal `this`),
+  # AND the same-file declaration map contains exactly one match.
+  # Returns `nil` for qualified non-`this` calls, ambiguous names, and
+  # names with no matching same-file declaration — callers fall back to
+  # the call site row.
+  private def resolve_same_file_line(call : LibTreeSitter::TSNode,
+                                     source : String,
+                                     decl_index : Hash(String, Int32?)) : Int32?
+    name_node = Noir::TreeSitter.field(call, "name")
+    return nil unless name_node
+    name = Noir::TreeSitter.node_text(name_node, source)
+    return nil if name.empty?
+
+    object = Noir::TreeSitter.field(call, "object")
+    unless object.nil?
+      return nil unless Noir::TreeSitter.node_type(object) == "this"
+    end
+
+    return nil unless decl_index.has_key?(name)
+    row = decl_index[name]
+    return nil if row.nil?
+    row + 1
   end
 end


### PR DESCRIPTION
## Summary
- `JavaCalleeExtractor` pre-walks the parsed root once into a `Hash(String, Int32?)` of `method_declaration` name → start row (`nil` marks ambiguous overloads).
- In `callees_in_method`, rewrite the emitted line for `method_invocation` nodes whose name is either unqualified or whose `object` is a literal `this` node, only when the index has exactly one declaration for that name.
- All other shapes (qualified non-`this`, ambiguous overloads, no match) keep the call-site line, preserving the conservatism rule.
- `callees_in_body` / `callees_in_lambda` entry points stay untouched so lambda-DSL analyzers continue emitting call-site lines as before.
- `spring_callees_spec` locks two existing same-file resolutions: `this.buildProfile` and `getLegacy`.

Follow-up to #1461 — Java/Spring track.

## Test plan
- [x] All 10 Java callee specs (spring, armeria, dropwizard, javalin, jaxrs, micronaut, play, quarkus, spark, vertx)
- [x] \`crystal spec spec/functional_test/testers/java/spring_spec.cr\`