### PR TITLE
feat(rust/gotham): swap analyzer to tree-sitter (parse-once)

### DIFF
--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -1,184 +1,188 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # Gotham analyzer (tree-sitter port). Gotham wires routes with a
+  # builder chain that pairs each verb call with a following `.to`:
+  #
+  #     Router::builder()
+  #         .get("/users/:id").to(user_handler)
+  #         .post("/users").to(create_user_handler)
+  #
+  # The analyzer walks `call_expression` nodes whose function is a
+  # `field_expression` named `to` — the receiver of `.to(handler)` is
+  # the `.<verb>("/path")` call, so each routing entry has both
+  # pieces locally and we don't need to thread state through the
+  # chain.
   class Gotham < RustEngine
-    # Maximum lines to look ahead for handler name
-    MAX_HANDLER_LOOKUP_LINES = 5
-
-    # Gotham uses builder pattern: Router::builder().get("/path").to(handler)
-    # Route paths must start with /
-    ROUTE_PATTERN = /\.(get|post|put|delete|patch|head|options)\s*\(\s*"(\/[^"]*)"\s*\)/
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
-      function_bodies = collect_function_bodies(lines)
 
-      lines.each_with_index do |line, index|
-        # Look for Gotham routing patterns like .get("/path")
-        next unless line.includes?(".") && (line.includes?("get") || line.includes?("post") ||
-                    line.includes?("put") || line.includes?("delete") ||
-                    line.includes?("patch") || line.includes?("head") ||
-                    line.includes?("options"))
-        match = line.match(ROUTE_PATTERN)
-        next unless match
+      Noir::TreeSitter.parse_rust(source) do |root|
+        function_index = build_function_index(root, source)
 
-        begin
-          method = match[1]
-          route_path = match[2]
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          route = decode_to_call(node, source)
+          next unless route
+          route_path, method, handler_name = route
 
-          # Parse path parameters (Gotham uses :param syntax)
-          params = [] of Param
-          final_path = route_path.gsub(/:(\w+)/) do |param_match|
-            param_name = param_match[1..-1] # Remove the ':'
-            params << Param.new(param_name, "", "path")
-            ":#{param_name}"
-          end
+          details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
+          endpoint = Endpoint.new(route_path, method, details)
+          extract_path_params(route_path, endpoint)
 
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(final_path, method.upcase, details)
-          params.each do |param|
-            endpoint.push_param(param)
-          end
-
-          # Try to find the handler function and extract cookies/headers
-          # Look for .to(handler_name) in nearby lines
-          handler_name = find_handler_name(lines, index)
-          if handler_name
-            if function_body = function_bodies[handler_name]?
-              body, body_start_line = function_body
-              extract_handler_params(body, endpoint)
-              attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line)) if include_callee
-            end
+          if handler_function = function_index[handler_name]?
+            scan_function(handler_function, source, endpoint)
+            attach_handler_callees(handler_function, source, path, endpoint) if include_callee
           end
 
           endpoints << endpoint
-        rescue
         end
       end
 
       endpoints
     end
 
-    # Find the handler function name from .to(handler) pattern
-    private def find_handler_name(lines : Array(String), start_index : Int32) : String?
-      (start_index...[start_index + MAX_HANDLER_LOOKUP_LINES, lines.size].min).each do |i|
-        line = lines[i]
-        match = line.match(/\.to\s*\(\s*(?:[A-Za-z_]\w*::)*([A-Za-z_]\w*)\s*\)/)
-        if match
-          return match[1]
+    # `.<verb>("/x").to(handler)` → `{path, METHOD, handler_name}` or
+    # `nil`. Reaches up one level: the `.to` call's receiver should
+    # itself be a `.<verb>("...")` call.
+    private def decode_to_call(call : LibTreeSitter::TSNode, source : String) : Tuple(String, String, String)?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      field = Noir::TreeSitter.field(fn_node, "field")
+      return unless field && Noir::TreeSitter.node_text(field, source) == "to"
+
+      receiver = Noir::TreeSitter.field(fn_node, "value")
+      return unless receiver && Noir::TreeSitter.node_type(receiver) == "call_expression"
+
+      verb_fn = Noir::TreeSitter.field(receiver, "function")
+      return unless verb_fn && Noir::TreeSitter.node_type(verb_fn) == "field_expression"
+      verb_field = Noir::TreeSitter.field(verb_fn, "field")
+      return unless verb_field
+      verb = Noir::TreeSitter.node_text(verb_field, source).downcase
+      return unless HTTP_VERBS.includes?(verb)
+
+      route_path = first_string_literal_text(Noir::TreeSitter.field(receiver, "arguments"), source)
+      return unless route_path
+      handler = first_identifier_argument(call, source)
+      return unless handler
+      {route_path, verb.upcase, handler}
+    end
+
+    private def extract_path_params(route : String, endpoint : Endpoint)
+      route.scan(/:(\w+)/) do |match|
+        endpoint.push_param(Param.new(match[1], "", "path"))
+      end
+    end
+
+    # Header / cookie / `header::Name` extraction from the handler
+    # body. Walks `call_expression` nodes once; `header::FooBar`
+    # appears as `scoped_identifier` and is converted to a header name
+    # by replacing underscores with hyphens (matches the legacy
+    # analyzer's gsub).
+    private def scan_function(function : LibTreeSitter::TSNode,
+                              source : String,
+                              endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+
+      walk(body) do |node|
+        case Noir::TreeSitter.node_type(node)
+        when "call_expression"
+          fn_text = call_function_text(node, source)
+          next if fn_text.nil?
+          if fn_text.ends_with?(".cookie")
+            name = first_string_literal_text(Noir::TreeSitter.field(node, "arguments"), source)
+            if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "cookie" }
+              endpoint.push_param(Param.new(name, "", "cookie"))
+            end
+          elsif fn_text.ends_with?(".headers().get")
+            name = first_string_literal_text(Noir::TreeSitter.field(node, "arguments"), source)
+            if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
+              endpoint.push_param(Param.new(name, "", "header"))
+            end
+          end
+        when "scoped_identifier"
+          text = Noir::TreeSitter.node_text(node, source)
+          if text.starts_with?("header::")
+            header_name = text.sub("header::", "").gsub("_", "-")
+            if !endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
+              endpoint.push_param(Param.new(header_name, "", "header"))
+            end
+          end
+        end
+      end
+    end
+
+    private def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                       source : String,
+                                       path : String,
+                                       endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
+    end
+
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
+    end
+
+    private def first_identifier_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      Noir::TreeSitter.each_named_child(args) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "identifier"
+          return Noir::TreeSitter.node_text(child, source)
+        when "scoped_identifier"
+          return Noir::TreeSitter.node_text(child, source).split("::").last
         end
       end
       nil
     end
 
