### PR TITLE
perf(go): skip callee extraction when flag is off

### DIFF
--- a/spec/functional_test/testers/go/beego_callees_spec.cr
+++ b/spec/functional_test/testers/go/beego_callees_spec.cr
@@ -40,4 +40,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/beego_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/chi_callees_spec.cr
+++ b/spec/functional_test/testers/go/chi_callees_spec.cr
@@ -45,4 +45,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/chi_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/echo_callees_spec.cr
+++ b/spec/functional_test/testers/go/echo_callees_spec.cr
@@ -36,4 +36,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/echo_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/fasthttp_callees_spec.cr
+++ b/spec/functional_test/testers/go/fasthttp_callees_spec.cr
@@ -39,4 +39,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/fasthttp_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/fiber_callees_spec.cr
+++ b/spec/functional_test/testers/go/fiber_callees_spec.cr
@@ -29,4 +29,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/fiber_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/gf_callees_spec.cr
+++ b/spec/functional_test/testers/go/gf_callees_spec.cr
@@ -44,4 +44,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/gf_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/gin_callees_spec.cr
+++ b/spec/functional_test/testers/go/gin_callees_spec.cr
@@ -52,4 +52,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/gin_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/goyave_callees_spec.cr
+++ b/spec/functional_test/testers/go/goyave_callees_spec.cr
@@ -43,4 +43,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/goyave_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/gozero_callees_spec.cr
+++ b/spec/functional_test/testers/go/gozero_callees_spec.cr
@@ -46,4 +46,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/gozero_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/hertz_callees_spec.cr
+++ b/spec/functional_test/testers/go/hertz_callees_spec.cr
@@ -38,4 +38,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/hertz_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/httprouter_callees_spec.cr
+++ b/spec/functional_test/testers/go/httprouter_callees_spec.cr
@@ -47,4 +47,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/httprouter_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/iris_callees_spec.cr
+++ b/spec/functional_test/testers/go/iris_callees_spec.cr
@@ -38,4 +38,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/iris_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/mux_callees_spec.cr
+++ b/spec/functional_test/testers/go/mux_callees_spec.cr
@@ -37,4 +37,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/go/mux_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -41,7 +41,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -56,7 +56,7 @@ module Analyzer::Go
       # isolated route walk and would need separate wiring. Tracking
       # that as a follow-up; for now Mount endpoints keep an empty
       # callees list.
-      package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies(file_contents_cache)
+      package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies_if(callees_needed?, file_contents_cache)
 
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
@@ -96,7 +96,7 @@ module Analyzer::Go
                   route_rows = Set(Int32).new
                   routes_by_line.each_key { |row| route_rows << row }
                   external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, dir)
-                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                   state = ChiRouteState.new
                   last_endpoint = Endpoint.new("", "")

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -46,7 +46,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # `e.Static("/url", "./dir")` — same shape as Gin/Fiber/etc.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -24,7 +24,7 @@ module Analyzer::Go
             # skip
           end
         end
-        package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies(file_contents)
+        package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies_if(callees_needed?, file_contents)
 
         base_paths.each do |current_base_path|
           base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
@@ -53,7 +53,7 @@ module Analyzer::Go
               route_rows = Set(Int32).new
               routes_by_line.each_key { |row| route_rows << row }
               external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
-              callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+              callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
               content.each_line.with_index do |line, index|
                 details = Details.new(PathInfo.new(path, index + 1))

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -42,7 +42,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # `app.Static("/url", "./dir")`.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -44,7 +44,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -48,7 +48,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # Gin uses `r.Static("/url", "./dir")`. Pick these up
                     # in a single tree-sitter pass up front; downstream

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -51,7 +51,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # `router.Static(&fs, "/prefix", false)` — the first
                     # `/`-prefixed string arg is both URL prefix and (with

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -53,7 +53,7 @@ module Analyzer::Go
                       route_rows = Set(Int32).new
                       routes_by_line.each_key { |row| route_rows << row }
                       external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                      callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                      callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
                     end
 
                     lines.each_with_index do |line, index|

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -49,7 +49,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # `h.Static("/url", "./dir")`.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -27,7 +27,7 @@ module Analyzer::Go
           # skip
         end
       end
-      package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies(file_contents)
+      package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies_if(callees_needed?, file_contents)
 
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
@@ -69,7 +69,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -42,7 +42,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -48,7 +48,7 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes(content, path, route_rows, external_fns)
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # Mux static-file: `r.PathPrefix("/x/").Handler(... http.Dir("./x/") ...)`
                     Noir::TreeSitterGoRouteExtractor.extract_mux_statics(content).each do |sp|

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -77,6 +77,7 @@ module Analyzer::Go
     # worry about cross-package leakage.
     def collect_package_function_bodies(file_contents : Hash(String, String)) : Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody))
       result = Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody)).new
