### PR TITLE
fix(go): also skip Go's _-prefixed toolchain-ignored directories

### DIFF
--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -11,8 +11,16 @@ module Analyzer::Go
     # calls in `*_test.go` to exercise the router. Skip both in the
     # cross-file pre-passes (so test-file groups don't pollute the
     # production group map) and in each analyzer's per-file loop.
+    #
+    # Also skip Go's toolchain-ignored directory prefixes: any
+    # path component starting with `_` (`_examples/`, `_assets/`,
+    # `_testdata/`) is excluded by `go build`/`go list` outright.
+    # `kataras/iris` alone parks 392 phantom endpoints under
+    # `_examples/...`; they're documented apps, not production
+    # routes the framework ships.
     def self.go_test_file?(path : String) : Bool
-      path.ends_with?("_test.go")
+      return true if path.ends_with?("_test.go")
+      path.split("/").any? { |seg| seg.starts_with?("_") }
     end
     # --- Tree-sitter group/route pre-pass --------------------------------
     #


### PR DESCRIPTION
## Summary

Go's build toolchain explicitly ignores any path component starting with `_` — `_examples/`, `_assets/`, `_testdata/`, `_*`. `go build`, `go list`, `go test` all exclude these by design (see [Go docs § Source file lists](https://pkg.go.dev/cmd/go#hdr-Package_lists)). Real route handlers never ship from them.

Extend `GoEngine.go_test_file?` (already used as the file-scan gate by every Go analyzer + the cross-file group/function pre-passes) to reject paths with any `_`-prefixed component.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — same intent as `#1575`'s `*_test.go` skip, extended to Go's other toolchain-ignored convention.

Verified across the cycle's clones:
- [`kataras/iris`](https://github.com/kataras/iris): **392 → 26** (`_examples/` tree gone; the remaining 26 come from `core/router/` and internal package source — real framework routes the user would import)
- [`go-chi/chi`](https://github.com/go-chi/chi): **26 → 2** (`_examples/` apps removed)
- gin-gonic/examples: 42 → 42 (no `_*` dirs — confirms no regression on the path-anchored Go scans)

## Test plan

- [x] `crystal spec spec/functional_test/testers/go/` — 1122 examples, 0 failures (no fixture changes needed — the test suite has no `_*` dirs)
- [x] `./bin/noir -b /path/to/kataras-iris -f json` — confirmed 392 → 26
- [x] `./bin/noir -b /path/to/go-chi-chi -f json` — confirmed 26 → 2