### PR TITLE
perf(analyzer/go): route Go File.read through the detector content cache

### DIFF
--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -26,7 +26,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -27,7 +27,7 @@ module Analyzer::Go
           package_files[dir] ||= [] of String
           package_files[dir] << scan_path
 
-          content = File.read(scan_path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(scan_path)
           file_contents_cache[scan_path] = content
           file_lines_cache[scan_path] = content.lines
 
@@ -70,7 +70,7 @@ module Analyzer::Go
                 break if path.nil?
                 next if File.directory?(path)
                 if File.exists?(path)
-                  content = file_contents_cache[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                  content = file_contents_cache[path]? || read_file_content(path)
                   lines = file_lines_cache[path]? || content.lines
 
                   dir = File.dirname(path)
@@ -291,7 +291,7 @@ module Analyzer::Go
         content =
           (file_contents_cache.try &.[search_path]?) ||
             begin
-              File.read(search_path, encoding: "utf-8", invalid: :skip)
+              read_file_content(search_path)
             rescue File::NotFoundError
               next
             end

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -25,7 +25,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = file_contents[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = file_contents[path]? || read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -22,7 +22,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = file_contents[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = file_contents[path]? || read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -25,7 +25,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -24,7 +24,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = file_contents[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = file_contents[path]? || read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -26,7 +26,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -30,7 +30,7 @@ module Analyzer::Go
 
                   # Handle both .go files and .api files
                   if File.exists?(path) && (File.extname(path) == ".go" || File.extname(path) == ".api")
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -29,7 +29,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = file_contents[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = file_contents[path]? || read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -22,7 +22,7 @@ module Analyzer::Go
       get_files_by_extension(".go").each do |fp|
         next if File.directory?(fp)
         begin
-          file_contents[fp] = File.read(fp, encoding: "utf-8", invalid: :skip)
+          file_contents[fp] = read_file_content(fp)
         rescue File::NotFoundError
           # skip
         end
@@ -42,7 +42,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -24,7 +24,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = file_contents[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = file_contents[path]? || read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -28,7 +28,7 @@ module Analyzer::Go
                   break if path.nil?
                   next if File.directory?(path)
                   if File.exists?(path)
-                    content = file_contents[path]? || File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = file_contents[path]? || read_file_content(path)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -35,7 +35,7 @@ module Analyzer::Go
       files_by_dir.each do |_dir, paths|
         paths.each do |path|
           begin
-            file_contents[path] = File.read(path, encoding: "utf-8", invalid: :skip)
+            file_contents[path] = read_file_content(path)
           rescue File::NotFoundError
             # skip
           end
@@ -102,7 +102,7 @@ module Analyzer::Go
       get_files_by_extension(".go").each do |path|
         next if File.directory?(path)
         begin
-          file_contents[path] = File.read(path, encoding: "utf-8", invalid: :skip)
+          file_contents[path] = read_file_content(path)
         rescue File::NotFoundError
           # skip
         end


### PR DESCRIPTION
## Summary
- The `Analyzer` base class already exposes `read_file_content(path)`, which checks the `CodeLocator` content cache (populated during the detector's file walk) before falling back to disk.
- Go-side analyzers were still going straight to `File.read`, so on a monorepo scan every `.go` file was paid for twice — once by the detector worker, again by the per-tech analyzer.
- This routes all Go reads through the cache:
  - `GoEngine#collect_package_groups_ts` and `#read_package_file_contents` (the cross-file group + function-body pre-passes).
  - Every framework analyzer's per-file `channel.receive` loop: beego, chi, echo, fiber, gf, gin, goyave, gozero, hertz, httprouter, iris, mux.
  - `chi.cr`'s deferred router-search read path.
- Analyzer-local `file_contents[path]?` caches are kept where present — they still catch repeat reads inside a single analyzer pass; the locator now catches the detector ↔ analyzer crossing.

## Test plan
- [x] `crystal spec spec/unit_test/detector/go/ spec/unit_test/miniparser/go_route_extractor_ts_spec.cr` — 20 examples, 0 failures.
- [x] `crystal spec spec/functional_test/testers/go/` — 1104 examples, 0 failures.
- [x] `crystal build src/noir.cr --no-codegen` clean.