### PR TITLE
Improve Rust scoped route detection

### DIFF
--- a/spec/functional_test/fixtures/rust/actix_web/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_web/src/main.rs
@@ -84,6 +84,36 @@ async fn update_article(
     HttpResponse::Ok().body("Updated")
 }
 
+// Scoped service registration. In real actix-web apps, handlers are
+// often declared with route attributes and mounted under web::scope(...)
+// from configure functions.
+#[get("/posts")]
+async fn scoped_posts() -> impl Responder {
+    HttpResponse::Ok().body("Scoped posts")
+}
+
+#[get("/reports/{id}")]
+async fn scoped_report(path: web::Path<u32>) -> impl Responder {
+    HttpResponse::Ok().body(format!("Report {}", path.into_inner()))
+}
+
+#[get("/nested")]
+async fn nested_scoped_posts() -> impl Responder {
+    HttpResponse::Ok().body("Nested scoped posts")
+}
+
+fn configure(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/api")
+            .service(scoped_posts)
+            .service(scoped_report),
+    );
+    cfg.service(
+        web::scope("/root")
+            .service(web::scope("/api").service(nested_scoped_posts)),
+    );
+}
+
 async fn manual_hello() -> impl Responder {
     HttpResponse::Ok().body("Hey there!")
 }

--- a/spec/functional_test/fixtures/rust/axum/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum/src/main.rs
@@ -23,7 +23,11 @@ async fn main() {
             Router::new()
                 .route("/users", get(handler))
                 .route("/admin", post(handler)),
-        );
+        )
+        // Real applications often keep a Router-returning function
+        // per module and mount it under a prefix.
+        .nest("/v1", v1_routes())
+        .nest("/root", api_routes());
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await
@@ -34,6 +38,20 @@ async fn main() {
 
 async fn handler() -> Html<&'static str> {
     Html("<h1>Hello, World!</h1>")
+}
+
+fn v1_routes() -> Router {
+    Router::new()
+        .route("/projects", get(handler))
+        .route("/projects/{id}", get(handler))
+}
+
+fn api_routes() -> Router {
+    Router::new().nest("/api", v2_routes())
+}
+
+fn v2_routes() -> Router {
+    Router::new().route("/audit", get(handler))
 }
 
 // Regression guard: routes registered inside `#[cfg(test)] mod tests`

