### PR TITLE
Improve Java Spring route extraction

### DIFF
--- a/spec/functional_test/fixtures/java/spring/src/MyRoutingConfiguration.java
+++ b/spec/functional_test/fixtures/java/spring/src/MyRoutingConfiguration.java
@@ -21,6 +21,7 @@ public class MyRoutingConfiguration {
 		return route()
 				/* Get */
 				.GET("/{user}", ACCEPT_JSON, userHandler::getUser)
+				.HEAD("/{user}/metadata", ACCEPT_JSON, userHandler::getUser)
 				.GET("/{user}/customers", ACCEPT_JSON, userHandler::getUserCustomers)
 				.GET("/{user}/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~", ACCEPT_JSON, userHandler::getUserCustomers)
 				// Delete
@@ -34,6 +35,7 @@ public class MyRoutingConfiguration {
 		// @formatter:off
 		return route().POST("/{user}", ACCEPT_JSON, userHandler::getUser)
 				.PUT("/{user}", ACCEPT_JSON, userHandler::getUserCustomers)
+				.OPTIONS("/{user}/options", ACCEPT_JSON, userHandler::getUserCustomers)
 				.build();
 		// @formatter:on
 	}

--- a/spec/functional_test/fixtures/java/spring/src/QuoteRouter.java
+++ b/spec/functional_test/fixtures/java/spring/src/QuoteRouter.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.ServerResponse;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -27,6 +28,7 @@ public class QuoteRouter {
 				.andRoute(
 					POST("/echo")
 					.and(accept(TEXT_PLAIN).and(contentType(TEXT_PLAIN))), quoteHandler::echo)
+				.andRoute(RequestPredicates.PATCH("/quotes/{id}"), quoteHandler::patch)
 				// Quotes
 				.andRoute(GET("/quotes").and(accept(APPLICATION_JSON)), quoteHandler::fetchQuotes)
 				.andRoute(GET("/quotes/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~").and(accept(APPLICATION_STREAM_JSON)), quoteHandler::streamQuotes);

--- a/spec/functional_test/testers/java/spring_spec.cr
+++ b/spec/functional_test/testers/java/spring_spec.cr
@@ -3,14 +3,17 @@ require "../../func_spec.cr"
 expected_endpoints = [
   # MyRoutingConfiguration.java
   Endpoint.new("/{user}", "GET", [Param.new("user", "", "path")]),
+  Endpoint.new("/{user}/metadata", "HEAD", [Param.new("user", "", "path")]),
   Endpoint.new("/{user}/customers", "GET", [Param.new("user", "", "path")]),
   Endpoint.new("/{user}/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~", "GET", [Param.new("user", "", "path")]),
   Endpoint.new("/{user}", "DELETE", [Param.new("user", "", "path")]),
   Endpoint.new("/{user}", "POST", [Param.new("user", "", "path")]),
   Endpoint.new("/{user}", "PUT", [Param.new("user", "", "path")]),
+  Endpoint.new("/{user}/options", "OPTIONS", [Param.new("user", "", "path")]),
   # QuoteRouter.java
   Endpoint.new("/hello", "GET"),
   Endpoint.new("/echo", "POST"),
+  Endpoint.new("/quotes/{id}", "PATCH", [Param.new("id", "", "path")]),
   Endpoint.new("/quotes", "GET"),
   Endpoint.new("/quotes/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~", "GET"),
   # ProductRouter.java — WebMvc.fn `nest(path("/product"), ...)`

--- a/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
@@ -157,6 +157,93 @@ describe Noir::TreeSitterJavaRouteExtractor do
     ])
   end
 
+  it "preserves empty path literals in mapping arrays" do
+    source = <<-JAVA
+      @RequestMapping({"", "/api"})
+      public class A {
+          @GetMapping({"", "/health"})
+          public void x() {}
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", ""},
+      {"GET", "/api/"},
+      {"GET", "/health"},
+      {"GET", "/api/health"},
+    ])
+  end
+
+  it "fans out class-level path arrays across method mappings" do
+    source = <<-JAVA
+      @RequestMapping({"/api", "/internal"})
+      public class A {
+          @GetMapping("/users")
+          public void x() {}
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/users"},
+      {"GET", "/internal/users"},
+    ])
+  end
+
+  it "resolves compile-time String constants and concatenated paths" do
+    source = <<-JAVA
+      package com.example;
+
+      public final class ApiPaths {
+          public static final String API = "/api";
+          public static final String USERS = API + "/users";
+          public static final String DETAIL = USERS + "/{id}";
+      }
+
+      @RestController
+      public class UsersController {
+          private static final String LOCAL = "/local";
+          private static final String DETAIL = LOCAL + "/{id}";
+
+          @GetMapping(ApiPaths.DETAIL)
+          public void show() {}
+
+          @PostMapping(path = DETAIL)
+          public void local() {}
+      }
+      JAVA
+
+    constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants(source)
+    constants["ApiPaths.DETAIL"].should eq("/api/users/{id}")
+    constants["UsersController.DETAIL"].should eq("/local/{id}")
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path, r.method_name} }.should eq([
+      {"GET", "/api/users/{id}", "show"},
+      {"POST", "/local/{id}", "local"},
+    ])
+  end
+
+  it "does not resolve unknown qualified constants by short name" do
+    source = <<-JAVA
+      public class UsersController {
+          private static final String PATH = "/local";
+
+          @GetMapping(External.PATH)
+          public void external() {}
+
+          @GetMapping(PATH)
+          public void local() {}
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path, r.method_name} }.should eq([
+      {"GET", "/local", "local"},
+    ])
+  end
+
   it "fans out method arrays in @RequestMapping" do
     # Matches fixtures/java/spring/src/ItemController.java: both the
     # single-method and array-method forms.

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -7,7 +7,7 @@ require "../../engines/java_engine"
 module Analyzer::Java
   class Spring < Analyzer
     REGEX_ROUTER_CODE_BLOCK = /route\(\)?.*?\);/m
