### PR TITLE
feat(rust/poem): swap analyzer to tree-sitter (parse-once)

### DIFF
--- a/spec/unit_test/ext/tree_sitter_rust_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_rust_spec.cr
@@ -1,0 +1,68 @@
+require "spec"
+require "../../../src/ext/tree_sitter/tree_sitter"
+
+describe "Noir::TreeSitter.parse_rust" do
+  it "parses an axum-style route registration into the expected node shape" do
+    source = <<-RS
+      use axum::{Router, routing::get};
+
+      async fn hello() -> &'static str { "hi" }
+
+      #[tokio::main]
+      async fn main() {
+          let app = Router::new().route("/hello", get(hello));
+      }
+      RS
+
+    types = [] of String
+    visit = uninitialized Proc(LibTreeSitter::TSNode, Nil)
+    visit = ->(n : LibTreeSitter::TSNode) do
+      ty = Noir::TreeSitter.node_type(n)
+      types << ty unless ty.empty?
+      Noir::TreeSitter.each_named_child(n) { |c| visit.call(c) }
+    end
+    Noir::TreeSitter.parse_rust(source) { |root| visit.call(root) }
+
+    # tree-sitter-rust models receiver.method(args) as a `call_expression`
+    # whose function is a `field_expression`; there is no dedicated
+    # `method_call_expression` node type.
+    types.should contain("function_item")
+    types.should contain("call_expression")
+    types.should contain("field_expression")
+    types.should contain("scoped_identifier")
+    types.should contain("string_literal")
+  end
+
+  it "extracts the path string from .route(\"/users\", ...)" do
+    source = %(let app = Router::new().route("/users", get(list_users));)
+
+    extracted = [] of String
+    visit = uninitialized Proc(LibTreeSitter::TSNode, Nil)
+    visit = ->(n : LibTreeSitter::TSNode) do
+      if Noir::TreeSitter.node_type(n) == "string_content"
+        extracted << Noir::TreeSitter.node_text(n, source)
+      end
+      Noir::TreeSitter.each_named_child(n) { |c| visit.call(c) }
+    end
+    Noir::TreeSitter.parse_rust(source) { |root| visit.call(root) }
+
+    extracted.should contain("/users")
+  end
+
+  it "exposes macro_invocation for rocket-style #[get(...)] attributes" do
+    source = <<-RS
+      #[get("/api/v1/health")]
+      fn health() -> &'static str { "ok" }
+      RS
+
+    found_attribute = false
+    visit = uninitialized Proc(LibTreeSitter::TSNode, Nil)
+    visit = ->(n : LibTreeSitter::TSNode) do
+      found_attribute = true if Noir::TreeSitter.node_type(n) == "attribute_item"
+      Noir::TreeSitter.each_named_child(n) { |c| visit.call(c) }
+    end
+    Noir::TreeSitter.parse_rust(source) { |root| visit.call(root) }
+
+    found_attribute.should be_true
+  end
+end

--- a/spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr
@@ -1,0 +1,106 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/rust_callee_extractor_ts"
+
+describe Noir::RustCalleeExtractorTS do
+  describe ".callees_for_body_text" do
+    it "matches the legacy regex extractor on path / receiver / bare calls" do
+      body = <<-RUST
+        let user = UserService::create(payload).await;
+        state.users.find(user.id);
+        Json(user)
+        RUST
+
+      callees = Noir::RustCalleeExtractorTS.callees_for_body_text(body, "main.rs", 10)
+      callees.map { |name, _, line| {name, line} }.should eq([
+        {"UserService::create", 10},
+        {"state.users.find", 11},
+        {"Json", 12},
+      ])
+    end
+
+    it "drops chained-on-call receivers and turbofish wrappers" do
+      body = <<-RUST
+        let cookie = jar.get("token").unwrap();
+        execute::<UserService>(&payload);
+        RUST
+
+      callees = Noir::RustCalleeExtractorTS.callees_for_body_text(body, "main.rs", 5).map { |name, _, _| name }
+      # `jar.get(...).unwrap()` chains on a call — the outer `unwrap` is
+      # dropped; `jar.get` is the only kept receiver-style callee. The
+      # turbofish `execute::<…>` peels to `execute`.
+      callees.should contain("jar.get")
+      callees.should contain("execute")
+      callees.should_not contain("unwrap")
+    end
+
+    it "keeps namespaced calls whose last segment is a reserved wrapper" do
+      body = <<-RUST
+        Ok(user)
+        std::format!("user {}", user.id)
+        HttpResponse::Ok().json(user)
+        HttpResponse::Created().finish()
+        RUST
+
+      callees = Noir::RustCalleeExtractorTS.callees_for_body_text(body, "main.rs", 40)
+      names = callees.map { |name, _, _| name }
+      names.should contain("HttpResponse::Ok")
+      names.should contain("HttpResponse::Created")
+      names.should_not contain("Ok")
+      names.should_not contain("std::format!")
+    end
+
+    it "captures macro invocations with the trailing bang" do
+      body = <<-RUST
+        warn!("once");
+        log::info!("twice");
+        AuditLog::write("created");
+        RUST
+
+      callees = Noir::RustCalleeExtractorTS.callees_for_body_text(body, "main.rs", 1).map { |name, _, _| name }
+      callees.should contain("warn!")
+      callees.should contain("log::info!")
+      callees.should contain("AuditLog::write")
+    end
+
+    it "handles multi-line call expressions the regex scanner used to miss" do
+      body = <<-RUST
+        UserService::create(
+            payload,
+            ctx,
+        );
+        RUST
+
+      callees = Noir::RustCalleeExtractorTS.callees_for_body_text(body, "main.rs", 1).map { |name, _, line| {name, line} }
+      callees.should eq([{"UserService::create", 1}])
+    end
+  end
+
+  describe ".callees_in_body" do
+    it "walks a pre-parsed function body without re-parsing" do
+      source = <<-RUST
+        fn handler(state: AppState) {
+            UserService::list(state);
+            state.audit.write("listed");
+        }
+        RUST
+
+      found = [] of {String, Int32}
+      Noir::TreeSitter.parse_rust(source) do |root|
+        # The first named child should be the function_item.
+        fn_node = nil.as(LibTreeSitter::TSNode?)
+        Noir::TreeSitter.each_named_child(root) do |c|
+          fn_node = c if Noir::TreeSitter.node_type(c) == "function_item"
+        end
+        fn_node.should_not be_nil
+        body = Noir::TreeSitter.field(fn_node.not_nil!, "body")
+        body.should_not be_nil
+        Noir::RustCalleeExtractorTS.callees_in_body(body.not_nil!, source, "handler.rs").each do |name, _, line|
+          found << {name, line}
+        end
+      end
+
+      found.should contain({"UserService::list", 2})
+      found.should contain({"state.audit.write", 3})
+    end
+  end
+end

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -1,134 +1,209 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # actix-web analyzer (tree-sitter port). actix-web wires routes via
+  # `#[get("/path")]` / `#[post(...)]` attribute macros that sit as
+  # **siblings** of the `function_item` they decorate (this is how
+  # tree-sitter-rust models outer attributes — they aren't children of
+  # the item they attach to). The analyzer walks every container and
+  # pairs each routing attribute with the function_item that follows
+  # it, skipping intermediate attribute_items and doc comments.
   class ActixWeb < RustEngine
-    ROUTE_PATTERN            = /#\[(get|post|put|delete|patch)\("([^"]+)"\)\]/
-    FUNCTION_LOOKAHEAD_LINES = 20
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
 
-      lines.each_with_index do |line, index|
-        next unless line.to_s.includes? "#["
-        match = line.match(ROUTE_PATTERN)
-        next unless match
+      Noir::TreeSitter.parse_rust(source) do |root|
+        each_routing_pair(root) do |attr, function|
+          route = extract_route(attr, source)
+          next unless route
+          route_path, method, attr_row = route
 
-        begin
-          route_argument = match[2]
-          callback_argument = match[1]
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(route_argument, callback_to_method(callback_argument), details)
+          details = Details.new(PathInfo.new(path, attr_row))
+          endpoint = Endpoint.new(route_path, method, details)
 
-          extract_path_params(route_argument, endpoint)
-          extract_function_params(lines, index + 1, endpoint)
-          attach_handler_callees(lines, index + 1, path, endpoint) if include_callee
+          extract_path_params(route_path, endpoint)
+          extract_function_params(function, source, endpoint)
+          attach_handler_callees(function, source, path, endpoint) if include_callee
 
           endpoints << endpoint
-        rescue e
-          logger.debug "Error processing endpoint: #{e.message}"
         end
       end
 
       endpoints
     end
 
-    def callback_to_method(str)
-      method = str.split("(").first
-      if !method.in?(%w[get post put delete patch])
-        method = "get"
-      end
+    # `#[get("/x")]` → `{"/x", "GET", attr_row_1based}`. Returns `nil`
+    # for non-routing attributes (`#[derive(...)]`, `#[tokio::main]`,
+    # …) so the iterator just skips past them.
+    private def extract_route(attr_item : LibTreeSitter::TSNode,
+                              source : String) : Tuple(String, String, Int32)?
+      attr = find_named_child(attr_item, "attribute")
+      return unless attr
 
-      method.upcase
-    end
-
-    private def attach_handler_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      return unless function_index
-
-      function_body = extract_rust_function_body(lines, function_index)
-      return unless function_body
-
-      body, body_start_line = function_body
-      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
-      attach_rust_callees(endpoint, callees)
-    end
-
-    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
-      (start_index...[start_index + FUNCTION_LOOKAHEAD_LINES, lines.size].min).each do |index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
-        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
-      end
-    end
-
-    # Extract path parameters from the route pattern like /users/{id}
-    def extract_path_params(route : String, endpoint : Endpoint)
-      route.scan(/\{(\w+)\}/) do |match|
-        param_name = match[1]
-        endpoint.push_param(Param.new(param_name, "", "path"))
-      end
-    end
-
-    # Extract parameters from function signature and body
-    def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
-      # Look ahead up to 20 lines for the function definition and body
-      in_function = false
-      brace_count = 0
-      seen_opening_brace = false
-
-      (start_index...[start_index + FUNCTION_LOOKAHEAD_LINES, lines.size].min).each do |i|
-        line = lines[i]
-
-        # Track if we're inside the function
-        if line.includes?("async fn ") || line.includes?("fn ")
-          in_function = true
-        end
-
-        # Track braces to know when function ends
-        brace_count += line.count('{')
-        if brace_count > 0
-          seen_opening_brace = true
-        end
-        brace_count -= line.count('}')
-
-        # Extract query parameters from web::Query<T>
-        if line.includes?("web::Query<") || line.includes?(": web::Query")
-          endpoint.push_param(Param.new("query", "", "query"))
-        end
-
-        # Extract JSON body from web::Json<T>
-        if line.includes?("web::Json<") || line.includes?(": web::Json")
-          endpoint.push_param(Param.new("body", "", "json"))
-        end
-
-        # Extract form body from web::Form<T>
-        if line.includes?("web::Form<") || line.includes?(": web::Form")
-          endpoint.push_param(Param.new("form", "", "form"))
-        end
-
-        # Extract headers from .headers().get()
-        if line.includes?(".headers().get(")
-          match = line.match(/\.headers\(\)\.get\("([^"]+)"\)/)
-          if match
-            header_name = match[1]
-            endpoint.push_param(Param.new(header_name, "", "header"))
-          end
-        end
-
-        # Extract cookies from .cookie()
-        if line.includes?(".cookie(")
-          match = line.match(/\.cookie\("([^"]+)"\)/)
-          if match
-            cookie_name = match[1]
-            endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-          end
-        end
-
-        # Stop if we've moved past the function (brace count is back to 0 after we've seen an opening brace)
-        if in_function && seen_opening_brace && brace_count == 0 && i > start_index
+      # tree-sitter-rust models the attribute path as the attribute's
+      # required positional named child (identifier / scoped_identifier
+      # / self / super / crate / metavariable). There is no `path:`
+      # field — the named fields are `arguments` (the `(...)` token
+      # tree) and `value` (for `#[key = expr]` shapes).
+      verb = nil.as(String?)
+      Noir::TreeSitter.each_named_child(attr) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier", "scoped_identifier"
+          verb = Noir::TreeSitter.node_text(child, source).downcase
           break
         end
