### PR TITLE
Allow `wrk` and `mis` in typos config

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -15,6 +15,10 @@ nd = "nd"
 edn = "edn"
 # `paket` is the .NET dependency manager (paket.dependencies).
 paket = "paket"
+# Insomnia uses `wrk_` as the canonical prefix for workspace IDs in exports.
+wrk = "wrk"
+# `mis-route` / `mis-classification` are intentional hyphenated forms in comments.
+mis = "mis"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Summary
- Add `wrk` to typos allowlist — Insomnia's canonical workspace ID prefix used across the v4/v5 export fixtures (`wrk_1`, `wrk_v5_1`).
- Add `mis` to typos allowlist — covers intentional hyphenated phrases (`mis-route`, `mis-classification`) in NestJS and go-zero analyzer comments.

## Test plan
- [x] `typos` passes with no errors