### PR TITLE
perf(detector): skip detect() on files outside detector's language

### DIFF
--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -358,6 +358,13 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               # `detect` (`idempotent? == false`) — see
               # `Detector#idempotent?` for the contract.
               next if detector.idempotent? && detected_flags[idx].get
+              # Cheap filename precheck: most detectors gate on a
+              # fixed extension or path component. Skipping the
+              # `detect` dispatch (and the regex / `includes?`
+              # work inside it) for non-applicable files cuts the
+              # detector pass on language-heavy trees by an order
+              # of magnitude.
+              next unless detector.applicable?(file)
               if detector.detect(file, content)
                 detected_flags[idx].set
                 newly_added = false

--- a/src/detector/detectors/clojure/compojure.cr
+++ b/src/detector/detectors/clojure/compojure.cr
@@ -20,6 +20,10 @@ module Detector::Clojure
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".clj") || filename.ends_with?(".cljs") || filename.ends_with?(".cljc") || filename.ends_with?(".edn") || File.basename(filename) == "project.clj" || File.basename(filename) == "deps.edn"
+    end
+
     def set_name
       @name = "clojure_compojure"
     end

--- a/src/detector/detectors/cpp/crow.cr
+++ b/src/detector/detectors/cpp/crow.cr
@@ -19,6 +19,10 @@ module Detector::Cpp
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cpp") || filename.ends_with?(".cc") || filename.ends_with?(".cxx") || filename.ends_with?(".c") || filename.ends_with?(".h") || filename.ends_with?(".hpp") || filename.ends_with?(".hxx")
+    end
+
     def set_name
       @name = "cpp_crow"
     end

--- a/src/detector/detectors/cpp/drogon.cr
+++ b/src/detector/detectors/cpp/drogon.cr
@@ -20,6 +20,10 @@ module Detector::Cpp
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cpp") || filename.ends_with?(".cc") || filename.ends_with?(".cxx") || filename.ends_with?(".c") || filename.ends_with?(".h") || filename.ends_with?(".hpp") || filename.ends_with?(".hxx")
+    end
+
     def set_name
       @name = "cpp_drogon"
     end

--- a/src/detector/detectors/crystal/amber.cr
+++ b/src/detector/detectors/crystal/amber.cr
@@ -8,6 +8,10 @@ module Detector::Crystal
       file_contents.includes?("amberframework/amber")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
+    end
+
     def set_name
       @name = "crystal_amber"
     end

--- a/src/detector/detectors/crystal/grip.cr
+++ b/src/detector/detectors/crystal/grip.cr
@@ -8,6 +8,10 @@ module Detector::Crystal
       file_contents.includes?("grip-framework/grip")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
+    end
+
     def set_name
       @name = "crystal_grip"
     end

--- a/src/detector/detectors/crystal/kemal.cr
+++ b/src/detector/detectors/crystal/kemal.cr
@@ -9,6 +9,10 @@ module Detector::Crystal
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
+    end
+
     def set_name
       @name = "crystal_kemal"
     end

--- a/src/detector/detectors/crystal/lucky.cr
+++ b/src/detector/detectors/crystal/lucky.cr
@@ -8,6 +8,10 @@ module Detector::Crystal
       file_contents.includes?("luckyframework/lucky")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
+    end
+
     def set_name
       @name = "crystal_lucky"
     end

--- a/src/detector/detectors/crystal/marten.cr
+++ b/src/detector/detectors/crystal/marten.cr
@@ -8,6 +8,10 @@ module Detector::Crystal
       file_contents.includes?("martenframework/marten")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cr") || File.basename(filename) == "shard.yml" || File.basename(filename) == "shard.lock"
+    end
+
     def set_name
       @name = "crystal_marten"
     end

--- a/src/detector/detectors/csharp/aspnet_core_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_core_mvc.cr
@@ -33,6 +33,10 @@ module Detector::CSharp
       detected
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cs") || filename.ends_with?(".csproj") || filename.ends_with?(".vbproj") || filename.ends_with?(".sln") || filename.ends_with?(".json") || filename.ends_with?(".config")
+    end
+
     def set_name
       @name = "cs_aspnet_core_mvc"
     end

