### PR TITLE
Resolve Go same-package bare callees to definitions

### DIFF
--- a/spec/functional_test/testers/go/beego_callees_spec.cr
+++ b/spec/functional_test/testers/go/beego_callees_spec.cr
@@ -16,11 +16,13 @@ require "../../func_spec.cr"
 #   - GET /healthz  — inline `func(ctx *context.Context)` closure in
 #                     main.go.
 #   - GET /profile  — second named handler in handlers.go.
+helpers_path = "./spec/functional_test/fixtures/go/beego_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("ctx.Input.Query", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.Output.Body", line: 11))
   end,
 
@@ -29,8 +31,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.Output.Body", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/chi_callees_spec.cr
+++ b/spec/functional_test/testers/go/chi_callees_spec.cr
@@ -21,11 +21,13 @@ require "../../func_spec.cr"
 # get callees in this first cut — `analyze_router_function` runs its
 # own isolated route walk and would need separate wiring. Tracking
 # that as a follow-up in #1366.
+helpers_path = "./spec/functional_test/fixtures/go/chi_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("r.FormValue", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("w.Write", line: 11))
   end,
 
@@ -34,8 +36,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile/", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("w.Write", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/echo_callees_spec.cr
+++ b/spec/functional_test/testers/go/echo_callees_spec.cr
@@ -12,11 +12,13 @@ require "../../func_spec.cr"
 # Echo's existing file-local param extraction (FormValue/QueryParam/
 # Header.Get) does not follow into sibling files, so the form param
 # for POST /users isn't surfaced — params and callees stay orthogonal.
+helpers_path = "./spec/functional_test/fixtures/go/echo_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("c.FormValue", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("c.JSON", line: 11))
   end,
 
@@ -25,8 +27,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("c.JSON", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/fasthttp_callees_spec.cr
+++ b/spec/functional_test/testers/go/fasthttp_callees_spec.cr
@@ -15,11 +15,13 @@ require "../../func_spec.cr"
 #   - GET /healthz  — inline `func(ctx *fasthttp.RequestCtx)` closure
 #                     handler in main.go.
 #   - GET /profile  — second named handler in handlers.go.
+helpers_path = "./spec/functional_test/fixtures/go/fasthttp_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("ctx.FormValue", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.WriteString", line: 11))
   end,
 
@@ -28,8 +30,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.WriteString", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/fiber_callees_spec.cr
+++ b/spec/functional_test/testers/go/fiber_callees_spec.cr
@@ -5,11 +5,13 @@ require "../../func_spec.cr"
 # methods (`app.Get` / `app.Post`) and `*fiber.Ctx` receiver — the
 # extractor handles both transparently because it keys off the verb
 # field text without case-sensitive matching.
+helpers_path = "./spec/functional_test/fixtures/go/fiber_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("c.FormValue", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("c.JSON", line: 11))
   end,
 