+      end
+      return unless verb
+      return unless HTTP_VERBS.includes?(verb)
+
+      arguments = Noir::TreeSitter.field(attr, "arguments")
+      route_path = first_string_literal_text(arguments, source)
+      return unless route_path
+      {route_path, verb.upcase, Noir::TreeSitter.node_start_row(attr_item) + 1}
+    end
+
+    # Path params like `/users/{id}`.
+    def extract_path_params(route : String, endpoint : Endpoint)
+      route.scan(/\{(\w+)\}/) do |match|
+        endpoint.push_param(Param.new(match[1], "", "path"))
+      end
+    end
+
+    # Walk the function's `parameters` once and tag the endpoint with
+    # whichever extractor types appear. Each parameter's *text* is
+    # examined as a single slice — equivalent to the per-line scan in
+    # the legacy analyzer, bounded to the parameter list and free of
+    # comment / string-literal false positives.
+    def extract_function_params(function : LibTreeSitter::TSNode,
+                                source : String,
+                                endpoint : Endpoint)
+      params_node = Noir::TreeSitter.field(function, "parameters")
+      if params_node
+        Noir::TreeSitter.each_named_child(params_node) do |param|
+          text = Noir::TreeSitter.node_text(param, source)
+          if text.includes?("web::Query<") || text.includes?(": web::Query")
+            endpoint.push_param(Param.new("query", "", "query"))
+          end
+          if text.includes?("web::Json<") || text.includes?(": web::Json")
+            endpoint.push_param(Param.new("body", "", "json"))
+          end
+          if text.includes?("web::Form<") || text.includes?(": web::Form")
+            endpoint.push_param(Param.new("form", "", "form"))
+          end
+        end
+      end
+
+      body_node = Noir::TreeSitter.field(function, "body")
+      return unless body_node
+      collect_header_and_cookie_params(body_node, source, endpoint)
+    end
+
+    # Scan the body for `req.headers().get("X")` / `req.cookie("X")`
+    # — the legacy regex pass, now bounded to `call_expression`
+    # function texts so we don't false-positive on comments or string
+    # literals containing the same substring.
+    private def collect_header_and_cookie_params(body : LibTreeSitter::TSNode,
+                                                 source : String,
+                                                 endpoint : Endpoint)
+      walk(body) do |call|
+        next unless Noir::TreeSitter.node_type(call) == "call_expression"
+        fn_text = call_function_text(call, source)
+        next if fn_text.nil?
+
+        if fn_text.ends_with?(".headers().get")
+          first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source).try do |name|
+            endpoint.push_param(Param.new(name, "", "header"))
+          end
+        elsif fn_text.ends_with?(".cookie")
+          first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source).try do |name|
+            endpoint.push_param(Param.new(name, "", "cookie"))
+          end
+        end
+      end
+    end
+
+    private def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                       source : String,
+                                       path : String,
+                                       endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
+    end
+
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
+    end
+
+    # Walk `node`'s children at every depth and yield `(attribute_item,
+    # function_item)` pairs where the attribute immediately precedes
+    # the function (skipping intermediate attribute_items and doc
+    # comments). This matches how `#[get(...)] async fn handler` is
+    # laid out in the AST — both are top-level siblings, not parent /
+    # child.
+    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named.each_with_index do |child, idx|
+        if Noir::TreeSitter.node_type(child) == "attribute_item"
+          pair_function = find_paired_function(named, idx + 1)
+          block.call(child, pair_function) if pair_function
+        end
+        each_routing_pair(child, &block)
+      end
+    end
+
+    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
+      (start...named.size).each do |i|
+        next_node = named[i]
+        case Noir::TreeSitter.node_type(next_node)
+        when "function_item"
+          return next_node
+        when "attribute_item", "line_comment", "block_comment"
+          next
+        else
+          return # routing attributes only decorate functions
+        end
+      end
+      nil
+    end
+
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        next unless Noir::TreeSitter.node_type(child) == "string_literal"
+        Noir::TreeSitter.each_named_child(child) do |grand|
+          if Noir::TreeSitter.node_type(grand) == "string_content"
+            result = Noir::TreeSitter.node_text(grand, source)
+            break
+          end
+        end
+      end
+      result
+    end
+
+    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return child if Noir::TreeSitter.node_type(child) == type
+      end
+      nil
+    end
+
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
       end
     end
   end

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -1,75 +1,135 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # Axum analyzer (tree-sitter port). Each `.rs` file is parsed once
+  # with the vendored Rust grammar; route registrations are picked up
+  # by walking `call_expression` nodes whose function is a
+  # `field_expression` named `route`. Handler bodies are matched
+  # against a same-file `function_item` index so callee extraction
+  # shares the parsed tree instead of re-scanning the file with
+  # regexes and a body-text wrapper.
   class Axum < RustEngine
-    ROUTE_PATTERN = /\.route\("([^"]+)",\s*([^)]+)\)/
+    # Verbs accepted as the inner handler call (`get(...)`, `post(...)`,
+    # …). Anything outside this set is treated as `GET` to match the
+    # legacy fallback the regex analyzer used.
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
-      functions = include_callee ? collect_function_callees(lines, path) : Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
 
-      lines.each_with_index do |line, index|
-        next unless line.includes? ".route("
-        match = line.match(ROUTE_PATTERN)
-        next unless match
+      Noir::TreeSitter.parse_rust(source) do |root|
+        function_index = include_callee ? build_function_index(root, source) : Hash(String, LibTreeSitter::TSNode).new
 
-        begin
-          route_argument = match[1]
-          callback_argument = match[2]
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(route_argument, callback_to_method(callback_argument), details)
-          attach_route_callees(endpoint, callback_argument, functions) if include_callee
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          next unless route_call?(node, source)
+
+          route = extract_route(node, source)
+          next unless route
+
+          path_str, verb, handler_name = route
+          details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
+          endpoint = Endpoint.new(path_str, verb, details)
+
+          if include_callee && handler_name && (body_node = function_index[handler_name]?)
+            entries = Noir::RustCalleeExtractorTS.callees_in_body(body_node, source, path)
+            attach_rust_callees(endpoint, entries)
+          end
+
           endpoints << endpoint
-        rescue
         end
       end
 
       endpoints
     end
 
-    private def collect_function_callees(lines : Array(String), path : String) : Hash(String, Array(Noir::RustCalleeExtractor::Entry))
-      functions = Hash(String, Array(Noir::RustCalleeExtractor::Entry)).new
+    # `.route("...", get(handler))` — the chain is rooted on
+    # `Router::new()` but tree-sitter sees each `.route(...)` as its
+    # own `call_expression` because the receiver chain is left-folded.
+    private def route_call?(call : LibTreeSitter::TSNode, source : String) : Bool
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return false unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      field = Noir::TreeSitter.field(fn_node, "field")
+      return false unless field
+      Noir::TreeSitter.node_text(field, source) == "route"
+    end
 
-      lines.each_with_index do |line, index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
-        if match = stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\b/)
-          function_body = extract_rust_function_body(lines, index)
-          if function_body
-            body, body_start_line = function_body
-            functions[match[1]] = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
-          end
+    # Returns `{path, http_method, handler_name?}` for a valid
+    # `.route(path, verb(handler))` call, or `nil` when the shape
+    # doesn't match.
+    private def extract_route(call : LibTreeSitter::TSNode, source : String) : Tuple(String, String, String?)?
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(args) { |c| named << c }
+      return if named.size < 2
+
+      path = string_literal_text(named[0], source)
+      return unless path
+
+      method, handler = decode_handler(named[1], source)
+      {path, method, handler}
+    end
+
+    # `get(handler)` → `{"GET", "handler"}`. Defaults to `GET` when
+    # the verb is unrecognised, matching the legacy fallback.
+    private def decode_handler(node : LibTreeSitter::TSNode, source : String) : Tuple(String, String?)
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        fn_node = Noir::TreeSitter.field(node, "function")
+        if fn_node && Noir::TreeSitter.node_type(fn_node) == "identifier"
+          verb = Noir::TreeSitter.node_text(fn_node, source).downcase
+          method = HTTP_VERBS.includes?(verb) ? verb.upcase : "GET"
+          handler = first_identifier_argument(node, source)
+          return {method, handler}
         end
       end
-
-      functions
+      {"GET", nil}
     end
 
-    private def attach_route_callees(endpoint : Endpoint,
-                                     callback_argument : String,
-                                     functions : Hash(String, Array(Noir::RustCalleeExtractor::Entry)))
-      handler = extract_route_handler(callback_argument)
-      return unless handler
-
-      if callees = functions[handler]?
-        attach_rust_callees(endpoint, callees)
+    private def first_identifier_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |child|
+        return Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "identifier"
       end
+      nil
     end
 
