### PR TITLE
refine(python/pyramid): coalesce multi-line add_view() calls

### DIFF
--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -84,7 +84,16 @@ module Analyzer::Python
             end
 
             # config.add_view(view_func, route_name="name", request_method="POST")
-            if av = line.match(/\.add_view\s*\((.+)\)/)
+            # Coalesce continuation lines so the args regex picks up
+            # multi-line add_view calls (the path/method kwargs live
+            # on continuation lines in fixtures wrapped to column
+            # limits).
+            add_view_line = if line.includes?(".add_view") && python_paren_delta(line) > 0
+                              join_until_python_call_closes(lines, line_index, line)
+                            else
+                              line
+                            end
+            if av = add_view_line.match(/\.add_view\s*\((.+)\)/)
               args = av[1]
               rn_match = args.match(/route_name\s*=\s*[rf]?['"]([^'"]+)['"]/)
               next if rn_match.nil?


### PR DESCRIPTION
## Summary
Pyramid's \`config.add_view(...)\` scan ran per source line, so the common wrapped form silently dropped the route binding:

\`\`\`python
config.add_view(
  deleted_view,
  route_name=\"deleted\",
  request_method=\"DELETE\",
)
\`\`\`

\`config.add_route\` discovery was already source-wide and worked; only the \`add_view\` line-by-line lookup needed paren-aware coalescing. Reuse the shared \`join_until_python_call_closes\` helper when the opening paren isn't balanced on the same line.

Smoke fixture: 3/4 → 4/4.

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)