### PR TITLE
Improve C# and C++ route analysis coverage

### DIFF
--- a/spec/functional_test/fixtures/cpp/crow/app.cpp
+++ b/spec/functional_test/fixtures/cpp/crow/app.cpp
@@ -25,6 +25,11 @@ int main() {
         return crow::response(200);
     });
 
+    CROW_ROUTE(app, "/enum").methods(crow::HTTPMethod::Post)([](const crow::request& req) {
+        auto v = req.url_params.get("v");
+        return crow::response(200);
+    });
+
     app.port(18080).multithreaded().run();
     return 0;
 }

--- a/spec/functional_test/fixtures/cpp/drogon/main.cpp
+++ b/spec/functional_test/fixtures/cpp/drogon/main.cpp
@@ -2,6 +2,13 @@
 
 using namespace drogon;
 
+void namedSearchHandler(const HttpRequestPtr &req,
+                        std::function<void(const HttpResponsePtr &)> &&callback) {
+    auto q = req->getParameter("q");
+    auto resp = HttpResponse::newHttpResponse();
+    callback(resp);
+}
+
 int main() {
     app().registerHandler(
         "/ping",
@@ -35,6 +42,8 @@ int main() {
             callback(resp);
         },
         {Get, Delete});
+
+    app().registerHandler("/named", &namedSearchHandler, {Get});
 
     app().run();
     return 0;

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Controllers/UsersController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Demo.Controllers
@@ -25,6 +26,12 @@ namespace Demo.Controllers
             return Created("", name);
         }
 
+        [HttpGet("raw")]
+        public Task<IEnumerable<string>> Raw([FromQuery] string filter, [FromServices] IUserRepository repository)
+        {
+            return repository.List(filter);
+        }
+
         [HttpPut("{id}")]
         public IActionResult Update([FromRoute] int id, [FromBody] string name)
         {
@@ -36,5 +43,10 @@ namespace Demo.Controllers
         {
             return NoContent();
         }
+    }
+
+    public interface IUserRepository
+    {
+        Task<IEnumerable<string>> List(string filter);
     }
 }

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Controllers/UsersController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Controllers/UsersController.cs
@@ -32,6 +32,12 @@ namespace Demo.Controllers
             return repository.List(filter);
         }
 
