### PR TITLE
fix(go): skip *_test.go across every Go analyzer

### DIFF
--- a/spec/functional_test/fixtures/go/echo/server_test.go
+++ b/spec/functional_test/fixtures/go/echo/server_test.go
@@ -1,0 +1,24 @@
+// Regression guard: Go pins `*_test.go` to test-only builds —
+// `go build` excludes them; only `go test` pulls them in. Real
+// route handlers never live there, but echo/chi/gin's own
+// `*_test.go` files register hundreds of router calls to
+// exercise the framework. None of the URLs below should surface
+// as endpoints in the functional spec.
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestRoutes(t *testing.T) {
+	e := echo.New()
+	e.GET("/should-not-appear-test-get", func(c echo.Context) error {
+		return c.String(http.StatusOK, "")
+	})
+	e.POST("/should-not-appear-test-post", func(c echo.Context) error {
+		return c.String(http.StatusOK, "")
+	})
+}

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -27,6 +27,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -84,6 +84,7 @@ module Analyzer::Go
                 path = channel.receive?
                 break if path.nil?
                 next if File.directory?(path)
+                next if GoEngine.go_test_file?(path)
                 if File.exists?(path)
                   content = file_contents_cache[path]? || read_file_content(path)
                   next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -26,6 +26,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/go_callee_extractor"
 require "../../../miniparsers/go_route_extractor_ts"
+require "../../engines/go_engine"
 
 module Analyzer::Go
   class Fasthttp < Analyzer
@@ -20,6 +21,7 @@ module Analyzer::Go
         file_contents = Hash(String, String).new
         go_files.each do |fp|
           next if File.directory?(fp)
+          next if GoEngine.go_test_file?(fp)
           begin
             file_contents[fp] = read_file_content(fp)
           rescue File::NotFoundError
@@ -32,6 +34,7 @@ module Analyzer::Go
           base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
           go_files.each do |path|
             next unless path.starts_with?(base_dir_prefix) || path == current_base_path
+            next if GoEngine.go_test_file?(path)
             if File.exists?(path)
               content = read_file_content(path)
               next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -23,6 +23,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -26,6 +26,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -25,6 +25,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -27,6 +27,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -29,6 +29,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
 
                   # Handle both .go files and .api files
                   if File.exists?(path) && (File.extname(path) == ".go" || File.extname(path) == ".api")

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -29,6 +29,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -43,6 +43,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -24,6 +24,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -29,6 +29,7 @@ module Analyzer::Go
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     next unless content.includes?(IMPORT_MARKER)

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -4,6 +4,16 @@ require "../../miniparsers/go_route_extractor_ts"
 
 module Analyzer::Go
   class GoEngine < Analyzer
+    # `*_test.go` is Go's hard-wired build-tag for test-only source.
+    # `go build` excludes these files entirely; only `go test` pulls
+    # them in. Real route handlers never live there, but framework
+    # repos (echo, chi, gin) park hundreds of `e.GET("/...", ...)`
+    # calls in `*_test.go` to exercise the router. Skip both in the
+    # cross-file pre-passes (so test-file groups don't pollute the
+    # production group map) and in each analyzer's per-file loop.
+    def self.go_test_file?(path : String) : Bool
+      path.ends_with?("_test.go")
+    end
     # --- Tree-sitter group/route pre-pass --------------------------------
     #
     # Does a cross-file fixpoint over every `.go` file in each package
@@ -27,6 +37,7 @@ module Analyzer::Go
 
       get_files_by_extension(".go").each do |path|
         next if File.directory?(path)
+        next if GoEngine.go_test_file?(path)
         dir = File.dirname(path)
         files_by_dir[dir] ||= [] of String
         files_by_dir[dir] << path
@@ -102,6 +113,7 @@ module Analyzer::Go
       file_contents = Hash(String, String).new
       get_files_by_extension(".go").each do |path|
         next if File.directory?(path)
+        next if GoEngine.go_test_file?(path)
         begin
           file_contents[path] = read_file_content(path)
         rescue File::NotFoundError


### PR DESCRIPTION
## Summary

Go pins `*_test.go` to test-only builds — `go build` excludes them entirely; only `go test` includes them. Real route handlers never live there, but framework repos and the typical real-world Go project both park `e.GET("/...")`-shaped calls inside test files to exercise the router under `httptest.NewServer`. Scanning [`labstack/echo`](https://github.com/labstack/echo) and [`go-chi/chi`](https://github.com/go-chi/chi) surfaced ~39 phantom endpoints each, all from `*_test.go` files.

Add `GoEngine.go_test_file?` as a single source of truth and apply it in three places:

1. The cross-file group pre-pass (`collect_package_groups_ts`) so a test-file `r.Group("/api")` doesn't pollute the production group map.
2. The cross-file function-body pre-pass (`read_package_file_contents`) so test-only handlers don't end up in the callee index.
3. Every analyzer's per-file consume loop (beego/chi/echo/fiber/gf/gin/gozero/hertz/httprouter/iris/mux and fasthttp), right after the existing `next if File.directory?(path)` guard. fasthttp extends `Analyzer` directly rather than `GoEngine`, so it picks up the helper via a new `require "../../engines/go_engine"`.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1572`/`#1573` (Maven `src/test/java/`, Django `tests/`), adapted to Go's `_test.go` naming.

New regression fixture `spec/functional_test/fixtures/go/echo/server_test.go` registers two routes inside a `TestRoutes` function. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified across the cycle's clones:
- labstack/echo: **39 → 0** (full repo was test-driven)
- go-chi/chi: **39 → 26** (test-file FPs in `middleware/*_test.go` removed, `_examples/` apps preserved)
- gin-gonic/examples: 42 → 42 (no test files in that repo, so nothing to gain — confirms no regression)

## Test plan

- [x] `crystal spec spec/functional_test/testers/go/` — 1122 examples, 0 failures (echo fixture extended with `server_test.go` regression)
- [x] `./bin/noir -b /path/to/labstack-echo` — 39 → 0
- [x] `./bin/noir -b /path/to/go-chi-chi` — 39 → 26