### PR TITLE
refine(python): coalesce multi-line decorators across analyzers

### DIFF
--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -48,12 +48,29 @@ module Analyzer::Python
       paren_depth = 0
 
       lines.each_with_index do |line, line_index|
-        line.scan(MOUNT_REGEX) do |match|
+        # Route(...) and Mount(...) calls commonly span multiple
+        # lines in real Starlette code. The line-level scan above
+        # captures only the call header (`Route(`) on the first
+        # line; the path string sits on a continuation line and
+        # never matches the body regex. Coalesce continuation lines
+        # into one logical string when the opening paren isn't
+        # balanced on this line so the body capture sees the path.
+        effective_line = if line.includes?("Route") && python_paren_delta(line) > 0
+                           join_until_python_call_closes(lines, line_index, line)
+                         else
+                           line
+                         end
+        # Lift `path=` keyword to the first positional slot so the
+        # existing ROUTE_REGEX (which expects a string right after
+        # `Route(`) matches `Route(path="/x", endpoint=h)`.
+        effective_line = effective_line.gsub(/(Route\s*\()\s*path\s*=\s*([rf]?['"][^'"]*['"])/, "\\1\\2,")
+
+        effective_line.scan(MOUNT_REGEX) do |match|
           next if match.size < 2
           mount_stack << {match[1], paren_depth + 1}
         end
 
-        line.scan(ROUTE_REGEX) do |match|
+        effective_line.scan(ROUTE_REGEX) do |match|
           next if match.size < 3
           route_path = match[1]
           tail = match[2]

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -503,5 +503,65 @@ module Analyzer::Python
         @params << param
       end
     end
+
+    # Net `(` − `)` count on a single Python source line, ignoring
+    # parens that fall inside single- or double-quoted strings on the
+    # same line. Sufficient for decorator / function-call headers,
+    # which never carry triple-quoted strings on the call line.
+    #
+    # Used by analyzers that walk source line-by-line and need to
+    # join continuation lines into one logical call (e.g. multi-line
+    # decorators in FastAPI / Litestar / Sanic / Bottle, multi-line
+    # `Route(...)` entries in Starlette).
+    def python_paren_delta(line : ::String) : Int32
+      depth = 0
+      in_quote = nil
+      escaped = false
+      line.each_char do |ch|
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when '('
+          depth += 1
+        when ')'
+          depth -= 1
+        end
+      end
+      depth
+    end
+
+    # Given a 0-based `index` into `lines` whose content `line` is
+    # known to open a Python call whose `(` is unbalanced, join
+    # continuation lines until the running paren delta drops to ≤ 0.
+    # Returns the joined string with newlines collapsed to single
+    # spaces so analyzer-side regexes don't need a multi-line flag.
+    # The caller is expected to short-circuit (`return line`) when
+    # the call already balances on the same line — this method
+    # always walks forward at least once.
+    def join_until_python_call_closes(lines : Array(::String),
+                                      index : Int32,
+                                      line : ::String) : ::String
+      pieces = [line]
+      delta = python_paren_delta(line)
+      i = index + 1
+      while i < lines.size && delta > 0
+        nxt = lines[i]
+        pieces << nxt
+        delta += python_paren_delta(nxt)
+        break if delta <= 0
+        i += 1
+      end
+      pieces.join(' ')
+    end
   end
 end

--- a/src/miniparsers/python_route_extractor.cr
+++ b/src/miniparsers/python_route_extractor.cr
@@ -121,15 +121,29 @@ module Noir
     def find_def_line(lines : Array(String), line_index : Int32, direction : Symbol = :down) : Int32
       case direction
       when :down
+        # Carry the decorator line's paren depth forward so the walk
+        # doesn't bail when it lands inside a multi-line decorator
+        # call like `@app.route(\n  "/x",\n  methods=[...]\n)`.
+        paren_depth = lines[line_index]? ? line_paren_delta(lines[line_index]) : 0
         i = line_index + 1
         while i < lines.size
-          stripped = lines[i].lstrip
-          if stripped.starts_with?("def ") || stripped.starts_with?("async def ") || stripped.starts_with?("class ")
+          line = lines[i]
+          stripped = line.lstrip
+          if paren_depth <= 0 && (stripped.starts_with?("def ") || stripped.starts_with?("async def ") || stripped.starts_with?("class "))
             return i
+          end
+          # While still inside the decorator's call parens, every
+          # continuation line is legal — accept it without checking
+          # the @/#/blank rule.
+          if paren_depth > 0
+            paren_depth += line_paren_delta(line)
+            i += 1
+            next
           end
           # A comment between the decorator and the def is legal Python;
           # skip it along with blank lines and chained decorators.
           if stripped.starts_with?("@") || stripped.starts_with?("#") || stripped.empty?
+            paren_depth += line_paren_delta(line)
             i += 1
             next
           end
@@ -146,6 +160,37 @@ module Noir
         end
       end
       line_index
+    end
+
+    # Net `(` − `)` count for a single line, ignoring parens inside
+    # single- or double-quoted strings on the same line. Used by
+    # `find_def_line` to walk through multi-line decorator headers
+    # without breaking the loop on continuation tokens.
+    private def line_paren_delta(line : String) : Int32
+      depth = 0
+      in_quote = nil
+      escaped = false
+      line.each_char do |ch|
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when '('
+          depth += 1
+        when ')'
+          depth -= 1
+        end
+      end
+      depth
     end
   end
 end

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -253,12 +253,19 @@ module Noir
           name = Noir::TreeSitter.field(arg, "name")
           value = Noir::TreeSitter.field(arg, "value")
           next unless name && value
-          # Accept both `methods=` (Flask / Sanic) and the singular
-          # `method=` (Bottle). decode_method_list handles a list or a
-          # bare string value.
           key = Noir::TreeSitter.node_text(name, source)
+          # `methods=` (Flask / Sanic) / `method=` (Bottle).
+          # `decode_method_list` handles a list or a bare string.
           if key == "methods" || key == "method"
             methods = decode_method_list(value, source)
+          elsif (key == "path" || key == "rule" || key == "uri") && path.empty? &&
+                Noir::TreeSitter.node_type(value) == "string"
+            # `path=`/`rule=`/`uri=` keyword forms — FastAPI's
+            # `@app.get(path="/x")`, Bottle's `@app.route(path="/x")`,
+            # Sanic / aiohttp variants. Only accept the keyword if no
+            # positional path has been seen, so a stray `path=` kwarg
+            # later in the call can't overwrite a real positional.
+            path = decode_string(value, source)
           end
         end
       end


### PR DESCRIPTION
## Summary
A common false-negative across the regex-based Python analyzers: route declarations that span multiple lines were silently dropped because the underlying scan ran per source line.

Three changes that fix it across Starlette / Sanic / Bottle (and any other Python analyzer that uses the shared helpers):

1. **`python_route_extractor.cr#find_def_line`** — when starting at a decorator line, carry the line's paren delta forward so the walk doesn't bail on continuation tokens inside multi-line decorator headers. Previously the first non-\`@\`, non-comment, non-blank continuation line broke the search; the decorator's handler was never found, the analyzer never emitted the route.

2. **`python_route_extractor_ts.cr`** — accept \`path=\` / \`rule=\` / \`uri=\` keyword arguments as the route path when no positional string was passed. Lets \`@app.get(path=\"/x\")\`, \`@app.route(path=\"/x\")\`, etc. surface as endpoints.

3. **`starlette.cr`** — coalesce multi-line \`Route(...)\` calls into one logical string so the body regex sees the path on a continuation line, and lift \`Route(path=\"/x\", endpoint=h)\` to the positional form so the existing scan matches.

Also adds shared helpers on \`PythonEngine\` (\`python_paren_delta\`, \`join_until_python_call_closes\`) for future analyzers that need to join continuation lines.

## Smoke fixture coverage

| Style | Before | After |
| --- | :---: | :---: |
| \`@app.route(\"/single\")\` | ✓ | ✓ |
| Multi-line decorator | ✗ | ✓ |
| \`@app.get(path=\"/keyword\")\` | ✗ | ✓ |
| Starlette \`Route(\\n \"/multi\", ...)\` | ✗ | ✓ |
| Starlette \`Route(path=\"/x\", ...)\` | ✗ | ✓ |

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)