### PR TITLE
Improve Kotlin route detection

### DIFF
--- a/spec/functional_test/fixtures/kotlin/ktor/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/Application.kt
@@ -16,6 +16,8 @@ fun main() {
 
 fun Application.configureRouting() {
     routing {
+        extensionRoutes()
+
         get("/") {
             call.respondText("Hello, World!")
         }

--- a/spec/functional_test/fixtures/kotlin/ktor/ExtensionRoutes.kt
+++ b/spec/functional_test/fixtures/kotlin/ktor/ExtensionRoutes.kt
@@ -1,0 +1,19 @@
+package com.example.ktor
+
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.http.*
+
+fun Route.extensionRoutes() {
+    route("/extension") {
+        get {
+            call.respondText("Extension route")
+        }
+
+        route("/method", HttpMethod.Post) {
+            handle {
+                call.respondText("Method route")
+            }
+        }
+    }
+}

--- a/spec/functional_test/testers/kotlin/ktor_spec.cr
+++ b/spec/functional_test/testers/kotlin/ktor_spec.cr
@@ -1,6 +1,8 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
+  Endpoint.new("/extension", "GET"),
+  Endpoint.new("/extension/method", "POST"),
   Endpoint.new("/", "GET"),
   Endpoint.new("/users/{id}", "GET", [
     Param.new("id", "", "path"),

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -38,6 +38,70 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
     ])
   end
 
+  it "extracts routes from Route extension functions" do
+    source = <<-KT
+      import io.ktor.server.routing.Route
+
+      fun Route.customerRoutes() {
+          route("/customer") {
+              get { }
+              post("/{id}") { }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/customer"},
+      {"POST", "/customer/{id}"},
+    ])
+  end
+
+  it "extracts routes from modified Route extension functions" do
+    source = <<-KT
+      import io.ktor.server.routing.Route
+
+      private fun Route.adminRoutes() {
+          get("/admin") { }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/admin"},
+    ])
+  end
+
+  it "extracts route(path, method) handlers" do
+    source = <<-KT
+      routing {
+          route("/hello", HttpMethod.Get) {
+              handle { call.respondText("ok") }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/hello"},
+    ])
+  end
+
+  it "treats install(RoutingRoot) as a routing entry point" do
+    source = <<-KT
+      fun Application.module() {
+          install(RoutingRoot) {
+              get("/installed") { }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/installed"},
+    ])
+  end
+
   it "treats authenticate{} as a passthrough wrapper" do
     source = <<-KT
       routing {
@@ -137,13 +201,31 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
     end
   end
 
-  it "skips verb DSL calls without a string-literal path" do
-    # `get { ... }` (resource-based routing) currently isn't
-    # supported. We just ignore it rather than emitting an empty
-    # path.
+  it "uses the current route prefix for verb DSL calls without a path argument" do
     source = <<-KT
       routing {
-          get { call.respondText("ok") }
+          route("/items") {
+              get { call.respondText("ok") }
+          }
+          get("/real") { }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/items"},
+      {"GET", "/real"},
+    ])
+  end
+
+  it "does not treat unrelated get calls as routes outside routing contexts" do
+    source = <<-KT
+      fun helper(client: HttpClient) {
+          client.get("/external")
+          get("/local-helper")
+      }
+
+      routing {
           get("/real") { }
       }
       KT

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -95,6 +95,67 @@ describe Noir::TreeSitterKotlinRouteExtractor do
     ])
   end
 
