### PR TITLE
fix(swift): skip Tests/ directories and *Tests.swift filenames

### DIFF
--- a/spec/functional_test/fixtures/swift/vapor/Tests/VaporAppTests/AppTests.swift
+++ b/spec/functional_test/fixtures/swift/vapor/Tests/VaporAppTests/AppTests.swift
@@ -1,0 +1,16 @@
+// Regression guard: Swift Package Manager parks XCTest sources under
+// `Tests/<TargetName>Tests/`. Routes registered inside these test
+// files exercise the router but never serve real traffic. None of
+// the URLs below should appear in the fixture's expected-endpoints
+// list.
+import Vapor
+import XCTest
+
+final class AppTests: XCTestCase {
+    func testRoutes() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        app.get("should-not-appear-tests-dir") { _ in "" }
+        app.post("should-not-appear-tests-dir-post") { _ in "" }
+    }
+}

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -11,6 +11,17 @@ module Analyzer::Swift
 
     abstract def analyze_file(path : String) : Array(Endpoint)
 
+    # `Tests/...` directory + `*Tests.swift` filename: the rigid Swift
+    # Package Manager / XCTest conventions for test sources.
+    def self.swift_test_path?(path : String) : Bool
+      return true if path.includes?("/Tests/")
+      File.basename(path).ends_with?("Tests.swift")
+    end
+
+    private def swift_test_path?(path : String) : Bool
+      SwiftEngine.swift_test_path?(path)
+    end
+
     # `.swift` extension filter baked in. Subclasses that need a custom
     # scan shape can override `analyze` and call this helper directly.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
@@ -22,6 +33,14 @@ module Analyzer::Swift
         parallel_analyze(channel) do |path|
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".swift"
+          # Swift Package Manager convention parks tests under
+          # `Tests/<TargetName>Tests/`. Real route handlers never
+          # live there, but vapor's own repo accounts for ~58
+          # phantom endpoints from `Tests/VaporTests/*Tests.swift`
+          # files that register routes against an inline test app.
+          # XCTest-style `*Tests.swift` filenames carry the same
+          # signal — pick them both up.
+          next if swift_test_path?(path)
 
           begin
             block.call(path)


### PR DESCRIPTION
## Summary

Swift Package Manager parks XCTest sources under `Tests/<TargetName>Tests/`, and the XCTest tradition names every test file `<Something>Tests.swift`. Real route handlers never live in either place, but framework repos like [`vapor/vapor`](https://github.com/vapor/vapor) park dozens of `app.get("/...", ...)` calls inside `Tests/VaporTests/` files to exercise the router under inline `Application(.testing)` instances.

Add `SwiftEngine.swift_test_path?` to the shared engine so all Swift analyzers (vapor, hummingbird, kitura) honor the same gate from `parallel_file_scan`. The filter triggers on:
- `/Tests/` anywhere in the path (SPM convention)
- filenames ending in `Tests.swift` (XCTest convention)

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1575` (Go `*_test.go`) and `#1576` (Python `tests/`), adapted to Swift's rigid layout.

New fixture `spec/functional_test/fixtures/swift/vapor/Tests/VaporAppTests/AppTests.swift` registers two routes inside an XCTestCase. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on vapor/vapor: total endpoints drop **100 → 42** with every `Tests/VaporTests/` artifact gone; the `Sources/Development/` and `Sources/Vapor/` framework-internal routes are preserved (they live in production source per Vapor's repo layout).

## Test plan

- [x] `crystal spec spec/functional_test/testers/swift/` — 178 examples, 0 failures (vapor fixture extended with `Tests/VaporAppTests/AppTests.swift` regression)
- [x] `./bin/noir -b /path/to/vapor-vapor -f json` — confirmed 100 → 42