### PR TITLE
Improve Go and Rust route extraction accuracy

### DIFF
--- a/spec/functional_test/fixtures/rust/actix_web/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_web/src/main.rs
@@ -87,3 +87,22 @@ async fn update_article(
 async fn manual_hello() -> impl Responder {
     HttpResponse::Ok().body("Hey there!")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[get("/should-not-appear-attr")]
+    async fn test_attr_route() -> impl Responder {
+        HttpResponse::Ok().finish()
+    }
+
+    async fn test_manual() -> impl Responder {
+        HttpResponse::Ok().finish()
+    }
+
+    fn test_app() {
+        let _app = actix_web::App::new()
+            .route("/should-not-appear-builder", web::get().to(test_manual));
+    }
+}

--- a/spec/functional_test/fixtures/rust/axum/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum/src/main.rs
@@ -5,7 +5,13 @@ async fn main() {
     let app = Router::new()
         .route("/", get(handler))
         .route("/foo", get(handler))
-        .route("/bar", post(handler));
+        .route("/bar", post(handler))
+        .nest(
+            "/api",
+            Router::new()
+                .route("/users", get(handler))
+                .route("/admin", post(handler)),
+        );
         
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await

--- a/spec/functional_test/testers/rust/axum_spec.cr
+++ b/spec/functional_test/testers/rust/axum_spec.cr
@@ -4,6 +4,8 @@ expected_endpoints = [
   Endpoint.new("/", "GET"),
   Endpoint.new("/foo", "GET"),
   Endpoint.new("/bar", "POST"),
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/admin", "POST"),
 ]
 
 FunctionalTester.new("fixtures/rust/axum/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -125,4 +125,73 @@ describe Noir::TreeSitterGoRouteExtractor do
     routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
     routes.map(&.path).should eq(["/legit"])
   end
+
+  it "resolves string constants and concatenations used as paths" do
+    source = <<-GO
+      package main
+      const api = "/api"
+      const users = "/users"
+
+      func main() {
+          r := gin.Default()
+          group := r.Group(api)
+          group.GET(users + "/:id", handler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/api/users/:id"}])
+  end
+
+  it "extracts routes registered on inline group chains" do
+    source = <<-GO
+      package main
+
+      func main() {
+          r := gin.Default()
+          r.Group("/api").GET("/users", handler)
+          r.Group("/api").Group("/v1").POST("/teams", handler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/users"},
+      {"POST", "/api/v1/teams"},
+    ])
+  end
+
+  it "collects group assignments from var declarations and later assignments" do
+    source = <<-GO
+      package main
+
+      func main() {
+          r := gin.Default()
+          var api = r.Group("/api")
+          var v1 *gin.RouterGroup
+          v1 = api.Group("/v1")
+          v1.GET("/users", handler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/api/v1/users"}])
+  end
+
+  it "does not loop on reassigned string identifiers" do
+    source = <<-GO
+      package main
+
+      func main() {
+          r := gin.Default()
+          path := "/first"
+          path = "/second"
+          r.GET(path, handler)
+          r.GET("/legit", handler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/legit"}])
+  end
 end

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -17,9 +17,12 @@ module Analyzer::Rust
       endpoints = [] of Endpoint
       source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
         each_routing_pair(root) do |attr, function|
+          next if RustEngine.inside_test_region?(attr, test_regions)
+
           route = extract_route(attr, source)
           next unless route
           route_path, method, attr_row = route
@@ -40,6 +43,8 @@ module Analyzer::Rust
         # `#[get(...)]` macro form, so manual builder-style routes
         # were silently dropped.
         walk_calls(root) do |call|
+          next if RustEngine.inside_test_region?(call, test_regions)
+
           builder_route = extract_builder_route(call, source)
           next unless builder_route
           route_path, methods = builder_route

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -38,15 +38,12 @@ module Analyzer::Rust
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = include_callee ? build_function_index(root, source) : Hash(String, LibTreeSitter::TSNode).new
 
-        walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "call_expression"
-          next unless route_call?(node, source)
-          next if RustEngine.inside_test_region?(node, test_regions)
-
+        walk_router_builders(root, source, "", test_regions) do |node, prefix|
           route = extract_route(node, source)
           next unless route
 
           path_str, methods, handler_name = route
+          path_str = join_paths(prefix, path_str) unless prefix.empty?
           methods.each do |verb|
             details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
             endpoint = Endpoint.new(path_str, verb, details)
@@ -75,6 +72,80 @@ module Analyzer::Rust
       Noir::TreeSitter.node_text(field, source) == "route"
     end
 
+    # Walks Axum router builder chains with an active path prefix.
+    # This keeps ordinary chained `.route(...)` behaviour while also
+    # applying `.nest("/api", Router::new().route(...))` prefixes to
+    # inline nested routers instead of emitting those inner routes at
+    # the root.
+    private def walk_router_builders(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     prefix : String,
+                                     test_regions : Array(Tuple(Int32, Int32)),
+                                     &block : LibTreeSitter::TSNode, String ->)
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        return if RustEngine.inside_test_region?(node, test_regions)
+
+        if route_call?(node, source)
+          block.call(node, prefix)
+          walk_receiver_chain(node, source, prefix, test_regions, &block)
+          return
+        end
+
+        if nest = extract_nest_call(node, source)
+          nest_prefix, nested_router = nest
+          walk_receiver_chain(node, source, prefix, test_regions, &block)
+          walk_router_builders(nested_router, source, join_paths(prefix, nest_prefix), test_regions, &block)
+          return
+        end
+
+        if merge_arg = extract_merge_call(node, source)
+          walk_receiver_chain(node, source, prefix, test_regions, &block)
+          walk_router_builders(merge_arg, source, prefix, test_regions, &block)
+          return
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_router_builders(child, source, prefix, test_regions, &block)
+      end
+    end
+
+    private def walk_receiver_chain(call : LibTreeSitter::TSNode,
+                                    source : String,
+                                    prefix : String,
+                                    test_regions : Array(Tuple(Int32, Int32)),
+                                    &block : LibTreeSitter::TSNode, String ->)
+      function = Noir::TreeSitter.field(call, "function")
+      return unless function && Noir::TreeSitter.node_type(function) == "field_expression"
+      receiver = Noir::TreeSitter.field(function, "value")
+      return unless receiver
+      walk_router_builders(receiver, source, prefix, test_regions, &block)
+    end
+
+    private def extract_nest_call(call : LibTreeSitter::TSNode,
+                                  source : String) : Tuple(String, LibTreeSitter::TSNode)?
+      return unless field_call_name(call, source) == "nest"
+      args = named_arguments(call)
+      return unless args.size >= 2
+      prefix = string_literal_text(args[0], source)
+      return unless prefix
+      {prefix, args[1]}
+    end
+
+    private def extract_merge_call(call : LibTreeSitter::TSNode,
+                                   source : String) : LibTreeSitter::TSNode?
+      return unless field_call_name(call, source) == "merge"
+      args = named_arguments(call)
+      args.first?
+    end
+
+    private def field_call_name(call : LibTreeSitter::TSNode, source : String) : String?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      field = Noir::TreeSitter.field(fn_node, "field")
+      field ? Noir::TreeSitter.node_text(field, source) : nil
+    end
+
     # Returns `{path, http_method, handler_name?}` for a valid
     # `.route(path, verb(handler))` call, or `nil` when the shape
     # doesn't match. Returns a list of methods because Axum allows
@@ -84,8 +155,7 @@ module Analyzer::Rust
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
 
-      named = [] of LibTreeSitter::TSNode
-      Noir::TreeSitter.each_named_child(args) { |c| named << c }
+      named = named_children(args)
       return if named.size < 2
 
       path = string_literal_text(named[0], source)
@@ -147,6 +217,22 @@ module Analyzer::Rust
         return Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "identifier"
       end
       nil
+    end
+
+    private def named_arguments(call : LibTreeSitter::TSNode) : Array(LibTreeSitter::TSNode)
+      args = Noir::TreeSitter.field(call, "arguments")
+      return [] of LibTreeSitter::TSNode unless args
+      named_children(args)
+    end
+
+    private def named_children(node : LibTreeSitter::TSNode) : Array(LibTreeSitter::TSNode)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named
+    end
+
+    private def join_paths(prefix : String, path : String) : String
+      "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
     end
 
     private def string_literal_text(node : LibTreeSitter::TSNode, source : String) : String?

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -112,14 +112,16 @@ module Noir
       routes = [] of Route
       group_prefixes = external_groups.dup
       Noir::TreeSitter.parse_go(source) do |root|
+        string_values = collect_string_values(root, source)
+
         walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "short_var_declaration"
-          collect_group(node, source, group_prefixes, group_method, group_aliases)
+          next unless group_assignment_node?(node)
+          collect_group(node, source, group_prefixes, group_method, group_aliases, string_values)
         end
 
         walk(root) do |node|
           next unless Noir::TreeSitter.node_type(node) == "call_expression"
-          if route = decode_verb_call(node, source, group_prefixes, extra_verbs)
+          if route = decode_verb_call(node, source, group_prefixes, extra_verbs, group_method, group_aliases, string_values)
             routes << route
           elsif handle_method && (route = decode_handle_call(node, source, group_prefixes, handle_method))
             routes << route
@@ -146,9 +148,11 @@ module Noir
                        group_aliases : Array(String) = [] of String) : Hash(String, String)
       group_prefixes = external_groups.dup
       Noir::TreeSitter.parse_go(source) do |root|
+        string_values = collect_string_values(root, source)
+
         walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "short_var_declaration"
-          collect_group(node, source, group_prefixes, group_method, group_aliases)
+          next unless group_assignment_node?(node)
+          collect_group(node, source, group_prefixes, group_method, group_aliases, string_values)
         end
       end
       group_prefixes
@@ -651,6 +655,68 @@ module Noir
       end
     end
 
+    private def group_assignment_node?(node : LibTreeSitter::TSNode) : Bool
+      case Noir::TreeSitter.node_type(node)
+      when "short_var_declaration", "assignment_statement", "var_spec"
+        true
+      else
+        false
+      end
+    end
+
+    private def collect_string_values(root : LibTreeSitter::TSNode, source : String) : Hash(String, String)
+      values = Hash(String, String).new
+      ambiguous = Set(String).new
+      loop do
+        changed = false
+        walk(root) do |node|
+          name_value = string_assignment(node, source, values)
+          next unless name_value
+          name, value = name_value
+          next if ambiguous.includes?(name)
+          if old_value = values[name]?
+            next if old_value == value
+            values.delete(name)
+            ambiguous.add(name)
+          else
+            values[name] = value
+          end
+          changed = true
+        end
+        break unless changed
+      end
+      values
+    end
+
+    private def string_assignment(node : LibTreeSitter::TSNode,
+                                  source : String,
+                                  values : Hash(String, String)) : Tuple(String, String)?
+      case Noir::TreeSitter.node_type(node)
+      when "const_spec", "var_spec"
+        name = Noir::TreeSitter.field(node, "name")
+        value = Noir::TreeSitter.field(node, "value")
+        return unless name && value
+        return unless Noir::TreeSitter.node_type(name) == "identifier"
+        expr = first_named_child(value)
+        return unless expr
+        text = string_expr_text(expr, source, values)
+        return unless text
+        {Noir::TreeSitter.node_text(name, source), text}
+      else
+        return unless group_assignment_node?(node)
+        left = Noir::TreeSitter.field(node, "left")
+        right = Noir::TreeSitter.field(node, "right")
+        return unless left && right
+        name = first_named_child(left)
+        expr = first_named_child(right)
+        return unless name && expr
+        return unless Noir::TreeSitter.node_type(name) == "identifier"
+        text = string_expr_text(expr, source, values)
+        return unless text
+        {Noir::TreeSitter.node_text(name, source), text}
+      end
+    end
+
     # Record `<name> := <parent>.Group("/prefix")`. Also accepts
     # `<name> = <parent>.Group(...)` (assignment) as a fallback, which
     # some codebases use for package-level groups. Resolves the prefix by
@@ -659,14 +725,19 @@ module Noir
                               source : String,
                               groups : Hash(String, String),
                               group_method : String,
-                              group_aliases : Array(String) = [] of String)
+                              group_aliases : Array(String) = [] of String,
+                              string_values : Hash(String, String) = Hash(String, String).new)
       left = Noir::TreeSitter.field(decl, "left")
       right = Noir::TreeSitter.field(decl, "right")
+      if Noir::TreeSitter.node_type(decl) == "var_spec"
+        left = Noir::TreeSitter.field(decl, "name")
+        right = Noir::TreeSitter.field(decl, "value")
+      end
       return unless left && right
 
       # `expression_list` wraps both sides; the single-variable case has
       # one named child on each side.
-      var_name_node = first_named_child(left)
+      var_name_node = identifier_or_first_child(left)
       rhs_node = first_named_child(right)
       return unless var_name_node && rhs_node
       return unless Noir::TreeSitter.node_type(var_name_node) == "identifier"
@@ -711,8 +782,8 @@ module Noir
             if inner_args
               prefix = nil
               Noir::TreeSitter.each_named_child(inner_args) do |arg|
-                next unless Noir::TreeSitter.node_type(arg) == "interpreted_string_literal"
-                prefix = decode_string_literal(arg, source)
+                prefix = string_expr_text(arg, source, string_values)
+                next unless prefix
                 break
               end
               return unless prefix
@@ -736,8 +807,8 @@ module Noir
 
       prefix = nil
       Noir::TreeSitter.each_named_child(args) do |arg|
-        next unless Noir::TreeSitter.node_type(arg) == "interpreted_string_literal"
-        prefix = decode_string_literal(arg, source)
+        prefix = string_expr_text(arg, source, string_values)
+        next unless prefix
         break
       end
       return unless prefix
@@ -758,7 +829,10 @@ module Noir
     private def decode_verb_call(call : LibTreeSitter::TSNode,
                                  source : String,
                                  groups : Hash(String, String),
-                                 extra_verbs : Array(String) = [] of String) : Route?
+                                 extra_verbs : Array(String) = [] of String,
+                                 group_method : String = "Group",
+                                 group_aliases : Array(String) = [] of String,
+                                 string_values : Hash(String, String) = Hash(String, String).new) : Route?
       function = Noir::TreeSitter.field(call, "function")
       return unless function
       return unless Noir::TreeSitter.node_type(function) == "selector_expression"
@@ -766,12 +840,13 @@ module Noir
       operand = Noir::TreeSitter.field(function, "operand")
       field = Noir::TreeSitter.field(function, "field")
       return unless operand && field
-      return unless Noir::TreeSitter.node_type(operand) == "identifier"
 
       verb = Noir::TreeSitter.node_text(field, source)
       return unless HTTP_VERB_METHODS.includes?(verb) || extra_verbs.includes?(verb)
 
-      router_name = Noir::TreeSitter.node_text(operand, source)
+      router_info = router_operand_info(operand, source, groups, group_method, group_aliases, string_values)
+      return unless router_info
+      router_name, chain_prefix = router_info
       # Reject known non-router operands so call shapes like
       # `gjson.Get(json, path)`, `header.Get("Content-Type")`, or
       # `params.Get("user")` don't surface as endpoints.
@@ -782,19 +857,14 @@ module Noir
 
       raw_path = nil
       handler_text = ""
-      index = 0
       Noir::TreeSitter.each_named_child(args) do |arg|
-        case Noir::TreeSitter.node_type(arg)
-        when "interpreted_string_literal", "raw_string_literal"
-          if raw_path.nil?
-            raw_path = decode_string_literal(arg, source)
-          end
+        if raw_path.nil?
+          raw_path = string_expr_text(arg, source, string_values)
         else
           # First non-string positional arg after the path is treated as
           # the handler — matches Gin/Echo/Fiber calling conventions.
           handler_text = Noir::TreeSitter.node_text(arg, source) if handler_text.empty? && !raw_path.nil?
         end
-        index += 1
       end
 
       return unless raw_path
@@ -809,11 +879,9 @@ module Noir
       return if raw_path.includes?("://")
       return if handler_text.empty?
 
-      resolved = if prefix = groups[router_name]?
-                   join_paths(prefix, raw_path)
-                 else
-                   raw_path
-                 end
+      base_prefix = groups[router_name]? || ""
+      base_prefix = join_paths(base_prefix, chain_prefix) unless chain_prefix.empty?
+      resolved = base_prefix.empty? ? raw_path : join_paths(base_prefix, raw_path)
 
       # Fiber's `app.All(...)` is the same "match any method" intent
       # as Gin's `r.Any(...)` and Echo's `e.Any(...)`. Normalize so
@@ -830,6 +898,54 @@ module Noir
         handler_text,
         Noir::TreeSitter.node_start_row(call),
       )
+    end
+
+    private def router_operand_info(operand : LibTreeSitter::TSNode,
+                                    source : String,
+                                    groups : Hash(String, String),
+                                    group_method : String,
+                                    group_aliases : Array(String),
+                                    string_values : Hash(String, String)) : Tuple(String, String)?
+      case Noir::TreeSitter.node_type(operand)
+      when "identifier"
+        {Noir::TreeSitter.node_text(operand, source), ""}
+      when "call_expression"
+        group_chain_operand_info(operand, source, groups, group_method, group_aliases, string_values)
+      end
+    end
+
+    private def group_chain_operand_info(call : LibTreeSitter::TSNode,
+                                         source : String,
+                                         groups : Hash(String, String),
+                                         group_method : String,
+                                         group_aliases : Array(String),
+                                         string_values : Hash(String, String)) : Tuple(String, String)?
+      function = Noir::TreeSitter.field(call, "function")
+      return unless function
+      return unless Noir::TreeSitter.node_type(function) == "selector_expression"
+      field = Noir::TreeSitter.field(function, "field")
+      parent = Noir::TreeSitter.field(function, "operand")
+      return unless field && parent
+
+      method_name = Noir::TreeSitter.node_text(field, source)
+      return unless method_name == group_method || group_aliases.includes?(method_name)
+
+      prefix = ""
+      if method_name == group_method
+        args = Noir::TreeSitter.field(call, "arguments")
+        return unless args
+        Noir::TreeSitter.each_named_child(args) do |arg|
+          prefix = string_expr_text(arg, source, string_values) || ""
+          break unless prefix.empty?
+        end
+        return if prefix.empty?
+      end
+
+      parent_info = router_operand_info(parent, source, groups, group_method, group_aliases, string_values)
+      return unless parent_info
+      router_name, parent_prefix = parent_info
+      chain_prefix = prefix.empty? ? parent_prefix : join_paths(parent_prefix, prefix)
+      {router_name, chain_prefix}
     end
 
     # Decode `<router>.<handle_method>("METHOD", "/path", handler)` —
@@ -1008,6 +1124,33 @@ module Noir
       count = LibTreeSitter.ts_node_named_child_count(node)
       return if count == 0
       LibTreeSitter.ts_node_named_child(node, 0_u32)
+    end
+
+    private def identifier_or_first_child(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      return node if Noir::TreeSitter.node_type(node) == "identifier"
+      first_named_child(node)
+    end
+
+    private def string_expr_text(node : LibTreeSitter::TSNode,
+                                 source : String,
+                                 values : Hash(String, String)) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "interpreted_string_literal", "raw_string_literal"
+        decode_string_literal(node, source)
+      when "identifier"
+        values[Noir::TreeSitter.node_text(node, source)]?
+      when "binary_expression"
+        left = Noir::TreeSitter.field(node, "left")
+        right = Noir::TreeSitter.field(node, "right")
+        return unless left && right
+        left_text = string_expr_text(left, source, values)
+        right_text = string_expr_text(right, source, values)
+        return unless left_text && right_text
+        "#{left_text}#{right_text}"
+      when "parenthesized_expression"
+        child = first_named_child(node)
+        child ? string_expr_text(child, source, values) : nil
+      end
     end
 
     # Decode a Go string literal node's text content. Interpreted


### PR DESCRIPTION
## Summary
- Resolve Go route paths from string constants, concatenations, var assignments, and inline group chains
- Apply Axum nest prefixes to inline nested routers
- Filter Actix routes declared inside #[cfg(test)] regions

## Tests
- crystal spec spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
- crystal spec spec/functional_test/testers/rust/axum_spec.cr spec/functional_test/testers/rust/actix_web_spec.cr
- just test
- just build
- just check