### PR TITLE
perf(passive-scan): collapse or-condition into a single line walk

### DIFF
--- a/spec/unit_test/passive_scan/passive_scan_spec.cr
+++ b/spec/unit_test/passive_scan/passive_scan_spec.cr
@@ -176,6 +176,43 @@ describe NoirPassiveScan do
       results[0].line_number.should eq(2)
     end
 
+    it "emits one result per matcher hit when several matchers fire on the same line" do
+      logger = NoirLogger.new(false, false, false, true)
+      rules = [
+        PassiveScan.new(YAML.parse(<<-YAML)),
+          id: or-branch-multi
+          info:
+            name: or branch multi
+            author: [test]
+            severity: critical
+            description: ...
+            reference: [https://example.com]
+          matchers-condition: or
+          matchers:
+            - type: word
+              patterns:
+                - alpha
+              condition: or
+            - type: word
+              patterns:
+                - beta
+              condition: or
+          category: security
+          techs: ['*']
+          YAML
+      ]
+      # Line 1: matches alpha only. Line 2: matches both. Line 3: matches beta only.
+      file_content = "alpha line\nalpha and beta both here\nbeta line"
+      results = NoirPassiveScan.detect("test.txt", file_content, rules, logger)
+
+      # Three line hits, plus an extra hit on line 2 from the second matcher.
+      results.size.should eq(4)
+      # Line numbers must come back in ascending order — the single-pass
+      # walk over lines preserves natural ordering regardless of matcher
+      # composition.
+      results.map(&.line_number).should eq([1, 2, 2, 3])
+    end
+
     it "returns no results and takes the early-out when no matcher fires" do
       logger = NoirLogger.new(false, false, false, true)
       rules = [

--- a/src/passive_scan/detect.cr
+++ b/src/passive_scan/detect.cr
@@ -45,15 +45,22 @@ module NoirPassiveScan
         active_matchers = matchers.select { |matcher| match_content?(file_content, matcher) }
         next if active_matchers.empty?
 
-        active_matchers.each do |matcher|
-          index = 0
-          file_content.each_line do |line|
+        # Single pass over the file's lines, checking every surviving
+        # matcher per line. The previous shape ran `each_line` once
+        # per active matcher, which re-parsed line boundaries and
+        # allocated a fresh substring for every line × matcher pair —
+        # the dominant cost on large files in monorepo scans where a
+        # single rule can have multiple matchers and a single file can
+        # have hundreds of thousands of lines.
+        index = 0
+        file_content.each_line do |line|
+          active_matchers.each do |matcher|
             if match_content?(line, matcher)
               logger.sub "└── Detected: #{rule.info.name}"
               results << PassiveScanResult.new(rule, file_path, index + 1, line)
             end
-            index += 1
           end
+          index += 1
         end
       end
     end


### PR DESCRIPTION
## Summary
- The "or" branch of `NoirPassiveScan.detect_with_severity` iterated `file_content.each_line` once per surviving matcher — re-parsing line boundaries and allocating fresh per-line substrings on every pass.
- On a monorepo-sized file (hundreds of thousands of lines) with a multi-matcher rule, that's the dominant cost of the passive-scan phase.
- Walks lines once, checks every surviving matcher per line. The existing whole-file early-out that prunes never-firing matchers stays intact, so rules that can't possibly fire still skip the line loop entirely.

## Test plan
- [x] `crystal spec spec/unit_test/passive_scan/` — 41 examples, 0 failures.
- [x] New regression spec: rule with two or-matchers, file where line 1 hits matcher A, line 2 hits both, line 3 hits matcher B → four results in ascending line order (`[1, 2, 2, 3]`). Locks the new "single pass per line, all matchers checked per line" contract.
- [x] Existing or-branch line-ordering specs (`returns results when at least one matcher fires`, mixed-fire, no-fire early-out) still pass unchanged.