### PR TITLE
Refresh CLI banner with new owl ASCII art

### DIFF
--- a/src/banner.cr
+++ b/src/banner.cr
@@ -1,15 +1,41 @@
 def banner
-  content = <<-CONTENT
+  art = [
+    "           ùç  Y  wù           ",
+    "        ™w£ Í  ±  Í £w2        ",
+    "       ù£   Ï  Ï  Ï   £ù       ",
+    "      ù£    Ï  Ï  Ï  ± £ù      ",
+    "         Ï  Ï  Ï  Ï  Ï         ",
+    "     2YV±ÏÏÏÏÏÏÏÏÏÏÏÏÏ3ÍY2     ",
+    "         Ï  Ï  Ï  Ï  Ï         ",
+    "      ù£ ±  Ï  Ï  Ï  ± £ç      ",
+    "       ù£   Ï  Ï  Ï   £ç       ",
+    "        2w£ Í  ±  Í £©2        ",
+    "           ùw  Y  wù           ",
+  ]
 
-     ░██▒  ░██  ██████░ ██  ███████
-     ░███▓░ ██ ▒█▒   ██ ██  ██   ██     v#{Noir::VERSION}
-     ░████▓ ██ ▒█▒   ██ ██  ██▓████░
-     ░██ ██ ██ ▒█▒   ██ ██  ██ ░██░     Hunt every Endpoint,
-     ░██  █ ██ ▒█▒  ░██ ██  ██  ▒██     expose Shadow APIs,
-      ██   ░██  ██████░ ██░░██   ██░    map the Attack Surface.
+  name = "N O I R".colorize(:white).mode(:bold).to_s
+  version = "v#{Noir::VERSION}".colorize(:light_yellow).to_s
+  divider = "─" * 34
 
-    CONTENT
+  side = [
+    "",
+    "",
+    "  #{name}   #{version}",
+    "  #{divider.colorize(:dark_gray)}",
+    "",
+    "  Hunt every Endpoint,".colorize(:white).to_s,
+    "  expose Shadow APIs,".colorize(:white).to_s,
+    "  map the Attack Surface.".colorize(:white).to_s,
+    "",
+    "  #{"OWASP · github.com/owasp-noir/noir".colorize(:dark_gray)}",
+    "",
+  ]
+
+  art_color = Colorize::Color256.new(81)
+
   STDERR.puts ""
-  STDERR.puts content
+  art.each_with_index do |line, i|
+    STDERR.puts "#{line.colorize(art_color)}#{side[i]}"
+  end
   STDERR.puts ""
 end


### PR DESCRIPTION
## Summary
- Replaced the inline text banner in `src/banner.cr` with a textured owl ASCII figure on the left and a colorized info panel on the right (name, version, divider, tagline, project link).
- Rendered via 256-color cyan for the artwork plus `colorize` accents (bold white name, yellow version, dim gray meta) so the hierarchy reads clearly at startup.

## Preview
```
           ùç  Y  wù
        ™w£ Í  ±  Í £w2
       ù£   Ï  Ï  Ï   £ù         N O I R   v0.30.0
      ù£    Ï  Ï  Ï  ± £ù        ──────────────────────────────────
         Ï  Ï  Ï  Ï  Ï
     2YV±ÏÏÏÏÏÏÏÏÏÏÏÏÏ3ÍY2       Hunt every Endpoint,
         Ï  Ï  Ï  Ï  Ï           expose Shadow APIs,
      ù£ ±  Ï  Ï  Ï  ± £ç        map the Attack Surface.
       ù£   Ï  Ï  Ï   £ç
        2w£ Í  ±  Í £©2          OWASP · github.com/owasp-noir/noir
           ùw  Y  wù
```

## Test plan
- [x] `crystal build src/noir.cr` succeeds.
- [x] `noir -h` shows the new banner with correct alignment between the owl rows and the info panel.