+        [NonAction]
+        public Task<UserDto> LoadUser([FromQuery] string id)
+        {
+            return Task.FromResult(new UserDto());
+        }
+
         [HttpPut("{id}")]
         public IActionResult Update([FromRoute] int id, [FromBody] string name)
         {
@@ -48,5 +54,9 @@ namespace Demo.Controllers
     public interface IUserRepository
     {
         Task<IEnumerable<string>> List(string filter);
+    }
+
+    public class UserDto
+    {
     }
 }

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Program.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +16,26 @@ app.MapControllerRoute(
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
+
+var api = app.MapGroup("/api");
+var v1 = api.MapGroup("/v1");
+
+v1.MapGet("/grouped/{id}", async context =>
+{
+    var mode = context.Request.Query["mode"];
+    await context.Response.WriteAsync($"{mode}");
+});
+
+api.MapMethods("/bulk", new[] { "PATCH", "POST" }, context =>
+{
+    return Task.CompletedTask;
+});
+
+app.MapGroup("/chained").MapPost("/submit", async context =>
+{
+    var trace = context.Request.Headers["X-Trace"];
+    await context.Response.WriteAsync($"{trace}");
+});
 
 app.MapControllers();
 app.Run();

--- a/spec/functional_test/fixtures/csharp/aspnet_mvc/Controllers/ApiController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_mvc/Controllers/ApiController.cs
@@ -2,7 +2,7 @@ using System.Web.Mvc;
 
 namespace MyApp.Controllers
 {
-    [Route("api/[controller]")]
+    [RoutePrefix("api/[controller]")]
     public class ApiController : Controller
     {
         // GET: /api/Api/users/{id}

--- a/spec/functional_test/testers/cpp/crow_spec.cr
+++ b/spec/functional_test/testers/cpp/crow_spec.cr
@@ -14,9 +14,12 @@ expected_endpoints = [
   Endpoint.new("/search", "GET", [
     Param.new("q", "", "query"),
   ]),
+  Endpoint.new("/enum", "POST", [
+    Param.new("v", "", "query"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/cpp/crow/", {
   :techs     => 1,
-  :endpoints => 4,
+  :endpoints => 5,
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/cpp/drogon_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_spec.cr
@@ -18,6 +18,9 @@ expected_endpoints = [
     Param.new("Authorization", "", "header"),
     Param.new("session", "", "cookie"),
   ]),
+  Endpoint.new("/named", "GET", [
+    Param.new("q", "", "query"),
+  ]),
   # controllers/UsersController.cpp — PATH_LIST_BEGIN with PATH_ADD
   Endpoint.new("/api/users", "GET", [
     Param.new("search", "", "query"),

--- a/spec/functional_test/testers/cpp/drogon_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_spec.cr
@@ -34,7 +34,18 @@ expected_endpoints = [
   ]),
 ]
 
-FunctionalTester.new("fixtures/cpp/drogon/", {
+tester = FunctionalTester.new("fixtures/cpp/drogon/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+
+tester.perform_tests
+
+describe "Drogon analyzer edge cases" do
+  it "does not leak registerHandler params across sibling lambdas" do
+    ping = tester.app.endpoints.find { |e| e.url == "/ping" && e.method == "GET" }
+    ping.should_not be_nil
+    ping.as(Endpoint).params.any? { |p| p.name == "body" }.should be_false
+    ping.as(Endpoint).params.any? { |p| p.name == "Authorization" }.should be_false
+  end
+end

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
@@ -28,6 +28,9 @@ expected_endpoints = [
   Endpoint.new("/api/Users", "POST", [
     Param.new("name", "", "json"),
   ]),
+  Endpoint.new("/api/Users/raw", "GET", [
+    Param.new("filter", "", "query"),
+  ]),
   Endpoint.new("/api/Users/{id}", "PUT", [
     Param.new("id", "", "path"),
     Param.new("name", "", "json"),
@@ -78,6 +81,15 @@ expected_endpoints = [
     Param.new("id", "", "json"),
     Param.new("description", "", "json"),
   ]),
+  Endpoint.new("/api/v1/grouped/{id}", "GET", [
+    Param.new("id", "", "path"),
+    Param.new("mode", "", "query"),
+  ]),
+  Endpoint.new("/api/bulk", "PATCH"),
+  Endpoint.new("/api/bulk", "POST"),
+  Endpoint.new("/chained/submit", "POST", [
+    Param.new("X-Trace", "", "header"),
+  ]),
   Endpoint.new("/expression/null", "GET", [
     Param.new("intValue", "", "query"),
     Param.new("strValue", "", "query"),
@@ -114,5 +126,11 @@ describe "ASP.NET Core MVC analyzer edge cases" do
     ping = tester.app.endpoints.find { |e| e.url == "/mapped/ping" && e.method == "GET" }
     ping.should_not be_nil
     ping.as(Endpoint).params.empty?.should be_true
+  end
+
+  it "does not treat service-injected controller dependencies as request params" do
+    raw = tester.app.endpoints.find { |e| e.url == "/api/Users/raw" && e.method == "GET" }
+    raw.should_not be_nil
+    raw.as(Endpoint).params.any? { |p| p.name == "repository" }.should be_false
   end
 end

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
@@ -133,4 +133,8 @@ describe "ASP.NET Core MVC analyzer edge cases" do
     raw.should_not be_nil
     raw.as(Endpoint).params.any? { |p| p.name == "repository" }.should be_false
   end
+
+  it "does not report NonAction task-returning helpers as endpoints" do
+    tester.app.endpoints.any?(&.url.includes?("LoadUser")).should be_false
+  end
 end

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -9,8 +9,10 @@ module Analyzer::Cpp
     # CROW_BP_ROUTE(bp, "/path") — blueprint-scoped route registration.
     BP_ROUTE_REGEX = /CROW_BP_ROUTE\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]*)"\s*\)/
     # .methods("POST"_method, "GET"_method) clause.
-    METHODS_REGEX = /\.methods\s*\(([^)]*)\)/
-    METHOD_TOKEN  = /"([A-Za-z]+)"_method/
+    METHODS_REGEX     = /\.methods\s*\(([^)]*)\)/
+    METHOD_TOKEN      = /"([A-Za-z]+)"_method/
+    HTTP_METHOD_TOKEN = /(?:crow::)?HTTPMethod::([A-Za-z]+)/
+    CROW_METHOD_TOKEN = /CROW_HTTP_METHOD_([A-Za-z]+)/
     # Path placeholder: <int>, <string>, <uint>, <double>, <path> — and the
     # non-standard but occasionally seen <type:name> form.
     PATH_PARAM_REGEX = /<([^<>:]+)(?::([^<>]+))?>/
@@ -63,9 +65,7 @@ module Analyzer::Cpp
 
           methods = [] of String
           if methods_match = search_window.match(METHODS_REGEX)
-            methods_match[1].scan(METHOD_TOKEN) do |m|
-              methods << m[1].upcase
-            end
+            methods = parse_methods(methods_match[1])
           end
           methods << "GET" if methods.empty?
 
@@ -73,10 +73,12 @@ module Analyzer::Cpp
           details = Details.new(PathInfo.new(path, index + 1))
           route_offset = line_offsets[index] + (route_match.begin(0) || 0)
           route_callees = include_callee ? callees_for_route(source, path, route_offset + route_match[0].bytesize) : [] of Noir::CppCalleeExtractor::Entry
+          route_params = params_for_route(source, route_offset + route_match[0].bytesize)
 
           last_endpoints.clear
           methods.uniq.each do |method|
             endpoint = Endpoint.new(normalized_path, method, path_params.dup, details)
+            route_params.each { |param| push_unique(endpoint, param) }
             Noir::CppCalleeExtractor.attach_to(endpoint, route_callees) if include_callee
             result << endpoint
             last_endpoints << endpoint
@@ -96,6 +98,14 @@ module Analyzer::Cpp
 
       body, start_line = block
       Noir::CppCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def params_for_route(source : String, search_start : Int32) : Array(Param)
+      block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, search_start, next_route_offset(source, search_start))
+      return [] of Param unless block
+
+      body, _ = block
+      collect_params_from_block(body)
     end
 
     private def next_route_offset(source : String, search_start : Int32) : Int32
@@ -131,6 +141,40 @@ module Analyzer::Cpp
         "{#{name}}"
       end
       {normalized, params}
+    end
+
+    private def parse_methods(raw : String) : Array(String)
+      methods = [] of String
+      raw.scan(METHOD_TOKEN) do |m|
+        methods << m[1].upcase
+      end
+      raw.scan(HTTP_METHOD_TOKEN) do |m|
+        methods << normalize_method_name(m[1])
+      end
+      raw.scan(CROW_METHOD_TOKEN) do |m|
+        methods << normalize_method_name(m[1])
+      end
+      methods.reject(&.empty?).uniq!
+    end
+
+    private def normalize_method_name(name : String) : String
+      case name.upcase
+      when "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"
+        name.upcase
+      else
+        ""
+      end
+    end
+
+    private def collect_params_from_block(block : String) : Array(Param)
+      params = [] of Param
+      block.each_line do |line|
+        collect_params(line).each do |param|
+          next if params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+          params << param
+        end
+      end
+      params
     end
 
     private def collect_params(line : String) : Array(Param)

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -92,11 +92,12 @@ module Analyzer::Cpp
         line_number = find_line_number(lines, "registerHandler", match[1])
         match_start = match.begin(0) || 0
         callees = include_callee ? callees_for_block_after(content, path, match_start) : [] of Noir::CppCalleeExtractor::Entry
+        route_params = params_for_block_after(content, match_start)
 
         methods.each do |m|
           details = Details.new(PathInfo.new(path, line_number))
           endpoint = Endpoint.new(route, m, details)
-          file_params.each { |p| endpoint.push_param(p) }
+          route_params.each { |p| endpoint.push_param(p) }
           Noir::CppCalleeExtractor.attach_to(endpoint, callees) if include_callee
           endpoints << endpoint
         end
@@ -184,6 +185,14 @@ module Analyzer::Cpp
 
       body, start_line = block
       Noir::CppCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def params_for_block_after(content : String, search_start : Int32) : Array(Param)
+      block = Noir::CppCalleeExtractor.extract_block_after(content, search_start)
+      return [] of Param unless block
+
+      body, _ = block
+      extract_params(body.lines)
     end
 
     private def callees_for_handler(content : String, path : String, handler_target : HandlerTarget) : Array(Noir::CppCalleeExtractor::Entry)
@@ -289,7 +298,12 @@ module Analyzer::Cpp
     private def parse_methods(raw : String) : Array(String)
       methods = [] of String
       raw.split(",").each do |token|
-        name = token.strip.gsub(/^drogon::/, "").gsub(/^Http/, "").gsub(/Method$/, "")
+        name = token.strip
+          .gsub(/^drogon::/, "")
+          .gsub(/^HttpMethod::/, "")
+          .gsub(/^Http/, "")
+          .gsub(/Method$/, "")
+          .downcase.capitalize
         next if name.empty?
         if mapped = HTTP_METHODS[name]?
           methods << mapped unless methods.includes?(mapped)

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -92,7 +92,7 @@ module Analyzer::Cpp
         line_number = find_line_number(lines, "registerHandler", match[1])
         match_start = match.begin(0) || 0
         callees = include_callee ? callees_for_block_after(content, path, match_start) : [] of Noir::CppCalleeExtractor::Entry
-        route_params = params_for_block_after(content, match_start)
+        route_params = params_for_register_handler(content, match_start)
 
         methods.each do |m|
           details = Details.new(PathInfo.new(path, line_number))
@@ -187,12 +187,104 @@ module Analyzer::Cpp
       Noir::CppCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
-    private def params_for_block_after(content : String, search_start : Int32) : Array(Param)
+    private def params_for_register_handler(content : String, search_start : Int32) : Array(Param)
+      if params = params_for_inline_register_handler(content, search_start)
+        return params unless params.empty?
+      end
+
+      handler_target = handler_target_for_register_handler(content, search_start)
+      return [] of Param unless handler_target
+
+      params_for_handler(content, handler_target)
+    end
+
+    private def params_for_inline_register_handler(content : String, search_start : Int32) : Array(Param)?
       block = Noir::CppCalleeExtractor.extract_block_after(content, search_start)
+      return unless block
+
+      body, _ = block
+      extract_params(body.lines)
+    end
+
+    private def params_for_handler(content : String, handler_target : HandlerTarget) : Array(Param)
+      block = extract_method_body(content, handler_target)
       return [] of Param unless block
 
       body, _ = block
       extract_params(body.lines)
+    end
+
+    private def handler_target_for_register_handler(content : String, search_start : Int32) : HandlerTarget?
+      handler_index = content.index("registerHandler", search_start)
+      return unless handler_index
+
+      open_paren = Noir::CppCalleeExtractor.find_next_code_char(content, '(', handler_index)
+      return unless open_paren
+
+      close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
+      return unless close_paren
+
+      args = split_top_level_args(content[(open_paren + 1)...close_paren])
+      return if args.size < 2
+
+      raw_handler = args[1].strip
+      return if raw_handler.empty?
+      return if raw_handler.includes?("[]") || raw_handler.includes?("lambda")
+
+      normalize_handler_target(raw_handler)
+    end
+
+    private def split_top_level_args(raw : String) : Array(String)
+      args = [] of String
+      current = String::Builder.new
+      paren_depth = 0
+      brace_depth = 0
+      bracket_depth = 0
+      in_string = false
+      escaped = false
+
+      raw.each_char do |char|
+        if in_string
+          current << char
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == '"'
+            in_string = false
+          end
+          next
+        end
+
+        case char
+        when '"'
+          in_string = true
+        when '('
+          paren_depth += 1
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+        when '{'
+          brace_depth += 1
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+        when '['
+          bracket_depth += 1
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+        when ','
+          if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0
+            args << current.to_s.strip
+            current = String::Builder.new
+            next
+          end
+        end
+
+        current << char
+      end
+
+      tail = current.to_s.strip
+      args << tail unless tail.empty?
+      args
     end
 
     private def callees_for_handler(content : String, path : String, handler_target : HandlerTarget) : Array(Noir::CppCalleeExtractor::Entry)

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -286,6 +286,7 @@ module Analyzer::CSharp
       http_method = "GET"
       action_route = ""
       explicit_endpoint_attribute = false
+      non_action_attribute = false
       in_class = false
 
       i = 0
@@ -296,11 +297,12 @@ module Analyzer::CSharp
         if in_class
           http_method, action_route, found_attribute = update_http_context(line, http_method, action_route)
           explicit_endpoint_attribute ||= found_attribute
+          non_action_attribute = true if line.includes?("[NonAction")
         end
 
         if in_class && potential_action_signature?(line)
           signature, end_index = build_signature(lines, i)
-          if action_method?(signature, explicit_endpoint_attribute)
+          if !non_action_attribute && action_method?(signature, explicit_endpoint_attribute)
             action_name = extract_action_name(signature)
             unless action_name.empty?
               parameters = extract_parameters(signature, http_method)
@@ -328,8 +330,15 @@ module Analyzer::CSharp
               http_method = "GET"
               action_route = ""
               explicit_endpoint_attribute = false
+              non_action_attribute = false
             end
           end
+          if non_action_attribute
+            http_method = "GET"
+            action_route = ""
+            explicit_endpoint_attribute = false
+          end
+          non_action_attribute = false
           i = end_index
         end
 

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -16,19 +16,35 @@ module Analyzer::CSharp
     end
 
     private def analyze_route_builder_endpoints(include_callee : Bool)
-      map_regex = /Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/
-      map_methods_block_regex = /MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/
+      map_regex = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/m
+      chained_group_map_regex = /MapGroup\s*\(\s*"([^"]+)"\s*\)\s*\.Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/m
+      map_methods_block_regex = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/m
+      chained_group_map_methods_regex = /MapGroup\s*\(\s*"([^"]+)"\s*\)\s*\.MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/m
 
       get_files_by_extension(".cs").each do |file|
         next unless File.exists?(file)
         next if Common.csharp_test_path?(file)
 
-        lines = read_file_content(file).lines
+        content = read_file_content(file)
+        group_prefixes = extract_map_group_prefixes(content)
+        lines = content.lines
         lines.each_with_index do |line, index|
-          if match = map_regex.match(line)
-            http_method = match[1].upcase
-            route = match[2]
+          if route_builder_line?(line)
             block = extract_map_block(lines, index)
+            if chained_match = chained_group_map_regex.match(block)
+              http_method = chained_match[2].upcase
+              route = join_route_parts(chained_match[1], chained_match[3])
+            elsif match = map_regex.match(block)
+              receiver = match[1]?
+              http_method = match[2].upcase
+              route = apply_group_prefix(match[3], receiver, group_prefixes)
+            else
+              route = nil
+              http_method = nil
+            end
+
+            next unless route && http_method
+
             extra_params = extract_params_from_block(block)
             extra_params.concat(extract_bind_params_from_file(block, lines))
             endpoint = build_endpoint_from_route(route, http_method, file, index + 1, extra_params)
@@ -43,13 +59,18 @@ module Analyzer::CSharp
             route = nil
             methods = [] of String
 
-            if match = block.match(/MapMethods\s*\(\s*"([^"]+)"\s*,\s*new[^{]*\{([^}]*)\}/m)
-              route = match[1]
-              methods_list = match[2].split(",")
-              methods = methods_list.map(&.gsub(/["\s]/, "").upcase).reject(&.empty?).uniq!
+            if chained_match = chained_group_map_methods_regex.match(block)
+              route = join_route_parts(chained_match[1], chained_match[2])
+              methods_section = chained_match[3]
+              methods = methods_section.scan(/"([A-Za-z]+)"/).map(&.[1]?.to_s.upcase).reject(&.empty?).uniq!
+            elsif match = block.match(/(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*"([^"]+)"\s*,\s*new[^{]*\{([^}]*)\}/m)
+              receiver = match[1]?
+              route = apply_group_prefix(match[2], receiver, group_prefixes)
+              methods = match[3].split(",").map(&.gsub(/["\s]/, "").upcase).reject(&.empty?).uniq!
             elsif match = map_methods_block_regex.match(block)
-              route = match[1]
-              methods_section = match[2]
+              receiver = match[1]?
+              route = apply_group_prefix(match[2], receiver, group_prefixes)
+              methods_section = match[3]
               methods = methods_section.scan(/"([A-Za-z]+)"/).map(&.[1]?.to_s.upcase).reject(&.empty?).uniq!
             end
 
@@ -67,6 +88,47 @@ module Analyzer::CSharp
           end
         end
       end
+    end
+
+    private def route_builder_line?(line : String) : Bool
+      line.includes?("MapGet") ||
+        line.includes?("MapPost") ||
+        line.includes?("MapPut") ||
+        line.includes?("MapDelete") ||
+        line.includes?("MapPatch") ||
+        line.includes?("MapHead") ||
+        line.includes?("MapOptions")
+    end
+
+    private def extract_map_group_prefixes(content : String) : Hash(String, String)
+      prefixes = Hash(String, String).new
+      group_assignment_regex = /(?:var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\.MapGroup\s*\(\s*"([^"]+)"\s*\)/
+
+      content.scan(group_assignment_regex) do |match|
+        variable = match[1]
+        parent = match[2]
+        prefix = match[3]
+        parent_prefix = prefixes[parent]? || ""
+        prefixes[variable] = join_route_parts(parent_prefix, prefix)
+      end
+
+      prefixes
+    end
+
+    private def apply_group_prefix(route : String, receiver : String?, group_prefixes : Hash(String, String)) : String
+      return route unless receiver
+      prefix = group_prefixes[receiver]?
+      return route unless prefix
+      join_route_parts(prefix, route)
+    end
+
+    private def join_route_parts(*parts : String) : String
+      clean_parts = parts.compact_map do |part|
+        clean = part.strip.gsub(/^\//, "").gsub(/\/$/, "")
+        clean.empty? ? nil : clean
+      end
+      return "/" if clean_parts.empty?
+      "/" + clean_parts.join("/")
     end
 
     private def extract_map_block(lines : Array(String), start_index : Int32) : String
@@ -223,6 +285,7 @@ module Analyzer::CSharp
 
       http_method = "GET"
       action_route = ""
+      explicit_endpoint_attribute = false
       in_class = false
 
       i = 0
@@ -231,12 +294,13 @@ module Analyzer::CSharp
 
         in_class = true if line.includes?("class") && line.includes?("Controller")
         if in_class
-          http_method, action_route = update_http_context(line, http_method, action_route)
+          http_method, action_route, found_attribute = update_http_context(line, http_method, action_route)
+          explicit_endpoint_attribute ||= found_attribute
         end
 
         if in_class && potential_action_signature?(line)
           signature, end_index = build_signature(lines, i)
-          if action_method?(signature)
+          if action_method?(signature, explicit_endpoint_attribute)
             action_name = extract_action_name(signature)
             unless action_name.empty?
               parameters = extract_parameters(signature, http_method)
@@ -263,6 +327,7 @@ module Analyzer::CSharp
 
               http_method = "GET"
               action_route = ""
+              explicit_endpoint_attribute = false
             end
           end
           i = end_index
@@ -272,47 +337,60 @@ module Analyzer::CSharp
       end
     end
 
-    private def update_http_context(line : String, current_method : String, action_route : String) : Tuple(String, String)
+    private def update_http_context(line : String, current_method : String, action_route : String) : Tuple(String, String, Bool)
       http_method = current_method
       route = action_route
+      found_attribute = false
 
       if line.includes?("[HttpPost")
         http_method = "POST"
         route = extract_attribute_route(line, "HttpPost", route)
+        found_attribute = true
       elsif line.includes?("[HttpGet")
         http_method = "GET"
         route = extract_attribute_route(line, "HttpGet", route)
+        found_attribute = true
       elsif line.includes?("[HttpPut")
         http_method = "PUT"
         route = extract_attribute_route(line, "HttpPut", route)
+        found_attribute = true
       elsif line.includes?("[HttpDelete")
         http_method = "DELETE"
         route = extract_attribute_route(line, "HttpDelete", route)
+        found_attribute = true
       elsif line.includes?("[HttpPatch")
         http_method = "PATCH"
         route = extract_attribute_route(line, "HttpPatch", route)
+        found_attribute = true
       elsif line.includes?("[HttpHead")
         http_method = "HEAD"
         route = extract_attribute_route(line, "HttpHead", route)
+        found_attribute = true
       elsif line.includes?("[HttpOptions")
         http_method = "OPTIONS"
         route = extract_attribute_route(line, "HttpOptions", route)
+        found_attribute = true
       elsif line.includes?("[Route")
         route = extract_attribute_route(line, "Route", route)
+        found_attribute = true
       end
 
-      {http_method, route}
+      {http_method, route, found_attribute}
     end
 
     private def potential_action_signature?(line : String) : Bool
       line.includes?("public") && line.includes?("(") && !line.includes?(" class ")
     end
 
-    private def action_method?(signature : String) : Bool
+    private def action_method?(signature : String, explicit_endpoint_attribute : Bool) : Bool
+      return true if explicit_endpoint_attribute
+
       signature.includes?("ActionResult") ||
         signature.includes?("IActionResult") ||
         signature.includes?("JsonResult") ||
-        signature.includes?("ViewResult")
+        signature.includes?("ViewResult") ||
+        signature.includes?("IResult") ||
+        signature.matches?(/Task\s*<\s*(?:IEnumerable|List|PagedResult|Result|Response|[A-Z]\w*)/)
     end
 
     private def extract_controller_name(content : String) : String
@@ -338,9 +416,10 @@ module Analyzer::CSharp
 
       default_param_type = default_param_type(http_method)
 
-      param_list.split(',').each do |param_def|
+      split_csharp_parameters(param_list).each do |param_def|
         cleaned_def, param_type = normalize_param_definition(param_def)
         next if cleaned_def.empty?
+        next if param_type == "service"
 
         if match = cleaned_def.match(/(\w+)\s*(?:=\s*[^,]+)?\s*$/)
           param_name = match[1]
@@ -365,11 +444,14 @@ module Analyzer::CSharp
       cleaned = param_def.strip
 
       {
-        "FromQuery"  => "query",
-        "FromRoute"  => "path",
-        "FromBody"   => "json",
-        "FromHeader" => "header",
-        "FromForm"   => "form",
+        "FromQuery"         => "query",
+        "FromRoute"         => "path",
+        "FromBody"          => "json",
+        "FromHeader"        => "header",
+        "FromForm"          => "form",
+        "FromCookie"        => "cookie",
+        "FromServices"      => "service",
+        "FromKeyedServices" => "service",
       }.each do |attr, type|
         if cleaned.includes?("[#{attr}")
           param_type = type

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -80,6 +80,7 @@ module Analyzer::CSharp
       i = 0
       http_method = "GET" # Default method for tracking across lines
       action_route = ""   # Track action-level route
+      explicit_endpoint_attribute = false
 
       while i < lines.size
         line = lines[i]
@@ -88,24 +89,30 @@ module Analyzer::CSharp
         if line.includes?("[HttpPost")
           http_method = "POST"
           action_route = extract_attribute_route(line, "HttpPost")
+          explicit_endpoint_attribute = true
         elsif line.includes?("[HttpGet")
           http_method = "GET"
           action_route = extract_attribute_route(line, "HttpGet")
+          explicit_endpoint_attribute = true
         elsif line.includes?("[HttpPut")
           http_method = "PUT"
           action_route = extract_attribute_route(line, "HttpPut")
+          explicit_endpoint_attribute = true
         elsif line.includes?("[HttpDelete")
           http_method = "DELETE"
           action_route = extract_attribute_route(line, "HttpDelete")
+          explicit_endpoint_attribute = true
         elsif line.includes?("[HttpPatch")
           http_method = "PATCH"
           action_route = extract_attribute_route(line, "HttpPatch")
+          explicit_endpoint_attribute = true
         elsif line.includes?("[Route")
           action_route = extract_attribute_route(line, "Route")
+          explicit_endpoint_attribute = true
         end
 
         # Check for action method definition
-        if line.includes?("public") && line.includes?("ActionResult") && line.includes?("(")
+        if line.includes?("public") && line.includes?("(") && (line.includes?("ActionResult") || explicit_endpoint_attribute)
           signature, end_index = build_signature(lines, i)
           action_name = extract_action_name(signature)
           parameters = extract_parameters(signature, http_method)
@@ -127,6 +134,7 @@ module Analyzer::CSharp
             # Reset to default after processing the method
             http_method = "GET"
             action_route = ""
+            explicit_endpoint_attribute = false
           end
           i = end_index
         end
@@ -144,7 +152,7 @@ module Analyzer::CSharp
 
     private def extract_action_name(line : String) : String
       # Extract method name from: public ActionResult MethodName(params)
-      match = line.match(/public\s+\w+\s+(\w+)\s*\(/)
+      match = line.match(/public\s+(?:async\s+)?(?:override\s+)?(?:virtual\s+)?[\w<>\[\],\s]+\s+(\w+)\s*\(/)
       return "" unless match
       match[1]
     end
@@ -172,7 +180,7 @@ module Analyzer::CSharp
                            end
 
       # Parse individual parameters
-      param_list.split(',').each do |param_def|
+      split_csharp_parameters(param_list).each do |param_def|
         param_def = param_def.strip
         next if param_def.empty?
 
@@ -196,6 +204,8 @@ module Analyzer::CSharp
         elsif param_def.includes?("[FromCookie]")
           param_type = "cookie"
           param_def = param_def.gsub("[FromCookie]", "").strip
+        elsif param_def.includes?("[FromServices]") || param_def.includes?("[FromKeyedServices")
+          next
         end
 
         # Extract parameter name (last word before optional default value)
@@ -213,14 +223,14 @@ module Analyzer::CSharp
 
     private def extract_controller_route(content : String) : String
       # Extract [Route("...")] attribute from controller class
-      match = content.match(/\[Route\s*\(\s*"([^"]+)"\s*\)\s*\]\s*\n?\s*public\s+class\s+\w+Controller/)
+      match = content.match(/\[(?:Route|RoutePrefix)\s*\(\s*"([^"]+)"\s*\)\s*\]\s*\n?\s*public\s+class\s+\w+Controller/)
       return "" unless match
       match[1]
     end
 
     private def extract_attribute_route(line : String, attribute : String) : String
       # Extract route from [HttpGet("route")] or [Route("route")]
-      match = line.match(/\[#{attribute}\s*\(\s*"([^"]+)"\s*\)\s*\]/)
+      match = line.match(/\[#{attribute}[^(]*\(\s*"([^"]+)"/)
       return "" unless match
       match[1]
     end

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -38,6 +38,43 @@ module Analyzer::CSharp::Common
     {signature, index - 1}
   end
 
+  protected def split_csharp_parameters(param_list : String) : Array(String)
+    params = [] of String
+    current = String::Builder.new
+    generic_depth = 0
+    paren_depth = 0
+    bracket_depth = 0
+
+    param_list.each_char do |char|
+      case char
+      when '<'
+        generic_depth += 1
+      when '>'
+        generic_depth -= 1 if generic_depth > 0
+      when '('
+        paren_depth += 1
+      when ')'
+        paren_depth -= 1 if paren_depth > 0
+      when '['
+        bracket_depth += 1
+      when ']'
+        bracket_depth -= 1 if bracket_depth > 0
+      when ','
+        if generic_depth == 0 && paren_depth == 0 && bracket_depth == 0
+          params << current.to_s.strip
+          current = String::Builder.new
+          next
+        end
+      end
+
+      current << char
+    end
+
+    tail = current.to_s.strip
+    params << tail unless tail.empty?
+    params
+  end
+
   protected def extract_method_block(lines : Array(String), start_index : Int32) : String
     io = String::Builder.new
     brace = 0


### PR DESCRIPTION
## Summary
- add ASP.NET Core Minimal API MapGroup and chained group route handling
- improve C# controller action/parameter extraction, including service parameter filtering and RoutePrefix support
- tighten Crow/Drogon C++ route-local parameter extraction and support additional Crow/Drogon method declaration styles

## Tests
- crystal spec spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr spec/functional_test/testers/csharp/aspnet_mvc_spec.cr spec/functional_test/testers/cpp/crow_spec.cr spec/functional_test/testers/cpp/drogon_spec.cr spec/unit_test/miniparser/cpp_callee_extractor_spec.cr spec/unit_test/miniparser/csharp_callee_extractor_spec.cr
- just test
- just build
- just check