-    REGEX_ROUTE_CODE_LINE   = /((?:andRoute|route)\s*\(|\.)\s*(GET|POST|DELETE|PUT)\(\s*"([^"]*)/
+    REGEX_ROUTE_CODE_LINE   = /((?:andRoute|route)\s*\(|\.)\s*(?:RequestPredicates\.)?(GET|POST|DELETE|PUT|PATCH|HEAD|OPTIONS)\(\s*"([^"]*)/
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -66,14 +66,29 @@ module Noir
       routes
     end
 
+    def extract_string_constants(source : String) : Hash(String, String)
+      constants = Hash(String, String).new
+      Noir::TreeSitter.parse_java(source) do |root|
+        constants = extract_string_constants_from(root, source)
+      end
+      constants
+    end
+
     # `_from` variant — accept a pre-parsed `root` so the Spring
     # analyzer can amortise tree-sitter parses across multiple
     # extractions on the same file. Tree lifetime is the caller's
     # responsibility.
     def extract_routes_from(root : LibTreeSitter::TSNode, source : String) : Array(Route)
       routes = [] of Route
-      walk_classes(root, source, "", routes)
+      constants = extract_string_constants_from(root, source)
+      walk_classes(root, source, [""], routes, constants)
       routes
+    end
+
+    def extract_string_constants_from(root : LibTreeSitter::TSNode, source : String) : Hash(String, String)
+      constants = Hash(String, String).new
+      collect_string_constants(root, source, package_name(root, source), [] of String, constants)
+      constants
     end
 
     # ---- private helpers ----------------------------------------------
@@ -84,21 +99,28 @@ module Noir
     # accumulated from enclosing scopes.
     private def walk_classes(node : LibTreeSitter::TSNode,
                              source : String,
-                             outer_prefix : String,
-                             routes : Array(Route))
+                             outer_prefixes : Array(String),
+                             routes : Array(Route),
+                             constants : Hash(String, String))
       ty = Noir::TreeSitter.node_type(node)
       if ty == "class_declaration" || ty == "interface_declaration"
         class_name = class_simple_name(node, source)
-        class_prefix = class_mapping_prefix(node, source)
-        prefix = join_paths(outer_prefix, class_prefix)
+        class_prefixes = class_mapping_prefixes(node, source, constants, class_name)
+        class_prefixes = [""] if class_prefixes.empty?
+        prefixes = [] of String
+        outer_prefixes.each do |outer_prefix|
+          class_prefixes.each do |class_prefix|
+            prefixes << join_paths(outer_prefix, class_prefix)
+          end
+        end
 
         if body = Noir::TreeSitter.field(node, "body")
           Noir::TreeSitter.each_named_child(body) do |member|
             case Noir::TreeSitter.node_type(member)
             when "method_declaration"
