### PR TITLE
Add tRPC analyzer

### DIFF
--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -177,16 +177,16 @@ sort_by = "weight"
         <span class="tech-chip off">cookie</span>
         <span class="tech-chip off">static</span>
         <span class="tech-chip off">websocket</span>
-        <span class="tech-chip off">callee</span>
+        <span class="tech-chip on">callee</span>
       </div>
     </div>
     <div class="tech-card-row">
       <span class="tech-card-label">AI Context</span>
       <div class="tech-card-chips">
         <span class="tech-chip off">guards</span>
-        <span class="tech-chip off">sinks</span>
-        <span class="tech-chip off">validators</span>
-        <span class="tech-chip off">signals</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
       </div>
     </div>
   </article>
@@ -587,6 +587,33 @@ sort_by = "weight"
       <span class="tech-card-label">AI Context</span>
       <div class="tech-card-chips">
         <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Connect-RPC</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
         <span class="tech-chip on">sinks</span>
         <span class="tech-chip on">validators</span>
         <span class="tech-chip on">signals</span>
@@ -1357,6 +1384,33 @@ sort_by = "weight"
         <span class="tech-chip off">static</span>
         <span class="tech-chip off">websocket</span>
         <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Apollo Server</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip on">websocket</span>
+        <span class="tech-chip on">callee</span>
       </div>
     </div>
     <div class="tech-card-row">
@@ -2367,6 +2421,33 @@ sort_by = "weight"
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Robyn</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip on">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Sanic</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>
@@ -3134,6 +3215,33 @@ sort_by = "weight"
         <span class="tech-chip on">cookie</span>
         <span class="tech-chip on">static</span>
         <span class="tech-chip off">websocket</span>
+        <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">tRPC</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip on">websocket</span>
         <span class="tech-chip off">callee</span>
       </div>
     </div>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -177,16 +177,16 @@ Each card below lists a framework's supported features. **Route** covers endpoin
         <span class="tech-chip off">cookie</span>
         <span class="tech-chip off">static</span>
         <span class="tech-chip off">websocket</span>
-        <span class="tech-chip off">callee</span>
+        <span class="tech-chip on">callee</span>
       </div>
     </div>
     <div class="tech-card-row">
       <span class="tech-card-label">AI Context</span>
       <div class="tech-card-chips">
         <span class="tech-chip off">guards</span>
-        <span class="tech-chip off">sinks</span>
-        <span class="tech-chip off">validators</span>
-        <span class="tech-chip off">signals</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
       </div>
     </div>
   </article>
@@ -587,6 +587,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
       <span class="tech-card-label">AI Context</span>
       <div class="tech-card-chips">
         <span class="tech-chip on">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Connect-RPC</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
         <span class="tech-chip on">sinks</span>
         <span class="tech-chip on">validators</span>
         <span class="tech-chip on">signals</span>
@@ -1357,6 +1384,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
         <span class="tech-chip off">static</span>
         <span class="tech-chip off">websocket</span>
         <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Apollo Server</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip on">websocket</span>
+        <span class="tech-chip on">callee</span>
       </div>
     </div>
     <div class="tech-card-row">
@@ -2367,6 +2421,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
     </div>
   </article>
   <article class="tech-card">
+    <h3 class="tech-card-title">Robyn</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip on">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
     <h3 class="tech-card-title">Sanic</h3>
     <div class="tech-card-row">
       <span class="tech-card-label">Route</span>
@@ -3134,6 +3215,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
         <span class="tech-chip on">cookie</span>
         <span class="tech-chip on">static</span>
         <span class="tech-chip off">websocket</span>
+        <span class="tech-chip off">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">tRPC</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip on">static</span>
+        <span class="tech-chip on">websocket</span>
         <span class="tech-chip off">callee</span>
       </div>
     </div>

--- a/spec/functional_test/fixtures/typescript/trpc/package.json
+++ b/spec/functional_test/fixtures/typescript/trpc/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "trpc-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@trpc/server": "^10.0.0",
+    "@trpc/next": "^10.0.0",
+    "zod": "^3.22.0"
+  }
+}

