### PR TITLE
Improve ai_context precision and route fidelity

### DIFF
--- a/spec/functional_test/fixtures/crystal/kemal_auth/shard.yml
+++ b/spec/functional_test/fixtures/crystal/kemal_auth/shard.yml
@@ -1,0 +1,6 @@
+name: kemal_auth_fixture
+version: 0.1.0
+
+dependencies:
+  kemal:
+    github: kemalcr/kemal

--- a/spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/router.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/router.ex
@@ -1,0 +1,9 @@
+defmodule MyappWeb.Router do
+  use MyappWeb, :router
+
+  scope "/", MyappWeb do
+    get "/posts", PostController, :index
+    get "/posts/:id", PostController, :show
+    get "/public", PublicController, :index
+  end
+end

--- a/spec/functional_test/fixtures/elixir/phoenix_auth/mix.exs
+++ b/spec/functional_test/fixtures/elixir/phoenix_auth/mix.exs
@@ -1,0 +1,18 @@
+defmodule ElixirPhoenixAuth.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :elixir_phoenix_auth,
+      version: "0.1.0",
+      elixir: "~> 1.16",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"}
+    ]
+  end
+end

--- a/spec/functional_test/fixtures/go/gin_auth/go.mod
+++ b/spec/functional_test/fixtures/go/gin_auth/go.mod
@@ -1,0 +1,5 @@
+module gin_auth_fixture
+
+go 1.22
+
+require github.com/gin-gonic/gin v1.10.0

--- a/spec/functional_test/fixtures/php/laravel_auth/artisan
+++ b/spec/functional_test/fixtures/php/laravel_auth/artisan
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php
+
+use Illuminate\Foundation\Application;
+
+return new Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);

--- a/spec/functional_test/fixtures/php/laravel_auth/bootstrap/app.php
+++ b/spec/functional_test/fixtures/php/laravel_auth/bootstrap/app.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->create();

--- a/spec/functional_test/fixtures/php/laravel_auth/composer.json
+++ b/spec/functional_test/fixtures/php/laravel_auth/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "laravel/framework": "^10.0"
+  }
+}

--- a/spec/functional_test/fixtures/php/laravel_auth/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel_auth/routes/web.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/public', function () {
+    return response()->json(['message' => 'public']);
+});
+
+Route::get('/profile', function () {
+    return response()->json(['id' => auth()->id()]);
+})->middleware('auth');
+
+Route::post('/posts', function () {
+    return response()->json(['created' => true]);
+})->middleware('auth');

--- a/spec/functional_test/fixtures/python/django_auth/djangoproject/settings.py
+++ b/spec/functional_test/fixtures/python/django_auth/djangoproject/settings.py
@@ -7,6 +7,8 @@ INSTALLED_APPS = [
     'blog',
 ]
 
+ROOT_URLCONF = 'djangoproject.urls'
+
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.SessionAuthentication',

--- a/spec/functional_test/fixtures/ruby/rails_auth/Gemfile
+++ b/spec/functional_test/fixtures/ruby/rails_auth/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rails"

--- a/spec/functional_test/fixtures/ruby/rails_auth/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_auth/config/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  resources :posts, only: [:index, :show, :create, :destroy]
+end

--- a/spec/functional_test/testers/crystal/kemal_ai_context_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_ai_context_spec.cr
@@ -1,0 +1,43 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Kemal auth fixtures" do
+  fixture_path = "fixtures/crystal/kemal_auth/"
+  app_suffix = "spec/functional_test/fixtures/crystal/kemal_auth/app.cr"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "surfaces Kemal auth guards while leaving public routes clean" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    profile_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/profile" }
+    profile_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 4 }.should be_true
+    profile_context = profile_endpoint.ai_context
+    profile_context = profile_context.should_not be_nil
+    profile_context.guards.size.should eq(1)
+    profile_context.guards[0].source.should eq("crystal_auth")
+
+    secret_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/secret" }
+    secret_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 10 }.should be_true
+    secret_context = secret_endpoint.ai_context
+    secret_context = secret_context.should_not be_nil
+    secret_context.guards.size.should eq(1)
+    secret_context.guards[0].source.should eq("crystal_auth")
+
+    health_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/health" }
+    health_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 18 }.should be_true
+    health_context = health_endpoint.ai_context
+    health_context = health_context.should_not be_nil
+    health_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/csharp/aspnet_ai_context_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_ai_context_spec.cr
@@ -1,0 +1,45 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on ASP.NET auth fixtures" do
+  fixture_path = "fixtures/csharp/aspnet_auth/"
+  controller_suffix = "spec/functional_test/fixtures/csharp/aspnet_auth/Controllers/PostsController.cs"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "surfaces class-level and method-level authorize attributes while respecting AllowAnonymous" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    public_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/Posts" }
+    public_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 13 }.should be_true
+    public_context = public_endpoint.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+
+    show_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/Posts/{id}" }
+    show_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 19 }.should be_true
+    show_context = show_endpoint.ai_context
+    show_context = show_context.should_not be_nil
+    show_context.guards.size.should eq(1)
+    show_context.guards[0].source.should eq("aspnet_auth")
+    show_context.signals.map(&.kind).should contain("path_param")
+
+    create_endpoint = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/Posts" }
+    create_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 26 }.should be_true
+    create_context = create_endpoint.ai_context
+    create_context = create_context.should_not be_nil
+    create_context.guards.size.should eq(1)
+    create_context.guards[0].source.should eq("aspnet_auth")
+    create_context.signals.map(&.kind).should contain("state_change")
+  end
+end

--- a/spec/functional_test/testers/elixir/phoenix_ai_context_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_ai_context_spec.cr
@@ -1,0 +1,49 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Phoenix auth fixtures" do
+  fixture_path = "fixtures/elixir/phoenix_auth/"
+  post_suffix = "spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/post_controller.ex"
+  public_suffix = "spec/functional_test/fixtures/elixir/phoenix_auth/lib/myapp_web/controllers/public_controller.ex"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "preserves controller action paths so Phoenix auth plugs surface end-to-end" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    index_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts" }
+    index_endpoint.details.code_paths.any? { |info| info.path.ends_with?(post_suffix) && info.line == 6 }.should be_true
+    index_context = index_endpoint.ai_context
+    index_context = index_context.should_not be_nil
+    index_context.guards.size.should eq(1)
+    index_context.guards[0].source.should eq("elixir_auth")
+
+    show_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts/:id" }
+    show_endpoint.details.code_paths.any? { |info| info.path.ends_with?(post_suffix) && info.line == 11 }.should be_true
+    show_context = show_endpoint.ai_context
+    show_context = show_context.should_not be_nil
+    show_context.guards.size.should eq(1)
+    show_context.guards[0].source.should eq("elixir_auth")
+    show_signal_kinds = show_context.signals.map(&.kind)
+    show_signal_kinds.should contain("path_param")
+    show_signal_kinds.should contain("idor")
+    show_signal_kinds.should_not contain("sqli")
+    show_signal_kinds.should_not contain("ssti")
+
+    public_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public" }
+    public_endpoint.details.code_paths.any? { |info| info.path.ends_with?(public_suffix) && info.line == 4 }.should be_true
+    public_context = public_endpoint.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/go/chi_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/chi_hunt_ai_context_spec.cr
@@ -1,0 +1,36 @@
+require "../../func_spec.cr"
+
+describe "--ai-context Hunt signals on Chi fixtures" do
+  fixture_path = "fixtures/go/chi/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps sort-like signals while dropping broad analytics filter false positives" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    analytics_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/analytics" }.ai_context
+    analytics_context = analytics_context.should_not be_nil
+    analytics_context.signals.map(&.kind).should_not contain("sqli")
+    analytics_context.sinks.map(&.kind).should_not contain("sql")
+
+    search_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/search-test" }.ai_context
+    search_context = search_context.should_not be_nil
+    search_context.signals.map(&.kind).should_not contain("sqli")
+    search_context.sinks.map(&.kind).should_not contain("sql")
+
+    api_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api-test" }.ai_context
+    api_context = api_context.should_not be_nil
+    api_context.signals.map(&.name).should_not contain("header.User-Agent")
+  end
+end

--- a/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+describe "--ai-context Hunt signals on Echo fixtures" do
+  fixture_path = "fixtures/go/echo/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "drops redundant generic param signals when Hunt already provides a stronger label" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    pet_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/pet" }.ai_context
+    pet_context = pet_context.should_not be_nil
+    pet_context.signals.map(&.kind).should contain("sqli")
+    pet_context.signals.map(&.kind).should_not contain("query_builder_input")
+
+    review_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/items/:itemId/reviews" }.ai_context
+    review_context = review_context.should_not be_nil
+    review_context.signals.map(&.kind).should contain("sqli")
+    review_context.signals.map(&.kind).should_not contain("query_builder_input")
+
+    patch_context = endpoints.find! { |ep| ep.method == "PATCH" && ep.url == "/users/:id" }.ai_context
+    patch_context = patch_context.should_not be_nil
+    patch_context.signals.map(&.kind).should contain("path_param")
+    patch_context.signals.map(&.kind).should contain("idor")
+    patch_context.signals.map(&.kind).should_not contain("identifier_input")
+  end
+end

--- a/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
@@ -21,7 +21,7 @@ describe "--ai-context Hunt signals on Echo fixtures" do
 
     pet_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/pet" }.ai_context
     pet_context = pet_context.should_not be_nil
-    pet_context.signals.map(&.kind).should contain("sqli")
+    pet_context.signals.map(&.kind).should_not contain("sqli")
     pet_context.signals.map(&.kind).should_not contain("query_builder_input")
 
     review_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/items/:itemId/reviews" }.ai_context

--- a/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/echo_hunt_ai_context_spec.cr
@@ -33,6 +33,13 @@ describe "--ai-context Hunt signals on Echo fixtures" do
     patch_context = patch_context.should_not be_nil
     patch_context.signals.map(&.kind).should contain("path_param")
     patch_context.signals.map(&.kind).should contain("idor")
+    patch_context.signals.map(&.kind).should contain("idor_review")
     patch_context.signals.map(&.kind).should_not contain("identifier_input")
+    patch_context.signals.map(&.kind).should_not contain("guard_absence")
+
+    cache_context = endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/v2/admin/cache" }.ai_context
+    cache_context = cache_context.should_not be_nil
+    cache_context.signals.map(&.kind).should contain("guard_absence")
+    cache_context.signals.map(&.kind).should_not contain("idor_review")
   end
 end

--- a/spec/functional_test/testers/go/gin_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/gin_ai_context_spec.cr
@@ -1,0 +1,55 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Gin auth fixtures" do
+  fixture_path = "fixtures/go/gin_auth/"
+  main_suffix = "spec/functional_test/fixtures/go/gin_auth/main.go"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "captures group and inline middleware guards while keeping public routes unguarded" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    health_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/health" }
+    health_endpoint.details.code_paths.any? { |info| info.path.ends_with?(main_suffix) && info.line == 13 }.should be_true
+    health_context = health_endpoint.ai_context
+    health_context = health_context.should_not be_nil
+    health_context.guards.should be_empty
+
+    profile_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/profile" }
+    profile_endpoint.details.code_paths.any? { |info| info.path.ends_with?(main_suffix) && info.line == 24 }.should be_true
+    profile_context = profile_endpoint.ai_context
+    profile_context = profile_context.should_not be_nil
+    profile_context.guards.size.should eq(1)
+    profile_context.guards[0].source.should eq("go_auth")
+
+    dashboard_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/dashboard" }
+    dashboard_endpoint.details.code_paths.any? { |info| info.path.ends_with?(main_suffix) && info.line == 29 }.should be_true
+    dashboard_context = dashboard_endpoint.ai_context
+    dashboard_context = dashboard_context.should_not be_nil
+    dashboard_context.guards.size.should eq(1)
+    dashboard_context.guards[0].source.should eq("go_auth")
+
+    admin_endpoint = endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/admin/users/:id" }
+    admin_endpoint.details.code_paths.any? { |info| info.path.ends_with?(main_suffix) && info.line == 34 }.should be_true
+    admin_context = admin_endpoint.ai_context
+    admin_context = admin_context.should_not be_nil
+    admin_context.guards.size.should eq(1)
+    admin_context.guards[0].source.should eq("go_auth")
+    admin_context.signals.map(&.kind).should contain("state_change")
+    admin_signal_kinds = admin_context.signals.map(&.kind)
+    admin_signal_kinds.should contain("idor")
+    admin_signal_kinds.should_not contain("sqli")
+    admin_signal_kinds.should_not contain("ssti")
+  end
+end

--- a/spec/functional_test/testers/go/mux_ai_context_spec.cr
+++ b/spec/functional_test/testers/go/mux_ai_context_spec.cr
@@ -1,0 +1,35 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Mux fixtures" do
+  fixture_path = "fixtures/go/mux/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "classifies FormValue inputs according to the route method" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    submit_endpoint = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/submit" }
+    submit_endpoint.params.map { |param| {param.name, param.param_type} }.should contain({"password", "form"})
+    submit_context = submit_endpoint.ai_context
+    submit_context = submit_context.should_not be_nil
+    submit_context.signals.map(&.name).should contain("form.password")
+    submit_context.signals.map(&.name).should_not contain("query.password")
+
+    patch_endpoint = endpoints.find! { |ep| ep.method == "PATCH" && ep.url == "/items/{id}/status" }
+    patch_endpoint.params.map { |param| {param.name, param.param_type} }.should contain({"status", "form"})
+    patch_context = patch_endpoint.ai_context
+    patch_context = patch_context.should_not be_nil
+    patch_context.signals.map(&.kind).should contain("idor_review")
+  end
+end