-    private def extract_route_handler(callback_argument : String) : String?
-      if match = callback_argument.match(/\b(?:get|post|put|delete|patch|head|options)\s*\(\s*([A-Za-z_]\w*)/)
-        match[1]
+    private def string_literal_text(node : LibTreeSitter::TSNode, source : String) : String?
+      return unless Noir::TreeSitter.node_type(node) == "string_literal"
+      content = nil.as(String?)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        content = Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "string_content"
       end
+      content
     end
 
-    def callback_to_method(str)
-      method = str.split("(").first.strip
-      if !method.in?(%w[get post put delete])
-        method = "get"
+    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      index = {} of String => LibTreeSitter::TSNode
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "function_item"
+        name_node = Noir::TreeSitter.field(node, "name")
+        body_node = Noir::TreeSitter.field(node, "body")
+        next unless name_node && body_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        # First occurrence wins. axum handlers are rarely overloaded
+        # in the same file and the legacy analyzer behaved the same
+        # way (first `fn name` match in the line scan).
+        index[name] = body_node unless index.has_key?(name)
       end
+      index
+    end
 
-      method.upcase
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/rust/poem.cr
+++ b/src/analyzer/analyzers/rust/poem.cr
@@ -1,79 +1,166 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # Poem analyzer (tree-sitter port). Poem registers routes two ways:
+  #
+  #   1. Route chain: `Route::new().at("/path", get(handler))`. The
+  #      second argument to `.at` is a single `call_expression` or a
+  #      chain of `.<verb>(handler)` calls — each method registered
+  #      this way creates a separate endpoint sharing the same path.
+  #
+  #   2. poem-openapi macros: `#[oai(path = "/p", method = "get")]`
+  #      attached to functions inside an `impl Api { ... }` block.
   class Poem < RustEngine
-    HTTP_METHODS = %w[get post put delete patch head options]
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
 
-      # Strategy 1: Parse Route::new().at("/path", get(handler).post(...)) chains
-      parse_at_routes(lines, path, endpoints, include_callee)
+      Noir::TreeSitter.parse_rust(source) do |root|
+        function_index = build_function_index(root, source)
 
-      # Strategy 2: Parse #[oai(path = "...", method = "...")] poem-openapi attributes
-      parse_oai_attributes(lines, path, endpoints, include_callee)
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          at_call = decode_at_call(node, source)
+          next unless at_call
+          route_path, method_handler_pairs = at_call
 
-      endpoints
-    end
+          method_handler_pairs.each do |method, handler_name|
+            details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
+            normalized = normalize_path(route_path)
+            endpoint = Endpoint.new(normalized, method, details)
+            extract_path_params(route_path, endpoint)
 
-    def parse_at_routes(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
-      lines.each_with_index do |line, index|
-        next unless line.includes?(".at(")
+            if handler_function = function_index[handler_name.split("::").last]?
+              scan_function(handler_function, source, endpoint)
+              attach_handler_callees(handler_function, source, path, endpoint) if include_callee
+            end
 
-        path_match = line.match(/\.at\s*\(\s*"([^"]+)"\s*,\s*(.+)$/)
-        next unless path_match
-
-        route_path = path_match[1]
-        remainder = path_match[2]
-
-        methods_and_handlers = [] of Tuple(String, String)
-        remainder.scan(/\b(get|post|put|delete|patch|head|options)\s*\(\s*([\w:]+)/) do |m|
-          methods_and_handlers << {m[1].upcase, m[2]}
+            endpoints << endpoint
+          end
         end
 
-        next if methods_and_handlers.empty?
+        each_routing_pair(root) do |attr_item, function|
+          route = decode_oai_attribute(attr_item, source)
+          next unless route
+          route_path, method, attr_row = route
 
-        methods_and_handlers.each do |method, handler_name|
-          details = Details.new(PathInfo.new(path, index + 1))
-          normalized_path = normalize_path(route_path)
-          endpoint = Endpoint.new(normalized_path, method, details)
-
+          details = Details.new(PathInfo.new(path, attr_row))
+          normalized = normalize_path(route_path)
+          endpoint = Endpoint.new(normalized, method, details)
           extract_path_params(route_path, endpoint)
-          extract_handler_params(lines, handler_name, endpoint)
-          attach_handler_callees(lines, handler_name, path, endpoint) if include_callee
+          scan_function(function, source, endpoint)
+          attach_handler_callees(function, source, path, endpoint) if include_callee
 
           endpoints << endpoint
         end
       end
+
+      endpoints
     end
 
-    def parse_oai_attributes(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
-      lines.each_with_index do |line, index|
-        stripped = line.strip
-        next unless stripped.starts_with?("#[oai(")
+    # `.at("/path", get(h))` or `.at("/path", get(h).post(h2))` —
+    # return `{path, [(METHOD, handler_name), ...]}` or `nil`.
+    private def decode_at_call(call : LibTreeSitter::TSNode, source : String) : Tuple(String, Array(Tuple(String, String)))?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      field = Noir::TreeSitter.field(fn_node, "field")
+      return unless field && Noir::TreeSitter.node_text(field, source) == "at"
 
-        path_match = line.match(/path\s*=\s*"([^"]+)"/)
-        method_match = line.match(/method\s*=\s*"([^"]+)"/)
-        next unless path_match && method_match
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(args) { |c| named << c }
+      return if named.size < 2
 
-        route_path = path_match[1]
-        method = method_match[1].upcase
+      route_path = string_content_from_string_literal(named[0], source)
+      return unless route_path
 
-        details = Details.new(PathInfo.new(path, index + 1))
-        normalized_path = normalize_path(route_path)
-        endpoint = Endpoint.new(normalized_path, method, details)
+      pairs = decode_method_handler_chain(named[1], source)
+      return if pairs.empty?
+      {route_path, pairs}
+    end
 
-        extract_path_params(route_path, endpoint)
-        scan_function(lines, index + 1, endpoint)
-        attach_next_function_callees(lines, index + 1, path, endpoint) if include_callee
-
-        endpoints << endpoint
+    # Walk `.get(h).post(h2)` chains. Each step is a `call_expression`
+    # whose function is either an identifier (verb) — for the leaf —
+    # or a `field_expression { value: previous_call, field: verb }`.
+    private def decode_method_handler_chain(node : LibTreeSitter::TSNode, source : String) : Array(Tuple(String, String))
+      pairs = [] of Tuple(String, String)
+      current = node
+      while Noir::TreeSitter.node_type(current) == "call_expression"
+        fn_node = Noir::TreeSitter.field(current, "function")
+        break unless fn_node
+        verb = nil.as(String?)
+        receiver = nil.as(LibTreeSitter::TSNode?)
+        case Noir::TreeSitter.node_type(fn_node)
+        when "identifier"
+          verb = Noir::TreeSitter.node_text(fn_node, source).downcase
+        when "field_expression"
+          field = Noir::TreeSitter.field(fn_node, "field")
+          verb = Noir::TreeSitter.node_text(field, source).downcase if field
+          receiver = Noir::TreeSitter.field(fn_node, "value")
+        end
+        if verb && HTTP_VERBS.includes?(verb)
+          if handler = first_identifier_argument(current, source)
+            pairs << {verb.upcase, handler}
+          end
+        end
+        break unless receiver
+        current = receiver
       end
+      pairs.reverse
     end
 
-    # Convert Poem's :param syntax to {param} for output consistency
+    # `#[oai(path = "/x", method = "get")]`. The macro args are a
+    # `token_tree` whose named children include `identifier` and
+    # `string_literal` in source order.
+    private def decode_oai_attribute(attr_item : LibTreeSitter::TSNode,
+                                     source : String) : Tuple(String, String, Int32)?
+      attr = find_named_child(attr_item, "attribute")
+      return unless attr
+
+      attr_name = nil.as(String?)
+      Noir::TreeSitter.each_named_child(attr) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier", "scoped_identifier"
+          attr_name = Noir::TreeSitter.node_text(child, source)
+          break
+        end
+      end
+      return unless attr_name == "oai"
+
+      arguments = Noir::TreeSitter.field(attr, "arguments")
+      return unless arguments
+
+      route_path : String? = nil
+      method : String? = nil
+      pending = nil.as(String?)
+      Noir::TreeSitter.each_named_child(arguments) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier"
+          pending = Noir::TreeSitter.node_text(child, source)
+        when "string_literal"
+          value = string_content(child, source)
+          case pending
+          when "path"
+            route_path = value
+          when "method"
+            method = value.try(&.upcase)
+          end
+          pending = nil
+        end
+      end
+      rp = route_path
+      mt = method
+      return unless rp && mt
+      {rp, mt, Noir::TreeSitter.node_start_row(attr_item) + 1}
+    end
+
+    # Convert `:param` syntax to `{param}` and ensure leading slash.
     def normalize_path(route : String) : String
       result = route.gsub(/:(\w+)/) { "{#{$~[1]}}" }
       result.starts_with?("/") ? result : "/#{result}"
@@ -85,107 +172,157 @@ module Analyzer::Rust
       end
     end
 
-    def extract_handler_params(lines : Array(String), handler_name : String, endpoint : Endpoint)
-      function_index = find_handler_function_index(lines, handler_name)
-      scan_function(lines, function_index, endpoint) if function_index
-    end
-
-    # Walks a function starting at start_index: first extracts typed/destructured
-    # extractors from the signature, then scans the body for header/cookie access.
-    def scan_function(lines : Array(String), start_index : Int32, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      return unless function_index
-
-      in_signature = true
-      brace_count = 0
-      seen_opening_brace = false
-
-      (function_index...[function_index + 40, lines.size].min).each do |i|
-        line = lines[i]
-
-        if in_signature
-          extract_signature_params(line, endpoint)
-        end
-
-        brace_count += line.count('{')
-        if brace_count > 0
-          seen_opening_brace = true
-          in_signature = false
-        end
-        brace_count -= line.count('}')
-
-        unless in_signature
-          extract_body_params(line, endpoint)
-        end
-
-        if seen_opening_brace && brace_count == 0 && i > function_index
-          break
-        end
-      end
-    end
-
-    def extract_signature_params(line : String, endpoint : Endpoint)
-      if line.match(/Query\s*\(\s*[^)]+\s*\)/) || line.includes?(": Query<")
-        endpoint.push_param(Param.new("query", "", "query"))
-      end
-
-      if line.match(/Json\s*\(\s*[^)]+\s*\)/) || line.includes?(": Json<")
-        endpoint.push_param(Param.new("body", "", "json"))
-      end
-
-      if line.match(/Form\s*\(\s*[^)]+\s*\)/) || line.includes?(": Form<")
-        endpoint.push_param(Param.new("form", "", "form"))
-      end
-    end
-
-    def extract_body_params(line : String, endpoint : Endpoint)
-      if line.includes?("req.header(") || line.includes?(".header(")
-        match = line.match(/\.header\s*\(\s*"([^"]+)"\s*\)/)
-        if match
-          endpoint.push_param(Param.new(match[1], "", "header"))
+    # Walk parameters and body for extractor types + header / cookie
+    # calls. Bounded to the function so unrelated calls elsewhere in
+    # the file don't leak through.
+    private def scan_function(function : LibTreeSitter::TSNode,
+                              source : String,
+                              endpoint : Endpoint)
+      params_node = Noir::TreeSitter.field(function, "parameters")
+      if params_node
+        Noir::TreeSitter.each_named_child(params_node) do |param|
+          text = Noir::TreeSitter.node_text(param, source)
+          if !endpoint.params.any? { |p| p.name == "query" && p.param_type == "query" } &&
+             (text.includes?(": Query<") || text.match(/Query\s*\(\s*[^)]+\s*\)/))
+            endpoint.push_param(Param.new("query", "", "query"))
+          end
+          if !endpoint.params.any? { |p| p.name == "body" && p.param_type == "json" } &&
+             (text.includes?(": Json<") || text.match(/Json\s*\(\s*[^)]+\s*\)/))
+            endpoint.push_param(Param.new("body", "", "json"))
+          end
+          if !endpoint.params.any? { |p| p.name == "form" && p.param_type == "form" } &&
+             (text.includes?(": Form<") || text.match(/Form\s*\(\s*[^)]+\s*\)/))
+            endpoint.push_param(Param.new("form", "", "form"))
+          end
         end
       end
 
