### PR TITLE
feat(elixir): include callees when --ai-context is set

### DIFF
--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -66,7 +66,7 @@ module Analyzer::Elixir
 
     def extract_params_from_controller(content : String, controller_name : String, controller_path : String)
       lines = content.lines
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       # Find all function definitions and extract parameters
       lines.each_with_index do |line, index|

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -18,7 +18,7 @@ module Analyzer::Elixir
 
     def analyze_content(content : String, file_path : String) : Array(Endpoint)
       endpoints = Array(Endpoint).new
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       # Find all route blocks and extract params
       lines = content.lines


### PR DESCRIPTION
## Summary
Phoenix and Plug analyzers gated callee attachment on \`--include-callee\` alone, so \`--ai-context\` users got aggregated review context without any Elixir callees attached. The \`--ai-context\` help text promises "guards, callees, sinks, validators, signals" — extending the gate restores that contract.

## Notes
- Default-flag cost is unchanged (callees still skipped when neither flag is set).
- Part of the post-v0.30.0 callee-extraction series: #1509 (Rails), #1510 (Python), #1511 (Go).

## Test plan
- [x] \`crystal spec spec/functional_test/testers/elixir/\` (323 examples, 0 failures)