### PR TITLE
fix(crystal): skip /spec/ at project root and *_spec.cr files

### DIFF
--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -26,6 +26,15 @@ module Analyzer::Crystal
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".cr"
           next if path.includes?("lib")
+          # Crystal's standard test directory is `spec/`, and test
+          # files always end in `_spec.cr`. Crystal framework repos
+          # (lucky, marten, amber, kemal) park hundreds of route
+          # declarations there to exercise the framework. Production
+          # code never adopts either convention. The `spec/` dir
+          # is checked relative to the project root so nested
+          # fixtures under noir's own `spec/functional_test/...`
+          # tree don't accidentally trip the filter.
+          next if crystal_spec_path?(path)
 
           begin
             block.call(path)
@@ -35,6 +44,19 @@ module Analyzer::Crystal
         end
       rescue e
         logger.debug e
+      end
+    end
+
+    # `*_spec.cr` is Crystal's official spec filename — unambiguous
+    # at any depth. The `spec/` directory is only treated as test
+    # when it sits at the project root (or the immediate child of
+    # one of the configured `base_paths`); inside our fixture tree
+    # the framework apps themselves live under a `spec/` ancestor.
+    private def crystal_spec_path?(path : String) : Bool
+      return true if File.basename(path).ends_with?("_spec.cr")
+      base_paths.any? do |root|
+        normalized = root.ends_with?("/") ? root : "#{root}/"
+        path.starts_with?("#{normalized}spec/")
       end
     end
 


### PR DESCRIPTION
## Summary

Scanning [`luckyframework/lucky`](https://github.com/luckyframework/lucky), [`martenframework/marten`](https://github.com/martenframework/marten), and [`amberframework/amber`](https://github.com/amberframework/amber) surfaced hundreds of phantom endpoints from Crystal's standard `spec/` test directory: lucky **148 → 19**, marten **24 → 1**, amber **40 → 26**.

`*_spec.cr` is Crystal's official spec filename and the `spec/` directory is the canonical test layout — both ship with `crystal spec`. Production Crystal code never adopts either convention.

Two-pronged filter applied in `CrystalEngine#parallel_file_scan`:

1. **`*_spec.cr` filename** — accepted at any depth, mirroring how `crystal spec` discovers tests.
2. **`<base_path>/spec/` directory** — the project-root form only. Anchoring on `base_paths` keeps fixtures under noir's own `spec/functional_test/fixtures/...` tree (which would otherwise match the substring) scannable for the regression suite.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same instinct as `#1575` / `#1576` / `#1577` (Go / Python / Swift), adapted to Crystal's `crystal spec` convention with a careful nesting guard for our own test fixtures.

Verified:
- luckyframework/lucky: **148 → 19** (production routes in `src/lucky/{exposable,renderable,routable,...}.cr` remain)
- martenframework/marten: **24 → 1**
- amberframework/amber: **40 → 26**

## Test plan

- [x] `crystal spec spec/functional_test/testers/crystal/` — 340 examples, 0 failures (lucky/marten/amber/kemal/grip all still resolve via the `base_paths`-relative gate)
- [x] `./bin/noir -b /path/to/luckyframework-lucky / martenframework-marten / amberframework-amber -f json` — endpoint counts confirmed