### PR TITLE
fix(python/fastapi): preserve APIRouter(prefix=...) when parent layers a prefix

### DIFF
--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from app.api.routes import login
+from app.api.routes import login, items
 
 api_router = APIRouter()
 api_router.include_router(login.router)
+api_router.include_router(items.router)

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/items.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/items.py
@@ -1,0 +1,18 @@
+# Regression for fastapi-template's `APIRouter(prefix="/items")`
+# pattern: the router-level prefix must be preserved when the
+# parent layers its own prefix on top (via include_router).
+# Routes inside should surface at `/api/v1/items/...`, not
+# `/api/v1/...`.
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/items", tags=["items"])
+
+
+@router.get("/")
+def read_items():
+    return []
+
+
+@router.get("/{id}")
+def read_item(id: int):
+    return {"id": id}

--- a/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
@@ -10,6 +10,11 @@ require "../../func_spec.cr"
 expected_endpoints = [
   Endpoint.new("/api/v1/login/access-token", "POST"),
   Endpoint.new("/api/v1/login/test-token", "POST"),
+  # `APIRouter(prefix="/items")` — the router's own prefix must
+  # be preserved when the parent (api_router) layers `/api/v1`
+  # via `settings.API_V1_STR` on top, yielding `/api/v1/items/`.
+  Endpoint.new("/api/v1/items/", "GET"),
+  Endpoint.new("/api/v1/items/{id}", "GET", [Param.new("id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/python/fastapi_settings_prefix/", {

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -272,6 +272,22 @@ module Analyzer::Python
       result
     end
 
+    # Concatenate two URL-prefix segments, normalising the
+    # boundary so `combine_router_prefixes("/api/v1", "/users")`
+    # gives `/api/v1/users` and `combine_router_prefixes("",
+    # "/users")` gives `/users`. Trailing slashes are dropped on
+    # the parent so we don't end up with `/api/v1//users`.
+    private def combine_router_prefixes(parent : ::String, own : ::String) : ::String
+      return own if parent.empty?
+      return parent if own.empty?
+      normalized_parent = parent.ends_with?("/") ? parent[0..-2] : parent
+      if own.starts_with?("/")
+        "#{normalized_parent}#{own}"
+      else
+        "#{normalized_parent}/#{own}"
+      end
+    end
+
     # Configures the prefix for each router
     def configure_router_prefix(file : ::String, include_router_map : Hash(::String, Hash(::String, Router)), router_prefix : ::String = "")
       return if file.empty? || !File.exists?(file)
@@ -280,7 +296,17 @@ module Analyzer::Python
       source = read_file_content(file)
       import_modules = find_imported_modules(@fastapi_base_path, file, source)
       include_router_map[file].each do |instance_name, router_class|
-        router_class.prefix = router_prefix
+        # PREPEND the inherited prefix to the router's own. The
+        # initial pass captures `APIRouter(prefix="/users")`, so
+        # `router_class.prefix` may already be `/users`; if we
+        # overwrite it here with `router_prefix`, the constructor
+        # prefix is silently dropped and routes inside the router
+        # collapse to the parent's prefix only. Regression on
+        # full-stack-fastapi-template: `users.router` and
+        # `items.router` both declare `prefix=...` at construction
+        # time, but their routes were surfacing without the
+        # `/users` / `/items` segment.
+        router_class.prefix = combine_router_prefixes(router_prefix, router_class.prefix)
 
         # Parse '{app}.include_router({item}.router, prefix="{prefix}")' code
         source.scan(/#{instance_name}\.include_router\(([^\)]*)\)/).each do |match|


### PR DESCRIPTION
## Summary

Cycle 22 (FN focus). Scanning [`tiangolo/full-stack-fastapi-template`](https://github.com/tiangolo/full-stack-fastapi-template) surfaced a real prefix-chain bug: [`users.router`](https://github.com/tiangolo/full-stack-fastapi-template/blob/master/backend/app/api/routes/users.py#L29) and [`items.router`](https://github.com/tiangolo/full-stack-fastapi-template/blob/master/backend/app/api/routes/items.py#L10) both declare their own `APIRouter(prefix="/users")` / `prefix="/items")` at construction time, but those segments were disappearing from the emitted URLs.

Routes were surfacing at `/api/v1/me`, `/api/v1/{user_id}`, `/api/v1/{id}` instead of the correct `/api/v1/users/me`, `/api/v1/users/{user_id}`, `/api/v1/items/{id}`.

**Root cause**: `configure_router_prefix` overwrote `router_class.prefix = router_prefix`, dropping whatever the initial APIRouter scan had captured. The mount chain `app.include_router(api_router, prefix=settings.API_V1_STR)` → `api_router.include_router(users.router)` then resolved to `/api/v1` and that became the router's full prefix, with the constructor-time `/users` silently lost.

Replace the overwrite with a `combine_router_prefixes` helper that prepends the inherited segment to the router's own — with slash-boundary normalisation so `(/api/v1, /users)` → `/api/v1/users`, never `/api/v1//users`.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep. This is the second proper **FN** (missing-endpoint) fix in the series, alongside #1598 (Strapi declarative routes).

The existing `fastapi_settings_prefix` regression fixture gains an `items.py` with `APIRouter(prefix="/items")` plus two routes; the spec now asserts both surface at `/api/v1/items/...`.

Verified on tiangolo/full-stack-fastapi-template:
- `GET /api/v1/items/`, `GET /api/v1/items/{id}`, `POST /api/v1/items/`, `PUT /api/v1/items/{id}`, `DELETE /api/v1/items/{id}` now emit
- All `users` routes regain the `/users` segment
- `/utils/health-check/`, `/utils/test-email/` regain `/utils`
- `/private/users/` regains `/private`

Net `python_fastapi` distinct URLs: 21 → 23 (and many more deduped URLs reattribute correctly to their proper router).

## Test plan

- [x] `crystal spec spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr` — 12 examples, 0 failures (2 new expected endpoints)
- [x] `crystal spec spec/functional_test/testers/python/` — 975 examples, 0 failures (Django/Flask/Starlette/etc. unchanged)
- [x] `./bin/noir -b /path/to/full-stack-fastapi-template -f json` — confirmed all `/users/`, `/items/`, `/utils/`, `/private/` prefixes restored