### PR TITLE
fix(js/express): extract Parse Server `this.route('METHOD', '/path')` shape

### DIFF
--- a/spec/functional_test/fixtures/javascript/express/parse_router.js
+++ b/spec/functional_test/fixtures/javascript/express/parse_router.js
@@ -1,0 +1,12 @@
+// Regression guard: Parse Server's `PromiseRouter` exposes
+// `this.route('METHOD', '/path', ...)` for route registration.
+// Standard verb-DSL extraction doesn't fire on this shape.
+class PushAudiencesRouter extends PromiseRouter {
+  mountRoutes() {
+    this.route('GET', '/push_audiences', req => null);
+    this.route('GET', '/push_audiences/:objectId', req => null);
+    this.route('POST', '/push_audiences', req => null);
+    this.route('PUT', '/push_audiences/:objectId', req => null);
+    this.route('DELETE', '/push_audiences/:objectId', req => null);
+  }
+}

--- a/spec/functional_test/testers/javascript/express_spec.cr
+++ b/spec/functional_test/testers/javascript/express_spec.cr
@@ -72,6 +72,14 @@ expected_endpoints = [
   Endpoint.new("/api/admin", "PATCH"),
   Endpoint.new("/api/admin", "HEAD"),
   Endpoint.new("/api/admin", "OPTIONS"),
+  # Parse Server `this.route('METHOD', '/path', ...)` shape. The
+  # `PromiseRouter` base class is used widely across
+  # parse-community/parse-server's Routers/* tree.
+  Endpoint.new("/push_audiences", "GET"),
+  Endpoint.new("/push_audiences/:objectId", "GET", [Param.new("objectId", "", "path")]),
+  Endpoint.new("/push_audiences", "POST"),
+  Endpoint.new("/push_audiences/:objectId", "PUT", [Param.new("objectId", "", "path")]),
+  Endpoint.new("/push_audiences/:objectId", "DELETE", [Param.new("objectId", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/javascript/express/", {

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -49,6 +49,15 @@ module Analyzer::Javascript
           Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
             static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
           end
+
+          # Parse Server style `this.route('METHOD', '/path', ...)`
+          # declarations. The framework's PromiseRouter base class
+          # exposes a `route(method, path, ...handlers)` shape that
+          # the standard verb-DSL extractor doesn't recognise.
+          # parse-community/parse-server alone parks ~51 routes in
+          # `src/Routers/*.js` (AudiencesRouter, GlobalConfigRouter,
+          # UsersRouter, ...) via this pattern.
+          extract_parse_server_routes(path, content, result)
         rescue e
           logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
 
@@ -61,6 +70,37 @@ module Analyzer::Javascript
       process_static_dirs(static_dirs, result)
 
       result
+    end
+
+    # Recognise the Parse Server `this.route(<method>, <path>, ...)`
+    # idiom. The receiver is `this` because the call sites live
+    # inside a `class FooRouter extends PromiseRouter` method (or
+    # an indirect subclass like `ClassesRouter`). Match on
+    # `this.route('VERB', '/path', ...)` with a quoted method
+    # literal so non-PromiseRouter `this.route(...)` shapes (e.g.
+    # routing-controllers' `this.route` builder) don't accidentally
+    # fire — the latter takes no quoted-method first argument.
+    private def extract_parse_server_routes(path : String, content : String, result : Array(Endpoint))
+      pattern = /(^|[^.\w])this\.route\(\s*['"]([A-Z]+)['"]\s*,\s*['"]([^'"]+)['"]/m
+      seen = Set(Tuple(String, String)).new
+      content.scan(pattern) do |m|
+        next unless m.size >= 4
+        method = m[2].upcase
+        next unless ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes?(method)
+        url = m[3]
+        key = {method, url}
+        next if seen.includes?(key)
+        seen << key
+
+        line = m.begin ? content[0...m.begin].count('\n') + 1 : 1
+        details = Details.new(PathInfo.new(path, line))
+        endpoint = Endpoint.new(url, method, details)
+        url.scan(/:(\w+)/) do |pm|
+          next unless pm.size > 0
+          endpoint.push_param(Param.new(pm[1], "", "path"))
+        end
+        result << endpoint
+      end
     end
 
     # Process static directories and add endpoints for each file


### PR DESCRIPTION
## Summary

Cycle 23 (FN focus). Scanning [`parse-community/parse-server`](https://github.com/parse-community/parse-server)'s `src/Routers/*.js` surfaced ~51 phantom-undetected routes — `this.route('GET', '/serverInfo', ...)`, `this.route('POST', '/push_audiences', ...)`, etc.

The Parse Server [`PromiseRouter`](https://github.com/parse-community/parse-server/blob/alpha/src/PromiseRouter.js) base class exposes a `route(method, path, ...handlers)` shape that the standard verb-DSL extractor doesn't recognise. Result: parse-server's `src` tree emitted **5 endpoints** instead of the actual ~56.

Add `extract_parse_server_routes` to the Express analyzer. Matches `this.route('VERB', '/path', ...)` with a quoted method literal so unrelated `<receiver>.route` builders (e.g. routing-controllers' chain builder, which takes no method arg) don't accidentally fire. Path params are extracted from the URL.

New fixture `spec/functional_test/fixtures/javascript/express/parse_router.js` declares five `this.route(...)` calls inside a `PromiseRouter` subclass; the existing Express tester gains five expected endpoints.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep. Third proper FN fix in the series alongside #1598 (Strapi declarative) and #1600 (FastAPI prefix preserve).

Verified on parse-community/parse-server's `src/` tree: emitted **5 → 80** (75 routes recovered). The dedicated regex sits alongside the existing JSRouteExtractor pass; the shared extractor still owns the verb-DSL extraction, this pass catches only the parse-server-specific `this.route(...)` shape.

## Test plan

- [x] `crystal spec spec/functional_test/testers/javascript/express_spec.cr` — 120 examples, 0 failures (5 new expected endpoints)
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1785 examples, 0 failures
- [x] `./bin/noir -b /path/to/parse-server/src -t js_express` — confirmed 5 → 80