### PR TITLE
perf(js): broaden the test-file filter to .test.* / .spec.* + /tests/api/

### DIFF
--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -340,10 +340,12 @@ module Noir
       ".mirage.",
       "/tests/helpers/", # Ember convention (Discourse)
       "/test/helpers/",
-      ".test.ts", ".test.tsx", ".test.js", ".test.jsx",
-      ".test.mjs", ".test.cjs",
-      ".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx",
-      ".spec.mjs", ".spec.cjs",
+      # `.test.` / `.spec.` anywhere in the filename — covers
+      # `*.test.ts`, `*.spec.tsx`, and project-specific variants
+      # like Strapi's `*.test.api.ts`.
+      ".test.",
+      ".spec.",
+      "/tests/api/", # Strapi-style integration test bundles
       "/__tests__/",        # Jest convention (n8n, many TS projects)
       "/test/integration/", # supertest-style integration suites
       "/tests/integration/",


### PR DESCRIPTION
## Summary

#1553 added a path-marker set for skipping JS test files at the route-extractor level. Running the filter against the **Strapi** corpus surfaced two real-world cases the explicit-extension list missed:

- Strapi names its integration tests `*.test.api.ts` / `*.test.api.js`. The literal `.test.ts` / `.test.js` markers don't match those filenames.
- Strapi parks them under `/tests/api/`, which falls outside the existing `/tests/integration/` and `/tests/e2e/` markers.

Replace the per-extension enumeration with the shorter `.test.` / `.spec.` substring markers (the trailing dot keeps `app.testdomain.ts`-style false positives away), and add `/tests/api/` for the Strapi layout.

### Benchmark

| corpus | before | after |
| --- | ---: | ---: |
| strapi | 10.2 s | **8.9 s** |
| n8n | 55.5 s | 55.5 s |
| mattermost | 70 s | 70 s |
| discourse | 8.6 s | 8.6 s |

Endpoint count side-effects: Strapi 246 → 133 (113 dropped `request(strapi.app.callback()).get(...)` test invocations, not real routes).

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr spec/functional_test/testers/javascript/ spec/functional_test/testers/typescript/` — 1910 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: hyperfine sweep across n8n / mattermost / discourse / strapi.