### PR TITLE
fix(spec): order-independent parser-pool size assertion

### DIFF
--- a/spec/unit_test/ext/tree_sitter_parser_pool_spec.cr
+++ b/spec/unit_test/ext/tree_sitter_parser_pool_spec.cr
@@ -8,11 +8,16 @@ require "../../../src/ext/tree_sitter/tree_sitter"
 # allocating a fresh one.
 describe "Noir::TreeSitter parser pool" do
   it "keeps an idle parser in the pool after a parse call returns" do
+    # The pool is module-level state and other specs in the same
+    # run may have warmed it (e.g., any spec that exercises a
+    # Python miniparser). When the pool already has a parser, the
+    # `parse` call below pops it on checkout and pushes it back on
+    # checkin, leaving the size unchanged — so the meaningful
+    # contract is "at least one idle parser exists after parse
+    # returns", not strictly `before + 1`.
     language = LibTreeSitter.tree_sitter_python
-    before = Noir::TreeSitter.parser_pool_size(language)
     Noir::TreeSitter.parse_python("x = 1") { |_| }
-    after = Noir::TreeSitter.parser_pool_size(language)
-    after.should eq(before + 1)
+    Noir::TreeSitter.parser_pool_size(language).should be >= 1
   end
 
   it "reuses the pooled parser on the next parse call" do


### PR DESCRIPTION
## Summary
\`tree_sitter_parser_pool_spec.cr:15\` asserted \`after_size == before_size + 1\` for the Python parser pool. That held when this spec ran first, but the pool is module-level state — any earlier spec that exercises a Python miniparser primes the bucket, and a subsequent \`parse_python\` call then pops the pooled parser on checkout and pushes it back on checkin, leaving the bucket size unchanged.

The Crystal 1.19 CI job consistently runs the spec after one of those primers (1.20 happens to order them the other way), so the assertion fired there. The meaningful contract is \"at least one idle parser exists after a parse call returns\", not strictly \`before + 1\` — assert that instead. The two follow-up specs (parser reuse + per-language isolation) were already order-independent and stay unchanged.

## Test plan
- [x] \`just test-unit\` (1624 examples, 0 failures)