### PR TITLE
feat(detector/rails): detect Rails apps that declare rails in gemspec

### DIFF
--- a/spec/unit_test/detector/ruby/rails_spec.cr
+++ b/spec/unit_test/detector/ruby/rails_spec.cr
@@ -20,4 +20,42 @@ describe "Detect Ruby Rails" do
   it "gemfile/no_rails_components" do
     instance.detect("Gemfile", "gem 'sinatra'\ngem 'rack'").should be_false
   end
+
+  it "gemspec/add_dependency_rails" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.name = "spree_core"
+        s.add_dependency 'rails', '>= 7.2', '< 8.2'
+      end
+      RUBY
+    instance.detect("spree/core/spree_core.gemspec", contents).should be_true
+  end
+
+  it "gemspec/add_dependency_railties" do
+    contents = <<-RUBY
+      Gem::Specification.new do |spec|
+        spec.add_dependency "railties", "~> 8.0.0"
+      end
+      RUBY
+    instance.detect("foo.gemspec", contents).should be_true
+  end
+
+  it "gemspec/add_runtime_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_runtime_dependency 'rails', '~> 7.0'
+      end
+      RUBY
+    instance.detect("legacy.gemspec", contents).should be_true
+  end
+
+  it "gemspec/no_rails_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_dependency 'sinatra'
+        s.add_dependency 'rack'
+      end
+      RUBY
+    instance.detect("sinatra-thing.gemspec", contents).should be_false
+  end
 end

--- a/src/detector/detectors/ruby/rails.cr
+++ b/src/detector/detectors/ruby/rails.cr
@@ -7,21 +7,47 @@ module Detector::Ruby
     # actionpack + activerecord + ...). Treat `railties` as a unique
     # marker — it has no standalone use outside Rails — so those apps
     # are still detected.
-    RAILS_GEM_MARKERS = [
+    RAILS_GEMFILE_MARKERS = [
       "gem 'rails'",
       "gem \"rails\"",
       "gem 'railties'",
       "gem \"railties\"",
     ]
 
-    def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.includes?("Gemfile")
+    # Multi-engine Rails projects (Spree, Solidus, larger Solidus
+    # forks) push their Gemfile to just `gemspec` and declare
+    # `s.add_dependency 'rails'` / `s.add_dependency 'railties'`
+    # inside `<gem>.gemspec` files. Match both common DSL accessor
+    # names (`s`, `spec`) and the runtime-dependency variant.
+    RAILS_GEMSPEC_MARKERS = [
+      "add_dependency 'rails'",
+      "add_dependency \"rails\"",
+      "add_dependency 'railties'",
+      "add_dependency \"railties\"",
+      "add_runtime_dependency 'rails'",
+      "add_runtime_dependency \"rails\"",
+      "add_runtime_dependency 'railties'",
+      "add_runtime_dependency \"railties\"",
+    ]
 
-      RAILS_GEM_MARKERS.any? { |marker| file_contents.includes?(marker) }
+    def detect(filename : String, file_contents : String) : Bool
+      if filename.includes?("Gemfile")
+        return RAILS_GEMFILE_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      end
+
+      if filename.ends_with?(".gemspec")
+        return RAILS_GEMSPEC_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      end
+
+      false
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+      filename.ends_with?(".rb") ||
+        filename.ends_with?(".ru") ||
+        filename.ends_with?(".gemspec") ||
+        File.basename(filename) == "Gemfile" ||
+        File.basename(filename) == "Gemfile.lock"
     end
 
     def set_name


### PR DESCRIPTION
## Summary

Spree and a few other multi-engine Rails projects park their Gemfile at `gemspec` (zero gem entries) and put the actual `s.add_dependency 'rails'` / `s.add_dependency 'railties'` line inside each engine's `<gem>.gemspec` file. The Rails detector inspected only `Gemfile` / `Gemfile.lock`, so those apps came out as Rails-less.

### Change

- Extend `applicable?` to also cover `*.gemspec`.
- Add a second marker set (`RAILS_GEMSPEC_MARKERS`) for `add_dependency` and `add_runtime_dependency` shapes of `'rails'` and `'railties'`, both quote styles.

### Spree benchmark

| | before | after |
| --- | --- | --- |
| `ruby_rails` detector fires | no | yes |
| Endpoints (`ruby_rails`) | 0 | **103** |

Other Rails benchmark corpora (Chatwoot 358, Solidus 83, Diaspora 203, Redmine 266, Huginn 91, Mastodon 191, Forem 372, Discourse 1463) unchanged — they use the existing Gemfile path.

## Test plan

- [x] `crystal spec spec/unit_test/detector/ruby/` — 24 examples pass (4 new gemspec cases + 1 negative).
- [x] `crystal spec spec/functional_test/testers/ruby/` — 565 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: Spree scan now surfaces `ruby_rails` and 103 routes; the other 8 Rails corpora emit unchanged endpoint counts.