### PR TITLE
Improve CLI input validation

### DIFF
--- a/spec/unit_test/cli_validation_spec.cr
+++ b/spec/unit_test/cli_validation_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+require "../../src/cli_validation"
+
+describe Noir::CliValidation do
+  it "rejects missing base paths" do
+    options = create_test_options
+
+    expect_raises(Noir::CliValidation::Error, /Base path is required/) do
+      Noir::CliValidation.validate_base_paths!(options)
+    end
+  end
+
+  it "rejects nonexistent base paths" do
+    options = create_test_options
+    options["base"] = YAML::Any.new([YAML::Any.new("/tmp/noir-does-not-exist")])
+
+    expect_raises(Noir::CliValidation::Error, /Base path does not exist/) do
+      Noir::CliValidation.validate_base_paths!(options)
+    end
+  end
+
+  it "rejects invalid output formats" do
+    options = create_test_options
+    options["format"] = YAML::Any.new("madeup")
+
+    expect_raises(Noir::CliValidation::Error, /Invalid output format 'madeup'/) do
+      Noir::CliValidation.validate_output_format!(options)
+    end
+  end
+
+  it "rejects non-positive concurrency" do
+    options = create_test_options
+    options["concurrency"] = YAML::Any.new(0)
+
+    expect_raises(Noir::CliValidation::Error, /Invalid concurrency '0'/) do
+      Noir::CliValidation.validate_concurrency!(options)
+    end
+  end
+
+  it "normalizes valid concurrency to an integer" do
+    options = create_test_options
+    options["concurrency"] = YAML::Any.new("2")
+
+    Noir::CliValidation.validate_concurrency!(options)
+
+    options["concurrency"].as_i.should eq(2)
+  end
+
+  it "rejects output paths in missing directories" do
+    options = create_test_options
+    options["output"] = YAML::Any.new("/tmp/noir-missing-dir/out.txt")
+
+    expect_raises(Noir::CliValidation::Error, /Output directory does not exist/) do
+      Noir::CliValidation.validate_output_path!(options)
+    end
+  end
+
+  it "rejects unknown tagger names" do
+    options = create_test_options
+    options["use_taggers"] = YAML::Any.new("hunt,madeup")
+
+    expect_raises(Noir::CliValidation::Error, /Unknown tagger/) do
+      Noir::CliValidation.validate_tagger_names!(options)
+    end
+  end
+end

--- a/spec/unit_test/models/output_builder_spec.cr
+++ b/spec/unit_test/models/output_builder_spec.cr
@@ -1,5 +1,6 @@
 require "../../spec_helper"
 require "../../../src/models/output_builder.cr"
+require "../../../src/output_builder/*"
 
 describe "Initialize" do
   options = create_test_options
@@ -65,6 +66,25 @@ describe "Initialize" do
   it "OutputBuilderJsonl" do
     object = OutputBuilderJsonl.new options
     object.output_file.should eq("output.json")
+  end
+
+  it "truncates an output file on first write and appends later writes" do
+    output_file = File.tempname("noir-output-builder")
+    File.write(output_file, "old\n")
+
+    begin
+      options = create_test_options
+      options["output"] = YAML::Any.new(output_file)
+
+      object = OutputBuilder.new options
+      object.io = IO::Memory.new
+      object.ob_puts "new"
+      object.ob_puts "next"
+
+      File.read(output_file).should eq("new\nnext\n")
+    ensure
+      File.delete(output_file) if File.exists?(output_file)
+    end
   end
 end
 

--- a/spec/unit_test/tagger/tagger_spec.cr
+++ b/spec/unit_test/tagger/tagger_spec.cr
@@ -3,6 +3,24 @@ require "../../../src/utils/*"
 require "../../../src/tagger/tagger"
 
 describe "Tagger" do