-      if line.includes?(".cookie")
-        match = line.match(/\.cookie\s*\(\s*\)\s*\.\s*get\s*\(\s*"([^"]+)"\s*\)/)
-        match ||= line.match(/\.cookie\s*\(\s*"([^"]+)"\s*\)/)
-        if match
-          endpoint.push_param(Param.new(match[1], "", "cookie"))
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+
+      walk(body) do |call|
+        next unless Noir::TreeSitter.node_type(call) == "call_expression"
+        fn_text = call_function_text(call, source)
+        next if fn_text.nil?
+
+        if fn_text.ends_with?(".header") || fn_text == "header"
+          name = first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source)
+          if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
+            endpoint.push_param(Param.new(name, "", "header"))
+          end
+        elsif fn_text.ends_with?(".cookie().get") || fn_text == "cookie"
+          name = first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source)
+          if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "cookie" }
+            endpoint.push_param(Param.new(name, "", "cookie"))
+          end
         end
       end
     end
 
-    private def attach_handler_callees(lines : Array(String), handler_name : String, path : String, endpoint : Endpoint)
-      function_index = find_handler_function_index(lines, handler_name)
-      attach_function_callees(lines, function_index, path, endpoint) if function_index
+    private def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                       source : String,
+                                       path : String,
+                                       endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
     end
 
-    private def attach_next_function_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      attach_function_callees(lines, function_index, path, endpoint) if function_index
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
     end
 
-    private def attach_function_callees(lines : Array(String), function_index : Int32, path : String, endpoint : Endpoint)
-      function_body = extract_rust_function_body(lines, function_index)
-      return unless function_body
-
-      body, body_start_line = function_body
-      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
-      attach_rust_callees(endpoint, callees)
+    private def first_identifier_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier"
+          return Noir::TreeSitter.node_text(child, source)
+        when "scoped_identifier"
+          return Noir::TreeSitter.node_text(child, source)
+        end
+      end
+      nil
     end
 
-    private def find_handler_function_index(lines : Array(String), handler_name : String) : Int32?
-      local_name = handler_name.split("::").last
-      lines.each_with_index do |line, index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
-        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+#{local_name}\b/)
+    private def string_content_from_string_literal(node : LibTreeSitter::TSNode, source : String) : String?
+      return unless Noir::TreeSitter.node_type(node) == "string_literal"
+      string_content(node, source)
+    end
+
+    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      index = {} of String => LibTreeSitter::TSNode
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "function_item"
+        name_node = Noir::TreeSitter.field(node, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        index[name] = node unless index.has_key?(name)
+      end
+      index
+    end
+
+    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named.each_with_index do |child, idx|
+        if Noir::TreeSitter.node_type(child) == "attribute_item"
+          pair_function = find_paired_function(named, idx + 1)
+          block.call(child, pair_function) if pair_function
+        end
+        each_routing_pair(child, &block)
       end
     end
 
-    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
-      (start_index...[start_index + 40, lines.size].min).each do |index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
-        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
+    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
+      (start...named.size).each do |i|
+        next_node = named[i]
+        case Noir::TreeSitter.node_type(next_node)
+        when "function_item"
+          return next_node
+        when "attribute_item", "line_comment", "block_comment"
+          next
+        else
+          return
+        end
+      end
+      nil
+    end
+
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        if Noir::TreeSitter.node_type(child) == "string_literal"
+          result = string_content(child, source)
+        end
+      end
+      result
+    end
+
+    private def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(string_literal) do |grand|
+        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
+      end
+      nil
+    end
+
+    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return child if Noir::TreeSitter.node_type(child) == type
+      end
+      nil
+    end
+
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
       end
     end
   end

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -1,100 +1,130 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # Rocket analyzer (tree-sitter port). Rocket attaches routes via
+  # `#[get("/x")]` / `#[post("/x", data = "<body>")]` outer attribute
+  # macros. tree-sitter-rust leaves macro argument lists as
+  # `token_tree`, but the lexer still tags `string_literal` /
+  # `identifier` children inside — we walk those for the route path,
+  # the `data = "<...>"` form, query / path angle-bracket params, and
+  # `CookieJar` / `headers().get(...)` body uses.
   class Rocket < RustEngine
-    # Maximum lines to scan ahead for function body analysis
-    MAX_FUNCTION_SCAN_LINES = 30
-
-    # Enhanced pattern to capture path, query parameters, and data parameters
-    ROUTE_PATTERN = /#\[(get|post|delete|put|patch)\("([^"]+)"(?:, data = "<([^>]+)>")?\)\]/
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
 
-      lines.each_with_index do |line, index|
-        next unless line.includes?("#[") && line.includes?(")]")
-        match = line.match(ROUTE_PATTERN)
-        next unless match
+      Noir::TreeSitter.parse_rust(source) do |root|
+        each_routing_pair(root) do |attr, function|
+          route = extract_route(attr, source)
+          next unless route
+          route_path, method, data_param, attr_row = route
 
-        begin
-          callback_argument = match[1]
-          route_argument = match[2]
-          data_argument = match[3]?
+          details = Details.new(PathInfo.new(path, attr_row))
+          params = extract_params(route_path, data_param)
+          endpoint = Endpoint.new(route_path, method, params, details)
 
-          # Extract parameters from the route
-          params = extract_params(route_argument, data_argument)
-
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(route_argument, callback_to_method(callback_argument), params, details)
-
-          # Look ahead to extract cookies and headers from function signature/body
-          extract_function_params(lines, index + 1, endpoint)
-          attach_handler_callees(lines, index + 1, path, endpoint) if include_callee
+          extract_function_extras(function, source, endpoint)
+          attach_handler_callees(function, source, path, endpoint) if include_callee
 
           endpoints << endpoint
-        rescue
         end
       end
 
       endpoints
     end
 
-    def callback_to_method(str)
-      method = str.split("(").first
-      if !method.in?(%w[get post put patch delete])
-        method = "get"
+    # `#[get("/x")]` / `#[post("/x", data = "<body>")]` →
+    # `{route, METHOD, data_var?, attr_row_1based}`. Returns `nil` for
+    # non-routing attributes.
+    private def extract_route(attr_item : LibTreeSitter::TSNode,
+                              source : String) : Tuple(String, String, String?, Int32)?
+      attr = find_named_child(attr_item, "attribute")
+      return unless attr
+
+      verb = nil.as(String?)
+      Noir::TreeSitter.each_named_child(attr) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier", "scoped_identifier"
+          verb = Noir::TreeSitter.node_text(child, source).downcase
+          break
+        end
+      end
+      return unless verb
+      return unless HTTP_VERBS.includes?(verb)
+
+      arguments = Noir::TreeSitter.field(attr, "arguments")
+      return unless arguments
+      route_path, data_param = parse_token_tree(arguments, source)
+      return unless route_path
+      {route_path, verb.upcase, data_param, Noir::TreeSitter.node_start_row(attr_item) + 1}
+    end
+
+    # Walk the attribute's token_tree once. First `string_literal` is
+    # the route path. Any `identifier "data"` followed by a
+    # `string_literal` yields the data parameter variable name (the
+    # `<input>` form). Other keyword args are ignored — rocket's
+    # `format = "..."` / `rank = N` aren't endpoint-shaping.
+    private def parse_token_tree(token_tree : LibTreeSitter::TSNode,
+                                 source : String) : Tuple(String?, String?)
+      route_path : String? = nil
+      data_param : String? = nil
+      saw_data = false
+
+      Noir::TreeSitter.each_named_child(token_tree) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "string_literal"
+          text = string_content(child, source)
+          if route_path.nil?
+            route_path = text
+          elsif saw_data && data_param.nil?
+            # `data = "<input>"` — strip the angle brackets.
+            data_param = strip_angle_brackets(text) if text
+            saw_data = false
+          end
+        when "identifier"
+          saw_data = true if Noir::TreeSitter.node_text(child, source) == "data"
+        end
       end
 
-      method.upcase
+      {route_path, data_param}
     end
 
-    private def attach_handler_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      return unless function_index
-
-      function_body = extract_rust_function_body(lines, function_index)
-      return unless function_body
-
-      body, body_start_line = function_body
-      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
-      attach_rust_callees(endpoint, callees)
-    end
-
-    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
-      (start_index...[start_index + MAX_FUNCTION_SCAN_LINES, lines.size].min).each do |index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
-        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
+    private def strip_angle_brackets(value : String?) : String?
+      return unless value
+      if value.starts_with?('<') && value.ends_with?('>')
+        value[1..-2]
+      else
+        value
       end
     end
 
+    # `/users/<id>` / `/search?<q>&<limit>` / `data = "<body>"` get
+    # rolled together here so the legacy spec's param ordering stays
+    # stable.
     private def extract_params(route : String, data_param : String?) : Array(Param)
       params = [] of Param
 
-      # Extract path parameters from route (e.g., /users/<id> or /posts/<category>/<id>)
-      route.scan(/<(\w+)>/) do |match|
-        if match.size > 1
-          param_name = match[1]
-          params << Param.new(param_name, "", "path") unless param_exists?(params, param_name, "path")
+      parts = route.split("?", 2)
+      path_part = parts[0]
+      query_part = parts[1]?
+
+      path_part.scan(/<(\w+)>/) do |match|
+        name = match[1]
+        params << Param.new(name, "", "path") unless params.any? { |p| p.name == name && p.param_type == "path" }
+      end
+
+      if query_part
+        query_part.scan(/<(\w+)>/) do |match|
+          name = match[1]
+          params << Param.new(name, "", "query") unless params.any? { |p| p.name == name && p.param_type == "query" }
         end
       end
 
-      # Split route by '?' to separate path and query
-      parts = route.split("?")
-
-      # Extract query parameters (e.g., ?<query>&<limit>)
-      if parts.size > 1
-        query_string = parts[1]
-        query_string.scan(/<(\w+)>/) do |match|
-          if match.size > 1
-            param_name = match[1]
-            params << Param.new(param_name, "", "query") unless param_exists?(params, param_name, "query")
-          end
-        end
-      end
-
-      # Extract body/data parameter if present
       if data_param && !data_param.empty?
         params << Param.new(data_param, "", "body")
       end
@@ -102,68 +132,116 @@ module Analyzer::Rust
       params
     end
 
-    private def param_exists?(params : Array(Param), name : String, param_type : String) : Bool
-      params.any? { |p| p.name == name && p.param_type == param_type }
+    # Cookies and headers come from the function signature + body.
+    # The `CookieJar` signature gate from the legacy analyzer is
+    # preserved — `cookies.get(...)` only counts when the function
+    # actually takes a `CookieJar`.
+    private def extract_function_extras(function : LibTreeSitter::TSNode,
+                                        source : String,
+                                        endpoint : Endpoint)
+      has_cookie_jar = false
+      params_node = Noir::TreeSitter.field(function, "parameters")
+      if params_node
+        Noir::TreeSitter.each_named_child(params_node) do |param|
+          has_cookie_jar = true if Noir::TreeSitter.node_text(param, source).includes?("CookieJar")
+        end
+      end
+
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+
+      walk(body) do |call|
+        next unless Noir::TreeSitter.node_type(call) == "call_expression"
+        fn_text = call_function_text(call, source)
+        next if fn_text.nil?
+
+        if has_cookie_jar && (fn_text.ends_with?(".get") || fn_text.ends_with?(".get_private"))
+          name = first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source)
+          if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "cookie" }
+            endpoint.push_param(Param.new(name, "", "cookie"))
+          end
+        elsif fn_text.ends_with?(".headers().get")
+          name = first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source)
+          if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
+            endpoint.push_param(Param.new(name, "", "header"))
+          end
+        end
+      end
     end
 
