### PR TITLE
feat(ruby): include callees when --ai-context is set

### DIFF
--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -5,7 +5,7 @@ module Analyzer::Ruby
     GRAPE_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -3,7 +3,7 @@ require "../../engines/ruby_engine"
 module Analyzer::Ruby
   class Hanami < RubyEngine
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       framework_roots = discover_framework_roots("config/routes.rb")
       framework_roots = [@base_path] if framework_roots.empty?
 

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -7,7 +7,7 @@ module Analyzer::Ruby
     alias PrefixEntry = NamedTuple(depth: Int32, segments: Array(String), path_params: Array(String))
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -3,7 +3,7 @@ require "../../engines/ruby_engine"
 module Analyzer::Ruby
   class Sinatra < RubyEngine
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?)
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")


### PR DESCRIPTION
## Summary
Sinatra, Hanami, Roda, and Grape gated Ruby callee attachment on \`--include-callee\` alone. \`--ai-context\` users got aggregated review context without any Ruby callees attached — extend each gate so callees flow through under either flag.

Default-flag cost is unchanged. Rails was already widened in #1509.

Part of the post-v0.30.0 series: #1509 (Rails), #1510 (Python), #1511 (Go), #1512 (Elixir), #1513 (Clojure), #1514 (Crystal).

## Test plan
- [x] \`crystal spec spec/functional_test/testers/ruby/\` (565 examples, 0 failures)