--- a/spec/functional_test/fixtures/typescript/trpc/pages/api/trpc/[trpc].ts
+++ b/spec/functional_test/fixtures/typescript/trpc/pages/api/trpc/[trpc].ts
@@ -1,0 +1,7 @@
+import { createNextApiHandler } from '@trpc/server/adapters/next'
+import { appRouter } from '../../../server/root'
+
+export default createNextApiHandler({
+  router: appRouter,
+  createContext: () => ({}),
+})

--- a/spec/functional_test/fixtures/typescript/trpc/server/root.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/root.ts
@@ -1,0 +1,11 @@
+import { router, publicProcedure } from './trpc'
+import { userRouter } from './routers/user'
+import { postRouter } from './routers/post'
+
+export const appRouter = router({
+  user: userRouter,
+  post: postRouter,
+  health: publicProcedure.query(() => 'ok'),
+})
+
+export type AppRouter = typeof appRouter

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/post.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/post.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+import { router, publicProcedure } from '../trpc'
+
+export const postRouter = router({
+  list: publicProcedure.query(() => []),
+  byId: publicProcedure
+    .input(z.object({ postId: z.string() }))
+    .query(({ input }) => input),
+  liveFeed: publicProcedure.subscription(() => {
+    return null
+  }),
+})

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/user.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/user.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+import { router, publicProcedure } from '../trpc'
+
+export const userRouter = router({
+  list: publicProcedure.query(() => []),
+  byId: publicProcedure
+    .input(z.object({ id: z.string() }))
+    .query(({ input }) => input),
+  create: publicProcedure
+    .input(z.object({ name: z.string(), email: z.string() }))
+    .mutation(({ input }) => input),
+})

--- a/spec/functional_test/fixtures/typescript/trpc/server/trpc.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/trpc.ts
@@ -1,0 +1,6 @@
+import { initTRPC } from '@trpc/server'
+
+const t = initTRPC.create()
+
+export const router = t.router
+export const publicProcedure = t.procedure

