### PR TITLE
refine(js/nuxtjs): tighten detection, emit ANY for method-agnostic handlers

### DIFF
--- a/spec/functional_test/testers/javascript/nuxtjs_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/nuxtjs_callees_spec.cr
@@ -13,13 +13,13 @@ auth_callees = [
   Callee.new("authorizeUser", line: 5),
 ]
 
-expected_endpoints = [orders_endpoint] + ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].map do |method|
-  Endpoint.new("/auth", method, [
-    Param.new("session", "", "cookie"),
-  ]).tap do |ep|
-    auth_callees.each { |callee| ep.push_callee(callee) }
-  end
+auth_endpoint = Endpoint.new("/auth", "ANY", [
+  Param.new("session", "", "cookie"),
+]).tap do |ep|
+  auth_callees.each { |callee| ep.push_callee(callee) }
 end
+
+expected_endpoints = [orders_endpoint, auth_endpoint]
 
 FunctionalTester.new("fixtures/javascript/nuxtjs_callees/", {
   :techs     => 1,

--- a/spec/functional_test/testers/javascript/nuxtjs_spec.cr
+++ b/spec/functional_test/testers/javascript/nuxtjs_spec.cr
@@ -1,14 +1,10 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
-  # Basic API route
-  Endpoint.new("/api/hello", "GET"),
-  Endpoint.new("/api/hello", "POST"),
-  Endpoint.new("/api/hello", "PUT"),
-  Endpoint.new("/api/hello", "DELETE"),
-  Endpoint.new("/api/hello", "PATCH"),
-  Endpoint.new("/api/hello", "HEAD"),
-  Endpoint.new("/api/hello", "OPTIONS"),
+  # `defineEventHandler` accepts any HTTP method, so files
+  # without a method-suffixed name emit a single `ANY` endpoint
+  # rather than a near-duplicate row for every verb.
+  Endpoint.new("/api/hello", "ANY"),
 
   # GET-only route with query parameters
   Endpoint.new("/api/users", "GET", [
@@ -24,53 +20,19 @@ expected_endpoints = [
     Param.new("password", "", "body"),
   ]),
 
-  # Dynamic route with path parameter (from [id].ts)
-  Endpoint.new("/api/users/:id", "GET", [
-    Param.new("id", "", "path"),
-  ]),
-  Endpoint.new("/api/users/:id", "POST", [
-    Param.new("id", "", "path"),
-  ]),
-  Endpoint.new("/api/users/:id", "PUT", [
-    Param.new("id", "", "path"),
-  ]),
-  Endpoint.new("/api/users/:id", "PATCH", [
-    Param.new("id", "", "path"),
-  ]),
-  Endpoint.new("/api/users/:id", "HEAD", [
-    Param.new("id", "", "path"),
-  ]),
-  Endpoint.new("/api/users/:id", "OPTIONS", [
+  # Dynamic route with path parameter (from [id].ts).
+  Endpoint.new("/api/users/:id", "ANY", [
     Param.new("id", "", "path"),
   ]),
 
-  # DELETE-only route with path parameter and header (from [id].delete.ts)
-  # This will override the DELETE from [id].ts due to deduplication
+  # DELETE-only route with path parameter and header (from [id].delete.ts).
   Endpoint.new("/api/users/:id", "DELETE", [
     Param.new("id", "", "path"),
     Param.new("authorization", "", "header"),
   ]),
 
   # Server route (without /api prefix) with cookie
-  Endpoint.new("/auth", "GET", [
-    Param.new("session", "", "cookie"),
-  ]),
-  Endpoint.new("/auth", "POST", [
-    Param.new("session", "", "cookie"),
-  ]),
-  Endpoint.new("/auth", "PUT", [
-    Param.new("session", "", "cookie"),
-  ]),
-  Endpoint.new("/auth", "DELETE", [
-    Param.new("session", "", "cookie"),
-  ]),
-  Endpoint.new("/auth", "PATCH", [
-    Param.new("session", "", "cookie"),
-  ]),
-  Endpoint.new("/auth", "HEAD", [
-    Param.new("session", "", "cookie"),
-  ]),
-  Endpoint.new("/auth", "OPTIONS", [
+  Endpoint.new("/auth", "ANY", [
     Param.new("session", "", "cookie"),
   ]),
 ]

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -10,6 +10,9 @@ module Analyzer::Javascript
       parallel_file_scan([".js", ".ts", ".mjs", ".mts"]) do |path|
         # Focus on server/api and server/routes directories for Nuxt 3
         next unless path.includes?("/server/api/") || path.includes?("/server/routes/")
+        # Skip `*.test.ts` / `*.spec.ts` siblings — they don't
+        # define Nuxt event handlers, just exercise neighbors.
+        next if path.includes?(".test.") || path.includes?(".spec.")
         analyze_nuxt_file(path, result, mutex, include_callee)
       end
 
@@ -73,8 +76,13 @@ module Analyzer::Javascript
       url = url.gsub(/\/index$/, "")
       url = "/" if url.empty?
 
-      # Determine HTTP methods
-      methods = specific_method ? [specific_method] : ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+      # Determine HTTP methods. With a method-suffixed file name
+      # (`users.get.ts`) Nuxt only handles that verb. Without one
+      # the file's `defineEventHandler` runs for any incoming
+      # method, so emit a single `ANY` endpoint instead of seven
+      # near-duplicate rows — matching how Echo/Mux/etc. surface
+      # method-agnostic registrations.
+      methods = specific_method ? [specific_method] : ["ANY"]
 
       # Read file content to extract parameters
       begin

--- a/src/detector/detectors/javascript/nuxtjs.cr
+++ b/src/detector/detectors/javascript/nuxtjs.cr
@@ -19,10 +19,17 @@ module Detector::Javascript
         return true
       end
 
-      # Check for server/api or server/routes directory patterns
+      # Nuxt 3 server routes live under `/server/api/` or
+      # `/server/routes/`, but those paths are also used by
+      # several Koa/Express projects (Outline, etc.) for plain
+      # routers. Require the `defineEventHandler` call before
+      # claiming the file for Nuxt — the strong import signals
+      # above (defineNuxtConfig, @nuxt/..., bare `nuxt` import)
+      # still catch projects that lack the directory layout.
       if (filename.includes?("/server/api/") || filename.includes?("/server/routes/")) &&
          (filename.ends_with?(".js") || filename.ends_with?(".ts") ||
-         filename.ends_with?(".mjs") || filename.ends_with?(".mts"))
+         filename.ends_with?(".mjs") || filename.ends_with?(".mts")) &&
+         file_contents.includes?("defineEventHandler")
         return true
       end
 


### PR DESCRIPTION
## Summary

Running Noir against the Outline corpus surfaced three accuracy problems specific to the Nuxt path. None of them are perf wins by themselves, but together they cut 1274 phantom endpoints out of an Outline scan and bring the method shape in line with how Echo/Mux/etc. surface method-agnostic routes.

### 1. Detector — false-positive on Koa/Express projects under `server/routes/`

Outline uses Koa middleware mounted at `server/routes/`. The Nuxt detector treated any `.ts`/`.js` file under `server/routes/` or `server/api/` as Nuxt, so the Nuxt analyzer fired on Outline and emitted ~1.3 k phantom endpoints. Add a `defineEventHandler` check to the directory-pattern branch — the strong import signals above it (`defineNuxtConfig`, `from "@nuxt/..."`, bare `from "nuxt"`) still catch projects without the file layout.

### 2. Analyzer — single `ANY` endpoint for method-agnostic handlers

Nuxt 3's `defineEventHandler` accepts any HTTP method, but the analyzer was emitting seven near-duplicate rows (GET / POST / PUT / DELETE / PATCH / HEAD / OPTIONS) per file. Collapse to one row with method `ANY`, matching how Echo/Mux/Fiber surface their method-agnostic registrations. Files named `users.get.ts` / `users.post.ts` still emit the explicit verb.

### 3. Analyzer — skip `.test.` / `.spec.` siblings under server route directories

Test files placed next to event handlers (e.g. `users.test.ts`) don't define their own handler; they exercise the neighbor.

### Spec updates

Update `nuxtjs_spec` and `nuxtjs_callees_spec` to reflect the new emission shape — fewer rows, mostly `ANY`.

### Outline benchmark

| | before | after |
| --- | ---: | ---: |
| endpoints emitted | 1792 | **134** |
| `js_nuxtjs` analyzer fires | yes (false) | no |

Cal.com / Vendure / Hoppscotch don't use `defineEventHandler`, so they're unaffected.

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/nuxtjs_spec.cr spec/functional_test/testers/javascript/nuxtjs_callees_spec.cr` — 56 examples pass.
- [x] `crystal spec spec/functional_test/testers/javascript/ spec/functional_test/testers/typescript/` — 1777 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: Outline scan no longer surfaces phantom `js_nuxtjs` endpoints.