### PR TITLE
Improve F#, Groovy, and Haskell route analysis coverage

### DIFF
--- a/spec/functional_test/fixtures/fsharp/giraffe/Program.fs
+++ b/spec/functional_test/fixtures/fsharp/giraffe/Program.fs
@@ -40,3 +40,18 @@ let webApp =
         GET >=> routex "/foo(/?)" >=> handleFoo
         routeCi "/case" >=> text "case-insensitive"
     ]
+
+// Giraffe 6+ Endpoint Routing API — verb wraps a `[...]` list and the
+// route lines do not carry an explicit method on their own line.
+let endpoints =
+    [
+        GET [
+            route "/ping" handlerPing
+            route "/status" handlerStatus
+        ]
+        POST [ route "/submit" handlerSubmit ]
+        subRoute "/admin" [
+            GET [ route "/dashboard" handlerDashboard ]
+            DELETE [ routef "/sessions/%i" handlerKillSession ]
+        ]
+    ]

--- a/spec/functional_test/fixtures/groovy/grails/grails-app/conf/UrlMappings.groovy
+++ b/spec/functional_test/fixtures/groovy/grails/grails-app/conf/UrlMappings.groovy
@@ -22,5 +22,18 @@ class UrlMappings {
             action = "handle"
             method = "POST"
         }
+
+        // Named URL mapping — Grails uses the `name <id>:` prefix for
+        // reverse URL generation. The mapping itself is otherwise the
+        // same verbless paren-form.
+        name reports: "/api/reports"(controller: "reports", action: "list")
+
+        // `uri:` mapping — a path that redirects to another internal URI
+        // (no controller/action pair). Still an exposed endpoint.
+        "/api/legacy-alias"(uri: "/api/legacy")
+
+        // Singular `resource:` shortcut — singleton REST resource
+        // exposing GET/POST/PUT/PATCH/DELETE on the path itself.
+        "/api/profile"(resource: "profile")
     }
 }

--- a/spec/functional_test/fixtures/groovy/grails/grails-app/controllers/ReportController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails/grails-app/controllers/ReportController.groovy
@@ -1,0 +1,13 @@
+package demo
+
+// Controller using `void`-return actions, common in modern Grails
+// codebases that pair `respond`/`render` calls with strict typing.
+class ReportController {
+    void index() {
+        render 'reports index'
+    }
+
+    void show(Long id) {
+        render "report ${id}"
+    }
+}

--- a/spec/functional_test/fixtures/haskell/servant/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant/src/Api.hs
@@ -21,6 +21,12 @@ type UserAPI =
   :<|> "files" :> CaptureAll "path" Text :> Get '[JSON] FileResponse
   :<|> Header "X-Token" Text :> "secure" :> Get '[JSON] Secret
 
+type UploadAPI =
+       "upload" :> MultipartForm Mem (MultipartData Mem) :> Post '[JSON] ()
+  :<|> "stream" :> StreamGet NewlineFraming JSON (SourceIO String)
+  :<|> "uverb"  :> UVerb 'PATCH '[200] '[User]
+
 type API =
        "v1" :> UserAPI
+  :<|> "v1" :> UploadAPI
   :<|> "health" :> Get '[JSON] Health

--- a/spec/functional_test/testers/fsharp/giraffe_spec.cr
+++ b/spec/functional_test/testers/fsharp/giraffe_spec.cr
@@ -52,6 +52,16 @@ expected_endpoints << Endpoint.new("/foo(/?)", "GET")
 # routeCi without explicit method filter.
 fallback_methods.each { |m| expected_endpoints << Endpoint.new("/case", m) }
 
