### PR TITLE
Fix existing Ameba lint warnings

### DIFF
--- a/spec/unit_test/analyzer/specification/nginx_spec.cr
+++ b/spec/unit_test/analyzer/specification/nginx_spec.cr
@@ -41,8 +41,8 @@ describe "Nginx Analyzer" do
       {"/v1/users", "prefix"},
       {"^/admin/.*", "regex"},
     ])
-    endpoints.each { |e| e.method.should eq "ANY" }
-    endpoints.each { |e| e.protocol.should eq "https" }
+    endpoints.each(&.method.should(eq("ANY")))
+    endpoints.each(&.protocol.should(eq("https")))
   end
 
   it "emits method-specific endpoints from if (\\$request_method) blocks" do

--- a/spec/unit_test/utils/groovy_literal_scanner_spec.cr
+++ b/spec/unit_test/utils/groovy_literal_scanner_spec.cr
@@ -1,6 +1,13 @@
 require "spec"
 require "../../../src/utils/groovy_literal_scanner"
 
+private def expect_remaining(content : String, result : Int32?, expected : String)
+  result.should_not be_nil
+  if index = result
+    content[index..].should eq(expected)
+  end
+end
+
 describe Noir::GroovyLiteralScanner do
   describe "skip_literal" do
     context "single-line strings" do
@@ -8,28 +15,28 @@ describe Noir::GroovyLiteralScanner do
         content = %("hello" world)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
         result.should eq(7)
-        content[result.not_nil!..].should eq(" world")
+        expect_remaining(content, result, " world")
       end
 
       it "skips a single-quoted string" do
         content = %('hello' world)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
         result.should eq(7)
-        content[result.not_nil!..].should eq(" world")
+        expect_remaining(content, result, " world")
       end
 
       it "handles escaped quotes in double-quoted strings" do
         content = %("a\\"b" tail)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
         result.should eq(6)
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "handles escaped quotes in single-quoted strings" do
         content = %('a\\'b' tail)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
         result.should eq(6)
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "returns content size for an unterminated quoted string" do
@@ -43,30 +50,26 @@ describe Noir::GroovyLiteralScanner do
       it "skips a triple double-quoted string" do
         content = %("""line1\nline2""" tail)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
-        result.should_not be_nil
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "skips a triple single-quoted string" do
         content = %('''multi\nline''' tail)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
-        result.should_not be_nil
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "treats triple quote with single inner quote as still inside the literal" do
         content = %("""has " inside""" tail)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
-        result.should_not be_nil
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "respects an escaped closing triple quote" do
         # The third quote is escaped, so the literal continues past it.
         content = %("""a\\""" still""" tail)
         result = Noir::GroovyLiteralScanner.skip_literal(content, 0)
-        result.should_not be_nil
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
     end
 
@@ -76,7 +79,7 @@ describe Noir::GroovyLiteralScanner do
         # '/' is at index 8
         result = Noir::GroovyLiteralScanner.skip_literal(content, 8)
         result.should eq(13)
-        content[result.not_nil!..].should eq(", x)")
+        expect_remaining(content, result, ", x)")
       end
 
       it "skips a slashy literal after a keyword (return)" do
@@ -89,7 +92,7 @@ describe Noir::GroovyLiteralScanner do
         content = "case /abc/:"
         result = Noir::GroovyLiteralScanner.skip_literal(content, 5)
         result.should eq(10)
-        content[result.not_nil!..].should eq(":")
+        expect_remaining(content, result, ":")
       end
 
       it "honors escaped slashes inside a slashy literal" do
@@ -97,7 +100,7 @@ describe Noir::GroovyLiteralScanner do
         # '/' that starts the regex is at index 2
         result = Noir::GroovyLiteralScanner.skip_literal(content, 2)
         result.should eq(8)
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "does not treat // as a slashy literal start" do
@@ -136,16 +139,14 @@ describe Noir::GroovyLiteralScanner do
         content = "x = $/regex with /slash/$ tail"
         # '$' is at index 4
         result = Noir::GroovyLiteralScanner.skip_literal(content, 4)
-        result.should_not be_nil
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "respects an escaped closing delimiter ($/) in dollar-slashy" do
         # The first /$ is preceded by '$', meaning it's escaped per the module's rule.
         content = "x = $/foo$/$ still/$ tail"
         result = Noir::GroovyLiteralScanner.skip_literal(content, 4)
-        result.should_not be_nil
-        content[result.not_nil!..].should eq(" tail")
+        expect_remaining(content, result, " tail")
       end
 
       it "returns content size for unterminated dollar-slashy" do


### PR DESCRIPTION
## Summary
- replace Groovy literal scanner spec not_nil! assertions with a small helper
- use short block notation in nginx analyzer spec

## Tests
- crystal spec spec/unit_test/utils/groovy_literal_scanner_spec.cr spec/unit_test/analyzer/specification/nginx_spec.cr
- lib/ameba/bin/ameba.cr spec/unit_test/utils/groovy_literal_scanner_spec.cr spec/unit_test/analyzer/specification/nginx_spec.cr
- just check