### PR TITLE
fix(rust): share cfg(test) region detection across analyzers

### DIFF
--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -29,10 +29,11 @@ module Analyzer::Rust
 
       # `#[cfg(test)] mod tests { ... let app = Router::new().route(...); }`
       # is the canonical place doctests-as-unit-tests register routes in
-      # Rust source — axum-extra exercises this heavily. Find each
-      # cfg(test)-gated block's byte range up-front; routes whose call
-      # node starts inside one are unit-test fixtures, not endpoints.
-      test_regions = collect_cfg_test_regions(source)
+      # Rust source — axum-extra exercises this heavily. The shared
+      # `RustEngine.collect_cfg_test_regions` walks the cfg(test)-gated
+      # blocks once per file; we filter route calls whose start byte
+      # falls inside.
+      test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = include_callee ? build_function_index(root, source) : Hash(String, LibTreeSitter::TSNode).new
@@ -40,7 +41,7 @@ module Analyzer::Rust
         walk(root) do |node|
           next unless Noir::TreeSitter.node_type(node) == "call_expression"
           next unless route_call?(node, source)
-          next if inside_test_region?(node, test_regions)
+          next if RustEngine.inside_test_region?(node, test_regions)
 
           route = extract_route(node, source)
           next unless route
@@ -61,142 +62,6 @@ module Analyzer::Rust
       end
 
       endpoints
-    end
-
-    # Scan the source for `#[cfg(test)]` annotations, then capture the
-    # byte range of the following `mod`/`fn`/`impl` block via simple
-    # brace counting. String/char literals are skipped so a `{` inside
-    # `"foo {"` doesn't shift the depth. The annotated item is always
-    # one of these — axum's pattern never gates a `const`/`static` —
-    # so we don't try to handle non-block items.
-    private def collect_cfg_test_regions(source : String) : Array(Tuple(Int32, Int32))
-      regions = [] of Tuple(Int32, Int32)
-      bytes = source.to_slice
-      pattern = /\#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/
-      source.scan(pattern) do |match|
-        attr_start = match.begin || next
-        brace_idx = find_block_open_brace(bytes, attr_start + 1)
-        next unless brace_idx
-        close_idx = find_matching_close_brace(bytes, brace_idx)
-        next unless close_idx
-        regions << {attr_start, close_idx + 1}
-      end
-      regions
-    end
-
-    private def find_block_open_brace(bytes : Slice(UInt8), from : Int32) : Int32?
-      i = from
-      while i < bytes.size
-        c = bytes[i]
-        case c
-        when '"'.ord then i = skip_string_literal(bytes, i)
-        when '\''.ord then i = skip_char_or_lifetime(bytes, i)
-        when '/'.ord
-          if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
-            i = skip_line_comment(bytes, i)
-          elsif i + 1 < bytes.size && bytes[i + 1] == '*'.ord
-            i = skip_block_comment(bytes, i)
-          else
-            i += 1
-          end
-        when '{'.ord then return i
-        else i += 1
-        end
-      end
-      nil
-    end
-
-    private def find_matching_close_brace(bytes : Slice(UInt8), open_idx : Int32) : Int32?
-      depth = 1
-      i = open_idx + 1
-      while i < bytes.size && depth > 0
-        c = bytes[i]
-        case c
-        when '"'.ord then i = skip_string_literal(bytes, i); next
-        when '\''.ord then i = skip_char_or_lifetime(bytes, i); next
-        when '/'.ord
-          if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
-            i = skip_line_comment(bytes, i); next
-          elsif i + 1 < bytes.size && bytes[i + 1] == '*'.ord
-            i = skip_block_comment(bytes, i); next
-          end
-        when '{'.ord then depth += 1
-        when '}'.ord then depth -= 1
-        end
-        i += 1
-      end
-      depth == 0 ? i - 1 : nil
-    end
-
-    private def skip_string_literal(bytes : Slice(UInt8), from : Int32) : Int32
-      i = from + 1
-      while i < bytes.size
-        c = bytes[i]
-        if c == '\\'.ord
-          i += 2
-          next
-        end
-        if c == '"'.ord
-          return i + 1
-        end
-        i += 1
-      end
-      i
-    end
-
-    # Distinguish Rust char literals (`'x'`, `'\n'`, `'\u{...}'`) from
-    # lifetime annotations (`'a`, `'static`). A lifetime starts with
-    # `'` followed by an identifier-start char and is NOT immediately
-    # closed by another quote — most importantly, it never contains
-    # `{`/`}` so we can just step past the leading quote and keep
-    # scanning. A char literal does contain interior bytes we want to
-    # skip so a `'{'` doesn't perturb brace depth.
-    private def skip_char_or_lifetime(bytes : Slice(UInt8), from : Int32) : Int32
-      # `'x'` (3 bytes): bytes[from+2] is `'`.
-      if from + 2 < bytes.size && bytes[from + 2] == '\''.ord
-        return from + 3
-      end
-      # `'\<esc>'`: bytes[from+1] is `\`, scan for matching `'`.
-      if from + 1 < bytes.size && bytes[from + 1] == '\\'.ord
-        i = from + 2
-        while i < bytes.size
-          c = bytes[i]
-          if c == '\\'.ord
-            i += 2
-            next
-          end
-          return i + 1 if c == '\''.ord
-          i += 1
-        end
-        return i
-      end
-      # Otherwise treat as lifetime: only consume the apostrophe.
-      from + 1
-    end
-
-    private def skip_line_comment(bytes : Slice(UInt8), from : Int32) : Int32
-      i = from
-      while i < bytes.size && bytes[i] != '\n'.ord
-        i += 1
-      end
-      i
-    end
-
-    private def skip_block_comment(bytes : Slice(UInt8), from : Int32) : Int32
-      i = from + 2
-      while i + 1 < bytes.size
-        if bytes[i] == '*'.ord && bytes[i + 1] == '/'.ord
-          return i + 2
-        end
-        i += 1
-      end
-      bytes.size
-    end
-
-    private def inside_test_region?(node : LibTreeSitter::TSNode, regions : Array(Tuple(Int32, Int32))) : Bool
-      return false if regions.empty?
-      start_byte = LibTreeSitter.ts_node_start_byte(node).to_i
-      regions.any? { |s, e| start_byte >= s && start_byte < e }
     end
 
     # `.route("...", get(handler))` — the chain is rooted on

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -21,12 +21,18 @@ module Analyzer::Rust
       endpoints = [] of Endpoint
       source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      # `crates/core/src/routing.rs`-style `#[cfg(test)] mod tests