+# Giraffe Endpoint Routing — `GET [...]` wraps routes that inherit the verb.
+expected_endpoints << Endpoint.new("/ping", "GET")
+expected_endpoints << Endpoint.new("/status", "GET")
+expected_endpoints << Endpoint.new("/submit", "POST")
+# `subRoute "/admin" [...]` with bracket-style children.
+expected_endpoints << Endpoint.new("/admin/dashboard", "GET")
+expected_endpoints << Endpoint.new("/admin/sessions/:int", "DELETE", [
+  Param.new("int", "int", "path"),
+])
+
 FunctionalTester.new("fixtures/fsharp/giraffe/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/spec/functional_test/testers/groovy/grails_spec.cr
+++ b/spec/functional_test/testers/groovy/grails_spec.cr
@@ -45,6 +45,19 @@ expected_endpoints = [
   Endpoint.new("/v2/items", "GET"),
   # Closure-form mapping with `method = "POST"` assignment.
   Endpoint.new("/api/legacy", "POST"),
+  # `name <id>:` prefix on a verb-prefixed mapping is tolerated.
+  Endpoint.new("/api/reports", "GET"),
+  # `uri:` mapping — still an exposed endpoint despite no controller/action.
+  Endpoint.new("/api/legacy-alias", "GET"),
+  # Singular `resource:` shortcut — five REST verbs at the path itself.
+  Endpoint.new("/api/profile", "GET"),
+  Endpoint.new("/api/profile", "POST"),
+  Endpoint.new("/api/profile", "PUT"),
+  Endpoint.new("/api/profile", "PATCH"),
+  Endpoint.new("/api/profile", "DELETE"),
+  # `void`-return actions on `ReportController`.
+  Endpoint.new("/report/index", "GET"),
+  Endpoint.new("/report/show", "GET"),
   # Plugin-style `<Name>UrlMappings.groovy` is also processed.
   Endpoint.new("/plugin/status", "GET"),
 ]

--- a/spec/functional_test/testers/haskell/servant_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_spec.cr
@@ -24,6 +24,14 @@ expected_endpoints = [
   Endpoint.new("/v1/secure", "GET", [
     Param.new("X-Token", "Text", "header"),
   ]),
+  # MultipartForm produces a body param, with the underlying data type.
+  Endpoint.new("/v1/upload", "POST", [
+    Param.new("body", "MultipartData", "body"),
+  ]),
+  # `StreamGet NewlineFraming JSON ...` resolves to a GET endpoint.
+  Endpoint.new("/v1/stream", "GET"),
+  # `UVerb 'PATCH ...` resolves to a PATCH endpoint.
+  Endpoint.new("/v1/uverb", "PATCH"),
   Endpoint.new("/health", "GET"),
 ]
 

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -59,7 +59,7 @@ module Analyzer::Fsharp
       base.ends_with?("Test.fs")
     end
 
-    alias SubRouteScope = NamedTuple(prefix: String, end_pos: Int32, params: Array(Param))
+    alias SubRouteScope = NamedTuple(prefix: String, end_pos: Int32, params: Array(Param), method: String?)
 
     private def process_file(path : String, content : String, include_callee : Bool)
       cleaned = strip_fsharp_comments(content)
@@ -75,15 +75,17 @@ module Analyzer::Fsharp
         rest = cleaned[i..]
 
         # subRoute / subRouteCi / subRoutef "/prefix" (handler)
-        sub_match = rest.match(/\A(subRoute(?:Ci|f)?)\s+"([^"]+)"\s*\(/)
+        # or the Giraffe 6+ Endpoint Routing form: `subRoute "/prefix" [ ... ]`.
+        sub_match = rest.match(/\A(subRoute(?:Ci|f)?)\s+"([^"]+)"\s*([\(\[])/)
         if sub_match
           combinator = sub_match[1]
           raw_prefix = sub_match[2]
+          opener = sub_match[3]
           match_end_local = sub_match.end(0)
           if match_end_local
-            open_paren_abs = i + match_end_local - 1
-            close_paren = find_matching_paren(cleaned, open_paren_abs)
-            if close_paren
+            open_abs = i + match_end_local - 1
+            close_pos = opener == "(" ? find_matching_paren(cleaned, open_abs) : find_matching_bracket(cleaned, open_abs)
+            if close_pos
               translated_prefix, prefix_params = if combinator == "subRoutef"
                                                    translate_routef(raw_prefix)
                                                  else
