### PR TITLE
Improve TypeScript NestJS and TanStack Router coverage

### DIFF
--- a/spec/functional_test/fixtures/typescript/nestjs_advanced/events.controller.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_advanced/events.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Sse, UploadedFile, UploadedFiles, Post, HostParam, Get } from '@nestjs/common';
+
+// Versioned controller with a multi-version array — Nest expands this
+// into one route per version.
+@Controller({ path: 'events', version: ['1', '2'] })
+export class EventsController {
+  // Server-sent events: `@Sse` is GET under the hood.
+  @Sse('stream')
+  stream() {
+    return null;
+  }
+
+  // Bare @Sse() — no path segment.
+  @Sse()
+  liveAll() {
+    return null;
+  }
+}
+
+// Subdomain routing surfaces a @HostParam path-like parameter.
+@Controller({ host: ':account.example.com', path: 'tenant' })
+export class TenantController {
+  @Get(':slug')
+  describe(@HostParam('account') account: string) {
+    return { account };
+  }
+}
+
+// Multipart upload with explicit and implicit decorators. Multer
+// integration is the dominant way Nest apps accept files.
+@Controller('uploads')
+export class UploadsController {
+  @Post('avatar')
+  uploadAvatar(@UploadedFile('avatar') file: any) {
+    return file;
+  }
+
+  @Post('attachments')
+  uploadAttachments(@UploadedFiles('files') files: any[]) {
+    return files;
+  }
+
+  @Post('blob')
+  uploadBlob(@UploadedFile() file: any) {
+    return file;
+  }
+
+  @Post('bulk')
+  uploadBulk(@UploadedFiles() files: any[]) {
+    return files;
+  }
+
+  // Commented-out decorator must NOT be reported as a real route.
+  // @Get('/legacy/path')
+  // legacy() { return null; }
+}

--- a/spec/functional_test/fixtures/typescript/nestjs_advanced/main.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_advanced/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  // Real-world Nest apps overwhelmingly mount everything under a
+  // global prefix; the analyzer should propagate it to every route.
+  app.setGlobalPrefix('api');
+  app.enableVersioning();
+  await app.listen(3000);
+}
+bootstrap();

