### PR TITLE
perf(tree-sitter): pool parsers per language for faster large-codebase scans

### DIFF
--- a/spec/unit_test/ext/tree_sitter_parser_pool_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_parser_pool_spec.cr
@@ -1,0 +1,58 @@
+require "spec"
+require "../../../src/ext/tree_sitter/tree_sitter"
+
+# Pool reuse is the optimisation that makes monorepo scans avoid
+# re-paying `ts_parser_new` + `ts_parser_set_language` per file. The
+# specs lock the contract: after a `parse` call returns, a parser sits
+# idle in the language bucket; the next call pops it instead of
+# allocating a fresh one.
+describe "Noir::TreeSitter parser pool" do
+  it "keeps an idle parser in the pool after a parse call returns" do
+    language = LibTreeSitter.tree_sitter_python
+    before = Noir::TreeSitter.parser_pool_size(language)
+    Noir::TreeSitter.parse_python("x = 1") { |_| }
+    after = Noir::TreeSitter.parser_pool_size(language)
+    after.should eq(before + 1)
+  end
+
+  it "reuses the pooled parser on the next parse call" do
+    language = LibTreeSitter.tree_sitter_go
+    # Prime the pool.
+    Noir::TreeSitter.parse_go("package main") { |_| }
+    primed = Noir::TreeSitter.parser_pool_size(language)
+    primed.should be >= 1
+
+    # Reusing the parser must not grow the pool.
+    Noir::TreeSitter.parse_go("package main") { |_| }
+    Noir::TreeSitter.parser_pool_size(language).should eq(primed)
+  end
+
+  it "produces equivalent parse results across pooled invocations" do
+    source = "fn handler() {}"
+
+    first_types = [] of String
+    second_types = [] of String
+
+    collect = ->(into : Array(String), root : LibTreeSitter::TSNode) do
+      walk = uninitialized Proc(LibTreeSitter::TSNode, Nil)
+      walk = ->(n : LibTreeSitter::TSNode) do
+        into << Noir::TreeSitter.node_type(n)
+        Noir::TreeSitter.each_named_child(n) { |c| walk.call(c) }
+      end
+      walk.call(root)
+    end
+
+    Noir::TreeSitter.parse_rust(source) { |root| collect.call(first_types, root) }
+    Noir::TreeSitter.parse_rust(source) { |root| collect.call(second_types, root) }
+
+    second_types.should eq(first_types)
+    second_types.should contain("function_item")
+  end
+
+  it "isolates parsers per language" do
+    py_before = Noir::TreeSitter.parser_pool_size(LibTreeSitter.tree_sitter_python)
+    Noir::TreeSitter.parse_java("class A {}") { |_| }
+    Noir::TreeSitter.parser_pool_size(LibTreeSitter.tree_sitter_python).should eq(py_before)
+    Noir::TreeSitter.parser_pool_size(LibTreeSitter.tree_sitter_java).should be >= 1
+  end
+end

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -123,16 +123,63 @@ module Noir::TreeSitter
   # ceiling.
   MAX_AST_DEPTH = 1024
 
-  # Parses `source` with the given `language` and yields the root
-  # `LibTreeSitter::TSNode`. The parser and tree are freed when the
-  # block returns.
-  def self.parse(source : String, language : LibTreeSitter::TSLanguage, &)
+  # Per-language pool of idle parsers. Allocating a tree-sitter parser
+  # plus binding a language on every `parse` is cheap individually but
+  # adds up across the tens of thousands of files a monorepo scan
+  # touches — every Python/Go/Java/Kotlin/JS/Rust analyzer reuses the
+  # same grammar over and over. The pool keeps freshly-released parsers
+  # alive so the next call skips both `ts_parser_new` and
+  # `ts_parser_set_language`.
+  #
+  # tree-sitter parsers are not safe for concurrent use, so each fiber
+  # checks one out for the duration of a `parse` call and returns it
+  # when the block exits. The pool itself is mutex-guarded so the
+  # checkout/checkin pair is fiber-safe under the MT runtime as well.
+  @@parser_pool = Hash(UInt64, Array(LibTreeSitter::TSParser)).new
+  @@parser_pool_mutex = Mutex.new
+
+  private def self.checkout_parser(language : LibTreeSitter::TSLanguage) : LibTreeSitter::TSParser
+    key = language.address
+    @@parser_pool_mutex.synchronize do
+      if bucket = @@parser_pool[key]?
+        unless bucket.empty?
+          return bucket.pop
+        end
+      end
+    end
+
     parser = LibTreeSitter.ts_parser_new
     raise "ts_parser_new returned null" if parser.null?
