### PR TITLE
Improve JavaScript route edge detection

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_bracket_only/app.js
+++ b/spec/functional_test/fixtures/javascript/express_bracket_only/app.js
@@ -1,0 +1,10 @@
+const express = require('express');
+
+const router = express.Router();
+
+router['get']('/users', (req, res) => {
+  const limit = req.query.limit;
+  res.json({ limit });
+});
+
+module.exports = router;

--- a/spec/functional_test/fixtures/javascript/express_mount_edge_patterns/app.js
+++ b/spec/functional_test/fixtures/javascript/express_mount_edge_patterns/app.js
@@ -1,0 +1,35 @@
+const express = require('express');
+
+const app = express();
+const router = express.Router();
+const publicRouter = express.Router();
+const multiRouter = express.Router();
+const importedRouter = require('./routes/imported');
+
+const PUBLIC_PREFIX = '/public-api';
+const API_PREFIX = '/api/v1';
+
+router['get']('/bracket-literal', (req, res) => {
+  const mode = req.query['mode'];
+  const requestId = req.get('X-Request-Id');
+  res.json({ mode, requestId });
+});
+
+publicRouter.get('/status', (req, res) => {
+  const trace = req.cookies['traceId'];
+  res.json({ trace });
+});
+
+multiRouter.post('/things/:thingId', (req, res) => {
+  const { thingId } = req.params;
+  const { display_name: displayName, enabled = true } = req.body;
+  res.json({ thingId, displayName, enabled });
+});
+
+app.use('/api', router);
+app.use(PUBLIC_PREFIX, publicRouter);
+app.use([API_PREFIX, '/admin-api'], multiRouter);
+app.use(PUBLIC_PREFIX, importedRouter);
+app.use([API_PREFIX, '/admin-api'], importedRouter);
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/express_mount_edge_patterns/routes/imported.js
+++ b/spec/functional_test/fixtures/javascript/express_mount_edge_patterns/routes/imported.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/imported', (req, res) => {
+  const source = req.query.source;
+  res.json({ source });
+});
+
+module.exports = router;

--- a/spec/functional_test/fixtures/javascript/koa_prefix_edge_patterns/app.js
+++ b/spec/functional_test/fixtures/javascript/koa_prefix_edge_patterns/app.js
@@ -1,0 +1,22 @@
+const Koa = require('koa');
+const Router = require('@koa/router');
+
+const app = new Koa();
+const accountsRouter = new Router();
+
+accountsRouter.prefix('/api/accounts');
+
+accountsRouter.get('account-list', '/list', (ctx) => {
+  const page = ctx.query['page'];
+  ctx.body = { page };
+});
+
+accountsRouter.post('/create', (ctx) => {
+  const { account_id: accountId, name } = ctx.request.body;
+  const requestId = ctx.get('X-Request-Id');
+  ctx.body = { accountId, name, requestId };
+});
+
+app.use(accountsRouter.routes());
+
+module.exports = app;

