### PR TITLE
fix(java): apply src/test/ + src/it/ skip across every Java analyzer

### DIFF
--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../ext/tree_sitter/tree_sitter"
 require "../../../miniparsers/java_callee_extractor"
 
@@ -29,6 +30,7 @@ module Analyzer::Java
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if JavaEngine.test_path?(path)
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
                     content = read_file_content(path)

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/jaxrs_extractor_ts"
 require "../../../miniparsers/import_graph"
 
@@ -19,6 +20,7 @@ module Analyzer::Java
 
       file_list = all_files()
       file_list.each do |path|
+        next if JavaEngine.test_path?(path)
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/jvm_lambda_dsl_extractor_ts"
 
 module Analyzer::Java
@@ -40,6 +41,7 @@ module Analyzer::Java
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
+        next if JavaEngine.test_path?(path)
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/jaxrs_extractor_ts"
 require "../../../miniparsers/import_graph"
 
@@ -13,6 +14,7 @@ module Analyzer::Java
 
       file_list = all_files()
       file_list.each do |path|
+        next if JavaEngine.test_path?(path)
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/micronaut_extractor_ts"
 
 module Analyzer::Java
@@ -12,6 +13,7 @@ module Analyzer::Java
 
       file_list = all_files()
       file_list.each do |path|
+        next if JavaEngine.test_path?(path)
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/jaxrs_extractor_ts"
 require "../../../miniparsers/import_graph"
 
@@ -20,6 +21,7 @@ module Analyzer::Java
 
       file_list = all_files()
       file_list.each do |path|
+        next if JavaEngine.test_path?(path)
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/jvm_lambda_dsl_extractor_ts"
 
 module Analyzer::Java
@@ -39,6 +40,7 @@ module Analyzer::Java
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       file_list.each do |path|
+        next if JavaEngine.test_path?(path)
         next unless File.exists?(path)
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -2,6 +2,7 @@ require "../../../models/analyzer"
 require "../../../miniparsers/java_route_extractor_ts"
 require "../../../miniparsers/java_parameter_extractor_ts"
 require "../../../miniparsers/java_callee_extractor"
+require "../../engines/java_engine"
 
 module Analyzer::Java
   class Spring < Analyzer
@@ -52,16 +53,11 @@ module Analyzer::Java
             end
           end
         elsif File.exists?(path) && path.ends_with?(".java")
-          # Skip Maven/Gradle test sources: every Spring Boot project
-          # parks unit and integration tests under
-          # `src/test/java/...`. Those files routinely declare
-          # `@RestController` / `@GetMapping("/...")` against inline
-          # controllers purely to exercise MockMvc / WebTestClient,
-          # but they never serve real traffic. spring-projects/
-          # spring-boot's own repo contributed ~28 such phantom
-          # endpoints. The path layout is part of the build tools'
-          # contract so the heuristic is unambiguous.
-          next if path.includes?("/src/test/java/")
+          # Skip Maven/Gradle test sources via the shared
+          # `JavaEngine.test_path?` helper; see the helper doc for
+          # the rationale (`src/test/`, `src/it/` are unambiguous
+          # JVM build-tool conventions).
+          next if JavaEngine.test_path?(path)
           webflux_base_path = find_base_path(path, webflux_base_path_map)
           content = read_file_content(path)
 

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../engines/java_engine"
 require "../../../miniparsers/java_callee_extractor"
 require "wait_group"
 
@@ -28,6 +29,7 @@ module Analyzer::Java
                   path = channel.receive?
                   break if path.nil?
                   next if File.directory?(path)
+                  next if JavaEngine.test_path?(path)
 
                   if File.exists?(path) && (path.ends_with?(".java") || path.ends_with?(".kt"))
                     details = Details.new(PathInfo.new(path))

--- a/src/analyzer/engines/java_engine.cr
+++ b/src/analyzer/engines/java_engine.cr
@@ -1,0 +1,28 @@
+require "../../models/analyzer"
+
+# Shared helpers for the Java analyzers. They each extend `Analyzer`
+# directly rather than a language-specific engine (historically the
+# Java set was the first family to land and never got an intermediate
+# class), so the helpers live as class methods on the JavaEngine
+# module and the callers import it explicitly. Mirrors the pattern
+# `Analyzer::Kotlin::KotlinEngine` follows.
+module Analyzer::Java
+  module JavaEngine
+    # Maven/Gradle pin test sources to `src/test/<lang>/` — `java`,
+    # `kotlin`, `scala`, `groovy` all share the layout. Real route
+    # handlers never live there, but Quarkus, Micronaut, Spring,
+    # Javalin, JAX-RS and friends routinely declare inline
+    # controllers under `src/test/java/...` to exercise the
+    # framework. The path layout is part of the build tool's
+    # contract so the prefix check is unambiguous.
+    #
+    # Also covers Maven's archetype source-roots
+    # (`src/it/`, integration-test convention used by some Quarkus
+    # extensions and Apache projects) which sit alongside `src/test/`.
+    def self.test_path?(path : String) : Bool
+      return true if path.includes?("/src/test/")
+      return true if path.includes?("/src/it/")
+      false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Spring landed the `src/test/java/` skip in #1573, but every other Java analyzer (Quarkus, Micronaut, JAX-RS, Javalin, Armeria, Dropwizard, Spark, Vertx) still happily scanned Maven/Gradle test sources. Scanning [`quarkusio/quarkus`](https://github.com/quarkusio/quarkus) alone parked ~1,500 phantom endpoints under `src/test/java/...` and Maven's `src/it/` integration-test roots; [`micronaut-projects/micronaut-core`](https://github.com/micronaut-projects/micronaut-core) contributed ~200 more.

Promote the per-analyzer check to a shared `Analyzer::Java::JavaEngine.test_path?` (mirrors the pattern `KotlinEngine.test_path?` from #1578). Two paths are unambiguous JVM build-tool conventions:

- `/src/test/` — Maven / Gradle test-source root (any language)
- `/src/it/` — Maven Failsafe integration-test convention, used heavily by Quarkus extensions and Apache projects

Spring's inline filter migrates to the helper; eight other Java analyzers gain a one-line `next if JavaEngine.test_path?(path)` guard in their file-enumeration loops (file_list-each or channel-receive shapes, depending on the analyzer).

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending the Spring-only fix into the rest of the Java family, just like #1576 generalized the Django-only fix into the rest of Python.

Verified across the cycle's clones:
- quarkusio/quarkus: **3792 → 2255** endpoints (java_quarkus 3293 → 1899, java_jaxrs 132 → 10, java_vertx 48 → 27)
- micronaut-projects/micronaut-core: **436 → 232** endpoints (java_micronaut 434 → 230)
- spring-projects/spring-boot: regression-tested at 56 endpoints (unchanged from #1573 — refactor is behavior-preserving for Spring)

## Test plan

- [x] `crystal spec spec/functional_test/testers/java/` — 878 examples, 0 failures (Spring's existing `src/test/java/` regression fixture still asserts)
- [x] `./bin/noir -b /path/to/quarkusio-quarkus -f json` — confirmed 3792 → 2255
- [x] `./bin/noir -b /path/to/micronaut-core -f json` — confirmed 436 → 232