-    # Extract parameters from function signature and body (cookies, headers)
-    private def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      return unless function_index
+    private def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                       source : String,
+                                       path : String,
+                                       endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
+    end
 
-      in_function = false
-      brace_count = 0
-      seen_opening_brace = false
-      has_cookie_jar = false
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
+    end
 
-      (function_index...[function_index + MAX_FUNCTION_SCAN_LINES, lines.size].min).each do |i|
-        line = lines[i]
-
-        # Track if we're inside the function
-        if line.includes?("fn ")
-          in_function = true
+    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named.each_with_index do |child, idx|
+        if Noir::TreeSitter.node_type(child) == "attribute_item"
+          pair_function = find_paired_function(named, idx + 1)
+          block.call(child, pair_function) if pair_function
         end
+        each_routing_pair(child, &block)
+      end
+    end
 
-        # Track braces to know when function ends
-        brace_count += line.count('{')
-        if brace_count > 0
-          seen_opening_brace = true
+    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
+      (start...named.size).each do |i|
+        next_node = named[i]
+        case Noir::TreeSitter.node_type(next_node)
+        when "function_item"
+          return next_node
+        when "attribute_item", "line_comment", "block_comment"
+          next
+        else
+          return
         end
-        brace_count -= line.count('}')
+      end
+      nil
+    end
 
-        # Check if this function has CookieJar parameter
-        if line.includes?("CookieJar") || line.includes?("&CookieJar")
-          has_cookie_jar = true
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        if Noir::TreeSitter.node_type(child) == "string_literal"
+          result = string_content(child, source)
         end
+      end
+      result
+    end
 
-        # Extract cookies.get("name") or cookies.get_private("name") from within the function
-        # Only extract if we've seen CookieJar in this function
-        if has_cookie_jar && (line.includes?(".get(\"") || line.includes?(".get_private(\""))
-          line.scan(/\.get(?:_private)?\("([^"]+)"\)/) do |cookie_match|
-            if cookie_match.size > 1
-              cookie_name = cookie_match[1]
-              unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
-                endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-              end
-            end
-          end
-        end
+    private def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(string_literal) do |grand|
+        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
+      end
+      nil
+    end
 
