### PR TITLE
fix(rust/axum): skip routes in cfg(test) blocks and tests/ dirs

### DIFF
--- a/spec/functional_test/fixtures/rust/axum/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum/src/main.rs
@@ -17,3 +17,19 @@ async fn main() {
 async fn handler() -> Html<&'static str> {
     Html("<h1>Hello, World!</h1>")
 }
+
+// Regression guard: routes registered inside `#[cfg(test)] mod tests`
+// are unit-test fixtures, not production endpoints. None of the URLs
+// below should appear in the fixture's expected-endpoints list.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::routing::post;
+
+    #[tokio::test]
+    async fn test_app_routes() {
+        let _app = Router::new()
+            .route("/should-not-appear-get", get(handler))
+            .route("/should-not-appear-post", post(handler));
+    }
+}

--- a/spec/functional_test/fixtures/rust/axum/tests/integration.rs
+++ b/spec/functional_test/fixtures/rust/axum/tests/integration.rs
@@ -1,0 +1,11 @@
+// Regression guard: anything under `tests/` is a Rust integration
+// test binary (`cargo test --test integration`), never a production
+// endpoint. None of the URLs below should appear in the fixture's
+// expected-endpoints list.
+use axum::{routing::get, Router};
+
+#[tokio::test]
+async fn integration_routes() {
+    let _app: Router = Router::new()
+        .route("/should-not-appear-integration", get(|| async { "ok" }));
+}

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -18,8 +18,22 @@ module Analyzer::Rust
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      # Rust's `tests/` directory at the crate root holds integration
+      # tests that never ship as production endpoints; `*_test.rs` /
+      # `*_tests.rs` follow the same convention for unit-test files.
+      # Skip them up-front so axum's own `axum-macros/tests/...` (full
+      # `fn main()` files exercising the macros) and similarly-named
+      # files in user projects don't pollute the endpoint set.
+      return endpoints if test_only_path?(path)
       source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+
+      # `#[cfg(test)] mod tests { ... let app = Router::new().route(...); }`
+      # is the canonical place doctests-as-unit-tests register routes in
+      # Rust source — axum-extra exercises this heavily. Find each
+      # cfg(test)-gated block's byte range up-front; routes whose call
+      # node starts inside one are unit-test fixtures, not endpoints.
+      test_regions = collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = include_callee ? build_function_index(root, source) : Hash(String, LibTreeSitter::TSNode).new
@@ -27,6 +41,7 @@ module Analyzer::Rust
         walk(root) do |node|
           next unless Noir::TreeSitter.node_type(node) == "call_expression"
           next unless route_call?(node, source)
+          next if inside_test_region?(node, test_regions)
 
           route = extract_route(node, source)
           next unless route
@@ -47,6 +62,154 @@ module Analyzer::Rust
       end
 
       endpoints
