### PR TITLE
perf(ruby/rails): skip controller callee extraction when flag is off

### DIFF
--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -471,7 +471,7 @@ module Analyzer::Ruby
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |controller_file|
         controller_content = controller_file.gets_to_end
         param_type = "json" if controller_content.includes?("render json:")
-        callees_by_action = extract_action_callees(controller_content, path)
+        callees_by_action = extract_action_callees(controller_content, path) if callees_needed?
 
         controller_file.rewind
         this_method = ""
@@ -700,14 +700,17 @@ module Analyzer::Ruby
     end
 
     private def attach_callees_for_action(endpoint : Endpoint, data : ControllerData, action : String)
-      return unless include_callee?
+      return unless callees_needed?
       if callees = data.callees_by_action[action]?
         attach_ruby_callees(endpoint, callees)
       end
     end
 
-    private def include_callee? : Bool
-      any_to_bool(@options["include_callee"]?)
+    # Callees feed both `--include-callee` (direct output) and `--ai-context`
+    # (aggregated review context). Extraction is skipped when neither flag is
+    # set so default scans avoid the controller-body walk per action.
+    private def callees_needed? : Bool
+      any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
     end
 
     private def parent_resources_frame(stack : Array(Frame)) : Frame?


### PR DESCRIPTION
## Summary
- Rails controller scans called `extract_action_callees` on every controller file regardless of `--include-callee` / `--ai-context`, even though attachment was already gated. The extraction walks every action body and runs the per-action callee miniparser — wasted work on default scans.
- Move the gate up to the extraction call site and also widen it to include `--ai-context` (which aggregates callees as part of AI review context).

## Notes
- Behavior unchanged when either flag is set (specs `rails_callees_spec` and `rails_ai_context_spec` still pass).
- On large Rails codebases the saved work scales with controller count × action count.

Part of a follow-up series addressing the post-v0.30.0 callee-extraction regression: many analyzers run callee extraction unconditionally, and the same gate needs to be applied per framework. Python (Django/Flask/FastAPI/...) is the next target — `build_callees_from` there is called unconditionally and also walks the import graph.

## Test plan
- [x] `crystal spec spec/functional_test/testers/ruby/rails_spec.cr spec/functional_test/testers/ruby/rails_advanced_spec.cr spec/functional_test/testers/ruby/rails_monorepo_spec.cr spec/functional_test/testers/ruby/rails_callees_spec.cr spec/functional_test/testers/ruby/rails_ai_context_spec.cr` (565 passing across Ruby suite)
- [x] Mastodon scan: URL/method/params output identical before/after (192 endpoints)