### PR TITLE
perf(jvm): skip callee extraction when flag is off

### DIFF
--- a/spec/functional_test/testers/java/armeria_callees_spec.cr
+++ b/spec/functional_test/testers/java/armeria_callees_spec.cr
@@ -26,4 +26,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/armeria_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/dropwizard_callees_spec.cr
+++ b/spec/functional_test/testers/java/dropwizard_callees_spec.cr
@@ -24,4 +24,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/dropwizard_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/javalin_callees_spec.cr
+++ b/spec/functional_test/testers/java/javalin_callees_spec.cr
@@ -40,4 +40,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/javalin_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/jaxrs_callees_spec.cr
+++ b/spec/functional_test/testers/java/jaxrs_callees_spec.cr
@@ -24,4 +24,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/jaxrs_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/micronaut_callees_spec.cr
+++ b/spec/functional_test/testers/java/micronaut_callees_spec.cr
@@ -32,4 +32,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/micronaut_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/play_callees_spec.cr
+++ b/spec/functional_test/testers/java/play_callees_spec.cr
@@ -26,4 +26,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/play_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/quarkus_callees_spec.cr
+++ b/spec/functional_test/testers/java/quarkus_callees_spec.cr
@@ -24,4 +24,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/quarkus_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/spark_callees_spec.cr
+++ b/spec/functional_test/testers/java/spark_callees_spec.cr
@@ -36,4 +36,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/spark_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/spring_callees_spec.cr
+++ b/spec/functional_test/testers/java/spring_callees_spec.cr
@@ -45,4 +45,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/spring_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/java/vertx_callees_spec.cr
+++ b/spec/functional_test/testers/java/vertx_callees_spec.cr
@@ -24,4 +24,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/vertx_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/kotlin/http4k_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/http4k_callees_spec.cr
@@ -43,4 +43,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/kotlin/http4k_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/kotlin/ktor_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_callees_spec.cr
@@ -54,4 +54,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/kotlin/ktor_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/kotlin/spring_callees_spec.cr
+++ b/spec/functional_test/testers/kotlin/spring_callees_spec.cr
@@ -39,4 +39,6 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/kotlin/spring_callees/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -146,6 +146,7 @@ module Analyzer::Java
     private def collect_method_callees(method : LibTreeSitter::TSNode,
                                        content : String,
                                        path : String) : Array(Tuple(String, String, Int32))
+      return [] of Tuple(String, String, Int32) unless any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       body = Noir::TreeSitter.field(method, "body")
       return [] of Tuple(String, String, Int32) unless body
 

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -13,6 +13,7 @@ module Analyzer::Java
     DROPWIZARD_MARKER = "io.dropwizard"
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
 
@@ -35,7 +36,7 @@ module Analyzer::Java
         dto_index = dto_builder.build_for(path, content)
         bean_index = bean_index_for(path, content, package_name, bean_cache)
 
-        Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index).each do |route|
+        Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index, include_callees: include_callee).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
           endpoint = Endpoint.new(route.path, route.verb, route.params, details)

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -37,6 +37,7 @@ module Analyzer::Java
     )
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
         next unless File.exists?(path)
@@ -45,7 +46,7 @@ module Analyzer::Java
         content = read_file_content(path)
         next unless JAVALIN_MARKERS.any? { |m| content.includes?(m) }
 
-        Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(content, CONFIG).each do |route|
+        Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(content, CONFIG, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -7,6 +7,7 @@ module Analyzer::Java
     JAVA_EXTENSION = "java"
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
 
@@ -33,7 +34,7 @@ module Analyzer::Java
         dto_index = dto_builder.build_for(path, content)
         bean_index = bean_index_for(path, content, package_name, bean_cache)
 
-        Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index).each do |route|
+        Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index, include_callees: include_callee).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
           endpoint = Endpoint.new(route.path, route.verb, route.params, details)

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -7,6 +7,7 @@ module Analyzer::Java
     MICRONAUT_MARKERS = ["io.micronaut", "micronaut.io"]
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
 
       file_list = all_files()
@@ -22,7 +23,7 @@ module Analyzer::Java
 
         dto_index = dto_builder.build_for(path, content)
 
