### PR TITLE
fix(python/django): skip test files when discovering ROOT_URLCONF roots

### DIFF
--- a/spec/functional_test/fixtures/python/django/blog/tests.py
+++ b/spec/functional_test/fixtures/python/django/blog/tests.py
@@ -1,0 +1,19 @@
+# Regression guard: a `tests.py` file inside a Django app has its own
+# `ROOT_URLCONF` to spin up a self-contained test project, but the
+# routes it registers should NEVER surface as endpoints — they only
+# serve the test suite. The expected-endpoints list in the spec does
+# not include `/should-not-appear-test`.
+from django.urls import path
+from django.test import TestCase
+
+ROOT_URLCONF = "blog.tests"
+
+urlpatterns = [
+    path("should-not-appear-test", lambda r: None),
+    path("should-not-appear-test-2", lambda r: None),
+]
+
+
+class SmokeTest(TestCase):
+    def test_noop(self):
+        self.assertTrue(True)

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -56,6 +56,20 @@ module Analyzer::Python
       endpoints
     end
 
+    # True for files that follow Python/Django test-suite conventions
+    # and therefore should never serve real traffic:
+    #   * anything under a `/tests/` directory (Django, pytest, and
+    #     packaging defaults all agree on this layout)
+    #   * `tests.py` at any level (the legacy Django per-app test file)
+    #   * `test_*.py` / `*_test.py` (unittest/pytest discovery patterns)
+    private def django_test_path?(file : String) : Bool
+      return true if file.includes?("/tests/")
+      base = File.basename(file)
+      return true if base == "tests.py"
+      return true if base.starts_with?("test_") && base.ends_with?(".py")
+      base.ends_with?("_test.py")
+    end
+
     # Find all root Django URLs
     def find_root_django_urls : Array(DjangoUrls)
       root_django_urls_list = [] of DjangoUrls
@@ -73,6 +87,14 @@ module Analyzer::Python
                 break if file.nil?
                 next if File.directory?(file)
                 next if file.includes?("/site-packages/")
+                # Skip Python test files: each Django test app under
+                # `tests/<feature>/` carries its own `ROOT_URLCONF`
+                # the analyzer would otherwise treat as a real Django
+                # project root. Django's own repo contributes ~720
+                # such phantom endpoints. Standard test conventions
+                # (`tests/` dir, `tests.py`, `test_*.py`, `*_test.py`)
+                # are unambiguous in Python codebases.
+                next if django_test_path?(file)
                 if file.ends_with? ".py"
                   content = read_file_content(file)
                   content.scan(REGEX_ROOT_URLCONF) do |match|


### PR DESCRIPTION
## Summary

Scanning [`django/django`](https://github.com/django/django) surfaced 744 endpoints, **722** of them from the framework's own `tests/` tree. Each Django test app at `tests/<feature>/` ships a self-contained `urls.py` with its own `ROOT_URLCONF`, so `find_root_django_urls` happily picked them up as production roots and walked every URLconf reachable from them.

Filter the file-discovery walker on standard Python/Django test conventions:
- any file under a `/tests/` directory
- `tests.py` at any level (the legacy per-app test file)
- `test_*.py` / `*_test.py` (unittest/pytest discovery patterns)

These conventions are unambiguous — production Django code never adopts them — so a real-world false negative is far rarer than the volume of test artifacts we'd otherwise leak. The existing `site-packages` skip already covers pip-installed framework code, so this change only affects in-tree test fixtures.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep into Django — same instinct as `#1565`/`#1569`/`#1570`/`#1571`, adapted to Django's URLconf discovery.

New fixture: `spec/functional_test/fixtures/python/django/blog/tests.py` declares its own `ROOT_URLCONF` and registers two routes inside a Django `TestCase` context. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on django/django: total endpoints drop **744 → 0**. All routes in the framework repo are downstream of test-only roots, so this is the correct outcome — a real user project's `settings.py` / `urls.py` live outside `tests/` and continue to resolve normally.

## Test plan

- [x] `crystal spec spec/functional_test/testers/python/django_spec.cr` — 96 examples, 0 failures (fixture extended with `tests.py` regression)
- [x] `crystal spec spec/functional_test/testers/python/` — 975 examples, 0 failures
- [x] `./bin/noir -b /path/to/django-django -f json` — confirmed 744 → 0