### PR TITLE
fix(docs): prefix blog post card hrefs with base_url

### DIFF
--- a/docs/templates/blog_section.html
+++ b/docs/templates/blog_section.html
@@ -25,7 +25,7 @@
     <ul class="blog-post-list">
       {% for post in section.pages %}
       <li class="blog-post-card">
-        <a class="blog-post-card-link" href="{{ post.url }}">
+        <a class="blog-post-card-link" href="{{ base_url }}{{ post.url }}">
           <div class="blog-post-card-meta">
             <time datetime="{{ post.date }}">{{ post.date }}</time>
             {% if post.authors %}

--- a/docs/templates/taxonomy_term.html
+++ b/docs/templates/taxonomy_term.html
@@ -61,7 +61,7 @@
         {% set keep = (page.language == "ko" and is_ko) or (page.language != "ko" and not is_ko) %}
         {% if keep %}
         <li class="blog-post-card">
-          <a class="blog-post-card-link" href="{{ post.url }}">
+          <a class="blog-post-card-link" href="{{ base_url }}{{ post.url }}">
             <div class="blog-post-card-meta">
               <time datetime="{{ post.date }}">{{ post.date }}</time>
             </div>


### PR DESCRIPTION
## Summary
- Post card links on the blog index and author taxonomy pages were rendered as `/blog/<slug>/` because `{{ post.url }}` returns a root-absolute path without the GitHub Pages base path (`/noir`). Clicking a card from `https://owasp-noir.github.io/noir/blog/` landed on `https://owasp-noir.github.io/blog/<slug>/` (404).
- Prefix both card hrefs with `{{ base_url }}` so they resolve to `https://owasp-noir.github.io/noir/blog/<slug>/`, matching how every other nav/footer link in the templates is built.

## Test plan
- [ ] After GitHub Pages redeploy, visit `https://owasp-noir.github.io/noir/blog/` and confirm the "Welcome to the Noir blog" card links to `/noir/blog/welcome-to-the-noir-blog/`.
- [ ] Visit `https://owasp-noir.github.io/noir/ko/blog/` and confirm the KO card link keeps the `/noir/ko/...` prefix.
- [ ] Visit an author page under `/noir/authors/<slug>/` and confirm post cards point to `/noir/blog/...`.