### PR TITLE
refine(ts/nestjs): recognize empty / object / multi-line @Controller

### DIFF
--- a/spec/functional_test/fixtures/typescript/nestjs/extra-shapes.controller.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs/extra-shapes.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+
+// Empty @Controller() — routes use the method path as-is.
+@Controller()
+export class RootController {
+  @Get('health')
+  health() {
+    return { ok: true };
+  }
+}
+
+// Object syntax on a single line.
+@Controller({ path: 'tasks', version: '1' })
+export class TasksController {
+  @Get()
+  list() {
+    return [];
+  }
+
+  @Post()
+  create(@Body() dto: any) {
+    return {};
+  }
+}
+
+// Object syntax spanning multiple lines — common in larger
+// NestJS apps where the decorator carries auth/version metadata.
+@Controller({
+  path: 'webhooks',
+  version: '1',
+})
+export class WebhooksController {
+  @Post(':provider')
+  receive(@Param('provider') provider: string, @Body() body: any) {
+    return { provider };
+  }
+}

--- a/spec/functional_test/testers/typescript/nestjs_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_spec.cr
@@ -25,6 +25,18 @@ expected_endpoints = [
   Endpoint.new("/protected", "GET", [
     Param.new("authorization", "", "header"),
   ]),
+  # `@Controller()` (empty) — method path used as-is.
+  Endpoint.new("/health", "GET", [] of Param),
+  # `@Controller({ path: 'tasks', version: '1' })` (object).
+  Endpoint.new("/tasks", "GET", [] of Param),
+  Endpoint.new("/tasks", "POST", [
+    Param.new("body", "", "body"),
+  ]),
+  # Multi-line `@Controller({ path: 'webhooks', ... })`.
+  Endpoint.new("/webhooks/:provider", "POST", [
+    Param.new("provider", "", "path"),
+    Param.new("body", "", "body"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/typescript/nestjs/", {

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -81,16 +81,28 @@ module Analyzer::Javascript
       current_controller : Hash(Symbol, String)? = nil
       brace_count = 0
       in_class = false
+      skip_until = -1
 
       lines.each_with_index do |line, index|
-        # Check for @Controller decorator
-        if line =~ /@Controller\s*\(\s*['"`]([^'"`]*?)['"`]\s*\)/
-          controller_path = $1
-          current_controller = {
-            :base_path  => controller_path,
-            :content    => "",
-            :start_line => "1",
-          }
+        next if index <= skip_until
+
+        # Detect any of NestJS's `@Controller` shapes. The
+        # decorator header can span multiple lines (e.g.
+        # `@Controller({\n  path: '...',\n  version: ...\n})`),
+        # so coalesce continuation lines until the parens close
+        # before parsing.
+        if line.includes?("@Controller")
+          joined = join_decorator_header(lines, index)
+          base = parse_controller_decorator(joined[:text])
+          if !base.nil?
+            current_controller = {
+              :base_path  => base,
+              :content    => "",
+              :start_line => "1",
+            }
+            skip_until = joined[:last_line]
+            next if joined[:last_line] > index
+          end
         end
 
         # Check for class start after @Controller
@@ -117,6 +129,58 @@ module Analyzer::Javascript
       end
 
       controllers
+    end
+
+    # Coalesce a multi-line decorator header into a single string.
+    # Starts at `start_idx`, advances until the running open-paren
+    # count returns to zero. Returns the joined text plus the
+    # index of the last consumed line.
+    private def join_decorator_header(lines : Array(String), start_idx : Int32) : NamedTuple(text: String, last_line: Int32)
+      text = lines[start_idx]
+      depth = text.count('(') - text.count(')')
+      idx = start_idx
+      while depth > 0 && idx + 1 < lines.size
+        idx += 1
+        text += "\n" + lines[idx]
+        depth += lines[idx].count('(') - lines[idx].count(')')
+      end
+      {text: text, last_line: idx}
+    end
+
+    # Parse `@Controller(...)` and return the base path for the
+    # routes it scopes. Recognized shapes:
+    #
+    #   @Controller()                              -> ""
+    #   @Controller('users')                       -> "users"
+    #   @Controller(`v1/users`)                    -> "v1/users"
+    #   @Controller({ path: 'users' })             -> "users"
+    #   @Controller({ path: 'users', version: 1 }) -> "users"
+    #   @Controller({ version: 1, path: 'users' }) -> "users"
+    #   @Controller(SOME_CONST)                    -> ""  (best-effort
+    #     fallback: register the controller without a prefix rather
+    #     than miss every route inside it.)
+    #
+    # Returns nil when `text` isn't a `@Controller(...)` decorator.
+    private def parse_controller_decorator(text : String) : String?
+      return unless text.includes?("@Controller")
+      # Allow `(...)` to span newlines; the caller (`extract_controllers`)
+      # already joined the multi-line header for us.
+      match = text.match(/@Controller\s*\(([\s\S]*?)\)/m)
+      return unless match
+      inner = match[1].strip
+      return "" if inner.empty?
+
+      if str = inner.match(/^['"`]([^'"`]*)['"`]\s*$/)
+        return str[1]
+      end
+
+      if inner.starts_with?("{")
+        if obj = inner.match(/path\s*:\s*['"`]([^'"`]+)['"`]/)
+          return obj[1]
+        end
+      end
+
+      ""
     end
 
     private def process_http_methods(class_content : String, base_path : String, file_path : String, result : Array(Endpoint), include_callee : Bool, controller_start_line : Int32)

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -345,7 +345,7 @@ module Noir
       # like Strapi's `*.test.api.ts`.
       ".test.",
       ".spec.",
-      "/tests/api/", # Strapi-style integration test bundles
+      "/tests/api/",        # Strapi-style integration test bundles
       "/__tests__/",        # Jest convention (n8n, many TS projects)
       "/test/integration/", # supertest-style integration suites
       "/tests/integration/",


### PR DESCRIPTION
## Summary

The NestJS analyzer only handled the `@Controller('path')` string-argument shape, so several legitimate idioms produced zero or near-zero endpoints on real NestJS projects. Surfaced by benchmarking against Cal.com, Vendure, and Hoppscotch.

### New shapes recognized

- `@Controller()` (empty) — pin route at the method path.
- `@Controller({ path: 'x', version: '1' })` (object literal on one line).
- Multi-line variant of the object literal — common in larger apps:
  ```ts
  @Controller({
    path: 'webhooks',
    version: '1',
  })
  ```
- `@Controller(SOME_CONST)` — variable reference. Best-effort: register the controller with an empty prefix instead of dropping every route inside it.

### Implementation

- Pull `@Controller` parsing into `parse_controller_decorator` with a single switch over the four shapes above.
- `join_decorator_header` coalesces continuation lines so multi-line headers fit in one regex evaluation. Closes at the paren depth boundary so nested objects work.
- Added `extra-shapes.controller.ts` fixture plus matching spec entries for empty, object, and multi-line shapes.

### Benchmark (`ts_nestjs` endpoint count, real OSS targets)

| corpus | before | after |
| --- | ---: | ---: |
| cal.com (Next.js + NestJS API) | 0 | **173** |
| hoppscotch (NestJS backend) | 2 | **38** |
| vendure (NestJS) | 5 | 6 |

Cal.com is the dramatic one — every controller there uses multi-line `@Controller({ path: ..., version: API_VERSIONS_VALUES })`, so the entire `apps/api/v2` tree was previously invisible.

## Test plan

- [x] `crystal spec spec/functional_test/testers/typescript/nestjs_spec.cr` — 46 examples (4 new) pass.
- [x] `crystal spec spec/functional_test/testers/typescript/nestjs_callees_spec.cr spec/functional_test/testers/javascript/nestjs_*` — 80 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: bench against cal.com / vendure / hoppscotch.