--- a/src/detector/detectors/csharp/aspnet_mvc.cr
+++ b/src/detector/detectors/csharp/aspnet_mvc.cr
@@ -18,6 +18,10 @@ module Detector::CSharp
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".cs") || filename.ends_with?(".csproj") || filename.ends_with?(".vbproj") || filename.ends_with?(".sln") || filename.ends_with?(".json") || filename.ends_with?(".config")
+    end
+
     def set_name
       @name = "cs_aspnet_mvc"
     end

--- a/src/detector/detectors/dart/dart_frog.cr
+++ b/src/detector/detectors/dart/dart_frog.cr
@@ -28,6 +28,10 @@ module Detector::Dart
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
+    end
+
     def set_name
       @name = "dart_frog"
     end

--- a/src/detector/detectors/dart/serverpod.cr
+++ b/src/detector/detectors/dart/serverpod.cr
@@ -20,6 +20,10 @@ module Detector::Dart
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".dart") || File.basename(filename) == "pubspec.yaml" || File.basename(filename) == "pubspec.lock"
+    end
+
     def set_name
       @name = "dart_serverpod"
     end

--- a/src/detector/detectors/elixir/phoenix.cr
+++ b/src/detector/detectors/elixir/phoenix.cr
@@ -8,6 +8,10 @@ module Detector::Elixir
       file_contents.includes?("ElixirPhoenix")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".ex") || filename.ends_with?(".exs") || File.basename(filename) == "mix.exs"
+    end
+
     def set_name
       @name = "elixir_phoenix"
     end

--- a/src/detector/detectors/elixir/plug.cr
+++ b/src/detector/detectors/elixir/plug.cr
@@ -22,6 +22,10 @@ module Detector::Elixir
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".ex") || filename.ends_with?(".exs") || File.basename(filename) == "mix.exs"
+    end
+
     def set_name
       @name = "elixir_plug"
     end

--- a/src/detector/detectors/fsharp/giraffe.cr
+++ b/src/detector/detectors/fsharp/giraffe.cr
@@ -26,6 +26,10 @@ module Detector::Fsharp
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".fs") || filename.ends_with?(".fsx") || filename.ends_with?(".fsproj") || filename.ends_with?(".csproj") || File.basename(filename) == "paket.dependencies"
+    end
+
     def set_name
       @name = "fs_giraffe"
     end

--- a/src/detector/detectors/go/beego.cr
+++ b/src/detector/detectors/go/beego.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_beego"
     end

--- a/src/detector/detectors/go/chi.cr
+++ b/src/detector/detectors/go/chi.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_chi"
     end

--- a/src/detector/detectors/go/echo.cr
+++ b/src/detector/detectors/go/echo.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_echo"
     end

--- a/src/detector/detectors/go/fasthttp.cr
+++ b/src/detector/detectors/go/fasthttp.cr
@@ -12,6 +12,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_fasthttp"
     end

--- a/src/detector/detectors/go/fiber.cr
+++ b/src/detector/detectors/go/fiber.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_fiber"
     end

--- a/src/detector/detectors/go/gf.cr
+++ b/src/detector/detectors/go/gf.cr
@@ -6,6 +6,10 @@ module Detector::Go
       (filename.includes? "go.mod") && (file_contents.includes? "github.com/gogf/gf")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_gf"
     end

--- a/src/detector/detectors/go/gin.cr
+++ b/src/detector/detectors/go/gin.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_gin"
     end

--- a/src/detector/detectors/go/goyave.cr
+++ b/src/detector/detectors/go/goyave.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_goyave"
     end

--- a/src/detector/detectors/go/gozero.cr
+++ b/src/detector/detectors/go/gozero.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_gozero"
     end

--- a/src/detector/detectors/go/hertz.cr
+++ b/src/detector/detectors/go/hertz.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_hertz"
     end

--- a/src/detector/detectors/go/httprouter.cr
+++ b/src/detector/detectors/go/httprouter.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_httprouter"
     end

--- a/src/detector/detectors/go/iris.cr
+++ b/src/detector/detectors/go/iris.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_iris"
     end

--- a/src/detector/detectors/go/mux.cr
+++ b/src/detector/detectors/go/mux.cr
@@ -10,6 +10,10 @@ module Detector::Go
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.includes?("go.mod") || filename.ends_with?(".go")
+    end
+
     def set_name
       @name = "go_mux"
     end

--- a/src/detector/detectors/groovy/grails.cr
+++ b/src/detector/detectors/groovy/grails.cr
@@ -44,6 +44,10 @@ module Detector::Groovy
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".groovy") || filename.ends_with?(".gsp") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".java") || filename.ends_with?(".yml") || filename.ends_with?(".yaml") || filename.ends_with?(".xml") || filename.includes?("/grails-app/")
+    end
+
     def set_name
       @name = "groovy_grails"
     end

