### PR TITLE
fix(lua/lapis): skip Busted _spec.{lua,moon} + spec*/ root dirs

### DIFF
--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -28,12 +28,38 @@ module Analyzer::Lua
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".lua") || path.ends_with?(".moon")
+        # Skip Busted / OpenResty spec files. Lapis's own
+        # `spec/**/*_spec.moon` and `spec_openresty/`/`spec_cqueues/`
+        # trees define ~143 phantom routes against inline test
+        # apps. Production Lua never adopts the `_spec` filename
+        # or the `spec*/` directory layout.
+        next if lapis_test_path?(path)
 
         content = read_file_content(path)
         process_file(path, content, include_callee)
       end
 
       @result
+    end
+
+    # Busted convention: `<name>_spec.lua` / `<name>_spec.moon`,
+    # plus `spec/` / `spec_<variant>/` (e.g. `spec_openresty/`,
+    # `spec_cqueues/`) directories at the project root. The
+    # filename suffix is unambiguous anywhere in the tree; the
+    # directory match is anchored against the configured
+    # `base_paths` so our own fixture tree under
+    # `spec/functional_test/fixtures/lua/...` doesn't accidentally
+    # match.
+    private def lapis_test_path?(path : String) : Bool
+      base = File.basename(path)
+      return true if base.ends_with?("_spec.lua") || base.ends_with?("_spec.moon")
+      base_paths.any? do |root|
+        normalized = root.ends_with?("/") ? root : "#{root}/"
+        tail = path.lchop?(normalized)
+        next false unless tail
+        first_segment = tail.split("/", 2).first
+        first_segment == "spec" || first_segment.starts_with?("spec_")
+      end
     end
 
     private def process_file(path : String, content : String, include_callee : Bool)


### PR DESCRIPTION
## Summary

Scanning [`leafo/lapis`](https://github.com/leafo/lapis) surfaced 159 phantom endpoints; ~143 came from Lapis's own `spec/`, `spec_openresty/`, and `spec_cqueues/` test trees plus their `*_spec.moon` files.

Add `lapis_test_path?` covering both signals:

- **Filename suffix** `_spec.lua` / `_spec.moon` — Busted's discovery convention; matched anywhere in the tree.
- **`spec/` or `spec_<variant>/` directory at the project root** — Lapis's split between OpenResty and cqueues backends parks integration tests under `spec_<variant>/`.

The directory match is anchored against `base_paths` so files under noir's own `spec/functional_test/fixtures/lua/...` (sibling layout to other language fixtures) aren't caught by the substring. This is the same nesting guard pattern used in #1591 for Crystal's `spec/`.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep — extending the test-file filter into Lua's Busted convention.

Verified on leafo/lapis: total endpoints drop **159 → 22**. The remaining 22 routes are the framework's `example.lua` / `example.moon` demo apps.

## Test plan

- [x] `crystal spec spec/functional_test/testers/lua/` — 311 examples, 0 failures (the `base_paths`-anchored check keeps our `spec/.../lapis/` fixture tree scannable)
- [x] `./bin/noir -b /path/to/leafo-lapis -f json` — confirmed 159 → 22