### PR TITLE
perf(js): skip mock-server fixtures in route extraction

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -247,4 +247,46 @@ describe Noir::JSRouteExtractor do
       routes.size.should eq(0)
     end
   end
+
+  describe "test_stub_only?" do
+    it "skips files importing pretender without an HTTP server lib" do
+      content = <<-JS
+        import Pretender from "pretender";
+        const server = new Pretender();
+        server.get("/api/users", () => [200, {}, "[]"]);
+        JS
+      Noir::JSRouteExtractor.test_stub_only?("/app/tests/user-test.js", content).should be_true
+    end
+
+    it "keeps the file when express is also imported" do
+      content = <<-JS
+        import express from "express";
+        import Pretender from "pretender";
+        const app = express();
+        app.get("/api/users", (req, res) => res.json([]));
+        JS
+      Noir::JSRouteExtractor.test_stub_only?("/app/tests/user-test.js", content).should be_false
+    end
+
+    it "skips pretender helpers by path even without import markers" do
+      content = <<-JS
+        export default function (helper) {
+          this.post("/presence/update", () => helper.response(200, {}));
+        }
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/frontend/tests/helpers/presence-pretender.js",
+        content
+      ).should be_true
+    end
+
+    it "leaves non-test files untouched" do
+      content = <<-JS
+        const express = require("express");
+        const app = express();
+        app.get("/api/users", (req, res) => res.json([]));
+        JS
+      Noir::JSRouteExtractor.test_stub_only?("/app/src/server.js", content).should be_false
+    end
+  end
 end

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -32,6 +32,13 @@ module Noir
         # bundles — so a large frontend tree doesn't pay parser cost
         # for files that can't host an endpoint.
         return [] of Endpoint unless route_call_candidate?(content)
+        # Skip mock-server fixtures (pretender/mirage/MSW/nock).
+        # Their `server.get(...)` / handler-builder calls match the
+        # parser's route shape but are not real registrations; on
+        # Ember-based projects (Discourse, etc.) these files account
+        # for the bulk of analysis time and produce only false
+        # positives.
+        return [] of Endpoint if test_stub_only?(file_path, content)
         parser = JSParser.new(content)
         route_patterns = parser.parse_routes
         callees_by_route = if include_callees
@@ -268,6 +275,75 @@ module Noir
 
     def self.route_call_candidate?(content : String) : Bool
       PARSER_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) }
+    end
+
+    # Test-fixture libraries whose API mimics route registration:
+    # `pretender`/`miragejs` expose `server.get("/x", ...)`, MSW and
+    # nock expose handler builders, sinon-via-faker likewise. When
+    # these libraries are imported, virtually every route-shaped call
+    # in the file is a stub, not a real registration. Substring match
+    # is enough — these tokens never appear in production HTTP server
+    # source under normal circumstances.
+    TEST_STUB_LIBRARY_MARKERS = [
+      "pretender",
+      "miragejs",
+      "ember-cli-mirage",
+      "from \"msw\"", "from 'msw'",
+      "from \"msw/", "from 'msw/",
+      "require(\"msw\")", "require('msw')",
+      "from \"nock\"", "from 'nock'",
+      "require(\"nock\")", "require('nock')",
+      "setupApplicationTest",
+      "setupRenderingTest",
+    ]
+
+    # Real HTTP-server library imports. When any of these is present
+    # alongside a test-stub marker, the file is doing legitimate
+    # server work (e.g., spinning up a test instance of an Express
+    # app) and we still want to extract its routes.
+    HTTP_SERVER_LIBRARY_MARKERS = [
+      "from \"express\"", "from 'express'",
+      "require(\"express\")", "require('express')",
+      "from \"fastify\"", "from 'fastify'",
+      "require(\"fastify\")", "require('fastify')",
+      "from \"koa\"", "from 'koa'",
+      "require(\"koa\")", "require('koa')",
+      "from \"hono\"", "from 'hono'",
+      "require(\"hono\")", "require('hono')",
+      "from \"restify\"", "from 'restify'",
+      "require(\"restify\")", "require('restify')",
+      "from \"polka\"", "from 'polka'",
+      "from \"h3\"", "from 'h3'",
+      "from \"@nestjs/", "from '@nestjs/",
+    ]
+
+    # Path-level evidence that a file is a mock-server fixture.
+    # Pretender helpers in particular get a `helper`/`this` arg and
+    # call `this.get(...)` / `this.post(...)` directly, so they have
+    # no library-name imports the content filter can hook on — fall
+    # back to the convention-based filename match.
+    TEST_STUB_PATH_MARKERS = [
+      "-pretender.",  # *-pretender.js / *-pretender.ts
+      "-pretenders.", # *-pretenders.js
+      ".pretender.",  # *.pretender.js
+      "-mirage.",     # *-mirage.js
+      ".mirage.",
+      "/tests/helpers/", # Ember convention (Discourse)
+      "/test/helpers/",
+    ]
+
+    # True when the file's route-shaped calls are almost certainly
+    # mock-server stubs (Ember pretender, MSW, nock, ...) rather than
+    # real route registrations. Used as a follow-up filter after the
+    # cheap `route_call_candidate?` gate. Either a library import or
+    # a naming-convention path marker is enough; both routes exempt
+    # the file when it also imports a real HTTP server lib so unit
+    # tests that spin up an Express app keep working.
+    def self.test_stub_only?(file_path : String, content : String) : Bool
+      has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) }
+      has_path_marker = TEST_STUB_PATH_MARKERS.any? { |m| file_path.includes?(m) }
+      return false unless has_library || has_path_marker
+      HTTP_SERVER_LIBRARY_MARKERS.none? { |m| content.includes?(m) }
     end
 
     def self.attach_callees(endpoint : Endpoint,


### PR DESCRIPTION
## Summary

On Ember-based codebases (Discourse is the canonical case) the JS route extractor was spending the bulk of its time on test files whose `server.get(...)` / `this.post(...)` calls match the parser's route shape but are pretender / mirage / MSW / nock stubs, not real route registrations. The result was both wasted wallclock time tokenizing those files and large numbers of false-positive endpoints in the output.

This change adds a follow-up gate after the existing `route_call_candidate?` substring check that skips a file when it carries test-stub evidence and no real HTTP-server import:

- Library imports: `pretender`, `miragejs`, `ember-cli-mirage`, `msw`, `nock`, `setupApplicationTest`, `setupRenderingTest`.
- Path conventions: `*-pretender.js`, `*-mirage.js`, `/tests/helpers/`, `/test/helpers/`.

If the file also imports a real HTTP-server library (express / fastify / koa / hono / restify / polka / h3 / `@nestjs/...`) the filter does not fire, so unit tests that spin up a real test instance keep their routes.

### Discourse benchmark

| | Before | After |
| --- | --- | --- |
| Scan wallclock | 14.5 s | 8.9 s |
| `js_express` endpoints emitted | 532 | 1 |

The surviving endpoint is from `testem.js` (a Node test-runner config that does host a tiny Express-style server) — actually real.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — new `test_stub_only?` cases cover pretender import, mixed pretender + express import (kept), path-only pretender helper, and a production file (not skipped).
- [x] `crystal spec spec/functional_test/testers/javascript/` — full JS functional suite, all 1793 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: `hyperfine` on Discourse and Mastodon.