### PR TITLE
fix(ruby/sinatra): skip *_test.rb / *_spec.rb, RDoc comments, and `.delete` calls

### DIFF
--- a/spec/functional_test/fixtures/ruby/sinatra/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra/app.rb
@@ -1,5 +1,27 @@
 require 'sinatra'
 
+# Regression guard: route DSL inside an RDoc-style comment block is
+# documentation, not a registration. Neither URL should surface as
+# an endpoint.
+#
+#     get "/should-not-appear-doc" do
+#       erb :index
+#     end
+#
+#     post "/should-not-appear-doc-post" do
+#       :ok
+#     end
+
+# Regression guard: `headers.delete '...'` is a method call on a
+# response-headers hash, NOT a DELETE route registration. The shared
+# `line_to_endpoint` rejects verb shapes preceded by `.` or word chars.
+class HeaderShim
+  def reset(headers)
+    headers.delete 'content-length'
+    headers.delete 'content-type'
+  end
+end
+
 get '/' do
   puts param['query']
   puts cookies[:cookie1]

--- a/spec/functional_test/fixtures/ruby/sinatra/test/app_test.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra/test/app_test.rb
@@ -1,0 +1,21 @@
+# Regression guard: Minitest's `*_test.rb` convention skips file
+# scanning. Routes registered in this file (the inline TestApp
+# Sinatra::Base subclass below) should NOT surface as endpoints.
+require 'sinatra/base'
+require 'minitest/autorun'
+
+class TestApp < Sinatra::Base
+  get '/should-not-appear-test-get' do
+    'ok'
+  end
+
+  post '/should-not-appear-test-post' do
+    'ok'
+  end
+end
+
+class AppTest < Minitest::Test
+  def test_noop
+    assert true
+  end
+end

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -7,11 +7,23 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
+        # Minitest (`*_test.rb`) and RSpec (`*_spec.rb`) suites both
+        # register Sinatra routes from inline test apps purely to
+        # exercise the framework. Sinatra's own repo accounts for
+        # ~145 such routes; production code never adopts either
+        # filename convention so the suffix check is safe.
+        next if test_only_path?(path)
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           lines = file.each_line.to_a
           last_endpoint = Endpoint.new("", "")
           lines.each_with_index do |line, index|
             next unless line.valid_encoding?
+            # Skip Ruby comment lines — `sinatra-contrib/lib/sinatra/
+            # namespace.rb` and similar library sources keep DSL
+            # examples (`#     get '/dashboard' do`) inside RDoc
+            # comments. They look identical to real route
+            # registrations to the line-based matcher.
+            next if line.lstrip.starts_with?('#')
             endpoint = line_to_endpoint(line)
             if endpoint.method != ""
               details = Details.new(PathInfo.new(path, index + 1))
@@ -32,6 +44,11 @@ module Analyzer::Ruby
       end
 
       @result
+    end
+
+    private def test_only_path?(path : String) : Bool
+      base = File.basename(path)
+      base.ends_with?("_test.rb") || base.ends_with?("_spec.rb")
     end
 
     private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -10,7 +10,14 @@ module Analyzer::Ruby
     # and Sinatra (Rails uses a different per-line-multi-match shape).
     def line_to_endpoint(content : String, details : Details? = nil) : Endpoint
       HTTP_VERBS.each do |verb|
-        content.scan(/#{verb}\s+['"](.+?)['"]/) do |match|
+        # Reject method calls (`headers.delete 'content-length'`,
+        # `obj.get(:foo)`, …) that share a name with a DSL verb. The
+        # Sinatra route DSL always invokes the verb at a fresh
+        # statement boundary, never via a receiver. A negative
+        # lookbehind on `.` and word chars covers both
+        # `headers.delete` and `xdelete` (some unrelated identifier
+        # ending in the verb).
+        content.scan(/(?<![.\w])#{verb}\s+['"](.+?)['"]/) do |match|
           if match.size > 1
             if details
               return Endpoint.new(match[1], verb.upcase, details)


### PR DESCRIPTION
## Summary

Scanning [`sinatra/sinatra`](https://github.com/sinatra/sinatra) surfaced **158** endpoints, almost all false positives. Three distinct shapes were leaking through the Ruby Sinatra analyzer:

- **Test suites** — Minitest's `test/*_test.rb` and RSpec's `**/*_spec.rb` files register inline Sinatra apps (`class TestApp < Sinatra::Base ... get '/' do ... end`) purely to exercise the framework. The Sinatra repo accounts for ~145 such routes. Production code never adopts either filename convention.
- **RDoc comment blocks** — `sinatra-contrib/lib/sinatra/{namespace,cookies,required_params}.rb` ([example](https://github.com/sinatra/sinatra/blob/main/sinatra-contrib/lib/sinatra/namespace.rb#L24)) keep DSL examples inside `#`-prefixed comment blocks. The line-based matcher couldn't tell them apart from real registrations.
- **`headers.delete` method calls** — [`lib/sinatra/base.rb`](https://github.com/sinatra/sinatra/blob/main/lib/sinatra/base.rb#L187) calls `headers.delete 'content-length'` and `headers.delete 'content-type'` on the response-headers hash. The shared `line_to_endpoint` regex matched these as DELETE routes because it had no left-boundary anchor.

Three narrow fixes:

1. `Analyzer::Ruby::Sinatra#analyze` short-circuits on files whose basename ends with `_test.rb` or `_spec.rb`.
2. The per-line walker skips lines whose first non-whitespace char is `#`.
3. `RubyEngine#line_to_endpoint` adds a negative lookbehind `(?<![.\w])` to the verb regex so `headers.delete`, `xdelete`, and similar method calls stop matching. This is shared with the Hanami analyzer, so it benefits both detectors.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep into Ruby — same instinct as `#1567`/`#1569`/`#1570`, adapted to Ruby idioms.

Fixture updates:
- `spec/functional_test/fixtures/ruby/sinatra/app.rb` gains an RDoc comment block with bogus routes plus a `HeaderShim` class that calls `headers.delete '...'` twice.
- New `spec/functional_test/fixtures/ruby/sinatra/test/app_test.rb` registers two routes inside a Minitest test app.

The existing tester asserts an exact expected-endpoints list, so any leak from any of the three shapes would fail the spec.

Verified on sinatra/sinatra: total endpoints drop **158 → 13**. Remaining routes are two `examples/` apps, one framework-internal route in `lib/sinatra/base.rb` (`/__sinatra__/:image.png` dev-mode asset), and ten routes from `test/integration/app.rb` (a named Sinatra app file used as an integration-test fixture — not `_test.rb`, so it intentionally still scans).

## Test plan

- [x] `crystal spec spec/functional_test/testers/ruby/sinatra_spec.cr` — fixtures extended with all three regression shapes
- [x] `crystal spec spec/functional_test/testers/ruby/` — 565 examples, 0 failures
- [x] `./bin/noir -b /path/to/sinatra-sinatra -f json` — confirmed 158 → 13, all comment/test/`.delete` FPs gone