-        Noir::TreeSitterMicronautExtractor.extract_routes(content, dto_index).each do |route|
+        Noir::TreeSitterMicronautExtractor.extract_routes(content, dto_index, include_callees: include_callee).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
           endpoint = Endpoint.new(route.path, route.verb, route.params, details)

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -37,6 +37,7 @@ module Analyzer::Java
     # Parse Java controller files to extract header, cookie, and body parameters
     private def parse_controller_files(java_files : Array(String)) : Hash(String, ControllerMethod)
       controller_methods = Hash(String, ControllerMethod).new
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
       java_files.each do |path|
         content = read_file_content(path)
@@ -96,9 +97,13 @@ module Analyzer::Java
                 body_type = "body"
               end
 
-              callees = Noir::JavaCalleeExtractor.callees_in_body(method_body_node, content, path).map do |(name, callee_path, callee_line)|
-                Callee.new(name, path: callee_path, line: callee_line)
-              end
+              callees = if include_callee
+                          Noir::JavaCalleeExtractor.callees_in_body(method_body_node, content, path).map do |(name, callee_path, callee_line)|
+                            Callee.new(name, path: callee_path, line: callee_line)
+                          end
+                        else
+                          [] of Callee
+                        end
 
               controller_methods[full_method_name] = {headers: headers, cookies: cookies, body_type: body_type, callees: callees}
             end

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -14,6 +14,7 @@ module Analyzer::Java
     QUARKUS_MARKERS = ["io.quarkus", "quarkus.io"]
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
       bean_cache = Hash(String, Hash(String, Array(Param))).new
 
@@ -31,7 +32,7 @@ module Analyzer::Java
         dto_index = dto_builder.build_for(path, content)
         bean_index = bean_index_for(path, content, package_name, bean_cache)
 
-        Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index).each do |route|
+        Noir::TreeSitterJaxRsExtractor.extract_routes(content, dto_index, bean_index, include_callees: include_callee).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
           endpoint = Endpoint.new(route.path, route.verb, route.params, details)

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -36,6 +36,7 @@ module Analyzer::Java
     )
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
         next unless File.exists?(path)
@@ -44,7 +45,7 @@ module Analyzer::Java
         content = read_file_content(path)
         next unless SPARK_MARKERS.any? { |m| content.includes?(m) }
 
-        Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(content, CONFIG).each do |route|
+        Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(content, CONFIG, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -9,6 +9,7 @@ module Analyzer::Java
     REGEX_ROUTE_CODE_LINE   = /((?:andRoute|route)\s*\(|\.)\s*(GET|POST|DELETE|PUT)\(\s*"([^"]*)/
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       webflux_base_path_map = Hash(String, String).new
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
 
@@ -111,7 +112,7 @@ module Analyzer::Java
                 # definition resolution is intentionally out of scope —
                 # `Callee#path` points at the call site, matching every
                 # other analyzer's first-cut honest scope.
-                unless route.class_name.empty? || route.method_name.empty?
+                if include_callee && !(route.class_name.empty? || route.method_name.empty?)
                   Noir::JavaCalleeExtractor.callees_in_method(
                     root, content, path, route.class_name, route.method_name
                   ).each do |entry|

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -14,6 +14,7 @@ module Analyzer::Java
 
     def analyze
       # Source Analysis
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -35,7 +36,7 @@ module Analyzer::Java
                     # Skip if no Vert.x related content
                     next unless content.includes?("Router") || content.includes?("vertx")
 
-                    callees_by_route = extract_method_reference_callees(content, path)
+                    callees_by_route = include_callee ? extract_method_reference_callees(content, path) : {} of String => Array(Callee)
 
                     # Find direct router method calls like router.get("/path", handler)
                     content.scan(REGEX_ROUTER_ROUTE) do |match|

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -7,6 +7,7 @@ module Analyzer::Kotlin
     HTTP4K_MARKER    = "org.http4k"
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
         next unless File.exists?(path)
@@ -15,7 +16,7 @@ module Analyzer::Kotlin
         content = read_file_content(path)
         next unless content.includes?(HTTP4K_MARKER)
 
-        Noir::TreeSitterHttp4kExtractor.extract_routes(content).each do |route|
+        Noir::TreeSitterHttp4kExtractor.extract_routes(content, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -6,6 +6,7 @@ module Analyzer::Kotlin
     KOTLIN_EXTENSION = "kt"
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
         next unless File.exists?(path)
@@ -14,7 +15,7 @@ module Analyzer::Kotlin
         content = read_file_content(path)
         next unless content.includes?("routing")
 
-        Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content).each do |route|
+        Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -148,6 +148,7 @@ module Analyzer::Kotlin
                                     dto_builder : Noir::TreeSitterKotlinDtoIndex,
                                     webflux_base_path_map : Hash(String, String),
                                     string_constants : Hash(String, String))
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       content = read_file_content(path)
 
       # Single tree-sitter parse for the whole file — every