-              collect_method_routes(member, source, class_name, prefix, routes)
+              collect_method_routes(member, source, class_name, prefixes, routes, constants)
             when "class_declaration", "interface_declaration"
-              walk_classes(member, source, prefix, routes)
+              walk_classes(member, source, prefixes, routes, constants)
             end
           end
         end
@@ -106,7 +128,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_classes(child, source, outer_prefix, routes)
+        walk_classes(child, source, outer_prefixes, routes, constants)
       end
     end
 
@@ -117,24 +139,28 @@ module Noir
       ""
     end
 
-    # Pull a class-level `@RequestMapping(...)` / `@GetMapping(...)`
-    # path contribution. Returns the first path if the annotation lists
-    # multiple (`{"/a", "/b"}`) — Spring treats the class prefix as a
-    # single value, so picking one is fine. `""` when absent.
-    private def class_mapping_prefix(class_decl : LibTreeSitter::TSNode, source : String) : String
+    # Pull class-level `@RequestMapping(...)` / `@GetMapping(...)`
+    # path contributions. Spring treats `value` / `path` as `String[]`,
+    # so class-level arrays fan out across every method-level mapping.
+    private def class_mapping_prefixes(class_decl : LibTreeSitter::TSNode,
+                                       source : String,
+                                       constants : Hash(String, String),
+                                       class_name : String) : Array(String)
       each_annotation(class_decl, source) do |name, args_node|
         next unless ANNOTATION_VERBS.has_key?(name)
-        paths = annotation_paths(args_node, source)
-        return paths.first if !paths.empty?
+        paths = annotation_paths(args_node, source, constants, class_name)
+        return paths unless paths.empty?
+        return [] of String if annotation_has_path_argument?(args_node, source)
       end
-      ""
+      [] of String
     end
 
     private def collect_method_routes(method : LibTreeSitter::TSNode,
                                       source : String,
                                       class_name : String,
-                                      class_prefix : String,
-                                      routes : Array(Route))
+                                      class_prefixes : Array(String),
+                                      routes : Array(Route),
+                                      constants : Hash(String, String))
       method_name = ""
       if name_node = Noir::TreeSitter.field(method, "name")
         method_name = Noir::TreeSitter.node_text(name_node, source)
@@ -144,7 +170,8 @@ module Noir
         verb_default = ANNOTATION_VERBS[ann_name]?
         next unless ANNOTATION_VERBS.has_key?(ann_name)
 
-        paths = annotation_paths(args_node, source)
+        paths = annotation_paths(args_node, source, constants, class_name)
+        next if paths.empty? && annotation_has_path_argument?(args_node, source)
         paths = [""] if paths.empty?
 
         verbs =
@@ -159,9 +186,11 @@ module Noir
         # `@RequestMapping({"/a", "/b"}, method = {GET, POST})` emits
         # four routes.
         paths.each do |path|
-          full = join_paths(class_prefix, path)
-          verbs.each do |verb|
-            routes << Route.new(verb, full, class_name, method_name, ann_line)
+          class_prefixes.each do |class_prefix|
+            full = join_paths(class_prefix, path)
+            verbs.each do |verb|
+              routes << Route.new(verb, full, class_name, method_name, ann_line)
+            end
           end
         end
       end
@@ -213,7 +242,10 @@ module Noir
     #
     # Always returns an array. Empty when the annotation has no
     # path-like argument. Callers fan out into one endpoint per path.
-    private def annotation_paths(args_node : LibTreeSitter::TSNode?, source : String) : Array(String)
+    private def annotation_paths(args_node : LibTreeSitter::TSNode?,
+                                 source : String,
+                                 constants : Hash(String, String),
+                                 current_class : String = "") : Array(String)
       empty = [] of String
       return empty unless args_node
       return empty unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
@@ -222,30 +254,17 @@ module Noir
       keyword = [] of String
       Noir::TreeSitter.each_named_child(args_node) do |arg|
         case Noir::TreeSitter.node_type(arg)