+  it "resolves Kotlin string constants in mapping paths" do
+    source = <<-KT
+      package com.example
+
+      object ApiPaths {
+          const val PREFIX = "/api"
+      }
+
+      const val USERS = "/users"
+
+      @RequestMapping(ApiPaths.PREFIX)
+      class A {
+          @GetMapping(USERS + "/{id}")
+          fun x(): String = ""
+
+          @PostMapping(path = arrayOf(USERS, "/accounts"))
+          fun y(): String = ""
+      }
+      KT
+
+    constants = Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(source)
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, constants)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/users/{id}"},
+      {"POST", "/api/users"},
+      {"POST", "/api/accounts"},
+    ])
+  end
+
+  it "does not resolve simple mapping constants from the global index" do
+    source = <<-KT
+      package com.example
+
+      @RequestMapping("/api")
+      class A {
+          @GetMapping(USERS)
+          fun x(): String = ""
+      }
+      KT
+
+    constants = {"USERS" => "/wrong"} of String => String
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, constants)
+    routes.map(&.path).should_not contain("/api/wrong")
+  end
+
+  it "resolves fully-qualified mapping constants from the global index" do
+    source = <<-KT
+      package com.example
+
+      @RequestMapping(com.example.ApiPaths.PREFIX)
+      class A {
+          @GetMapping("/users")
+          fun x(): String = ""
+      }
+      KT
+
+    constants = {"com.example.ApiPaths.PREFIX" => "/api"} of String => String
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, constants)
+    routes.map(&.path).should eq(["/api/users"])
+  end
+
   it "emits prefix/ when the method path is empty" do
     # Kotlin Spring controllers routinely do
     # `@RequestMapping("/api/article")` on the class and `@GetMapping`

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -15,7 +15,7 @@ module Analyzer::Kotlin
         next if KotlinEngine.test_path?(path)
 
         content = read_file_content(path)
-        next unless content.includes?("routing")
+        next unless potential_ktor_route_file?(content)
 
         Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
@@ -24,6 +24,12 @@ module Analyzer::Kotlin
 
       Fiber.yield
       @result
+    end
+
+    private def potential_ktor_route_file?(content : String) : Bool
+      content.includes?("routing") ||
+        content.includes?("io.ktor.server.routing") ||
+        content.includes?("Route.")
     end
 
     private def build_endpoint(route : Noir::TreeSitterKotlinKtorRouteExtractor::Route, path : String) : Endpoint

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -84,48 +84,60 @@ module Noir
     def extract_routes(source : String, *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, 0, include_callees)
+        walk(root, source, "", routes, 0, include_callees, false)
       end
       routes
     end
 
     # ---- traversal ----------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool, active : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
-      if Noir::TreeSitter.node_type(node) == "call_expression"
+      ty = Noir::TreeSitter.node_type(node)
+
+      if ty == "function_declaration" && route_extension_function?(node, source)
+        if body = function_body_statements(node)
+          walk(body, source, prefix, routes, depth + 1, include_callees, true)
+        end
+        return
+      end
+
+      if ty == "call_expression"
         name = call_name(node, source)
         case
-        when HTTP_VERB_NAMES.has_key?(name)
+        when active && HTTP_VERB_NAMES.has_key?(name)
           emit_route(node, source, name, prefix, routes, include_callees)
           return
-        when name == "route"
+        when active && name == "route"
           path_arg = call_string_argument(node, source)
-          new_prefix = path_arg ? prefix + path_arg : prefix
+          new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
           if body = call_lambda_body(node)
-            walk(body, source, new_prefix, routes, depth + 1, include_callees)
+            if method = call_http_method_argument(node, source)
+              emit_method_route(node, body, source, method, new_prefix, routes, include_callees) if has_handle_call?(body, source)
+            end
+            walk(body, source, new_prefix, routes, depth + 1, include_callees, true)
           end
           return
-        when PASSTHROUGH_NAMES.includes?(name)
+        when name == "routing" || routing_install_call?(node, source) || (active && PASSTHROUGH_NAMES.includes?(name))
           if body = call_lambda_body(node)
-            walk(body, source, prefix, routes, depth + 1, include_callees)
+            walk(body, source, prefix, routes, depth + 1, include_callees, true)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1, include_callees)
+        walk(child, source, prefix, routes, depth + 1, include_callees, active)
       end
     end
 
     private def emit_route(node : LibTreeSitter::TSNode, source : String, name : String, prefix : String, routes : Array(Route), include_callees : Bool)
       path_arg = call_string_argument(node, source)
-      return unless path_arg
+      return unless path_arg || call_has_lambda?(node)
 
       verb = HTTP_VERB_NAMES[name]
-      full_path = prefix + path_arg
+      full_path = join_paths(prefix, path_arg || "")
       line = Noir::TreeSitter.node_start_row(node)
 
       receive_type : String? = nil
@@ -147,6 +159,29 @@ module Noir
             name, _path, line_no = entry
             callees << {name, line_no}
           end
