### PR TITLE
fix(optimizer): keep normalizing Django re_path named groups

### DIFF
--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -67,6 +67,28 @@ describe "EndpointOptimizer" do
       result[1].url.should eq("/files/{path}")
       result[2].url.should eq("/a/{x}/b/{y}")
     end
+
+    it "normalizes Django re_path named groups even when the body contains \\d / \\w classes" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/(?P<organization_slug>[^/]+)/issues/(?P<group_id>\\d+)/", "GET"),
+        Endpoint.new("/api/0/(?P<event_id>[A-Fa-f0-9-]{32,36})/", "GET"),
+      ]
+
+      result = optimizer.normalize_url_shapes(endpoints)
+      result[0].url.should eq("/{organization_slug}/issues/{group_id}/")
+      result[1].url.should eq("/api/0/{event_id}/")
+    end
+
+    it "still skips verbatim Express regex-literal routes" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/^\\/api\\/(\\d+)$/", "GET"),
+      ]
+
+      result = optimizer.normalize_url_shapes(endpoints)
+      result[0].url.should eq("/^\\/api\\/(\\d+)$/")
+    end
   end
 
   describe "combine_url_and_endpoints" do

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -62,10 +62,12 @@ class EndpointOptimizer
 
       # Skip URLs that look like a verbatim regex literal — Express
       # accepts `app.get(/^\/api\/(\d+)$/, handler)` and the route
-      # extractor preserves the literal as the URL. Detect via
-      # escaped slashes (`\/`) or regex character classes (`\d`/`\w`/
-      # `\s`/`\D`/`\W`/`\S`/`(\d+)` etc.) the path forms never carry.
-      next if url.includes?("\\/") || url.matches?(/\\[dswDSW]/)
+      # extractor preserves the literal as the URL. The unique
+      # signal is escaped slashes (`\/`); plain `\d`/`\w` classes
+      # are also legal inside Django/Pyramid `re_path` named
+      # groups (`(?P<id>\d+)`), so checking those alone would
+      # over-shoot and leave Django patterns un-normalized.
+      next if url.includes?("\\/")
 
       # Python `re_path` named groups: `(?P<name>...)` → `{name}`.
       # Use a hand-walked replacement so the inner regex body (which


### PR DESCRIPTION
## Summary

The verbatim-regex-route carve-out in `normalize_url_shapes` was over-shooting. It checks two signals to spot Express's regex-literal route shape (`app.get(/^\/api\/(\d+)$/, handler)`):

1. Escaped slashes (`\/`) — unique to JS regex literals, since path strings never carry them.
2. Character classes (`\d` / `\w` / `\s` / `\D` / `\W` / `\S`) — meant as a backup signal.

Signal #2 is wrong: Django `re_path` and Pyramid named-group patterns legitimately contain `\d`/`\w` inside `(?P<name>...)` (e.g. `(?P<group_id>\d+)`, `(?P<event_id>[A-Fa-f0-9-]{32,36})`). Skipping those URLs leaves the raw regex form in the output instead of the canonical `{name}` placeholder.

### Sentry impact

| | before | after |
| --- | ---: | ---: |
| Django endpoints emitted | 10031 | 10031 |
| URLs carrying raw regex (`(?P<...>`/`\d`/`\w`) | **107** | **0** |

Examples:
- `/(?P<organization_slug>[^/]+)/(?P<project_id>[^/]+)/issues/(?P<group_id>\d+)/` → `/{organization_slug}/{project_id}/issues/{group_id}/`
- `/api/0/(?P<event_id>[A-Fa-f0-9-]{32,36})/` → `/api/0/{event_id}/`

The Express regex-literal carve-out still fires via the unique `\/` signal; verified with a regression spec.

## Test plan

- [x] `crystal spec spec/unit_test/optimizer/` — 15 examples (2 new) pass.
- [x] `crystal spec spec/functional_test/testers/python/ spec/functional_test/testers/javascript/` — 2785 examples pass; no Django/Express regressions.
- [x] `just check` — format + ameba clean.
- [x] Manual: Sentry scan — Django URL output no longer contains regex literals.