### PR TITLE
refine(optimizer): normalize leaky URL shapes after analyzer pass

### DIFF
--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -25,8 +25,143 @@ class EndpointOptimizer
   def optimize(endpoints : Array(Endpoint)) : Array(Endpoint)
     optimized = optimize_endpoints(endpoints)
     optimized = combine_url_and_endpoints(optimized)
+    optimized = normalize_url_shapes(optimized)
     optimized = add_path_parameters(optimized)
     optimized
+  end
+
+  # Normalize cross-framework URL shapes the analyzers can't always
+  # resolve without language context. Rewrites a small set of well-
+  # known leaky forms into the canonical `{name}` placeholder so the
+  # downstream `add_path_parameters` pass picks them up as path
+  # params instead of literal noise.
+  #
+  # Covered shapes:
+  #   - `(?P<name>pattern)` — Python `re_path`-style named groups.
+  #     Bleeds through Django's `re_path` route table; rewrite to
+  #     `{name}` and drop the regex body.
+  #   - `${name}` / `${obj.field}` — JS/TS template literals that
+  #     analyzers can't statically resolve (handler files reference
+  #     captured variables, not literal paths). Rewrite to `{name}`
+  #     (or `{field}` for `${obj.field}`) so the AI/output payload
+  #     surfaces it as a path placeholder rather than as a literal
+  #     `${...}` segment.
+  #   - Python regex anchors `^` (leading) and `$`/`\Z` (trailing) —
+  #     `re_path` patterns commonly include these.
+  #   - Python regex backslash-escaped dots `\.` — rewrite to plain
+  #     `.` for the visible URL.
+  def normalize_url_shapes(endpoints : Array(Endpoint)) : Array(Endpoint)
+    # `Endpoint` is a value-type struct in Crystal, so mutating
+    # through the block-local binding only edits a copy. Rewrite
+    # via array index so the in-place change actually persists.
+    endpoints.each_with_index do |endpoint, idx|
+      url = endpoint.url
+      next if url.empty?
+
+      # Skip URLs that look like a verbatim regex literal — Express
+      # accepts `app.get(/^\/api\/(\d+)$/, handler)` and the route
+      # extractor preserves the literal as the URL. Detect via
+      # escaped slashes (`\/`) or regex character classes (`\d`/`\w`/
+      # `\s`/`\D`/`\W`/`\S`/`(\d+)` etc.) the path forms never carry.
+      next if url.includes?("\\/") || url.matches?(/\\[dswDSW]/)
+
+      # Python `re_path` named groups: `(?P<name>...)` → `{name}`.
+      # Use a hand-walked replacement so the inner regex body (which
+      # can contain its own balanced parens / brackets) is consumed
+      # correctly without writing a recursive regex.
+      url = strip_python_named_groups(url)
+
+      # JS/TS template-literal interpolations the parser couldn't
+      # resolve. Pick the rightmost identifier token in the
+      # expression — it's almost always the value-carrying name:
+      #   `${id}`                 → `{id}`
+      #   `${obj.field}`          → `{field}`
+      #   `${get(id)}`            → `{id}`
+      #   `${getThing().id}`      → `{id}`
+      #   `${utils.fmt(value)}`   → `{value}`
+      # Falls back to `{var}` when the expression has no extractable
+      # identifier (e.g., `${1+2}` or `${"raw"}`).
+      url = url.gsub(/\$\{([^{}]+)\}/) do |_match|
+        expr = $1.to_s
+        tokens = expr.split(/[^A-Za-z0-9_]/).reject(&.empty?)
+        name = tokens.last? || ""
+        name.empty? ? "{var}" : "{#{name}}"
+      end
+
+      # Strip Python regex anchors at the path boundary.
+      url = url.sub(/^\/\^/, "/")
+      url = url.sub(/\$$/, "")
+      url = url.sub(/\\Z$/, "")
+      url = url.sub(/\/\$$/, "/")
+
+      # Backslash-escaped dots (re_path `r"\.json"`) → literal dot.
+      url = url.gsub("\\.", ".")
+
+      # Final double-slash collapse in case the rewrites left an
+      # adjacent pair (e.g., trimming a leading `^` after `/`).
+      # Skip when the URL carries a scheme like `https://` — the
+      # HAR / OAS detectors emit absolute URLs and the `//` after
+      # the colon is structural, not a path separator.
+      unless url.matches?(/\A[a-zA-Z][a-zA-Z0-9+.\-]*:\/\//)
+        url = url.gsub_repeatedly("//", "/")
+      end
+
+      endpoint.url = url
+      endpoints[idx] = endpoint
+    end
+
+    endpoints
+  end
+
+  # Rewrites every `(?P<name>...)` occurrence in `url` to `{name}`,
+  # consuming the matching `)` even when the inner pattern contains
+  # nested parens. Returns `url` unchanged when no named group is
+  # present.
+  private def strip_python_named_groups(url : String) : String
+    return url unless url.includes?("(?P<")
+
+    result = String::Builder.new
+    i = 0
+    size = url.size
+    while i < size
+      if i + 3 < size && url[i] == '(' && url[i + 1] == '?' && url[i + 2] == 'P' && url[i + 3] == '<'
+        close_name = url.index('>', i + 4)
+        unless close_name
+          result << url[i..]
+          break
+        end
+        name = url[(i + 4)...close_name]
+
+        # Walk to the matching `)` from after the name's `>`.
+        depth = 1
+        j = close_name + 1
+        while j < size && depth > 0
+          ch = url[j]
+          case ch
+          when '\\'
+            j += 2
+            next
+          when '['
+            close_bracket = url.index(']', j + 1) || size
+            j = close_bracket + 1
+            next
+          when '('
+            depth += 1
+          when ')'
+            depth -= 1
+          end
+          j += 1
+        end
+
+        result << "{#{name}}"
+        i = j
+      else
+        result << url[i]
+        i += 1
+      end
+    end
+
+    result.to_s
   end
 
   # Remove duplicated endpoints and parameters, validate HTTP methods, clean URLs


### PR DESCRIPTION
## Summary
Some analyzers leave source-language syntax in their URLs the analyzer couldn't statically resolve. The downstream output (OAS export, AI context, JSON) then carries those literal artifacts. Add a small \`normalize_url_shapes\` pass between \`combine_url_and_endpoints\` and \`add_path_parameters\` that rewrites well-known forms into the canonical \`{name}\` placeholder.

### Shapes covered

| Source | Before | After |
| --- | --- | --- |
| Python \`re_path\` named groups | \`/plugins/channel/(?P<channel_slug>[.0-9A-Za-z_\-]+)/\` | \`/plugins/channel/{channel_slug}/\` |
| JS/TS template literals | \`/api/v1/accounts/\${id}/follow\` | \`/api/v1/accounts/{id}/follow\` |
| JS/TS member-access literals | \`/posts/\${originalPost.id}\` | \`/posts/{id}\` |
| Python anchors / escapes | \`/\.well-known/...\`, \`/^api\$\` | \`/.well-known/...\`, \`/api\` |

The pass intentionally skips:
- URLs that look like a verbatim regex literal (escaped slashes \`\/\` or regex escapes \`\d\`/\`\w\`/\`\s\`). Express's \`app.get(/^\\/regex-(\\d+)\$/, h)\` shape uses the regex literal as the URL; we must preserve it.
- The final double-slash collapse on URLs that carry a scheme (\`https://\`); HAR/OAS detectors emit absolute URLs and the \`//\` after the colon is structural.

### Bug fix
Also fixes a latent struct-mutation bug: \`Endpoint\` is a value-type struct in Crystal, so \`endpoint.url = url\` inside an \`each\` block was only editing a copy. Write back via \`endpoints[idx] = endpoint\`.

### Sample after on real corpora
- saleor (Django): 4 of 7 endpoints had \`(?P<...>...)\` regex bleeding through — now clean \`{name}\` placeholders.
- discourse: 9 \`\${...}\` template-literal URLs from frontend → \`{name}\`.
- mastodon: 20+ \`\${...}\` API endpoints from React frontend → \`{id}\` / \`{name}\`.

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] \`just test-unit\` (1624 examples, 0 failures)
- [x] Express regex-route fixture preserved verbatim (\`/^\\/regex-(\\d+)\$/\`).
- [x] HAR absolute-URL fixture preserved (\`https://www.hahwul.com/\`).
- [x] Saleor scan: \`/plugins/(?P<plugin_id>...)/\` → \`/plugins/{plugin_id}/\`.