### PR TITLE
fix(js): treat axios + Rails Webpacker app/javascript/ as client-only

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -406,6 +406,59 @@ describe Noir::JSRouteExtractor do
       ).should be_false
     end
 
+    it "skips axios-only HTTP-client files" do
+      # Regression: mastodon `app/javascript/entrypoints/public.tsx`
+      # chains `axios.get('/api/v1/accounts/lookup', { params: ... })`
+      # — a browser-side AJAX call, not an Express route. axios is
+      # almost exclusively used to make outbound HTTP calls, so its
+      # presence alongside `.get(`/`.post(` shapes is a strong signal
+      # the file isn't a server.
+      content = <<-TS
+        import axios from "axios";
+        axios.get("/api/v1/foo", { params: { x: 1 } });
+        TS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/src/api/client.ts",
+        content
+      ).should be_true
+    end
+
+    it "keeps axios files that also import a real HTTP server lib" do
+      # Exemption guard: a real backend that uses axios internally for
+      # outbound calls should still scan when it also imports
+      # express/fastify/...
+      content = <<-JS
+        import express from "express";
+        import axios from "axios";
+        const app = express();
+        app.get("/proxy", async (req, res) => {
+          const data = await axios.get("https://upstream");
+          res.json(data.data);
+        });
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/src/server.js",
+        content
+      ).should be_false
+    end
+
+    it "skips files under Rails Webpacker app/javascript/" do
+      # Regression: Mastodon's redux action modules under
+      # `app/javascript/mastodon/actions/*.js` use `api().get('/url')`
+      # via a local axios wrapper. The `axios` filename hint doesn't
+      # fire because the wrapper hides the import, but the
+      # `app/javascript/` path marker is unambiguous on Rails-with-
+      # Webpacker layouts.
+      content = <<-JS
+        import api from "../api";
+        api().get("/api/v1/accounts/lookup");
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/javascript/mastodon/actions/accounts.js",
+        content
+      ).should be_true
+    end
+
     it "skips .test-d.ts type-only test files" do
       # Regression: fastify/fastify's `test/types/*.test-d.ts` files
       # register sample routes purely to assert their inferred typings.

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -368,6 +368,18 @@ module Noir
       # HTTP requests against an app under test, not registrations.
       "from \"supertest\"", "from 'supertest'",
       "require(\"supertest\")", "require('supertest')",
+      # axios: the dominant HTTP-client lib for both browser and Node.
+      # Files that import axios but don't also import an HTTP-server
+      # lib are almost always making outbound calls (`axios.get(url,
+      # config)`), not registering routes. Mastodon's
+      # `app/javascript/**/*.{ts,tsx,js}` tree alone accounts for ~72
+      # phantom Express endpoints from chains like
+      # `axios.get('/api/v1/accounts/lookup', { params: {...} })`.
+      # The HTTP-server-import exemption (below) keeps real backend
+      # files alive — production servers that internally call axios
+      # still scan because they also import express/fastify/...
+      "from \"axios\"", "from 'axios'",
+      "require(\"axios\")", "require('axios')",
     ]
 
     # Real HTTP-server library imports. When any of these is present
@@ -424,6 +436,15 @@ module Noir
       "/.output/",
       "/coverage/",
       "/vendor/",
+      # Rails Webpacker / esbuild / Vite source root. Anything under
+      # `app/javascript/` in a Rails app is browser-side code that
+      # calls into the backend (`api().get('/x')`, `axios.get('/y')`),
+      # never a route registration. Mastodon's repo alone parks ~68
+      # phantom Express endpoints across
+      # `app/javascript/mastodon/actions/*.js` redux modules. The
+      # HTTP-server-import exemption keeps the rare case of a SSR
+      # entrypoint that genuinely runs express alive.
+      "/app/javascript/",
     ]
 
     # Hard test-file markers: when the filename itself follows a


### PR DESCRIPTION
## Summary

Scanning [`mastodon/mastodon`](https://github.com/mastodon/mastodon) surfaced 78 phantom Express endpoints, all from `app/javascript/**/*.{ts,tsx,js}` files that make outbound HTTP calls via axios or a local axios wrapper. Examples:

- [`app/javascript/entrypoints/public.tsx:220`](https://github.com/mastodon/mastodon/blob/main/app/javascript/entrypoints/public.tsx#L220) — `axios.get('/api/v1/accounts/lookup', { params: ... })`
- [`app/javascript/mastodon/actions/server.js:29`](https://github.com/mastodon/mastodon/blob/main/app/javascript/mastodon/actions/server.js#L29) — `api().get('/api/v2/instance')` where `api` is a local axios wrapper

Two complementary signals extend the existing test-stub machinery:

1. **`axios` library marker** — axios is almost exclusively used as an outbound HTTP client (browser or Node). Files that import it without also importing an HTTP-server lib are making API calls, not registering routes.
2. **`/app/javascript/` path marker** — Rails Webpacker / esbuild / Vite source root. Any Rails app's frontend lives here, and files often use thin local wrappers (`api`, `client`, `http`) that hide their axios dependency from the file-level marker scan. The path-level signal catches them.

Both extend `TEST_STUB_LIBRARY_MARKERS` / `TEST_STUB_PATH_MARKERS`, so the existing `HTTP_SERVER_LIBRARY_MARKERS` exemption keeps real backends alive — files that legitimately import express/fastify/koa/hono/... continue to scan even if they also use axios or sit under `app/javascript/`.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1566` (supertest) and `#1574` (.test-d.ts), this time targeting the frontend-HTTP-client shape.

Three new unit specs cover the angles: axios-only files filtered, axios + express files retained (exemption), and `app/javascript/` paths filtered when no server lib is present.

Verified on mastodon/mastodon: total endpoints **196 → 122**; `js_express` drops **78 → 4** with every Redux-action FP gone. The four remaining js_express endpoints come from `streaming/index.js`, the real Node.js streaming server. `ruby_rails` endpoint count is unchanged at 118.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — 50 examples, 0 failures (adds 3 specs)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1777 examples, 0 failures
- [x] `./bin/noir -b /path/to/mastodon-mastodon -f json` — confirmed 196 → 122, js_express 78 → 4