### PR TITLE
fix(hono): apply test-stub filter to extract_on_routes pass

### DIFF
--- a/spec/functional_test/fixtures/javascript/hono/app.test.ts
+++ b/spec/functional_test/fixtures/javascript/hono/app.test.ts
@@ -1,0 +1,14 @@
+// Regression guard: hono's own `*.test.ts` suites register routes
+// via `app.on('GET', '/path', ...)` to exercise the typing layer.
+// The primary route extractor already skips files that match a
+// test-stub marker; the auxiliary `extract_on_routes` pass in the
+// Hono analyzer has to honor the same gate, or these routes leak
+// out as if they were real endpoints. None of the URLs below should
+// surface in the fixture's expected-endpoints list.
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.on('GET', '/should-not-appear-1', (c) => c.json({}))
+app.on('GET', '/should-not-appear-2', (c) => c.json({}))
+app.on('POST', '/should-not-appear-3', (c) => c.json({}))

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -23,8 +23,14 @@ module Analyzer::Javascript
             result << endpoint
           end
 
-          # Extract app.on() patterns not handled by JSRouteExtractor
-          extract_on_routes(path, content, result, callees_by_route)
+          # Extract app.on() patterns not handled by JSRouteExtractor.
+          # The primary extractor already gates on `test_stub_only?`;
+          # this auxiliary pass has its own regex walk, so it has to
+          # repeat the same gate — without it, `app.on('GET', '/x10',
+          # ...)` from hono's own `*.test.ts` suites slips through.
+          unless Noir::JSRouteExtractor.test_stub_only?(path, content)
+            extract_on_routes(path, content, result, callees_by_route)
+          end
 
           Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
             static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }


### PR DESCRIPTION
## Summary

Scanning [`honojs/hono`](https://github.com/honojs/hono) surfaced ten false positives from `src/hono.test.ts` (the `/on/1` … `/on/9` set at [lines 3197–3261](https://github.com/honojs/hono/blob/main/src/hono.test.ts#L3197)) and `src/types.test.ts` (`/x10` at [line 409](https://github.com/honojs/hono/blob/main/src/types.test.ts#L409)). All ten files have the `.test.ts` filename convention the shared `test_stub_only?` filter already knows about — so why did they leak?

The Hono analyzer runs two passes per file:

1. `Noir::JSRouteExtractor.extract_routes` — already gated on `test_stub_only?`.
2. `extract_on_routes` — an auxiliary regex sweep added to catch the `app.on('GET', '/path', ...)` shape the JSParser doesn't model. **No** gate.

Pass #2 happily emitted every `app.on(...)` it found in the test files. Reuse the same gate before invoking it. The exemption for files that import a real HTTP-server lib (express/fastify/hono/…) still applies, so legit test-harness files that spin up their own Hono instance keep their `app.on(...)` routes.

A new `spec/functional_test/fixtures/javascript/hono/app.test.ts` fixture registers three `app.on(...)` calls; the existing Hono functional suite asserts an exact expected-endpoints list, so any leak would fail the spec.

This continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as #1566 (supertest), this time on the secondary-pass side of the Hono analyzer.

Verified on honojs/hono: total endpoints 24 → 14, with all `/on/N` and `/x10` artifacts gone.

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/hono_spec.cr` — 78 examples, 0 failures (new fixture in place, expected endpoints unchanged)
- [x] `./bin/noir -b /path/to/honojs-hono -f json` — confirmed 24 → 14, `/on/N` and `/x10` gone