+        end
+      end
+
+      routes << Route.new(verb, full_path, line, receive_type, query_params, header_params, callees)
+    end
+
+    private def emit_method_route(node : LibTreeSitter::TSNode,
+                                  body : LibTreeSitter::TSNode,
+                                  source : String,
+                                  verb : String,
+                                  full_path : String,
+                                  routes : Array(Route),
+                                  include_callees : Bool)
+      line = Noir::TreeSitter.node_start_row(node)
+      query_params = [] of String
+      header_params = [] of String
+      receive_type = scan_handler_body(body, source, query_params, header_params)
+
+      callees = [] of Tuple(String, Int32)
+      if include_callees
+        Noir::KotlinCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+          name, _path, line_no = entry
+          callees << {name, line_no}
         end
       end
 
@@ -177,6 +212,8 @@ module Noir
         else
           ""
         end
+      when "navigation_expression"
+        last_navigation_segment(first, source)
       else
         ""
       end
@@ -209,6 +246,80 @@ module Noir
       nil
     end
 
+    private def call_http_method_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      first = first_named_child(call)
+      return unless first
+      return unless Noir::TreeSitter.node_type(first) == "call_expression"
+
+      args = nil
+      Noir::TreeSitter.each_named_child(first) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "call_suffix"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          args = sub if Noir::TreeSitter.node_type(sub) == "value_arguments"
+        end
+      end
+      return unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+        Noir::TreeSitter.each_named_child(arg) do |child|
+          if verb = http_method_value(child, source)
+            return verb
+          end
+        end
+      end
+      nil
+    end
+
+    private def http_method_value(node : LibTreeSitter::TSNode, source : String) : String?
+      candidate =
+        case Noir::TreeSitter.node_type(node)
+        when "simple_identifier"
+          Noir::TreeSitter.node_text(node, source)
+        when "navigation_expression"
+          last_navigation_segment(node, source)
+        else
+          ""
+        end
+
+      return if candidate.empty?
+      upcased = candidate.upcase
+      HTTP_VERB_NAMES.values.includes?(upcased) ? upcased : nil
+    end
+
+    private def routing_install_call?(call : LibTreeSitter::TSNode, source : String) : Bool
+      return false unless call_name(call, source) == "install"
+
+      first = first_named_child(call)
+      return false unless first
+      return false unless Noir::TreeSitter.node_type(first) == "call_expression"
+
+      args = nil
+      Noir::TreeSitter.each_named_child(first) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "call_suffix"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          args = sub if Noir::TreeSitter.node_type(sub) == "value_arguments"
+        end
+      end
+      return false unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+        Noir::TreeSitter.each_named_child(arg) do |child|
+          case Noir::TreeSitter.node_type(child)
+          when "simple_identifier"
+            name = Noir::TreeSitter.node_text(child, source)
+            return true if name == "Routing" || name == "RoutingRoot"
+          when "navigation_expression"
+            text = Noir::TreeSitter.node_text(child, source)
+            name = last_navigation_segment(child, source)
+            return true if name == "Routing" || name == "RoutingRoot" || text.ends_with?("Routing.Plugin")
+          end
+        end
+      end
+      false
+    end
+
     # Locate the lambda body (`statements` node) of a call_expression's
     # trailing lambda — `foo(...) { body }` or `foo { body }`.
     private def call_lambda_body(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
@@ -225,6 +336,58 @@ module Noir
           when "lambda_literal"
             return lambda_statements(sub)
           end
+        end
+      end
+      nil
+    end
+
+    private def call_has_lambda?(call : LibTreeSitter::TSNode) : Bool
+      Noir::TreeSitter.each_named_child(call) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "call_suffix"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          return true if Noir::TreeSitter.node_type(sub) == "annotated_lambda"
+          return true if Noir::TreeSitter.node_type(sub) == "lambda_literal"
+        end
+      end
+      false
+    end
+
+    private def has_handle_call?(node : LibTreeSitter::TSNode, source : String, depth : Int32 = 0) : Bool
+      return false if depth > Noir::TreeSitter::MAX_AST_DEPTH
+      if Noir::TreeSitter.node_type(node) == "call_expression" && call_name(node, source) == "handle"
+        return true
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return true if has_handle_call?(child, source, depth + 1)
+      end
+      false
+    end
+
+    private def route_extension_function?(func : LibTreeSitter::TSNode, source : String) : Bool
+      receiver = nil
+      Noir::TreeSitter.each_named_child(func) do |child|
+        if Noir::TreeSitter.node_type(child) == "user_type"
+          receiver = child
+          break
+        end
+      end
+      return false unless receiver
+
+      last_type = ""
+      Noir::TreeSitter.each_named_child(receiver) do |child|
+        if Noir::TreeSitter.node_type(child) == "type_identifier"
+          last_type = Noir::TreeSitter.node_text(child, source)
+        end
+      end
+      last_type == "Route" || last_type == "Routing"
+    end
+
+    private def function_body_statements(func : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(func) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "function_body"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          return sub if Noir::TreeSitter.node_type(sub) == "statements"
         end
       end
       nil
@@ -386,6 +549,23 @@ module Noir
       end
     end
 
+    private def last_navigation_segment(node : LibTreeSitter::TSNode, source : String) : String
+      result = ""
+      Noir::TreeSitter.each_named_child(node) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "simple_identifier"
+          result = Noir::TreeSitter.node_text(child, source)
+        when "navigation_suffix"
+          Noir::TreeSitter.each_named_child(child) do |sub|
+            if Noir::TreeSitter.node_type(sub) == "simple_identifier"
+              result = Noir::TreeSitter.node_text(sub, source)
+            end
+          end
+        end
+      end
+      result
+    end
+
     # `["x"]` → `"x"`. Anything else (interpolated string, identifier
     # key) returns nil so the caller skips emitting a param.
     private def indexing_string_key(idx : LibTreeSitter::TSNode, source : String) : String?
@@ -398,6 +578,13 @@ module Noir
         end
       end
       nil
+    end
+
+    private def join_paths(prefix : String, suffix : String) : String
+      return "/" if prefix.empty? && suffix.empty?
+      return suffix if prefix.empty?
+      return prefix.rstrip('/') if suffix.empty?
+      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -109,7 +109,8 @@ module Noir
     # responsibility.
     def extract_routes_from(root : LibTreeSitter::TSNode, source : String, string_constants = Hash(String, String).new) : Array(Route)
       routes = [] of Route
-      walk_classes(root, source, "", routes)
+      local_string_constants = extract_string_constants(source)
+      walk_classes(root, source, "", routes, string_constants, local_string_constants)
       collect_gateway_routes(source, string_constants, routes)
       routes
     end
@@ -119,10 +120,12 @@ module Noir
     private def walk_classes(node : LibTreeSitter::TSNode,
                              source : String,
                              outer_prefix : String,
-                             routes : Array(Route))
+                             routes : Array(Route),
+                             string_constants : Hash(String, String),
+                             local_string_constants : Hash(String, String))
       ty = Noir::TreeSitter.node_type(node)
       if ty == "class_declaration" || ty == "object_declaration" || ty == "interface_declaration"
-        process_class(node, source, outer_prefix, [] of LibTreeSitter::TSNode, routes)
+        process_class(node, source, outer_prefix, [] of LibTreeSitter::TSNode, routes, string_constants, local_string_constants)
         return
       end
 
@@ -140,13 +143,13 @@ module Noir
         child = LibTreeSitter.ts_node_named_child(node, i.to_u32)
         case Noir::TreeSitter.node_type(child)
         when "class_declaration", "object_declaration", "interface_declaration"
-          process_class(child, source, outer_prefix, pending, routes)
+          process_class(child, source, outer_prefix, pending, routes, string_constants, local_string_constants)
           pending = [] of LibTreeSitter::TSNode
         when "prefix_expression"
           pending << child if prefix_expression_has_annotation?(child)
         else
           pending = [] of LibTreeSitter::TSNode
-          walk_classes(child, source, outer_prefix, routes)
+          walk_classes(child, source, outer_prefix, routes, string_constants, local_string_constants)
         end
       end
     end
@@ -155,18 +158,20 @@ module Noir
                               source : String,
                               outer_prefix : String,
                               pending : Array(LibTreeSitter::TSNode),
-                              routes : Array(Route))
+                              routes : Array(Route),
+                              string_constants : Hash(String, String),
+                              local_string_constants : Hash(String, String))
       class_name = type_identifier_text(node, source)
