### PR TITLE
fix(csharp): skip /test/, /tests/, /testassets/, *Tests.cs paths

### DIFF
--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc/test/ShouldNotAppearControllerTests.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc/test/ShouldNotAppearControllerTests.cs
@@ -1,0 +1,18 @@
+// Regression guard: anything under `/test/`, `/tests/`, or
+// `/testassets/` is .NET test infrastructure (xUnit/NUnit/MSTest
+// fixtures), never a real route handler. None of the URLs below
+// should appear in the fixture's expected-endpoints list.
+using Microsoft.AspNetCore.Mvc;
+
+namespace MyApp.Test;
+
+[ApiController]
+[Route("[controller]")]
+public class ShouldNotAppearControllerTests : ControllerBase
+{
+    [HttpGet("should-not-appear-test")]
+    public string Get() => "";
+
+    [HttpPost("should-not-appear-test")]
+    public string Post() => "";
+}

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -21,6 +21,7 @@ module Analyzer::CSharp
 
       get_files_by_extension(".cs").each do |file|
         next unless File.exists?(file)
+        next if Common.csharp_test_path?(file)
 
         lines = read_file_content(file).lines
         lines.each_with_index do |line, index|
@@ -199,6 +200,7 @@ module Analyzer::CSharp
     private def analyze_controllers(route_patterns : Array(String), include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
         base = File.basename(file)
+        next false if Common.csharp_test_path?(file)
         base.includes?("Controller") && !base.ends_with?("RouteConfig.cs") && base != "Program.cs" && base != "Startup.cs"
       end
 

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -55,6 +55,7 @@ module Analyzer::CSharp
 
     private def analyze_controllers(include_callee : Bool)
       controller_files = get_files_by_extension(".cs").select do |file|
+        next false if Common.csharp_test_path?(file)
         file.includes?("Controller") && !file.includes?("RouteConfig")
       end
 

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -1,6 +1,28 @@
 require "../../../miniparsers/csharp_callee_extractor"
 
 module Analyzer::CSharp::Common
+  # Standard .NET test-source conventions:
+  #
+  #   * `/test/` and `/tests/` parent directories — Microsoft's
+  #     own repos park unit + integration tests under
+  #     `src/<Project>/test/...` (aspnetcore) or `tests/...`
+  #     (smaller solutions).
+  #   * `/testassets/` — aspnetcore's helper-controller convention
+  #     for spinning up a real server inside the test harness.
+  #   * `Tests.cs` / `Test.cs` filename — xUnit / NUnit / MSTest
+  #     suffix convention.
+  #
+  # dotnet/aspnetcore alone parks ~3,600 phantom endpoints under
+  # `src/Mvc/test/...` and similar trees. Production code never
+  # adopts any of these.
+  def self.csharp_test_path?(path : String) : Bool
+    return true if path.includes?("/test/")
+    return true if path.includes?("/tests/")
+    return true if path.includes?("/testassets/")
+    base = File.basename(path)
+    return true if base.ends_with?("Tests.cs")
+    base.ends_with?("Test.cs")
+  end
   protected def build_signature(lines : Array(String), start_index : Int32) : Tuple(String, Int32)
     signature = lines[start_index]
     paren_count = signature.count('(') - signature.count(')')


### PR DESCRIPTION
## Summary

Scanning [`dotnet/aspnetcore`](https://github.com/dotnet/aspnetcore) surfaced 4477 phantom `cs_aspnet_core_mvc` endpoints, ~3,600 of them from the framework's own `src/<Project>/test/...` trees plus aspnetcore-specific `testassets/` helper controllers (`Components.TestServer` etc.) that exist solely to spin up a real server inside MSTest/xUnit runs.

Add `Analyzer::CSharp::Common.csharp_test_path?` covering the unambiguous .NET test layouts:

- `/test/` — Microsoft repo convention (`src/Mvc/test/...`, `src/Identity/test/...`)
- `/tests/` — smaller-solution convention
- `/testassets/` — aspnetcore's helper-controller subdir
- `*Tests.cs` / `*Test.cs` — xUnit / NUnit / MSTest filename

Both C# analyzers (AspNetCoreMvc, AspNetMvc) gate their controller discovery on the helper. AspNetCoreMvc also gates the `MapGet`/`MapPost` route-builder pass since the same test trees contain minimal-API style registrations.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending the same convention-based test filter into C# alongside Java/Kotlin/Python/Go/Rust/PHP/Perl.

New regression fixture `spec/functional_test/fixtures/csharp/aspnet_core_mvc/test/ShouldNotAppearControllerTests.cs` registers two routes under the test layout. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified:
- dotnet/aspnetcore: **4559 → 952** (cs_aspnet_core_mvc 4477 → 870)
- dotnet/eShop: unchanged at 61 (its app code is under `src/<App>/`, not `src/test/...`, confirming no regression on real .NET apps)

## Test plan

- [x] `crystal spec spec/functional_test/testers/csharp/` — 318 examples, 0 failures (fixture extended with `test/ShouldNotAppearControllerTests.cs` regression)
- [x] `./bin/noir -b /path/to/dotnet-aspnetcore -f json` — confirmed 4559 → 952
- [x] `./bin/noir -b /path/to/dotnet-eShop -f json` — confirmed unchanged at 61