### PR TITLE
fix(ruby): apply *_test.rb / *_spec.rb skip to grape + roda

### DIFF
--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -9,6 +9,10 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")
+        # Skip Minitest / RSpec test files — Grape's own
+        # `spec/grape/**/*_spec.rb` defines ~117 phantom routes
+        # that exercise the DSL via `Grape::API.new`.
+        next if RubyEngine.ruby_test_path?(path)
         content = read_file_content(path)
         next unless content.includes?("Grape::API")
         process_file(path, content, include_callee)

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -11,6 +11,10 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")
+        # Skip Minitest / RSpec test files — Roda's own
+        # `spec/plugin/*_spec.rb` parks ~46 phantom routes that
+        # exercise the routing tree via `Roda` subclasses.
+        next if RubyEngine.ruby_test_path?(path)
         analyze_file(path, include_callee)
       end
 

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -12,7 +12,7 @@ module Analyzer::Ruby
         # exercise the framework. Sinatra's own repo accounts for
         # ~145 such routes; production code never adopts either
         # filename convention so the suffix check is safe.
-        next if test_only_path?(path)
+        next if RubyEngine.ruby_test_path?(path)
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           lines = file.each_line.to_a
           last_endpoint = Endpoint.new("", "")
@@ -44,11 +44,6 @@ module Analyzer::Ruby
       end
 
       @result
-    end
-
-    private def test_only_path?(path : String) : Bool
-      base = File.basename(path)
-      base.ends_with?("_test.rb") || base.ends_with?("_spec.rb")
     end
 
     private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -5,6 +5,18 @@ module Analyzer::Ruby
   abstract class RubyEngine < Analyzer
     HTTP_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
+    # Minitest's `*_test.rb` and RSpec's `*_spec.rb` conventions are
+    # rigid in Ruby — `rake test` / `mri test` only run files matching
+    # the first, and `rspec` discovers the second. Production Ruby
+    # never adopts either filename, so the suffix check is safe for
+    # every Ruby analyzer (sinatra, grape, roda, hanami). Promoted
+    # from `Analyzer::Ruby::Sinatra` (#1571) so the rest of the
+    # family stays in sync.
+    def self.ruby_test_path?(path : String) : Bool
+      base = File.basename(path)
+      base.ends_with?("_test.rb") || base.ends_with?("_spec.rb")
+    end
+
     # Match the `<verb> "<path>"` idiom on a single line and return the first
     # endpoint found, or an empty endpoint if none match. Shared by Hanami
     # and Sinatra (Rails uses a different per-line-multi-match shape).


### PR DESCRIPTION
## Summary

Sinatra got the Minitest/RSpec filename skip in #1571 but the other Ruby framework analyzers — Grape and Roda — still scanned test files. Scanning [`ruby-grape/grape`](https://github.com/ruby-grape/grape) surfaced 117 phantom routes from `spec/grape/**/*_spec.rb`, and [`jeremyevans/roda`](https://github.com/jeremyevans/roda) parked all 46 of its endpoints under `spec/plugin/*_spec.rb`.

Promote the helper from `Analyzer::Ruby::Sinatra#test_only_path?` to `RubyEngine.ruby_test_path?` so every Ruby analyzer (sinatra, grape, roda, and any future addition) shares one source of truth. Grape and Roda each gain a one-line guard in their file loop.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending the Sinatra-only fix across the Ruby family, mirroring the Django→Python (#1576), Spring→Java (#1583), and axum→Rust (#1584) generalizations.

Verified:
- ruby-grape/grape: **125 → 7** (only benchmark/* legitimate)
- jeremyevans/roda: **47 → 0** (framework has no production routes — every endpoint was a spec)
- sinatra/sinatra: unchanged at 13 (Sinatra's filter migrated to the shared helper — pure refactor)

## Test plan

- [x] `crystal spec spec/functional_test/testers/ruby/` — 569 examples, 0 failures (Sinatra's existing regression fixtures keep asserting via the shared helper)
- [x] `./bin/noir -b /path/to/ruby-grape-grape -f json` — confirmed 125 → 7
- [x] `./bin/noir -b /path/to/jeremyevans-roda -f json` — confirmed 47 → 0