### PR TITLE
fix(js): treat supertest imports as a test-only marker

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -363,6 +363,49 @@ describe Noir::JSRouteExtractor do
       ).should be_true
     end
 
+    it "skips supertest harnesses that don't otherwise look like tests" do
+      # Regression: expressjs/express keeps its supertest suites under
+      # `test/`/`test/acceptance/` with plain `*.js` filenames (e.g.
+      # `app.router.js`, `acceptance/web-service.js`). None match the
+      # `.test.`/`.spec.` filename convention or a TEST_STUB_PATH_MARKER,
+      # and they `require('../')` instead of literal `'express'`, so
+      # without a supertest marker the test client's
+      # `request(app).get('/api/users?api-key=foo')` chain leaks through
+      # as a route.
+      content = <<-JS
+        var request = require('supertest')
+          , app = require('../../examples/web-service');
+
+        describe('web-service', function(){
+          it('responds', function(done){
+            request(app).get('/api/users?api-key=foo').expect(200, done);
+          })
+        })
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/test/acceptance/web-service.js",
+        content
+      ).should be_true
+    end
+
+    it "keeps supertest-using files that also import the real server lib" do
+      # Exemption guard: a regular project file that imports both
+      # supertest and express should still scan — the `app.get(...)`
+      # registrations are real, and the supertest call sits next to
+      # them only because the file boots its own test harness.
+      content = <<-JS
+        import express from "express";
+        import request from "supertest";
+        const app = express();
+        app.get("/api/users", (req, res) => res.json([]));
+        request(app).get("/api/users").expect(200);
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/src/server.js",
+        content
+      ).should be_false
+    end
+
     it "skips bundled dist/ output files" do
       content = <<-JS
         // webpack bundle output with thousands of .get( / .post( noise

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -362,6 +362,12 @@ module Noir
       # in the same shape.
       "from \"@playwright/test\"", "from '@playwright/test'",
       "from \"playwright\"", "from 'playwright'",
+      # supertest: the canonical `request(app).get(...)` test client.
+      # Production code never depends on supertest, so its presence is
+      # a strong signal the surrounding `.get(`/`.post(` calls are
+      # HTTP requests against an app under test, not registrations.
+      "from \"supertest\"", "from 'supertest'",
+      "require(\"supertest\")", "require('supertest')",
     ]
 
     # Real HTTP-server library imports. When any of these is present


### PR DESCRIPTION
## Summary

While surveying [`expressjs/express`](https://github.com/expressjs/express) for the analyzer-accuracy series, the existing `test_stub_only?` filter let an entire shape of false positive through: supertest's [`request(app).get('/api/users?api-key=foo')`](https://github.com/expressjs/express/blob/master/test/acceptance/web-service.js#L26) chains were emitted as if they were Express route registrations.

The supertest harnesses didn't trigger any existing marker:
- The files live at `test/acceptance/*.js` and `test/*.js` — none of the curated `TEST_STUB_PATH_MARKERS` (`/test/integration/`, `/test/e2e/`, …) match.
- Their filenames don't carry the `.test.`/`.spec.` convention.
- They `require('../')` (Express's own root) instead of literal `'express'`, so the `HTTP_SERVER_LIBRARY_MARKERS` exemption fires the wrong way.

Adding `supertest` to `TEST_STUB_LIBRARY_MARKERS` is the right cut: production code never depends on supertest, so its presence is a strong signal the surrounding `.get(`/`.post(` calls are HTTP requests against an app under test rather than registrations. The existing exemption still keeps legit harness files alive — if the same file imports literal `'express'`/`'fastify'`/`'hono'`/… we keep its routes.

This continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep.

Verified on the expressjs/express tree: total endpoints drop 190 → 61, with every supertest-driven artifact (including the literal `?api-key=foo` URLs and the `/^\\/user\\/[0-9]+$/` regex paths) gone.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` (adds 2 specs: supertest-only file filtered, supertest+express file scanned)
- [x] `crystal spec spec/functional_test/testers/javascript/` (1777 examples, 0 failures)
- [x] `./bin/noir -b /path/to/expressjs-express -f json` — confirmed 190 → 61, all supertest FPs gone