### PR TITLE
feat(rust/loco): swap analyzer to tree-sitter (parse-once)

### DIFF
--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -1,65 +1,68 @@
 require "../../engines/rust_engine"
+require "../../../ext/tree_sitter/tree_sitter"
+require "../../../miniparsers/rust_callee_extractor_ts"
 
 module Analyzer::Rust
+  # Loco analyzer (tree-sitter port). Loco follows Rails conventions:
+  # `pub async fn <action>` inside a controller module/impl becomes
+  # a RESTful endpoint whose path/method derive from the action name.
+  # Loco rides on Axum, so parameter extraction picks up the standard
+  # Axum extractor types (`Path<T>`, `Query<T>`, `Json<T>`, `Form<T>`,
+  # `HeaderMap`).
   class Loco < RustEngine
-    # Loco follows Rails conventions with controllers and actions.
-    # Loco uses Axum under the hood, so parameters are extracted using Axum patterns.
-
-    # Simple pattern to match function definitions
-    FN_PATTERN = /pub\s+async\s+fn\s+(\w+)/
+    REST_ACTIONS = Set{"index", "show", "new", "create", "edit", "update", "destroy", "delete"}
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = read_file_content(path).lines
+      source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?)
 
-      lines.each_with_index do |line, index|
-        next unless line.to_s.includes? "pub async fn"
-        match = line.match(FN_PATTERN)
-        next unless match
+      Noir::TreeSitter.parse_rust(source) do |root|
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "function_item"
+          next unless public_async?(node, source)
+          name_node = Noir::TreeSitter.field(node, "name")
+          next unless name_node
+          action = Noir::TreeSitter.node_text(name_node, source)
 
-        begin
-          method_name = match[1]
-          # Convert Rails-style action names to route paths
-          endpoint_path = action_to_path(method_name, path)
-          details = Details.new(PathInfo.new(path, index + 1))
-          # Infer HTTP method from action name and context
-          http_method = infer_http_method(method_name, line)
-
+          endpoint_path = action_to_path(action, path)
+          http_method = infer_http_method(action, node, source)
+          details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
           endpoint = Endpoint.new(endpoint_path, http_method, details)
-          function_body = extract_rust_function_body(lines, index)
 
-          # Extract path parameters from the endpoint path
           extract_path_params(endpoint_path, endpoint)
-
-          # Extract parameters from function signature and body
-          extract_function_params(lines, index, endpoint, function_body.try(&.[0]))
-          if include_callee && function_body
-            body, body_start_line = function_body
-            attach_rust_callees(endpoint, Noir::RustCalleeExtractor.callees_for_body(body, path, body_start_line))
-          end
+          extract_function_params(node, source, endpoint)
+          attach_handler_callees(node, source, path, endpoint) if include_callee
 
           endpoints << endpoint
-        rescue e
-          # Log the exception for debugging
-          logger.debug "Error parsing Loco endpoint: #{e.message}"
         end
       end
 
       endpoints
     end
 
-    private def action_to_path(action_name : String, file_path : String) : String
-      # Extract controller name from file path if possible
-      controller = ""
-      if file_path.includes?("/controllers/") || file_path.includes?("/controller/")
-        path_parts = file_path.split("/")
-        controller_file = path_parts.last.gsub(/\.rs$/, "")
-        controller = controller_file.gsub(/_controller$/, "")
+    # Loco analysers are scoped to `pub async fn` items only — the
+    # legacy regex `pub\s+async\s+fn\s+(\w+)` enforced both modifiers.
+    # tree-sitter exposes them as children of the `function_item`'s
+    # `visibility_modifier` and `function_modifiers` nodes.
+    private def public_async?(function : LibTreeSitter::TSNode, source : String) : Bool
+      has_pub = false
+      has_async = false
+      Noir::TreeSitter.each_named_child(function) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "visibility_modifier"
+          has_pub = Noir::TreeSitter.node_text(child, source).starts_with?("pub")
+        when "function_modifiers"
+          has_async = Noir::TreeSitter.node_text(child, source).includes?("async")
+        end
       end
