### PR TITLE
fix(perl/mojolicious): skip /t/ directory and *.t test scripts

### DIFF
--- a/spec/functional_test/fixtures/perl/mojolicious/t/api.t
+++ b/spec/functional_test/fixtures/perl/mojolicious/t/api.t
@@ -1,0 +1,20 @@
+# Regression guard: a Perl test script under `t/` (CPAN convention)
+# or with a `.t` extension is test code, never a real route handler.
+# Neither URL below should appear in the fixture's expected-endpoints
+# list.
+use Mojolicious::Lite;
+use Test::More;
+
+get '/should-not-appear-test' => sub {
+    my $c = shift;
+    $c->render(text => 'ok');
+};
+
+post '/should-not-appear-test' => sub {
+    my $c = shift;
+    $c->render(text => 'ok');
+};
+
+ok 1, 'noop test';
+
+done_testing;

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -30,6 +30,12 @@ module Analyzer::Perl
       ext = File.extname(path)
       return [] of Endpoint unless ext == ".pl" || ext == ".pm" ||
                                    ext == ".psgi" || ext == ".t"
+      # Skip standard Perl test conventions: anything under `/t/`
+      # (CPAN convention for test scripts) or with a `.t` filename
+      # (which is also a test script — accepted above so analyzers
+      # *could* opt in, but Mojolicious's own `t/mojolicious/*.t`
+      # accounts for ~1100 phantom endpoints).
+      return [] of Endpoint if perl_test_path?(path, ext)
 
       endpoints = [] of Endpoint
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
@@ -37,6 +43,12 @@ module Analyzer::Perl
         endpoints.concat(analyze_content(content, path, include_callee, controller_callees))
       end
       endpoints
+    end
+
+    private def perl_test_path?(path : String, ext : String) : Bool
+      return true if ext == ".t"
+      return true if path.includes?("/t/")
+      false
     end
 
     def analyze_content(content : String,


### PR DESCRIPTION
## Summary

Scanning [`mojolicious/mojo`](https://github.com/mojolicious/mojo) surfaced **1285** phantom endpoints, 1183 of them from the framework's own `t/mojolicious/*.t` and `t/mojo/*.t` test scripts.

The Mojolicious analyzer accepts `.t` as a valid extension so analyzers *could* opt in to scanning test scripts, but the framework repo proves that registering routes in tests is the rule, not the exception. CPAN's two test conventions are unambiguous:
- Any file under a `/t/` directory
- Any file with a `.t` extension

Production Perl code never adopts either naming. Add `perl_test_path?` and short-circuit `analyze_file` on it.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1575` / `#1576` / `#1577` / `#1578` / `#1581` / `#1583` / `#1584` (Go / Python / Swift / Kotlin / PHP / Java / Rust), adapted to Perl's CPAN convention.

New fixture `spec/functional_test/fixtures/perl/mojolicious/t/api.t` registers two routes inside a `Mojolicious::Lite` test script. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on mojolicious/mojo: total endpoints drop **1285 → 95**. The remaining 95 are framework-internal documentation routes (`lib/Mojolicious.pm`, `lib/Mojo.pm` docstring examples) and `examples/` apps.

## Test plan

- [x] `crystal spec spec/functional_test/testers/perl/` — 148 examples, 0 failures (fixture extended with `t/api.t` regression)
- [x] `./bin/noir -b /path/to/mojolicious-mojo -f json` — confirmed 1285 → 95