### PR TITLE
Improve Clojure and Dart route analysis coverage

### DIFF
--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -23,6 +23,15 @@
   (POST "/notes" {:keys [title body]}
     {:title title :body body})
 
+  ; Namespace-qualified `:my.ns/keys` should still lift bound symbols.
+  (POST "/comments" {:my.ns/keys [author message]}
+    {:author author :message message})
+
+  ; `:as` followed by a destructuring map: keys inside bind the request map,
+  ; NOT query params. Only `id` and `q` should be lifted.
+  (GET "/profile/:id" [id q :as {:keys [headers]}]
+    {:id id :q q})
+
   (context "/api" []
     (POST "/users" request
       request)

--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -11,6 +11,18 @@
   (GET "/search" [q page]
     {:q q :page page})
 
+  ; `:as request` should NOT emit `as` or `request` as query params.
+  (GET "/feed" [cursor :as request]
+    {:cursor cursor})
+
+  ; `& rest` rest-binding should NOT emit `rest` as a query param.
+  (GET "/tags" [tag & rest]
+    {:tag tag})
+
+  ; Map destructuring of the request map — `:keys` should be lifted (한글 주석도 OK).
+  (POST "/notes" {:keys [title body]}
+    {:title title :body body})
+
   (context "/api" []
     (POST "/users" request
       request)

--- a/spec/functional_test/fixtures/dart/dart_frog/routes/posts/[...slug].dart
+++ b/spec/functional_test/fixtures/dart/dart_frog/routes/posts/[...slug].dart
@@ -1,0 +1,11 @@
+import 'package:dart_frog/dart_frog.dart';
+
+// Catch-all route: matches /posts/a, /posts/a/b, /posts/a/b/c, etc.
+Response onRequest(RequestContext context, String slug) {
+  switch (context.request.method) {
+    case HttpMethod.get:
+      return Response.json(body: {'slug': slug});
+    default:
+      return Response(statusCode: 405);
+  }
+}

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -19,6 +19,14 @@ expected_endpoints = [
     Param.new("title", "", "query"),
     Param.new("body", "", "query"),
   ]),
+  Endpoint.new("/comments", "POST", [
+    Param.new("author", "", "query"),
+    Param.new("message", "", "query"),
+  ]),
+  Endpoint.new("/profile/:id", "GET", [
+    Param.new("id", "", "path"),
+    Param.new("q", "", "query"),
+  ]),
   Endpoint.new("/api/users", "POST"),
   Endpoint.new("/api/admin/users/:id", "DELETE", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -9,6 +9,16 @@ expected_endpoints = [
     Param.new("q", "", "query"),
     Param.new("page", "", "query"),
   ]),
+  Endpoint.new("/feed", "GET", [
+    Param.new("cursor", "", "query"),
+  ]),
+  Endpoint.new("/tags", "GET", [
+    Param.new("tag", "", "query"),
+  ]),
+  Endpoint.new("/notes", "POST", [
+    Param.new("title", "", "query"),
+    Param.new("body", "", "query"),
+  ]),
   Endpoint.new("/api/users", "POST"),
   Endpoint.new("/api/admin/users/:id", "DELETE", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/dart/dart_frog_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_spec.cr
@@ -25,6 +25,8 @@ expected_endpoints = [
   Endpoint.new("/api/health", "PUT"),
   Endpoint.new("/api/health", "DELETE"),
   Endpoint.new("/api/health", "PATCH"),
+  # `posts/[...slug].dart` — catch-all wildcard collapses to a path param.
+  Endpoint.new("/posts/{slug}", "GET", [Param.new("slug", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/dart/dart_frog/", {

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -148,14 +148,19 @@ module Analyzer::Clojure
       path_param_set = path_param_names.to_set
       inner = binding[1...binding.size - 1]
 
-      # Vector binding may carry destructuring sub-maps like
+      # `:as`/`:or` followed by a `{...}` block bind/default the whole
+      # request map — keys inside are existing symbols, not query params.
+      # Strip those maps before any further harvesting.
+      inner_clean = inner.gsub(/:(?:as|or)\s*\{[^{}]*\}/, " ")
+
+      # Vector binding may carry inline destructuring sub-maps like
       # `[foo {:keys [bar]}]`. Capture inline `:keys`/`:strs`/`:syms`
       # before stripping the embedded maps from token scanning.
-      embedded_keys = extract_destructured_keys(inner)
+      embedded_keys = extract_destructured_keys(inner_clean)
 
       # Strip embedded `{...}` blocks so we don't catch token names
       # *inside* destructuring shapes via the loose word scanner.
-      inner_no_maps = inner.gsub(/\{[^{}]*\}/, " ")
+      inner_no_maps = inner_clean.gsub(/\{[^{}]*\}/, " ")
 
       skip_next = false
       inner_no_maps.scan(/:?[A-Za-z_][\w\-!?*]*/) do |match|
@@ -182,8 +187,9 @@ module Analyzer::Clojure
       end
 
       # Drop `&` rest-bindings: the symbol immediately after `&` collects
-      # remaining args, not a query param. Detect by scanning original `inner`.
-      rest_match = inner.match(/&\s+([A-Za-z_][\w\-!?*]*)/)
+      # remaining args, not a query param. Detect by scanning the cleaned
+      # inner so the `:as`/`:or` strip doesn't interfere.
+      rest_match = inner_clean.match(/&\s+([A-Za-z_][\w\-!?*]*)/)
       if rest_match
         names.delete(rest_match[1])
       end
@@ -210,7 +216,9 @@ module Analyzer::Clojure
 
     private def extract_destructured_keys(text : String) : Array(String)
       keys = [] of String
-      text.scan(/:(?:keys|strs|syms)\s+\[([^\]]+)\]/) do |match|
+      # Match plain `:keys`/`:strs`/`:syms` and namespace-qualified forms
+      # like `:my.ns/keys` (the value half drops the namespace at bind time).
+      text.scan(/:(?:[A-Za-z_][\w\-.]*\/)?(?:keys|strs|syms)\s+\[([^\]]+)\]/) do |match|
         match[1].scan(/[A-Za-z_][\w\-!?*]*/) do |inner|
           keys << inner[0]
         end

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -106,7 +106,7 @@ module Analyzer::Clojure
       body_start = route_body_start(source, args_start, form_end)
       return if body_start >= form_end
 
-      body = source[body_start...form_end]
+      body = source.byte_slice(body_start, form_end - body_start)
       start_line = line_number_for(source, body_start)
       callees = Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line)
       Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
@@ -140,20 +140,82 @@ module Analyzer::Clojure
     end
 
     private def extract_query_param_names(binding : String, path_param_names : Array(String)) : Array(String)
-      return [] of String if !binding.starts_with?('[') || binding.includes?('{')
+      # `{:keys [...]}` style request-map destructuring — extract keys directly.
+      return extract_keys_from_map(binding, path_param_names) if binding.starts_with?('{')
+      return [] of String if !binding.starts_with?('[')
 
       names = [] of String
       path_param_set = path_param_names.to_set
       inner = binding[1...binding.size - 1]
 
-      inner.scan(/[A-Za-z_][\w\-!?]*/) do |match|
+      # Vector binding may carry destructuring sub-maps like
+      # `[foo {:keys [bar]}]`. Capture inline `:keys`/`:strs`/`:syms`
+      # before stripping the embedded maps from token scanning.
+      embedded_keys = extract_destructured_keys(inner)
+
+      # Strip embedded `{...}` blocks so we don't catch token names
+      # *inside* destructuring shapes via the loose word scanner.
+      inner_no_maps = inner.gsub(/\{[^{}]*\}/, " ")
+
+      skip_next = false
+      inner_no_maps.scan(/:?[A-Za-z_][\w\-!?*]*/) do |match|
         token = match[0]
+
+        # `:as` / `:or` bind the whole request map / supply defaults —
+        # the following symbol is not a query param.
+        if token == ":as" || token == ":or"
+          skip_next = true
+          next
+        end
+
+        # Skip Clojure-style keywords (`:foo`) entirely.
+        next if token.starts_with?(':')
+
+        if skip_next
+          skip_next = false
+          next
+        end
+
         next if path_param_set.includes?(token)
         next if names.includes?(token)
         names << token
       end
 
+      # Drop `&` rest-bindings: the symbol immediately after `&` collects
+      # remaining args, not a query param. Detect by scanning original `inner`.
+      rest_match = inner.match(/&\s+([A-Za-z_][\w\-!?*]*)/)
+      if rest_match
+        names.delete(rest_match[1])
+      end
+
+      embedded_keys.each do |key|
+        next if path_param_set.includes?(key)
+        next if names.includes?(key)
+        names << key
+      end
+
       names
+    end
+
+    private def extract_keys_from_map(binding : String, path_param_names : Array(String)) : Array(String)
+      names = [] of String
+      path_param_set = path_param_names.to_set
+      extract_destructured_keys(binding).each do |key|
+        next if path_param_set.includes?(key)
+        next if names.includes?(key)
+        names << key
+      end
+      names
+    end
+
+    private def extract_destructured_keys(text : String) : Array(String)
+      keys = [] of String
+      text.scan(/:(?:keys|strs|syms)\s+\[([^\]]+)\]/) do |match|
+        match[1].scan(/[A-Za-z_][\w\-!?*]*/) do |inner|
+          keys << inner[0]
+        end
+      end
+      keys
     end
 
     private def extract_binding(source : String, index : Int32, limit : Int32) : String?
@@ -163,8 +225,11 @@ module Analyzer::Clojure
       case source.byte_at(i).unsafe_chr
       when '['
         binding_end = find_matching_delimiter(source, i, '[', ']', limit)
-        binding_end > i ? source[i..binding_end] : nil
-      when '(', '{'
+        binding_end > i ? source.byte_slice(i, binding_end - i + 1) : nil
+      when '{'
+        binding_end = find_matching_delimiter(source, i, '{', '}', limit)
+        binding_end > i ? source.byte_slice(i, binding_end - i + 1) : nil
+      when '('
         nil
       else
         token, _ = read_symbol(source, i, limit)
@@ -180,7 +245,7 @@ module Analyzer::Clojure
           i = skip_comment(source, i, limit)
         when '"'
           literal_end = skip_string(source, i, limit)
-          return {decode_string_literal(source[i..literal_end]), literal_end}
+          return {decode_string_literal(source.byte_slice(i, literal_end - i + 1)), literal_end}
         when '(', '[', '{'
           break
         else
@@ -211,7 +276,7 @@ module Analyzer::Clojure
         i += 1
       end
 
-      {source[index...i], i}
+      {source.byte_slice(index, i - index), i}
     end
 
     private def skip_ws_and_comments(source : String, index : Int32, limit : Int32) : Int32
@@ -280,7 +345,7 @@ module Analyzer::Clojure
     end
 
     private def line_number_for(source : String, index : Int32) : Int32
-      source[0...index].count('\n') + 1
+      source.byte_slice(0, index).count('\n') + 1
     end
 
     private def whitespace?(char : Char) : Bool

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -123,6 +123,13 @@ module Analyzer::Dart
     end
 
     private def convert_segment(seg : String) : String
+      # Catch-all segment, e.g. `[...slug]` matches one or more path
+      # segments. Surface as `{slug}` so the dynamic part is at least
+      # captured as a path param even though the framework binds it
+      # to a list.
+      if m = seg.match(/^\[\.\.\.(\w+)\]$/)
+        return "{#{m[1]}}"
+      end
       if m = seg.match(/^\[(\w+)\]$/)
         return "{#{m[1]}}"
       end


### PR DESCRIPTION
## Summary
Enriches the existing Compojure and Dart Frog analyzers with patterns we saw producing FP/FN against open-source apps:

- **Compojure**
  - Filter `:as`/`:or` and `&` rest-bindings so `[id :as req]` and `[id & more]` no longer leak `req`/`more` as query params.
  - Lift `:keys` from `{:keys [...]}` request-map destructuring, including when it appears inside a vector binding (`[foo {:keys [bar]}]`).
  - Switch internal slices to `byte_slice` so non-ASCII characters (em-dash, Korean comments, etc.) in real-world Clojure sources no longer truncate the scan partway through `defroutes`.

- **Dart Frog**
  - Collapse catch-all `[...slug]` segments to `{slug}` path params instead of emitting the literal bracket form.

- **Serverpod**
  - Audited; no FP found — `StreamingSession session` doesn't match the anchored `\A\s*Session\s+` regex, so framework lifecycle hooks (`streamOpened`/`streamClosed`/`handleStreamMessage`) are already filtered. No code change.

## Test plan
- [x] `crystal spec spec/functional_test/testers/clojure/ spec/functional_test/testers/dart/ spec/unit_test/detector/clojure/ spec/unit_test/detector/dart/` (286 examples, 0 failures)
- [x] `just br` builds clean
- [x] Manual: ran release binary against updated `fixtures/clojure/compojure/` (10 endpoints) and `fixtures/dart/dart_frog/` (18 endpoints) — counts match testers