### PR TITLE
Improve Swift and Scala route analysis coverage

### DIFF
--- a/spec/unit_test/analyzer/analyzer_scala_akka_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_scala_akka_spec.cr
@@ -50,3 +50,55 @@ describe "scala akka callee extraction" do
     Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
   end
 end
+
+describe "scala akka route extraction" do
+  it "tracks composite path prefixes, matcher names, and pathEnd routes" do
+    options = create_test_options
+    instance = Analyzer::Scala::Akka.new(options)
+
+    temp_dir = File.tempname("scala_akka_routes_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "Routes.scala")
+
+    File.write(temp_file, <<-SCALA)
+      import akka.http.scaladsl.server.Directives._
+
+      object Routes {
+        val route =
+          pathPrefix("api" / "v1" / Segment) { tenantId =>
+            concat(
+              pathEndOrSingleSlash {
+                get {
+                  complete("tenant root")
+                }
+              },
+              path("users" / JavaUUID) { userId =>
+                get {
+                  complete(userId.toString)
+                }
+              }
+            )
+          }
+      }
+      SCALA
+
+    endpoints = instance.analyze_file(temp_file)
+    root_endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/api/v1/{tenantId}" }
+    user_endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/api/v1/{tenantId}/users/{userId}" }
+
+    root_endpoint.should_not be_nil
+    user_endpoint.should_not be_nil
+
+    if root_endpoint
+      root_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"tenantId", "path"})
+    end
+
+    if user_endpoint
+      user_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"tenantId", "path"})
+      user_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"userId", "path"})
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_scala_play_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_scala_play_spec.cr
@@ -1,0 +1,65 @@
+require "../../spec_helper"
+require "../../../src/models/code_locator"
+require "../../../src/analyzer/analyzers/scala/play"
+
+describe "scala play analyzer" do
+  it "extracts controller params from injected async actions with body parsers" do
+    options = create_test_options
+
+    temp_dir = File.tempname("scala_play_test")
+    conf_dir = File.join(temp_dir, "conf")
+    controller_dir = File.join(temp_dir, "app", "controllers")
+    Dir.mkdir_p(conf_dir)
+    Dir.mkdir_p(controller_dir)
+
+    routes_path = File.join(conf_dir, "routes")
+    routes_content = <<-ROUTES
+      POST /users/:id controllers.HomeController.create(id: Long)
+      ROUTES
+    File.write(routes_path, routes_content)
+
+    controller_path = File.join(controller_dir, "HomeController.scala")
+    controller_content = <<-SCALA
+      package controllers
+
+      import javax.inject._
+      import play.api.mvc._
+
+      @Singleton
+      class HomeController @Inject()(cc: ControllerComponents) extends AbstractController(cc) {
+        def create(id: Long) = Action.async(parse.json) { implicit request =>
+          val auth = request.headers.get("Authorization")
+          val session = request.cookies.get("session")
+          Future.successful(Ok)
+        }
+      }
+      SCALA
+    File.write(controller_path, controller_content)
+
+    CodeLocator.instance.clear_all
+    CodeLocator.instance.register_file(routes_path, routes_content)
+    CodeLocator.instance.register_file(controller_path, controller_content)
+
+    options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+    endpoints = Analyzer::Scala::Play.new(options).analyze
+    endpoint = endpoints.find { |e| e.method == "POST" && e.url == "/users/:id" }
+
+    endpoint.should_not be_nil
+
+    if endpoint
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"id", "path"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"Authorization", "header"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"session", "cookie"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"body", "json"})
+    end
+  ensure
+    CodeLocator.instance.clear_all
+    File.delete(routes_path) if routes_path && File.exists?(routes_path)
+    File.delete(controller_path) if controller_path && File.exists?(controller_path)
+    Dir.delete(controller_dir) if controller_dir && Dir.exists?(controller_dir)
+    app_dir = temp_dir ? File.join(temp_dir, "app") : nil
+    Dir.delete(app_dir) if app_dir && Dir.exists?(app_dir)
+    Dir.delete(conf_dir) if conf_dir && Dir.exists?(conf_dir)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_scala_scalatra_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_scala_scalatra_spec.cr
@@ -1,0 +1,39 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/scala/scalatra"
+
+describe "scala scalatra analyzer" do
+  it "accepts route definitions with extra route arguments" do
+    options = create_test_options
+    instance = Analyzer::Scala::Scalatra.new(options)
+
+    temp_dir = File.tempname("scala_scalatra_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "MyServlet.scala")
+
+    File.write(temp_file, <<-SCALA)
+      import org.scalatra._
+
+      class MyServlet extends ScalatraServlet {
+        get("/users/:id", request.getHeader("X-Enabled") != null) {
+          val expand = params("expand")
+          val auth = request.getHeader("Authorization")
+          s"user $expand $auth"
+        }
+      }
+      SCALA
+
+    endpoints = instance.analyze_file(temp_file)
+    endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/users/:id" }
+
+    endpoint.should_not be_nil
+
+    if endpoint
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"id", "path"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"expand", "query"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"Authorization", "header"})
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_swift_hummingbird_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_swift_hummingbird_spec.cr
@@ -1,0 +1,60 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/swift/hummingbird"
+
+describe "swift hummingbird analyzer" do
+  it "tracks grouped route prefixes and named handlers" do
+    options = create_test_options
+    options["include_callee"] = YAML::Any.new(true)
+    instance = Analyzer::Swift::Hummingbird.new(options)
+
+    temp_dir = File.tempname("swift_hummingbird_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Hummingbird
+
+      func createUser(
+          _ request: Request,
+          context: BasicRequestContext
+      ) async throws -> User {
+          let id = try context.parameters.require("id", as: String.self)
+          let payload = try await request.decode(as: CreateUser.self, context: context)
+          return try await UserService.create(id, payload)
+      }
+
+      func routes(_ router: Router<BasicRequestContext>) {
+          router.group("api") { api in
+              api.post("users/:id", use: createUser)
+          }
+
+          let admin = router.group("admin")
+          admin.get("reports") { request, context async throws in
+              let token = request.headers["Authorization"]
+              return try await ReportService.list(token)
+          }
+      }
+      SWIFT
+
+    endpoints = instance.analyze_file(temp_file)
+    create_endpoint = endpoints.find { |e| e.method == "POST" && e.url == "/api/users/:id" }
+    report_endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/admin/reports" }
+
+    create_endpoint.should_not be_nil
+    report_endpoint.should_not be_nil
+
+    if create_endpoint
+      create_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"id", "path"})
+      create_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"body", "json"})
+      create_endpoint.callees.map(&.name).should contain("UserService.create")
+    end
+
+    if report_endpoint
+      report_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"Authorization", "header"})
+      report_endpoint.callees.map(&.name).should contain("ReportService.list")
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_swift_hummingbird_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_swift_hummingbird_spec.cr
@@ -57,4 +57,31 @@ describe "swift hummingbird analyzer" do
     File.delete(temp_file) if temp_file && File.exists?(temp_file)
     Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
   end