-      class_prefix = class_mapping_prefix(node, source, pending)
+      class_prefix = class_mapping_prefix(node, source, pending, string_constants, local_string_constants)
       prefix = join_paths(outer_prefix, class_prefix)
 
       if body = class_body(node)
         Noir::TreeSitter.each_named_child(body) do |member|
           case Noir::TreeSitter.node_type(member)
           when "function_declaration"
-            collect_function_routes(member, source, class_name, prefix, routes)
+            collect_function_routes(member, source, class_name, prefix, routes, string_constants, local_string_constants)
           when "class_declaration", "object_declaration", "interface_declaration"
-            walk_classes(member, source, prefix, routes)
+            walk_classes(member, source, prefix, routes, string_constants, local_string_constants)
           end
         end
       end
@@ -212,10 +217,12 @@ module Noir
 
     private def class_mapping_prefix(class_decl : LibTreeSitter::TSNode,
                                      source : String,
-                                     stray_annotation_nodes : Array(LibTreeSitter::TSNode) = [] of LibTreeSitter::TSNode) : String
+                                     stray_annotation_nodes : Array(LibTreeSitter::TSNode) = [] of LibTreeSitter::TSNode,
+                                     string_constants = Hash(String, String).new,
+                                     local_string_constants = Hash(String, String).new) : String
       each_annotation(class_decl, source) do |name, args|
         next unless ANNOTATION_VERBS.has_key?(name)
