### PR TITLE
Improve PHP route analysis coverage

### DIFF
--- a/spec/functional_test/fixtures/php/laravel/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel/routes/web.php
@@ -45,3 +45,17 @@ Route::match(['get', 'post'], '/contact', function () {
 Route::any('/webhook', function () {
     return response()->json(['status' => 'ok']);
 });
+
+Route::middleware('auth:sanctum')->get('/me', [UserController::class, 'me']);
+
+Route::middleware(['auth'])->prefix('api/v1')->group(function () {
+    Route::get('/profile', [UserController::class, 'profile']);
+    Route::post('/profile', [UserController::class, 'updateProfile']);
+    Route::apiResource('tokens', ProductController::class);
+
+    Route::prefix('reports')->group(function () {
+        Route::get('/daily', [ProductController::class, 'dailyReport']);
+    });
+});
+
+Route::prefix('tenant/{tenant}')->middleware('auth')->get('/dashboard', [UserController::class, 'tenantDashboard']);

--- a/spec/functional_test/fixtures/php/php/modern.php
+++ b/spec/functional_test/fixtures/php/php/modern.php
@@ -1,0 +1,7 @@
+<?
+    $id = $_GET["id"];
+    $session = $_COOKIE["session_id"];
+    $authorization = $_SERVER["HTTP_AUTHORIZATION"];
+    $name = filter_input(INPUT_POST, "name");
+    $avatar = $_FILES["avatar"];
+?>

--- a/spec/functional_test/fixtures/php/symfony/src/Controller/AdminController.php
+++ b/spec/functional_test/fixtures/php/symfony/src/Controller/AdminController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(path: '/api/admin')]
+class AdminController extends AbstractController
+{
+    #[Route(path: '/stats', methods: ['GET'])]
+    public function stats(): JsonResponse
+    {
+        return $this->json(['ok' => true]);
+    }
+
+    /**
+     * @Route(path="/reports/{id}", methods={"POST"})
+     */
+    public function report(string $id): JsonResponse
+    {
+        return $this->json(['id' => $id]);
+    }
+}

--- a/spec/functional_test/testers/php/laravel_spec.cr
+++ b/spec/functional_test/testers/php/laravel_spec.cr
@@ -18,9 +18,19 @@ expected_endpoints = [
   Endpoint.new("/webhook", "POST"),
   Endpoint.new("/products", "GET"),
   Endpoint.new("/products", "POST"),
+  Endpoint.new("/user", "GET"),
+  Endpoint.new("/admin/settings", "GET"),
+  Endpoint.new("/admin/settings", "POST"),
+  Endpoint.new("/me", "GET"),
+  Endpoint.new("/api/v1/profile", "GET"),
+  Endpoint.new("/api/v1/profile", "POST"),
+  Endpoint.new("/api/v1/tokens", "GET"),
+  Endpoint.new("/api/v1/tokens/{id}", "DELETE", [Param.new("id", "", "path")]),
+  Endpoint.new("/api/v1/reports/daily", "GET"),
+  Endpoint.new("/tenant/{tenant}/dashboard", "GET", [Param.new("tenant", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/php/laravel/", {
   :techs     => 2,  # Detection still sees both php_laravel and php_pure
-  :endpoints => 45, # Analysis suppresses redundant php_pure endpoints
+  :endpoints => 53, # Analysis suppresses redundant php_pure and unprefixed group endpoints
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/php_spec.cr
+++ b/spec/functional_test/testers/php/php_spec.cr
@@ -15,6 +15,7 @@ expected_endpoints = [
     Param.new("name", "", "form"),
     Param.new("avatar", "", "file"),
     Param.new("AUTHORIZATION", "", "header"),
+    Param.new("session_id", "", "cookie"),
   ]),
   Endpoint.new("/post.php", "GET"),
   Endpoint.new("/post.php", "POST", [

--- a/spec/functional_test/testers/php/php_spec.cr
+++ b/spec/functional_test/testers/php/php_spec.cr
@@ -6,6 +6,16 @@ expected_endpoints = [
     Param.new("X-API-KEY", "", "header"),
     Param.new("param1", "", "query"),
   ]),
+  Endpoint.new("/modern.php", "GET", [
+    Param.new("id", "", "query"),
+    Param.new("session_id", "", "cookie"),
+    Param.new("AUTHORIZATION", "", "header"),
+  ]),
+  Endpoint.new("/modern.php", "POST", [
+    Param.new("name", "", "form"),
+    Param.new("avatar", "", "file"),
+    Param.new("AUTHORIZATION", "", "header"),
+  ]),
   Endpoint.new("/post.php", "GET"),
   Endpoint.new("/post.php", "POST", [
     Param.new("param1", "", "form"),

--- a/spec/functional_test/testers/php/symfony_callees_spec.cr
+++ b/spec/functional_test/testers/php/symfony_callees_spec.cr
@@ -61,17 +61,29 @@ products_update = Endpoint.new("/api/products/{slug}", "PATCH", [
   ep.push_callee(Callee.new("$this->json", line: 41))
 end
 
+admin_stats = Endpoint.new("/api/admin/stats", "GET").tap do |ep|
+  ep.push_callee(Callee.new("$this->json", line: 15))
+end
+
+admin_report = Endpoint.new("/api/admin/reports/{id}", "POST", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("$this->json", line: 23))
+end
+
 expected_endpoints = [
   users_index,
   users_create,
   users_update,
   products_create,
   products_update,
+  admin_stats,
+  admin_report,
 ]
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,
-  :endpoints => 18,
+  :endpoints => 20,
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/php/symfony_spec.cr
+++ b/spec/functional_test/testers/php/symfony_spec.cr
@@ -42,6 +42,11 @@ expected_endpoints = [
     Param.new("X-CSRF-Token", "", "header"),
     Param.new("preferences", "", "cookie"),
   ]),
+  # From AdminController class-level prefix and named path attributes
+  Endpoint.new("/api/admin/stats", "GET"),
+  Endpoint.new("/api/admin/reports/{id}", "POST", [
+    Param.new("id", "", "path"),
+  ]),
   # From routes.yaml
   Endpoint.new("/api/health", "GET"),
   Endpoint.new("/api/docs", "GET"),
@@ -64,5 +69,5 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,  # Detection still sees php_symfony and php_pure
-  :endpoints => 18, # Analysis suppresses redundant php_pure file endpoints
+  :endpoints => 20, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -2,6 +2,13 @@ require "../../engines/php_engine"
 
 module Analyzer::Php
   class Laravel < PhpEngine
+    private struct RouteGroup
+      getter prefix, body, body_start, body_end
+
+      def initialize(@prefix : String, @body : String, @body_start : Int32, @body_end : Int32)
+      end
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
@@ -82,68 +89,107 @@ module Analyzer::Php
                                        include_callee : Bool,
                                        base_line : Int32 = 1) : Array(Endpoint)
       endpoints = [] of Endpoint
+      route_groups = extract_route_groups(content)
 
       # 1. Simple routes: Route::get, Route::post, etc.
       verb_regex = /Route::(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
       pos = 0
       while route_match = content.match(verb_regex, pos)
-        methods = [route_match[1].upcase]
-        route_path = route_match[2]
-        full_path = build_full_path(prefix, route_path)
-        route_line = base_line + newline_count_before(content, route_match.begin(0))
-        handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
-        params = extract_brace_path_params(full_path)
+        if inside_laravel_group_body?(route_match.begin(0), route_groups)
+          pos = route_match.end(0)
+        else
+          methods = [route_match[1].upcase]
+          route_path = route_match[2]
+          full_path = build_full_path(prefix, route_path)
+          route_line = base_line + newline_count_before(content, route_match.begin(0))
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          params = extract_brace_path_params(full_path)
 
-        methods.each do |http_method|
-          details = Details.new(PathInfo.new(file_path, route_line))
-          endpoint = Endpoint.new(full_path, http_method, params, details.dup)
-          attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
-          endpoints << endpoint
+          methods.each do |http_method|
+            details = Details.new(PathInfo.new(file_path, route_line))
+            endpoint = Endpoint.new(full_path, http_method, params, details.dup)
+            attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
+            endpoints << endpoint
+          end
+          pos = next_pos
         end
-        pos = next_pos
+      end
+
+      chained_verb_regex = /Route::((?:\w+\s*\([^;]*?\)\s*->\s*)+)(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
+      pos = 0
+      while route_match = content.match(chained_verb_regex, pos)
+        if inside_laravel_group_body?(route_match.begin(0), route_groups)
+          pos = route_match.end(0)
+        else
+          route_prefix = extract_group_prefix("Route::#{route_match[1]}")
+          methods = [route_match[2].upcase]
+          route_path = route_match[3]
+          full_path = build_full_path(build_full_path(prefix, route_prefix), route_path)
+          route_line = base_line + newline_count_before(content, route_match.begin(0))
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          params = extract_brace_path_params(full_path)
+
+          methods.each do |http_method|
+            details = Details.new(PathInfo.new(file_path, route_line))
+            endpoint = Endpoint.new(full_path, http_method, params, details.dup)
+            attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
+            endpoints << endpoint
+          end
+          pos = next_pos
+        end
       end
 
       match_regex = /Route::match\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"]\s*,/mi
       pos = 0
       while route_match = content.match(match_regex, pos)
-        methods = extract_methods_from_array(route_match[1])
-        route_path = route_match[2]
-        full_path = build_full_path(prefix, route_path)
-        route_line = base_line + newline_count_before(content, route_match.begin(0))
-        handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
-        params = extract_brace_path_params(full_path)
+        if inside_laravel_group_body?(route_match.begin(0), route_groups)
+          pos = route_match.end(0)
+        else
+          methods = extract_methods_from_array(route_match[1])
+          route_path = route_match[2]
+          full_path = build_full_path(prefix, route_path)
+          route_line = base_line + newline_count_before(content, route_match.begin(0))
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          params = extract_brace_path_params(full_path)
 
-        methods.each do |http_method|
-          details = Details.new(PathInfo.new(file_path, route_line))
-          endpoint = Endpoint.new(full_path, http_method, params, details.dup)
-          attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
-          endpoints << endpoint
+          methods.each do |http_method|
+            details = Details.new(PathInfo.new(file_path, route_line))
+            endpoint = Endpoint.new(full_path, http_method, params, details.dup)
+            attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
+            endpoints << endpoint
+          end
+          pos = next_pos
         end
-        pos = next_pos
       end
 
       any_regex = /Route::any\s*\(\s*['"]([^'"]+)['"]\s*,/mi
       pos = 0
       while route_match = content.match(any_regex, pos)
-        methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
-        route_path = route_match[1]
-        full_path = build_full_path(prefix, route_path)
-        route_line = base_line + newline_count_before(content, route_match.begin(0))
-        handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
-        params = extract_brace_path_params(full_path)
+        if inside_laravel_group_body?(route_match.begin(0), route_groups)
+          pos = route_match.end(0)
+        else
+          methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+          route_path = route_match[1]
+          full_path = build_full_path(prefix, route_path)
+          route_line = base_line + newline_count_before(content, route_match.begin(0))
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          params = extract_brace_path_params(full_path)
 
-        methods.each do |http_method|
-          details = Details.new(PathInfo.new(file_path, route_line))
-          endpoint = Endpoint.new(full_path, http_method, params, details.dup)
-          attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
-          endpoints << endpoint
+          methods.each do |http_method|
+            details = Details.new(PathInfo.new(file_path, route_line))
+            endpoint = Endpoint.new(full_path, http_method, params, details.dup)
+            attach_route_callees(endpoint, handler_body, file_path, body_start_line) if include_callee
+            endpoints << endpoint
+          end
+          pos = next_pos
         end
-        pos = next_pos
       end
 
       # 2. Resource routes
       resource_matches = content.scan(/Route::resource\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi)
       resource_matches.each do |match|
+        next if inside_laravel_group_body?(match.begin(0), route_groups)
+
         resource_name = match[1]
         full_resource_path = build_full_path(prefix, resource_name)
         route_line = base_line + newline_count_before(content, match.begin(0))
@@ -152,44 +198,20 @@ module Analyzer::Php
 
       api_resource_matches = content.scan(/Route::apiResource\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi)
       api_resource_matches.each do |match|
+        next if inside_laravel_group_body?(match.begin(0), route_groups)
+
         resource_name = match[1]
         full_resource_path = build_full_path(prefix, resource_name)
         route_line = base_line + newline_count_before(content, match.begin(0))
         endpoints.concat(create_api_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line))
       end
 
-      # 3. Group routes (recursive)
-      # Route::prefix(...)->group(...)
-      fluent_group_matches = content.scan(/Route::prefix\s*\(\s*['"]([^'"]+)['"]\s*\)->group\s*\(\s*function\s*\([^)]*\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi)
-      fluent_group_matches.each do |match|
-        group_prefix = match[1]
-        group_content = match[2]
-        group_base_line = base_line + newline_count_before(content, match.begin(2))
-        new_prefix = build_full_path(prefix, group_prefix)
-        endpoints.concat(analyze_routes_content(group_content, new_prefix, file_path, include_callee, group_base_line))
-      end
-
-      # Route::group with array options
-      group_matches = content.scan(/Route::group\s*\(\s*\[(.*?)\]\s*,\s*function\s*\([^)]*\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi)
-      group_matches.each do |match|
-        options_str = match[1]
-        group_content = match[2]
-
-        new_prefix = prefix
-        if prefix_match = options_str.match(/['"]prefix['"]\s*=>\s*['"]([^'"]+)['"]/)
-          new_prefix = build_full_path(prefix, prefix_match[1])
-        end
-
-        group_base_line = base_line + newline_count_before(content, match.begin(2))
-        endpoints.concat(analyze_routes_content(group_content, new_prefix, file_path, include_callee, group_base_line))
-      end
-
-      # Simple group with no prefix: Route::group(function() { ... })
-      simple_group_matches = content.scan(/Route::group\s*\(\s*function\s*\([^)]*\)\s*\{((?:[^{}]|{[^{}]*})*)\}/mi)
-      simple_group_matches.each do |match|
-        group_content = match[1]
-        group_base_line = base_line + newline_count_before(content, match.begin(1))
-        endpoints.concat(analyze_routes_content(group_content, prefix, file_path, include_callee, group_base_line))
+      # 3. Group routes (recursive). Extract group bodies before scanning nested
+      # routes so prefixed groups do not also emit unprefixed endpoints.
+      route_groups.each do |group|
+        new_prefix = group.prefix.empty? ? prefix : build_full_path(prefix, group.prefix)
+        group_base_line = base_line + newline_count_before(content, group.body_start)
+        endpoints.concat(analyze_routes_content(group.body, new_prefix, file_path, include_callee, group_base_line))
       end
 
       endpoints
@@ -309,6 +331,61 @@ module Analyzer::Php
       return 0 if pos <= 0
 
       content[0...pos].count('\n')
+    end
+
+    private def extract_route_groups(content : String) : Array(RouteGroup)
+      groups = [] of RouteGroup
+      group_regex = /Route::(?:\w+\s*\([^;]*?\)\s*->\s*)*group\s*\(/mi
+      pos = 0
+
+      while group_match = content.match(group_regex, pos)
+        group_start = group_match.begin(0)
+        body_info = extract_group_closure_body_after(content, group_match.end(0))
+        if body_info
+          body, body_start, body_end = body_info
+          prelude = content[group_start...body_start]
+          groups << RouteGroup.new(extract_group_prefix(prelude), body, body_start, body_end)
+          pos = body_end + 1
+        else
+          pos = group_match.end(0)
+        end
+      end
+
+      groups
+    end
+
+    private def extract_group_closure_body_after(content : String, pos : Int32) : Tuple(String, Int32, Int32)?
+      return unless pos < content.size
+
+      context = content[pos..]
+      function_match = context.match(/function\s*\([^)]*\)\s*\{/mi)
+      return unless function_match
+
+      function_start = function_match.begin(0)
+      pre_function = context[0...function_start]
+      return if pre_function.includes?(";")
+
+      brace_pos = pos + function_match.end(0) - 1
+      body_end = find_matching_php_close_brace(content, brace_pos)
+      return unless body_end
+
+      {content[(brace_pos + 1)...body_end], brace_pos + 1, body_end}
+    end
+
+    private def extract_group_prefix(prelude : String) : String
+      if prefix_match = prelude.match(/(?:->|::)prefix\s*\(\s*['"]([^'"]+)['"]\s*\)/i)
+        return prefix_match[1]
+      end
+
+      if prefix_match = prelude.match(/['"]prefix['"]\s*=>\s*['"]([^'"]+)['"]/i)
+        return prefix_match[1]
+      end
+
+      ""
+    end
+
+    private def inside_laravel_group_body?(pos : Int32, groups : Array(RouteGroup)) : Bool
+      groups.any? { |group| pos >= group.body_start && pos < group.body_end }
     end
 
     private def create_resource_endpoints(resource : String, file_path : String, line : Int32? = nil) : Array(Endpoint)

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -17,28 +17,14 @@ module Analyzer::Php
 
         content.each_line do |line|
           if allow_patterns.any? { |pattern| line.includes? pattern }
-            match = line.strip.match(/\$_(.*?)\['(.*?)'\]/)
+            superglobal_matches = line.scan(/\$_(GET|POST|REQUEST|SERVER|COOKIE|FILES)\s*\[\s*['"]([^'"]+)['"]\s*\]/)
+            superglobal_matches.each do |match|
+              apply_param_reference(match[1], match[2], params_query, params_body, methods)
+            end
 
-            if match
-              method = match[1]
-              param_name = match[2]
-
-              if method == "GET"
-                params_query << Param.new(param_name, "", "query")
-              elsif method == "POST"
-                params_body << Param.new(param_name, "", "form")
-                methods << "POST"
-              elsif method == "REQUEST"
-                params_query << Param.new(param_name, "", "query")
-                params_body << Param.new(param_name, "", "form")
-                methods << "POST"
-              elsif method == "SERVER"
-                if param_name.includes? "HTTP_"
-                  param_name = param_name.sub("HTTP_", "").gsub("_", "-")
-                  params_query << Param.new(param_name, "", "header")
-                  params_body << Param.new(param_name, "", "header")
-                end
-              end
+            filter_input_matches = line.scan(/filter_input\s*\(\s*INPUT_(GET|POST|REQUEST|SERVER|COOKIE)\s*,\s*['"]([^'"]+)['"]/)
+            filter_input_matches.each do |match|
+              apply_param_reference(match[1], match[2], params_query, params_body, methods)
             end
           end
         rescue
@@ -54,6 +40,34 @@ module Analyzer::Php
       end
 
       endpoints
+    end
+
+    private def apply_param_reference(method : String,
+                                      param_name : String,
+                                      params_query : Array(Param),
+                                      params_body : Array(Param),
+                                      methods : Array(String))
+      if method == "GET"
+        params_query << Param.new(param_name, "", "query")
+      elsif method == "POST"
+        params_body << Param.new(param_name, "", "form")
+        methods << "POST"
+      elsif method == "REQUEST"
+        params_query << Param.new(param_name, "", "query")
+        params_body << Param.new(param_name, "", "form")
+        methods << "POST"
+      elsif method == "SERVER"
+        if param_name.includes? "HTTP_"
+          header_name = param_name.sub("HTTP_", "").gsub("_", "-")
+          params_query << Param.new(header_name, "", "header")
+          params_body << Param.new(header_name, "", "header")
+        end
+      elsif method == "COOKIE"
+        params_query << Param.new(param_name, "", "cookie")
+      elsif method == "FILES"
+        params_body << Param.new(param_name, "", "file")
+        methods << "POST"
+      end
     end
 
     private def attach_file_callees(endpoints : Array(Endpoint), content : String, path : String)
@@ -109,7 +123,7 @@ module Analyzer::Php
     end
 
     def allow_patterns
-      ["$_GET", "$_POST", "$_REQUEST", "$_SERVER"]
+      ["$_GET", "$_POST", "$_REQUEST", "$_SERVER", "$_COOKIE", "$_FILES", "filter_input"]
     end
   end
 end

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -64,6 +64,7 @@ module Analyzer::Php
         end
       elsif method == "COOKIE"
         params_query << Param.new(param_name, "", "cookie")
+        params_body << Param.new(param_name, "", "cookie")
       elsif method == "FILES"
         params_body << Param.new(param_name, "", "file")
         methods << "POST"

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -2,6 +2,13 @@ require "../../engines/php_engine"
 
 module Analyzer::Php
   class Symfony < PhpEngine
+    private struct ClassRoutePrefix
+      getter path, body_start, body_end
+
+      def initialize(@path : String, @body_start : Int32, @body_end : Int32)
+      end
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
@@ -26,33 +33,38 @@ module Analyzer::Php
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         content = file.gets_to_end
+        class_prefixes = extract_class_route_prefixes(content)
 
         # Look for route annotations (@Route) - more flexible pattern
         # Track offset to find each match correctly
         offset = 0
-        content.scan(/@Route\s*\(\s*["']([^"']+)["'][^)]*\)/m) do |match|
-          route_path = match[1]
+        content.scan(/@Route\s*\((.*?)\)/m) do |match|
+          route_path = extract_symfony_route_path(match[1])
+          next unless route_path
+
           full_match = match[0]
 
           # Find this specific match starting from current offset
           route_start = content.index(full_match, offset)
           if route_start
             offset = route_start + full_match.size
+            next if route_applies_to_class?(content, offset)
 
             # Extract methods from the annotation itself
-            methods = extract_methods_from_annotation_context(full_match)
+            methods = extract_methods_from_symfony_context(full_match)
             methods = ["GET"] if methods.empty?
 
             method_body = extract_php_method_body_after(content, route_start)
 
-            params = extract_brace_path_params(route_path)
+            full_path = build_full_path(class_prefix_for_position(class_prefixes, route_start), route_path)
+            params = extract_brace_path_params(full_path)
             # Extract additional parameters from method body
             params.concat(extract_method_params(method_body[0])) if method_body
 
             details = Details.new(PathInfo.new(path))
 
             methods.each do |method|
-              endpoint = Endpoint.new(route_path, method.upcase, params, details)
+              endpoint = Endpoint.new(full_path, method.upcase, params, details)
               attach_method_callees(endpoint, method_body, path) if include_callee
               endpoints << endpoint
             end
@@ -62,29 +74,33 @@ module Analyzer::Php
         # Look for route attributes (#[Route]) - PHP 8 style
         # Track offset to find each match correctly
         offset = 0
-        content.scan(/#\[Route\s*\(\s*['"]([^'"]+)['"][^)]*\)/m) do |match|
-          route_path = match[1]
+        content.scan(/#\[Route\s*\((.*?)\)\]/m) do |match|
+          route_path = extract_symfony_route_path(match[1])
+          next unless route_path
+
           full_match = match[0]
 
           # Find this specific match starting from current offset
           route_start = content.index(full_match, offset)
           if route_start
             offset = route_start + full_match.size
+            next if route_applies_to_class?(content, offset)
 
             # Extract methods from the attribute itself
-            methods = extract_methods_from_attribute_context(full_match)
+            methods = extract_methods_from_symfony_context(full_match)
             methods = ["GET"] if methods.empty?
 
             method_body = extract_php_method_body_after(content, route_start)
 
-            params = extract_brace_path_params(route_path)
+            full_path = build_full_path(class_prefix_for_position(class_prefixes, route_start), route_path)
+            params = extract_brace_path_params(full_path)
             # Extract additional parameters from method body
             params.concat(extract_method_params(method_body[0])) if method_body
 
             details = Details.new(PathInfo.new(path))
 
             methods.each do |method|
-              endpoint = Endpoint.new(route_path, method.upcase, params, details)
+              endpoint = Endpoint.new(full_path, method.upcase, params, details)
               attach_method_callees(endpoint, method_body, path) if include_callee
               endpoints << endpoint
             end
@@ -95,34 +111,92 @@ module Analyzer::Php
       endpoints
     end
 
-    private def extract_methods_from_annotation_context(context : String) : Array(String)
+    private def extract_class_route_prefixes(content : String) : Array(ClassRoutePrefix)
+      prefixes = [] of ClassRoutePrefix
+      class_regex = /\bclass\s+\w+[^{]*\{/m
+      offset = 0
+
+      while class_match = content.match(class_regex, offset)
+        class_start = class_match.begin(0)
+        brace_pos = class_match.end(0) - 1
+        class_end = find_matching_php_close_brace(content, brace_pos)
+        if class_end
+          prefix = route_prefix_before_class(content, class_start)
+          prefixes << ClassRoutePrefix.new(prefix, brace_pos + 1, class_end) if prefix
+          offset = class_end + 1
+        else
+          offset = class_match.end(0)
+        end
+      end
+
+      prefixes
+    end
+
+    private def route_prefix_before_class(content : String, class_start : Int32) : String?
+      lookbehind_start = Math.max(0, class_start - 600)
+      prelude = content[lookbehind_start...class_start]
+
+      if attribute_match = prelude.match(/#\[Route\s*\((.*?)\)\]\s*$/m)
+        return extract_symfony_route_path(attribute_match[1])
+      end
+
+      if annotation_match = prelude.match(/@Route\s*\((.*?)\).*?\*\/\s*$/m)
+        return extract_symfony_route_path(annotation_match[1])
+      end
+
+      nil
+    end
+
+    private def route_applies_to_class?(content : String, route_end : Int32) : Bool
+      next_target = content.match(/\b(class|function)\b/m, route_end)
+      return false unless next_target
+
+      next_target[1] == "class"
+    end
+
+    private def class_prefix_for_position(prefixes : Array(ClassRoutePrefix), pos : Int32) : String
+      prefix = prefixes.find { |class_prefix| pos >= class_prefix.body_start && pos < class_prefix.body_end }
+      prefix ? prefix.path : ""
+    end
+
+    private def extract_symfony_route_path(context : String) : String?
+      if path_match = context.match(/(?:^|[,(]\s*)path\s*[:=]\s*['"]([^'"]+)['"]/i)
+        return path_match[1]
+      end
+
+      if path_match = context.match(/^\s*['"]([^'"]+)['"]/)
+        return path_match[1]
+      end
+
+      nil
+    end
+
+    private def extract_methods_from_symfony_context(context : String) : Array(String)
       methods = [] of String
 
-      # Look for methods={"GET","POST"} or methods={"GET"}
-      if match = context.match(/methods\s*=\s*\{([^}]+)\}/)
+      if match = context.match(/methods\s*[:=]\s*\[([^\]]+)\]/)
         methods_str = match[1]
-        method_matches = methods_str.scan(/["']([^"']+)["']/)
-        method_matches.each do |method_match|
-          methods << method_match[1]
+        methods_str.scan(/['"]([^'"]+)['"]/).each do |method_match|
+          methods << method_match[1].upcase
         end
+      elsif match = context.match(/methods\s*=\s*\{([^}]+)\}/)
+        methods_str = match[1]
+        methods_str.scan(/["']([^"']+)["']/).each do |method_match|
+          methods << method_match[1].upcase
+        end
+      elsif match = context.match(/methods\s*[:=]\s*['"]([^'"]+)['"]/)
+        methods << match[1].upcase
       end
 
       methods
     end
 
+    private def extract_methods_from_annotation_context(context : String) : Array(String)
+      extract_methods_from_symfony_context(context)
+    end
+
     private def extract_methods_from_attribute_context(context : String) : Array(String)
-      methods = [] of String
-
-      # Look for methods: ['GET', 'POST'] or methods: ['GET']
-      if match = context.match(/methods\s*:\s*\[([^\]]+)\]/)
-        methods_str = match[1]
-        method_matches = methods_str.scan(/['"]([^'"]+)['"]/)
-        method_matches.each do |method_match|
-          methods << method_match[1]
-        end
-      end
-
-      methods
+      extract_methods_from_symfony_context(context)
     end
 
     private def analyze_yaml_routes(path : String) : Array(Endpoint)


### PR DESCRIPTION
## Summary
- improve Laravel route extraction for fluent middleware/prefix chains and nested groups while avoiding unprefixed duplicate group endpoints
- support Symfony class-level route prefixes and named path syntax for attributes/annotations
- expand pure PHP parameter extraction for double-quoted superglobals, cookies, files, and filter_input

## Tests
- crystal spec spec/functional_test/testers/php --error-trace
- just build
- just check
- just test