### PR TITLE
feat(clojure): include callees when --ai-context is set

### DIFF
--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -17,7 +17,7 @@ module Analyzer::Clojure
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       all_files.each do |path|
         next unless clojure_file?(path)
 


### PR DESCRIPTION
## Summary
Compojure gated callee extraction on \`--include-callee\` alone. \`--ai-context\` users got aggregated review context without any Clojure callees attached — extend the gate so callees flow through under either flag.

Default-flag cost is unchanged. Part of the post-v0.30.0 series: #1509 (Rails), #1510 (Python), #1511 (Go), #1512 (Elixir).

## Test plan
- [x] \`crystal spec spec/functional_test/testers/clojure/\` (68 examples, 0 failures)