### PR TITLE
fix(js/adonisjs): apply the shared JSRouteExtractor test-stub gate

### DIFF
--- a/spec/functional_test/fixtures/javascript/adonisjs/tests/api.spec.ts
+++ b/spec/functional_test/fixtures/javascript/adonisjs/tests/api.spec.ts
@@ -1,0 +1,8 @@
+// Regression guard: japa / vitest / jest test files (`*.spec.ts`,
+// `*.test.ts`) under AdonisJS's `tests/` tree register routes only
+// to exercise the framework. None of the URLs below should appear
+// in the fixture's expected-endpoints list.
+import Route from '@adonisjs/core/services/router'
+
+Route.get('/should-not-appear-test', async () => 'ok')
+Route.post('/should-not-appear-test', async () => 'ok')

--- a/src/analyzer/analyzers/javascript/adonisjs.cr
+++ b/src/analyzer/analyzers/javascript/adonisjs.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/adonisjs_extractor_ts"
+require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
   class Adonisjs < Analyzer
@@ -17,6 +18,11 @@ module Analyzer::Javascript
 
         content = read_file_content(path)
         next unless ADONIS_MARKERS.any? { |m| content.includes?(m) }
+        # Reuse the shared JS test-stub gate so `*.spec.ts` /
+        # `*.test.ts` (japa, vitest, jest) AdonisJS test scaffolds
+        # don't leak. adonisjs/core's own repo parks ~19 phantom
+        # endpoints in `tests/providers.spec.ts` alone.
+        next if Noir::JSRouteExtractor.test_stub_only?(path, content)
 
         Noir::TreeSitterAdonisJsExtractor.extract_routes(content).each do |route|
           @result << build_endpoint(route, path)


### PR DESCRIPTION
## Summary

The AdonisJS analyzer scans every `.js/.ts/.mjs/.cjs` file that imports `@adonisjs/core` or `@ioc:Adonis`, but it never honored the same `test_stub_only?` gate the rest of the JS family uses. Scanning [`adonisjs/core`](https://github.com/adonisjs/core) accounts for 19 phantom endpoints from `tests/providers.spec.ts` alone (it imports `@adonisjs/core` to construct a real router under test).

Adding `next if Noir::JSRouteExtractor.test_stub_only?(path, content)` to the analyzer's file loop picks up the standard `*.spec.ts`/`*.test.ts` filename markers plus every other `TEST_STUB` convention shipped with the shared filter (axios, supertest, `app/javascript/`, …).

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — wiring AdonisJS into the same machinery the rest of the JS analyzers already share.

New fixture `spec/functional_test/fixtures/javascript/adonisjs/tests/api.spec.ts` registers two routes inside a japa test file. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on adonisjs/core: total endpoints drop **21 → 2**. The remaining two are framework-internal documentation examples in `providers/hash_provider.ts` and `providers/app_provider.ts`.

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/adonisjs_spec.cr` — 62 examples, 0 failures (fixture extended with `tests/api.spec.ts` regression)
- [x] `./bin/noir -b /path/to/adonisjs-core -f json` — confirmed 21 → 2