### PR TITLE
Improve Ruby route analyzers

### DIFF
--- a/spec/functional_test/fixtures/ruby/grape/app.rb
+++ b/spec/functional_test/fixtures/ruby/grape/app.rb
@@ -38,4 +38,19 @@ class API < Grape::API
     post do
     end
   end
+
+  resource :accounts do
+    route_param :account_id do
+      get "profile" do
+        params[:expand]
+      end
+    end
+  end
+
+  version "v2", using: :path
+
+  resource :status do
+    get do
+    end
+  end
 end

--- a/spec/functional_test/fixtures/ruby/roda/app.rb
+++ b/spec/functional_test/fixtures/ruby/roda/app.rb
@@ -34,5 +34,22 @@ class App < Roda
         end
       end
     end
+
+    r.is "projects", Integer do |project_id|
+      r.get do
+      end
+    end
+
+    r.on "teams" do
+      r.get Integer do |team_id|
+      end
+    end
+
+    r.on "organizations" do
+      r.on :org_id, Integer do |org_id, project_id|
+        r.get do
+        end
+      end
+    end
   end
 end

--- a/spec/functional_test/fixtures/ruby/sinatra/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra/app.rb
@@ -31,3 +31,13 @@ end
 post "/update" do
   puts "update"
 end
+
+namespace "/api" do
+  get "/widgets" do
+    params[:page]
+  end
+
+  post("/widgets") do
+    request.env["HTTP_X_TRACE_ID"]
+  end
+end

--- a/spec/functional_test/testers/ruby/grape_spec.cr
+++ b/spec/functional_test/testers/ruby/grape_spec.cr
@@ -16,9 +16,14 @@ expected_endpoints = [
   ]),
   Endpoint.new("/orders", "GET"),
   Endpoint.new("/orders", "POST"),