@@ -18,8 +20,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("c.JSON", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/gf_callees_spec.cr
+++ b/spec/functional_test/testers/go/gf_callees_spec.cr
@@ -19,12 +19,14 @@ require "../../func_spec.cr"
 #                          group.GET("/profile", listProfile) })`.
 #                          Locks in the closure-scoped group prefix
 #                          (`/api`) + named handler from sibling file.
+helpers_path = "./spec/functional_test/fixtures/go/gf_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "GET").tap do |ep|
     ep.push_callee(Callee.new("r.GetQuery", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
     ep.push_callee(Callee.new("name.String", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("r.Response.Write", line: 11))
   end,
 
@@ -33,8 +35,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/api/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("r.Response.Write", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/gin_callees_spec.cr
+++ b/spec/functional_test/testers/go/gin_callees_spec.cr
@@ -19,7 +19,11 @@ require "../../func_spec.cr"
 #                            scope to their own body.
 #
 # Line assertions verify that `start_row` arithmetic from the wrapped
-# external parse maps back to the original file's lines.
+# external parse maps back to the original file's lines. Bare same-package
+# callees (saveUser, auditLog, buildProfile) resolve to their definition in
+# helpers.go; selector calls (c.PostForm, c.JSON) stay at the call-site.
+helpers_path = "./spec/functional_test/fixtures/go/gin_callees/helpers.go"
+
 expected_endpoints = [
   # Note: Gin's existing PostForm/Query/GetHeader param extraction is
   # file-local — it scans the same file as the route declaration. Since
@@ -29,8 +33,8 @@ expected_endpoints = [
   # handler binding; the two features are intentionally orthogonal.
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("c.PostForm", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("c.JSON", line: 11))
   end,
 
@@ -39,8 +43,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("c.JSON", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/goyave_callees_spec.cr
+++ b/spec/functional_test/testers/go/goyave_callees_spec.cr
@@ -19,11 +19,13 @@ require "../../func_spec.cr"
 #                     real line in main.go (line 19, not the
 #                     RegisterRoutes wrapper line).
 #   - GET /profile  — second named handler in handlers.go.
+helpers_path = "./spec/functional_test/fixtures/go/goyave_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("request.QueryParams.Get", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("response.JSON", line: 11))
   end,
 
@@ -32,8 +34,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("response.JSON", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/gozero_callees_spec.cr
+++ b/spec/functional_test/testers/go/gozero_callees_spec.cr
@@ -19,11 +19,13 @@ require "../../func_spec.cr"
 #   - GET /healthz  — inline closure in main.go.
 #   - GET /profile  — second named handler in handlers.go.
 #   - GET /legacy   — declared in `legacy.api` (DSL); zero callees.
+helpers_path = "./spec/functional_test/fixtures/go/gozero_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("r.FormValue", line: 10))
-    ep.push_callee(Callee.new("saveUser", line: 11))
-    ep.push_callee(Callee.new("auditLog", line: 12))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("httpx.OkJson", line: 13))
   end,
 
@@ -32,8 +34,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 17))
-    ep.push_callee(Callee.new("auditLog", line: 18))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("httpx.OkJson", line: 19))
   end,
 

--- a/spec/functional_test/testers/go/hertz_callees_spec.cr
+++ b/spec/functional_test/testers/go/hertz_callees_spec.cr
@@ -14,11 +14,13 @@ require "../../func_spec.cr"
 #
 # Also note `string(name)` in handlers.go is filtered by `BUILTINS` —
 # Go primitive type-conversions don't surface as callees.
+helpers_path = "./spec/functional_test/fixtures/go/hertz_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("ctx.PostForm", line: 10))
-    ep.push_callee(Callee.new("saveUser", line: 11))
-    ep.push_callee(Callee.new("auditLog", line: 12))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.JSON", line: 13))
   end,
 
@@ -27,8 +29,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 17))
-    ep.push_callee(Callee.new("auditLog", line: 18))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.JSON", line: 19))
   end,
 ]

--- a/spec/functional_test/testers/go/httprouter_callees_spec.cr
+++ b/spec/functional_test/testers/go/httprouter_callees_spec.cr
@@ -23,11 +23,13 @@ require "../../func_spec.cr"
 #   - GET /profile  — method-first form `r.Handle("GET", "/profile",
 #                     listProfile)`, second named handler in sibling
 #                     file.
+helpers_path = "./spec/functional_test/fixtures/go/httprouter_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("r.FormValue", line: 10))
-    ep.push_callee(Callee.new("saveUser", line: 11))
-    ep.push_callee(Callee.new("auditLog", line: 12))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("w.Write", line: 13))
   end,
 
@@ -36,8 +38,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 17))
-    ep.push_callee(Callee.new("auditLog", line: 18))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("w.Write", line: 19))
   end,
 ]

--- a/spec/functional_test/testers/go/iris_callees_spec.cr
+++ b/spec/functional_test/testers/go/iris_callees_spec.cr
@@ -14,11 +14,13 @@ require "../../func_spec.cr"
 # This fixture does not exercise the ANY-route fan-out path; the
 # callee push lives in both branches of iris.cr, but adding an
 # `.Any("/x", h)` here would just re-state the same assertion N times.
+helpers_path = "./spec/functional_test/fixtures/go/iris_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("ctx.PostValue", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.JSON", line: 11))
   end,
 