-        when "string_literal"
-          positional << decode_string_literal(arg, source)
+        when "string_literal", "identifier", "field_access", "binary_expression", "parenthesized_expression"
+          collect_string_values(arg, source, constants, positional, current_class)
         when "element_value_array_initializer"
-          Noir::TreeSitter.each_named_child(arg) do |elem|
-            if Noir::TreeSitter.node_type(elem) == "string_literal"
-              positional << decode_string_literal(elem, source)
-            end
-          end
+          collect_string_values(arg, source, constants, positional, current_class)
         when "element_value_pair"
           key = Noir::TreeSitter.field(arg, "key")
           val = Noir::TreeSitter.field(arg, "value")
           next unless key && val
           k = Noir::TreeSitter.node_text(key, source)
           next unless k == "value" || k == "path"
-          case Noir::TreeSitter.node_type(val)
-          when "string_literal"
-            keyword << decode_string_literal(val, source)
-          when "element_value_array_initializer"
-            Noir::TreeSitter.each_named_child(val) do |elem|
-              if Noir::TreeSitter.node_type(elem) == "string_literal"
-                keyword << decode_string_literal(elem, source)
-              end
-            end
-          end
+          collect_string_values(val, source, constants, keyword, current_class)
         when "ERROR"
           # `@RequestMapping("/x", method = RequestMethod.GET)` is a
           # positional+keyword mix that Java technically disallows, but
@@ -253,20 +272,36 @@ module Noir
           # tolerate it. tree-sitter flags it as an `ERROR` node; recover
           # any string literal inside so we don't regress on fixtures
           # using this shape.
-          Noir::TreeSitter.each_named_child(arg) do |elem|
-            if Noir::TreeSitter.node_type(elem) == "string_literal"
-              positional << decode_string_literal(elem, source)
-            end
-          end
+          collect_string_values(arg, source, constants, positional, current_class)
         end
       end
       keyword.empty? ? positional : keyword
     end
 
+    private def annotation_has_path_argument?(args_node : LibTreeSitter::TSNode?, source : String) : Bool
+      return false unless args_node
+      return false unless Noir::TreeSitter.node_type(args_node) == "annotation_argument_list"
+
+      Noir::TreeSitter.each_named_child(args_node) do |arg|
+        case Noir::TreeSitter.node_type(arg)
+        when "string_literal", "identifier", "field_access", "binary_expression", "parenthesized_expression",
+             "element_value_array_initializer", "ERROR"
+          return true
+        when "element_value_pair"
+          key = Noir::TreeSitter.field(arg, "key")
+          next unless key
+          k = Noir::TreeSitter.node_text(key, source)
+          return true if k == "value" || k == "path"
+        end
+      end
+
+      false
+    end
+
     # Known HTTP-verb identifiers we consider valid `method = ...` values.
     # Used when reconstructing verbs from ERROR nodes around the
     # invalid `[...]` bracket syntax.
-    VERB_IDENTIFIERS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+    VERB_IDENTIFIERS = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE"}
 
     # Extract verbs from an annotation's `method = ...` argument.
     # Supports the single form (`method = RequestMethod.GET`) and the
@@ -337,6 +372,132 @@ module Noir
         end
       end
       buf
