### PR TITLE
fix(play): skip src/test/ and src/sbt-test/ in Scala + Java analyzers

### DIFF
--- a/spec/functional_test/fixtures/scala/play/src/sbt-test/sample/conf/routes
+++ b/spec/functional_test/fixtures/scala/play/src/sbt-test/sample/conf/routes
@@ -1,0 +1,6 @@
+# Regression guard: routes files under `src/sbt-test/...` are
+# sbt-plugin test fixtures. Production traffic never reaches them.
+# Neither URL below should appear in the fixture's
+# expected-endpoints list.
+GET     /should-not-appear-sbt-test     controllers.HomeController.index
+POST    /should-not-appear-sbt-test     controllers.HomeController.create

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -14,6 +14,13 @@ module Analyzer::Java
       # First pass: find all routes files and Java controller files
       file_list.each do |path|
         next unless File.exists?(path)
+        # Skip test sources: Play's own repo parks `routes` files
+        # under `dev-mode/sbt-plugin/src/sbt-test/...` (sbt-plugin
+        # test fixtures) and `dev-mode/play-routes-compiler/src/test/
+        # resources/`. Both `/src/test/` (Maven/Gradle convention) and
+        # `/src/sbt-test/` (sbt-plugin's per-fixture test trees) are
+        # unambiguous — production code never adopts either.
+        next if path.includes?("/src/test/") || path.includes?("/src/sbt-test/")
 
         if path.ends_with?("routes") || path.ends_with?("routes.conf") || path.includes?("/conf/routes")
           routes_files << path

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -13,6 +13,14 @@ module Analyzer::Scala
       # First pass: find all routes files and Scala controller files
       file_list.each do |path|
         next unless File.exists?(path)
+        # Skip test sources: Play's own repo parks ~300 phantom
+        # endpoints in `dev-mode/sbt-plugin/src/sbt-test/.../conf/routes`
+        # (sbt-plugin test fixtures) and `dev-mode/play-routes-compiler/
+        # src/test/resources/*.routes`. Both `/src/test/` (Maven/Gradle
+        # convention) and `/src/sbt-test/` (sbt-plugin's per-fixture
+        # test trees) are unambiguous — production code never adopts
+        # either.
+        next if path.includes?("/src/test/") || path.includes?("/src/sbt-test/")
 
         if path.ends_with?("routes") || path.ends_with?("routes.conf") || path.includes?("/conf/routes")
           routes_files << path


### PR DESCRIPTION
## Summary

Scanning [`playframework/playframework`](https://github.com/playframework/playframework) surfaced **342** endpoints, almost all phantom: 298 from the Java Play analyzer and 44 from the Scala Play analyzer. Both come from Play's own routing test infrastructure:

- `dev-mode/sbt-plugin/src/sbt-test/play-sbt-plugin/<fixture>/conf/routes` — per-fixture sbt-plugin acceptance tests. The `src/sbt-test/` layout is sbt-plugin's analogue of `src/test/`; sbt's `scripted` task uses these fixtures as standalone build trees.
- `dev-mode/play-routes-compiler/src/test/resources/*.routes` — routes-compiler unit-test resources.

Add a `path.includes?("/src/test/") || path.includes?("/src/sbt-test/")` gate to the file-enumeration loop in both analyzers (Scala + Java both have the same `routes_files << path` shape; both needed the guard).

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1573` (Java/Spring `src/test/java/`), this time covering the rest of the JVM test layouts plus sbt's `scripted` convention.

New fixture `spec/functional_test/fixtures/scala/play/src/sbt-test/sample/conf/routes` declares two bogus routes under the test layout; the existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on playframework/playframework: total endpoints drop **342 → 44**; the entire `dev-mode/sbt-plugin/` and `dev-mode/play-routes-compiler/src/test/` trees are gone. The 44 remaining routes are from `documentation/manual/` (intentional documentation samples — left in place pending a broader docs-only filter discussion).

## Test plan

- [x] `crystal spec spec/functional_test/testers/scala/` — 290 examples, 0 failures (Scala Play fixture extended with `src/sbt-test/` regression)
- [x] `crystal spec spec/functional_test/testers/java/play_spec.cr` — 72 examples, 0 failures
- [x] `./bin/noir -b /path/to/playframework -f json` — confirmed 342 → 44