### PR TITLE
perf(js): treat strict filename markers as unconditional test signal

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -258,14 +258,37 @@ describe Noir::JSRouteExtractor do
       Noir::JSRouteExtractor.test_stub_only?("/app/tests/user-test.js", content).should be_true
     end
 
-    it "keeps the file when express is also imported" do
+    it "keeps the file when express is also imported (path-marker route only)" do
+      # Library + directory markers honor an HTTP-server-import
+      # exemption so legit test-server harnesses keep their
+      # routes. The path here triggers TEST_STUB_PATH_MARKERS via
+      # `/cypress/` (without the strict filename markers) so the
+      # exemption code path is the one under test.
       content = <<-JS
         import express from "express";
         import Pretender from "pretender";
         const app = express();
         app.get("/api/users", (req, res) => res.json([]));
         JS
-      Noir::JSRouteExtractor.test_stub_only?("/app/tests/user-test.js", content).should be_false
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/cypress/helpers/api-server.js",
+        content
+      ).should be_false
+    end
+
+    it "skips strict-filename test markers unconditionally" do
+      # Filenames like `foo.test.ts` / `bar.e2e-spec.ts` never
+      # define real routes — even when the file imports an HTTP
+      # server lib for type-only references (NestJS e2e style).
+      content = <<-JS
+        import { NestExpressApplication } from "@nestjs/platform-express";
+        import request from "supertest";
+        await request(app).get("/api/users");
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/src/users/users.controller.e2e-spec.ts",
+        content
+      ).should be_true
     end
 
     it "skips pretender helpers by path even without import markers" do

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -340,11 +340,6 @@ module Noir
       ".mirage.",
       "/tests/helpers/", # Ember convention (Discourse)
       "/test/helpers/",
-      # `.test.` / `.spec.` anywhere in the filename — covers
-      # `*.test.ts`, `*.spec.tsx`, and project-specific variants
-      # like Strapi's `*.test.api.ts`.
-      ".test.",
-      ".spec.",
       "/tests/api/",        # Strapi-style integration test bundles
       "/__tests__/",        # Jest convention (n8n, many TS projects)
       "/test/integration/", # supertest-style integration suites
@@ -368,14 +363,34 @@ module Noir
       "/vendor/",
     ]
 
+    # Hard test-file markers: when the filename itself follows a
+    # ubiquitous test convention, the file practically never
+    # defines real routes. Skip these even when the file imports
+    # a real HTTP server lib — NestJS e2e tests routinely import
+    # `@nestjs/platform-express` for type-only references, and
+    # supertest harnesses import the same modules they exercise.
+    # The supertest `request(app).get(...)` shape would otherwise
+    # ride the HTTP-server-import exemption straight back into the
+    # parser.
+    TEST_STUB_FILENAME_MARKERS = [
+      ".test.",
+      ".spec.",
+      "-spec.",
+      "-test.",
+    ]
+
     # True when the file's route-shaped calls are almost certainly
-    # mock-server stubs (Ember pretender, MSW, nock, ...) rather than
-    # real route registrations. Used as a follow-up filter after the
-    # cheap `route_call_candidate?` gate. Either a library import or
-    # a naming-convention path marker is enough; both routes exempt
-    # the file when it also imports a real HTTP server lib so unit
-    # tests that spin up an Express app keep working.
+    # mock-server stubs (Ember pretender, MSW, nock, ...) rather
+    # than real route registrations. Two routes:
+    #
+    #   * Filename markers fire unconditionally — `foo.test.ts` is
+    #     a test no matter what it imports.
+    #   * Library + directory markers honor an exemption — if the
+    #     file also imports a real HTTP server lib (express,
+    #     fastify, ...), keep it so legit test-server harnesses
+    #     (e.g. mattermost's `webhook_serve.js`) keep their routes.
     def self.test_stub_only?(file_path : String, content : String) : Bool
+      return true if TEST_STUB_FILENAME_MARKERS.any? { |m| file_path.includes?(m) }
       has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) }
       has_path_marker = TEST_STUB_PATH_MARKERS.any? { |m| file_path.includes?(m) }
       return false unless has_library || has_path_marker


### PR DESCRIPTION
## Summary

The HTTP-server-import exemption (added in #1543) was too permissive once filename markers grew beyond pretender/mirage naming. Two concrete cases the existing rules let slip through, surfaced by benchmarking Cal.com:

- NestJS e2e suites named `*.e2e-spec.ts` import `@nestjs/platform-express` for type-only references.
- Supertest harnesses import the same modules they exercise.

Both shapes hit the HTTP-server-import exemption and ended up parsed, producing hundreds of phantom routes from `request(app).get('/api/...')` invocations.

### Change

Split the path markers into two sets:

- **`TEST_STUB_FILENAME_MARKERS` — strict, unconditional.** Filenames matching `.test.` / `.spec.` / `-spec.` / `-test.` are skipped regardless of imports. The convention is unambiguous; real route registrations live in production-named files.
- **`TEST_STUB_PATH_MARKERS` (existing) + `TEST_STUB_LIBRARY_MARKERS`** keep their HTTP-server-import exemption so legit test-server harnesses (mattermost's `webhook_serve.js`, etc.) still emit their routes.

### Cal.com benchmark

| | before | after |
| --- | ---: | ---: |
| `js_express` raw emission | 509 | **26** |
| total endpoints (post-dedup) | 808 | 585 |

The 223 dropped routes were `request(strapi.app.callback()).get(...)` / `request(app).get(...)` supertest invocations from `*.e2e-spec.ts` files. The actual controller routes are still emitted by the NestJS analyzer (173, unchanged).

n8n / mattermost / discourse / strapi unchanged (those projects don't use the `-spec.` filename convention).

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — 44 examples pass (added strict-filename case; updated exemption case to target `/cypress/helpers/` path).
- [x] `crystal spec spec/functional_test/testers/javascript/ spec/functional_test/testers/typescript/` — 1777 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: bench against cal.com / n8n / mattermost / strapi / discourse.