+      return result unless callees_needed?
       file_contents.each do |path, content|
         dir = File.dirname(path)
         fns = Noir::GoCalleeExtractor.collect_function_bodies(content, path)

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -78,6 +78,15 @@ module Noir::GoCalleeExtractor
     bodies
   end
 
+  # Like `package_function_bodies`, but returns an empty map immediately
+  # when `enabled` is false. Module-level twin of the
+  # `GoEngine#collect_package_function_bodies` gate for analyzers that
+  # don't inherit from `GoEngine`.
+  def package_function_bodies_if(enabled : Bool, file_contents : Hash(String, String)) : Hash(String, Hash(String, FunctionBody))
+    return Hash(String, Hash(String, FunctionBody)).new unless enabled
+    package_function_bodies(file_contents)
+  end
+
   # Returns the cross-file function-body map for the given directory,
   # or an empty map. Mirrors `GoEngine#ts_function_bodies_for_directory`.
   def function_bodies_for_directory(package_bodies : Hash(String, Hash(String, FunctionBody)), dir : String) : Hash(String, FunctionBody)
@@ -103,6 +112,18 @@ module Noir::GoCalleeExtractor
       end
     end
     bodies
+  end
+
+  # Like `callees_for_routes`, but returns an empty map immediately when
+  # `enabled` is false. Lets analyzers skip the tree-sitter walk on
+  # default scans where callees won't be observed.
+  def callees_for_routes_if(enabled : Bool,
+                            source : String,
+                            file_path : String,
+                            route_rows : Set(Int32),
+                            external_functions : Hash(String, FunctionBody))
+    return Hash(Int32, Array(Tuple(String, String, Int32))).new unless enabled
+    callees_for_routes(source, file_path, route_rows, external_functions)
   end
 
   # For each call_expression at a row in `route_rows`, find the handler

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -56,6 +56,14 @@ class Analyzer
     File.read(path, encoding: "utf-8", invalid: :skip)
   end
 
+  # Callees feed `--include-callee` (direct output) and `--ai-context`
+  # (aggregated review context). Analyzers should consult this before
+  # running their callee extractor so the work is skipped on default
+  # scans where neither flag is set.
+  def callees_needed? : Bool
+    any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+  end
+
   def parallel_analyze(channel : Channel(String), &block : String -> Nil)
     WaitGroup.wait do |wg|
       worker_count = @options["concurrency"].to_s.to_i


### PR DESCRIPTION
## Summary
Every Go analyzer (Beego/Chi/Echo/Fasthttp/Fiber/GF/Gin/Goyave/Gozero/Hertz/Httprouter/Iris/Mux) ran two unconditional callee passes:

- a pre-pass that tree-sitter-parses every \`.go\` file in each package directory to build a name→function-body map (\`collect_package_function_bodies\` / \`package_function_bodies\`)
- a per-file pass (\`Noir::GoCalleeExtractor.callees_for_routes\`) that walks handler bodies and resolves identifiers against the pre-pass map

Neither output is observed unless \`--include-callee\` or \`--ai-context\` is set. This PR wires a \`callees_needed?\` helper into the base \`Analyzer\` and adds \`package_function_bodies_if\` / \`callees_for_routes_if\` thin wrappers in \`GoCalleeExtractor\` so both the \`GoEngine\` subclasses (10 analyzers) and the few that inherit \`Analyzer\` directly (Chi/Fasthttp/Httprouter) flow through the same gate.

## Benchmark
photoprism (Gin-based, 2315 .go files, 594 endpoints; 3 runs each):

| Configuration                  |   Time   | Relative |
| ------------------------------ | -------: | -------: |
| main HEAD                      | 12.19 s  | 1.00 |
| perf branch (default)          | 10.46 s  | **1.17× faster** |
| perf branch --include-callee   | 12.14 s  | parity with main (callees on) |

Endpoint set unchanged (594 URLs/methods/params identical before/after).

## Notes
- \`callees_needed?\` is added to base \`Analyzer\` so future framework gates (Elixir/Clojure/etc.) can reuse it. The Python PR (#1510) declared a private duplicate on \`PythonEngine\`; that local copy will be folded into the base helper as a small follow-up once both PRs land.
- Part of the post-v0.30.0 callee-extraction series: #1509 (Rails), #1510 (Python).

## Test plan
- [x] \`just test-unit\` (1624 examples, 0 failures)
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] photoprism scan: 594 endpoints, identical URL/method/params set before/after