### PR TITLE
fix(optimizer): strip Spring inline regex from path variables

### DIFF
--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -53,6 +53,20 @@ describe "EndpointOptimizer" do
       result[0].url.should eq("/api/users")
       result[1].url.should eq("/api/data")
     end
+
+    it "strips Spring inline regex constraints from path variables" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/users/{id:[0-9]+}", "GET"),
+        Endpoint.new("/files/{path:.*}", "GET"),
+        Endpoint.new("/a/{x:[^/]+}/b/{y}", "GET"),
+      ]
+
+      result = optimizer.normalize_url_shapes(endpoints)
+      result[0].url.should eq("/users/{id}")
+      result[1].url.should eq("/files/{path}")
+      result[2].url.should eq("/a/{x}/b/{y}")
+    end
   end
 
   describe "combine_url_and_endpoints" do

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -50,6 +50,8 @@ class EndpointOptimizer
   #     `re_path` patterns commonly include these.
   #   - Python regex backslash-escaped dots `\.` — rewrite to plain
   #     `.` for the visible URL.
+  #   - Spring `{name:regex}` — strip the inline regex constraint so
+  #     the placeholder is `{name}` regardless of framework dialect.
   def normalize_url_shapes(endpoints : Array(Endpoint)) : Array(Endpoint)
     # `Endpoint` is a value-type struct in Crystal, so mutating
     # through the block-local binding only edits a copy. Rewrite
@@ -70,6 +72,15 @@ class EndpointOptimizer
       # can contain its own balanced parens / brackets) is consumed
       # correctly without writing a recursive regex.
       url = strip_python_named_groups(url)
+
+      # Spring `{name:regex}` path variables — strip the inline regex
+      # constraint so downstream consumers see the canonical `{name}`
+      # placeholder. Spring accepts `{id:[0-9]+}`, `{path:.*}`, etc.;
+      # the regex body matters to the framework but is noise in the
+      # endpoint surface.
+      url = url.gsub(/\{([A-Za-z_][A-Za-z0-9_]*):[^{}]+\}/) do |_match|
+        "{#{$1}}"
+      end
 
       # JS/TS template-literal interpolations the parser couldn't
       # resolve. Pick the rightmost identifier token in the


### PR DESCRIPTION
## Summary

- Spring path variables permit an inline regex constraint such as `/users/{id:[0-9]+}` or `/files/{path:.*}`. The regex governs framework matching but is noise on the endpoint surface and breaks parity across analyzers that emit the bare `{name}` form.
- The optimizer's `normalize_url_shapes` pass now rewrites `{name:regex}` → `{name}` alongside the existing Python `(?P<name>...)`, JS `${expr}`, and anchor strips. Path-param extraction then picks up the placeholder consistently.

## Test plan

- [x] `crystal spec spec/unit_test/optimizer/optimizer_spec.cr` — new case covers `{id:[0-9]+}`, `{path:.*}`, mixed `{x:[^/]+}/b/{y}`.
- [x] `crystal spec spec/functional_test/testers/java/spring_spec.cr spec/functional_test/testers/java/jaxrs_spec.cr spec/functional_test/testers/kotlin/spring_spec.cr` — existing fixtures unchanged.
- [x] `just check` — format + ameba clean.
- [x] Manual: Kotlin Spring smoke with `@GetMapping("/regex/{id:[0-9]+}")` now emits `/api/v1/regex/{id}`.