@@ -91,8 +93,33 @@ module Analyzer::Fsharp
                                                  end
               scope_stack << {
                 prefix:  translated_prefix,
-                end_pos: close_paren,
+                end_pos: close_pos,
                 params:  prefix_params,
+                method:  nil,
+              }
+              i += match_end_local
+              next
+            end
+          end
+        end
+
+        # Giraffe Endpoint Routing: `GET [ route "/" h; route "/x" h ]`.
+        # The verb token wraps a list of routes. When this form is used,
+        # the embedded `route` lines do not carry the verb on their own
+        # line, so we push a method-only scope until the matching `]`.
+        verb_list_match = rest.match(/\A(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\[/)
+        if verb_list_match && verb_list_method_context?(cleaned, i)
+          verb = verb_list_match[1]
+          match_end_local = verb_list_match.end(0)
+          if match_end_local
+            open_bracket_abs = i + match_end_local - 1
+            close_bracket = find_matching_bracket(cleaned, open_bracket_abs)
+            if close_bracket
+              scope_stack << {
+                prefix:  "",
+                end_pos: close_bracket,
+                params:  [] of Param,
+                method:  verb,
               }
               i += match_end_local
               next
@@ -134,6 +161,30 @@ module Analyzer::Fsharp
       params
     end
 
+    # Innermost scope-supplied HTTP verb (Endpoint Routing wrapper), if any.
+    private def scope_method(scope_stack : Array(SubRouteScope)) : String?
+      scope_stack.reverse_each do |scope|
+        m = scope[:method]
+        return m if m
+      end
+      nil
+    end
+
+    # Distinguishes a Giraffe Endpoint-Routing `GET [...]` wrapper from
+    # an ordinary `GET >=> route ...` chain where `[` appears later on
+    # the same line in a literal context. We require the `[` to follow
+    # the verb after only whitespace AND for there to be no `>=>`
+    # between the verb and the bracket.
+    private def verb_list_method_context?(text : String, offset : Int32) : Bool
+      # Token-boundary check: must be preceded by start-of-string,
+      # whitespace, `[`, `;`, or `,`.
+      if offset > 0
+        prev = text[offset - 1]
+        return false unless prev.whitespace? || prev == '[' || prev == ';' || prev == ',' || prev == '('
+      end
+      true
+    end
+
     private def emit_route(path : String, content : String, cleaned : String,
                            offset : Int32, scope_stack : Array(SubRouteScope),
                            path_pattern : String, routef : Bool, include_callee : Bool)
@@ -145,7 +196,7 @@ module Analyzer::Fsharp
       full_url = current_prefix(scope_stack) + url
       full_params = current_prefix_params(scope_stack) + params
 
-      method = find_method_for_route(cleaned, offset)
+      method = find_method_for_route(cleaned, offset) || scope_method(scope_stack)
       methods = method ? [method] : FALLBACK_METHODS
 
       line = line_for_offset(content, offset)
@@ -357,7 +408,16 @@ module Analyzer::Fsharp
     end
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
-      return unless open_idx < text.size && text[open_idx] == '('
+      find_matching_delimiter(text, open_idx, '(', ')')
+    end
+
+    private def find_matching_bracket(text : String, open_idx : Int32) : Int32?
+      find_matching_delimiter(text, open_idx, '[', ']')
+    end
+
+    private def find_matching_delimiter(text : String, open_idx : Int32,
+                                        opener : Char, closer : Char) : Int32?
+      return unless open_idx < text.size && text[open_idx] == opener
       depth = 1
       i = open_idx + 1
       in_string = false
@@ -379,9 +439,9 @@ module Analyzer::Fsharp
         when '"', '\''
           in_string = true
           string_quote = c
-        when '('
+        when opener
           depth += 1
-        when ')'
+        when closer
           depth -= 1
           return i if depth == 0
         else

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -268,6 +268,25 @@ module Analyzer::Groovy
             i = match_end ? i + match_end : i + 1
             next
           end
+
+          # Void / primitive-return method form: `void name(...) { ... }`,
+          # `int count(...) { ... }`. Distinct from the uppercase-return
+          # pattern above to avoid colliding with field declarations and
+          # `def` actions.
+          m3 = rest.match(/\A(public\s+|protected\s+)?(void|int|long|boolean|byte|short|float|double|char)\s+([a-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:throws\s+[A-Za-z0-9_,\s.]+)?\s*\{/)
+          if m3
+            name = m3[3]
+            unless SKIP_ACTION_NAMES.includes?(name)
+              open_brace = i + (m3.end(0) || 1) - 1
+              if action_body = extract_braced_block(body, open_brace)
+                action_body_text, action_body_start = action_body
+                actions << {name: name, offset: i, body: action_body_text, body_start: action_body_start}
+              end
+            end
+            match_end = m3.end(0)
+            i = match_end ? i + match_end : i + 1
+            next
+          end
         end
 
         i += 1
@@ -371,8 +390,11 @@ module Analyzer::Groovy
                                        text : String, prefix : String)
       remaining = consume_groups(path, content, text, prefix)
 
-      # Verb-prefixed mappings: `get '/users'(controller: ..., action: ...)`
-      pattern = /\b(get|post|put|delete|patch|head|options)\s+(['"])([^'"]+)\2\s*\((.*?)\)/m
+      # Verb-prefixed mappings: `get '/users'(controller: ..., action: ...)`.
+      # An optional `name <id>:` prefix names the mapping for reverse URL
+      # lookup; it does not affect the URL itself but must be tolerated
+      # so we don't drop the endpoint.
+      pattern = /(?:\bname\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?\b(get|post|put|delete|patch|head|options)\s+(['"])([^'"]+)\2\s*\((.*?)\)/m
       remaining.scan(pattern) do |match|
         verb = match[1].upcase
         url_pattern = prefix + match[3]
@@ -383,8 +405,10 @@ module Analyzer::Groovy
       end
 
       # Verbless paren-form: `'/path'(controller: ..., action: ...,
-      # method: 'POST')` and the `(resources: 'name')` REST shortcut.
-      simple_pattern = /(?:^|\n)\s*(['"])([^'"]+)\1\s*\(([^)]*?)\)/m
+      # method: 'POST')`, the `(resources: 'name')` / `(resource: 'name')`
+      # REST shortcut, and `'/path'(uri: '/some/where')` redirect-style
+      # mappings.
+      simple_pattern = /(?:^|\n)\s*(?:name\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?(['"])([^'"]+)\1\s*\(([^)]*?)\)/m
       remaining.scan(simple_pattern) do |match|
         url_pattern = prefix + match[2]
         body_args = match[3]
@@ -400,7 +424,19 @@ module Analyzer::Groovy
           next
         end
 
-        next unless body_args.includes?("controller:") || body_args.includes?("action:") || body_args.includes?("view:")
+        # Singular `resource:` (single REST resource — no list endpoint,
+        # no `:id`-keyed entries). Common in Grails for singleton resources.
+        if body_args.match(/\bresource:\s*['"]/)
+          {"GET", "POST", "PUT", "PATCH", "DELETE"}.each do |verb|
+            @result << Endpoint.new(translate_pattern(url_pattern), verb,
+              extract_path_params(url_pattern),
+              Details.new(PathInfo.new(path, line)))
+          end
+          next
+        end
+
+        next unless body_args.includes?("controller:") || body_args.includes?("action:") ||
+                    body_args.includes?("view:") || body_args.includes?("uri:")
         verb = extract_method_arg(body_args) || "GET"
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -489,11 +489,22 @@ module Analyzer::Haskell
         when "ReqBody", "ReqBody'", "StreamBody", "StreamBody'"
           type = extract_type_arg(args)
           params << Param.new("body", type, "body")
+        when "MultipartForm", "MultipartForm'"
+          # `MultipartForm Mem (MultipartData Mem)` — second positional
+          # argument carries the data type; fall back to "Multipart" when
+          # not parseable.
+          type = extract_multipart_type(args)
+          params << Param.new("body", type, "body")
         else
           mapped = http_method_for(head)
           if mapped
             method = mapped
-          elsif head == "Verb"
+          elsif head == "Verb" || head == "UVerb"
+            verb = extract_verb_method(args)
+            method = verb if verb
+          elsif head == "Stream"
+            # `Stream 'GET 200 NewlineFraming JSON ...` — first positional
+            # token is the HTTP verb (optionally promoted with a leading `'`).
             verb = extract_verb_method(args)
             method = verb if verb
           end
@@ -511,21 +522,35 @@ module Analyzer::Haskell
 
     private def http_method_for(token : String) : String?
       case token
-      when "Get", "GetNoContent"
+      when "Get", "GetNoContent", "StreamGet"
         "GET"
-      when "Post", "PostNoContent", "PostCreated", "PostAccepted", "PostNonAuthoritative", "PostResetContent"
+      when "Post", "PostNoContent", "PostCreated", "PostAccepted",
+           "PostNonAuthoritative", "PostResetContent", "StreamPost"
         "POST"
-      when "Put", "PutNoContent", "PutCreated", "PutAccepted"
+      when "Put", "PutNoContent", "PutCreated", "PutAccepted", "StreamPut"
         "PUT"
-      when "Delete", "DeleteNoContent", "DeleteAccepted"
+      when "Delete", "DeleteNoContent", "DeleteAccepted", "StreamDelete"
         "DELETE"
-      when "Patch", "PatchNoContent"
+      when "Patch", "PatchNoContent", "StreamPatch"
         "PATCH"
       when "Head"
         "HEAD"
       when "Options"
         "OPTIONS"
       end
+    end
+
+    private def extract_multipart_type(args : String) : String
+      remaining = args.strip
+      # Skip the first positional argument (typically `Mem` or `Tmp`).
+      m = remaining.match(/\A[A-Za-z][A-Za-z0-9_']*\s*(.*)\z/m)
+      remaining = m[1] if m
+      remaining = remaining.strip
+      # The next token is either `(MultipartData Mem)` or a bare type
+      # constructor. Strip a leading paren if present.
+      remaining = remaining[1..].strip if remaining.starts_with?("(")
+      m = remaining.match(/\A([A-Za-z][A-Za-z0-9_']*)/)
+      m ? m[1] : "Multipart"
     end
 
     private def extract_verb_method(args : String) : String?


### PR DESCRIPTION
## Summary
Enrich the **F#/Giraffe**, **Groovy/Grails**, and **Haskell/Servant** analyzers with patterns common in real-world apps that were previously dropped or assigned the wrong verb. These additions extend the existing AI context base rather than fixing a regression.

### Giraffe (F#)
- Recognize the Giraffe 6+ **Endpoint Routing API**: `GET [ route "/" h; route "/x" h ]` now treats the wrapping verb as a method scope so embedded routes inherit it instead of falling back to all verbs.
- Bracket-style `subRoute "/prefix" [ ... ]` joins the existing paren form: nested routes get the prefix applied.
- Shared `find_matching_delimiter` helper consolidates paren/bracket scanning.

### Grails (Groovy)
- Tolerate the **`name <id>:`** mapping prefix on both verb-prefixed and verbless URL mappings (Grails reverse-URL naming).
- Surface `'/path'(uri: '/other')` redirect-style mappings as endpoints.
- Singular `'/path'(resource: 'name')` REST shortcut expands to the five singleton verbs (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`).
- Pick up `void` and primitive-return actions (`void show()`, `int count()`) alongside `def` and uppercase typed-return forms.

### Servant (Haskell)
- `StreamGet` / `StreamPost` / `StreamPut` / `StreamDelete` / `StreamPatch` map to their HTTP verbs.
- Generic `Stream 'GET …` and `UVerb 'PATCH …` extract the verb from the first promoted arg.
- `MultipartForm Mem (MultipartData Mem)` emits a body parameter with the underlying data type — multipart endpoints stop being silently dropped.

## Test plan
- [x] `crystal spec spec/functional_test` — 10,959 examples, 0 failures
- [x] `crystal spec spec/unit_test` — 1,686 examples, 0 failures
- [x] `crystal tool format --check` clean
- [x] `lib/ameba/bin/ameba.cr` clean for touched files
- [x] New fixtures cover each new pattern (Giraffe endpoint routing, Grails `name`/`uri`/`resource`/`void`, Servant `MultipartForm`/`StreamGet`/`UVerb`)