### PR TITLE
chore(just): add build-release recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 alias b := build
+alias br := build-release
 alias ds := docs-serve
 alias dsup := docs-supported
 alias vc := version-check
@@ -8,10 +9,15 @@ alias vu := version-update
 default:
     @just --list
 
-# Build noir binary.
+# Build noir binary (debug; fast incremental compile, slower runtime).
 [group('build')]
 build:
     shards build
+
+# Build noir binary with --release (slower compile, 2–3x faster runtime; use for benchmarks).
+[group('build')]
+build-release:
+    shards build --release
 
 # Update shards.nix.
 [group('build')]


### PR DESCRIPTION
## Summary
\`just build\` invokes \`shards build\` without \`--release\`, so the resulting binary is unoptimized and 2–3× slower than the brew/distribution artifact. Repeatedly running such a debug binary in a benchmark next to brew shows what looks like a large regression that is just the optimization-level gap (e.g. saleor 6.27s debug vs 1.53s release on the same code).

Add \`just build-release\` (alias \`br\`) that calls \`shards build --release\`. Use it for any perf comparison against brew or other release artifacts. The plain \`build\` recipe is unchanged so dev incremental compile stays fast.

## Test plan
- [x] \`just --list\` shows the new recipe under the build group with an alias.
- [x] \`just build-release\` succeeds.