@@ -27,8 +29,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("ctx.JSON", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/go/mux_callees_spec.cr
+++ b/spec/functional_test/testers/go/mux_callees_spec.cr
@@ -13,11 +13,13 @@ require "../../func_spec.cr"
 #   - GET /healthz  — same chain shape with an inline closure handler
 #                     in main.go.
 #   - GET /profile  — second named handler in handlers.go.
+helpers_path = "./spec/functional_test/fixtures/go/mux_callees/helpers.go"
+
 expected_endpoints = [
   Endpoint.new("/users", "POST").tap do |ep|
     ep.push_callee(Callee.new("r.FormValue", line: 8))
-    ep.push_callee(Callee.new("saveUser", line: 9))
-    ep.push_callee(Callee.new("auditLog", line: 10))
+    ep.push_callee(Callee.new("saveUser", helpers_path, 3))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("w.Write", line: 11))
   end,
 
@@ -26,8 +28,8 @@ expected_endpoints = [
   end,
 
   Endpoint.new("/profile", "GET").tap do |ep|
-    ep.push_callee(Callee.new("buildProfile", line: 15))
-    ep.push_callee(Callee.new("auditLog", line: 16))
+    ep.push_callee(Callee.new("buildProfile", helpers_path, 10))
+    ep.push_callee(Callee.new("auditLog", helpers_path, 7))
     ep.push_callee(Callee.new("w.Write", line: 17))
   end,
 ]

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -136,16 +136,16 @@ module Noir::GoCalleeExtractor
         case Noir::TreeSitter.node_type(handler_arg)
         when "func_literal"
           if body = Noir::TreeSitter.field(handler_arg, "body")
-            walk_calls_in_node(body, source, file_path, callees, 0)
+            walk_calls_in_node(body, source, file_path, callees, 0, external_functions)
           end
         when "identifier"
           name = Noir::TreeSitter.node_text(handler_arg, source)
           if fn_node = local_functions[name]?
             if body = Noir::TreeSitter.field(fn_node, "body")
-              walk_calls_in_node(body, source, file_path, callees, 0)
+              walk_calls_in_node(body, source, file_path, callees, 0, external_functions)
             end
           elsif extern = external_functions[name]?
-            callees.concat(calls_in_external(extern))
+            callees.concat(calls_in_external(extern, external_functions))
           end
         else
           # selector_expression / method values — out of scope for now.
@@ -185,7 +185,8 @@ module Noir::GoCalleeExtractor
                                  source : String,
                                  file_path : String,
                                  sink : Array(Tuple(String, String, Int32)),
-                                 line_offset : Int32)
+                                 line_offset : Int32,
+                                 external_functions : Hash(String, FunctionBody))
     walk(body_node) do |n|
       next unless Noir::TreeSitter.node_type(n) == "call_expression"
       func = Noir::TreeSitter.field(n, "function")
@@ -194,8 +195,14 @@ module Noir::GoCalleeExtractor
       next if name.empty?
       next if BUILTINS.includes?(name)
       next if name.starts_with?("_")
-      row = Noir::TreeSitter.node_start_row(func) + line_offset
-      sink << {name, file_path, row + 1}
+      # Same-package bare identifier callees are rewritten to point at the
+      # function definition; selector/method calls stay at the call-site.
+      if Noir::TreeSitter.node_type(func) == "identifier" && (extern = external_functions[name]?)
+        sink << {name, extern.file_path, extern.start_row + 1}
+      else
+        row = Noir::TreeSitter.node_start_row(func) + line_offset
+        sink << {name, file_path, row + 1}
+      end
     end
   end
 
@@ -204,7 +211,8 @@ module Noir::GoCalleeExtractor
   # in a `package` line so tree-sitter Go can parse it as a complete
   # `source_file`; the wrap adds exactly one row, which we subtract via
   # `start_row - 1` to map walked rows back to the original file.
-  private def calls_in_external(fn : FunctionBody) : Array(Tuple(String, String, Int32))
+  private def calls_in_external(fn : FunctionBody,
+                                external_functions : Hash(String, FunctionBody)) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
     wrapped = "package _noir_callee_wrap\n#{fn.source}\n"
     line_offset = fn.start_row - 1
@@ -212,7 +220,7 @@ module Noir::GoCalleeExtractor
       Noir::TreeSitter.each_named_child(root) do |child|
         next unless Noir::TreeSitter.node_type(child) == "function_declaration"
         if body = Noir::TreeSitter.field(child, "body")
-          walk_calls_in_node(body, wrapped, fn.file_path, sink, line_offset)
+          walk_calls_in_node(body, wrapped, fn.file_path, sink, line_offset, external_functions)
           break
         end
       end


### PR DESCRIPTION
## Summary
- Thread the existing package function-body map through `walk_calls_in_node` and `calls_in_external` in `GoCalleeExtractor`. When a call's `func` node type is a bare `identifier` and the name appears in the package map, rewrite the emitted callee's file/line to the definition's location.
- Selector calls (`c.JSON`, `db.Save`) stay at the call site — the rewrite condition keys on the AST node type, not the rendered name, so the conservatism rule is preserved.
- Updates all 13 Go callee specs (gin, chi, echo, fiber, hertz, beego, gf, gozero, goyave, iris, mux, httprouter, fasthttp) to lock the resolved positions of `saveUser`, `auditLog`, `buildProfile` in the sibling `helpers.go`.

Follow-up to #1461 — Go track.

## Test plan
- [x] 13 Go callee specs (368 examples)
- [x] Full \`spec/functional_test/testers/go/\` (1100 examples)