### PR TITLE
docs: cover --set-pvalue family, --only-techs, --no-color, --build-info

### DIFF
--- a/docs/content/get_started/running/index.ko.md
+++ b/docs/content/get_started/running/index.ko.md
@@ -93,7 +93,10 @@ noir -b . --include-path --include-techs -f json -o results.json
 대규모 모노레포에는 여러 프레임워크가 포함될 수 있습니다. 필요한 것만 스캔할 수 있습니다:
 
 ```bash
-# Rails와 Django 엔드포인트만 스캔
+# Rails와 Django 디텍터만 실행 (나머지는 건너뜀)
+noir -b . --only-techs rails,django
+
+# 디텍터는 돌리지 않고 결과에 강제로 태그만 부여
 noir -b . --techs rails,django
 
 # Express를 제외한 모든 것 스캔
@@ -102,6 +105,8 @@ noir -b . --exclude-techs express
 # glob으로 파일 단위 제외 (모노레포에서 유용 — 쉼표 구분)
 noir -b . --exclude-path "*_test.go,vendor/*,**/node_modules/**"
 ```
+
+`--only-techs`와 `--techs`는 비슷해 보이지만 다릅니다: `--only-techs`는 디텍터 리스트를 필터링해서 그 항목만 실제로 탐지를 수행(스캔 속도 향상)하고, `--techs`는 탐지 없이 결과에 기술 태그만 강제로 추가(스택을 이미 알고 있을 때 사용)합니다.
 
 ## 출력 보강하기
 
@@ -129,12 +134,16 @@ noir -b . --ai-context
 | `--include-techs` | 탐지된 기술 표시 |
 | `--include-callee` | 1-hop 핸들러 callee 첨부 |
 | `--ai-context` | AI 리뷰용 guard/sink/validator/signal 첨부 |
-| `--techs` | 이 프레임워크만 스캔 |
+| `--set-pvalue` / `--set-pvalue-<type>` | 출력에 파라미터 값을 채워 넣음 ([HTTP 클라이언트 명령어](@/usage/output_formats/curl/index.md) 참고) |
+| `--only-techs` | 이 디텍터만 실행 (나머지 건너뜀) |
+| `--techs` | 디텍터는 건너뛰고 결과에 기술 태그만 강제 추가 |
 | `--exclude-techs` | 이 프레임워크 건너뛰기 |
 | `--exclude-path` | 쉼표 구분 glob 패턴에 매치되는 파일 제외 |
 | `--config-file <경로>` | YAML 설정 파일에서 기본 옵션 로드 |
 | `--verbose` | 상세 로깅 |
 | `--no-log` | 모든 로그 억제 |
+| `--no-color` | plain 출력의 ANSI 색상 비활성화 |
+| `--build-info` | noir / Crystal / LLVM 버전과 타깃 트리플 출력 |
 | `--help` | 전체 도움말 |
 
 ---

--- a/docs/content/get_started/running/index.md
+++ b/docs/content/get_started/running/index.md
@@ -93,7 +93,10 @@ noir -b . --include-path --include-techs -f json -o results.json
 Large monorepos may contain many frameworks. You can narrow the scan to what matters:
 
 ```bash
-# Only scan for Rails and Django endpoints
+# Run only the Rails and Django detectors (skip everything else)
+noir -b . --only-techs rails,django
+
+# Force-tag the project with these techs without running their detectors
 noir -b . --techs rails,django
 
 # Scan everything except Express
@@ -102,6 +105,8 @@ noir -b . --exclude-techs express
 # Skip files by glob (useful in monorepos — comma-separated)
 noir -b . --exclude-path "*_test.go,vendor/*,**/node_modules/**"
 ```
+
+`--only-techs` and `--techs` look similar but do different things: `--only-techs` filters the detector list (faster scan, only those detectors run), while `--techs` adds techs to the result without running detection (useful when you already know the stack and want to skip discovery).
 
 ## Enrich the Output
 