+      # { Router::with_path(...).get(...) }` blocks would otherwise
+      # leak into the endpoint set. See `RustEngine.collect_cfg_test_regions`
+      # for the shared helper's rationale.
+      test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = build_function_index(root, source)
 
         walk(root) do |node|
           next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          next if RustEngine.inside_test_region?(node, test_regions)
           chain = decode_router_chain(node, source)
           next unless chain
           route_path, method, handler_name = chain
@@ -44,6 +50,7 @@ module Analyzer::Rust
         end
 
         each_routing_pair(root) do |attr_item, function|
+          next if RustEngine.inside_test_region?(attr_item, test_regions)
           route = decode_endpoint_macro(attr_item, source)
           next unless route
           route_path, method, attr_row = route

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -53,6 +53,136 @@ module Analyzer::Rust
       base.ends_with?("_test.rs") || base.ends_with?("_tests.rs")
     end
 
+    # Scan the source for `#[cfg(test)]` annotations, then capture
+    # the byte range of the following `mod`/`fn`/`impl` block via
+    # simple brace counting. String/char literals are skipped so a
+    # `{` inside `"foo {"` doesn't shift the depth. Rust lifetimes
+    # like `'a` look like char literals to a naive quote scanner
+    # and would otherwise drop the close-brace search into oblivion
+    # — see `skip_char_or_lifetime`.
+    #
+    # Shared with all Rust analyzers: axum's `extract/path/mod.rs`,
+    # salvo's `crates/core/src/routing.rs`, and similar framework
+    # source files mix production routes with `#[cfg(test)] mod
+    # tests { ... }` blocks. Each analyzer that uses tree-sitter
+    # can call this once per file, then drop any route call whose
+    # `ts_node_start_byte` falls in one of the returned ranges.
+    def self.collect_cfg_test_regions(source : String) : Array(Tuple(Int32, Int32))
+      regions = [] of Tuple(Int32, Int32)
+      bytes = source.to_slice
+      pattern = /\#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/
+      source.scan(pattern) do |match|
+        attr_start = match.begin || next
+        brace_idx = find_block_open_brace(bytes, attr_start + 1)
+        next unless brace_idx
+        close_idx = find_matching_close_brace(bytes, brace_idx)
+        next unless close_idx
+        regions << {attr_start, close_idx + 1}
+      end
+      regions
+    end
+
+    def self.inside_test_region?(node : LibTreeSitter::TSNode, regions : Array(Tuple(Int32, Int32))) : Bool
+      return false if regions.empty?
+      start_byte = LibTreeSitter.ts_node_start_byte(node).to_i
+      regions.any? { |s, e| start_byte >= s && start_byte < e }
+    end
+
+    private def self.find_block_open_brace(bytes : Slice(UInt8), from : Int32) : Int32?
+      i = from
+      while i < bytes.size
+        c = bytes[i]
+        case c
+        when '"'.ord then i = skip_string_literal(bytes, i)
+        when '\''.ord then i = skip_char_or_lifetime(bytes, i)
+        when '/'.ord
+          if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
+            i = skip_line_comment(bytes, i)
+          elsif i + 1 < bytes.size && bytes[i + 1] == '*'.ord
+            i = skip_block_comment(bytes, i)
+          else
+            i += 1
+          end
+        when '{'.ord then return i
+        else i += 1
+        end
+      end
+      nil
+    end
+
+    private def self.find_matching_close_brace(bytes : Slice(UInt8), open_idx : Int32) : Int32?
+      depth = 1
+      i = open_idx + 1
+      while i < bytes.size && depth > 0
+        c = bytes[i]
+        case c
+        when '"'.ord then i = skip_string_literal(bytes, i); next
+        when '\''.ord then i = skip_char_or_lifetime(bytes, i); next
+        when '/'.ord
+          if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
+            i = skip_line_comment(bytes, i); next
+          elsif i + 1 < bytes.size && bytes[i + 1] == '*'.ord
+            i = skip_block_comment(bytes, i); next
+          end
+        when '{'.ord then depth += 1
+        when '}'.ord then depth -= 1
+        end
+        i += 1
+      end
+      depth == 0 ? i - 1 : nil
+    end
+
+    private def self.skip_string_literal(bytes : Slice(UInt8), from : Int32) : Int32
+      i = from + 1
+      while i < bytes.size
+        c = bytes[i]
+        if c == '\\'.ord
+          i += 2
+          next
+        end
+        return i + 1 if c == '"'.ord
+        i += 1
+      end
+      i
+    end
+
+    private def self.skip_char_or_lifetime(bytes : Slice(UInt8), from : Int32) : Int32
+      if from + 2 < bytes.size && bytes[from + 2] == '\''.ord
+        return from + 3
+      end
+      if from + 1 < bytes.size && bytes[from + 1] == '\\'.ord
+        i = from + 2
+        while i < bytes.size
+          c = bytes[i]
+          if c == '\\'.ord
+            i += 2
+            next
+          end
+          return i + 1 if c == '\''.ord
+          i += 1
+        end
+        return i
+      end
+      from + 1
+    end
+
+    private def self.skip_line_comment(bytes : Slice(UInt8), from : Int32) : Int32
+      i = from
+      while i < bytes.size && bytes[i] != '\n'.ord
+        i += 1
+      end
+      i
+    end
+
+    private def self.skip_block_comment(bytes : Slice(UInt8), from : Int32) : Int32
+      i = from + 2
+      while i + 1 < bytes.size
+        return i + 2 if bytes[i] == '*'.ord && bytes[i + 1] == '/'.ord
+        i += 1
+      end
+      bytes.size
+    end
+
     protected def attach_rust_callees(endpoint : Endpoint, callees : Array(Noir::RustCalleeExtractor::Entry))
       Noir::RustCalleeExtractor.attach_to(endpoint, callees)
     end