--- a/src/detector/detectors/haskell/servant.cr
+++ b/src/detector/detectors/haskell/servant.cr
@@ -19,6 +19,10 @@ module Detector::Haskell
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".hs") || filename.ends_with?(".cabal") || filename.ends_with?(".dhall") || File.basename(filename) == "stack.yaml" || File.basename(filename) == "package.yaml"
+    end
+
     def set_name
       @name = "haskell_servant"
     end

--- a/src/detector/detectors/haskell/yesod.cr
+++ b/src/detector/detectors/haskell/yesod.cr
@@ -22,6 +22,10 @@ module Detector::Haskell
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".hs") || filename.ends_with?(".cabal") || filename.ends_with?(".dhall") || File.basename(filename) == "stack.yaml" || File.basename(filename) == "package.yaml"
+    end
+
     def set_name
       @name = "haskell_yesod"
     end

--- a/src/detector/detectors/java/armeria.cr
+++ b/src/detector/detectors/java/armeria.cr
@@ -13,6 +13,10 @@ module Detector::Java
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_armeria"
     end

--- a/src/detector/detectors/java/dropwizard.cr
+++ b/src/detector/detectors/java/dropwizard.cr
@@ -7,6 +7,10 @@ module Detector::Java
       file_contents.includes?("io.dropwizard")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_dropwizard"
     end

--- a/src/detector/detectors/java/javalin.cr
+++ b/src/detector/detectors/java/javalin.cr
@@ -7,6 +7,10 @@ module Detector::Java
       file_contents.includes?("io.javalin")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_javalin"
     end

--- a/src/detector/detectors/java/jaxrs.cr
+++ b/src/detector/detectors/java/jaxrs.cr
@@ -13,6 +13,10 @@ module Detector::Java
       file_contents.includes?("jakarta.ws.rs") || file_contents.includes?("javax.ws.rs")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_jaxrs"
     end

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -21,6 +21,10 @@ module Detector::Java
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".jsp") || filename.ends_with?(".java") || filename.ends_with?(".xml")
+    end
+
     def set_name
       @name = "java_jsp"
     end

--- a/src/detector/detectors/java/micronaut.cr
+++ b/src/detector/detectors/java/micronaut.cr
@@ -7,6 +7,10 @@ module Detector::Java
       file_contents.includes?("io.micronaut") || file_contents.includes?("micronaut.io")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_micronaut"
     end

--- a/src/detector/detectors/java/play.cr
+++ b/src/detector/detectors/java/play.cr
@@ -24,6 +24,10 @@ module Detector::Java
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_play"
     end

--- a/src/detector/detectors/java/quarkus.cr
+++ b/src/detector/detectors/java/quarkus.cr
@@ -7,6 +7,10 @@ module Detector::Java
       file_contents.includes?("io.quarkus") || file_contents.includes?("quarkus.io")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_quarkus"
     end

--- a/src/detector/detectors/java/spark.cr
+++ b/src/detector/detectors/java/spark.cr
@@ -9,6 +9,10 @@ module Detector::Java
         file_contents.includes?("import static spark.")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_spark"
     end

--- a/src/detector/detectors/java/spring.cr
+++ b/src/detector/detectors/java/spring.cr
@@ -10,6 +10,10 @@ module Detector::Java
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_spring"
     end

--- a/src/detector/detectors/java/vertx.cr
+++ b/src/detector/detectors/java/vertx.cr
@@ -13,6 +13,10 @@ module Detector::Java
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+    end
+
     def set_name
       @name = "java_vertx"
     end

--- a/src/detector/detectors/javascript/adonisjs.cr
+++ b/src/detector/detectors/javascript/adonisjs.cr
@@ -28,6 +28,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_adonisjs"
     end

--- a/src/detector/detectors/javascript/astro.cr
+++ b/src/detector/detectors/javascript/astro.cr
@@ -22,6 +22,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_astro"
     end

--- a/src/detector/detectors/javascript/elysia.cr
+++ b/src/detector/detectors/javascript/elysia.cr
@@ -24,6 +24,10 @@ module Detector::Javascript
         file_contents.includes?("require(\"elysia\")")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_elysia"
     end