--- a/spec/functional_test/testers/go/mux_spec.cr
+++ b/spec/functional_test/testers/go/mux_spec.cr
@@ -10,7 +10,7 @@ expected_endpoints = [
   ]),
   Endpoint.new("/submit", "POST", [
     Param.new("username", "", "form"),
-    Param.new("password", "", "query"),
+    Param.new("password", "", "form"),
     Param.new("User-Agent", "", "header"),
   ]),
   Endpoint.new("/users/{id}", "GET", [
@@ -35,7 +35,7 @@ expected_endpoints = [
   # handlers.go: PATCH method with path variable and form param
   Endpoint.new("/items/{id}/status", "PATCH", [
     Param.new("id", "", "path"),
-    Param.new("status", "", "query"),
+    Param.new("status", "", "form"),
   ]),
   # handlers.go: multiple path variables with query param
   Endpoint.new("/shops/{shopId}/products/{productId}", "GET", [

--- a/spec/functional_test/testers/java/spring_ai_context_spec.cr
+++ b/spec/functional_test/testers/java/spring_ai_context_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Spring auth fixtures" do
+  fixture_path = "fixtures/java/spring_auth/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "surfaces Spring auth guards on protected handlers only" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    admin_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/admin/users" }.ai_context
+    admin_context = admin_context.should_not be_nil
+    admin_context.guards.size.should eq(1)
+    admin_context.guards[0].source.should eq("spring_auth")
+
+    delete_context = endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/api/posts/{id}" }.ai_context
+    delete_context = delete_context.should_not be_nil
+    delete_context.guards.size.should eq(1)
+    delete_context.signals.map(&.kind).should contain("path_param")
+    delete_context.signals.map(&.kind).should contain("state_change")
+
+    public_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/public/health" }.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/java/spring_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/java/spring_hunt_ai_context_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+describe "--ai-context Hunt signals on Spring fixtures" do
+  fixture_path = "fixtures/java/spring/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps body identifiers from inheriting path-style Hunt IDOR noise" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/items/" }.ai_context
+    create_context = create_context.should_not be_nil
+    create_context.signals.map(&.kind).should_not contain("idor")
+    create_context.signals.map(&.kind).should_not contain("identifier_input")
+
+    client_create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/v2/items" }.ai_context
+    client_create_context = client_create_context.should_not be_nil
+    client_create_context.signals.map(&.kind).should_not contain("idor")
+    client_create_context.signals.map(&.kind).should_not contain("identifier_input")
+
+    update_context = endpoints.find! { |ep| ep.method == "PUT" && ep.url == "/items/update/{id}" }.ai_context
+    update_context = update_context.should_not be_nil
+    update_context.signals.map(&.kind).should contain("idor")
+    update_context.signals.map(&.kind).should_not contain("identifier_input")
+  end
+end

--- a/spec/functional_test/testers/javascript/express_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/express_ai_context_spec.cr
@@ -1,0 +1,42 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Express auth fixtures" do
+  fixture_path = "fixtures/javascript/express_auth/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps guard detections route-local and still enriches protected handlers" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+    endpoints.size.should eq(5)
+
+    public_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public" }.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+
+    profile_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/profile" }.ai_context
+    profile_context = profile_context.should_not be_nil
+    profile_context.guards.size.should eq(1)
+    profile_context.guards[0].source.should eq("express_auth")
+    profile_context.callees.map(&.name).should contain("res.json")
+
+    post_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/data" }.ai_context
+    post_context = post_context.should_not be_nil
+    post_context.guards.size.should eq(1)
+    post_context.signals.map(&.kind).should contain("state_change")
+
+    health_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/health" }.ai_context
+    health_context = health_context.should_not be_nil
+    health_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/javascript/fastify_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_ai_context_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Fastify auth fixtures" do
+  fixture_path = "fixtures/javascript/fastify_auth/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps auth detections on protected routes only" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+    endpoints.size.should eq(5)
+
+    secure_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/secure" }.ai_context
+    secure_context = secure_context.should_not be_nil
+    secure_context.guards.size.should eq(1)
+    secure_context.guards[0].source.should eq("js_misc_auth")
+
+    public_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public/health" }.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
@@ -44,5 +44,9 @@ describe "--ai-context Hunt signals on Fastify fixtures" do
     process_context.signals.map(&.kind).should contain("idor")
     process_context.signals.map(&.kind).should contain("idor_review")
     process_context.signals.map(&.kind).should_not contain("guard_absence")
+
+    upload_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/upload" }.ai_context
+    upload_context = upload_context.should_not be_nil
+    upload_context.signals.map(&.kind).should_not contain("file_input")
   end
 end

--- a/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
@@ -34,11 +34,11 @@ describe "--ai-context Hunt signals on Fastify fixtures" do
     dashboard_context.signals.map(&.kind).should_not contain("ssrf")
     dashboard_context.signals.map(&.kind).should_not contain("sqli")
 
-    admin_create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/create" }.ai_context
+    admin_create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/admin/users/create" }.ai_context
     admin_create_context = admin_create_context.should_not be_nil
     admin_create_context.signals.map(&.kind).should_not contain("sqli")
 
-    process_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/process/:methodId" }.ai_context
+    process_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/payments/process/:methodId" }.ai_context
     process_context = process_context.should_not be_nil
     process_context.signals.map(&.kind).should contain("path_param")
     process_context.signals.map(&.kind).should contain("idor")

--- a/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+describe "--ai-context Hunt signals on Fastify fixtures" do
+  fixture_path = "fixtures/javascript/fastify/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "avoids broad Hunt false positives on common body and view fields" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    register_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/register" }.ai_context
+    register_context = register_context.should_not be_nil
+    register_context.signals.map(&.kind).should_not contain("idor")
+
+    product_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/products" }.ai_context
+    product_context = product_context.should_not be_nil
+    product_context.signals.map(&.kind).should_not contain("ssti")
+    product_context.signals.map(&.kind).should_not contain("sqli")
+
+    dashboard_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/dashboard" }.ai_context
+    dashboard_context = dashboard_context.should_not be_nil
+    dashboard_context.signals.map(&.kind).should_not contain("ssti")
+    dashboard_context.signals.map(&.kind).should_not contain("ssrf")
+    dashboard_context.signals.map(&.kind).should_not contain("sqli")
+
+    admin_create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/create" }.ai_context
+    admin_create_context = admin_create_context.should_not be_nil
+    admin_create_context.signals.map(&.kind).should_not contain("sqli")
+  end
+end

--- a/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_hunt_ai_context_spec.cr
@@ -37,5 +37,12 @@ describe "--ai-context Hunt signals on Fastify fixtures" do
     admin_create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/create" }.ai_context
     admin_create_context = admin_create_context.should_not be_nil
     admin_create_context.signals.map(&.kind).should_not contain("sqli")
+
+    process_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/process/:methodId" }.ai_context
+    process_context = process_context.should_not be_nil
+    process_context.signals.map(&.kind).should contain("path_param")
+    process_context.signals.map(&.kind).should contain("idor")
+    process_context.signals.map(&.kind).should contain("idor_review")
+    process_context.signals.map(&.kind).should_not contain("guard_absence")
   end
 end

--- a/spec/functional_test/testers/javascript/fastify_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_spec.cr
@@ -33,38 +33,38 @@ expected_endpoints = [
     Param.new("view", "", "query"),
     Param.new("sessionId", "", "cookie"),
   ]),
-  # Routes from plugin functions (detected without prefix in current implementation)
-  Endpoint.new("/status", "GET", [
+  # Routes from plugin functions
+  Endpoint.new("/api/v1/status", "GET", [
     Param.new("format", "", "query"),
     Param.new("x-status-key", "", "header"),
   ]),
-  Endpoint.new("/config", "PUT", [
+  Endpoint.new("/api/v1/config", "PUT", [
     Param.new("theme", "", "json"),
     Param.new("notifications", "", "json"),
     Param.new("configToken", "", "cookie"),
   ]),
-  Endpoint.new("/stats", "GET", [
+  Endpoint.new("/admin/stats", "GET", [
     Param.new("period", "", "query"),
     Param.new("admin-token", "", "header"),
   ]),
-  Endpoint.new("/users/create", "POST", [
+  Endpoint.new("/admin/users/create", "POST", [
     Param.new("username", "", "json"),
     Param.new("role", "", "json"),
     Param.new("permissions", "", "json"),
     Param.new("masterKey", "", "cookie"),
   ]),
-  Endpoint.new("/system/logs", "GET", [
+  Endpoint.new("/admin/system/logs", "GET", [
     Param.new("date", "", "query"),
     Param.new("level", "", "query"),
   ]),
-  Endpoint.new("/process/:methodId", "POST", [
+  Endpoint.new("/payments/process/:methodId", "POST", [
     Param.new("methodId", "", "path"),
     Param.new("amount", "", "json"),
     Param.new("currency", "", "json"),
     Param.new("description", "", "json"),
     Param.new("payment-key", "", "header"),
   ]),
-  Endpoint.new("/transactions", "GET", [
+  Endpoint.new("/payments/transactions", "GET", [
     Param.new("startDate", "", "query"),
     Param.new("endDate", "", "query"),
     Param.new("merchant-id", "", "header"),

--- a/spec/functional_test/testers/kotlin/ktor_ai_context_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_ai_context_spec.cr
@@ -1,0 +1,57 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Ktor auth fixtures" do
+  fixture_path = "fixtures/kotlin/ktor_auth/"
+  app_suffix = "spec/functional_test/fixtures/kotlin/ktor_auth/src/Application.kt"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "captures authenticate blocks while leaving public Ktor routes unguarded" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    public_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public" }
+    public_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 10 }.should be_true
+    public_context = public_endpoint.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+
+    profile_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/profile" }
+    profile_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 15 }.should be_true
+    profile_context = profile_endpoint.ai_context
+    profile_context = profile_context.should_not be_nil
+    profile_context.guards.size.should eq(1)
+    profile_context.guards[0].source.should eq("ktor_auth")
+    profile_context.callees.map(&.name).should contain("call.principal")
+
+    post_endpoint = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/data" }
+    post_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 20 }.should be_true
+    post_context = post_endpoint.ai_context
+    post_context = post_context.should_not be_nil
+    post_context.guards.size.should eq(1)
+    post_context.signals.map(&.kind).should contain("state_change")
+
+    admin_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/admin/dashboard" }
+    admin_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 27 }.should be_true
+    admin_context = admin_endpoint.ai_context
+    admin_context = admin_context.should_not be_nil
+    admin_context.guards.size.should eq(1)
+    admin_context.guards[0].source.should eq("ktor_auth")
+
+    health_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/health" }
+    health_endpoint.details.code_paths.any? { |info| info.path.ends_with?(app_suffix) && info.line == 33 }.should be_true
+    health_context = health_endpoint.ai_context
+    health_context = health_context.should_not be_nil
+    health_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/kotlin/ktor_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_spec.cr
@@ -4,34 +4,28 @@ expected_endpoints = [
   Endpoint.new("/", "GET"),
   Endpoint.new("/users/{id}", "GET", [
     Param.new("id", "", "path"),
-    Param.new("id", "", "query"),
   ]),
   Endpoint.new("/users", "POST", [Param.new("body", "User", "json")]),
   Endpoint.new("/users/{id}", "PUT", [
     Param.new("id", "", "path"),
-    Param.new("id", "", "query"),
     Param.new("X-API-Key", "", "header"),
   ]),
   Endpoint.new("/users/{id}", "DELETE", [
     Param.new("id", "", "path"),
-    Param.new("id", "", "query"),
   ]),
   Endpoint.new("/api/status", "GET"),
   Endpoint.new("/api/v1/health", "GET"),
   Endpoint.new("/api/v1/submit", "POST", [Param.new("body", "SubmitData", "json")]),
   Endpoint.new("/api/v1/items/{itemId}", "GET", [
     Param.new("itemId", "", "path"),
-    Param.new("itemId", "", "query"),
     Param.new("category", "", "query"),
   ]),
   Endpoint.new("/partial/{resourceId}", "PATCH", [
     Param.new("resourceId", "", "path"),
-    Param.new("resourceId", "", "query"),
     Param.new("Authorization", "", "header"),
   ]),
   Endpoint.new("/check/{id}", "HEAD", [
     Param.new("id", "", "path"),
-    Param.new("id", "", "query"),
   ]),
   Endpoint.new("/settings", "OPTIONS"),
 ]

--- a/spec/functional_test/testers/php/cakephp_spec.cr
+++ b/spec/functional_test/testers/php/cakephp_spec.cr
@@ -16,6 +16,6 @@ expected_endpoints = [
 ]
 
 FunctionalTester.new("fixtures/php/cakephp/", {
-  :techs     => 2,  # php_cakephp and php_pure
-  :endpoints => 14, # 12 CakePHP routes + 2 php_pure files (routes.php, ArticlesController.php)
+  :techs     => 2,  # Detection still sees php_cakephp and php_pure
+  :endpoints => 12, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/codeigniter_spec.cr
+++ b/spec/functional_test/testers/php/codeigniter_spec.cr
@@ -40,6 +40,6 @@ expected_endpoints = [
 ]
 
 FunctionalTester.new("fixtures/php/codeigniter/", {
-  :techs     => 2,  # php_codeigniter + php_pure
-  :endpoints => 40, # 38 CodeIgniter routes + 2 php_pure files (Routes.php, Home.php)
+  :techs     => 2,  # Detection still sees php_codeigniter and php_pure
+  :endpoints => 38, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/laravel_ai_context_spec.cr
+++ b/spec/functional_test/testers/php/laravel_ai_context_spec.cr
@@ -1,0 +1,47 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Laravel auth fixtures" do
+  fixture_path = "fixtures/php/laravel_auth/"
+  routes_suffix = "spec/functional_test/fixtures/php/laravel_auth/routes/web.php"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps route middleware guards on protected Laravel routes only" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+    endpoints.size.should eq(3)
+    endpoints.all? { |ep| ep.details.technology == "php_laravel" }.should be_true
+
+    public_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public" }
+    public_endpoint.details.code_paths.any? { |info| info.path.ends_with?(routes_suffix) && info.line == 5 }.should be_true
+    public_context = public_endpoint.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+
+    profile_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/profile" }
+    profile_endpoint.details.code_paths.any? { |info| info.path.ends_with?(routes_suffix) && info.line == 9 }.should be_true
+    profile_context = profile_endpoint.ai_context
+    profile_context = profile_context.should_not be_nil
+    profile_context.guards.size.should eq(1)
+    profile_context.guards[0].source.should eq("php_auth")
+    profile_context.callees.map(&.name).should contain("response")
+
+    posts_endpoint = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/posts" }
+    posts_endpoint.details.code_paths.any? { |info| info.path.ends_with?(routes_suffix) && info.line == 13 }.should be_true
+    posts_context = posts_endpoint.ai_context
+    posts_context = posts_context.should_not be_nil
+    posts_context.guards.size.should eq(1)
+    posts_context.guards[0].source.should eq("php_auth")
+    posts_context.signals.map(&.kind).should contain("state_change")
+  end
+end

--- a/spec/functional_test/testers/php/laravel_spec.cr
+++ b/spec/functional_test/testers/php/laravel_spec.cr
@@ -21,6 +21,6 @@ expected_endpoints = [
 ]
 
 FunctionalTester.new("fixtures/php/laravel/", {
-  :techs     => 2,  # Both php_laravel and php_pure are detected
-  :endpoints => 51, # Total detected endpoints
+  :techs     => 2,  # Detection still sees both php_laravel and php_pure
+  :endpoints => 45, # Analysis suppresses redundant php_pure endpoints
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/slim_callees_spec.cr
+++ b/spec/functional_test/testers/php/slim_callees_spec.cr
@@ -53,7 +53,7 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/slim_callees/", {
   :techs     => 2,
-  :endpoints => 7,
+  :endpoints => 6,
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/php/slim_spec.cr
+++ b/spec/functional_test/testers/php/slim_spec.cr
@@ -19,6 +19,6 @@ expected_endpoints = [
 ]
 
 FunctionalTester.new("fixtures/php/slim/", {
-  :techs     => 2,  # php_slim and php_pure
-  :endpoints => 13, # 12 Slim routes + 1 php_pure GET for index.php
+  :techs     => 2,  # Detection still sees php_slim and php_pure
+  :endpoints => 12, # Analysis suppresses the redundant php_pure file endpoint
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/symfony_callees_spec.cr
+++ b/spec/functional_test/testers/php/symfony_callees_spec.cr
@@ -71,7 +71,7 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,
-  :endpoints => 20,
+  :endpoints => 18,
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/php/symfony_spec.cr
+++ b/spec/functional_test/testers/php/symfony_spec.cr
@@ -60,11 +60,9 @@ expected_endpoints = [
   Endpoint.new("/webhooks/{provider}", "POST", [
     Param.new("provider", "", "path"),
   ]),
-  Endpoint.new("/src/Controller/UserController.php", "GET"),
-  Endpoint.new("/src/Controller/ProductController.php", "GET"),
 ]
 
 FunctionalTester.new("fixtures/php/symfony/", {
-  :techs     => 2,  # Both php_symfony and php_pure are detected
-  :endpoints => 20, # Updated to include all methods from UserController (was 17, now 20)
+  :techs     => 2,  # Detection still sees php_symfony and php_pure
+  :endpoints => 18, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/yii_callees_spec.cr
+++ b/spec/functional_test/testers/php/yii_callees_spec.cr
@@ -62,7 +62,7 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/yii/", {
   :techs     => 2,
-  :endpoints => 23,
+  :endpoints => 20,
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/php/yii_spec.cr
+++ b/spec/functional_test/testers/php/yii_spec.cr
@@ -51,13 +51,9 @@ expected_endpoints = [
     Param.new("q", "", "query"),
     Param.new("tag", "", "query"),
   ]),
-  # php_pure analyzer emits a generic GET endpoint per .php file
-  Endpoint.new("/config/web.php", "GET"),
-  Endpoint.new("/controllers/PostController.php", "GET"),
-  Endpoint.new("/controllers/UserController.php", "GET"),
 ]
 
 FunctionalTester.new("fixtures/php/yii/", {
   :techs     => 2,
-  :endpoints => 23,
+  :endpoints => 20,
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/django_ai_context_spec.cr
+++ b/spec/functional_test/testers/python/django_ai_context_spec.cr
@@ -1,0 +1,59 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Django auth fixtures" do
+  fixture_path = "fixtures/python/django_auth/"
+  views_suffix = "spec/functional_test/fixtures/python/django_auth/blog/views.py"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "preserves handler source locations and surfaces Django auth guards only on protected views" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+    endpoints.size.should eq(7)
+
+    public_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public/" }
+    public_endpoint.details.code_paths.any? { |info| info.path.ends_with?(views_suffix) && info.line == 10 }.should be_true
+    public_context = public_endpoint.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+
+    list_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts/" }
+    list_endpoint.details.code_paths.any? { |info| info.path.ends_with?(views_suffix) && info.line == 15 }.should be_true
+    list_context = list_endpoint.ai_context
+    list_context = list_context.should_not be_nil
+    list_context.guards.size.should eq(1)
+    list_context.guards[0].source.should eq("django_auth")
+
+    detail_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts/<int:pk>/" }
+    detail_endpoint.details.code_paths.any? { |info| info.path.ends_with?(views_suffix) && info.line == 24 }.should be_true
+    detail_context = detail_endpoint.ai_context
+    detail_context = detail_context.should_not be_nil
+    detail_context.guards.size.should eq(1)
+    detail_context.guards[0].source.should eq("django_auth")
+
+    create_post_endpoint = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/posts/create/" }
+    create_post_endpoint.details.code_paths.any? { |info| info.path.ends_with?(views_suffix) && info.line == 20 }.should be_true
+    create_post_context = create_post_endpoint.ai_context
+    create_post_context = create_post_context.should_not be_nil
+    create_post_context.guards.size.should eq(1)
+    create_post_context.guards[0].source.should eq("django_auth")
+    create_post_context.signals.map(&.kind).should contain("state_change")
+
+    api_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/posts/" }
+    api_endpoint.details.code_paths.any? { |info| info.path.ends_with?(views_suffix) && info.line == 32 }.should be_true
+    api_context = api_endpoint.ai_context
+    api_context = api_context.should_not be_nil
+    api_context.guards.size.should eq(1)
+    api_context.guards[0].source.should eq("django_auth")
+  end
+end

--- a/spec/functional_test/testers/python/fastapi_ai_context_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_ai_context_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on FastAPI auth fixtures" do
+  fixture_path = "fixtures/python/fastapi_auth/"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "captures dependency-based auth while leaving public handlers unguarded" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    profile_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/profile" }.ai_context
+    profile_context = profile_context.should_not be_nil
+    profile_context.guards.size.should eq(1)
+    profile_context.guards[0].source.should eq("fastapi_auth")
+    profile_context.callees.map(&.name).should contain("Depends")
+
+    admin_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/admin" }.ai_context
+    admin_context = admin_context.should_not be_nil
+    admin_context.guards.size.should eq(1)
+    admin_context.guards[0].source.should eq("fastapi_auth")
+
+    public_context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/public" }.ai_context
+    public_context = public_context.should_not be_nil
+    public_context.guards.should be_empty
+  end
+end

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -34,7 +34,6 @@ expected_endpoints = [
   ]),
   Endpoint.new("/admin/refunds/new_list", "GET", [
     Param.new("X-Page", "", "header"),
-    Param.new("status", "", "query"),
   ]),
 
   # Namespaced `to: "ctrl#action"` resolves against `admin/monitor_controller.rb`,

--- a/spec/functional_test/testers/ruby/rails_ai_context_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_ai_context_spec.cr
@@ -1,0 +1,67 @@
+require "../../func_spec.cr"
+
+describe "--ai-context on Rails auth fixtures" do
+  fixture_path = "fixtures/ruby/rails_auth/"
+  controller_suffix = "spec/functional_test/fixtures/ruby/rails_auth/app/controllers/posts_controller.rb"
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "preserves controller action lines and respects skip_before_action overrides" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+    options["ai_context"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoints = app.endpoints
+
+    index_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts" }
+    index_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 5 }.should be_true
+    index_context = index_endpoint.ai_context
+    index_context = index_context.should_not be_nil
+    index_context.guards.should be_empty
+    index_endpoint.params.map(&.name).should be_empty
+    index_context.signals.map(&.kind).should_not contain("identifier_input")
+    index_context.signals.map(&.kind).should_not contain("idor")
+
+    show_endpoint = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts/1" }
+    show_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 9 }.should be_true
+    show_endpoint.params.map { |param| {param.name, param.param_type} }.should eq([{"id", "path"}])
+    show_context = show_endpoint.ai_context
+    show_context = show_context.should_not be_nil
+    show_context.guards.size.should eq(1)
+    show_context.guards[0].source.should eq("ruby_auth")
+    show_context.signals.map(&.kind).should contain("path_param")
+    show_context.signals.map(&.kind).should_not contain("identifier_input")
+    show_context.signals.map(&.kind).should contain("idor")
+
+    create_endpoint = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/posts" }
+    create_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 13 }.should be_true
+    create_context = create_endpoint.ai_context
+    create_context = create_context.should_not be_nil
+    create_context.guards.size.should eq(1)
+    create_context.guards[0].source.should eq("ruby_auth")
+    create_endpoint.params.map(&.name).sort.should eq(["body", "title"])
+    create_context.signals.map(&.kind).should contain("state_change")
+    create_context.signals.map(&.kind).should_not contain("identifier_input")
+    create_context.signals.map(&.kind).should_not contain("idor")
+    create_context.validators.map(&.kind).should contain("validation")
+
+    destroy_endpoint = endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/posts/1" }
+    destroy_endpoint.details.code_paths.any? { |info| info.path.ends_with?(controller_suffix) && info.line == 19 }.should be_true
+    destroy_context = destroy_endpoint.ai_context
+    destroy_context = destroy_context.should_not be_nil
+    destroy_context.guards.size.should eq(1)
+    destroy_context.guards[0].source.should eq("ruby_auth")
+    destroy_endpoint.params.map { |param| {param.name, param.param_type} }.should eq([{"id", "path"}])
+    destroy_context.signals.map(&.kind).should contain("path_param")
+    destroy_context.signals.map(&.kind).should_not contain("identifier_input")
+    destroy_context.signals.map(&.kind).should contain("idor")
+    destroy_context.validators.should be_empty
+  end
+end

--- a/spec/functional_test/testers/ruby/rails_monorepo_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_monorepo_spec.cr
@@ -14,10 +14,7 @@ expected_endpoints = [
     Param.new("title", "", "json"),
     Param.new("context", "", "json"),
   ]),
-  Endpoint.new("/posts/1", "PUT", [
-    Param.new("title", "", "json"),
-    Param.new("context", "", "json"),
-  ]),
+  Endpoint.new("/posts/1", "PUT"),
   Endpoint.new("/posts/1", "DELETE"),
   Endpoint.new("/up", "GET"),
 ]

--- a/spec/functional_test/testers/ruby/rails_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_spec.cr
@@ -11,7 +11,6 @@ expected_endpoints = [
     Param.new("X-API-KEY", "", "header"),
   ]),
   Endpoint.new("/posts", "POST", [
-    Param.new("id", "", "json"),
     Param.new("title", "", "json"),
     Param.new("context", "", "json"),
   ]),

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -109,6 +109,30 @@ describe "NoirAIContext" do
     end
   end
 
+  it "treats camelCase path ids as identifier routes for idor review" do
+    source = <<-CODE
+      fastify.post("/process/:methodId", async (request, reply) => {
+        return { ok: true }
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/process/:methodId", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_param(Param.new("methodId", "", "path"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should contain("path_param")
+      context.signals.map(&.kind).should contain("idor_review")
+      context.signals.map(&.kind).should_not contain("guard_absence")
+    end
+  end
+
   it "avoids broad sink false positives from request locals and non-template json renders" do
     source = <<-CODE
       def create_user(request)

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -64,7 +64,7 @@ describe "NoirAIContext" do
     end
   end
 
-  it "adds low-confidence guard absence signals for unguarded state-changing endpoints" do
+  it "prefers idor review over generic guard absence on unguarded identifier routes" do
     source = <<-CODE
       post "/projects/:id/rotate" do
         rotate_secret(params[:id])
@@ -82,8 +82,30 @@ describe "NoirAIContext" do
       context = endpoints[0].ai_context
       context = context.should_not be_nil
 
-      context.signals.map(&.kind).should contain("guard_absence")
       context.signals.map(&.kind).should contain("idor_review")
+      context.signals.map(&.kind).should_not contain("guard_absence")
+    end
+  end
+
+  it "keeps guard absence for unguarded state-changing endpoints without identifier paths" do
+    source = <<-CODE
+      delete "/cache" do
+        clear_cache()
+      end
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/cache", "DELETE")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should contain("guard_absence")
+      context.signals.map(&.kind).should_not contain("idor_review")
     end
   end
 

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -235,6 +235,30 @@ describe "NoirAIContext" do
     end
   end
 
+  it "does not treat bare query params as query-builder signals by default" do
+    source = <<-CODE
+      e.GET("/pet", func(c echo.Context) error {
+        _ = c.QueryParam("query")
+        return c.String(http.StatusOK, "pet")
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/pet", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_param(Param.new("query", "", "query"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should_not contain("query_builder_input")
+      context.signals.map(&.name).should_not contain("query.query")
+    end
+  end
+
   it "avoids treating generic user agent headers as identifier inputs" do
     source = <<-CODE
       r.Get("/api-test", func(w http.ResponseWriter, r *http.Request) {

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -283,6 +283,28 @@ describe "NoirAIContext" do
     end
   end
 
+  it "does not treat upload-flavored headers as file inputs by default" do
+    source = <<-CODE
+      fastify.post("/upload", async (request, reply) => {
+        return { uploaded: true }
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/upload", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_param(Param.new("upload-token", "", "header"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should_not contain("file_input")
+    end
+  end
+
   it "avoids treating generic user agent headers as identifier inputs" do
     source = <<-CODE
       r.Get("/api-test", func(w http.ResponseWriter, r *http.Request) {

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -1,0 +1,265 @@
+require "../../spec_helper"
+require "../../../src/ai_context/augmentor"
+
+def with_temp_ai_context_source(content : String, &block : String ->)
+  path = "/tmp/noir-ai-context-#{Random.rand(1_000_000)}.txt"
+  File.write(path, content)
+  begin
+    yield path
+  ensure
+    File.delete(path) if File.exists?(path)
+  end
+end
+
+describe "NoirAIContext" do
+  it "builds aggregated AI context from callees and tags" do
+    source = <<-CODE
+      app.post("/users/:id/avatar", requireAuth, async (req, res) => {
+        const user = await User.find_by_sql(req.params.id)
+        ParamsValidator.validate(req.body)
+        return res.redirect(req.body.next)
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/users/:id/avatar", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      details.technology = "js_express"
+      endpoint.details = details
+
+      id_param = Param.new("id", "1", "path")
+      id_param.add_tag(Tag.new("idor", "This parameter may be vulnerable to Insecure Direct Object Reference (IDOR) attacks.", "Hunt"))
+      endpoint.push_param(id_param)
+      endpoint.push_param(Param.new("next", "/dashboard", "json"))
+      endpoint.push_param(Param.new("file", "avatar.png", "form"))
+      endpoint.push_callee(Callee.new("User.find_by_sql", path, 2))
+      endpoint.push_callee(Callee.new("ParamsValidator.validate", path, 3))
+      endpoint.push_callee(Callee.new("res.redirect", path, 4))
+      endpoint.add_tag(Tag.new("auth", "Protected by Express requireAuth middleware", "express_auth"))
+      endpoint.add_tag(Tag.new("jwt", "JWT endpoint for token-based authentication.", "JWT"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.guards.size.should eq(1)
+      context.guards[0].source.should eq("express_auth")
+      guard_snippet = context.guards[0].snippet
+      guard_snippet.should_not be_nil
+      guard_snippet.not_nil!.should contain("app.post")
+
+      context.callees.map(&.name).should contain("User.find_by_sql")
+      context.callees.first.snippet.should_not be_nil
+      context.sinks.map(&.kind).should contain("sql")
+      context.sinks.map(&.kind).should contain("redirect")
+      context.validators.map(&.kind).should contain("validation")
+      context.signals.map(&.kind).should contain("route_definition")
+      context.signals.map(&.kind).should contain("path_param")
+      context.signals.map(&.kind).should contain("redirect_input")
+      context.signals.map(&.kind).should contain("file_input")
+      context.signals.map(&.kind).should contain("idor")
+      context.signals.map(&.name).should contain("jwt")
+    end
+  end
+
+  it "adds low-confidence guard absence signals for unguarded state-changing endpoints" do
+    source = <<-CODE
+      post "/projects/:id/rotate" do
+        rotate_secret(params[:id])
+      end
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/projects/:id/rotate", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_param(Param.new("id", "7", "path"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should contain("guard_absence")
+      context.signals.map(&.kind).should contain("idor_review")
+    end
+  end
+
+  it "avoids broad sink false positives from request locals and non-template json renders" do
+    source = <<-CODE
+      def create_user(request)
+        post = Post.new(request.POST.get("title"))
+        return render json: post.save
+      end
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/posts", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_callee(Callee.new("request.POST.get", path, 2))
+      endpoint.push_callee(Callee.new("render", path, 3))
+      endpoint.push_callee(Callee.new("post.save", path, 3))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.sinks.should be_empty
+    end
+  end
+
+  it "avoids broad write/check heuristics for audit logs and health probes" do
+    source = <<-CODE
+      def status
+        AuditLog.write("status")
+        Health.check()
+      end
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/status", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_callee(Callee.new("AuditLog.write", path, 2))
+      endpoint.push_callee(Callee.new("Health.check", path, 3))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.sinks.should be_empty
+      context.validators.should be_empty
+    end
+  end
+
+  it "suppresses low-value identifier signals for bare POST body ids" do
+    source = <<-CODE
+      @PostMapping("/items")
+      public Item createItem(@RequestBody Item item) { }
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/items", "POST")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_param(Param.new("id", "", "json"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should contain("state_change")
+      context.signals.map(&.kind).should_not contain("identifier_input")
+    end
+  end
+
+  it "prefers Hunt idor over generic identifier signals for path-based updates" do
+    source = <<-CODE
+      @PutMapping("/items/{id}")
+      public Item updateItem(@PathVariable Long id, @RequestBody Item item) { }
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/items/{id}", "PUT")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      path_id = Param.new("id", "", "path")
+      path_id.add_tag(Tag.new("idor", "This parameter may be vulnerable to Insecure Direct Object Reference (IDOR) attacks.", "Hunt"))
+      endpoint.push_param(path_id)
+      endpoint.push_param(Param.new("id", "", "json"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should_not contain("identifier_input")
+      context.signals.map(&.kind).should contain("path_param")
+      context.signals.map(&.kind).should contain("idor")
+      context.signals.map(&.name).should contain("path.id")
+    end
+  end
+
+  it "prefers Hunt sqli over generic query builder signals for the same param" do
+    source = <<-CODE
+      e.GET("/items/:itemId/reviews", func(c echo.Context) error {
+        _ = c.QueryParam("sort")
+        return c.JSON(http.StatusOK, nil)
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/items/:itemId/reviews", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      sort_param = Param.new("sort", "", "query")
+      sort_param.add_tag(Tag.new("sqli", "This parameter may be vulnerable to SQL Injection attacks.", "Hunt"))
+      endpoint.push_param(sort_param)
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.kind).should_not contain("query_builder_input")
+      context.signals.map(&.kind).should contain("sqli")
+      context.signals.map(&.name).should contain("query.sort")
+    end
+  end
+
+  it "avoids treating generic user agent headers as identifier inputs" do
+    source = <<-CODE
+      r.Get("/api-test", func(w http.ResponseWriter, r *http.Request) {
+        apiKey := r.Header.Get("X-API-Key")
+        userAgent := r.Header.Get("User-Agent")
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/api-test", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_param(Param.new("X-API-Key", "", "header"))
+      endpoint.push_param(Param.new("User-Agent", "", "header"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.signals.map(&.name).should contain("header.X-API-Key")
+      context.signals.map(&.name).should_not contain("header.User-Agent")
+    end
+  end
+
+  it "avoids treating request query accessors as sql sinks" do
+    source = <<-CODE
+      r.Get("/search-test", func(w http.ResponseWriter, r *http.Request) {
+        query := r.URL.Query().Get("q")
+        page := r.URL.Query().Get("page")
+      })
+      CODE
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/search-test", "GET")
+      details = endpoint.details
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_callee(Callee.new("r.URL.Query", path, 2))
+      endpoint.push_param(Param.new("q", "", "query"))
+      endpoint.push_param(Param.new("page", "", "query"))
+
+      endpoints = NoirAIContext.apply([endpoint])
+      context = endpoints[0].ai_context
+      context = context.should_not be_nil
+
+      context.sinks.map(&.kind).should_not contain("sql")
+    end
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_selection_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_selection_spec.cr
@@ -1,0 +1,18 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzer.cr"
+
+describe "filter_redundant_generic_techs" do
+  it "drops php_pure when a framework-specific php analyzer is present" do
+    filter_redundant_generic_techs(["php_pure", "php_laravel"]).should eq(["php_laravel"])
+    filter_redundant_generic_techs(["php_symfony", "php_pure"]).should eq(["php_symfony"])
+  end
+
+  it "keeps php_pure when no framework-specific php analyzer is present" do
+    filter_redundant_generic_techs(["php_pure"]).should eq(["php_pure"])
+  end
+
+  it "does not affect unrelated technologies" do
+    techs = ["php_laravel", "python_django", "js_express"]
+    filter_redundant_generic_techs(techs).should eq(techs)
+  end
+end

--- a/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
@@ -48,4 +48,17 @@ describe Noir::RubyCalleeExtractor do
       {"head", 32},
     ])
   end
+
+  it "does not extract bare words from string literals" do
+    body = <<-RUBY
+      format.html { redirect_to post_url(@post), notice: "Post was successfully created." }
+      RUBY
+
+    callees = Noir::RubyCalleeExtractor.callees_for_body(body, "posts_controller.rb", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"format.html", 40},
+      {"redirect_to", 40},
+      {"post_url", 40},
+    ])
+  end
 end

--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -11,6 +11,9 @@ describe "Initialize 2 arguments" do
   it "detect_params" do
     endpoint.params.should eq([] of Param)
   end
+  it "has no ai_context by default" do
+    endpoint.ai_context.should be_nil
+  end
 end
 
 describe "Initialize 3 arguments" do

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../src/options.cr"
 
 describe "default_options" do
   it "init" do
@@ -14,6 +15,11 @@ describe "default_options" do
   it "has default native tool-calling allowlist" do
     noir_options = create_test_options
     noir_options["ai_native_tools_allowlist"].to_s.should eq("openai,xai,github")
+  end
+
+  it "has ai_context disabled by default" do
+    noir_options = create_test_options
+    noir_options["ai_context"].should be_false
   end
 end
 
@@ -67,6 +73,21 @@ describe "run_options_parser" do
     begin
       noir_options = run_options_parser()
       noir_options["ai_agent"].should be_true
+    ensure
+      ARGV.clear
+      ARGV.concat(original_argv)
+    end
+  end
+
+  it "supports --ai-context flag" do
+    original_argv = ARGV.dup
+
+    ARGV.clear
+    ARGV.concat(["-b", "./single_app", "--ai-context"])
+
+    begin
+      noir_options = run_options_parser()
+      noir_options["ai_context"].should be_true
     ensure
       ARGV.clear
       ARGV.concat(original_argv)

--- a/spec/unit_test/output_builder/common_spec.cr
+++ b/spec/unit_test/output_builder/common_spec.cr
@@ -14,6 +14,7 @@ describe "OutputBuilderCommon" do
       "include_techs"  => YAML::Any.new(false),
       "include_path"   => YAML::Any.new(false),
       "include_callee" => YAML::Any.new(false),
+      "ai_context"     => YAML::Any.new(false),
       "status_codes"   => YAML::Any.new(false),
       "exclude_codes"  => YAML::Any.new(""),
     }
@@ -42,6 +43,7 @@ describe "OutputBuilderCommon" do
       "include_techs"  => YAML::Any.new(true),
       "include_path"   => YAML::Any.new(false),
       "include_callee" => YAML::Any.new(false),
+      "ai_context"     => YAML::Any.new(false),
       "status_codes"   => YAML::Any.new(false),
       "exclude_codes"  => YAML::Any.new(""),
     }
@@ -70,6 +72,7 @@ describe "OutputBuilderCommon" do
       "include_techs"  => YAML::Any.new(true),
       "include_path"   => YAML::Any.new(false),
       "include_callee" => YAML::Any.new(false),
+      "ai_context"     => YAML::Any.new(false),
       "status_codes"   => YAML::Any.new(false),
       "exclude_codes"  => YAML::Any.new(""),
     }
@@ -97,6 +100,7 @@ describe "OutputBuilderCommon" do
       "include_path"   => YAML::Any.new(true),
       "include_callee" => YAML::Any.new(false),
       "include_techs"  => YAML::Any.new(true),
+      "ai_context"     => YAML::Any.new(false),
       "status_codes"   => YAML::Any.new(false),
       "exclude_codes"  => YAML::Any.new(""),
     }
@@ -117,5 +121,36 @@ describe "OutputBuilderCommon" do
     output.should contain("file:")
     output.should contain("/app/test.py")
     output.should contain("line 42")
+  end
+
+  it "should display ai_context when ai_context flag is set" do
+    options = {
+      "debug"          => YAML::Any.new(false),
+      "verbose"        => YAML::Any.new(false),
+      "color"          => YAML::Any.new(false),
+      "nolog"          => YAML::Any.new(false),
+      "output"         => YAML::Any.new(""),
+      "include_path"   => YAML::Any.new(false),
+      "include_callee" => YAML::Any.new(false),
+      "include_techs"  => YAML::Any.new(false),
+      "ai_context"     => YAML::Any.new(true),
+      "status_codes"   => YAML::Any.new(false),
+      "exclude_codes"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderCommon.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/test", "GET")
+    context = AIContext.new
+    context.push_guard(AIContextEntry.new("auth", "auth", source: "express_auth", description: "Protected by auth middleware"))
+    context.push_sink(AIContextEntry.new("sql", "User.find_by_sql", source: "callee", line: 12))
+    endpoint.ai_context = context
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("ai_context:")
+    output.should contain("guards:")
+    output.should contain("sql: User.find_by_sql")
   end
 end

--- a/spec/unit_test/output_builder/oas3_spec.cr
+++ b/spec/unit_test/output_builder/oas3_spec.cr
@@ -23,6 +23,9 @@ describe "OutputBuilderOas3" do
     endpoint1.push_param(Param.new("api_key", "key123", "header"))
     endpoint1.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
     endpoint1.push_callee(Callee.new("AuditLog.record", line: 13))
+    context = AIContext.new
+    context.push_guard(AIContextEntry.new("auth", "auth", source: "express_auth", description: "Protected by Express requireAuth middleware"))
+    endpoint1.ai_context = context
 
     endpoint2 = Endpoint.new("/pets", "POST")
     endpoint2.push_param(Param.new("name", "Fluffy", "json"))
@@ -92,6 +95,8 @@ describe "OutputBuilderOas3" do
     callees[1]["name"].as_s.should eq("AuditLog.record")
     callees[1].as_h.has_key?("path").should be_false
     callees[1]["line"].as_i.should eq(13)
+    get_op["x-noir-ai-context"]["guards"].as_a.size.should eq(1)
+    get_op["x-noir-ai-context"]["guards"][0]["source"].as_s.should eq("express_auth")
 
     # Check POST endpoint with JSON body
     post_json_op = paths["/pets"]["post"]

--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -23,6 +23,9 @@ describe "OutputBuilderPostman" do
     endpoint1.push_param(Param.new("api_key", "key123", "header"))
     endpoint1.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
     endpoint1.push_callee(Callee.new("AuditLog.record", line: 13))
+    context = AIContext.new
+    context.push_guard(AIContextEntry.new("auth", "auth", source: "express_auth", description: "Protected by auth middleware"))
+    endpoint1.ai_context = context
 
     endpoint2 = Endpoint.new("/pets", "POST")
     endpoint2.push_param(Param.new("name", "Fluffy", "json"))
@@ -62,9 +65,9 @@ describe "OutputBuilderPostman" do
     item1["request"]["url"]["variable"][0]["key"].as_s.should eq("petId")
     item1["request"]["header"].as_a.size.should eq(1)
     item1["request"]["header"][0]["key"].as_s.should eq("api_key")
-    item1["description"].as_s.should contain("Noir callees:")
-    item1["description"].as_s.should contain("PetService.find (app/controllers/pets.cr:12)")
-    item1["description"].as_s.should contain("AuditLog.record (line 13)")
+    item1["description"].as_s.should contain("Noir AI context:")
+    item1["description"].as_s.should contain("guards:")
+    item1["description"].as_s.should contain("auth: auth [express_auth]")
 
     # Check second item (POST with JSON body)
     item2 = items[1]

--- a/spec/unit_test/output_builder/sarif_spec.cr
+++ b/spec/unit_test/output_builder/sarif_spec.cr
@@ -21,6 +21,9 @@ describe "OutputBuilderSarif" do
     endpoint.push_param(Param.new("id", "1", "query"))
     endpoint.push_callee(Callee.new("PetService.find", "app/controllers/pets.cr", 12))
     endpoint.push_callee(Callee.new("AuditLog.record", line: 13))
+    context = AIContext.new
+    context.push_guard(AIContextEntry.new("auth", "auth", source: "express_auth", description: "Protected by auth middleware"))
+    endpoint.ai_context = context
     endpoints = [endpoint]
 
     builder.print(endpoints)
@@ -53,6 +56,9 @@ describe "OutputBuilderSarif" do
     callees[1]["name"].as_s.should eq("AuditLog.record")
     callees[1].as_h.has_key?("path").should be_false
     callees[1]["line"].as_i.should eq(13)
+    guards = results[0]["properties"]["noir"]["ai_context"]["guards"].as_a
+    guards.size.should eq(1)
+    guards[0]["source"].as_s.should eq("express_auth")
   end
 
   it "print with endpoints and passive results" do

--- a/spec/unit_test/tagger/tagger_spec.cr
+++ b/spec/unit_test/tagger/tagger_spec.cr
@@ -23,10 +23,7 @@ describe "Tagger" do
       endpoint.params.each do |param|
         case param.name
         when "query"
-          param.tags.empty?.should be_false
-          param.tags.each do |tag|
-            tag.name.should eq("sqli")
-          end
+          param.tags.should be_empty
         when "url"
           param.tags.empty?.should be_false
           param.tags.each do |tag|

--- a/spec/unit_test/tagger/tagger_spec.cr
+++ b/spec/unit_test/tagger/tagger_spec.cr
@@ -15,7 +15,7 @@ describe "Tagger" do
       Endpoint.new("/api/sign_ups", "POST", [
         Param.new("url", "", "cookie"),
         Param.new("command", "", "cookie"),
-        Param.new("role", "", "cookie"),
+        Param.new("sort", "", "query"),
       ]),
     ]
     NoirTaggers.run_tagger(expected_endpoints, noir_options, "hunt")
@@ -32,7 +32,7 @@ describe "Tagger" do
           param.tags.each do |tag|
             tag.name.should eq("ssrf")
           end
-        when "role"
+        when "sort"
           param.tags.empty?.should be_false
           param.tags.each do |tag|
             tag.name.should eq("sqli")

--- a/spec/unit_test/tagger/taggers/hunt_param_spec.cr
+++ b/spec/unit_test/tagger/taggers/hunt_param_spec.cr
@@ -52,7 +52,7 @@ describe "HuntParamTagger" do
       endpoint.params[0].tags[0].name.should eq("ssrf")
     end
 
-    it "tags SQLi vulnerable parameters" do
+    it "does not treat bare query parameters as SQLi by default" do
       tagger = HuntParamTagger.new(default_tagger_options)
 
       endpoint = Endpoint.new("/users", "GET", [
@@ -61,9 +61,7 @@ describe "HuntParamTagger" do
 
       tagger.perform([endpoint])
 
-      endpoint.params[0].tags.size.should be >= 1
-      tag_names = endpoint.params[0].tags.map(&.name)
-      tag_names.should contain("sqli")
+      endpoint.params[0].tags.map(&.name).should_not contain("sqli")
     end
 
     it "tags IDOR vulnerable parameters" do
@@ -251,7 +249,7 @@ describe "HuntParamTagger" do
       endpoint.params[1].tags.size.should eq(0)
     end
 
-    it "can tag multiple parameters in one endpoint" do
+    it "can tag multiple parameters in one endpoint while leaving generic query names alone" do
       tagger = HuntParamTagger.new(default_tagger_options)
 
       endpoint = Endpoint.new("/search", "GET", [
@@ -262,7 +260,7 @@ describe "HuntParamTagger" do
 
       tagger.perform([endpoint])
 
-      endpoint.params[0].tags.size.should be >= 1
+      endpoint.params[0].tags.size.should eq(0)
       endpoint.params[1].tags.size.should eq(1)
       endpoint.params[2].tags.size.should eq(1)
     end

--- a/spec/unit_test/tagger/taggers/hunt_param_spec.cr
+++ b/spec/unit_test/tagger/taggers/hunt_param_spec.cr
@@ -196,6 +196,20 @@ describe "HuntParamTagger" do
       tag_names.should_not contain("sqli")
     end
 
+    it "treats camelCase path ids as IDOR-oriented identifiers" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/payments/:methodId", "GET", [
+        Param.new("methodId", "card", "path"),
+      ])
+
+      tagger.perform([endpoint])
+
+      tag_names = endpoint.params[0].tags.map(&.name)
+      tag_names.should contain("idor")
+      tag_names.should_not contain("sqli")
+    end
+
     it "tags file inclusion vulnerable parameters" do
       tagger = HuntParamTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/hunt_param_spec.cr
+++ b/spec/unit_test/tagger/taggers/hunt_param_spec.cr
@@ -56,12 +56,11 @@ describe "HuntParamTagger" do
       tagger = HuntParamTagger.new(default_tagger_options)
 
       endpoint = Endpoint.new("/users", "GET", [
-        Param.new("id", "123", "query"),
+        Param.new("query", "select * from users", "query"),
       ])
 
       tagger.perform([endpoint])
 
-      # 'id' matches both sqli and idor
       endpoint.params[0].tags.size.should be >= 1
       tag_names = endpoint.params[0].tags.map(&.name)
       tag_names.should contain("sqli")
@@ -79,6 +78,124 @@ describe "HuntParamTagger" do
       endpoint.params[0].tags.size.should be >= 1
       tag_names = endpoint.params[0].tags.map(&.name)
       tag_names.should contain("idor")
+    end
+
+    it "keeps generic id parameters focused on IDOR heuristics" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/:id", "GET", [
+        Param.new("id", "123", "path"),
+      ])
+
+      tagger.perform([endpoint])
+
+      tag_names = endpoint.params[0].tags.map(&.name)
+      tag_names.should contain("idor")
+      tag_names.should_not contain("sqli")
+      tag_names.should_not contain("ssti")
+    end
+
+    it "does not tag body ids as Hunt IDOR by default" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/items", "POST", [
+        Param.new("id", "123", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("idor")
+    end
+
+    it "does not tag emails as Hunt IDOR by default" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/register", "POST", [
+        Param.new("email", "user@example.com", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("idor")
+    end
+
+    it "does not treat common name fields as SSTI or SQLi by default" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/profile", "POST", [
+        Param.new("name", "alice", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      tag_names = endpoint.params[0].tags.map(&.name)
+      tag_names.should_not contain("ssti")
+      tag_names.should_not contain("sqli")
+    end
+
+    it "does not treat role flags as SQLi by default" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/admin/users", "POST", [
+        Param.new("role", "admin", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("sqli")
+    end
+
+    it "does not treat generic from filters as SQLi by default" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/analytics", "GET", [
+        Param.new("from", "2025-01-01", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("sqli")
+    end
+
+    it "keeps sort controls tagged as SQLi-oriented query builder inputs" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/reviews", "GET", [
+        Param.new("sort", "created_at", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should contain("sqli")
+    end
+
+    it "does not treat view switches as SSTI or SSRF by default" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/dashboard", "GET", [
+        Param.new("view", "summary", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      tag_names = endpoint.params[0].tags.map(&.name)
+      tag_names.should_not contain("ssti")
+      tag_names.should_not contain("ssrf")
+      tag_names.should_not contain("sqli")
+    end
+
+    it "keeps path users focused on IDOR heuristics" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/:user", "GET", [
+        Param.new("user", "alice", "path"),
+      ])
+
+      tagger.perform([endpoint])
+
+      tag_names = endpoint.params[0].tags.map(&.name)
+      tag_names.should contain("idor")
+      tag_names.should_not contain("sqli")
     end
 
     it "tags file inclusion vulnerable parameters" do
@@ -165,6 +282,19 @@ describe "HuntParamTagger" do
 
       endpoint1.params[0].tags.size.should be >= 1
       endpoint2.params[0].tags.size.should eq(0)
+    end
+
+    it "does not add duplicate Hunt tags that already exist" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/:id", "GET", [
+        Param.new("id", "123", "path"),
+      ])
+      endpoint.params[0].add_tag(Tag.new("idor", "existing", "Hunt"))
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.count { |tag| tag.name == "idor" && tag.tagger == "Hunt" }.should eq(1)
     end
   end
 end

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -414,17 +414,6 @@ module NoirAIContext
       return unless STATE_CHANGING_METHODS.includes?(endpoint.method)
       return unless context.guards.empty?
 
-      context.push_signal(AIContextEntry.new(
-        "guard_absence",
-        endpoint.method,
-        source: "heuristic",
-        description: "No auth guard was detected for this state-changing endpoint. This may be real or a heuristic blind spot; review manually.",
-        path: anchor.try(&.path),
-        line: anchor.try(&.line),
-        confidence: 28,
-        snippet: route_snippet
-      ))
-
       if endpoint.params.any? { |param| param.param_type == "path" && identifier_like?(param.name) }
         context.push_signal(AIContextEntry.new(
           "idor_review",
@@ -434,6 +423,17 @@ module NoirAIContext
           path: anchor.try(&.path),
           line: anchor.try(&.line),
           confidence: 36,
+          snippet: route_snippet
+        ))
+      else
+        context.push_signal(AIContextEntry.new(
+          "guard_absence",
+          endpoint.method,
+          source: "heuristic",
+          description: "No auth guard was detected for this state-changing endpoint. This may be real or a heuristic blind spot; review manually.",
+          path: anchor.try(&.path),
+          line: anchor.try(&.line),
+          confidence: 28,
           snippet: route_snippet
         ))
       end

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -526,13 +526,25 @@ module NoirAIContext
     end
 
     private def identifier_like?(name : String) : Bool
-      matches_any?(name, PARAM_PATTERNS.find { |pattern| pattern.kind == "identifier_input" }.not_nil!.name_patterns)
+      return true if matches_any?(name, PARAM_PATTERNS.find { |pattern| pattern.kind == "identifier_input" }.not_nil!.name_patterns)
+      return true if identifier_suffix_like?(name)
+
+      false
     end
 
     private def header_identifier_like?(name : String) : Bool
       normalized = name.downcase
       return true if normalized.matches?(/\b[a-z0-9_-]*id\b/)
       return true if normalized.matches?(/\b(client|account|order|profile|project|merchant|store|user)[_-]?id\b/)
+
+      false
+    end
+
+    private def identifier_suffix_like?(name : String) : Bool
+      return true if name == "id"
+      return true if name.matches?(/[_-]id$/i)
+      return true if name.matches?(/[a-z0-9]Id$/)
+      return true if name.matches?(/[a-z0-9]ID$/)
 
       false
     end

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -291,6 +291,7 @@ module NoirAIContext
     end
 
     private def skip_param_signal?(endpoint : Endpoint, param : Param, pattern : PatternDefinition) : Bool
+      return true if pattern.kind == "file_input" && param.param_type == "header"
       return false unless pattern.kind == "identifier_input"
       return !header_identifier_like?(param.name) if param.param_type == "header"
       return false unless BODY_LIKE_PARAM_TYPES.includes?(param.param_type)

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -145,7 +145,7 @@ module NoirAIContext
         "query_builder_input",
         "Query-builder-like input can influence filtering, sorting, or data access clauses",
         70,
-        name_patterns: [/\b(sort|order|filter|where|search|query|select|field|column)\b/i]
+        name_patterns: [/\b(sort|order|filter|where|search|select|field|column)\b/i]
       ),
     ] of PatternDefinition
 

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -1,0 +1,613 @@
+require "../models/endpoint"
+
+module NoirAIContext
+  extend self
+
+  def apply(endpoints : Array(Endpoint)) : Array(Endpoint)
+    Builder.new.apply(endpoints)
+  end
+
+  private class PatternDefinition
+    getter kind : String
+    getter description : String
+    getter confidence : Int32
+    getter name_patterns : Array(Regex)
+    getter source_patterns : Array(Regex)
+
+    def initialize(@kind : String,
+                   @description : String,
+                   @confidence : Int32,
+                   *,
+                   @name_patterns : Array(Regex) = [] of Regex,
+                   @source_patterns : Array(Regex) = [] of Regex)
+    end
+  end
+
+  private class Builder
+    ROUTE_SNIPPET_RADIUS  =   2
+    SOURCE_SCAN_RADIUS    =   6
+    CALLEE_SNIPPET_RADIUS =   1
+    MAX_SNIPPET_CHARS     = 240
+    MAX_ROUTE_SCOPE_LINES =  12
+
+    STATE_CHANGING_METHODS = Set{"POST", "PUT", "PATCH", "DELETE"}
+    BODY_LIKE_PARAM_TYPES  = Set{"json", "form"}
+
+    SINK_PATTERNS = [
+      PatternDefinition.new(
+        "sql",
+        "Potential SQL/data-store sink inferred from code or callee name",
+        78,
+        name_patterns: [/raw_?sql/i, /find_?by_?sql/i, /\bquery\b/i, /\bexecute\b/i, /\bselect\b/i],
+        source_patterns: [/find_by_sql/i, /\braw(sql|_sql)\b/i, /\bselect\b.+\bfrom\b/i, /\bexecute(Query|Sql)?\b/i]
+      ),
+      PatternDefinition.new(
+        "command_exec",
+        "Potential command execution sink inferred from code or callee name",
+        82,
+        name_patterns: [/\bexec\b/i, /\bsystem\b/i, /\bspawn\b/i, /\bpopen\b/i, /\bshell\b/i],
+        source_patterns: [/\bexec\s*\(/i, /\bsystem\s*\(/i, /\bspawn\s*\(/i, /\bpopen\s*\(/i, /ProcessBuilder/i, /Runtime\.getRuntime/i, /subprocess\./i]
+      ),
+      PatternDefinition.new(
+        "file_io",
+        "Potential file I/O sink inferred from code or callee name",
+        68,
+        name_patterns: [/\bfile\b/i, /\bread\b/i, /\bupload\b/i, /\bdownload\b/i],
+        source_patterns: [/\bFile\.(open|read|write)/, /\bread(File|_text)\b/i, /\bwrite(File|_text)\b/i, /\bsend_file\b/i, /\bsendFile\b/i, /\bdownload\b/i, /\bupload\b/i]
+      ),
+      PatternDefinition.new(
+        "redirect",
+        "Potential redirect sink inferred from code or callee name",
+        74,
+        name_patterns: [/\bredirect\b/i, /\bredirect_to\b/i],
+        source_patterns: [/\bredirect(_to)?\s*\(/i, /\bres\.redirect\b/i, /Response\.Redirect/i]
+      ),
+      PatternDefinition.new(
+        "template_render",
+        "Potential template/render sink inferred from code or callee name",
+        62,
+        name_patterns: [/\brender\b/i, /\btemplate\b/i, /\bhtml\b/i, /\brespond\b/i],
+        source_patterns: [/\brender(_template)?\s*\(/i, /\breturn\s+render\b/i, /\brespond_to\b/i]
+      ),
+      PatternDefinition.new(
+        "outbound_http",
+        "Potential outbound HTTP/client sink inferred from code or callee name",
+        64,
+        name_patterns: [/\bhttp\b/i, /\bfetch\b/i, /\bclient\b/i, /\baxios\b/i],
+        source_patterns: [/requests\.(get|post|put|delete)/i, /\bfetch\s*\(/i, /\baxios\./i, /\bhttp\.(Get|Post|NewRequest)/, /\bclient\.(get|post|request)/i]
+      ),
+    ] of PatternDefinition
+
+    VALIDATOR_PATTERNS = [
+      PatternDefinition.new(
+        "validation",
+        "Potential validation step inferred from code or callee name",
+        64,
+        name_patterns: [/\bvalidate\b/i, /\bvalidator\b/i, /\bverify\b/i, /\bpermit\b/i],
+        source_patterns: [/\bvalidate\w*\s*\(/i, /\bvalidator\b/i, /\bpermit\s*\(/i, /\bverify\w*\s*\(/i]
+      ),
+      PatternDefinition.new(
+        "sanitization",
+        "Potential sanitization or escaping step inferred from code or callee name",
+        68,
+        name_patterns: [/\bsanitize\b/i, /\bescape\b/i, /\bencode\b/i, /\bnormalize\b/i, /\bclean\b/i],
+        source_patterns: [/\bsanitize\w*\s*\(/i, /\bescape\w*\s*\(/i, /\bhtml_escape\b/i, /\bnormalize\w*\s*\(/i, /\bclean\w*\s*\(/i]
+      ),
+    ] of PatternDefinition
+
+    GUARD_PATTERNS = [
+      PatternDefinition.new(
+        "guard",
+        "Potential authz/authn guard inferred from nearby source",
+        52,
+        source_patterns: [
+          /passport\.authenticate/i,
+          /expressjwt/i,
+          /\bauthenticate\w*\b/i,
+          /\bauthorize\w*\b/i,
+          /\brequireAuth\b/i,
+          /\bverifyToken\b/i,
+          /\bcheckPermission\b/i,
+          /Depends\s*\(\s*get_current_/i,
+          /Security\s*\(/i,
+          /before_action\s+:\w*auth/i,
+          /\.Use\s*\(\s*\w*Auth\w*/i,
+        ]
+      ),
+    ] of PatternDefinition
+
+    PARAM_PATTERNS = [
+      PatternDefinition.new(
+        "credential_input",
+        "Credential-bearing input; review secret handling, logging, and auth bypass paths",
+        86,
+        name_patterns: [/\b(pass(word)?|token|secret|api[_-]?key|authorization|session|cookie|jwt|bearer)\b/i]
+      ),
+      PatternDefinition.new(
+        "identifier_input",
+        "Identifier-like input frequently drives authorization and object lookup decisions",
+        74,
+        name_patterns: [/\bid\b/i, /\buser(_id)?\b/i, /\baccount(_id)?\b/i, /\border(_id)?\b/i, /\bprofile\b/i, /\bdoc(ument)?\b/i, /\bproject(_id)?\b/i]
+      ),
+      PatternDefinition.new(
+        "redirect_input",
+        "Redirect or callback-like input may affect navigation or outbound requests",
+        76,
+        name_patterns: [/\b(url|uri|redirect|return|next|continue|dest|destination|callback)\b/i]
+      ),
+      PatternDefinition.new(
+        "file_input",
+        "File-like input may influence upload, download, or path traversal behavior",
+        78,
+        name_patterns: [/\b(file|upload|attachment|image|document|filename|filepath|path)\b/i]
+      ),
+      PatternDefinition.new(
+        "query_builder_input",
+        "Query-builder-like input can influence filtering, sorting, or data access clauses",
+        70,
+        name_patterns: [/\b(sort|order|filter|where|search|query|select|field|column)\b/i]
+      ),
+    ] of PatternDefinition
+
+    @file_cache : Hash(String, Array(String))
+
+    def initialize
+      @file_cache = {} of String => Array(String)
+    end
+
+    def apply(endpoints : Array(Endpoint)) : Array(Endpoint)
+      endpoints.map! do |endpoint|
+        context = build_context(endpoint)
+        endpoint.ai_context = context.empty? ? nil : context
+        endpoint
+      end
+
+      endpoints
+    end
+
+    private def build_context(endpoint : Endpoint) : AIContext
+      context = AIContext.new
+      anchor = endpoint.details.code_paths.first?
+      route_snippet = snippet_for(anchor.try(&.path), anchor.try(&.line), ROUTE_SNIPPET_RADIUS)
+
+      add_route_signal(context, endpoint, anchor, route_snippet)
+      add_technology_signal(context, endpoint, anchor, route_snippet)
+      add_method_signal(context, endpoint, anchor, route_snippet)
+      add_internal_signal(context, endpoint, anchor, route_snippet)
+      add_param_signals(context, endpoint, anchor, route_snippet)
+      add_tag_entries(context, endpoint, anchor, route_snippet)
+      add_callee_entries(context, endpoint)
+      add_source_scan_entries(context, endpoint)
+      add_missing_guard_signal(context, endpoint, anchor, route_snippet)
+
+      context
+    end
+
+    private def add_route_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      context.push_signal(AIContextEntry.new(
+        "route_definition",
+        "#{endpoint.method} #{endpoint.url}",
+        source: "route",
+        description: "Primary route registration or controller entrypoint",
+        path: anchor.try(&.path),
+        line: anchor.try(&.line),
+        confidence: 100,
+        snippet: route_snippet
+      ))
+    end
+
+    private def add_technology_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      return unless technology = endpoint.details.technology
+
+      context.push_signal(AIContextEntry.new(
+        "technology",
+        technology,
+        source: "detector",
+        description: "Detected framework or language technology for this endpoint",
+        path: anchor.try(&.path),
+        line: anchor.try(&.line),
+        confidence: 96,
+        snippet: route_snippet
+      ))
+    end
+
+    private def add_method_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      return unless STATE_CHANGING_METHODS.includes?(endpoint.method)
+
+      description = case endpoint.method
+                    when "DELETE"
+                      "State-changing delete endpoint; review authorization, ownership, and destructive side effects"
+                    else
+                      "State-changing endpoint; review authz, validation, and side effects"
+                    end
+
+      context.push_signal(AIContextEntry.new(
+        "state_change",
+        endpoint.method,
+        source: "http_method",
+        description: description,
+        path: anchor.try(&.path),
+        line: anchor.try(&.line),
+        confidence: 88,
+        snippet: route_snippet
+      ))
+    end
+
+    private def add_internal_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      return unless endpoint.internal
+
+      context.push_signal(AIContextEntry.new(
+        "internal_endpoint",
+        "#{endpoint.method} #{endpoint.url}",
+        source: "endpoint",
+        description: "Analyzer marked this endpoint as internal-only or non-public",
+        path: anchor.try(&.path),
+        line: anchor.try(&.line),
+        confidence: 78,
+        snippet: route_snippet
+      ))
+    end
+
+    private def add_param_signals(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      endpoint.params.each do |param|
+        add_path_param_signal(context, param, anchor, route_snippet)
+
+        PARAM_PATTERNS.each do |pattern|
+          next unless matches_any?(param.name, pattern.name_patterns)
+          next if skip_param_signal?(endpoint, param, pattern)
+          next if redundant_param_signal?(param, pattern)
+
+          description = if param.param_type == "path" && pattern.kind == "identifier_input"
+                          "Path parameter selects a server-side resource; review authorization and ownership checks"
+                        else
+                          pattern.description
+                        end
+
+          context.push_signal(AIContextEntry.new(
+            pattern.kind,
+            "#{param.param_type}.#{param.name}",
+            source: "param",
+            description: description,
+            path: anchor.try(&.path),
+            line: anchor.try(&.line),
+            confidence: pattern.confidence,
+            snippet: route_snippet
+          ))
+        end
+
+        param.tags.each do |tag|
+          context.push_signal(AIContextEntry.new(
+            tag.name,
+            "#{param.param_type}.#{param.name}",
+            source: "param_tagger:#{tag.tagger}",
+            description: "#{tag.description} Matched by parameter-name heuristic.",
+            path: anchor.try(&.path),
+            line: anchor.try(&.line),
+            confidence: 58,
+            snippet: route_snippet
+          ))
+        end
+      end
+    end
+
+    private def skip_param_signal?(endpoint : Endpoint, param : Param, pattern : PatternDefinition) : Bool
+      return false unless pattern.kind == "identifier_input"
+      return !header_identifier_like?(param.name) if param.param_type == "header"
+      return false unless BODY_LIKE_PARAM_TYPES.includes?(param.param_type)
+      param.name == "id"
+    end
+
+    private def redundant_param_signal?(param : Param, pattern : PatternDefinition) : Bool
+      case pattern.kind
+      when "query_builder_input"
+        param.tags.any? { |tag| tag.name == "sqli" }
+      when "identifier_input"
+        param.param_type == "path" && param.tags.any? { |tag| tag.name == "idor" }
+      else
+        false
+      end
+    end
+
+    private def add_path_param_signal(context : AIContext, param : Param, anchor : PathInfo?, route_snippet : String?)
+      return unless param.param_type == "path"
+
+      context.push_signal(AIContextEntry.new(
+        "path_param",
+        param.name,
+        source: "param",
+        description: "Path parameter participates in route selection and often controls object lookup",
+        path: anchor.try(&.path),
+        line: anchor.try(&.line),
+        confidence: 84,
+        snippet: route_snippet
+      ))
+    end
+
+    private def add_tag_entries(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      endpoint.tags.each do |tag|
+        entry = AIContextEntry.new(
+          guard_tag?(tag) ? "auth_guard" : tag.name,
+          guard_tag?(tag) ? guard_name_from_tag(tag) : tag.name,
+          source: tag.tagger,
+          description: tag.description,
+          path: anchor.try(&.path),
+          line: anchor.try(&.line),
+          confidence: tag.name == "auth" ? 86 : 74,
+          snippet: route_snippet
+        )
+
+        if guard_tag?(tag)
+          context.push_guard(entry)
+        else
+          context.push_signal(entry)
+          if tag.name == "file_upload"
+            context.push_sink(AIContextEntry.new(
+              "file_io",
+              "file_upload",
+              source: tag.tagger,
+              description: "Endpoint characteristics suggest file upload or file handling behavior",
+              path: anchor.try(&.path),
+              line: anchor.try(&.line),
+              confidence: 80,
+              snippet: route_snippet
+            ))
+          end
+        end
+      end
+    end
+
+    private def add_callee_entries(context : AIContext, endpoint : Endpoint)
+      endpoint.callees.each do |callee|
+        callee_snippet = snippet_for(callee.path, callee.line, CALLEE_SNIPPET_RADIUS)
+
+        context.push_callee(AIContextEntry.new(
+          "callee",
+          callee.name,
+          source: "callee",
+          description: "Direct 1-hop handler callee extracted from the endpoint body",
+          path: callee.path,
+          line: callee.line,
+          confidence: 92,
+          snippet: callee_snippet
+        ))
+
+        if sink = detect_from_patterns(callee.name, callee_snippet, SINK_PATTERNS, callee.path, callee.line, "callee")
+          context.push_sink(sink)
+        end
+
+        if validator = detect_from_patterns(callee.name, callee_snippet, VALIDATOR_PATTERNS, callee.path, callee.line, "callee")
+          context.push_validator(validator)
+        end
+      end
+    end
+
+    private def add_source_scan_entries(context : AIContext, endpoint : Endpoint)
+      return if endpoint.details.code_paths.empty?
+
+      endpoint.details.code_paths.each do |path_info|
+        route_scope = route_scope_snippet_for(path_info.path, path_info.line)
+
+        if context.guards.empty?
+          if guard = detect_from_patterns("", route_scope, GUARD_PATTERNS, path_info.path, path_info.line, "route_source")
+            context.push_guard(guard)
+          end
+        end
+
+        snippet = route_scope || snippet_for(path_info.path, path_info.line, SOURCE_SCAN_RADIUS)
+        next if snippet.nil?
+
+        if context.sinks.empty?
+          if sink = detect_from_patterns("", snippet, SINK_PATTERNS, path_info.path, path_info.line, "route_source")
+            context.push_sink(sink)
+          end
+        end
+
+        if context.validators.empty?
+          if validator = detect_from_patterns("", snippet, VALIDATOR_PATTERNS, path_info.path, path_info.line, "route_source")
+            context.push_validator(validator)
+          end
+        end
+      end
+    end
+
+    private def add_missing_guard_signal(context : AIContext, endpoint : Endpoint, anchor : PathInfo?, route_snippet : String?)
+      return unless STATE_CHANGING_METHODS.includes?(endpoint.method)
+      return unless context.guards.empty?
+
+      context.push_signal(AIContextEntry.new(
+        "guard_absence",
+        endpoint.method,
+        source: "heuristic",
+        description: "No auth guard was detected for this state-changing endpoint. This may be real or a heuristic blind spot; review manually.",
+        path: anchor.try(&.path),
+        line: anchor.try(&.line),
+        confidence: 28,
+        snippet: route_snippet
+      ))
+
+      if endpoint.params.any? { |param| param.param_type == "path" && identifier_like?(param.name) }
+        context.push_signal(AIContextEntry.new(
+          "idor_review",
+          endpoint.url,
+          source: "heuristic",
+          description: "State-changing endpoint uses path identifiers without a detected guard; review object-level authorization carefully.",
+          path: anchor.try(&.path),
+          line: anchor.try(&.line),
+          confidence: 36,
+          snippet: route_snippet
+        ))
+      end
+    end
+
+    private def guard_tag?(tag : Tag) : Bool
+      return true if tag.name == "auth"
+      tag.tagger.downcase.ends_with?("_auth")
+    end
+
+    private def guard_name_from_tag(tag : Tag) : String
+      description = tag.description
+      return description.sub(/^Protected by\s+/, "") if description.starts_with?("Protected by ")
+      tag.name
+    end
+
+    private def detect_from_patterns(name : String,
+                                     snippet : String?,
+                                     patterns : Array(PatternDefinition),
+                                     path : String?,
+                                     line : Int32?,
+                                     source : String) : AIContextEntry?
+      patterns.each do |pattern|
+        next if suppress_pattern_detection?(pattern.kind, name, snippet)
+
+        name_match = name_match_text(name, pattern.name_patterns)
+        snippet_match = snippet_match_text(snippet, pattern.source_patterns)
+        next unless name_match || snippet_match
+        next if source == "callee" && name_match.nil?
+
+        evidence_name = name_match || snippet_match || pattern.kind
+        return AIContextEntry.new(
+          pattern.kind,
+          evidence_name,
+          source: source,
+          description: pattern.description,
+          path: path,
+          line: line,
+          confidence: source == "route_source" ? pattern.confidence - 12 : pattern.confidence,
+          snippet: snippet
+        )
+      end
+
+      nil
+    end
+
+    private def suppress_pattern_detection?(kind : String, name : String, snippet : String?) : Bool
+      case kind
+      when "sql"
+        return true if name.matches?(/\b(URL\.Query|QueryParam|request\.query|req\.query|query_params|searchParams)\b/i)
+        return true if snippet && snippet.matches?(/\b(URL\.Query\(\)\.Get|QueryParam\(|request\.query\.|req\.query\.|searchParams\.get)\b/i)
+      when "template_render"
+        return false unless snippet
+        return true if snippet.matches?(/\brender\s+(json|plain|xml|body|status):/i)
+        return true if snippet.matches?(/\brespond(Text|Bytes|File|Json|Redirect)\b/)
+      when "outbound_http"
+        return true if name.starts_with?("request.")
+        return true if name == "request"
+      end
+
+      false
+    end
+
+    private def name_match_text(name : String, patterns : Array(Regex)) : String?
+      return if name.empty?
+
+      patterns.each do |pattern|
+        if match = name.match(pattern)
+          return normalize_label(match[0])
+        end
+      end
+
+      nil
+    end
+
+    private def snippet_match_text(snippet : String?, patterns : Array(Regex)) : String?
+      return unless snippet
+
+      patterns.each do |pattern|
+        if match = snippet.match(pattern)
+          return normalize_label(match[0])
+        end
+      end
+
+      nil
+    end
+
+    private def matches_any?(name : String, patterns : Array(Regex)) : Bool
+      patterns.any? { |pattern| name.matches?(pattern) }
+    end
+
+    private def identifier_like?(name : String) : Bool
+      matches_any?(name, PARAM_PATTERNS.find { |pattern| pattern.kind == "identifier_input" }.not_nil!.name_patterns)
+    end
+
+    private def header_identifier_like?(name : String) : Bool
+      normalized = name.downcase
+      return true if normalized.matches?(/\b[a-z0-9_-]*id\b/)
+      return true if normalized.matches?(/\b(client|account|order|profile|project|merchant|store|user)[_-]?id\b/)
+
+      false
+    end
+
+    private def normalize_label(text : String) : String
+      text.gsub(/\s+/, " ").strip[0, Math.min(text.gsub(/\s+/, " ").strip.size, 64)]
+    end
+
+    private def snippet_for(path : String?, line : Int32?, radius : Int32) : String?
+      return unless path && line
+
+      lines = read_lines(path)
+      return if line < 1 || line > lines.size
+
+      start_idx = Math.max(line - radius - 1, 0)
+      end_idx = Math.min(line + radius - 1, lines.size - 1)
+      selected = [] of String
+
+      (start_idx..end_idx).each do |idx|
+        selected << "#{idx + 1}: #{lines[idx].strip}"
+      end
+
+      snippet = selected.join(" | ").gsub(/\s+/, " ").strip
+      return if snippet.empty?
+      snippet.size > MAX_SNIPPET_CHARS ? snippet[0, MAX_SNIPPET_CHARS] : snippet
+    end
+
+    private def route_scope_snippet_for(path : String?, line : Int32?) : String?
+      return unless path && line
+
+      lines = read_lines(path)
+      return if line < 1 || line > lines.size
+
+      start_idx = line - 1
+      selected = [] of String
+      brace_depth = 0
+      seen_block = false
+      paren_balance = 0
+
+      start_idx.upto(Math.min(start_idx + MAX_ROUTE_SCOPE_LINES - 1, lines.size - 1)) do |idx|
+        raw_line = lines[idx]
+        selected << "#{idx + 1}: #{raw_line.strip}"
+
+        sanitized = raw_line.gsub(/(['"]).*?\1/, "\"\"")
+        opens = sanitized.count('{')
+        closes = sanitized.count('}')
+        brace_depth += opens - closes
+        paren_balance += sanitized.count('(') - sanitized.count(')')
+
+        seen_block ||= opens > 0 || sanitized.matches?(/\bdo\b/)
+
+        if seen_block
+          break if brace_depth <= 0
+        else
+          stripped = sanitized.strip
+          statement_done = stripped.ends_with?(";") || stripped.ends_with?(")") || stripped.ends_with?(" do")
+          break if statement_done && paren_balance <= 0
+        end
+      end
+
+      snippet = selected.join(" | ").gsub(/\s+/, " ").strip
+      return if snippet.empty?
+      snippet.size > MAX_SNIPPET_CHARS ? snippet[0, MAX_SNIPPET_CHARS] : snippet
+    end
+
+    private def read_lines(path : String) : Array(String)
+      if cached = @file_cache[path]?
+        return cached
+      end
+
+      lines = File.read(path, encoding: "utf-8", invalid: :skip).split("\n")
+      @file_cache[path] = lines
+      lines
+    rescue
+      [] of String
+    end
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -137,6 +137,25 @@ def initialize_analyzers(logger : NoirLogger)
   analyzers
 end
 
+def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
+  filtered = techs.dup
+
+  php_frameworks = Set{
+    "php_laravel",
+    "php_symfony",
+    "php_cakephp",
+    "php_codeigniter",
+    "php_slim",
+    "php_yii",
+  }
+
+  if filtered.includes?("php_pure") && filtered.any? { |tech| php_frameworks.includes?(tech) }
+    filtered.reject!("php_pure")
+  end
+
+  filtered
+end
+
 def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLogger)
   result = [] of Endpoint
   file_analyzer = FileAnalyzer.new options
@@ -165,7 +184,7 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   end
 
   # Run tech analyzers concurrently to avoid long stalls from a single analyzer
-  selected_techs = techs.select { |t| analyzer.has_key?(t) }
+  selected_techs = filter_redundant_generic_techs(techs).select { |t| analyzer.has_key?(t) }
   mutex = Mutex.new
 
   WaitGroup.wait do |wg|

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -88,6 +88,8 @@ module Analyzer::Elixir
           callees = include_callee ? callees_from_function_block(lines, index, block_end, controller_path) : nil
 
           matching_endpoints.each do |endpoint|
+            append_code_path(endpoint.details, PathInfo.new(controller_path, index + 1))
+
             # Extract parameters from the function block
             params = extract_params_from_function_block(lines, index, block_end, endpoint.method)
             params.each { |param| endpoint.push_param(param) }
@@ -195,6 +197,11 @@ module Analyzer::Elixir
       end
 
       params
+    end
+
+    private def append_code_path(details : Details, path_info : PathInfo)
+      return if details.code_paths.any? { |existing| existing == path_info }
+      details.add_path(path_info)
     end
 
     private def callees_from_function_block(lines : Array(String),

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -83,9 +83,9 @@ module Analyzer::Go
                       elsif line.includes?("Query().Get(")
                         add_param_to_endpoint(get_param(line, "Query"), last_endpoint)
                       elsif line.includes?("PostFormValue(")
-                        add_param_to_endpoint(get_param(line, "PostFormValue"), last_endpoint)
+                        add_param_to_endpoint(get_param(line, "PostFormValue", last_endpoint), last_endpoint)
                       elsif line.includes?("FormValue(")
-                        add_param_to_endpoint(get_param(line, "FormValue"), last_endpoint)
+                        add_param_to_endpoint(get_param(line, "FormValue", last_endpoint), last_endpoint)
                       elsif line.includes?("Header.Get(")
                         add_param_to_endpoint(get_param(line, "Header"), last_endpoint)
                       elsif line.includes?("Cookie(")
@@ -138,7 +138,7 @@ module Analyzer::Go
       end
     end
 
-    def get_param(line : String, pattern : String) : Param
+    def get_param(line : String, pattern : String, endpoint : Endpoint? = nil) : Param
       param_name = ""
       param_type = ""
 
@@ -166,7 +166,7 @@ module Analyzer::Go
         # Handle r.FormValue("password") pattern
         if match = line.match(/FormValue\s*\(\s*[\"']([^\"']+)[\"']\s*\)/)
           param_name = match[1]
-          param_type = "query"
+          param_type = form_value_param_type(endpoint)
         end
       when "Header"
         # Handle r.Header.Get("User-Agent") pattern
@@ -183,6 +183,17 @@ module Analyzer::Go
       end
 
       Param.new(param_name, "", param_type)
+    end
+
+    private def form_value_param_type(endpoint : Endpoint?) : String
+      return "query" unless endpoint
+
+      case endpoint.method
+      when "GET", "HEAD", ""
+        "query"
+      else
+        "form"
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -14,9 +14,12 @@ module Analyzer::Javascript
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|
-            # Add file location details
-            details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-            endpoint.details = details
+            # Preserve the precise route line supplied by the shared extractor.
+            # Falling back to path-only keeps older behavior if a parser result
+            # somehow lacks location metadata.
+            if endpoint.details.code_paths.empty?
+              endpoint.details = Details.new(PathInfo.new(path))
+            end
 
             # Parse path parameters from the URL path itself
             if endpoint.url.includes?(":")

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -26,12 +26,14 @@ module Analyzer::Kotlin
     private def build_endpoint(route : Noir::TreeSitterKotlinKtorRouteExtractor::Route, path : String) : Endpoint
       details = Details.new(PathInfo.new(path, route.line + 1))
       params = [] of Param
+      path_param_names = Set(String).new
 
       # Path placeholders (`{id}`) — emit one path-typed param per
       # placeholder. The optimizer also synthesises these from the
       # URL string, but emitting here keeps parity with the legacy
       # analyzer.
       route.path.scan(/\{([^}]+)\}/) do |match|
+        path_param_names << match[1]
         params << Param.new(match[1], "", "path")
       end
 
@@ -40,6 +42,7 @@ module Analyzer::Kotlin
       end
 
       route.query_params.each do |name|
+        next if path_param_names.includes?(name)
         params << Param.new(name, "", "query")
       end
 

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -82,7 +82,6 @@ module Analyzer::Php
                                        include_callee : Bool,
                                        base_line : Int32 = 1) : Array(Endpoint)
       endpoints = [] of Endpoint
-      details = Details.new(PathInfo.new(file_path))
 
       # 1. Simple routes: Route::get, Route::post, etc.
       verb_regex = /Route::(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
@@ -91,10 +90,12 @@ module Analyzer::Php
         methods = [route_match[1].upcase]
         route_path = route_match[2]
         full_path = build_full_path(prefix, route_path)
+        route_line = base_line + newline_count_before(content, route_match.begin(0))
         handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
         params = extract_brace_path_params(full_path)
 
         methods.each do |http_method|
+          details = Details.new(PathInfo.new(file_path, route_line))
           endpoint = Endpoint.new(full_path, http_method, params, details.dup)
           attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
           endpoints << endpoint
@@ -108,10 +109,12 @@ module Analyzer::Php
         methods = extract_methods_from_array(route_match[1])
         route_path = route_match[2]
         full_path = build_full_path(prefix, route_path)
+        route_line = base_line + newline_count_before(content, route_match.begin(0))
         handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
         params = extract_brace_path_params(full_path)
 
         methods.each do |http_method|
+          details = Details.new(PathInfo.new(file_path, route_line))
           endpoint = Endpoint.new(full_path, http_method, params, details.dup)
           attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
           endpoints << endpoint
@@ -125,10 +128,12 @@ module Analyzer::Php
         methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
         route_path = route_match[1]
         full_path = build_full_path(prefix, route_path)
+        route_line = base_line + newline_count_before(content, route_match.begin(0))
         handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
         params = extract_brace_path_params(full_path)
 
         methods.each do |http_method|
+          details = Details.new(PathInfo.new(file_path, route_line))
           endpoint = Endpoint.new(full_path, http_method, params, details.dup)
           attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
           endpoints << endpoint
@@ -141,14 +146,16 @@ module Analyzer::Php
       resource_matches.each do |match|
         resource_name = match[1]
         full_resource_path = build_full_path(prefix, resource_name)
-        endpoints.concat(create_resource_endpoints(full_resource_path.lstrip('/'), file_path))
+        route_line = base_line + newline_count_before(content, match.begin(0))
+        endpoints.concat(create_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line))
       end
 
       api_resource_matches = content.scan(/Route::apiResource\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi)
       api_resource_matches.each do |match|
         resource_name = match[1]
         full_resource_path = build_full_path(prefix, resource_name)
-        endpoints.concat(create_api_resource_endpoints(full_resource_path.lstrip('/'), file_path))
+        route_line = base_line + newline_count_before(content, match.begin(0))
+        endpoints.concat(create_api_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line))
       end
 
       # 3. Group routes (recursive)
@@ -304,9 +311,9 @@ module Analyzer::Php
       content[0...pos].count('\n')
     end
 
-    private def create_resource_endpoints(resource : String, file_path : String) : Array(Endpoint)
+    private def create_resource_endpoints(resource : String, file_path : String, line : Int32? = nil) : Array(Endpoint)
       endpoints = [] of Endpoint
-      details = Details.new(PathInfo.new(file_path))
+      details = Details.new(PathInfo.new(file_path, line))
 
       # Standard Laravel resource routes
       resource_routes = [
@@ -329,9 +336,9 @@ module Analyzer::Php
       endpoints
     end
 
-    private def create_api_resource_endpoints(resource : String, file_path : String) : Array(Endpoint)
+    private def create_api_resource_endpoints(resource : String, file_path : String, line : Int32? = nil) : Array(Endpoint)
       endpoints = [] of Endpoint
-      details = Details.new(PathInfo.new(file_path))
+      details = Details.new(PathInfo.new(file_path, line))
 
       # API resource routes (excludes create and edit forms)
       api_resource_routes = [

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -133,10 +133,9 @@ module Analyzer::Python
 
           if File.exists?(new_route_path)
             new_django_urls = DjangoUrls.new("#{django_urls.prefix}#{route}", new_route_path, django_urls.basepath)
-            details = Details.new(PathInfo.new(new_route_path))
             unless @visited_url_paths.has_key? new_django_urls.filepath
               extract_endpoints(new_django_urls).each do |endpoint|
-                endpoint.details = details
+                append_code_path(endpoint.details, PathInfo.new(new_route_path))
                 endpoints << endpoint
               end
             end
@@ -144,9 +143,9 @@ module Analyzer::Python
         end
         next if new_django_urls
 
-        details = Details.new(PathInfo.new(django_urls.filepath))
+        route_path = PathInfo.new(django_urls.filepath)
         if view == ""
-          endpoints << Endpoint.new(url, "GET", details)
+          endpoints << Endpoint.new(url, "GET", Details.new(route_path))
         else
           dotted_as_names_split = view.split(".")
 
@@ -166,12 +165,12 @@ module Analyzer::Python
 
           if filepath != "" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.match(function_or_class_name)
             extract_endpoints_from_file(url, filepath, function_or_class_name).each do |endpoint|
-              endpoint.details = details
+              append_code_path(endpoint.details, route_path)
               endpoints << endpoint
             end
           else
             # By default, Django allows requests with methods other than GET as well
-            endpoints << Endpoint.new(url, "GET", details)
+            endpoints << Endpoint.new(url, "GET", Details.new(route_path))
           end
         end
       end
@@ -242,6 +241,7 @@ module Analyzer::Python
           # codeblock starts at the `def` line, so `body_start_line` is
           # that line's 0-based index — derived from the char offset.
           body_start_line = content[0, function_start_index].count('\n')
+          definition_line = body_start_line + 1
           handler_callees = build_callees_from(
             function_codeblock,
             body_start_line,
@@ -251,7 +251,8 @@ module Analyzer::Python
           )
 
           suspicious_http_methods.uniq.each do |http_method_name|
-            endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params))
+            details = Details.new(PathInfo.new(filepath, definition_line))
+            endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params), details)
             handler_callees.each { |c| endpoint.push_callee(c) }
             endpoints << endpoint
           end
@@ -284,7 +285,9 @@ module Analyzer::Python
           end
 
           body_start_line = content[0, class_start_index].count('\n')
+          class_definition_line = body_start_line + 1
           method_callees = Hash(String, Array(Callee)).new
+          method_lines = Hash(String, Int32).new
 
           # Check HTTP methods in class methods
           lines.each_with_index do |line, offset|
@@ -292,6 +295,7 @@ module Analyzer::Python
             if !method_function_match.nil?
               method_name = method_function_match[1].upcase
               suspicious_http_methods << method_name
+              method_lines[method_name] = body_start_line + offset + 2
 
               if codeblock = parse_code_block(lines[offset..])
                 method_callees[method_name] = build_callees_from(
@@ -310,7 +314,9 @@ module Analyzer::Python
           end
 
           suspicious_http_methods.uniq.each do |http_method_name|
-            endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params))
+            definition_line = method_lines[http_method_name]? || class_definition_line
+            details = Details.new(PathInfo.new(filepath, definition_line))
+            endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params), details)
             if callees = method_callees[http_method_name]?
               callees.each { |c| endpoint.push_callee(c) }
             end
@@ -322,7 +328,12 @@ module Analyzer::Python
       end
 
       # Default to GET method
-      [Endpoint.new(url, "GET")]
+      [Endpoint.new(url, "GET", Details.new(PathInfo.new(filepath)))]
+    end
+
+    private def append_code_path(details : Details, path_info : PathInfo)
+      return if details.code_paths.any? { |existing| existing == path_info }
+      details.add_path(path_info)
     end
 
     # Extract parameters from a line of code

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -27,7 +27,7 @@ module Analyzer::Ruby
       lines = content.lines
 
       lines.each_with_index do |raw_line, index|
-        line = Noir::RubyCalleeExtractor.strip_comment(raw_line)
+        line = Noir::RubyCalleeExtractor.strip_comment(raw_line, preserve_strings: true)
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?('#')
 

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -42,10 +42,12 @@ module Analyzer::Ruby
     record ControllerData,
       param_type : String,
       params_method : Hash(String, Array(Param)),
-      permit_body_params : Array(Param),
-      permit_query_params : Array(Param),
+      params_body_by_action : Hash(String, Array(Param)),
+      params_query_by_action : Hash(String, Array(Param)),
       defined_actions : Set(String),
-      callees_by_action : Hash(String, Array(Noir::RubyCalleeExtractor::Entry))
+      helper_calls_by_action : Hash(String, Array(String)),
+      callees_by_action : Hash(String, Array(Noir::RubyCalleeExtractor::Entry)),
+      action_lines : Hash(String, Int32)
 
     @controller_data_cache = Hash(String, ControllerData).new
 
@@ -379,8 +381,6 @@ module Analyzer::Ruby
       data = extract_controller_data(path)
       defined_actions = data.defined_actions
       params_method = data.params_method
-      params_body = data.permit_body_params
-      deduplication_params_query = dedup_by_name(data.permit_query_params)
 
       methods = [] of String
       {"index", "show", "create", "update", "destroy"}.each do |name|
@@ -400,34 +400,38 @@ module Analyzer::Ruby
         end
       end
 
-      details = Details.new(PathInfo.new(path))
       index_url = compose_url(path_prefix, "/#{resource}")
       member_url = compose_url(path_prefix, singular ? "/#{resource}" : "/#{resource}/1")
 
       methods.each do |method|
         case method
         when "GET/INDEX"
-          last_params = (params_method["index"]? || [] of Param) + deduplication_params_query
+          last_params = action_params(data, "index", "GET")
+          details = Details.new(PathInfo.new(path, data.action_lines["index"]?))
           endpoint = Endpoint.new(index_url, "GET", last_params, details)
           attach_callees_for_action(endpoint, data, "index")
           @result << endpoint
         when "GET/SHOW"
-          last_params = (params_method["show"]? || [] of Param) + deduplication_params_query
+          last_params = promote_identifier_to_path(action_params(data, "show", "GET"))
+          details = Details.new(PathInfo.new(path, data.action_lines["show"]?))
           endpoint = Endpoint.new(member_url, "GET", last_params, details)
           attach_callees_for_action(endpoint, data, "show")
           @result << endpoint
         when "POST"
-          last_params = (params_method["create"]? || [] of Param) + params_body
+          last_params = action_params(data, "create", method)
+          details = Details.new(PathInfo.new(path, data.action_lines["create"]?))
           endpoint = Endpoint.new(index_url, method, last_params, details)
           attach_callees_for_action(endpoint, data, "create")
           @result << endpoint
         when "DELETE"
-          last_params = params_method["destroy"]? || [] of Param
+          last_params = promote_identifier_to_path(action_params(data, "destroy", method))
+          details = Details.new(PathInfo.new(path, data.action_lines["destroy"]?))
           endpoint = Endpoint.new(member_url, method, last_params, details)
           attach_callees_for_action(endpoint, data, "destroy")
           @result << endpoint
         else
-          last_params = (params_method["update"]? || [] of Param) + params_body
+          last_params = promote_identifier_to_path(action_params(data, "update", method))
+          details = Details.new(PathInfo.new(path, data.action_lines["update"]?))
           endpoint = Endpoint.new(member_url, method, last_params, details)
           attach_callees_for_action(endpoint, data, "update")
           @result << endpoint
@@ -448,15 +452,18 @@ module Analyzer::Ruby
       return cached if cached
 
       params_method = Hash(String, Array(Param)).new
-      permit_body_params = [] of Param
-      permit_query_params = [] of Param
+      params_body_by_action = Hash(String, Array(Param)).new
+      params_query_by_action = Hash(String, Array(Param)).new
       defined_actions = Set(String).new
+      helper_calls_by_action = Hash(String, Array(String)).new
       callees_by_action = Hash(String, Array(Noir::RubyCalleeExtractor::Entry)).new
+      action_lines = Hash(String, Int32).new
+      method_bodies = Hash(String, Array(String)).new
       param_type = "form"
 
       unless File.exists?(path)
-        empty = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params,
-          defined_actions, callees_by_action)
+        empty = ControllerData.new(param_type, params_method, params_body_by_action, params_query_by_action,
+          defined_actions, helper_calls_by_action, callees_by_action, action_lines)
         @controller_data_cache[path] = empty
         return empty
       end
@@ -464,12 +471,12 @@ module Analyzer::Ruby
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |controller_file|
         controller_content = controller_file.gets_to_end
         param_type = "json" if controller_content.includes?("render json:")
-        callees_by_action = extract_action_callees(controller_content, path) if include_callee?
+        callees_by_action = extract_action_callees(controller_content, path)
 
         controller_file.rewind
         this_method = ""
 
-        controller_file.each_line do |raw_line|
+        controller_file.each_line.with_index do |raw_line, index|
           line = strip_inline_comment(raw_line)
 
           if line.includes?("def ")
@@ -478,23 +485,34 @@ module Analyzer::Ruby
             unless func_name.empty?
               this_method = func_name
               defined_actions << func_name
+              action_lines[func_name] = index + 1
+              method_bodies[this_method] ||= [] of String
             end
+          end
+
+          unless this_method.empty?
+            method_bodies[this_method] ||= [] of String
+            method_bodies[this_method] << line
           end
 
           if pm = line.match(/permit\s*\(([^)]*)\)/)
             pm[1].split(',').each do |raw|
               name = raw.gsub(/[:\s'"]/, "")
-              next if name.empty?
-              permit_body_params << Param.new(name, "", param_type)
-              permit_query_params << Param.new(name, "", "query")
+              next if name.empty? || this_method.empty?
+              params_body_by_action[this_method] ||= [] of Param
+              params_body_by_action[this_method] << Param.new(name, "", param_type)
+              params_query_by_action[this_method] ||= [] of Param
+              params_query_by_action[this_method] << Param.new(name, "", "query")
             end
           end
 
           line.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
             name = (m[1]? || m[2]?).to_s.strip
-            next if name.empty?
-            permit_body_params << Param.new(name, "", param_type)
-            permit_query_params << Param.new(name, "", "query")
+            next if name.empty? || this_method.empty?
+            params_body_by_action[this_method] ||= [] of Param
+            params_body_by_action[this_method] << Param.new(name, "", param_type)
+            params_query_by_action[this_method] ||= [] of Param
+            params_query_by_action[this_method] << Param.new(name, "", "query")
           end
 
           if hm = line.match(/request\.headers\[\s*['"]([^'"]+)['"]\s*\]/)
@@ -514,8 +532,10 @@ module Analyzer::Ruby
         end
       end
 
-      data = ControllerData.new(param_type, params_method, permit_body_params, permit_query_params,
-        defined_actions, callees_by_action)
+      helper_calls_by_action = build_helper_call_map(method_bodies, defined_actions)
+
+      data = ControllerData.new(param_type, params_method, params_body_by_action, params_query_by_action,
+        defined_actions, helper_calls_by_action, callees_by_action, action_lines)
       @controller_data_cache[path] = data
       data
     end
@@ -603,25 +623,75 @@ module Analyzer::Ruby
 
     # Build params for a custom action (member/collection or explicit
     # controller#action). Mirrors the resources flow: per-action headers/cookies
-    # plus the controller's shared permitted/body/query params for the verb.
+    # plus the action-local body/query params for the verb.
     private def params_for_action(controller_path : String?, action : String, verb : String) : Array(Param)
       return [] of Param if controller_path.nil?
       data = extract_controller_data(controller_path)
       return [] of Param unless data.defined_actions.includes?(action)
 
-      result = [] of Param
-      data.params_method[action]?.try &.each { |p| result << p }
+      action_params(data, action, verb)
+    end
 
-      case verb
-      when "GET", "HEAD", "OPTIONS"
-        result.concat(dedup_by_name(data.permit_query_params))
-      when "DELETE"
-        # No shared body params for delete, matching the resources flow.
-      else
-        result.concat(data.permit_body_params)
+    private def action_params(data : ControllerData, action : String, verb : String) : Array(Param)
+      result = [] of Param
+      merge_action_params(result, data, action, verb)
+
+      helper_names = data.helper_calls_by_action[action]? || [] of String
+      helper_names.each do |helper_name|
+        next if helper_name == action
+        merge_action_params(result, data, helper_name, verb)
       end
 
       result
+    end
+
+    private def merge_action_params(result : Array(Param), data : ControllerData, action : String, verb : String)
+      data.params_method[action]?.try &.each { |p| push_unique_param(result, clone_param(p)) }
+
+      source_params = case verb
+                      when "GET", "HEAD", "OPTIONS", "DELETE"
+                        dedup_by_name(data.params_query_by_action[action]? || [] of Param)
+                      else
+                        dedup_by_name(data.params_body_by_action[action]? || [] of Param)
+                      end
+
+      source_params.each do |param|
+        push_unique_param(result, clone_param(param))
+      end
+    end
+
+    private def push_unique_param(params : Array(Param), param : Param)
+      params << param unless params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+    end
+
+    private def promote_identifier_to_path(params : Array(Param)) : Array(Param)
+      params.each_index do |index|
+        next unless params[index].name == "id"
+        param = params[index]
+        param.param_type = "path"
+        params[index] = param
+      end
+      params
+    end
+
+    private def clone_param(param : Param) : Param
+      Param.new(param.name, param.value, param.param_type)
+    end
+
+    private def build_helper_call_map(method_bodies : Hash(String, Array(String)), defined_actions : Set(String)) : Hash(String, Array(String))
+      helper_calls = Hash(String, Array(String)).new
+
+      method_bodies.each do |method_name, body_lines|
+        body = body_lines.join("\n")
+        defined_actions.each do |candidate|
+          next if candidate == method_name
+          next unless body.matches?(/\b#{Regex.escape(candidate)}\b/)
+          helper_calls[method_name] ||= [] of String
+          helper_calls[method_name] << candidate unless helper_calls[method_name].includes?(candidate)
+        end
+      end
+
+      helper_calls
     end
 
     private def attach_callees_for_action(endpoint : Endpoint, controller_path : String?, action : String)

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -124,7 +124,7 @@ module Analyzer::Ruby
     private def extract_route_block(lines : Array(String), index : Int32) : Tuple(String, Int32)?
       return if index >= lines.size
 
-      start_line = Noir::RubyCalleeExtractor.strip_comment(lines[index]).strip
+      start_line = Noir::RubyCalleeExtractor.strip_comment(lines[index], preserve_strings: true).strip
       return extract_ruby_do_block(lines, index) if start_line.match(/\bdo\b/)
       extract_ruby_brace_block(lines, index) if start_line.includes?('{')
     end
@@ -132,7 +132,7 @@ module Analyzer::Ruby
     private def extract_ruby_brace_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
       return if start_index >= lines.size
 
-      start_line = Noir::RubyCalleeExtractor.strip_comment(lines[start_index])
+      start_line = Noir::RubyCalleeExtractor.strip_comment(lines[start_index], preserve_strings: true)
       open_index = start_line.index('{')
       return unless open_index
 
@@ -153,7 +153,7 @@ module Analyzer::Ruby
 
       index = start_index + 1
       while index < lines.size
-        body, depth = consume_brace_block_fragment(Noir::RubyCalleeExtractor.strip_comment(lines[index]), depth)
+        body, depth = consume_brace_block_fragment(Noir::RubyCalleeExtractor.strip_comment(lines[index], preserve_strings: true), depth)
         if depth == 0
           body_lines << body unless body.empty?
           break
@@ -284,7 +284,7 @@ module Analyzer::Ruby
     end
 
     private def strip_comment(line : String) : String
-      Noir::RubyCalleeExtractor.strip_comment(line)
+      Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: true)
     end
 
     private def count_opens(line : String) : Int32

--- a/src/completions.cr
+++ b/src/completions.cr
@@ -18,6 +18,7 @@ def generate_zsh_completion_script
       '--exclude-codes[Exclude specific HTTP response codes (comma-separated)]:status:' \\
       '--include-path[Include file path in the plain result]' \\
       '--include-techs[Include technology in the plain result]' \\
+      '--ai-context[Include aggregated AI review context]' \\
       '--no-color[Disable color output]' \\
       '--no-log[Displaying only the results]' \\
       '-P[Perform a passive scan for security issues using rules from the specified path]' \\
@@ -83,6 +84,7 @@ def generate_bash_completion_script
             --exclude-codes
             --include-path
             --include-techs
+            --ai-context
             --no-color
             --no-log
             -P --passive-scan
@@ -181,6 +183,7 @@ def generate_fish_completion_script
     complete -c noir -n '__fish_noir_needs_command' -a '--exclude-codes' -d 'Exclude specific HTTP response codes (comma-separated)'
     complete -c noir -n '__fish_noir_needs_command' -a '--include-path' -d 'Include file path in the plain result'
     complete -c noir -n '__fish_noir_needs_command' -a '--include-techs' -d 'Include technology in the plain result'
+    complete -c noir -n '__fish_noir_needs_command' -a '--ai-context' -d 'Include aggregated AI review context'
     complete -c noir -n '__fish_noir_needs_command' -a '--no-color' -d 'Disable color output'
     complete -c noir -n '__fish_noir_needs_command' -a '--no-log' -d 'Displaying only the results'
     complete -c noir -n '__fish_noir_needs_command' -a '-P' -d 'Perform a passive scan for security issues using rules from the specified path'

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -44,7 +44,7 @@ class ConfigInitializer
       symbolized_hash = parsed_yaml.transform_keys(&.to_s)
 
       # Transform specific keys from "yes"/"no" to true/false for old version noir config
-      ["color", "debug", "include_path", "include_techs", "include_callee", "nolog", "send_req", "all_taggers"].each do |key|
+      ["color", "debug", "include_path", "include_techs", "include_callee", "ai_context", "nolog", "send_req", "all_taggers"].each do |key|
         if symbolized_hash[key] == "yes"
           symbolized_hash[key] = YAML::Any.new(true)
         elsif symbolized_hash[key] == "no"
@@ -99,6 +99,7 @@ class ConfigInitializer
       "include_path"                 => YAML::Any.new(false),
       "include_techs"                => YAML::Any.new(false),
       "include_callee"               => YAML::Any.new(false),
+      "ai_context"                   => YAML::Any.new(false),
       "nolog"                        => YAML::Any.new(false),
       "output"                       => YAML::Any.new(""),
       "send_es"                      => YAML::Any.new(""),
@@ -191,6 +192,9 @@ class ConfigInitializer
 
       # Whether to include 1-hop handler callees in the output
       include_callee: #{options["include_callee"]}
+
+      # Whether to include aggregated AI review context in the output
+      ai_context: #{options["ai_context"]}
 
       # Whether to disable logging
       nolog: #{options["nolog"]}

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -92,6 +92,16 @@ module Noir
               end
             end
           end
+
+          body.scan(/\b\w+\.register\s*\(\s*(\w+)\s*,\s*\{[^}]*prefix\s*:\s*['"]([^'"]+)['"]/) do |m|
+            if m.size >= 3
+              child_func = m[1]
+              prefix = m[2]
+              if function_names.includes?(child_func)
+                internal_mounts << {func_name, child_func, prefix}
+              end
+            end
+          end
         end
 
         # Seed function-specific prefixes from CodeLocator
@@ -109,6 +119,15 @@ module Noir
               prefixes_by_function[func_name] << value
             end
           end
+        end
+
+        # Seed same-file Fastify plugin registrations from top-level mounts.
+        content.scan(/\b\w+\.register\s*\(\s*(\w+)\s*,\s*\{[^}]*prefix\s*:\s*['"]([^'"]+)['"]/) do |m|
+          next unless m.size >= 3
+          func_name = m[1]
+          prefix = m[2]
+          next unless function_names.includes?(func_name)
+          prefixes_by_function[func_name] << prefix unless prefixes_by_function[func_name].includes?(prefix)
         end
 
         # Propagate prefixes through internal mounts with max iteration protection

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -55,7 +55,8 @@ module Noir::RubyCalleeExtractor
     RESERVED.includes?(last)
   end
 
-  def strip_comment(line : String) : String
+  def strip_comment(line : String, preserve_strings : Bool = false) : String
+    stripped = String::Builder.new
     in_string = false
     escaped = false
     quote = '\0'
@@ -63,21 +64,29 @@ module Noir::RubyCalleeExtractor
     line.each_char_with_index do |char, index|
       if in_string
         if escaped
+          stripped << (preserve_strings ? char : ' ')
           escaped = false
         elsif char == '\\'
+          stripped << (preserve_strings ? char : ' ')
           escaped = true
         elsif char == quote
+          stripped << char
           in_string = false
+        else
+          stripped << (preserve_strings ? char : ' ')
         end
       elsif char == '"' || char == '\''
         in_string = true
         quote = char
+        stripped << char
       elsif char == '#'
-        return line[0, index]
+        return stripped.to_s
+      else
+        stripped << char
       end
     end
 
-    line
+    stripped.to_s
   end
 
   private def dedup_entries(entries : Array(Entry)) : Array(Entry)

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -5,6 +5,7 @@ struct Endpoint
   include JSON::Serializable
   include YAML::Serializable
   property url, method, params, protocol, details, tags, callees, internal
+  property ai_context : AIContext?
 
   # Per-endpoint context for AI code reviewers: 1-hop callees from the
   # handler body. Best-effort, intentionally incomplete on dynamic
@@ -17,6 +18,7 @@ struct Endpoint
     @protocol = "http"
     @tags = [] of Tag
     @callees = [] of Callee
+    @ai_context = nil
   end
 
   def initialize(@url : String, @method : String, @details : Details)
@@ -25,6 +27,7 @@ struct Endpoint
     @tags = [] of Tag
     @callees = [] of Callee
     @internal = false
+    @ai_context = nil
   end
 
   def details=(details : Details)
@@ -201,5 +204,85 @@ struct Callee
 
   def ==(other : Callee) : Bool
     @name == other.name && @path == other.path && @line == other.line
+  end
+end
+
+struct AIContext
+  include JSON::Serializable
+  include YAML::Serializable
+
+  MAX_PER_SECTION = 16
+
+  property guards : Array(AIContextEntry) = [] of AIContextEntry
+  property callees : Array(AIContextEntry) = [] of AIContextEntry
+  property sinks : Array(AIContextEntry) = [] of AIContextEntry
+  property validators : Array(AIContextEntry) = [] of AIContextEntry
+  property signals : Array(AIContextEntry) = [] of AIContextEntry
+
+  def initialize
+    @guards = [] of AIContextEntry
+    @callees = [] of AIContextEntry
+    @sinks = [] of AIContextEntry
+    @validators = [] of AIContextEntry
+    @signals = [] of AIContextEntry
+  end
+
+  def empty? : Bool
+    @guards.empty? &&
+      @callees.empty? &&
+      @sinks.empty? &&
+      @validators.empty? &&
+      @signals.empty?
+  end
+
+  def push_guard(entry : AIContextEntry)
+    push_entry(@guards, entry)
+  end
+
+  def push_callee(entry : AIContextEntry)
+    push_entry(@callees, entry)
+  end
+
+  def push_sink(entry : AIContextEntry)
+    push_entry(@sinks, entry)
+  end
+
+  def push_validator(entry : AIContextEntry)
+    push_entry(@validators, entry)
+  end
+
+  def push_signal(entry : AIContextEntry)
+    push_entry(@signals, entry)
+  end
+
+  private def push_entry(bucket : Array(AIContextEntry), entry : AIContextEntry)
+    return if bucket.size >= MAX_PER_SECTION
+    return if bucket.any? { |existing| existing == entry }
+    bucket << entry
+  end
+end
+
+struct AIContextEntry
+  include JSON::Serializable
+  include YAML::Serializable
+
+  property kind, name, source, description, path, line, confidence, snippet
+
+  def initialize(@kind : String,
+                 @name : String,
+                 @source : String? = nil,
+                 @description : String? = nil,
+                 @path : String? = nil,
+                 @line : Int32? = nil,
+                 @confidence : Int32? = nil,
+                 @snippet : String? = nil)
+  end
+
+  def ==(other : AIContextEntry) : Bool
+    @kind == other.kind &&
+      @name == other.name &&
+      @source == other.source &&
+      @path == other.path &&
+      @line == other.line
   end
 end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -5,6 +5,7 @@ require "../passive_scan/rules.cr"
 require "../deliver/*"
 require "../output_builder/*"
 require "../optimizer/llm_optimizer.cr"
+require "../ai_context/augmentor.cr"
 require "./endpoint.cr"
 require "./logger.cr"
 require "../utils/*"
@@ -64,6 +65,10 @@ class NoirRunner
     @concurrency = @options["concurrency"].to_s.to_i
 
     @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
+
+    if ai_context_enabled?
+      @options["include_callee"] = YAML::Any.new(true)
+    end
 
     if any_to_bool(@options["passive_scan"])
       @logger.info "Passive scanner enabled."
@@ -138,10 +143,22 @@ class NoirRunner
     elsif @options["use_taggers"] != ""
       @logger.success "Running #{@options["use_taggers"]} taggers."
       NoirTaggers.run_tagger @endpoints, @options, @options["use_taggers"].to_s
+    elsif ai_context_enabled?
+      @logger.success "Running AI-context taggers."
+      NoirTaggers.run_tagger @endpoints, @options, "all"
+    end
+
+    if ai_context_enabled?
+      @logger.success "Building aggregated AI context."
+      NoirAIContext.apply(@endpoints)
     end
 
     # Run deliver
     deliver
+  end
+
+  private def ai_context_enabled? : Bool
+    any_to_bool(@options["ai_context"]?)
   end
 
   def update_status_codes

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -157,6 +157,60 @@ class OutputBuilder
     operation["x-noir-callees"] = JSON::Any.new(noir_callees_json(endpoint))
   end
 
+  protected def noir_ai_context_entry_json(entry : AIContextEntry) : JSON::Any
+    data = {
+      "kind" => JSON::Any.new(entry.kind),
+      "name" => JSON::Any.new(entry.name),
+    } of String => JSON::Any
+
+    if source = entry.source
+      data["source"] = JSON::Any.new(source)
+    end
+
+    if description = entry.description
+      data["description"] = JSON::Any.new(description)
+    end
+
+    if path = entry.path
+      data["path"] = JSON::Any.new(path)
+    end
+
+    if line = entry.line
+      data["line"] = JSON::Any.new(line.to_i64)
+    end
+
+    if confidence = entry.confidence
+      data["confidence"] = JSON::Any.new(confidence.to_i64)
+    end
+
+    if snippet = entry.snippet
+      data["snippet"] = JSON::Any.new(snippet)
+    end
+
+    JSON::Any.new(data)
+  end
+
+  protected def noir_ai_context_json(endpoint : Endpoint) : JSON::Any?
+    context = endpoint.ai_context
+    return unless context
+    return if context.empty?
+
+    JSON::Any.new({
+      "guards"     => JSON::Any.new(context.guards.map { |entry| noir_ai_context_entry_json(entry) }),
+      "callees"    => JSON::Any.new(context.callees.map { |entry| noir_ai_context_entry_json(entry) }),
+      "sinks"      => JSON::Any.new(context.sinks.map { |entry| noir_ai_context_entry_json(entry) }),
+      "validators" => JSON::Any.new(context.validators.map { |entry| noir_ai_context_entry_json(entry) }),
+      "signals"    => JSON::Any.new(context.signals.map { |entry| noir_ai_context_entry_json(entry) }),
+    } of String => JSON::Any)
+  end
+
+  protected def add_noir_ai_context_extension(operation : Hash(String, JSON::Any), endpoint : Endpoint)
+    context_json = noir_ai_context_json(endpoint)
+    if context_json
+      operation["x-noir-ai-context"] = context_json
+    end
+  end
+
   protected def noir_callees_description(endpoint : Endpoint) : String?
     return if endpoint.callees.empty?
 
@@ -164,6 +218,20 @@ class OutputBuilder
     endpoint.callees.each do |callee|
       lines << "- #{format_noir_callee(callee)}"
     end
+    lines.join("\n")
+  end
+
+  protected def noir_ai_context_description(endpoint : Endpoint) : String?
+    context = endpoint.ai_context
+    return unless context
+    return if context.empty?
+
+    lines = ["Noir AI context:"]
+    append_ai_context_description(lines, "guards", context.guards)
+    append_ai_context_description(lines, "callees", context.callees)
+    append_ai_context_description(lines, "sinks", context.sinks)
+    append_ai_context_description(lines, "validators", context.validators)
+    append_ai_context_description(lines, "signals", context.signals)
     lines.join("\n")
   end
 
@@ -181,6 +249,26 @@ class OutputBuilder
     end
 
     callee.name
+  end
+
+  private def format_ai_context_entry(entry : AIContextEntry) : String
+    label = "#{entry.kind}: #{entry.name}"
+    label += " (#{entry.path}:#{entry.line})" if entry.path && entry.line
+    label += " (#{entry.path})" if entry.path && entry.line.nil?
+    label += " (line #{entry.line})" if entry.path.nil? && entry.line
+    label += " [#{entry.source}]" if entry.source
+    label += " - #{entry.description}" if entry.description
+    label += " :: #{entry.snippet}" if entry.snippet
+    label
+  end
+
+  private def append_ai_context_description(lines : Array(String), label : String, entries : Array(AIContextEntry))
+    return if entries.empty?
+
+    lines << "- #{label}:"
+    entries.each do |entry|
+      lines << "  - #{format_ai_context_entry(entry)}"
+    end
   end
 
   macro define_getter_methods(names)

--- a/src/options.cr
+++ b/src/options.cr
@@ -82,7 +82,7 @@ private def full_examples_and_env : String
         $ noir -b . -u http://example.com --send-proxy http://localhost:8090
 
       #{"Detailed analysis".colorize(:yellow)}
-        $ noir -b . -T --include-path
+        $ noir -b . --ai-context --include-path
 
       #{"JSON or YAML output without logs".colorize(:yellow)}
         $ noir -b . -f json --no-log
@@ -188,6 +188,9 @@ def run_options_parser
     end
     parser.on "--include-callee", "Include 1-hop handler callees in plain output (best-effort, see docs)" do
       noir_options["include_callee"] = YAML::Any.new(true)
+    end
+    parser.on "--ai-context", "Include aggregated AI review context (guards, callees, sinks, validators, signals)" do
+      noir_options["ai_context"] = YAML::Any.new(true)
     end
     parser.on "--no-color", "Disable color output" do
       noir_options["color"] = YAML::Any.new(false)

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -102,7 +102,17 @@ class OutputBuilderCommon < OutputBuilder
         end
       end
 
-      if any_to_bool(@options["include_callee"]) && !endpoint.callees.empty?
+      context = endpoint.ai_context
+      if any_to_bool(@options["ai_context"]) && !context.nil?
+        unless context.empty?
+          r_buffer << "\n  ○ ai_context:"
+          append_ai_context_block(r_buffer, "guards", context.guards)
+          append_ai_context_block(r_buffer, "callees", context.callees)
+          append_ai_context_block(r_buffer, "sinks", context.sinks)
+          append_ai_context_block(r_buffer, "validators", context.validators)
+          append_ai_context_block(r_buffer, "signals", context.signals)
+        end
+      elsif any_to_bool(@options["include_callee"]) && !endpoint.callees.empty?
         r_buffer << "\n  ○ callees: "
         endpoint.callees.each_with_index do |callee, index|
           prefix = index == endpoint.callees.size - 1 ? "└── " : "├── "
@@ -114,5 +124,26 @@ class OutputBuilderCommon < OutputBuilder
 
       ob_puts r_buffer.to_s
     end
+  end
+
+  private def append_ai_context_block(r_buffer : String::Builder, label : String, entries : Array(AIContextEntry))
+    return if entries.empty?
+
+    r_buffer << "\n    - #{label}:"
+    entries.each do |entry|
+      r_entry = format_ai_context_entry(entry).colorize(:light_cyan).toggle(@is_color)
+      r_buffer << "\n      * #{r_entry}"
+    end
+  end
+
+  private def format_ai_context_entry(entry : AIContextEntry) : String
+    label = "#{entry.kind}: #{entry.name}"
+    label += " [#{entry.source}]" if entry.source
+    label += " (#{entry.path}:#{entry.line})" if entry.path && entry.line
+    label += " (#{entry.path})" if entry.path && entry.line.nil?
+    label += " (line #{entry.line})" if entry.path.nil? && entry.line
+    label += " - #{entry.description}" if entry.description
+    label += " :: #{entry.snippet}" if entry.snippet
+    label
   end
 end

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -99,6 +99,7 @@ class OutputBuilderOas2 < OutputBuilder
       end
 
       add_noir_callees_extension(operation, endpoint)
+      add_noir_ai_context_extension(operation, endpoint)
 
       # Convert path parameters from :param to {param} format for OAS2
       uri = URI.parse(endpoint.url)

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -117,6 +117,7 @@ class OutputBuilderOas3 < OutputBuilder
       end
 
       add_noir_callees_extension(operation, endpoint)
+      add_noir_ai_context_extension(operation, endpoint)
 
       # Convert path parameters from :param to {param} format for OAS3
       uri = URI.parse(endpoint.url)

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -153,7 +153,7 @@ class OutputBuilderPostman < OutputBuilder
         "request" => JSON::Any.new(request),
       } of String => JSON::Any
 
-      if description = noir_callees_description(endpoint)
+      if description = noir_ai_context_description(endpoint) || noir_callees_description(endpoint)
         item["description"] = JSON::Any.new(description)
       end
 

--- a/src/output_builder/sarif.cr
+++ b/src/output_builder/sarif.cr
@@ -81,11 +81,11 @@ class OutputBuilderSarif < OutputBuilder
       end
     end
 
-    attach_noir_callees(log.to_json, endpoints)
+    attach_noir_properties(log.to_json, endpoints)
   end
 
-  private def attach_noir_callees(message : String, endpoints : Array(Endpoint)) : String
-    return message unless endpoints.any? { |endpoint| !endpoint.callees.empty? }
+  private def attach_noir_properties(message : String, endpoints : Array(Endpoint)) : String
+    return message unless endpoints.any? { |endpoint| !endpoint.callees.empty? || !endpoint.ai_context.nil? }
 
     sarif = JSON.parse(message)
     runs = sarif["runs"].as_a
@@ -102,12 +102,19 @@ class OutputBuilderSarif < OutputBuilder
       endpoint = endpoints[endpoint_index]?
       endpoint_index += 1
       next unless endpoint
-      next if endpoint.callees.empty?
 
       properties = result["properties"]?.try(&.as_h?) || {} of String => JSON::Any
-      properties["noir"] = JSON::Any.new({
-        "callees" => JSON::Any.new(noir_callees_json(endpoint)),
-      } of String => JSON::Any)
+      noir_props = {} of String => JSON::Any
+      unless endpoint.callees.empty?
+        noir_props["callees"] = JSON::Any.new(noir_callees_json(endpoint))
+      end
+      context_json = noir_ai_context_json(endpoint)
+      if context_json
+        noir_props["ai_context"] = context_json
+      end
+      next if noir_props.empty?
+
+      properties["noir"] = JSON::Any.new(noir_props)
       result["properties"] = JSON::Any.new(properties)
     end
 

--- a/src/tagger/framework_taggers/javascript/js_misc_auth.cr
+++ b/src/tagger/framework_taggers/javascript/js_misc_auth.cr
@@ -2,6 +2,8 @@ require "../../../models/framework_tagger"
 require "../../../models/endpoint"
 
 class JsMiscAuthTagger < FrameworkTagger
+  MAX_ROUTE_SCOPE_LINES = 12
+
   # Fastify auth patterns
   FASTIFY_PATTERNS = [
     {/onRequest.*authenticate/, "Fastify onRequest authenticate hook"},
@@ -66,15 +68,9 @@ class JsMiscAuthTagger < FrameworkTagger
       next if line_num.nil?
       line_idx = line_num - 1
 
-      # Check route definition line for auth middleware
-      description = check_route_line(lines, line_idx)
-      if description
-        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "js_misc_auth"))
-        return
-      end
-
-      # Check nearby context (hooks, before handlers)
-      description = check_nearby_auth(lines, line_idx)
+      # Check the route statement/block itself so nearby auth hooks from
+      # previous routes do not bleed into public handlers.
+      description = check_route_scope(route_scope(lines, line_idx))
       if description
         endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "js_misc_auth"))
         return
@@ -82,40 +78,44 @@ class JsMiscAuthTagger < FrameworkTagger
     end
   end
 
-  private def check_route_line(lines : Array(String), line_idx : Int32) : String?
-    return if line_idx < 0 || line_idx >= lines.size
-
-    # Check the route definition line and adjacent lines
-    start_idx = [line_idx - 2, 0].max
-    end_idx = [line_idx + 3, lines.size - 1].min
-
-    (start_idx..end_idx).each do |idx|
-      current = lines[idx]
-
-      all_patterns = FASTIFY_PATTERNS + KOA_PATTERNS + RESTIFY_PATTERNS + GENERIC_NODE_AUTH
+  private def check_route_scope(scope : Array(String)) : String?
+    all_patterns = FASTIFY_PATTERNS + KOA_PATTERNS + RESTIFY_PATTERNS + GENERIC_NODE_AUTH
+    scope.each do |current|
       all_patterns.each do |pattern, desc|
         return desc if current.matches?(pattern)
       end
     end
-
     nil
   end
 
-  private def check_nearby_auth(lines : Array(String), line_idx : Int32) : String?
-    # Walk backwards to find hooks or middleware applied to this route context
-    idx = line_idx - 1
-    while idx >= 0 && idx >= line_idx - 10
-      current = lines[idx].strip
-      break if current.empty? && idx < line_idx - 3
+  private def route_scope(lines : Array(String), line_idx : Int32) : Array(String)
+    return [] of String if line_idx < 0 || line_idx >= lines.size
 
-      all_patterns = FASTIFY_PATTERNS + KOA_PATTERNS + RESTIFY_PATTERNS
-      all_patterns.each do |pattern, desc|
-        return desc if current.matches?(pattern)
+    selected = [] of String
+    brace_depth = 0
+    paren_balance = 0
+    seen_block = false
+
+    line_idx.upto(Math.min(line_idx + MAX_ROUTE_SCOPE_LINES - 1, lines.size - 1)) do |idx|
+      raw_line = lines[idx]
+      selected << raw_line
+
+      sanitized = raw_line.gsub(/(['"]).*?\1/, "\"\"")
+      opens = sanitized.count('{')
+      closes = sanitized.count('}')
+      brace_depth += opens - closes
+      paren_balance += sanitized.count('(') - sanitized.count(')')
+      seen_block ||= opens > 0
+
+      if seen_block
+        break if brace_depth <= 0
+      else
+        stripped = sanitized.strip
+        statement_done = stripped.ends_with?(";") || stripped.ends_with?(")")
+        break if statement_done && paren_balance <= 0
       end
-
-      idx -= 1
     end
 
-    nil
+    selected
   end
 end

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -47,7 +47,7 @@ class HuntParamTagger < Tagger
         TAG_DEFINITIONS.each do |k, v|
           next if param.param_type == "path" && !PATH_ALLOWED_TAGS.includes?(k)
           next if skip_idor_body_heuristic?(k, param)
-          if v["words"].includes? param.name
+          if tag_matches_param_name?(k, v["words"].as(Array(String)), param)
             next if param.tags.any? { |existing| existing.name == k && existing.tagger == "Hunt" }
             tag = Tag.new(k, v["description"].to_s, "Hunt")
             param.add_tag(tag)
@@ -62,5 +62,22 @@ class HuntParamTagger < Tagger
     return false unless BODY_LIKE_PARAM_TYPES.includes?(param.param_type)
 
     param.name == "id"
+  end
+
+  private def tag_matches_param_name?(tag_name : String, words : Array(String), param : Param) : Bool
+    return true if words.includes?(param.name)
+    return false unless tag_name == "idor"
+    return false unless param.param_type == "path"
+
+    identifier_suffix_like?(param.name)
+  end
+
+  private def identifier_suffix_like?(name : String) : Bool
+    return true if name == "id"
+    return true if name.matches?(/[_-]id$/i)
+    return true if name.matches?(/[a-z0-9]Id$/)
+    return true if name.matches?(/[a-z0-9]ID$/)
+
+    false
   end
 end

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -15,7 +15,7 @@ class HuntParamTagger < Tagger
       "description" => "This parameter may be vulnerable to Server Side Request Forgery (SSRF) attacks.",
     },
     "sqli" => {
-      "words"       => ["select", "report", "update", "query", "sort", "where", "search", "params", "process", "row", "table", "sel", "results", "sleep", "fetch", "order", "keyword", "column", "field", "delete", "filter"],
+      "words"       => ["select", "report", "update", "sort", "where", "search", "params", "process", "row", "table", "sel", "results", "sleep", "fetch", "order", "keyword", "column", "field", "delete", "filter"],
       "description" => "This parameter may be vulnerable to SQL Injection attacks.",
     },
     "idor" => {

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -2,21 +2,24 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class HuntParamTagger < Tagger
+  PATH_ALLOWED_TAGS = Set{"idor", "file-inclusion"}
+  BODY_LIKE_PARAM_TYPES = Set{"json", "form"}
+
   TAG_DEFINITIONS = {
     "ssti" => {
-      "words"       => ["template", "preview", "id", "view", "activity", "name", "content", "redirect"],
+      "words"       => ["template", "preview", "activity", "content", "redirect"],
       "description" => "This parameter may be vulnerable to Server Side Template Injection (SSTI) attacks.",
     },
     "ssrf" => {
-      "words"       => ["dest", "redirect", "uri", "path", "continue", "url", "window", "next", "data", "reference", "site", "html", "val", "validate", "domain", "callback", "return", "page", "feed", "host", "port", "to", "out", "view", "dir", "show", "navigation", "open"],
+      "words"       => ["dest", "redirect", "uri", "path", "continue", "url", "window", "next", "reference", "site", "html", "validate", "domain", "callback", "return", "feed", "host", "port", "dir", "navigation", "open"],
       "description" => "This parameter may be vulnerable to Server Side Request Forgery (SSRF) attacks.",
     },
     "sqli" => {
-      "words"       => ["id", "select", "report", "role", "update", "query", "user", "name", "sort", "where", "search", "params", "process", "row", "view", "table", "from", "sel", "results", "sleep", "fetch", "order", "keyword", "column", "field", "delete", "string", "number", "filter"],
+      "words"       => ["select", "report", "update", "query", "sort", "where", "search", "params", "process", "row", "table", "sel", "results", "sleep", "fetch", "order", "keyword", "column", "field", "delete", "filter"],
       "description" => "This parameter may be vulnerable to SQL Injection attacks.",
     },
     "idor" => {
-      "words"       => ["id", "user", "account", "number", "order", "false", "doc", "key", "email", "group", "profile", "edit", "report"],
+      "words"       => ["id", "user", "account", "number", "order", "false", "doc", "key", "group", "profile", "edit", "report"],
       "description" => "This parameter may be vulnerable to Insecure Direct Object Reference (IDOR) attacks.",
     },
     "file-inclusion" => {
@@ -39,20 +42,25 @@ class HuntParamTagger < Tagger
   end
 
   def perform(endpoints : Array(Endpoint))
-    tagger = {} of String => Hash(String, Array(String) | String)
-    TAG_DEFINITIONS.each do |key, value|
-      tagger[key] = {"words" => value["words"], "description" => value["description"]}
-    end
-
     endpoints.each do |endpoint|
       endpoint.params.each do |param|
         TAG_DEFINITIONS.each do |k, v|
+          next if param.param_type == "path" && !PATH_ALLOWED_TAGS.includes?(k)
+          next if skip_idor_body_heuristic?(k, param)
           if v["words"].includes? param.name
+            next if param.tags.any? { |existing| existing.name == k && existing.tagger == "Hunt" }
             tag = Tag.new(k, v["description"].to_s, "Hunt")
             param.add_tag(tag)
           end
         end
       end
     end
+  end
+
+  private def skip_idor_body_heuristic?(tag_name : String, param : Param) : Bool
+    return false unless tag_name == "idor"
+    return false unless BODY_LIKE_PARAM_TYPES.includes?(param.param_type)
+
+    param.name == "id"
   end
 end


### PR DESCRIPTION
## Summary
- improve `--ai-context` precision across frameworks by reducing redundant and low-signal heuristics
- expand auth/ai_context functional coverage across major frameworks and add focused unit regressions
- improve analyzer fidelity for Fastify plugin prefixes and Mux form/query classification

## Key changes
- add shared `src/ai_context/augmentor.cr` with route-local guard/sink/validator enrichment and tighter heuristic gating
- tighten Hunt/tagger behavior for generic query names and camelCase path identifiers
- preserve or improve route/code-path fidelity in Django, Laravel, Rails, Phoenix, Ktor, Fastify, and PHP analyzer selection
- propagate Fastify same-file plugin prefixes in the shared JS extractor
- classify Mux `FormValue` according to request method and suppress header-only `file_input` noise

## Validation
- `just build`
- `just test`
