### PR TITLE
perf(detector/spec): add applicable? predicates to spec detectors

### DIFF
--- a/src/detector/detectors/specification/grpc.cr
+++ b/src/detector/detectors/specification/grpc.cr
@@ -15,6 +15,10 @@ module Detector::Specification
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".proto")
+    end
+
     def set_name
       @name = "grpc"
     end

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -24,6 +24,10 @@ module Detector::Specification
       false
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".har") || filename.ends_with?(".json")
+    end
+
     def set_name
       @name = "har"
     end

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -32,6 +32,10 @@ module Detector::Specification
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+    end
+
     def set_name
       @name = "oas2"
     end

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -32,6 +32,10 @@ module Detector::Specification
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".json") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+    end
+
     def set_name
       @name = "oas3"
     end

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -25,6 +25,10 @@ module Detector::Specification
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".json")
+    end
+
     def set_name
       @name = "postman"
     end

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -23,6 +23,10 @@ module Detector::Specification
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".raml") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+    end
+
     def set_name
       @name = "raml"
     end

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -22,6 +22,10 @@ module Detector::Specification
       check
     end
 
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+    end
+
     def set_name
       @name = "zap_sites_tree"
     end


### PR DESCRIPTION
## Summary
Round out #1519 by adding filename predicates to the seven specification detectors (\`grpc\`, \`har\`, \`oas2\`, \`oas3\`, \`postman\`, \`raml\`, \`zap_sites_tree\`). They were left at the default \`true\` and ran on every file — even though their bodies all bail on filename extension immediately. Lifting that predicate skips the \`detect\` dispatch (and the \`valid_json?\` / \`valid_yaml?\` / \`JSON.parse\` calls inside) for files outside \`.json\`/\`.yaml\`/\`.yml\`/\`.har\`/\`.proto\`/\`.raml\`.

Marginal on saleor (≤2%) since the inner \`File.read\`-then-bail path was already fast, but defense in depth and consistent with the rest of the detector pass.

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)