### PR TITLE
perf(js): broaden test-stub filter to Jest/Cypress/Playwright + dist bundles

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -288,5 +288,67 @@ describe Noir::JSRouteExtractor do
         JS
       Noir::JSRouteExtractor.test_stub_only?("/app/src/server.js", content).should be_false
     end
+
+    it "skips Jest-style test files by name" do
+      content = <<-JS
+        import request from "supertest";
+        describe("users", () => {
+          it("works", async () => {
+            await request(app).get("/api/users").expect(200);
+          });
+        });
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/packages/cli/test/integration/users.controller.test.ts",
+        content
+      ).should be_true
+    end
+
+    it "skips files under /__tests__/ directories" do
+      content = <<-JS
+        await client.get("/foo");
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/src/modules/data-table/__tests__/data-table.controller.test.ts",
+        content
+      ).should be_true
+    end
+
+    it "skips Cypress e2e specs" do
+      content = <<-JS
+        /// <reference types="cypress" />
+        describe("login", () => {
+          cy.request("POST", "/api/login");
+        });
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/e2e-tests/cypress/tests/login_spec.ts",
+        content
+      ).should be_true
+    end
+
+    it "skips Playwright e2e specs" do
+      content = <<-JS
+        import { test, expect } from "@playwright/test";
+        test("ping", async ({ request }) => {
+          await request.get("/api/health");
+        });
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/tests/e2e/health.spec.ts",
+        content
+      ).should be_true
+    end
+
+    it "skips bundled dist/ output files" do
+      content = <<-JS
+        // webpack bundle output with thousands of .get( / .post( noise
+        app.get("/x");
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/.github/actions/check-results/dist/index.js",
+        content
+      ).should be_true
+    end
   end
 end

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -295,6 +295,16 @@ module Noir
       "require(\"nock\")", "require('nock')",
       "setupApplicationTest",
       "setupRenderingTest",
+      # Cypress: e2e suites use `cy.request(...)` / `cy.get(...)`
+      # shaped calls that match the parser's route hint but are
+      # test invocations, not registrations.
+      "/// <reference types=\"cypress\" />",
+      "from \"cypress\"", "from 'cypress'",
+      "require(\"cypress\")", "require('cypress')",
+      # Playwright: e2e suites use `request.get(...)` / `page.goto`
+      # in the same shape.
+      "from \"@playwright/test\"", "from '@playwright/test'",
+      "from \"playwright\"", "from 'playwright'",
     ]
 
     # Real HTTP-server library imports. When any of these is present
@@ -330,6 +340,30 @@ module Noir
       ".mirage.",
       "/tests/helpers/", # Ember convention (Discourse)
       "/test/helpers/",
+      ".test.ts", ".test.tsx", ".test.js", ".test.jsx",
+      ".test.mjs", ".test.cjs",
+      ".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx",
+      ".spec.mjs", ".spec.cjs",
+      "/__tests__/",        # Jest convention (n8n, many TS projects)
+      "/test/integration/", # supertest-style integration suites
+      "/tests/integration/",
+      "/test/e2e/",
+      "/tests/e2e/",
+      "/cypress/", # Cypress e2e tree (Mattermost: e2e-tests/cypress/)
+      "/playwright/",
+      "/e2e-tests/",
+      # Bundled output: GitHub Action `dist/` blobs, Next.js
+      # `.next`, Nuxt `.nuxt`/`.output`, generic `dist/`, `build/`,
+      # `coverage/`, `vendor/`. These contain webpacked third-party
+      # code where every `.get(`/`.post(` is library noise, not an
+      # app route.
+      "/dist/",
+      "/build/",
+      "/.next/",
+      "/.nuxt/",
+      "/.output/",
+      "/coverage/",
+      "/vendor/",
     ]
 
     # True when the file's route-shaped calls are almost certainly


### PR DESCRIPTION
## Summary

Benchmarks against several well-known OSS targets (n8n, mattermost, plus the existing discourse/mastodon set) surfaced two large noise classes that were falling through the JS route extractor's pre-filter:

1. **Unit / integration test files.** Jest, Vitest, supertest, and similar suites use both file-name conventions (`*.test.ts`, `*.spec.ts`) and directory layouts (`/__tests__/`, `/test/integration/`, `/tests/e2e/`). The route-shaped calls in these files are test-client invocations against an external server, not route registrations.
2. **End-to-end frameworks.** Cypress and Playwright suites live under `/cypress/`, `/playwright/`, or `/e2e-tests/` and use `cy.request(...)` / `page.goto(...)` / `request.get(...)` shapes that match the parser's hint filter exactly.
3. **Bundled output.** GitHub Action `dist/index.js` blobs, Next.js `.next/`, Nuxt `.nuxt/`/`.output/`, generic `dist/`, `build/`, `coverage/`, and `vendor/` directories contain webpacked third-party code with thousands of library `.get(`/`.post(` calls.

Extend `TEST_STUB_LIBRARY_MARKERS` with cypress and playwright imports, and `TEST_STUB_PATH_MARKERS` with the file-name + directory conventions above. The existing exemption stays — any file that also imports a real HTTP server lib (express, fastify, koa, hono, restify, polka, h3, @nestjs/...) keeps being analyzed, so legitimate test-server harnesses like mattermost's `e2e-tests/cypress/webhook_serve.js` still emit their routes.

### Benchmarks (release build, hyperfine 2 runs)

| corpus | before | after | Δ |
| --- | ---: | ---: | ---: |
| n8n        | 130 s | **55 s** | -75 s |
| mattermost |  87 s | **69 s** | -18 s |
| discourse  | 8.7 s | 8.6 s    | flat |
| mastodon   | 3.3 s | 3.3 s    | flat |

Discourse and mastodon are flat (they were already filtered by the prior `pretender`/`/tests/helpers/` rules); n8n and mattermost are the new wins.

### Quality side-effect

The dropped files were emitting hundreds of phantom endpoints (e.g., `cy.request("POST", ...)` calls in mattermost's cypress suite). Real endpoints — actual Express, Fastify, Hono, NestJS registrations — are unaffected because the HTTP-server-import exemption still applies.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — 43 examples pass (5 new cases for Jest, `/__tests__/`, Cypress, Playwright, dist).
- [x] `crystal spec spec/functional_test/testers/javascript/ spec/functional_test/testers/typescript/` — 1905 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: hyperfine across 4 corpora; endpoints inspected to confirm real routes survive (mattermost's `webhook_serve.js` still emits its 23 routes).