### PR TITLE
Clean up ameba/format findings across recently added analyzers

### DIFF
--- a/spec/functional_test/testers/specification/envoy_spec.cr
+++ b/spec/functional_test/testers/specification/envoy_spec.cr
@@ -32,4 +32,3 @@ FunctionalTester.new("fixtures/specification/envoy/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
-

--- a/spec/unit_test/analyzer/specification/apisix_spec.cr
+++ b/spec/unit_test/analyzer/specification/apisix_spec.cr
@@ -67,14 +67,12 @@ describe "Apisix Analyzer" do
 
     endpoints = analyze_apisix(yaml_content: yaml)
     internal = endpoints.find { |ep| ep.url == "/internal" && ep.method == "DELETE" }
-    internal.should_not be_nil
-    internal = internal.not_nil!
+    raise "expected /internal DELETE endpoint" unless internal
     internal_hosts = internal.params.select { |p| p.name == "Host" && p.param_type == "header" }.map(&.value).sort!
     internal_hosts.should eq(["api.example.com", "internal.example.com"])
 
     admin = endpoints.find { |ep| ep.url == "/admin" && ep.method == "GET" }
-    admin.should_not be_nil
-    admin = admin.not_nil!
+    raise "expected /admin GET endpoint" unless admin
     admin_hosts = admin.params.select { |p| p.name == "Host" && p.param_type == "header" }.map(&.value)
     admin_hosts.should eq(["admin.example.com"])
   end

--- a/src/analyzer/analyzers/csharp/fastendpoints.cr
+++ b/src/analyzer/analyzers/csharp/fastendpoints.cr
@@ -12,9 +12,9 @@ module Analyzer::CSharp
     # base is a candidate.
     BASE_TYPE_REGEX = /:\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*,\s*)*(Endpoint(?:WithoutRequest)?(?:<[^>]*>)?|Ep<[^>]*>)/
 
-    VERB_CALL_REGEX = /\b(Get|Post|Put|Patch|Delete|Options|Head)\s*\(\s*"([^"]+)"/m
-    VERBS_CALL_REGEX = /\bVerbs\s*\(\s*([^)]*)\)/m
-    ROUTES_CALL_REGEX = /\bRoutes\s*\(\s*([^)]*)\)/m
+    VERB_CALL_REGEX       = /\b(Get|Post|Put|Patch|Delete|Options|Head)\s*\(\s*"([^"]+)"/m
+    VERBS_CALL_REGEX      = /\bVerbs\s*\(\s*([^)]*)\)/m
+    ROUTES_CALL_REGEX     = /\bRoutes\s*\(\s*([^)]*)\)/m
     HTTP_VERB_TOKEN_REGEX = /(?:Http\.)?(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)/
 
     def analyze
@@ -111,7 +111,7 @@ module Analyzer::CSharp
     # collapsing to `Page` at the first inner `<`.
     private def extract_request_type(base : String) : String?
       start = base.index('<')
-      return nil unless start
+      return unless start
       depth = 0
       io = String::Builder.new
       i = start
@@ -134,7 +134,7 @@ module Analyzer::CSharp
         i += 1
       end
       arg = io.to_s.strip
-      return nil if arg.empty?
+      return if arg.empty?
       # Look up by the outer type name when the request is generic
       # (e.g. `Page<User>` → index entry for `Page`).
       outer = arg.split('<').first.strip
@@ -207,7 +207,7 @@ module Analyzer::CSharp
     end
 
     private def build_endpoint(raw_route : String, http_method : String, file : String, line : Int32, request_params : Array(Param)) : Endpoint?
-      return nil if raw_route.empty?
+      return if raw_route.empty?
 
       route = normalize_route(raw_route)
       path_params = build_path_params(route)
