### PR TITLE
Add unit specs for GroovyLiteralScanner and CrystalCalleeExtractor

### DIFF
--- a/spec/unit_test/miniparser/crystal_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/crystal_callee_extractor_spec.cr
@@ -1,0 +1,127 @@
+require "spec"
+require "../../../src/miniparsers/crystal_callee_extractor"
+
+describe Noir::CrystalCalleeExtractor do
+  describe "callees_for_body" do
+    it "extracts receiver, namespaced, and bare callees" do
+      body = <<-CR
+        UserService.find(id)
+        Noir::Models::User.create!
+        log("hello")
+        render "ok"
+        CR
+
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, "svc.cr", 10)
+      names = callees.map { |name, _, line| {name, line} }
+
+      names.should contain({"UserService.find", 10})
+      names.should contain({"Noir::Models::User.create!", 11})
+      names.should contain({"log", 12})
+      names.should contain({"render", 13})
+    end
+
+    it "preserves source file and start_line offsets" do
+      body = "do_work(arg)\n"
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, "app/foo.cr", 42)
+      callees.size.should eq(1)
+      name, path, line = callees[0]
+      name.should eq("do_work")
+      path.should eq("app/foo.cr")
+      line.should eq(42)
+    end
+
+    it "ignores Crystal reserved words even when followed by parens" do
+      body = <<-CR
+        return(value)
+        if(condition)
+        while(more)
+        CR
+
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, "x.cr", 1)
+      callees.map { |name, _, _| name }.should be_empty
+    end
+
+    it "skips callees that appear inside a comment" do
+      body = <<-CR
+        real_call(arg)
+        # ignored_call("nope")
+        CR
+
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, "x.cr", 1)
+      names = callees.map { |name, _, _| name }
+      names.should contain("real_call")
+      names.should_not contain("ignored_call")
+    end
+
+    it "dedups identical name+path+line entries" do
+      # Same line, same call: should appear once
+      body = "save(x) save(y)\n"
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, "x.cr", 1)
+      callees.count { |name, _, _| name == "save" }.should eq(1)
+    end
+
+    it "captures instance and class variable receivers" do
+      body = "@logger.info(\"hi\")\n@@cache.fetch!(key)\n"
+      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, "x.cr", 1)
+      names = callees.map { |name, _, _| name }
+      names.should contain("@logger.info")
+      names.should contain("@@cache.fetch!")
+    end
+  end
+
+  describe "strip_comment" do
+    it "removes everything after an unquoted '#'" do
+      Noir::CrystalCalleeExtractor.strip_comment("foo # bar").should eq("foo ")
+    end
+
+    it "ignores '#' inside a double-quoted string" do
+      line = "puts \"value #x\" # trailing"
+      result = Noir::CrystalCalleeExtractor.strip_comment(line)
+      result.should eq("puts \"value #x\" ")
+    end
+
+    it "ignores '#' inside a single-quoted character literal" do
+      line = "x = '#' # comment"
+      result = Noir::CrystalCalleeExtractor.strip_comment(line)
+      result.should eq("x = '#' ")
+    end
+
+    it "respects escaped quotes so the string is not closed prematurely" do
+      line = "puts \"a\\\"#\" # actual comment"
+      result = Noir::CrystalCalleeExtractor.strip_comment(line)
+      result.should eq("puts \"a\\\"#\" ")
+    end
+
+    it "returns the line unchanged when no comment is present" do
+      Noir::CrystalCalleeExtractor.strip_comment("call_thing(a, b)")
+        .should eq("call_thing(a, b)")
+    end
+  end
+
+  describe "attach_to" do
+    it "pushes each callee onto the endpoint" do
+      endpoint = Endpoint.new("/api/v1/users", "GET")
+      entries = [
+        {"Service.find", "app/svc.cr", 10},
+        {"helper", "app/svc.cr", 12},
+      ] of Noir::CrystalCalleeExtractor::Entry
+
+      Noir::CrystalCalleeExtractor.attach_to(endpoint, entries)
+
+      endpoint.callees.size.should eq(2)
+      endpoint.callees[0].name.should eq("Service.find")
+      endpoint.callees[1].line.should eq(12)
+    end
+
+    it "dedups callees with the same name+path inside the endpoint" do
+      endpoint = Endpoint.new("/", "GET")
+      entries = [
+        {"helper", "app/svc.cr", 10},
+        {"helper", "app/svc.cr", 99}, # same name+path => deduped by push_callee
+      ] of Noir::CrystalCalleeExtractor::Entry
+
+      Noir::CrystalCalleeExtractor.attach_to(endpoint, entries)
+      endpoint.callees.size.should eq(1)
+    end
+  end
+end

