### PR TITLE
fix(java/spring): skip files under src/test/java/

### DIFF
--- a/spec/functional_test/fixtures/java/spring/src/test/java/com/example/ShouldNotAppearController.java
+++ b/spec/functional_test/fixtures/java/spring/src/test/java/com/example/ShouldNotAppearController.java
@@ -1,0 +1,24 @@
+// Regression guard: Maven/Gradle convention puts unit and
+// integration tests under `src/test/java/...`. Spring projects
+// routinely declare inline `@RestController` classes there to
+// exercise MockMvc / WebTestClient, but the routes never serve
+// real traffic. None of the URLs below should appear in the
+// fixture's expected-endpoints list.
+package com.example;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ShouldNotAppearController {
+    @GetMapping("/should-not-appear-test-get")
+    public String get() {
+        return "";
+    }
+
+    @PostMapping("/should-not-appear-test-post")
+    public String post() {
+        return "";
+    }
+}

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -52,6 +52,16 @@ module Analyzer::Java
             end
           end
         elsif File.exists?(path) && path.ends_with?(".java")
+          # Skip Maven/Gradle test sources: every Spring Boot project
+          # parks unit and integration tests under
+          # `src/test/java/...`. Those files routinely declare
+          # `@RestController` / `@GetMapping("/...")` against inline
+          # controllers purely to exercise MockMvc / WebTestClient,
+          # but they never serve real traffic. spring-projects/
+          # spring-boot's own repo contributed ~28 such phantom
+          # endpoints. The path layout is part of the build tools'
+          # contract so the heuristic is unambiguous.
+          next if path.includes?("/src/test/java/")
           webflux_base_path = find_base_path(path, webflux_base_path_map)
           content = read_file_content(path)
 


### PR DESCRIPTION
## Summary

Scanning [`spring-projects/spring-boot`](https://github.com/spring-projects/spring-boot) surfaced ~28 phantom endpoints in `java_spring`, all from `src/test/java/...` trees in the framework's `integration-test/` and `module/spring-boot-webmvc-test/` subprojects. Those files declare inline `@RestController` / `@GetMapping("/...")` against fixture controllers (e.g. [`ExampleController1.java`](https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-webmvc-test/src/test/java/org/springframework/boot/webmvc/test/autoconfigure/mockmvc/ExampleController1.java)) used by MockMvc and WebTestClient suites, never to serve real traffic.

Maven and Gradle both pin test sources to `src/test/java/` — the layout is part of the build tool's contract, not a project-specific convention — so a path-prefix check is unambiguous. The gate is on the `.java` branch only; the WebFlux YAML-config discovery loop (which keys on directories ending in `/src`) runs before it.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep into Spring — same instinct as `#1572`/`#1569`/`#1570`/`#1571`, adapted to the Maven/Gradle source layout.

New regression fixture `spec/functional_test/fixtures/java/spring/src/test/java/com/example/ShouldNotAppearController.java` registers two routes under the test layout. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on spring-projects/spring-boot: total endpoints drop 92 → 56; `java_spring` goes 73 → 36 with every `src/test/java/...` test controller gone.

## Test plan

- [x] `crystal spec spec/functional_test/testers/java/spring_spec.cr` — 136 examples, 0 failures (fixture extended with src/test/java/ regression)
- [x] `crystal spec spec/functional_test/testers/java/` — 878 examples, 0 failures
- [x] `./bin/noir -b /path/to/spring-projects-spring-boot -f json` — confirmed java_spring 73 → 36