### PR TITLE
perf(analyzer/python): route Python File.read through the detector content cache

### DIFF
--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -74,7 +74,7 @@ module Analyzer::Python
                 next if File.directory?(file)
                 next if file.includes?("/site-packages/")
                 if file.ends_with? ".py"
-                  content = File.read(file, encoding: "utf-8", invalid: :skip)
+                  content = read_file_content(file)
                   content.scan(REGEX_ROOT_URLCONF) do |match|
                     next if match.size != 2
                     dotted_as_urlconf = match[1].split(".")
@@ -186,7 +186,7 @@ module Analyzer::Python
       suspicious_http_methods = ["GET"]
       suspicious_params = Array(Param).new
 
-      content = File.read(filepath, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(filepath)
       content_lines = content.split "\n"
 
       # Function Based View

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -44,7 +44,7 @@ module Analyzer::Python
     end
 
     private def analyze_file(path : ::String, definition_base_path : ::String)
-      source = File.read(path, encoding: "utf-8", invalid: :skip)
+      source = read_file_content(path)
       lines = source.lines
       return unless lines.any?(&.includes?("falcon"))
 

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -18,7 +18,7 @@ module Analyzer::Python
           python_files.each do |path|
             next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             next if path.includes?("/site-packages/")
-            source = File.read(path, encoding: "utf-8", invalid: :skip)
+            source = read_file_content(path)
 
             source.each_line do |line|
               line = line.gsub(" ", "")
@@ -63,7 +63,7 @@ module Analyzer::Python
         configure_router_prefix(fastapi_base_file, include_router_map)
 
         include_router_map.each do |path, router_map|
-          source = File.read(path, encoding: "utf-8", invalid: :skip)
+          source = read_file_content(path)
           definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @fastapi_base_path
           import_modules = find_imported_modules(@fastapi_base_path, path, source)
           codelines = source.split("\n")
@@ -145,7 +145,7 @@ module Analyzer::Python
                                 # Skip if import module path is not identified
                                 next if import_module_path.empty?
 
-                                import_module_source = File.read(import_module_path, encoding: "utf-8", invalid: :skip)
+                                import_module_source = read_file_content(import_module_path)
                                 new_params = find_base_model_params(import_module_source, param.type, param.name)
                               else
                                 # Parse model class from current source
@@ -202,7 +202,7 @@ module Analyzer::Python
       return if file.empty? || !File.exists?(file)
 
       # Parse the source file for router configuration
-      source = File.read(file, encoding: "utf-8", invalid: :skip)
+      source = read_file_content(file)
       import_modules = find_imported_modules(@fastapi_base_path, file, source)
       include_router_map[file].each do |instance_name, router_class|
         router_class.prefix = router_prefix

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -180,7 +180,7 @@ module Analyzer::Python
 
     private def fetch_file_content(path : ::String) : ::String
       unless @file_content_cache.has_key?(path)
-        @file_content_cache[path] = File.read(path, encoding: "utf-8", invalid: :skip)
+        @file_content_cache[path] = read_file_content(path)
       end
       @file_content_cache[path]
     end

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -393,7 +393,7 @@ module Analyzer::Python
     private def read_file_content(file_path : ::String) : ::String
       return @file_content_cache[file_path] if @file_content_cache.has_key?(file_path)
       content = begin
-        File.read(file_path, encoding: "utf-8", invalid: :skip)
+        CodeLocator.instance.content_for(file_path) || File.read(file_path, encoding: "utf-8", invalid: :skip)
       rescue e : IO::Error
         @logger.debug "Failed to read file: #{file_path} (#{e.message})"
         ""

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -333,7 +333,7 @@ module Analyzer::Python
                                                   caller_path : ::String,
                                                   caller_source : ::String?) : Array(Callee)
       source_cache = Hash(::String, ::String).new
-      source_cache[caller_path] = caller_source || File.read(caller_path, encoding: "utf-8", invalid: :skip)
+      source_cache[caller_path] = caller_source || read_file_content(caller_path)
       import_map = find_imported_modules(app_base_path, caller_path, source_cache[caller_path])
 
       callees.map do |callee|
@@ -366,7 +366,7 @@ module Analyzer::Python
       imported_path = imported.first
       return if imported_path.empty? || !File.exists?(imported_path)
 
-      imported_source = source_cache[imported_path] ||= File.read(imported_path, encoding: "utf-8", invalid: :skip)
+      imported_source = source_cache[imported_path] ||= read_file_content(imported_path)
       imported_parts = parts.size == 1 ? parts : parts[1..]
       find_python_definition(imported_path, imported_source, imported_parts) ||
         find_python_definition(imported_path, imported_source, parts)


### PR DESCRIPTION
## Summary
- Sibling of #1503 (Go) and #1504 (JS), applied to the Python family. Every `.py` file the detector pre-loaded was being re-read from disk on the analyzer side.
- `FastAPI` (4 sites: detector pass, `configure_router` pass, cross-file model-param resolution, prefix-configuration read), `Falcon`, `Django` (urlconf root scan + view resolver), `Sanic` (`fetch_file_content` cache fill) → all swap to the base `read_file_content` helper.
- `PythonEngine#resolve_python_callee_definitions` (caller + import reads) → same swap on the shared engine.
- `Tornado` keeps its private `read_file_content` override (it carries per-instance caching + `IO::Error` swallowing the base helper doesn't), but threads a `CodeLocator.instance.content_for` check ahead of `File.read` so detector-cached content wins here too.

## Test plan
- [x] `crystal build src/noir.cr --no-codegen` clean.
- [x] `crystal spec spec/unit_test/detector/python/ spec/functional_test/testers/python/` — 1001 examples, 0 failures.