--- a/src/detector/detectors/javascript/express.cr
+++ b/src/detector/detectors/javascript/express.cr
@@ -14,6 +14,10 @@ module Detector::Javascript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_express"
     end

--- a/src/detector/detectors/javascript/fastify.cr
+++ b/src/detector/detectors/javascript/fastify.cr
@@ -16,6 +16,10 @@ module Detector::Javascript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_fastify"
     end

--- a/src/detector/detectors/javascript/fresh.cr
+++ b/src/detector/detectors/javascript/fresh.cr
@@ -28,6 +28,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_fresh"
     end

--- a/src/detector/detectors/javascript/hapi.cr
+++ b/src/detector/detectors/javascript/hapi.cr
@@ -14,6 +14,10 @@ module Detector::Javascript
         file_contents.includes?("from \"hapi\"")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_hapi"
     end

--- a/src/detector/detectors/javascript/hono.cr
+++ b/src/detector/detectors/javascript/hono.cr
@@ -9,6 +9,10 @@ module Detector::Javascript
           file_contents.match(/new\s+Hono\s*\(/))
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_hono"
     end

--- a/src/detector/detectors/javascript/koa.cr
+++ b/src/detector/detectors/javascript/koa.cr
@@ -16,6 +16,10 @@ module Detector::Javascript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_koa"
     end

--- a/src/detector/detectors/javascript/nestjs.cr
+++ b/src/detector/detectors/javascript/nestjs.cr
@@ -17,6 +17,10 @@ module Detector::Javascript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_nestjs"
     end

--- a/src/detector/detectors/javascript/nextjs.cr
+++ b/src/detector/detectors/javascript/nextjs.cr
@@ -54,6 +54,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_nextjs"
     end

--- a/src/detector/detectors/javascript/nitro.cr
+++ b/src/detector/detectors/javascript/nitro.cr
@@ -19,6 +19,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_nitro"
     end

--- a/src/detector/detectors/javascript/nuxtjs.cr
+++ b/src/detector/detectors/javascript/nuxtjs.cr
@@ -29,6 +29,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_nuxtjs"
     end

--- a/src/detector/detectors/javascript/remix.cr
+++ b/src/detector/detectors/javascript/remix.cr
@@ -37,6 +37,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_remix"
     end

--- a/src/detector/detectors/javascript/restify.cr
+++ b/src/detector/detectors/javascript/restify.cr
@@ -14,6 +14,10 @@ module Detector::Javascript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_restify"
     end

--- a/src/detector/detectors/javascript/sveltekit.cr
+++ b/src/detector/detectors/javascript/sveltekit.cr
@@ -32,6 +32,10 @@ module Detector::Javascript
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".cjs") || filename.ends_with?(".jsx") || filename.ends_with?(".ts") || filename.ends_with?(".tsx") || File.basename(filename) == "package.json"
+    end
+
     def set_name
       @name = "js_sveltekit"
     end

--- a/src/detector/detectors/kotlin/http4k.cr
+++ b/src/detector/detectors/kotlin/http4k.cr
@@ -7,6 +7,10 @@ module Detector::Kotlin
       file_contents.includes?("org.http4k")
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".kt") || filename.ends_with?(".kts") || filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties")
+    end
+
     def set_name
       @name = "kotlin_http4k"
     end

--- a/src/detector/detectors/kotlin/ktor.cr
+++ b/src/detector/detectors/kotlin/ktor.cr
@@ -10,6 +10,10 @@ module Detector::Kotlin
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".kt") || filename.ends_with?(".kts") || filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties")
+    end
+
     def set_name
       @name = "kotlin_ktor"
     end

--- a/src/detector/detectors/kotlin/spring.cr
+++ b/src/detector/detectors/kotlin/spring.cr
@@ -10,6 +10,10 @@ module Detector::Kotlin
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".kt") || filename.ends_with?(".kts") || filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties")
+    end
+
     def set_name
       @name = "kotlin_spring"
     end

--- a/src/detector/detectors/lua/lapis.cr
+++ b/src/detector/detectors/lua/lapis.cr
@@ -28,6 +28,10 @@ module Detector::Lua
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".lua") || filename.ends_with?(".moon") || filename.ends_with?(".rockspec")
+    end
+
     def set_name
       @name = "lua_lapis"
     end

