### PR TITLE
fix(js): treat got/purest/ky/superagent/etc. as HTTP-client markers

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -406,6 +406,24 @@ describe Noir::JSRouteExtractor do
       ).should be_false
     end
 
+    it "skips files using other HTTP-client libs (got, purest, ky, ...)" do
+      # Regression: Strapi's `providers-registry.js` uses `purest`
+      # for OAuth provider calls — `discord.get('users/@me')` is an
+      # outbound API call, not a Koa route. The same pattern shows
+      # up across the Node ecosystem with got, ky, superagent,
+      # node-fetch, ofetch, undici, request — none of these libs
+      # are ever used to register routes.
+      content = <<-JS
+        const purest = require('purest');
+        const discord = purest({ provider: 'discord' });
+        discord.get('users/@me');
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/src/providers.js",
+        content
+      ).should be_true
+    end
+
     it "skips axios-only HTTP-client files" do
       # Regression: mastodon `app/javascript/entrypoints/public.tsx`
       # chains `axios.get('/api/v1/accounts/lookup', { params: ... })`

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -380,6 +380,29 @@ module Noir
       # still scan because they also import express/fastify/...
       "from \"axios\"", "from 'axios'",
       "require(\"axios\")", "require('axios')",
+      # The rest of the Node.js HTTP-client family. Each is almost
+      # exclusively used for outbound calls and never to register
+      # routes. Strapi's `purest`-based OAuth provider registry
+      # accounts for 6 phantom Koa endpoints (`discord.get('users/
+      # @me')` etc.); the others (got, ky, superagent, node-fetch,
+      # ofetch, undici, request) crop up in similar shapes across
+      # most Node backends.
+      "from \"purest\"", "from 'purest'",
+      "require(\"purest\")", "require('purest')",
+      "from \"got\"", "from 'got'",
+      "require(\"got\")", "require('got')",
+      "from \"ky\"", "from 'ky'",
+      "require(\"ky\")", "require('ky')",
+      "from \"superagent\"", "from 'superagent'",
+      "require(\"superagent\")", "require('superagent')",
+      "from \"node-fetch\"", "from 'node-fetch'",
+      "require(\"node-fetch\")", "require('node-fetch')",
+      "from \"ofetch\"", "from 'ofetch'",
+      "require(\"ofetch\")", "require('ofetch')",
+      "from \"undici\"", "from 'undici'",
+      "require(\"undici\")", "require('undici')",
+      "from \"request\"", "from 'request'",
+      "require(\"request\")", "require('request')",
     ]
 
     # Real HTTP-server library imports. When any of these is present


### PR DESCRIPTION
## Summary

#1580 added `axios` to `TEST_STUB_LIBRARY_MARKERS` to filter Mastodon's frontend-API call sites. Scanning [`strapi/strapi`](https://github.com/strapi/strapi) surfaced the same shape under a different lib: [`providers-registry.js`](https://github.com/strapi/strapi/blob/main/packages/plugins/users-permissions/server/services/providers-registry.js) builds OAuth providers via `purest` and calls `discord.get('users/@me')`, `twitter.get('account/verify_credentials')`, etc. — 6 phantom Koa endpoints from outbound API calls.

Extend the marker list to the rest of the Node.js HTTP-client family:

- `purest` — provider-aware HTTP wrapper (strapi)
- `got` — sindresorhus's HTTP client
- `ky` — fetch-based HTTP client
- `superagent` — older HTTP client, still common
- `node-fetch` — fetch polyfill for Node
- `ofetch` — unjs / Nuxt's HTTP client
- `undici` — Node's native HTTP client
- `request` — deprecated but still in the wild

Each is almost exclusively used for outbound calls and never to register routes. The existing `HTTP_SERVER_LIBRARY_MARKERS` exemption still keeps real backend files alive — production servers that internally call any of these libs continue to scan because they also import express/fastify/koa/hono/...

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending #1580 from axios to the rest of the Node HTTP-client ecosystem.

Verified on strapi/strapi: total endpoints drop **45 → 39**; `js_koa` drops **14 → 8** with every `purest`-based OAuth provider URL gone. The remaining 8 koa endpoints are real Strapi internals (`/_health`, `/{adminPath}/:path*`).

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — 51 examples, 0 failures (adds spec for `purest`)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1777 examples, 0 failures
- [x] `./bin/noir -b /path/to/strapi-strapi -f json` — confirmed js_koa 14 → 8