+    end
+
+    private def package_name(root : LibTreeSitter::TSNode, source : String) : String
+      Noir::TreeSitter.each_named_child(root) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "package_declaration"
+        text = Noir::TreeSitter.node_text(child, source)
+        if match = text.match(/\A\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
+          return match[1]
+        end
+      end
+      ""
+    end
+
+    private def collect_string_constants(node : LibTreeSitter::TSNode,
+                                         source : String,
+                                         package_name : String,
+                                         class_stack : Array(String),
+                                         constants : Hash(String, String))
+      ty = Noir::TreeSitter.node_type(node)
+      if ty == "class_declaration" || ty == "interface_declaration" || ty == "enum_declaration" || ty == "annotation_type_declaration"
+        name = class_simple_name(node, source)
+        next_stack = name.empty? ? class_stack : class_stack + [name]
+        Noir::TreeSitter.each_named_child(node) do |child|
+          collect_string_constants(child, source, package_name, next_stack, constants)
+        end
+        return
+      end
+
+      if ty == "field_declaration" && string_field?(node, source)
+        Noir::TreeSitter.each_named_child(node) do |child|
+          next unless Noir::TreeSitter.node_type(child) == "variable_declarator"
+          name = Noir::TreeSitter.field(child, "name")
+          value = Noir::TreeSitter.field(child, "value")
+          next unless name && value
+          const_name = Noir::TreeSitter.node_text(name, source)
+          next unless resolved = resolve_string_value(value, source, constants, class_stack.join("."))
+
+          constants[const_name] ||= resolved
+          unless class_stack.empty?
+            class_name = class_stack.join(".")
+            constants["#{class_name}.#{const_name}"] ||= resolved
+            constants["#{package_name}.#{class_name}.#{const_name}"] ||= resolved unless package_name.empty?
+          end
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_string_constants(child, source, package_name, class_stack, constants)
+      end
+    end
+
+    private def string_field?(field_decl : LibTreeSitter::TSNode, source : String) : Bool
+      if type_node = Noir::TreeSitter.field(field_decl, "type")
+        type_text = Noir::TreeSitter.node_text(type_node, source)
+        return type_text == "String" || type_text == "java.lang.String"
+      end
+
+      Noir::TreeSitter.each_named_child(field_decl) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "type_identifier" || Noir::TreeSitter.node_type(child) == "scoped_type_identifier"
+        type_text = Noir::TreeSitter.node_text(child, source)
+        return true if type_text == "String" || type_text == "java.lang.String"
+      end
+      false
+    end
+
+    private def collect_string_values(node : LibTreeSitter::TSNode,
+                                      source : String,
+                                      constants : Hash(String, String),
+                                      sink : Array(String),
+                                      current_class : String = "")
+      case Noir::TreeSitter.node_type(node)
+      when "element_value_array_initializer", "ERROR"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          collect_string_values(child, source, constants, sink, current_class)
+        end
+      else
+        if resolved = resolve_string_value(node, source, constants, current_class)
+          sink << resolved
+        end
+      end
+    end
+
+    private def resolve_string_value(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     constants : Hash(String, String),
+                                     current_class : String = "",
+                                     depth = 0) : String?
+      return if depth > 16
+
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        decode_string_literal(node, source)
+      when "identifier", "field_access"
+        resolve_constant_reference(Noir::TreeSitter.node_text(node, source), constants, current_class)
+      when "binary_expression"
+        left = Noir::TreeSitter.field(node, "left")
+        right = Noir::TreeSitter.field(node, "right")
+        return unless left && right
+        return unless Noir::TreeSitter.node_text(node, source).includes?("+")
+        left_value = resolve_string_value(left, source, constants, current_class, depth + 1)
+        right_value = resolve_string_value(right, source, constants, current_class, depth + 1)
+        return unless left_value && right_value
+        "#{left_value}#{right_value}"
+      when "parenthesized_expression"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          if value = resolve_string_value(child, source, constants, current_class, depth + 1)
+            return value
+          end
+        end
+      end
+    end
+
+    private def resolve_constant_reference(name : String,
+                                           constants : Hash(String, String),
+                                           current_class : String = "") : String?
+      unless name.includes?(".") || current_class.empty?
+        if resolved = constants["#{current_class}.#{name}"]?
+          return resolved
+        end
+      end
+
+      if resolved = constants[name]?
+        return resolved
+      end
+
+      nil
     end
 
     # Join a class prefix and a method path with exactly one `/`. Also


### PR DESCRIPTION
## Summary
- resolve Java Spring mapping paths from compile-time String constants and concatenations
- fan out class-level mapping path arrays across method mappings
- detect additional Spring functional router verbs and RequestPredicates-qualified calls
- add regressions for empty path literals and unresolved qualified constants

## Tests
- `crystal spec spec/unit_test/miniparser/java_route_extractor_ts_spec.cr`
- `crystal spec spec/functional_test`
- `just check`
- `just build`

Note: a full `just test` run passed unit tests but one functional invocation briefly picked up a neighboring worktree path (`../experienced-crustacean`) and failed unrelated Python FastAPI expectations. Re-running `crystal spec spec/functional_test` in this worktree passed 11582 examples.
