### PR TITLE
fix(js): cover OSS regression patterns across routers

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_optional_brace_params/app.js
+++ b/spec/functional_test/fixtures/javascript/express_optional_brace_params/app.js
@@ -1,0 +1,6 @@
+const express = require('express')
+const app = express()
+
+app.all('/user/:id{/:op}', function userAction(req, res) {
+  res.send('ok')
+})

--- a/spec/functional_test/fixtures/javascript/fastify_inline_register_prefix/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_inline_register_prefix/app.js
@@ -1,0 +1,15 @@
+const fastify = require('fastify')({ logger: true })
+
+fastify.register(function (instance, options, done) {
+  instance.get('/hello', (req, reply) => {
+    reply.send({ greet: 'hello' })
+  })
+  done()
+}, { prefix: '/english' })
+
+fastify.register(function (instance, options, done) {
+  instance.get('/hello', (req, reply) => {
+    reply.send({ greet: 'ciao' })
+  })
+  done()
+}, { prefix: '/italian' })

--- a/spec/functional_test/fixtures/javascript/koa_constructor_prefix_recipe/api-versioning.ts
+++ b/spec/functional_test/fixtures/javascript/koa_constructor_prefix_recipe/api-versioning.ts
@@ -1,0 +1,31 @@
+import Koa from 'koa'
+import Router from 'koa-router'
+
+const app = new Koa()
+
+const getUsersV1 = async (ctx) => {
+  ctx.body = { users: [], version: 'v1' }
+}
+
+const getUserV1 = async (ctx) => {
+  ctx.body = { user: { id: ctx.params.id }, version: 'v1' }
+}
+
+const getUsersV2 = async (ctx) => {
+  ctx.body = { users: [], version: 'v2' }
+}
+
+const getUserV2 = async (ctx) => {
+  ctx.body = { user: { id: ctx.params.id }, version: 'v2' }
+}
+
+const v1Router = new Router({ prefix: '/api/v1' })
+v1Router.get('/users', getUsersV1)
+v1Router.get('/users/:id', getUserV1)
+
+const v2Router = new Router({ prefix: '/api/v2' })
+v2Router.get('/users', getUsersV2)
+v2Router.get('/users/:id', getUserV2)
+
+app.use(v1Router.routes())
+app.use(v2Router.routes())

--- a/spec/functional_test/fixtures/javascript/restify_client_noise/client.js
+++ b/spec/functional_test/fixtures/javascript/restify_client_noise/client.js
@@ -1,0 +1,8 @@
+const clients = require('restify-clients')
+
+const client = clients.createJSONClient({
+  url: 'http://localhost:8080',
+})
+
+client.get('/todo', function noop() {})
+client.del('/todo/example', function noop() {})

--- a/spec/functional_test/fixtures/javascript/restify_client_noise/server.js
+++ b/spec/functional_test/fixtures/javascript/restify_client_noise/server.js
@@ -1,0 +1,11 @@
+const restify = require('restify')
+
+const server = restify.createServer()
+
+server.get('/todo', function listTodos(req, res, next) {
+  return next()
+})
+
+server.del('/todo/:name', function deleteTodo(req, res, next) {
+  return next()
+})

