### PR TITLE
fix(fsharp/giraffe): skip /tests/ + *Tests.fs sources

### DIFF
--- a/spec/functional_test/fixtures/fsharp/giraffe/tests/RoutingTests.fs
+++ b/spec/functional_test/fixtures/fsharp/giraffe/tests/RoutingTests.fs
@@ -1,0 +1,13 @@
+// Regression guard: F#/Giraffe test sources live under `tests/` or
+// have a `*Tests.fs` filename. Routes registered there exercise the
+// HttpHandler combinators but never serve real traffic. None of the
+// URLs below should appear in the fixture's expected-endpoints list.
+module Giraffe.Tests.RoutingTests
+
+open Giraffe
+
+let testApp : HttpHandler =
+    choose [
+        route "/should-not-appear-test" >=> text "ok"
+        route "/should-not-appear-test2" >=> text "ok"
+    ]

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -37,12 +37,26 @@ module Analyzer::Fsharp
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".fs") || path.ends_with?(".fsx")
+        # Skip .NET test conventions: `/tests/` and `/test/`
+        # parent dirs, and `*Tests.fs` filenames. Giraffe's own
+        # `tests/Giraffe.Tests/*.fs` accounts for ~218 phantom
+        # endpoints — full `webApp` HttpHandler trees built only
+        # to exercise the routing combinators.
+        next if fsharp_test_path?(path)
 
         content = read_file_content(path)
         process_file(path, content, include_callee)
       end
 
       @result
+    end
+
+    private def fsharp_test_path?(path : String) : Bool
+      return true if path.includes?("/tests/")
+      return true if path.includes?("/test/")
+      base = File.basename(path)
+      return true if base.ends_with?("Tests.fs")
+      base.ends_with?("Test.fs")
     end
 
     alias SubRouteScope = NamedTuple(prefix: String, end_pos: Int32, params: Array(Param))


### PR DESCRIPTION
## Summary

Scanning [`giraffe-fsharp/Giraffe`](https://github.com/giraffe-fsharp/Giraffe) surfaced 296 `fs_giraffe` endpoints; 218 of them lived under `tests/Giraffe.Tests/*.fs` — full HttpHandler trees built only to exercise the routing combinators against TestServer. The analyzer walked every `.fs`/`.fsx` file without honoring .NET's test-directory conventions.

Add `fsharp_test_path?` covering `/tests/`, `/test/`, `*Tests.fs`, and `*Test.fs`. The conventions are unambiguous in F# projects — both `samples/` and `src/` production code never adopt them.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending the same convention-based test filter into F# alongside C#/Java/Kotlin and the rest of the JVM family.

New fixture `spec/functional_test/fixtures/fsharp/giraffe/tests/RoutingTests.fs` declares two phantom routes inside a `Tests` module. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on giraffe-fsharp/Giraffe: total endpoints drop **296 → 78**. The remaining 78 are `samples/EndpointRoutingApp`, `samples/ResponseCachingApp`, etc. — the framework's intentional example apps.

## Test plan

- [x] `crystal spec spec/functional_test/testers/fsharp/` — 204 examples, 0 failures (fixture extended with `tests/RoutingTests.fs` regression)
- [x] `./bin/noir -b /path/to/giraffe-fsharp-Giraffe -f json` — confirmed 296 → 78