### PR TITLE
Improve axum route analysis coverage

### DIFF
--- a/spec/functional_test/fixtures/rust/axum/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum/src/main.rs
@@ -1,4 +1,5 @@
-use axum::{response::Html, routing::get, Router};
+use axum::{response::Html, routing::{any, get, post}, Router};
+use tower_http::services::ServeDir;
 
 #[tokio::main]
 async fn main() {
@@ -6,13 +7,24 @@ async fn main() {
         .route("/", get(handler))
         .route("/foo", get(handler))
         .route("/bar", post(handler))
+        // Verb-agnostic registration — typically used for WebSocket
+        // upgrade endpoints. axum 0.7 exports `routing::any`.
+        .route("/ws", any(handler))
+        // Service-shaped registration mounts a tower service at a
+        // single path. Common for one-off file responders.
+        .route_service("/favicon.ico", ServeDir::new("assets"))
+        // Sub-tree service mount — the static-files idiom.
+        .nest_service("/assets", ServeDir::new("static"))
+        // Catch-all fallback handler, often used to serve an SPA's
+        // index.html for unknown paths.
+        .fallback(handler)
         .nest(
             "/api",
             Router::new()
                 .route("/users", get(handler))
                 .route("/admin", post(handler)),
         );
-        
+
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
         .unwrap();
@@ -36,6 +48,9 @@ mod tests {
     async fn test_app_routes() {
         let _app = Router::new()
             .route("/should-not-appear-get", get(handler))
-            .route("/should-not-appear-post", post(handler));
+            .route("/should-not-appear-post", post(handler))
+            .route_service("/should-not-appear-service", ServeDir::new("x"))
+            .nest_service("/should-not-appear-nest-service", ServeDir::new("y"))
+            .fallback(handler);
     }
 }

--- a/spec/functional_test/testers/rust/axum_spec.cr
+++ b/spec/functional_test/testers/rust/axum_spec.cr
@@ -4,6 +4,10 @@ expected_endpoints = [
   Endpoint.new("/", "GET"),
   Endpoint.new("/foo", "GET"),
   Endpoint.new("/bar", "POST"),
+  Endpoint.new("/ws", "ANY"),
+  Endpoint.new("/favicon.ico", "ANY"),
+  Endpoint.new("/assets/*", "ANY"),
+  Endpoint.new("/*", "ANY"),
   Endpoint.new("/api/users", "GET"),
   Endpoint.new("/api/admin", "POST"),
 ]

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -13,8 +13,16 @@ module Analyzer::Rust
   class Axum < RustEngine
     # Verbs accepted as the inner handler call (`get(...)`, `post(...)`,
     # …). Anything outside this set is treated as `GET` to match the
-    # legacy fallback the regex analyzer used.
-    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
+    # legacy fallback the regex analyzer used. `any` covers
+    # `axum::routing::any(handler)` — a verb-agnostic registration
+    # commonly used for WebSocket upgrades and reverse-proxy fallbacks.
+    HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options", "any"}
+
+    # Method emitted for service-shaped registrations (`route_service`,
+    # `nest_service`, `fallback_service`). Services aren't bound to a
+    # specific HTTP method — `tower-http::services::ServeDir` accepts
+    # whatever the client sends — so we mirror axum's `any` verb.
+    SERVICE_METHOD = "ANY"
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
@@ -61,15 +69,16 @@ module Analyzer::Rust
       endpoints
     end
 
-    # `.route("...", get(handler))` — the chain is rooted on
-    # `Router::new()` but tree-sitter sees each `.route(...)` as its
-    # own `call_expression` because the receiver chain is left-folded.
-    private def route_call?(call : LibTreeSitter::TSNode, source : String) : Bool
-      fn_node = Noir::TreeSitter.field(call, "function")
-      return false unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
-      field = Noir::TreeSitter.field(fn_node, "field")
-      return false unless field
-      Noir::TreeSitter.node_text(field, source) == "route"
+    # Field-call names whose extracted shape `extract_route` knows
+    # how to read. `route_service`, `nest_service`, and the two
+    # `fallback*` variants surface in roughly half of all real-world
+    # axum apps (static-file mounts, SPA fallbacks, websocket upgrades).
+    ROUTER_EMIT_NAMES = Set{"route", "route_service", "nest_service", "fallback", "fallback_service"}
+
+    private def router_emit?(call : LibTreeSitter::TSNode, source : String) : Bool
+      name = field_call_name(call, source)
+      return false unless name
+      ROUTER_EMIT_NAMES.includes?(name)
     end
 
     # Walks Axum router builder chains with an active path prefix.
@@ -85,7 +94,12 @@ module Analyzer::Rust
       if Noir::TreeSitter.node_type(node) == "call_expression"
         return if RustEngine.inside_test_region?(node, test_regions)
 
-        if route_call?(node, source)
+        # `.route`, `.route_service`, `.nest_service`, and
+        # `.fallback` / `.fallback_service` all register endpoints;
+        # `extract_route` knows how to read each shape and returns
+        # `nil` for anything else. Treating them uniformly here keeps
+        # the receiver-chain walk single-pass.
+        if router_emit?(node, source)
           block.call(node, prefix)
           walk_receiver_chain(node, source, prefix, test_regions, &block)
           return
@@ -146,23 +160,62 @@ module Analyzer::Rust
       field ? Noir::TreeSitter.node_text(field, source) : nil
     end
 
-    # Returns `{path, http_method, handler_name?}` for a valid
-    # `.route(path, verb(handler))` call, or `nil` when the shape
-    # doesn't match. Returns a list of methods because Axum allows
-    # chaining (`get(handler).post(handler)`); each verb in the
-    # chain emits a separate endpoint.
+    # Returns `{path, http_methods, handler_name?}` for a valid
+    # router-emit call, or `nil` when the shape doesn't match.
+    # Dispatches by the field-call name:
+    # * `route(path, verb(handler))` — usual case; returns one or
+    #   more verbs from the `get(...)`/`post(...)` chain.
+    # * `route_service(path, svc)` / `nest_service(prefix, svc)` —
+    #   service-shaped mounts; verb is `ANY` because tower services
+    #   don't restrict methods.
+    # * `fallback(handler)` / `fallback_service(svc)` — catch-all
+    #   registration; we emit at `/*` so the endpoint surfaces in
+    #   downstream tooling without colliding with a real path.
     private def extract_route(call : LibTreeSitter::TSNode, source : String) : Tuple(String, Array(String), String?)?
-      args = Noir::TreeSitter.field(call, "arguments")
-      return unless args
+      kind = field_call_name(call, source)
+      return unless kind
 
-      named = named_children(args)
-      return if named.size < 2
+      case kind
+      when "route"
+        args = Noir::TreeSitter.field(call, "arguments")
+        return unless args
+        named = named_children(args)
+        return if named.size < 2
+        path = string_literal_text(named[0], source)
+        return unless path
+        methods, handler = decode_handler(named[1], source)
+        {path, methods, handler}
+      when "route_service"
+        args = Noir::TreeSitter.field(call, "arguments")
+        return unless args
+        named = named_children(args)
+        return if named.size < 1
+        path = string_literal_text(named[0], source)
+        return unless path
+        {path, [SERVICE_METHOD], nil}
+      when "nest_service"
+        args = Noir::TreeSitter.field(call, "arguments")
+        return unless args
+        named = named_children(args)
+        return if named.size < 1
+        prefix = string_literal_text(named[0], source)
+        return unless prefix
+        {join_paths(prefix, "/*"), [SERVICE_METHOD], nil}
+      when "fallback", "fallback_service"
+        args = Noir::TreeSitter.field(call, "arguments")
+        return unless args
+        named = named_children(args)
+        # Router-level `.fallback(handler)` (one arg) and the rare
+        # path-scoped `.fallback("/api/*", handler)` (two args, only
+        # available on `MethodRouter`) — bail on anything else.
+        handler = named.last?.try { |n| identifier_text(n, source) }
+        {"/*", [SERVICE_METHOD], handler}
+      end
+    end
 
-      path = string_literal_text(named[0], source)
-      return unless path
-
-      methods, handler = decode_handler(named[1], source)
-      {path, methods, handler}
+    private def identifier_text(node : LibTreeSitter::TSNode, source : String) : String?
+      return Noir::TreeSitter.node_text(node, source) if Noir::TreeSitter.node_type(node) == "identifier"
+      nil
     end
 
     # `get(handler)` → `{["GET"], "handler"}`.


### PR DESCRIPTION
## Summary
- Extend the Rust axum analyzer beyond `.route(path, verb(handler))` so apps using verb-agnostic and service-shaped registrations no longer drop endpoints.
- Recognize `routing::any`, `.route_service`, `.nest_service`, and `.fallback` / `.fallback_service` through a single dispatch table; tower-service mounts surface as `ANY` since services don't bind to a method.
- Fixture now exercises each new shape under production code plus a `#[cfg(test)]` regression guard, so the `should-not-appear-*` variants stay filtered.

This is the first PR in a Rust analyzer accuracy series — follow-ups will target the remaining FN gaps in actix-web (`#[route(..., method = "...")]` + scope propagation), warp (`path!` macro), poem / salvo (sub-router prefix propagation), and rocket (`mount` prefix joining).

## Test plan
- [x] `crystal spec spec/functional_test/testers/rust/` — 922 examples, 0 failures
- [x] `crystal spec spec/unit_test/.../rust*` — 30 examples, 0 failures
- [x] `just check` — 930 inspected, 0 failures