--- a/spec/functional_test/testers/javascript/express_optional_brace_params_spec.cr
+++ b/spec/functional_test/testers/javascript/express_optional_brace_params_spec.cr
@@ -1,0 +1,36 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/user/:id{/:op}", "GET", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+  Endpoint.new("/user/:id{/:op}", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+  Endpoint.new("/user/:id{/:op}", "PUT", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+  Endpoint.new("/user/:id{/:op}", "DELETE", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+  Endpoint.new("/user/:id{/:op}", "PATCH", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+  Endpoint.new("/user/:id{/:op}", "HEAD", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+  Endpoint.new("/user/:id{/:op}", "OPTIONS", [
+    Param.new("id", "", "path"),
+    Param.new("op", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/express_optional_brace_params/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/fastify_inline_register_prefix_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_inline_register_prefix_spec.cr
@@ -1,0 +1,10 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/english/hello", "GET"),
+  Endpoint.new("/italian/hello", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/fastify_inline_register_prefix/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/koa_constructor_prefix_recipe_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_constructor_prefix_recipe_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/api/v1/users", "GET"),
+  Endpoint.new("/api/v1/users/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/api/v2/users", "GET"),
+  Endpoint.new("/api/v2/users/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/koa_constructor_prefix_recipe/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/koa_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_spec.cr
@@ -7,7 +7,7 @@ expected_endpoints = [
     Param.new("id", "", "path"),
   ]),
   Endpoint.new("/info", "GET"),
-  Endpoint.new("/settings", "GET"),
+  Endpoint.new("/admin/settings", "GET"),
   Endpoint.new("/status", "GET"),
   Endpoint.new("/simple", "GET"),
   Endpoint.new("/items/:itemId", "DELETE", [

--- a/spec/functional_test/testers/javascript/restify_client_noise_spec.cr
+++ b/spec/functional_test/testers/javascript/restify_client_noise_spec.cr
@@ -1,0 +1,13 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/todo", "GET"),
+  Endpoint.new("/todo/:name", "DELETE", [
+    Param.new("name", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/restify_client_noise/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+describe "nestjs param dedupe" do
+  tester = FunctionalTester.new("fixtures/typescript/nestjs/", {
+    :techs => 1,
+  }, [] of Endpoint)
+
+  locator = CodeLocator.instance
+  locator.clear_all
+  tester.app.detect
+  tester.app.analyze
+
+  endpoint = tester.app.endpoints.find { |ep| ep.method == "DELETE" && ep.url == "/users/:id" }
+
+  it "keeps a single path param for DELETE /users/:id" do
+    endpoint.should_not be_nil
+    if endpoint
+      path_params = endpoint.params.select { |param| param.name == "id" && param.param_type == "path" }
+      path_params.size.should eq(1)
+    end
+  end
+end

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -284,7 +284,7 @@ module Analyzer::Javascript
       method_params.scan(/@Query\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/) do |param_match|
         if param_match.size > 0
           param_name = param_match[1]
-          endpoint.push_param(Param.new(param_name, "", "query"))
+          push_unique_param(endpoint, Param.new(param_name, "", "query"))
         end
       end
 
@@ -292,20 +292,20 @@ module Analyzer::Javascript
       method_params.scan(/@Param\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/) do |param_match|
         if param_match.size > 0
           param_name = param_match[1]
-          endpoint.push_param(Param.new(param_name, "", "path"))
+          push_unique_param(endpoint, Param.new(param_name, "", "path"))
         end
       end
 
       # Extract @Body() - indicates request body
       if method_params.includes?("@Body()")
-        endpoint.push_param(Param.new("body", "", "body"))
+        push_unique_param(endpoint, Param.new("body", "", "body"))
       end
 
       # Extract @Headers parameters
       method_params.scan(/@Headers\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/) do |param_match|
         if param_match.size > 0
           param_name = param_match[1]
-          endpoint.push_param(Param.new(param_name, "", "header"))
+          push_unique_param(endpoint, Param.new(param_name, "", "header"))
         end
       end
     end
@@ -331,6 +331,11 @@ module Analyzer::Javascript
           end
         end
       end
+    end
+
+    private def push_unique_param(endpoint : Endpoint, param : Param)
+      return if endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+      endpoint.push_param(param)
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -11,6 +11,7 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
+          next if client_library_file?(content)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|
@@ -47,6 +48,13 @@ module Analyzer::Javascript
       process_static_dirs(static_dirs, result)
 
       result
+    end
+
+    private def client_library_file?(content : String) : Bool
+      content.includes?("restify-clients") ||
+        content.includes?("createJSONClient(") ||
+        content.includes?("createStringClient(") ||
+        content.includes?("createHttpClient(")
     end
 
     # Process static directories and add endpoints for each file

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -92,6 +92,7 @@ module Noir
       # 1. Variables assigned from express.Router()
       # 2. Variables that have route methods called on them (.get, .post, etc.)
       identify_router_variables(router_variables)
+      scan_router_constructor_prefixes(router_prefixes, router_variables)
 
       # First pass: scan for router.use("/prefix", ..., routerVariable) patterns
       # Handles middleware chains like app.use('/api', auth, router)
@@ -254,6 +255,63 @@ module Noir
       end
 
       result.empty? ? prefixes : result
+    end
+
+    # Koa/@koa-router commonly attaches route prefixes in the constructor:
+    #   const router = new Router({ prefix: '/api/v1' })
+    # Seed those prefixes before the generic route scan so later
+    # `router.get(...)` calls emit their full paths.
+    private def scan_router_constructor_prefixes(router_prefixes : Hash(String, Array(String)), router_variables : Set(String))
+      idx = 0
+      while idx < @tokens.size - 6
+        if @tokens[idx].type == :identifier &&
+           idx + 1 < @tokens.size &&
+           @tokens[idx + 1].value == "="
+          router_var = @tokens[idx].value
+          scan_idx = idx + 2
+          scan_idx += 1 if scan_idx < @tokens.size && @tokens[scan_idx].value == "new"
+          next unless scan_idx < @tokens.size
+
+          constructor = @tokens[scan_idx]
+          if (constructor.type == :identifier || constructor.type == :keyword) &&
+             (constructor.value == "Router" || constructor.value.ends_with?("Router") || router_variables.includes?(router_var))
+            while scan_idx < @tokens.size &&
+                  @tokens[scan_idx].type != :lparen &&
+                  @tokens[scan_idx].value != ";"
+              scan_idx += 1
+            end
+
+            if scan_idx < @tokens.size && @tokens[scan_idx].type == :lparen
+              paren_depth = 1
+              inner_idx = scan_idx + 1
+              prefix = ""
+
+              while inner_idx < @tokens.size && paren_depth > 0
+                token = @tokens[inner_idx]
+                if token.type == :lparen
+                  paren_depth += 1
+                elsif token.type == :rparen
+                  paren_depth -= 1
+                elsif paren_depth == 1 &&
+                      token.value == "prefix" &&
+                      inner_idx + 2 < @tokens.size &&
+                      @tokens[inner_idx + 1].type == :colon &&
+                      @tokens[inner_idx + 2].type == :string
+                  prefix = @tokens[inner_idx + 2].value
+                  break
+                end
+                inner_idx += 1
+              end
+
+              unless prefix.empty?
+                router_prefixes[router_var] << prefix unless router_prefixes[router_var].includes?(prefix)
+                router_variables.add(router_var)
+              end
+            end
+          end
+        end
+        idx += 1
+      end
     end
 
     # Format a regex token value into a path string.

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -126,6 +126,50 @@ module Noir
           end
         end
 
+        # Track inline anonymous Fastify plugins:
+        #   fastify.register(function (instance, options, done) { ... }, { prefix: '/x' })
+        #   fastify.register((instance, options) => { ... }, { prefix: '/x' })
+        #
+        # These callbacks have no stable function name, so they can't reuse the
+        # function-scoped CodeLocator path. Keep their body ranges local and apply
+        # the prefix directly to routes whose start position falls inside.
+        anonymous_register_ranges = [] of Tuple(Int32, Int32, String)
+        anonymous_register_patterns = [
+          /\b\w+\.register\s*\(\s*(?:async\s+)?function\s*\([^)]*\)\s*\{/,
+          /\b\w+\.register\s*\(\s*(?:async\s+)?\([^)]*\)\s*=>\s*\{/,
+          /\b\w+\.register\s*\(\s*(?:async\s+)?\w+\s*=>\s*\{/,
+        ]
+        seen_anonymous_registers = Set(String).new
+
+        anonymous_register_patterns.each do |register_pattern|
+          content.scan(register_pattern) do |m|
+            match_start = m.begin(0)
+            next unless match_start
+
+            register_paren_idx = content.index("(", match_start)
+            open_brace_idx = content.index("{", match_start)
+            next unless register_paren_idx && open_brace_idx
+
+            close_brace_idx = find_matching_brace(content, open_brace_idx)
+            close_paren_idx = find_matching_paren(content, register_paren_idx)
+            next unless close_brace_idx && close_paren_idx
+            next if close_brace_idx >= close_paren_idx
+
+            trailer = content[(close_brace_idx + 1)...close_paren_idx]
+            next unless trailer
+
+            prefix_match = trailer.match(/prefix\s*:\s*['"]([^'"]+)['"]/)
+            next unless prefix_match
+
+            prefix = prefix_match[1]
+            key = "#{open_brace_idx}:#{close_brace_idx}:#{prefix}"
+            next if seen_anonymous_registers.includes?(key)
+
+            anonymous_register_ranges << {open_brace_idx, close_brace_idx, prefix}
+            seen_anonymous_registers.add(key)
+          end
+        end
+
         # Seed function-specific prefixes from CodeLocator
         prefixes_by_function = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
         function_names.each do |func_name|
@@ -196,6 +240,19 @@ module Noir
                 prefixes = func_prefixes
                 break
               end
+            end
+          end
+          if prefixes.empty? && pattern.start_pos >= 0
+            containing_registers = [] of Tuple(String, Int32)
+            anonymous_register_ranges.each do |start_idx, end_idx, prefix|
+              if start_idx <= pattern.start_pos && pattern.start_pos <= end_idx
+                containing_registers << {prefix, end_idx - start_idx}
+              end
+            end
+            unless containing_registers.empty?
+              containing_registers.sort_by! { |_, span| span }
+              anonymous_prefix = containing_registers.first[0]
+              prefixes = [anonymous_prefix]
             end
           end
           if prefixes.empty? && !file_prefixes.empty?

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -296,7 +296,7 @@ class EndpointOptimizer
       end
 
       # Handle /:param patterns
-      scans = endpoint.url.scan(/\/:([^\/]+)/).flatten
+      scans = endpoint.url.scan(/\/:([^\/{}]+)/).flatten
       scans.each do |match|
         new_value = apply_pvalue("path", match[1], "")
         if new_value != ""


### PR DESCRIPTION
## Summary
- preserve Fastify prefixes for anonymous inline `register(..., { prefix })` plugins from the official `route-prefix.js` example
- honor Koa constructor prefixes, skip Restify client SDK noise, dedupe NestJS decorator params, and stop brace optional segments from creating bogus Express path params
- add regression fixtures/specs derived from OSS examples for Fastify, Koa, Restify, Express, plus a targeted NestJS param-dedupe spec

## OSS rounds
1. Fastify `examples/route-prefix.js`: restored `/english/hello` and `/italian/hello`
2. @koa/router `recipes/api-versioning`: restored `/api/v1/*` and `/api/v2/*` constructor prefixes
3. Restify `examples/todoapp/lib`: removed client-side false positives from `client.js`
4. Nest sample `05-sql-typeorm`: removed duplicate `id` path params on `DELETE /users/:id`
5. Express `examples/route-separation`: stopped bogus `id{` / `op}` params for `/user/:id{/:op}`

## Testing
- crystal spec spec/functional_test/testers/javascript/fastify_inline_register_prefix_spec.cr spec/functional_test/testers/javascript/koa_constructor_prefix_recipe_spec.cr spec/functional_test/testers/javascript/restify_client_noise_spec.cr spec/functional_test/testers/javascript/express_optional_brace_params_spec.cr spec/functional_test/testers/typescript/nestjs_param_dedupe_spec.cr
- just build
- just test
- crystal run src/noir.cr -- -b /tmp/noir-oss-fastify/examples -t js_fastify -f json
- crystal run src/noir.cr -- -b /tmp/noir-oss-koa-router/recipes/api-versioning -t js_koa -f json
- crystal run src/noir.cr -- -b /tmp/noir-oss-restify/examples/todoapp/lib -t js_restify -f json
- crystal run src/noir.cr -- -b /tmp/noir-oss-nest/sample/05-sql-typeorm/src -t ts_nestjs -f json
- crystal run src/noir.cr -- -b /tmp/noir-oss-express/examples/route-separation -t js_express -f json