### PR TITLE
fix(kotlin): skip test-source paths across ktor / spring / http4k

### DIFF
--- a/spec/functional_test/fixtures/kotlin/ktor/src/test/kotlin/ApplicationTest.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/src/test/kotlin/ApplicationTest.kt
@@ -1,0 +1,24 @@
+// Regression guard: Gradle parks JVM test sources under
+// `src/test/kotlin/...`. Routes registered there exercise the
+// framework's routing DSL but never serve real traffic. None of the
+// URLs below should appear in the fixture's expected-endpoints list.
+package com.example
+
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.response.*
+import org.junit.jupiter.api.Test
+
+class ApplicationTest {
+    @Test
+    fun testRoutes() {
+        // Inline test app that registers routes; the analyzer should
+        // skip this file entirely because of its `/src/test/` path.
+        val module: Application.() -> Unit = {
+            routing {
+                get("/should-not-appear-test-get") { call.respondText("") }
+                post("/should-not-appear-test-post") { call.respondText("") }
+            }
+        }
+    }
+}

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/http4k_extractor_ts"
+require "../../engines/kotlin_engine"
 
 module Analyzer::Kotlin
   class Http4k < Analyzer
@@ -12,6 +13,7 @@ module Analyzer::Kotlin
       file_list.each do |path|
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
+        next if KotlinEngine.test_path?(path)
 
         content = read_file_content(path)
         next unless content.includes?(HTTP4K_MARKER)

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/kotlin_ktor_route_extractor_ts"
+require "../../engines/kotlin_engine"
 
 module Analyzer::Kotlin
   class Ktor < Analyzer
@@ -11,6 +12,7 @@ module Analyzer::Kotlin
       file_list.each do |path|
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
+        next if KotlinEngine.test_path?(path)
 
         content = read_file_content(path)
         next unless content.includes?("routing")

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../miniparsers/kotlin_route_extractor_ts"
 require "../../../miniparsers/kotlin_parameter_extractor_ts"
 require "../../../miniparsers/kotlin_callee_extractor"
+require "../../engines/kotlin_engine"
 require "../../../utils/utils.cr"
 
 module Analyzer::Kotlin
@@ -18,6 +19,7 @@ module Analyzer::Kotlin
         next unless File.exists?(path)
         next if File.directory?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
+        next if KotlinEngine.test_path?(path)
 
         content = read_file_content(path)
         Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(content).each do |name, value|
@@ -31,6 +33,7 @@ module Analyzer::Kotlin
         if File.directory?(path)
           process_directory(path, webflux_base_path_map)
         elsif path.ends_with?(".#{KOTLIN_EXTENSION}")
+          next if KotlinEngine.test_path?(path)
           process_kotlin_file(path, dto_builder, webflux_base_path_map, string_constants)
         end
       end

--- a/src/analyzer/engines/kotlin_engine.cr
+++ b/src/analyzer/engines/kotlin_engine.cr
@@ -1,0 +1,38 @@
+require "../../models/analyzer"
+
+# Shared helpers for the three Kotlin analyzers (ktor / spring /
+# http4k). They each extend `Analyzer` directly rather than a
+# language-specific engine, so the helpers live as class methods on
+# `Analyzer::Kotlin::KotlinEngine` and the callers import it
+# explicitly. Promoting to a real engine class would be churn for
+# little gain — three analyzers, one helper.
+module Analyzer::Kotlin
+  module KotlinEngine
+    # Standard Kotlin/JUnit/Gradle test-source conventions:
+    #
+    #   * `/src/test/`                — Maven/Gradle JVM test root
+    #   * `/jvmTest/` `/commonTest/`  — Gradle Kotlin Multiplatform test source sets
+    #   * `/jsTest/` `/nativeTest/`
+    #   * `/test/` anywhere under a Gradle `kotlin { }` source dir (KMP
+    #     uses `<target>/test/` rather than the `src/test/` Maven layout)
+    #   * `/testData/`                — Kotlin compiler-plugin fixture dir
+    #     used by `ktor-compiler-plugin/testData/...`
+    #   * Filenames ending in `Test.kt` / `Tests.kt` — JUnit/Kotest
+    #
+    # ktor's own repo registers ~370 phantom endpoints from
+    # `ktor-client/...-tests/` modules and `*/jvm/test/...` directories
+    # that exercise the routing DSL under inline test servers.
+    def self.test_path?(path : String) : Bool
+      return true if path.includes?("/src/test/")
+      return true if path.includes?("/jvmTest/")
+      return true if path.includes?("/commonTest/")
+      return true if path.includes?("/jsTest/")
+      return true if path.includes?("/nativeTest/")
+      return true if path.includes?("/test/")
+      return true if path.includes?("/testData/")
+      base = File.basename(path)
+      return true if base.ends_with?("Test.kt")
+      base.ends_with?("Tests.kt")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Scanning [`ktorio/ktor`](https://github.com/ktorio/ktor) surfaced 441 phantom `kotlin_ktor` endpoints, nearly all from Gradle test source sets:
- `src/test/kotlin/` (Maven/Gradle JVM test root)
- `jvm/test/`, `common/test/`, `js/test/`, `native/test/` (Gradle Kotlin Multiplatform `<target>/test/` layout)
- `testData/` (Kotlin compiler-plugin fixture dir used by `ktor-compiler-plugin/testData/...`)
- `*Test.kt` / `*Tests.kt` (JUnit / Kotest filename conventions)

Introduce a shared `Analyzer::Kotlin::KotlinEngine.test_path?` helper next to the existing per-language engines, and gate the file-enumeration loop in each Kotlin analyzer (ktor, spring, http4k) on it. The Spring analyzer's two passes (string-constant pre-pass + per-file process) both pick up the gate; ktor and http4k each have a single loop.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1575` / `#1576` / `#1577` (Go / Python / Swift), adapted to Kotlin's Gradle/Maven layout and KMP source-set conventions.

New fixture `spec/functional_test/fixtures/kotlin/ktor/src/test/kotlin/ApplicationTest.kt` registers two routes under `src/test/`. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on ktorio/ktor: total endpoints drop **524 → 114**; `kotlin_ktor` goes **441 → 31**. The remaining 30 are from `ktor-server-test-suites/jvm/src/` — abstract test-suite scaffolding that lives in Gradle "main" source sets rather than `test/`, so it escapes a path-based filter. Worth a follow-up but out of scope for the cross-cutting cycle 4 sweep.

## Test plan

- [x] `crystal spec spec/functional_test/testers/kotlin/` — 291 examples, 0 failures (ktor fixture extended with `src/test/kotlin/ApplicationTest.kt` regression)
- [x] `./bin/noir -b /path/to/ktorio-ktor -f json` — confirmed kotlin_ktor 441 → 31