### PR TITLE
chore(ci): fix ameba lint + typos failures on main

### DIFF
--- a/spec/functional_test/fixtures/elixir/plug/lib/router.ex
+++ b/spec/functional_test/fixtures/elixir/plug/lib/router.ex
@@ -12,7 +12,7 @@ defmodule ElixirPlug.Router do
   Same regression, for the alternate triple-single heredoc delimiter
   Phoenix uses in `verified_routes.ex`.
 
-      get "/should-not-appear-tripple-single", do: nil
+      get "/should-not-appear-triple-single", do: nil
   '''
   def docs, do: :ok
 

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -23,6 +23,7 @@ module Analyzer::CSharp::Common
     return true if base.ends_with?("Tests.cs")
     base.ends_with?("Test.cs")
   end
+
   protected def build_signature(lines : Array(String), start_index : Int32) : Tuple(String, Int32)
     signature = lines[start_index]
     paren_count = signature.count('(') - signature.count(')')

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -382,18 +382,18 @@ module Analyzer::Python
 
       if attr_match = expr.match(/^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$/)
         module_alias, attr_name = attr_match[1], attr_match[2]
-        return nil unless import_modules.has_key?(module_alias)
+        return unless import_modules.has_key?(module_alias)
         module_path = import_modules[module_alias].first
         const_name = attr_name
       elsif name_match = expr.match(/^([A-Za-z_][A-Za-z0-9_]*)$/)
         bare_name = name_match[1]
-        return nil unless import_modules.has_key?(bare_name)
+        return unless import_modules.has_key?(bare_name)
         module_path = import_modules[bare_name].first
         const_name = bare_name
       end
 
-      return nil unless module_path && const_name
-      return nil unless File.exists?(module_path)
+      return unless module_path && const_name
+      return unless File.exists?(module_path)
 
       module_source = read_file_content(module_path)
       # Match either a typed assignment (`NAME: str = "..."`) or a

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -20,8 +20,9 @@ module Analyzer::Go
     # routes the framework ships.
     def self.go_test_file?(path : String) : Bool
       return true if path.ends_with?("_test.go")
-      path.split("/").any? { |seg| seg.starts_with?("_") }
+      path.split("/").any?(&.starts_with?("_"))
     end
+
     # --- Tree-sitter group/route pre-pass --------------------------------
     #
     # Does a cross-file fixpoint over every `.go` file in each package

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -93,7 +93,7 @@ module Analyzer::Rust
       while i < bytes.size
         c = bytes[i]
         case c
-        when '"'.ord then i = skip_string_literal(bytes, i)
+        when '"'.ord  then i = skip_string_literal(bytes, i)
         when '\''.ord then i = skip_char_or_lifetime(bytes, i)
         when '/'.ord
           if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
@@ -104,7 +104,7 @@ module Analyzer::Rust
             i += 1
           end
         when '{'.ord then return i
-        else i += 1
+        else              i += 1
         end
       end
       nil
@@ -116,7 +116,7 @@ module Analyzer::Rust
       while i < bytes.size && depth > 0
         c = bytes[i]
         case c
-        when '"'.ord then i = skip_string_literal(bytes, i); next
+        when '"'.ord  then i = skip_string_literal(bytes, i); next
         when '\''.ord then i = skip_char_or_lifetime(bytes, i); next
         when '/'.ord
           if i + 1 < bytes.size && bytes[i + 1] == '/'.ord

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -447,12 +447,12 @@ module Noir
       "/cypress/", # Cypress e2e tree (Mattermost: e2e-tests/cypress/)
       "/playwright/",
       "/e2e-tests/",
-      "/e2e/",     # Ghost's `e2e/helpers/services/*` mock servers,
-                   # Cypress's plain `e2e/` layout
-      "/mirage/",  # Ember mirage stub-server config trees (Ghost,
-                   # Discourse legacy admin)
+      "/e2e/", # Ghost's `e2e/helpers/services/*` mock servers,
+      # Cypress's plain `e2e/` layout
+      "/mirage/", # Ember mirage stub-server config trees (Ghost,
+      # Discourse legacy admin)
       "/__mocks__/", # Jest manual-mock convention used across the
-                     # TS ecosystem
+      # TS ecosystem
       # Bundled output: GitHub Action `dist/` blobs, Next.js
       # `.next`, Nuxt `.nuxt`/`.output`, generic `dist/`, `build/`,
       # `coverage/`, `vendor/`. These contain webpacked third-party


### PR DESCRIPTION
## Summary

CI has been red on main since #1599. `crystal-ameba/github-action@master` reports nine findings (any severity fails the lint job) and `crate-ci/typos` flagged one misspelling. None of those CI breaks affected behaviour — they're all source-formatting / style / spell issues — but the red main was masking signal.

Fixes:

- `crystal tool format` over four files touched during the recent FN sweep:
  - `src/analyzer/analyzers/csharp/common.cr`
  - `src/analyzer/engines/go_engine.cr`
  - `src/analyzer/engines/rust_engine.cr`
  - `src/miniparsers/js_route_extractor.cr`
  These tripped `Lint/Formatting`.
- `return nil unless …` → `return unless …` (×4) in fastapi.cr's `resolve_constant_value` — `Style/RedundantNilInControlExpression`.
- `any? { |seg| seg.starts_with?("_") }` → `any?(&.starts_with?("_"))` in `go_engine.cr` — `Style/VerboseBlock`.
- `tripple-single` → `triple-single` in `elixir/plug/lib/router.ex` regression fixture — typos.

No behaviour change.

## Test plan

- [x] `./lib/ameba/bin/ameba src/` — 396 inspected, 0 failures (was 9)
- [x] `typos .` — exit 0 (was 1 hit)
- [x] `shards build` — clean
- [x] `crystal spec spec/functional_test/` — 10,665 examples, 0 failures
- [x] `crystal spec spec/unit_test/` — 1,661 examples, 0 failures