--- a/spec/functional_test/testers/rust/actix_web_spec.cr
+++ b/spec/functional_test/testers/rust/actix_web_spec.cr
@@ -11,6 +11,11 @@ expected_endpoints = [
   Endpoint.new("/protected", "GET"),
   Endpoint.new("/session", "GET"),
   Endpoint.new("/articles/{id}", "PUT"),
+  Endpoint.new("/api/posts", "GET"),
+  Endpoint.new("/api/reports/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/root/api/nested", "GET"),
 ]
 
 FunctionalTester.new("fixtures/rust/actix_web/", {

--- a/spec/functional_test/testers/rust/axum_spec.cr
+++ b/spec/functional_test/testers/rust/axum_spec.cr
@@ -10,6 +10,9 @@ expected_endpoints = [
   Endpoint.new("/*", "ANY"),
   Endpoint.new("/api/users", "GET"),
   Endpoint.new("/api/admin", "POST"),
+  Endpoint.new("/v1/projects", "GET"),
+  Endpoint.new("/v1/projects/{id}", "GET"),
+  Endpoint.new("/root/api/audit", "GET"),
 ]
 
 FunctionalTester.new("fixtures/rust/axum/", {

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -20,6 +20,8 @@ module Analyzer::Rust
       test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
+        scoped_services = collect_service_registrations(root, source, test_regions)
+
         each_routing_pair(root) do |attr, function|
           next if RustEngine.inside_test_region?(attr, test_regions)
 
@@ -27,14 +29,17 @@ module Analyzer::Rust
           next unless route
           route_path, method, attr_row = route
 
-          details = Details.new(PathInfo.new(path, attr_row))
-          endpoint = Endpoint.new(route_path, method, details)
+          handler_name = function_name(function, source)
+          prefixes = handler_name ? scoped_services[handler_name]? : nil
 
-          extract_path_params(route_path, endpoint)
-          extract_function_params(function, source, endpoint)
-          attach_handler_callees(function, source, path, endpoint) if include_callee
-
-          endpoints << endpoint
+          if prefixes && !prefixes.empty?
+            prefixes.each do |prefix|
+              endpoint_path = scoped_route_path(prefix, route_path)
+              endpoints << build_attribute_endpoint(endpoint_path, method, attr_row, path, function, source, include_callee)
+            end
+          else
+            endpoints << build_attribute_endpoint(route_path, method, attr_row, path, function, source, include_callee)
+          end
         end
 
         # Second pass: `App::new().route("/path", web::<verb>().to(handler))`
@@ -60,13 +65,97 @@ module Analyzer::Rust
       endpoints
     end
 
+    private def build_attribute_endpoint(route_path : String,
+                                         method : String,
+                                         attr_row : Int32,
+                                         file_path : String,
+                                         function : LibTreeSitter::TSNode,
+                                         source : String,
+                                         include_callee : Bool) : Endpoint
+      details = Details.new(PathInfo.new(file_path, attr_row))
+      endpoint = Endpoint.new(route_path, method, details)
+
+      extract_path_params(route_path, endpoint)
+      extract_function_params(function, source, endpoint)
+      attach_handler_callees(function, source, file_path, endpoint) if include_callee
+
+      endpoint
+    end
+
+    # Actix attribute routes are commonly mounted with
+    # `web::scope("/api").service(handler)`. The attribute itself only
+    # carries the local path, so the service registration is needed to
+    # avoid emitting `/posts` when the real endpoint is `/api/posts`.
+    private def collect_service_registrations(root : LibTreeSitter::TSNode,
+                                              source : String,
+                                              test_regions : Array(Tuple(Int32, Int32))) : Hash(String, Array(String))
+      registrations = {} of String => Array(String)
+      collect_service_registrations(root, source, test_regions, "", registrations)
+      registrations
+    end
+
+    private def collect_service_registrations(node : LibTreeSitter::TSNode,
+                                              source : String,
+                                              test_regions : Array(Tuple(Int32, Int32)),
+                                              active_prefix : String,
+                                              registrations : Hash(String, Array(String)))
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        return if RustEngine.inside_test_region?(node, test_regions)
+
+        if field_call_name(node, source) == "service"
+          args = Noir::TreeSitter.field(node, "arguments")
+          return unless args
+          named = named_children(args)
+          return unless named.size == 1
+
+          function = Noir::TreeSitter.field(node, "function")
+          return unless function
+          receiver = Noir::TreeSitter.field(function, "value")
+          receiver_prefix = receiver ? (extract_scope_prefix(receiver, source) || "") : ""
+          service_prefix = scoped_route_path(active_prefix, receiver_prefix)
+
+          if handler_name = service_handler_name(named[0], source)
+            push_registration(registrations, handler_name, service_prefix)
+          else
+            collect_service_registrations(named[0], source, test_regions, service_prefix, registrations)
+          end
+
+          collect_service_registrations(receiver, source, test_regions, active_prefix, registrations) if receiver
+          return
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_service_registrations(child, source, test_regions, active_prefix, registrations)
+      end
+    end
+
+    private def push_registration(registrations : Hash(String, Array(String)),
+                                  handler_name : String,
+                                  prefix : String)
+      prefixes = registrations[handler_name] ||= [] of String
+      prefixes << prefix unless prefixes.includes?(prefix)
+    end
+
+    private def service_handler_name(node : LibTreeSitter::TSNode, source : String) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "identifier"
+        Noir::TreeSitter.node_text(node, source)
+      when "scoped_identifier"
+        Noir::TreeSitter.node_text(node, source).split("::").last
+      end
+    end
+
+    private def function_name(function : LibTreeSitter::TSNode, source : String) : String?
+      name = Noir::TreeSitter.field(function, "name")
+      name ? Noir::TreeSitter.node_text(name, source) : nil
+    end
+
     # Walks `call_expression` nodes whose receiver chain looks like
     # `<owner>.route(<path_lit>, web::<verb>().to(<handler>))` (i.e.,
     # `App::new().route(...)`, `web::scope("/x").route(...)`,
     # `web::resource("/y").route(...)`) and returns
     # `{path, [verbs]}`. Returns `nil` when the shape doesn't match.
-    # Scope-prefix application is intentionally out of scope here —
-    # it requires walking the parent chain.
     private def extract_builder_route(call : LibTreeSitter::TSNode, source : String) : Tuple(String, Array(String))?
       function = Noir::TreeSitter.field(call, "function")
       return unless function
@@ -95,6 +184,9 @@ module Analyzer::Rust
         return unless path_lit
         methods = extract_web_verbs(named[0], source)
         return if methods.empty?
+        if scope_prefix = extract_scope_prefix(receiver, source)
+          path_lit = scoped_route_path(scope_prefix, path_lit)
+        end
         return {path_lit, methods}
       end
 
@@ -112,8 +204,7 @@ module Analyzer::Rust
       if receiver
         scope_prefix = extract_scope_prefix(receiver, source)
         if scope_prefix
-          combined = "#{scope_prefix.rstrip('/')}/#{path_lit.lstrip('/')}"
-          path_lit = combined
+          path_lit = scoped_route_path(scope_prefix, path_lit)
         end
       end
 
@@ -148,6 +239,33 @@ module Analyzer::Rust
         end
       end
       nil
+    end
+
+    private def field_call_name(call : LibTreeSitter::TSNode, source : String) : String?
+      function = Noir::TreeSitter.field(call, "function")
+      return unless function && Noir::TreeSitter.node_type(function) == "field_expression"
+      field = Noir::TreeSitter.field(function, "field")
+      field ? Noir::TreeSitter.node_text(field, source) : nil
+    end
+
+    private def named_children(node : LibTreeSitter::TSNode) : Array(LibTreeSitter::TSNode)
+      named = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(node) { |c| named << c }
+      named
+    end
+
+    private def scoped_route_path(prefix : String, route_path : String) : String
+      normalized_prefix = prefix.starts_with?("/") ? prefix : "/#{prefix}"
+      normalized_path = route_path.starts_with?("/") ? route_path : "/#{route_path}"
+
+      return normalized_path if normalized_prefix == "/"
+      clean_prefix = normalized_prefix.rstrip('/')
+      return normalized_path if normalized_path == clean_prefix || normalized_path.starts_with?("#{clean_prefix}/")
+
+      suffix = normalized_path.lstrip('/')
+      return clean_prefix if suffix.empty?
+
+      "#{clean_prefix}/#{suffix}"
     end
 
     # Find the path string carried by a `web::resource(<path>)` call.

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -45,8 +45,11 @@ module Analyzer::Rust
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = include_callee ? build_function_index(root, source) : Hash(String, LibTreeSitter::TSNode).new
+        router_functions = build_router_function_index(root, source)
+        mounted_router_names = collect_mounted_router_names(root, source, test_regions)
+        nested_router_prefixes = collect_nested_router_prefixes(root, source, test_regions, "", mounted_router_names)
 
-        walk_router_builders(root, source, "", test_regions) do |node, prefix|
+        walk_router_builders(root, source, "", test_regions, mounted_router_names) do |node, prefix|
           route = extract_route(node, source)
           next unless route
 
@@ -62,6 +65,51 @@ module Analyzer::Rust
             end
 
             endpoints << endpoint
+          end
+        end
+
+        processed_mounts = Set(String).new
+        mount_queue = [] of Tuple(String, String)
+        nested_router_prefixes.each do |router_name, prefixes|
+          prefixes.each { |prefix| mount_queue << {router_name, prefix} }
+        end
+
+        mount_index = 0
+        while mount_index < mount_queue.size
+          router_name, prefix = mount_queue[mount_index]
+          mount_index += 1
+
+          mount_key = "#{router_name}\0#{prefix}"
+          next if processed_mounts.includes?(mount_key)
+          processed_mounts.add(mount_key)
+
+          router_function = router_functions[router_name]?
+          next unless router_function
+
+          walk_router_builders(router_function, source, prefix, test_regions, Set(String).new) do |node, active_prefix|
+            route = extract_route(node, source)
+            next unless route
+
+            path_str, methods, handler_name = route
+            path_str = join_paths(active_prefix, path_str) unless active_prefix.empty?
+            methods.each do |verb|
+              details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
+              endpoint = Endpoint.new(path_str, verb, details)
+
+              if include_callee && handler_name && (body_node = function_index[handler_name]?)
+                entries = Noir::RustCalleeExtractorTS.callees_in_body(body_node, source, path)
+                attach_rust_callees(endpoint, entries)
+              end
+
+              endpoints << endpoint
+            end
+          end
+
+          collect_nested_router_prefixes(router_function, source, test_regions, prefix, Set(String).new).each do |nested_name, prefixes|
+            prefixes.each do |nested_prefix|
+              nested_key = "#{nested_name}\0#{nested_prefix}"
+              mount_queue << {nested_name, nested_prefix} unless processed_mounts.includes?(nested_key)
+            end
           end
         end
       end
@@ -90,7 +138,14 @@ module Analyzer::Rust
                                      source : String,
                                      prefix : String,
                                      test_regions : Array(Tuple(Int32, Int32)),
+                                     mounted_router_names : Set(String),
                                      &block : LibTreeSitter::TSNode, String ->)
+      if prefix.empty? && Noir::TreeSitter.node_type(node) == "function_item"
+        if name = function_name(node, source)
+          return if mounted_router_names.includes?(name)
+        end
+      end
+
       if Noir::TreeSitter.node_type(node) == "call_expression"
         return if RustEngine.inside_test_region?(node, test_regions)
 
@@ -101,26 +156,26 @@ module Analyzer::Rust
         # the receiver-chain walk single-pass.
         if router_emit?(node, source)
           block.call(node, prefix)
-          walk_receiver_chain(node, source, prefix, test_regions, &block)
+          walk_receiver_chain(node, source, prefix, test_regions, mounted_router_names, &block)
           return
         end
 
         if nest = extract_nest_call(node, source)
           nest_prefix, nested_router = nest
-          walk_receiver_chain(node, source, prefix, test_regions, &block)
-          walk_router_builders(nested_router, source, join_paths(prefix, nest_prefix), test_regions, &block)
+          walk_receiver_chain(node, source, prefix, test_regions, mounted_router_names, &block)
+          walk_router_builders(nested_router, source, join_paths(prefix, nest_prefix), test_regions, mounted_router_names, &block)
           return
         end
 
         if merge_arg = extract_merge_call(node, source)
-          walk_receiver_chain(node, source, prefix, test_regions, &block)
-          walk_router_builders(merge_arg, source, prefix, test_regions, &block)
+          walk_receiver_chain(node, source, prefix, test_regions, mounted_router_names, &block)
+          walk_router_builders(merge_arg, source, prefix, test_regions, mounted_router_names, &block)
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_router_builders(child, source, prefix, test_regions, &block)
+        walk_router_builders(child, source, prefix, test_regions, mounted_router_names, &block)
       end
     end
 
@@ -128,12 +183,13 @@ module Analyzer::Rust
                                     source : String,
                                     prefix : String,
                                     test_regions : Array(Tuple(Int32, Int32)),
+                                    mounted_router_names : Set(String),
                                     &block : LibTreeSitter::TSNode, String ->)
       function = Noir::TreeSitter.field(call, "function")
       return unless function && Noir::TreeSitter.node_type(function) == "field_expression"
       receiver = Noir::TreeSitter.field(function, "value")
       return unless receiver
-      walk_router_builders(receiver, source, prefix, test_regions, &block)
+      walk_router_builders(receiver, source, prefix, test_regions, mounted_router_names, &block)
     end
 
     private def extract_nest_call(call : LibTreeSitter::TSNode,
@@ -151,6 +207,112 @@ module Analyzer::Rust
       return unless field_call_name(call, source) == "merge"
       args = named_arguments(call)
       args.first?
+    end
+
+    private def collect_mounted_router_names(root : LibTreeSitter::TSNode,
+                                             source : String,
+                                             test_regions : Array(Tuple(Int32, Int32))) : Set(String)
+      names = Set(String).new
+
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "call_expression"
+        next if RustEngine.inside_test_region?(node, test_regions)
+
+        nest = extract_nest_call(node, source)
+        next unless nest
+
+        _, nested_router = nest
+        router_name = router_function_call_name(nested_router, source)
+        names.add(router_name) if router_name
+      end
+
+      names
+    end
+
+    private def collect_nested_router_prefixes(root : LibTreeSitter::TSNode,
+                                               source : String,
+                                               test_regions : Array(Tuple(Int32, Int32)),
+                                               active_prefix : String,
+                                               skip_function_names : Set(String)) : Hash(String, Array(String))
+      prefixes = {} of String => Array(String)
+      collect_nested_router_prefixes(root, source, test_regions, active_prefix, skip_function_names, prefixes)
+      prefixes
+    end
+
+    private def collect_nested_router_prefixes(node : LibTreeSitter::TSNode,
+                                               source : String,
+                                               test_regions : Array(Tuple(Int32, Int32)),
+                                               active_prefix : String,
+                                               skip_function_names : Set(String),
+                                               prefixes : Hash(String, Array(String)))
+      if Noir::TreeSitter.node_type(node) == "function_item"
+        if name = function_name(node, source)
+          return if skip_function_names.includes?(name)
+        end
+      end
+
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        return if RustEngine.inside_test_region?(node, test_regions)
+
+        if nest = extract_nest_call(node, source)
+          nest_prefix, nested_router = nest
+          mounted_prefix = join_paths(active_prefix, nest_prefix)
+
+          if router_name = router_function_call_name(nested_router, source)
+            entries = prefixes[router_name] ||= [] of String
+            entries << mounted_prefix unless entries.includes?(mounted_prefix)
+          else
+            collect_nested_router_prefixes(nested_router, source, test_regions, mounted_prefix, skip_function_names, prefixes)
+          end
+
+          walk_receiver_chain_for_mounts(node, source, active_prefix, test_regions, skip_function_names, prefixes)
+          return
+        end
+
+        if merge_arg = extract_merge_call(node, source)
+          collect_nested_router_prefixes(merge_arg, source, test_regions, active_prefix, skip_function_names, prefixes)
+          walk_receiver_chain_for_mounts(node, source, active_prefix, test_regions, skip_function_names, prefixes)
+          return
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_nested_router_prefixes(child, source, test_regions, active_prefix, skip_function_names, prefixes)
+      end
+    end
+
+    private def walk_receiver_chain_for_mounts(call : LibTreeSitter::TSNode,
+                                               source : String,
+                                               active_prefix : String,
+                                               test_regions : Array(Tuple(Int32, Int32)),
+                                               skip_function_names : Set(String),
+                                               prefixes : Hash(String, Array(String)))
+      function = Noir::TreeSitter.field(call, "function")
+      return unless function && Noir::TreeSitter.node_type(function) == "field_expression"
+      receiver = Noir::TreeSitter.field(function, "value")
+      return unless receiver
+      collect_nested_router_prefixes(receiver, source, test_regions, active_prefix, skip_function_names, prefixes)
+    end
+
+    private def router_function_call_name(node : LibTreeSitter::TSNode, source : String) : String?
+      return unless Noir::TreeSitter.node_type(node) == "call_expression"
+      function = Noir::TreeSitter.field(node, "function")
+      return unless function
+
+      case Noir::TreeSitter.node_type(function)
+      when "identifier"
+        Noir::TreeSitter.node_text(function, source)
+      when "scoped_identifier"
+        name = Noir::TreeSitter.node_text(function, source).split("::").last
+        return if name == "new"
+        name
+      when "generic_function"
+        inner = Noir::TreeSitter.field(function, "function")
+        return unless inner
+        name = Noir::TreeSitter.node_text(inner, source).split("::").last
+        return if name == "new"
+        name
+      end
     end
 
     private def field_call_name(call : LibTreeSitter::TSNode, source : String) : String?
@@ -295,6 +457,23 @@ module Analyzer::Rust
         content = Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "string_content"
       end
       content
+    end
+
+    private def build_router_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      index = {} of String => LibTreeSitter::TSNode
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "function_item"
+        name = function_name(node, source)
+        body_node = Noir::TreeSitter.field(node, "body")
+        next unless name && body_node
+        index[name] = body_node unless index.has_key?(name)
+      end
+      index
+    end
+
+    private def function_name(function : LibTreeSitter::TSNode, source : String) : String?
+      name_node = Noir::TreeSitter.field(function, "name")
+      name_node ? Noir::TreeSitter.node_text(name_node, source) : nil
     end
 
     private def build_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)


### PR DESCRIPTION
## Summary
- resolve Actix Web attribute routes mounted through `web::scope(...).service(...)`, including nested scopes
- resolve Axum Router-returning functions mounted with `.nest(...)`, preserving nested parent prefixes
- add Rust functional fixtures for scoped Actix services and nested Axum router functions

## Tests
- `crystal spec spec/functional_test/testers/rust/actix_web_spec.cr spec/functional_test/testers/rust/axum_spec.cr`
- `crystal spec spec/functional_test/testers/rust spec/unit_test/analyzer/rust_engine_spec.cr spec/unit_test/miniparser/rust_callee_extractor_spec.cr spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr spec/unit_test/detector/rust spec/unit_test/tagger/framework_taggers/rust_auth_spec.cr`
- `just build`
- `just test`
- `just check`