+      has_pub && has_async
+    end
 
-      # Convert Rails-style action names to RESTful paths
-      case action_name
+    private def action_to_path(action : String, file_path : String) : String
+      controller = controller_name_from_path(file_path)
+
+      case action
       when "index"
         controller.empty? ? "/" : "/#{controller}"
       when "show"
@@ -70,170 +73,154 @@ module Analyzer::Rust
         controller.empty? ? "/" : "/#{controller}"
       when "edit"
         controller.empty? ? "/:id/edit" : "/#{controller}/:id/edit"
-      when "update"
-        controller.empty? ? "/:id" : "/#{controller}/:id"
-      when "destroy", "delete"
+      when "update", "destroy", "delete"
         controller.empty? ? "/:id" : "/#{controller}/:id"
       else
-        # For custom actions, create a path based on action name
         base_path = controller.empty? ? "" : "/#{controller}"
-        "#{base_path}/#{action_name.gsub(/([A-Z])/, "_\\1").downcase.lstrip("_")}"
+        "#{base_path}/#{action.gsub(/([A-Z])/, "_\\1").downcase.lstrip("_")}"
       end
     end
 
-    private def infer_http_method(action_name : String, line : String) : String
-      # Infer HTTP method from Rails conventions and line context
-      case action_name
+    private def controller_name_from_path(file_path : String) : String
+      return "" unless file_path.includes?("/controllers/") || file_path.includes?("/controller/")
+      file = file_path.split("/").last.gsub(/\.rs$/, "")
+      file.gsub(/_controller$/, "")
+    end
+
+    private def infer_http_method(action : String, function : LibTreeSitter::TSNode, source : String) : String
+      case action
       when "index", "show", "new", "edit"
         "GET"
       when "create", "login", "signup", "register"
         "POST"
       when "update"
-        if line.includes?("PUT") || line.includes?("put")
-          "PUT"
-        else
-          "PATCH"
-        end
+        signature_text(function, source).includes?("PUT") ? "PUT" : "PATCH"
       when "destroy", "delete"
         "DELETE"
       else
-        # Check line for HTTP method hints
-        if line.includes?("post") || line.includes?("POST")
-          "POST"
-        elsif line.includes?("put") || line.includes?("PUT")
-          "PUT"
-        elsif line.includes?("delete") || line.includes?("DELETE")
-          "DELETE"
-        elsif line.includes?("patch") || line.includes?("PATCH")
-          "PATCH"
-          # Check if Form<T> is present, which typically indicates POST
-        elsif line.includes?("Form<")
-          "POST"
-        else
-          "GET"
-        end
+        sig = signature_text(function, source)
+        return "POST" if sig.includes?("Form<")
+        return "POST" if sig =~ /\bpost\b/i
+        return "PUT" if sig =~ /\bput\b/i
+        return "DELETE" if sig =~ /\bdelete\b/i
+        return "PATCH" if sig =~ /\bpatch\b/i
+        "GET"
       end
     end
 
-    # Extract path parameters from the route pattern like /:id
+    # Function signature minus the body — used by `infer_http_method`
+    # so we don't get false hits on `let post = …` style locals.
+    private def signature_text(function : LibTreeSitter::TSNode, source : String) : String
+      params = Noir::TreeSitter.field(function, "parameters")
+      return "" unless params
+      return_type = Noir::TreeSitter.field(function, "return_type")
+      start_byte = LibTreeSitter.ts_node_start_byte(function).to_i
+      end_byte =
+        if return_type
+          LibTreeSitter.ts_node_end_byte(return_type).to_i
+        else
+          LibTreeSitter.ts_node_end_byte(params).to_i
+        end
+      source.byte_slice(start_byte, end_byte - start_byte)
+    end
+
     private def extract_path_params(route : String, endpoint : Endpoint)
       route.scan(/:(\w+)/) do |match|
