### PR TITLE
Add callee extraction for more analyzers

### DIFF
--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/empty.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/empty.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/empty')()
+
+const unrelated = {
+  loader: () => Secret.run(),
+}

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/post.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/post.ts
@@ -2,11 +2,11 @@ import { z } from 'zod'
 import { router, publicProcedure } from '../trpc'
 
 export const postRouter = router({
-  list: publicProcedure.query(() => []),
+  list: publicProcedure.query(() => PostService.list()),
   byId: publicProcedure
     .input(z.object({ postId: z.string() }))
-    .query(({ input }) => input),
+    .query(({ input }) => PostService.find(input.postId)),
   liveFeed: publicProcedure.subscription(() => {
-    return null
+    return FeedService.live()
   }),
 })

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/user.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/user.ts
@@ -2,11 +2,14 @@ import { z } from 'zod'
 import { router, publicProcedure } from '../trpc'
 
 export const userRouter = router({
-  list: publicProcedure.query(() => []),
+  list: publicProcedure.query(() => UserService.list()),
   byId: publicProcedure
     .input(z.object({ id: z.string() }))
-    .query(({ input }) => input),
+    .query(({ input }) => UserService.find(input.id)),
   create: publicProcedure
     .input(z.object({ name: z.string(), email: z.string() }))
-    .mutation(({ input }) => input),
+    .mutation(({ input }) => {
+      AuditLog.write(input.email)
+      return UserService.create(input)
+    }),
 })

