### PR TITLE
fix(js/nuxt): skip test/fixtures/ mini-Nuxt scenarios

### DIFF
--- a/spec/functional_test/fixtures/javascript/nuxtjs/test/fixtures/sample/server/api/ignored.ts
+++ b/spec/functional_test/fixtures/javascript/nuxtjs/test/fixtures/sample/server/api/ignored.ts
@@ -1,0 +1,7 @@
+// Regression guard: a `test/fixtures/<scenario>/server/api/` file is
+// a mini-Nuxt fixture used to test the framework, never a real
+// endpoint. This URL should NOT appear in the fixture's
+// expected-endpoints list.
+export default defineEventHandler(() => {
+  return { message: "should-not-appear-test-fixture" }
+})

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -13,6 +13,12 @@ module Analyzer::Javascript
         # Skip `*.test.ts` / `*.spec.ts` siblings — they don't
         # define Nuxt event handlers, just exercise neighbors.
         next if path.includes?(".test.") || path.includes?(".spec.")
+        # Skip mini-Nuxt fixtures used to test the framework itself.
+        # nuxt/nuxt parks 18 phantom endpoints under
+        # `test/fixtures/<scenario>/server/api/` — each fixture is a
+        # full Nuxt project the test suite spins up, but none of the
+        # routes serve real traffic.
+        next if path.includes?("/test/fixtures/") || path.includes?("/tests/fixtures/")
         analyze_nuxt_file(path, result, mutex, include_callee)
       end
 


### PR DESCRIPTION
## Summary

Scanning [`nuxt/nuxt`](https://github.com/nuxt/nuxt) surfaced 18 phantom endpoints from `test/fixtures/<scenario>/server/api/` and `server/routes/`. Each test fixture is a full mini-Nuxt project the framework's test suite boots to exercise behaviour, but their event handlers never serve real traffic.

The existing `.test.` / `.spec.` filename gate doesn't catch these because fixture files (`hello.ts`, `users.get.ts`, …) use the ordinary Nuxt naming. The `/test/fixtures/` (and `/tests/fixtures/`) path is a strong, unambiguous signal — production Nuxt apps never park their `server/api/` tree under a `test/fixtures/` parent.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep.

New fixture `spec/functional_test/fixtures/javascript/nuxtjs/test/fixtures/sample/server/api/ignored.ts` declares an event handler under the test-fixture layout. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on nuxt/nuxt: total endpoints drop **19 → 1**. The single remaining route is `playground/server/api/test.ts`, the intentional sandbox app.

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/nuxtjs_spec.cr` — 34 examples, 0 failures (fixture extended with `test/fixtures/sample/...` regression)
- [x] `./bin/noir -b /path/to/nuxt-nuxt -f json` — confirmed 19 → 1