+    end
+
+    # Cargo convention: every `.rs` immediately under a crate's `tests/`
+    # directory is an integration test binary, never a production
+    # endpoint. We accept the slightly broader `**/tests/**/*.rs` match
+    # because real Rust apps almost never park production code in a
+    # directory named `tests`; the rare false negative is preferable to
+    # leaking framework internals like axum-extra's mod-test fixtures.
+    private def test_only_path?(path : String) : Bool
+      return true if path.includes?("/tests/")
+      base = File.basename(path)
+      base.ends_with?("_test.rs") || base.ends_with?("_tests.rs")
+    end
+
+    # Scan the source for `#[cfg(test)]` annotations, then capture the
+    # byte range of the following `mod`/`fn`/`impl` block via simple
+    # brace counting. String/char literals are skipped so a `{` inside
+    # `"foo {"` doesn't shift the depth. The annotated item is always
+    # one of these — axum's pattern never gates a `const`/`static` —
+    # so we don't try to handle non-block items.
+    private def collect_cfg_test_regions(source : String) : Array(Tuple(Int32, Int32))
+      regions = [] of Tuple(Int32, Int32)
+      bytes = source.to_slice
+      pattern = /\#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/
+      source.scan(pattern) do |match|
+        attr_start = match.begin || next
+        brace_idx = find_block_open_brace(bytes, attr_start + 1)
+        next unless brace_idx
+        close_idx = find_matching_close_brace(bytes, brace_idx)
+        next unless close_idx
+        regions << {attr_start, close_idx + 1}
+      end
+      regions
+    end
+
+    private def find_block_open_brace(bytes : Slice(UInt8), from : Int32) : Int32?
+      i = from
+      while i < bytes.size
+        c = bytes[i]
+        case c
+        when '"'.ord then i = skip_string_literal(bytes, i)
+        when '\''.ord then i = skip_char_or_lifetime(bytes, i)
+        when '/'.ord
+          if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
+            i = skip_line_comment(bytes, i)
+          elsif i + 1 < bytes.size && bytes[i + 1] == '*'.ord
+            i = skip_block_comment(bytes, i)
+          else
+            i += 1
+          end
+        when '{'.ord then return i
+        else i += 1
+        end
+      end
+      nil
+    end
+
+    private def find_matching_close_brace(bytes : Slice(UInt8), open_idx : Int32) : Int32?
+      depth = 1
+      i = open_idx + 1
+      while i < bytes.size && depth > 0
+        c = bytes[i]
+        case c
+        when '"'.ord then i = skip_string_literal(bytes, i); next
+        when '\''.ord then i = skip_char_or_lifetime(bytes, i); next
+        when '/'.ord
+          if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
+            i = skip_line_comment(bytes, i); next
+          elsif i + 1 < bytes.size && bytes[i + 1] == '*'.ord
+            i = skip_block_comment(bytes, i); next
+          end
+        when '{'.ord then depth += 1
+        when '}'.ord then depth -= 1
+        end
+        i += 1
+      end
+      depth == 0 ? i - 1 : nil
+    end
+
+    private def skip_string_literal(bytes : Slice(UInt8), from : Int32) : Int32
+      i = from + 1
+      while i < bytes.size
+        c = bytes[i]
+        if c == '\\'.ord
+          i += 2
+          next
+        end
+        if c == '"'.ord
+          return i + 1
+        end
+        i += 1
+      end
+      i
+    end
+
+    # Distinguish Rust char literals (`'x'`, `'\n'`, `'\u{...}'`) from
+    # lifetime annotations (`'a`, `'static`). A lifetime starts with
+    # `'` followed by an identifier-start char and is NOT immediately
+    # closed by another quote — most importantly, it never contains
+    # `{`/`}` so we can just step past the leading quote and keep
+    # scanning. A char literal does contain interior bytes we want to
+    # skip so a `'{'` doesn't perturb brace depth.
+    private def skip_char_or_lifetime(bytes : Slice(UInt8), from : Int32) : Int32
+      # `'x'` (3 bytes): bytes[from+2] is `'`.
+      if from + 2 < bytes.size && bytes[from + 2] == '\''.ord
+        return from + 3
+      end
+      # `'\<esc>'`: bytes[from+1] is `\`, scan for matching `'`.
+      if from + 1 < bytes.size && bytes[from + 1] == '\\'.ord
+        i = from + 2
+        while i < bytes.size
+          c = bytes[i]
+          if c == '\\'.ord
+            i += 2
+            next
+          end
+          return i + 1 if c == '\''.ord
+          i += 1
+        end
+        return i
+      end
+      # Otherwise treat as lifetime: only consume the apostrophe.
+      from + 1
+    end
+
+    private def skip_line_comment(bytes : Slice(UInt8), from : Int32) : Int32
+      i = from
+      while i < bytes.size && bytes[i] != '\n'.ord
+        i += 1
+      end
+      i
+    end
+
+    private def skip_block_comment(bytes : Slice(UInt8), from : Int32) : Int32
+      i = from + 2
+      while i + 1 < bytes.size
+        if bytes[i] == '*'.ord && bytes[i + 1] == '/'.ord
+          return i + 2
+        end
+        i += 1
+      end
+      bytes.size
+    end
+
+    private def inside_test_region?(node : LibTreeSitter::TSNode, regions : Array(Tuple(Int32, Int32))) : Bool
+      return false if regions.empty?
+      start_byte = LibTreeSitter.ts_node_start_byte(node).to_i
+      regions.any? { |s, e| start_byte >= s && start_byte < e }
     end
 
     # `.route("...", get(handler))` — the chain is rooted on


### PR DESCRIPTION
## Summary

Surveying [`tokio-rs/axum`](https://github.com/tokio-rs/axum) surfaced two large FP shapes the Tree-sitter Rust route extractor was emitting:

- `axum/src/**/mod.rs` keeps `Router::new().route(...)` calls inside `#[cfg(test)] mod tests { ... }` blocks. axum-extra and axum's own [`extract/path/mod.rs`](https://github.com/tokio-rs/axum/blob/main/axum/src/extract/path/mod.rs#L605) use this pattern extensively — 111 doctest-style routes leaked through.
- `axum-macros/tests/**/*.rs` are full `fn main()` integration-test binaries exercising the proc-macro derives. Rust's `tests/` directory is a Cargo convention for integration tests that never ship as production endpoints.

Two narrow guards in `analyze_file`:

1. **`test_only_path?`** — skip files under `/tests/` and files matching `*_test.rs` / `*_tests.rs`. Cargo's `tests/` convention is rigid enough that a real-world false negative here is far rarer than the volume of test artifacts we'd otherwise leak.
2. **`collect_cfg_test_regions`** — pre-pass that captures the byte range of every `#[cfg(test)]`-gated block via a brace counter. The counter is string/char/comment/lifetime aware — Rust lifetimes like `'a` look like char literals to a naïve quote scanner and would otherwise drop the close-brace search into oblivion. Routes whose call node starts inside any region are skipped.

This extends the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep into Rust — same instinct as `#1566`/`#1567`, just adapted to a tree-sitter callable on a different grammar.

Fixture updates:
- `spec/functional_test/fixtures/rust/axum/src/main.rs` now ends with a `#[cfg(test)] mod tests` block registering two extra routes.
- New sibling `spec/functional_test/fixtures/rust/axum/tests/integration.rs` registers one more.

The existing tester asserts an exact expected-endpoints list, so any leak from either path would fail the spec.

Verified on tokio-rs/axum: total endpoints drop 162 → 51, with every `axum/src/**/mod.rs` test artifact and every `axum-macros/tests/...` file removed; the entire `examples/` tree is untouched.

## Test plan

- [x] `crystal spec spec/functional_test/testers/rust/axum_spec.cr` (fixture extended with cfg(test) + tests/ regression cases)
- [x] `crystal spec spec/functional_test/testers/rust/` (910 examples, 0 failures)
- [x] `./bin/noir -b /path/to/tokio-rs-axum -f json` — confirmed 162 → 51, all cfg(test) and tests/ FPs gone