-        param_name = match[1]
-        endpoint.push_param(Param.new(param_name, "", "path"))
+        endpoint.push_param(Param.new(match[1], "", "path"))
       end
     end
 
-    # Extract parameters from function signature and body
-    # Loco uses Axum extractors, so we look for patterns like:
-    # - Path<T> for path parameters
-    # - Query<T> for query parameters
-    # - Json<T> for JSON body
-    # - Form<T> for form data
-    # - HeaderMap or headers for header access
-    private def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint, body : String? = nil)
-      # Look ahead up to 30 lines for the function definition and body
-      in_function = false
-      brace_count = 0
-      seen_opening_brace = false
-      function_signature = ""
-
-      (start_index...[start_index + 30, lines.size].min).each do |i|
-        line = lines[i]
-
-        # Build the function signature (can span multiple lines)
-        if !seen_opening_brace
-          function_signature += " " + line.strip
-        end
-
-        # Track if we're inside the function
-        if line.includes?("async fn ") || line.includes?("fn ")
-          in_function = true
-        end
-
-        # Track braces to know when function ends
-        brace_count += line.count('{')
-        if brace_count > 0
-          seen_opening_brace = true
-        end
-        brace_count -= line.count('}')
-
-        # Stop if we've moved past the function
-        if in_function && seen_opening_brace && brace_count == 0 && i > start_index
-          break
-        end
-
-        # Also stop if we hit another function
-        if i > start_index && line.strip.starts_with?("pub async fn") || line.strip.starts_with?("async fn")
-          break
+    # Loco rides on Axum; extractor types appear in the parameter
+    # list. Query / Json / Form get default param names matching the
+    # legacy analyzer; Path<T> is already captured from the route
+    # pattern.
+    private def extract_function_params(function : LibTreeSitter::TSNode,
+                                        source : String,
+                                        endpoint : Endpoint)
+      params = Noir::TreeSitter.field(function, "parameters")
+      has_header_map = false
+      if params
+        Noir::TreeSitter.each_named_child(params) do |param|
+          text = Noir::TreeSitter.node_text(param, source)
+          if text.includes?("Query<") && !endpoint.params.any? { |p| p.name == "query" && p.param_type == "query" }
+            endpoint.push_param(Param.new("query", "", "query"))
+          end
+          if text.includes?("Json<") && !endpoint.params.any? { |p| p.name == "body" && p.param_type == "json" }
+            endpoint.push_param(Param.new("body", "", "json"))
+          end
+          if text.includes?("Form<") && !endpoint.params.any? { |p| p.name == "form" && p.param_type == "form" }
+            endpoint.push_param(Param.new("form", "", "form"))
+          end
+          has_header_map = true if text.includes?("HeaderMap")
         end
       end
 
-      # Extract the parameter section (between parentheses, before ->)
-      # Split signature at -> to separate parameters from return type
-      param_section = function_signature.split("->").first? || function_signature
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
 
-      # Now extract parameters from the parameter section only
+      walk(body) do |call|
+        next unless Noir::TreeSitter.node_type(call) == "call_expression"
+        fn_text = call_function_text(call, source)
+        next if fn_text.nil?
 
-      # Extract Query parameters - Query<T> in function parameters
-      if param_section.includes?("Query<")
-        endpoint.push_param(Param.new("query", "", "query"))
+        if has_header_map && (fn_text.ends_with?(".get") || fn_text == "get")
+          name = first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source)
+          if name && header_name?(name) && !endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
+            endpoint.push_param(Param.new(name, "", "header"))
+          end
+        elsif fn_text.ends_with?(".cookie") || fn_text == "cookie"
+          name = first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source)
+          if name && !endpoint.params.any? { |p| p.name == name && p.param_type == "cookie" }
+            endpoint.push_param(Param.new(name, "", "cookie"))
+          end
+        end
       end
+    end
 
