### PR TITLE
fix(js): treat .test-d.ts as a test-stub filename marker

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -406,6 +406,25 @@ describe Noir::JSRouteExtractor do
       ).should be_false
     end
 
+    it "skips .test-d.ts type-only test files" do
+      # Regression: fastify/fastify's `test/types/*.test-d.ts` files
+      # register sample routes purely to assert their inferred typings.
+      # The `.test.`/`.spec.`/`-test.`/`-spec.` markers don't catch the
+      # `.test-d.` suffix that tsd / expect-type use for type-test
+      # files, so the JSParser was happy to emit every shape as a
+      # route.
+      content = <<-TS
+        import fastify from "fastify";
+        const app = fastify();
+        app.get("/typed", { schema: {} }, (req, reply) => reply.send({}));
+        app.post("/typed", (req, reply) => reply.send({}));
+        TS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/test/types/schema.test-d.ts",
+        content
+      ).should be_true
+    end
+
     it "skips bundled dist/ output files" do
       content = <<-JS
         // webpack bundle output with thousands of .get( / .post( noise

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -440,6 +440,12 @@ module Noir
       ".spec.",
       "-spec.",
       "-test.",
+      # tsd / expect-type style type-only test files. fastify's
+      # `test/types/*.test-d.ts` suites register sample routes purely
+      # to assert their inferred typings — no production endpoints,
+      # but the JSParser pre-filter sees the same `app.get(`/`.post(`
+      # shapes.
+      ".test-d.",
     ]
 
     # True when the file's route-shaped calls are almost certainly


### PR DESCRIPTION
## Summary

Scanning [`fastify/fastify`](https://github.com/fastify/fastify) surfaced 10 phantom endpoints from `test/types/*.test-d.ts` files. Those suites register sample routes purely to assert that fastify's request/reply generics infer the expected types — they're type-only tests run by [`tsd`](https://github.com/SamVerschueren/tsd) / `expect-type` and never serve real traffic.

The existing `.test.` / `.spec.` / `-test.` / `-spec.` markers don't catch the `.test-d.` suffix because they require the literal `.` after `test`. Adding `.test-d.` to `TEST_STUB_FILENAME_MARKERS` resolves the fastify case and any other repo that follows the tsd convention.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1566` (supertest), just one more filename convention to recognize.

Verified on fastify/fastify: total endpoints drop 18 → 8, with all `test/types/*.test-d.ts` artifacts removed; the remaining set is the `examples/` and `integration/` apps.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — 47 examples, 0 failures (adds spec for `/app/test/types/schema.test-d.ts`)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1777 examples, 0 failures
- [x] `./bin/noir -b /path/to/fastify-fastify -f json` — confirmed 18 → 8