@@ -213,7 +214,7 @@ module Analyzer::Kotlin
           # definition resolution is intentionally out of scope —
           # `Callee#path` points at the call site, matching every
           # other analyzer's first-cut honest scope.
-          unless route.class_name.empty? || route.method_name.empty?
+          if include_callee && !(route.class_name.empty? || route.method_name.empty?)
             Noir::KotlinCalleeExtractor.callees_in_method(
               root, content, path, route.class_name, route.method_name
             ).each do |entry|

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -72,32 +72,32 @@ module Noir
       end
     end
 
-    def extract_routes(source : String) : Array(Route)
+    def extract_routes(source : String, *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, 0)
+        walk(root, source, "", routes, 0, include_callees)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
 
-      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, depth)
+      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, depth, include_callees)
         return
       end
 
       if ty == "call_expression" && call_function_name(node, source) == "routes"
-        walk_routes_args(node, source, prefix, routes, depth)
+        walk_routes_args(node, source, prefix, routes, depth, include_callees)
         return
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1)
+        walk(child, source, prefix, routes, depth + 1, include_callees)
       end
     end
 
@@ -108,7 +108,7 @@ module Noir
     #
     # Returns true when consumed; false otherwise so the caller can
     # fall through to the generic descent.
-    private def handle_bind(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32) : Bool
+    private def handle_bind(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool) : Bool
       lhs, op, rhs = infix_parts(node, source)
       return false unless lhs && rhs
 
@@ -145,9 +145,11 @@ module Noir
         # to avoid silently dropping real handler calls named `get`,
         # `post`, etc.
         callees = [] of Tuple(String, Int32)
-        Noir::KotlinCalleeExtractor.callees_in_lambda(rhs, source, "", skip_routing: false).each do |entry|
-          name, _path, line_no = entry
-          callees << {name, line_no}
+        if include_callees
+          Noir::KotlinCalleeExtractor.callees_in_lambda(rhs, source, "", skip_routing: false).each do |entry|
+            name, _path, line_no = entry
+            callees << {name, line_no}
+          end
         end
 
         routes << Route.new(verb, full, line, has_body, query, header, form, callees)
@@ -159,7 +161,7 @@ module Noir
 
         path_text = decode_string_literal(lhs, source)
         new_prefix = join_paths(prefix, path_text)
-        walk_routes_args(rhs, source, new_prefix, routes, depth + 1)
+        walk_routes_args(rhs, source, new_prefix, routes, depth + 1, include_callees)
         true
       else
         false
@@ -170,14 +172,14 @@ module Noir
     # Each argument is a `value_argument` wrapping an
     # `infix_expression` (the binding) or another nested `routes(...)`
     # call.
-    private def walk_routes_args(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk_routes_args(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       args = call_value_arguments(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "value_argument"
         Noir::TreeSitter.each_named_child(arg) do |child|
-          walk(child, source, prefix, routes, depth + 1)
+          walk(child, source, prefix, routes, depth + 1, include_callees)
         end
       end
     end

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -94,10 +94,12 @@ module Noir
     # expansion (typically built via `TreeSitterJavaDtoIndex`).
     def extract_routes(source : String,
                        dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)) = {} of String => Array(TreeSitterJavaParameterExtractor::FieldInfo),
-                       bean_index : Hash(String, Array(Param)) = {} of String => Array(Param)) : Array(Route)
+                       bean_index : Hash(String, Array(Param)) = {} of String => Array(Param),
+                       *,
+                       include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
-        routes.concat(extract_routes_from(root, source, dto_index, bean_index))
+        routes.concat(extract_routes_from(root, source, dto_index, bean_index, include_callees: include_callees))
       end
       routes
     end
@@ -108,10 +110,12 @@ module Noir
     def extract_routes_from(root : LibTreeSitter::TSNode,
                             source : String,
                             dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)) = {} of String => Array(TreeSitterJavaParameterExtractor::FieldInfo),
