### PR TITLE
fix(go): drop verb-shaped calls with absolute URLs or no handler

### DIFF
--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -84,4 +84,45 @@ describe Noir::TreeSitterGoRouteExtractor do
     routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
     routes.map(&.path).should eq(["/real"])
   end
+
+  it "rejects net/http client calls that share the GET/POST method names" do
+    # Regression: `http.Get("http://localhost:8080/")` from
+    # gin-gonic/examples/otel emitted a bogus `/http://localhost:8080/`
+    # route. Real router paths are relative and never carry a scheme,
+    # so reject absolute URLs to keep the net/http client API out.
+    source = <<-GO
+      package main
+      func main() {
+          r := gin.Default()
+          r.GET("/legit", handler)
+          http.Get("http://localhost:8080/")
+          http.Post("https://example.com/api", "application/json", nil)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map(&.path).should eq(["/legit"])
+  end
+
+  it "rejects single-arg verb calls like gin.Context.Get value lookups" do
+    # Regression: `c.Get("clientChan")` from
+    # gin-gonic/examples/server-sent-event emitted a bogus `/clientChan`
+    # route. Real route registrations always pass a handler argument
+    # after the path; value-lookup helpers take a single string.
+    source = <<-GO
+      package main
+      func handler(c *gin.Context) {
+          v, ok := c.Get("clientChan")
+          _ = v
+          _ = ok
+      }
+      func main() {
+          r := gin.Default()
+          r.GET("/legit", handler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map(&.path).should eq(["/legit"])
+  end
 end

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -794,6 +794,16 @@ module Noir
 
       return unless raw_path
 
+      # Filter out non-router method calls that masquerade as verb routes:
+      #   * `http.Get("http://...")` — net/http client call. Real route
+      #     paths are relative to the router and never carry a scheme.
+      #   * `c.Get("clientChan")` — `gin.Context.Get` value lookup. Real
+      #     route registrations always pass a handler argument after the
+      #     path; the lookup helpers take a single string and nothing
+      #     else.
+      return if raw_path.includes?("://")
+      return if handler_text.empty?
+
       resolved = if prefix = groups[router_name]?
                    join_paths(prefix, raw_path)
                  else


### PR DESCRIPTION
## Summary

Surveying [`gin-gonic/examples`](https://github.com/gin-gonic/examples) surfaced two false-positive shapes that the Tree-sitter Go route extractor was promoting to endpoints. Both come from selector-style calls whose verb name (`Get`, `Post`, …) coincides with a real HTTP verb but whose operand isn't on the existing `NON_ROUTER_OPERANDS` deny-list:

- `http.Get("http://localhost:8080/")` — net/http client call in [`gin-gonic/examples/otel/main.go:40`](https://github.com/gin-gonic/examples/blob/master/otel/main.go#L40). Emitted a bogus `/http:/localhost:8080/` route.
- `c.Get("clientChan")` — `gin.Context.Get` value lookup in [`gin-gonic/examples/server-sent-event/main.go:57`](https://github.com/gin-gonic/examples/blob/master/server-sent-event/main.go#L57). Emitted a bogus `/clientChan` route.

Two narrow guards in `decode_verb_call` knock both out without disturbing real Gin/Echo/Fiber/Hertz/Iris routes:

1. Reject the call when the path literal contains `://` — route paths are relative to the router and never carry a scheme.
2. Reject the call when no non-string positional arg follows the path — real registrations always pass a handler.

This rounds out the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) series by tightening Go precision on a couple of well-known router-look-alike idioms.

Verified on `gin-gonic/examples`: total endpoints went 44 → 42 with the two bogus URLs gone.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/go_route_extractor_ts_spec.cr` (adds 2 regression specs)
- [x] `crystal spec spec/functional_test/testers/go/` (1122 examples, 0 failures)
- [x] `./bin/noir -b /path/to/gin-gonic-examples -f json` — confirmed FPs gone, endpoint set otherwise unchanged