-      # Extract Path parameters from Path<T> in function parameters
-      # Note: We already extracted path params from the route, but this handles explicit Path<T> extractors
-      if param_section.includes?("Path<")
-        # The path params are already extracted from the route pattern, so we don't need to add duplicates
-        # Just verify they're there
-      end
+    # The legacy analyzer only kept header-like strings (with a dash
+    # or one of the canonical names) to avoid capturing every random
+    # `.get("foo")` inside the body.
+    private def header_name?(name : String) : Bool
+      name.includes?("-") || name.in?(%w[Authorization Content-Type Accept])
+    end
 
-      # Extract JSON body from Json<T> in parameters (not return type)
-      if param_section.includes?("Json<")
-        endpoint.push_param(Param.new("body", "", "json"))
-      end
+    private def attach_handler_callees(function : LibTreeSitter::TSNode,
+                                       source : String,
+                                       path : String,
+                                       endpoint : Endpoint)
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+      entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+      attach_rust_callees(endpoint, entries)
+    end
 
-      # Extract form body from Form<T> in parameters (not return type)
-      if param_section.includes?("Form<")
-        endpoint.push_param(Param.new("form", "", "form"))
-      end
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node
+      Noir::TreeSitter.node_text(fn_node, source)
+    end
 
-      # Extract headers - look for HeaderMap or headers parameter
-      if param_section.includes?("HeaderMap") || param_section.includes?(": HeaderMap")
-        # Look in the function body for specific header usage
-        each_function_body_line(lines, start_index, body) do |line|
-          # Extract specific header names from .get("header_name") or headers.get("header_name")
-          if line.includes?(".get(\"")
-            line.scan(/\.get\("([^"]+)"\)/) do |match|
-              header_name = match[1]
-              # Only add if it looks like a header name (contains dashes or is common header)
-              if header_name.includes?("-") || header_name.in?(%w[Authorization Content-Type Accept])
-                endpoint.push_param(Param.new(header_name, "", "header"))
-              end
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      result : String? = nil
+      walk(node) do |child|
+        next if result
+        if Noir::TreeSitter.node_type(child) == "string_literal"
+          Noir::TreeSitter.each_named_child(child) do |grand|
+            if Noir::TreeSitter.node_type(grand) == "string_content"
+              result = Noir::TreeSitter.node_text(grand, source)
+              break
             end
           end
         end
       end
-
-      # Extract cookies from cookie access patterns
-      each_function_body_line(lines, start_index, body) do |line|
-        # Look for .cookie("name") patterns
-        if line.includes?(".cookie(\"")
-          line.scan(/\.cookie\("([^"]+)"\)/) do |match|
-            cookie_name = match[1]
-            endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-          end
-        end
-      end
+      result
     end
 
-    private def each_function_body_line(lines : Array(String), start_index : Int32, body : String?, &)
-      if body
-        body.each_line do |line|
-          yield line
-        end
-      else
-        (start_index...[start_index + 30, lines.size].min).each do |i|
-          yield lines[i]
-        end
+    private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk(child, &block)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Re-ports `Analyzer::Rust::Loco` (Rails-style framework on top of Axum) onto tree-sitter (stacked on #1485 → … → #1476).
- Every `pub async fn <action>` becomes an endpoint. The analyzer walks `function_item` nodes, gates on `visibility_modifier == pub` + `function_modifiers` containing `async` (AST equivalent of the `pub\s+async\s+fn` regex), and assembles paths / methods from the action name + the controller derived from the file path.
- Axum extractor types (`Query<T>` / `Json<T>` / `Form<T>` / `HeaderMap`) come from the function's `parameters` field; header / cookie names from `call_expression`s in the body.

Stacked on #1485. Merge order: #1476 → … → #1485 → this.

## Test plan
- [x] `crystal spec spec/functional_test/testers/rust/loco_spec.cr spec/functional_test/testers/rust/loco_callees_spec.cr` — 100 examples, 0 failures
- [x] `crystal tool format` + `ameba` clean