### PR TITLE
Resolve JS/TS same-file local callees to definitions

### DIFF
--- a/spec/functional_test/testers/javascript/express_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/express_callees_spec.cr
@@ -3,22 +3,26 @@ require "../../func_spec.cr"
 # Regression test for --include-callee on Express. Express consumes
 # JSRouteExtractor after its router-mount pre-scan, so parser-covered
 # handlers can reuse the shared JS callee extractor.
+#
+# Bare identifier callees that match a same-file top-level function or
+# const-arrow declaration are resolved to the declaration line; member
+# expressions and unknown identifiers stay at the call site.
 expected_endpoints = [
   Endpoint.new("/users/:id", "POST", [
     Param.new("id", "", "path"),
     Param.new("include", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("parseUser", line: 9))
+    ep.push_callee(Callee.new("parseUser", line: 25))
     ep.push_callee(Callee.new("serviceFactory().save", line: 10))
     ep.push_callee(Callee.new("AuditLog.write", line: 11))
     ep.push_callee(Callee.new("res.json", line: 13))
-    ep.push_callee(Callee.new("serializeUser", line: 13))
+    ep.push_callee(Callee.new("serializeUser", line: 33))
   end,
 
   Endpoint.new("/api/profile", "GET", [
     Param.new("sessionId", "", "cookie"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("loadProfile", line: 18))
+    ep.push_callee(Callee.new("loadProfile", line: 37))
     ep.push_callee(Callee.new("res.send", line: 20))
   end,
 ]

--- a/spec/functional_test/testers/javascript/fastify_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_callees_spec.cr
@@ -7,7 +7,7 @@ expected_endpoints = [
   Endpoint.new("/users/:id", "POST", [
     Param.new("id", "", "path"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("parseUser", line: 7))
+    ep.push_callee(Callee.new("parseUser", line: 20))
     ep.push_callee(Callee.new("serviceFactory().save", line: 8))
     ep.push_callee(Callee.new("AuditLog.write", line: 9))
     ep.push_callee(Callee.new("reply.send", line: 11))
@@ -16,7 +16,7 @@ expected_endpoints = [
   Endpoint.new("/profile", "GET", [
     Param.new("userId", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("loadProfile", line: 15))
+    ep.push_callee(Callee.new("loadProfile", line: 28))
     ep.push_callee(Callee.new("reply.send", line: 17))
   end,
 ]

--- a/spec/functional_test/testers/javascript/hono_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_callees_spec.cr
@@ -8,7 +8,7 @@ expected_endpoints = [
     Param.new("id", "", "path"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("c.req.param", line: 8))
-    ep.push_callee(Callee.new("parseUser", line: 9))
+    ep.push_callee(Callee.new("parseUser", line: 29))
     ep.push_callee(Callee.new("serviceFactory().save", line: 10))
     ep.push_callee(Callee.new("AuditLog.write", line: 11))
     ep.push_callee(Callee.new("c.json", line: 13))
@@ -18,7 +18,7 @@ expected_endpoints = [
     Param.new("sessionId", "", "cookie"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("getCookie", line: 17))
-    ep.push_callee(Callee.new("buildProfile", line: 18))
+    ep.push_callee(Callee.new("buildProfile", line: 37))
     ep.push_callee(Callee.new("c.json", line: 20))
   end,
 

--- a/spec/functional_test/testers/javascript/koa_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_callees_spec.cr
@@ -8,17 +8,17 @@ expected_endpoints = [
     Param.new("X-Actor", "", "header"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("ctx.get", line: 9))
-    ep.push_callee(Callee.new("parseBody", line: 10))
+    ep.push_callee(Callee.new("parseBody", line: 24))
     ep.push_callee(Callee.new("serviceFactory().save", line: 11))
     ep.push_callee(Callee.new("AuditLog.write", line: 12))
-    ep.push_callee(Callee.new("serializeUser", line: 14))
+    ep.push_callee(Callee.new("serializeUser", line: 32))
   end,
 
   Endpoint.new("/session", "GET", [
     Param.new("sessionId", "", "cookie"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("ctx.cookies.get", line: 18))
-    ep.push_callee(Callee.new("loadProfile", line: 19))
+    ep.push_callee(Callee.new("loadProfile", line: 36))
   end,
 ]
 

--- a/spec/functional_test/testers/javascript/restify_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/restify_callees_spec.cr
@@ -10,22 +10,22 @@ expected_endpoints = [
     Param.new("X-Actor", "", "header"),
   ]).tap do |ep|
     ep.push_callee(Callee.new("req.header", line: 9))
-    ep.push_callee(Callee.new("parseUser", line: 10))
+    ep.push_callee(Callee.new("parseUser", line: 34))
     ep.push_callee(Callee.new("serviceFactory().save", line: 11))
     ep.push_callee(Callee.new("AuditLog.write", line: 12))
     ep.push_callee(Callee.new("res.send", line: 14))
-    ep.push_callee(Callee.new("serializeUser", line: 14))
+    ep.push_callee(Callee.new("serializeUser", line: 42))
   end,
 
   Endpoint.new("/health", "GET").tap do |ep|
-    ep.push_callee(Callee.new("loadHealth", line: 20))
+    ep.push_callee(Callee.new("loadHealth", line: 46))
     ep.push_callee(Callee.new("res.send", line: 21))
   end,
 
   Endpoint.new("/profile", "GET", [
     Param.new("userId", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("loadProfile", line: 28))
+    ep.push_callee(Callee.new("loadProfile", line: 50))
     ep.push_callee(Callee.new("res.send", line: 30))
   end,
 ]

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -33,11 +33,13 @@ module Noir::JSCalleeExtractor
   }
 
   alias Entry = Tuple(String, String, Int32)
+  alias Definitions = Hash(String, Int32?)
 
   def callees_for_routes(source : String, file_path : String) : Hash(String, Array(Entry))
     by_route = {} of String => Array(Entry)
     Noir::TreeSitter.parse_javascript(source) do |root|
-      walk_routes(root, source, file_path, by_route, 0)
+      definitions = top_level_definitions(root, source)
+      walk_routes(root, source, file_path, by_route, 0, definitions)
     end
     by_route
   rescue
@@ -73,8 +75,9 @@ module Noir::JSCalleeExtractor
     source_for_ast = normalize_handler_source(source)
     sink = [] of Entry
     Noir::TreeSitter.parse_javascript(source_for_ast) do |root|
+      definitions = top_level_definitions(root, source_for_ast)
       if handler = exported_handler(root, root, source_for_ast, export_name, 0)
-        walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0)
+        walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0, definitions)
       end
     end
 
@@ -91,8 +94,9 @@ module Noir::JSCalleeExtractor
     event_handler_calls = event_handler_call_names(source_for_ast)
     sink = [] of Entry
     Noir::TreeSitter.parse_javascript(source_for_ast) do |root|
+      definitions = top_level_definitions(root, source_for_ast)
       if handler = exported_event_handler(root, root, source_for_ast, event_handler_calls, 0)
-        walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0)
+        walk_callees(handler_body(handler), source_for_ast, file_path, sink, 0, definitions)
       end
     end
 
@@ -105,11 +109,66 @@ module Noir::JSCalleeExtractor
     "#{method.upcase}::#{path}::#{line}"
   end
 
+  # Collect same-file top-level declarations that we can use to resolve
+  # bare-identifier callees to their definition lines. Walks only the
+  # program's immediate children (and `export_statement` wrappers); nested
+  # scopes are ignored. Names declared more than once are mapped to `nil`
+  # so callers can leave ambiguous references at the call site.
+  private def top_level_definitions(root : LibTreeSitter::TSNode, source : String) : Definitions
+    definitions = Definitions.new
+    Noir::TreeSitter.each_named_child(root) do |child|
+      collect_top_level_definition(child, source, definitions)
+    end
+    definitions
+  end
+
+  private def collect_top_level_definition(node : LibTreeSitter::TSNode,
+                                           source : String,
+                                           definitions : Definitions)
+    type = Noir::TreeSitter.node_type(node)
+    case type
+    when "function_declaration", "generator_function_declaration"
+      if name_node = Noir::TreeSitter.field(node, "name")
+        record_definition(definitions, Noir::TreeSitter.node_text(name_node, source), node)
+      end
+    when "lexical_declaration", "variable_declaration"
+      Noir::TreeSitter.each_named_child(node) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "variable_declarator"
+        name_node = Noir::TreeSitter.field(child, "name")
+        value_node = Noir::TreeSitter.field(child, "value")
+        next unless name_node && value_node
+        next unless Noir::TreeSitter.node_type(name_node) == "identifier"
+
+        case Noir::TreeSitter.node_type(value_node)
+        when "arrow_function", "function_expression"
+          record_definition(definitions, Noir::TreeSitter.node_text(name_node, source), child)
+        end
+      end
+    when "export_statement"
+      if declaration = Noir::TreeSitter.field(node, "declaration")
+        collect_top_level_definition(declaration, source, definitions)
+      end
+    end
+  end
+
+  private def record_definition(definitions : Definitions,
+                                name : String,
+                                node : LibTreeSitter::TSNode)
+    return if name.empty?
+
+    if definitions.has_key?(name)
+      definitions[name] = nil
+    else
+      definitions[name] = Noir::TreeSitter.node_start_row(node) + 1
+    end
+  end
+
   private def walk_routes(node : LibTreeSitter::TSNode,
                           source : String,
                           file_path : String,
                           by_route : Hash(String, Array(Entry)),
-                          depth : Int32)
+                          depth : Int32,
+                          definitions : Definitions)
     return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
     if Noir::TreeSitter.node_type(node) == "call_expression"
@@ -117,12 +176,12 @@ module Noir::JSCalleeExtractor
       if route_info
         method, path, handler = route_info
         line = Noir::TreeSitter.node_start_row(node) + 1
-        by_route[route_key(method, path, line)] = callees_in_handler(handler, source, file_path)
+        by_route[route_key(method, path, line)] = callees_in_handler(handler, source, file_path, definitions)
       end
     end
 
     Noir::TreeSitter.each_named_child(node) do |child|
-      walk_routes(child, source, file_path, by_route, depth + 1)
+      walk_routes(child, source, file_path, by_route, depth + 1, definitions)
     end
   end
 
@@ -172,9 +231,12 @@ module Noir::JSCalleeExtractor
     {method, strings[1], handler}
   end
 
-  private def callees_in_handler(handler : LibTreeSitter::TSNode, source : String, file_path : String) : Array(Entry)
+  private def callees_in_handler(handler : LibTreeSitter::TSNode,
+                                 source : String,
+                                 file_path : String,
+                                 definitions : Definitions) : Array(Entry)
     sink = [] of Entry
-    walk_callees(handler_body(handler), source, file_path, sink, 0)
+    walk_callees(handler_body(handler), source, file_path, sink, 0, definitions)
     sink
   end
 
@@ -536,23 +598,30 @@ module Noir::JSCalleeExtractor
                            source : String,
                            file_path : String,
                            sink : Array(Entry),
-                           depth : Int32)
+                           depth : Int32,
+                           definitions : Definitions = Definitions.new)
     return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
     skip_function_child : LibTreeSitter::TSNode? = nil
     if Noir::TreeSitter.node_type(node) == "call_expression"
+      function = Noir::TreeSitter.field(node, "function") || first_named_child(node)
       name = callee_text(node, source)
       unless name.empty?
         line = Noir::TreeSitter.node_start_row(node) + 1
+        if function && Noir::TreeSitter.node_type(function) == "identifier"
+          if definitions.has_key?(name) && (def_line = definitions[name])
+            line = def_line
+          end
+        end
         sink << {name, file_path, line}
-        skip_function_child = Noir::TreeSitter.field(node, "function") || first_named_child(node)
+        skip_function_child = function
       end
     end
 
     Noir::TreeSitter.each_named_child(node) do |child|
       next if skip_function_child && same_node?(child, skip_function_child)
 
-      walk_callees(child, source, file_path, sink, depth + 1)
+      walk_callees(child, source, file_path, sink, depth + 1, definitions)
     end
   end
 


### PR DESCRIPTION
## Summary
- `JSCalleeExtractor` builds a `Hash(String, Int32?)` of same-file top-level declarations once per parse (`top_level_definitions`) covering `function_declaration`, `generator_function_declaration`, and `lexical_declaration`/`variable_declaration` initialized with `arrow_function`/`function_expression`. Duplicate names map to `nil` (ambiguous).
- Threads the map through `walk_routes` / `callees_in_handler` / `walk_callees`. When a call's `function` field is a bare `identifier` and the name is mapped to a non-nil line, the emitted callee line is rewritten to the declaration.
- Member-expression callees (`obj.foo`, `serviceFactory().save`, `res.json`, …) keep the call-site line, preserving conservatism.
- `callees_for_function_body` (NestJS/Next.js) is intentionally left untouched — it parses a synthetic wrapper around a body fragment, so original-file top-level declarations aren't visible from there.
- Updates 5 callees specs (express, fastify, hono, koa, restify) to lock the resolved positions of same-file helper definitions.

Follow-up to #1461 — JS/TS track.

## Test plan
- [x] All 1864 JS/TS functional specs pass
- [x] 45 JS extractor/route unit specs pass