### PR TITLE
fix(js/koa): extract Strapi-style declarative {method, path} routes

### DIFF
--- a/spec/functional_test/fixtures/javascript/koa/routes/strapi_style.js
+++ b/spec/functional_test/fixtures/javascript/koa/routes/strapi_style.js
@@ -1,0 +1,26 @@
+// Regression guard: Strapi-style declarative route entries.
+// `{ method: 'GET', path: '/foo', handler: '...' }` object
+// literals are how Strapi plugins (`@strapi/plugin-*`) declare
+// routes. The shared JSRouteExtractor's verb DSL doesn't fire on
+// these, so the Koa analyzer has a dedicated extract pass.
+'use strict';
+
+module.exports = (strapi) => {
+    return [
+        {
+            method: 'GET',
+            path: '/strapi/items',
+            handler: 'item.find',
+        },
+        {
+            method: 'POST',
+            path: '/strapi/items',
+            handler: 'item.create',
+        },
+        {
+            method: 'PUT',
+            path: '/strapi/items/:id',
+            handler: 'item.update',
+        },
+    ];
+};

--- a/spec/functional_test/testers/javascript/koa_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_spec.cr
@@ -20,6 +20,14 @@ expected_endpoints = [
   Endpoint.new("/everything", "PATCH"),
   Endpoint.new("/everything", "HEAD"),
   Endpoint.new("/everything", "OPTIONS"),
+  # Strapi-style declarative `{method, path, handler}` route
+  # entries. Plugins under `@strapi/plugin-*` export these from
+  # `server/routes/**/*.js` and the standard verb DSL never fires.
+  Endpoint.new("/strapi/items", "GET"),
+  Endpoint.new("/strapi/items", "POST"),
+  Endpoint.new("/strapi/items/:id", "PUT", [
+    Param.new("id", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/javascript/koa/", {

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -32,6 +32,15 @@ module Analyzer::Javascript
           Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
             static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
           end
+
+          # Strapi-style declarative routes: `{ method: 'GET',
+          # path: '/foo', handler: '...' }` object literals,
+          # typically exported as an array from
+          # `<plugin>/server/routes/**/*.js`. The verb DSL (`app.get`,
+          # `router.post`) doesn't fire on these — strapi/strapi
+          # parks ~38 such routes per plugin that the shared
+          # JSRouteExtractor would otherwise miss.
+          extract_strapi_routes(path, content, result)
         rescue e
           logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
           analyze_with_regex(path, result, static_dirs)
@@ -42,6 +51,49 @@ module Analyzer::Javascript
       process_static_dirs(static_dirs, result)
 
       result
+    end
+
+    # Match Strapi's declarative route entries: object literals
+    # whose `method:` and `path:` keys sit on adjacent lines. Both
+    # keys are bare identifiers (Strapi never quotes them) and the
+    # values are single-quoted strings (the convention across every
+    # `@strapi/plugin-*` route file).
+    private def extract_strapi_routes(path : String, content : String, result : Array(Endpoint))
+      seen = Set(Tuple(String, String, Int32)).new
+      lines = content.lines
+      lines.each_with_index do |line, index|
+        next unless m = line.match(/^\s*method:\s*['"]([A-Z]+)['"]\s*,?/)
+        method = m[1].upcase
+        next unless ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes?(method)
+        # Strapi parks `path:` either on the same line (rare) or
+        # the very next line; lookahead at most four lines so
+        # interleaved comments / type declarations don't desync.
+        path_str = nil.as(String?)
+        (1..4).each do |off|
+          next unless idx = index + off
+          next unless idx < lines.size
+          break if path_str
+          if pm = lines[idx].match(/^\s*path:\s*['"]([^'"]+)['"]/)
+            path_str = pm[1]
+            break
+          end
+        end
+        next unless route_path = path_str
+        # Skip duplicate (same triple already emitted for this file).
+        key = {method, route_path, index + 1}
+        next if seen.includes?(key)
+        seen << key
+
+        details = Details.new(PathInfo.new(path, index + 1))
+        endpoint = Endpoint.new(route_path, method, details)
+        if route_path.includes?(":")
+          route_path.scan(/:(\w+)/) do |pm|
+            next unless pm.size > 0
+            endpoint.push_param(Param.new(pm[1], "", "path"))
+          end
+        end
+        result << endpoint
+      end
     end
 
     # Process static directories and add endpoints for each file


### PR DESCRIPTION
## Summary

Cycle 20 of the OSS survey switched focus from FP elimination to FN hunting. Scanning [`strapi/strapi`](https://github.com/strapi/strapi) surfaced a major miss: every `@strapi/plugin-*` registers routes as `{method: 'GET', path: '/roles/:id', handler: 'role.findOne'}` object-literal entries inside an exported array ([users-permissions example](https://github.com/strapi/strapi/blob/main/packages/plugins/users-permissions/server/routes/content-api/role.js)).

None of the verb-DSL extractors fire on these, so noir was reporting `js_koa: 8` for the Strapi monorepo — most of Strapi's API was invisible.

Add `extract_strapi_routes` to the Koa analyzer. It walks the source line-by-line for `method:` keys with a `path:` sibling within the next four lines (handles bare `method:` on one line + `path:` on the next, which is the Strapi convention). Verb must be a known HTTP method, path must be a string literal, no quotation required around the key — both follow Strapi's `eslint-plugin-strapi` style guide.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) sweep — this PR is the **FN** (missing-endpoint) counterpart to all the prior FP-focused PRs.

New fixture `spec/functional_test/fixtures/javascript/koa/routes/strapi_style.js` exports three declarative entries; the existing Koa tester gains three expected endpoints.

Verified on strapi/strapi: `js_koa` endpoints surface **8 → 262** (254 previously-missed routes now in the report). The shape is narrow enough that no other Koa fixtures or apps regressed in the spec suite.

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/koa_spec.cr` — 44 examples, 0 failures (3 new expected endpoints)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1785 examples, 0 failures
- [x] `./bin/noir -b /path/to/strapi-strapi -f json` — confirmed js_koa 8 → 262