### PR TITLE
fix(php): skip /Tests/, /tests/, *Test.php across every PHP analyzer

### DIFF
--- a/spec/functional_test/fixtures/php/symfony/tests/Controller/UserControllerTest.php
+++ b/spec/functional_test/fixtures/php/symfony/tests/Controller/UserControllerTest.php
@@ -1,0 +1,19 @@
+<?php
+// Regression guard: PHPUnit suites live under `tests/` (Laravel/
+// CakePHP/PHPUnit default) or `Tests/` (Symfony PSR-4 convention).
+// Routes declared inside these classes serve the test suite, never
+// real traffic. Neither URL below should appear in the fixture's
+// expected-endpoints list.
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\Annotation\Route;
+
+class UserControllerTest extends WebTestCase
+{
+    #[Route('/should-not-appear-tests-dir', methods: ['GET'])]
+    public function shouldNotAppearGet(): void {}
+
+    #[Route('/should-not-appear-tests-dir', methods: ['POST'])]
+    public function shouldNotAppearPost(): void {}
+}

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -30,6 +30,7 @@ module Analyzer::Php
         parallel_analyze(channel) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
+          next if PhpEngine.test_path?(path)
 
           begin
             block.call(path)
@@ -40,6 +41,26 @@ module Analyzer::Php
       rescue e
         logger.debug e
       end
+    end
+
+    # Standard PHP test-source conventions:
+    #
+    #   * `/Tests/`               — PSR-4 / Symfony convention
+    #     (`src/Symfony/Bundle/FrameworkBundle/Tests/...`)
+    #   * `/tests/`               — Laravel / CakePHP / PHPUnit default
+    #   * `*Test.php` filename    — PHPUnit suffix convention
+    #   * `*Tests.php` filename   — pluralized variant (rare)
+    #
+    # symfony/symfony's own repo accounts for ~63 phantom endpoints
+    # under `src/Symfony/Bundle/FrameworkBundle/Tests/...`. The
+    # conventions are unambiguous — production routing never adopts
+    # any of them.
+    def self.test_path?(path : String) : Bool
+      return true if path.includes?("/Tests/")
+      return true if path.includes?("/tests/")
+      base = File.basename(path)
+      return true if base.ends_with?("Test.php")
+      base.ends_with?("Tests.php")
     end
 
     # Route composition helper. Will migrate to a PHP route extractor when that


### PR DESCRIPTION
## Summary

Scanning [`symfony/symfony`](https://github.com/symfony/symfony) surfaced 63 phantom endpoints from `src/Symfony/Bundle/FrameworkBundle/Tests/Functional/...` — the framework's own functional-test bundle (controllers with `#[Route(...)]` attributes, YAML routes under `Tests/`). PHPUnit and Symfony both pin tests to layouts production routing never adopts:

- `/Tests/` — PSR-4 / Symfony bundle convention
- `/tests/` — Laravel / CakePHP / PHPUnit default
- `*Test.php` — PHPUnit suffix convention
- `*Tests.php` — pluralized variant

Add `PhpEngine.test_path?` and gate the shared `parallel_file_scan` loop on it. All six PHP analyzers (laravel, symfony, cakephp, codeigniter, slim, yii) inherit the engine so the change applies uniformly without per-analyzer churn.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1575` / `#1576` / `#1577` / `#1578` (Go / Python / Swift / Kotlin), this time covering PHP.

New fixture `spec/functional_test/fixtures/php/symfony/tests/Controller/UserControllerTest.php` declares two `#[Route(...)]` attributes inside a PHPUnit test class. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on symfony/symfony: total endpoints drop **63 → 4**. The four remaining routes are framework-internal doc examples (`AsRoutingConditionService.php`, `AttributeClassLoader.php`) that real user apps never include.

## Test plan

- [x] `crystal spec spec/functional_test/testers/php/symfony_spec.cr` — 90 examples, 0 failures (fixture extended with `tests/Controller/UserControllerTest.php` regression)
- [x] `crystal spec spec/functional_test/testers/php/` — 819 examples, 0 failures
- [x] `./bin/noir -b /path/to/symfony-symfony -f json` — confirmed 63 → 4