+
+  it "does not read one-line closure string literals as route segments" do
+    options = create_test_options
+    instance = Analyzer::Swift::Hummingbird.new(options)
+
+    temp_dir = File.tempname("swift_hummingbird_inline_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Hummingbird
+
+      func routes(_ router: Router<BasicRequestContext>) {
+          router.get("hello") { request, context in Foo.make(request, "bar") }
+          router.group("api") { api in api.get("status") { request, context in Foo.make(request, "baz") } }
+      }
+      SWIFT
+
+    endpoints = instance.analyze_file(temp_file)
+    endpoints.map(&.url).should contain("/hello")
+    endpoints.map(&.url).should contain("/api/status")
+    endpoints.map(&.url).should_not contain("/hello/bar")
+    endpoints.map(&.url).should_not contain("/api/baz/status")
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
 end

--- a/spec/unit_test/analyzer/analyzer_swift_kitura_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_swift_kitura_spec.cr
@@ -1,0 +1,42 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/swift/kitura"
+
+describe "swift kitura analyzer" do
+  it "extracts params from named route handlers without callee mode" do
+    options = create_test_options
+    instance = Analyzer::Swift::Kitura.new(options)
+
+    temp_dir = File.tempname("swift_kitura_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Kitura
+
+      func createUser(request: RouterRequest, response: RouterResponse, next: @escaping () -> Void) throws {
+          let id = request.parameters["id"]
+          let expand = request.queryParameters["expand"]
+          let auth = request.headers["Authorization"]
+          let payload = try request.read(as: User.self)
+          try response.send(payload).end()
+          next()
+      }
+
+      let router = Router()
+      router.post("/users/:id", handler: createUser)
+      SWIFT
+
+    endpoint = instance.analyze_file(temp_file).find { |e| e.method == "POST" && e.url == "/users/:id" }
+    endpoint.should_not be_nil
+
+    if endpoint
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"id", "path"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"expand", "query"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"Authorization", "header"})
+      endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"body", "json"})
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/spec/unit_test/analyzer/analyzer_swift_vapor_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_swift_vapor_spec.cr
@@ -56,4 +56,31 @@ describe "swift vapor analyzer" do
     File.delete(temp_file) if temp_file && File.exists?(temp_file)
     Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
   end
+
+  it "does not read one-line closure string literals as route segments" do
+    options = create_test_options
+    instance = Analyzer::Swift::Vapor.new(options)
+
+    temp_dir = File.tempname("swift_vapor_inline_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Vapor
+
+      func routes(_ app: Application) throws {
+          app.get("hello") { req in Foo.make(req, "bar") }
+          app.on(.POST, "submit", body: .collect(maxSize: "1mb")) { req in Foo.make(req, "baz") }
+      }
+      SWIFT
+
+    endpoints = instance.analyze_file(temp_file)
+    endpoints.map(&.url).should contain("/hello")
+    endpoints.map(&.url).should contain("/submit")
+    endpoints.map(&.url).should_not contain("/hello/bar")
+    endpoints.map(&.url).should_not contain("/submit/1mb/baz")
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
 end

--- a/spec/unit_test/analyzer/analyzer_swift_vapor_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_swift_vapor_spec.cr
@@ -1,0 +1,59 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/swift/vapor"
+
+describe "swift vapor analyzer" do
+  it "tracks grouped route prefixes and named handlers" do
+    options = create_test_options
+    options["include_callee"] = YAML::Any.new(true)
+    instance = Analyzer::Swift::Vapor.new(options)
+
+    temp_dir = File.tempname("swift_vapor_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Vapor
+
+      func createUser(
+          _ req: Request
+      ) throws -> EventLoopFuture<User> {
+          let tenant = req.parameters.get("tenantID")
+          let payload = try req.content.decode(CreateUser.self)
+          return UserService.create(tenant, payload, on: req.db)
+      }
+
+      func routes(_ app: Application) throws {
+          app.group("api", ":tenantID") { tenantRoutes in
+              tenantRoutes.post("users", use: createUser)
+          }
+
+          let admin = app.grouped("admin", "v1")
+          admin.on(.GET, "reports") { req async throws in
+              let token = req.headers["Authorization"].first
+              return try await ReportService.list(token)
+          }
+      }
+      SWIFT
+
+    endpoints = instance.analyze_file(temp_file)
+    create_endpoint = endpoints.find { |e| e.method == "POST" && e.url == "/api/:tenantID/users" }
+    report_endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/admin/v1/reports" }
+
+    create_endpoint.should_not be_nil
+    report_endpoint.should_not be_nil
+
+    if create_endpoint
+      create_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"tenantID", "path"})
+      create_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"body", "json"})
+      create_endpoint.callees.map(&.name).should contain("UserService.create")
+    end
+
+    if report_endpoint
+      report_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"Authorization", "header"})
+      report_endpoint.callees.map(&.name).should contain("ReportService.list")
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+end

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -21,35 +21,20 @@ module Analyzer::Scala
         stripped_line = scala_code_line(line).strip
         structural_line = scala_structural_line(line).strip
 
-        # Handle pathPrefix: pathPrefix("api") { ... }
-        if path_prefix_match = stripped_line.match(/pathPrefix\s*\(\s*"([^"]+)"\s*\)/)
-          prefix = path_prefix_match[1]
-          prefix = "/#{prefix}" unless prefix.starts_with?("/")
+        # Handle pathPrefix: pathPrefix("api" / "v1") { ... }
+        if path_prefix_args = directive_args(stripped_line, "pathPrefix")
+          prefix = akka_path_from_args(path_prefix_args, path_param_names(stripped_line))
           prefix_stack.push(prefix)
           # Record the depth at which this prefix was added (after we count the opening brace)
           prefix_depths.push(brace_depth + 1)
         end
 
         # Handle path with potential matchers: path("users" / IntNumber) { userId => ... }
