### PR TITLE
feat(detector/ruby): detect Sinatra / Hanami via gemspec dependency

### DIFF
--- a/spec/unit_test/detector/ruby/hanami_spec.cr
+++ b/spec/unit_test/detector/ruby/hanami_spec.cr
@@ -11,4 +11,21 @@ describe "Detect Ruby Hanami" do
   it "gemfile/double_quot" do
     instance.detect("Gemfile", "gem \"hanami\"").should be_true
   end
+  it "gemspec/add_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_dependency 'hanami', '~> 2.0'
+      end
+      RUBY
+    instance.detect("my_app.gemspec", contents).should be_true
+  end
+  it "gemspec/no_hanami_dep" do
+    contents = <<-RUBY
+      Gem::Specification.new do |spec|
+        spec.name = "hanami"
+        spec.add_dependency 'dry-system'
+      end
+      RUBY
+    instance.detect("hanami.gemspec", contents).should be_false
+  end
 end

--- a/spec/unit_test/detector/ruby/sinatra_spec.cr
+++ b/spec/unit_test/detector/ruby/sinatra_spec.cr
@@ -11,4 +11,28 @@ describe "Detect Ruby Sinatra" do
   it "gemfile/double_quot" do
     instance.detect("Gemfile", "gem \"sinatra\"").should be_true
   end
+  it "gemspec/add_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_dependency 'sinatra', '~> 4.0'
+      end
+      RUBY
+    instance.detect("gollum.gemspec", contents).should be_true
+  end
+  it "gemspec/add_runtime_dependency" do
+    contents = <<-RUBY
+      Gem::Specification.new do |spec|
+        spec.add_runtime_dependency "sinatra", ">= 2.0"
+      end
+      RUBY
+    instance.detect("foo.gemspec", contents).should be_true
+  end
+  it "gemspec/no_sinatra_dep" do
+    contents = <<-RUBY
+      Gem::Specification.new do |s|
+        s.add_dependency 'rails'
+      end
+      RUBY
+    instance.detect("foo.gemspec", contents).should be_false
+  end
 end

--- a/src/detector/detectors/ruby/hanami.cr
+++ b/src/detector/detectors/ruby/hanami.cr
@@ -2,17 +2,41 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Hanami < Detector
+    GEMFILE_MARKERS = [
+      "gem 'hanami'",
+      "gem \"hanami\"",
+    ]
+
+    # Apps that vendor Hanami via a gemspec declare it as
+    # `s.add_dependency 'hanami'`. The Hanami framework's own
+    # repo deliberately won't match — its gemspec only carries
+    # `spec.name = "hanami"`, and there are no app-level routes
+    # to extract from the library source.
+    GEMSPEC_MARKERS = [
+      "add_dependency 'hanami'",
+      "add_dependency \"hanami\"",
+      "add_runtime_dependency 'hanami'",
+      "add_runtime_dependency \"hanami\"",
+    ]
+
     def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.includes?("Gemfile")
+      if filename.includes?("Gemfile")
+        return GEMFILE_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      end
 
-      check = file_contents.includes?("gem 'hanami'")
-      check = check || file_contents.includes?("gem \"hanami\"")
+      if filename.ends_with?(".gemspec")
+        return GEMSPEC_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      end
 
-      check
+      false
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+      filename.ends_with?(".rb") ||
+        filename.ends_with?(".ru") ||
+        filename.ends_with?(".gemspec") ||
+        File.basename(filename) == "Gemfile" ||
+        File.basename(filename) == "Gemfile.lock"
     end
 
     def set_name

--- a/src/detector/detectors/ruby/sinatra.cr
+++ b/src/detector/detectors/ruby/sinatra.cr
@@ -2,17 +2,39 @@ require "../../../models/detector"
 
 module Detector::Ruby
   class Sinatra < Detector
+    GEMFILE_MARKERS = [
+      "gem 'sinatra'",
+      "gem \"sinatra\"",
+    ]
+
+    # Single-gem repos (e.g. Gollum) park their Gemfile at
+    # `gemspec` and declare `s.add_dependency 'sinatra'` inside
+    # the gemspec instead. Walk those files too.
+    GEMSPEC_MARKERS = [
+      "add_dependency 'sinatra'",
+      "add_dependency \"sinatra\"",
+      "add_runtime_dependency 'sinatra'",
+      "add_runtime_dependency \"sinatra\"",
+    ]
+
     def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.includes?("Gemfile")
+      if filename.includes?("Gemfile")
+        return GEMFILE_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      end
 
-      check = file_contents.includes?("gem 'sinatra'")
-      check = check || file_contents.includes?("gem \"sinatra\"")
+      if filename.ends_with?(".gemspec")
+        return GEMSPEC_MARKERS.any? { |marker| file_contents.includes?(marker) }
+      end
 
-      check
+      false
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".rb") || filename.ends_with?(".ru") || File.basename(filename) == "Gemfile" || File.basename(filename) == "Gemfile.lock"
+      filename.ends_with?(".rb") ||
+        filename.ends_with?(".ru") ||
+        filename.ends_with?(".gemspec") ||
+        File.basename(filename) == "Gemfile" ||
+        File.basename(filename) == "Gemfile.lock"
     end
 
     def set_name


### PR DESCRIPTION
## Summary

Single-gem repos that vendor Sinatra or Hanami — Gollum is the canonical Sinatra example — park their `Gemfile` at `gemspec` and declare `s.add_dependency 'sinatra'` / `s.add_dependency 'hanami'` inside `<gem>.gemspec`. The Sinatra and Hanami detectors only inspected `Gemfile`, so those projects came out as untyped: **Gollum produced zero endpoints** despite being a Sinatra-powered wiki with 96 real routes.

### Change

Mirror the Rails detector pattern from #1559:

- Extend `applicable?` to also cover `*.gemspec`.
- Add a second marker set covering both `add_dependency` and `add_runtime_dependency` shapes for the respective gem name.
- Sinatra: `'sinatra'`. Hanami: `'hanami'`.

The Hanami framework's own repo deliberately won't match — its gemspec only carries `spec.name = "hanami"`, with no `add_dependency`. Correct, since there are no app-level routes to extract from the library source.

### Gollum benchmark

| | before | after |
| --- | --- | --- |
| `ruby_sinatra` detector fires | no | yes |
| Endpoints emitted | 0 | **96** |

Devdocs / sidekiq / sinatra framework itself emit unchanged counts (existing Gemfile path).

## Test plan

- [x] `crystal spec spec/unit_test/detector/ruby/` — 29 examples pass (5 new cases: Sinatra add_dependency, add_runtime_dependency, negative; Hanami add_dependency, framework-itself negative).
- [x] `crystal spec spec/functional_test/testers/ruby/` — 565 examples pass.
- [x] `just check` — format + ameba clean.
- [x] Manual: Gollum scan now surfaces `ruby_sinatra` and 96 routes; the other Sinatra/Hanami corpora are unchanged.