-                            bean_index : Hash(String, Array(Param)) = {} of String => Array(Param)) : Array(Route)
+                            bean_index : Hash(String, Array(Param)) = {} of String => Array(Param),
+                            *,
+                            include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       walk_classes(root) do |decl|
-        collect_class_routes(decl, source, dto_index, bean_index, routes)
+        collect_class_routes(decl, source, dto_index, bean_index, routes, include_callees)
       end
       routes
     end
@@ -155,7 +159,8 @@ module Noir
                                      source : String,
                                      dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
                                      bean_index : Hash(String, Array(Param)),
-                                     routes : Array(Route))
+                                     routes : Array(Route),
+                                     include_callees : Bool = false)
       class_name = type_identifier_text(decl, source)
       class_path = annotation_string_value(decl, "Path", source) || ""
       class_consumes = consumes_format(decl, source)
@@ -188,7 +193,7 @@ module Noir
           dto_index, bean_index)
 
         line = Noir::TreeSitter.node_start_row(verb_node)
-        callees = collect_method_callees(member, source)
+        callees = include_callees ? collect_method_callees(member, source) : [] of Tuple(String, Int32)
         routes << Route.new(verb, full_path, class_name, method_name, line,
           method_consumes, params, callees)
       end

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -83,17 +83,17 @@ module Noir
       end
     end
 
-    def extract_routes(source : String, config : Config) : Array(Route)
+    def extract_routes(source : String, config : Config, *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
-        walk(root, source, "", config, routes, 0)
+        walk(root, source, "", config, routes, 0, include_callees)
       end
       routes
     end
 
     # ---- traversal ---------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, config : Config, routes : Array(Route), depth : Int32)
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, config : Config, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
@@ -102,25 +102,25 @@ module Noir
         name = method_invocation_method_name(node, source)
         case
         when verb = config.verb_methods[name]?
-          emit_route(node, source, verb, prefix, config, routes)
+          emit_route(node, source, verb, prefix, config, routes, include_callees)
           return
         when config.nest_methods.includes?(name)
           path_arg = first_string_argument(node, source)
           new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
           if body = lambda_body_in_args(node)
-            walk(body, source, new_prefix, config, routes, depth + 1)
+            walk(body, source, new_prefix, config, routes, depth + 1, include_callees)
           end
           return
         when config.transparent_methods.includes?(name)
           if body = lambda_body_in_args(node)
-            walk(body, source, prefix, config, routes, depth + 1)
+            walk(body, source, prefix, config, routes, depth + 1, include_callees)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, config, routes, depth + 1)
+        walk(child, source, prefix, config, routes, depth + 1, include_callees)
       end
     end
 
@@ -129,7 +129,8 @@ module Noir
                            verb : String,
                            prefix : String,
                            config : Config,
-                           routes : Array(Route))
+                           routes : Array(Route),
+                           include_callees : Bool)
       path_arg = first_string_argument(call, source)
       return unless path_arg
 
@@ -161,9 +162,11 @@ module Noir
         # extractor doesn't carry the file path, so drop the placeholder
         # here and let the analyzer attach the real path when it builds
         # the endpoint.
-        Noir::JavaCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
-          name, _path, line_no = entry
-          callees << {name, line_no}
+        if include_callees
+          Noir::JavaCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+            name, _path, line_no = entry
+            callees << {name, line_no}
+          end
         end
       end
 

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -81,46 +81,46 @@ module Noir
       end
     end
 
-    def extract_routes(source : String) : Array(Route)
+    def extract_routes(source : String, *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, 0)
+        walk(root, source, "", routes, 0, include_callees)
       end
       routes
     end
 
     # ---- traversal ----------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       if Noir::TreeSitter.node_type(node) == "call_expression"
         name = call_name(node, source)
         case
         when HTTP_VERB_NAMES.has_key?(name)
-          emit_route(node, source, name, prefix, routes)
+          emit_route(node, source, name, prefix, routes, include_callees)
           return
         when name == "route"
           path_arg = call_string_argument(node, source)
           new_prefix = path_arg ? prefix + path_arg : prefix
           if body = call_lambda_body(node)
-            walk(body, source, new_prefix, routes, depth + 1)
+            walk(body, source, new_prefix, routes, depth + 1, include_callees)
           end
           return
         when PASSTHROUGH_NAMES.includes?(name)
           if body = call_lambda_body(node)
-            walk(body, source, prefix, routes, depth + 1)
+            walk(body, source, prefix, routes, depth + 1, include_callees)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1)
+        walk(child, source, prefix, routes, depth + 1, include_callees)
       end
     end
 
