### PR TITLE
fix(php/yii): skip console (CLI) controllers

### DIFF
--- a/spec/functional_test/fixtures/php/yii/commands/MigrateController.php
+++ b/spec/functional_test/fixtures/php/yii/commands/MigrateController.php
@@ -1,0 +1,21 @@
+<?php
+// Regression guard: Yii's console controllers expose CLI commands
+// (`yii migrate/up`, `yii fixture/load`), not HTTP routes. None of
+// the action methods below should surface as endpoints in the
+// fixture's expected list.
+namespace app\commands;
+
+use yii\console\Controller;
+
+class MigrateController extends Controller
+{
+    public function actionUp($limit = 0)
+    {
+        return 0;
+    }
+
+    public function actionDown($limit = 0)
+    {
+        return 0;
+    }
+}

--- a/src/analyzer/analyzers/php/yii.cr
+++ b/src/analyzer/analyzers/php/yii.cr
@@ -111,11 +111,31 @@ module Analyzer::Php
       normalized
     end
 
+    # A Yii controller is a console (CLI) controller when it extends
+    # any class under `yii\console\Controller` — directly via
+    # `extends \yii\console\Controller` / `extends yii\console\Controller`,
+    # or via a `use yii\console\Controller` import paired with
+    # `extends Controller`. Production code uses the same hierarchy
+    # for built-in `migrate`, `fixture`, `cache`, etc. commands.
+    private def console_controller?(content : String) : Bool
+      return true if content.matches?(/extends\s+\\?yii\\console\\Controller/)
+      return true if content.includes?("yii\\console\\Controller") &&
+                     content.matches?(/extends\s+(?:Console)?Controller\b/)
+      false
+    end
+
     private def analyze_controller(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       controller_name = extract_controller_name(path, content)
       return endpoints if controller_name.empty?
+
+      # Skip console (CLI) controllers — they expose CLI commands
+      # like `migrate/up`, `fixture/load`, never HTTP routes. The
+      # framework repo's `framework/console/controllers/*` parks 25
+      # phantom HTTP endpoints when they're really `yii migrate up`
+      # style invocations.
+      return endpoints if console_controller?(content)
 
       # Detect REST (ActiveController / rest\Controller) — exposes standard CRUD verbs.
       # Match both fully-qualified names and `use`-imported short names.


### PR DESCRIPTION
## Summary

Scanning [`yiisoft/yii2`](https://github.com/yiisoft/yii2) surfaced 25 phantom HTTP endpoints from `framework/console/controllers/*` — `migrate/up`, `fixture/load`, `cache/flush`, etc. Those are Yii CLI commands invoked via `yii <cmd>`, never served over HTTP. They share the same `actionFoo()` method shape as web controllers, which is how the analyzer got fooled.

Yii's `\yii\console\Controller` base class is unambiguous. Detect files that extend it (directly via the fully-qualified name, or through `use yii\console\Controller` + `extends Controller`) and short-circuit `analyze_controller` for them. Web controllers (`extends \yii\web\Controller`, `extends Controller` after a `use yii\web\Controller`) keep their existing path.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — a framework-specific shape (CLI vs HTTP controller hierarchy) rather than the cross-cutting test filters most prior PRs in this series have targeted.

New fixture `spec/functional_test/fixtures/php/yii/commands/MigrateController.php` mirrors a real Yii CLI controller. The existing tester asserts an exact expected-endpoints list, so any leak would fail.

Verified on yiisoft/yii2: total endpoints **25 → 0** (every endpoint in the framework repo came from a console controller; once a real Yii app is scanned, only its web controllers — under `controllers/` or `modules/*/controllers/` — surface).

## Test plan

- [x] `crystal spec spec/functional_test/testers/php/yii_spec.cr` — 76 examples, 0 failures (fixture extended with `commands/MigrateController.php`)
- [x] `./bin/noir -b /path/to/yiisoft-yii2 -f json` — confirmed 25 → 0