### PR TITLE
perf(analyzer): route remaining language families through the detector content cache

### DIFF
--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -22,7 +22,7 @@ module Analyzer::CSharp
       get_files_by_extension(".cs").each do |file|
         next unless File.exists?(file)
 
-        lines = File.read(file, encoding: "utf-8", invalid: :skip).lines
+        lines = read_file_content(file).lines
         lines.each_with_index do |line, index|
           if match = map_regex.match(line)
             http_method = match[1].upcase
@@ -152,7 +152,7 @@ module Analyzer::CSharp
 
       files.each do |file|
         begin
-          content = File.read(file, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(file)
           patterns.concat(extract_route_patterns(content))
         rescue e
           logger.debug "Failed to read #{file}: #{e.message}"
@@ -210,7 +210,7 @@ module Analyzer::CSharp
     private def analyze_controller_file(file : String, route_patterns : Array(String), include_callee : Bool)
       return unless File.exists?(file)
 
-      content = File.read(file, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(file)
       return unless content.includes?("Controller")
 
       controller_name = extract_controller_name(content)

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -66,7 +66,7 @@ module Analyzer::CSharp
     private def analyze_controller_file(file : String, include_callee : Bool)
       return unless File.exists?(file)
 
-      content = File.read(file, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(file)
       return unless content.includes?("Controller") && content.includes?("ActionResult")
 
       lines = content.lines

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -53,7 +53,7 @@ module Analyzer::Elixir
         next unless File.exists?(controller_path)
 
         begin
-          content = File.read(controller_path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(controller_path)
           controller_name = File.basename(controller_path, ".ex")
 
           # Extract parameters from each action in the controller

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -31,7 +31,7 @@ module Analyzer::Java
                   next if File.directory?(path)
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
 
                     # Annotation-based services (`@Get("/x")` etc.) —
                     # Kotlin files reach here too, but tree-sitter-java

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -39,7 +39,7 @@ module Analyzer::Java
       controller_methods = Hash(String, ControllerMethod).new
 
       java_files.each do |path|
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
 
         # Extract package name
         package_name = ""

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -30,7 +30,7 @@ module Analyzer::Java
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
                     details = Details.new(PathInfo.new(path))
-                    content = File.read(path, encoding: "utf-8", invalid: :skip)
+                    content = read_file_content(path)
 
                     # Skip if no Vert.x related content
                     next unless content.includes?("Router") || content.includes?("vertx")

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -166,7 +166,7 @@ module Analyzer::Php
       controller_path = resolve_cakephp_controller_path(routes_file_path, controller_name)
       return unless controller_path && File.exists?(controller_path)
 
-      content = File.read(controller_path, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(controller_path)
       method_match = content.match(/(?:public|protected|private)\s+function\s+#{action_name}\s*\(/)
       return unless method_match
 

--- a/src/analyzer/analyzers/php/codeigniter.cr
+++ b/src/analyzer/analyzers/php/codeigniter.cr
@@ -154,7 +154,7 @@ module Analyzer::Php
       controller_path = resolve_ci4_controller_path(routes_file_path, controller_name, controller_namespace)
       return unless controller_path && File.exists?(controller_path)
 
-      content = File.read(controller_path, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(controller_path)
       method_match = content.match(/(?:public|protected|private)\s+function\s+#{action_name}\s*\(/)
       return unless method_match
 

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -38,7 +38,7 @@ module Analyzer::Scala
       controller_methods = Hash(String, ControllerMethod).new
 
       scala_files.each do |path|
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
 
         # Extract package name
         package_name = ""


### PR DESCRIPTION
## Summary
- Finishes the cache-first migration started in #1503 (Go), #1504 (JS), and #1505 (Python). Every `File.read` on these analyzers was hitting disk for files the detector had already loaded into the content cache.
- Migrated to `read_file_content`:
  - C#: `AspNetMvc`, `AspNetCoreMvc` (3 sites).
  - Elixir: `Phoenix`.
  - Java: `Armeria`, `Play`, `Vertx` (the non-tree-sitter analyzers still on direct file reads).
  - PHP: `CakePHP`, `CodeIgniter`.
  - Scala: `Play`.
- Skipped: `specification/{oas2,oas3,grpc,postman,raml,zap_sites_tree}` — those read user-provided spec files at explicit paths, not anything in the detector's file_map walk, so the cache will always miss for them.

## Test plan
- [x] `crystal build src/noir.cr --no-codegen` clean.
- [x] `crystal spec spec/unit_test/` — 1623 examples, 0 failures.
- [x] `crystal spec spec/functional_test/testers/{csharp,elixir,java,php,scala}/` — 2628 examples, 0 failures.