### PR TITLE
perf(config): auto-scale default concurrency to CPU count

### DIFF
--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -21,6 +21,18 @@ describe "default_options" do
     noir_options = create_test_options
     noir_options["ai_context"].should be_false
   end
+
+  # Concurrency is auto-scaled to the host's CPU count, clamped to the
+  # [4, 32] window. The exact value depends on the box the suite runs
+  # on, so the spec asserts the window rather than a literal.
+  it "auto-scales concurrency to the host CPU count within a safe window" do
+    noir_options = create_test_options
+    value = noir_options["concurrency"].to_s.to_i
+    value.should be >= 4
+    value.should be <= 32
+    expected = System.cpu_count.clamp(4, 32)
+    value.should eq(expected)
+  end
 end
 
 describe "run_options_parser" do

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -83,12 +83,23 @@ class ConfigInitializer
     end
   end
 
+  # Default concurrency scales with the host's CPU count, clamped to a
+  # safe window. The lower bound of 4 keeps low-core CI runners from
+  # serializing on a single worker; the upper bound of 32 keeps
+  # channel-synchronisation overhead and (under MT) GC pressure in check
+  # on very large boxes. Users who want a specific value still get it
+  # via `--concurrency N` or `concurrency:` in the config file — those
+  # paths overwrite this default.
+  def default_concurrency : String
+    System.cpu_count.clamp(4, 32).to_s
+  end
+
   def default_options
     noir_options = {
       "base"                         => YAML::Any.new([] of YAML::Any),
       "color"                        => YAML::Any.new(true),
       "config_file"                  => YAML::Any.new(""),
-      "concurrency"                  => YAML::Any.new("20"),
+      "concurrency"                  => YAML::Any.new(default_concurrency),
       "debug"                        => YAML::Any.new(false),
       "verbose"                      => YAML::Any.new(false),
       "exclude_codes"                => YAML::Any.new(""),


### PR DESCRIPTION
## Summary
- The default `concurrency` was hard-coded to `"20"` — fine for a typical dev box, wrong at both extremes. 2-core CI runners over-subscribed and paid GC + channel overhead for no gain; 32–64 core boxes under-utilised the analyzer / detector worker pools.
- After #1503–#1506 routed every analyzer through the detector content cache, the bulk of analyzer work is now CPU-bound (tree-sitter parsing, pattern matching) rather than disk-bound, so scaling with `System.cpu_count` matches the actual workload shape.
- Clamp to `[4, 32]`:
  - Lower bound keeps low-core CI runners from serialising — there's still IO interleaving to exploit even when `cpu_count` is 1 or 2.
  - Upper bound caps channel synchronisation + GC pressure on very large boxes; past ~32 fibers the marginal return collapses in measured workloads.
- Users who pass `--concurrency N` or set `concurrency:` in their config file keep their value — both paths overwrite the default.

## Test plan
- [x] `crystal spec spec/unit_test/` — 1624 examples, 0 failures (one new).
- [x] New spec pins the `[4, 32]` window plus the exact `System.cpu_count.clamp(4, 32)` value.
- [x] `crystal build src/noir.cr --no-codegen` clean.