### PR DESCRIPTION
## Summary

axum landed `collect_cfg_test_regions` in #1569 to filter routes registered inside `#[cfg(test)] mod tests { ... }` blocks. Scanning [`salvo-rs/salvo`](https://github.com/salvo-rs/salvo) surfaced the same shape: [`crates/core/src/routing.rs`](https://github.com/salvo-rs/salvo/blob/main/crates/core/src/routing.rs) parks ~14 `Router::with_path(...).get(...)` calls inside a cfg(test) block to exercise the routing trie under unit tests.

Promote the entire cfg(test) region machinery from `axum.cr` to `RustEngine.collect_cfg_test_regions` / `inside_test_region?` so every Rust analyzer that uses tree-sitter can reuse it without duplicating the brace-counter + Rust-lifetime-aware scanner.

- **axum** now calls the shared API (behavior unchanged from #1569; the local copy is gone).
- **salvo** gains both passes (router chain + `#[endpoint(...)]` macro pair walk) of test-region gating.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending the same cross-cutting test-filter pattern (#1583 Java, #1584 Rust path filter, #1589 C#) into Rust's cfg(test) shape.

Verified:
- salvo-rs/salvo: **79 → 60** endpoints (`crates/core/src/routing.rs` cfg(test) tests removed; production routes in `examples/` and the rest of `crates/core` preserved)
- axum: 51 → 51 (unchanged — same logic, just relocated)

## Test plan

- [x] `crystal spec spec/functional_test/testers/rust/` — 910 examples, 0 failures (axum's existing cfg(test) regression fixture still asserts via the shared helper)
- [x] `./bin/noir -b /path/to/salvo-rs-salvo -f json` — confirmed 79 → 60
- [x] `./bin/noir -b /path/to/tokio-rs-axum -f json` — confirmed 51 (no regression)