### PR TITLE
perf(go): gate per-file route extraction on framework import marker

### DIFF
--- a/spec/functional_test/testers/go/chi_spec.cr
+++ b/spec/functional_test/testers/go/chi_spec.cr
@@ -9,7 +9,7 @@ expected_endpoints = [
   Endpoint.new("/articles/{month}-{day}-{year}", "GET"),
   Endpoint.new("/articles/", "POST"),
   Endpoint.new("/articles/search", "GET"),
-  Endpoint.new("/articles/{articleSlug:[a-z-]+}", "GET", [Param.new("articleSlug", "", "path")]),
+  Endpoint.new("/articles/{articleSlug}", "GET", [Param.new("articleSlug", "", "path")]),
   Endpoint.new("/articles/{articleID}/", "GET", [Param.new("articleID", "", "path")]),
   Endpoint.new("/articles/{articleID}/", "PUT", [Param.new("articleID", "", "path")]),
   Endpoint.new("/articles/{articleID}/", "DELETE", [Param.new("articleID", "", "path")]),

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -3,6 +3,8 @@ require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class Beego < GoEngine
+    IMPORT_MARKER = "github.com/beego/beego"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -27,6 +29,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -10,6 +10,14 @@ module Analyzer::Go
   end
 
   class Chi < Analyzer
+    # Go enforces per-file imports, so any file using chi's router
+    # types must mention the package path. Filter on this marker
+    # to avoid touching the bulk of files in projects whose
+    # detection matched on a single dummy/fixture file (the chi
+    # extractor is loose enough that another framework's verb
+    # calls would otherwise surface as chi routes).
+    IMPORT_MARKER = "github.com/go-chi/chi"
+
     def analyze
       result = [] of Endpoint
 
@@ -28,6 +36,12 @@ module Analyzer::Go
           package_files[dir] << scan_path
 
           content = read_file_content(scan_path)
+          # Cache contents for every Go file in the package — the
+          # cross-file callee map and Mount-expansion walker both
+          # need handler/helper functions that live in non-chi
+          # source files (`handlers.go`, `helpers.go`). The
+          # IMPORT_MARKER gate fires later, in the per-file route
+          # extraction loop, where the savings actually matter.
           file_contents_cache[scan_path] = content
           file_lines_cache[scan_path] = content.lines
 
@@ -35,6 +49,7 @@ module Analyzer::Go
           # in `r.Mount("/admin", adminRouter())` is a *symbol*, not a
           # route, and it determines which function bodies to exclude from
           # the free-floating TS extraction pass below.
+          next unless content.includes?(".Mount(")
           content.each_line do |scan_line|
             if scan_line.includes?(".Mount(")
               if scan_match = scan_line.match(/[a-zA-Z]\w*\.Mount\(\s*"([^"]+)"\s*,\s*([^(]+)\(\)/)
@@ -71,6 +86,7 @@ module Analyzer::Go
                 next if File.directory?(path)
                 if File.exists?(path)
                   content = file_contents_cache[path]? || read_file_content(path)
+                  next unless content.includes?(IMPORT_MARKER)
                   lines = file_lines_cache[path]? || content.lines
 
                   dir = File.dirname(path)

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -2,6 +2,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Echo < GoEngine
+    IMPORT_MARKER = "github.com/labstack/echo"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -26,6 +28,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -4,6 +4,8 @@ require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class Fasthttp < Analyzer
+    IMPORT_MARKER = "github.com/valyala/fasthttp"
+
     def analyze
       # Source Analysis
       begin
@@ -32,6 +34,7 @@ module Analyzer::Go
             next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             if File.exists?(path)
               content = read_file_content(path)
+              next unless content.includes?(IMPORT_MARKER)
               last_endpoint = Endpoint.new("", "")
 
               # Tree-sitter pre-pass: fasthttp has no groups, so we just

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -2,6 +2,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Fiber < GoEngine
+    IMPORT_MARKER = "github.com/gofiber/fiber"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -23,6 +25,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -3,6 +3,8 @@ require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class Gf < GoEngine
+    IMPORT_MARKER = "github.com/gogf/gf"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -26,6 +28,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -2,6 +2,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Gin < GoEngine
+    IMPORT_MARKER = "github.com/gin-gonic/gin"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -25,6 +27,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -3,6 +3,8 @@ require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class Goyave < GoEngine
+    IMPORT_MARKER = "goyave.dev/goyave"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -27,6 +29,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -3,6 +3,8 @@ require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class GoZero < GoEngine
+    IMPORT_MARKER = "github.com/zeromicro/go-zero"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -31,6 +33,9 @@ module Analyzer::Go
                   # Handle both .go files and .api files
                   if File.exists?(path) && (File.extname(path) == ".go" || File.extname(path) == ".api")
                     content = read_file_content(path)
+                    # `.api` files are gozero's DSL (no Go imports);
+                    # only gate `.go` files on the import marker.
+                    next if File.extname(path) == ".go" && !content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -10,6 +10,7 @@ module Analyzer::Go
     # and uses the same parameter accessors on the RequestContext:
     #   ctx.Query / DefaultQuery / PostForm / DefaultPostForm / GetHeader / Cookie
     HTTP_METHODS_EXPANDED = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
+    IMPORT_MARKER         = "github.com/cloudwego/hertz"
 
     def analyze
       public_dirs = [] of (Hash(String, String))
@@ -30,6 +31,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -4,6 +4,8 @@ require "../../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class Httprouter < Analyzer
+    IMPORT_MARKER = "github.com/julienschmidt/httprouter"
+
     PARAM_PATTERNS = [
       {"ByName(", /ByName\s*\(\s*[\"']([^\"']+)[\"']\s*\)/, "path"},
       {"Query().Get(", /Query\(\)\s*\.\s*Get\s*\(\s*[\"']([^\"']+)[\"']\s*\)/, "query"},
@@ -43,6 +45,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -2,7 +2,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Iris < GoEngine
-    HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
+    HTTP_METHODS  = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
+    IMPORT_MARKER = "github.com/kataras/iris"
 
     def analyze
       # Iris uses `.Party(...)` for route groups; pass that into both the
@@ -25,6 +26,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -2,6 +2,8 @@ require "../../engines/go_engine"
 
 module Analyzer::Go
   class Mux < GoEngine
+    IMPORT_MARKER = "github.com/gorilla/mux"
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -29,6 +31,7 @@ module Analyzer::Go
                   next if File.directory?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
+                    next unless content.includes?(IMPORT_MARKER)
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 


### PR DESCRIPTION
## Summary

Each Go framework analyzer was walking every `.go` file in the project, regardless of whether the file actually imports that framework. On projects where a single fixture or test file matched a secondary framework's detector — photoprism is the canonical case, with one chi-using `docker/dummy/oidc/server.go` next to its 154 gin files — both analyzers would scan all ~2.3k Go files and emit nearly identical route sets. Chi's `r.Get(...)` shape picks up gin's `r.GET(...)` calls (Go HTTP verbs are case-insensitive) and vice versa, leaving the optimizer to dedupe hundreds of phantom endpoints.

Go enforces per-file imports, so any file invoking a framework's router types must mention the package path. Add an `IMPORT_MARKER` constant to each of the 13 Go analyzers and `next unless content.includes?(IMPORT_MARKER)` at the top of each per-file route walk. The marker strings mirror the detector checks already in `src/detector/detectors/go/*`.

| analyzer | marker |
| --- | --- |
| chi | `github.com/go-chi/chi` |
| gin | `github.com/gin-gonic/gin` |
| echo | `github.com/labstack/echo` |
| fiber | `github.com/gofiber/fiber` |
| mux | `github.com/gorilla/mux` |
| hertz | `github.com/cloudwego/hertz` |
| iris | `github.com/kataras/iris` |
| httprouter | `github.com/julienschmidt/httprouter` |
| fasthttp | `github.com/valyala/fasthttp` |
| beego | `github.com/beego/beego` |
| gf | `github.com/gogf/gf` |
| gozero | `github.com/zeromicro/go-zero` (only applied to `.go`; `.api` DSL is exempt) |
| goyave | `goyave.dev/goyave` |

Cross-file scaffolding (`collect_package_groups_ts`, `collect_package_function_bodies`, chi's pre-scan that caches contents and locates Mount targets) is left ungated so handler/helper functions defined in non-framework files (`handlers.go`, `helpers.go`) still feed the callee map.

Also updates `chi_spec.cr` to expect the canonical `{articleSlug}` form — chi's `{name:regex}` constraint is now normalized away by the optimizer pass (#1542) to match Spring and other framework dialects.

### Photoprism benchmark

| | Before | After |
| --- | --- | --- |
| Scan wallclock | 4.27 s | 1.87 s |
| `go_chi` endpoints emitted | 674 | 1 |
| `go_gin` endpoints emitted | 675 | 190 |

The remaining 1 chi endpoint is the real one (`docker/dummy/oidc/app/server.go`); the dropped 485 gin endpoints were phantom hits from non-gin files.

## Test plan

- [x] `crystal spec spec/functional_test/testers/go/` — 1104 examples pass.
- [x] `crystal spec spec/unit_test/` — 1632 examples pass.
- [x] `just check` — format + ameba clean.
- [x] `hyperfine` on photoprism, mall, mastodon — only photoprism (the affected target) moves.