### PR TITLE
chore(lint): clear ameba and crystal-format CI failures

### DIFF
--- a/spec/functional_test/testers/ruby/rails_ai_context_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_ai_context_spec.cr
@@ -46,7 +46,7 @@ describe "--ai-context on Rails auth fixtures" do
     create_context = create_context.should_not be_nil
     create_context.guards.size.should eq(1)
     create_context.guards[0].source.should eq("ruby_auth")
-    create_endpoint.params.map(&.name).sort.should eq(["body", "title"])
+    create_endpoint.params.map(&.name).sort!.should eq(["body", "title"])
     create_context.signals.map(&.kind).should contain("state_change")
     create_context.signals.map(&.kind).should_not contain("identifier_input")
     create_context.signals.map(&.kind).should_not contain("idor")

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 require "../../../src/ai_context/augmentor"
 
-def with_temp_ai_context_source(content : String, &block : String ->)
+def with_temp_ai_context_source(content : String, & : String ->)
   path = "/tmp/noir-ai-context-#{Random.rand(1_000_000)}.txt"
   File.write(path, content)
   begin
@@ -46,9 +46,8 @@ describe "NoirAIContext" do
 
       context.guards.size.should eq(1)
       context.guards[0].source.should eq("express_auth")
-      guard_snippet = context.guards[0].snippet
-      guard_snippet.should_not be_nil
-      guard_snippet.not_nil!.should contain("app.post")
+      guard_snippet = context.guards[0].snippet.should_not be_nil
+      guard_snippet.should contain("app.post")
 
       context.callees.map(&.name).should contain("User.find_by_sql")
       context.callees.first.snippet.should_not be_nil

--- a/spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr
@@ -91,10 +91,10 @@ describe Noir::RustCalleeExtractorTS do
         Noir::TreeSitter.each_named_child(root) do |c|
           fn_node = c if Noir::TreeSitter.node_type(c) == "function_item"
         end
-        fn_node.should_not be_nil
-        body = Noir::TreeSitter.field(fn_node.not_nil!, "body")
-        body.should_not be_nil
-        Noir::RustCalleeExtractorTS.callees_in_body(body.not_nil!, source, "handler.rs").each do |name, _, line|
+        fn_node_unwrapped = fn_node.should_not be_nil
+        body = Noir::TreeSitter.field(fn_node_unwrapped, "body")
+        body_unwrapped = body.should_not be_nil
+        Noir::RustCalleeExtractorTS.callees_in_body(body_unwrapped, source, "handler.rs").each do |name, _, line|
           found << {name, line}
         end
       end

--- a/src/ai_context/augmentor.cr
+++ b/src/ai_context/augmentor.cr
@@ -527,7 +527,7 @@ module NoirAIContext
     end
 
     private def identifier_like?(name : String) : Bool
-      return true if matches_any?(name, PARAM_PATTERNS.find { |pattern| pattern.kind == "identifier_input" }.not_nil!.name_patterns)
+      return true if matches_any?(name, PARAM_PATTERNS.find! { |pattern| pattern.kind == "identifier_input" }.name_patterns)
       return true if identifier_suffix_like?(name)
 
       false

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -380,7 +380,6 @@ module Analyzer::Ruby
 
       data = extract_controller_data(path)
       defined_actions = data.defined_actions
-      params_method = data.params_method
 
       methods = [] of String
       {"index", "show", "create", "update", "destroy"}.each do |name|

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -61,7 +61,7 @@ module Noir::RubyCalleeExtractor
     escaped = false
     quote = '\0'
 
-    line.each_char_with_index do |char, index|
+    line.each_char do |char|
       if in_string
         if escaped
           stripped << (preserve_strings ? char : ' ')

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -2,7 +2,7 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class HuntParamTagger < Tagger
-  PATH_ALLOWED_TAGS = Set{"idor", "file-inclusion"}
+  PATH_ALLOWED_TAGS     = Set{"idor", "file-inclusion"}
   BODY_LIKE_PARAM_TYPES = Set{"json", "form"}
 
   TAG_DEFINITIONS = {


### PR DESCRIPTION
## Summary
The ameba/CI lint step had accumulated 10 warnings (all pre-existing across earlier landings); fix each so the lint job passes again:

| File | Rule | Fix |
| --- | --- | --- |
| \`src/tagger/taggers/hunt_param.cr\` | Lint/Formatting | \`crystal tool format\` |
| \`src/analyzer/analyzers/ruby/rails.cr:383\` | Lint/UselessAssign | drop unused \`params_method =\` |
| \`src/miniparsers/ruby_callee_extractor.cr:64\` | Lint/UnusedArgument | \`each_char_with_index\` → \`each_char\` |
| \`src/ai_context/augmentor.cr:530\` | Lint/NotNilAfterNoBang + Lint/NotNil | \`find {...}.not_nil!\` → \`find! {...}\` |
| \`spec/functional_test/testers/ruby/rails_ai_context_spec.cr:49\` | Performance/ChainedCallWithNoBang | \`sort\` → \`sort!\` after chained \`map\` |
| \`spec/unit_test/ai_context/augmentor_spec.cr:4\` | Lint/UnusedBlockArgument | name the unused block arg \`&\` |
| \`spec/unit_test/ai_context/augmentor_spec.cr:51\` | Lint/NotNil | unwrap \`should_not be_nil\` once instead of asserting then \`.not_nil!\`-ing |
| \`spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr:95,97\` | Lint/NotNil | same \`should_not be_nil\` unwrap pattern |

No behavior changes; this is pure tooling hygiene.

## Test plan
- [x] \`lib/ameba/bin/ameba.cr\` — 912 inspected, 0 failures
- [x] \`crystal tool format --check\` — clean
- [x] \`just test-func\` (10582 examples, 0 failures)
- [x] \`just test-unit\` (1624 examples, 0 failures)

Note: The CI test job on Crystal 1.19 was also reporting a separate failure in \`spec/unit_test/ext/tree_sitter_parser_pool_spec.cr:15\` (parser-pool size assertion fired off an "Unhandled exception in spawn" before the assertion ran). It's unrelated to lint and reproduces on 1.19 only — left for a separate PR.