### PR TITLE
feat(crystal): include callees when --ai-context is set

### DIFF
--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -21,7 +21,7 @@ module Analyzer::Crystal
         end
       end
 
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
       last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -12,7 +12,7 @@ module Analyzer::Crystal
         end
       end
 
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
       last_endpoint = Endpoint.new("", "")
       current_scopes = [] of String

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -19,7 +19,7 @@ module Analyzer::Crystal
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path)
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       # Pre-scan: build mount_map (variable_name => mount_path)
       mount_map = {} of String => String

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -17,7 +17,7 @@ module Analyzer::Crystal
         end
       end
 
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       last_endpoint = Endpoint.new("", "")
 
       lines.each_with_index do |line, index|

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -56,7 +56,7 @@ module Analyzer::Crystal
     end
 
     private def include_callee? : Bool
-      any_to_bool(@options["include_callee"]?)
+      any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
     end
 
     private def read_source_lines(path : String) : Array(String)


### PR DESCRIPTION
## Summary
Amber, Grip, Kemal, Lucky, and Marten gated Crystal callee extraction on \`--include-callee\` alone. \`--ai-context\` users got aggregated review context without any Crystal callees attached — extend each analyzer's gate so callees flow through under either flag.

Default-flag cost is unchanged. Part of the post-v0.30.0 series: #1509 (Rails), #1510 (Python), #1511 (Go), #1512 (Elixir), #1513 (Clojure).

## Test plan
- [x] \`crystal spec spec/functional_test/testers/crystal/\` (340 examples, 0 failures)