-        if path_match = stripped_line.match(/path\s*\(\s*"([^"]+)"/)
-          route_path = path_match[1]
-          route_path = "/#{route_path}" unless route_path.starts_with?("/")
-
-          # Check for path parameter matchers and extract parameter name
-          param_name = "id"
-          has_param = false
-
-          if stripped_line =~ /\/\s*(IntNumber|LongNumber|Segment|Remaining|JavaUUID)/
-            has_param = true
-            # Try to extract parameter name from pattern like: { userId => or { (userId) =>
-            if param_var_match = stripped_line.match(/\{\s*\(?\s*(\w+)\s*\)?\s*=>/)
-              param_name = param_var_match[1]
-            end
-            route_path = "#{route_path}/{#{param_name}}"
-          end
+        if path_args = directive_args(stripped_line, "path")
+          route_path = akka_path_from_args(path_args, path_param_names(stripped_line))
 
           # Build full path with prefix
-          full_path = prefix_stack.empty? ? route_path : "#{prefix_stack.join("")}#{route_path}"
+          full_path = join_paths(prefix_stack, route_path)
 
           # Find HTTP methods in the following lines within the same block
           block = extract_block_from_index(lines, index)
@@ -62,15 +47,31 @@ module Analyzer::Scala
             if block_content =~ /\b#{method}\s*\{/
               endpoint = create_endpoint(full_path, method.upcase, path)
 
-              # Add path parameter if detected
-              if has_param
-                endpoint.push_param(Param.new(param_name, "", "path"))
-              end
+              extract_path_params(endpoint, full_path)
 
               # Extract additional parameters from the block
               extract_params_from_block(endpoint, block_content)
               attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
 
+              endpoints << endpoint
+            end
+          end
+        end
+
+        if stripped_line.includes?("pathEnd") || stripped_line.includes?("pathEndOrSingleSlash")
+          full_path = prefix_stack.empty? ? "/" : prefix_stack.join("")
+          block = extract_block_from_index(lines, index)
+          next unless block
+
+          block_content = block[0]
+          block_end = block[2]
+
+          HTTP_METHODS.each do |method|
+            if block_content =~ /\b#{method}\s*\{/
+              endpoint = create_endpoint(full_path, method.upcase, path)
+              extract_path_params(endpoint, full_path)
+              extract_params_from_block(endpoint, block_content)
+              attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
               endpoints << endpoint
             end
           end
@@ -170,6 +171,59 @@ module Analyzer::Scala
       # Extract optional headers: optionalHeaderValueByName("X-API-Key") { ... }
       block.scan(/optionalHeaderValueByName\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
         endpoint.push_param(Param.new(match[1], "", "header"))
+      end
+    end
+
+    private def directive_args(line : String, directive : String) : String?
+      match = line.match(/(?<![.\w])#{Regex.escape(directive)}\s*\(([^)]*)\)/)
+      return unless match
+
+      match[1]
+    end
+
+    private def akka_path_from_args(args : String, param_names : Array(String)) : String
+      segments = [] of String
+      param_index = 0
+
+      args.scan(/"([^"]+)"|(IntNumber|LongNumber|Segment|Remaining|JavaUUID)/) do |match|
+        if literal = match[1]?
+          segments.concat(literal.split('/').reject(&.empty?))
+        elsif match[2]?
+          param_name = param_names[param_index]? || default_param_name(param_index)
+          segments << "{#{param_name}}"
+          param_index += 1
+        end
+      end
+
+      return "/" if segments.empty?
+
+      "/#{segments.join("/")}"
+    end
+
+    private def default_param_name(index : Int32) : String
+      index == 0 ? "id" : "id#{index + 1}"
+    end
+
+    private def path_param_names(line : String) : Array(String)
+      match = line.match(/\{\s*\(?\s*([^=]+?)\s*\)?\s*=>/)
+      return [] of String unless match
+
+      match[1].split(',').map(&.strip).reject(&.empty?)
+    end
+
+    private def join_paths(prefix_stack : Array(String), route_path : String) : String
+      parts = prefix_stack + [route_path]
+      normalized = parts.join("").gsub(%r{/+}, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
+    end
+
+    private def extract_path_params(endpoint : Endpoint, route_path : String)
+      route_path.scan(/\{(\w+)\}/) do |match|
+        param_name = match[1]
+        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "path" }
+          endpoint.push_param(Param.new(param_name, "", "path"))
+        end
       end
     end
 

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -4,6 +4,7 @@ module Analyzer::Scala
   class Play < Analyzer
     # Stores parsed controller methods with their parameters
     alias ControllerMethod = NamedTuple(headers: Array(String), cookies: Array(String), body_type: String?)
+    alias MethodBody = NamedTuple(signature: String, body: String)
 
     def analyze
       file_list = all_files()
@@ -54,8 +55,9 @@ module Analyzer::Scala
           package_name = pkg_match[1]
         end
 
-        # Find all classes/objects in the file
-        class_regex = /(?:class|object)\s+(\w+)(?:\s+extends\s+[\w\s,]+)?\s*\{/
+        # Find all classes/objects in the file. Play controllers commonly carry
+        # constructor injection before `extends`.
+        class_regex = /(?:class|object)\s+(\w+)[^{}]*\{/
         class_matches = content.scan(class_regex)
 
         class_matches.each do |class_match|
@@ -77,8 +79,11 @@ module Analyzer::Scala
             full_method_name = package_name.empty? ? "#{class_name}.#{method_name}" : "#{package_name}.#{class_name}.#{method_name}"
 
             # Find the method body (from def to the matching closing brace)
-            method_body = extract_method_body(class_content, method_name)
-            next if method_body.empty?
+            method = extract_method_body(class_content, method_name)
+            next unless method
+
+            method_body = method[:body]
+            method_signature = method[:signature]
 
             headers = [] of String
             cookies = [] of String
@@ -105,13 +110,14 @@ module Analyzer::Scala
             end
 
             # Extract body type: request.body.asJson, request.body.asFormUrlEncoded, parse.json, parse.form
-            if method_body.match(/request\s*\.\s*body\s*\.\s*asJson|parse\s*\.\s*json|Json\s*\.\s*parse|\.body\s*\.\s*asJson/)
+            body_source = "#{method_signature}\n#{method_body}"
+            if body_source.match(/request\s*\.\s*body\s*\.\s*asJson|parse\s*\.\s*json|Json\s*\.\s*parse|\.body\s*\.\s*asJson/)
               body_type = "json"
-            elsif method_body.match(/request\s*\.\s*body\s*\.\s*as(?:FormUrlEncoded|MultipartFormData)|parse\s*\.\s*form/)
+            elsif body_source.match(/request\s*\.\s*body\s*\.\s*as(?:FormUrlEncoded|MultipartFormData)|parse\s*\.\s*form/)
               body_type = "form"
-            elsif method_body.match(/request\s*\.\s*body\s*\.\s*asXml/)
+            elsif body_source.match(/request\s*\.\s*body\s*\.\s*asXml/)
               body_type = "xml"
-            elsif method_body.match(/request\s*\.\s*body\s*\.\s*as(?:Text|Raw|Bytes)|parse\s*\.\s*text/)
+            elsif body_source.match(/request\s*\.\s*body\s*\.\s*as(?:Text|Raw|Bytes)|parse\s*\.\s*text/)
               body_type = "body"
             end
 
@@ -124,15 +130,15 @@ module Analyzer::Scala
     end
 
     # Extract method body from content
-    private def extract_method_body(content : String, method_name : String) : String
+    private def extract_method_body(content : String, method_name : String) : MethodBody?
       # Find method start - Scala methods with Action
       # Handles: Action { ... }, Action { request => ... }, Action.async { ... }, Action(parse.json) { ... }
-      method_start_regex = /def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?\s*=\s*Action(?:\s*(?:\([^)]*\)|\.async))?\s*\{\s*(?:\w+\s*=>\s*)?/
+      method_start_regex = /def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?\s*=\s*Action(?:\s*\.async)?(?:\s*\([^)]*\))?(?:\s*\.async)?\s*\{\s*(?:\w+\s*=>\s*)?/
       match = content.match(method_start_regex)
-      return "" unless match
+      return unless match
 
       start_index = match.end
-      return "" unless start_index
+      return unless start_index
 
       # Find matching closing brace
       brace_count = 1
@@ -147,7 +153,9 @@ module Analyzer::Scala
         end_index += 1
       end
 
-      content[start_index...end_index - 1]
+      signature = match[0]
+      body = content[start_index...end_index - 1]
+      {signature: signature, body: body}
     end
 
     # Process a Play routes file

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -19,9 +19,9 @@ module Analyzer::Scala
 
         # Match Scalatra route definitions: get("/path") { ... }
         HTTP_METHODS.each do |method|
-          # Match: get("/users/:id") { ... }
+          # Match: get("/users/:id") { ... } and get("/users", operation(...)) { ... }
           # Ensure it's not a method call on an object (e.g., cookies.get)
-          if route_match = stripped_line.match(/(?<!\.)#{method}\s*\(\s*"([^"]+)"\s*\)/)
+          if route_match = stripped_line.match(/(?<![.\w])#{method}\s*\(\s*"([^"]+)"/)
             route_path = route_match[1]
             # Only process if it looks like a URL path (starts with /)
             next unless route_path.starts_with?("/")

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -9,34 +9,51 @@ module Analyzer::Swift
     # Patterns for route definitions in Hummingbird:
     # router.get("path") { ... }
     # router.post("path") { ... }
-    ROUTE_PATTERN              = /(\w+)\.(get|post|put|delete|patch)\(([^)]+)\)/
+    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\((.*)\)/
     ROUTE_BODY_LOOKAHEAD_LIMIT = 5
+    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.group\s*\((.*)\)/
+    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group\s*\((.*)\)\s*\{\s*([A-Za-z_]\w*)\s+in/
+    FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      handler_bodies = named_handler_bodies(lines)
+      prefix_by_receiver = {} of String => String
+      group_prefix_stack = [] of Tuple(String, Int32)
+      brace_depth = 0
 
       lines.each_with_index do |line, index|
-        next unless route_definition_line?(line)
-        match = line.match(ROUTE_PATTERN)
-        next unless match
+        stripped_line = code_line(line)
+        register_group_assignment(stripped_line, prefix_by_receiver)
+        register_group_closure(stripped_line, prefix_by_receiver, group_prefix_stack, brace_depth)
+
+        match = route_definition_line?(stripped_line) ? stripped_line.match(ROUTE_PATTERN) : nil
+        unless match
+          brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
+          next
+        end
 
         begin
+          receiver = match[1]
           method = match[2].upcase
           route_args = match[3]
-          route_path = parse_route_path(route_args)
+          route_path = join_paths(prefix_for_receiver(receiver, prefix_by_receiver), parse_route_path(route_args))
 
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint = Endpoint.new(route_path, method, details)
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
-          attach_route_callees(lines, index, path, endpoint) if include_callee
+          extract_named_handler_params(lines[index], handler_bodies, endpoint)
+          attach_route_callees(lines, index, path, endpoint, handler_bodies) if include_callee
 
           endpoints << endpoint
         rescue e
           logger.debug "Error processing endpoint: #{e.message}"
+        ensure
+          brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
         end
       end
 
@@ -91,52 +108,7 @@ module Analyzer::Swift
         end
         brace_count -= line.count('}')
 
-        # Extract query parameters from request.uri.queryParameters
-        if line.includes?("request.uri.queryParameters.get(") ||
-           line.includes?("request.uri.queryParameters[")
-          match = line.match(/request\.uri\.queryParameters\.get\(["']([^"']+)["']\)/) ||
-                  line.match(/request\.uri\.queryParameters\[["']([^"']+)["']\]/)
-          if match
-            query_name = match[1]
-            endpoint.push_param(Param.new(query_name, "", "query"))
-          end
-        end
-
-        # Extract body parameters from request.decode
-        if line.includes?("request.decode(") || line.includes?("await request.decode")
-          endpoint.push_param(Param.new("body", "", "json"))
-        end
-
-        # Extract headers from request.headers
-        if line.includes?("request.headers[")
-          match = line.match(/request\.headers\[["']([^"']+)["']\]/)
-          if match
-            header_name = match[1]
-            endpoint.push_param(Param.new(header_name, "", "header"))
-          end
-        end
-
-        # Extract cookies from request.cookies
-        if line.includes?("request.cookies[")
-          match = line.match(/request\.cookies\[["']([^"']+)["']\]/)
-          if match
-            cookie_name = match[1]
-            endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-          end
-        end
-
-        # Extract path parameters from context.parameters.require or context.parameters.get
-        if line.includes?("context.parameters.require(") ||
-           line.includes?("context.parameters.get(")
-          match = line.match(/context\.parameters\.(require|get)\(["']([^"']+)["']\)/)
-          if match
-            param_name = match[2]
-            if !existing_path_params.includes?(param_name)
-              endpoint.push_param(Param.new(param_name, "", "path"))
-              existing_path_params.add(param_name)
-            end
-          end
-        end
+        extract_params_from_line(line, endpoint, existing_path_params)
 
         if in_function && seen_opening_brace && brace_count == 0 && i > start_index
           break
@@ -162,8 +134,15 @@ module Analyzer::Swift
         !line.includes?("request.uri.queryParameters")
     end
 
-    private def attach_route_callees(lines : Array(String), route_index : Int32, path : String, endpoint : Endpoint)
+    private def attach_route_callees(lines : Array(String),
+                                     route_index : Int32,
+                                     path : String,
+                                     endpoint : Endpoint,
+                                     handler_bodies : Hash(String, Tuple(String, Int32)))
       body, start_line = route_body(lines, route_index)
+      if body.empty?
+        body, start_line = named_handler_body(lines[route_index], route_index, handler_bodies)
+      end
       return if body.empty?
 
       callees = Noir::SwiftCalleeExtractor.callees_for_body(body, path, start_line)
@@ -232,6 +211,249 @@ module Analyzer::Swift
     private def structural_opening_brace(line : String) : Int32?
       stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
       stripped.index('{')
+    end
+
+    private def register_group_assignment(line : String, prefix_by_receiver : Hash(String, String))
+      match = line.match(GROUP_ASSIGN_PATTERN)
+      return unless match
+
+      variable = match[1]
+      base = match[2]
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(match[3]))
+    end
+
+    private def register_group_closure(line : String,
+                                       prefix_by_receiver : Hash(String, String),
+                                       group_prefix_stack : Array(Tuple(String, Int32)),
+                                       brace_depth : Int32)
+      match = line.match(GROUP_CLOSURE_PATTERN)
+      return unless match
+
+      base = match[1]
+      variable = match[3]
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(match[2]))
+      group_prefix_stack << {variable, brace_depth + 1}
+    end
+
+    private def update_group_depth(line : String,
+                                   brace_depth : Int32,
+                                   group_prefix_stack : Array(Tuple(String, Int32)),
+                                   prefix_by_receiver : Hash(String, String)) : Int32
+      structural, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
+      depth = brace_depth + structural.count('{') - structural.count('}')
+
+      while !group_prefix_stack.empty? && depth < group_prefix_stack.last[1]
+        variable, _ = group_prefix_stack.pop
+        prefix_by_receiver.delete(variable)
+      end
+
+      depth
+    end
+
+    private def prefix_for_receiver(receiver : String, prefix_by_receiver : Hash(String, String)) : String
+      receiver.split('.').reverse_each do |part|
+        if prefix = prefix_by_receiver[part]?
+          return prefix
+        end
+      end
+
+      ""
+    end
+
+    private def join_paths(prefix : String, path : String) : String
+      return normalize_path(path) if prefix.empty? || prefix == "/"
+      return normalize_path(prefix) if path.empty? || path == "/"
+
+      "#{normalize_path(prefix).rstrip("/")}/#{path.lstrip("/")}"
+    end
+
+    private def normalize_path(path : String) : String
+      normalized = path.empty? ? "/" : path
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized.gsub(%r{/+}, "/")
+    end
+
+    private def code_line(line : String) : String
+      line.split("//", 2).first
+    end
+
+    private def extract_named_handler_params(route_line : String,
+                                             handler_bodies : Hash(String, Tuple(String, Int32)),
+                                             endpoint : Endpoint)
+      handler_name = route_handler_name(route_line)
+      return unless handler_name
+
+      body = handler_bodies[handler_name]?
+      return unless body
+
+      existing_path_params = Set(String).new
+      endpoint.params.each do |p|
+        existing_path_params.add(p.name) if p.param_type == "path"
+      end
+
+      body[0].each_line do |line|
+        extract_params_from_line(line, endpoint, existing_path_params)
+      end
+    end
+
+    private def extract_params_from_line(line : String, endpoint : Endpoint, existing_path_params : Set(String))
+      # Extract query parameters from request.uri.queryParameters
+      if line.includes?("request.uri.queryParameters.get(") ||
+         line.includes?("request.uri.queryParameters[")
+        match = line.match(/request\.uri\.queryParameters\.get\(["']([^"']+)["']\)/) ||
+                line.match(/request\.uri\.queryParameters\[["']([^"']+)["']\]/)
+        if match
+          query_name = match[1]
+          endpoint.push_param(Param.new(query_name, "", "query"))
+        end
+      end
+
+      # Extract body parameters from request.decode
+      if line.includes?("request.decode(") || line.includes?("await request.decode")
+        endpoint.push_param(Param.new("body", "", "json"))
+      end
+
+      # Extract headers from request.headers
+      if line.includes?("request.headers[")
+        match = line.match(/request\.headers\[["']([^"']+)["']\]/)
+        if match
+          header_name = match[1]
+          endpoint.push_param(Param.new(header_name, "", "header"))
+        end
+      end
+
+      # Extract cookies from request.cookies
+      if line.includes?("request.cookies[")
+        match = line.match(/request\.cookies\[["']([^"']+)["']\]/)
+        if match
+          cookie_name = match[1]
+          endpoint.push_param(Param.new(cookie_name, "", "cookie"))
+        end
+      end
+
+      # Extract path parameters from context.parameters.require or context.parameters.get
+      if line.includes?("context.parameters.require(") ||
+         line.includes?("context.parameters.get(")
+        match = line.match(/context\.parameters\.(require|get)\(["']([^"']+)["']\)/)
+        if match
+          param_name = match[2]
+          if !existing_path_params.includes?(param_name)
+            endpoint.push_param(Param.new(param_name, "", "path"))
+            existing_path_params.add(param_name)
+          end
+        end
+      end
+    end
+
+    private def named_handler_body(route_line : String,
+                                   route_index : Int32,
+                                   handler_bodies : Hash(String, Tuple(String, Int32))) : Tuple(String, Int32)
+      handler_name = route_handler_name(route_line)
+      return {"", route_index + 2} unless handler_name
+
+      handler_bodies[handler_name]? || {"", route_index + 2}
+    end
+
+    private def route_handler_name(route_line : String) : String?
+      stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(route_line, 0, false)
+      if match = stripped.match(/\buse:\s*([A-Za-z_]\w*)/)
+        return match[1]
+      end
+
+      nil
+    end
+
+    private def named_handler_bodies(lines : Array(String)) : Hash(String, Tuple(String, Int32))
+      bodies = {} of String => Tuple(String, Int32)
+      block_comment_depth = 0
+      in_multiline_string = false
+
+      lines.each_with_index do |line, index|
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        match = stripped.match(FUNCTION_SIGNATURE_PATTERN)
+        next unless match
+
+        handler_name = match[1]
+        next if bodies.has_key?(handler_name)
+
+        opening = stripped.index('{')
+        if opening
+          bodies[handler_name] = body_after_opening_brace(lines, index, opening)
+          next
+        end
+
+        if location = next_opening_brace(lines, index + 1, block_comment_depth, in_multiline_string)
+          opening_index, opening_brace = location
+          bodies[handler_name] = body_after_opening_brace(lines, opening_index, opening_brace)
+        end
+      end
+
+      bodies
+    end
+
+    private def next_opening_brace(lines : Array(String),
+                                   start_index : Int32,
+                                   block_comment_depth : Int32,
+                                   in_multiline_string : Bool) : Tuple(Int32, Int32)?
+      (start_index...[start_index + LOOKAHEAD_LIMIT, lines.size].min).each do |index|
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          lines[index],
+          block_comment_depth,
+          in_multiline_string
+        )
+        if opening = stripped.index('{')
+          return {index, opening}
+        end
+
+        break if stripped.match(FUNCTION_SIGNATURE_PATTERN)
+      end
+
+      nil
+    end
+
+    private def body_after_opening_brace(lines : Array(String), opening_index : Int32, opening_brace : Int32) : Tuple(String, Int32)
+      route_line = lines[opening_index]
+      first_fragment = route_line[(opening_brace + 1)..]? || ""
+      clean_fragment, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
+      body_lines = [] of String
+      brace_count = 1 + clean_fragment.count('{') - clean_fragment.count('}')
+
+      if brace_count <= 0
+        closing_brace = clean_fragment.rindex('}')
+        first_fragment = first_fragment[0...closing_brace] if closing_brace
+        return {first_fragment, opening_index + 1}
+      end
+
+      body_lines << first_fragment
+      index = opening_index + 1
+
+      while index < lines.size && brace_count > 0
+        line = lines[index]
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        next_brace_count = brace_count + stripped.count('{') - stripped.count('}')
+
+        if next_brace_count <= 0
+          if line.strip != "}"
+            closing_brace = stripped.rindex('}')
+            body_lines << (closing_brace ? line[0...closing_brace] : line)
+          end
+          break
+        end
+
+        body_lines << line
+        brace_count = next_brace_count
+        index += 1
+      end
+
+      {body_lines.join("\n"), opening_index + 1}
     end
   end
 end

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -9,10 +9,10 @@ module Analyzer::Swift
     # Patterns for route definitions in Hummingbird:
     # router.get("path") { ... }
     # router.post("path") { ... }
-    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\((.*)\)/
+    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\(/
     ROUTE_BODY_LOOKAHEAD_LIMIT = 5
-    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.group\s*\((.*)\)/
-    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group\s*\((.*)\)\s*\{\s*([A-Za-z_]\w*)\s+in/
+    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.group\s*\(/
+    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group\s*\(/
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
     def analyze_file(path : String) : Array(Endpoint)
@@ -38,7 +38,10 @@ module Analyzer::Swift
         begin
           receiver = match[1]
           method = match[2].upcase
-          route_args = match[3]
+          args = call_arguments(stripped_line, match.end(0) || 0)
+          next unless args
+
+          route_args = args[0]
           route_path = join_paths(prefix_for_receiver(receiver, prefix_by_receiver), parse_route_path(route_args))
 
           details = Details.new(PathInfo.new(path, index + 1))
@@ -219,7 +222,10 @@ module Analyzer::Swift
 
       variable = match[1]
       base = match[2]
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(match[3]))
+      args = call_arguments(line, match.end(0) || 0)
+      return unless args
+
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
     end
 
     private def register_group_closure(line : String,
@@ -230,9 +236,52 @@ module Analyzer::Swift
       return unless match
 
       base = match[1]
-      variable = match[3]
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(match[2]))
+      args = call_arguments(line, match.end(0) || 0)
+      return unless args
+
+      after_call = line[(args[1] + 1)..]? || ""
+      closure_match = after_call.match(/^\s*\{\s*([A-Za-z_]\w*)\s+in/)
+      return unless closure_match
+
+      variable = closure_match[1]
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
       group_prefix_stack << {variable, brace_depth + 1}
+    end
+
+    private def call_arguments(line : String, args_start : Int32) : Tuple(String, Int32)?
+      depth = 1
+      in_string = false
+      escaped = false
+      quote = '"'
+      index = args_start
+
+      while index < line.size
+        char = line[index]
+
+        if in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '('
+          depth += 1
+        elsif char == ')'
+          depth -= 1
+          if depth == 0
+            return {line[args_start...index], index}
+          end
+        end
+
+        index += 1
+      end
+
+      nil
     end
 
     private def update_group_depth(line : String,

--- a/src/analyzer/analyzers/swift/kitura.cr
+++ b/src/analyzer/analyzers/swift/kitura.cr
@@ -18,7 +18,7 @@ module Analyzer::Swift
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      handler_bodies = include_callee ? named_handler_bodies(lines) : {} of String => Tuple(String, Int32)
+      handler_bodies = named_handler_bodies(lines)
 
       lines.each_with_index do |line, index|
         next unless route_definition_line?(line)
@@ -37,6 +37,7 @@ module Analyzer::Swift
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
+          extract_named_handler_params(lines[index], handler_bodies, endpoint)
           attach_route_callees(lines, index, path, endpoint, handler_bodies) if include_callee
 
           endpoints << endpoint
@@ -96,49 +97,7 @@ module Analyzer::Swift
         end
         brace_count -= line.count('}')
 
-        # Extract query parameters from request.queryParameters
-        if line.includes?("request.queryParameters[")
-          match = line.match(/request\.queryParameters\[["']([^"']+)["']\]/)
-          if match
-            query_name = match[1]
-            endpoint.push_param(Param.new(query_name, "", "query"))
-          end
-        end
-
-        # Extract body parameters from request.body or try? request.read
-        if line.includes?("request.body") || line.includes?("request.read")
-          endpoint.push_param(Param.new("body", "", "json"))
-        end
-
-        # Extract headers from request.headers
-        if line.includes?("request.headers[")
-          match = line.match(/request\.headers\[["']([^"']+)["']\]/)
-          if match
-            header_name = match[1]
-            endpoint.push_param(Param.new(header_name, "", "header"))
-          end
-        end
-
-        # Extract cookies from request.cookies
-        if line.includes?("request.cookies[")
-          match = line.match(/request\.cookies\[["']([^"']+)["']\]/)
-          if match
-            cookie_name = match[1]
-            endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-          end
-        end
-
-        # Extract path parameters from request.parameters
-        if line.includes?("request.parameters[")
-          match = line.match(/request\.parameters\[["']([^"']+)["']\]/)
-          if match
-            param_name = match[1]
-            if !existing_path_params.includes?(param_name)
-              endpoint.push_param(Param.new(param_name, "", "path"))
-              existing_path_params.add(param_name)
-            end
-          end
-        end
+        extract_params_from_line(line, endpoint, existing_path_params)
 
         if in_function && seen_opening_brace && brace_count == 0 && i > start_index
           break
@@ -268,6 +227,71 @@ module Analyzer::Swift
       end
 
       nil
+    end
+
+    private def extract_named_handler_params(route_line : String,
+                                             handler_bodies : Hash(String, Tuple(String, Int32)),
+                                             endpoint : Endpoint)
+      handler_name = route_handler_name(route_line)
+      return unless handler_name
+
+      body = handler_bodies[handler_name]?
+      return unless body
+
+      existing_path_params = Set(String).new
+      endpoint.params.each do |p|
+        existing_path_params.add(p.name) if p.param_type == "path"
+      end
+
+      body[0].each_line do |line|
+        extract_params_from_line(line, endpoint, existing_path_params)
+      end
+    end
+
+    private def extract_params_from_line(line : String, endpoint : Endpoint, existing_path_params : Set(String))
+      # Extract query parameters from request.queryParameters
+      if line.includes?("request.queryParameters[")
+        match = line.match(/request\.queryParameters\[["']([^"']+)["']\]/)
+        if match
+          query_name = match[1]
+          endpoint.push_param(Param.new(query_name, "", "query"))
+        end
+      end
+
+      # Extract body parameters from request.body or try? request.read
+      if line.includes?("request.body") || line.includes?("request.read")
+        endpoint.push_param(Param.new("body", "", "json"))
+      end
+
+      # Extract headers from request.headers
+      if line.includes?("request.headers[")
+        match = line.match(/request\.headers\[["']([^"']+)["']\]/)
+        if match
+          header_name = match[1]
+          endpoint.push_param(Param.new(header_name, "", "header"))
+        end
+      end
+
+      # Extract cookies from request.cookies
+      if line.includes?("request.cookies[")
+        match = line.match(/request\.cookies\[["']([^"']+)["']\]/)
+        if match
+          cookie_name = match[1]
+          endpoint.push_param(Param.new(cookie_name, "", "cookie"))
+        end
+      end
+
+      # Extract path parameters from request.parameters
+      if line.includes?("request.parameters[")
+        match = line.match(/request\.parameters\[["']([^"']+)["']\]/)
+        if match
+          param_name = match[1]
+          if !existing_path_params.includes?(param_name)
+            endpoint.push_param(Param.new(param_name, "", "path"))
+            existing_path_params.add(param_name)
+          end
+        end
+      end
     end
 
     private def body_after_opening_brace(lines : Array(String), opening_index : Int32, opening_brace : Int32) : Tuple(String, Int32)

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -10,10 +10,10 @@ module Analyzer::Swift
     # app.get("path") { ... }
     # app.post("path", "segment") { ... }
     # routes.get("path", ":param") { ... }
-    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\((.*)\)/
-    ON_ROUTE_PATTERN           = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.on\s*\(\s*\.(GET|POST|PUT|DELETE|PATCH)\s*,(.*)\)/
-    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.grouped\s*\((.*)\)/
-    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group(?:ed)?\s*\((.*)\)\s*\{\s*([A-Za-z_]\w*)\s+in/
+    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\(/
+    ON_ROUTE_PATTERN           = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.on\s*\(/
+    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.grouped\s*\(/
+    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group(?:ed)?\s*\(/
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
     def analyze_file(path : String) : Array(Endpoint)
@@ -211,11 +211,21 @@ module Analyzer::Swift
       return unless route_definition_line?(line)
 
       if match = line.match(ON_ROUTE_PATTERN)
-        return {match[1], match[2], match[3]}
+        args = call_arguments(line, match.end(0) || 0)
+        return unless args
+
+        route_args = args[0]
+        method_match = route_args.match(/^\s*\.(GET|POST|PUT|DELETE|PATCH)\s*,(.*)$/)
+        return unless method_match
+
+        return {match[1], method_match[1], method_match[2]}
       end
 
       if match = line.match(ROUTE_PATTERN)
-        return {match[1], match[2].upcase, match[3]}
+        args = call_arguments(line, match.end(0) || 0)
+        return unless args
+
+        return {match[1], match[2].upcase, args[0]}
       end
 
       nil
@@ -227,7 +237,10 @@ module Analyzer::Swift
 
       variable = match[1]
       base = match[2]
-      prefix = parse_route_path(match[3])
+      args = call_arguments(line, match.end(0) || 0)
+      return unless args
+
+      prefix = parse_route_path(args[0])
       prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), prefix)
     end
 
@@ -239,10 +252,52 @@ module Analyzer::Swift
       return unless match
 
       base = match[1]
-      args = match[2]
-      variable = match[3]
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args))
+      args = call_arguments(line, match.end(0) || 0)
+      return unless args
+
+      after_call = line[(args[1] + 1)..]? || ""
+      closure_match = after_call.match(/^\s*\{\s*([A-Za-z_]\w*)\s+in/)
+      return unless closure_match
+
+      variable = closure_match[1]
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
       group_prefix_stack << {variable, brace_depth + 1}
+    end
+
+    private def call_arguments(line : String, args_start : Int32) : Tuple(String, Int32)?
+      depth = 1
+      in_string = false
+      escaped = false
+      quote = '"'
+      index = args_start
+
+      while index < line.size
+        char = line[index]
+
+        if in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '('
+          depth += 1
+        elsif char == ')'
+          depth -= 1
+          if depth == 0
+            return {line[args_start...index], index}
+          end
+        end
+
+        index += 1
+      end
+
+      nil
     end
 
     private def update_group_depth(line : String,

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -10,33 +10,49 @@ module Analyzer::Swift
     # app.get("path") { ... }
     # app.post("path", "segment") { ... }
     # routes.get("path", ":param") { ... }
-    ROUTE_PATTERN = /(\w+)\.(get|post|put|delete|patch)\(([^)]+)\)/
+    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\((.*)\)/
+    ON_ROUTE_PATTERN           = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.on\s*\(\s*\.(GET|POST|PUT|DELETE|PATCH)\s*,(.*)\)/
+    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.grouped\s*\((.*)\)/
+    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group(?:ed)?\s*\((.*)\)\s*\{\s*([A-Za-z_]\w*)\s+in/
+    FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      handler_bodies = named_handler_bodies(lines)
+      prefix_by_receiver = {} of String => String
+      group_prefix_stack = [] of Tuple(String, Int32)
+      brace_depth = 0
 
       lines.each_with_index do |line, index|
-        next unless route_definition_line?(line)
-        match = line.match(ROUTE_PATTERN)
-        next unless match
+        stripped_line = code_line(line)
+        register_group_assignment(stripped_line, prefix_by_receiver)
+        register_group_closure(stripped_line, prefix_by_receiver, group_prefix_stack, brace_depth)
+
+        route = route_parts(stripped_line)
+        unless route
+          brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
+          next
+        end
 
         begin
-          method = match[2].upcase
-          route_args = match[3]
-          route_path = parse_route_path(route_args)
+          receiver, method, route_args = route
+          route_path = join_paths(prefix_for_receiver(receiver, prefix_by_receiver), parse_route_path(route_args))
 
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint = Endpoint.new(route_path, method, details)
 
           extract_path_params(route_path, endpoint)
           extract_function_params(lines, index + 1, endpoint)
-          attach_route_callees(lines, index, path, endpoint) if include_callee
+          extract_named_handler_params(lines[index], handler_bodies, endpoint)
+          attach_route_callees(lines, index, path, endpoint, handler_bodies) if include_callee
 
           endpoints << endpoint
         rescue e
           logger.debug "Error processing endpoint: #{e.message}"
+        ensure
+          brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
         end
       end
 
@@ -55,6 +71,8 @@ module Analyzer::Swift
       # Extract quoted strings only (path segments)
       path_segments = [] of String
       segments.each do |seg|
+        break if seg.match(/^\w+\s*:/)
+
         # Match quoted strings
         if match = seg.match(/^["']([^"']+)["']/)
           path_segments << match[1]
@@ -102,50 +120,7 @@ module Analyzer::Swift
         end
         brace_count -= line.count('}')
 
-        # Extract query parameters from req.query
-        if line.includes?("req.query[") || line.includes?("req.query.get(")
-          match = line.match(/req\.query\[["']([^"']+)["']\]/) ||
-                  line.match(/req\.query\.get\(["']([^"']+)["']\)/)
-          if match
-            query_name = match[1]
-            endpoint.push_param(Param.new(query_name, "", "query"))
-          end
-        end
-
-        # Extract body parameters from req.content.decode
-        if line.includes?("req.content.decode(") || line.includes?("try req.content.decode")
-          endpoint.push_param(Param.new("body", "", "json"))
-        end
-
-        # Extract headers from req.headers
-        if line.includes?("req.headers[")
-          match = line.match(/req\.headers\[["']([^"']+)["']\]/)
-          if match
-            header_name = match[1]
-            endpoint.push_param(Param.new(header_name, "", "header"))
-          end
-        end
-
-        # Extract cookies from req.cookies
-        if line.includes?("req.cookies[")
-          match = line.match(/req\.cookies\[["']([^"']+)["']\]/)
-          if match
-            cookie_name = match[1]
-            endpoint.push_param(Param.new(cookie_name, "", "cookie"))
-          end
-        end
-
-        # Extract path parameters from req.parameters.get
-        if line.includes?("req.parameters.get(")
-          match = line.match(/req\.parameters\.get\(["']([^"']+)["']\)/)
-          if match
-            param_name = match[1]
-            if !existing_path_params.includes?(param_name)
-              endpoint.push_param(Param.new(param_name, "", "path"))
-              existing_path_params.add(param_name)
-            end
-          end
-        end
+        extract_params_from_line(line, endpoint, existing_path_params)
 
         if in_function && seen_opening_brace && brace_count == 0 && i > start_index
           break
@@ -161,7 +136,7 @@ module Analyzer::Swift
     private def route_definition?(line : String) : Bool
       line.includes?(".get(") || line.includes?(".post(") ||
         line.includes?(".put(") || line.includes?(".delete(") ||
-        line.includes?(".patch(")
+        line.includes?(".patch(") || line.includes?(".on(")
     end
 
     # Check if a line is a route definition but not a parameter access
@@ -171,8 +146,15 @@ module Analyzer::Swift
         !line.includes?("req.query")
     end
 
-    private def attach_route_callees(lines : Array(String), route_index : Int32, path : String, endpoint : Endpoint)
+    private def attach_route_callees(lines : Array(String),
+                                     route_index : Int32,
+                                     path : String,
+                                     endpoint : Endpoint,
+                                     handler_bodies : Hash(String, Tuple(String, Int32)))
       body, start_line = route_body(lines, route_index)
+      if body.empty?
+        body, start_line = named_handler_body(lines[route_index], handler_bodies, route_index)
+      end
       return if body.empty?
 
       callees = Noir::SwiftCalleeExtractor.callees_for_body(body, path, start_line)
@@ -223,6 +205,263 @@ module Analyzer::Swift
       end
 
       {body_lines.join("\n"), route_index + 1}
+    end
+
+    private def route_parts(line : String) : Tuple(String, String, String)?
+      return unless route_definition_line?(line)
+
+      if match = line.match(ON_ROUTE_PATTERN)
+        return {match[1], match[2], match[3]}
+      end
+
+      if match = line.match(ROUTE_PATTERN)
+        return {match[1], match[2].upcase, match[3]}
+      end
+
+      nil
+    end
+
+    private def register_group_assignment(line : String, prefix_by_receiver : Hash(String, String))
+      match = line.match(GROUP_ASSIGN_PATTERN)
+      return unless match
+
+      variable = match[1]
+      base = match[2]
+      prefix = parse_route_path(match[3])
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), prefix)
+    end
+
+    private def register_group_closure(line : String,
+                                       prefix_by_receiver : Hash(String, String),
+                                       group_prefix_stack : Array(Tuple(String, Int32)),
+                                       brace_depth : Int32)
+      match = line.match(GROUP_CLOSURE_PATTERN)
+      return unless match
+
+      base = match[1]
+      args = match[2]
+      variable = match[3]
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args))
+      group_prefix_stack << {variable, brace_depth + 1}
+    end
+
+    private def update_group_depth(line : String,
+                                   brace_depth : Int32,
+                                   group_prefix_stack : Array(Tuple(String, Int32)),
+                                   prefix_by_receiver : Hash(String, String)) : Int32
+      structural, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
+      depth = brace_depth + structural.count('{') - structural.count('}')
+
+      while !group_prefix_stack.empty? && depth < group_prefix_stack.last[1]
+        variable, _ = group_prefix_stack.pop
+        prefix_by_receiver.delete(variable)
+      end
+
+      depth
+    end
+
+    private def prefix_for_receiver(receiver : String, prefix_by_receiver : Hash(String, String)) : String
+      receiver.split('.').reverse_each do |part|
+        if prefix = prefix_by_receiver[part]?
+          return prefix
+        end
+      end
+
+      ""
+    end
+
+    private def join_paths(prefix : String, path : String) : String
+      return normalize_path(path) if prefix.empty? || prefix == "/"
+      return normalize_path(prefix) if path.empty? || path == "/"
+
+      "#{normalize_path(prefix).rstrip("/")}/#{path.lstrip("/")}"
+    end
+
+    private def normalize_path(path : String) : String
+      normalized = path.empty? ? "/" : path
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized.gsub(%r{/+}, "/")
+    end
+
+    private def code_line(line : String) : String
+      line.split("//", 2).first
+    end
+
+    private def extract_named_handler_params(route_line : String,
+                                             handler_bodies : Hash(String, Tuple(String, Int32)),
+                                             endpoint : Endpoint)
+      handler_name = route_handler_name(route_line)
+      return unless handler_name
+
+      body = handler_bodies[handler_name]?
+      return unless body
+
+      existing_path_params = Set(String).new
+      endpoint.params.each do |p|
+        existing_path_params.add(p.name) if p.param_type == "path"
+      end
+
+      body[0].each_line do |line|
+        extract_params_from_line(line, endpoint, existing_path_params)
+      end
+    end
+
+    private def extract_params_from_line(line : String, endpoint : Endpoint, existing_path_params : Set(String))
+      # Extract query parameters from req.query
+      if line.includes?("req.query[") || line.includes?("req.query.get(")
+        match = line.match(/req\.query\[["']([^"']+)["']\]/) ||
+                line.match(/req\.query\.get\(["']([^"']+)["']\)/)
+        if match
+          query_name = match[1]
+          endpoint.push_param(Param.new(query_name, "", "query"))
+        end
+      end
+
+      # Extract body parameters from req.content.decode
+      if line.includes?("req.content.decode(") || line.includes?("try req.content.decode")
+        endpoint.push_param(Param.new("body", "", "json"))
+      end
+
+      # Extract headers from req.headers
+      if line.includes?("req.headers[")
+        match = line.match(/req\.headers\[["']([^"']+)["']\]/)
+        if match
+          header_name = match[1]
+          endpoint.push_param(Param.new(header_name, "", "header"))
+        end
+      end
+
+      # Extract cookies from req.cookies
+      if line.includes?("req.cookies[")
+        match = line.match(/req\.cookies\[["']([^"']+)["']\]/)
+        if match
+          cookie_name = match[1]
+          endpoint.push_param(Param.new(cookie_name, "", "cookie"))
+        end
+      end
+
+      # Extract path parameters from req.parameters.get
+      if line.includes?("req.parameters.get(")
+        match = line.match(/req\.parameters\.get\(["']([^"']+)["']\)/)
+        if match
+          param_name = match[1]
+          if !existing_path_params.includes?(param_name)
+            endpoint.push_param(Param.new(param_name, "", "path"))
+            existing_path_params.add(param_name)
+          end
+        end
+      end
+    end
+
+    private def named_handler_body(route_line : String,
+                                   handler_bodies : Hash(String, Tuple(String, Int32)),
+                                   route_index : Int32) : Tuple(String, Int32)
+      handler_name = route_handler_name(route_line)
+      return {"", route_index + 2} unless handler_name
+
+      handler_bodies[handler_name]? || {"", route_index + 2}
+    end
+
+    private def route_handler_name(route_line : String) : String?
+      stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(route_line, 0, false)
+      if match = stripped.match(/\buse:\s*([A-Za-z_]\w*)/)
+        return match[1]
+      end
+
+      nil
+    end
+
+    private def named_handler_bodies(lines : Array(String)) : Hash(String, Tuple(String, Int32))
+      bodies = {} of String => Tuple(String, Int32)
+      block_comment_depth = 0
+      in_multiline_string = false
+
+      lines.each_with_index do |line, index|
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        match = stripped.match(FUNCTION_SIGNATURE_PATTERN)
+        next unless match
+
+        handler_name = match[1]
+        next if bodies.has_key?(handler_name)
+
+        opening = stripped.index('{')
+        if opening
+          bodies[handler_name] = body_after_opening_brace(lines, index, opening)
+          next
+        end
+
+        if location = next_opening_brace(lines, index + 1, block_comment_depth, in_multiline_string)
+          opening_index, opening_brace = location
+          bodies[handler_name] = body_after_opening_brace(lines, opening_index, opening_brace)
+        end
+      end
+
+      bodies
+    end
+
+    private def next_opening_brace(lines : Array(String),
+                                   start_index : Int32,
+                                   block_comment_depth : Int32,
+                                   in_multiline_string : Bool) : Tuple(Int32, Int32)?
+      (start_index...[start_index + LOOKAHEAD_LIMIT, lines.size].min).each do |index|
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          lines[index],
+          block_comment_depth,
+          in_multiline_string
+        )
+        if opening = stripped.index('{')
+          return {index, opening}
+        end
+
+        break if stripped.match(FUNCTION_SIGNATURE_PATTERN)
+      end
+
+      nil
+    end
+
+    private def body_after_opening_brace(lines : Array(String), opening_index : Int32, opening_brace : Int32) : Tuple(String, Int32)
+      route_line = lines[opening_index]
+      first_fragment = route_line[(opening_brace + 1)..]? || ""
+      clean_fragment, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
+      body_lines = [] of String
+      brace_count = 1 + clean_fragment.count('{') - clean_fragment.count('}')
+
+      if brace_count <= 0
+        closing_brace = clean_fragment.rindex('}')
+        first_fragment = first_fragment[0...closing_brace] if closing_brace
+        return {first_fragment, opening_index + 1}
+      end
+
+      body_lines << first_fragment
+      index = opening_index + 1
+
+      while index < lines.size && brace_count > 0
+        line = lines[index]
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        next_brace_count = brace_count + stripped.count('{') - stripped.count('}')
+
+        if next_brace_count <= 0
+          if line.strip != "}"
+            closing_brace = stripped.rindex('}')
+            body_lines << (closing_brace ? line[0...closing_brace] : line)
+          end
+          break
+        end
+
+        body_lines << line
+        brace_count = next_brace_count
+        index += 1
+      end
+
+      {body_lines.join("\n"), opening_index + 1}
     end
   end
 end


### PR DESCRIPTION
## Summary
- expand Swift Vapor and Hummingbird route detection for grouped routers, named handlers, and multiline handler signatures
- extract Kitura named-handler params outside callee mode
- improve Scala Akka, Scalatra, and Play coverage for common DSL/controller patterns
- add focused regression specs for the new Swift and Scala route styles

## Tests
- just test
- just build
- just check