+  it "lists regular and framework tagger names for validation" do
+    NoirTaggers.available_tagger_names.should contain("hunt")
+    NoirTaggers.available_tagger_names.should contain("django_auth")
+    NoirTaggers.available_tagger_names.should contain("all")
+  end
+
+  it "detects unknown tagger names" do
+    NoirTaggers.unknown_tagger_names("hunt,madeup,django_auth").should eq(["madeup"])
+  end
+
+  it "rejects unknown tagger names before running" do
+    noir_options = create_test_options
+
+    expect_raises(ArgumentError, /Unknown tagger/) do
+      NoirTaggers.run_tagger([] of Endpoint, noir_options, "madeup")
+    end
+  end
+
   it "hunt_tagger" do
     noir_options = create_test_options
     expected_endpoints = [

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -1,0 +1,107 @@
+require "colorize"
+require "yaml"
+require "./tagger/tagger"
+
+module Noir::CliValidation
+  class Error < Exception
+  end
+
+  VALID_OUTPUT_FORMATS = %w[
+    plain
+    yaml
+    json
+    jsonl
+    toml
+    markdown-table
+    sarif
+    html
+    curl
+    httpie
+    powershell
+    oas2
+    oas3
+    postman
+    only-url
+    only-param
+    only-header
+    only-cookie
+    only-tag
+    mermaid
+  ]
+
+  def self.validate!(options : Hash(String, YAML::Any))
+    validate_base_paths!(options)
+    validate_output_format!(options)
+    validate_concurrency!(options)
+    validate_output_path!(options)
+    validate_tagger_names!(options)
+  end
+
+  def self.validate_base_paths!(options : Hash(String, YAML::Any))
+    base_paths = options["base"].as_a.map(&.to_s)
+    if base_paths.empty?
+      raise Error.new("Base path is required.\nPlease use -b or --base-path to set base path.\nIf you need help, use -h or --help.")
+    end
+
+    base_paths.each do |base_path|
+      unless File.exists?(base_path)
+        raise Error.new("Base path does not exist: #{base_path}")
+      end
+
+      unless File.directory?(base_path)
+        raise Error.new("Base path is not a directory: #{base_path}")
+      end
+    end
+  end
+
+  def self.validate_output_format!(options : Hash(String, YAML::Any))
+    format = options["format"].to_s
+    return if VALID_OUTPUT_FORMATS.includes?(format)
+
+    raise Error.new("Invalid output format '#{format}'. Valid formats: #{VALID_OUTPUT_FORMATS.join(", ")}")
+  end
+
+  def self.validate_concurrency!(options : Hash(String, YAML::Any))
+    raw_value = options["concurrency"].to_s
+    value = raw_value.to_i?
+    if value.nil? || value < 1
+      raise Error.new("Invalid concurrency '#{raw_value}'. Concurrency must be an integer greater than or equal to 1.")
+    end
+
+    options["concurrency"] = YAML::Any.new(value)
+  end
+
+  def self.validate_output_path!(options : Hash(String, YAML::Any))
+    output_path = options["output"].to_s
+    return if output_path.empty?
+
+    if File.exists?(output_path) && File.directory?(output_path)
+      raise Error.new("Output path is a directory: #{output_path}")
+    end
+
+    output_dir = File.dirname(output_path)
+    return if output_dir == "." || output_dir.empty?
+    return if Dir.exists?(output_dir)
+
+    raise Error.new("Output directory does not exist: #{output_dir}")
+  end
+
+  def self.validate_tagger_names!(options : Hash(String, YAML::Any))
+    use_taggers = options["use_taggers"].to_s
+    return if use_taggers.empty?
+
+    unknown_taggers = NoirTaggers.unknown_tagger_names(use_taggers)
+    return if unknown_taggers.empty?
+
+    raise Error.new("Unknown tagger(s): #{unknown_taggers.join(", ")}. Use --list-taggers to see available taggers.")
+  end
+
+  def self.exit_with_error(message : String) : NoReturn
+    lines = message.lines
+    STDERR.puts "ERROR: #{lines.first}".colorize(:yellow)
+    lines[1..]?.try do |rest|
+      rest.each { |line| STDERR.puts line }
+    end
+    exit(1)
+  end
+end

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -1,7 +1,11 @@
 require "./logger"
 require "./endpoint"
+require "../utils/*"
+require "colorize"
 
 class OutputBuilder
+  @@prepared_output_files = Set(String).new
+
   @logger : NoirLogger
   @options : Hash(String, YAML::Any)
   @is_debug : Bool
@@ -27,10 +31,22 @@ class OutputBuilder
   def ob_puts(message)
     @io.puts message
     if @output_file != ""
-      File.open(@output_file, "a") do |file|
-        file.puts message
+      begin
+        File.open(@output_file, output_file_mode) do |file|
+          file.puts message
+        end
+      rescue e : File::Error
+        STDERR.puts "ERROR: Could not write output file '#{@output_file}': #{e.message}".colorize(:yellow)
+        exit(1)
       end
     end
+  end
+
+  private def output_file_mode : String
+    return "a" if @@prepared_output_files.includes?(@output_file)
+
+    @@prepared_output_files << @output_file
+    "w"
   end
 
   def print

--- a/src/noir.cr
+++ b/src/noir.cr
@@ -3,6 +3,7 @@ require "colorize"
 require "./models/noir.cr"
 require "./banner.cr"
 require "./options.cr"
+require "./cli_validation.cr"
 require "./techs/techs.cr"
 require "./llm/cache"
 require "./llm/prompt_overrides"
@@ -40,14 +41,6 @@ if noir_options.has_key?("override_llm_optimize_prompt")
   LLM::PromptOverrides.llm_optimize_prompt = noir_options["override_llm_optimize_prompt"].to_s
 end
 
-# Check base path
-if noir_options["base"].as_a.empty?
-  STDERR.puts "ERROR: Base path is required.".colorize(:yellow)
-  STDERR.puts "Please use -b or --base-path to set base path."
-  STDERR.puts "If you need help, use -h or --help."
-  exit(1)
-end
-
 if noir_options["url"] != "" && !noir_options["url"].to_s.includes?("://")
   STDERR.puts "WARNING: The protocol (http or https) is missing in the URL '#{noir_options["url"]}'. Defaulting to 'https://'.".colorize(Colorize::Color256.new(208))
   noir_options["url"] = YAML::Any.new("https://#{noir_options["url"]}")
@@ -79,6 +72,12 @@ if noir_options["exclude_codes"] != ""
       exit(1)
     end
   end
+end
+
+begin
+  Noir::CliValidation.validate!(noir_options)
+rescue e : Noir::CliValidation::Error
+  Noir::CliValidation.exit_with_error(e.message || "Invalid options.")
 end
 
 # Run Noir

--- a/src/options.cr
+++ b/src/options.cr
@@ -355,7 +355,13 @@ def run_options_parser
       noir_options["config_file"] = YAML::Any.new(v)
     end
     parser.on "--concurrency N", "Concurrency level" do |v|
-      noir_options["concurrency"] = YAML::Any.new(v.to_i)
+      value = v.to_i?
+      if value.nil? || value < 1
+        STDERR.puts "ERROR: Invalid concurrency '#{v}'. Concurrency must be an integer greater than or equal to 1.".colorize(:yellow)
+        exit(1)
+      end
+
+      noir_options["concurrency"] = YAML::Any.new(value)
     end
     parser.on "--generate-completion SHELL", "Generate completion script (zsh|bash|fish)" do |shell|
       case shell

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -159,7 +159,30 @@ module NoirTaggers
     HasFrameworkTaggers
   end
 
+  def self.available_tagger_names : Array(String)
+    names = [] of String
+    HasTaggers.each_key { |name| names << name.to_s }
+    HasFrameworkTaggers.each_key { |name| names << name.to_s }
+    names << "all"
+    names.sort
+  end
+
+  def self.unknown_tagger_names(use_taggers : String) : Array(String)
+    requested = use_taggers.split(",").map(&.strip).reject(&.empty?)
+    valid_names = available_tagger_names
+    requested.reject { |name| valid_names.includes?(name) }
+  end
+
+  def self.validate_tagger_names!(use_taggers : String)
+    unknown = unknown_tagger_names(use_taggers)
+    return if unknown.empty?
+
+    raise ArgumentError.new("Unknown tagger(s): #{unknown.join(", ")}")
+  end
+
   def self.run_tagger(endpoints : Array(Endpoint), options : Hash(String, YAML::Any), use_taggers : String)
+    validate_tagger_names!(use_taggers)
+
     tagger_list = [] of Tagger
 
     HasTaggers.each_value do |tagger|


### PR DESCRIPTION
## Summary

- add centralized CLI validation for base paths, output formats, concurrency, output paths, and tagger names
- make invalid CLI input fail before scanning with user-facing errors instead of silent fallback, hangs, or stack traces
- make `-o/--output` truncate on the first write of each run so repeated runs do not silently append stale results

## Validation

- `just build`
- `just test`
- `just check`
- manual CLI checks for invalid base path, invalid format, `--concurrency 0`, unknown tagger, missing output directory, repeated `-o`, and JSON parseability

## Notes

`--list-techs` discoverability is tracked separately for a future subcommand-style CLI: #1610