-    private def collect_function_bodies(lines : Array(String)) : Hash(String, Tuple(String, Int32))
-      function_bodies = {} of String => Tuple(String, Int32)
-      in_block_comment = false
-      index = 0
-
-      while index < lines.size
-        stripped, in_block_comment = Noir::RustCalleeExtractor.strip_comment_with_state(lines[index], in_block_comment)
-        match = stripped.strip.match(/^(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\b/)
-
-        if match
-          function_body = extract_rust_function_body_with_end(lines, index)
-          if function_body
-            body, body_start_line, end_index = function_body
-            function_bodies[match[1]] = {body, body_start_line}
-            index = end_index
-            in_block_comment = false
-          end
-        end
-
-        index += 1
+    private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      index = {} of String => LibTreeSitter::TSNode
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "function_item"
+        name_node = Noir::TreeSitter.field(node, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        index[name] = node unless index.has_key?(name)
       end
-
-      function_bodies
+      index
     end
 
-    # Extract cookies and headers from the handler function body
-    private def extract_handler_params(body : String, endpoint : Endpoint)
-      in_block_comment = false
-
-      body.each_line do |raw_line|
-        line, in_block_comment = strip_comments_preserving_strings(raw_line, in_block_comment)
-
-        # Extract cookies from .cookie() or cookies().get() patterns
-        if line.includes?(".cookie(")
-          match = line.match(/\.cookie\s*\(\s*"([^"]+)"\s*\)/)
-          if match
-            cookie_name = match[1]
-            unless endpoint.params.any? { |p| p.name == cookie_name && p.param_type == "cookie" }
-              endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-            end
-          end
-        end
-
-        # Extract headers from .headers().get() or HeaderMap access
-        if line.includes?(".headers()") && line.includes?(".get(")
-          match = line.match(/\.headers\(\)\s*\.get\s*\(\s*"([^"]+)"\s*\)/)
-          if match
-            header_name = match[1]
-            unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
-              endpoint.push_param(Param.new(header_name, "", "header"))
-            end
-          end
-        end
-
-        # Extract headers using header::XXX patterns (Gotham-style)
-        if line.includes?("header::")
-          match = line.match(/header::(\w+)/)
-          if match
-            header_name = match[1].gsub("_", "-")
-            unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
-              endpoint.push_param(Param.new(header_name, "", "header"))
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        if Noir::TreeSitter.node_type(child) == "string_literal"
+          Noir::TreeSitter.each_named_child(child) do |grand|
+            if Noir::TreeSitter.node_type(grand) == "string_content"
+              result = Noir::TreeSitter.node_text(grand, source)
+              break
             end
           end
         end
       end
+      result
     end
 
-    private def strip_comments_preserving_strings(line : String, in_block_comment : Bool) : Tuple(String, Bool)
-      in_string = false
-      escaped = false
-      index = 0
-      stripped = String::Builder.new
-
-      while index < line.size
-        char = line[index]
-
-        if in_block_comment
-          if char == '*' && line[index + 1]? == '/'
-            in_block_comment = false
-            index += 1
-          end
-        elsif in_string
-          stripped << char
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == '"'
-            in_string = false
-          end
-        elsif char == '"'
-          in_string = true
-          stripped << char
-        elsif char == '/' && line[index + 1]? == '/'
-          return {stripped.to_s, in_block_comment}
-        elsif char == '/' && line[index + 1]? == '*'
-          in_block_comment = true
-          index += 1
-        else
-          stripped << char
-        end
-
-        index += 1
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
       end
-
-      {stripped.to_s, in_block_comment}
     end
   end
 end


### PR DESCRIPTION
## Summary

- Re-ports `Analyzer::Rust::Gotham` onto tree-sitter (stacked on #1482 → … → #1476).
- Gotham wires routes with a `.<verb>("/path").to(handler)` builder chain. The analyzer walks `call_expression` nodes whose function is a `field_expression` named `to` — the receiver is the `.<verb>(...)` call, so each routing pair is self-contained.
- Handler bodies are located via a same-file `function_item` index. Cookie / header extraction walks `call_expression`s for `.cookie(...)` / `.headers().get(...)` shapes plus `scoped_identifier` nodes for `header::Foo_Bar` references (converted to `Foo-Bar`).
- Removes the custom `strip_comments_preserving_strings` helper — the AST handles comments + strings for free.

Stacked on #1482. Merge order: #1476 → #1477 → #1478 → #1479 → #1480 → #1481 → #1482 → this.

## Test plan
- [x] `crystal spec spec/functional_test/testers/rust/gotham_spec.cr spec/functional_test/testers/rust/gotham_callees_spec.cr` — 92 examples, 0 failures
- [x] `crystal tool format` + `ameba` clean