### PR TITLE
perf(js): pre-filter files without route calls before lex+parse

### DIFF
--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -54,6 +54,15 @@ module Analyzer::Javascript
     )
       content = CodeLocator.instance.content_for(main_file) || File.read(main_file, encoding: "utf-8", invalid: :skip)
 
+      # Cheap pre-filter: every code path in this scanner is downstream
+      # of a `.use(...)` call (literal mount, no-prefix mount, or the
+      # `defaultRoutes.forEach(... router.use(...))` config-array form,
+      # which also contains `.use(`). Substring-checking once skips the
+      # imports parse + three full-content regex scans on the vast
+      # majority of files in a large codebase (tests, helpers, UI
+      # components, fixtures), which contain no router mounts at all.
+      return unless content.includes?(".use(") || content.includes?(".use (")
+
       # Parse imports
       imports = parse_imports(content, main_file)
       require_map = imports[:require_map]

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -23,6 +23,15 @@ module Noir
 
       begin
         content = content || File.read(file_path, encoding: "utf-8", invalid: :skip)
+
+        # Cheap pre-filter: every shape the JSParser knows about ends
+        # in a verb call (`x.get(`, `.post(`, ...), a Fastify/Restify
+        # `.route(` registration, or an Express-style mount (`.use(`).
+        # Skip the lex+parse pass entirely for files that contain none
+        # of these — UI components, fixtures, helpers, third-party JS
+        # bundles — so a large frontend tree doesn't pay parser cost
+        # for files that can't host an endpoint.
+        return [] of Endpoint unless route_call_candidate?(content)
         parser = JSParser.new(content)
         route_patterns = parser.parse_routes
         callees_by_route = if include_callees
@@ -234,6 +243,25 @@ module Noir
         # If parser fails, return empty array
         [] of Endpoint
       end
+    end
+
+    # Pre-filter for `extract_routes`: returns false when `content`
+    # contains no shape the JS parser knows how to emit (any verb
+    # invocation pattern like `.get(`/`.post(`/... or Fastify/Restify
+    # `.route(`, plus Express-style mounts `.use(` which feed into the
+    # cross-file router prefix table). Substring-checking is millions
+    # of times cheaper than tokenizing the file.
+    PARSER_ROUTE_CALL_HINTS = [
+      ".get(", ".post(", ".put(", ".delete(", ".patch(",
+      ".options(", ".head(", ".all(",
+      ".route(", ".register(", ".use(",
+      ".get (", ".post (", ".put (", ".delete (", ".patch (",
+      ".options (", ".head (", ".all (",
+      ".route (", ".register (", ".use (",
+    ]
+
+    def self.route_call_candidate?(content : String) : Bool
+      PARSER_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) }
     end
 
     def self.attach_callees(endpoint : Endpoint,


### PR DESCRIPTION
## Summary
Express scans on a large frontend codebase (Discourse: ~2.8k \`.js\`/\`.ts\` files, 18MB) were dominated by tokenizing every JS/TS file in the tree — including UI components, fixtures, helpers, and bundled third-party assets that can never host an endpoint.

Two cheap substring pre-filters that skip the lex+parse round-trip on files that cannot host the patterns each scanner emits:

- \`JSRouteExtractor.extract_routes\`: returns early when the file has none of \`.get(\`/\`.post(\`/\`.put(\`/\`.delete(\`/\`.patch(\`/\`.options(\`/\`.head(\`/\`.all(\`/\`.route(\`/\`.register(\`/\`.use(\` (with optional whitespace before the paren). Avoids \`JSParser.new\` and the four function-pattern regex scans on files that the parser can't emit a route from.
- \`RouterMountScanner.process_file_for_mounts\`: every code path in the scanner is downstream of a \`.use(\` call, so files without \`.use(\` get nothing to do — skip the imports parse and the three full-content regex scans.

The fast path is one \`String#includes?\` per hint until one matches or the list runs out — millions of times cheaper than tokenizing.

## Benchmark
Discourse (2.8k \`.js\`/\`.ts\` files, 532 endpoints; \`hyperfine --warmup 1 --runs 3\`):

| Configuration | Time | Relative |
| --- | ---: | ---: |
| main HEAD     | 320.7 s ± 9.5 | 1.00 |
| perf branch   | 137.3 s ± 4.8 | **2.34× faster** |

Same 532 endpoints, identical URL/method set before/after.

## Notes
- This is a meaningful chunk of the post-v0.30.0 regression: v0.30.0 scanned Discourse in ~50s; the current PR halves the 320s wall back toward that baseline. Remaining cost is in the parser/extractor itself for files that do contain route calls — a separate investigation.
- Independent of the callee-extraction gate series (#1509-#1517), which addressed a different cost source.

## Test plan
- [x] \`crystal spec spec/functional_test/testers/javascript/\` (1793 examples, 0 failures)
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] Discourse scan: identical 532 URL/method set before/after