### PR TITLE
fix(spec/csharp): expect canonical {name} for routes with type constraint

### DIFF
--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
@@ -22,7 +22,7 @@ expected_endpoints = [
   Endpoint.new("/api/Users", "GET", [
     Param.new("traceId", "", "header"),
   ]),
-  Endpoint.new("/api/Users/{id:int}", "GET", [
+  Endpoint.new("/api/Users/{id}", "GET", [
     Param.new("id", "", "path"),
   ]),
   Endpoint.new("/api/Users", "POST", [
@@ -37,7 +37,7 @@ expected_endpoints = [
     Param.new("soft", "", "query"),
   ]),
   Endpoint.new("/admin/Dashboard", "GET"),
-  Endpoint.new("/admin/reports/{year:int}/{month:int}", "GET", [
+  Endpoint.new("/admin/reports/{year}/{month}", "GET", [
     Param.new("year", "", "path"),
     Param.new("month", "", "path"),
   ]),


### PR DESCRIPTION
## Summary

CI tests started failing on `main` after #1542 (Spring `{name:regex}` normalization) — ASP.NET Core MVC route templates use the same `{name:type}` shape (`{id:int}`, `{year:int}/{month:int}`), so the optimizer now strips the `:int` portion and the csharp spec's hard-coded expectations no longer match.

```
1) expected endpoint [GET::/api/Users/{id:int}] not found in tester: fixtures/csharp/aspnet_core_mvc/
2) expected endpoint [GET::/admin/reports/{year:int}/{month:int}] not found in tester: fixtures/csharp/aspnet_core_mvc/
```

Mirror the chi spec fix from #1545: update the two affected csharp/aspnet_core_mvc cases to expect the canonical `{name}` form. The behavior is intentional — Noir now emits a consistent placeholder shape across Spring, chi, ASP.NET Core, and any other framework that supports inline route constraints.

Note: `spec/functional_test/testers/go/iris_spec.cr` and `spec/functional_test/testers/cpp/drogon_spec.cr` already document this canonicalization (`# Path param type annotation stripped: {id:uint64} → {id}`), so they're already in sync.

## Test plan

- [x] `crystal spec spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr` — 155 examples pass.