### PR TITLE
refine(ruby/rails): support legacy `match ... via:` routes

### DIFF
--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -265,10 +265,61 @@ module Analyzer::Ruby
             next
           end
 
+          # `match` — Rails legacy multi-verb route. Requires `via:`
+          # (or, on older codebases, defaults to ANY). Emits one
+          # endpoint per verb listed under via, all sharing the
+          # same path/controller#action.
+          if line.starts_with?("match ") || line.starts_with?("match\t") || line.starts_with?("match'") || line.starts_with?("match\"")
+            rest = line.lchop("match")
+            if sm = rest.match(/^\s*['"]([^'"]+)['"]/)
+              path = sm[1]
+              prefix = current_path_prefix(stack)
+              path_part = path.starts_with?("/") ? path : "/#{path}"
+              url = prefix.empty? ? path_part : "/#{prefix}#{path_part}"
+
+              match_verbs = parse_match_verbs(rest)
+              ctrl_action = parse_controller_action(rest)
+
+              ctrl_path = nil.as(String?)
+              action_name = nil.as(String?)
+              if ctrl_action
+                ctrl_name, action = ctrl_action
+                ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
+                action_name = action
+              end
+
+              match_verbs.each do |match_verb|
+                action_params = if name = action_name
+                                  params_for_action(ctrl_path, name, match_verb)
+                                else
+                                  [] of Param
+                                end
+                endpoint = Endpoint.new(url, match_verb, action_params, details)
+                attach_callees_for_action(endpoint, ctrl_path, action_name) if action_name
+                @result << endpoint
+              end
+            end
+            next
+          end
+
           # Unknown DSL line that still opens a block (e.g. `constraints ... do`).
           stack << Frame.new(:neutral) if opens_block
         end
       end
+    end
+
+    # Pull the verb list out of a `match ... :via => :get` or
+    # `match ... via: [:get, :post]` declaration. Returns the
+    # single-element `["ANY"]` when `via:` is missing or empty —
+    # modern Rails raises in that case but the older Redmine
+    # idiom is permissive.
+    private def parse_match_verbs(rest : String) : Array(String)
+      via_match = rest.match(/:?via\s*(?:=>|:)\s*(\[[^\]]+\]|:\w+)/)
+      return ["ANY"] unless via_match
+      tail = via_match[1]
+      verbs = [] of String
+      tail.scan(/:(\w+)/) { |sm| verbs << sm[1].upcase }
+      verbs.empty? ? ["ANY"] : verbs.uniq
     end
 
     private def strip_inline_comment(line : String) : String


### PR DESCRIPTION
## Summary

Redmine and other older Rails apps still rely heavily on the legacy `match 'path', :to => 'ctrl#action', :via => [:get, :post]` DSL. The Rails analyzer recognized the modern `get`/`post`/`put`/`patch`/`delete`/`head`/`options` lines but skipped `match` entirely, so those routes never made it into the output — on Redmine alone that was 72 declarations covering signin / signout / 2FA / news preview and the rest of the legacy surface.

### Change

- Add a `match`-line branch alongside the verb branch in the routes-file scanner.
- Parse the path (positional string), `:to => 'ctrl#action'` via the existing helper, and a new `parse_match_verbs` that accepts both hashrocket and 1.9-style `:via` (`:via => :get`, `via: [:get, :post]`).
- Emit one endpoint per verb under `:via`, sharing the path and controller#action.
- Fall back to a single `ANY` endpoint when `:via` is missing — older Rails was permissive there.

### Benchmark (`ruby_rails` endpoint count)

| corpus | before | after |
| --- | ---: | ---: |
| **redmine** | 266 | **381** |
| diaspora | 203 | 220 |
| mastodon | 191 | 196 |
| chatwoot, solidus, spree, forem, discourse | unchanged | unchanged |

Spot-check (post-fix):

```
$ noir -b redmine -f json | jq '...'
GET /login           POST /login
GET /news/preview    POST /news/preview    PUT /news/preview    PATCH /news/preview
```

## Test plan

- [x] `crystal spec spec/functional_test/testers/ruby/` — 565 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: Redmine routes now include `match`-generated endpoints, verbs parsed correctly.