--- a/spec/unit_test/utils/groovy_literal_scanner_spec.cr
+++ b/spec/unit_test/utils/groovy_literal_scanner_spec.cr
@@ -1,0 +1,172 @@
+require "spec"
+require "../../../src/utils/groovy_literal_scanner"
+
+describe Noir::GroovyLiteralScanner do
+  describe "skip_literal" do
+    context "single-line strings" do
+      it "skips a double-quoted string" do
+        content = %("hello" world)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should eq(7)
+        content[result.not_nil!..].should eq(" world")
+      end
+
+      it "skips a single-quoted string" do
+        content = %('hello' world)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should eq(7)
+        content[result.not_nil!..].should eq(" world")
+      end
+
+      it "handles escaped quotes in double-quoted strings" do
+        content = %("a\\"b" tail)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should eq(6)
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "handles escaped quotes in single-quoted strings" do
+        content = %('a\\'b' tail)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should eq(6)
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "returns content size for an unterminated quoted string" do
+        content = %("never ends)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should eq(content.size)
+      end
+    end
+
+    context "triple-quoted strings" do
+      it "skips a triple double-quoted string" do
+        content = %("""line1\nline2""" tail)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should_not be_nil
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "skips a triple single-quoted string" do
+        content = %('''multi\nline''' tail)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should_not be_nil
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "treats triple quote with single inner quote as still inside the literal" do
+        content = %("""has " inside""" tail)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should_not be_nil
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "respects an escaped closing triple quote" do
+        # The third quote is escaped, so the literal continues past it.
+        content = %("""a\\""" still""" tail)
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should_not be_nil
+        content[result.not_nil!..].should eq(" tail")
+      end
+    end
+
+    context "slashy regex literals" do
+      it "skips a slashy literal after an opening paren" do
+        content = "matches(/foo/, x)"
+        # '/' is at index 8
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 8)
+        result.should eq(13)
+        content[result.not_nil!..].should eq(", x)")
+      end
+
+      it "skips a slashy literal after a keyword (return)" do
+        content = "return /abc/"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 7)
+        result.should eq(content.size)
+      end
+
+      it "skips a slashy literal after the 'case' keyword" do
+        content = "case /abc/:"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 5)
+        result.should eq(10)
+        content[result.not_nil!..].should eq(":")
+      end
+
+      it "honors escaped slashes inside a slashy literal" do
+        content = "= /a\\/b/ tail"
+        # '/' that starts the regex is at index 2
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 2)
+        result.should eq(8)
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "does not treat // as a slashy literal start" do
+        content = "= // comment"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 2)
+        result.should be_nil
+      end
+
+      it "does not treat /* as a slashy literal start" do
+        content = "= /* block */"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 2)
+        result.should be_nil
+      end
+
+      it "does not treat /= as a slashy literal start" do
+        content = "x /= 2"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 2)
+        result.should be_nil
+      end
+
+      it "treats '/' after an identifier as division (returns nil)" do
+        content = "x / y"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 2)
+        result.should be_nil
+      end
+
+      it "treats '/' at the start of input as a slashy literal" do
+        content = "/abc/"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
+        result.should eq(5)
+      end
+    end
+
+    context "dollar-slashy literals" do
+      it "skips a basic dollar-slashy literal" do
+        content = "x = $/regex with /slash/$ tail"
+        # '$' is at index 4
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 4)
+        result.should_not be_nil
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "respects an escaped closing delimiter ($/) in dollar-slashy" do
+        # The first /$ is preceded by '$', meaning it's escaped per the module's rule.
+        content = "x = $/foo$/$ still/$ tail"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 4)
+        result.should_not be_nil
+        content[result.not_nil!..].should eq(" tail")
+      end
+
+      it "returns content size for unterminated dollar-slashy" do
+        content = "x = $/never closes"
+        result = Noir::GroovyLiteralScanner.skip_literal(content, 4)
+        result.should eq(content.size)
+      end
+    end
+
+    context "non-literal positions" do
+      it "returns nil for an arbitrary identifier character" do
+        Noir::GroovyLiteralScanner.skip_literal("name", 0).should be_nil
+      end
+
+      it "returns nil when pos is out of bounds" do
+        Noir::GroovyLiteralScanner.skip_literal("abc", 10).should be_nil
+      end
+
+      it "returns nil for a standalone '$' that is not followed by '/'" do
+        Noir::GroovyLiteralScanner.skip_literal("$foo", 0).should be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds direct unit coverage for `Noir::GroovyLiteralScanner` — single/triple-quoted strings, slashy-regex context rules (preceding chars + keywords like `case`/`return`), dollar-slashy with escaped delimiters, and non-literal positions.
- Adds direct unit coverage for `Noir::CrystalCalleeExtractor` — receiver/namespaced/bare callees, `start_line` offsets, `strip_comment` quote-state handling (incl. escapes), entry dedup, and `attach_to` dedup via `Endpoint#push_callee`.
- Both modules were previously exercised only indirectly through analyzer integration tests; this surfaces regressions in isolation.

## Test plan
- [x] `crystal spec spec/unit_test` — 2018 examples, 0 failures
- [x] `crystal spec spec/unit_test/utils/groovy_literal_scanner_spec.cr` — 24 examples
- [x] `crystal spec spec/unit_test/miniparser/crystal_callee_extractor_spec.cr` — 13 examples