### PR TITLE
Fix callee lint issues

### DIFF
--- a/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
@@ -29,5 +29,7 @@ it "does not attach callees from unrelated objects after empty file routes" do
 
   empty = app.endpoints.find { |endpoint| endpoint.method == "GET" && endpoint.url == "/empty" }
   empty.should_not be_nil
-  empty.not_nil!.callees.map(&.name).includes?("Secret.run").should be_false
+  if empty
+    empty.callees.map(&.name).includes?("Secret.run").should be_false
+  end
 end

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -310,7 +310,7 @@ module Analyzer::Typescript
 
         resolver_source = value[(open_paren + 1)...close_paren]
         line = value[0, open_paren + 1].count('\n') + 1
-        return arrow_function_body(resolver_source, line) || function_expression_body(resolver_source, line)
+        arrow_function_body(resolver_source, line) || function_expression_body(resolver_source, line)
       end
     end
 


### PR DESCRIPTION
## Summary
- avoid not_nil! in the TanStack Router callee regression spec
- remove redundant return in tRPC callee resolver parsing

## Tests
- crystal spec spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr spec/functional_test/testers/typescript/trpc_callees_spec.cr
- lib/ameba/bin/ameba.cr src/analyzer/analyzers/typescript/trpc.cr spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr