### PR TITLE
refine(go): cover .Handle/.Add registrations and normalize ALL→ANY

### DIFF
--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -32,7 +32,7 @@ module Analyzer::Go
                     # Tree-sitter pre-pass: every Echo verb route
                     # (`e.GET`, `g.POST`, …) with its group prefix applied.
                     cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups)
+                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
                       routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -31,7 +31,7 @@ module Analyzer::Go
                     # because it's a sibling expression, not part of the route
                     # argument list.
                     cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups)
+                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
                       routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -34,7 +34,11 @@ module Analyzer::Go
                     # /GetHeader/Cookie) to the most recently declared route —
                     # matching the legacy `last_endpoint` semantics.
                     cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups)
+                    # Gin also accepts `r.Handle(method, path, handler)`
+                    # alongside the verb shortcuts (`r.GET`, etc.),
+                    # so opt into the method-first decoder so those
+                    # registrations surface as endpoints too.
+                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Handle")
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
                       routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -800,9 +800,16 @@ module Noir
                    raw_path
                  end
 
+      # Fiber's `app.All(...)` is the same "match any method" intent
+      # as Gin's `r.Any(...)` and Echo's `e.Any(...)`. Normalize so
+      # output is consistent across frameworks and the optimizer's
+      # `allowed_methods` filter (which knows `ANY` but not `ALL`)
+      # doesn't quietly demote it to GET.
+      normalized_verb = verb.upcase == "ALL" ? "ANY" : verb.upcase
+
       Route.new(
         router_name,
-        verb.upcase,
+        normalized_verb,
         resolved,
         raw_path,
         handler_text,


### PR DESCRIPTION
## Summary
Three Go-router gaps surfaced while smoke-testing Gin/Echo/Fiber against representative fixtures:

1. **Gin \`r.Handle(method, path, handler)\` silently dropped.** The tree-sitter extractor already has a \`handle_method\` parameter (used by httprouter), but Gin wasn't passing it. Pass \`handle_method: \"Handle\"\` so \`r.Handle(\"PUT\", \"/x\", h)\`-style declarations surface.

2. **Echo \`e.Add(method, path, handler)\` and Fiber \`app.Add(...)\` silently dropped.** Same shape, different method name. Pass \`handle_method: \"Add\"\` for both.

3. **Fiber \`app.All(...)\` demoted to GET.** Fiber's All registers a route for every HTTP method, matching Gin/Echo's \`Any(...)\` semantics. The extractor emitted verb \"ALL\", which the optimizer's \`allowed_methods\` set doesn't include — it quietly fell back to GET. Normalize ALL → ANY at extraction time so output is consistent across frameworks and the optimizer keeps the verb intact.

## Smoke fixtures
- Gin: 9/10 → **10/10** (\`PUT /handle-style\` added)
- Echo: 4/6 → 5/6 (\`PUT /add-style\` added; multi-method \`e.Match(...)\` still out of scope)
- Fiber: 4/6 → 5/6 (\`ANY /all\` now correct verb, \`PUT /add-style\` added; \`app.Use\` is middleware so intentionally not a route)

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)