+  Endpoint.new("/accounts/{account_id}/profile", "GET", [
+    Param.new("account_id", "", "path"),
+    Param.new("expand", "", "query"),
+  ]),
+  Endpoint.new("/v2/status", "GET"),
 ]
 
 FunctionalTester.new("fixtures/ruby/grape/", {
   :techs     => 1,
-  :endpoints => 7,
+  :endpoints => 9,
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/ruby/roda_spec.cr
+++ b/spec/functional_test/testers/ruby/roda_spec.cr
@@ -20,6 +20,16 @@ expected_endpoints = [
     Param.new("session", "", "cookie"),
   ]),
   Endpoint.new("/api/v1/items", "GET"),
+  Endpoint.new("/projects/{project_id}", "GET", [
+    Param.new("project_id", "", "path"),
+  ]),
+  Endpoint.new("/teams/{team_id}", "GET", [
+    Param.new("team_id", "", "path"),
+  ]),
+  Endpoint.new("/organizations/{org_id}/{project_id}", "GET", [
+    Param.new("org_id", "", "path"),
+    Param.new("project_id", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/ruby/roda/", {

--- a/spec/functional_test/testers/ruby/sinatra_spec.cr
+++ b/spec/functional_test/testers/ruby/sinatra_spec.cr
@@ -7,9 +7,15 @@ expected_endpoints = [
     Param.new("cookie2", "", "cookie"),
   ]),
   Endpoint.new("/update", "POST"),
+  Endpoint.new("/api/widgets", "GET", [
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/api/widgets", "POST", [
+    Param.new("HTTP_X_TRACE_ID", "", "header"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/ruby/sinatra/", {
   :techs     => 1,
-  :endpoints => 2,
+  :endpoints => 4,
 }, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -25,6 +25,7 @@ module Analyzer::Ruby
       prefix_segments = [] of String
       block_kinds = [] of Symbol
       class_prefix = ""
+      version_prefix = ""
       pending_params = [] of String
       in_params_block = false
       last_endpoint : Endpoint? = nil
@@ -56,21 +57,35 @@ module Analyzer::Ruby
           next
         end
 
+        if m = stripped.match(/^version\s+(.+)\busing:\s*:path\b/)
+          version_prefix = parse_first_grape_version(m[1])
+          next
+        end
+
         if m = stripped.match(/^(?:resource|resources|namespace|group|segment)\s+['":]([\w\/\-:]+)[\'""]?\s+do\b/)
           prefix_segments << m[1].to_s
           block_kinds << :prefix
           next
         end
 
+        if m = stripped.match(/^route_param\s+(?::(\w+)|['"]([^'"]+)['"])\s+do\b/)
+          name = (m[1]? || m[2]?).to_s
+          unless name.empty?
+            prefix_segments << "{#{name}}"
+            block_kinds << :prefix
+            next
+          end
+        end
+
         verb_handled = false
         GRAPE_VERBS.each do |verb|
           if m = stripped.match(/^#{verb}\b(?:\s+(['":][\w\/\-:]+[\'""]?))?(?:\s*,[^#]*?)?\s*do\b/)
             raw_path = (m[1]? || "").to_s.gsub(/['"]/, "")
-            ep_path = build_path(class_prefix, prefix_segments, raw_path)
+            ep_path = build_path(class_prefix, version_prefix, prefix_segments, raw_path)
             details = Details.new(PathInfo.new(path, index + 1))
             endpoint = Endpoint.new(ep_path, verb.upcase, details)
 
-            extract_path_params(raw_path).each do |param_name|
+            extract_path_params(ep_path).each do |param_name|
               endpoint.push_param(Param.new(param_name, "", "path"))
             end
 
@@ -89,9 +104,13 @@ module Analyzer::Ruby
           end
 
           if m = stripped.match(/^#{verb}\s+do\b/)
-            ep_path = build_path(class_prefix, prefix_segments, "")
+            ep_path = build_path(class_prefix, version_prefix, prefix_segments, "")
             details = Details.new(PathInfo.new(path, index + 1))
             endpoint = Endpoint.new(ep_path, verb.upcase, details)
+
+            extract_path_params(ep_path).each do |param_name|
+              endpoint.push_param(Param.new(param_name, "", "path"))
+            end
 
             pending_params.each do |param_name|
               endpoint.push_param(Param.new(param_name, "", "json"))
@@ -112,17 +131,17 @@ module Analyzer::Ruby
         if le = last_endpoint
           line.scan(/\bparams\[['"]?:?([\w-]+)['"]?\]/) do |match|
             if match.size > 1
-              le.push_param(Param.new(match[1], "", "query"))
+              push_grape_param(le, Param.new(match[1], "", "query"))
             end
           end
           line.scan(/\bheaders\[['"]?:?([\w-]+)['"]?\]/) do |match|
             if match.size > 1
-              le.push_param(Param.new(match[1], "", "header"))
+              push_grape_param(le, Param.new(match[1], "", "header"))
             end
           end
           line.scan(/\bcookies\[['"]?:?([\w-]+)['"]?\]/) do |match|
             if match.size > 1
-              le.push_param(Param.new(match[1], "", "cookie"))
+              push_grape_param(le, Param.new(match[1], "", "cookie"))
             end
           end
         end
@@ -140,6 +159,22 @@ module Analyzer::Ruby
       end
     end
 
+    private def push_grape_param(endpoint : Endpoint, param : Param)
+      return if param.param_type == "query" && endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == "path" }
+      return if endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+      endpoint.push_param(param)
+    end
+
+    private def parse_first_grape_version(args : String) : String
+      if m = args.match(/['"]([^'"]+)['"]/)
+        return m[1]
+      end
+      if m = args.match(/:(\w+)/)
+        return m[1]
+      end
+      ""
+    end
+
     private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
       if block = extract_ruby_do_block(lines, index)
         body, body_start_line = block
@@ -148,9 +183,10 @@ module Analyzer::Ruby
       end
     end
 
-    private def build_path(class_prefix : String, prefix_segments : Array(String), raw : String) : String
+    private def build_path(class_prefix : String, version_prefix : String, prefix_segments : Array(String), raw : String) : String
       parts = [] of String
       parts << class_prefix unless class_prefix.empty?
+      parts << version_prefix unless version_prefix.empty?
       prefix_segments.each { |s| parts << s }
       unless raw.empty?
         cleaned = raw.starts_with?('/') ? raw[1..] : raw
@@ -165,6 +201,9 @@ module Analyzer::Ruby
       names = [] of String
       raw.scan(/:([a-zA-Z_][\w]*)/) do |m|
         names << m[1] if m.size > 1
+      end
+      raw.scan(/\{([a-zA-Z_][\w]*)\}/) do |m|
+        names << m[1] if m.size > 1 && !names.includes?(m[1])
       end
       names
     end

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -75,8 +75,8 @@ module Analyzer::Ruby
                                    prefix_stack : Array(PrefixEntry),
                                    lines : Array(String),
                                    include_callee : Bool) : Int32
-      if m = line.match(/\br\.on\s+(.+?)\s*(?:do\b|\{)/)
-        segments, path_params = parse_on_args(m[1])
+      if m = line.match(/\br\.(?:on|is)\s+(.+?)\s*(?:do\b\s*(?:\|([^|]*)\|)?|\{\s*(?:\|([^|]*)\|)?)/)
+        segments, path_params = parse_on_args(m[1], m[2]? || m[3]?)
         unless segments.empty? && path_params.empty?
           prefix_stack << {depth: depth + 1, segments: segments, path_params: path_params}
         end
@@ -94,6 +94,19 @@ module Analyzer::Ruby
       end
 
       HTTP_METHOD_MATCHERS.each do |verb|
+        if m = line.match(/\br\.#{verb}\s+(.+?)\s*(?:do\b\s*(?:\|([^|]*)\|)?|\{\s*(?:\|([^|]*)\|)?)/)
+          segments, path_params = parse_on_args(m[1], m[2]? || m[3]?)
+          unless segments.empty? && path_params.empty?
+            url = build_url(collect_segments(prefix_stack), nil, segments)
+            ep = build_endpoint(url, verb.upcase, path, index)
+            apply_path_params(ep, prefix_stack)
+            path_params.each { |name| ep.push_param(Param.new(name, "", "path")) }
+            attach_route_callees(ep, lines, index, path) if include_callee
+            @result << ep
+            return @result.size - 1
+          end
+        end
+
         if m = line.match(/\br\.#{verb}\s+['"]([^'"]+)['"]/)
           url = build_url(collect_segments(prefix_stack), m[1], nil)
           ep = build_endpoint(url, verb.upcase, path, index)
@@ -268,9 +281,12 @@ module Analyzer::Ruby
       end
     end
 
-    private def parse_on_args(args : String) : Tuple(Array(String), Array(String))
+    private def parse_on_args(args : String, block_args : String? = nil) : Tuple(Array(String), Array(String))
       segments = [] of String
       path_params = [] of String
+      matcher_arg_names = block_args ? block_args.split(",").map(&.strip).reject(&.empty?) : [] of String
+      matcher_index = 0
+
       args.split(",").each do |part|
         token = part.strip
         next if token.empty?
@@ -280,6 +296,16 @@ module Analyzer::Ruby
             segments << "{#{name}}"
             path_params << name
           end
+          matcher_index += 1
+        elsif token.matches?(/\A(?:Integer|String|Float|Hash|Array|[A-Z]\w*)\z/)
+          if name = matcher_arg_names[matcher_index]?
+            clean_name = name.gsub(/[^\w]/, "")
+            unless clean_name.empty?
+              segments << "{#{clean_name}}"
+              path_params << clean_name
+            end
+          end
+          matcher_index += 1
         elsif m = token.match(/['"]([^'"]+)['"]/)
           segments << m[1]
         end

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -16,6 +16,8 @@ module Analyzer::Ruby
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           lines = file.each_line.to_a
           last_endpoint = Endpoint.new("", "")
+          prefix_stack = [] of NamedTuple(depth: Int32, path: String)
+          depth = 0
           lines.each_with_index do |line, index|
             next unless line.valid_encoding?
             # Skip Ruby comment lines — `sinatra-contrib/lib/sinatra/
@@ -23,9 +25,16 @@ module Analyzer::Ruby
             # examples (`#     get '/dashboard' do`) inside RDoc
             # comments. They look identical to real route
             # registrations to the line-based matcher.
-            next if line.lstrip.starts_with?('#')
+            stripped = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: true).strip
+            next if stripped.empty? || stripped.starts_with?('#')
+
+            if ns = stripped.match(/^namespace\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s+do\b/)
+              prefix_stack << {depth: depth + 1, path: ns[1]}
+            end
+
             endpoint = line_to_endpoint(line)
             if endpoint.method != ""
+              endpoint.url = sinatra_prefixed_path(prefix_stack, endpoint.url)
               details = Details.new(PathInfo.new(path, index + 1))
               endpoint.details = details
               attach_route_callees(endpoint, lines, index, path) if include_callee
@@ -38,6 +47,11 @@ module Analyzer::Ruby
               if last_endpoint.method != ""
                 last_endpoint.push_param(param)
               end
+            end
+
+            depth += sinatra_block_opens(stripped) - sinatra_block_closes(stripped)
+            while !prefix_stack.empty? && prefix_stack.last[:depth] > depth
+              prefix_stack.pop
             end
           end
         end
@@ -56,12 +70,12 @@ module Analyzer::Ruby
 
     def line_to_param(content : String) : Param
       if content.includes? "param["
-        param = content.split("param[")[1].split("]")[0].gsub("\"", "").gsub("'", "")
+        param = content.split("param[")[1].split("]")[0].gsub("\"", "").gsub("'", "").gsub(":", "")
         return Param.new(param, "", "query")
       end
 
       if content.includes? "params["
-        param = content.split("params[")[1].split("]")[0].gsub("\"", "").gsub("'", "")
+        param = content.split("params[")[1].split("]")[0].gsub("\"", "").gsub("'", "").gsub(":", "")
         return Param.new(param, "", "query")
       end
 
@@ -81,6 +95,28 @@ module Analyzer::Ruby
       end
 
       Param.new("", "", "")
+    end
+
+    private def sinatra_prefixed_path(prefix_stack : Array(NamedTuple(depth: Int32, path: String)), path : String) : String
+      parts = [] of String
+      prefix_stack.each { |entry| append_sinatra_path(parts, entry[:path]) }
+      append_sinatra_path(parts, path)
+      parts.empty? ? "/" : "/#{parts.join("/")}"
+    end
+
+    private def append_sinatra_path(parts : Array(String), raw : String)
+      raw.split("/").each do |piece|
+        trimmed = piece.strip
+        parts << trimmed unless trimmed.empty?
+      end
+    end
+
+    private def sinatra_block_opens(line : String) : Int32
+      line.scan(/\bdo\b|\{/).size
+    end
+
+    private def sinatra_block_closes(line : String) : Int32
+      line.scan(/\bend\b|\}/).size
     end
   end
 end

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -29,7 +29,7 @@ module Analyzer::Ruby
         # lookbehind on `.` and word chars covers both
         # `headers.delete` and `xdelete` (some unrelated identifier
         # ending in the verb).
-        content.scan(/(?<![.\w])#{verb}\s+['"](.+?)['"]/) do |match|
+        content.scan(/(?<![.\w])#{verb}\s*\(?\s*['"](.+?)['"]/) do |match|
           if match.size > 1
             if details
               return Endpoint.new(match[1], verb.upcase, details)


### PR DESCRIPTION
## Summary
- add Sinatra namespace and parenthesized route handling
- add Grape route_param/path-version support and avoid duplicate path/query params
- add Roda typed matcher support, including mixed symbol + typed matcher captures

## Tests
- crystal spec spec/functional_test/testers/ruby
- just build
- just test
- just check