+    unless LibTreeSitter.ts_parser_set_language(parser, language)
+      LibTreeSitter.ts_parser_delete(parser)
+      raise "ts_parser_set_language failed (ABI mismatch?)"
+    end
+    parser
+  end
+
+  private def self.checkin_parser(language : LibTreeSitter::TSLanguage, parser : LibTreeSitter::TSParser)
+    key = language.address
+    @@parser_pool_mutex.synchronize do
+      bucket = @@parser_pool[key] ||= [] of LibTreeSitter::TSParser
+      bucket << parser
+    end
+  end
+
+  # Idle parser count for a given language. Exposed for tests and
+  # diagnostics; not part of the public API contract.
+  def self.parser_pool_size(language : LibTreeSitter::TSLanguage) : Int32
+    @@parser_pool_mutex.synchronize do
+      (@@parser_pool[language.address]? || [] of LibTreeSitter::TSParser).size
+    end
+  end
+
+  # Parses `source` with the given `language` and yields the root
+  # `LibTreeSitter::TSNode`. The parser is checked out from a per-language
+  # pool and returned when the block exits; the tree is freed in the
+  # same `ensure`.
+  def self.parse(source : String, language : LibTreeSitter::TSLanguage, &)
+    parser = checkout_parser(language)
     begin
-      unless LibTreeSitter.ts_parser_set_language(parser, language)
-        raise "ts_parser_set_language failed (ABI mismatch?)"
-      end
       tree = LibTreeSitter.ts_parser_parse_string(parser, Pointer(Void).null.as(LibTreeSitter::TSTree), source.to_unsafe, source.bytesize.to_u32)
       raise "ts_parser_parse_string returned null" if tree.null?
       begin
@@ -141,7 +188,7 @@ module Noir::TreeSitter
         LibTreeSitter.ts_tree_delete(tree)
       end
     ensure
-      LibTreeSitter.ts_parser_delete(parser)
+      checkin_parser(language, parser)
     end
   end
 


### PR DESCRIPTION
## Summary
- Tree-sitter's `parse` helper allocated a fresh `TSParser` + bound the grammar + freed the parser on every call. That pattern is fine at one-shot but adds up in monorepo-scale scans where every Python/Go/Java/Kotlin/JS/Rust analyzer parses thousands of files against the same grammar.
- This adds a per-language parser pool keyed by `TSLanguage` pointer. Released parsers go back to the bucket; subsequent parses pop an idle one and skip both `ts_parser_new` and `ts_parser_set_language`.
- Mutex-guarded so the pool stays correct under the MT runtime (`WaitGroup.spawn` already runs analyzers as concurrent fibers).
- Block-based public API is unchanged — every existing call site (`parse_python`, `parse_go`, `parse_java`, `parse_kotlin`, `parse_javascript`, `parse_rust`, plus all `<lang>_extractor_ts.cr` and callee extractors) picks up the speedup transparently.

## Test plan
- [x] `crystal spec spec/unit_test/ext/tree_sitter_parser_pool_spec.cr` — 4 new specs cover: pool grows after a parse, the next parse reuses (no growth), repeat parses produce identical AST shapes, languages stay isolated.
- [x] `crystal spec spec/unit_test/ext/` — 15 examples, 0 failures.
- [x] `crystal spec spec/unit_test/miniparser/` — 238 examples, 0 failures (every existing tree-sitter-backed extractor stays green).