### PR TITLE
Improve JavaScript route analysis accuracy

### DIFF
--- a/spec/functional_test/fixtures/javascript/fastify_route_config/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_route_config/app.js
@@ -1,0 +1,33 @@
+const fastify = require('fastify')()
+
+// Multi-line route config with a single method.
+fastify.route({
+  method: 'GET',
+  url: '/single',
+  handler: async (request, reply) => {
+    return { ok: true }
+  }
+})
+
+// Array `method` form covering multiple verbs.
+fastify.route({
+  method: ['GET', 'POST'],
+  url: '/items/:id',
+  handler: async (request, reply) => {
+    return { id: request.params.id }
+  }
+})
+
+// Plural `methods:` is also accepted by some Fastify versions.
+fastify.route({
+  methods: ['PUT', 'PATCH'],
+  url: '/users/:userId',
+  handler: async (request, reply) => {
+    return { ok: true }
+  }
+})
+
+// Verify single-line short form still works (regression).
+fastify.get('/regression', async () => ({ ok: true }))
+
+module.exports = fastify

--- a/spec/functional_test/fixtures/javascript/fastify_route_config/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_route_config/app.js
@@ -19,10 +19,12 @@ fastify.route({
 })
 
 // Plural `methods:` is also accepted by some Fastify versions.
+// Also exercises handler-body param extraction (request.body.*).
 fastify.route({
   methods: ['PUT', 'PATCH'],
   url: '/users/:userId',
   handler: async (request, reply) => {
+    const email = request.body.email
     return { ok: true }
   }
 })

--- a/spec/functional_test/fixtures/javascript/hono_on_array/app.ts
+++ b/spec/functional_test/fixtures/javascript/hono_on_array/app.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+// Single-method app.on (regression coverage)
+app.on('GET', '/single', (c) => c.text('ok'))
+
+// Array-method app.on (new coverage)
+app.on(['GET', 'POST'], '/items/:id', (c) => {
+  const id = c.req.param('id')
+  return c.json({ id })
+})
+
+// Lower-case methods inside array should normalize
+app.on(['put', 'patch'], '/users/:userId', (c) => {
+  const userId = c.req.param('userId')
+  return c.json({ userId })
+})
+
+export default app

--- a/spec/functional_test/fixtures/javascript/nestjs_versioning/cats.controller.ts
+++ b/spec/functional_test/fixtures/javascript/nestjs_versioning/cats.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Body, Param } from '@nestjs/common'
+
+// URI versioning via a single version string.
+@Controller({ path: 'cats', version: '1' })
+export class CatsControllerV1 {
+  @Get()
+  list() {
+    return []
+  }
+
+  @Get(':id')
+  byId(@Param('id') id: string) {
+    return { id }
+  }
+}
+
+// URI versioning across multiple versions on one controller.
+@Controller({ path: 'cats', version: ['2', '3'] })
+export class CatsControllerV2 {
+  @Post()
+  create(@Body() body: unknown) {
+    return body
+  }
+}
+
+// VERSION_NEUTRAL — emit without a version prefix.
+@Controller({ path: 'health', version: 'VERSION_NEUTRAL' })
+export class HealthController {
+  @Get()
+  ping() {
+    return { ok: true }
+  }
+}

--- a/spec/functional_test/testers/javascript/fastify_route_config_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_route_config_spec.cr
@@ -10,9 +10,11 @@ expected_endpoints = [
   ]),
   Endpoint.new("/users/:userId", "PUT", [
     Param.new("userId", "", "path"),
+    Param.new("email", "", "json"),
   ]),
   Endpoint.new("/users/:userId", "PATCH", [
     Param.new("userId", "", "path"),
+    Param.new("email", "", "json"),
   ]),
   Endpoint.new("/regression", "GET"),
 ]