--- a/src/detector/detectors/perl/mojolicious.cr
+++ b/src/detector/detectors/perl/mojolicious.cr
@@ -25,6 +25,10 @@ module Detector::Perl
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".pl") || filename.ends_with?(".pm") || filename.ends_with?(".t") || File.basename(filename) == "cpanfile" || File.basename(filename) == "Makefile.PL" || File.basename(filename) == "dist.ini" || File.basename(filename) == "META.json" || File.basename(filename) == "META.yml"
+    end
+
     def set_name
       @name = "perl_mojolicious"
     end

--- a/src/detector/detectors/php/cakephp.cr
+++ b/src/detector/detectors/php/cakephp.cr
@@ -23,6 +23,10 @@ module Detector::Php
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_cakephp"
     end

--- a/src/detector/detectors/php/codeigniter.cr
+++ b/src/detector/detectors/php/codeigniter.cr
@@ -48,6 +48,10 @@ module Detector::Php
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_codeigniter"
     end

--- a/src/detector/detectors/php/laravel.cr
+++ b/src/detector/detectors/php/laravel.cr
@@ -44,6 +44,10 @@ module Detector::Php
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_laravel"
     end

--- a/src/detector/detectors/php/php.cr
+++ b/src/detector/detectors/php/php.cr
@@ -11,6 +11,10 @@ module Detector::Php
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_pure"
     end

--- a/src/detector/detectors/php/slim.cr
+++ b/src/detector/detectors/php/slim.cr
@@ -17,6 +17,10 @@ module Detector::Php
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_slim"
     end

--- a/src/detector/detectors/php/symfony.cr
+++ b/src/detector/detectors/php/symfony.cr
@@ -32,6 +32,10 @@ module Detector::Php
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_symfony"
     end

--- a/src/detector/detectors/php/yii.cr
+++ b/src/detector/detectors/php/yii.cr
@@ -37,6 +37,10 @@ module Detector::Php
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".php") || filename.ends_with?(".phtml") || File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
+    end
+
     def set_name
       @name = "php_yii"
     end

--- a/src/detector/detectors/python/aiohttp.cr
+++ b/src/detector/detectors/python/aiohttp.cr
@@ -11,6 +11,10 @@ module Detector::Python
       !!(has_from_import || has_import)
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_aiohttp"
     end

--- a/src/detector/detectors/python/bottle.cr
+++ b/src/detector/detectors/python/bottle.cr
@@ -12,6 +12,10 @@ module Detector::Python
       !!(has_from_import || has_import)
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_bottle"
     end

--- a/src/detector/detectors/python/django.cr
+++ b/src/detector/detectors/python/django.cr
@@ -12,6 +12,10 @@ module Detector::Python
       !!(has_from_import || has_import)
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_django"
     end

--- a/src/detector/detectors/python/falcon.cr
+++ b/src/detector/detectors/python/falcon.cr
@@ -13,6 +13,10 @@ module Detector::Python
       !!(has_from_import || has_import)
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_falcon"
     end

--- a/src/detector/detectors/python/fastapi.cr
+++ b/src/detector/detectors/python/fastapi.cr
@@ -10,6 +10,10 @@ module Detector::Python
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_fastapi"
     end

--- a/src/detector/detectors/python/flask.cr
+++ b/src/detector/detectors/python/flask.cr
@@ -12,6 +12,10 @@ module Detector::Python
       !!(has_from_import || has_import)
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_flask"
     end

--- a/src/detector/detectors/python/litestar.cr
+++ b/src/detector/detectors/python/litestar.cr
@@ -10,6 +10,10 @@ module Detector::Python
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_litestar"
     end

--- a/src/detector/detectors/python/pyramid.cr
+++ b/src/detector/detectors/python/pyramid.cr
@@ -11,6 +11,10 @@ module Detector::Python
       !!(has_from_import || has_import)
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_pyramid"
     end

--- a/src/detector/detectors/python/sanic.cr
+++ b/src/detector/detectors/python/sanic.cr
@@ -10,6 +10,10 @@ module Detector::Python
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_sanic"
     end

--- a/src/detector/detectors/python/starlette.cr
+++ b/src/detector/detectors/python/starlette.cr
@@ -10,6 +10,10 @@ module Detector::Python
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_starlette"
     end

--- a/src/detector/detectors/python/tornado.cr
+++ b/src/detector/detectors/python/tornado.cr
@@ -10,6 +10,10 @@ module Detector::Python
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".py")
+    end
+
     def set_name
       @name = "python_tornado"
     end

