### PR TITLE
Fix ameba RedundantNilInControlExpression in Java callee extractor

### DIFF
--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -202,18 +202,18 @@ module Noir::JavaCalleeExtractor
                                      source : String,
                                      decl_index : Hash(String, Int32?)) : Int32?
     name_node = Noir::TreeSitter.field(call, "name")
-    return nil unless name_node
+    return unless name_node
     name = Noir::TreeSitter.node_text(name_node, source)
-    return nil if name.empty?
+    return if name.empty?
 
     object = Noir::TreeSitter.field(call, "object")
     unless object.nil?
-      return nil unless Noir::TreeSitter.node_type(object) == "this"
+      return unless Noir::TreeSitter.node_type(object) == "this"
     end
 
-    return nil unless decl_index.has_key?(name)
+    return unless decl_index.has_key?(name)
     row = decl_index[name]
-    return nil if row.nil?
+    return if row.nil?
     row + 1
   end
 end


### PR DESCRIPTION
## Summary
- Drop explicit `nil` from `return nil` guards in `resolve_same_file_line` so ameba's `Style/RedundantNilInControlExpression` rule passes.
- Behavior unchanged — a bare `return` already yields `nil`, and the method's `Int32?` return type is preserved.

Lint had been failing on `src/miniparsers/java_callee_extractor.cr` with 5 occurrences of this rule (introduced via #1470's Java callee work).

## Test plan
- [x] `crystal tool format --check`
- [x] `crystal lib/ameba/bin/ameba.cr` → 887 inspected, 0 failures
- [x] `crystal spec spec/functional_test/testers/java/javalin_callees_spec.cr` → 30 examples, 0 failures