--- a/spec/functional_test/testers/javascript/adonisjs_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/adonisjs_callees_spec.cr
@@ -1,0 +1,17 @@
+require "../../func_spec.cr"
+
+root = Endpoint.new("/", "GET")
+root.push_callee(Callee.new("HomeController.index"))
+
+create = Endpoint.new("/api/v1/users", "POST")
+create.push_callee(Callee.new("UsersController.store"))
+
+resource = Endpoint.new("/articles/:id", "DELETE")
+resource.push_callee(Callee.new("ArticlesController.destroy"))
+
+FunctionalTester.new("fixtures/javascript/adonisjs/", {
+  :techs     => 1,
+  :endpoints => 22,
+}, [root, create, resource], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/astro_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/astro_callees_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+list = Endpoint.new("/api/users", "GET")
+list.push_callee(Callee.new("JSON.stringify"))
+
+create = Endpoint.new("/api/users", "POST")
+create.push_callee(Callee.new("request.json"))
+create.push_callee(Callee.new("JSON.stringify"))
+
+update = Endpoint.new("/api/users/{id}", "PUT")
+update.push_callee(Callee.new("request.json"))
+update.push_callee(Callee.new("JSON.stringify"))
+
+FunctionalTester.new("fixtures/javascript/astro/", {
+  :techs     => 1,
+  :endpoints => 15,
+}, [list, create, update], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/fresh_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/fresh_callees_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+list = Endpoint.new("/api/users", "GET")
+list.push_callee(Callee.new("Response"))
+
+create = Endpoint.new("/api/users", "POST")
+create.push_callee(Callee.new("req.json"))
+create.push_callee(Callee.new("JSON.stringify"))
+
+show = Endpoint.new("/users/{id}", "GET")
+show.push_callee(Callee.new("ctx.render"))
+
+FunctionalTester.new("fixtures/javascript/fresh/", {
+  :techs     => 1,
+  :endpoints => 13,
+}, [list, create, show], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/hapi_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/hapi_callees_spec.cr
@@ -1,0 +1,11 @@
+require "../../func_spec.cr"
+
+destroy = Endpoint.new("/users/{id}", "DELETE")
+destroy.push_callee(Callee.new("h.response().code"))
+
+FunctionalTester.new("fixtures/javascript/hapi/", {
+  :techs     => 1,
+  :endpoints => 12,
+}, [destroy], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/scala/play_callees_spec.cr
+++ b/spec/functional_test/testers/scala/play_callees_spec.cr
@@ -1,0 +1,20 @@
+require "../../func_spec.cr"
+
+index = Endpoint.new("/", "GET")
+index.push_callee(Callee.new("Ok"))
+
+protected_endpoint = Endpoint.new("/api/protected", "GET")
+protected_endpoint.push_callee(Callee.new("request.headers.get"))
+protected_endpoint.push_callee(Callee.new("request.cookies.get"))
+protected_endpoint.push_callee(Callee.new("Ok"))
+
+post_data = Endpoint.new("/api/data", "POST")
+post_data.push_callee(Callee.new("request.headers.get"))
+post_data.push_callee(Callee.new("Json.toJson"))
+
+FunctionalTester.new("fixtures/scala/play/", {
+  :techs     => 1,
+  :endpoints => 17,
+}, [index, protected_endpoint, post_data], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
@@ -1,0 +1,33 @@
+require "../../func_spec.cr"
+
+posts = Endpoint.new("/posts", "GET")
+posts.push_callee(Callee.new("PostsComponent"))
+
+shop = Endpoint.new("/shop", "GET")
+shop.push_callee(Callee.new("ShopComponent"))
+
+docs = Endpoint.new("/docs", "GET")
+docs.push_callee(Callee.new("DocsRootComponent"))
+
+FunctionalTester.new("fixtures/typescript/tanstack_router/", {
+  :techs     => 1,
+  :endpoints => 10,
+}, [posts, shop, docs], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests
+
+it "does not attach callees from unrelated objects after empty file routes" do
+  config_init = ConfigInitializer.new
+  noir_options = config_init.default_options
+  noir_options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/tanstack_router/")])
+  noir_options["nolog"] = YAML::Any.new(true)
+  noir_options["include_callee"] = YAML::Any.new(true)
+
+  app = NoirRunner.new(noir_options)
+  app.detect
+  app.analyze
+
+  empty = app.endpoints.find { |endpoint| endpoint.method == "GET" && endpoint.url == "/empty" }
+  empty.should_not be_nil
+  empty.not_nil!.callees.map(&.name).includes?("Secret.run").should be_false
+end

--- a/spec/functional_test/testers/typescript/tanstack_router_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_spec.cr
@@ -32,6 +32,9 @@ expected_endpoints = [
   # Root-route files with a path should still be scanned even when
   # they do not contain createRoute() code-route assignments.
   Endpoint.new("/docs", "GET", [] of Param),
+  # Empty file routes should emit the route without borrowing later
+  # unrelated object literals as route config.
+  Endpoint.new("/empty", "GET", [] of Param),
 ]
 
 FunctionalTester.new("fixtures/typescript/tanstack_router/", {

--- a/spec/functional_test/testers/typescript/trpc_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_callees_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+list = Endpoint.new("/api/trpc/user.list", "GET")
+list.push_callee(Callee.new("UserService.list", line: 5))
+
+create = Endpoint.new("/api/trpc/user.create", "POST")
+create.push_callee(Callee.new("AuditLog.write", line: 12))
+create.push_callee(Callee.new("UserService.create", line: 13))
+
+feed = Endpoint.new("/api/trpc/post.liveFeed", "SUBSCRIBE")
+feed.push_callee(Callee.new("FeedService.live", line: 10))
+
+FunctionalTester.new("fixtures/typescript/trpc/", {
+  :techs     => 1,
+  :endpoints => 7,
+}, [list, create, feed], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/javascript/adonisjs.cr
+++ b/src/analyzer/analyzers/javascript/adonisjs.cr
@@ -24,8 +24,9 @@ module Analyzer::Javascript
         # endpoints in `tests/providers.spec.ts` alone.
         next if Noir::JSRouteExtractor.test_stub_only?(path, content)
 
-        Noir::TreeSitterAdonisJsExtractor.extract_routes(content).each do |route|
-          @result << build_endpoint(route, path)
+        include_callee = callees_needed?
+        Noir::TreeSitterAdonisJsExtractor.extract_routes(content, include_callee).each do |route|
+          @result << build_endpoint(route, path, include_callee)
         end
       end
 
@@ -33,7 +34,7 @@ module Analyzer::Javascript
       @result
     end
 
-    private def build_endpoint(route : Noir::TreeSitterAdonisJsExtractor::Route, path : String) : Endpoint
+    private def build_endpoint(route : Noir::TreeSitterAdonisJsExtractor::Route, path : String, include_callee : Bool) : Endpoint
       details = Details.new(PathInfo.new(path, route.line + 1))
       params = [] of Param
 
@@ -44,7 +45,15 @@ module Analyzer::Javascript
         params << Param.new(match[1], "", "path")
       end
 
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+      attach_route_callees(endpoint, route.callees, path) if include_callee
+      endpoint
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, callees : Array(Noir::JSCalleeExtractor::Entry), path : String)
+      callees.each do |name, callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: callee_path.empty? ? path : callee_path, line: line))
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/astro.cr
+++ b/src/analyzer/analyzers/javascript/astro.cr
@@ -87,7 +87,9 @@ module Analyzer::Javascript
       methods = detect_api_methods(content)
       mutex.synchronize do
         methods.each do |verb|
-          result << build_endpoint(url, verb, path)
+          endpoint = build_endpoint(url, verb, path)
+          attach_exported_callees(endpoint, content, path, verb) if callees_needed?
+          result << endpoint
         end
       end
     end
@@ -99,6 +101,12 @@ module Analyzer::Javascript
         endpoint.push_param(Param.new(match[1], "", "path"))
       end
       endpoint
+    end
+
+    private def attach_exported_callees(endpoint : Endpoint, content : String, path : String, verb : String)
+      Noir::JSCalleeExtractor.callees_for_exported_function(content, path, verb).each do |name, callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+      end
     end
 
     # Filesystem path → URL pattern. Strips the file extension,

--- a/src/analyzer/analyzers/javascript/elysia.cr
+++ b/src/analyzer/analyzers/javascript/elysia.cr
@@ -15,8 +15,9 @@ module Analyzer::Javascript
         content = read_file_content(path)
         next unless ELYSIA_MARKERS.any? { |m| content.includes?(m) }
 
-        Noir::TreeSitterElysiaExtractor.extract_routes(content).each do |route|
-          @result << build_endpoint(route, path)
+        include_callee = callees_needed?
+        Noir::TreeSitterElysiaExtractor.extract_routes(content, include_callee).each do |route|
+          @result << build_endpoint(route, path, include_callee)
         end
       end
 
@@ -24,7 +25,7 @@ module Analyzer::Javascript
       @result
     end
 
-    private def build_endpoint(route : Noir::TreeSitterElysiaExtractor::Route, path : String) : Endpoint
+    private def build_endpoint(route : Noir::TreeSitterElysiaExtractor::Route, path : String, include_callee : Bool) : Endpoint
       params = [] of Param
       route.query_params.each { |name| params << Param.new(name, "", "query") }
       route.header_params.each { |name| params << Param.new(name, "", "header") }
@@ -32,7 +33,15 @@ module Analyzer::Javascript
       params << Param.new("body", "", "json") if route.has_body?
 
       details = Details.new(PathInfo.new(path, route.line + 1))
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+      attach_route_callees(endpoint, route.callees, path) if include_callee
+      endpoint
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, callees : Array(Noir::JSCalleeExtractor::Entry), path : String)
+      callees.each do |name, _callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -1,4 +1,6 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
+require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
   # Fresh is Deno's filesystem-routed framework. Routes live under
@@ -80,7 +82,11 @@ module Analyzer::Javascript
         next if verbs.empty?
 
         mutex.synchronize do
-          verbs.each { |verb| result << build_endpoint(url, verb, path) }
+          verbs.each do |verb|
+            endpoint = build_endpoint(url, verb, path)
+            attach_handler_callees(endpoint, content, path, verb) if callees_needed?
+            result << endpoint
+          end
         end
       end
 
@@ -94,6 +100,78 @@ module Analyzer::Javascript
         endpoint.push_param(Param.new(match[1], "", "path"))
       end
       endpoint
+    end
+
+    private def attach_handler_callees(endpoint : Endpoint, content : String, path : String, verb : String)
+      callees = Noir::JSCalleeExtractor.callees_for_exported_function(content, path, verb)
+      callees = callees_for_handler_object_method(content, path, verb) if callees.empty?
+      callees = Noir::JSCalleeExtractor.callees_for_exported_function(content, path, "handler") if callees.empty?
+      callees.each do |name, callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+      end
+    end
+
+    private def callees_for_handler_object_method(content : String, path : String, verb : String) : Array(Noir::JSCalleeExtractor::Entry)
+      handler_block = extract_handler_object(content)
+      return [] of Noir::JSCalleeExtractor::Entry unless handler_block
+
+      if method = handler_block.match(/(?:^|[\{,\s])(?:async\s+)?#{verb}\s*\([^)]*\)\s*\{(.*?)^\s*\}/m)
+        start_line = content[0, content.index(method[0]) || 0].count('\n') + 1
+        return Noir::JSCalleeExtractor.callees_for_function_body(method[1], path, start_line, language: javascript_source_language(path))
+      end
+
+      if property = handler_block.match(/(?:^|[\{,\s])#{verb}\s*:\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/)
+        body_start = property.end(0) || 0
+        body = handler_block[body_start..]? || ""
+        block_start = content.index(handler_block) || 0
+        absolute_body_start = block_start + body_start
+        start_line = content[0, absolute_body_start].count('\n') + 1
+        body, start_line = extract_arrow_handler_body(body, start_line)
+        return Noir::JSCalleeExtractor.callees_for_function_body(body, path, start_line, language: javascript_source_language(path))
+      end
+
+      [] of Noir::JSCalleeExtractor::Entry
+    end
+
+    private def extract_arrow_handler_body(body : String, start_line : Int32) : Tuple(String, Int32)
+      offset = 0
+      while offset < body.size && body[offset].whitespace?
+        offset += 1
+      end
+
+      body_start_line = start_line + body[0, offset].count('\n')
+      stripped = body[offset..]? || ""
+
+      if stripped.starts_with?("{")
+        if close = Noir::JSRouteExtractor.find_matching_brace(stripped, 0)
+          return {stripped[1...close], body_start_line}
+        end
+      end
+
+      end_pos = top_level_comma(stripped) || stripped.size
+      {stripped[0...end_pos], body_start_line > 1 ? body_start_line - 1 : 1}
+    end
+
+    private def top_level_comma(source : String) : Int32?
+      depth = 0
+      i = 0
+      while i < source.size
+        case source[i]
+        when '\'', '"', '`'
+          quote = source[i]
+          i += 1
+          while i < source.size && source[i] != quote
+            i += source[i] == '\\' ? 2 : 1
+          end
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1
+        when ','
+          return i if depth == 0
+        end
+        i += 1
+      end
     end
 
     private def strip_extension(name : String) : String

--- a/src/analyzer/analyzers/javascript/hapi.cr
+++ b/src/analyzer/analyzers/javascript/hapi.cr
@@ -15,8 +15,9 @@ module Analyzer::Javascript
         content = read_file_content(path)
         next unless HAPI_MARKERS.any? { |m| content.includes?(m) }
 
-        Noir::TreeSitterHapiExtractor.extract_routes(content).each do |route|
-          @result << build_endpoint(route, path)
+        include_callee = callees_needed?
+        Noir::TreeSitterHapiExtractor.extract_routes(content, include_callee).each do |route|
+          @result << build_endpoint(route, path, include_callee)
         end
       end
 
@@ -24,7 +25,7 @@ module Analyzer::Javascript
       @result
     end
 
-    private def build_endpoint(route : Noir::TreeSitterHapiExtractor::Route, path : String) : Endpoint
+    private def build_endpoint(route : Noir::TreeSitterHapiExtractor::Route, path : String, include_callee : Bool) : Endpoint
       params = [] of Param
       route.query_params.each { |name| params << Param.new(name, "", "query") }
       route.header_params.each { |name| params << Param.new(name, "", "header") }
@@ -32,7 +33,15 @@ module Analyzer::Javascript
       params << Param.new("body", "", "json") if route.has_body?
 
       details = Details.new(PathInfo.new(path, route.line + 1))
-      Endpoint.new(route.path, route.verb, params, details)
+      endpoint = Endpoint.new(route.path, route.verb, params, details)
+      attach_route_callees(endpoint, route.callees, path) if include_callee
+      endpoint
+    end
+
+    private def attach_route_callees(endpoint : Endpoint, callees : Array(Noir::JSCalleeExtractor::Entry), path : String)
+      callees.each do |name, _callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
     end
   end
 end

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -1,9 +1,10 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/scala_callee_extractor"
 
 module Analyzer::Scala
   class Play < Analyzer
     # Stores parsed controller methods with their parameters
-    alias ControllerMethod = NamedTuple(headers: Array(String), cookies: Array(String), body_type: String?)
+    alias ControllerMethod = NamedTuple(headers: Array(String), cookies: Array(String), body_type: String?, callees: Array(Noir::ScalaCalleeExtractor::Entry))
     alias MethodBody = NamedTuple(signature: String, body: String)
 
     def analyze
@@ -121,7 +122,8 @@ module Analyzer::Scala
               body_type = "body"
             end
 
-            controller_methods[full_method_name] = {headers: headers, cookies: cookies, body_type: body_type}
+            callees = callees_needed? ? Noir::ScalaCalleeExtractor.callees_for_body(method_body, path, line_number_for_method_body(content, class_start_idx, method_name)) : [] of Noir::ScalaCalleeExtractor::Entry
+            controller_methods[full_method_name] = {headers: headers, cookies: cookies, body_type: body_type, callees: callees}
           end
         end
       end
@@ -281,7 +283,19 @@ module Analyzer::Scala
             endpoint.push_param(Param.new("body", "", body_type))
           end
         end
+
+        method_info[:callees].each do |name, path, line|
+          endpoint.push_callee(Callee.new(name, path: path, line: line))
+        end
       end
+    end
+
+    private def line_number_for_method_body(content : String, class_start_idx : Int32, method_name : String) : Int32
+      if method_start = content.index(/def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?\s*=\s*Action/, class_start_idx)
+        return content[0, method_start].count('\n') + 1
+      end
+
+      1
     end
 
     # Create an endpoint with the given path and method

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -1,4 +1,5 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Typescript
@@ -58,6 +59,7 @@ module Analyzer::Typescript
           endpoint = create_endpoint(normalized_path, "GET", path)
           extract_path_parameters(normalized_path, endpoint)
           extract_search_params(content, endpoint)
+          attach_file_route_callees(content, path, match.begin(0) || 0, endpoint) if callees_needed?
           result << endpoint
         end
       end
@@ -76,6 +78,7 @@ module Analyzer::Typescript
           endpoint = create_endpoint(normalized_path, "GET", path)
           extract_path_parameters(normalized_path, endpoint)
           extract_search_params(content, endpoint)
+          attach_file_route_callees(content, path, match.begin(0) || 0, endpoint) if callees_needed?
           result << endpoint
         end
       end
@@ -96,6 +99,7 @@ module Analyzer::Typescript
           endpoint = create_endpoint(resolved_path, "GET", path, route.start_pos, content)
           extract_path_parameters(resolved_path, endpoint)
           extract_search_params_from_route_block(route.block, endpoint)
+          attach_route_block_callees(route.block, path, line_for_pos(content, route.start_pos), endpoint) if callees_needed?
           result << endpoint
         end
       end
@@ -110,6 +114,7 @@ module Analyzer::Typescript
 
           endpoint = create_endpoint(normalized_path, "GET", path, match.begin(0) || 0, content)
           extract_path_parameters(normalized_path, endpoint)
+          attach_route_block_callees(match[0], path, line_for_pos(content, match.begin(0) || 0), endpoint) if callees_needed?
           result << endpoint
         end
       end
@@ -206,6 +211,69 @@ module Analyzer::Typescript
       line = content.empty? ? 1 : content.to_slice[0, start_pos].count('\n'.ord.to_u8) + 1
       endpoint.details = Details.new(PathInfo.new(file_path, line))
       endpoint
+    end
+
+    private def attach_file_route_callees(content : String, path : String, start_pos : Int32, endpoint : Endpoint)
+      call_open = content.index('(', start_pos)
+      return unless call_open
+      call_close = Noir::JSRouteExtractor.find_matching_paren(content, call_open)
+      return unless call_close
+
+      second_call_open = skip_whitespace(content, call_close + 1)
+      return unless content[second_call_open]? == '('
+
+      config_open = skip_whitespace(content, second_call_open + 1)
+      return unless content[config_open]? == '{'
+
+      second_call_close = Noir::JSRouteExtractor.find_matching_paren(content, second_call_open)
+      return unless second_call_close
+
+      config_close = Noir::JSRouteExtractor.find_matching_brace(content, config_open)
+      return unless config_close
+      return if config_close > second_call_close
+
+      block = content[(config_open + 1)...config_close]
+      attach_route_block_callees(block, path, line_for_pos(content, config_open), endpoint)
+    end
+
+    private def skip_whitespace(content : String, pos : Int32) : Int32
+      i = pos
+      while i < content.size && content[i].whitespace?
+        i += 1
+      end
+      i
+    end
+
+    private def attach_route_block_callees(block : String, path : String, start_line : Int32, endpoint : Endpoint)
+      attach_identifier_slot_callees(block, path, start_line, endpoint)
+      attach_function_slot_callees(block, path, start_line, endpoint)
+    end
+
+    private def attach_identifier_slot_callees(block : String, path : String, start_line : Int32, endpoint : Endpoint)
+      block.scan(/\b(component|loader|beforeLoad|pendingComponent|errorComponent)\s*:\s*([A-Za-z_$][\w$]*)/) do |match|
+        line = start_line + block[0, match.begin(2) || 0].count('\n')
+        endpoint.push_callee(Callee.new(match[2], path: path, line: line))
+      end
+    end
+
+    private def attach_function_slot_callees(block : String, path : String, start_line : Int32, endpoint : Endpoint)
+      block.scan(/\b(loader|beforeLoad)\s*:\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/) do |match|
+        body_start = match.end(0) || 0
+        body = block[body_start..]?.try(&.strip) || ""
+        line = start_line + block[0, body_start].count('\n')
+        if body.starts_with?("{")
+          if close = Noir::JSRouteExtractor.find_matching_brace(body, 0)
+            body = body[1...close]
+          end
+        end
+        Noir::JSCalleeExtractor.callees_for_function_body(body, path, line, language: javascript_source_language(path)).each do |name, callee_path, callee_line|
+          endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+        end
+      end
+    end
+
+    private def line_for_pos(content : String, pos : Int32) : Int32
+      content[0, pos].count('\n') + 1
     end
 
     private def extract_path_parameters(url : String, endpoint : Endpoint)

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -1,4 +1,5 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Typescript
@@ -49,7 +50,7 @@ module Analyzer::Typescript
 
       used_as_child = Set(String).new
       routers.each_value do |router|
-        each_top_level_kv(router.body) do |_key, value|
+        each_top_level_kv(router.body) do |_key, value, _value_line|
           ident = extract_identifier(value)
           used_as_child.add(ident) if ident && routers.has_key?(ident)
         end
@@ -164,7 +165,8 @@ module Analyzer::Typescript
 
         if i >= n || body[i] == ','
           # Shorthand: `userRouter,` — value is the same identifier.
-          yield key, key unless key.empty?
+          value_line = body[0, i].count('\n') + 1
+          yield key, key, value_line unless key.empty?
           i += 1 if i < n && body[i] == ','
           next
         end
@@ -179,7 +181,8 @@ module Analyzer::Typescript
         value_start = i
         value_end = skip_top_level_to_comma(body, i)
         value = body[value_start...value_end]
-        yield key, value unless key.empty?
+        value_line = body[0, value_start].count('\n') + 1
+        yield key, value, value_line unless key.empty?
         i = value_end
       end
     end
@@ -244,7 +247,7 @@ module Analyzer::Typescript
       return if visited.includes?(router.name)
       visited.add(router.name)
 
-      each_top_level_kv(router.body) do |key, value|
+      each_top_level_kv(router.body) do |key, value, value_line|
         next if key.empty?
 
         if ident = extract_identifier(value)
@@ -265,6 +268,8 @@ module Analyzer::Typescript
         endpoint.details = Details.new(PathInfo.new(router.file, router.line))
 
         attach_input_params(value, method, endpoint)
+        procedure_line = router.line + value_line - 1
+        attach_procedure_callees(value, router.file, procedure_line, endpoint) if callees_needed?
 
         result << endpoint
       end
@@ -280,6 +285,58 @@ module Analyzer::Typescript
       return "POST" if value.match(/\.\s*mutation\s*\(/)
       return "GET" if value.match(/\.\s*query\s*\(/)
       nil
+    end
+
+    private def attach_procedure_callees(value : String, file_path : String, procedure_line : Int32, endpoint : Endpoint)
+      resolver = procedure_resolver_body(value)
+      return unless resolver
+
+      body, relative_line = resolver
+      Noir::JSCalleeExtractor.callees_for_function_body(
+        body,
+        file_path,
+        procedure_line + relative_line - 1,
+        language: javascript_source_language(file_path)
+      ).each do |name, callee_path, line|
+        endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+      end
+    end
+
+    private def procedure_resolver_body(value : String) : Tuple(String, Int32)?
+      if resolver_match = value.match(/\.\s*(?:query|mutation|subscription)\s*\(/)
+        open_paren = (resolver_match.end(0) || 0) - 1
+        close_paren = Noir::JSRouteExtractor.find_matching_paren(value, open_paren)
+        return unless close_paren
+
+        resolver_source = value[(open_paren + 1)...close_paren]
+        line = value[0, open_paren + 1].count('\n') + 1
+        return arrow_function_body(resolver_source, line) || function_expression_body(resolver_source, line)
+      end
+    end
+
+    private def arrow_function_body(source : String, start_line : Int32) : Tuple(String, Int32)?
+      arrow = source.index("=>")
+      return unless arrow
+
+      after_arrow = source[(arrow + 2)..].strip
+      line = start_line + source[0, arrow + 2].count('\n')
+      if after_arrow.starts_with?("{")
+        if close = Noir::JSRouteExtractor.find_matching_brace(after_arrow, 0)
+          return {after_arrow[1...close], line}
+        end
+      end
+
+      {after_arrow, line}
+    end
+
+    private def function_expression_body(source : String, start_line : Int32) : Tuple(String, Int32)?
+      if match = source.match(/\bfunction\b[^{]*\{/)
+        open_brace = (match.end(0) || 0) - 1
+        if close = Noir::JSRouteExtractor.find_matching_brace(source, open_brace)
+          line = start_line + source[0, open_brace + 1].count('\n')
+          return {source[(open_brace + 1)...close], line}
+        end
+      end
     end
 
     private def attach_input_params(value : String, method : String, endpoint : Endpoint)

--- a/src/miniparsers/adonisjs_extractor_ts.cr
+++ b/src/miniparsers/adonisjs_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./js_callee_extractor"
 
 module Noir
   # Tree-sitter-backed AdonisJS extractor.
@@ -83,22 +84,23 @@ module Noir
       getter verb : String
       getter path : String
       getter line : Int32
+      getter callees : Array(JSCalleeExtractor::Entry)
 
-      def initialize(@verb, @path, @line)
+      def initialize(@verb, @path, @line, @callees = [] of JSCalleeExtractor::Entry)
       end
     end
 
-    def extract_routes(source : String) : Array(Route)
+    def extract_routes(source : String, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_javascript(source) do |root|
-        walk(root, source, "", routes, 0)
+        walk(root, source, "", routes, 0, include_callees)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       if Noir::TreeSitter.node_type(node) == "call_expression"
@@ -106,34 +108,34 @@ module Noir
 
         case
         when HTTP_VERB_METHODS.has_key?(method)
-          emit_verb(node, source, HTTP_VERB_METHODS[method], prefix, routes)
+          emit_verb(node, source, HTTP_VERB_METHODS[method], prefix, routes, include_callees)
           return
         when method == "any"
-          ANY_VERBS.each { |verb| emit_verb(node, source, verb, prefix, routes) }
+          ANY_VERBS.each { |verb| emit_verb(node, source, verb, prefix, routes, include_callees) }
           return
         when method == GROUP_METHOD
-          walk_group(node, source, prefix, routes, depth)
+          walk_group(node, source, prefix, routes, depth, include_callees)
           return
         when method == "resource"
-          emit_resource(node, source, prefix, ANY_VERBS_ALL, routes)
+          emit_resource(node, source, prefix, ANY_VERBS_ALL, routes, include_callees)
           return
         when method == "prefix"
-          handle_prefix(node, source, prefix, routes, depth)
+          handle_prefix(node, source, prefix, routes, depth, include_callees)
           return
         when method == "only"
-          handle_resource_filter(node, source, prefix, :only, routes)
+          handle_resource_filter(node, source, prefix, :only, routes, include_callees)
           return
         when method == "except"
-          handle_resource_filter(node, source, prefix, :except, routes)
+          handle_resource_filter(node, source, prefix, :except, routes, include_callees)
           return
         when TRANSPARENT_MODIFIERS.includes?(method)
-          handle_transparent(node, source, prefix, routes, depth)
+          handle_transparent(node, source, prefix, routes, depth, include_callees)
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1)
+        walk(child, source, prefix, routes, depth + 1, include_callees)
       end
     end
 
@@ -144,24 +146,24 @@ module Noir
 
     # `Route.group(cb).prefix('/x')` — capture '/x' and walk the
     # inner call's group with the joined prefix.
-    private def handle_prefix(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def handle_prefix(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       arg = first_string_argument(call, source)
       receiver = chain_receiver(call)
       return unless receiver
 
       new_prefix = arg ? join_paths(prefix, arg) : prefix
-      walk(receiver, source, new_prefix, routes, depth + 1)
+      walk(receiver, source, new_prefix, routes, depth + 1, include_callees)
     end
 
-    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       receiver = chain_receiver(call)
       return unless receiver
-      walk(receiver, source, prefix, routes, depth + 1)
+      walk(receiver, source, prefix, routes, depth + 1, include_callees)
     end
 
     # `.only([...])` / `.except([...])` modifiers on `.resource(...)`.
     # Walk back to the resource call with the action filter applied.
-    private def handle_resource_filter(call : LibTreeSitter::TSNode, source : String, prefix : String, mode : Symbol, routes : Array(Route))
+    private def handle_resource_filter(call : LibTreeSitter::TSNode, source : String, prefix : String, mode : Symbol, routes : Array(Route), include_callees : Bool)
       receiver = chain_receiver(call)
       return unless receiver
       return unless Noir::TreeSitter.node_type(receiver) == "call_expression"
@@ -177,10 +179,10 @@ module Noir
         else
           ANY_VERBS_ALL
         end
-      emit_resource(receiver, source, prefix, effective, routes)
+      emit_resource(receiver, source, prefix, effective, routes, include_callees)
     end
 
-    private def walk_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       args = arguments_node(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
@@ -188,20 +190,21 @@ module Noir
                     Noir::TreeSitter.node_type(arg) == "function_expression" ||
                     Noir::TreeSitter.node_type(arg) == "function"
         if body = function_body(arg)
-          walk(body, source, prefix, routes, depth + 1)
+          walk(body, source, prefix, routes, depth + 1, include_callees)
         end
       end
     end
 
-    private def emit_verb(call : LibTreeSitter::TSNode, source : String, verb : String, prefix : String, routes : Array(Route))
+    private def emit_verb(call : LibTreeSitter::TSNode, source : String, verb : String, prefix : String, routes : Array(Route), include_callees : Bool)
       path = first_string_argument(call, source)
       return unless path
       full = join_paths(prefix, path)
       line = Noir::TreeSitter.node_start_row(call)
-      routes << Route.new(verb, full, line)
+      callees = include_callees ? route_callees(call, source, line) : [] of JSCalleeExtractor::Entry
+      routes << Route.new(verb, full, line, callees)
     end
 
-    private def emit_resource(call : LibTreeSitter::TSNode, source : String, prefix : String, actions : Array(String), routes : Array(Route))
+    private def emit_resource(call : LibTreeSitter::TSNode, source : String, prefix : String, actions : Array(String), routes : Array(Route), include_callees : Bool)
       name = first_string_argument(call, source)
       return unless name
       base = join_paths(prefix, name.starts_with?("/") ? name : "/#{name}")
@@ -212,8 +215,24 @@ module Noir
         next unless verb_path
         verb, suffix = verb_path
         url = suffix.empty? ? base : "#{base.rstrip('/')}#{suffix}"
-        routes << Route.new(verb, url, line)
+        callees = include_callees ? [{controller_action(call, source, action), "", line + 1}] : [] of JSCalleeExtractor::Entry
+        routes << Route.new(verb, url, line, callees)
       end
+    end
+
+    private def route_callees(call : LibTreeSitter::TSNode, source : String, line : Int32) : Array(JSCalleeExtractor::Entry)
+      entries = [] of JSCalleeExtractor::Entry
+      if controller = string_argument_at(call, source, 1)
+        entries << {controller, "", line + 1}
+      elsif handler = function_argument(call)
+        entries = JSCalleeExtractor.callees_for_handler_node(handler, source, "")
+      end
+      entries
+    end
+
+    private def controller_action(call : LibTreeSitter::TSNode, source : String, action : String) : String
+      controller = string_argument_at(call, source, 1) || "resource"
+      "#{controller}.#{action}"
     end
 
     # ---- shape helpers ----------------------------------------------
@@ -250,10 +269,27 @@ module Noir
     end
 
     private def first_string_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      string_argument_at(call, source, 0)
+    end
+
+    private def string_argument_at(call : LibTreeSitter::TSNode, source : String, target_index : Int32) : String?
+      args = arguments_node(call)
+      return unless args
+      index = 0
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "string"
+        return decode_string(arg, source) if index == target_index
+        index += 1
+      end
+      nil
+    end
+
+    private def function_argument(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
       args = arguments_node(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
-        return decode_string(arg, source) if Noir::TreeSitter.node_type(arg) == "string"
+        type = Noir::TreeSitter.node_type(arg)
+        return arg if type == "arrow_function" || type == "function_expression" || type == "function"
       end
       nil
     end

--- a/src/miniparsers/elysia_extractor_ts.cr
+++ b/src/miniparsers/elysia_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./js_callee_extractor"
 
 module Noir
   # Tree-sitter-backed Elysia extractor.
@@ -75,49 +76,51 @@ module Noir
       getter query_params : Array(String)
       getter header_params : Array(String)
       getter cookie_params : Array(String)
+      getter callees : Array(JSCalleeExtractor::Entry)
 
       def initialize(@verb, @path, @line, @has_body,
-                     @query_params, @header_params, @cookie_params)
+                     @query_params, @header_params, @cookie_params,
+                     @callees = [] of JSCalleeExtractor::Entry)
       end
     end
 
-    def extract_routes(source : String) : Array(Route)
+    def extract_routes(source : String, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_javascript(source) do |root|
-        walk(root, source, "", routes, 0)
+        walk(root, source, "", routes, 0, include_callees)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       if Noir::TreeSitter.node_type(node) == "call_expression"
         method = chain_method_name(node, source)
         case
         when HTTP_VERB_METHODS.has_key?(method)
-          emit_route(node, source, HTTP_VERB_METHODS[method], prefix, routes)
-          walk_chain_predecessor(node, source, prefix, routes, depth)
+          emit_route(node, source, HTTP_VERB_METHODS[method], prefix, routes, include_callees)
+          walk_chain_predecessor(node, source, prefix, routes, depth, include_callees)
           return
         when method == "all"
-          ALL_VERBS.each { |verb| emit_route(node, source, verb, prefix, routes) }
-          walk_chain_predecessor(node, source, prefix, routes, depth)
+          ALL_VERBS.each { |verb| emit_route(node, source, verb, prefix, routes, include_callees) }
+          walk_chain_predecessor(node, source, prefix, routes, depth, include_callees)
           return
         when GROUP_METHODS.includes?(method)
-          handle_group(node, source, prefix, routes, depth)
-          walk_chain_predecessor(node, source, prefix, routes, depth)
+          handle_group(node, source, prefix, routes, depth, include_callees)
+          walk_chain_predecessor(node, source, prefix, routes, depth, include_callees)
           return
         when TRANSPARENT_METHODS.includes?(method)
-          handle_transparent(node, source, prefix, routes, depth)
-          walk_chain_predecessor(node, source, prefix, routes, depth)
+          handle_transparent(node, source, prefix, routes, depth, include_callees)
+          walk_chain_predecessor(node, source, prefix, routes, depth, include_callees)
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1)
+        walk(child, source, prefix, routes, depth + 1, include_callees)
       end
     end
 
@@ -138,16 +141,16 @@ module Noir
     # Continue down the chain into the prior link's call_expression
     # — `a.get(...).post(...)` outer has the inner `a.get(...)` as
     # the member_expression's first child.
-    private def walk_chain_predecessor(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def walk_chain_predecessor(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       callee = first_named_child(call)
       return unless callee
       return unless Noir::TreeSitter.node_type(callee) == "member_expression"
       inner = first_named_child(callee)
       return unless inner
-      walk(inner, source, prefix, routes, depth + 1) if Noir::TreeSitter.node_type(inner) == "call_expression"
+      walk(inner, source, prefix, routes, depth + 1, include_callees) if Noir::TreeSitter.node_type(inner) == "call_expression"
     end
 
-    private def handle_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def handle_group(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       args = arguments_node(call)
       return unless args
 
@@ -164,21 +167,21 @@ module Noir
       return unless group_path && group_body
 
       new_prefix = join_paths(prefix, group_path)
-      walk(group_body, source, new_prefix, routes, depth + 1)
+      walk(group_body, source, new_prefix, routes, depth + 1, include_callees)
     end
 
-    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32)
+    private def handle_transparent(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       args = arguments_node(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "arrow_function"
         if body = arrow_body(arg)
-          walk(body, source, prefix, routes, depth + 1)
+          walk(body, source, prefix, routes, depth + 1, include_callees)
         end
       end
     end
 
-    private def emit_route(call : LibTreeSitter::TSNode, source : String, verb : String, prefix : String, routes : Array(Route))
+    private def emit_route(call : LibTreeSitter::TSNode, source : String, verb : String, prefix : String, routes : Array(Route), include_callees : Bool)
       args = arguments_node(call)
       return unless args
 
@@ -201,6 +204,7 @@ module Noir
       header_params = [] of String
       cookie_params = [] of String
       has_body = false
+      callees = [] of JSCalleeExtractor::Entry
 
       if handler
         scan_handler(handler, source, 0) do |kind, value|
@@ -211,10 +215,11 @@ module Noir
           when :body   then has_body = true
           end
         end
+        callees = JSCalleeExtractor.callees_for_handler_node(handler, source, "") if include_callees
       end
 
       routes << Route.new(verb, full_path, line, has_body,
-        query_params, header_params, cookie_params)
+        query_params, header_params, cookie_params, callees)
     end
 
     # ---- handler-body scan ------------------------------------------

--- a/src/miniparsers/hapi_extractor_ts.cr
+++ b/src/miniparsers/hapi_extractor_ts.cr
@@ -1,5 +1,6 @@
 require "../ext/tree_sitter/tree_sitter"
 require "../models/endpoint"
+require "./js_callee_extractor"
 
 module Noir
   # Tree-sitter-backed Hapi extractor.
@@ -55,32 +56,34 @@ module Noir
       getter query_params : Array(String)
       getter header_params : Array(String)
       getter cookie_params : Array(String)
+      getter callees : Array(JSCalleeExtractor::Entry)
 
       def initialize(@verb, @path, @line, @has_body,
-                     @query_params, @header_params, @cookie_params)
+                     @query_params, @header_params, @cookie_params,
+                     @callees = [] of JSCalleeExtractor::Entry)
       end
     end
 
-    def extract_routes(source : String) : Array(Route)
+    def extract_routes(source : String, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       Noir::TreeSitter.parse_javascript(source) do |root|
-        walk(root, source, routes, 0)
+        walk(root, source, routes, 0, include_callees)
       end
       routes
     end
 
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, routes : Array(Route), depth : Int32)
+    private def walk(node : LibTreeSitter::TSNode, source : String, routes : Array(Route), depth : Int32, include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       if Noir::TreeSitter.node_type(node) == "call_expression" && route_call?(node, source)
-        emit_routes(node, source, routes)
+        emit_routes(node, source, routes, include_callees)
         return
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, routes, depth + 1)
+        walk(child, source, routes, depth + 1, include_callees)
       end
     end
 
@@ -97,23 +100,23 @@ module Noir
       false
     end
 
-    private def emit_routes(call : LibTreeSitter::TSNode, source : String, routes : Array(Route))
+    private def emit_routes(call : LibTreeSitter::TSNode, source : String, routes : Array(Route), include_callees : Bool)
       args = arguments_node(call)
       return unless args
 
       Noir::TreeSitter.each_named_child(args) do |arg|
         case Noir::TreeSitter.node_type(arg)
         when "object"
-          emit_route_object(arg, source, routes)
+          emit_route_object(arg, source, routes, include_callees)
         when "array"
           Noir::TreeSitter.each_named_child(arg) do |elem|
-            emit_route_object(elem, source, routes) if Noir::TreeSitter.node_type(elem) == "object"
+            emit_route_object(elem, source, routes, include_callees) if Noir::TreeSitter.node_type(elem) == "object"
           end
         end
       end
     end
 
-    private def emit_route_object(obj : LibTreeSitter::TSNode, source : String, routes : Array(Route))
+    private def emit_route_object(obj : LibTreeSitter::TSNode, source : String, routes : Array(Route), include_callees : Bool)
       methods = [] of String
       path : String? = nil
       handler : LibTreeSitter::TSNode? = nil
@@ -141,6 +144,7 @@ module Noir
       header_params = [] of String
       cookie_params = [] of String
       has_body = false
+      callees = [] of JSCalleeExtractor::Entry
 
       if handler
         scan_handler(handler, source, 0) do |kind, value|
@@ -151,11 +155,12 @@ module Noir
           when :body   then has_body = true
           end
         end
+        callees = JSCalleeExtractor.callees_for_handler_node(handler, source, "") if include_callees
       end
 
       methods.each do |verb|
         routes << Route.new(verb, resolved_path, line, has_body,
-          query_params, header_params, cookie_params)
+          query_params, header_params, cookie_params, callees)
       end
     end
 

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -69,6 +69,16 @@ module Noir::JSCalleeExtractor
     language == :typescript ? fallback_callees_for_function_body(body, file_path, open_brace_line) : [] of Entry
   end
 
+  def callees_for_handler_node(handler : LibTreeSitter::TSNode,
+                               source : String,
+                               file_path : String) : Array(Entry)
+    sink = [] of Entry
+    walk_callees(handler_body(handler), source, file_path, sink, 0)
+    dedup_entries(sink)
+  rescue
+    [] of Entry
+  end
+
   def callees_for_exported_function(source : String,
                                     file_path : String,
                                     export_name : String) : Array(Entry)

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -15,7 +15,8 @@ module NoirTechs
     "haskell_scotty", "haskell_servant", "haskell_yesod",
     "java_armeria", "java_dropwizard", "java_jaxrs", "java_javalin", "java_micronaut",
     "java_play", "java_quarkus", "java_spark", "java_spring", "java_vertx",
-    "js_apollo", "js_express", "js_fastify", "js_hono", "js_koa", "js_nestjs", "js_nextjs",
+    "js_adonisjs", "js_apollo", "js_astro", "js_elysia", "js_express", "js_fastify",
+    "js_fresh", "js_hapi", "js_hono", "js_koa", "js_nestjs", "js_nextjs",
     "js_nitro", "js_nuxtjs", "js_remix", "js_restify", "js_sveltekit",
     "kotlin_http4k", "kotlin_ktor", "kotlin_spring",
     "lua_lapis",
@@ -26,9 +27,9 @@ module NoirTechs
     "ruby_grape", "ruby_hanami", "ruby_rails", "ruby_roda", "ruby_sinatra",
     "rust_actix_web", "rust_axum", "rust_gotham", "rust_loco", "rust_poem",
     "rust_rocket", "rust_rwf", "rust_salvo", "rust_tide", "rust_warp",
-    "scala_akka", "scala_http4s", "scala_scalatra", "scala_tapir", "scala_zio_http",
+    "scala_akka", "scala_http4s", "scala_play", "scala_scalatra", "scala_tapir", "scala_zio_http",
     "swift_hummingbird", "swift_kitura", "swift_vapor",
-    "ts_nestjs",
+    "ts_nestjs", "ts_tanstack_router", "ts_trpc",
   ]
 
   AI_CONTEXT_GUARD_SUPPORTED_TECHS = [


### PR DESCRIPTION
## Summary
- add callee extraction for AdonisJS, Astro, Elysia, Fresh, Hapi, tRPC, TanStack Router, and Scala Play analyzers
- advertise the newly supported techs in CALLEE_SUPPORTED_TECHS
- add functional coverage for callee output and regression cases for Fresh handler properties, TanStack empty file routes, and tRPC callee line anchoring

## Tests
- crystal spec spec/functional_test/testers/typescript/tanstack_router_spec.cr spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr spec/functional_test/testers/javascript/fresh_callees_spec.cr spec/functional_test/testers/typescript/trpc_callees_spec.cr
- just build
- just test