--- a/spec/functional_test/testers/typescript/trpc_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_spec.cr
@@ -1,0 +1,23 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/api/trpc/user.list", "GET", [] of Param),
+  Endpoint.new("/api/trpc/user.byId", "GET", [
+    Param.new("id", "", "query"),
+  ]),
+  Endpoint.new("/api/trpc/user.create", "POST", [
+    Param.new("name", "", "body"),
+    Param.new("email", "", "body"),
+  ]),
+  Endpoint.new("/api/trpc/post.list", "GET", [] of Param),
+  Endpoint.new("/api/trpc/post.byId", "GET", [
+    Param.new("postId", "", "query"),
+  ]),
+  Endpoint.new("/api/trpc/post.liveFeed", "SUBSCRIBE", [] of Param),
+  Endpoint.new("/api/trpc/health", "GET", [] of Param),
+]
+
+FunctionalTester.new("fixtures/typescript/trpc/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -149,6 +149,7 @@ def initialize_analyzers(logger : NoirLogger)
     {"swift_hummingbird", Swift::Hummingbird},
     {"ts_nestjs", Typescript::Nestjs},
     {"ts_tanstack_router", Typescript::TanstackRouter},
+    {"ts_trpc", Typescript::TRPC},
     {"ai", AI::Unified},
   ])
 

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -1,0 +1,379 @@
+require "../../engines/javascript_engine"
+require "../../../miniparsers/js_route_extractor"
+
+module Analyzer::Typescript
+  class TRPC < Analyzer::Javascript::JavascriptEngine
+    DEFAULT_PREFIX = "/api/trpc"
+
+    private struct Router
+      getter name : String
+      getter body : String
+      getter file : String
+      getter line : Int32
+
+      def initialize(@name : String, @body : String, @file : String, @line : Int32)
+      end
+    end
+
+    def analyze
+      result = [] of Endpoint
+      routers = Hash(String, Router).new
+      routers_mu = Mutex.new
+      prefix_mu = Mutex.new
+      url_prefix = DEFAULT_PREFIX
+
+      parallel_file_scan([".js", ".ts", ".jsx", ".tsx", ".cts", ".mts", ".cjs", ".mjs"]) do |path|
+        begin
+          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+            raw = file.gets_to_end
+            content = Noir::JSRouteExtractor.strip_js_comments(raw)
+            collected = collect_routers(content, path)
+            unless collected.empty?
+              routers_mu.synchronize do
+                collected.each { |r| routers[r.name] = r }
+              end
+            end
+            if found = extract_prefix(content)
+              prefix_mu.synchronize do
+                url_prefix = found
+              end
+            end
+          end
+        rescue e
+          logger.debug "Error analyzing tRPC file #{path}: #{e.message}"
+        end
+        nil
+      end
+
+      return result if routers.empty?
+
+      used_as_child = Set(String).new
+      routers.each_value do |router|
+        each_top_level_kv(router.body) do |_key, value|
+          ident = extract_identifier(value)
+          used_as_child.add(ident) if ident && routers.has_key?(ident)
+        end
+      end
+
+      roots = routers.values.reject { |r| used_as_child.includes?(r.name) }
+      roots = routers.values if roots.empty?
+
+      roots.each do |root|
+        flatten_router(root, "", routers, url_prefix, result, Set(String).new)
+      end
+
+      result
+    end
+
+    private def collect_routers(content : String, path : String) : Array(Router)
+      collected = [] of Router
+      # Capture `(export )? (const|let|var) NAME = <prefix>?(router|createTRPCRouter)({...})`.
+      # Prefix tolerates `t.router(`, `initTRPC.create().router(`, `_.router(` etc.
+      pattern = /\b(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:[\w$]+\s*(?:\(\s*\))?\s*\.\s*)?(?:router|createTRPCRouter)\s*\(\s*\{/
+
+      content.scan(pattern) do |match|
+        match_start = match.begin(0) || 0
+        match_end = match.end(0) || 0
+        next if match_end == 0
+
+        brace_open = match_end - 1
+        next unless content[brace_open]? == '{'
+
+        brace_close = Noir::JSRouteExtractor.find_matching_brace(content, brace_open)
+        next unless brace_close
+
+        body = content[(brace_open + 1)...brace_close]
+        line = content[0, match_start].count('\n') + 1
+        collected << Router.new(match[1], body, path, line)
+      end
+
+      collected
+    end
+
+    private def extract_prefix(content : String) : String?
+      # Explicit endpoint option in fetch/openapi handlers.
+      if m = content.match(/endpoint\s*:\s*['"`]([^'"`]+)['"`]/)
+        return m[1]
+      end
+
+      # Express/Koa-style mounting: `app.use('/api/trpc', trpcExpress.createExpressMiddleware(...))`.
+      if m = content.match(/\.\s*use\s*\(\s*['"`]([^'"`]+)['"`]\s*,\s*[^)]*?(?:trpcExpress\.createExpressMiddleware|createExpressMiddleware|createKoaMiddleware)/m)
+        return m[1]
+      end
+
+      # Fastify plugin: `fastify.register(fastifyTRPCPlugin, { prefix: '/api/trpc' })`.
+      if m = content.match(/(?:fastifyTRPCPlugin|fastifyTRPC)\b[^)]*?prefix\s*:\s*['"`]([^'"`]+)['"`]/m)
+        return m[1]
+      end
+
+      nil
+    end
+
+    private def each_top_level_kv(body : String, &)
+      i = 0
+      n = body.size
+      while i < n
+        while i < n && (body[i].whitespace? || body[i] == ',' || body[i] == ';')
+          i += 1
+        end
+        break if i >= n
+
+        key = case body[i]
+              when '\'', '"', '`'
+                quote = body[i]
+                j = i + 1
+                while j < n && body[j] != quote
+                  j += body[j] == '\\' ? 2 : 1
+                end
+                literal = body[(i + 1)...j]
+                i = j < n ? j + 1 : j
+                literal
+              when '['
+                # Computed key like ['foo']: ... — skip the bracket span.
+                if close = find_matching_bracket(body, i)
+                  literal = body[(i + 1)...close].strip.gsub(/^['"`]|['"`]$/, "")
+                  i = close + 1
+                  literal
+                else
+                  i = skip_top_level_to_comma(body, i)
+                  ""
+                end
+              else
+                c = body[i]
+                if c.ascii_letter? || c == '_' || c == '$'
+                  j = i
+                  while j < n && (body[j].ascii_alphanumeric? || body[j] == '_' || body[j] == '$')
+                    j += 1
+                  end
+                  literal = body[i...j]
+                  i = j
+                  literal
+                else
+                  i = skip_top_level_to_comma(body, i)
+                  ""
+                end
+              end
+
+        if key.empty?
+          next
+        end
+
+        while i < n && body[i].whitespace?
+          i += 1
+        end
+
+        if i >= n || body[i] == ','
+          # Shorthand: `userRouter,` — value is the same identifier.
+          yield key, key unless key.empty?
+          i += 1 if i < n && body[i] == ','
+          next
+        end
+
+        unless body[i] == ':'
+          # Spread, method shorthand, or other construct we don't handle.
+          i = skip_top_level_to_comma(body, i)
+          next
+        end
+
+        i += 1
+        value_start = i
+        value_end = skip_top_level_to_comma(body, i)
+        value = body[value_start...value_end]
+        yield key, value unless key.empty?
+        i = value_end
+      end
+    end
+
+    private def find_matching_bracket(body : String, open : Int32) : Int32?
+      depth = 0
+      i = open
+      n = body.size
+      while i < n
+        c = body[i]
+        if c == '['
+          depth += 1
+        elsif c == ']'
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+      nil
+    end
+
+    private def skip_top_level_to_comma(body : String, start : Int32) : Int32
+      depth = 0
+      i = start
+      n = body.size
+      while i < n
+        c = body[i]
+        case c
+        when '\'', '"', '`'
+          quote = c
+          i += 1
+          while i < n && body[i] != quote
+            i += body[i] == '\\' ? 2 : 1
+          end
+          i += 1
+          next
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1
+          return i if depth < 0
+        when ','
+          return i if depth == 0
+        else
+          # nothing
+        end
+        i += 1
+      end
+      i
+    end
+
+    private def extract_identifier(value : String) : String?
+      v = value.strip
+      return if v.empty?
+      if m = v.match(/\A([A-Za-z_$][\w$]*)\z/)
+        return m[1]
+      end
+      nil
+    end
+
+    private def flatten_router(router : Router, prefix_dotted : String, routers : Hash(String, Router), url_prefix : String, result : Array(Endpoint), visited : Set(String))
+      return if visited.includes?(router.name)
+      visited.add(router.name)
+
+      each_top_level_kv(router.body) do |key, value|
+        next if key.empty?
+
+        if ident = extract_identifier(value)
+          if child = routers[ident]?
+            child_prefix = prefix_dotted.empty? ? key : "#{prefix_dotted}.#{key}"
+            flatten_router(child, child_prefix, routers, url_prefix, result, visited)
+            next
+          end
+        end
+
+        method = procedure_method(value)
+        next unless method
+
+        dotted = prefix_dotted.empty? ? key : "#{prefix_dotted}.#{key}"
+        base = url_prefix.empty? ? "/" : url_prefix.chomp('/')
+        url = "#{base}/#{dotted}"
+        endpoint = Endpoint.new(url, method)
+        endpoint.details = Details.new(PathInfo.new(router.file, router.line))
+
+        attach_input_params(value, method, endpoint)
+
+        result << endpoint
+      end
+
+      visited.delete(router.name)
+    end
+
+    private def procedure_method(value : String) : String?
+      # tRPC subscriptions ride the WebSocket link; map them to the
+      # AsyncAPI `SUBSCRIBE` verb the optimizer allow-lists, since
+      # plain `WS` would be normalized down to `GET`.
+      return "SUBSCRIBE" if value.match(/\.\s*subscription\s*\(/)
+      return "POST" if value.match(/\.\s*mutation\s*\(/)
+      return "GET" if value.match(/\.\s*query\s*\(/)
+      nil
+    end
+
+    private def attach_input_params(value : String, method : String, endpoint : Endpoint)
+      param_type = method == "POST" ? "body" : "query"
+
+      # Locate the .input(...) call; without one, every method exposes the
+      # raw `input` slot — GETs serialize it as ?input=, mutations send the
+      # body verbatim. We still surface that so consumers see the contract.
+      input_match = value.match(/\.\s*input\s*\(/)
+      unless input_match
+        return
+      end
+
+      open_paren_end = input_match.end(0) || 0
+      return if open_paren_end == 0
+      open_paren = open_paren_end - 1
+      close_paren = Noir::JSRouteExtractor.find_matching_paren(value, open_paren)
+      return unless close_paren
+
+      input_body = value[(open_paren + 1)...close_paren]
+
+      # Shallow z.object({...}) — pull top-level field names. Deeper schemas
+      # are intentionally skipped; the issue calls deep parsing out as the
+      # hardest piece and we only need leaf field names for the common case.
+      if obj_match = input_body.match(/z\.object\s*\(\s*\{/)
+        brace_end = obj_match.end(0) || 0
+        if brace_end > 0
+          brace_open = brace_end - 1
+          if close_brace = Noir::JSRouteExtractor.find_matching_brace(input_body, brace_open)
+            schema = input_body[(brace_open + 1)...close_brace]
+            extract_schema_fields(schema).each do |name|
+              next if name.empty? || name == "z"
+              unless endpoint.params.any? { |p| p.name == name && p.param_type == param_type }
+                endpoint.push_param(Param.new(name, "", param_type))
+              end
+            end
+            return
+          end
+        end
+      end
+
+      # Fallback: opaque schema, still expose the input slot.
+      unless endpoint.params.any? { |p| p.name == "input" && p.param_type == param_type }
+        endpoint.push_param(Param.new("input", "", param_type))
+      end
+    end
+
+    private def extract_schema_fields(schema : String) : Array(String)
+      fields = [] of String
+      depth = 0
+      i = 0
+      n = schema.size
+      key_start = -1
+
+      while i < n
+        c = schema[i]
+        case c
+        when '\'', '"', '`'
+          quote = c
+          i += 1
+          while i < n && schema[i] != quote
+            i += schema[i] == '\\' ? 2 : 1
+          end
+          i += 1
+          next
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1
+        end
+
+        if depth == 0
+          if key_start < 0 && (c.ascii_letter? || c == '_' || c == '$')
+            key_start = i
+          elsif key_start >= 0 && !(c.ascii_alphanumeric? || c == '_' || c == '$')
+            name = schema[key_start...i]
+            # Only emit when followed (after whitespace) by `:` — that's how
+            # we distinguish a property key from any other identifier left
+            # at depth 0 by oddly formatted schemas.
+            j = i
+            while j < n && schema[j].whitespace?
+              j += 1
+            end
+            fields << name if j < n && schema[j] == ':'
+            key_start = -1
+          end
+        else
+          key_start = -1
+        end
+
+        i += 1
+      end
+
+      fields
+    end
+  end
+end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -173,6 +173,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     Swift::Hummingbird,
     Typescript::Nestjs,
     Typescript::TanstackRouter,
+    Typescript::TRPC,
   ])
 
   # Handle --only-techs: filter detector_list to only specified techs

--- a/src/detector/detectors/typescript/trpc.cr
+++ b/src/detector/detectors/typescript/trpc.cr
@@ -1,0 +1,42 @@
+require "../../../models/detector"
+
+module Detector::Typescript
+  class TRPC < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
+                          filename.ends_with?(".cts") || filename.ends_with?(".mts") ||
+                          filename.ends_with?(".js") || filename.ends_with?(".jsx") ||
+                          filename.ends_with?(".cjs") || filename.ends_with?(".mjs") ||
+                          File.basename(filename) == "package.json"
+
+      if File.basename(filename) == "package.json"
+        return file_contents.includes?("\"@trpc/server\"") || file_contents.includes?("\"@trpc/next\"")
+      end
+
+      if file_contents.match(/import[^'"`]+from\s+['"`]@trpc\/server(?:\/[^'"`]*)?['"`]/) ||
+         file_contents.match(/require\(\s*['"`]@trpc\/server(?:\/[^'"`]*)?['"`]\s*\)/) ||
+         file_contents.match(/import[^'"`]+from\s+['"`]@trpc\/next['"`]/) ||
+         file_contents.match(/initTRPC\b/) ||
+         file_contents.match(/createTRPCRouter\s*\(/) ||
+         file_contents.match(/fetchRequestHandler\s*\(/) ||
+         file_contents.match(/createNextApiHandler\s*\(/) ||
+         file_contents.match(/trpcExpress\.createExpressMiddleware\s*\(/)
+        return true
+      end
+
+      false
+    end
+
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
+        filename.ends_with?(".cts") || filename.ends_with?(".mts") ||
+        filename.ends_with?(".js") || filename.ends_with?(".jsx") ||
+        filename.ends_with?(".cjs") || filename.ends_with?(".mjs") ||
+        File.basename(filename) == "package.json"
+    end
+
+    def set_name
+      @name = "ts_trpc"
+    end
+  end
+end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1342,6 +1342,24 @@ module NoirTechs
         :websocket   => false,
       },
     },
+    :ts_trpc => {
+      :framework => "tRPC",
+      :language  => "TypeScript",
+      :similar   => ["trpc", "ts-trpc", "ts_trpc", "@trpc/server", "@trpc/next"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => false,
+          :body   => true,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => true,
+        :websocket   => true,
+      },
+    },
     :kotlin_http4k => {
       :framework => "http4k",
       :language  => "Kotlin",


### PR DESCRIPTION
## Summary

Closes #1641.

Adds a tRPC analyzer that enriches Noir's already-strong TypeScript coverage with the dominant typed-RPC layer in modern TS stacks (Next.js / T3 / Nuxt). Procedures are statically declared in source but reach the wire as flat HTTP endpoints, so the analyzer flattens the router tree into the `/api/trpc/<dotted>` surface the runtime actually exposes.

### How it works

- **Multi-file router collection** — scans `.ts/.tsx/.js/.jsx/.mts/.cts/.mjs/.cjs` for `router({...})` / `t.router({...})` / `createTRPCRouter({...})` assignments, including `initTRPC.create().router({...})`.
- **Tree flattening** — chooses root routers (those not referenced as values inside another router block), then walks each block top-level key by key. Keys whose value is another known router are recursed with the dotted prefix; procedure keys emit endpoints.
- **Method mapping** — `.query()` → `GET`, `.mutation()` → `POST`, `.subscription()` → `SUBSCRIBE` (the AsyncAPI verb the optimizer allow-lists; plain `WS` would get downgraded to `GET`).
- **Input shape** — shallow `z.object({...})` parsing surfaces per-field body (mutation) or query (query/subscription) params; opaque schemas degrade to a single `input` slot.
- **URL prefix** — defaults to `/api/trpc`, but reads an explicit `endpoint:` (fetch / OpenAPI handler), fastify `prefix:`, or `app.use('/x', trpcExpress.createExpressMiddleware ...)` mount when present.

### What's new

- `src/detector/detectors/typescript/trpc.cr` — detects `@trpc/server`, `@trpc/next`, `initTRPC`, `createTRPCRouter`, `fetchRequestHandler`, `createNextApiHandler`, `trpcExpress.createExpressMiddleware`.
- `src/analyzer/analyzers/typescript/trpc.cr` — regex + brace-matched parser, no tree-sitter dependency.
- Wired into `analyzer.cr`, `detector.cr`, `techs.cr` as `ts_trpc`.
- Functional fixture `spec/functional_test/fixtures/typescript/trpc/` mirrors a Next.js T3 layout (`pages/api/trpc/[trpc].ts` + `server/root.ts` + `server/routers/*.ts`) with cross-router nesting, query + mutation + subscription, and `z.object` body schemas.
- Regenerated supported-tech docs.

## Test plan

- [x] `just build`
- [x] `just check` — 995 files, 0 failures
- [x] `just test-unit` — 1798 examples, 0 failures
- [x] `just test-func` — 12126 examples, 0 failures (includes 24 new tRPC checks covering GET/POST/SUBSCRIBE, dotted nesting across files, and body/query field extraction)