-        paths = annotation_paths(args, source)
+        paths = annotation_paths(args, source, string_constants, local_string_constants)
         return paths.first unless paths.empty?
       end
 
@@ -231,7 +238,7 @@ module Noir
           next unless ANNOTATION_VERBS.has_key?(name)
           next unless args
           buf = [] of String
-          collect_string_values(args, source, buf)
+          collect_string_values(args, source, buf, string_constants, local_string_constants)
           return buf.first unless buf.empty?
         end
       end
@@ -306,14 +313,16 @@ module Noir
                                         source : String,
                                         class_name : String,
                                         class_prefix : String,
-                                        routes : Array(Route))
+                                        routes : Array(Route),
+                                        string_constants : Hash(String, String),
+                                        local_string_constants : Hash(String, String))
       method_name = function_name(func, source)
 
       each_annotation(func, source) do |ann_name, args, ann_line|
         next unless ANNOTATION_VERBS.has_key?(ann_name)
         verb_default = ANNOTATION_VERBS[ann_name]?
 
-        paths = annotation_paths(args, source)
+        paths = annotation_paths(args, source, string_constants, local_string_constants)
         paths = [""] if paths.empty?
 
         verbs =
@@ -597,7 +606,10 @@ module Noir
     # Kotlin `value_arguments` contains `value_argument` children.
     # Each argument is either positional (a single child that's a
     # literal) or named (has a `simple_identifier` + expression).
-    private def annotation_paths(args_node : LibTreeSitter::TSNode?, source : String) : Array(String)
+    private def annotation_paths(args_node : LibTreeSitter::TSNode?,
+                                 source : String,
+                                 string_constants : Hash(String, String),
+                                 local_string_constants : Hash(String, String)) : Array(String)
       empty = [] of String
       return empty unless args_node
       return empty unless Noir::TreeSitter.node_type(args_node) == "value_arguments"
@@ -612,9 +624,9 @@ module Noir
 
         if kind == :keyword
           next unless key == "value" || key == "path"
-          collect_string_values(value_node, source, keyword)
+          collect_string_values(value_node, source, keyword, string_constants, local_string_constants)
         else
-          collect_string_values(value_node, source, positional)
+          collect_string_values(value_node, source, positional, string_constants, local_string_constants)
         end
       end
 
@@ -643,18 +655,19 @@ module Noir
       {named ? :keyword : :positional, key, value}
     end
 