--- a/src/detector/detectors/ruby/grape.cr
+++ b/src/detector/detectors/ruby/grape.cr
@@ -17,6 +17,10 @@ module Detector::Ruby
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+    end
+
     def set_name
       @name = "ruby_grape"
     end

--- a/src/detector/detectors/ruby/hanami.cr
+++ b/src/detector/detectors/ruby/hanami.cr
@@ -11,6 +11,10 @@ module Detector::Ruby
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+    end
+
     def set_name
       @name = "ruby_hanami"
     end

--- a/src/detector/detectors/ruby/rails.cr
+++ b/src/detector/detectors/ruby/rails.cr
@@ -11,6 +11,10 @@ module Detector::Ruby
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+    end
+
     def set_name
       @name = "ruby_rails"
     end

--- a/src/detector/detectors/ruby/roda.cr
+++ b/src/detector/detectors/ruby/roda.cr
@@ -17,6 +17,10 @@ module Detector::Ruby
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+    end
+
     def set_name
       @name = "ruby_roda"
     end

--- a/src/detector/detectors/ruby/sinatra.cr
+++ b/src/detector/detectors/ruby/sinatra.cr
@@ -11,6 +11,10 @@ module Detector::Ruby
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+    end
+
     def set_name
       @name = "ruby_sinatra"
     end

--- a/src/detector/detectors/rust/actix_web.cr
+++ b/src/detector/detectors/rust/actix_web.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_actix_web"
     end

--- a/src/detector/detectors/rust/axum.cr
+++ b/src/detector/detectors/rust/axum.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_axum"
     end

--- a/src/detector/detectors/rust/gotham.cr
+++ b/src/detector/detectors/rust/gotham.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_gotham"
     end

--- a/src/detector/detectors/rust/loco.cr
+++ b/src/detector/detectors/rust/loco.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_loco"
     end

--- a/src/detector/detectors/rust/poem.cr
+++ b/src/detector/detectors/rust/poem.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_poem"
     end

--- a/src/detector/detectors/rust/rocket.cr
+++ b/src/detector/detectors/rust/rocket.cr
@@ -10,6 +10,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_rocket"
     end

--- a/src/detector/detectors/rust/rwf.cr
+++ b/src/detector/detectors/rust/rwf.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_rwf"
     end

--- a/src/detector/detectors/rust/salvo.cr
+++ b/src/detector/detectors/rust/salvo.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_salvo"
     end

--- a/src/detector/detectors/rust/tide.cr
+++ b/src/detector/detectors/rust/tide.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_tide"
     end

--- a/src/detector/detectors/rust/warp.cr
+++ b/src/detector/detectors/rust/warp.cr
@@ -11,6 +11,10 @@ module Detector::Rust
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".rs") || File.basename(filename) == "Cargo.toml" || File.basename(filename) == "Cargo.lock"
+    end
+
     def set_name
       @name = "rust_warp"
     end

--- a/src/detector/detectors/scala/akka.cr
+++ b/src/detector/detectors/scala/akka.cr
@@ -10,6 +10,10 @@ module Detector::Scala
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
+    end
+
     def set_name
       @name = "scala_akka"
     end

--- a/src/detector/detectors/scala/play.cr
+++ b/src/detector/detectors/scala/play.cr
@@ -25,6 +25,10 @@ module Detector::Scala
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
+    end
+
     def set_name
       @name = "scala_play"
     end

--- a/src/detector/detectors/scala/scalatra.cr
+++ b/src/detector/detectors/scala/scalatra.cr
@@ -10,6 +10,10 @@ module Detector::Scala
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".scala") || filename.ends_with?(".sbt") || File.basename(filename) == "build.sbt"
+    end
+
     def set_name
       @name = "scala_scalatra"
     end

--- a/src/detector/detectors/swift/hummingbird.cr
+++ b/src/detector/detectors/swift/hummingbird.cr
@@ -16,6 +16,10 @@ module Detector::Swift
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".swift") || File.basename(filename) == "Package.swift"
+    end
+
     def set_name
       @name = "swift_hummingbird"
     end

--- a/src/detector/detectors/swift/kitura.cr
+++ b/src/detector/detectors/swift/kitura.cr
@@ -16,6 +16,10 @@ module Detector::Swift
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".swift") || File.basename(filename) == "Package.swift"
+    end
+
     def set_name
       @name = "swift_kitura"
     end

