### PR TITLE
Improve TypeScript analyzer route coverage

### DIFF
--- a/spec/functional_test/fixtures/typescript/nestjs_advanced/events.controller.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_advanced/events.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Sse, UploadedFile, UploadedFiles, Post, HostParam, Get } from '@nestjs/common';
+import { Controller, Sse, UploadedFile, UploadedFiles, Post, HostParam, Get, Headers, Query } from '@nestjs/common';
 
 // Versioned controller with a multi-version array — Nest expands this
 // into one route per version.
@@ -23,6 +23,11 @@ export class TenantController {
   @Get(':slug')
   describe(@HostParam('account') account: string) {
     return { account };
+  }
+
+  @Get('lookup')
+  lookup(@Query() query: Record<string, string>, @Headers() headers: Record<string, string>) {
+    return { query, headers };
   }
 }
 
@@ -50,7 +55,20 @@ export class UploadsController {
     return files;
   }
 
+  @Post('public')
+  uploadPublic(@UploadedFile() file: any) {
+    return file;
+  }
+
   // Commented-out decorator must NOT be reported as a real route.
   // @Get('/legacy/path')
   // legacy() { return null; }
+}
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return { ok: true };
+  }
 }

--- a/spec/functional_test/fixtures/typescript/nestjs_advanced/main.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_advanced/main.ts
@@ -1,11 +1,17 @@
 import { NestFactory } from '@nestjs/core';
+import { RequestMethod } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   // Real-world Nest apps overwhelmingly mount everything under a
   // global prefix; the analyzer should propagate it to every route.
-  app.setGlobalPrefix('api');
+  app.setGlobalPrefix('api', {
+    exclude: [
+      'health',
+      { path: 'uploads/public', method: RequestMethod.ALL },
+    ],
+  });
   app.enableVersioning();
   await app.listen(3000);
 }

--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/_auth.settings.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/_auth.settings.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_auth/settings')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    tab: String(search.tab ?? 'profile'),
+    page: Number(search.page ?? 1),
+  }),
+  component: SettingsComponent,
+})
+
+function SettingsComponent() {
+  return null
+}

--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/_auth.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/_auth.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_auth')({
+  component: AuthLayout,
+})
+
+function AuthLayout() {
+  return null
+}

--- a/spec/functional_test/fixtures/typescript/trpc/server/root.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/root.ts
@@ -1,10 +1,12 @@
 import { router, publicProcedure } from './trpc'
 import { userRouter } from './routers/user'
 import { postRouter } from './routers/post'
+import { accountRouter } from './routers/account'
 
 export const appRouter = router({
   user: userRouter,
   post: postRouter,
+  account: accountRouter,
   health: publicProcedure.query(() => 'ok'),
 })
 

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/account.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/account.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+import { router, protectedProcedure, publicProcedure } from '../trpc'
+
+const accountProcedures = {
+  me: publicProcedure.query(() => AccountService.current()),
+  update: protectedProcedure
+    .input(z.object({ displayName: z.string() }))
+    .mutation(({ input }) => AccountService.update(input)),
+}
+
+export const accountRouter: ReturnType<typeof router> = router(accountProcedures)

--- a/spec/functional_test/testers/typescript/nestjs_advanced_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_advanced_spec.cr
@@ -7,6 +7,8 @@ require "../../func_spec.cr"
 #   - `@UploadedFile`/`@UploadedFiles` (named + unnamed)
 #   - `@HostParam` surfacing subdomain captures
 #   - commented-out decorators ignored (FP fix)