--- a/spec/functional_test/testers/javascript/fastify_route_config_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_route_config_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/single", "GET"),
+  Endpoint.new("/items/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/items/:id", "POST", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/users/:userId", "PUT", [
+    Param.new("userId", "", "path"),
+  ]),
+  Endpoint.new("/users/:userId", "PATCH", [
+    Param.new("userId", "", "path"),
+  ]),
+  Endpoint.new("/regression", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/fastify_route_config/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/hono_on_array_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_on_array_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/single", "GET"),
+  Endpoint.new("/items/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/items/:id", "POST", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/users/:userId", "PUT", [
+    Param.new("userId", "", "path"),
+  ]),
+  Endpoint.new("/users/:userId", "PATCH", [
+    Param.new("userId", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/hono_on_array/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/nestjs_versioning_spec.cr
+++ b/spec/functional_test/testers/javascript/nestjs_versioning_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/v1/cats", "GET"),
+  Endpoint.new("/v1/cats/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/v2/cats", "POST", [
+    Param.new("body", "", "body"),
+  ]),
+  Endpoint.new("/v3/cats", "POST", [
+    Param.new("body", "", "body"),
+  ]),
+  Endpoint.new("/health", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/nestjs_versioning/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -91,7 +91,7 @@ module Analyzer::Javascript
       # Match the call site `instance.route(` and walk the balanced
       # parens to capture the whole config object — line-by-line regex
       # would clip multi-line objects.
-      content.scan(/\b(?:fastify|app|server|instance)\s*\.\s*route\s*\(/) do |m|
+      content.scan(/\b(?:fastify|app|server)\s*\.\s*route\s*\(/) do |m|
         call_start = m.begin(0)
         next unless call_start
 
@@ -134,6 +134,16 @@ module Analyzer::Javascript
         # Compute line number from the call site offset.
         line_no = content[0...call_start].count('\n') + 1
 
+        # Pre-scan the config body for handler params (request.body.x,
+        # request.query.x, ...). The shorthand `.get(url, handler)`
+        # path uses the same `line_to_param` helper, so reusing it
+        # here keeps param coverage at parity.
+        body_params = [] of Param
+        config.each_line do |handler_line|
+          p = line_to_param(handler_line)
+          body_params << p if p.name != "" && !body_params.any? { |bp| bp.name == p.name && bp.param_type == p.param_type }
+        end
+
         methods.each do |method|
           method_up = method.upcase
           next if result.any? { |e| e.url == url && e.method == method_up }
@@ -145,6 +155,10 @@ module Analyzer::Javascript
             next unless pm.size > 0
             param = Param.new(pm[1], "", "path")
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == pm[1] && p.param_type == "path" }
+          end
+
+          body_params.each do |bp|
+            endpoint.push_param(bp) unless endpoint.params.any? { |p| p.name == bp.name && p.param_type == bp.param_type }
           end
 
           result << endpoint

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -34,6 +34,13 @@ module Analyzer::Javascript
             result << endpoint
           end
 
+          # Auxiliary pass for `fastify.route({ method, url })` shapes
+          # the parser doesn't yet handle (multi-line config objects
+          # and the `methods: ['GET','POST']` array form).
+          unless Noir::JSRouteExtractor.test_stub_only?(path, content)
+            extract_route_configs(path, content, result)
+          end
+
           # Extract static path declarations
           Noir::JSRouteExtractor.extract_static_paths(content).each do |static_path|
             static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
@@ -70,6 +77,77 @@ module Analyzer::Javascript
             endpoint = Endpoint.new(url, "GET", details)
             result << endpoint unless result.any? { |e| e.url == url && e.method == "GET" }
           end
+        end
+      end
+    end
+
+    # Walks a file for `fastify.route({ ... })` registrations that the
+    # shared parser misses: the config object may span multiple lines,
+    # and `methods` may be an array. For each block, decode the method
+    # (or methods) and the url/path and emit one endpoint per method.
+    private def extract_route_configs(path : String, content : String, result : Array(Endpoint))
+      http_methods = %w[get post put delete patch options head]
+
+      # Match the call site `instance.route(` and walk the balanced
+      # parens to capture the whole config object — line-by-line regex
+      # would clip multi-line objects.
+      content.scan(/\b(?:fastify|app|server|instance)\s*\.\s*route\s*\(/) do |m|
+        call_start = m.begin(0)
+        next unless call_start
+
+        paren_open = content.index("(", call_start)
+        next unless paren_open
+
+        paren_close = Noir::JSRouteExtractor.find_matching_paren(content, paren_open)
+        next unless paren_close && paren_close > paren_open
+
+        config = content[(paren_open + 1)...paren_close]
+        # Only treat this as an object-literal route() call. Bare
+        # references like `route(handler)` aren't config objects and
+        # would just produce noise.
+        next unless config.lstrip.starts_with?("{")
+
+        methods = [] of String
+        url = ""
+
+        # Single-method form: `method: 'GET'`
+        if mm = config.match(/method\s*:\s*['"](\w+)['"]/)
+          method = mm[1].downcase
+          methods << method if http_methods.includes?(method)
+        end
+
+        # Array form: `method: ['GET', 'POST']` or `methods: [...]`.
+        # Fastify accepts both keys depending on version, so cover both.
+        if am = config.match(/methods?\s*:\s*\[([^\]]+)\]/)
+          am[1].scan(/['"](\w+)['"]/) do |entry|
+            method = entry[1].downcase
+            methods << method if http_methods.includes?(method) && !methods.includes?(method)
+          end
+        end
+
+        if um = config.match(/(?:url|path)\s*:\s*['"]([^'"]+)['"]/)
+          url = um[1]
+        end
+
+        next if methods.empty? || url.empty?
+
+        # Compute line number from the call site offset.
+        line_no = content[0...call_start].count('\n') + 1
+
+        methods.each do |method|
+          method_up = method.upcase
+          next if result.any? { |e| e.url == url && e.method == method_up }
+
+          endpoint = Endpoint.new(url, method_up)
+          endpoint.details = Details.new(PathInfo.new(path, line_no))
+
+          url.scan(/:(\w+)/) do |pm|
+            next unless pm.size > 0
+            param = Param.new(pm[1], "", "path")
+            endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == pm[1] && p.param_type == "path" }
+          end
+
+          result << endpoint
         end
       end
     end

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -73,31 +73,51 @@ module Analyzer::Javascript
       http_methods = %w[get post put delete patch options head]
       lines = content.lines
       lines.each_with_index do |line, index|
-        # app.on('GET', '/path', ...) or app.on("GET", "/path", ...)
+        methods = [] of String
+        url = ""
+
+        # app.on('GET', '/path', ...) - single method string
         if line =~ /\b(?:app|router|hono)\s*\.\s*on\s*\(\s*['"](\w+)['"]\s*,\s*['"]([^'"]+)['"]/
           method = $1.downcase
-          url = $2
           if http_methods.includes?(method)
-            unless result.any? { |e| e.url == url && e.method == method.upcase }
-              endpoint = Endpoint.new(url, method.upcase)
-              details = Details.new(PathInfo.new(path, index + 1))
-              endpoint.details = details
-              Noir::JSRouteExtractor.attach_callees(endpoint, callees_by_route, method.upcase, url, index + 1)
-
-              # Extract params from subsequent lines in the handler body
-              ((index + 1)...lines.size).each do |i|
-                handler_line = lines[i]
-                break if handler_line =~ /^\s*\}\s*\)\s*$/
-                line_to_params(handler_line).each do |param|
-                  endpoint.push_param(param)
-                end
-              end
-
-              extract_path_params(endpoint)
-
-              result << endpoint
-            end
+            methods << method
+            url = $2
           end
+        # app.on(['GET', 'POST'], '/path', ...) - array of methods
+        elsif line =~ /\b(?:app|router|hono)\s*\.\s*on\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"]/
+          methods_str = $1
+          url = $2
+          methods_str.scan(/['"](\w+)['"]/) do |m|
+            method = m[1].downcase
+            methods << method if http_methods.includes?(method) && !methods.includes?(method)
+          end
+        end
+
+        next if methods.empty? || url.empty?
+
+        # Pre-extract handler-body params once so each method-variant
+        # endpoint gets the same params without re-walking lines.
+        body_params = [] of Param
+        ((index + 1)...lines.size).each do |i|
+          handler_line = lines[i]
+          break if handler_line =~ /^\s*\}\s*\)\s*$/
+          line_to_params(handler_line).each do |param|
+            body_params << param
+          end
+        end
+
+        methods.each do |method|
+          next if result.any? { |e| e.url == url && e.method == method.upcase }
+
+          endpoint = Endpoint.new(url, method.upcase)
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          Noir::JSRouteExtractor.attach_callees(endpoint, callees_by_route, method.upcase, url, index + 1)
+
+          body_params.each { |param| endpoint.push_param(param) }
+          extract_path_params(endpoint)
+
+          result << endpoint
         end
       end
     end
@@ -191,13 +211,27 @@ module Analyzer::Javascript
         return http_methods.map { |m| Endpoint.new(path, m.upcase) }
       end
 
-      # app.on('GET', '/path', ...) or app.on(['GET', 'POST'], '/path', ...)
+      # app.on('GET', '/path', ...) - single method string
       if line =~ /\b(?:app|router|hono)\s*\.\s*on\s*\(\s*['"](\w+)['"]\s*,\s*['"]([^'"]+)['"]/
         method = $1.downcase
         path = $2
         if http_methods.includes?(method)
           return [Endpoint.new(path, method.upcase)]
         end
+      end
+
+      # app.on(['GET', 'POST'], '/path', ...) - array of methods
+      if line =~ /\b(?:app|router|hono)\s*\.\s*on\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"]/
+        methods_str = $1
+        path = $2
+        endpoints = [] of Endpoint
+        methods_str.scan(/['"](\w+)['"]/) do |m|
+          method = m[1].downcase
+          if http_methods.includes?(method) && !endpoints.any? { |e| e.method == method.upcase }
+            endpoints << Endpoint.new(path, method.upcase)
+          end
+        end
+        return endpoints unless endpoints.empty?
       end
 
       [] of Endpoint

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -70,16 +70,49 @@ module Analyzer::Javascript
         controller_content = controller_info[:content]
         controller_start_line = controller_info[:start_line]
 
+        # Apply controller-level URI versioning. NestJS's default
+        # `VersioningType.URI` prepends `v<n>` to the route, so
+        # `@Controller({ path: 'cats', version: '1' })` becomes
+        # `/v1/cats/...`. Header/Media-Type versioning leaves the URL
+        # untouched — we conservatively emit the v-prefixed variant
+        # since URI is the most common shape in OSS Nest apps.
+        versions = controller_info[:versions]
+        if !versions.empty?
+          base_paths = expand_versions(base_paths, versions)
+        end
+
         process_http_methods(controller_content, base_paths, path, result, include_callee, controller_start_line, literal_values)
       end
     end
 
+    # Combine the controller's base paths with each version into a
+    # set of `v<version>/<base>` paths. `'VERSION_NEUTRAL'` (Nest's
+    # sentinel) is rendered as no prefix.
+    private def expand_versions(base_paths : Array(String), versions : Array(String)) : Array(String)
+      expanded = [] of String
+      versions.each do |v|
+        prefix = v == "VERSION_NEUTRAL" ? "" : "v#{v}"
+        base_paths.each do |bp|
+          if prefix.empty?
+            expanded << bp
+          elsif bp.empty?
+            expanded << prefix
+          else
+            normalized = bp.starts_with?("/") ? bp[1..] : bp
+            expanded << "#{prefix}/#{normalized}"
+          end
+        end
+      end
+      expanded.uniq
+    end
+
     private def extract_controllers(content : String, literal_values : Hash(String, Array(String)))
-      controllers = [] of NamedTuple(base_paths: Array(String), content: String, start_line: Int32)
+      controllers = [] of NamedTuple(base_paths: Array(String), versions: Array(String), content: String, start_line: Int32)
 
       # Find all @Controller decorators and their associated class content
       lines = content.split("\n")
       current_base_paths : Array(String)? = nil
+      current_versions : Array(String) = [] of String
       current_content = [] of String
       controller_start_line = 1
       brace_count = 0
@@ -99,6 +132,7 @@ module Analyzer::Javascript
           base_paths = parse_controller_decorator(joined[:text], literal_values)
           if !base_paths.nil?
             current_base_paths = base_paths
+            current_versions = parse_controller_versions(joined[:text])
             current_content.clear
             controller_start_line = 1
             skip_until = joined[:last_line]
@@ -124,10 +158,12 @@ module Analyzer::Javascript
           if brace_count == 0 && line.includes?('}')
             controllers << {
               base_paths: current_base_paths,
+              versions:   current_versions,
               content:    current_content.join("\n") + "\n",
               start_line: controller_start_line,
             }
             current_base_paths = nil
+            current_versions = [] of String
             current_content.clear
             in_class = false
           end
@@ -135,6 +171,43 @@ module Analyzer::Javascript
       end
 
       controllers
+    end
+
+    # Pull versions out of a `@Controller({ ..., version: ... })`
+    # decorator. Recognized shapes:
+    #   version: '1'                 -> ["1"]
+    #   version: 1                   -> ["1"]
+    #   version: ['1', '2']          -> ["1", "2"]
+    #   version: VERSION_NEUTRAL     -> ["VERSION_NEUTRAL"]
+    # When no `version:` key is present, returns an empty array
+    # (meaning: leave the route URL untouched).
+    private def parse_controller_versions(text : String) : Array(String)
+      inner = decorator_inner(text, "Controller")
+      return [] of String unless inner
+      return [] of String unless inner.starts_with?("{")
+
+      versions = [] of String
+
+      # version: ['1', '2']
+      if am = inner.match(/\bversion\s*:\s*\[([^\]]+)\]/)
+        am[1].scan(/['"]([^'"]+)['"]/) do |m|
+          versions << m[1] unless versions.includes?(m[1])
+        end
+        return versions unless versions.empty?
+      end
+
+      # version: '1' or version: "1"
+      if sm = inner.match(/\bversion\s*:\s*['"]([^'"]+)['"]/)
+        versions << sm[1]
+        return versions
+      end
+
+      # version: 1 (numeric literal) or version: VERSION_NEUTRAL (identifier)
+      if im = inner.match(/\bversion\s*:\s*([A-Za-z_][\w.]*|\d+)/)
+        versions << im[1]
+      end
+
+      versions
     end
 
     # Coalesce a multi-line decorator header into a single string.


### PR DESCRIPTION
## Summary
- **Hono**: recognize array-form `app.on(['GET','POST'], '/path', ...)` — emits one endpoint per method, sharing the same handler-body param scan as the existing single-method form.
- **Fastify**: handle multi-line `fastify.route({ method/methods, url })` config objects (the parser only covered single-line shapes), including the `method: ['GET','POST']` array form.
- **NestJS**: apply URI versioning from `@Controller({ path, version })` — covers string (`'1'`), numeric (`1`), array (`['1','2']`), and `VERSION_NEUTRAL` shapes.

These enrich Noir's existing JS framework coverage with patterns that show up regularly in real OSS apps. New functional fixtures + specs cover each case; the full JS suite (1869 examples) and detector unit suite remain green.

## Test plan
- [x] `crystal spec spec/functional_test/testers/javascript/hono_on_array_spec.cr spec/functional_test/testers/javascript/fastify_route_config_spec.cr spec/functional_test/testers/javascript/nestjs_versioning_spec.cr` — 57 examples, 0 failures
- [x] `crystal spec spec/functional_test/testers/javascript/` — 1869 examples, 0 failures
- [x] `crystal spec spec/unit_test/detector/javascript/` — 95 examples, 0 failures