### PR TITLE
fix(js): add /e2e/, /mirage/, /__mocks__/ as strict path markers

### DIFF
--- a/spec/unit_test/miniparser/js_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_route_extractor_spec.cr
@@ -258,12 +258,14 @@ describe Noir::JSRouteExtractor do
       Noir::JSRouteExtractor.test_stub_only?("/app/tests/user-test.js", content).should be_true
     end
 
-    it "keeps the file when express is also imported (path-marker route only)" do
-      # Library + directory markers honor an HTTP-server-import
-      # exemption so legit test-server harnesses keep their
-      # routes. The path here triggers TEST_STUB_PATH_MARKERS via
-      # `/cypress/` (without the strict filename markers) so the
-      # exemption code path is the one under test.
+    it "keeps the file when express is also imported (lenient path-marker route)" do
+      # Library + the lenient TEST_STUB_PATH_MARKERS honor an
+      # HTTP-server-import exemption so legit test-server harnesses
+      # keep their routes. `/dist/` is part of the lenient set
+      # (bundled output paths) — it triggers the path-marker code
+      # path but the exemption keeps it scanned when an HTTP server
+      # lib is imported. Strict markers like `/cypress/` and `/e2e/`
+      # skip unconditionally and are covered by separate specs.
       content = <<-JS
         import express from "express";
         import Pretender from "pretender";
@@ -271,7 +273,7 @@ describe Noir::JSRouteExtractor do
         app.get("/api/users", (req, res) => res.json([]));
         JS
       Noir::JSRouteExtractor.test_stub_only?(
-        "/app/cypress/helpers/api-server.js",
+        "/app/dist/server-bundle.js",
         content
       ).should be_false
     end
@@ -404,6 +406,37 @@ describe Noir::JSRouteExtractor do
         "/app/src/server.js",
         content
       ).should be_false
+    end
+
+    it "skips Ember mirage stub-server configs by /mirage/ path" do
+      # Regression: TryGhost/Ghost's `ghost/admin/mirage/config/*.js`
+      # files configure an Ember mirage stub server. `server.get(...)`
+      # / `server.post(...)` are mock-server handlers, not real
+      # Express routes — Ghost alone parks ~53 phantom endpoints
+      # here.
+      content = <<-JS
+        import {paginatedResponse} from '../utils';
+        export default function mockOffers(server) {
+          server.post('/offers/');
+          server.get('/offers/', paginatedResponse('offers'));
+        }
+        JS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/ghost/admin/mirage/config/offers.js",
+        content
+      ).should be_true
+    end
+
+    it "skips e2e helper mock servers by /e2e/ path" do
+      content = <<-TS
+        import express from "express";
+        const app = express();
+        app.get("/v1/products/:id", (req, res) => res.json({}));
+        TS
+      Noir::JSRouteExtractor.test_stub_only?(
+        "/app/e2e/helpers/services/stripe/fake-stripe-server.ts",
+        content
+      ).should be_true
     end
 
     it "skips files using other HTTP-client libs (got, purest, ky, ...)" do

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -447,6 +447,12 @@ module Noir
       "/cypress/", # Cypress e2e tree (Mattermost: e2e-tests/cypress/)
       "/playwright/",
       "/e2e-tests/",
+      "/e2e/",     # Ghost's `e2e/helpers/services/*` mock servers,
+                   # Cypress's plain `e2e/` layout
+      "/mirage/",  # Ember mirage stub-server config trees (Ghost,
+                   # Discourse legacy admin)
+      "/__mocks__/", # Jest manual-mock convention used across the
+                     # TS ecosystem
       # Bundled output: GitHub Action `dist/` blobs, Next.js
       # `.next`, Nuxt `.nuxt`/`.output`, generic `dist/`, `build/`,
       # `coverage/`, `vendor/`. These contain webpacked third-party
@@ -496,14 +502,39 @@ module Noir
     # mock-server stubs (Ember pretender, MSW, nock, ...) rather
     # than real route registrations. Two routes:
     #
