### PR TITLE
feat(spec): expand OAS2/OAS3 coverage ($ref, multipart, body params)

### DIFF
--- a/spec/functional_test/fixtures/specification/oas3/refs_multipart/doc.yml
+++ b/spec/functional_test/fixtures/specification/oas3/refs_multipart/doc.yml
@@ -1,0 +1,64 @@
+openapi: 3.0.0
+info:
+  title: Refs and Multipart Coverage
+  version: 1.0.0
+paths:
+  /users/{userId}/avatar:
+    parameters:
+      - name: userId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: X-Trace-Id
+        in: header
+        schema:
+          type: string
+    post:
+      summary: Upload avatar (multipart) referenced via component
+      requestBody:
+        $ref: '#/components/requestBodies/AvatarUpload'
+      responses:
+        '201':
+          description: Uploaded
+  /users:
+    post:
+      summary: Create user (JSON body via $ref)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewUser'
+      responses:
+        '201':
+          description: Created
+components:
+  requestBodies:
+    AvatarUpload:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              avatar:
+                type: string
+                format: binary
+              caption:
+                type: string
+  schemas:
+    NewUser:
+      allOf:
+        - $ref: '#/components/schemas/UserBase'
+        - type: object
+          properties:
+            password:
+              type: string
+    UserBase:
+      type: object
+      properties:
+        email:
+          type: string
+        name:
+          type: string

