### PR TITLE
fix(java/spring): honor `nest(path("/prefix"), ...)` in WebMvc.fn / WebFlux.fn

### DIFF
--- a/spec/functional_test/fixtures/java/spring/src/ProductRouter.java
+++ b/spec/functional_test/fixtures/java/spring/src/ProductRouter.java
@@ -1,0 +1,27 @@
+// Regression guard: WebMvc.fn / WebFlux.fn `nest()` prefix.
+// `nest(RequestPredicates.path("/product"), builder -> ...)` /
+// `nest(path("/product"), ...)` adds `/product` to every verb
+// call inside the lambda. Without prefix awareness routes would
+// surface stripped of the prefix.
+package org.test;
+
+import static org.springframework.web.servlet.function.RouterFunctions.route;
+import static org.springframework.web.servlet.function.ServerResponse.ok;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RequestPredicates;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+@Configuration
+public class ProductRouter {
+
+    @Bean
+    public RouterFunction<ServerResponse> productSearch() {
+        return route().nest(RequestPredicates.path("/product"), builder -> builder
+                .GET("/name/{name}", req -> ok().body("by-name"))
+                .GET("/id/{id}", req -> ok().body("by-id")))
+            .build();
+    }
+}

--- a/spec/functional_test/testers/java/spring_spec.cr
+++ b/spec/functional_test/testers/java/spring_spec.cr
@@ -13,6 +13,10 @@ expected_endpoints = [
   Endpoint.new("/echo", "POST"),
   Endpoint.new("/quotes", "GET"),
   Endpoint.new("/quotes/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~", "GET"),
+  # ProductRouter.java — WebMvc.fn `nest(path("/product"), ...)`
+  # adds `/product` to every verb call inside the lambda body.
+  Endpoint.new("/product/name/{name}", "GET", [Param.new("name", "", "path")]),
+  Endpoint.new("/product/id/{id}", "GET", [Param.new("id", "", "path")]),
   # ItemController.java
   Endpoint.new("/items/{id}", "GET", [Param.new("id", "", "path")]),
   Endpoint.new("/items/json/{id}", "GET", [Param.new("id", "", "path")]),

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -136,12 +136,32 @@ module Analyzer::Java
             # worth a dedicated tree-sitter walk yet.
             content.scan(REGEX_ROUTER_CODE_BLOCK) do |route_code|
               method_code = route_code[0]
+              # Pick up `nest(RequestPredicates.path("/prefix"), ...)`
+              # / `nest(path("/prefix"), ...)` byte ranges so verb
+              # calls inside the nested lambda get the prefix added.
+              # Servlet-fn and WebFlux both use this idiom heavily;
+              # without prefix awareness routes like
+              # `route().nest(path("/product"), builder ->
+              # builder.GET("/name/{name}", ...))` surfaced as
+              # `GET /name/{name}` instead of `GET /product/name/{name}`.
+              nest_prefixes = collect_nest_prefixes(method_code)
+
               method_code.scan(REGEX_ROUTE_CODE_LINE) do |match|
                 next if match.size != 4
                 method = match[2]
                 endpoint = match[3].gsub(/\n/, "")
+                nest_prefix = ""
+                if pos = match.begin
+                  nest_prefixes.each do |start_b, end_b, prefix|
+                    if pos >= start_b && pos < end_b
+                      nest_prefix = prefix
+                      break
+                    end
+                  end
+                end
+                composed = nest_prefix.empty? ? endpoint : join_paths(nest_prefix, endpoint)
                 details = Details.new(PathInfo.new(path))
-                @result << Endpoint.new(join_paths(url, endpoint), method, details)
+                @result << Endpoint.new(join_paths(url, composed), method, details)
               end
             end
           end
@@ -150,6 +170,62 @@ module Analyzer::Java
       Fiber.yield
 
       @result
+    end
+
+    # Collect every `nest(<predicate-with-path>, ...)` block in the
+    # router code along with the path prefix it carries and the
+    # byte range of its parenthesised argument list. Returns
+    # `[{start_byte, end_byte, prefix}, ...]`. Inner verb calls
+    # whose match position falls inside `[start, end)` should have
+    # `prefix` prepended.
+    private def collect_nest_prefixes(code : String) : Array(Tuple(Int32, Int32, String))
+      regions = [] of Tuple(Int32, Int32, String)
+      pattern = /\.nest\s*\(\s*(?:RequestPredicates\.)?path\s*\(\s*"([^"]+)"\s*\)\s*,/
+      code.scan(pattern) do |match|
+        next unless match.size >= 2 && match.begin
+        prefix = match[1]
+        # Find the `(` that opens the `.nest(` call: the first
+        # `(` after `.nest`. We look for it from the match offset
+        # forward up to the `,` we matched.
+        nest_marker = code.index(".nest", match.begin)
+        next unless nest_marker
+        open_idx = code.index('(', nest_marker)
+        next unless open_idx
+        close_idx = find_matching_paren(code, open_idx)
+        next unless close_idx
+        regions << {open_idx, close_idx, prefix}
+      end
+      regions
+    end
+
+    # Find the matching `)` for the `(` at `open_idx`, skipping
+    # string literals so `"(foo)"` doesn't perturb depth.
+    private def find_matching_paren(code : String, open_idx : Int32) : Int32?
+      depth = 1
+      i = open_idx + 1
+      bytes = code.to_slice
+      in_string = false
+      escape = false
+      while i < bytes.size && depth > 0
+        c = bytes[i]
+        if in_string
+          if escape
+            escape = false
+          elsif c == '\\'.ord
+            escape = true
+          elsif c == '"'.ord
+            in_string = false
+          end
+        else
+          case c
+          when '"'.ord then in_string = true
+          when '('.ord then depth += 1
+          when ')'.ord then depth -= 1
+          end
+        end
+        i += 1
+      end
+      depth == 0 ? i - 1 : nil
     end
 
     def find_base_path(current_path : String, base_paths : Hash(String, String))


### PR DESCRIPTION
## Summary

Cycle 24 (FN focus). Scanning [`eugenp/tutorials`](https://github.com/eugenp/tutorials) surfaced a prefix-stripping bug for Spring's functional routing DSL. [`ProductController.java`](https://github.com/eugenp/tutorials/blob/master/spring-boot-modules/spring-boot-mvc-2/src/main/java/com/baeldung/springbootmvc/ctrl/ProductController.java) declares:

```java
return route().nest(RequestPredicates.path("/product"), builder ->
    builder.GET("/name/{name}", ...).GET("/id/{id}", ...))
```

noir emitted `GET /name/{name}` and `GET /id/{id}` — the `/product` segment from the `nest` predicate was lost.

Pre-scan the router code block for `nest((RequestPredicates.)?path("/prefix"), ...)` patterns and record `[start_byte, end_byte, prefix]` for the parenthesised argument list. When the verb regex matches inside one of those ranges, prepend the prefix before joining with the controller base path. Parentheses are matched with a string-aware depth counter so `"(foo)"` inside a string literal doesn't collapse depth.

Continues the [`project_analyzer_accuracy`](https://github.com/owasp-noir/noir/tree/main) precision sweep. Fourth FN fix in the series alongside #1598 (Strapi declarative), #1600 (FastAPI prefix preserve), #1601 (Parse Server `this.route`).

New regression fixture `spec/functional_test/fixtures/java/spring/src/ProductRouter.java` declares a `nest` block with two verb calls; the existing Spring tester gains the two prefixed expectations.

Verified on eugenp/tutorials: `GET /product/name/{name}` and `GET /product/id/{id}` now surface from `spring-boot-mvc-2/.../ProductController.java` instead of the bare `/name/{name}` / `/id/{id}`.

## Test plan

- [x] `crystal spec spec/functional_test/testers/java/spring_spec.cr` — 144 examples, 0 failures (2 new expected endpoints)
- [x] `crystal spec spec/functional_test/testers/java/` — 886 examples, 0 failures
- [x] `./bin/noir -b /path/to/eugenp-tutorials/spring-boot-modules/spring-boot-mvc-2` — confirmed prefix-honoring routes