--- a/spec/functional_test/testers/javascript/express_bracket_only_spec.cr
+++ b/spec/functional_test/testers/javascript/express_bracket_only_spec.cr
@@ -1,0 +1,12 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/users", "GET", [
+    Param.new("limit", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/express_bracket_only/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/express_mount_edge_patterns_spec.cr
+++ b/spec/functional_test/testers/javascript/express_mount_edge_patterns_spec.cr
@@ -1,0 +1,35 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/api/bracket-literal", "GET", [
+    Param.new("mode", "", "query"),
+    Param.new("X-Request-Id", "", "header"),
+  ]),
+  Endpoint.new("/public-api/status", "GET", [
+    Param.new("traceId", "", "cookie"),
+  ]),
+  Endpoint.new("/api/v1/things/:thingId", "POST", [
+    Param.new("thingId", "", "path"),
+    Param.new("display_name", "", "json"),
+    Param.new("enabled", "", "json"),
+  ]),
+  Endpoint.new("/admin-api/things/:thingId", "POST", [
+    Param.new("thingId", "", "path"),
+    Param.new("display_name", "", "json"),
+    Param.new("enabled", "", "json"),
+  ]),
+  Endpoint.new("/public-api/imported", "GET", [
+    Param.new("source", "", "query"),
+  ]),
+  Endpoint.new("/api/v1/imported", "GET", [
+    Param.new("source", "", "query"),
+  ]),
+  Endpoint.new("/admin-api/imported", "GET", [
+    Param.new("source", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/express_mount_edge_patterns/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/koa_prefix_edge_patterns_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_prefix_edge_patterns_spec.cr
@@ -1,0 +1,17 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/api/accounts/list", "GET", [
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/api/accounts/create", "POST", [
+    Param.new("account_id", "", "json"),
+    Param.new("name", "", "json"),
+    Param.new("X-Request-Id", "", "header"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/koa_prefix_edge_patterns/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -70,6 +70,7 @@ module Analyzer::Javascript
       require_map = imports[:require_map]
       function_map = imports[:function_map]
       var_to_function = imports[:var_to_function]
+      prefix_constants = extract_string_constants(content)
 
       # Store arrays of prefixes per router variable to support multi-mount scenarios
       var_prefix = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
@@ -78,20 +79,22 @@ module Analyzer::Javascript
       # `.use('/prefix', router)` and Hono-style `.route('/prefix', childApp)`
       # both contribute cross-file prefixes to the same locator table.
       scan_literal_mount_calls(content, "use", main_file, locator,
-        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts, prefix_constants)
       scan_literal_mount_calls(content, "route", main_file, locator,
-        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+        require_map, function_map, var_to_function, var_prefix, global_deferred_mounts, prefix_constants)
 
       # Scan for .use(router) patterns where prefix is omitted (defaults to '/')
       # The negative lookahead `(?!\s*['"])` prevents matching calls that have a
       # string literal as the first argument, avoiding double processing with the above scan.
-      content.scan(/(\w+)\.use\s*\((?!\s*['"])/) do |m|
+      content.scan(/(\w+)\.use\s*\(/) do |m|
         next unless m.size >= 2
 
         caller = m[1]
         prefix = "/"
         # Position scanner to start right after the opening parenthesis
         match_end = (m.begin(0) || 0) + m[0].size
+        args = extract_use_call_args(content, match_end)
+        next if explicit_mount_prefix_args?(args, prefix_constants)
 
         process_use_call(content, match_end, caller, prefix, main_file, locator,
           require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
@@ -171,6 +174,7 @@ module Analyzer::Javascript
       var_to_function : Hash(String, String),
       var_prefix : Hash(String, Array(String)),
       global_deferred_mounts : Array(Tuple(String, String, String, String)),
+      prefix_constants : Hash(String, String),
     )
       content.scan(/(\w+)\.#{call_name}\s*\(\s*['"]([^'"]+)['"]\s*,\s*/) do |m|
         next unless m.size >= 3
@@ -182,6 +186,121 @@ module Analyzer::Javascript
         process_use_call(content, match_end, caller, prefix, main_file, locator,
           require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
       end
+
+      content.scan(/(\w+)\.#{call_name}\s*\(\s*`([^`$]+)`\s*,\s*/) do |m|
+        next unless m.size >= 3
+
+        caller = m[1]
+        prefix = m[2]
+        match_end = m.end(0) || 0
+
+        process_use_call(content, match_end, caller, prefix, main_file, locator,
+          require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+      end
+
+      content.scan(/(\w+)\.#{call_name}\s*\(\s*(\w+)\s*,\s*/) do |m|
+        next unless m.size >= 3
+
+        prefix = prefix_constants[m[2]]?
+        next unless prefix
+
+        caller = m[1]
+        match_end = m.end(0) || 0
+
+        process_use_call(content, match_end, caller, prefix, main_file, locator,
+          require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+      end
+
+      content.scan(/(\w+)\.#{call_name}\s*\(\s*\[([^\]]+)\]\s*,\s*/m) do |m|
+        next unless m.size >= 3
+
+        caller = m[1]
+        prefixes = extract_mount_prefixes_from_array(m[2], prefix_constants)
+        next if prefixes.empty?
+
+        match_end = m.end(0) || 0
+        prefixes.each do |prefix|
+          process_use_call(content, match_end, caller, prefix, main_file, locator,
+            require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
+        end
+      end
+    end
+
+    private def extract_string_constants(content : String) : Hash(String, String)
+      constants = Hash(String, String).new
+      content.scan(/(?:const|let|var)\s+(\w+)\s*=\s*['"]([^'"]+)['"]/) do |m|
+        next unless m.size >= 3
+        value = m[2]
+        constants[m[1]] = value if mount_prefix?(value)
+      end
+      content.scan(/(?:const|let|var)\s+(\w+)\s*=\s*`([^`$]+)`/) do |m|
+        next unless m.size >= 3
+        value = m[2]
+        constants[m[1]] = value if mount_prefix?(value)
+      end
+      constants
+    end
+
+    private def extract_mount_prefixes_from_array(body : String, constants : Hash(String, String)) : Array(String)
+      prefixes = [] of String
+      body.scan(/['"]([^'"]+)['"]|`([^`$]+)`|\b(\w+)\b/) do |m|
+        value = m[1]? || m[2]?
+        if value.nil?
+          identifier = m[3]?
+          value = constants[identifier]? if identifier
+        end
+        next unless value && mount_prefix?(value)
+        prefixes << value unless prefixes.includes?(value)
+      end
+      prefixes
+    end
+
+    private def mount_prefix?(value : String) : Bool
+      value.starts_with?("/") || value == "*"
+    end
+
+    private def explicit_mount_prefix_args?(args : String, constants : Hash(String, String)) : Bool
+      first_arg = first_top_level_argument(args).strip
+      return false if first_arg.empty?
+      return true if first_arg.starts_with?("'") || first_arg.starts_with?("\"") || first_arg.starts_with?("`")
+      return true if first_arg.starts_with?("[") && !extract_mount_prefixes_from_array(first_arg, constants).empty?
+
+      if first_arg =~ /\A(\w+)\z/
+        return constants.has_key?($1)
+      end
+
+      false
+    end
+
+    private def first_top_level_argument(args : String) : String
+      depth = 0
+      quote = nil.as(Char?)
+      escaped = false
+      args.each_char_with_index do |char, index|
+        if quote
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
+          end
+          next
+        end
+
+        case char
+        when '\'', '"', '`'
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+        when ','
+          return args[0...index] if depth == 0
+        end
+      end
+
+      args
     end
 
     # Detect mounts synthesized from a config array iterated via forEach/map,

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -43,6 +43,15 @@ module Noir
       end
     end
 
+    private def http_method_name?(value : String) : Bool
+      case value.downcase
+      when "get", "post", "put", "delete", "options", "head", "patch", "del", "all"
+        true
+      else
+        false
+      end
+    end
+
     private def http_method?(token : JSToken) : Bool
       token.type == :http_method || (token.type == :keyword && token.value == "delete")
     end
@@ -103,9 +112,17 @@ module Noir
            (idx + 1 < @tokens.size) && (@tokens[idx + 1].type == :dot) &&
            (idx + 2 < @tokens.size) && (@tokens[idx + 2].value == "use" || @tokens[idx + 2].value == "register") &&
            (idx + 3 < @tokens.size) && (@tokens[idx + 3].type == :lparen) &&
-           (idx + 4 < @tokens.size) && (@tokens[idx + 4].type == :string)
+           (idx + 4 < @tokens.size) &&
+           (@tokens[idx + 4].type == :string ||
+           @tokens[idx + 4].type == :template_literal ||
+           @tokens[idx + 4].type == :identifier ||
+           @tokens[idx + 4].type == :lbracket)
           parent_router = @tokens[idx].value
-          prefix = @tokens[idx + 4].value
+          prefixes = route_path_entries_from_args(idx + 4).map(&.path)
+          if prefixes.empty?
+            idx += 1
+            next
+          end
 
           # Collect all identifiers after the path to find the router
           # Routers can be before or after middleware in .use() calls
@@ -133,7 +150,9 @@ module Noir
           router_identifier = find_router_candidate(candidates, router_variables)
 
           if router_identifier
-            router_prefixes[router_identifier] << prefix unless router_prefixes[router_identifier].includes?(prefix)
+            prefixes.each do |prefix|
+              router_prefixes[router_identifier] << prefix unless router_prefixes[router_identifier].includes?(prefix)
+            end
             router_parents[router_identifier] << parent_router unless router_parents[router_identifier].includes?(parent_router)
             router_variables.add(router_identifier)
           end
@@ -312,6 +331,27 @@ module Noir
         end
         idx += 1
       end
+
+      # Koa/@koa-router also allows prefixes to be attached after
+      # construction:
+      #   const router = new Router()
+      #   router.prefix('/api')
+      idx = 0
+      while idx < @tokens.size - 4
+        if @tokens[idx].type == :identifier &&
+           idx + 4 < @tokens.size &&
+           @tokens[idx + 1].type == :dot &&
+           @tokens[idx + 2].value == "prefix" &&
+           @tokens[idx + 3].type == :lparen
+          router_var = @tokens[idx].value
+          route_path_entries_from_args(idx + 4).each do |prefix_entry|
+            prefix = prefix_entry.path
+            router_prefixes[router_var] << prefix unless router_prefixes[router_var].includes?(prefix)
+            router_variables.add(router_var)
+          end
+        end
+        idx += 1
+      end
     end
 
     # Format a regex token value into a path string.
@@ -368,6 +408,71 @@ module Noir
       end
 
       paths
+    end
+
+    private def path_entries_from_token(start_idx : Int32) : Array(PathEntry)
+      paths = [] of PathEntry
+      return paths unless start_idx < @tokens.size
+
+      token = @tokens[start_idx]
+      if token.type == :lbracket
+        paths = extract_array_paths(start_idx)
+      elsif token.type == :string
+        paths << PathEntry.new(token.value, false)
+      elsif token.type == :template_literal || token.type == :identifier
+        path = resolve_dynamic_path(start_idx)
+        paths << PathEntry.new(path, false) if path
+      elsif token.type == :regex
+        paths << PathEntry.new(format_regex_path(token.value), true)
+      end
+
+      paths
+    end
+
+    private def route_path_entries_from_args(first_arg_idx : Int32, allow_named_route : Bool = false) : Array(PathEntry)
+      paths = path_entries_from_token(first_arg_idx).select { |path| valid_route_path?(path.path) }
+      return paths unless paths.empty? && allow_named_route
+
+      # Koa/@koa-router supports named routes:
+      #   router.get("route-name", "/real-path", handler)
+      # If the first argument is not path-like, try the next top-level
+      # argument before giving up.
+      if second_arg_idx = next_top_level_arg_index(first_arg_idx)
+        return path_entries_from_token(second_arg_idx).select { |path| valid_route_path?(path.path) }
+      end
+
+      [] of PathEntry
+    end
+
+    private def next_top_level_arg_index(start_idx : Int32) : Int32?
+      idx = start_idx
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+
+      while idx < @tokens.size
+        token = @tokens[idx]
+        case token.type
+        when :lparen
+          paren_depth += 1
+        when :rparen
+          break if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+          paren_depth -= 1 if paren_depth > 0
+        when :lbracket
+          bracket_depth += 1
+        when :rbracket
+          bracket_depth -= 1 if bracket_depth > 0
+        when :lbrace
+          brace_depth += 1
+        when :rbrace
+          brace_depth -= 1 if brace_depth > 0
+        when :comma
+          return idx + 1 if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+        end
+        idx += 1
+      end
+
+      nil
     end
 
     # Pre-scan tokens to identify router variables
@@ -499,23 +604,29 @@ module Noir
            @tokens[idx + 3].type == :lparen
           router_var = @tokens[idx].value
           method = @tokens[idx + 2].value
-          # read path at idx+4
-          path_token = @tokens[idx + 4]
-          paths = [] of PathEntry
-
-          if path_token.type == :lbracket
-            # Handle array of paths
-            paths = extract_array_paths(idx + 4)
-          elsif path_token.type == :string || path_token.type == :template_literal || path_token.type == :identifier
-            path = resolve_dynamic_path(idx + 4)
-            path ||= (path_token.type == :string ? path_token.value : nil)
-            paths << PathEntry.new(path, false) if path && valid_route_path?(path)
-          elsif path_token.type == :regex
-            path = format_regex_path(path_token.value)
-            paths << PathEntry.new(path, true)
-          end
+          paths = route_path_entries_from_args(idx + 4, allow_named_route: router_var.downcase.includes?("router"))
 
           # Create one route for each path with prefix
+          start_pos = @tokens[idx].position
+          each_prefixed_path(paths, router_var, router_prefixes) do |path_entry, prefixed_path|
+            results << create_route_with_params(method, prefixed_path, path_entry.path, start_pos, path_entry.is_regex?)
+          end
+
+          idx += 1
+          next
+        end
+
+        # Pattern 1b: identifier [ 'http_method' ] ( 'path' )
+        if @tokens[idx].type == :identifier &&
+           @tokens[idx + 1].type == :lbracket &&
+           @tokens[idx + 2].type == :string &&
+           http_method_name?(@tokens[idx + 2].value) &&
+           @tokens[idx + 3].type == :rbracket &&
+           @tokens[idx + 4].type == :lparen
+          router_var = @tokens[idx].value
+          method = @tokens[idx + 2].value
+          paths = route_path_entries_from_args(idx + 5, allow_named_route: router_var.downcase.includes?("router"))
+
           start_pos = @tokens[idx].position
           each_prefixed_path(paths, router_var, router_prefixes) do |path_entry, prefixed_path|
             results << create_route_with_params(method, prefixed_path, path_entry.path, start_pos, path_entry.is_regex?)
@@ -534,17 +645,7 @@ module Noir
           # resolve path at idx+4
           paths = [] of PathEntry
           if idx + 4 < limit
-            t = @tokens[idx + 4]
-            if t.type == :lbracket
-              # Handle array of paths
-              paths = extract_array_paths(idx + 4)
-            elsif t.type == :string || t.type == :template_literal || t.type == :identifier
-              path = resolve_dynamic_path(idx + 4)
-              path ||= (t.type == :string ? t.value : nil)
-              paths << PathEntry.new(path, false) if path
-            elsif t.type == :regex
-              paths << PathEntry.new(format_regex_path(t.value), true)
-            end
+            paths = route_path_entries_from_args(idx + 4)
           end
 
           start_pos = @tokens[idx].position
@@ -616,37 +717,13 @@ module Noir
         if path_idx < @tokens.size &&
            @tokens[path_idx].type == :lparen &&
            path_idx + 1 < @tokens.size
-          base_path : String? = nil
-          # Check for regular string
-          if @tokens[path_idx + 1].type == :string
-            base_path = @tokens[path_idx + 1].value
-            @position = path_idx + 2
-          elsif @tokens[path_idx + 1].type == :regex
-            # Handle regex route path
-            base_path = format_regex_path(@tokens[path_idx + 1].value)
-            @position = path_idx + 2
-            # Check for template literal or dynamic path construction
-          elsif @tokens[path_idx + 1].type == :template_literal ||
-                @tokens[path_idx + 1].type == :identifier
-            resolved_path = resolve_dynamic_path(path_idx + 1)
-            if resolved_path
-              base_path = resolved_path
-              # Skip past the resolved tokens - find the end of the expression
-              skip_idx = path_idx + 1
-              while skip_idx < @tokens.size &&
-                    (@tokens[skip_idx].type == :identifier ||
-                    @tokens[skip_idx].type == :plus ||
-                    @tokens[skip_idx].type == :string ||
-                    @tokens[skip_idx].type == :template_literal)
-                skip_idx += 1
-              end
-              @position = skip_idx
-            end
-          end
+          router_var = @tokens[idx].value
+          path_entries = route_path_entries_from_args(path_idx + 1, allow_named_route: router_var.downcase.includes?("router"))
+          @position = path_idx + 2 unless path_entries.empty?
 
-          if base_path
-            router_var = @tokens[idx].value
-            raw_path = base_path
+          path_entries.each do |path_entry|
+            base_path = path_entry.path
+            raw_path = path_entry.path
             start_pos = @tokens[idx].position
 
             # Get all prefixes (supports multi-mount)
@@ -659,8 +736,10 @@ module Noir
             prefixes_to_apply.each do |prefix|
               path = prefix.empty? ? base_path : URLPath.join(prefix, base_path)
               route = JSRoutePattern.new(method, path, raw_path, start_pos)
-              extract_path_params(path).each do |param|
-                route.push_param(param)
+              unless path_entry.is_regex?
+                extract_path_params(path).each do |param|
+                  route.push_param(param)
+                end
               end
               results << route
             end
@@ -789,38 +868,18 @@ module Noir
         if path_idx < @tokens.size &&
            @tokens[path_idx].type == :lparen &&
            path_idx + 1 < @tokens.size
-          base_path : String? = nil
-          # Check for regular string
-          if @tokens[path_idx + 1].type == :string
-            base_path = @tokens[path_idx + 1].value
-            @position = path_idx + 2
-            # Check for template literal or dynamic path construction
-          elsif @tokens[path_idx + 1].type == :template_literal ||
-                @tokens[path_idx + 1].type == :identifier
-            resolved_path = resolve_dynamic_path(path_idx + 1)
-            if resolved_path
-              base_path = resolved_path
-              # Skip past the resolved tokens - find the end of the expression
-              skip_idx = path_idx + 1
-              while skip_idx < @tokens.size &&
-                    (@tokens[skip_idx].type == :identifier ||
-                    @tokens[skip_idx].type == :plus ||
-                    @tokens[skip_idx].type == :string ||
-                    @tokens[skip_idx].type == :template_literal)
-                skip_idx += 1
-              end
-              @position = skip_idx
-            end
-          end
+          router_var = @tokens[idx - 1].type == :identifier ? @tokens[idx - 1].value : ""
+          path_entries = route_path_entries_from_args(path_idx + 1, allow_named_route: router_var.downcase.includes?("router"))
+          @position = path_idx + 2 unless path_entries.empty?
 
-          if base_path
-            raw_path = base_path
+          path_entries.each do |path_entry|
+            base_path = path_entry.path
+            raw_path = path_entry.path
             start_pos = @tokens[idx].position
 
             # Get all prefixes (supports multi-mount)
             prefixes_to_apply = [""] # Default: no prefix
-            if @tokens[idx - 1].type == :identifier
-              router_var = @tokens[idx - 1].value
+            unless router_var.empty?
               if @router_prefixes.has_key?(router_var)
                 prefixes_to_apply = @router_prefixes[router_var]
               end
@@ -829,8 +888,10 @@ module Noir
             prefixes_to_apply.each do |prefix|
               path = prefix.empty? ? base_path : URLPath.join(prefix, base_path)
               route = JSRoutePattern.new(method, path, raw_path, start_pos)
-              extract_path_params(path).each do |param|
-                route.push_param(param)
+              unless path_entry.is_regex?
+                extract_path_params(path).each do |param|
+                  route.push_param(param)
+                end
               end
               results << route
             end

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -330,8 +330,11 @@ module Noir
       ".route (", ".register (", ".use (",
     ]
 
+    BRACKET_ROUTE_CALL_PATTERN = /\[\s*['"](?:get|post|put|delete|del|patch|options|head|all)['"]\s*\]\s*\(/i
+
     def self.route_call_candidate?(content : String) : Bool
-      PARSER_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) }
+      PARSER_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) } ||
+        content.matches?(BRACKET_ROUTE_CALL_PATTERN)
     end
 
     # Test-fixture libraries whose API mimics route registration:
@@ -599,6 +602,11 @@ module Noir
         route_declarations << "#{method}(\"#{lookup_path}\""
         # Method call with template literals
         route_declarations << "#{method}(`#{lookup_path}`"
+        # Bracket method notation: router['get']('/path', ...)
+        route_declarations << "['#{method}']('#{lookup_path}'"
+        route_declarations << "[\"#{method}\"](\"#{lookup_path}\""
+        route_declarations << "['#{method}'](\"#{lookup_path}\""
+        route_declarations << "[\"#{method}\"]('#{lookup_path}'"
       end
 
       # Also handle app.route('/path').method() pattern
@@ -616,6 +624,20 @@ module Noir
           idx = found_idx
           found_declaration = declaration
           break
+        end
+      end
+
+      # Koa/@koa-router named routes put a route name before the real path:
+      #   router.get("route-name", "/path", handler)
+      if idx.nil?
+        escaped_path = Regex.escape(lookup_path)
+        method_variations.each do |method|
+          named_route_pattern = /#{Regex.escape(method)}\s*\(\s*['"][^'"]+['"]\s*,\s*['"]#{escaped_path}['"]/
+          if named_match = content.match(named_route_pattern)
+            idx = named_match.begin(0)
+            found_declaration = method
+            break
+          end
         end
       end
 
@@ -787,7 +809,17 @@ module Noir
         if match.size > 0
           params = match[1].split(",").map(&.strip)
           params.each do |param|
-            clean_param = param.split("=").first.strip
+            clean_param = clean_destructured_param(param)
+            endpoint.push_param(Param.new(clean_param, "", "json")) unless clean_param.empty?
+          end
+        end
+      end
+
+      handler_body.scan(/(?:const|let|var)\s*\{\s*([^}]+)\s*\}\s*=\s*ctx\.request\.body/) do |match|
+        if match.size > 0
+          params = match[1].split(",").map(&.strip)
+          params.each do |param|
+            clean_param = clean_destructured_param(param)
             endpoint.push_param(Param.new(clean_param, "", "json")) unless clean_param.empty?
           end
         end
@@ -812,7 +844,7 @@ module Noir
         if match.size > 0
           params = match[1].split(",").map(&.strip)
           params.each do |param|
-            clean_param = param.split("=").first.strip
+            clean_param = clean_destructured_param(param)
             endpoint.push_param(Param.new(clean_param, "", "json")) unless clean_param.empty?
           end
         end
@@ -823,7 +855,7 @@ module Noir
         if match.size > 0
           params = match[1].split(",").map(&.strip)
           params.each do |param|
-            clean_param = param.split("=").first.strip
+            clean_param = clean_destructured_param(param)
             endpoint.push_param(Param.new(clean_param, "", "form")) unless clean_param.empty?
           end
         end
@@ -836,7 +868,17 @@ module Noir
         if match.size > 0
           params = match[1].split(",").map(&.strip)
           params.each do |param|
-            clean_param = param.split("=").first.strip
+            clean_param = clean_destructured_param(param)
+            endpoint.push_param(Param.new(clean_param, "", "query")) unless clean_param.empty?
+          end
+        end
+      end
+
+      handler_body.scan(/(?:const|let|var)\s*\{\s*([^}]+)\s*\}\s*=\s*ctx(?:\.request)?\.query/) do |match|
+        if match.size > 0
+          params = match[1].split(",").map(&.strip)
+          params.each do |param|
+            clean_param = clean_destructured_param(param)
             endpoint.push_param(Param.new(clean_param, "", "query")) unless clean_param.empty?
           end
         end
@@ -844,6 +886,24 @@ module Noir
 
       # Look for req.query.X
       handler_body.scan(/(?:req|request)\.query\.(\w+)/) do |match|
+        if match.size > 0
+          endpoint.push_param(Param.new(match[1], "", "query"))
+        end
+      end
+
+      handler_body.scan(/(?:req|request)\.query\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |match|
+        if match.size > 0
+          endpoint.push_param(Param.new(match[1], "", "query"))
+        end
+      end
+
+      handler_body.scan(/ctx(?:\.request)?\.query\.(\w+)/) do |match|
+        if match.size > 0
+          endpoint.push_param(Param.new(match[1], "", "query"))
+        end
+      end
+
+      handler_body.scan(/ctx(?:\.request)?\.query\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |match|
         if match.size > 0
           endpoint.push_param(Param.new(match[1], "", "query"))
         end
@@ -884,6 +944,12 @@ module Noir
         end
       end
 
+      handler_body.scan(/(?:req|request)\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+        if match.size > 0
+          endpoint.push_param(Param.new(match[1], "", "header"))
+        end
+      end
+
       # Koa-style headers: ctx.headers['X'], ctx.header['X'], ctx.get('X')
       handler_body.scan(/ctx\.headers\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |match|
         if match.size > 0
@@ -914,6 +980,12 @@ module Noir
     def self.extract_cookie_params(handler_body : String, endpoint : Endpoint)
       # Look for req.cookies.X (Express-style)
       handler_body.scan(/(?:req|request)\.cookies\.(\w+)/) do |match|
+        if match.size > 0
+          endpoint.push_param(Param.new(match[1], "", "cookie"))
+        end
+      end
+
+      handler_body.scan(/(?:req|request)\.cookies\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |match|
         if match.size > 0
           endpoint.push_param(Param.new(match[1], "", "cookie"))
         end
@@ -962,6 +1034,16 @@ module Noir
           endpoint.push_param(Param.new(match[1], "", "path")) unless endpoint.params.any? { |p| p.name == match[1] && p.param_type == "path" }
         end
       end
+    end
+
+    private def self.clean_destructured_param(param : String) : String
+      clean_param = param.split("=").first.strip
+      clean_param = clean_param.lchop("...").strip
+      clean_param = clean_param.split(":").first.strip if clean_param.includes?(":")
+      clean_param = clean_param[1..-2] if clean_param.size >= 2 &&
+                                          ((clean_param.starts_with?("'") && clean_param.ends_with?("'")) ||
+                                          (clean_param.starts_with?("\"") && clean_param.ends_with?("\"")))
+      clean_param
     end
 
     # Extract static path declarations from JavaScript content


### PR DESCRIPTION
## Summary
- detect bracket-notation JavaScript routes and keep the extractor prefilter in sync
- resolve Express mount prefixes from constants, template literals, and arrays without adding unprefixed duplicates
- support Koa router prefix()/named-route forms and broaden JS handler parameter extraction

## Tests
- crystal spec spec/functional_test/testers/javascript
- just build
- just test
- just check