--- a/src/detector/detectors/swift/vapor.cr
+++ b/src/detector/detectors/swift/vapor.cr
@@ -16,6 +16,10 @@ module Detector::Swift
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".swift") || File.basename(filename) == "Package.swift"
+    end
+
     def set_name
       @name = "swift_vapor"
     end

--- a/src/detector/detectors/typescript/nestjs.cr
+++ b/src/detector/detectors/typescript/nestjs.cr
@@ -17,6 +17,10 @@ module Detector::Typescript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".ts") || filename.ends_with?(".tsx") || filename.ends_with?(".cts") || filename.ends_with?(".mts") || filename.ends_with?(".js") || filename.ends_with?(".jsx") || filename.ends_with?(".cjs") || filename.ends_with?(".mjs") || File.basename(filename) == "package.json" || File.basename(filename) == "tsconfig.json"
+    end
+
     def set_name
       @name = "ts_nestjs"
     end

--- a/src/detector/detectors/typescript/tanstack_router.cr
+++ b/src/detector/detectors/typescript/tanstack_router.cr
@@ -18,6 +18,10 @@ module Detector::Typescript
       end
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".ts") || filename.ends_with?(".tsx") || filename.ends_with?(".cts") || filename.ends_with?(".mts") || filename.ends_with?(".js") || filename.ends_with?(".jsx") || filename.ends_with?(".cjs") || filename.ends_with?(".mjs") || File.basename(filename) == "package.json" || File.basename(filename) == "tsconfig.json"
+    end
+
     def set_name
       @name = "ts_tanstack_router"
     end

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -29,6 +29,22 @@ class Detector
     false
   end
 
+  # Cheap filename-only filter the detector pass uses to skip
+  # `detect` on files the detector cannot possibly match. The
+  # default `true` preserves prior behavior (every detector runs on
+  # every file). Override with the same predicate the body of
+  # `detect` starts with — e.g., `filename.ends_with?(".py")` for a
+  # Python framework detector — so the detector loop avoids the
+  # `detect` dispatch on files outside the detector's language.
+  #
+  # On large codebases (saleor's 4255 `.py` files) this lifts ~100
+  # virtual `detect` calls per file out of the hot loop because
+  # most detectors' inner first-line is exactly this kind of cheap
+  # filename check.
+  def applicable?(filename : String) : Bool
+    true
+  end
+
   # Whether the detector can be skipped on subsequent files once it
   # has matched. Defaults to `true` (idempotent — the detector only
   # signals tech presence). Detectors that perform side effects in


### PR DESCRIPTION
## Summary
The detector pass runs every detector on every file. Each detector's \`detect()\` starts with a cheap filename predicate (e.g., \`filename.ends_with?(".py")\`) that returns false on files outside its language. On large monorepos the cumulative cost of dispatching through ~100 of these methods per file dominates the detect phase even though almost all of them short-circuit immediately.

This PR lifts the filename predicate into a new \`Detector#applicable?\` hook the detector loop calls before \`detect\`. The check is one cheap \`String#ends_with?\` per detector and skips the \`detect\` dispatch (and any in-body regex / \`includes?\` work) for files in unrelated languages.

\`Detector#applicable?\` defaults to \`true\` so spec/RAML/OAS detectors (which run on JSON/YAML across the tree) and any detector that hasn't been migrated keep their prior behavior.

## Benchmark
Saleor (4255 \`.py\` files, 7 endpoints; \`hyperfine --warmup 2 --runs 5\`):

| Configuration | Time | Notes |
| --- | ---: | --- |
| brew v0.30.0   | 2.22 s | baseline |
| main HEAD      | 6.27 s | 2.82× slower than baseline |
| perf branch    | 3.79 s | **1.65× faster than main HEAD** (recovers most of the regression) |

Same 7 endpoints, identical URL/method/params set, same detected tech (\`python_django\`).

## Notes
- Part of the post-v0.30.0 perf series. The callee gate series (#1509-#1517) addressed analyzer-pass cost; this PR addresses detector-pass cost. Together they bring saleor back close to v0.30.0 speed.
- Discourse bench (Express, 2.8k .js/.ts) is running in the background; the bigger #1518 \`js_route_extractor\` pre-filter already cut that scan by 2.34×, so further gains here are expected to be smaller for that target.

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] \`just test-unit\` (1624 examples, 0 failures)
- [x] saleor scan: identical 7 URL/method/params set, same detected tech