+    # Path markers strict enough that the HTTP-server-import
+    # exemption shouldn't apply: `/e2e/`, `/cypress/`, `/playwright/`,
+    # `/__mocks__/`, `/__tests__/`, `/e2e-tests/`, `/mirage/`. Real
+    # apps never park production handlers under any of these — even
+    # when the harness file imports express to spin up a faked
+    # service (Ghost's `e2e/helpers/services/stripe/fake-stripe-server.ts`
+    # is the canonical example). Keeping the exemption out of these
+    # paths catches the harness fakes without affecting legit
+    # backend code.
+    STRICT_TEST_PATH_MARKERS = [
+      "/e2e/",
+      "/cypress/",
+      "/playwright/",
+      "/__mocks__/",
+      "/__tests__/",
+      "/e2e-tests/",
+      "/mirage/",
+    ]
+
     #   * Filename markers fire unconditionally — `foo.test.ts` is
     #     a test no matter what it imports.
-    #   * Library + directory markers honor an exemption — if the
-    #     file also imports a real HTTP server lib (express,
-    #     fastify, ...), keep it so legit test-server harnesses
-    #     (e.g. mattermost's `webhook_serve.js`) keep their routes.
+    #   * Strict path markers also fire unconditionally — `e2e/`,
+    #     `cypress/`, etc. are dedicated test/mock trees that never
+    #     contain production handlers, even when the harness file
+    #     imports a server lib.
+    #   * Library + the remaining directory markers honor an
+    #     exemption — if the file also imports a real HTTP server
+    #     lib (express, fastify, ...), keep it so legit test-server
+    #     harnesses (e.g. mattermost's `webhook_serve.js`) keep
+    #     their routes.
     def self.test_stub_only?(file_path : String, content : String) : Bool
       return true if TEST_STUB_FILENAME_MARKERS.any? { |m| file_path.includes?(m) }
+      return true if STRICT_TEST_PATH_MARKERS.any? { |m| file_path.includes?(m) }
       has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) }
       has_path_marker = TEST_STUB_PATH_MARKERS.any? { |m| file_path.includes?(m) }
       return false unless has_library || has_path_marker


### PR DESCRIPTION
## Summary

Scanning [`TryGhost/Ghost`](https://github.com/TryGhost/Ghost) surfaced 73 phantom endpoints from two mock-server tree shapes:

- **`ghost/admin/mirage/config/*.js` (53 endpoints)** — Ember mirage stub-server config files. They call `server.get(...)` / `server.post(...)` on the mirage instance, not a real Express app, but the analyzer was happy to emit each as an endpoint.
- **`e2e/helpers/services/*/fake-*-server.ts` (17 endpoints)** — e2e fake servers spun up with `import express from "express"` inside the test harness. The existing `TEST_STUB_PATH_MARKERS` list covered these directories, but the HTTP-server-import exemption kept them scanning.

Two changes:

1. Add `/mirage/`, `/e2e/`, `/__mocks__/` to the path-marker list (alongside the existing `/cypress/`, `/playwright/`, `/e2e-tests/`, `/__tests__/`).
2. Promote all genuinely test-only directories to a new `STRICT_TEST_PATH_MARKERS` bucket that fires unconditionally, bypassing the HTTP-server-import exemption. The exemption was added in #1566 for "user spun up a test server with real express" scenarios in module trees, but a path that mentions `/e2e/`, `/cypress/`, `/playwright/`, `/__mocks__/`, `/__tests__/`, `/e2e-tests/`, or `/mirage/` is unambiguous — real production routes never sit there. The lenient bucket (bundled-output paths like `/dist/`, `/build/`, Rails Webpacker's `/app/javascript/`) keeps the exemption.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep.

Two new specs cover the mirage and e2e regression cases. The existing "keeps file when express is also imported" spec migrated from `/cypress/` (now strict) to `/dist/` (still lenient).

Verified on TryGhost/Ghost: total endpoints drop **361 → 288**. The 53 mirage configs and 17 e2e helpers are gone; everything else (production `ghost/core` routes) is preserved.

## Test plan

- [x] `crystal spec spec/unit_test/miniparser/js_route_extractor_spec.cr` — 53 examples, 0 failures (adds 2 specs, migrates 1)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1777 examples, 0 failures
- [x] `./bin/noir -b /path/to/TryGhost-Ghost -f json` — confirmed 361 → 288