### PR TITLE
fix(elixir): skip routes in docstring heredocs and *_test.exs files

### DIFF
--- a/spec/functional_test/fixtures/elixir/plug/lib/router.ex
+++ b/spec/functional_test/fixtures/elixir/plug/lib/router.ex
@@ -1,4 +1,21 @@
 defmodule ElixirPlug.Router do
+  @moduledoc """
+  Regression guard: any route DSL snippet inside a `\"\"\"` heredoc
+  (`@moduledoc` / `@doc` / `~S\"\"\"`) is documentation, not a real
+  registration. None of the URLs below should surface as endpoints.
+
+      get "/should-not-appear-doc", do: nil
+      post "/should-not-appear-doc-post", do: nil
+  """
+
+  @doc ~S'''
+  Same regression, for the alternate triple-single heredoc delimiter
+  Phoenix uses in `verified_routes.ex`.
+
+      get "/should-not-appear-tripple-single", do: nil
+  '''
+  def docs, do: :ok
+
   use Plug.Router
 
   plug :match

--- a/spec/functional_test/fixtures/elixir/plug/test/router_test.exs
+++ b/spec/functional_test/fixtures/elixir/plug/test/router_test.exs
@@ -1,0 +1,21 @@
+# Regression guard: ExUnit `*_test.exs` files register routes only to
+# exercise the framework; the routes never serve real traffic. None of
+# the URLs below should appear in the fixture's expected-endpoints list.
+defmodule ElixirPlug.RouterTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  defmodule TestRouter do
+    use Plug.Router
+
+    plug :match
+    plug :dispatch
+
+    get "/should-not-appear-test-get", do: send_resp(conn, 200, "")
+    post "/should-not-appear-test-post", do: send_resp(conn, 200, "")
+  end
+
+  test "noop" do
+    assert true
+  end
+end

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -5,6 +5,13 @@ module Analyzer::Elixir
     def analyze_file(path : String) : Array(Endpoint)
       ext = File.extname(path)
       return [] of Endpoint unless ext == ".ex" || ext == ".exs"
+      # Elixir convention: `*_test.exs` files are ExUnit test
+      # modules. They register routes (often via inline
+      # `Plug.Router`-using modules or `defmodule TestRouter do ... use
+      # Phoenix.Router`) purely to exercise the framework; the routes
+      # never serve real traffic. Phoenix's own repo and any
+      # `phx.gen.auth` scaffold's tests trip this hard.
+      return [] of Endpoint if test_only_path?(path)
 
       endpoints = [] of Endpoint
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
@@ -22,7 +29,26 @@ module Analyzer::Elixir
 
       # Find all route blocks and extract params
       lines = content.lines
+      # Elixir lets `@moduledoc` / `@doc` / `~S` / `~s` use either
+      # triple-double (`\"\"\"`) or triple-single (`'''`) delimiters.
+      # Phoenix's `verified_routes.ex` opens the module doc with
+      # `~S'''` and embeds Phoenix.Router examples (`get \"/...\",
+      # Ctrl, :show`) inside it — those would otherwise leak. Track
+      # both delimiters independently so a `~H\"\"\"` template inside
+      # a `~S'''` outer doc doesn't pop the outer state.
+      in_triple_double = false
+      in_triple_single = false
       lines.each_with_index do |line, index|
+        if line.includes?("\"\"\"")
+          line.scan(/"""/).size.times { in_triple_double = !in_triple_double }
+          next
+        end
+        if line.includes?("'''")
+          line.scan(/'''/).size.times { in_triple_single = !in_triple_single }
+          next
+        end
+        next if in_triple_double || in_triple_single
+
         line_endpoints = line_to_endpoint(line.strip)
         line_endpoints.each do |endpoint|
           if endpoint.method != ""
@@ -42,6 +68,14 @@ module Analyzer::Elixir
       end
 
       endpoints
+    end
+
+    # ExUnit's filename convention is rigid: every test module sits in
+    # a file named `*_test.exs`, and `mix test` ignores anything else.
+    # Skipping by suffix is safe because production code never adopts
+    # that name.
+    private def test_only_path?(path : String) : Bool
+      File.basename(path).ends_with?("_test.exs")
     end
 
     def extract_params_from_block(lines : Array(String), start_index : Int32, method : String, block_end : Int32? = nil) : Array(Param)


### PR DESCRIPTION
## Summary

Scanning [`phoenixframework/phoenix`](https://github.com/phoenixframework/phoenix) surfaced 88 FPs from the Elixir Plug analyzer. Two distinct shapes:

- `lib/phoenix/{router,controller,verified_routes}.ex` embed example route DSL snippets (`get "/posts/:post_id", PostController, :show`) inside `@moduledoc` / `@doc` heredocs. The analyzer line-scans for verb+path shapes from anywhere in the source, including documentation, and emits 20 phantom endpoints. [`verified_routes.ex`](https://github.com/phoenixframework/phoenix/blob/main/lib/phoenix/verified_routes.ex#L2) opens its `@moduledoc` with the alternate `~S'''` triple-single delimiter, so a `"""`-only heredoc tracker still misses it.
- `test/**/*_test.exs` files register routes inside ExUnit modules (e.g. inline `defmodule TestRouter do use Plug.Router; get ... end`) purely to exercise the framework. ExUnit's filename convention is rigid — `mix test` only runs `*_test.exs` — so production code never adopts the suffix.

Two small additions to `Analyzer::Elixir::Plug`:

1. **`test_only_path?`** short-circuits `analyze_file` on `_test.exs`.
2. Inside `analyze_content` a pair of toggles (`in_triple_double`, `in_triple_single`) tracks open `"""` and `'''` heredocs independently; route extraction is skipped while either is active. A `~H""" ... """` template embedded inside an outer `~S''' ... '''` correctly leaves the outer state intact (the inner `"""` flips back and forth while the outer `'''` stays held).

This continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep into Elixir — same instinct as `#1566`/`#1567`/`#1569`, just adapted to a different language's idioms.

Fixture updates:
- `spec/functional_test/fixtures/elixir/plug/lib/router.ex` now has a `@moduledoc """` and a `~S'''` heredoc, each containing `get`/`post` shapes that must not leak.
- New `spec/functional_test/fixtures/elixir/plug/test/router_test.exs` registers two routes inside an inline `Plug.Router` module.

The existing tester asserts an exact expected-endpoints list, so any leak from either path would fail the spec.

Verified on phoenixframework/phoenix: total endpoints drop 88 → 0; every route belonged to a `_test.exs` file or a docstring.

## Test plan

- [x] `crystal spec spec/functional_test/testers/elixir/` — 323 examples, 0 failures (fixtures extended with heredoc + `_test.exs` regression cases)
- [x] `./bin/noir -b /path/to/phoenixframework-phoenix -f json` — confirmed 88 → 0, all docstring and test-file FPs gone