@@ -129,12 +134,16 @@ See [Callee Coverage](@/usage/supported/callee_coverage/index.md) and [AI Contex
 | `--include-techs` | Show detected technologies |
 | `--include-callee` | Attach 1-hop handler callees |
 | `--ai-context` | Attach guards, sinks, validators, and signals for AI review |
-| `--techs` | Only scan these frameworks |
+| `--set-pvalue` / `--set-pvalue-<type>` | Fill parameter values in output (see [HTTP Client Commands](@/usage/output_formats/curl/index.md)) |
+| `--only-techs` | Run only these tech detectors (skip the rest) |
+| `--techs` | Force-tag these techs without running their detectors |
 | `--exclude-techs` | Skip these frameworks |
 | `--exclude-path` | Skip files matching a comma-separated glob list |
 | `--config-file <path>` | Load default options from a YAML config file |
 | `--verbose` | Detailed logging |
 | `--no-log` | Suppress all logs |
+| `--no-color` | Disable ANSI colors in plain output |
+| `--build-info` | Print noir / Crystal / LLVM versions and target triple |
 | `--help` | Full help |
 
 ---

--- a/docs/content/usage/output_formats/curl/index.ko.md
+++ b/docs/content/usage/output_formats/curl/index.ko.md
@@ -52,3 +52,43 @@ Invoke-WebRequest -Method GET -Uri "https://www.example.com/" -Headers @{"x-api-
 Invoke-WebRequest -Method POST -Uri "https://www.example.com/query" -Headers @{"Cookie"="my_auth="} -Body "query=" -ContentType "application/x-www-form-urlencoded"
 Invoke-WebRequest -Method GET -Uri "https://www.example.com/token" -Body "client_id=&redirect_url=&grant_type=" -ContentType "application/x-www-form-urlencoded"
 ```
+
+## 파라미터 값 채우기
+
+Noir는 기본적으로 파라미터 값을 비워두기 때문에(`x-api-key=`, `query=` …) 생성된 명령은 템플릿처럼 동작합니다. 그대로 실행하거나 퍼징 입력 시드를 만들고 싶다면 `--set-pvalue` 계열로 값을 미리 채울 수 있습니다.
+
+| 플래그 | 적용 범위 |
+|---|---|
+| `--set-pvalue VALUE` | 모든 파라미터 타입 |
+| `--set-pvalue-query VALUE` | 쿼리 스트링 |
+| `--set-pvalue-form VALUE` | 폼 바디 (`application/x-www-form-urlencoded`) |
+| `--set-pvalue-json VALUE` | JSON 바디 |
+| `--set-pvalue-header VALUE` | 요청 헤더 |
+| `--set-pvalue-cookie VALUE` | 쿠키 |
+| `--set-pvalue-path VALUE` | 경로 파라미터 |
+
+`VALUE`는 두 가지 형태를 받습니다.
+
+| 형태 | 동작 |
+|---|---|
+| `<value>` | 대상 타입의 모든 파라미터에 사용 |
+| `<name>=<value>` 또는 `<name>:<value>` | 이름이 `<name>`인 파라미터에만 사용 |
+
+모든 플래그는 반복 사용 가능하며, 동일 파라미터에 매치되면 타입별 규칙이 일반 `--set-pvalue`보다 우선합니다.
+
+```bash
+# 모든 파라미터를 `test`로 채움
+noir -b . -f curl -u https://example.com --set-pvalue "test"
+
+# `Authorization` 헤더와 `id` 경로 파라미터에만 값 채움
+noir -b . -f curl -u https://example.com \
+  --set-pvalue-header "Authorization=Bearer xyz" \
+  --set-pvalue-path "id=42"
+
+# 쿼리/폼은 기본 `1`이지만 `limit`은 항상 10
+noir -b . -f curl -u https://example.com \
+  --set-pvalue-query "1" \
+  --set-pvalue-query "limit=10"
+```
+
+같은 플래그는 HTTPie와 PowerShell 출력에도 적용되며, OpenAPI / Postman / JSON 등 값이 렌더링되는 다른 형식에도 전파됩니다.

--- a/docs/content/usage/output_formats/curl/index.md
+++ b/docs/content/usage/output_formats/curl/index.md
@@ -52,3 +52,43 @@ Invoke-WebRequest -Method GET -Uri "https://www.example.com/" -Headers @{"x-api-
 Invoke-WebRequest -Method POST -Uri "https://www.example.com/query" -Headers @{"Cookie"="my_auth="} -Body "query=" -ContentType "application/x-www-form-urlencoded"
 Invoke-WebRequest -Method GET -Uri "https://www.example.com/token" -Body "client_id=&redirect_url=&grant_type=" -ContentType "application/x-www-form-urlencoded"
 ```
+
+## Filling Parameter Values
+
+By default Noir leaves parameter values empty (`x-api-key=`, `query=`, …) so the commands work as templates. Pre-populate values with the `--set-pvalue` family — handy when you want a script you can run as-is, or when you want to seed fuzzing input.
+
+| Flag | Scope |
+|---|---|
+| `--set-pvalue VALUE` | All parameter types |
+| `--set-pvalue-query VALUE` | Query string |
+| `--set-pvalue-form VALUE` | Form body (`application/x-www-form-urlencoded`) |
+| `--set-pvalue-json VALUE` | JSON body |
+| `--set-pvalue-header VALUE` | Request headers |
+| `--set-pvalue-cookie VALUE` | Cookies |
+| `--set-pvalue-path VALUE` | Path parameters |
+
+`VALUE` accepts two forms:
+
+| Form | Behavior |
+|---|---|
+| `<value>` | Used for every parameter of the targeted type |
+| `<name>=<value>` or `<name>:<value>` | Used only for parameters named `<name>` |
+
+All flags are repeatable, and per-type rules win over the generic `--set-pvalue` when both match.
+
+```bash
+# Fill every parameter with `test`
+noir -b . -f curl -u https://example.com --set-pvalue "test"
+
+# Fill only the `Authorization` header and `id` path param
+noir -b . -f curl -u https://example.com \
+  --set-pvalue-header "Authorization=Bearer xyz" \
+  --set-pvalue-path "id=42"
+
+# Mix: default `1` for query/form, but `limit` always 10
+noir -b . -f curl -u https://example.com \
+  --set-pvalue-query "1" \
+  --set-pvalue-query "limit=10"
+```
+
+The same flags apply to HTTPie and PowerShell output, and feed downstream into the OpenAPI, Postman, and JSON formats wherever values are rendered.


### PR DESCRIPTION
## Summary

Follow-up to #1499 that closes the last documentation gaps surfaced by the flag-coverage audit.

## Changes

- **`usage/output_formats/curl/`** (en + ko) — new "Filling Parameter Values" section documenting `--set-pvalue` and `--set-pvalue-<type>` (7 variants), including the `<value>` vs. `<name>=<value>` / `<name>:<value>` syntaxes and the per-type-wins precedence rule. cURL is the natural home because empty parameter values (`x-api-key=`, `query=`) are most visible there.
- **`get_started/running/`** (en + ko) — new `--only-techs` example next to `--techs` with a one-line explanation of the distinction (detector filter vs. forced tagging without detection). Quick Reference grows rows for `--set-pvalue*`, `--only-techs`, `--no-color`, `--build-info`, and the `--techs` row is rephrased to reflect its actual behavior.

## Re-audit

Every flag in `src/options.cr` now has at least one docs reference, with the intentional exceptions of:
- `--help-all` (CLI-only meta flag, discovered via `--help`)
- `--format` (covered as the `-f` short form)
- Deprecated `--ollama` / `--ollama-model` (kept out of docs to nudge users toward `--ai-provider`)

## Test plan
- [x] Re-ran the doc-coverage check: only the three intentional exceptions above remain unreferenced.
- [x] New internal link from Quick Reference to `output_formats/curl/` resolves.
- [x] No source changes — docs only.