### PR TITLE
fix(python): centralize and apply pytest/unittest test-file filter

### DIFF
--- a/spec/functional_test/fixtures/python/django/tests/test_views.py
+++ b/spec/functional_test/fixtures/python/django/tests/test_views.py
@@ -1,0 +1,17 @@
+# Regression guard: a file under a `tests/` directory should be
+# skipped by the analyzer's test-file filter. The Django blog tests.py
+# already covers the `tests.py` filename convention; this file covers
+# the `tests/` directory convention with a pytest-style `test_*.py`
+# filename. None of the URLs below should surface as endpoints.
+from django.urls import path
+
+ROOT_URLCONF = "tests.test_views"
+
+urlpatterns = [
+    path("should-not-appear-tests-dir", lambda r: None),
+    path("should-not-appear-test-prefix", lambda r: None),
+]
+
+
+def test_noop():
+    assert True

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -39,6 +39,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -37,6 +37,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -56,20 +56,6 @@ module Analyzer::Python
       endpoints
     end
 
-    # True for files that follow Python/Django test-suite conventions
-    # and therefore should never serve real traffic:
-    #   * anything under a `/tests/` directory (Django, pytest, and
-    #     packaging defaults all agree on this layout)
-    #   * `tests.py` at any level (the legacy Django per-app test file)
-    #   * `test_*.py` / `*_test.py` (unittest/pytest discovery patterns)
-    private def django_test_path?(file : String) : Bool
-      return true if file.includes?("/tests/")
-      base = File.basename(file)
-      return true if base == "tests.py"
-      return true if base.starts_with?("test_") && base.ends_with?(".py")
-      base.ends_with?("_test.py")
-    end
-
     # Find all root Django URLs
     def find_root_django_urls : Array(DjangoUrls)
       root_django_urls_list = [] of DjangoUrls
@@ -94,7 +80,7 @@ module Analyzer::Python
                 # such phantom endpoints. Standard test conventions
                 # (`tests/` dir, `tests.py`, `test_*.py`, `*_test.py`)
                 # are unambiguous in Python codebases.
-                next if django_test_path?(file)
+                next if PythonEngine.python_test_path?(file)
                 if file.ends_with? ".py"
                   content = read_file_content(file)
                   content.scan(REGEX_ROOT_URLCONF) do |match|

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -34,6 +34,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           analyze_file(path, current_base_path)

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -18,6 +18,7 @@ module Analyzer::Python
           python_files.each do |path|
             next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             next if path.includes?("/site-packages/")
+            next if PythonEngine.python_test_path?(path)
             source = read_file_content(path)
 
             source.each_line do |line|

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -48,6 +48,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           file_content = fetch_file_content(path)

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -26,6 +26,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
 
           source = read_file_content(path)
           next unless source.includes?("litestar")

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -45,6 +45,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
 
           content = read_file_content(path)
           next unless content.includes?("pyramid")
@@ -62,6 +63,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           content = read_file_content(path)

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -40,6 +40,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -25,6 +25,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
 
           source = read_file_content(path)
           next unless source.includes?("starlette")

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -41,6 +41,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -14,6 +14,26 @@ module Analyzer::Python
     # Regex for valid Python module names
     DOT_NATION = /[a-zA-Z_][a-zA-Z0-9_.]*/
 
+    # Standard Python/pytest/unittest test-file conventions. A file
+    # under any of these patterns ships with `python -m pytest` or
+    # `python -m unittest` and never serves real traffic in
+    # production. Centralized so every analyzer can opt in via
+    # `next if PythonEngine.python_test_path?(path)`.
+    #
+    #   * `/tests/`          — pytest discovery default (Django,
+    #                          Litestar, FastAPI all use it)
+    #   * `tests.py`         — the legacy Django per-app test module
+    #   * `test_*.py`        — unittest / pytest default discovery
+    #   * `*_test.py`        — pytest-go style suffix (rare in Python,
+    #                          but cheap to include)
+    def self.python_test_path?(path : String) : Bool
+      return true if path.includes?("/tests/")
+      base = File.basename(path)
+      return true if base == "tests.py"
+      return true if base.starts_with?("test_") && base.ends_with?(".py")
+      base.ends_with?("_test.py")
+    end
+
     # Parses the definition of a function from the source lines starting at a given index
     def parse_function_def(source_lines : Array(::String), start_index : Int32) : FunctionDefinition?
       parameters = [] of FunctionParameter


### PR DESCRIPTION
## Summary

The Django analyzer landed a `tests/`-aware skip in #1572, but every other Python analyzer (FastAPI, Flask, Litestar, Starlette, Sanic, Bottle, Tornado, Aiohttp, Falcon, Pyramid) still happily scanned test files. Scanning [`litestar-org/litestar`](https://github.com/litestar-org/litestar) surfaced **173** phantom endpoints (134 from `tests/unit/`, 36 from `tests/e2e/`, 3 from `tests/examples/`).

Promote the Django-local helper to a shared `PythonEngine.python_test_path?` so all eleven analyzers stay in sync, and add the gate to every analyzer's file-enumeration loop — right after the existing `next if path.includes?("/site-packages/")` guard. The filter covers all four standard Python test conventions:

- `/tests/` directory (pytest discovery default — Django, Litestar, FastAPI all use it)
- `tests.py` (legacy Django per-app test module)
- `test_*.py` (unittest / pytest default discovery)
- `*_test.py` (less common in Python but cheap to include)

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1572` (Django) and `#1575` (Go `*_test.go`), this time a cross-Python sweep so the next OSS clone doesn't surface the same shape under a different framework.

New regression fixture `spec/functional_test/fixtures/python/django/tests/test_views.py` declares its own `ROOT_URLCONF` from inside a `tests/` directory; the existing Django tester asserts an exact expected-endpoints list, so any leak would fail.

Verified across the cycle's clones:
- litestar-org/litestar: **259 → 85** (173 test FPs removed; docs/examples & framework internals preserved)
- django/django: still 0 → 0 (helper migration is a pure refactor; behavior unchanged from #1572)
- tiangolo/full-stack-fastapi-template: still 30 → 30 (no test files in that repo, confirms no regression)

## Test plan

- [x] `crystal spec spec/functional_test/testers/python/django_spec.cr` — 96 examples, 0 failures (Django fixture extended with `tests/test_views.py`)
- [x] `crystal spec spec/functional_test/testers/python/` — 975 examples, 0 failures
- [x] `./bin/noir -b /path/to/litestar-org-litestar` — confirmed 259 → 85