@@ -298,12 +298,12 @@ module Analyzer::CSharp
     private def extract_props_from_block(block : String) : Array(Param)
       params = [] of Param
       from_attr_map = {
-        "FromQuery"     => "query",
-        "FromRoute"     => "path",
-        "FromBody"      => "json",
-        "FromHeader"    => "header",
-        "FromForm"      => "form",
-        "FromCookie"    => "cookie",
+        "FromQuery"  => "query",
+        "FromRoute"  => "path",
+        "FromBody"   => "json",
+        "FromHeader" => "header",
+        "FromForm"   => "form",
+        "FromCookie" => "cookie",
         # `[FromClaim]` reads from the auth principal's JWT claims —
         # not a request-side binding, so skip rather than mis-tag as
         # `header`.

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -17,8 +17,8 @@ module Analyzer::Go
   # file that registers the handler instead of (or in addition to)
   # the proto file.
   class ConnectRpc < GoEngine
-    IMPORT_MARKER       = "connectrpc.com/connect"
-    HANDLER_NAME_REGEX  = /New(\w+ServiceHandler)\s*\(/
+    IMPORT_MARKER         = "connectrpc.com/connect"
+    HANDLER_NAME_REGEX    = /New(\w+ServiceHandler)\s*\(/
     CONNECT_CONTENT_TYPES = "application/proto, application/json, application/connect+proto, application/connect+json"
 
     alias MessageFields = Array(Param)

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -103,7 +103,7 @@ module Analyzer::Go
     # method/path from the Operation composite literal and resolving
     # the handler's Input struct fields for param classification.
     private def extract_huma_endpoints(source : String, path : String,
-                                      structs : Hash(String, Array(StructField))) : Array(Endpoint)
+                                       structs : Hash(String, Array(StructField))) : Array(Endpoint)
       endpoints = [] of Endpoint
       Noir::TreeSitter.parse_go(source) do |root|
         walk_calls(root) do |call|
@@ -126,17 +126,19 @@ module Analyzer::Go
             end
             arg_index += 1
           end
-          next if op_node.nil?
 
-          method, route_path = decode_operation(op_node.not_nil!, source)
+          operation_arg = op_node
+          next if operation_arg.nil?
+
+          method, route_path = decode_operation(operation_arg, source)
           next if method.empty? || route_path.empty?
 
           row = Noir::TreeSitter.node_start_row(call) + 1
           details = Details.new(PathInfo.new(path, row))
           endpoint = Endpoint.new(route_path, method.upcase, details)
 
-          if handler_node
-            input_type = extract_input_struct_name(handler_node.not_nil!, source)
+          if handler_arg = handler_node
+            input_type = extract_input_struct_name(handler_arg, source)
             if input_type && (fields = structs[input_type]?)
               fields.each do |field|
                 push_field_param(endpoint, field)
@@ -165,7 +167,7 @@ module Analyzer::Go
       body = Noir::TreeSitter.field(node, "body")
       return {method, path} if body.nil?
 
-      Noir::TreeSitter.each_named_child(body.not_nil!) do |child|
+      Noir::TreeSitter.each_named_child(body) do |child|
         next unless Noir::TreeSitter.node_type(child) == "keyed_element"
 
         # tree-sitter-go wraps each side of a keyed_element in a
@@ -183,10 +185,13 @@ module Analyzer::Go
           value_field ||= children[1]
         end
 
-        key_text = unwrap_literal_text(key_node.not_nil!, source)
-        value_node = unwrap_literal_node(value_field.not_nil!)
-        next if value_node.nil?
-        value = value_node.not_nil!
+        key = key_node
+        val_field = value_field
+        next if key.nil? || val_field.nil?
+
+        key_text = unwrap_literal_text(key, source)
+        value = unwrap_literal_node(val_field)
+        next if value.nil?
 
         case key_text
         when "Method"
@@ -220,8 +225,6 @@ module Analyzer::Go
       case Noir::TreeSitter.node_type(node)
       when "interpreted_string_literal", "raw_string_literal"
         Noir::TreeSitter.node_text(node, source).gsub(/^["`]|["`]$/, "")
-      else
-        nil
       end
     end
 
@@ -242,21 +245,21 @@ module Analyzer::Go
     #   func(ctx context.Context, input *FooInput) (*FooOutput, error) { ... }
     # We want `FooInput` (second parameter, dereferenced).
     private def extract_input_struct_name(node : LibTreeSitter::TSNode, source : String) : String?
-      return nil unless Noir::TreeSitter.node_type(node) == "func_literal"
+      return unless Noir::TreeSitter.node_type(node) == "func_literal"
 
       params = Noir::TreeSitter.field(node, "parameters")
-      return nil if params.nil?
+      return if params.nil?
 
       decls = [] of LibTreeSitter::TSNode
-      Noir::TreeSitter.each_named_child(params.not_nil!) do |decl|
+      Noir::TreeSitter.each_named_child(params) do |decl|
         decls << decl if Noir::TreeSitter.node_type(decl) == "parameter_declaration"
       end
-      return nil if decls.size < 2
+      return if decls.size < 2
 
       type_node = Noir::TreeSitter.field(decls[1], "type")
-      return nil if type_node.nil?
+      return if type_node.nil?
 
-      text = Noir::TreeSitter.node_text(type_node.not_nil!, source).strip
+      text = Noir::TreeSitter.node_text(type_node, source).strip
       text = text.lchop('*')
       # Strip package qualifier (e.g., "pkg.Foo" -> "Foo") — Huma input
       # types are nearly always local to the package, so we keep the
@@ -283,10 +286,12 @@ module Analyzer::Go
           name_node = Noir::TreeSitter.field(node, "name")
           type_node = Noir::TreeSitter.field(node, "type")
           next if name_node.nil? || type_node.nil?
-          next unless Noir::TreeSitter.node_type(type_node.not_nil!) == "struct_type"
+          nn = name_node
+          tn = type_node
+          next unless Noir::TreeSitter.node_type(tn) == "struct_type"
 
-          struct_name = Noir::TreeSitter.node_text(name_node.not_nil!, source)
-          fields = extract_struct_fields(type_node.not_nil!, source)
+          struct_name = Noir::TreeSitter.node_text(nn, source)
+          fields = extract_struct_fields(tn, source)
           result[struct_name] ||= fields
         end
       end
@@ -304,32 +309,28 @@ module Analyzer::Go
           break
         end
       end
-      return fields if field_list.nil?
+      fl = field_list
+      return fields if fl.nil?
 
-      Noir::TreeSitter.each_named_child(field_list.not_nil!) do |decl|
+      Noir::TreeSitter.each_named_child(fl) do |decl|
         next unless Noir::TreeSitter.node_type(decl) == "field_declaration"
 
         tag = ""
-        tag_node = Noir::TreeSitter.field(decl, "tag")
-        if tag_node
-          tag = Noir::TreeSitter.node_text(tag_node.not_nil!, source)
+        if tag_node = Noir::TreeSitter.field(decl, "tag")
+          tag = Noir::TreeSitter.node_text(tag_node, source)
           tag = tag.gsub(/^[`"]|[`"]$/, "")
         end
 
-        name_node = Noir::TreeSitter.field(decl, "name")
-        if name_node
-          field_name = Noir::TreeSitter.node_text(name_node.not_nil!, source)
+        if name_node = Noir::TreeSitter.field(decl, "name")
+          field_name = Noir::TreeSitter.node_text(name_node, source)
           fields << StructField.new(field_name, tag)
-        else
+        elsif type_node = Noir::TreeSitter.field(decl, "type")
           # Embedded field — name comes from the type itself; we don't
           # need to descend into embedded structs for Huma input types
           # in practice (huma.Operation isn't extended that way), so
           # leave a placeholder so the slot is preserved.
-          type_node = Noir::TreeSitter.field(decl, "type")
-          if type_node
-            field_name = Noir::TreeSitter.node_text(type_node.not_nil!, source)
-            fields << StructField.new(field_name, tag)
-          end
+          field_name = Noir::TreeSitter.node_text(type_node, source)
+          fields << StructField.new(field_name, tag)
         end
       end
       fields
@@ -373,7 +374,7 @@ module Analyzer::Go
     private def unwrap_literal_text(node : LibTreeSitter::TSNode, source : String) : String
       inner = unwrap_literal_node(node)
       return "" if inner.nil?
-      Noir::TreeSitter.node_text(inner.not_nil!, source)
+      Noir::TreeSitter.node_text(inner, source)
     end
 
     private def walk_calls(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)

--- a/src/analyzer/analyzers/javascript/apollo.cr
+++ b/src/analyzer/analyzers/javascript/apollo.cr
@@ -135,9 +135,9 @@ module Analyzer::Javascript
     # that line counts and offsets stay aligned) and the byte position
     # just past the closing backtick.
     private def extract_template_literal(content : String, start_pos : Int32) : Tuple(String, Int32)?
-      return nil if start_pos >= content.size || content[start_pos] != '`'
+      return if start_pos >= content.size || content[start_pos] != '`'
       end_pos = find_closing_backtick(content, start_pos + 1)
-      return nil if end_pos.nil?
+      return if end_pos.nil?
 
       raw = content[(start_pos + 1)...end_pos]
       {strip_interpolations(raw), end_pos + 1}

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -113,21 +113,21 @@ module Analyzer::Scala
     # path params, query params, binding name (or nil).
     private def parse_case_header(header : String)
       cleaned = header.strip
-      return nil unless cleaned.starts_with?("case ")
+      return unless cleaned.starts_with?("case ")
       body = cleaned[("case ".size)..].strip
 
       binding_name : String? = nil
       if at_match = body.match(/^(\w+)\s*@\s*/)
         binding_name = at_match[1]
-        body = body[at_match.end(0).not_nil!..]
+        body = body[at_match[0].size..]
       end
 
       method_match = body.match(/^(?:\(\s*)?([A-Z]+(?:\s*\|\s*[A-Z]+)*)(?:\s*\))?\s*->\s*Root\b/)
-      return nil unless method_match
+      return unless method_match
       methods = method_match[1].split('|').map(&.strip).select { |m| HTTP_METHODS.includes?(m) }
-      return nil if methods.empty?
+      return if methods.empty?
 
-      remainder = body[method_match.end(0).not_nil!..].strip
+      remainder = body[method_match[0].size..].strip
 
       path_part = remainder
       query_part = ""

--- a/src/analyzer/analyzers/scala/zio_http.cr
+++ b/src/analyzer/analyzers/scala/zio_http.cr
@@ -23,11 +23,9 @@ module Analyzer::Scala
         while m = stripped.match(/(?<![.\w])Method\.([A-Z]+)/, offset)
           method = m[1]
           method_end = m.end(0) || 0
+          offset = method_end
 
-          unless HTTP_METHODS.includes?(method)
-            offset = method_end
-            next
-          end
+          next unless HTTP_METHODS.includes?(method)
 
           rest = stripped[method_end..]
           arrow_idx = rest.index("->")
@@ -51,7 +49,6 @@ module Analyzer::Scala
           end
 
           endpoints << endpoint
-          offset = method_end
         end
       end
 
@@ -137,10 +134,10 @@ module Analyzer::Scala
     private def extract_handler_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
       structural = scala_structural_line(lines[start_index])
       opening_match = structural.match(/(?<![.\w])handler\s*\{/) || structural.match(/->\s*\{/)
-      return nil unless opening_match
+      return unless opening_match
       opening_brace_in_structural = (opening_match.end(0) || 1) - 1
       block = extract_scala_brace_block_with_end_at(lines, start_index, opening_brace_in_structural)
-      return nil unless block
+      return unless block
       {block[0], block[1]}
     end
 

--- a/src/analyzer/analyzers/specification/envoy.cr
+++ b/src/analyzer/analyzers/specification/envoy.cr
@@ -120,8 +120,8 @@ module Analyzer::Specification
     end
 
     private def extract_method_yaml(match : YAML::Any) : String?
-      return nil unless headers_node = match["headers"]?
-      return nil unless headers = headers_node.as_a?
+      return unless headers_node = match["headers"]?
+      return unless headers = headers_node.as_a?
       headers.each do |header|
         next unless header["name"]?.try(&.as_s?) == ":method"
         if exact = header["exact_match"]?.try(&.as_s?)
@@ -206,8 +206,8 @@ module Analyzer::Specification
     end
 
     private def extract_method_json(match : JSON::Any) : String?
-      return nil unless headers_node = match["headers"]?
-      return nil unless headers = headers_node.as_a?
+      return unless headers_node = match["headers"]?
+      return unless headers = headers_node.as_a?
       headers.each do |header|
         next unless header["name"]?.try(&.as_s?) == ":method"
         if exact = header["exact_match"]?.try(&.as_s?)

--- a/src/analyzer/analyzers/specification/odata.cr
+++ b/src/analyzer/analyzers/specification/odata.cr
@@ -10,23 +10,23 @@ module Analyzer::Specification
   # context.
   class OData < Analyzer
     EDM_PRIMITIVE_BODY_TYPES = {
-      "Edm.String"   => "string",
-      "Edm.Boolean"  => "boolean",
-      "Edm.Int16"    => "int",
-      "Edm.Int32"    => "int",
-      "Edm.Int64"    => "int",
-      "Edm.Decimal"  => "number",
-      "Edm.Double"   => "number",
-      "Edm.Single"   => "number",
-      "Edm.Byte"     => "int",
-      "Edm.SByte"    => "int",
-      "Edm.Guid"     => "string",
-      "Edm.DateTime" => "string",
-      "Edm.Date"     => "string",
-      "Edm.TimeOfDay" => "string",
+      "Edm.String"         => "string",
+      "Edm.Boolean"        => "boolean",
+      "Edm.Int16"          => "int",
+      "Edm.Int32"          => "int",
+      "Edm.Int64"          => "int",
+      "Edm.Decimal"        => "number",
+      "Edm.Double"         => "number",
+      "Edm.Single"         => "number",
+      "Edm.Byte"           => "int",
+      "Edm.SByte"          => "int",
+      "Edm.Guid"           => "string",
+      "Edm.DateTime"       => "string",
+      "Edm.Date"           => "string",
+      "Edm.TimeOfDay"      => "string",
       "Edm.DateTimeOffset" => "string",
-      "Edm.Duration" => "string",
-      "Edm.Binary"   => "string",
+      "Edm.Duration"       => "string",
+      "Edm.Binary"         => "string",
     }
 
     alias EntityType = NamedTuple(properties: Array(NamedTuple(name: String, type: String)), keys: Array(String))
@@ -251,7 +251,7 @@ module Analyzer::Specification
     end
 
     private def function_url(name : String, operation : Operation?) : String
-      return "/#{name}()" unless operation && !operation[:parameters].empty?
+      return "/#{name}()" if operation.nil? || operation[:parameters].empty?
       args = operation[:parameters].map { |p| "#{p[:name]}={#{p[:name]}}" }.join(",")
       "/#{name}(#{args})"
     end

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -172,7 +172,7 @@ module Analyzer::Specification
       end
     end
 
-    private def scan_matchers(expression : String, &block : String, Array(String) ->)
+    private def scan_matchers(expression : String, & : String, Array(String) ->)
       expression.scan(/([A-Za-z]+)\s*\(([^)]*)\)/) do |match|
         next unless match.size >= 3
         name = match[1]


### PR DESCRIPTION
## Summary
- Cleans up the 42 ameba + `crystal tool format` findings that accumulated across the latest batch of analyzer PRs (Huma, FastEndpoints, http4s, ZIO HTTP, Apollo, Envoy, OData, Traefik, APISIX spec).
- No behavior changes — all fixes are local refactors that bring recently added analyzers up to the project's lint bar without touching public surface.
- Notable: `huma.cr` swaps `not_nil!` chains for assignment-narrowing (`if x = field(...)`) so closure-captured tree-sitter nodes type-narrow at compile time instead of relying on runtime asserts.

## Test plan
- [x] `just check` — 1076 files inspected, 0 failures
- [x] `crystal spec spec/unit_test` — 1897 examples, 0 failures
- [x] Functional specs for Huma / http4s / ZIO HTTP / OData / APISIX / Envoy — 214 examples, 0 failures