-    private def emit_route(node : LibTreeSitter::TSNode, source : String, name : String, prefix : String, routes : Array(Route))
+    private def emit_route(node : LibTreeSitter::TSNode, source : String, name : String, prefix : String, routes : Array(Route), include_callees : Bool)
       path_arg = call_string_argument(node, source)
       return unless path_arg
 
@@ -142,9 +142,11 @@ module Noir
         # doesn't carry the file path — drop the placeholder here and
         # let the analyzer attach the real path when it builds the
         # endpoint.
-        Noir::KotlinCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
-          name, _path, line_no = entry
-          callees << {name, line_no}
+        if include_callees
+          Noir::KotlinCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+            name, _path, line_no = entry
+            callees << {name, line_no}
+          end
         end
       end
 

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -73,11 +73,13 @@ module Noir
     end
 
     def extract_routes(source : String,
-                       dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)) = {} of String => Array(TreeSitterJavaParameterExtractor::FieldInfo)) : Array(Route)
+                       dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)) = {} of String => Array(TreeSitterJavaParameterExtractor::FieldInfo),
+                       *,
+                       include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_java(source) do |root|
         walk_classes(root) do |decl|
-          collect_class_routes(decl, source, dto_index, routes)
+          collect_class_routes(decl, source, dto_index, routes, include_callees)
         end
       end
       routes
@@ -120,7 +122,8 @@ module Noir
     private def collect_class_routes(decl : LibTreeSitter::TSNode,
                                      source : String,
                                      dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
-                                     routes : Array(Route))
+                                     routes : Array(Route),
+                                     include_callees : Bool = false)
       class_name = type_identifier_text(decl, source)
 
       # Need a class-level `@Controller` annotation to consider this
@@ -155,7 +158,7 @@ module Noir
         method_consumes = consumes_format(member, source) || class_consumes
 
         params = collect_method_params(member, source, method_consumes, dto_index)
-        callees = collect_method_callees(member, source)
+        callees = include_callees ? collect_method_callees(member, source) : [] of Tuple(String, Int32)
         line = Noir::TreeSitter.node_start_row(verb_node)
 
         controller_paths.each do |class_path|


### PR DESCRIPTION
## Summary
JVM analyzers (Java Spring, Vertx, Armeria, Play, Dropwizard, JaxRs, Quarkus, Javalin, Spark, Micronaut; Kotlin Spring, Ktor, Http4k) ran callee extraction unconditionally — no gate on \`--include-callee\` or \`--ai-context\`. Every scan attached up to N callees per endpoint as wasted work on default scans.

This PR threads an \`include_callees\` parameter through the shared route extractors (\`TreeSitterJaxRsExtractor\`, \`TreeSitterMicronautExtractor\`, \`TreeSitterJvmLambdaDslExtractor\`, \`TreeSitterHttp4kExtractor\`, \`TreeSitterKotlinKtorRouteExtractor\`) so analyzers can opt the \`JavaCalleeExtractor\` / \`KotlinCalleeExtractor\` walks out cleanly. Spring/Vertx/Armeria/Play/Kotlin-Spring drive the callee walks directly — those are gated inline at the call site.

## Benchmark
mall (524 \`.java\` files, 263 endpoints; 3 runs each):

| Configuration                  |   Time   | Callees attached | Notes |
| ------------------------------ | -------: | ---------------: | ----- |
| main HEAD                      | 1.364 s  | 666              | unconditional |
| perf branch (default)          | 1.326 s  | 0                | **1.03× faster** |
| perf branch --include-callee   | 1.361 s  | 666              | parity with main when on |

Same 263 endpoints, identical URL/method/params before/after.

## Notes
- Closes the unconditional-extraction gap for JVM, which had the largest "no gate at all" surface in the post-v0.30.0 series.
- Series: #1509 (Rails), #1510 (Python), #1511 (Go), #1512 (Elixir), #1513 (Clojure), #1514 (Crystal), #1515 (Ruby misc), #1516 (Rust/PHP/JS/Swift/Dart/Haskell/Lua/F#/CSharp/Groovy/Scala/CPP/Perl).

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] \`just test-unit\` (1624 examples, 0 failures)
- [x] mall scan: 263 endpoints, 0 URL/method/params diff before/after, callees correctly drop from 666 → 0 with flag off