--- a/spec/functional_test/testers/typescript/nestjs_advanced_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_advanced_spec.cr
@@ -1,0 +1,42 @@
+require "../../func_spec.cr"
+
+# Coverage for real-world NestJS patterns the analyzer used to miss:
+#   - `app.setGlobalPrefix('api')` propagation
+#   - `@Controller({ version: ['1', '2'] })` → `/v1` and `/v2`
+#   - `@Sse()` treated as GET
+#   - `@UploadedFile`/`@UploadedFiles` (named + unnamed)
+#   - `@HostParam` surfacing subdomain captures
+#   - commented-out decorators ignored (FP fix)
+expected_endpoints = [
+  # /events under v1 and v2 with @Sse('stream') + bare @Sse()
+  Endpoint.new("/api/v1/events/stream", "GET", [] of Param),
+  Endpoint.new("/api/v2/events/stream", "GET", [] of Param),
+  Endpoint.new("/api/v1/events", "GET", [] of Param),
+  Endpoint.new("/api/v2/events", "GET", [] of Param),
+
+  # Subdomain host param surfaces as a path-typed param.
+  Endpoint.new("/api/tenant/:slug", "GET", [
+    Param.new("slug", "", "path"),
+    Param.new("account", "", "path"),
+  ]),
+
+  # Multipart upload routes — named file / files args.
+  Endpoint.new("/api/uploads/avatar", "POST", [
+    Param.new("avatar", "", "body"),
+  ]),
+  Endpoint.new("/api/uploads/attachments", "POST", [
+    Param.new("files", "", "body"),
+  ]),
+  # Bare @UploadedFile() / @UploadedFiles() default to 'file' / 'files'.
+  Endpoint.new("/api/uploads/blob", "POST", [
+    Param.new("file", "", "body"),
+  ]),
+  Endpoint.new("/api/uploads/bulk", "POST", [
+    Param.new("files", "", "body"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/typescript/nestjs_advanced/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/typescript/nestjs_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_spec.cr
@@ -27,13 +27,14 @@ expected_endpoints = [
   ]),
   # `@Controller()` (empty) — method path used as-is.
   Endpoint.new("/health", "GET", [] of Param),
-  # `@Controller({ path: 'tasks', version: '1' })` (object).
-  Endpoint.new("/tasks", "GET", [] of Param),
-  Endpoint.new("/tasks", "POST", [
+  # `@Controller({ path: 'tasks', version: '1' })` — versioned
+  # controllers route under `/v<version>` per Nest URI versioning.
+  Endpoint.new("/v1/tasks", "GET", [] of Param),
+  Endpoint.new("/v1/tasks", "POST", [
     Param.new("body", "", "body"),
   ]),
-  # Multi-line `@Controller({ path: 'webhooks', ... })`.
-  Endpoint.new("/webhooks/:provider", "POST", [
+  # Multi-line `@Controller({ path: 'webhooks', version: '1' })`.
+  Endpoint.new("/v1/webhooks/:provider", "POST", [
     Param.new("provider", "", "path"),
     Param.new("body", "", "body"),
   ]),

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -12,15 +12,41 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      global_prefix_holder = [] of String
+      global_prefix_mutex = Mutex.new
 
       parallel_file_scan(extensions) do |path|
-        analyze_nestjs_file(path, result, static_dirs, include_callee)
+        analyze_nestjs_file(path, result, static_dirs, include_callee, global_prefix_holder, global_prefix_mutex)
       end
 
       # Process static directories to create endpoints for static files
       process_static_dirs(static_dirs, result)
 
+      # Apply discovered global prefix (`app.setGlobalPrefix('api')`)
+      # — the bootstrap call mounts every controller under that prefix.
+      apply_global_prefix(result, global_prefix_holder.first?)
+
       result
+    end
+
+    # Prepend the discovered `app.setGlobalPrefix('api')` value to
+    # every endpoint URL. Endpoints whose URL already starts with the
+    # normalized prefix (e.g. controllers that hard-coded `/api/...`)
+    # are left untouched so we don't double-prefix.
+    private def apply_global_prefix(result : Array(Endpoint), prefix : String?)
+      return if prefix.nil? || prefix.empty?
+      normalized = prefix.starts_with?("/") ? prefix : "/#{prefix}"
+      normalized = normalized.chomp("/")
+      return if normalized.empty?
+
+      # `Endpoint` is a struct (value type), so the block-local
+      # binding is a copy — write back through the index to make the
+      # URL change visible to callers.
+      result.each_with_index do |endpoint, idx|
+        next if endpoint.url.starts_with?(normalized + "/") || endpoint.url == normalized
+        endpoint.url = endpoint.url.starts_with?("/") ? "#{normalized}#{endpoint.url}" : "#{normalized}/#{endpoint.url}"
+        result[idx] = endpoint
+      end
     end
 
     # Process static directories and add endpoints for each file
@@ -45,7 +71,7 @@ module Analyzer::Javascript
       end
     end
 
-    private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool)
+    private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool, global_prefix_holder : Array(String), global_prefix_mutex : Mutex)
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         content = file.gets_to_end
 
@@ -54,10 +80,34 @@ module Analyzer::Javascript
           static_dirs << static_path unless static_dirs.any? { |s| s["static_path"] == static_path["static_path"] && s["file_path"] == static_path["file_path"] }
         end
 
-        analyze_nestjs_controllers(content, path, result, include_callee)
+        # Strip JS/TS comments so commented-out decorators
+        # (e.g. `// @Get('/old')`) don't generate phantom routes.
+        sanitized = Noir::JSRouteExtractor.strip_js_comments(content)
+
+        # `app.setGlobalPrefix('api')` in a bootstrap file scopes
+        # every controller below it. Record it now; apply once after
+        # all files have been parsed.
+        if prefix = extract_global_prefix(sanitized)
+          global_prefix_mutex.synchronize do
+            global_prefix_holder << prefix if global_prefix_holder.empty?
+          end
+        end
+
+        analyze_nestjs_controllers(sanitized, path, result, include_callee)
       end
     rescue e : Exception
       logger.debug "Error analyzing NestJS file #{path}: #{e.message}"
+    end
+
+    # Detect `app.setGlobalPrefix('api')` (single string-literal arg).
+    # Returns the prefix or nil. Constants and dynamic expressions
+    # are ignored conservatively — false-positive prefixing would
+    # mis-route everything.
+    private def extract_global_prefix(content : String) : String?
+      content.scan(/\.setGlobalPrefix\s*\(\s*(['"`])([^'"`]+)\1\s*[,)]/) do |match|
+        return match[2] if match.size > 2 && !match[2].empty?
+      end
+      nil
     end
 
     private def analyze_nestjs_controllers(content : String, path : String, result : Array(Endpoint), include_callee : Bool)
@@ -394,10 +444,13 @@ module Analyzer::Javascript
         "Patch"   => ["PATCH"],
         "Options" => ["OPTIONS"],
         "Head"    => ["HEAD"],
+        # `@Sse` opens a Server-Sent Events stream — HTTP GET under
+        # the hood, so it counts as a real route.
+        "Sse"     => ["GET"],
         "All"     => ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
       }
 
-      class_content.scan(/@(Get|Post|Put|Delete|Patch|Options|Head|All)\s*\(/) do |match|
+      class_content.scan(/@(Get|Post|Put|Delete|Patch|Options|Head|Sse|All)\s*\(/) do |match|
         decorator_start = match.begin(0)
         next unless decorator_start
 
@@ -534,6 +587,29 @@ module Analyzer::Javascript
           param_name = param_match[1]
           push_unique_param(endpoint, Param.new(param_name, "", "header"))
         end
+      end
+
+      # `@HostParam('account')` — subdomain capture when the controller
+      # uses `@Controller({ host: ':account.example.com' })`.
+      method_params.scan(/@HostParam\s*\(\s*['"`]([^'"`]+)['"`][\s\S]*?\)/) do |param_match|
+        push_unique_param(endpoint, Param.new(param_match[1], "", "path")) if param_match.size > 0
+      end
+
+      # `@UploadedFile('field')` / `@UploadedFiles('field')` — multer
+      # integration. Unnamed forms get a generic 'file' / 'files' body
+      # param so consumers still see the upload surface.
+      method_params.scan(/@UploadedFile\s*\(\s*['"`]([^'"`]+)['"`][\s\S]*?\)/) do |param_match|
+        push_unique_param(endpoint, Param.new(param_match[1], "", "body")) if param_match.size > 0
+      end
+      if method_params =~ /@UploadedFile\s*\(\s*\)/
+        push_unique_param(endpoint, Param.new("file", "", "body"))
+      end
+
+      method_params.scan(/@UploadedFiles\s*\(\s*['"`]([^'"`]+)['"`][\s\S]*?\)/) do |param_match|
+        push_unique_param(endpoint, Param.new(param_match[1], "", "body")) if param_match.size > 0
+      end
+      if method_params =~ /@UploadedFiles\s*\(\s*\)/
+        push_unique_param(endpoint, Param.new("files", "", "body"))
       end
     end
 

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -26,7 +26,10 @@ module Analyzer::Typescript
 
     private def analyze_tanstack_file(path : String, result : Array(Endpoint))
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
+        raw = file.gets_to_end
+        # Comments can hold stale routes; drop them so a commented-out
+        # `createFileRoute('/old')` doesn't get reported.
+        content = Noir::JSRouteExtractor.strip_js_comments(raw)
 
         # Extract routes from createFileRoute
         analyze_file_routes(content, path, result)
@@ -142,8 +145,15 @@ module Analyzer::Typescript
     end
 
     private def extract_parent_route(block : String) : String?
-      match = block.match(/getParentRoute\s*:\s*\(\s*\)\s*=>\s*([A-Za-z_$][\w$]*)/)
-      match.try(&.[1])
+      # Tolerate parens around the identifier, e.g. `() => (rootRoute)`,
+      # and arrow-body bracing like `() => { return rootRoute }`, which
+      # both show up in real-world TanStack apps when teams add an
+      # explicit `return` for clarity.
+      arrow_match = block.match(/getParentRoute\s*:\s*\(\s*\)\s*=>\s*\(?\s*([A-Za-z_$][\w$]*)\s*\)?/)
+      return arrow_match[1] if arrow_match
+
+      body_match = block.match(/getParentRoute\s*\(\s*\)\s*\{\s*return\s+([A-Za-z_$][\w$]*)/)
+      body_match.try(&.[1])
     end
 
     private def resolve_code_route_path(route : CodeRoute, route_map : Hash(String, CodeRoute), resolving = Set(String).new) : String
@@ -250,9 +260,14 @@ module Analyzer::Typescript
         end
       end
 
-      # Look for useSearch hook usage
-      # Example: const { page, filter } = Route.useSearch()
-      use_search_pattern = /(?:const|let|var)\s*\{([^}]+)\}\s*=\s*(?:Route\.)?useSearch\s*\(/
+      # Look for useSearch hook usage. Three call shapes show up
+      # across TanStack v1 apps:
+      #   - Route.useSearch()                       (file-route scope)
+      #   - useSearch({ from: '/posts' })           (component-level)
+      #   - getRouteApi('/posts').useSearch()       (extracted API)
+      # All three should map search-destructured names back to query
+      # params on the corresponding route.
+      use_search_pattern = /(?:const|let|var)\s*\{([^}]+)\}\s*=\s*(?:Route\.|[\w$]+\.)?useSearch\s*\(/
       content.scan(use_search_pattern) do |match|
         if match.size > 0
           params_str = match[1]
@@ -264,6 +279,12 @@ module Analyzer::Typescript
           end
         end
       end
+
+      # `getRouteApi('/path').useSearch()` produces a `search` value
+      # that's typically used field-by-field afterwards. Treat any
+      # destructured names from the search return value the same as
+      # the Route.useSearch case above. Pattern handled by the unified
+      # regex already.
     end
 
     private def extract_search_params_from_route_block(route_block : String, endpoint : Endpoint)

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -706,6 +706,80 @@ module Noir
       JSLiteralScanner.find_matching_paren(content, open_paren_idx)
     end
 
+    # Replace JS/TS comments with whitespace of the same shape.
+    # Preserves newlines and column offsets so downstream line/column
+    # math (`controller_start_line`, regex `.begin(0)`, etc.) stays
+    # accurate. Comment bodies are blanked to spaces so a commented-
+    # out decorator like `// @Get('/old')` never matches the route
+    # regex.
+    def self.strip_js_comments(content : String) : String
+      builder = String::Builder.new(content.bytesize)
+      state = :code
+      escaped = false
+      chars = content.chars
+      i = 0
+      len = chars.size
+
+      while i < len
+        char = chars[i]
+        case state
+        when :code
+          if char == '/' && i + 1 < len
+            nxt = chars[i + 1]
+            if nxt == '/'
+              state = :line_comment
+              builder << "  "
+              i += 2
+              next
+            elsif nxt == '*'
+              state = :block_comment
+              builder << "  "
+              i += 2
+              next
+            end
+          end
+          case char
+          when '\''
+            state = :single
+          when '"'
+            state = :double
+          when '`'
+            state = :template
+          end
+          builder << char
+        when :single, :double, :template
+          builder << char
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif (state == :single && char == '\'') ||
+                (state == :double && char == '"') ||
+                (state == :template && char == '`')
+            state = :code
+          end
+        when :line_comment
+          if char == '\n'
+            state = :code
+            builder << '\n'
+          else
+            builder << ' '
+          end
+        when :block_comment
+          if char == '*' && i + 1 < len && chars[i + 1] == '/'
+            state = :code
+            builder << "  "
+            i += 2
+            next
+          end
+          builder << (char == '\n' ? '\n' : ' ')
+        end
+        i += 1
+      end
+
+      builder.to_s
+    end
+
     def self.extract_body_params(handler_body : String, endpoint : Endpoint)
       # Look for req.body.X or const/let/var { X } = req.body
       # First check the destructuring pattern


### PR DESCRIPTION
## Summary
- NestJS: propagate `app.setGlobalPrefix('api')`, recognize `@Sse`, `@UploadedFile`/`@UploadedFiles`, and `@HostParam`, and unstale the `nestjs_spec` expectations that PR #1621 left behind (URI versioning emits `/v1/...`).
- TanStack Router: tolerate `getParentRoute: () => (rootRoute)` and method-body forms, and recognize `getRouteApi(...).useSearch()` destructures in addition to `Route.useSearch()`.
- Shared: strip JS/TS comments via `Noir::JSRouteExtractor.strip_js_comments` before route extraction so a commented-out `// @Get('/old')` no longer surfaces as a phantom route.

Adds a `nestjs_advanced` fixture exercising the new patterns end-to-end (global prefix, multi-version `version: ['1','2']`, SSE, named/unnamed uploads, subdomain `@HostParam`, commented-out FP). All existing TS specs continue to pass.

## Test plan
- [x] `crystal spec spec/functional_test/testers/typescript/` — 175 examples, 0 failures
- [x] `crystal spec spec/functional_test/ spec/unit_test/` — 12,784 examples, 0 failures
- [x] `./bin/noir -b spec/functional_test/fixtures/typescript/nestjs_advanced/ -f json` shows `/api/v1/events/stream`, `/api/uploads/avatar`, `/api/tenant/:slug`, etc. — global prefix, version expansion, SSE→GET, host param all combined.
- [x] `./bin/noir -b spec/functional_test/fixtures/typescript/nestjs/` continues to emit `/v1/tasks`, `/v1/webhooks/:provider` from the existing fixture (matches the updated expectations).