+#   - `setGlobalPrefix(..., { exclude: [...] })` avoiding prefix FPs
+#   - unnamed `@Query()` / `@Headers()` surfacing broad request params
 expected_endpoints = [
   # /events under v1 and v2 with @Sse('stream') + bare @Sse()
   Endpoint.new("/api/v1/events/stream", "GET", [] of Param),
@@ -18,6 +20,10 @@ expected_endpoints = [
   Endpoint.new("/api/tenant/:slug", "GET", [
     Param.new("slug", "", "path"),
     Param.new("account", "", "path"),
+  ]),
+  Endpoint.new("/api/tenant/lookup", "GET", [
+    Param.new("query", "", "query"),
+    Param.new("headers", "", "header"),
   ]),
 
   # Multipart upload routes — named file / files args.
@@ -34,6 +40,12 @@ expected_endpoints = [
   Endpoint.new("/api/uploads/bulk", "POST", [
     Param.new("files", "", "body"),
   ]),
+  # Global-prefix exclude: this POST remains unprefixed.
+  Endpoint.new("/uploads/public", "POST", [
+    Param.new("file", "", "body"),
+  ]),
+  # Global-prefix exclude: health remains unprefixed.
+  Endpoint.new("/health", "GET", [] of Param),
 ]
 
 FunctionalTester.new("fixtures/typescript/nestjs_advanced/", {

--- a/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
@@ -11,7 +11,7 @@ docs.push_callee(Callee.new("DocsRootComponent"))
 
 FunctionalTester.new("fixtures/typescript/tanstack_router/", {
   :techs     => 1,
-  :endpoints => 10,
+  :endpoints => 11,
 }, [posts, shop, docs], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/typescript/tanstack_router_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_spec.cr
@@ -29,6 +29,12 @@ expected_endpoints = [
   ]),
   # Pathless layout routes (leading underscore) should not add a URL segment.
   Endpoint.new("/login", "GET", [] of Param),
+  # File-route pathless layout segments should not become URL
+  # segments or standalone layout endpoints.
+  Endpoint.new("/settings", "GET", [
+    Param.new("tab", "", "query"),
+    Param.new("page", "", "query"),
+  ]),
   # Root-route files with a path should still be scanned even when
   # they do not contain createRoute() code-route assignments.
   Endpoint.new("/docs", "GET", [] of Param),

--- a/spec/functional_test/testers/typescript/trpc_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_callees_spec.cr
@@ -12,7 +12,7 @@ feed.push_callee(Callee.new("FeedService.live", line: 10))
 
 FunctionalTester.new("fixtures/typescript/trpc/", {
   :techs     => 1,
-  :endpoints => 7,
+  :endpoints => 9,
 }, [list, create, feed], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/typescript/trpc_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_spec.cr
@@ -14,6 +14,10 @@ expected_endpoints = [
     Param.new("postId", "", "query"),
   ]),
   Endpoint.new("/api/trpc/post.liveFeed", "SUBSCRIBE", [] of Param),
+  Endpoint.new("/api/trpc/account.me", "GET", [] of Param),
+  Endpoint.new("/api/trpc/account.update", "POST", [
+    Param.new("displayName", "", "body"),
+  ]),
   Endpoint.new("/api/trpc/health", "GET", [] of Param),
 ]
 

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -4,6 +4,22 @@ require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
   class Nestjs < JavascriptEngine
+    private struct GlobalPrefixExclude
+      getter path : String
+      getter method : String?
+
+      def initialize(@path : String, @method : String? = nil)
+      end
+    end
+
+    private struct GlobalPrefixConfig
+      getter prefix : String
+      getter excludes : Array(GlobalPrefixExclude)
+
+      def initialize(@prefix : String, @excludes : Array(GlobalPrefixExclude))
+      end
+    end
+
     def analyze
       analyze_with_extensions([".js", ".jsx"])
     end
@@ -12,7 +28,7 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      global_prefix_holder = [] of String
+      global_prefix_holder = [] of GlobalPrefixConfig
       global_prefix_mutex = Mutex.new
 
       parallel_file_scan(extensions) do |path|
@@ -33,8 +49,12 @@ module Analyzer::Javascript
     # every endpoint URL. Endpoints whose URL already starts with the
     # normalized prefix (e.g. controllers that hard-coded `/api/...`)
     # are left untouched so we don't double-prefix.
-    private def apply_global_prefix(result : Array(Endpoint), prefix : String?)
-      return if prefix.nil? || prefix.empty?
+    private def apply_global_prefix(result : Array(Endpoint), config : GlobalPrefixConfig?)
+      return unless config
+
+      prefix = config.prefix
+      return if prefix.empty?
+
       normalized = prefix.starts_with?("/") ? prefix : "/#{prefix}"
       normalized = normalized.chomp("/")
       return if normalized.empty?
@@ -43,10 +63,37 @@ module Analyzer::Javascript
       # binding is a copy — write back through the index to make the
       # URL change visible to callers.
       result.each_with_index do |endpoint, idx|
+        next if global_prefix_excluded?(endpoint, config.excludes)
         next if endpoint.url.starts_with?(normalized + "/") || endpoint.url == normalized
         endpoint.url = endpoint.url.starts_with?("/") ? "#{normalized}#{endpoint.url}" : "#{normalized}/#{endpoint.url}"
         result[idx] = endpoint
       end
+    end
+
+    private def global_prefix_excluded?(endpoint : Endpoint, excludes : Array(GlobalPrefixExclude)) : Bool
+      excludes.any? do |exclude|
+        next false if exclude.method && exclude.method != "ALL" && exclude.method != endpoint.method
+        exclude_path_matches?(endpoint.url, exclude.path)
+      end
+    end
+
+    private def exclude_path_matches?(url : String, exclude_path : String) : Bool
+      normalized_url = normalize_path_for_prefix_exclude(url)
+      normalized_exclude = normalize_path_for_prefix_exclude(exclude_path)
+
+      if normalized_exclude.ends_with?("*")
+        normalized_url.starts_with?(normalized_exclude.rstrip('*'))
+      else
+        normalized_url == normalized_exclude
+      end
+    end
+
+    private def normalize_path_for_prefix_exclude(path : String) : String
+      normalized = path.strip
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized = normalized.gsub_repeatedly("//", "/")
+      normalized = normalized.chomp("/") unless normalized == "/"
+      normalized
     end
 
     # Process static directories and add endpoints for each file
@@ -71,7 +118,7 @@ module Analyzer::Javascript
       end
     end
 
-    private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool, global_prefix_holder : Array(String), global_prefix_mutex : Mutex)
+    private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool, global_prefix_holder : Array(GlobalPrefixConfig), global_prefix_mutex : Mutex)
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         content = file.gets_to_end
 
@@ -87,7 +134,7 @@ module Analyzer::Javascript
         # `app.setGlobalPrefix('api')` in a bootstrap file scopes
         # every controller below it. Record it now; apply once after
         # all files have been parsed.
-        if prefix = extract_global_prefix(sanitized)
+        if prefix = extract_global_prefix_config(sanitized)
           global_prefix_mutex.synchronize do
             global_prefix_holder << prefix if global_prefix_holder.empty?
           end
@@ -99,14 +146,104 @@ module Analyzer::Javascript
       logger.debug "Error analyzing NestJS file #{path}: #{e.message}"
     end
 
-    # Detect `app.setGlobalPrefix('api')` (single string-literal arg).
-    # Returns the prefix or nil. Constants and dynamic expressions
-    # are ignored conservatively — false-positive prefixing would
-    # mis-route everything.
-    private def extract_global_prefix(content : String) : String?
-      content.scan(/\.setGlobalPrefix\s*\(\s*(['"`])([^'"`]+)\1\s*[,)]/) do |match|
-        return match[2] if match.size > 2 && !match[2].empty?
+    # Detect `app.setGlobalPrefix('api', { exclude: [...] })`.
+    # Constants and dynamic expressions are ignored conservatively —
+    # false-positive prefixing would mis-route every controller.
+    private def extract_global_prefix_config(content : String) : GlobalPrefixConfig?
+      literal_values = extract_literal_values(content)
+
+      content.scan(/\.setGlobalPrefix\s*\(/) do |match|
+        open_paren = (match.end(0) || 0) - 1
+        next if open_paren < 0
+
+        close_paren = Noir::JSRouteExtractor.find_matching_paren(content, open_paren)
+        next unless close_paren
+
+        args = split_top_level(content[(open_paren + 1)...close_paren], ',')
+        next if args.empty?
+
+        prefixes = literal_paths_from_expression(args[0], literal_values)
+        next if prefixes.nil?
+        next if prefixes.size != 1 || prefixes[0].empty?
+
+        excludes = args.size > 1 ? extract_global_prefix_excludes(args[1], literal_values) : [] of GlobalPrefixExclude
+        return GlobalPrefixConfig.new(prefixes[0], excludes)
       end
+      nil
+    end
+
+    private def extract_global_prefix_excludes(options : String, literal_values : Hash(String, Array(String))) : Array(GlobalPrefixExclude)
+      excludes = [] of GlobalPrefixExclude
+      match = options.match(/\bexclude\s*:/)
+      return excludes unless match
+
+      idx = match.end(0)
+      while idx < options.size && options[idx].whitespace?
+        idx += 1
+      end
+      return excludes unless options[idx]? == '['
+
+      close = find_matching_bracket(options, idx)
+      return excludes unless close
+
+      split_top_level(options[(idx + 1)...close], ',').each do |entry|
+        excludes.concat(parse_global_prefix_exclude_entry(entry, literal_values))
+      end
+      excludes
+    end
+
+    private def parse_global_prefix_exclude_entry(entry : String, literal_values : Hash(String, Array(String))) : Array(GlobalPrefixExclude)
+      stripped = entry.strip
+      return [] of GlobalPrefixExclude if stripped.empty?
+
+      paths = [] of String
+      method : String? = nil
+
+      if stripped.starts_with?("{")
+        if path_match = stripped.match(/(?:^|[,{]\s*)path\s*:\s*([\s\S]*?)(?:,\s*\w+\s*:|\}\s*$)/m)
+          paths = literal_paths_from_expression(path_match[1].strip, literal_values) || [] of String
+        end
+
+        if method_match = stripped.match(/\bmethod\s*:\s*(?:RequestMethod\.)?([A-Za-z]+)/)
+          method = method_match[1].upcase
+        end
+      else
+        paths = literal_paths_from_expression(stripped, literal_values) || [] of String
+      end
+
+      paths.map { |path| GlobalPrefixExclude.new(path, method) }
+    end
+
+    private def find_matching_bracket(text : String, open_idx : Int32) : Int32?
+      depth = 0
+      quote : Char? = nil
+      escaped = false
+
+      text.each_char_with_index do |char, idx|
+        next if idx < open_idx
+
+        if quote
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
+          end
+          next
+        end
+
+        case char
+        when '\'', '"', '`'
+          quote = char
+        when '['
+          depth += 1
+        when ']'
+          depth -= 1
+          return idx if depth == 0
+        end
+      end
+
       nil
     end
 
@@ -561,6 +698,9 @@ module Analyzer::Javascript
           push_unique_param(endpoint, Param.new(param_name, "", "query"))
         end
       end
+      if method_params =~ /@Query\s*\(\s*(?:\)|[^'"`][\s\S]*?\))/
+        push_unique_param(endpoint, Param.new("query", "", "query"))
+      end
 
       # Extract @Param parameters (path parameters)
       method_params.scan(/@Param\s*\(\s*['"`]([^'"`]+)['"`][\s\S]*?\)/) do |param_match|
@@ -587,6 +727,9 @@ module Analyzer::Javascript
           param_name = param_match[1]
           push_unique_param(endpoint, Param.new(param_name, "", "header"))
         end
+      end
+      if method_params =~ /@Headers\s*\(\s*(?:\)|[^'"`][\s\S]*?\))/
+        push_unique_param(endpoint, Param.new("headers", "", "header"))
       end
 
       # `@HostParam('account')` — subdomain capture when the controller

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -53,6 +53,8 @@ module Analyzer::Typescript
       content.scan(file_route_pattern) do |match|
         if match.size > 0
           route_path = match[1]
+          next if pathless_only_route?(route_path)
+
           # Convert TanStack Router path params ($param) to standard format (:param)
           normalized_path = normalize_path(route_path)
 
@@ -73,6 +75,8 @@ module Analyzer::Typescript
       content.scan(lazy_file_route_pattern) do |match|
         if match.size > 0
           route_path = match[1]
+          next if pathless_only_route?(route_path)
+
           normalized_path = normalize_path(route_path)
 
           endpoint = create_endpoint(normalized_path, "GET", path)
@@ -200,10 +204,25 @@ module Analyzer::Typescript
       stripped.starts_with?("_") && !stripped.empty?
     end
 
+    private def pathless_only_route?(path : String) : Bool
+      segments = path.split('/').reject(&.empty?)
+      !segments.empty? && segments.all? { |segment| pathless_segment?(segment) }
+    end
+
     private def normalize_path(path : String) : String
       # TanStack Router uses $param for path parameters
       # Convert to standard :param format
-      path.gsub(/\$(\w+)/, ":\\1")
+      normalized = path.gsub(/\$(\w+)/, ":\\1")
+      remove_pathless_segments(normalized)
+    end
+
+    private def remove_pathless_segments(path : String) : String
+      absolute = path.starts_with?("/")
+      kept = path.split('/').reject(&.empty?).reject { |segment| pathless_segment?(segment) }
+      return "/" if kept.empty?
+
+      normalized = kept.join("/")
+      absolute ? "/#{normalized}" : normalized
     end
 
     private def create_endpoint(url : String, method : String, file_path : String, start_pos : Int32 = 0, content : String = "") : Endpoint
@@ -328,6 +347,8 @@ module Analyzer::Typescript
         end
       end
 
+      extract_validate_search_function_params(content, endpoint)
+
       # Look for useSearch hook usage. Three call shapes show up
       # across TanStack v1 apps:
       #   - Route.useSearch()                       (file-route scope)
@@ -358,6 +379,82 @@ module Analyzer::Typescript
     private def extract_search_params_from_route_block(route_block : String, endpoint : Endpoint)
       # Extract search params from the route definition block
       extract_search_params(route_block, endpoint)
+    end
+
+    private def extract_validate_search_function_params(content : String, endpoint : Endpoint)
+      content.scan(/\bvalidateSearch\s*:/) do |match|
+        value_start = match.end(0) || 0
+        value_end = skip_top_level_to_comma(content, value_start)
+        value = content[value_start...value_end]
+        search_name = validate_search_argument_name(value)
+        next unless search_name
+
+        value.scan(/\b#{Regex.escape(search_name)}\s*\.\s*([A-Za-z_$][\w$]*)/) do |param_match|
+          push_unique_query_param(endpoint, param_match[1])
+        end
+
+        value.scan(/\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*#{Regex.escape(search_name)}\b/) do |destructure_match|
+          destructure_match[1].split(",").each do |param|
+            param_name = param.strip.split(":").first.strip.split("=").first.strip
+            push_unique_query_param(endpoint, param_name)
+          end
+        end
+      end
+    end
+
+    private def validate_search_argument_name(value : String) : String?
+      if match = value.match(/\A\s*(?:async\s*)?\(\s*([A-Za-z_$][\w$]*)\b/)
+        match[1]
+      elsif match = value.match(/\A\s*(?:async\s*)?([A-Za-z_$][\w$]*)\s*=>/)
+        match[1]
+      elsif match = value.match(/\A\s*(?:async\s*)?function[^(]*\(\s*([A-Za-z_$][\w$]*)\b/)
+        match[1]
+      end
+    end
+
+    private def skip_top_level_to_comma(text : String, start : Int32) : Int32
+      depth = 0
+      quote : Char? = nil
+      escaped = false
+      i = start
+
+      while i < text.size
+        char = text[i]
+
+        if quote
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
+          end
+          i += 1
+          next
+        end
+
+        case char
+        when '\'', '"', '`'
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+        when ','
+          return i if depth == 0
+        end
+
+        i += 1
+      end
+
+      i
+    end
+
+    private def push_unique_query_param(endpoint : Endpoint, param_name : String)
+      return if param_name.empty?
+      return if endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+
+      endpoint.push_param(Param.new(param_name, "", "query"))
     end
   end
 end

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -70,7 +70,7 @@ module Analyzer::Typescript
       collected = [] of Router
       # Capture `(export )? (const|let|var) NAME = <prefix>?(router|createTRPCRouter)({...})`.
       # Prefix tolerates `t.router(`, `initTRPC.create().router(`, `_.router(` etc.
-      pattern = /\b(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:[\w$]+\s*(?:\(\s*\))?\s*\.\s*)?(?:router|createTRPCRouter)\s*\(\s*\{/
+      pattern = /\b(?:export\s+)?(?:const|let|var)\s+(\w+)(?:\s*:[^=]+)?\s*=\s*(?:[\w$]+\s*(?:\(\s*\))?\s*\.\s*)?(?:router|createTRPCRouter)\s*\(\s*\{/
 
       content.scan(pattern) do |match|
         match_start = match.begin(0) || 0
@@ -88,7 +88,42 @@ module Analyzer::Typescript
         collected << Router.new(match[1], body, path, line)
       end
 
+      identifier_arg_pattern = /\b(?:export\s+)?(?:const|let|var)\s+(\w+)(?:\s*:[^=]+)?\s*=\s*(?:[\w$]+\s*(?:\(\s*\))?\s*\.\s*)?(?:router|createTRPCRouter)\s*\(\s*([A-Za-z_$][\w$]*)\s*\)/
+
+      content.scan(identifier_arg_pattern) do |match|
+        match_start = match.begin(0) || 0
+        body_info = extract_object_assignment_body(content, match[2])
+        next unless body_info
+
+        body, object_line = body_info
+        line = object_line > 0 ? object_line : content[0, match_start].count('\n') + 1
+        collected << Router.new(match[1], body, path, line)
+      end
+
       collected
+    end
+
+    private def extract_object_assignment_body(content : String, identifier : String) : Tuple(String, Int32)?
+      escaped = Regex.escape(identifier)
+      pattern = /\b(?:export\s+)?(?:const|let|var)\s+#{escaped}(?:\s*:[^=]+)?\s*=\s*\{/
+
+      content.scan(pattern) do |match|
+        match_start = match.begin(0) || 0
+        match_end = match.end(0) || 0
+        next if match_end == 0
+
+        brace_open = match_end - 1
+        next unless content[brace_open]? == '{'
+
+        brace_close = Noir::JSRouteExtractor.find_matching_brace(content, brace_open)
+        next unless brace_close
+
+        body = content[(brace_open + 1)...brace_close]
+        line = content[0, match_start].count('\n') + 1
+        return {body, line}
+      end
+
+      nil
     end
 
     private def extract_prefix(content : String) : String?


### PR DESCRIPTION
## Summary
- handle NestJS global prefix excludes, including RequestMethod.ALL, plus unnamed @Query/@Headers params
- normalize TanStack Router pathless file routes and extract function-style validateSearch params
- collect tRPC routers built from separated procedure objects
- add TypeScript fixtures for NestJS, TanStack Router, and tRPC coverage

## Tests
- crystal spec spec/functional_test/testers/typescript/trpc_spec.cr spec/functional_test/testers/typescript/trpc_callees_spec.cr spec/functional_test/testers/typescript/tanstack_router_spec.cr spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr spec/functional_test/testers/typescript/nestjs_advanced_spec.cr spec/functional_test/testers/typescript/nestjs_spec.cr spec/unit_test/detector/typescript spec/unit_test/miniparser/js_route_extractor_spec.cr
- just build
- just check
- just test