-        # Extract headers from request.headers().get() pattern
-        if line.includes?(".headers().get(")
-          match = line.match(/\.headers\(\)\.get\((?:HeaderName::from_static\()?"([^"]+)"/)
-          if match
-            header_name = match[1]
-            unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
-              endpoint.push_param(Param.new(header_name, "", "header"))
-            end
-          end
-        end
+    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return child if Noir::TreeSitter.node_type(child) == type
+      end
+      nil
+    end
 
-        # Stop if we've moved past the function
-        if in_function && seen_opening_brace && brace_count == 0 && i > start_index
-          break
-        end
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
       end
     end
   end

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -1,192 +1,299 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # Salvo analyzer (tree-sitter port). Salvo wires routes in two
+  # shapes, both handled here:
+  #
+  #   1. Router-chain DSL:
+  #        Router::with_path("users/<id>").get(get_user)
+  #      Each `.with_path(...)` / `.path(...)` is paired with the
+  #      following `.<verb>(handler)` method in the same chain.
+  #
+  #   2. Attribute macro:
+  #        #[endpoint(method = Post, path = "/api/submit/<id>")]
+  #        async fn submit_form(...) { ... }
   class Salvo < RustEngine
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
 
-      # Strategy 1: Parse Router chain patterns
-      # e.g., Router::with_path("users/<id>").get(get_user)
-      # e.g., Router::new().push(Router::with_path("items").get(list_items))
-      parse_router_chains(lines, path, endpoints, include_callee)
+      Noir::TreeSitter.parse_rust(source) do |root|
+        function_index = build_function_index(root, source)
 
-      # Strategy 2: Parse #[endpoint] macro patterns
-      # e.g., #[endpoint(method = Get, path = "/api/users")]
-      parse_endpoint_macros(lines, path, endpoints, include_callee)
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          chain = decode_router_chain(node, source)
+          next unless chain
+          route_path, method, handler_name = chain
+
+          details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
+          endpoint = Endpoint.new("/#{route_path.lstrip('/')}", method, details)
+          extract_path_params(route_path, endpoint)
+
+          if handler_function = function_index[handler_name]?
+            extract_function_params(handler_function, source, endpoint)
+            attach_handler_callees(handler_function, source, path, endpoint) if include_callee
+          end
+
+          endpoints << endpoint
+        end
+
+        each_routing_pair(root) do |attr_item, function|
+          route = decode_endpoint_macro(attr_item, source)
+          next unless route
+          route_path, method, attr_row = route
+
+          details = Details.new(PathInfo.new(path, attr_row))
+          endpoint = Endpoint.new(route_path, method, details)
+          extract_path_params(route_path, endpoint)
+          extract_function_params(function, source, endpoint)
+          attach_handler_callees(function, source, path, endpoint) if include_callee
+
+          endpoints << endpoint
+        end
+      end
 
       endpoints
     end
 
-    def parse_router_chains(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
-      lines.each_with_index do |line, index|
-        # Match Router::with_path("...").method(handler) or .path("...").method(handler)
-        # Pattern: with_path("path") followed by .method(handler)
-        if line.includes?("with_path(") || line.includes?(".path(")
-          # Extract path from with_path("...") or .path("...")
-          path_match = line.match(/(?:with_path|\.path)\s*\(\s*"([^"]+)"\s*\)/)
-          if path_match
-            route_path = path_match[1]
+    # `<chain>.with_path("x").get(handler)` — tree-sitter sees each
+    # method call as its own `call_expression { function:
+    # field_expression { field: "get", value: call_expression {
+    # function: field_expression { field: "with_path", … } } } }`.
+    # When the outer call's verb is an HTTP verb AND the receiver is a
+    # `.with_path(...)` / `.path(...)` call, we have a complete chain.
+    private def decode_router_chain(call : LibTreeSitter::TSNode, source : String) : Tuple(String, String, String)?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      verb_field = Noir::TreeSitter.field(fn_node, "field")
+      return unless verb_field
+      verb = Noir::TreeSitter.node_text(verb_field, source).downcase
+      return unless HTTP_VERBS.includes?(verb)
 
-            # Look for HTTP method in same line or nearby lines
-            search_range = [index, [index + 3, lines.size - 1].min]
-            (search_range[0]..search_range[1]).each do |i|
-              method_match = lines[i].match(/\.(get|post|put|delete|patch|head|options)\s*\(/)
-              if method_match
-                method = method_match[1].upcase
-                details = Details.new(PathInfo.new(path, index + 1))
-                endpoint = Endpoint.new("/#{route_path.lstrip('/')}", method, details)
+      receiver = Noir::TreeSitter.field(fn_node, "value")
+      return unless receiver && Noir::TreeSitter.node_type(receiver) == "call_expression"
+      receiver_fn = Noir::TreeSitter.field(receiver, "function")
+      return unless receiver_fn
+      # `with_path(...)` shows up as both a chain method
+      # (`field_expression` with `field: "with_path"`) and a path
+      # constructor (`scoped_identifier` like `Router::with_path`).
+      # Accept either shape and key off the trailing segment.
+      receiver_name =
+        case Noir::TreeSitter.node_type(receiver_fn)
+        when "field_expression"
+          (field = Noir::TreeSitter.field(receiver_fn, "field")) ? Noir::TreeSitter.node_text(field, source) : ""
+        when "scoped_identifier"
+          Noir::TreeSitter.node_text(receiver_fn, source).split("::").last
+        else
+          ""
+        end
+      return unless receiver_name == "with_path" || receiver_name == "path"
 
-                # Extract path parameters like <id>
-                extract_path_params(route_path, endpoint)
+      route_path = first_string_literal_text(Noir::TreeSitter.field(receiver, "arguments"), source)
+      return unless route_path
 
-                # Look for handler function and extract params
-                handler_match = lines[i].match(/\.(get|post|put|delete|patch|head|options)\s*\(\s*(\w+)/)
-                if handler_match
-                  handler_name = handler_match[2]
-                  extract_handler_params(lines, handler_name, endpoint)
-                  attach_handler_callees(lines, handler_name, path, endpoint) if include_callee
-                end
+      handler_name = first_identifier_argument(call, source)
+      return unless handler_name
+      {route_path, verb.upcase, handler_name}
+    end
 
-                endpoints << endpoint
-                break
-              end
+    # `#[endpoint(method = Post, path = "/x")]`. tree-sitter-rust
+    # leaves the macro arguments as a `token_tree`, but the inner
+    # tokens are still tagged — we look for the `method` / `path`
+    # keywords and pull the following identifier / string literal.
+    private def decode_endpoint_macro(attr_item : LibTreeSitter::TSNode,
+                                      source : String) : Tuple(String, String, Int32)?
+      attr = find_named_child(attr_item, "attribute")
+      return unless attr
+
+      attr_name = nil.as(String?)
+      Noir::TreeSitter.each_named_child(attr) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier", "scoped_identifier"
+          attr_name = Noir::TreeSitter.node_text(child, source)
+          break
+        end
+      end
+      return unless attr_name == "endpoint"
+
+      arguments = Noir::TreeSitter.field(attr, "arguments")
+      return unless arguments
+
+      method = "GET"
+      route_path = "/"
+      saw_method = false
+      saw_path = false
+      Noir::TreeSitter.each_named_child(arguments) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier"
+          name = Noir::TreeSitter.node_text(child, source)
+          case name
+          when "method"
+            saw_method = true
+          when "path"
+            saw_path = true
+          else
+            method = name.upcase if saw_method
+            saw_method = false
+          end
+        when "string_literal"
+          if saw_path
+            text = string_content(child, source)
+            route_path = text if text
+            saw_path = false
+          end
+        end
+      end
+      {route_path, method, Noir::TreeSitter.node_start_row(attr_item) + 1}
+    end
+
+    private def extract_path_params(route : String, endpoint : Endpoint)
+      route.scan(/<(\w+)>/) do |match|
+        endpoint.push_param(Param.new(match[1], "", "path"))
+      end
+    end
+
+    # Walk parameters + body looking for QueryParam / JsonBody /
+    # FormBody / req.header / req.cookie shapes. Bounded to the
+    # function so unrelated calls in the file don't bleed in.
+    private def extract_function_params(function : LibTreeSitter::TSNode,
+                                        source : String,
+                                        endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+
+      walk(body) do |node|
+        text = Noir::TreeSitter.node_text(node, source)
+        case Noir::TreeSitter.node_type(node)
+        when "let_declaration", "type_identifier", "scoped_type_identifier", "generic_type"
+          if text.includes?("QueryParam") && !endpoint.params.any? { |p| p.name == "query" && p.param_type == "query" }
+            endpoint.push_param(Param.new("query", "", "query"))
+          end
+          if text.includes?("JsonBody") && !endpoint.params.any? { |p| p.name == "body" && p.param_type == "json" }
+            endpoint.push_param(Param.new("body", "", "json"))
+          end
+          if text.includes?("FormBody") && !endpoint.params.any? { |p| p.name == "form" && p.param_type == "form" }
+            endpoint.push_param(Param.new("form", "", "form"))
+          end
+        when "call_expression"
+          fn_text = call_function_text(node, source)
+          next if fn_text.nil?
+          if fn_text == "req.query" && !endpoint.params.any? { |p| p.name == "query" && p.param_type == "query" }
+            endpoint.push_param(Param.new("query", "", "query"))
+          end
+          if fn_text == "req.header" || fn_text.ends_with?("req.headers().get")
+            if name = first_string_literal_text(Noir::TreeSitter.field(node, "arguments"), source)
+              endpoint.push_param(Param.new(name, "", "header")) unless endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
+            end
+          end
+          if fn_text == "req.cookie"
+            if name = first_string_literal_text(Noir::TreeSitter.field(node, "arguments"), source)
+              endpoint.push_param(Param.new(name, "", "cookie")) unless endpoint.params.any? { |p| p.name == name && p.param_type == "cookie" }
             end
           end
         end
       end
     end
 
-    def parse_endpoint_macros(lines : Array(String), path : String, endpoints : Array(Endpoint), include_callee : Bool)
-      lines.each_with_index do |line, index|
-        # Match #[endpoint(method = Get, path = "/path")]
-        if line.strip.starts_with?("#[endpoint(")
-          method = "GET"
-          route_path = "/"
+    private def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                       source : String,
+                                       path : String,
+                                       endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
+    end
 
-          method_match = line.match(/method\s*=\s*(\w+)/)
-          if method_match
-            method = method_match[1].upcase
-          end
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
+    end
 
-          path_match = line.match(/path\s*=\s*"([^"]+)"/)
-          if path_match
-            route_path = path_match[1]
-          end
+    private def first_identifier_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |child|
+        return Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "identifier"
+      end
+      nil
+    end
 
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(route_path, method, details)
+    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      index = {} of String => LibTreeSitter::TSNode
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "function_item"
+        name_node = Noir::TreeSitter.field(node, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        index[name] = node unless index.has_key?(name)
+      end
+      index
+    end
 
-          extract_path_params(route_path, endpoint)
-          extract_function_params(lines, index + 1, endpoint)
-          attach_next_function_callees(lines, index + 1, path, endpoint) if include_callee
-
-          endpoints << endpoint
+    private def each_routing_pair(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode, LibTreeSitter::TSNode ->)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named.each_with_index do |child, idx|
+        if Noir::TreeSitter.node_type(child) == "attribute_item"
+          pair_function = find_paired_function(named, idx + 1)
+          block.call(child, pair_function) if pair_function
         end
+        each_routing_pair(child, &block)
       end
     end
 
-    # Extract path parameters from the route pattern like /users/<id>
-    def extract_path_params(route : String, endpoint : Endpoint)
-      route.scan(/<(\w+)>/) do |match|
-        param_name = match[1]
-        endpoint.push_param(Param.new(param_name, "", "path"))
-      end
-    end
-
-    # Look for handler function definition and extract params from its signature/body
-    def extract_handler_params(lines : Array(String), handler_name : String, endpoint : Endpoint)
-      function_index = find_handler_function_index(lines, handler_name)
-      extract_function_params(lines, function_index, endpoint) if function_index
-    end
-
-    # Extract parameters from function signature and body
-    def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      return unless function_index
-
-      brace_count = 0
-      seen_opening_brace = false
-
-      (function_index...[function_index + 30, lines.size].min).each do |i|
-        line = lines[i]
-
-        brace_count += line.count('{')
-        if brace_count > 0
-          seen_opening_brace = true
-        end
-        brace_count -= line.count('}')
-
-        # Extract query parameters from QueryParam or req.query
-        if line.includes?("QueryParam") || line.includes?("req.query")
-          endpoint.push_param(Param.new("query", "", "query"))
-        end
-
-        # Extract JSON body from JsonBody
-        if line.includes?("JsonBody")
-          endpoint.push_param(Param.new("body", "", "json"))
-        end
-
-        # Extract form body from FormBody
-        if line.includes?("FormBody")
-          endpoint.push_param(Param.new("form", "", "form"))
-        end
-
-        # Extract headers from req.header/req.headers
-        if line.includes?("req.header(") || line.includes?("req.headers().get(")
-          match = line.match(/req\.header(?:s\(\)\.get)?\s*\(\s*"([^"]+)"\s*\)/)
-          if match
-            header_name = match[1]
-            endpoint.push_param(Param.new(header_name, "", "header"))
-          end
-        end
-
-        # Extract cookies from req.cookie
-        if line.includes?("req.cookie(")
-          match = line.match(/req\.cookie\s*\(\s*"([^"]+)"\s*\)/)
-          if match
-            cookie_name = match[1]
-            endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-          end
-        end
-
-        if seen_opening_brace && brace_count == 0 && i > function_index
-          break
+    private def find_paired_function(named : Array(LibTreeSitter::TSNode), start : Int32) : LibTreeSitter::TSNode?
+      (start...named.size).each do |i|
+        next_node = named[i]
+        case Noir::TreeSitter.node_type(next_node)
+        when "function_item"
+          return next_node
+        when "attribute_item", "line_comment", "block_comment"
+          next
+        else
+          return
         end
       end
+      nil
     end
 
-    private def attach_handler_callees(lines : Array(String), handler_name : String, path : String, endpoint : Endpoint)
-      function_index = find_handler_function_index(lines, handler_name)
-      attach_function_callees(lines, function_index, path, endpoint) if function_index
-    end
-
-    private def attach_next_function_callees(lines : Array(String), start_index : Int32, path : String, endpoint : Endpoint)
-      function_index = find_next_function_index(lines, start_index)
-      attach_function_callees(lines, function_index, path, endpoint) if function_index
-    end
-
-    private def attach_function_callees(lines : Array(String), function_index : Int32, path : String, endpoint : Endpoint)
-      function_body = extract_rust_function_body(lines, function_index)
-      return unless function_body
-
-      body, body_start_line = function_body
-      callees = Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)
-      attach_rust_callees(endpoint, callees)
-    end
-
-    private def find_handler_function_index(lines : Array(String), handler_name : String) : Int32?
-      lines.each_with_index do |line, index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(line).strip
-        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+#{handler_name}\b/)
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        if Noir::TreeSitter.node_type(child) == "string_literal"
+          result = string_content(child, source)
+        end
       end
+      result
     end
 
-    private def find_next_function_index(lines : Array(String), start_index : Int32) : Int32?
-      (start_index...[start_index + 30, lines.size].min).each do |index|
-        stripped = Noir::RustCalleeExtractor.strip_comment(lines[index]).strip
-        return index if stripped.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+[A-Za-z_]\w*\b/)
+    private def string_content(string_literal : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(string_literal) do |grand|
+        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
+      end
+      nil
+    end
+
+    private def find_named_child(node : LibTreeSitter::TSNode, type : String) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return child if Noir::TreeSitter.node_type(child) == type
+      end
+      nil
+    end
+
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
       end
     end
   end

--- a/src/ext/tree_sitter/build.sh
+++ b/src/ext/tree_sitter/build.sh
@@ -58,7 +58,7 @@ fi
 # Each grammar ships `parser.c` (always, auto-generated). Most also ship
 # `scanner.c` (hand-written custom lexer for context-sensitive tokens) —
 # Go does not, so we compile scanner.c only when the file exists.
-GRAMMARS="python go java kotlin javascript"
+GRAMMARS="python go java kotlin javascript rust"
 OBJS="$RUNTIME_OBJ"
 for g in $GRAMMARS; do
   GD="$D/grammars/$g"

--- a/src/ext/tree_sitter/grammars/rust/scanner.c
+++ b/src/ext/tree_sitter/grammars/rust/scanner.c
@@ -1,0 +1,393 @@
+#include "tree_sitter/alloc.h"
+#include "tree_sitter/parser.h"
+
+#include <wctype.h>
+
+enum TokenType {
+    STRING_CONTENT,
+    RAW_STRING_LITERAL_START,
+    RAW_STRING_LITERAL_CONTENT,
+    RAW_STRING_LITERAL_END,
+    FLOAT_LITERAL,
+    BLOCK_OUTER_DOC_MARKER,
+    BLOCK_INNER_DOC_MARKER,
+    BLOCK_COMMENT_CONTENT,
+    LINE_DOC_CONTENT,
+    ERROR_SENTINEL
+};
+
+typedef struct {
+    uint8_t opening_hash_count;
+} Scanner;
+
+void *tree_sitter_rust_external_scanner_create() { return ts_calloc(1, sizeof(Scanner)); }
+
+void tree_sitter_rust_external_scanner_destroy(void *payload) { ts_free((Scanner *)payload); }
+
+unsigned tree_sitter_rust_external_scanner_serialize(void *payload, char *buffer) {
+    Scanner *scanner = (Scanner *)payload;
+    buffer[0] = (char)scanner->opening_hash_count;
+    return 1;
+}
+
+void tree_sitter_rust_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+    Scanner *scanner = (Scanner *)payload;
+    scanner->opening_hash_count = 0;
+    if (length == 1) {
+        Scanner *scanner = (Scanner *)payload;
+        scanner->opening_hash_count = buffer[0];
+    }
+}
+
+static inline bool is_num_char(int32_t c) { return c == '_' || iswdigit(c); }
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+static inline bool process_string(TSLexer *lexer) {
+    bool has_content = false;
+    for (;;) {
+        if (lexer->lookahead == '\"' || lexer->lookahead == '\\') {
+            break;
+        }
+        if (lexer->eof(lexer)) {
+            return false;
+        }
+        has_content = true;
+        advance(lexer);
+    }
+    lexer->result_symbol = STRING_CONTENT;
+    lexer->mark_end(lexer);
+    return has_content;
+}
+
+static inline bool scan_raw_string_start(Scanner *scanner, TSLexer *lexer) {
+    if (lexer->lookahead == 'b' || lexer->lookahead == 'c') {
+        advance(lexer);
+    }
+    if (lexer->lookahead != 'r') {
+        return false;
+    }
+    advance(lexer);
+
+    uint8_t opening_hash_count = 0;
+    while (lexer->lookahead == '#') {
+        advance(lexer);
+        opening_hash_count++;
+    }
+
+    if (lexer->lookahead != '"') {
+        return false;
+    }
+    advance(lexer);
+    scanner->opening_hash_count = opening_hash_count;
+
+    lexer->result_symbol = RAW_STRING_LITERAL_START;
+    return true;
+}
+
+static inline bool scan_raw_string_content(Scanner *scanner, TSLexer *lexer) {
+    for (;;) {
+        if (lexer->eof(lexer)) {
+            return false;
+        }
+        if (lexer->lookahead == '"') {
+            lexer->mark_end(lexer);
+            advance(lexer);
+            unsigned hash_count = 0;
+            while (lexer->lookahead == '#' && hash_count < scanner->opening_hash_count) {
+                advance(lexer);
+                hash_count++;
+            }
+            if (hash_count == scanner->opening_hash_count) {
+                lexer->result_symbol = RAW_STRING_LITERAL_CONTENT;
+                return true;
+            }
+        } else {
+            advance(lexer);
+        }
+    }
+}
+
+static inline bool scan_raw_string_end(Scanner *scanner, TSLexer *lexer) {
+    advance(lexer);
+    for (unsigned i = 0; i < scanner->opening_hash_count; i++) {
+        advance(lexer);
+    }
+    lexer->result_symbol = RAW_STRING_LITERAL_END;
+    return true;
+}
+
+static inline bool process_float_literal(TSLexer *lexer) {
+    lexer->result_symbol = FLOAT_LITERAL;
+
+    advance(lexer);
+    while (is_num_char(lexer->lookahead)) {
+        advance(lexer);
+    }
+
+    bool has_fraction = false, has_exponent = false;
+
+    if (lexer->lookahead == '.') {
+        has_fraction = true;
+        advance(lexer);
+        if (iswalpha(lexer->lookahead)) {
+            // The dot is followed by a letter: 1.max(2) => not a float but an integer
+            return false;
+        }
+
+        if (lexer->lookahead == '.') {
+            return false;
+        }
+        while (is_num_char(lexer->lookahead)) {
+            advance(lexer);
+        }
+    }
+
+    lexer->mark_end(lexer);
+
+    if (lexer->lookahead == 'e' || lexer->lookahead == 'E') {
+        has_exponent = true;
+        advance(lexer);
+        if (lexer->lookahead == '+' || lexer->lookahead == '-') {
+            advance(lexer);
+        }
+        if (!is_num_char(lexer->lookahead)) {
+            return true;
+        }
+        advance(lexer);
+        while (is_num_char(lexer->lookahead)) {
+            advance(lexer);
+        }
+
+        lexer->mark_end(lexer);
+    }
+
+    if (!has_exponent && !has_fraction) {
+        return false;
+    }
+
+    if (lexer->lookahead != 'u' && lexer->lookahead != 'i' && lexer->lookahead != 'f') {
+        return true;
+    }
+    advance(lexer);
+    if (!iswdigit(lexer->lookahead)) {
+        return true;
+    }
+
+    while (iswdigit(lexer->lookahead)) {
+        advance(lexer);
+    }
+
+    lexer->mark_end(lexer);
+    return true;
+}
+
+static inline bool process_line_doc_content(TSLexer *lexer) {
+    lexer->result_symbol = LINE_DOC_CONTENT;
+    for (;;) {
+        if (lexer->eof(lexer)) {
+            return true;
+        }
+        if (lexer->lookahead == '\n') {
+            // Include the newline in the doc content node.
+            // Line endings are useful for markdown injection.
+            advance(lexer);
+            return true;
+        }
+        advance(lexer);
+    }
+}
+
+typedef enum {
+    LeftForwardSlash,
+    LeftAsterisk,
+    Continuing,
+} BlockCommentState;
+
+typedef struct {
+    BlockCommentState state;
+    unsigned nestingDepth;
+} BlockCommentProcessing;
+
+static inline void process_left_forward_slash(BlockCommentProcessing *processing, char current) {
+    if (current == '*') {
+        processing->nestingDepth += 1;
+    }
+    processing->state = Continuing;
+};
+
+static inline void process_left_asterisk(BlockCommentProcessing *processing, char current, TSLexer *lexer) {
+    if (current == '*') {
+        lexer->mark_end(lexer);
+        processing->state = LeftAsterisk;
+        return;
+    }
+
+    if (current == '/') {
+        processing->nestingDepth -= 1;
+    }
+
+    processing->state = Continuing;
+}
+
+static inline void process_continuing(BlockCommentProcessing *processing, char current) {
+    switch (current) {
+        case '/':
+            processing->state = LeftForwardSlash;
+            break;
+        case '*':
+            processing->state = LeftAsterisk;
+            break;
+    }
+}
+
+static inline bool process_block_comment(TSLexer *lexer, const bool *valid_symbols) {
+    char first = (char)lexer->lookahead;
+    // The first character is stored so we can safely advance inside
+    // these if blocks. However, because we only store one, we can only
+    // safely advance 1 time. Since there's a chance that an advance could
+    // happen in one state, we must advance in all states to ensure that
+    // the program ends up in a sane state prior to processing the block
+    // comment if need be.
+    if (valid_symbols[BLOCK_INNER_DOC_MARKER] && first == '!') {
+        lexer->result_symbol = BLOCK_INNER_DOC_MARKER;
+        advance(lexer);
+        return true;
+    }
+    if (valid_symbols[BLOCK_OUTER_DOC_MARKER] && first == '*') {
+        advance(lexer);
+        lexer->mark_end(lexer);
+        // If the next token is a / that means that it's an empty block comment.
+        if (lexer->lookahead == '/') {
+            return false;
+        }
+        // If the next token is a * that means that this isn't a BLOCK_OUTER_DOC_MARKER
+        // as BLOCK_OUTER_DOC_MARKER's only have 2 * not 3 or more.
+        if (lexer->lookahead != '*') {
+            lexer->result_symbol = BLOCK_OUTER_DOC_MARKER;
+            return true;
+        }
+    } else {
+        advance(lexer);
+    }
+
+    if (valid_symbols[BLOCK_COMMENT_CONTENT]) {
+        BlockCommentProcessing processing = {Continuing, 1};
+        // Manually set the current state based on the first character
+        switch (first) {
+            case '*':
+                processing.state = LeftAsterisk;
+                if (lexer->lookahead == '/') {
+                    // This case can happen in an empty doc block comment
+                    // like /*!*/. The comment has no contents, so bail.
+                    return false;
+                }
+                break;
+            case '/':
+                processing.state = LeftForwardSlash;
+                break;
+            default:
+                processing.state = Continuing;
+                break;
+        }
+
+        // For the purposes of actually parsing rust code, this
+        // is incorrect as it considers an unterminated block comment
+        // to be an error. However, for the purposes of syntax highlighting
+        // this should be considered successful as otherwise you are not able
+        // to syntax highlight a block of code prior to closing the
+        // block comment
+        while (!lexer->eof(lexer) && processing.nestingDepth != 0) {
+            // Set first to the current lookahead as that is the second character
+            // as we force an advance in the above code when we are checking if we
+            // need to handle a block comment inner or outer doc comment signifier
+            // node
+            first = (char)lexer->lookahead;
+            switch (processing.state) {
+                case LeftForwardSlash:
+                    process_left_forward_slash(&processing, first);
+                    break;
+                case LeftAsterisk:
+                    process_left_asterisk(&processing, first, lexer);
+                    break;
+                case Continuing:
+                    lexer->mark_end(lexer);
+                    process_continuing(&processing, first);
+                    break;
+                default:
+                    break;
+            }
+            advance(lexer);
+            if (first == '/' && processing.nestingDepth != 0) {
+                lexer->mark_end(lexer);
+            }
+        }
+        lexer->result_symbol = BLOCK_COMMENT_CONTENT;
+        return true;
+    }
+
+    return false;
+}
+
+bool tree_sitter_rust_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    // The documentation states that if the lexical analysis fails for some reason
+    // they will mark every state as valid and pass it to the external scanner
+    // However, we can't do anything to help them recover in that case so we
+    // should just fail.
+    /*
+      link: https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners
+      If a syntax error is encountered during regular parsing, Tree-sitter’s
+      first action during error recovery will be to call the external scanner’s
+      scan function with all tokens marked valid. The scanner should detect this
+      case and handle it appropriately. One simple method of detection is to add
+      an unused token to the end of the externals array, for example
+
+      externals: $ => [$.token1, $.token2, $.error_sentinel],
+
+      then check whether that token is marked valid to determine whether
+      Tree-sitter is in error correction mode.
+    */
+    if (valid_symbols[ERROR_SENTINEL]) {
+        return false;
+    }
+
+    Scanner *scanner = (Scanner *)payload;
+
+    if (valid_symbols[BLOCK_COMMENT_CONTENT] || valid_symbols[BLOCK_INNER_DOC_MARKER] ||
+        valid_symbols[BLOCK_OUTER_DOC_MARKER]) {
+        return process_block_comment(lexer, valid_symbols);
+    }
+
+    if (valid_symbols[STRING_CONTENT] && !valid_symbols[FLOAT_LITERAL]) {
+        return process_string(lexer);
+    }
+
+    if (valid_symbols[LINE_DOC_CONTENT]) {
+        return process_line_doc_content(lexer);
+    }
+
+    while (iswspace(lexer->lookahead)) {
+        skip(lexer);
+    }
+
+    if (valid_symbols[RAW_STRING_LITERAL_START] &&
+        (lexer->lookahead == 'r' || lexer->lookahead == 'b' || lexer->lookahead == 'c')) {
+        return scan_raw_string_start(scanner, lexer);
+    }
+
+    if (valid_symbols[RAW_STRING_LITERAL_CONTENT]) {
+        return scan_raw_string_content(scanner, lexer);
+    }
+
+    if (valid_symbols[RAW_STRING_LITERAL_END] && lexer->lookahead == '"') {
+        return scan_raw_string_end(scanner, lexer);
+    }
+
+    if (valid_symbols[FLOAT_LITERAL] && iswdigit(lexer->lookahead)) {
+        return process_float_literal(lexer);
+    }
+
+    return false;
+}

--- a/src/ext/tree_sitter/grammars/rust/tree_sitter/alloc.h
+++ b/src/ext/tree_sitter/grammars/rust/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/src/ext/tree_sitter/grammars/rust/tree_sitter/array.h
+++ b/src/ext/tree_sitter/grammars/rust/tree_sitter/array.h
@@ -1,0 +1,291 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/src/ext/tree_sitter/grammars/rust/tree_sitter/parser.h
+++ b/src/ext/tree_sitter/grammars/rust/tree_sitter/parser.h
@@ -1,0 +1,287 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+// Used to index the field and supertype maps.
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t abi_version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexerMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
+};
+
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    const TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  const TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -107,6 +107,7 @@ lib LibTreeSitter
   fun tree_sitter_java : TSLanguage
   fun tree_sitter_kotlin : TSLanguage
   fun tree_sitter_javascript : TSLanguage
+  fun tree_sitter_rust : TSLanguage
 end
 
 # Thin high-level facade. Keeps tree lifetime tied to an object so callers
@@ -170,6 +171,13 @@ module Noir::TreeSitter
   # `parse_typescript` (not yet vendored).
   def self.parse_javascript(source : String, &)
     parse(source, LibTreeSitter.tree_sitter_javascript) { |root| yield root }
+  end
+
+  # Parses `source` with the Rust grammar and yields the root node.
+  # Covers `.rs` files. Used by the Rust framework analyzers
+  # (axum, actix-web, rocket, …) and the Rust callee extractor.
+  def self.parse_rust(source : String, &)
+    parse(source, LibTreeSitter.tree_sitter_rust) { |root| yield root }
   end
 
   # Convenience: returns the root-node s-expression for `source`.

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -1,34 +1,23 @@
 require "../models/endpoint"
+require "./rust_callee_extractor_ts"
 
 module Noir::RustCalleeExtractor
   extend self
 
   alias Entry = Tuple(String, String, Int32)
 
-  RESERVED = Set{
-    "as", "async", "await", "break", "const", "continue", "crate",
-    "dyn", "else", "enum", "extern", "false", "fn", "for", "if",
-    "impl", "in", "let", "loop", "match", "mod", "move", "mut",
-    "pub", "ref", "return", "self", "Self", "static", "struct",
-    "super", "trait", "true", "type", "unsafe", "use", "where",
-    "while", "Ok", "Err", "Some", "None", "format", "format!",
-    "vec", "vec!", "println", "println!",
-  }
+  # Kept as a public constant for any external caller that still
+  # consults the reserved set; the active implementation lives on
+  # `Noir::RustCalleeExtractorTS::RESERVED` (same contents).
+  RESERVED = Noir::RustCalleeExtractorTS::RESERVED
 
-  PATH_CALL_REGEX     = /((?:[A-Za-z_]\w*::)+[A-Za-z_]\w*[!?]?)\s*(?:\(|!)/
-  RECEIVER_CALL_REGEX = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*[!?]?)+)\s*\(/
-  BARE_CALL_REGEX     = /(?<![.\w:])([A-Za-z_]\w*[!?]?)(?:\s*\(|!)/
-
+  # Walk `body` (a function body extracted as raw text by the engine)
+  # and return every callee. Internally delegates to the tree-sitter
+  # extractor which walks the parsed AST instead of running per-line
+  # regexes. The public signature stays identical so existing
+  # analyzers don't need to change.
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
-    entries = [] of Entry
-    in_block_comment = false
-
-    body.lines.each_with_index do |line, index|
-      stripped, in_block_comment = strip_comment_with_state(line, in_block_comment)
-      scan_line(stripped, file_path, start_line + index, entries)
-    end
-
-    dedup_entries(entries)
+    Noir::RustCalleeExtractorTS.callees_for_body_text(body, file_path, start_line)
   end
 
   def attach_to(endpoint : Endpoint, callees : Array(Entry))
@@ -81,48 +70,5 @@ module Noir::RustCalleeExtractor
     end
 
     {stripped.to_s, in_block_comment}
-  end
-
-  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
-    line.scan(PATH_CALL_REGEX) do |match|
-      name = match[1]
-      next if skip_callee?(name)
-
-      entries << {name, file_path, line_number}
-    end
-
-    line.scan(RECEIVER_CALL_REGEX) do |match|
-      name = match[1]
-      next if skip_callee?(name)
-
-      entries << {name, file_path, line_number}
-    end
-
-    line.scan(BARE_CALL_REGEX) do |match|
-      name = match[1]
-      next if skip_callee?(name)
-
-      entries << {name, file_path, line_number}
-    end
-  end
-
-  private def skip_callee?(name : String) : Bool
-    return true if name.empty?
-
-    last = name.split('.').last.split("::").last
-    RESERVED.includes?(last) && (!name.includes?("::") || last.includes?('!'))
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/rust_callee_extractor_ts.cr
+++ b/src/miniparsers/rust_callee_extractor_ts.cr
@@ -1,0 +1,198 @@
+require "../ext/tree_sitter/tree_sitter"
+
+# Tree-sitter-backed Rust callee extractor. Replaces the regex
+# line-scanner in `Noir::RustCalleeExtractor` with an AST walker over
+# the vendored `tree-sitter-rust` grammar. Catches calls that span
+# lines, sees through string/comment context for free (the parser
+# already does that), and exposes a parse-once entry point so analyzers
+# can share a single parsed tree per file.
+#
+# Three call shapes are recognised, mirroring the legacy extractor:
+#
+#   1. Path call            `Foo::bar(...)`        → "Foo::bar"
+#   2. Receiver chain       `obj.users.find(...)`  → "obj.users.find"
+#   3. Bare call            `foo(...)`             → "foo"
+#   4. Macro invocation     `println!(...)`        → "println!"
+#                           `std::format!(...)`    → "std::format!"
+#
+# Receivers rooted on another call result (`foo().bar()`) are dropped
+# as noise — same convention used by `Noir::JavaCalleeExtractor` and
+# `Noir::GoCalleeExtractor`.
+module Noir::RustCalleeExtractorTS
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  # Rust keywords + commonly-aliased control-flow constructors that
+  # surface as `call_expression`s but carry no useful callee signal.
+  # Kept in sync with the legacy regex extractor's `RESERVED` set so
+  # callers see no behaviour change when swapping the implementation.
+  RESERVED = Set{
+    "as", "async", "await", "break", "const", "continue", "crate",
+    "dyn", "else", "enum", "extern", "false", "fn", "for", "if",
+    "impl", "in", "let", "loop", "match", "mod", "move", "mut",
+    "pub", "ref", "return", "self", "Self", "static", "struct",
+    "super", "trait", "true", "type", "unsafe", "use", "where",
+    "while", "Ok", "Err", "Some", "None", "format", "format!",
+    "vec", "vec!", "println", "println!",
+  }
+
+  # Walk `body` (typically a `block` from a `function_item`'s `body`
+  # field, but any subtree works) and return every callee inside.
+  # Line numbers are taken straight from the tree-sitter node row, so
+  # `source` must be the *full file text* that was parsed — callers
+  # using a wrapper or sub-extract should use `callees_for_body_text`
+  # instead.
+  def callees_in_body(body : LibTreeSitter::TSNode,
+                      source : String,
+                      file_path : String) : Array(Entry)
+    sink = [] of Entry
+    walk(body) do |node|
+      case Noir::TreeSitter.node_type(node)
+      when "call_expression"
+        name = call_callee_text(node, source)
+        push_entry(sink, name, file_path, node) if name
+      when "macro_invocation"
+        name = macro_callee_text(node, source)
+        push_entry(sink, name, file_path, node) if name
+      end
+    end
+    dedup(sink)
+  end
+
+  # Drop-in replacement for `Noir::RustCalleeExtractor.callees_for_body`.
+  # Wraps `body_text` in a synthetic `fn _() { ... }` so the grammar
+  # has a complete top-level item to parse, then translates wrapper-
+  # relative rows back to file-relative ones (`start_line` is the
+  # 1-based file line of the body's first line).
+  #
+  # This shim exists for back-compat with the existing engine that
+  # extracts function bodies as raw text. New code should parse the
+  # file once and call `callees_in_body` with the body node directly.
+  def callees_for_body_text(body_text : String,
+                            file_path : String,
+                            start_line : Int32) : Array(Entry)
+    return [] of Entry if body_text.empty?
+
+    wrapped = String.build do |io|
+      io << "fn __noir_wrap__() {\n"
+      io << body_text
+      io << "\n}\n"
+    end
+
+    raw = [] of Entry
+    Noir::TreeSitter.parse_rust(wrapped) do |root|
+      fn_node = first_function_item(root)
+      next unless fn_node
+      body_node = Noir::TreeSitter.field(fn_node, "body")
+      next unless body_node
+      raw = callees_in_body(body_node, wrapped, file_path)
+    end
+
+    # Wrapper row 1 == body_text line 0 == file line `start_line`.
+    # `raw`'s line is `row + 1`, so subtract the wrapper preamble row
+    # (1) and the +1 row offset to get the body-relative index, then
+    # add `start_line` to land at the file row.
+    raw.map { |name, path, line| {name, path, start_line + line - 2} }
+  end
+
+  # ---- private helpers -----------------------------------------------
+
+  private def push_entry(sink : Array(Entry),
+                         name : String,
+                         file_path : String,
+                         node : LibTreeSitter::TSNode) : Nil
+    return if skip_callee?(name)
+    sink << {name, file_path, Noir::TreeSitter.node_start_row(node) + 1}
+  end
+
+  # Reconstruct callee text from a `call_expression`'s `function` field.
+  # Returns `nil` when the callee is rooted on a non-identifier shape
+  # (call result, parenthesised expression, …) so the walker drops it.
+  private def call_callee_text(call : LibTreeSitter::TSNode, source : String) : String?
+    fn_node = Noir::TreeSitter.field(call, "function")
+    return unless fn_node
+    callee_text_from(fn_node, source)
+  end
+
+  private def callee_text_from(node : LibTreeSitter::TSNode, source : String) : String?
+    case Noir::TreeSitter.node_type(node)
+    when "identifier", "scoped_identifier"
+      Noir::TreeSitter.node_text(node, source)
+    when "field_expression"
+      receiver_chain(node, source)
+    when "generic_function"
+      # `foo::<T>()` — peel the turbofish and try again on the inner
+      # path/identifier.
+      inner = Noir::TreeSitter.field(node, "function")
+      inner ? callee_text_from(inner, source) : nil
+    end
+  end
+
+  # Reconstruct `a.b.c` style receivers. Returns `nil` once the chain
+  # hits a non-identifier root (call_expression, parenthesised_expression,
+  # …) so chained-on-call noise (`foo().bar`) gets dropped.
+  private def receiver_chain(node : LibTreeSitter::TSNode, source : String) : String?
+    case Noir::TreeSitter.node_type(node)
+    when "identifier", "scoped_identifier", "self"
+      Noir::TreeSitter.node_text(node, source)
+    when "field_expression"
+      value = Noir::TreeSitter.field(node, "value")
+      field = Noir::TreeSitter.field(node, "field")
+      return unless value && field
+      inner = receiver_chain(value, source)
+      return unless inner
+      "#{inner}.#{Noir::TreeSitter.node_text(field, source)}"
+    end
+  end
+
+  # `println!(...)`, `std::format!(...)`. The trailing `!` is added so
+  # the result matches the legacy regex extractor's output verbatim.
+  private def macro_callee_text(macro_inv : LibTreeSitter::TSNode, source : String) : String?
+    name_node = Noir::TreeSitter.field(macro_inv, "macro")
+    return unless name_node
+    case Noir::TreeSitter.node_type(name_node)
+    when "identifier", "scoped_identifier"
+      "#{Noir::TreeSitter.node_text(name_node, source)}!"
+    end
+  end
+
+  # Mirrors the legacy `RustCalleeExtractor#skip_callee?`. Keeps
+  # namespaced calls whose last segment happens to be a reserved
+  # wrapper (`HttpResponse::Ok`) while still dropping `std::format!`
+  # style noise.
+  private def skip_callee?(name : String) : Bool
+    return true if name.empty?
+    last = name.split('.').last.split("::").last
+    RESERVED.includes?(last) && (!name.includes?("::") || last.includes?('!'))
+  end
+
+  private def dedup(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      if seen.includes?(key)
+        false
+      else
+        seen.add(key)
+        true
+      end
+    end
+  end
+
+  private def first_function_item(root : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+    found : LibTreeSitter::TSNode? = nil
+    Noir::TreeSitter.each_named_child(root) do |child|
+      next if found
+      found = child if Noir::TreeSitter.node_type(child) == "function_item"
+    end
+    found
+  end
+
+  private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    block.call(node)
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk(child, &block)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Re-ports `Analyzer::Rust::Poem` on top of the tree-sitter stack (#1481 → #1480 → … → #1476).
- Two routing shapes preserved:
  1. `Route::new().at("/path", get(handler).post(other))` — chained `.<verb>(handler)` builder on the second `.at` argument generates one endpoint per verb.
  2. `#[oai(path = "/x", method = "get")]` decorating functions inside an `impl Api { ... }` block. The routing-pair walker descends into impl bodies via the recursive sibling pairing.
- `:param` → `{param}` normalisation preserved. Path / query / json / form extractor types come from the function's `parameters`; header / cookie names from `call_expression` shapes in the body.

Stacked on #1481. Merge order: #1476 → #1477 → #1478 → #1479 → #1480 → #1481 → this.

## Test plan
- [x] `crystal spec spec/functional_test/testers/rust/poem_spec.cr` — 34 examples, 0 failures
- [x] `crystal tool format` + `ameba` clean