### PR TITLE
Improve Ruby and FastAPI route accuracy

### DIFF
--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/main.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
-from app.api.routes import login, items
+from app.api.routes import login, items, dynamic
 
 api_router = APIRouter()
 api_router.include_router(login.router)
 api_router.include_router(items.router)
+api_router.include_router(dynamic.router)

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/dynamic.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/dynamic.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+DYNAMIC_PREFIX = "/dynamic"
+
+router = APIRouter(prefix=f"{DYNAMIC_PREFIX}/v1")
+
+
+@router.get("/probe")
+def read_probe():
+    return {"ok": True}

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/items.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/items.py
@@ -5,7 +5,12 @@
 # `/api/v1/...`.
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/items", tags=["items"])
+ITEMS_PREFIX = "/items"
+
+router = APIRouter(
+    prefix=ITEMS_PREFIX,
+    tags=["items"],
+)
 
 
 @router.get("/")

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/main.py
@@ -7,5 +7,7 @@ from fastapi import FastAPI
 from app.api.main import api_router
 from app.core.config import settings
 
+API_PREFIX = settings.API_V1_STR
+
 app = FastAPI()
-app.include_router(api_router, prefix=settings.API_V1_STR)
+app.include_router(api_router, prefix=API_PREFIX)

--- a/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/likes_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/likes_controller.rb
@@ -1,0 +1,7 @@
+class LikesController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -35,7 +35,9 @@ Rails.application.routes.draw do
   resources :scans, controller: "billing/scans", only: [:index]
 
   concern :commentable do
-    resources :comments, only: [:index, :show]
+    resources :comments, only: [:index, :show] do
+      resources :likes, only: [:index, :show]
+    end
   end
 
   resources :posts, concerns: :commentable

--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -34,9 +34,11 @@ Rails.application.routes.draw do
 
   resources :scans, controller: "billing/scans", only: [:index]
 
-  resources :posts do
-    resources :comments
+  concern :commentable do
+    resources :comments, only: [:index, :show]
   end
+
+  resources :posts, concerns: :commentable
 
   get "up" => "rails/health#show"
   get "ping", to: "monitor#ping"

