### PR TITLE
perf(python): skip callee extraction when flag is off

### DIFF
--- a/spec/functional_test/testers/python/aiohttp_callees_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_callees_spec.cr
@@ -23,4 +23,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/aiohttp_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/bottle_callees_spec.cr
+++ b/spec/functional_test/testers/python/bottle_callees_spec.cr
@@ -22,4 +22,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/bottle_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/django_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_callees_spec.cr
@@ -59,7 +59,9 @@ expected_endpoints = [
 tester = FunctionalTester.new("fixtures/python/django_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints)
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
 tester.perform_tests
 
 it "keeps Django class-based view callees scoped to each HTTP method" do

--- a/spec/functional_test/testers/python/falcon_callees_spec.cr
+++ b/spec/functional_test/testers/python/falcon_callees_spec.cr
@@ -20,4 +20,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/falcon_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/fastapi_callees_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_callees_spec.cr
@@ -51,4 +51,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/fastapi_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/flask_callees_spec.cr
+++ b/spec/functional_test/testers/python/flask_callees_spec.cr
@@ -53,4 +53,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/flask_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/litestar_callees_spec.cr
+++ b/spec/functional_test/testers/python/litestar_callees_spec.cr
@@ -22,4 +22,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/litestar_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/pyramid_callees_spec.cr
+++ b/spec/functional_test/testers/python/pyramid_callees_spec.cr
@@ -15,4 +15,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/pyramid_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/sanic_callees_spec.cr
+++ b/spec/functional_test/testers/python/sanic_callees_spec.cr
@@ -25,4 +25,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/sanic_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/starlette_callees_spec.cr
+++ b/spec/functional_test/testers/python/starlette_callees_spec.cr
@@ -56,4 +56,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/starlette_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/python/tornado_callees_spec.cr
+++ b/spec/functional_test/testers/python/tornado_callees_spec.cr
@@ -39,4 +39,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/python/tornado_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/analyzer/python_engine_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_spec.cr
@@ -19,7 +19,9 @@ end
 
 describe Analyzer::Python::PythonEngine do
   it "keeps call-site coordinates when a Python callee definition is unreachable" do
-    harness = PythonEngineSpecHarness.new(create_test_options)
+    options = create_test_options
+    options["include_callee"] = YAML::Any.new(true)
+    harness = PythonEngineSpecHarness.new(options)
     source = <<-PY
       def handler():
           unknown_call()

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -298,6 +298,7 @@ module Analyzer::Python
                            *,
                            definition_base_path : ::String? = nil,
                            source : ::String? = nil) : Array(Callee)
+      return [] of Callee unless callees_needed?
       return [] of Callee if body.empty?
       callees = Noir::PythonCalleeExtractor.calls_in(body).map do |entry|
         name, row = entry
@@ -307,6 +308,14 @@ module Analyzer::Python
       return callees unless base_path = definition_base_path
 
       resolve_python_callee_definitions(callees, base_path, path, source)
+    end
+
+    # Callees feed both `--include-callee` (direct output) and `--ai-context`
+    # (aggregated review context). Skip the tree-sitter walk and import-graph
+    # resolution when neither flag is set so default Python scans avoid the
+    # per-handler callee build.
+    private def callees_needed? : Bool
+      any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
     end
 
     # Convenience wrapper around `build_callees_from`: parse + push in


### PR DESCRIPTION
## Summary
- Every Python analyzer (Django/Flask/FastAPI/Aiohttp/Bottle/Falcon/Litestar/Pyramid/Sanic/Starlette/Tornado) called `build_callees_from` / `push_callees_from` from its route emitter unconditionally. The helper runs the tree-sitter callee walk and, when `definition_base_path` is provided, reads neighboring modules to build an import map for resolution. None of that work is observable when neither \`--include-callee\` nor \`--ai-context\` is set.
- Centralize the gate in `PythonEngine#build_callees_from`: bail with an empty list before the extractor runs when callees aren't needed. Since `push_callees_from` routes through `build_callees_from`, the gate covers both paths and all 11 analyzers without touching individual call sites.

## Test changes
- Each `*_callees_spec.cr` previously relied on the unconditional behavior. They now pass `include_callee: true` via the `option_overrides` argument that `FunctionalTester` already supports (mirrors `rails_callees_spec.cr`).
- `python_engine_spec.cr`'s harness similarly sets the flag, since it asserts that callees are returned.

## Follow-up
Part of the post-v0.30.0 callee-extraction series — Rails was #1509. Next likely targets: Go (Gin/Chi/Echo/... all extract unconditionally), Elixir (Phoenix/Plug), Clojure/Compojure. Open question for a separate investigation: discourse-class scans regressed 6× since v0.30.0 even though JS callees are already gated — the bulk of the cost is in the JS route/mount path, not in callee extraction.

## Test plan
- [x] \`just test-unit\` (1624 examples, 0 failures)
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] saleor diff: 7 endpoints both before/after, identical URL/method/params