### PR TITLE
fix(ruby/rails): resolve simple local-var string interpolation in routes.rb

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -1,6 +1,13 @@
 Rails.application.routes.draw do
   root "home#index"
 
+  # Regression guard: a local string variable + `#{var}` interpolation
+  # should resolve to the literal value. Both routes below should end
+  # up with `/c/:channel_title/:channel_id` substituted into the URL.
+  base_c_route = "/c/:channel_title/:channel_id"
+  get "#{base_c_route}/:message_id" => "chat#respond"
+  post "#{base_c_route}/messages" => "chat#create"
+
   namespace :admin do
     resources :reports
     resources :refunds do

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -9,6 +9,14 @@ expected_endpoints = [
   # root "home#index"
   Endpoint.new("/", "GET"),
 
+  # Local string variable + `#{var}` interpolation: the analyzer
+  # captures `base_c_route = "..."` and substitutes the literal in
+  # subsequent route declarations. Discourse's chat plugin
+  # depends on this resolution to avoid phantom `/#{base_c_route}/...`
+  # entries.
+  Endpoint.new("/c/:channel_title/:channel_id/:message_id", "GET"),
+  Endpoint.new("/c/:channel_title/:channel_id/messages", "POST"),
+
   # namespace :admin do resources :reports end
   Endpoint.new("/admin/reports", "GET"),
   Endpoint.new("/admin/reports/1", "GET"),
@@ -91,6 +99,7 @@ expected_endpoints = [
 # endpoints (e.g. no POST /api/items, no DELETE /internal/statements, no
 # /scans/1) and devise_for emits its full route set.
 total_endpoints = 1 +  # root
+                  2 +  # `#{base_c_route}` interpolation resolved to 2 routes
                   5 +  # admin/reports
                   4 +  # admin/refunds member (change_status, purge, update_metadata) + collection (new_list)
                   1 +  # admin/monitor/heartbeat (namespaced `to:`)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -80,11 +80,40 @@ module Analyzer::Ruby
     private def parse_routes_file(routes_path : String, framework_root : String)
       details = Details.new(PathInfo.new(routes_path))
       stack = [] of Frame
+      # Routes files routinely DRY repeated prefixes into local
+      # string vars (`base_c_route = "/c/:channel_title/:channel_id"`)
+      # then use them with Ruby interpolation
+      # (`get "#{base_c_route}/:message_id" => "ctrl#act"`). The
+      # line-based parser saw the literal `#{base_c_route}` survive
+      # into URLs. discourse/discourse alone parked ~153 phantom
+      # routes with `#{...}` in them. Track the assignments as we
+      # walk the file and expand interpolations before route
+      # matching.
+      local_string_vars = Hash(String, String).new
 
       File.open(routes_path, "r", encoding: "utf-8", invalid: :skip) do |file|
         file.each_line do |raw_line|
           line = strip_inline_comment(raw_line).strip
           next if line.empty?
+
+          # Capture `name = "literal"` assignments at any nesting.
+          # We only resolve simple string-literal RHS; anything more
+          # complex (method calls, concatenation) stays opaque and
+          # the original `#{...}` falls through unchanged.
+          if assign = line.match(/^([a-z_][a-z0-9_]*)\s*=\s*["']([^"']+)["']\s*$/)
+            local_string_vars[assign[1]] = assign[2]
+          end
+
+          # Expand interpolations in-place so downstream regexes
+          # see the resolved path. We only substitute names we've
+          # actually seen — unresolved `#{...}` survives, which is
+          # better than producing an empty `/` placeholder.
+          unless local_string_vars.empty?
+            line = line.gsub(/\#\{([a-z_][a-z0-9_]*)\}/) do |match|
+              name = $~[1]
+              local_string_vars[name]? || match
+            end
+          end
 
           # Handle `end` (top of stack pops one).
           if line == "end" || line.starts_with?("end ") || line.starts_with?("end;") || line.starts_with?("end#")


### PR DESCRIPTION
## Summary

Scanning [`discourse/discourse`](https://github.com/discourse/discourse) surfaced ~150 phantom routes whose URLs contained raw Ruby string interpolation — `/#{base_c_route}/:message_id`, `/#{root_path}/trusted-session`, etc. The line-based Rails parser kept the `#{...}` placeholder intact even when the referenced variable was a simple string literal assigned right above the route block.

Add a per-file `local_string_vars` map in `parse_routes_file`. As we walk lines:
- `^name = "literal"$` assignments are captured into the map.
- Before route-matching the line, `#{name}` references are expanded against the map. Unresolved names survive unchanged — better than producing an empty `/` placeholder.

This handles the common DRY pattern Discourse's chat plugin uses ([`plugins/chat/config/routes.rb:115`](https://github.com/discourse/discourse/blob/main/plugins/chat/config/routes.rb#L115)):

```ruby
base_c_route = "/c/:channel_title/:channel_id"
get "#{base_c_route}/:message_id" => "chat#respond"
```

Block-iteration vars (`%w[users u].each do |root_path|`) still slip through — properly resolving them would require emitting each route N times, one per array element. Left for a follow-up.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep.

Fixture extension: `spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb` now declares a `base_c_route` var and uses it in two route registrations. The tester's expected-endpoints list adds the two resolved URLs and bumps the count.

Verified on discourse/discourse: phantom `#{...}` routes drop **153 → 150** (the 3 simple-var cases in the chat plugin's `base_c_route` / `base_channel_route` blocks resolve correctly). The remaining 150 are all `#{root_path}` block-iteration vars.

## Test plan

- [x] `crystal spec spec/functional_test/testers/ruby/rails_advanced_spec.cr` — 94 examples, 0 failures (new interpolation case asserts)
- [x] `crystal spec spec/functional_test/testers/ruby/` — 569 examples, 0 failures
- [x] `./bin/noir -b /path/to/discourse-discourse -f json` — confirmed `base_c_route` interpolations resolve