### PR TITLE
fix(js/nestjs): emit accurate decorator line numbers

### DIFF
--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -198,9 +198,23 @@ module Analyzer::Javascript
           # Construct full URL path
           full_path = combine_paths(base_path, route_path)
 
+          # Resolve the decorator's line number inside the original
+          # file: walk newlines from the class start to the
+          # `class_content` offset where the regex matched. Falls
+          # back to the class start line when `match.begin` is nil
+          # (very early Crystal versions). Without this, every
+          # NestJS endpoint pointed at line 1 of the file and
+          # dedup against the same method+url-from-other-files
+          # collapsed the per-file attribution.
+          decorator_line = if pos = match.begin
+                             controller_start_line + class_content[0...pos].count('\n')
+                           else
+                             controller_start_line
+                           end
+
           # Create endpoint
           endpoint = Endpoint.new(full_path, method.upcase)
-          endpoint.details = Details.new(PathInfo.new(file_path, 1))
+          endpoint.details = Details.new(PathInfo.new(file_path, decorator_line))
 
           # Extract path parameters from URL
           extract_path_parameters(full_path, endpoint)


### PR DESCRIPTION
## Summary

The NestJS analyzer always set `PathInfo.line = 1` for every endpoint, so the JSON output pointed users at the top of the file no matter where the decorator actually lived. With the optimizer's (method, url) dedup collapsing routes that share a URL across files (NestJS versioned controllers, e.g. calcom's `event-types_2024_06_14/...` vs `2024_04_15/...`), the resulting `code_paths[0].path` attached to whichever single file dedup kept first — and the line-1 attribution masked the cross-file ambiguity in the UX.

Walk newlines from `controller_start_line` to the regex `match.begin` offset inside `class_content` to compute the decorator's real line. Falls back to the class start line on older Crystal versions where `match.begin` is nil.

This is the first PR of cycle 21 (FN focus). It's technically a precision/attribution fix rather than emitting new endpoints, but in practice it unblocks downstream UX work (jumping to source from the report) and makes the dedup behavior auditable instead of opaque.

Verified on calcom/cal.com: 140 NestJS endpoints, line numbers now span 100..600+ instead of all 1. Total count unchanged.

## Test plan

- [x] `crystal spec spec/functional_test/testers/typescript/nestjs_spec.cr spec/functional_test/testers/javascript/nestjs_spec.cr` — 78 examples, 0 failures
- [x] `./bin/noir -b /path/to/calcom-cal.com -f json` — confirmed line numbers now resolve per decorator