### PR TITLE
refine(rust/rocket): canonicalize route path to {name} shape

### DIFF
--- a/spec/functional_test/testers/rust/rocket_callees_spec.cr
+++ b/spec/functional_test/testers/rust/rocket_callees_spec.cr
@@ -5,7 +5,7 @@ index = Endpoint.new("/", "GET").tap do |ep|
   ep.push_callee(Callee.new("render_home", line: 18))
 end
 
-get_user = Endpoint.new("/users/<id>?<verbose>", "GET", [
+get_user = Endpoint.new("/users/{id}", "GET", [
   Param.new("id", "", "path"),
   Param.new("verbose", "", "query"),
   Param.new("x-trace-id", "", "header"),

--- a/spec/functional_test/testers/rust/rocket_spec.cr
+++ b/spec/functional_test/testers/rust/rocket_spec.cr
@@ -5,18 +5,18 @@ expected_endpoints = [
   Endpoint.new("/customer", "POST", [
     Param.new("input", "", "body"),
   ]),
-  Endpoint.new("/users/<id>", "GET", [
+  Endpoint.new("/users/{id}", "GET", [
     Param.new("id", "", "path"),
   ]),
-  Endpoint.new("/posts/<category>/<id>", "GET", [
+  Endpoint.new("/posts/{category}/{id}", "GET", [
     Param.new("category", "", "path"),
     Param.new("id", "", "path"),
   ]),
-  Endpoint.new("/search?<query>&<limit>", "GET", [
+  Endpoint.new("/search", "GET", [
     Param.new("query", "", "query"),
     Param.new("limit", "", "query"),
   ]),
-  Endpoint.new("/filter?<name>&<age>&<active>", "GET", [
+  Endpoint.new("/filter", "GET", [
     Param.new("name", "", "query"),
     Param.new("age", "", "query"),
     Param.new("active", "", "query"),
@@ -24,14 +24,14 @@ expected_endpoints = [
   Endpoint.new("/users", "POST", [
     Param.new("user", "", "body"),
   ]),
-  Endpoint.new("/products/<id>", "PUT", [
+  Endpoint.new("/products/{id}", "PUT", [
     Param.new("id", "", "path"),
     Param.new("product", "", "body"),
   ]),
   Endpoint.new("/login", "POST", [
     Param.new("credentials", "", "body"),
   ]),
-  Endpoint.new("/items/<id>?<version>", "POST", [
+  Endpoint.new("/items/{id}", "POST", [
     Param.new("id", "", "path"),
     Param.new("version", "", "query"),
     Param.new("item", "", "body"),

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -26,7 +26,16 @@ module Analyzer::Rust
 
           details = Details.new(PathInfo.new(path, attr_row))
           params = extract_params(route_path, data_param)
-          endpoint = Endpoint.new(route_path, method, params, details)
+          # Rocket route attributes carry their query params inline
+          # (`/path?<q>&<limit>`) and bracket their path params
+          # (`/with-param/<id>`). The query spec gets parsed into
+          # actual params in `extract_params` above, but the URL we
+          # ship out should be the canonical bare path with `{name}`
+          # placeholders — strip the `?...` suffix and convert
+          # `<name>` → `{name}` so output matches every other
+          # framework's path shape.
+          canonical_path = canonicalize_rocket_path(route_path)
+          endpoint = Endpoint.new(canonical_path, method, params, details)
 
           extract_function_extras(function, source, endpoint)
           attach_handler_callees(function, source, path, endpoint) if include_callee
@@ -106,6 +115,20 @@ module Analyzer::Rust
     # `/users/<id>` / `/search?<q>&<limit>` / `data = "<body>"` get
     # rolled together here so the legacy spec's param ordering stays
     # stable.
+    # `/path/<id>?<q>&<limit>` → `/path/{id}`. Strips the inline
+    # query-spec suffix Rocket attributes use to declare query
+    # params and converts the `<name>` path bracket form to the
+    # canonical `{name}` placeholder. Trailing `..` segments
+    # (`<page..>`) drop the trailing dots so the placeholder is
+    # the bare identifier.
+    private def canonicalize_rocket_path(route : String) : String
+      path_part = route.split("?", 2)[0]
+      path_part.gsub(/<([^>]+)>/) do |_|
+        name = $1.split("..").first.strip
+        "{#{name}}"
+      end
+    end
+
     private def extract_params(route : String, data_param : String?) : Array(Param)
       params = [] of Param
 


### PR DESCRIPTION
## Summary
Rocket route attributes use a Rocket-specific path syntax:

\`\`\`rust
#[get(\"/users/<id>\")]
#[get(\"/search?<query>&<limit>\")]
#[get(\"/spread?<page..>\")]
\`\`\`

The analyzer was surfacing the raw attribute string as the endpoint URL, leaking \`<id>\` brackets and the \`?<q>&<limit>\` query-spec suffix into output that every other framework emits in \`/path/{id}\` form. Downstream consumers (OAS export, AI context, dedup keys) ended up with framework-specific URL shapes for Rocket and \`{name}\` for everything else.

Convert the bracket form to \`{name}\`, drop the trailing \`..\` spread marker (\`<page..>\` → \`{page}\`), and strip the entire \`?<...>...\` query suffix at extraction time. Query params are already pulled into the endpoint's params list by \`extract_params\`, so the URL only needs the bare path.

Updated the two existing Rocket spec fixtures to match the canonical shape; param contracts unchanged.

## Test plan
- [x] \`just test-func\` (10582 examples, 0 failures)