### PR TITLE
perf(js): skip prefix-resolution pipeline when no routes were parsed

### DIFF
--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -44,6 +44,12 @@ module Noir
           STDERR.puts "Warning: Maximum iterations reached in JS parser, parsing may be incomplete"
         end
 
+        # No route patterns means the rest of this method has nothing
+        # to emit — every downstream step (function_ranges build,
+        # internal-mount scan, prefix propagation) exists to attribute
+        # prefixes to routes the parser already found.
+        return [] of Endpoint if route_patterns.empty?
+
         # Check if this file has a router prefix from cross-file mounting
         locator = CodeLocator.instance
 


### PR DESCRIPTION
## Summary
Files that pass the route-call pre-filter (#1518) but yield no routes from \`JSParser.parse_routes\` were still paying the full prefix-resolution pipeline:

- 4-regex scan over the whole file to build \`function_ranges\`
- Per-function \`find_matching_brace\` walks (character-by-character)
- Two more whole-file regex scans for internal mount + Fastify plugin registrations
- Fixpoint over \`internal_mounts\` with up to 100 iterations
- \`CodeLocator\` lookups per function name

All of that work exists to attribute prefixes to routes the parser already found. Empty \`route_patterns\` means nothing to attribute — bail with \`[] of Endpoint\` immediately.

Common shapes that hit this fast-out: utility files that wrap a verb method in a helper but never call it directly, comment- or documentation-heavy files where the parser bails on shape, and test/fixture files whose route shapes are non-Express.

## Benchmark
Discourse (~2.8k \`.js\`/\`.ts\` files, 532 endpoints; \`hyperfine --warmup 1 --runs 3\`):

| Configuration | Time | Relative |
| --- | ---: | ---: |
| main HEAD     | 121.66 s | 1.00 |
| perf branch   |  63.96 s | **1.90× faster** |

Same 532 endpoints, identical URL/method set before/after.

## Post-v0.30.0 regression status
With this PR plus #1518, the discourse scan recovers from 311s (6.22× regression) → 64s (≈1.32× over the v0.30.0 baseline of 48.5s). Most of the remaining gap is in the parser itself for the ~644 files that do contain route calls — separate investigation.

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] \`crystal spec spec/functional_test/testers/javascript/\` (1793 examples, 0 failures)
- [x] Discourse scan: identical 532 URL/method set before/after