--- a/spec/functional_test/testers/specification/oas2_spec.cr
+++ b/spec/functional_test/testers/specification/oas2_spec.cr
@@ -2,7 +2,9 @@ require "../../func_spec.cr"
 
 expected_endpoints = [
   Endpoint.new("/v1/pets", "GET"),
-  Endpoint.new("/v1/pets", "POST"),
+  Endpoint.new("/v1/pets", "POST", [
+    Param.new("name", "", "json"),
+  ]),
   Endpoint.new("/v1/pets/search", "GET", [
     Param.new("name", "", "query"),
     Param.new("X-Request-Id", "", "header"),
@@ -15,7 +17,11 @@ expected_endpoints = [
     Param.new("pet_name", "", "form"),
   ]),
   Endpoint.new("/v1/pets/{petId}", "GET", [Param.new("petId", "", "path")]),
-  Endpoint.new("/v1/pets/{petId}", "PUT", [Param.new("petId", "", "path")]),
+  Endpoint.new("/v1/pets/{petId}", "PUT", [
+    Param.new("petId", "", "path"),
+    Param.new("name", "", "json"),
+    Param.new("breed", "", "json"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/specification/oas2/", {

--- a/spec/functional_test/testers/specification/oas3_spec.cr
+++ b/spec/functional_test/testers/specification/oas3_spec.cr
@@ -37,6 +37,23 @@ FunctionalTester.new("fixtures/specification/oas3/nil_cast/", {
   :endpoints => 0,
 }, nil).perform_tests
 
+FunctionalTester.new("fixtures/specification/oas3/refs_multipart/", {
+  :techs     => 1,
+  :endpoints => 2,
+}, [
+  Endpoint.new("/users/{userId}/avatar", "POST", [
+    Param.new("userId", "", "path"),
+    Param.new("X-Trace-Id", "", "header"),
+    Param.new("avatar", "", "form"),
+    Param.new("caption", "", "form"),
+  ]),
+  Endpoint.new("/users", "POST", [
+    Param.new("email", "", "json"),
+    Param.new("name", "", "json"),
+    Param.new("password", "", "json"),
+  ]),
+]).perform_tests
+
 FunctionalTester.new("fixtures/specification/oas3/param_in_path/", {
   :techs     => 1,
   :endpoints => 4,

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -2,120 +2,297 @@ require "../../../models/analyzer"
 
 module Analyzer::Specification
   class Oas2 < Analyzer
+    HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+
+    # Resolves a `#/definitions/Name` pointer against the spec root.
+    # Returns the referenced node, or nil when the ref cannot be followed.
+    private def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
+      return unless ref.starts_with?("#/")
+      node = root
+      ref[2..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[decoded]?
+        node = next_node
+      end
+      node
+    end
+
+    private def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
+      return unless ref.starts_with?("#/")
+      node = root
+      ref[2..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[YAML::Any.new(decoded)]?
+        node = next_node
+      end
+      node
+    end
+
+    # Walks a body schema and emits a Param per top-level property.
+    private def collect_body_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param))
+      if ref = schema["$ref"]?.try(&.as_s?)
+        if resolved = resolve_ref_json(root, ref)
+          collect_body_props_json(root, resolved, param_type, params)
+        end
+        return
+      end
+
+      if props = schema["properties"]?.try(&.as_h?)
+        props.each do |name, _|
+          params << Param.new(name.to_s, "", param_type)
+        end
+      end
+
+      if all_of = schema["allOf"]?.try(&.as_a?)
+        all_of.each { |s| collect_body_props_json(root, s, param_type, params) }
+      end
+    end
+
+    private def collect_body_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param))
+      if ref_node = schema[YAML::Any.new("$ref")]?
+        if ref = ref_node.as_s?
+          if resolved = resolve_ref_yaml(root, ref)
+            collect_body_props_yaml(root, resolved, param_type, params)
+          end
+        end
+        return
+      end
+
+      if props_node = schema[YAML::Any.new("properties")]?
+        if props = props_node.as_h?
+          props.each do |name, _|
+            params << Param.new(name.to_s, "", param_type)
+          end
+        end
+      end
+
+      if all_of_node = schema[YAML::Any.new("allOf")]?
+        if all_of = all_of_node.as_a?
+          all_of.each { |s| collect_body_props_yaml(root, s, param_type, params) }
+        end
+      end
+    end
+
+    # Maps an OAS2 parameter object onto Noir's Param types.
+    # `consumes` lets body params pick form vs. json when the route advertises
+    # `multipart/form-data` or `application/x-www-form-urlencoded`.
+    private def param_type_for_body(consumes : Array(String)) : String
+      if consumes.any? { |c| c.starts_with?("multipart/form-data") || c.starts_with?("application/x-www-form-urlencoded") }
+        "form"
+      else
+        "json"
+      end
+    end
+
+    private def extract_param_json(root : JSON::Any, param_obj : JSON::Any, consumes : Array(String), params : Array(Param))
+      # Parameters can themselves be $ref'd.
+      if ref = param_obj["$ref"]?.try(&.as_s?)
+        if resolved = resolve_ref_json(root, ref)
+          extract_param_json(root, resolved, consumes, params)
+        end
+        return
+      end
+
+      name = param_obj["name"]?.try(&.to_s) || ""
+      location = param_obj["in"]?.try(&.to_s) || ""
+      case location
+      when "query"
+        params << Param.new(name, "", "query")
+      when "header"
+        params << Param.new(name, "", "header")
+      when "form", "formData"
+        params << Param.new(name, "", "form")
+      when "body"
+        if schema = param_obj["schema"]?
+          collect_body_props_json(root, schema, param_type_for_body(consumes), params)
+        end
+      end
+    end
+
+    private def extract_param_yaml(root : YAML::Any, param_obj : YAML::Any, consumes : Array(String), params : Array(Param))
+      if ref_node = param_obj[YAML::Any.new("$ref")]?
+        if ref = ref_node.as_s?
+          if resolved = resolve_ref_yaml(root, ref)
+            extract_param_yaml(root, resolved, consumes, params)
+          end
+        end
+        return
+      end
+
+      name = param_obj[YAML::Any.new("name")]?.try(&.to_s) || ""
+      location = param_obj[YAML::Any.new("in")]?.try(&.to_s) || ""
+      case location
+      when "query"
+        params << Param.new(name, "", "query")
+      when "header"
+        params << Param.new(name, "", "header")
+      when "form", "formData"
+        params << Param.new(name, "", "form")
+      when "body"
+        if schema = param_obj[YAML::Any.new("schema")]?
+          collect_body_props_yaml(root, schema, param_type_for_body(consumes), params)
+        end
+      end
+    end
+
+    private def consumes_json(root : JSON::Any, method_obj : JSON::Any) : Array(String)
+      list = [] of String
+      if method_consumes = method_obj["consumes"]?.try(&.as_a?)
+        method_consumes.each { |c| list << c.to_s }
+      elsif global = root["consumes"]?.try(&.as_a?)
+        global.each { |c| list << c.to_s }
+      end
+      list
+    end
+
+    private def consumes_yaml(root : YAML::Any, method_obj : YAML::Any) : Array(String)
+      list = [] of String
+      if method_consumes_node = method_obj[YAML::Any.new("consumes")]?
+        if arr = method_consumes_node.as_a?
+          arr.each { |c| list << c.to_s }
+        end
+      elsif global_node = root[YAML::Any.new("consumes")]?
+        if arr = global_node.as_a?
+          arr.each { |c| list << c.to_s }
+        end
+      end
+      list
+    end
+
     def analyze
       locator = CodeLocator.instance
       swagger_jsons = locator.all("swagger-json")
       swagger_yamls = locator.all("swagger-yaml")
 
       if swagger_jsons.is_a?(Array(String))
-        swagger_jsons.each do |swagger_json|
-          if File.exists?(swagger_json)
-            details = Details.new(PathInfo.new(swagger_json))
-            content = File.read(swagger_json, encoding: "utf-8", invalid: :skip)
-            json_obj = JSON.parse(content)
-            base_path = ""
-            begin
-              if json_obj["basePath"].to_s != ""
-                base_path = json_obj["basePath"].to_s
-              end
-            rescue e
-              @logger.debug "Exception of #{swagger_json}/basePath"
-              @logger.debug_sub e
-            end
-
-            begin
-              paths = json_obj["paths"].as_h
-              paths.each do |path, path_obj|
-                path_obj.as_h.each do |method, method_obj|
-                  params = [] of Param
-
-                  if method_obj.as_h.has_key?("parameters")
-                    method_obj["parameters"].as_a.each do |param_obj|
-                      param_name = param_obj["name"].to_s
-                      case param_obj["in"].to_s
-                      when "query"
-                        params << Param.new(param_name, "", "query")
-                      when "form", "formData"
-                        params << Param.new(param_name, "", "form")
-                      when "header"
-                        params << Param.new(param_name, "", "header")
-                      end
-                    end
-                    @result << Endpoint.new(base_path + path, method.upcase, params, details)
-                  else
-                    @result << Endpoint.new(base_path + path, method.upcase, details)
-                  end
-                rescue e
-                  @logger.debug "Exception of #{swagger_json}/paths/path/method"
-                  @logger.debug_sub e
-                end
-              rescue e
-                @logger.debug "Exception of #{swagger_json}/paths/path"
-                @logger.debug_sub e
-              end
-            rescue e
-              @logger.debug "Exception of #{swagger_json}/paths"
-              @logger.debug_sub e
-            end
-          end
-        end
+        swagger_jsons.each { |path| process_json(path) }
       end
 
       if swagger_yamls.is_a?(Array(String))
-        swagger_yamls.each do |swagger_yaml|
-          if File.exists?(swagger_yaml)
-            details = Details.new(PathInfo.new(swagger_yaml))
-            content = File.read(swagger_yaml, encoding: "utf-8", invalid: :skip)
-            yaml_obj = YAML.parse(content)
-            base_path = ""
-            begin
-              if yaml_obj["basePath"].to_s != ""
-                base_path = yaml_obj["basePath"].to_s
-              end
-            rescue e
-              @logger.debug "Exception of #{swagger_yaml}/basePath"
-              @logger.debug_sub e
-            end
-
-            begin
-              paths = yaml_obj["paths"].as_h
-              paths.each do |path, path_obj|
-                path_obj.as_h.each do |method, method_obj|
-                  params = [] of Param
-
-                  if method_obj.as_h.has_key?("parameters")
-                    method_obj["parameters"].as_a.each do |param_obj|
-                      param_name = param_obj["name"].to_s
-                      case param_obj["in"].to_s
-                      when "query"
-                        params << Param.new(param_name, "", "query")
-                      when "form", "formData"
-                        params << Param.new(param_name, "", "form")
-                      when "header"
-                        params << Param.new(param_name, "", "header")
-                      end
-                    end
-                    @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
-                  else
-                    @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
-                  end
-                rescue e
-                  @logger.debug "Exception of #{swagger_yaml}/paths/path/method"
-                  @logger.debug_sub e
-                end
-              rescue e
-                @logger.debug "Exception of #{swagger_yaml}/paths/path"
-                @logger.debug_sub e
-              end
-            rescue e
-              @logger.debug "Exception of #{swagger_yaml}/paths"
-              @logger.debug_sub e
-            end
-          end
-        end
+        swagger_yamls.each { |path| process_yaml(path) }
       end
 
       @result
+    end
+
+    private def process_json(swagger_json : String)
+      return unless File.exists?(swagger_json)
+      details = Details.new(PathInfo.new(swagger_json))
+      content = File.read(swagger_json, encoding: "utf-8", invalid: :skip)
+      json_obj = JSON.parse(content)
+      base_path = ""
+      begin
+        if json_obj["basePath"].to_s != ""
+          base_path = json_obj["basePath"].to_s
+        end
+      rescue e
+        @logger.debug "Exception of #{swagger_json}/basePath"
+        @logger.debug_sub e
+      end
+
+      begin
+        paths = json_obj["paths"].as_h
+        paths.each do |path, path_obj|
+          path_level_params = [] of Param
+          if path_obj_h = path_obj.as_h?
+            if shared = path_obj_h["parameters"]?.try(&.as_a?)
+              shared.each do |param_obj|
+                extract_param_json(json_obj, param_obj, [] of String, path_level_params)
+              end
+            end
+          end
+
+          path_obj.as_h.each do |method, method_obj|
+            next unless HTTP_METHODS.includes?(method.to_s.downcase)
+            params = path_level_params.dup
+            consumes = consumes_json(json_obj, method_obj)
+
+            if method_params = method_obj["parameters"]?.try(&.as_a?)
+              method_params.each do |param_obj|
+                extract_param_json(json_obj, param_obj, consumes, params)
+              end
+            end
+
+            if params.size > 0
+              @result << Endpoint.new(base_path + path, method.upcase, params, details)
+            else
+              @result << Endpoint.new(base_path + path, method.upcase, details)
+            end
+          rescue e
+            @logger.debug "Exception of #{swagger_json}/paths/path/method"
+            @logger.debug_sub e
+          end
+        rescue e
+          @logger.debug "Exception of #{swagger_json}/paths/path"
+          @logger.debug_sub e
+        end
+      rescue e
+        @logger.debug "Exception of #{swagger_json}/paths"
+        @logger.debug_sub e
+      end
+    end
+
+    private def process_yaml(swagger_yaml : String)
+      return unless File.exists?(swagger_yaml)
+      details = Details.new(PathInfo.new(swagger_yaml))
+      content = File.read(swagger_yaml, encoding: "utf-8", invalid: :skip)
+      yaml_obj = YAML.parse(content)
+      base_path = ""
+      begin
+        if yaml_obj["basePath"].to_s != ""
+          base_path = yaml_obj["basePath"].to_s
+        end
+      rescue e
+        @logger.debug "Exception of #{swagger_yaml}/basePath"
+        @logger.debug_sub e
+      end
+
+      begin
+        paths = yaml_obj["paths"].as_h
+        paths.each do |path, path_obj|
+          path_level_params = [] of Param
+          if path_obj_h = path_obj.as_h?
+            if shared_node = path_obj_h[YAML::Any.new("parameters")]?
+              if shared = shared_node.as_a?
+                shared.each do |param_obj|
+                  extract_param_yaml(yaml_obj, param_obj, [] of String, path_level_params)
+                end
+              end
+            end
+          end
+
+          path_obj.as_h.each do |method, method_obj|
+            next unless HTTP_METHODS.includes?(method.to_s.downcase)
+            params = path_level_params.dup
+            consumes = consumes_yaml(yaml_obj, method_obj)
+
+            if method_params_node = method_obj[YAML::Any.new("parameters")]?
+              if method_params = method_params_node.as_a?
+                method_params.each do |param_obj|
+                  extract_param_yaml(yaml_obj, param_obj, consumes, params)
+                end
+              end
+            end
+
+            if params.size > 0
+              @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
+            else
+              @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
+            end
+          rescue e
+            @logger.debug "Exception of #{swagger_yaml}/paths/path/method"
+            @logger.debug_sub e
+          end
+        rescue e
+          @logger.debug "Exception of #{swagger_yaml}/paths/path"
+          @logger.debug_sub e
+        end
+      rescue e
+        @logger.debug "Exception of #{swagger_yaml}/paths"
+        @logger.debug_sub e
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -98,15 +98,19 @@ module Analyzer::Specification
       name = param_obj["name"]?.try(&.to_s) || ""
       location = param_obj["in"]?.try(&.to_s) || ""
       case location
-      when "query"
-        params << Param.new(name, "", "query")
-      when "header"
-        params << Param.new(name, "", "header")
-      when "form", "formData"
-        params << Param.new(name, "", "form")
       when "body"
         if schema = param_obj["schema"]?
           collect_body_props_json(root, schema, param_type_for_body(consumes), params)
+        end
+      else
+        return if name.empty?
+        case location
+        when "query"
+          params << Param.new(name, "", "query")
+        when "header"
+          params << Param.new(name, "", "header")
+        when "form", "formData"
+          params << Param.new(name, "", "form")
         end
       end
     end
@@ -124,15 +128,19 @@ module Analyzer::Specification
       name = param_obj[YAML::Any.new("name")]?.try(&.to_s) || ""
       location = param_obj[YAML::Any.new("in")]?.try(&.to_s) || ""
       case location
-      when "query"
-        params << Param.new(name, "", "query")
-      when "header"
-        params << Param.new(name, "", "header")
-      when "form", "formData"
-        params << Param.new(name, "", "form")
       when "body"
         if schema = param_obj[YAML::Any.new("schema")]?
           collect_body_props_yaml(root, schema, param_type_for_body(consumes), params)
+        end
+      else
+        return if name.empty?
+        case location
+        when "query"
+          params << Param.new(name, "", "query")
+        when "header"
+          params << Param.new(name, "", "header")
+        when "form", "formData"
+          params << Param.new(name, "", "form")
         end
       end
     end

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -2,6 +2,8 @@ require "../../../models/analyzer"
 
 module Analyzer::Specification
   class Oas3 < Analyzer
+    HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
+
     def get_base_path(servers)
       base_path = @url
       servers.as_a.each do |server_obj|
@@ -16,6 +18,172 @@ module Analyzer::Specification
       end
 
       base_path
+    end
+
+    # Maps an OAS3 request-body content type to a Noir param type.
+    private def param_type_for_content(content_type : String) : String?
+      case content_type
+      when "application/json", .starts_with?("application/json")
+        "json"
+      when "application/x-www-form-urlencoded"
+        "form"
+      when "multipart/form-data", .starts_with?("multipart/form-data")
+        "form"
+      end
+    end
+
+    # Resolves `#/components/schemas/Name` etc. against the spec root.
+    private def resolve_ref_json(root : JSON::Any, ref : String) : JSON::Any?
+      return unless ref.starts_with?("#/")
+      node = root
+      ref[2..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[decoded]?
+        node = next_node
+      end
+      node
+    end
+
+    private def resolve_ref_yaml(root : YAML::Any, ref : String) : YAML::Any?
+      return unless ref.starts_with?("#/")
+      node = root
+      ref[2..].split('/').each do |segment|
+        decoded = segment.gsub("~1", "/").gsub("~0", "~")
+        return unless hash = node.as_h?
+        return unless next_node = hash[YAML::Any.new(decoded)]?
+        node = next_node
+      end
+      node
+    end
+
+    # Walks an OAS3 schema, emitting one Param per top-level property.
+    # Follows `$ref` and flattens `allOf` so referenced/composed schemas
+    # surface their members.
+    private def collect_schema_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+      if ref = schema["$ref"]?.try(&.as_s?)
+        return if seen.includes?(ref)
+        seen << ref
+        if resolved = resolve_ref_json(root, ref)
+          collect_schema_props_json(root, resolved, param_type, params, seen)
+        end
+        return
+      end
+
+      if props = schema["properties"]?.try(&.as_h?)
+        props.each do |name, _|
+          params << Param.new(name.to_s, "", param_type)
+        end
+      end
+
+      if all_of = schema["allOf"]?.try(&.as_a?)
+        all_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
+      end
+    end
+
+    private def collect_schema_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+      if ref_node = schema[YAML::Any.new("$ref")]?
+        if ref = ref_node.as_s?
+          return if seen.includes?(ref)
+          seen << ref
+          if resolved = resolve_ref_yaml(root, ref)
+            collect_schema_props_yaml(root, resolved, param_type, params, seen)
+          end
+        end
+        return
+      end
+
+      if props_node = schema[YAML::Any.new("properties")]?
+        if props = props_node.as_h?
+          props.each do |name, _|
+            params << Param.new(name.to_s, "", param_type)
+          end
+        end
+      end
+
+      if all_of_node = schema[YAML::Any.new("allOf")]?
+        if all_of = all_of_node.as_a?
+          all_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
+        end
+      end
+    end
+
+    private def extract_param_json(root : JSON::Any, param_obj : JSON::Any, params : Array(Param))
+      if ref = param_obj["$ref"]?.try(&.as_s?)
+        if resolved = resolve_ref_json(root, ref)
+          extract_param_json(root, resolved, params)
+        end
+        return
+      end
+
+      name = param_obj["name"]?.try(&.to_s) || ""
+      location = param_obj["in"]?.try(&.to_s) || ""
+      case location
+      when "query"
+        params << Param.new(name, "", "query")
+      when "header"
+        params << Param.new(name, "", "header")
+      when "cookie"
+        params << Param.new(name, "", "cookie")
+      end
+    end
+
+    private def extract_param_yaml(root : YAML::Any, param_obj : YAML::Any, params : Array(Param))
+      if ref_node = param_obj[YAML::Any.new("$ref")]?
+        if ref = ref_node.as_s?
+          if resolved = resolve_ref_yaml(root, ref)
+            extract_param_yaml(root, resolved, params)
+          end
+        end
+        return
+      end
+
+      name = param_obj[YAML::Any.new("name")]?.try(&.to_s) || ""
+      location = param_obj[YAML::Any.new("in")]?.try(&.to_s) || ""
+      case location
+      when "query"
+        params << Param.new(name, "", "query")
+      when "header"
+        params << Param.new(name, "", "header")
+      when "cookie"
+        params << Param.new(name, "", "cookie")
+      end
+    end
+
+    private def extract_request_body_json(root : JSON::Any, request_body : JSON::Any, params : Array(Param))
+      # The requestBody object itself can be $ref'd to components.requestBodies.
+      if ref = request_body["$ref"]?.try(&.as_s?)
+        if resolved = resolve_ref_json(root, ref)
+          extract_request_body_json(root, resolved, params)
+        end
+        return
+      end
+      return unless content = request_body["content"]?.try(&.as_h?)
+      content.each do |content_type, content_obj|
+        next unless param_type = param_type_for_content(content_type.to_s)
+        if schema = content_obj["schema"]?
+          collect_schema_props_json(root, schema, param_type, params)
+        end
+      end
+    end
+
+    private def extract_request_body_yaml(root : YAML::Any, request_body : YAML::Any, params : Array(Param))
+      if ref_node = request_body[YAML::Any.new("$ref")]?
+        if ref = ref_node.as_s?
+          if resolved = resolve_ref_yaml(root, ref)
+            extract_request_body_yaml(root, resolved, params)
+          end
+        end
+        return
+      end
+      return unless content_node = request_body[YAML::Any.new("content")]?
+      return unless content = content_node.as_h?
+      content.each do |content_type, content_obj|
+        next unless param_type = param_type_for_content(content_type.to_s)
+        if schema_node = content_obj[YAML::Any.new("schema")]?
+          collect_schema_props_yaml(root, schema_node, param_type, params)
+        end
+      end
     end
 
     def analyze
@@ -38,118 +206,7 @@ module Analyzer::Specification
               @logger.debug_sub e
             end
 
-            begin
-              paths = json_obj["paths"].as_h
-              paths.each do |path, path_obj|
-                params_of_path = [] of Param
-                methods_of_path = [] of String
-                path_obj.as_h.each do |method, method_obj|
-                  params = [] of Param
-
-                  # Param in Path
-                  begin
-                    if method == "parameters"
-                      method_obj.as_a.each do |param_obj|
-                        param_name = param_obj["name"].to_s
-                        if param_obj["in"] == "query"
-                          param = Param.new(param_name, "", "query")
-                          params_of_path << param
-                        elsif param_obj["in"] == "header"
-                          param = Param.new(param_name, "", "header")
-                          params_of_path << param
-                        elsif param_obj["in"] == "cookie"
-                          param = Param.new(param_name, "", "cookie")
-                          params_of_path << param
-                        end
-                      end
-                    end
-
-                    if method == "requestBody"
-                      method_obj["content"].as_h.each do |content_type, content_obj|
-                        if content_type == "application/json"
-                          content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                            param = Param.new(param_name.to_s, "", "json")
-                            params_of_path << param
-                          end
-                        elsif content_type == "application/x-www-form-urlencoded"
-                          content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                            param = Param.new(param_name.to_s, "", "form")
-                            params_of_path << param
-                          end
-                        end
-                      end
-                    end
-                  rescue e
-                    @logger.debug "Exception of #{oas3_json}/paths/parameters"
-                    @logger.debug_sub e
-                  end
-
-                  # Param in Method
-                  begin
-                    if method_obj.is_a?(JSON::Any) || method_obj.is_a?(Hash(String, JSON::Any))
-                      if method_obj.as_h.has_key?("parameters")
-                        method_obj["parameters"].as_a.each do |param_obj|
-                          param_name = param_obj["name"].to_s
-                          if param_obj["in"] == "query"
-                            param = Param.new(param_name, "", "query")
-                            params << param
-                          elsif param_obj["in"] == "header"
-                            param = Param.new(param_name, "", "header")
-                            params << param
-                          elsif param_obj["in"] == "cookie"
-                            param = Param.new(param_name, "", "cookie")
-                            params << param
-                          end
-                        end
-                      end
-                    end
-                  rescue e
-                    @logger.debug "Exception of #{oas3_json}/paths/method/parameters"
-                    @logger.debug_sub e
-                  end
-
-                  begin
-                    if method_obj.as_h.has_key?("requestBody")
-                      method_obj["requestBody"]["content"].as_h.each do |content_type, content_obj|
-                        if content_type == "application/json"
-                          content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                            param = Param.new(param_name, "", "json")
-                            params << param
-                          end
-                        elsif content_type == "application/x-www-form-urlencoded"
-                          content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                            param = Param.new(param_name, "", "form")
-                            params << param
-                          end
-                        end
-                      end
-                    end
-                  rescue e
-                    @logger.debug "Exception of #{oas3_json}/paths/method/parameters"
-                    @logger.debug_sub e
-                  end
-
-                  if params.size > 0 && (method.to_s.upcase != "PARAMETERS" && method.to_s.upcase != "REQUESTBODY")
-                    @result << Endpoint.new(base_path + path, method.upcase, params, details)
-                    methods_of_path << method.to_s.upcase
-                  elsif method.to_s.upcase != "PARAMETERS" && method.to_s.upcase != "REQUESTBODY"
-                    @result << Endpoint.new(base_path + path, method.upcase, details)
-                    methods_of_path << method.to_s.upcase
-                  end
-                rescue e
-                  @logger.debug "Exception of #{oas3_json}/paths/endpoint"
-                  @logger.debug_sub e
-                end
-                if params_of_path.size > 0
-                  methods_of_path.each do |method_path|
-                    @result << Endpoint.new(base_path + path, method_path.upcase, params_of_path, details)
-                  end
-                end
-              end
-            rescue e
-              @logger.debug "Exception of #{oas3_json}/paths"
-              @logger.debug_sub e
-            end
+            process_paths_json(json_obj, base_path, details, oas3_json)
           end
         end
       end
@@ -168,119 +225,112 @@ module Analyzer::Specification
               @logger.debug_sub e
             end
 
-            begin
-              paths = yaml_obj["paths"].as_h
-              paths.each do |path, path_obj|
-                params_of_path = [] of Param
-                methods_of_path = [] of String
-                path_obj.as_h.each do |method, method_obj|
-                  params = [] of Param
-
-                  # Param in Path
-                  begin
-                    if method == "parameters"
-                      method_obj.as_a.each do |param_obj|
-                        param_name = param_obj["name"].to_s
-                        if param_obj["in"] == "query"
-                          param = Param.new(param_name, "", "query")
-                          params_of_path << param
-                        elsif param_obj["in"] == "header"
-                          param = Param.new(param_name, "", "header")
-                          params_of_path << param
-                        elsif param_obj["in"] == "cookie"
-                          param = Param.new(param_name, "", "cookie")
-                          params_of_path << param
-                        end
-                      end
-                    end
-
-                    if method == "requestBody"
-                      method_obj["content"].as_h.each do |content_type, content_obj|
-                        if content_type == "application/json"
-                          content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                            param = Param.new(param_name.to_s, "", "json")
-                            params_of_path << param
-                          end
-                        elsif content_type == "application/x-www-form-urlencoded"
-                          content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                            param = Param.new(param_name.to_s, "", "form")
-                            params_of_path << param
-                          end
-                        end
-                      end
-                    end
-                  rescue e
-                    @logger.debug "Exception of #{oas3_yaml}/paths/parameters"
-                    @logger.debug_sub e
-                  end
-
-                  # Param in Method
-                  begin
-                    if method_obj.is_a?(YAML::Any) || method_obj.is_a?(Hash(String, YAML::Any))
-                      if method_obj.as_h.has_key?("parameters")
-                        method_obj["parameters"].as_a.each do |param_obj|
-                          param_name = param_obj["name"].to_s
-                          if param_obj["in"] == "query"
-                            param = Param.new(param_name, "", "query")
-                            params << param
-                          elsif param_obj["in"] == "header"
-                            param = Param.new(param_name, "", "header")
-                            params << param
-                          elsif param_obj["in"] == "cookie"
-                            param = Param.new(param_name, "", "cookie")
-                            params << param
-                          end
-                        end
-                      end
-
-                      if method_obj.as_h.has_key?("requestBody")
-                        method_obj["requestBody"]["content"].as_h.each do |content_type, content_obj|
-                          if content_type == "application/json"
-                            content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                              param = Param.new(param_name.to_s, "", "json")
-                              params << param
-                            end
-                          elsif content_type == "application/x-www-form-urlencoded"
-                            content_obj["schema"]["properties"].as_h.each do |param_name, _|
-                              param = Param.new(param_name.to_s, "", "form")
-                              params << param
-                            end
-                          end
-                        end
-                      end
-                    end
-                  rescue e
-                    @logger.debug "Exception of #{oas3_yaml}/paths/method/parameters"
-                    @logger.debug_sub e
-                  end
-
-                  if params.size > 0 && (method.to_s.upcase != "PARAMETERS" && method.to_s.upcase != "REQUESTBODY")
-                    @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
-                    methods_of_path << method.to_s.upcase
-                  elsif method.to_s.upcase != "PARAMETERS" && method.to_s.upcase != "REQUESTBODY"
-                    @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
-                    methods_of_path << method.to_s.upcase
-                  end
-                end
-
-                if params_of_path.size > 0
-                  methods_of_path.each do |method_path|
-                    @result << Endpoint.new(base_path + path.to_s, method_path.to_s.upcase, params_of_path, details)
-                  end
-                end
-              rescue e
-                @logger.debug "Exception of #{oas3_yaml}/paths/endpoint"
-                @logger.debug_sub e
-              end
-            rescue e
-              @logger.debug "Exception of #{oas3_yaml}/paths"
-              @logger.debug_sub e
-            end
+            process_paths_yaml(yaml_obj, base_path, details, oas3_yaml)
           end
         end
       end
 
       @result
+    end
+
+    private def process_paths_json(json_obj : JSON::Any, base_path : String, details : Details, source : String)
+      paths = json_obj["paths"].as_h
+      paths.each do |path, path_obj|
+        path_level_params = [] of Param
+        if path_obj_h = path_obj.as_h?
+          if shared = path_obj_h["parameters"]?.try(&.as_a?)
+            shared.each do |param_obj|
+              extract_param_json(json_obj, param_obj, path_level_params)
+            end
+          end
+        end
+
+        path_obj.as_h.each do |method, method_obj|
+          next unless HTTP_METHODS.includes?(method.to_s.downcase)
+          params = path_level_params.dup
+
+          begin
+            if method_obj_h = method_obj.as_h?
+              if method_params = method_obj_h["parameters"]?.try(&.as_a?)
+                method_params.each do |param_obj|
+                  extract_param_json(json_obj, param_obj, params)
+                end
+              end
+
+              if request_body = method_obj_h["requestBody"]?
+                extract_request_body_json(json_obj, request_body, params)
+              end
+            end
+          rescue e
+            @logger.debug "Exception of #{source}/paths/method/parameters"
+            @logger.debug_sub e
+          end
+
+          if params.size > 0
+            @result << Endpoint.new(base_path + path, method.upcase, params, details)
+          else
+            @result << Endpoint.new(base_path + path, method.upcase, details)
+          end
+        rescue e
+          @logger.debug "Exception of #{source}/paths/endpoint"
+          @logger.debug_sub e
+        end
+      end
+    rescue e
+      @logger.debug "Exception of #{source}/paths"
+      @logger.debug_sub e
+    end
+
+    private def process_paths_yaml(yaml_obj : YAML::Any, base_path : String, details : Details, source : String)
+      paths = yaml_obj["paths"].as_h
+      paths.each do |path, path_obj|
+        path_level_params = [] of Param
+        if path_obj_h = path_obj.as_h?
+          if shared_node = path_obj_h[YAML::Any.new("parameters")]?
+            if shared = shared_node.as_a?
+              shared.each do |param_obj|
+                extract_param_yaml(yaml_obj, param_obj, path_level_params)
+              end
+            end
+          end
+        end
+
+        path_obj.as_h.each do |method, method_obj|
+          next unless HTTP_METHODS.includes?(method.to_s.downcase)
+          params = path_level_params.dup
+
+          begin
+            if method_obj_h = method_obj.as_h?
+              if method_params_node = method_obj_h[YAML::Any.new("parameters")]?
+                if method_params = method_params_node.as_a?
+                  method_params.each do |param_obj|
+                    extract_param_yaml(yaml_obj, param_obj, params)
+                  end
+                end
+              end
+
+              if request_body = method_obj_h[YAML::Any.new("requestBody")]?
+                extract_request_body_yaml(yaml_obj, request_body, params)
+              end
+            end
+          rescue e
+            @logger.debug "Exception of #{source}/paths/method/parameters"
+            @logger.debug_sub e
+          end
+
+          if params.size > 0
+            @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, params, details)
+          else
+            @result << Endpoint.new(base_path + path.to_s, method.to_s.upcase, details)
+          end
+        rescue e
+          @logger.debug "Exception of #{source}/paths/endpoint"
+          @logger.debug_sub e
+        end
+      end
+    rescue e
+      @logger.debug "Exception of #{source}/paths"
+      @logger.debug_sub e
     end
   end
 end

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -23,11 +23,11 @@ module Analyzer::Specification
     # Maps an OAS3 request-body content type to a Noir param type.
     private def param_type_for_content(content_type : String) : String?
       case content_type
-      when "application/json", .starts_with?("application/json")
+      when .starts_with?("application/json")
         "json"
       when "application/x-www-form-urlencoded"
         "form"
-      when "multipart/form-data", .starts_with?("multipart/form-data")
+      when .starts_with?("multipart/form-data")
         "form"
       end
     end
@@ -118,6 +118,7 @@ module Analyzer::Specification
 
       name = param_obj["name"]?.try(&.to_s) || ""
       location = param_obj["in"]?.try(&.to_s) || ""
+      return if name.empty?
       case location
       when "query"
         params << Param.new(name, "", "query")
@@ -140,6 +141,7 @@ module Analyzer::Specification
 
       name = param_obj[YAML::Any.new("name")]?.try(&.to_s) || ""
       location = param_obj[YAML::Any.new("in")]?.try(&.to_s) || ""
+      return if name.empty?
       case location
       when "query"
         params << Param.new(name, "", "query")
@@ -190,7 +192,6 @@ module Analyzer::Specification
       locator = CodeLocator.instance
       oas3_jsons = locator.all("oas3-json")
       oas3_yamls = locator.all("oas3-yaml")
-      base_path = @url
 
       if oas3_jsons.is_a?(Array(String))
         oas3_jsons.each do |oas3_json|
@@ -199,6 +200,7 @@ module Analyzer::Specification
             content = File.read(oas3_json, encoding: "utf-8", invalid: :skip)
             json_obj = JSON.parse(content)
 
+            base_path = @url
             begin
               base_path = get_base_path json_obj["servers"]
             rescue e
@@ -218,6 +220,7 @@ module Analyzer::Specification
             content = File.read(oas3_yaml, encoding: "utf-8", invalid: :skip)
             yaml_obj = YAML.parse(content)
 
+            base_path = @url
             begin
               base_path = get_base_path yaml_obj["servers"]
             rescue e


### PR DESCRIPTION
## Summary

Spec-based analyzers were silently dropping common OpenAPI patterns. Most notably **OAS2 body parameters** (`in: body` + schema `$ref`) produced zero params, and **OAS3 only handled** `application/json` and `application/x-www-form-urlencoded` request bodies. Real-world specs almost always reach for refs (`#/definitions/...`, `#/components/schemas/...`) or use multipart uploads, so the extracted endpoint params were materially incomplete — and downstream AI context (one of Noir's strengths) was missing fields it should have had.

This PR enriches the existing OAS analyzers so spec-driven endpoints carry the same parameter detail as code-driven ones.

### OAS2 (Swagger 2.0) — `src/analyzer/analyzers/specification/oas2.cr`
- Extract `in: body` parameters via `schema.properties` (was dropped entirely).
- Resolve `$ref` against the spec root (e.g. `#/definitions/NewPet`, `#/parameters/...`).
- Honor path-level shared `parameters` block across all methods at that path.
- Pick body param type from `consumes`: `form` for `multipart/form-data` or `application/x-www-form-urlencoded`, `json` otherwise.
- Skip non-HTTP-method keys (`parameters`, `$ref`) explicitly via a method allowlist.

### OAS3 — `src/analyzer/analyzers/specification/oas3.cr`
- Handle `multipart/form-data` request bodies (common for uploads).
- Resolve `$ref` for requestBody objects, schemas, and parameter objects. Cycle-safe via a `seen` set so recursive refs can't loop.
- Flatten `allOf` so composed schemas surface their member properties.
- Drop the dead path-level `requestBody` branch (not valid in OAS3 — only `parameters` is allowed at path level alongside operations).

### Tests
- OAS2 tester now asserts the body params on `POST /v1/pets` (`name`) and `PUT /v1/pets/{petId}` (`name`, `breed`), which previously were silently missing.
- New fixture `spec/functional_test/fixtures/specification/oas3/refs_multipart/` exercises:
  - requestBody `$ref` to `components/requestBodies` with `multipart/form-data`
  - path-level `parameters` (path + header) shared across operations
  - schema `$ref` to `components/schemas`
  - `allOf` composition (NewUser = UserBase + password)

## Test plan
- [x] `crystal spec spec/functional_test/testers/specification/oas2_spec.cr spec/functional_test/testers/specification/oas3_spec.cr` — 122 examples, 0 failures
- [x] Full `crystal spec spec/functional_test/` — 10,691 examples, 0 failures
- [x] `crystal spec spec/unit_test/` — 1,663 examples, 0 failures
- [x] `crystal lib/ameba/bin/ameba.cr` on changed files — clean