### PR TITLE
perf(analyzer/js): route JS File.read through the detector content cache

### DIFF
--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -52,7 +52,7 @@ module Analyzer::Javascript
       file_contexts : Hash(String, FileContext),
       global_deferred_mounts : Array(Tuple(String, String, String, String)),
     )
-      content = File.read(main_file, encoding: "utf-8", invalid: :skip)
+      content = CodeLocator.instance.content_for(main_file) || File.read(main_file, encoding: "utf-8", invalid: :skip)
 
       # Parse imports
       imports = parse_imports(content, main_file)
@@ -445,7 +445,7 @@ module Analyzer::Javascript
       return false unless File.file?(file_path)
 
       begin
-        content = File.read(file_path, encoding: "utf-8", invalid: :skip)
+        content = CodeLocator.instance.content_for(file_path) || File.read(file_path, encoding: "utf-8", invalid: :skip)
         # Look for common route definition patterns
         # Matches: router.get(, router.post(, .get(, .post(, etc.
         content.matches?(/\.(get|post|put|delete|patch|all|head|options)\s*\(/)

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -10,7 +10,7 @@ module Analyzer::Javascript
 
       parallel_file_scan do |path|
         begin
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -10,7 +10,7 @@ module Analyzer::Javascript
 
       parallel_file_scan do |path|
         begin
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           include_callee = any_to_bool(@options["include_callee"])
           callees_by_route = include_callee ? Noir::JSCalleeExtractor.callees_for_routes(content, path) : {} of String => Array(Noir::JSCalleeExtractor::Entry)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -10,7 +10,7 @@ module Analyzer::Javascript
 
       parallel_file_scan([".js", ".ts", ".mjs"]) do |path|
         begin
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -65,7 +65,7 @@ module Analyzer::Javascript
 
       # Read file content to extract parameters
       begin
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         callees = include_callee ? Noir::JSCalleeExtractor.callees_for_default_event_handler(content, path, language: javascript_source_language(path)) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |method|

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -78,7 +78,7 @@ module Analyzer::Javascript
 
       # Read file content to extract parameters
       begin
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         callees = include_callee ? Noir::JSCalleeExtractor.callees_for_default_event_handler(content, path, language: javascript_source_language(path)) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |method|

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -10,7 +10,7 @@ module Analyzer::Javascript
 
       parallel_file_scan do |path|
         begin
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|


### PR DESCRIPTION
## Summary
- Sibling of #1503, applied to the JavaScript family. Detector-pre-cached file content was being ignored — every `.js`/`.ts`/`.mjs` file paid for a disk read twice (detector population + analysis).
- Six `JavascriptEngine`-backed analyzers (hono, koa, fastify, restify, nitro, nuxtjs) now use the existing `read_file_content` helper on the `Analyzer` base.
- The two `RouterMountScanner` reads (plain class, not an `Analyzer`) get the inline `CodeLocator.instance.content_for(...) || File.read(...)` shape since the helper lives on the analyzer base. `CodeLocator` is already imported there.

## Test plan
- [x] `crystal build src/noir.cr --no-codegen` clean.
- [x] `crystal spec spec/unit_test/detector/javascript/ spec/functional_test/testers/javascript/` — 1888 examples, 0 failures.