--- a/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
@@ -12,6 +12,9 @@ expected_endpoints = [
   # via `settings.API_V1_STR` on top, yielding `/api/v1/items/`.
   Endpoint.new("/api/v1/items/", "GET"),
   Endpoint.new("/api/v1/items/{id}", "GET", [Param.new("id", "", "path")]),
+  # Interpolated f-string prefixes are not resolved yet; the analyzer
+  # should fall back instead of emitting `/{DYNAMIC_PREFIX}/v1/probe`.
+  Endpoint.new("/api/v1/probe", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/fastapi_settings_prefix/", {

--- a/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
@@ -1,12 +1,9 @@
 require "../../func_spec.cr"
 
-# Regression: full-stack-fastapi-template style `prefix=settings.API_V1_STR`.
-# The expression is an attribute reference on an imported BaseSettings
-# instance — not a string literal. Before fix #1568 the analyzer used the
-# raw expression text as the prefix and emitted garbage URLs like
-# `/settings.API_V1_STR/login/access-token`. The resolver now follows the
-# import edge into `app/core/config.py`, finds `API_V1_STR: str = "/api/v1"`,
-# and prefixes routes with the literal value.
+# Regression: full-stack-fastapi-template style `prefix=API_PREFIX` where
+# the local alias points at `settings.API_V1_STR`. The resolver follows the
+# local assignment, then the imported BaseSettings instance, and prefixes
+# routes with the literal value instead of emitting garbage expression URLs.
 expected_endpoints = [
   Endpoint.new("/api/v1/login/access-token", "POST"),
   Endpoint.new("/api/v1/login/test-token", "POST"),

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -67,8 +67,8 @@ expected_endpoints = [
 
   # Rails concerns: `concern :commentable do resources :comments end`
   # should not emit top-level `/comments` routes, and applying the concern
-  # with `resources :posts, concerns: :commentable` should emit the nested
-  # comment routes.
+  # with `resources :posts, concerns: :commentable` should emit nested
+  # comments and preserve nested resources inside the concern.
   Endpoint.new("/posts", "GET"),
   Endpoint.new("/posts/1", "GET"),
   Endpoint.new("/posts", "POST"),
@@ -76,6 +76,8 @@ expected_endpoints = [
   Endpoint.new("/posts/1", "DELETE"),
   Endpoint.new("/posts/1/comments", "GET"),
   Endpoint.new("/posts/1/comments/1", "GET"),
+  Endpoint.new("/posts/1/comments/1/likes", "GET"),
+  Endpoint.new("/posts/1/comments/1/likes/1", "GET"),
 
   # hash-rocket and to: forms. #1359: `=> "ctrl#action"` / `to: "ctrl#action"`
   # resolves the controller and attaches the action's params.
@@ -110,7 +112,7 @@ total_endpoints = 1 +  # root
                   4 +  # internal/statements except:[destroy]
                   1 +  # /scans only:[index] via controller override
                   5 +  # posts
-                  2 +  # posts/1/comments
+                  4 +  # posts/1/comments + nested likes from concern
                   2 +  # /up + /ping
                   20 + # devise_for :users
                   1    # mount sidekiq

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -65,7 +65,10 @@ expected_endpoints = [
   # resources :scans, controller: "billing/scans", only: [:index]
   Endpoint.new("/scans", "GET"),
 
-  # nested resources :posts do resources :comments end
+  # Rails concerns: `concern :commentable do resources :comments end`
+  # should not emit top-level `/comments` routes, and applying the concern
+  # with `resources :posts, concerns: :commentable` should emit the nested
+  # comment routes.
   Endpoint.new("/posts", "GET"),
   Endpoint.new("/posts/1", "GET"),
   Endpoint.new("/posts", "POST"),

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -21,8 +21,11 @@ module Analyzer::Python
             next if PythonEngine.python_test_path?(path)
             source = read_file_content(path)
 
-            source.each_line do |line|
-              line = line.gsub(" ", "")
+            import_modules = find_imported_modules(current_base_path, path, source)
+            codelines = source.split("\n")
+            codelines.each_with_index do |original_line, index|
+              effective_line = coalesce_constructor_call(codelines, index, original_line, "APIRouter")
+              line = effective_line.gsub(" ", "")
               match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:fastapi\.)?FastAPI\(/
               if !match.nil?
                 fastapi_instance_name = match[1]
@@ -49,10 +52,10 @@ module Analyzer::Python
               if !match.nil?
                 prefix = ""
                 router_instance_name = match[1]
-                param_codes = line.split("APIRouter", 2)[1]
-                prefix_match = param_codes.match /prefix\s*=\s*['"]([^'"]*)['"]/
-                if !prefix_match.nil? && prefix_match.size == 2
-                  prefix = prefix_match[1]
+                if param_codes = effective_line.split("APIRouter", 2)[1]?
+                  if raw_prefix = extract_python_keyword_expression(param_codes, "prefix")
+                    prefix = resolve_string_expression(raw_prefix, source, import_modules) || ""
+                  end
                 end
 
                 if include_router_map.has_key?(path)
@@ -331,7 +334,7 @@ module Analyzer::Python
                 # via `from … import …`, look up its definition.
                 if lit = raw_value.match(/^['"]([^'"]*)['"]/)
                   prefix = lit[1]
-                elsif resolved = resolve_constant_value(raw_value, import_modules)
+                elsif resolved = resolve_string_expression(raw_value, source, import_modules)
                   prefix = resolved
                 end
               end
@@ -406,6 +409,85 @@ module Analyzer::Python
       end
 
       nil
+    end
+
+    private def resolve_string_expression(expression : ::String,
+                                          source : ::String,
+                                          import_modules : Hash(::String, Tuple(::String, Int32)),
+                                          depth : Int32 = 0) : ::String?
+      return if depth > 3
+
+      expr = expression.strip
+      if lit = expr.match(/^[rf]?['"]([^'"]*)['"]/)
+        return lit[1]
+      end
+
+      if local = resolve_constant_in_source(expr, source, import_modules, depth)
+        return local
+      end
+
+      resolve_constant_value(expr, import_modules)
+    end
+
+    private def resolve_constant_in_source(expression : ::String,
+                                           source : ::String,
+                                           import_modules : Hash(::String, Tuple(::String, Int32)),
+                                           depth : Int32) : ::String?
+      return unless expression.matches?(/^[A-Za-z_][A-Za-z0-9_]*$/)
+      pattern = /^\s*#{Regex.escape(expression)}\s*(?::[^=]+)?=\s*([^#]+)/
+      source.each_line do |line|
+        next unless match = line.match(pattern)
+        raw_value = match[1].strip
+        next if raw_value.empty?
+        return resolve_string_expression(raw_value, source, import_modules, depth + 1)
+      end
+      nil
+    end
+
+    private def extract_python_keyword_expression(call_tail : ::String, keyword : ::String) : ::String?
+      match = call_tail.match(/\b#{Regex.escape(keyword)}\s*=/)
+      return unless match
+
+      index = match.end
+      expression = String.build do |io|
+        depth = 0
+        in_quote = nil
+        escaped = false
+        while index < call_tail.size
+          ch = call_tail[index]
+          if in_quote
+            io << ch
+            if escaped
+              escaped = false
+            elsif ch == '\\'
+              escaped = true
+            elsif ch == in_quote
+              in_quote = nil
+            end
+          else
+            case ch
+            when '\'', '"'
+              in_quote = ch
+              io << ch
+            when '(', '[', '{'
+              depth += 1
+              io << ch
+            when ')', ']', '}'
+              break if depth <= 0 && ch == ')'
+              depth -= 1 if depth > 0
+              io << ch
+            when ','
+              break if depth == 0
+              io << ch
+            else
+              io << ch
+            end
+          end
+          index += 1
+        end
+      end.strip
+
+      expression.empty? ? nil : expression
     end
 
     # Infers the type of the parameter based on its default value or type annotation
@@ -495,6 +577,26 @@ module Analyzer::Python
                                            line : ::String,
                                            instance_name : ::String) : ::String
       return line unless line.matches?(/\b#{instance_name}\.(add_api_route|add_api_websocket_route)\s*\(/)
+      return line if python_call_balanced?(line)
+
+      pieces = [line]
+      depth = python_paren_delta(line)
+      i = index + 1
+      while i < codelines.size && depth > 0
+        nxt = codelines[i]
+        pieces << nxt
+        depth += python_paren_delta(nxt)
+        break if depth <= 0
+        i += 1
+      end
+      pieces.join(' ')
+    end
+
+    private def coalesce_constructor_call(codelines : Array(::String),
+                                          index : Int32,
+                                          line : ::String,
+                                          constructor_name : ::String) : ::String
+      return line unless line.matches?(/\b#{Regex.escape(constructor_name)}\s*\(/)
       return line if python_call_balanced?(line)
 
       pieces = [line]

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -418,8 +418,11 @@ module Analyzer::Python
       return if depth > 3
 
       expr = expression.strip
-      if lit = expr.match(/^[rf]?['"]([^'"]*)['"]/)
-        return lit[1]
+      if lit = expr.match(/^([rRuUbBfF]*)['"]([^'"]*)['"]/)
+        prefixes = lit[1].downcase
+        value = lit[2]
+        return if prefixes.includes?("f") && value.includes?("{")
+        return value
       end
 
       if local = resolve_constant_in_source(expr, source, import_modules, depth)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -49,6 +49,11 @@ module Analyzer::Ruby
       callees_by_action : Hash(String, Array(Noir::RubyCalleeExtractor::Entry)),
       action_lines : Hash(String, Int32)
 
+    record ConcernResource,
+      kind_kw : String,
+      name : String,
+      options : Hash(String, String)
+
     @controller_data_cache = Hash(String, ControllerData).new
 
     def analyze
@@ -90,6 +95,7 @@ module Analyzer::Ruby
       # walk the file and expand interpolations before route
       # matching.
       local_string_vars = Hash(String, String).new
+      concern_resources = Hash(String, Array(ConcernResource)).new
 
       File.open(routes_path, "r", encoding: "utf-8", invalid: :skip) do |file|
         file.each_line do |raw_line|
@@ -126,6 +132,14 @@ module Analyzer::Ruby
           # Outermost: Rails.application.routes.draw do ... end
           if line.starts_with?("Rails.application.routes.draw")
             stack << Frame.new(:neutral) if opens_block
+            next
+          end
+
+          # concern :commentable do
+          if m = line.match(/^concern\s+:(\w+)/)
+            name = m[1]
+            concern_resources[name] ||= [] of ConcernResource
+            stack << Frame.new(:concern, resource_name: name) if opens_block
             next
           end
 
@@ -188,47 +202,39 @@ module Analyzer::Ruby
             next
           end
 
+          # concerns :commentable / concerns [:commentable, :taggable]
+          if m = line.match(/^concerns\s+(.*)/)
+            emit_concern_resources(parse_symbol_list(m[1]), concern_resources, framework_root, stack)
+            next
+          end
+
           # resources :foo / resource :foo
           if m = line.match(/^(resources?)\s+:(\w+)/)
             kind_kw = m[1]
             name = m[2]
-            singular = (kind_kw == "resource")
             options = parse_options(line)
 
-            controller_subdir = current_controller_subdir(stack)
-            ctrl_override = options["controller"]?
-            file_base = if ctrl_override
-                          ctrl_override.includes?('/') ? ctrl_override : (controller_subdir.empty? ? ctrl_override : "#{controller_subdir}/#{ctrl_override}")
-                        else
-                          controller_subdir.empty? ? name : "#{controller_subdir}/#{name}"
-                        end
-
-            only_list = parse_symbol_list(options["only"]?)
-            except_list = parse_symbol_list(options["except"]?)
-
-            url_segment = options["path"]? || name
-            path_prefix = current_path_prefix(stack)
-
-            candidates = [] of String
-            candidates << "#{framework_root}/app/controllers/#{file_base}_controller.rb"
-            unless ctrl_override
-              candidates << "#{framework_root}/app/controllers/#{file_base}s_controller.rb"
-              candidates << "#{framework_root}/app/controllers/#{file_base}es_controller.rb"
+            if concern_name = current_concern_definition(stack)
+              concern_resources[concern_name] ||= [] of ConcernResource
+              concern_resources[concern_name] << ConcernResource.new(kind_kw, name, options)
+              stack << Frame.new(:neutral) if opens_block
+              next
             end
 
-            existing_controller_path = candidates.find { |c| File.exists?(c) }
+            existing_controller_path = emit_resource_routes(framework_root, stack, kind_kw, name, options)
 
-            candidates.each do |ctrl_path|
-              @result += controller_to_endpoint(
-                ctrl_path, @url, url_segment,
-                path_prefix: path_prefix,
-                only: only_list,
-                except: except_list,
-                singular: singular,
-              )
+            concern_names = parse_symbol_list(options["concerns"]?)
+            unless concern_names.empty?
+              url_segment = options["path"]? || name
+              virtual_stack = stack.dup
+              virtual_stack << Frame.new(:resources, path: (kind_kw == "resource" ? url_segment : "#{url_segment}/1"),
+                resource_name: name, controller_path: existing_controller_path)
+              emit_concern_resources(concern_names, concern_resources, framework_root, virtual_stack)
             end
 
             if opens_block
+              url_segment = options["path"]? || name
+              singular = (kind_kw == "resource")
               child_path = singular ? url_segment : "#{url_segment}/1"
               stack << Frame.new(:resources, path: child_path, resource_name: name,
                 controller_path: existing_controller_path)
@@ -337,6 +343,65 @@ module Analyzer::Ruby
       end
     end
 
+    private def current_concern_definition(stack : Array(Frame)) : String?
+      if frame = stack.reverse.find { |f| f.kind == :concern }
+        return frame.resource_name
+      end
+      nil
+    end
+
+    private def emit_concern_resources(names : Array(String),
+                                       concern_resources : Hash(String, Array(ConcernResource)),
+                                       framework_root : String,
+                                       stack : Array(Frame))
+      names.each do |name|
+        next unless resources = concern_resources[name]?
+        resources.each do |resource|
+          emit_resource_routes(framework_root, stack, resource.kind_kw, resource.name, resource.options)
+        end
+      end
+    end
+
+    private def emit_resource_routes(framework_root : String,
+                                     stack : Array(Frame),
+                                     kind_kw : String,
+                                     name : String,
+                                     options : Hash(String, String)) : String?
+      singular = (kind_kw == "resource")
+      controller_subdir = current_controller_subdir(stack)
+      ctrl_override = options["controller"]?
+      file_base = if ctrl_override
+                    ctrl_override.includes?('/') ? ctrl_override : (controller_subdir.empty? ? ctrl_override : "#{controller_subdir}/#{ctrl_override}")
+                  else
+                    controller_subdir.empty? ? name : "#{controller_subdir}/#{name}"
+                  end
+
+      only_list = parse_symbol_list(options["only"]?)
+      except_list = parse_symbol_list(options["except"]?)
+      url_segment = options["path"]? || name
+      path_prefix = current_path_prefix(stack)
+
+      candidates = [] of String
+      candidates << "#{framework_root}/app/controllers/#{file_base}_controller.rb"
+      unless ctrl_override
+        candidates << "#{framework_root}/app/controllers/#{file_base}s_controller.rb"
+        candidates << "#{framework_root}/app/controllers/#{file_base}es_controller.rb"
+      end
+
+      existing_controller_path = candidates.find { |c| File.exists?(c) }
+      candidates.each do |ctrl_path|
+        @result += controller_to_endpoint(
+          ctrl_path, @url, url_segment,
+          path_prefix: path_prefix,
+          only: only_list,
+          except: except_list,
+          singular: singular,
+        )
+      end
+
+      existing_controller_path
+    end
+
     # Pull the verb list out of a `match ... :via => :get` or
     # `match ... via: [:get, :post]` declaration. Returns the
     # single-element `["ANY"]` when `via:` is missing or empty —
@@ -400,7 +465,7 @@ module Analyzer::Ruby
 
     private def parse_symbol_list(raw : String?) : Array(String)
       return [] of String if raw.nil?
-      raw.split(',').map(&.strip.lchop(':').strip).reject(&.empty?)
+      raw.gsub(/[\[\]]/, "").split(',').map(&.strip.lchop(':').strip).reject(&.empty?)
     end
 
     private def current_path_prefix(stack : Array(Frame)) : String

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -52,7 +52,8 @@ module Analyzer::Ruby
     record ConcernResource,
       kind_kw : String,
       name : String,
-      options : Hash(String, String)
+      options : Hash(String, String),
+      stack : Array(Frame)
 
     @controller_data_cache = Hash(String, ControllerData).new
 
@@ -216,8 +217,13 @@ module Analyzer::Ruby
 
             if concern_name = current_concern_definition(stack)
               concern_resources[concern_name] ||= [] of ConcernResource
-              concern_resources[concern_name] << ConcernResource.new(kind_kw, name, options)
-              stack << Frame.new(:neutral) if opens_block
+              concern_resources[concern_name] << ConcernResource.new(kind_kw, name, options, current_concern_relative_stack(stack))
+              if opens_block
+                url_segment = options["path"]? || name
+                singular = (kind_kw == "resource")
+                child_path = singular ? url_segment : "#{url_segment}/1"
+                stack << Frame.new(:resources, path: child_path, resource_name: name)
+              end
               next
             end
 
@@ -350,6 +356,18 @@ module Analyzer::Ruby
       nil
     end
 
+    private def current_concern_relative_stack(stack : Array(Frame)) : Array(Frame)
+      index = stack.size - 1
+      while index >= 0
+        if stack[index].kind == :concern
+          return [] of Frame if index == stack.size - 1
+          return stack[(index + 1)..].dup
+        end
+        index -= 1
+      end
+      [] of Frame
+    end
+
     private def emit_concern_resources(names : Array(String),
                                        concern_resources : Hash(String, Array(ConcernResource)),
                                        framework_root : String,
@@ -357,7 +375,7 @@ module Analyzer::Ruby
       names.each do |name|
         next unless resources = concern_resources[name]?
         resources.each do |resource|
-          emit_resource_routes(framework_root, stack, resource.kind_kw, resource.name, resource.options)
+          emit_resource_routes(framework_root, stack + resource.stack, resource.kind_kw, resource.name, resource.options)
         end
       end
     end


### PR DESCRIPTION
## Summary
- resolve FastAPI router prefixes from multiline APIRouter constructors, local constants, and local aliases that point to imported settings values
- support Rails concern/concerns route DSL so concern definitions do not emit top-level false positives and applied concerns emit nested routes
- add functional regression fixtures for full-stack FastAPI-style prefixes and Rails concern routing

## Tests
- crystal spec spec/functional_test/testers/python spec/functional_test/testers/ruby
- just test
- just build
- just check