-    # Collect string literal values from a node. Handles a single
-    # `string_literal`, a `collection_literal` with string children,
-    # or `arrayOf("/a", "/b")` call expressions.
-    private def collect_string_values(node : LibTreeSitter::TSNode, source : String, sink : Array(String))
+    # Collect path values from a node. Handles string literals,
+    # constants, `PATH + "/suffix"`, collection literals, and
+    # `arrayOf("/a", PATH)` call expressions.
+    private def collect_string_values(node : LibTreeSitter::TSNode,
+                                      source : String,
+                                      sink : Array(String),
+                                      string_constants : Hash(String, String),
+                                      local_string_constants : Hash(String, String))
       case Noir::TreeSitter.node_type(node)
-      when "string_literal"
-        text = decode_string_literal(node, source)
-        sink << text unless text.empty?
       when "collection_literal"
         # Kotlin's `[...]` array syntax inside annotations.
         Noir::TreeSitter.each_named_child(node) do |elem|
-          collect_string_values(elem, source, sink)
+          collect_string_values(elem, source, sink, string_constants, local_string_constants)
         end
       when "parenthesized_expression"
         # Stray-annotation case: `@RequestMapping("/x")` gets parsed
@@ -662,7 +675,7 @@ module Noir
         # carrying a bare `string_literal` (no `value_arguments`
         # wrapper).
         Noir::TreeSitter.each_named_child(node) do |elem|
-          collect_string_values(elem, source, sink)
+          collect_string_values(elem, source, sink, string_constants, local_string_constants)
         end
       when "call_expression"
         # `arrayOf("/a", "/b")` — walk the value_arguments.
@@ -673,13 +686,66 @@ module Noir
               Noir::TreeSitter.each_named_child(suf) do |va|
                 next unless Noir::TreeSitter.node_type(va) == "value_argument"
                 Noir::TreeSitter.each_named_child(va) do |v|
-                  collect_string_values(v, source, sink) if Noir::TreeSitter.node_type(v) == "string_literal"
+                  collect_string_values(v, source, sink, string_constants, local_string_constants)
                 end
               end
             end
           end
         end
+      else
+        if value = resolve_string_value(node, source, string_constants, local_string_constants)
+          sink << value unless value.empty?
+        end
       end
+    end
+
+    private def resolve_string_value(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     string_constants : Hash(String, String),
+                                     local_string_constants : Hash(String, String)) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        decode_string_literal(node, source)
+      when "simple_identifier"
+        local_string_constants[Noir::TreeSitter.node_text(node, source)]?
+      when "navigation_expression"
+        text = Noir::TreeSitter.node_text(node, source)
+        local_string_constants[text]? || fully_qualified_constant(text, string_constants)
+      when "parenthesized_expression"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          return resolve_string_value(child, source, string_constants, local_string_constants)
+        end
+      when "additive_expression"
+        parts = [] of String
+        Noir::TreeSitter.each_named_child(node) do |child|
+          part = resolve_string_value(child, source, string_constants, local_string_constants)
+          return unless part
+          parts << part
+        end
+        parts.join
+      end
+    end
+
+    private def fully_qualified_constant(text : String, string_constants : Hash(String, String)) : String?
+      return unless text.count('.') >= 2
+      string_constants[text]?
+    end
+
+    private def last_navigation_segment(node : LibTreeSitter::TSNode, source : String) : String
+      result = ""
+      Noir::TreeSitter.each_named_child(node) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "simple_identifier"
+          result = Noir::TreeSitter.node_text(child, source)
+        when "navigation_suffix"
+          Noir::TreeSitter.each_named_child(child) do |sub|
+            if Noir::TreeSitter.node_type(sub) == "simple_identifier"
+              result = Noir::TreeSitter.node_text(sub, source)
+            end
+          end
+        end
+      end
+      result
     end
 
     # Extract verbs from `method = RequestMethod.X` / `method =


### PR DESCRIPTION
## Summary
- detect Ktor Route extension functions, pathless verb routes, route(path, HttpMethod) handlers, and RoutingRoot install blocks
- constrain Ktor route extraction to routing contexts to reduce false positives
- resolve Kotlin Spring mapping constants from local scope or fully-qualified names to avoid global simple-name collisions

## Tests
- crystal spec spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr spec/functional_test/testers/kotlin/ktor_spec.cr spec/functional_test/testers/kotlin/spring_spec.cr
- just test
- just check
- just build