### PR TITLE
fix(js/hono): preserve cross-file route prefixes

### DIFF
--- a/spec/functional_test/fixtures/javascript/hono_cross_file_mount/api.ts
+++ b/spec/functional_test/fixtures/javascript/hono_cross_file_mount/api.ts
@@ -1,0 +1,24 @@
+import { Hono } from 'hono'
+
+const api = new Hono()
+
+api.get('/', (c) => {
+  return c.json({ message: 'Hello' })
+})
+
+api.get('/posts', async (c) => {
+  const limit = c.req.query('limit')
+  return c.json({ posts: [], limit })
+})
+
+api.post('/posts', async (c) => {
+  const { title, body } = await c.req.json()
+  return c.json({ title, body }, 201)
+})
+
+api.get('/posts/:id', (c) => {
+  const id = c.req.param('id')
+  return c.json({ id })
+})
+
+export default api

--- a/spec/functional_test/fixtures/javascript/hono_cross_file_mount/index.ts
+++ b/spec/functional_test/fixtures/javascript/hono_cross_file_mount/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono'
+import api from './api'
+
+const app = new Hono()
+
+app.get('/', (c) => c.text('Pretty Blog API'))
+app.route('/api', api)
+
+export default app

--- a/spec/functional_test/testers/javascript/hono_cross_file_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_cross_file_mount_spec.cr
@@ -1,0 +1,20 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/api/", "GET"),
+  Endpoint.new("/api/posts", "GET", [
+    Param.new("limit", "", "query"),
+  ]),
+  Endpoint.new("/api/posts", "POST", [
+    Param.new("title", "", "json"),
+    Param.new("body", "", "json"),
+  ]),
+  Endpoint.new("/api/posts/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/hono_cross_file_mount/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -55,13 +55,15 @@ module Analyzer::Javascript
       content = CodeLocator.instance.content_for(main_file) || File.read(main_file, encoding: "utf-8", invalid: :skip)
 
       # Cheap pre-filter: every code path in this scanner is downstream
-      # of a `.use(...)` call (literal mount, no-prefix mount, or the
-      # `defaultRoutes.forEach(... router.use(...))` config-array form,
-      # which also contains `.use(`). Substring-checking once skips the
-      # imports parse + three full-content regex scans on the vast
-      # majority of files in a large codebase (tests, helpers, UI
-      # components, fixtures), which contain no router mounts at all.
-      return unless content.includes?(".use(") || content.includes?(".use (")
+      # of a `.use(...)` or `.route(...)` call (literal mount, no-prefix
+      # mount, the `defaultRoutes.forEach(... router.use(...))`
+      # config-array form, plus Hono-style `app.route('/api', child)`
+      # mounts). Substring-checking once skips the imports parse + three
+      # full-content regex scans on the vast majority of files in a large
+      # codebase (tests, helpers, UI components, fixtures), which contain
+      # no router mounts at all.
+      return unless content.includes?(".use(") || content.includes?(".use (") ||
+                    content.includes?(".route(") || content.includes?(".route (")
 
       # Parse imports
       imports = parse_imports(content, main_file)
@@ -72,17 +74,13 @@ module Analyzer::Javascript
       # Store arrays of prefixes per router variable to support multi-mount scenarios
       var_prefix = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
 
-      # Scan for .use('/prefix', ...) patterns with explicit path prefix
-      content.scan(/(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*/) do |m|
-        next unless m.size >= 3
-
-        caller = m[1]
-        prefix = m[2]
-        match_end = m.end(0) || 0
-
-        process_use_call(content, match_end, caller, prefix, main_file, locator,
-          require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
-      end
+      # Scan for mount calls with explicit path prefixes. Express-style
+      # `.use('/prefix', router)` and Hono-style `.route('/prefix', childApp)`
+      # both contribute cross-file prefixes to the same locator table.
+      scan_literal_mount_calls(content, "use", main_file, locator,
+        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+      scan_literal_mount_calls(content, "route", main_file, locator,
+        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
 
       # Scan for .use(router) patterns where prefix is omitted (defaults to '/')
       # The negative lookahead `(?!\s*['"])` prevents matching calls that have a
@@ -160,6 +158,29 @@ module Analyzer::Javascript
           deferred_key = router_file_direct || router_var || ""
           global_deferred_mounts << {main_file, caller, prefix, deferred_key} unless deferred_key.empty?
         end
+      end
+    end
+
+    private def scan_literal_mount_calls(
+      content : String,
+      call_name : String,
+      main_file : String,
+      locator : CodeLocator,
+      require_map : Hash(String, String),
+      function_map : Hash(String, String),
+      var_to_function : Hash(String, String),
+      var_prefix : Hash(String, Array(String)),
+      global_deferred_mounts : Array(Tuple(String, String, String, String)),
+    )
+      content.scan(/(\w+)\.#{call_name}\s*\(\s*['"]([^'"]+)['"]\s*,\s*/) do |m|
+        next unless m.size >= 3
+
+        caller = m[1]
+        prefix = m[2]
+        match_end = m.end(0) || 0
+
+        process_use_call(content, match_end, caller, prefix, main_file, locator,
+          require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
       end
     end
 

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -1,12 +1,15 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "./express/router_mount_scanner"
 
 module Analyzer::Javascript
   class Hono < JavascriptEngine
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
+
+      scan_for_router_mounts
 
       parallel_file_scan do |path|
         begin
@@ -192,6 +195,11 @@ module Analyzer::Javascript
       end
 
       [] of Endpoint
+    end
+
+    private def scan_for_router_mounts
+      scanner = RouterMountScanner.new(all_files, @base_paths, base_path, logger)
+      scanner.scan
     end
   end
 end


### PR DESCRIPTION
## Summary
- preserve Hono cross-file route prefixes by scanning `.route("/prefix", child)` mounts through the shared JS router mount scanner
- run the shared mount scanner before Hono route extraction so mounted child apps inherit their prefixes
- add a functional regression fixture/spec covering the OSS-derived cross-file Hono mount case

## Testing
- crystal spec spec/functional_test/testers/javascript/hono_spec.cr spec/functional_test/testers/javascript/hono_cross_file_mount_spec.cr
- just build
- just test
- ./bin/noir -b /tmp/noir-oss-hono-examples/blog/src -f json