### PR TITLE
perf(js): pre-filter `extract_static_paths` on `.use(` substring

### DIFF
--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -624,6 +624,12 @@ module Noir
     def self.extract_static_paths(content : String) : Array(Hash(String, String))
       static_paths = [] of Hash(String, String)
 
+      # Cheap pre-filter: every static-mount shape (Express
+      # `express.static`, Koa `serve`/`mount`, fastify-static) is a
+      # `.use(` call. Files without `.use(` cannot host one — skip
+      # the four regex scans on the vast majority of JS/TS files.
+      return static_paths unless content.includes?(".use(") || content.includes?(".use (")
+
       # Express patterns:
       # app.use('/static', express.static('public'))
       # app.use(express.static('public'))


### PR DESCRIPTION
## Summary
Every static-mount shape \`extract_static_paths\` handles — Express \`express.static\`, Koa \`serve\`/\`mount\`, fastify-static — is a \`.use(\` call. The four regex scans only ever fire on files that contain that substring, so probing for it up front skips the regex work on files that can't host a static mount.

Mirrors the same shape as the \`extract_routes\` (#1518) and \`RouterMountScanner\` pre-filters. Not measurable on Discourse (the regex was already fast on files without \`.use(\`), but the fast path is the right default for unmoderately-sized frontend trees that have a few static mounts and thousands of other files.

## Test plan
- [x] \`crystal spec spec/functional_test/testers/javascript/\` (1793 examples, 0 failures)
- [x] \`just test-func\` (10582 examples, 0 failures)