### PR TITLE
feat(detector/rails): detect Rails apps using individual gems

### DIFF
--- a/spec/unit_test/detector/ruby/rails_spec.cr
+++ b/spec/unit_test/detector/ruby/rails_spec.cr
@@ -11,4 +11,13 @@ describe "Detect Ruby Rails" do
   it "gemfile/double_quot" do
     instance.detect("Gemfile", "gem \"rails\"").should be_true
   end
+  it "gemfile/railties_single_quot" do
+    instance.detect("Gemfile", "gem 'railties', '~> 8.0.0'").should be_true
+  end
+  it "gemfile/railties_double_quot" do
+    instance.detect("Gemfile", "gem \"railties\", \"~> 8.0.0\"").should be_true
+  end
+  it "gemfile/no_rails_components" do
+    instance.detect("Gemfile", "gem 'sinatra'\ngem 'rack'").should be_false
+  end
 end

--- a/src/detector/detectors/ruby/rails.cr
+++ b/src/detector/detectors/ruby/rails.cr
@@ -2,13 +2,22 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Rails < Detector
+    # Modern Rails apps frequently skip the umbrella `gem "rails"` line
+    # and pull the individual frameworks they actually use (railties +
+    # actionpack + activerecord + ...). Treat `railties` as a unique
+    # marker — it has no standalone use outside Rails — so those apps
+    # are still detected.
+    RAILS_GEM_MARKERS = [
+      "gem 'rails'",
+      "gem \"rails\"",
+      "gem 'railties'",
+      "gem \"railties\"",
+    ]
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.includes?("Gemfile")
 
-      check = file_contents.includes?("gem 'rails'")
-      check = check || file_contents.includes?("gem \"rails\"")
-
-      check
+      RAILS_GEM_MARKERS.any? { |marker| file_contents.includes?(marker) }
     end
 
     def applicable?(filename : String) : Bool


### PR DESCRIPTION
## Summary

Modern Rails projects frequently skip the umbrella `gem "rails"` line and pull only the individual frameworks they actually use — `railties`, `actionpack`, `activerecord`, `activesupport`, etc. The Rails detector required the umbrella gem literally and missed those apps entirely.

Discourse is the canonical example: its `Gemfile` lists `actionpack`, `actionview`, `actionmailer`, `activerecord`, `activesupport`, and `railties`, but no bare `gem "rails"`. The detector skipped it, so the `ruby_rails` analyzer never ran and ~1.4k real routes were missing from the output.

Accept `gem "railties"` / `gem 'railties'` as an equivalent signature — `railties` has no standalone use outside Rails, so the signal is unique and unambiguous. The umbrella-gem path keeps working unchanged.

### Discourse impact

| | Before | After |
| --- | --- | --- |
| `ruby_rails` analyzer runs | no | yes |
| Endpoints from Rails | 0 | 1463 |
| Scan time | 8.9 s | 9.0 s |

## Test plan

- [x] `crystal spec spec/unit_test/detector/ruby/` — 20 examples pass (new cases cover both quote styles of `railties` plus a negative case).
- [x] `crystal spec spec/functional_test/testers/ruby/` — 565 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: Discourse scan now surfaces the `ruby_rails` analyzer and ~1.4k routes.