### PR TITLE
Improve Python endpoint analyzer coverage

### DIFF
--- a/spec/functional_test/fixtures/python/aiohttp/app.py
+++ b/spec/functional_test/fixtures/python/aiohttp/app.py
@@ -1,6 +1,9 @@
 from aiohttp import web
 
+import external_handlers
+
 routes = web.RouteTableDef()
+admin_routes = web.RouteTableDef()
 
 
 async def index(request):
@@ -29,6 +32,51 @@ async def update_user(request):
 async def delete_user(request):
     user_id = request.match_info.get('id')
     return web.Response(text=f"deleted {user_id}")
+
+
+async def websocket_feed(request):
+    channel = request.match_info['channel']
+    token = request.query.get('token')
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+    await ws.send_str(f"{channel}:{token}")
+    return ws
+
+
+class ReportView(web.View):
+    async def get(self):
+        report_id = self.request.match_info['id']
+        verbose = self.request.query.get('verbose')
+        return web.Response(text=f"report {report_id} verbose={verbose}")
+
+    async def post(self):
+        data = await self.request.json()
+        title = data['title']
+        return web.Response(text=f"created report {title}")
+
+
+class AuditView(web.View):
+    async def get(self):
+        audit_id = self.request.match_info['audit_id']
+        page = self.request.query.get('page')
+        return web.Response(text=f"audit {audit_id} page={page}")
+
+    async def delete(self):
+        audit_id = self.request.match_info['audit_id']
+        token = self.request.headers['X-Audit-Token']
+        return web.Response(text=f"delete audit {audit_id} token={token}")
+
+
+@routes.view('/decorated/{item_id}')
+class DecoratedView(web.View):
+    async def get(self):
+        item_id = self.request.match_info['item_id']
+        return web.Response(text=f"decorated {item_id}")
+
+    async def patch(self):
+        data = await self.request.json()
+        status = data.get('status')
+        return web.Response(text=f"decorated status {status}")
 
 
 @routes.get('/admin')
@@ -60,6 +108,36 @@ async def search(request):
     return web.Response(text=f"search {category} q={q}")
 
 
+@admin_routes.get('/stats')
+async def admin_stats(request):
+    section = request.query.get('section')
+    return web.Response(text=f"admin stats {section}")
+
+
+async def admin_health(request):
+    check = request.match_info['check']
+    return web.Response(text=f"admin health {check}")
+
+
+async def tenant_detail(request):
+    tenant_id = request.match_info['tenant_id']
+    expand = request.query.get('expand')
+    return web.Response(text=f"tenant {tenant_id} {expand}")
+
+
+async def tenant_create(request):
+    data = await request.json()
+    name = data['name']
+    return web.Response(text=f"tenant {name}")
+
+
+tenant_routes = [
+    web.get('/tenants/{tenant_id}', tenant_detail),
+    web.post('/tenants', tenant_create),
+    web.patch('/external/{external_id}', external_handlers.external_patch),
+]
+
+
 def setup_routes(app):
     app.router.add_get('/', index)
     app.router.add_get('/users', list_users)
@@ -67,11 +145,27 @@ def setup_routes(app):
     app.router.add_put('/users/{id}', update_user)
     app.router.add_delete('/users/{id}', delete_user)
     app.router.add_route('PATCH', '/users/{id}', update_user)
+    app.router.add_get('/feed/{channel}', websocket_feed)
+    app.router.add_routes([web.view('/reports/{id}', ReportView)])
+    app.router.add_static('/assets/', path='static')
+
+
+def setup_admin_routes(admin_app):
+    admin_app.add_routes(admin_routes)
+    admin_app.router.add_get('/health/{check}', admin_health)
+    admin_app.router.add_view('/audit/{audit_id}', AuditView)
+    admin_app.router.add_static('/static/', path='admin_static')
 
 
 def main():
     app = web.Application()
+    admin_app = web.Application()
+    tenant_app = web.Application()
     setup_routes(app)
+    setup_admin_routes(admin_app)
+    tenant_app.router.add_routes(tenant_routes)
+    app.add_subapp('/admin', admin_app)
+    app.add_subapp('/tenant-api', tenant_app)
     app.router.add_routes(routes)
     web.run_app(app)
 

--- a/spec/functional_test/fixtures/python/aiohttp/external_handlers.py
+++ b/spec/functional_test/fixtures/python/aiohttp/external_handlers.py
@@ -1,0 +1,9 @@
+from aiohttp import web
+
+
+async def external_patch(request):
+    external_id = request.match_info['external_id']
+    mode = request.query.get('mode')
+    data = await request.json()
+    title = data.get('title')
+    return web.Response(text=f"external {external_id} {mode} {title}")

--- a/spec/functional_test/fixtures/python/bottle/app.py
+++ b/spec/functional_test/fixtures/python/bottle/app.py
@@ -1,6 +1,9 @@
 from bottle import Bottle, route, get, post, request, run
 
 app = Bottle()
+admin_app = Bottle()
+api_app = Bottle()
+nested_admin_app = Bottle()
 
 
 # Bare decorator — uses the module's default app.
@@ -40,12 +43,69 @@ def get_user(id):
     return {"id": id}
 
 
+@admin_app.get('/dashboard')
+def admin_dashboard():
+    section = request.query.get('section')
+    return {"section": section}
+
+
+@admin_app.post('/reports/<report_id:int>')
+def admin_report(report_id):
+    body = request.json
+    title = body.get('title')
+    return {"id": report_id, "title": title}
+
+
+@nested_admin_app.get('/metrics/<metric_id:int>')
+def nested_metric(metric_id):
+    window = request.query.get('window')
+    return {"id": metric_id, "window": window}
+
+
 # Module-qualified call: bottle.route used directly.
 @route('/search', method='GET')
 def search():
     q = request.query['q']
     page = request.query.get('page')
     return [q, page]
+
+
+@route(path='/keyword/login', method='POST')
+def keyword_login():
+    token = request.headers.get('X-Login-Token')
+    payload = request.json
+    username = payload.get('username')
+    return {"token": token, "username": username}
+
+
+@get(path='/keyword/status/<status_id:int>')
+def keyword_status(status_id):
+    region = request.query.get('region')
+    return {"status_id": status_id, "region": region}
+
+
+@route(
+    '/bulk',
+    method=[
+        'PUT',
+        'PATCH',
+    ],
+)
+def bulk_update():
+    body = request.json
+    action = body['action']
+    return {"action": action}
+
+
+def programmatic_health():
+    probe = request.query.get('probe')
+    return {"probe": probe}
+
+
+app.route('/health', method='GET', callback=programmatic_health)
+api_app.mount('/admin', nested_admin_app)
+app.mount('/admin', admin_app)
+app.mount('/api', api_app)
 
 
 if __name__ == '__main__':

--- a/spec/functional_test/fixtures/python/django/blog/api_router.py
+++ b/spec/functional_test/fixtures/python/django/blog/api_router.py
@@ -1,0 +1,10 @@
+from rest_framework.routers import DefaultRouter
+
+from . import views
+
+
+api_router = DefaultRouter()
+api_router.register(r'library-media', views.MediaViewSet, basename='library-media')
+
+direct_imported_router = DefaultRouter()
+direct_imported_router.register(r'direct-media', views.MediaViewSet, basename='direct-media')

--- a/spec/functional_test/fixtures/python/django/blog/urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/urls.py
@@ -1,10 +1,55 @@
-from django.urls import path
+from django.urls import include, path, re_path
+from rest_framework.routers import DefaultRouter
 from django.views.decorators.cache import cache_page
 
 from . import views
+from .api_router import api_router, direct_imported_router as imported_direct_router
 
 app_name = "blog"
+router = DefaultRouter()
+router.register(r'articles', views.ArticleViewSet, basename='article')
+router.register(r'media', views.MediaViewSet, basename='media')
+router.register(prefix=r'keyword-media', viewset=views.MediaViewSet, basename='keyword-media')
+direct_router = DefaultRouter()
+direct_router.register(r'direct-articles', views.ArticleViewSet, basename='direct-article')
+
+local_patterns = [
+    path(
+        'reports/',
+        views.local_report_list,
+        name='local_report_list'),
+    path(
+        'reports/<slug:report_slug>/',
+        views.local_report_detail,
+        name='local_report_detail'),
+]
+
+namespace_patterns = [
+    path(
+        'exports/',
+        views.local_export,
+        name='local_export'),
+]
+
+base_patterns = [
+    path(
+        'combined/',
+        views.combined_report,
+        name='combined_report'),
+]
+
+extended_patterns = [
+    path(
+        'extended/',
+        views.extended_report,
+        name='extended_report'),
+]
+
 urlpatterns = [
+    path('api/', include(router.urls)),
+    path('imported-api/', include(api_router.urls)),
+    path('local/', include(local_patterns)),
+    path('namespaced/', include((namespace_patterns, app_name), namespace='nested')),
     path(
         r'',
         views.IndexView.as_view(),
@@ -52,6 +97,10 @@ urlpatterns = [
         views.LinkListView.as_view(),
         name='links'),
     path(
+        'feedback/',
+        views.FeedbackView.as_view(),
+        name='feedback'),
+    path(
         r'upload',
         views.fileupload,
         name='upload'),
@@ -67,4 +116,12 @@ urlpatterns = [
         r'delete_test',
         views.delete_test,
         name='delete_test'),
+    re_path(
+        r'^legacy/(?P<legacy_id>[0-9]+)/$',
+        views.legacy_detail,
+        name='legacy_detail'),
 ]
+urlpatterns = base_patterns + urlpatterns
+urlpatterns.extend(extended_patterns)
+urlpatterns += direct_router.urls
+urlpatterns += imported_direct_router.urls

--- a/spec/functional_test/fixtures/python/django/blog/views.py
+++ b/spec/functional_test/fixtures/python/django/blog/views.py
@@ -9,16 +9,64 @@ from django.shortcuts import get_object_or_404
 from django.shortcuts import render
 from django.templatetags.static import static
 from django.utils import timezone
+from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from haystack.views import SearchView
+from rest_framework import mixins, viewsets
+from rest_framework.decorators import action
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from blog.models import Article, Category, LinkShowType, Links, Tag
 from comments.forms import CommentForm
 from djangoblog.utils import cache, get_blog_setting, get_sha256
 
 logger = logging.getLogger(__name__)
+
+
+class ArticleViewSet(ReadOnlyModelViewSet):
+    lookup_url_kwarg = "article_id"
+
+    def list(self, request):
+        status = request.query_params.get("status")
+        return HttpResponse(status)
+
+    def retrieve(self, request, article_id=None):
+        preview = request.query_params.get("preview")
+        return HttpResponse(preview)
+
+    @action(detail=True, methods=["post"], url_path="publish")
+    def publish(self, request, article_id=None):
+        reason = request.data.get("reason")
+        return HttpResponse(reason)
+
+    @action(detail=False, methods=["get"])
+    def stats(self, request):
+        period = request.query_params.get("period")
+        return HttpResponse(period)
+
+    @action(detail=False, methods=["get", "post"], url_path="bulk-status")
+    def bulk_status(self, request):
+        scope = request.query_params.get("scope")
+        return HttpResponse(scope)
+
+
+class MediaViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    lookup_url_kwarg = "media_id"
+
+    @action(
+        detail=True,
+        methods=["patch"],
+        url_path="moderate",
+    )
+    def moderate(self, request, media_id=None):
+        state = request.data.get("state")
+        return HttpResponse(state)
 
 
 class ArticleListView(ListView):
@@ -266,7 +314,10 @@ class ArchivesView(ArticleListView):
         return Article.objects.filter(status='p').all()
 
     def get_queryset_cache_key(self):
+        year = self.request.GET.get('year')
         cache_key = 'archives'
+        if year:
+            cache_key = '{cache_key}_{year}'.format(cache_key=cache_key, year=year)
         return cache_key
 
 
@@ -276,6 +327,16 @@ class LinkListView(ListView):
 
     def get_queryset(self):
         return Links.objects.filter(is_enable=True)
+
+
+class FeedbackView(View):
+    def get(self, request):
+        topic = request.GET.get('topic')
+        return HttpResponse(topic)
+
+    def post(self, request):
+        message = request.POST.get('message')
+        return HttpResponse(message)
 
 
 class EsSearchView(SearchView):
@@ -375,6 +436,33 @@ def delete_test(request):
         return 'delete'
 
     return "test"
+
+def legacy_detail(request, legacy_id):
+    preview = request.GET.get('preview')
+    return HttpResponse(f"{legacy_id}:{preview}")
+
+def local_report_list(request):
+    owner = request.GET.get('owner')
+    return HttpResponse(owner)
+
+def local_report_detail(request, report_slug):
+    preview = request.GET.get('preview')
+    return HttpResponse(f"{report_slug}:{preview}")
+
+def local_export(request):
+    since = request.GET.get('since')
+    return HttpResponse(since)
+
+def combined_report(request):
+    owner = request.GET.get('owner')
+    return HttpResponse(owner)
+
+def extended_report(request):
+    if request.method == 'POST':
+        token = request.POST.get('token')
+        return HttpResponse(token)
+
+    return HttpResponse("extended")
 
 def server_error_view(request, template_name='blog/error_page.html'):
     return render(request,

--- a/spec/functional_test/fixtures/python/falcon/app.py
+++ b/spec/functional_test/fixtures/python/falcon/app.py
@@ -1,4 +1,6 @@
 import falcon
+import resources
+from external_resources import ImportedReportResource
 
 
 class ThingsResource:
@@ -43,9 +45,35 @@ class UploadResource:
         resp.status = falcon.HTTP_200
 
 
+class ProfileResource:
+    def on_post(self, req, resp):
+        payload = req.media
+        username = payload['username']
+        email = payload.get('email')
+        resp.media = {'username': username, 'email': email}
+
+
+class SyncMediaResource:
+    def on_patch(self, req, resp):
+        payload = req.get_media()
+        title = payload['title']
+        state = payload.get('state')
+        resp.media = {'title': title, 'state': state}
+
+
+reports_resource = ThingsResource()
+external_profile_resource = resources.ExternalProfileResource()
+
 app = falcon.App()
 app.add_route('/things', ThingsResource())
+app.add_route('/reports', reports_resource)
 app.add_route('/things/{thing_id:int}', ThingResource())
 app.add_route('/things/{thing_id:int}/items', ThingResource(), suffix='item')
 app.add_route('/auth', AuthResource())
 app.add_route('/uploads/{name}', UploadResource())
+app.add_route('/profiles', ProfileResource())
+app.add_route('/sync-media', SyncMediaResource())
+app.add_route('/external/reports', ImportedReportResource())
+app.add_route('/external/widgets/{widget_id:int}', resources.WidgetResource())
+app.add_route('/external/profiles/{profile_id:int}', external_profile_resource, suffix='detail')
+app.add_static_route('/assets', './public')

--- a/spec/functional_test/fixtures/python/falcon/external_resources.py
+++ b/spec/functional_test/fixtures/python/falcon/external_resources.py
@@ -1,0 +1,9 @@
+class ImportedReportResource:
+    def on_get(self, req, resp):
+        owner = req.get_param('owner')
+        resp.media = {'owner': owner}
+
+    def on_post(self, req, resp):
+        payload = req.media
+        name = payload['name']
+        resp.media = {'name': name}

--- a/spec/functional_test/fixtures/python/falcon/resources.py
+++ b/spec/functional_test/fixtures/python/falcon/resources.py
@@ -1,0 +1,15 @@
+class WidgetResource:
+    def on_get(self, req, resp, widget_id):
+        trace_id = req.get_header('X-Trace-ID')
+        resp.media = {'widget_id': widget_id, 'trace_id': trace_id}
+
+    def on_patch(self, req, resp, widget_id):
+        payload = req.media
+        status = payload.get('status')
+        resp.media = {'widget_id': widget_id, 'status': status}
+
+
+class ExternalProfileResource:
+    def on_get_detail(self, req, resp, profile_id):
+        session = req.cookies.get('session')
+        resp.media = {'profile_id': profile_id, 'session': session}

--- a/spec/functional_test/fixtures/python/fastapi/api.py
+++ b/spec/functional_test/fixtures/python/fastapi/api.py
@@ -1,10 +1,13 @@
 import http
+import external_handlers
 from typing import FrozenSet, Optional,Union
+from fastapi_utils.cbv import cbv
 from typing_extensions import Annotated
 from fastapi.responses import JSONResponse
-from fastapi import FastAPI, Path, Query, status, Body, Header, Cookie, Depends, Request, Response, APIRouter
+from fastapi import FastAPI, Path, Query, status, Body, Header, Cookie, Depends, Security, Request, Response, APIRouter, WebSocket
 
 api : APIRouter = APIRouter()
+tenant_api = APIRouter(prefix="/tenants/{tenant_id}")
 BASE_ROUTE = "/constant"
 KEYWORD_ROUTE = "/keyword"
 
@@ -72,11 +75,91 @@ def keyword_fstring_route(q: int = Query()):
 def escaped_brace_fstring_route(item_id: int):
     return {"item_id": item_id}
 
+def resolve_account_id() -> int:
+    return 1
+
+def resolve_api_key() -> str:
+    return "secret"
+
+@api.get("/dependency/items/{item_id}")
+def dependency_route(
+    item_id: int,
+    account_id: int = Depends(resolve_account_id),
+    api_key: str = Security(resolve_api_key),
+    q: str = Query(),
+):
+    return {"item_id": item_id, "account_id": account_id, "api_key": api_key, "q": q}
+
+@cbv(api)
+class ItemViews:
+    @api.get("/cbv/items/{item_id}")
+    def get_item(self, item_id: int, include_meta: bool = Query(False)):
+        return {"item_id": item_id, "include_meta": include_meta}
+
 def registered_handler():
     return {"ok": True}
+
+
+def registered_item_handler(
+    item_id: int,
+    q: int = Query(),
+    payload: Annotated[Union[str, None], Body()] = None,
+):
+    return {"item_id": item_id, "q": q, "payload": payload}
+
+
+def tenant_registered_handler(
+    tenant_id: str,
+    q: int = Query(),
+):
+    return {"tenant_id": tenant_id, "q": q}
+
+
+@api.websocket("/ws/{room_id}")
+async def websocket_endpoint(
+    websocket: WebSocket,
+    room_id: str,
+    token: str = Query(),
+):
+    await websocket.accept()
+    await websocket.send_json({"room_id": room_id, "token": token})
+    await websocket.close()
+
+
+async def registered_websocket_handler(
+    websocket: WebSocket,
+    channel: str,
+    client_id: str = Query(),
+):
+    await websocket.accept()
+    await websocket.send_json({"channel": channel, "client_id": client_id})
+    await websocket.close()
 
 api.add_api_route(
     BASE_ROUTE + "/registered",
     registered_handler,
     methods=("POST",),
+)
+
+api.add_api_route(
+    f"{BASE_ROUTE}/registered/{{item_id}}",
+    endpoint=registered_item_handler,
+    methods=["PUT"],
+)
+
+api.add_api_route(
+    "/external/{item_id}",
+    endpoint=external_handlers.external_item_handler,
+    methods=["PATCH"],
+)
+
+tenant_api.add_api_route(
+    "/registered",
+    endpoint=tenant_registered_handler,
+    methods=["GET"],
+)
+
+api.add_api_websocket_route(
+    "/ws/registered/{channel}",
+    endpoint=registered_websocket_handler,
 )

--- a/spec/functional_test/fixtures/python/fastapi/external_handlers.py
+++ b/spec/functional_test/fixtures/python/fastapi/external_handlers.py
@@ -1,0 +1,12 @@
+from typing import Union
+
+from fastapi import Body, Query
+from typing_extensions import Annotated
+
+
+def external_item_handler(
+    item_id: int,
+    q: str = Query(),
+    payload: Annotated[Union[str, None], Body()] = None,
+):
+    return {"item_id": item_id, "q": q, "payload": payload}

--- a/spec/functional_test/fixtures/python/fastapi/main.py
+++ b/spec/functional_test/fixtures/python/fastapi/main.py
@@ -1,11 +1,29 @@
 import http
 from typing import FrozenSet, Optional
 
-from fastapi import FastAPI, Path, Query
+from fastapi import APIRouter, FastAPI, Path, Query
+from fastapi.staticfiles import StaticFiles
 from api import api
+from api import tenant_api
 
 app : FastAPI = FastAPI()
+local_router = APIRouter(prefix="/local")
 app.include_router(api, prefix="/api")
+app.include_router(tenant_api, prefix="/api")
+app.include_router(
+    router=local_router,
+    prefix="/v1",
+)
+app.mount(
+    "/assets",
+    StaticFiles(directory="public"),
+    name="assets",
+)
+
+
+@local_router.get("/status")
+def local_status(region: str = Query()):
+    return {"region": region}
 
 @app.get("/main")
 def main():

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/main.py
@@ -4,5 +4,8 @@ from app.api.routes import login, items, dynamic
 
 api_router = APIRouter()
 api_router.include_router(login.router)
-api_router.include_router(items.router)
+api_router.include_router(
+    router=items.router,
+    tags=["items"],
+)
 api_router.include_router(dynamic.router)

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/main.py
@@ -2,7 +2,7 @@
 # `prefix=settings.API_V1_STR` is an attribute reference, not a string
 # literal. The previous configure_router_prefix logic kept the raw
 # expression and emitted garbage URLs like `/settings.API_V1_STR/...`.
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
 from app.api.main import api_router
 from app.core.config import settings
@@ -10,4 +10,8 @@ from app.core.config import settings
 API_PREFIX = settings.API_V1_STR
 
 app = FastAPI()
-app.include_router(api_router, prefix=API_PREFIX)
+app.include_router(
+    router=api_router,
+    prefix=API_PREFIX,
+    dependencies=[Depends(lambda: True)],
+)

--- a/spec/functional_test/fixtures/python/flask_advanced/app.py
+++ b/spec/functional_test/fixtures/python/flask_advanced/app.py
@@ -5,12 +5,15 @@ Flask test fixture for advanced features:
 - add_url_rule with view assignments
 """
 from flask import Flask, Blueprint, request, jsonify
-from flask.views import MethodView
+from flask.views import MethodView, View
+import external_views
 
-app = Flask(__name__)
+app = Flask(__name__, static_url_path='/assets', static_folder='public')
 
 # Blueprint with shortcut decorators
 bp = Blueprint('api', __name__, url_prefix='/api')
+parent_bp = Blueprint('parent', __name__)
+nested_bp = Blueprint('nested', __name__)
 
 @app.get('/app-get')
 def app_get():
@@ -100,12 +103,49 @@ class AsyncAPI(MethodView):
         title = request.json.get('title')
         return jsonify({'title': title})
 
+class ReportView(View):
+    """Pluggable View using dispatch_request and class-level methods"""
+
+    methods = [
+        'GET',
+        'POST',
+    ]
+
+    def dispatch_request(self):
+        if request.method == 'POST':
+            payload = request.get_json()
+            title = payload.get('title')
+            return jsonify({'title': title})
+
+        owner = request.args.get('owner')
+        return jsonify({'owner': owner})
+
 @bp.post('/get-json')
 def use_get_json():
     """Test request.get_json() detection"""
     payload = request.get_json()
     action = payload.get('action')
     return jsonify({'action': action})
+
+@nested_bp.get('/reports/<int:report_id>')
+def nested_report(report_id):
+    """Nested blueprint route should inherit parent and app prefixes"""
+    mode = request.args.get('mode')
+    return jsonify({'report_id': report_id, 'mode': mode})
+
+
+def registered_search():
+    """Function view registered with add_url_rule"""
+    term = request.args.get('term')
+    trace_id = request.headers.get('X-Trace-Id')
+    return jsonify({'term': term, 'trace_id': trace_id})
+
+
+def registered_create():
+    """Keyword view_func registered with add_url_rule"""
+    payload = request.get_json()
+    name = payload['name']
+    return jsonify({'name': name})
 
 # Register MethodView with add_url_rule
 user_view = UserAPI.as_view('user_api')
@@ -121,6 +161,9 @@ bp.add_url_rule('/async', view_func=async_view, methods=['GET', 'POST'])
 # add_url_rule without explicit methods (should infer from class)
 bp.add_url_rule('/items-inferred', view_func=ItemAPI.as_view('item_inferred'))
 
+# flask.views.View uses dispatch_request with class-level methods
+bp.add_url_rule('/reports-view', view_func=ReportView.as_view('reports_view'))
+
 # add_url_rule with rule= keyword argument (not first positional)
 bp.add_url_rule(view_func=item_view, rule='/items-kwarg', methods=['GET', 'POST'])
 
@@ -133,8 +176,26 @@ bp.add_url_rule('/items-no-endpoint', item_view, methods=['GET', 'POST'])
 # add_url_rule with tuple methods syntax
 bp.add_url_rule('/items-tuple', view_func=item_view, methods=('GET', 'POST'))
 
+# add_url_rule split across lines, matching large app style
+bp.add_url_rule(
+    '/items-multiline',
+    view_func=item_view,
+    methods=[
+        'GET',
+        'POST',
+    ],
+)
+
+# add_url_rule with function views should preserve handler params
+bp.add_url_rule('/registered-search', 'registered_search', registered_search, methods=['GET'])
+bp.add_url_rule(rule='/registered-create', endpoint='registered_create', view_func=registered_create, methods=['POST'])
+bp.add_url_rule('/external-search', view_func=external_views.external_search, methods=['GET'])
+
+parent_bp.register_blueprint(nested_bp, url_prefix='/child')
+
 # Register blueprint
 app.register_blueprint(bp)
+app.register_blueprint(parent_bp, url_prefix='/mounted')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/spec/functional_test/fixtures/python/flask_advanced/external_views.py
+++ b/spec/functional_test/fixtures/python/flask_advanced/external_views.py
@@ -1,0 +1,7 @@
+from flask import jsonify, request
+
+
+def external_search():
+    term = request.args.get('term')
+    trace_id = request.headers.get('X-Trace-Id')
+    return jsonify({'term': term, 'trace_id': trace_id})

--- a/spec/functional_test/fixtures/python/litestar/app.py
+++ b/spec/functional_test/fixtures/python/litestar/app.py
@@ -1,5 +1,8 @@
-from litestar import Litestar, get, post, put, delete, route, Router
+import external_handlers
+from litestar import Controller, Litestar, get, post, put, delete, route, Router, websocket
 from litestar.connection import Request
+from litestar.handlers import WebsocketListener
+from litestar.params import Dependency
 from pydantic import BaseModel
 
 
@@ -10,6 +13,19 @@ class UserCreate(BaseModel):
 
 class UserUpdate(BaseModel):
     name: str
+
+
+class ReportCreate(BaseModel):
+    title: str
+
+
+class UserService:
+    def get_status(self) -> str:
+        return "ok"
+
+
+def provide_user_service() -> UserService:
+    return UserService()
 
 
 @get("/")
@@ -47,9 +63,19 @@ async def search(q: str) -> dict:
     return {"q": q}
 
 
+@get("/dependency/{user_id:int}")
+async def dependency_route(user_id: int, service: UserService = Dependency(provide_user_service), q: str = "") -> dict:
+    return {"user_id": user_id, "status": service.get_status(), "q": q}
+
+
 @route("/multi", http_method=["GET", "POST"])
 async def multi(request: Request) -> dict:
     return {}
+
+
+@websocket("/ws/{room_id:str}")
+async def room_socket(socket: WebsocketListener, room_id: str, token: str) -> None:
+    await socket.accept()
 
 
 @get("/headers")
@@ -74,7 +100,27 @@ async def get_item(item_id: int) -> dict:
     return {}
 
 
+@get("/summary")
+async def inline_summary(request: Request) -> dict:
+    mode = request.query_params.get("mode")
+    return {"mode": mode}
+
+
+class ReportsController(Controller):
+    path = "/reports/{org_id:int}"
+
+    @get("/{report_id:int}")
+    async def get_report(self, org_id: int, report_id: int, include_meta: bool = False) -> dict:
+        return {"org_id": org_id, "report_id": report_id, "include_meta": include_meta}
+
+    @post("")
+    async def create_report(self, org_id: int, data: ReportCreate) -> dict:
+        return {"org_id": org_id, "title": data.title}
+
+
 router = Router(path="/api", route_handlers=[list_items, get_item])
+admin_router = Router(path="/admin", route_handlers=[ReportsController])
+external_router = Router(path="/external", route_handlers=[external_handlers.external_summary])
 
 
 app = Litestar(route_handlers=[
@@ -85,8 +131,13 @@ app = Litestar(route_handlers=[
     update_user,
     delete_user,
     search,
+    dependency_route,
     multi,
+    room_socket,
     get_headers,
     get_cookies,
+    Router(path="/inline", route_handlers=[inline_summary]),
     router,
+    admin_router,
+    external_router,
 ])

--- a/spec/functional_test/fixtures/python/litestar/external_handlers.py
+++ b/spec/functional_test/fixtures/python/litestar/external_handlers.py
@@ -1,0 +1,8 @@
+from litestar import get
+from litestar.connection import Request
+
+
+@get("/summary")
+async def external_summary(request: Request) -> dict:
+    mode = request.query_params.get("mode")
+    return {"mode": mode}

--- a/spec/functional_test/fixtures/python/pyramid/app.py
+++ b/spec/functional_test/fixtures/python/pyramid/app.py
@@ -1,5 +1,5 @@
 from pyramid.config import Configurator
-from pyramid.view import view_config
+from pyramid.view import view_config, view_defaults
 from wsgiref.simple_server import make_server
 
 
@@ -32,9 +32,37 @@ def login_view(request):
     return {"ok": bool(username and password)}
 
 
+@view_config(route_name="about", request_method="GET", renderer="json")
+def about_view(request):
+    source = request.params["source"]
+    return {"source": source}
+
+
+@view_config(route_name="external_report", request_method="GET", renderer="json")
+def external_report_view(request):
+    include = request.params.get("include")
+    return {"include": include}
+
+
 def ping_view(request):
     fmt = request.GET.get("format")
     return {"pong": True, "format": fmt}
+
+
+@view_defaults(route_name="orders", renderer="json")
+class OrdersView:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(request_method="GET")
+    def list(self):
+        status = self.request.params.get("status")
+        return {"status": status}
+
+    @view_config(request_method="POST")
+    def create(self):
+        order_id = self.request.json_body["order_id"]
+        return {"order_id": order_id}
 
 
 def main(global_config, **settings):
@@ -43,7 +71,14 @@ def main(global_config, **settings):
     config.add_route("user", "/users/{id}")
     config.add_route("api_items", "/api/items")
     config.add_route("api_login", "/api/login")
+    config.add_route(pattern="/about", name="about")
     config.add_route("ping", "/ping")
+    config.add_route("orders", "/orders")
+    config.add_static_view(
+        name="assets",
+        path="public",
+        cache_max_age=3600,
+    )
     config.add_view(ping_view, route_name="ping", request_method="GET", renderer="json")
     config.scan()
     return config.make_wsgi_app()

--- a/spec/functional_test/fixtures/python/pyramid/routes.py
+++ b/spec/functional_test/fixtures/python/pyramid/routes.py
@@ -1,0 +1,2 @@
+def includeme(config):
+    config.add_route("external_report", "/external/reports/{report_id}")

--- a/spec/functional_test/fixtures/python/quart/app.py
+++ b/spec/functional_test/fixtures/python/quart/app.py
@@ -1,7 +1,11 @@
 from quart import Quart, Blueprint, request, websocket, jsonify
+from quart.views import MethodView, View
+import external_views
 
 app = Quart(__name__)
 api = Blueprint("api", __name__, url_prefix="/api/v1")
+parent_bp = Blueprint("parent", __name__)
+nested_bp = Blueprint("nested", __name__)
 
 
 @app.route("/items", methods=["GET", "POST"])
@@ -30,6 +34,48 @@ async def create_user():
     return jsonify({"username": body["username"]})
 
 
+@nested_bp.get("/reports/<int:report_id>")
+async def nested_report(report_id):
+    mode = request.args.get("mode")
+    return jsonify({"report_id": report_id, "mode": mode})
+
+
+async def registered_search():
+    term = request.args.get("term")
+    trace_id = request.headers.get("X-Trace-Id")
+    return jsonify({"term": term, "trace_id": trace_id})
+
+
+async def registered_create():
+    body = await request.get_json()
+    return jsonify({"name": body["name"]})
+
+
+class ReportView(MethodView):
+    async def get(self, report_id):
+        include = request.args.get("include")
+        return jsonify({"id": report_id, "include": include})
+
+    async def post(self):
+        body = await request.get_json()
+        return jsonify({"title": body["title"]})
+
+
+class DispatchReportView(View):
+    methods = [
+        "GET",
+        "POST",
+    ]
+
+    async def dispatch_request(self):
+        if request.method == "POST":
+            body = await request.get_json()
+            return jsonify({"name": body["name"]})
+
+        owner = request.args.get("owner")
+        return jsonify({"owner": owner})
+
+
 @app.websocket("/ws")
 async def ws():
     while True:
@@ -38,6 +84,14 @@ async def ws():
 
 
 app.register_blueprint(api)
+parent_bp.register_blueprint(nested_bp, url_prefix="/child")
+app.register_blueprint(parent_bp, url_prefix="/mounted")
+app.add_url_rule("/reports/<int:report_id>", view_func=ReportView.as_view("report_detail"), methods=["GET"])
+app.add_url_rule("/reports", view_func=ReportView.as_view("report_create"), methods=["POST"])
+app.add_url_rule("/dispatch-reports", view_func=DispatchReportView.as_view("dispatch_reports"))
+api.add_url_rule("/registered-search", "registered_search", registered_search, methods=["GET"])
+api.add_url_rule(rule="/registered-create", endpoint="registered_create", view_func=registered_create, methods=["POST"])
+api.add_url_rule("/external-search", view_func=external_views.external_search, methods=["GET"])
 
 
 if __name__ == "__main__":

--- a/spec/functional_test/fixtures/python/quart/external_views.py
+++ b/spec/functional_test/fixtures/python/quart/external_views.py
@@ -1,0 +1,7 @@
+from quart import jsonify, request
+
+
+async def external_search():
+    term = request.args.get("term")
+    trace_id = request.headers.get("X-Trace-Id")
+    return jsonify({"term": term, "trace_id": trace_id})

--- a/spec/functional_test/fixtures/python/robyn/app.py
+++ b/spec/functional_test/fixtures/python/robyn/app.py
@@ -55,9 +55,15 @@ async def websocket_endpoint():
     return {"ws": True}
 
 
+@app.websocket("/live/:room_id")
+async def live_updates():
+    return {"live": True}
+
+
 # SubRouter with positional `/api` prefix; routes under it inherit the
 # `/api` mount.
 api = SubRouter(__file__, "/api")
+admin = SubRouter(__file__, "/admin")
 
 
 @api.get("/items")
@@ -67,10 +73,32 @@ async def list_items():
 
 @api.post("/items/:item_id/tags")
 async def tag_item(request):
+    tag = request.json().get("tag")
+    priority = request.json()["priority"]
     return {"ok": True}
 
 
+@admin.get("/metrics/:metric_id")
+async def admin_metric(request):
+    window = request.query_params.get("window")
+    return {"window": window}
+
+
+v2 = SubRouter(
+    __file__,
+    "/v2",
+)
+
+
+@v2.get("/reports/:report_id")
+async def get_report(request):
+    include = request.query_params.get("include")
+    return {"include": include}
+
+
+api.include_router(admin)
 app.include_router(api)
+app.include_router(v2)
 
 
 if __name__ == "__main__":

--- a/spec/functional_test/fixtures/python/sanic/app.py
+++ b/spec/functional_test/fixtures/python/sanic/app.py
@@ -1,11 +1,14 @@
 import sys
 import json
 import hashlib
-from sanic import Sanic, response
+import external_handlers
+from sanic import Blueprint, Sanic, response
 from sanic.request import Request
+from sanic.views import HTTPMethodView
 
 app = Sanic("test_app")
 app.config.SECRET = "dd2e7b987b357908fac0118ecdf0d3d2cae7b5a635f802d6"
+reports_bp = Blueprint("reports", url_prefix="/reports")
 
 @app.route('/sign', methods=['GET', 'POST'])
 async def sign_sample(request: Request):
@@ -56,6 +59,68 @@ async def get_ip(request: Request):
 @app.route('/')
 async def index(request: Request):
     return response.html('<html><body>Index page</body></html>')
+
+@app.websocket('/feed/<channel>')
+async def feed_socket(request: Request, ws, channel: str):
+    token = request.args.get('token')
+    await ws.send(json.dumps({'channel': channel, 'token': token}))
+
+@reports_bp.get('/<report_id:int>')
+async def get_report(request: Request, report_id: int):
+    include = request.args.get('include')
+    return response.json({'id': report_id, 'include': include})
+
+@reports_bp.post('/create')
+async def create_report(request: Request):
+    record = request.json
+    title = record.get('title')
+    return response.json({'title': title})
+
+
+async def update_report(request: Request, report_id: int):
+    record = request.json
+    status = record.get('status')
+    return response.json({'id': report_id, 'status': status})
+
+
+async def audit_reports(request: Request):
+    actor = request.args.get('actor')
+    return response.json({'actor': actor})
+
+
+class ReportMethodView(HTTPMethodView):
+    async def get(self, request: Request, report_id: int):
+        include = request.args.get('include')
+        return response.json({'id': report_id, 'include': include})
+
+    async def post(self, request: Request, report_id: int):
+        record = request.json
+        title = record.get('title')
+        return response.json({'id': report_id, 'title': title})
+
+
+app.add_route(
+    update_report,
+    '/reports/<report_id:int>/status',
+    methods=['PATCH'],
+)
+app.add_route(
+    ReportMethodView.as_view(),
+    '/class-reports/<report_id:int>',
+)
+app.add_route(
+    external_handlers.external_status,
+    '/external/<item_id:int>',
+    methods=['PUT'],
+)
+reports_bp.add_route(
+    handler=audit_reports,
+    uri='/audit',
+    methods=['GET'],
+)
+app.static('/assets', './static')
+reports_bp.static('/files', './report_files')
+app.blueprint(reports_bp, url_prefix="/api/v1")
 
 if __name__ == "__main__":
     port = 80

--- a/spec/functional_test/fixtures/python/sanic/external_handlers.py
+++ b/spec/functional_test/fixtures/python/sanic/external_handlers.py
@@ -1,0 +1,9 @@
+from sanic import response
+from sanic.request import Request
+
+
+async def external_status(request: Request, item_id: int):
+    trace = request.args.get('trace')
+    record = request.json
+    state = record.get('state')
+    return response.json({'id': item_id, 'trace': trace, 'state': state})

--- a/spec/functional_test/fixtures/python/starlette/app.py
+++ b/spec/functional_test/fixtures/python/starlette/app.py
@@ -1,7 +1,11 @@
+import external_views
+
 from starlette.applications import Starlette
-from starlette.routing import Route, Mount
+from starlette.endpoints import HTTPEndpoint, WebSocketEndpoint
+from starlette.routing import Route, Mount, Router, WebSocketRoute
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
+from starlette.staticfiles import StaticFiles
 
 
 async def homepage(request):
@@ -45,6 +49,78 @@ async def profile(request):
     return Response(name)
 
 
+async def admin_dashboard(request):
+    section = request.query_params.get('section')
+    return JSONResponse({"section": section})
+
+
+async def internal_status(request):
+    region = request.query_params.get('region')
+    return JSONResponse({"region": region})
+
+
+async def audit_entry(request):
+    entry_id = request.path_params['entry_id']
+    source = request.query_params.get('source')
+    return JSONResponse({"entry_id": entry_id, "source": source})
+
+
+async def nested_metric(request):
+    metric_id = request.path_params['metric_id']
+    window = request.query_params.get('window')
+    return JSONResponse({"metric_id": metric_id, "window": window})
+
+
+async def chat_socket(websocket):
+    room = websocket.path_params['room']
+    token = websocket.query_params.get('token')
+    await websocket.accept()
+    await websocket.send_json({"room": room, "token": token})
+    await websocket.close()
+
+
+class ReportEndpoint(HTTPEndpoint):
+    async def get(self, request):
+        report_id = request.path_params['report_id']
+        include = request.query_params.get('include')
+        return JSONResponse({"report_id": report_id, "include": include})
+
+    async def post(self, request):
+        payload = await request.json()
+        title = payload['title']
+        return JSONResponse({"title": title})
+
+
+class NotificationSocket(WebSocketEndpoint):
+    async def on_connect(self, websocket):
+        topic = websocket.path_params['topic']
+        client = websocket.headers.get('X-Client')
+        await websocket.accept()
+
+
+admin_routes = [
+    Route('/dashboard', admin_dashboard),
+    Route('/reports/{report_id:int}', ReportEndpoint),
+]
+
+internal_routes = [
+    Route('/status', internal_status),
+]
+
+v1_routes = [
+    Route('/metrics/{metric_id:int}', nested_metric),
+]
+
+nested_routes = [
+    Mount('/v1', routes=v1_routes),
+]
+
+internal_app = Starlette(routes=internal_routes)
+programmatic_app = Router()
+programmatic_app.add_route('/audit/{entry_id:int}', audit_entry, methods=['GET'])
+programmatic_app.add_websocket_route('/ws/{room}', chat_socket)
+
+
 app = Starlette(routes=[
     Route('/', homepage),
     Route('/users/{user_id}', get_user),
@@ -52,8 +128,21 @@ app = Starlette(routes=[
     Route('/search', search),
     Route('/upload', upload, methods=['POST']),
     Route('/profile/{name:str}', profile),
+    Route('/external/{item_id:int}', external_views.external_item),
+    Route('/reports/{report_id:int}', ReportEndpoint),
     Mount('/api', routes=[
         Route('/items', list_items),
         Route('/items/{id:int}', get_item),
     ]),
+    Mount('/admin', routes=admin_routes),
+    Mount('/internal', app=internal_app),
+    Mount('/nested', routes=nested_routes),
+    Mount('/programmatic', app=programmatic_app),
+    Mount(
+        '/assets',
+        app=StaticFiles(directory='public'),
+        name='assets',
+    ),
+    WebSocketRoute('/ws/{room}', chat_socket),
+    WebSocketRoute('/notifications/{topic:str}', NotificationSocket),
 ])

--- a/spec/functional_test/fixtures/python/starlette/external_views.py
+++ b/spec/functional_test/fixtures/python/starlette/external_views.py
@@ -1,0 +1,9 @@
+from starlette.responses import JSONResponse
+
+
+async def external_item(request):
+    item_id = request.path_params["item_id"]
+    q = request.query_params.get("q")
+    payload = await request.json()
+    title = payload.get("title")
+    return JSONResponse({"item_id": item_id, "q": q, "title": title})

--- a/spec/functional_test/fixtures/python/tornado/alt_app.py
+++ b/spec/functional_test/fixtures/python/tornado/alt_app.py
@@ -104,3 +104,21 @@ deep_dotted_routes = [
 ]
 
 app11 = tornado.web.Application(deep_dotted_routes)
+
+# Test: add_handlers() with variable and inline route lists
+extra_routes = [
+    (r"/metrics", HealthHandler),
+]
+
+app11.add_handlers(r".*", extra_routes)
+app11.add_handlers(r".*", [
+    (r"/version", StatusHandler),
+])
+
+# Test: URLSpec helper objects in route lists
+urlspec_routes = [
+    tornado.web.url(r"/named-url", StatusHandler, name="named_url"),
+    tornado.web.URLSpec(r"/spec-url", HealthHandler, name="spec_url"),
+]
+
+app12 = tornado.web.Application(urlspec_routes)

--- a/spec/functional_test/fixtures/python/tornado/app.py
+++ b/spec/functional_test/fixtures/python/tornado/app.py
@@ -1,4 +1,5 @@
 import tornado.web
+import tornado.websocket
 import tornado.escape
 from handlers import ApiHandler, SearchHandler
 from admin import AdminHandler
@@ -24,10 +25,28 @@ class AuthHandler(tornado.web.RequestHandler):
         if token and api_key:
             self.write("Authenticated")
 
+class ChatSocket(tornado.websocket.WebSocketHandler):
+    def open(self, room_id):
+        token = self.get_argument("token")
+        self.write_message(f"joined {room_id} with {token}")
+
+class ProductHandler(tornado.web.RequestHandler):
+    def get(self, product_id):
+        expand = self.get_argument("expand")
+        self.write({"product_id": product_id, "expand": expand})
+
+class NamedItemHandler(tornado.web.RequestHandler):
+    def get(self, item_id):
+        trace = self.request.headers.get("X-Trace-ID")
+        self.write({"item_id": item_id, "trace": trace})
+
 routes = [
     (r"/", MainHandler),
     (r"/users", UserHandler),
     (r"/auth", AuthHandler),
+    (r"/ws/([^/]+)", ChatSocket),
+    (r"/products/([0-9]+)", ProductHandler),
+    (r"/named/(?P<item_id>[^/]+)", NamedItemHandler),
     (r"/api", ApiHandler),
     (r"/search", SearchHandler),
     (r"/items(?:/(\d+))?", SearchHandler),

--- a/spec/functional_test/testers/python/aiohttp_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_spec.cr
@@ -19,6 +19,26 @@ expected_endpoints = [
   Endpoint.new("/users/{id}", "PATCH", [
     Param.new("id", "", "path"),
   ]),
+  Endpoint.new("/feed/{channel}", "GET", [
+    Param.new("channel", "", "path"),
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/reports/{id}", "GET", [
+    Param.new("id", "", "path"),
+    Param.new("verbose", "", "query"),
+  ]),
+  Endpoint.new("/reports/{id}", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("title", "", "json"),
+  ]),
+  Endpoint.new("/assets/*", "GET"),
+  Endpoint.new("/decorated/{item_id}", "GET", [
+    Param.new("item_id", "", "path"),
+  ]),
+  Endpoint.new("/decorated/{item_id}", "PATCH", [
+    Param.new("item_id", "", "path"),
+    Param.new("status", "", "json"),
+  ]),
   Endpoint.new("/admin", "GET", [
     Param.new("session", "", "cookie"),
     Param.new("User-Agent", "", "header"),
@@ -34,9 +54,43 @@ expected_endpoints = [
     Param.new("category", "", "path"),
     Param.new("q", "", "query"),
   ]),
+  Endpoint.new("/admin/stats", "GET", [
+    Param.new("section", "", "query"),
+  ]),
+  Endpoint.new("/admin/health/{check}", "GET", [
+    Param.new("check", "", "path"),
+  ]),
+  Endpoint.new("/admin/audit/{audit_id}", "GET", [
+    Param.new("audit_id", "", "path"),
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/admin/audit/{audit_id}", "DELETE", [
+    Param.new("audit_id", "", "path"),
+    Param.new("X-Audit-Token", "", "header"),
+  ]),
+  Endpoint.new("/admin/static/*", "GET"),
+  Endpoint.new("/tenant-api/tenants/{tenant_id}", "GET", [
+    Param.new("tenant_id", "", "path"),
+    Param.new("expand", "", "query"),
+  ]),
+  Endpoint.new("/tenant-api/tenants", "POST", [
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/tenant-api/external/{external_id}", "PATCH", [
+    Param.new("external_id", "", "path"),
+    Param.new("mode", "", "query"),
+    Param.new("title", "", "json"),
+  ]),
 ]
 
-FunctionalTester.new("fixtures/python/aiohttp/", {
+tester = FunctionalTester.new("fixtures/python/aiohttp/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "marks aiohttp WebSocketResponse handlers with ws protocol" do
+  feed = tester.app.endpoints.find { |endpoint| endpoint.url == "/feed/{channel}" }
+  feed.should_not be_nil
+  feed.try(&.protocol).should eq("ws")
+end

--- a/spec/functional_test/testers/python/bottle_spec.cr
+++ b/spec/functional_test/testers/python/bottle_spec.cr
@@ -20,9 +20,37 @@ expected_endpoints = [
   Endpoint.new("/users/<id:int>", "GET", [
     Param.new("id", "", "path"),
   ]),
+  Endpoint.new("/admin/dashboard", "GET", [
+    Param.new("section", "", "query"),
+  ]),
+  Endpoint.new("/admin/reports/<report_id:int>", "POST", [
+    Param.new("report_id", "", "path"),
+    Param.new("title", "", "json"),
+  ]),
+  Endpoint.new("/api/admin/metrics/<metric_id:int>", "GET", [
+    Param.new("metric_id", "", "path"),
+    Param.new("window", "", "query"),
+  ]),
   Endpoint.new("/search", "GET", [
     Param.new("q", "", "query"),
     Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/keyword/login", "POST", [
+    Param.new("username", "", "json"),
+    Param.new("X-Login-Token", "", "header"),
+  ]),
+  Endpoint.new("/keyword/status/<status_id:int>", "GET", [
+    Param.new("status_id", "", "path"),
+    Param.new("region", "", "query"),
+  ]),
+  Endpoint.new("/bulk", "PUT", [
+    Param.new("action", "", "json"),
+  ]),
+  Endpoint.new("/bulk", "PATCH", [
+    Param.new("action", "", "json"),
+  ]),
+  Endpoint.new("/health", "GET", [
+    Param.new("probe", "", "query"),
   ]),
 ]
 

--- a/spec/functional_test/testers/python/django_spec.cr
+++ b/spec/functional_test/testers/python/django_spec.cr
@@ -1,6 +1,93 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
+  Endpoint.new("/api/articles/", "GET", [
+    Param.new("status", "", "query"),
+  ]),
+  Endpoint.new("/api/articles/{article_id}/", "GET", [
+    Param.new("preview", "", "query"),
+    Param.new("article_id", "", "path"),
+  ]),
+  Endpoint.new("/api/articles/{article_id}/publish/", "POST", [
+    Param.new("reason", "", "form"),
+    Param.new("article_id", "", "path"),
+  ]),
+  Endpoint.new("/api/articles/stats/", "GET", [
+    Param.new("period", "", "query"),
+  ]),
+  Endpoint.new("/api/articles/bulk-status/", "GET", [
+    Param.new("scope", "", "query"),
+  ]),
+  Endpoint.new("/api/articles/bulk-status/", "POST", [
+    Param.new("scope", "", "query"),
+  ]),
+  Endpoint.new("/api/media/", "GET"),
+  Endpoint.new("/api/media/{media_id}/", "GET", [
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/api/media/{media_id}/moderate/", "PATCH", [
+    Param.new("state", "", "form"),
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/api/keyword-media/", "GET"),
+  Endpoint.new("/api/keyword-media/{media_id}/", "GET", [
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/api/keyword-media/{media_id}/moderate/", "PATCH", [
+    Param.new("state", "", "form"),
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/imported-api/library-media/", "GET"),
+  Endpoint.new("/imported-api/library-media/{media_id}/", "GET", [
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/imported-api/library-media/{media_id}/moderate/", "PATCH", [
+    Param.new("state", "", "form"),
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/direct-articles/", "GET", [
+    Param.new("status", "", "query"),
+  ]),
+  Endpoint.new("/direct-articles/{article_id}/", "GET", [
+    Param.new("preview", "", "query"),
+    Param.new("article_id", "", "path"),
+  ]),
+  Endpoint.new("/direct-articles/{article_id}/publish/", "POST", [
+    Param.new("reason", "", "form"),
+    Param.new("article_id", "", "path"),
+  ]),
+  Endpoint.new("/direct-articles/stats/", "GET", [
+    Param.new("period", "", "query"),
+  ]),
+  Endpoint.new("/direct-articles/bulk-status/", "GET", [
+    Param.new("scope", "", "query"),
+  ]),
+  Endpoint.new("/direct-articles/bulk-status/", "POST", [
+    Param.new("scope", "", "query"),
+  ]),
+  Endpoint.new("/direct-media/", "GET"),
+  Endpoint.new("/direct-media/{media_id}/", "GET", [
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/direct-media/{media_id}/moderate/", "PATCH", [
+    Param.new("state", "", "form"),
+    Param.new("media_id", "", "path"),
+  ]),
+  Endpoint.new("/local/reports/", "GET", [
+    Param.new("owner", "", "query"),
+  ]),
+  Endpoint.new("/local/reports/<slug:report_slug>/", "GET", [
+    Param.new("preview", "", "query"),
+    Param.new("report_slug", "", "path"),
+  ]),
+  Endpoint.new("/namespaced/exports/", "GET", [
+    Param.new("since", "", "query"),
+  ]),
+  Endpoint.new("/combined/", "GET", [
+    Param.new("owner", "", "query"),
+  ]),
+  Endpoint.new("/extended/", "GET", [Param.new("token", "", "form")]),
+  Endpoint.new("/extended/", "POST", [Param.new("token", "", "form")]),
   Endpoint.new("/", "GET"),
   Endpoint.new("/page/<int:page>/", "GET", [
     Param.new("page", "", "path"),
@@ -33,8 +120,10 @@ expected_endpoints = [
     Param.new("tag_name", "", "path"),
     Param.new("page", "", "path"),
   ]),
-  Endpoint.new("/archives.html", "GET"),
+  Endpoint.new("/archives.html", "GET", [Param.new("year", "", "query")]),
   Endpoint.new("/links.html", "GET"),
+  Endpoint.new("/feedback/", "GET", [Param.new("topic", "", "query")]),
+  Endpoint.new("/feedback/", "POST", [Param.new("message", "", "form")]),
   Endpoint.new("/upload", "GET", [Param.new("sign", "", "query"), Param.new("sign", "", "query"), Param.new("X_FORWARDED_FOR", "", "header"), Param.new("X_REAL_IP", "", "header")]),
   Endpoint.new("/upload", "POST", [Param.new("sign", "", "query"), Param.new("X_FORWARDED_FOR", "", "header"), Param.new("X_REAL_IP", "", "header")]),
   Endpoint.new("/not_found", "GET", [Param.new("app_type", "", "cookie")]),
@@ -44,6 +133,10 @@ expected_endpoints = [
   Endpoint.new("/test", "PATCH", [Param.new("test_param", "", "form")]),
   Endpoint.new("/delete_test", "GET"),
   Endpoint.new("/delete_test", "DELETE"),
+  Endpoint.new("/legacy/{legacy_id}/", "GET", [
+    Param.new("preview", "", "query"),
+    Param.new("legacy_id", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/python/django/", {

--- a/spec/functional_test/testers/python/falcon_spec.cr
+++ b/spec/functional_test/testers/python/falcon_spec.cr
@@ -8,6 +8,13 @@ expected_endpoints = [
   Endpoint.new("/things", "POST", [
     Param.new("body", "", "json"),
   ]),
+  Endpoint.new("/reports", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("limit", "", "query"),
+  ]),
+  Endpoint.new("/reports", "POST", [
+    Param.new("body", "", "json"),
+  ]),
   Endpoint.new("/things/{thing_id}", "GET", [
     Param.new("X-API-Key", "", "header"),
     Param.new("thing_id", "", "path"),
@@ -31,6 +38,33 @@ expected_endpoints = [
     Param.new("body", "", "form"),
     Param.new("name", "", "path"),
   ]),
+  Endpoint.new("/profiles", "POST", [
+    Param.new("username", "", "json"),
+    Param.new("email", "", "json"),
+  ]),
+  Endpoint.new("/sync-media", "PATCH", [
+    Param.new("title", "", "json"),
+    Param.new("state", "", "json"),
+  ]),
+  Endpoint.new("/external/reports", "GET", [
+    Param.new("owner", "", "query"),
+  ]),
+  Endpoint.new("/external/reports", "POST", [
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/external/widgets/{widget_id}", "GET", [
+    Param.new("X-Trace-ID", "", "header"),
+    Param.new("widget_id", "", "path"),
+  ]),
+  Endpoint.new("/external/widgets/{widget_id}", "PATCH", [
+    Param.new("status", "", "json"),
+    Param.new("widget_id", "", "path"),
+  ]),
+  Endpoint.new("/external/profiles/{profile_id}", "GET", [
+    Param.new("session", "", "cookie"),
+    Param.new("profile_id", "", "path"),
+  ]),
+  Endpoint.new("/assets/*", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/falcon/", {

--- a/spec/functional_test/testers/python/fastapi_callees_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_callees_spec.cr
@@ -15,7 +15,7 @@ require "../../func_spec.cr"
 #   4. DELETE /orders/{...} — blank line + comment between the route
 #                              decorator and the def. Same fragility,
 #                              same fix path.
-#   5. GET /reports         — @api.get on an APIRouter declared in
+#   5. GET /internal/reports — @api.get on an APIRouter declared in
 #                              a separate file; locks in that the
 #                              include_router emit branch also pushes
 #                              callees.
@@ -43,7 +43,7 @@ expected_endpoints = [
     ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 
-  Endpoint.new("/reports", "GET").tap do |ep|
+  Endpoint.new("/internal/reports", "GET").tap do |ep|
     ep.push_callee(Callee.new("db.fetch_report", db_path, 9))
   end,
 ]

--- a/spec/functional_test/testers/python/fastapi_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_spec.cr
@@ -1,19 +1,64 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
-  Endpoint.new("/query/param-required/int", "GET", [Param.new("query", "", "query")]),
-  Endpoint.new("/items/{item_id}", "PUT", [Param.new("item_id", "", "path"), Param.new("name", "", "form"), Param.new("size", "", "form")]),
-  Endpoint.new("/hidden_header", "GET", [Param.new("hidden_header", "", "header")]),
-  Endpoint.new("/cookie_examples/", "GET", [Param.new("data", "", "cookie")]),
-  Endpoint.new("/dummypath", "POST", [Param.new("dummy", "", "json")]),
-  Endpoint.new("/constant/concat", "GET"),
-  Endpoint.new("/keyword/fstring", "GET", [Param.new("q", "", "query")]),
-  Endpoint.new("/keyword/items/{item_id}", "GET", [Param.new("item_id", "", "path")]),
-  Endpoint.new("/constant/registered", "POST"),
+  Endpoint.new("/api/query/param-required/int", "GET", [Param.new("query", "", "query")]),
+  Endpoint.new("/api/items/{item_id}", "PUT", [Param.new("item_id", "", "path"), Param.new("name", "", "form"), Param.new("size", "", "form")]),
+  Endpoint.new("/api/hidden_header", "GET", [Param.new("hidden_header", "", "header")]),
+  Endpoint.new("/api/cookie_examples/", "GET", [Param.new("data", "", "cookie")]),
+  Endpoint.new("/api/dummypath", "POST", [Param.new("dummy", "", "json")]),
+  Endpoint.new("/api/constant/concat", "GET"),
+  Endpoint.new("/api/keyword/fstring", "GET", [Param.new("q", "", "query")]),
+  Endpoint.new("/api/keyword/items/{item_id}", "GET", [Param.new("item_id", "", "path")]),
+  Endpoint.new("/api/dependency/items/{item_id}", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("item_id", "", "path"),
+  ]),
+  Endpoint.new("/api/cbv/items/{item_id}", "GET", [
+    Param.new("include_meta", "False", "query"),
+    Param.new("item_id", "", "path"),
+  ]),
+  Endpoint.new("/api/constant/registered", "POST"),
+  Endpoint.new("/api/constant/registered/{item_id}", "PUT", [
+    Param.new("item_id", "", "path"),
+    Param.new("q", "", "query"),
+    Param.new("payload", "", "form"),
+  ]),
+  Endpoint.new("/api/external/{item_id}", "PATCH", [
+    Param.new("item_id", "", "path"),
+    Param.new("q", "", "query"),
+    Param.new("payload", "", "form"),
+  ]),
+  Endpoint.new("/api/tenants/{tenant_id}/registered", "GET", [
+    Param.new("tenant_id", "", "path"),
+    Param.new("q", "", "query"),
+  ]),
+  Endpoint.new("/api/ws/{room_id}", "GET", [
+    Param.new("room_id", "", "path"),
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/api/ws/registered/{channel}", "GET", [
+    Param.new("channel", "", "path"),
+    Param.new("client_id", "", "query"),
+  ]),
+  Endpoint.new("/v1/local/status", "GET", [
+    Param.new("region", "", "query"),
+  ]),
+  Endpoint.new("/assets/*", "GET"),
   Endpoint.new("/main", "GET"),
 ]
 
-FunctionalTester.new("fixtures/python/fastapi/", {
+tester = FunctionalTester.new("fixtures/python/fastapi/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "marks FastAPI websocket endpoints with ws protocol" do
+  websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/api/ws/{room_id}" }
+  websocket_route.should_not be_nil
+  websocket_route.try(&.protocol).should eq("ws")
+
+  registered_websocket = tester.app.endpoints.find { |endpoint| endpoint.url == "/api/ws/registered/{channel}" }
+  registered_websocket.should_not be_nil
+  registered_websocket.try(&.protocol).should eq("ws")
+end

--- a/spec/functional_test/testers/python/flask_advanced_spec.cr
+++ b/spec/functional_test/testers/python/flask_advanced_spec.cr
@@ -26,9 +26,16 @@ expected_endpoints = [
   # request.get_json()
   Endpoint.new("/api/get-json", "POST", [Param.new("action", "", "json")]),
 
+  # Nested blueprint registration
+  Endpoint.new("/mounted/child/reports/<int:report_id>", "GET", [Param.new("mode", "", "query")]),
+
   # MethodView - ItemAPI (inferred methods, no explicit methods= arg)
   Endpoint.new("/api/items-inferred", "GET", [Param.new("page", "", "query")]),
   Endpoint.new("/api/items-inferred", "POST", [Param.new("name", "", "json")]),
+
+  # flask.views.View dispatch_request with class-level methods
+  Endpoint.new("/api/reports-view", "GET", [Param.new("owner", "", "query")]),
+  Endpoint.new("/api/reports-view", "POST", [Param.new("title", "", "json")]),
 
   # MethodView - AsyncAPI (async def)
   Endpoint.new("/api/async", "GET", [Param.new("category", "", "query")]),
@@ -49,6 +56,26 @@ expected_endpoints = [
   # add_url_rule with tuple methods syntax
   Endpoint.new("/api/items-tuple", "GET", [Param.new("page", "", "query")]),
   Endpoint.new("/api/items-tuple", "POST", [Param.new("name", "", "json")]),
+
+  # add_url_rule split across lines
+  Endpoint.new("/api/items-multiline", "GET", [Param.new("page", "", "query")]),
+  Endpoint.new("/api/items-multiline", "POST", [Param.new("name", "", "json")]),
+
+  # add_url_rule with function views
+  Endpoint.new("/api/registered-search", "GET", [
+    Param.new("term", "", "query"),
+    Param.new("X-Trace-Id", "", "header"),
+  ]),
+  Endpoint.new("/api/registered-create", "POST", [
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/api/external-search", "GET", [
+    Param.new("term", "", "query"),
+    Param.new("X-Trace-Id", "", "header"),
+  ]),
+
+  # Explicit Flask static route
+  Endpoint.new("/assets/*", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/flask_advanced/", {

--- a/spec/functional_test/testers/python/litestar_spec.cr
+++ b/spec/functional_test/testers/python/litestar_spec.cr
@@ -8,15 +8,41 @@ expected_endpoints = [
   Endpoint.new("/users/{user_id}", "PUT", [Param.new("user_id", "", "path"), Param.new("data", "", "json")]),
   Endpoint.new("/users/{user_id}", "DELETE", [Param.new("user_id", "", "path")]),
   Endpoint.new("/search", "GET", [Param.new("q", "", "query")]),
+  Endpoint.new("/dependency/{user_id}", "GET", [
+    Param.new("user_id", "", "path"),
+    Param.new("q", "", "query"),
+  ]),
   Endpoint.new("/multi", "GET"),
   Endpoint.new("/multi", "POST"),
+  Endpoint.new("/ws/{room_id}", "GET", [
+    Param.new("room_id", "", "path"),
+    Param.new("token", "", "query"),
+  ]),
   Endpoint.new("/headers", "GET", [Param.new("X-Token", "", "header")]),
   Endpoint.new("/cookies", "GET", [Param.new("session", "", "cookie")]),
+  Endpoint.new("/inline/summary", "GET", [Param.new("mode", "", "query")]),
   Endpoint.new("/api/items", "GET"),
   Endpoint.new("/api/items/{item_id}", "GET", [Param.new("item_id", "", "path")]),
+  Endpoint.new("/admin/reports/{org_id}/{report_id}", "GET", [
+    Param.new("org_id", "", "path"),
+    Param.new("report_id", "", "path"),
+    Param.new("include_meta", "", "query"),
+  ]),
+  Endpoint.new("/admin/reports/{org_id}", "POST", [
+    Param.new("org_id", "", "path"),
+    Param.new("data", "", "json"),
+  ]),
+  Endpoint.new("/external/summary", "GET", [Param.new("mode", "", "query")]),
 ]
 
-FunctionalTester.new("fixtures/python/litestar/", {
+tester = FunctionalTester.new("fixtures/python/litestar/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "marks Litestar websocket endpoints with ws protocol" do
+  websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/{room_id}" }
+  websocket_route.should_not be_nil
+  websocket_route.try(&.protocol).should eq("ws")
+end

--- a/spec/functional_test/testers/python/pyramid_spec.cr
+++ b/spec/functional_test/testers/python/pyramid_spec.cr
@@ -18,9 +18,23 @@ expected_endpoints = [
     Param.new("username", "", "json"),
     Param.new("password", "", "json"),
   ]),
+  Endpoint.new("/about", "GET", [
+    Param.new("source", "", "query"),
+  ]),
+  Endpoint.new("/external/reports/{report_id}", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
+  ]),
   Endpoint.new("/ping", "GET", [
     Param.new("format", "", "query"),
   ]),
+  Endpoint.new("/orders", "GET", [
+    Param.new("status", "", "query"),
+  ]),
+  Endpoint.new("/orders", "POST", [
+    Param.new("order_id", "", "json"),
+  ]),
+  Endpoint.new("/assets/*", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/pyramid/", {

--- a/spec/functional_test/testers/python/quart_spec.cr
+++ b/spec/functional_test/testers/python/quart_spec.cr
@@ -6,6 +6,27 @@ expected_endpoints = [
   Endpoint.new("/healthz", "GET"),
   Endpoint.new("/items/<int:item_id>", "DELETE"),
   Endpoint.new("/api/v1/users", "POST", [Param.new("username", "", "json")]),
+  Endpoint.new("/mounted/child/reports/<int:report_id>", "GET", [
+    Param.new("mode", "", "query"),
+  ]),
+  Endpoint.new("/reports/<int:report_id>", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
+  ]),
+  Endpoint.new("/reports", "POST", [Param.new("title", "", "json")]),
+  Endpoint.new("/dispatch-reports", "GET", [Param.new("owner", "", "query")]),
+  Endpoint.new("/dispatch-reports", "POST", [Param.new("name", "", "json")]),
+  Endpoint.new("/api/v1/registered-search", "GET", [
+    Param.new("term", "", "query"),
+    Param.new("X-Trace-Id", "", "header"),
+  ]),
+  Endpoint.new("/api/v1/registered-create", "POST", [
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/api/v1/external-search", "GET", [
+    Param.new("term", "", "query"),
+    Param.new("X-Trace-Id", "", "header"),
+  ]),
   Endpoint.new("/ws", "GET"),
 ]
 

--- a/spec/functional_test/testers/python/robyn_spec.cr
+++ b/spec/functional_test/testers/python/robyn_spec.cr
@@ -25,9 +25,22 @@ expected_endpoints = [
     Param.new("User-Agent", "", "header"),
   ]),
   Endpoint.new("/ws", "GET"),
+  Endpoint.new("/live/{room_id}", "GET", [
+    Param.new("room_id", "", "path"),
+  ]),
   Endpoint.new("/api/items", "GET"),
   Endpoint.new("/api/items/{item_id}/tags", "POST", [
     Param.new("item_id", "", "path"),
+    Param.new("tag", "", "json"),
+    Param.new("priority", "", "json"),
+  ]),
+  Endpoint.new("/api/admin/metrics/{metric_id}", "GET", [
+    Param.new("metric_id", "", "path"),
+    Param.new("window", "", "query"),
+  ]),
+  Endpoint.new("/v2/reports/{report_id}", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
   ]),
 ]
 

--- a/spec/functional_test/testers/python/sanic_spec.cr
+++ b/spec/functional_test/testers/python/sanic_spec.cr
@@ -9,9 +9,47 @@ expected_endpoints = [
   Endpoint.new("/delete_record", "DELETE", [Param.new("name", "", "json")]),
   Endpoint.new("/get_ip", "GET"),
   Endpoint.new("/", "GET"),
+  Endpoint.new("/feed/{channel}", "GET", [
+    Param.new("channel", "", "path"),
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/api/v1/reports/{report_id}", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
+  ]),
+  Endpoint.new("/api/v1/reports/create", "POST", [Param.new("title", "", "json")]),
+  Endpoint.new("/reports/{report_id}/status", "PATCH", [
+    Param.new("status", "", "json"),
+    Param.new("report_id", "", "path"),
+  ]),
+  Endpoint.new("/api/v1/reports/audit", "GET", [
+    Param.new("actor", "", "query"),
+  ]),
+  Endpoint.new("/class-reports/{report_id}", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
+  ]),
+  Endpoint.new("/class-reports/{report_id}", "POST", [
+    Param.new("report_id", "", "path"),
+    Param.new("title", "", "json"),
+  ]),
+  Endpoint.new("/external/{item_id}", "PUT", [
+    Param.new("item_id", "", "path"),
+    Param.new("trace", "", "query"),
+    Param.new("state", "", "json"),
+  ]),
+  Endpoint.new("/assets/*", "GET"),
+  Endpoint.new("/api/v1/reports/files/*", "GET"),
 ]
 
-FunctionalTester.new("fixtures/python/sanic/", {
+tester = FunctionalTester.new("fixtures/python/sanic/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "marks Sanic websocket endpoints with ws protocol" do
+  feed = tester.app.endpoints.find { |endpoint| endpoint.url == "/feed/{channel}" }
+  feed.should_not be_nil
+  feed.try(&.protocol).should eq("ws")
+end

--- a/spec/functional_test/testers/python/starlette_spec.cr
+++ b/spec/functional_test/testers/python/starlette_spec.cr
@@ -15,11 +15,72 @@ expected_endpoints = [
   Endpoint.new("/search", "GET", [Param.new("q", "", "query")]),
   Endpoint.new("/upload", "POST", [Param.new("body", "", "form")]),
   Endpoint.new("/profile/{name}", "GET", [Param.new("name", "", "path")]),
+  Endpoint.new("/external/{item_id}", "GET", [
+    Param.new("item_id", "", "path"),
+    Param.new("q", "", "query"),
+    Param.new("title", "", "json"),
+  ]),
+  Endpoint.new("/reports/{report_id}", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
+  ]),
+  Endpoint.new("/reports/{report_id}", "POST", [
+    Param.new("report_id", "", "path"),
+    Param.new("title", "", "json"),
+  ]),
   Endpoint.new("/api/items", "GET"),
   Endpoint.new("/api/items/{id}", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/dashboard", "GET", [Param.new("section", "", "query")]),
+  Endpoint.new("/admin/reports/{report_id}", "GET", [
+    Param.new("report_id", "", "path"),
+    Param.new("include", "", "query"),
+  ]),
+  Endpoint.new("/admin/reports/{report_id}", "POST", [
+    Param.new("report_id", "", "path"),
+    Param.new("title", "", "json"),
+  ]),
+  Endpoint.new("/internal/status", "GET", [
+    Param.new("region", "", "query"),
+  ]),
+  Endpoint.new("/nested/v1/metrics/{metric_id}", "GET", [
+    Param.new("metric_id", "", "path"),
+    Param.new("window", "", "query"),
+  ]),
+  Endpoint.new("/programmatic/audit/{entry_id}", "GET", [
+    Param.new("entry_id", "", "path"),
+    Param.new("source", "", "query"),
+  ]),
+  Endpoint.new("/programmatic/ws/{room}", "GET", [
+    Param.new("room", "", "path"),
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/assets/*", "GET"),
+  Endpoint.new("/ws/{room}", "GET", [
+    Param.new("room", "", "path"),
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/notifications/{topic}", "GET", [
+    Param.new("topic", "", "path"),
+    Param.new("X-Client", "", "header"),
+  ]),
 ]
 
-FunctionalTester.new("fixtures/python/starlette/", {
+tester = FunctionalTester.new("fixtures/python/starlette/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "marks Starlette WebSocketRoute endpoints with ws protocol" do
+  chat = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/{room}" }
+  chat.should_not be_nil
+  chat.try(&.protocol).should eq("ws")
+
+  notifications = tester.app.endpoints.find { |endpoint| endpoint.url == "/notifications/{topic}" }
+  notifications.should_not be_nil
+  notifications.try(&.protocol).should eq("ws")
+
+  programmatic = tester.app.endpoints.find { |endpoint| endpoint.url == "/programmatic/ws/{room}" }
+  programmatic.should_not be_nil
+  programmatic.try(&.protocol).should eq("ws")
+end

--- a/spec/functional_test/testers/python/tornado_spec.cr
+++ b/spec/functional_test/testers/python/tornado_spec.cr
@@ -5,6 +5,9 @@ expected_endpoints = [
   Endpoint.new("/users", "GET"),
   Endpoint.new("/users", "POST", [Param.new("username", "", "form"), Param.new("email", "", "form")]),
   Endpoint.new("/auth", "POST", [Param.new("X-API-Key", "", "header"), Param.new("auth_token", "", "cookie")]),
+  Endpoint.new("/ws/([^/]+)", "GET", [Param.new("room_id", "", "path"), Param.new("token", "", "query")]),
+  Endpoint.new("/products/([0-9]+)", "GET", [Param.new("product_id", "", "path"), Param.new("expand", "", "query")]),
+  Endpoint.new("/named/{item_id}", "GET", [Param.new("item_id", "", "path"), Param.new("X-Trace-ID", "", "header")]),
   Endpoint.new("/api", "GET", [Param.new("X-API-Key", "", "header")]),
   Endpoint.new("/api", "POST", [Param.new("", "", "json")]),
   Endpoint.new("/search", "GET", [Param.new("tags", "", "query"), Param.new("q", "", "query")]),
@@ -29,9 +32,22 @@ expected_endpoints = [
   Endpoint.new("/multiline-triple", "GET"),
   Endpoint.new("/multiline-triple", "POST"),
   Endpoint.new("/deep", "GET", [Param.new("token", "", "query")]),
+  Endpoint.new("/metrics", "GET"),
+  Endpoint.new("/metrics", "POST"),
+  Endpoint.new("/version", "GET"),
+  Endpoint.new("/named-url", "GET"),
+  Endpoint.new("/spec-url", "GET"),
+  Endpoint.new("/spec-url", "POST"),
 ]
 
-FunctionalTester.new("fixtures/python/tornado/", {
+tester = FunctionalTester.new("fixtures/python/tornado/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+it "marks Tornado WebSocketHandler endpoints with ws protocol" do
+  websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/([^/]+)" }
+  websocket_route.should_not be_nil
+  websocket_route.try(&.protocol).should eq("ws")
+end

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -32,6 +32,8 @@ module Analyzer::Python
     def analyze
       handler_routes = Hash(::String, Array(Tuple(::String, ::String, Int32, ::String))).new
       # path => [{route_path, http_method, line_index, handler_name}]
+      class_view_routes = Hash(::String, Array(Tuple(::String, Int32, ::String))).new
+      # path => [{route_path, line_index, class_name}]
 
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
@@ -47,28 +49,45 @@ module Analyzer::Python
             lines = file_content.lines
             next unless lines.any?(&.includes?("aiohttp"))
 
+            import_modules = find_imported_modules(current_base_path, path, file_content)
+            app_prefixes = collect_app_prefixes(lines)
+            route_table_prefixes = collect_route_table_prefixes(lines, app_prefixes)
+            route_list_prefixes = collect_route_list_prefixes(lines, app_prefixes)
+
             handler_routes[path] ||= [] of Tuple(::String, ::String, Int32, ::String)
+            class_view_routes[path] ||= [] of Tuple(::String, Int32, ::String)
 
             # Tree-sitter pre-pass for Style B decorators. aiohttp's
             # `@routes.route("METHOD", "/path")` has a method-first signature
             # that the generic extractor would misread as path="METHOD", so
             # we skip any decoration whose attribute is literally `route`
             # and fall back to a dedicated regex below for that shape only.
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
+            view_attributes = {"view" => "GET"}
+            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: view_attributes).each do |deco|
               next if deco.attribute_name == "route"
-              deco.methods.uniq.each do |deco_method|
-                def_line = deco.def_line >= 0 ? deco.def_line : deco.decorator_line
-                next if def_line == deco.decorator_line
-                emit_endpoint(
-                  path,
-                  lines,
-                  def_line,
-                  deco.path,
-                  deco_method,
-                  deco.decorator_line,
-                  definition_base_path: current_base_path,
-                  source: file_content
-                )
+              prefixes = route_table_prefixes[deco.router_name]? || [""]
+              if deco.attribute_name == "view"
+                prefixes.each do |prefix|
+                  class_view_routes[path] << {join_paths(prefix, deco.path), deco.decorator_line, deco.def_name}
+                end
+                next
+              end
+
+              prefixes.each do |prefix|
+                deco.methods.uniq.each do |deco_method|
+                  def_line = deco.def_line >= 0 ? deco.def_line : deco.decorator_line
+                  next if def_line == deco.decorator_line
+                  emit_endpoint(
+                    path,
+                    lines,
+                    def_line,
+                    join_paths(prefix, deco.path),
+                    deco_method,
+                    deco.decorator_line,
+                    definition_base_path: current_base_path,
+                    source: file_content
+                  )
+                end
               end
             end
 
@@ -98,26 +117,63 @@ module Analyzer::Python
 
               # Style A: app.router.add_<method>("/path", handler)
               methods_re = HTTP_METHOD_NAMES.join("|")
-              if add_match = stripped.match(/\.add_(#{methods_re})\([rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/)
-                method_name = add_match[1]
-                route_path = add_match[2]
-                handler_name = add_match[3]
+              if add_match = stripped.match(/(#{DOT_NATION})\.add_(#{methods_re})\([rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/)
+                receiver = add_match[1]
+                method_name = add_match[2]
+                route_path = add_match[3]
+                handler_name = add_match[4]
                 if orig_match = line.match(/\.add_#{method_name}\s*\(\s*[rf]?['"]([^'"]*)['"]/)
                   route_path = orig_match[1]
                 end
-                handler_routes[path] << {route_path, method_name.upcase, line_index, handler_name}
+                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                  handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+                end
+              end
+
+              # Static file route:
+              #   app.router.add_static("/static/", path="...")
+              # aiohttp serves all files below the mounted prefix, so expose
+              # it as a GET wildcard endpoint. Respect sub-app prefixes via
+              # the same receiver prefix table as imperative routes.
+              if static_match = stripped.match(/(#{DOT_NATION})\.add_static\([rf]?['"]([^'"]*)['"]/)
+                receiver = static_match[1]
+                static_path = static_match[2]
+                if orig_match = line.match(/\.add_static\s*\(\s*[rf]?['"]([^'"]*)['"]/)
+                  static_path = orig_match[1]
+                end
+                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                  full_path = static_route_path(join_paths(prefix, static_path))
+                  result << Endpoint.new(full_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
+                end
               end
 
               # Style A: app.router.add_route("METHOD", "/path", handler)
-              add_route_match = stripped.match(/\.add_route\([rf]?['"]([A-Za-z*]+)['"]\s*,\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/)
+              add_route_match = stripped.match(/(#{DOT_NATION})\.add_route\([rf]?['"]([A-Za-z*]+)['"]\s*,\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/)
               if add_route_match
-                method = add_route_match[1].upcase
-                route_path = add_route_match[2]
-                handler_name = add_route_match[3]
+                receiver = add_route_match[1]
+                method = add_route_match[2].upcase
+                route_path = add_route_match[3]
+                handler_name = add_route_match[4]
                 if orig_match = line.match(/\.add_route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
                   route_path = orig_match[1]
                 end
-                handler_routes[path] << {route_path, method, line_index, handler_name}
+                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                  handler_routes[path] << {join_paths(prefix, route_path), method, line_index, handler_name}
+                end
+              end
+
+              # Style D: class-based views via
+              # `app.router.add_view("/path", ViewClass)`.
+              if add_view_match = stripped.match(/(#{DOT_NATION})\.add_view\([rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/)
+                receiver = add_view_match[1]
+                route_path = add_view_match[2]
+                class_name = add_view_match[3].split(".").last
+                if orig_match = line.match(/\.add_view\s*\(\s*[rf]?['"]([^'"]*)['"]/)
+                  route_path = orig_match[1]
+                end
+                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                  class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
+                end
               end
 
               # Style C: `web.<method>("/path", handler)` route entries that
@@ -135,7 +191,24 @@ module Analyzer::Python
                   method_name = web_match[1]
                   route_path = web_match[2]
                   handler_name = web_match[3]
-                  handler_routes[path] << {route_path, method_name.upcase, line_index, handler_name}
+                  prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
+                    handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+                  end
+                end
+              end
+
+              # Style D: class-based views via `web.view("/path", ViewClass)`.
+              # aiohttp dispatches to async `get` / `post` / ... methods on
+              # the class, so emit one endpoint per method definition.
+              if stripped.match(/\bweb\.view\s*\(/)
+                effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+                effective_line.scan(/\bweb\.view\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/) do |view_match|
+                  next if view_match.size < 3
+                  route_path = view_match[1]
+                  class_name = view_match[2].split(".").last
+                  prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
+                    class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
+                  end
                 end
               end
             end
@@ -144,6 +217,18 @@ module Analyzer::Python
             handler_routes[path].each do |route_path, method, line_index, handler_name|
               def_index = find_handler_def(lines, handler_name)
               if def_index.nil?
+                if emit_external_handler_endpoint(
+                     path,
+                     route_path,
+                     method,
+                     line_index,
+                     handler_name,
+                     import_modules,
+                     definition_base_path: current_base_path
+                   )
+                  next
+                end
+
                 # Handler is defined in another module (common with
                 # `app.add_routes([web.get("/x", handler_from_other_file)])`).
                 # Emit the endpoint anyway with path params parsed from
@@ -168,11 +253,62 @@ module Analyzer::Python
                 source: file_content
               )
             end
+
+            # Resolve class-based `web.view(...)` registrations by finding
+            # HTTP verb methods on the referenced `web.View` subclass.
+            class_view_routes[path].each do |route_path, line_index, class_name|
+              emit_class_view_endpoints(
+                path,
+                lines,
+                route_path,
+                line_index,
+                class_name,
+                definition_base_path: current_base_path,
+                source: file_content
+              )
+            end
           end
         end
       end
 
       result
+    end
+
+    private def emit_class_view_endpoints(path : ::String,
+                                          lines : Array(::String),
+                                          route_path : ::String,
+                                          report_line : Int32,
+                                          class_name : ::String,
+                                          *,
+                                          definition_base_path : ::String,
+                                          source : ::String)
+      class_index = find_class_def(lines, class_name)
+      if class_index.nil?
+        details = Details.new(PathInfo.new(path, report_line + 1))
+        endpoint = Endpoint.new(route_path, "GET", details)
+        route_path.scan(/\{(\w+)(?::[^}]+)?\}/) do |path_match|
+          endpoint.push_param(Param.new(path_match[1], "", "path"))
+        end
+        result << endpoint
+        return
+      end
+
+      method_defs = find_class_http_method_defs(lines, class_index)
+      method_defs.each do |method, method_index|
+        body = extract_function_body(lines, method_index)
+        request_params = extract_request_params(body, method, "self.request")
+        emit_endpoint_with_params_and_callees(
+          path,
+          route_path,
+          method,
+          report_line,
+          method_index + 1,
+          body,
+          request_params,
+          definition_base_path: definition_base_path,
+          source: source
+        )
+      end
     end
 
     private def process_decorator_route(path : ::String,
@@ -209,6 +345,30 @@ module Analyzer::Python
       function_body = extract_function_body(lines, def_index)
       request_params = extract_request_params(function_body, method)
 
+      emit_endpoint_with_params_and_callees(
+        path,
+        route_path,
+        method,
+        report_line,
+        def_index + 1,
+        function_body,
+        request_params,
+        definition_base_path: definition_base_path,
+        source: source
+      )
+    end
+
+    private def emit_endpoint_with_params_and_callees(path : ::String,
+                                                      route_path : ::String,
+                                                      method : ::String,
+                                                      report_line : Int32,
+                                                      body_start_line : Int32,
+                                                      function_body : ::String,
+                                                      request_params : Array(Param),
+                                                      *,
+                                                      definition_base_path : ::String,
+                                                      source : ::String,
+                                                      handler_path : ::String? = nil)
       seen = Set(::String).new
       all_params = [] of Param
 
@@ -230,20 +390,119 @@ module Analyzer::Python
 
       details = Details.new(PathInfo.new(path, report_line + 1))
       endpoint = Endpoint.new(route_path, method, details)
+      endpoint.protocol = "ws" if websocket_response_body?(function_body)
       all_params.each { |p| endpoint.push_param(p) }
 
-      # extract_function_body skips the def line, so body row 0 lives
-      # at def_index + 1.
       push_callees_from(
         endpoint,
         function_body,
-        def_index + 1,
-        path,
+        body_start_line,
+        handler_path || path,
         definition_base_path: definition_base_path,
         source: source
       )
 
       result << endpoint
+    end
+
+    private def emit_external_handler_endpoint(path : ::String,
+                                               route_path : ::String,
+                                               method : ::String,
+                                               report_line : Int32,
+                                               handler_name : ::String,
+                                               import_modules : Hash(::String, Tuple(::String, Int32)),
+                                               *,
+                                               definition_base_path : ::String) : Bool
+      resolved = resolve_external_handler(handler_name, path, import_modules)
+      return false unless resolved
+
+      handler_path, function_name = resolved
+      return false unless File.exists?(handler_path)
+
+      handler_source = read_file_content(handler_path)
+      handler_lines = handler_source.lines
+      def_index = find_handler_def(handler_lines, function_name)
+      return false unless def_index
+
+      function_body = extract_function_body(handler_lines, def_index)
+      request_params = extract_request_params(function_body, method)
+      emit_endpoint_with_params_and_callees(
+        path,
+        route_path,
+        method,
+        report_line,
+        def_index + 1,
+        function_body,
+        request_params,
+        definition_base_path: definition_base_path,
+        source: handler_source,
+        handler_path: handler_path
+      )
+
+      true
+    end
+
+    private def resolve_external_handler(handler_name : ::String,
+                                         current_path : ::String,
+                                         import_modules : Hash(::String, Tuple(::String, Int32))) : Tuple(::String, ::String)?
+      reference = handler_name.strip
+      return if reference.empty?
+
+      if reference.includes?(".")
+        receiver, function_name = reference.split(".", 2)
+        if import_info = import_modules[receiver]?
+          import_path = import_info.first
+          return {import_path, function_name} unless import_path.empty?
+        end
+
+        sibling_module_path = File.join(File.dirname(current_path), "#{receiver}.py")
+        return {sibling_module_path, function_name} if File.exists?(sibling_module_path)
+
+        return
+      end
+
+      if import_info = import_modules[reference]?
+        import_path = import_info.first
+        return {import_path, reference} unless import_path.empty?
+      end
+
+      nil
+    end
+
+    private def websocket_response_body?(function_body : ::String) : Bool
+      function_body.includes?("WebSocketResponse")
+    end
+
+    private def find_class_def(lines : Array(::String), class_name : ::String) : Int32?
+      lines.each_with_index do |line, idx|
+        if line.match(/^\s*class\s+#{Regex.escape(class_name)}\s*[\(:]/)
+          return idx
+        end
+      end
+      nil
+    end
+
+    private def find_class_http_method_defs(lines : Array(::String), class_index : Int32) : Array(Tuple(::String, Int32))
+      class_line = lines[class_index]
+      class_indent = class_line.size - class_line.lstrip.size
+      methods = [] of Tuple(::String, Int32)
+      methods_re = HTTP_METHOD_NAMES.join("|")
+
+      i = class_index + 1
+      while i < lines.size
+        line = lines[i]
+        unless line.strip.empty?
+          indent = line.size - line.lstrip.size
+          break if indent <= class_indent
+
+          if method_match = line.match(/^\s*(?:async\s+)?def\s+(#{methods_re})\s*\(/)
+            methods << {method_match[1].upcase, i}
+          end
+        end
+        i += 1
+      end
+
+      methods
     end
 
     private def find_handler_def(lines : Array(::String), handler_name : ::String) : Int32?
@@ -288,6 +547,209 @@ module Analyzer::Python
       methods.uniq
     end
 
+    private def collect_app_prefixes(lines : Array(::String)) : Hash(::String, Array(::String))
+      prefixes = Hash(::String, Array(::String)).new
+      mounts = [] of Tuple(::String, ::String, ::String)
+
+      lines.each_with_index do |line, index|
+        stripped = line.gsub(" ", "")
+        if app_match = stripped.match(/^(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:web\.)?Application\(/)
+          prefixes[app_match[1]] ||= [""]
+        end
+
+        next unless line.includes?(".add_subapp(")
+
+        effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        effective_line.scan(/(#{DOT_NATION})\.add_subapp\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(#{DOT_NATION})/) do |mount_match|
+          next if mount_match.size < 4
+          parent = normalize_receiver(mount_match[1])
+          prefix = mount_match[2]
+          child = normalize_receiver(mount_match[3])
+          mounts << {parent, prefix, child}
+          prefixes[child] ||= [] of ::String
+        end
+      end
+
+      mounted_children = Set(::String).new
+      mounts.each { |_, _, child| mounted_children << child }
+      mounted_children.each do |child|
+        prefixes[child].try(&.delete(""))
+      end
+
+      changed = true
+      while changed
+        changed = false
+        mounts.each do |parent, mount_prefix, child|
+          parent_prefixes = prefixes[parent]? || [""]
+          prefixes[child] ||= [] of ::String
+          parent_prefixes.each do |parent_prefix|
+            child_prefix = join_paths(parent_prefix, mount_prefix)
+            unless prefixes[child].includes?(child_prefix)
+              prefixes[child] << child_prefix
+              changed = true
+            end
+          end
+        end
+      end
+
+      prefixes
+    end
+
+    private def collect_route_table_prefixes(lines : Array(::String),
+                                             app_prefixes : Hash(::String, Array(::String))) : Hash(::String, Array(::String))
+      prefixes = Hash(::String, Array(::String)).new
+
+      lines.each_with_index do |line, index|
+        next unless line.includes?(".add_routes(")
+
+        effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        effective_line.scan(/(#{DOT_NATION})\.add_routes\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})/) do |routes_match|
+          next if routes_match.size < 3
+          receiver = routes_match[1]
+          route_table = routes_match[2]
+          prefixes[route_table] ||= [] of ::String
+          prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+            prefixes[route_table] << prefix unless prefixes[route_table].includes?(prefix)
+          end
+        end
+      end
+
+      prefixes
+    end
+
+    private def collect_route_list_prefixes(lines : Array(::String),
+                                            app_prefixes : Hash(::String, Array(::String))) : Hash(Int32, Array(::String))
+      route_list_ranges = collect_route_list_ranges(lines)
+      prefixes = Hash(Int32, Array(::String)).new do |hash, key|
+        hash[key] = [] of ::String
+      end
+
+      lines.each_with_index do |line, index|
+        next unless line.includes?(".add_routes(")
+
+        effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        effective_line.scan(/(#{DOT_NATION})\.add_routes\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})/) do |routes_match|
+          next if routes_match.size < 3
+          receiver = routes_match[1]
+          route_list = routes_match[2]
+          ranges = route_list_ranges[route_list]?
+          next unless ranges
+
+          prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+            ranges.each do |range|
+              (range[0]..range[1]).each do |line_index|
+                prefixes[line_index] << prefix unless prefixes[line_index].includes?(prefix)
+              end
+            end
+          end
+        end
+      end
+
+      prefixes
+    end
+
+    private def collect_route_list_ranges(lines : Array(::String)) : Hash(::String, Array(Tuple(Int32, Int32)))
+      ranges = Hash(::String, Array(Tuple(Int32, Int32))).new do |hash, key|
+        hash[key] = [] of Tuple(Int32, Int32)
+      end
+
+      lines.each_with_index do |line, index|
+        assignment_match = line.match(/^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*\[/)
+        next unless assignment_match
+
+        start_index = index
+        end_index = index
+        delta = python_bracket_delta(line)
+        contains_web_route = line.includes?("web.")
+        line_index = index + 1
+        while line_index < lines.size && delta > 0
+          next_line = lines[line_index]
+          contains_web_route = true if next_line.includes?("web.")
+          delta += python_bracket_delta(next_line)
+          end_index = line_index
+          line_index += 1
+        end
+
+        next unless contains_web_route
+        ranges[assignment_match[1]] << {start_index, end_index}
+      end
+
+      ranges
+    end
+
+    private def python_bracket_delta(line : ::String) : Int32
+      depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      line.each_char do |ch|
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when '['
+          depth += 1
+        when ']'
+          depth -= 1
+        end
+      end
+
+      depth
+    end
+
+    private def prefixes_for_add_routes_call(line : ::String,
+                                             app_prefixes : Hash(::String, Array(::String)),
+                                             route_list_prefixes : Hash(Int32, Array(::String)),
+                                             line_index : Int32) : Array(::String)
+      if add_routes_match = line.match(/(#{DOT_NATION})\.add_routes\s*\(/)
+        prefixes_for_receiver(add_routes_match[1], app_prefixes)
+      elsif prefixes = route_list_prefixes[line_index]?
+        prefixes
+      else
+        [""]
+      end
+    end
+
+    private def prefixes_for_receiver(receiver : ::String,
+                                      app_prefixes : Hash(::String, Array(::String))) : Array(::String)
+      app_prefixes[normalize_receiver(receiver)]? || [""]
+    end
+
+    private def normalize_receiver(receiver : ::String) : ::String
+      normalized = receiver.strip
+      normalized = normalized[0...-7] if normalized.ends_with?(".router")
+      normalized.split(".").last
+    end
+
+    private def join_paths(prefix : ::String, path : ::String) : ::String
+      return normalize_path(path) if prefix.empty?
+      return normalize_path(prefix) if path.empty?
+
+      normalize_path("#{prefix}/#{path}")
+    end
+
+    private def static_route_path(path : ::String) : ::String
+      normalized = normalize_path(path)
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
+    end
+
+    private def normalize_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
+    end
+
     DICT_ACCESSORS = {
       "headers" => "header",
       "cookies" => "cookie",
@@ -295,9 +757,10 @@ module Analyzer::Python
 
     DICT_METHOD_NAMES = Set{"get", "getall", "getone", "items", "keys", "values", "pop"}
 
-    private def extract_request_params(body : ::String, method : ::String) : Array(Param)
+    private def extract_request_params(body : ::String, method : ::String, request_expr : ::String = "request") : Array(Param)
       params = [] of Param
       seen = Set(::String).new
+      request_pattern = Regex.escape(request_expr)
 
       record = ->(name : ::String, type : ::String) do
         key = "#{type}:#{name}"
@@ -308,38 +771,38 @@ module Analyzer::Python
       end
 
       # request.match_info["name"] / .get("name") — path parameter access
-      body.scan(/request\.match_info\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+      body.scan(/#{request_pattern}\.match_info\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
         record.call(m[1], "path")
       end
-      body.scan(/request\.match_info\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+      body.scan(/#{request_pattern}\.match_info\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
         record.call(m[1], "path")
       end
 
       # request.query["x"] / request.query.get("x") / request.rel_url.query[...]
-      body.scan(/request\.(?:rel_url\.)?query\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+      body.scan(/#{request_pattern}\.(?:rel_url\.)?query\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
         record.call(m[1], "query")
       end
-      body.scan(/request\.(?:rel_url\.)?query\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+      body.scan(/#{request_pattern}\.(?:rel_url\.)?query\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
         record.call(m[1], "query")
       end
 
       DICT_ACCESSORS.each do |accessor, param_type|
-        body.scan(/request\.#{accessor}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+        body.scan(/#{request_pattern}\.#{accessor}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
           record.call(m[1], param_type)
         end
-        body.scan(/request\.#{accessor}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+        body.scan(/#{request_pattern}\.#{accessor}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
           record.call(m[1], param_type)
         end
       end
 
       # JSON body: await request.json() and subsequent dict access on the returned var.
       json_vars = [] of ::String
-      body.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+request\.json\s*\(/) do |m|
+      body.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{request_pattern}\.json\s*\(/) do |m|
         json_vars << m[1]
       end
 
       # If request.json() is awaited at all, flag the body with a generic entry.
-      if body.match(/await\s+request\.json\s*\(/)
+      if body.match(/await\s+#{request_pattern}\.json\s*\(/)
         record.call("body", "json") if json_vars.empty?
       end
 
@@ -354,11 +817,11 @@ module Analyzer::Python
 
       # Form body: await request.post()
       form_vars = [] of ::String
-      body.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+request\.post\s*\(/) do |m|
+      body.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{request_pattern}\.post\s*\(/) do |m|
         form_vars << m[1]
       end
 
-      if body.match(/await\s+request\.post\s*\(/)
+      if body.match(/await\s+#{request_pattern}\.post\s*\(/)
         record.call("body", "form") if form_vars.empty?
       end
 

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -45,33 +45,39 @@ module Analyzer::Python
             lines = file_content.lines
             next unless lines.any?(&.includes?("bottle"))
 
+            router_prefixes = collect_router_prefixes(lines)
+
             # Tree-sitter pre-pass for Form 1 (`@<var>.route(...)` /
             # `@<var>.<method>(...)`). Replaces the per-line regex sweep.
             Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
               methods_literal = deco.methods.map { |m| "'#{m}'" }.join(",")
               extra_params = "methods=[#{methods_literal}]"
-              process_route(
-                path,
-                lines,
-                line_index: deco.decorator_line,
-                route_path: deco.path,
-                extra_params: extra_params,
-                definition_base_path: current_base_path,
-                source: file_content
-              )
+              prefixes = router_prefixes[deco.router_name]? || [""]
+              prefixes.each do |prefix|
+                process_route(
+                  path,
+                  lines,
+                  line_index: deco.decorator_line,
+                  route_path: join_paths(prefix, deco.path),
+                  extra_params: extra_params,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
+              end
             end
 
             # Form 2 still needs per-line regex — bare `@route("/path")` has
             # no router object, so the tree-sitter extractor (which gates
             # on `<router>.<attr>`) doesn't match it.
             lines.each_with_index do |line, line_index|
-              stripped = line.gsub(" ", "")
+              effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+              stripped = effective_line.gsub(" ", "")
               BARE_DECORATORS.each do |deco_name|
                 # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
                 if bare_match = stripped.match(/^@#{deco_name}\([rf]?['"]([^'"]*)['"](.*)/)
                   # Recover spaces in path via the original line.
                   path_value = bare_match[1]
-                  if orig_match = line.match(/@#{deco_name}\s*\(\s*[rf]?['"]([^'"]*)['"]/)
+                  if orig_match = effective_line.match(/@#{deco_name}\s*\(\s*[rf]?['"]([^'"]*)['"]/)
                     path_value = orig_match[1]
                   end
                   extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
@@ -84,7 +90,30 @@ module Analyzer::Python
                     definition_base_path: current_base_path,
                     source: file_content
                   )
+                elsif kw_path_match = effective_line.match(/^\s*@#{deco_name}\s*\([^)]*\b(?:path|rule|uri)\s*=\s*[rf]?['"]([^'"]*)['"]/m)
+                  extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
+                  process_route(
+                    path,
+                    lines,
+                    line_index,
+                    kw_path_match[1],
+                    extra,
+                    definition_base_path: current_base_path,
+                    source: file_content
+                  )
                 end
+              end
+
+              if !line.lstrip.starts_with?("@") && effective_line.includes?(".route(")
+                process_programmatic_route(
+                  path,
+                  lines,
+                  line_index,
+                  effective_line,
+                  router_prefixes,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
               end
             end
           end
@@ -92,6 +121,92 @@ module Analyzer::Python
       end
 
       result
+    end
+
+    private def process_programmatic_route(path : String,
+                                           lines : Array(String),
+                                           line_index : Int32,
+                                           line : String,
+                                           router_prefixes : Hash(String, Array(String)),
+                                           *,
+                                           definition_base_path : String,
+                                           source : String)
+      route_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.route\s*\((.*)\)\s*$/m)
+      return unless route_match
+
+      receiver = route_match[1]
+      args = split_python_arguments(route_match[2])
+      route_path = extract_keyword_string(args, "path") ||
+                   extract_keyword_string(args, "rule") ||
+                   extract_keyword_string(args, "uri") ||
+                   args[0]?.try { |arg| extract_python_string(arg) }
+      return unless route_path
+
+      callback_name = extract_callback_name(args)
+      return unless callback_name
+
+      prefixes = router_prefixes[receiver]? || [""]
+      prefixes.each do |prefix|
+        process_route_for_function(
+          path,
+          lines,
+          line_index,
+          join_paths(prefix, route_path),
+          route_match[2],
+          callback_name,
+          definition_base_path: definition_base_path,
+          source: source
+        )
+      end
+    end
+
+    private def collect_router_prefixes(lines : Array(::String)) : Hash(::String, Array(::String))
+      prefixes = Hash(::String, Array(::String)).new
+      prefixes["app"] = [""]
+      mounts = [] of Tuple(::String, ::String, ::String)
+
+      lines.each_with_index do |line, index|
+        stripped = line.gsub(" ", "")
+        if instance_match = stripped.match(/^(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:bottle\.)?Bottle\(/)
+          prefixes[instance_match[1]] ||= [""]
+        end
+
+        next unless line.includes?(".mount(")
+
+        effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        effective_line.scan(/\b(#{PYTHON_VAR_NAME_REGEX})\.mount\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})/) do |mount_match|
+          next if mount_match.size < 4
+          parent_router = mount_match[1]
+          prefix = mount_match[2]
+          child_router = mount_match[3]
+          mounts << {parent_router, prefix, child_router}
+          prefixes[child_router] ||= [] of ::String
+          prefixes[child_router].delete("")
+        end
+      end
+
+      changed = true
+      iterations = 0
+      while changed && iterations < mounts.size
+        changed = false
+        iterations += 1
+
+        mounts.each do |parent_router, mount_prefix, child_router|
+          parent_prefixes = prefixes[parent_router]?
+          next unless parent_prefixes
+
+          prefixes[child_router] ||= [] of ::String
+          parent_prefixes.each do |parent_prefix|
+            composed_prefix = join_paths(parent_prefix, mount_prefix)
+            next if prefixes[child_router].includes?(composed_prefix)
+
+            prefixes[child_router] << composed_prefix
+            changed = true
+          end
+        end
+      end
+
+      prefixes
     end
 
     # Turn an (extra_params) string from a decorator into the list of HTTP
@@ -131,7 +246,38 @@ module Analyzer::Python
 
       def_index = Noir::PythonRouteExtractor.find_def_line(lines, line_index)
       return if def_index == line_index
+      process_route_at_def(path, lines, line_index, route_path, methods, def_index,
+        definition_base_path: definition_base_path, source: source)
+    end
 
+    private def process_route_for_function(path : String,
+                                           lines : Array(String),
+                                           line_index : Int32,
+                                           route_path : String,
+                                           extra_params : String,
+                                           function_name : String,
+                                           *,
+                                           definition_base_path : String,
+                                           source : String)
+      methods = extract_methods(extra_params)
+      methods = ["GET"] if methods.empty?
+
+      def_index = find_function_def(lines, function_name)
+      return unless def_index
+
+      process_route_at_def(path, lines, line_index, route_path, methods, def_index,
+        definition_base_path: definition_base_path, source: source)
+    end
+
+    private def process_route_at_def(path : String,
+                                     lines : Array(String),
+                                     line_index : Int32,
+                                     route_path : String,
+                                     methods : Array(String),
+                                     def_index : Int32,
+                                     *,
+                                     definition_base_path : String,
+                                     source : String)
       function_body = extract_function_body(lines, def_index)
 
       request_params = extract_request_params(function_body)
@@ -160,6 +306,118 @@ module Analyzer::Python
         handler_callees.each { |c| endpoint.push_callee(c) }
         result << endpoint
       end
+    end
+
+    private def find_function_def(lines : Array(String), function_name : String) : Int32?
+      lines.each_with_index do |line, index|
+        stripped = line.lstrip
+        if stripped.starts_with?("def #{function_name}(") ||
+           stripped.starts_with?("def #{function_name} (") ||
+           stripped.starts_with?("async def #{function_name}(") ||
+           stripped.starts_with?("async def #{function_name} (")
+          return index
+        end
+      end
+
+      nil
+    end
+
+    private def split_python_arguments(args : String) : Array(String)
+      parts = [] of String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      args.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when ','
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+
+    private def extract_keyword_string(args : Array(String), keyword : String) : String?
+      args.each do |arg|
+        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        next unless keyword_match
+
+        return extract_python_string(keyword_match[1])
+      end
+
+      nil
+    end
+
+    private def extract_python_string(expression : String) : String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
+
+    private def extract_callback_name(args : Array(String)) : String?
+      args.each do |arg|
+        callback_match = arg.match(/^\s*callback\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*$/)
+        return callback_match[1] if callback_match
+      end
+
+      nil
+    end
+
+    private def join_paths(prefix : ::String, path : ::String) : ::String
+      return normalize_path(path) if prefix.empty?
+      return normalize_path(prefix) if path.empty?
+
+      normalize_path("#{prefix}/#{path}")
+    end
+
+    private def normalize_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
     end
 
     # Walk forward from `def_index` collecting lines at strictly greater
@@ -205,6 +463,7 @@ module Analyzer::Python
     private def extract_request_params(body : String) : Array(Param)
       params = [] of Param
       seen = Set(String).new
+      json_variables = [] of String
 
       record = ->(name : String, type : String) do
         key = "#{type}:#{name}"
@@ -212,6 +471,10 @@ module Analyzer::Python
           params << Param.new(name, "", type)
           seen << key
         end
+      end
+
+      body.scan(/([A-Za-z_][A-Za-z0-9_]*)\s*=\s*request\.json\b/) do |m|
+        json_variables << m[1] unless json_variables.includes?(m[1])
       end
 
       DICT_ACCESSORS.each do |accessor, param_type|
@@ -233,6 +496,15 @@ module Analyzer::Python
       # Bottle-specific cookie helper.
       body.scan(/request\.get_cookie\s*\(\s*['"]([^'"]+)['"]/) do |m|
         record.call(m[1], "cookie")
+      end
+
+      json_variables.each do |var|
+        body.scan(/#{Regex.escape(var)}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          record.call(m[1], "json")
+        end
+        body.scan(/#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+          record.call(m[1], "json")
+        end
       end
 
       params

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -9,16 +9,17 @@ module Analyzer::Python
 
     # Regular expressions for extracting Django URL configurations
     REGEX_ROOT_URLCONF  = /\s*ROOT_URLCONF\s*=\s*r?['"]([^'"\\]*)['"]/
-    REGEX_ROUTE_MAPPING = /(?:url|path|register)\s*\(\s*r?['"]([^"']*)['"][^,]*,\s*([^),]*)/
-    REGEX_INCLUDE_URLS  = /include\s*\(\s*r?['"]([^'"\\]*)['"]/
+    REGEX_ROUTE_MAPPING = /\b(?:url|path|re_path|register)\s*\(\s*r?['"]([^"']*)['"][^,]*,\s*([^),]*)/
+    REGEX_INCLUDE_URLS  = /\binclude\s*\(\s*r?['"]([^'"\\]*)['"]/
 
     # Map request parameters to their respective fields
     REQUEST_PARAM_FIELD_MAP = {
-      "GET"     => {["GET"], "query"},
-      "POST"    => {["POST"], "form"},
-      "COOKIES" => {nil, "cookie"},
-      "META"    => {nil, "header"},
-      "data"    => {["POST", "PUT", "PATCH"], "form"},
+      "GET"          => {["GET"], "query"},
+      "POST"         => {["POST"], "form"},
+      "COOKIES"      => {nil, "cookie"},
+      "META"         => {nil, "header"},
+      "data"         => {["POST", "PUT", "PATCH"], "form"},
+      "query_params" => {nil, "query"},
     }
 
     # Map request parameter types to HTTP methods
@@ -114,76 +115,642 @@ module Analyzer::Python
 
       file = File.open(django_urls.filepath, encoding: "utf-8", invalid: :skip)
       content = file.gets_to_end
+      original_content = content
       package_map = find_imported_modules(@django_base_path, url_base_path, content)
+      import_aliases = extract_python_import_aliases(original_content)
+      drf_router_registrations = extract_drf_router_registrations(content)
+      urlpattern_lists = extract_urlpattern_lists(content)
+      route_path = PathInfo.new(django_urls.filepath)
 
-      # Temporary fix to parse only the string after "urlpatterns = ["
-      keywords = ["urlpatterns", "=", "["]
-      keywords.each do |keyword|
-        if !content.includes? keyword
-          return endpoints
-        end
+      direct_router_endpoints = extract_drf_direct_router_endpoints(
+        django_urls,
+        original_content,
+        drf_router_registrations,
+        package_map,
+        import_aliases,
+        route_path
+      )
 
-        content = content.split(keyword, 2)[1]
-      end
+      urlpatterns_contents = extract_urlpatterns_contents(original_content, urlpattern_lists)
+      return direct_router_endpoints if urlpatterns_contents.empty?
 
-      # TODO: Parse correct urlpatterns from variable concatenation case
-      content.scan(REGEX_ROUTE_MAPPING) do |route_match|
-        next if route_match.size != 3
-        route = route_match[1]
-        route = route.gsub(/^\^/, "").gsub(/\$$/, "")
-        view = route_match[2].split(",")[0]
-        url = "/#{django_urls.prefix}/#{route}".gsub(/\/+/, "/")
-        new_django_urls = nil
-        view.scan(REGEX_INCLUDE_URLS) do |include_pattern_match|
-          # Detect new URL configurations
-          next if include_pattern_match.size != 2
-          new_route_path = "#{@django_base_path}/#{include_pattern_match[1].gsub(".", "/")}.py"
+      urlpatterns_contents.each do |urlpatterns_content|
+        extract_route_mappings(urlpatterns_content).each do |route_mapping|
+          route, view = route_mapping
+          route = normalize_django_route(route)
+          url = "/#{django_urls.prefix}/#{route}".gsub(/\/+/, "/")
+          new_django_urls = nil
+          view.scan(REGEX_INCLUDE_URLS) do |include_pattern_match|
+            # Detect new URL configurations
+            next if include_pattern_match.size != 2
+            new_route_path = "#{@django_base_path}/#{include_pattern_match[1].gsub(".", "/")}.py"
 
-          if File.exists?(new_route_path)
-            new_django_urls = DjangoUrls.new("#{django_urls.prefix}#{route}", new_route_path, django_urls.basepath)
-            unless @visited_url_paths.has_key? new_django_urls.filepath
-              extract_endpoints(new_django_urls).each do |endpoint|
-                append_code_path(endpoint.details, PathInfo.new(new_route_path))
+            if File.exists?(new_route_path)
+              new_django_urls = DjangoUrls.new("#{django_urls.prefix}#{route}", new_route_path, django_urls.basepath)
+              unless @visited_url_paths.has_key? new_django_urls.filepath
+                extract_endpoints(new_django_urls).each do |endpoint|
+                  append_code_path(endpoint.details, PathInfo.new(new_route_path))
+                  endpoints << endpoint
+                end
+              end
+            end
+          end
+          next if new_django_urls
+
+          if local_patterns = extract_local_include_target(view)
+            if pattern_content = urlpattern_lists[local_patterns]?
+              extract_local_urlpattern_endpoints(django_urls, route, pattern_content, package_map, route_path, urlpattern_lists, import_aliases, drf_router_registrations).each do |endpoint|
                 endpoints << endpoint
               end
+              next
+            end
+          end
+
+          if router_name = extract_drf_router_include_target(view)
+            router_endpoints = extract_drf_router_endpoints_for_router(
+              django_urls,
+              route,
+              router_name,
+              drf_router_registrations,
+              package_map,
+              import_aliases,
+              route_path
+            )
+            unless router_endpoints.empty?
+              endpoints.concat(router_endpoints)
+              next
+            end
+          end
+
+          if view == ""
+            endpoints << Endpoint.new(url, "GET", Details.new(route_path))
+          else
+            view = extract_wrapped_view_reference(view)
+            dotted_as_names_split = view.split(".")
+
+            filepath = ""
+            function_or_class_name = ""
+            dotted_as_names_split.each_with_index do |name, index|
+              if (package_map.has_key? name) && (index < dotted_as_names_split.size)
+                filepath, package_type = package_map[name]
+                function_or_class_name = name
+                if package_type == PackageType::FILE && index + 1 < dotted_as_names_split.size
+                  function_or_class_name = dotted_as_names_split[index + 1]
+                end
+
+                break
+              end
+            end
+
+            if filepath != "" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.match(function_or_class_name)
+              extract_endpoints_from_file(url, filepath, function_or_class_name).each do |endpoint|
+                append_code_path(endpoint.details, route_path)
+                endpoints << endpoint
+              end
+            else
+              # By default, Django allows requests with methods other than GET as well
+              endpoints << Endpoint.new(url, "GET", Details.new(route_path))
             end
           end
         end
-        next if new_django_urls
+      end
 
-        route_path = PathInfo.new(django_urls.filepath)
+      endpoints.concat(direct_router_endpoints)
+      endpoints
+    end
+
+    private def extract_urlpatterns_contents(content : ::String, urlpattern_lists : Hash(::String, ::String)) : Array(::String)
+      contents = [] of ::String
+      lines = content.split("\n")
+
+      lines.each_with_index do |line, index|
+        if line.matches?(/^\s*urlpatterns\s*=/)
+          logical_line = collect_python_expression(lines, index, line)
+          if assignment_match = logical_line.match(/^\s*urlpatterns\s*=\s*(.+)$/m)
+            add_urlpattern_expression_contents(contents, assignment_match[1], urlpattern_lists)
+          end
+        elsif line.matches?(/^\s*urlpatterns\s*\+=/)
+          logical_line = collect_python_expression(lines, index, line)
+          if append_match = logical_line.match(/^\s*urlpatterns\s*\+=\s*(.+)$/m)
+            add_urlpattern_expression_contents(contents, append_match[1], urlpattern_lists)
+          end
+        elsif line.matches?(/^\s*urlpatterns\s*\.\s*extend\s*\(/)
+          logical_line = collect_python_expression(lines, index, line)
+          if extend_match = logical_line.match(/^\s*urlpatterns\s*\.\s*extend\s*\((.*)\)\s*$/m)
+            add_urlpattern_expression_contents(contents, extend_match[1], urlpattern_lists)
+          end
+        end
+      end
+
+      contents.uniq
+    end
+
+    private def collect_python_expression(lines : Array(::String), index : Int32, line : ::String) : ::String
+      pieces = [line]
+      delta = python_paren_delta(line) + python_bracket_delta(line)
+      line_index = index + 1
+      while line_index < lines.size && delta > 0
+        pieces << lines[line_index]
+        delta += python_paren_delta(lines[line_index]) + python_bracket_delta(lines[line_index])
+        line_index += 1
+      end
+
+      pieces.join("\n")
+    end
+
+    private def add_urlpattern_expression_contents(contents : Array(::String),
+                                                   expression : ::String,
+                                                   urlpattern_lists : Hash(::String, ::String)) : Nil
+      split_python_expression_terms(expression).each do |term|
+        term = term.strip
+        next if term.empty? || term == "urlpatterns"
+
+        if term.matches?(/\b(?:url|path|re_path)\s*\(/)
+          contents << term
+          next
+        end
+
+        identifier_match = term.match(/\A([A-Za-z_][A-Za-z0-9_]*)\z/)
+        next unless identifier_match
+
+        if pattern_content = urlpattern_lists[identifier_match[1]]?
+          contents << pattern_content
+        end
+      end
+    end
+
+    private def split_python_expression_terms(expression : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      expression.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when '+'
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+
+    private def extract_urlpattern_lists(content : ::String) : Hash(::String, ::String)
+      pattern_lists = Hash(::String, ::String).new
+      lines = content.split("\n")
+
+      lines.each_with_index do |line, index|
+        assignment_match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\[/)
+        next unless assignment_match
+
+        pieces = [line]
+        delta = python_bracket_delta(line)
+        line_index = index + 1
+        while line_index < lines.size && delta > 0
+          pieces << lines[line_index]
+          delta += python_bracket_delta(lines[line_index])
+          line_index += 1
+        end
+
+        pattern_lists[assignment_match[1]] = pieces.join("\n")
+      end
+
+      pattern_lists
+    end
+
+    private def python_bracket_delta(line : ::String) : Int32
+      depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      line.each_char do |ch|
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when '['
+          depth += 1
+        when ']'
+          depth -= 1
+        end
+      end
+
+      depth
+    end
+
+    private def extract_route_mappings(content : ::String) : Array(Tuple(::String, ::String))
+      mappings = [] of Tuple(::String, ::String)
+      lines = content.split("\n")
+
+      lines.each_with_index do |line, index|
+        next unless line.matches?(/\b(?:url|path|re_path|register)\s*\(/)
+
+        logical_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        call_match = logical_line.match(/\b(?:url|path|re_path|register)\s*\((.*)\)/m)
+        next unless call_match
+
+        args = split_python_arguments(call_match[1])
+        next if args.size < 2
+
+        route = extract_python_string(args[0])
+        next unless route
+
+        mappings << {route, args[1].strip}
+      end
+
+      mappings
+    end
+
+    private def normalize_django_route(route : ::String) : ::String
+      normalized = route.gsub(/^\^/, "").gsub(/\$$/, "")
+      normalized.gsub(/\(\?P<([A-Za-z_][A-Za-z0-9_]*)>[^)]*\)/) do
+        "{#{$~[1]}}"
+      end
+    end
+
+    private def extract_python_import_aliases(content : ::String) : Hash(::String, ::String)
+      aliases = Hash(::String, ::String).new
+      lines = content.split("\n")
+
+      lines.each_with_index do |line, index|
+        next unless line.lstrip.starts_with?("from ")
+
+        import_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        import_match = import_line.match(/from\s+[^'"\s\\]+\s+import\s+(.+)/m)
+        next unless import_match
+
+        imports = import_match[1].strip
+        imports = imports.lchop("(").rchop(")").strip
+        split_python_arguments(imports).each do |import_expr|
+          import_expr = import_expr.gsub(/[()]/, "").strip
+          next if import_expr.empty? || import_expr == "*"
+
+          if alias_match = import_expr.match(/\A([A-Za-z_][A-Za-z0-9_]*)\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\z/)
+            aliases[alias_match[2]] = alias_match[1]
+          elsif name_match = import_expr.match(/\A([A-Za-z_][A-Za-z0-9_]*)\z/)
+            aliases[name_match[1]] = name_match[1]
+          end
+        end
+      end
+
+      aliases
+    end
+
+    private def extract_drf_router_registrations(content : ::String) : Hash(::String, Array(DjangoDrfRegistration))
+      registrations = Hash(::String, Array(DjangoDrfRegistration)).new do |hash, key|
+        hash[key] = [] of DjangoDrfRegistration
+      end
+      lines = content.split("\n")
+
+      lines.each_with_index do |line, index|
+        next unless line.includes?(".register(")
+
+        logical_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        register_match = logical_line.match(/\b([A-Za-z_][A-Za-z0-9_]*)\.register\s*\((.*)\)/m)
+        next unless register_match
+
+        args = split_python_arguments(register_match[2])
+        next if args.empty?
+
+        prefix = extract_python_string(args[0]) || extract_python_keyword_string(args, "prefix")
+        next unless prefix
+
+        view_ref = extract_python_keyword_expression(args, "viewset") || args[1]?.try(&.strip)
+        next unless view_ref
+        view_ref = clean_python_reference(view_ref)
+        next if view_ref.empty?
+
+        registrations[register_match[1]] << DjangoDrfRegistration.new(prefix, view_ref)
+      end
+
+      registrations
+    end
+
+    private def extract_drf_router_include_target(view : ::String) : ::String?
+      include_match = view.match(/\binclude\s*\(\s*(?:\(\s*)?([A-Za-z_][A-Za-z0-9_]*)\.urls\b/)
+      include_match ? include_match[1] : nil
+    end
+
+    private def extract_local_include_target(view : ::String) : ::String?
+      include_match = view.match(/\binclude\s*\(\s*(?:\(\s*)?([A-Za-z_][A-Za-z0-9_]*)\b/)
+      return unless include_match
+      return if view.includes?("#{include_match[1]}.urls")
+
+      include_match[1]
+    end
+
+    private def extract_local_urlpattern_endpoints(django_urls : DjangoUrls,
+                                                   mount_route : ::String,
+                                                   pattern_content : ::String,
+                                                   package_map,
+                                                   route_path : PathInfo,
+                                                   urlpattern_lists : Hash(::String, ::String),
+                                                   import_aliases : Hash(::String, ::String),
+                                                   drf_router_registrations : Hash(::String, Array(DjangoDrfRegistration))) : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      extract_route_mappings(pattern_content).each do |route_mapping|
+        route, view = route_mapping
+        route = normalize_django_route(route)
+        nested_mount = join_url_parts(mount_route, route).lchop("/")
+
+        if local_patterns = extract_local_include_target(view)
+          if nested_pattern_content = urlpattern_lists[local_patterns]?
+            extract_local_urlpattern_endpoints(django_urls, nested_mount, nested_pattern_content, package_map, route_path, urlpattern_lists, import_aliases, drf_router_registrations).each do |endpoint|
+              endpoints << endpoint
+            end
+            next
+          end
+        end
+
+        if router_name = extract_drf_router_include_target(view)
+          router_endpoints = extract_drf_router_endpoints_for_router(
+            django_urls,
+            nested_mount,
+            router_name,
+            drf_router_registrations,
+            package_map,
+            import_aliases,
+            route_path
+          )
+          unless router_endpoints.empty?
+            endpoints.concat(router_endpoints)
+            next
+          end
+        end
+
+        url = join_url_parts(django_urls.prefix, mount_route, route)
         if view == ""
           endpoints << Endpoint.new(url, "GET", Details.new(route_path))
-        else
-          dotted_as_names_split = view.split(".")
+          next
+        end
 
-          filepath = ""
-          function_or_class_name = ""
-          dotted_as_names_split.each_with_index do |name, index|
-            if (package_map.has_key? name) && (index < dotted_as_names_split.size)
-              filepath, package_type = package_map[name]
-              function_or_class_name = name
-              if package_type == PackageType::FILE && index + 1 < dotted_as_names_split.size
-                function_or_class_name = dotted_as_names_split[index + 1]
-              end
-
-              break
-            end
-          end
-
-          if filepath != "" && /^[a-zA-Z_][a-zA-Z0-9_]*$/.match(function_or_class_name)
+        view = extract_wrapped_view_reference(view)
+        resolved = resolve_django_view_reference(view, package_map)
+        if resolved
+          filepath, function_or_class_name = resolved
+          if /^[a-zA-Z_][a-zA-Z0-9_]*$/.match(function_or_class_name)
             extract_endpoints_from_file(url, filepath, function_or_class_name).each do |endpoint|
               append_code_path(endpoint.details, route_path)
               endpoints << endpoint
             end
-          else
-            # By default, Django allows requests with methods other than GET as well
-            endpoints << Endpoint.new(url, "GET", Details.new(route_path))
+            next
           end
+        end
+
+        endpoints << Endpoint.new(url, "GET", Details.new(route_path))
+      end
+
+      endpoints
+    end
+
+    private def extract_drf_direct_router_endpoints(django_urls : DjangoUrls,
+                                                    content : ::String,
+                                                    drf_router_registrations : Hash(::String, Array(DjangoDrfRegistration)),
+                                                    package_map,
+                                                    import_aliases : Hash(::String, ::String),
+                                                    route_path : PathInfo) : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      extract_drf_direct_router_names(content).each do |router_name|
+        endpoints.concat extract_drf_router_endpoints_for_router(
+          django_urls,
+          "",
+          router_name,
+          drf_router_registrations,
+          package_map,
+          import_aliases,
+          route_path
+        )
+      end
+
+      endpoints
+    end
+
+    private def extract_drf_direct_router_names(content : ::String) : Array(::String)
+      router_names = [] of ::String
+
+      content.scan(/\burlpatterns\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
+        router_names << match[1] if match.size == 2
+      end
+
+      content.scan(/\burlpatterns\s*\+=\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
+        router_names << match[1] if match.size == 2
+      end
+
+      content.scan(/\burlpatterns\b[^\n]*\+\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
+        router_names << match[1] if match.size == 2
+      end
+
+      content.scan(/\burlpatterns\s*\.\s*extend\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\s*\)/) do |match|
+        router_names << match[1] if match.size == 2
+      end
+
+      router_names.uniq
+    end
+
+    private def extract_drf_router_endpoints(django_urls : DjangoUrls,
+                                             mount_route : ::String,
+                                             registration : DjangoDrfRegistration,
+                                             package_map) : Array(Endpoint)
+      resolved = resolve_django_view_reference(registration.view_ref, package_map)
+      return [] of Endpoint unless resolved
+
+      filepath, class_name = resolved
+      route_base = join_url_parts(django_urls.prefix, mount_route, registration.prefix)
+      extract_drf_viewset_endpoints(route_base, filepath, class_name)
+    end
+
+    private def extract_drf_router_endpoints_for_router(django_urls : DjangoUrls,
+                                                        mount_route : ::String,
+                                                        router_name : ::String,
+                                                        drf_router_registrations : Hash(::String, Array(DjangoDrfRegistration)),
+                                                        package_map : Hash(::String, Tuple(::String, Int32)),
+                                                        import_aliases : Hash(::String, ::String),
+                                                        route_path : PathInfo) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      registrations = drf_router_registrations[router_name]? || [] of DjangoDrfRegistration
+      registration_package_map = package_map
+      router_path_info = route_path
+
+      if registrations.empty?
+        imported_router = package_map[router_name]?
+        return endpoints unless imported_router
+
+        imported_path, _imported_type = imported_router
+        return endpoints unless File.exists?(imported_path)
+
+        imported_content = read_file_content(imported_path)
+        imported_registrations = extract_drf_router_registrations(imported_content)
+        imported_router_name = import_aliases[router_name]? || router_name
+        registrations = imported_registrations[imported_router_name]? || [] of DjangoDrfRegistration
+        return endpoints if registrations.empty?
+
+        registration_package_map = find_imported_modules(@django_base_path, imported_path, imported_content)
+        router_path_info = PathInfo.new(imported_path)
+      end
+
+      registrations.each do |registration|
+        extract_drf_router_endpoints(django_urls, mount_route, registration, registration_package_map).each do |endpoint|
+          append_code_path(endpoint.details, route_path)
+          append_code_path(endpoint.details, router_path_info)
+          endpoints << endpoint
         end
       end
 
       endpoints
+    end
+
+    private def extract_wrapped_view_reference(view : ::String) : ::String
+      if as_view_match = view.match(/([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\.as_view\s*\(/)
+        return as_view_match[1]
+      end
+
+      view
+    end
+
+    private def extract_python_string(expression : ::String) : ::String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
+
+    private def extract_python_keyword_expression(args : Array(::String), keyword : ::String) : ::String?
+      args.each do |arg|
+        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        return keyword_match[1].strip if keyword_match
+      end
+
+      nil
+    end
+
+    private def extract_python_keyword_string(args : Array(::String), keyword : ::String) : ::String?
+      if expression = extract_python_keyword_expression(args, keyword)
+        return extract_python_string(expression)
+      end
+
+      nil
+    end
+
+    private def clean_python_reference(expression : ::String) : ::String
+      reference = expression.strip
+      reference = reference.split("#", 2)[0].strip
+      return reference if reference.matches?(/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/)
+
+      ""
+    end
+
+    private def split_python_arguments(args : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      args.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when ','
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
     end
 
     # Extract endpoints from a given file
@@ -273,7 +840,7 @@ module Analyzer::Python
       regext_http_methods = HTTP_METHODS.join "|"
       class_start_index = content.index /class\s+#{function_or_class_name}\s*[\(:]/
       if !class_start_index.nil?
-        class_codeblock = parse_code_block(content[class_start_index..])
+        class_codeblock = parse_python_class_codeblock(content, class_start_index) || parse_code_block(content[class_start_index..])
         if !class_codeblock.nil?
           lines = class_codeblock.split "\n"
           class_define_line = lines[0]
@@ -296,12 +863,23 @@ module Analyzer::Python
           class_definition_line = body_start_line + 1
           method_callees = Hash(String, Array(Callee)).new
           method_lines = Hash(String, Int32).new
+          common_params = Array(Param).new
+          method_params = Hash(String, Array(Param)).new do |hash, key|
+            hash[key] = [] of Param
+          end
+          current_http_method : String? = nil
 
           # Check HTTP methods in class methods
           lines.each_with_index do |line, offset|
             method_function_match = line.match(/\s+(?:async\s+)?def\s+(#{regext_http_methods})\s*\(/)
+            any_method_function_match = line.match(/\s+(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
+            if !any_method_function_match.nil?
+              current_http_method = nil
+            end
+
             if !method_function_match.nil?
               method_name = method_function_match[1].upcase
+              current_http_method = method_name
               suspicious_http_methods << method_name
               method_lines[method_name] = body_start_line + offset + 2
 
@@ -317,14 +895,19 @@ module Analyzer::Python
             end
 
             extract_params_from_line(line, suspicious_http_methods).each do |param|
-              suspicious_params << param
+              if method_name = current_http_method
+                method_params[method_name] << param
+              else
+                common_params << param
+              end
             end
           end
 
           suspicious_http_methods.uniq.each do |http_method_name|
             definition_line = method_lines[http_method_name]? || class_definition_line
             details = Details.new(PathInfo.new(filepath, definition_line))
-            endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, suspicious_params), details)
+            endpoint_params = common_params + (method_params[http_method_name]? || [] of Param)
+            endpoint = Endpoint.new(url, http_method_name, filter_params(http_method_name, endpoint_params), details)
             if callees = method_callees[http_method_name]?
               callees.each { |c| endpoint.push_callee(c) }
             end
@@ -337,6 +920,272 @@ module Analyzer::Python
 
       # Default to GET method
       [Endpoint.new(url, "GET", Details.new(PathInfo.new(filepath)))]
+    end
+
+    private def extract_drf_viewset_endpoints(route_base : ::String, filepath : ::String, class_name : ::String) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      content = read_file_content(filepath)
+      class_start_index = content.index /class\s+#{class_name}\s*[\(:]/
+      return endpoints unless class_start_index
+
+      class_codeblock = parse_python_class_codeblock(content, class_start_index) || parse_code_block(content[class_start_index..])
+      return endpoints unless class_codeblock
+
+      lines = class_codeblock.split("\n")
+      class_define_line = extract_python_definition_header(lines)
+      body_lines = lines[1..]
+      body_start_line = content[0, class_start_index].count('\n')
+      class_definition_line = body_start_line + 1
+      lookup_param = extract_drf_lookup_param(class_codeblock)
+      actions = default_drf_viewset_actions(class_define_line)
+
+      body_lines.each_with_index do |line, offset|
+        method_match = line.match(/\s+(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
+        next unless method_match
+
+        action_name = method_match[1]
+        method_actions = [] of DjangoDrfAction
+        if action = drf_action_for_method(action_name)
+          method_actions << action
+        else
+          method_actions = extract_drf_action_decorators(body_lines, offset, action_name)
+        end
+        next if method_actions.empty?
+
+        codeblock = parse_code_block(body_lines[offset..])
+        method_actions.each do |drf_action|
+          drf_action.definition_line = body_start_line + offset + 2
+          if codeblock
+            codeblock.split("\n").each do |body_line|
+              extract_params_from_line(body_line, [drf_action.method]).each do |param|
+                drf_action.params << param
+              end
+            end
+          end
+
+          actions.reject! { |existing| existing.name == drf_action.name && existing.method == drf_action.method && existing.detail == drf_action.detail }
+          actions << drf_action
+        end
+      end
+
+      actions.each do |action|
+        endpoint_path = drf_action_path(route_base, lookup_param, action)
+        params = filter_params(action.method, action.params)
+        params << Param.new(lookup_param, "", "path") if action.detail
+        params = dedupe_params(params)
+        details = Details.new(PathInfo.new(filepath, action.definition_line || class_definition_line))
+        endpoints << Endpoint.new(endpoint_path, action.method, params, details)
+      end
+
+      endpoints
+    end
+
+    private def default_drf_viewset_actions(class_define_line : ::String) : Array(DjangoDrfAction)
+      actions = [] of DjangoDrfAction
+
+      if class_define_line.includes?("ReadOnlyModelViewSet")
+        actions << DjangoDrfAction.new("list", "GET", false, "")
+        actions << DjangoDrfAction.new("retrieve", "GET", true, "")
+      elsif class_define_line.includes?("ModelViewSet")
+        actions << DjangoDrfAction.new("list", "GET", false, "")
+        actions << DjangoDrfAction.new("create", "POST", false, "")
+        actions << DjangoDrfAction.new("retrieve", "GET", true, "")
+        actions << DjangoDrfAction.new("update", "PUT", true, "")
+        actions << DjangoDrfAction.new("partial_update", "PATCH", true, "")
+        actions << DjangoDrfAction.new("destroy", "DELETE", true, "")
+      end
+
+      actions << DjangoDrfAction.new("list", "GET", false, "") if class_define_line.includes?("ListModelMixin")
+      actions << DjangoDrfAction.new("create", "POST", false, "") if class_define_line.includes?("CreateModelMixin")
+      actions << DjangoDrfAction.new("retrieve", "GET", true, "") if class_define_line.includes?("RetrieveModelMixin")
+      actions << DjangoDrfAction.new("update", "PUT", true, "") if class_define_line.includes?("UpdateModelMixin")
+      actions << DjangoDrfAction.new("partial_update", "PATCH", true, "") if class_define_line.includes?("UpdateModelMixin")
+      actions << DjangoDrfAction.new("destroy", "DELETE", true, "") if class_define_line.includes?("DestroyModelMixin")
+
+      actions
+    end
+
+    private def drf_action_for_method(method_name : ::String) : DjangoDrfAction?
+      case method_name
+      when "list"
+        DjangoDrfAction.new(method_name, "GET", false, "")
+      when "create"
+        DjangoDrfAction.new(method_name, "POST", false, "")
+      when "retrieve"
+        DjangoDrfAction.new(method_name, "GET", true, "")
+      when "update"
+        DjangoDrfAction.new(method_name, "PUT", true, "")
+      when "partial_update"
+        DjangoDrfAction.new(method_name, "PATCH", true, "")
+      when "destroy"
+        DjangoDrfAction.new(method_name, "DELETE", true, "")
+      end
+    end
+
+    private def extract_drf_action_decorators(lines : Array(::String), method_line_index : Int32, method_name : ::String) : Array(DjangoDrfAction)
+      index = method_line_index - 1
+      while index >= 0
+        stripped = lines[index].strip
+        break if stripped.empty? || stripped.starts_with?("def ") || stripped.starts_with?("class ")
+
+        if stripped.starts_with?("@action") || stripped == ")" || stripped.includes?("url_path") || stripped.includes?("methods") || stripped.includes?("detail")
+          decorator_source = collect_preceding_decorator_source(lines, index)
+          next unless decorator_source.includes?("@action")
+
+          args_match = decorator_source.match(/@action\s*\((.*?)\)/m)
+          args = args_match ? args_match[1] : ""
+          detail = args.matches?(/\bdetail\s*=\s*True\b/)
+          methods = extract_drf_action_methods(args)
+          url_path = extract_drf_action_url_path(args) || method_name.gsub("_", "-")
+          return methods.map { |method| DjangoDrfAction.new(method_name, method, detail, url_path) }
+        end
+
+        index -= 1
+      end
+
+      [] of DjangoDrfAction
+    end
+
+    private def extract_python_definition_header(lines : Array(::String)) : ::String
+      header = [] of ::String
+      delta = 0
+
+      lines.each do |line|
+        header << line.strip
+        delta += python_paren_delta(line)
+        break if delta <= 0 && line.includes?(":")
+      end
+
+      header.join(" ")
+    end
+
+    private def collect_preceding_decorator_source(lines : Array(::String), index : Int32) : ::String
+      start_index = index
+      while start_index > 0
+        previous = lines[start_index - 1].strip
+        break if previous.empty? || previous.matches?(/^(?:async\s+)?def\s+/) || previous.starts_with?("class ")
+        start_index -= 1
+        break if previous.starts_with?("@")
+      end
+
+      lines[start_index..index].join("\n")
+    end
+
+    private def parse_python_class_codeblock(content : ::String, class_start_index : Int32) : ::String?
+      lines = content[class_start_index..].split("\n")
+      return if lines.empty?
+
+      class_indent = lines[0].size - lines[0].lstrip.size
+      collected = [] of ::String
+      delta = 0
+      index = 0
+      header_closed = false
+
+      while index < lines.size
+        line = lines[index]
+        collected << line
+        delta += python_paren_delta(line)
+        index += 1
+
+        if delta <= 0 && line.includes?(":")
+          header_closed = true
+          break
+        end
+      end
+      return unless header_closed
+
+      while index < lines.size
+        line = lines[index]
+        if line.strip.empty?
+          collected << line
+          index += 1
+          next
+        end
+
+        indent = line.size - line.lstrip.size
+        break if indent <= class_indent
+
+        collected << line
+        index += 1
+      end
+
+      collected.join("\n").strip
+    end
+
+    private def extract_drf_action_methods(args : ::String) : Array(::String)
+      methods_match = args.match(/\bmethods\s*=\s*(\[[^\]]*\]|\([^\)]*\)|[rf]?['"][^'"]+['"])/)
+      return ["GET"] unless methods_match
+
+      methods = methods_match[1].scan(/[rf]?['"]([^'"]+)['"]/).map(&.[1].upcase)
+      methods.empty? ? ["GET"] : methods
+    end
+
+    private def extract_drf_action_url_path(args : ::String) : ::String?
+      url_path_match = args.match(/\burl_path\s*=\s*[rf]?['"]([^'"]+)['"]/)
+      url_path_match ? url_path_match[1] : nil
+    end
+
+    private def extract_drf_lookup_param(class_codeblock : ::String) : ::String
+      if lookup_url_kwarg = class_codeblock.match(/\blookup_url_kwarg\s*=\s*[rf]?['"]([^'"]+)['"]/)
+        return lookup_url_kwarg[1]
+      end
+
+      if lookup_field = class_codeblock.match(/\blookup_field\s*=\s*[rf]?['"]([^'"]+)['"]/)
+        return lookup_field[1]
+      end
+
+      "pk"
+    end
+
+    private def drf_action_path(route_base : ::String, lookup_param : ::String, action : DjangoDrfAction) : ::String
+      parts = [route_base]
+      parts << "{#{lookup_param}}" if action.detail
+      parts << action.path unless action.path.empty?
+      ensure_trailing_slash(join_url_parts(parts))
+    end
+
+    private def join_url_parts(parts : Array(::String)) : ::String
+      cleaned = parts.map(&.strip).reject(&.empty?)
+      return "/" if cleaned.empty?
+
+      "/#{cleaned.join("/")}".gsub(/\/+/, "/")
+    end
+
+    private def join_url_parts(*parts : ::String) : ::String
+      join_url_parts(parts.to_a)
+    end
+
+    private def ensure_trailing_slash(path : ::String) : ::String
+      return "/" if path == ""
+      path.ends_with?("/") ? path : "#{path}/"
+    end
+
+    private def dedupe_params(params : Array(Param)) : Array(Param)
+      deduped = [] of Param
+      params.each do |param|
+        next if deduped.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+        deduped << param
+      end
+
+      deduped
+    end
+
+    private def resolve_django_view_reference(view_ref : ::String, package_map) : Tuple(::String, ::String)?
+      dotted_as_names_split = view_ref.split(".")
+
+      dotted_as_names_split.each_with_index do |name, index|
+        next unless package_map.has_key?(name)
+
+        filepath, package_type = package_map[name]
+        function_or_class_name = name
+        if package_type == PackageType::FILE && index + 1 < dotted_as_names_split.size
+          function_or_class_name = dotted_as_names_split[index + 1]
+        end
+
+        return {filepath, function_or_class_name}
+      end
+
+      nil
     end
 
     private def append_code_path(details : Details, path_info : PathInfo)
@@ -455,6 +1304,27 @@ module Analyzer::Python
         if !File.directory? @filepath
           raise "The filepath for DjangoView (#{@filepath}) does not exist."
         end
+      end
+    end
+
+    struct DjangoDrfRegistration
+      property prefix, view_ref
+
+      def initialize(@prefix : ::String, @view_ref : ::String)
+      end
+    end
+
+    class DjangoDrfAction
+      property name, method, detail, path, params, definition_line
+
+      @definition_line : Int32?
+
+      def initialize(@name : ::String,
+                     @method : ::String,
+                     @detail : Bool,
+                     @path : ::String,
+                     @params = [] of Param,
+                     @definition_line = nil)
       end
     end
   end

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -51,11 +51,22 @@ module Analyzer::Python
 
       routes = [] of Tuple(Int32, ::String, ::String, ::String)
       classes = Hash(::String, Int32).new
+      resource_instances = Hash(::String, ::String).new
+      import_map = find_imported_modules(definition_base_path, path, source)
+      source_cache = Hash(::String, ::String).new
+      source_cache[path] = source
+      class_cache = Hash(::String, Hash(::String, Int32)).new
 
       lines.each_with_index do |line, line_index|
         # Record class definitions for later responder lookup.
         if class_match = line.match(/^\s*class\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*[\(:]/)
           classes[class_match[1]] = line_index
+        end
+
+        if instance_match = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)(?::[^=]+)?\s*=\s*((?:[a-zA-Z_][a-zA-Z0-9_]*\.)*[a-zA-Z_][a-zA-Z0-9_]*)\s*\(/)
+          instance_name = instance_match[1]
+          resource_ref = instance_match[2]
+          resource_instances[instance_name] = resource_ref
         end
 
         # `xxx.add_route('/path', ResourceClass(), suffix='item')`
@@ -75,57 +86,83 @@ module Analyzer::Python
         if line.includes?(".add_route") && line.includes?("(")
           effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
 
-          route_match = effective_line.match(/\.add_route\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*([a-zA-Z_][a-zA-Z0-9_]*)/)
+          route_match = effective_line.match(/\.add_route\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*((?:[a-zA-Z_][a-zA-Z0-9_]*\.)*[a-zA-Z_][a-zA-Z0-9_]*)/)
           if route_match
             route_path = route_match[1]
-            class_name = route_match[2]
+            resource_ref = route_match[2]
             suffix = ""
             if suffix_match = effective_line.match(/suffix\s*=\s*['"]([^'"]*)['"]/)
               suffix = suffix_match[1]
             end
-            routes << {line_index, route_path, class_name, suffix}
+            routes << {line_index, route_path, resource_ref, suffix}
           else
             # Keyword form. `uri_template=` / `path=` for the path
             # (`path=` accepted because some Falcon helper APIs and
             # older docs use it interchangeably); `resource=` for the
             # responder.
             kw_path_match = effective_line.match(/(?:uri_template|path)\s*=\s*[rf]?['"]([^'"]*)['"]/)
-            kw_resource_match = effective_line.match(/resource\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)/)
+            kw_resource_match = effective_line.match(/resource\s*=\s*((?:[a-zA-Z_][a-zA-Z0-9_]*\.)*[a-zA-Z_][a-zA-Z0-9_]*)/)
             if kw_path_match && kw_resource_match
               route_path = kw_path_match[1]
-              class_name = kw_resource_match[1]
+              resource_ref = kw_resource_match[1]
               suffix = ""
               if suffix_match = effective_line.match(/suffix\s*=\s*['"]([^'"]*)['"]/)
                 suffix = suffix_match[1]
               end
-              routes << {line_index, route_path, class_name, suffix}
+              routes << {line_index, route_path, resource_ref, suffix}
             end
+          end
+        end
+
+        if line.includes?(".add_static_route") && line.includes?("(")
+          effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+          if static_path = extract_static_route_path(effective_line)
+            details = Details.new(PathInfo.new(path, line_index + 1))
+            result << Endpoint.new(static_route_path(static_path), "GET", details)
           end
         end
       end
 
       routes.each do |route_info|
-        line_index, route_path, class_name, suffix = route_info
-        class_line = classes[class_name]?
-        next if class_line.nil?
+        line_index, route_path, resource_ref, suffix = route_info
+        resource_ref = resource_instances[resource_ref]? || resource_ref
+        resolved_class = resolve_resource_class(
+          resource_ref,
+          path,
+          source,
+          lines,
+          classes,
+          import_map,
+          source_cache,
+          class_cache
+        )
+        next if resolved_class.nil?
+
+        class_path, class_source, class_lines, class_line = resolved_class
 
         responder_name = suffix.empty? ? nil : suffix
         emit_endpoints_for_class(
-          path,
-          lines,
-          class_line,
-          route_path,
-          line_index,
-          responder_name,
+          route_file_path: path,
+          class_file_path: class_path,
+          lines: class_lines,
+          class_line: class_line,
+          route_path: route_path,
+          route_line: line_index,
+          suffix: responder_name,
           definition_base_path: definition_base_path,
-          source: source
+          source: class_source
         )
       end
     end
 
-    private def emit_endpoints_for_class(path : ::String, lines : Array(::String), class_line : Int32,
-                                         route_path : ::String, route_line : Int32, suffix : ::String?,
-                                         *,
+    private def emit_endpoints_for_class(*,
+                                         route_file_path : ::String,
+                                         class_file_path : ::String,
+                                         lines : Array(::String),
+                                         class_line : Int32,
+                                         route_path : ::String,
+                                         route_line : Int32,
+                                         suffix : ::String?,
                                          definition_base_path : ::String,
                                          source : ::String)
       class_indent = indent_level(lines[class_line])
@@ -149,7 +186,7 @@ module Analyzer::Python
               params = extract_request_params(body_lines, http_method)
               path_params_from_url(route_path).each { |p| params << p }
 
-              details = Details.new(PathInfo.new(path, route_line + 1))
+              details = Details.new(PathInfo.new(route_file_path, route_line + 1))
               endpoint = Endpoint.new(normalize_path(route_path), http_method, params)
               endpoint.details = details
 
@@ -157,7 +194,7 @@ module Analyzer::Python
                 endpoint,
                 codeblock || "",
                 i,
-                path,
+                class_file_path,
                 definition_base_path: definition_base_path,
                 source: source
               )
@@ -185,12 +222,145 @@ module Analyzer::Python
       nil
     end
 
+    private def resolve_resource_class(resource_ref : ::String,
+                                       current_path : ::String,
+                                       current_source : ::String,
+                                       current_lines : Array(::String),
+                                       current_classes : Hash(::String, Int32),
+                                       import_map : Hash(::String, Tuple(::String, Int32)),
+                                       source_cache : Hash(::String, ::String),
+                                       class_cache : Hash(::String, Hash(::String, Int32))) : Tuple(::String, ::String, Array(::String), Int32)?
+      parts = resource_ref.split(".")
+      return if parts.empty?
+
+      if parts.size == 1
+        class_name = parts[0]
+        if class_line = current_classes[class_name]?
+          return {current_path, current_source, current_lines, class_line}
+        end
+
+        if imported = import_map[class_name]?
+          return resolve_class_in_file(imported[0], class_name, source_cache, class_cache)
+        end
+
+        return
+      end
+
+      import_name = parts[0]
+      class_name = parts[-1]
+      return unless imported = import_map[import_name]?
+
+      resolve_class_in_file(imported[0], class_name, source_cache, class_cache)
+    end
+
+    private def resolve_class_in_file(file_path : ::String,
+                                      class_name : ::String,
+                                      source_cache : Hash(::String, ::String),
+                                      class_cache : Hash(::String, Hash(::String, Int32))) : Tuple(::String, ::String, Array(::String), Int32)?
+      return if file_path.empty? || !File.exists?(file_path)
+
+      source = source_cache[file_path] ||= read_file_content(file_path)
+      lines = source.lines
+      classes = class_cache[file_path] ||= collect_classes(lines)
+      return unless class_line = classes[class_name]?
+
+      {file_path, source, lines, class_line}
+    end
+
+    private def collect_classes(lines : Array(::String)) : Hash(::String, Int32)
+      classes = Hash(::String, Int32).new
+      lines.each_with_index do |line, line_index|
+        if class_match = line.match(/^\s*class\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*[\(:]/)
+          classes[class_match[1]] = line_index
+        end
+      end
+      classes
+    end
+
     private def path_params_from_url(route_path : ::String) : Array(Param)
       params = [] of Param
       route_path.scan(/\{([a-zA-Z_][a-zA-Z0-9_]*)(?::[^}]+)?\}/) do |match|
         params << Param.new(match[1], "", "path")
       end
       params
+    end
+
+    private def extract_static_route_path(line : ::String) : ::String?
+      call_match = line.match(/\.add_static_route\s*\((.*)\)\s*$/m)
+      return unless call_match
+
+      args = split_python_arguments(call_match[1])
+      extract_keyword_string(args, "prefix") || args[0]?.try { |arg| extract_python_string(arg) }
+    end
+
+    private def split_python_arguments(args : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      args.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '(', '[', '{'
+          depth += 1
+          current << ch
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+          current << ch
+        when ','
+          if depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+
+    private def extract_keyword_string(args : Array(::String), keyword : ::String) : ::String?
+      args.each do |arg|
+        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        next unless keyword_match
+
+        return extract_python_string(keyword_match[1])
+      end
+
+      nil
+    end
+
+    private def extract_python_string(expression : ::String) : ::String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
+
+    private def static_route_path(route_path : ::String) : ::String
+      normalized = normalize_path(route_path)
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized = normalized.gsub(/\/+/, "/")
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
     end
 
     # Strip Falcon type converters from the URL so `/things/{id:int}` is
@@ -205,6 +375,10 @@ module Analyzer::Python
     private def extract_request_params(body_lines : Array(::String), http_method : ::String) : Array(Param)
       params = [] of Param
       seen = Set(::String).new
+      media_vars = [] of ::String
+      media_access_seen = false
+      media_field_seen = false
+      body_method = http_method != "GET" && http_method != "HEAD" && http_method != "OPTIONS"
 
       record = ->(name : ::String, type : ::String) do
         key = "#{type}:#{name}"
@@ -212,6 +386,18 @@ module Analyzer::Python
           params << Param.new(name, "", type)
           seen << key
         end
+      end
+
+      body_lines.each do |line|
+        line.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:await\s+)?req\.media\b/) do |m|
+          media_vars << m[1] unless media_vars.includes?(m[1])
+          media_access_seen = true
+        end
+        line.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:await\s+)?req\.get_media\s*\(/) do |m|
+          media_vars << m[1] unless media_vars.includes?(m[1])
+          media_access_seen = true
+        end
+        media_access_seen = true if line.matches?(/req\.media\b/) || line.matches?(/req\.get_media\s*\(/)
       end
 
       body_lines.each do |line|
@@ -243,20 +429,36 @@ module Analyzer::Python
           record.call(m[1], "cookie")
         end
 
-        # req.media / await req.get_media() — body (json for write methods).
-        if line.matches?(/req\.media\b/) || line.matches?(/req\.get_media\s*\(/)
-          if http_method != "GET" && http_method != "HEAD" && http_method != "OPTIONS"
-            record.call("body", "json")
+        # req.media["name"] / req.media.get("name") and variables assigned
+        # from req.media / await req.get_media().
+        if body_method
+          line.scan(/req\.media\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+            media_field_seen = true
+            record.call(m[1], "json")
+          end
+          line.scan(/req\.media\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+            media_field_seen = true
+            record.call(m[1], "json")
+          end
+          media_vars.each do |var|
+            line.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+              media_field_seen = true
+              record.call(m[1], "json")
+            end
+            line.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+              media_field_seen = true
+              record.call(m[1], "json")
+            end
           end
         end
 
         # req.bounded_stream — raw body, treat as form for write methods.
         if line.includes?("req.bounded_stream")
-          if http_method != "GET" && http_method != "HEAD" && http_method != "OPTIONS"
-            record.call("body", "form")
-          end
+          record.call("body", "form") if body_method
         end
       end
+
+      record.call("body", "json") if body_method && media_access_seen && !media_field_seen
 
       params
     end

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -21,7 +21,7 @@ module Analyzer::Python
             next if PythonEngine.python_test_path?(path)
             source = read_file_content(path)
 
-            import_modules = find_imported_modules(current_base_path, path, source)
+            import_modules = find_fastapi_imported_modules(current_base_path, path, source)
             codelines = source.split("\n")
             codelines.each_with_index do |original_line, index|
               effective_line = coalesce_constructor_call(codelines, index, original_line, "APIRouter")
@@ -77,7 +77,7 @@ module Analyzer::Python
         include_router_map.each do |path, router_map|
           source = read_file_content(path)
           definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @fastapi_base_path
-          import_modules = find_imported_modules(@fastapi_base_path, path, source)
+          import_modules = find_fastapi_imported_modules(@fastapi_base_path, path, source)
           codelines = source.split("\n")
           router_map.each do |instance_name, router_class|
             codelines.each_with_index do |line, index|
@@ -100,6 +100,7 @@ module Analyzer::Python
               if route_call = parse_fastapi_route_decorator(effective_line, instance_name, source, import_modules)
                 route_attr, http_route_path, _extra_params = route_call
                 http_method_name = route_attr.downcase
+                websocket_route = http_method_name == "websocket"
                 if http_method_name.in?(%w[websocket route api_route])
                   http_method_name = "GET"
                 elsif !HTTP_METHODS.includes?(http_method_name)
@@ -135,6 +136,9 @@ module Analyzer::Python
                     function_params.each do |param|
                       # https://fastapi.tiangolo.com/tutorial/path-params-numeric-validations/#order-the-parameters-as-you-need-tricks
                       next if param.name == "*"
+                      next if param.name.in?(%w[self cls])
+                      next if param.type == "WebSocket"
+                      next if fastapi_dependency_param?(param)
 
                       unless query_params.includes?(param.name)
                         # Default value is numeric or string only
@@ -205,6 +209,7 @@ module Analyzer::Python
                 details = Details.new(PathInfo.new(path, index + 1))
                 full_path = router_class.join(http_route_path)
                 base_endpoint = Endpoint.new(full_path, emit_methods.first, params, details)
+                base_endpoint.protocol = "ws" if websocket_route
 
                 # `parse_code_block(codelines[def_line..])` keeps the
                 # def line, so body row 0 lives at file line `def_line`.
@@ -225,6 +230,7 @@ module Analyzer::Python
                                       base_endpoint
                                     else
                                       Endpoint.new(full_path, method, params, details).tap do |dup_ep|
+                                        dup_ep.protocol = "ws" if websocket_route
                                         base_endpoint.callees.each { |c| dup_ep.push_callee(c) }
                                       end
                                     end
@@ -242,15 +248,44 @@ module Analyzer::Python
               prog_line = coalesce_programmatic_call(codelines, index, line, instance_name)
               if prog_call = parse_fastapi_programmatic_route(prog_line, instance_name, source, import_modules)
                 prog_attr, prog_path, prog_tail = prog_call
+                prog_websocket_route = prog_attr.includes?("websocket")
                 prog_methods = extract_declared_methods(prog_tail)
                 if prog_methods.empty?
-                  prog_methods = prog_attr.includes?("websocket") ? ["GET"] : ["GET"]
+                  prog_methods = prog_websocket_route ? ["GET"] : ["GET"]
                 end
                 prog_full = router_class.join(prog_path)
                 prog_details = Details.new(PathInfo.new(path, index + 1))
-                prog_methods.each do |m|
-                  result << Endpoint.new(prog_full, m, [] of Param, prog_details)
+                prog_params = [] of Param
+                prog_callees = [] of Callee
+                if handler = resolve_programmatic_handler(prog_tail, path, source, import_modules)
+                  handler_path, handler_name = handler
+                  handler_source = handler_path == path ? source : read_file_content(handler_path)
+                  handler_lines = handler_source.split("\n")
+                  handler_imports = handler_path == path ? import_modules : find_fastapi_imported_modules(definition_base_path, handler_path, handler_source)
+                  if handler_def_line = find_function_def_line(handler_lines, handler_name)
+                    prog_params = extract_fastapi_handler_params(handler_lines, handler_def_line, prog_full, handler_source, handler_imports)
+                    if handler_codeblock = parse_code_block(handler_lines[handler_def_line..])
+                      prog_callees = build_callees_from(
+                        handler_codeblock,
+                        handler_def_line,
+                        handler_path,
+                        definition_base_path: definition_base_path,
+                        source: handler_source
+                      )
+                    end
+                  end
                 end
+                prog_methods.each do |m|
+                  endpoint = Endpoint.new(prog_full, m, prog_params, prog_details)
+                  endpoint.protocol = "ws" if prog_websocket_route
+                  prog_callees.each { |c| endpoint.push_callee(c) }
+                  result << endpoint
+                end
+              end
+
+              mount_line = coalesce_mount_call(codelines, index, line, instance_name)
+              if static_mount_path = parse_fastapi_static_mount(mount_line, instance_name, source, import_modules)
+                result << Endpoint.new(static_route_path(router_class.join(static_mount_path)), "GET", Details.new(PathInfo.new(path, index + 1)))
               end
             end
           end
@@ -279,14 +314,34 @@ module Analyzer::Python
       end
     end
 
+    private def find_fastapi_imported_modules(app_base_path : ::String,
+                                              file_path : ::String,
+                                              source : ::String? = nil) : Hash(::String, Tuple(::String, Int32))
+      import_modules = find_imported_modules(app_base_path, file_path, source)
+      local_base_path = File.dirname(file_path)
+      return import_modules if local_base_path == app_base_path
+
+      local_import_modules = find_imported_modules(local_base_path, file_path, source)
+      local_import_modules.each do |name, import_info|
+        import_modules[name] = import_info unless import_modules.has_key?(name)
+      end
+
+      import_modules
+    end
+
     # Configures the prefix for each router
-    def configure_router_prefix(file : ::String, include_router_map : Hash(::String, Hash(::String, Router)), router_prefix : ::String = "")
+    def configure_router_prefix(file : ::String,
+                                include_router_map : Hash(::String, Hash(::String, Router)),
+                                router_prefix : ::String = "",
+                                target_instance_name : ::String? = nil)
       return if file.empty? || !File.exists?(file)
 
       # Parse the source file for router configuration
       source = read_file_content(file)
-      import_modules = find_imported_modules(@fastapi_base_path, file, source)
+      import_modules = find_fastapi_imported_modules(@fastapi_base_path, file, source)
       include_router_map[file].each do |instance_name, router_class|
+        next if target_instance_name && instance_name != target_instance_name
+
         # PREPEND the inherited prefix to the router's own. The
         # initial pass captures `APIRouter(prefix="/users")`, so
         # `router_class.prefix` may already be `/users`; if we
@@ -299,54 +354,109 @@ module Analyzer::Python
         # `/users` / `/items` segment.
         router_class.prefix = combine_router_prefixes(router_prefix, router_class.prefix)
 
-        # Parse '{app}.include_router({item}.router, prefix="{prefix}")' code
-        source.scan(/#{instance_name}\.include_router\(([^\)]*)\)/).each do |match|
-          if match.size > 0
-            params = match[1].split(",")
-            prefix = ""
-            router_instance_name = params[0].strip
-            if params.size != 1
-              select_params = params.select(&.strip.starts_with?("prefix"))
-              if select_params.size != 0
-                raw_value = select_params.first.split("=", 2)[1]?.try(&.strip) || ""
-                # Only set prefix when the value is a quoted string
-                # literal. Anything else — `prefix=settings.API_V1_STR`,
-                # `prefix=f"{base}/v1"`, `prefix=API_PREFIX` — is a
-                # cross-file reference we can't resolve from the call
-                # site alone. Letting the raw expression flow through
-                # to `router_class.join` used to surface garbage URLs
-                # like `/settings.API_V1_STR/me` (regression seen on
-                # full-stack-fastapi-template). Try one more rescue
-                # path before falling back to empty: when the value
-                # is a bare top-level constant (`API_V1_STR`) imported
-                # via `from … import …`, look up its definition.
-                if lit = raw_value.match(/^['"]([^'"]*)['"]/)
-                  prefix = lit[1]
-                elsif resolved = resolve_string_expression(raw_value, source, import_modules)
-                  prefix = resolved
-                end
-              end
+        # Parse `{app}.include_router(...)` calls. Real FastAPI apps
+        # often use keyword form (`router=users.router`) and nested
+        # options (`dependencies=[Depends(...)]`), so parse arguments
+        # with the same top-level splitter used by route decorators
+        # instead of a comma split or a regex that stops at the first
+        # nested `)`.
+        extract_include_router_calls(source, instance_name).each do |args|
+          router_instance_name = extract_include_router_target(args)
+          next if router_instance_name.empty?
+
+          prefix = ""
+          if raw_value = extract_python_keyword_expression(args, "prefix")
+            # Only set prefix when the value is a quoted string
+            # literal. Anything else — `prefix=settings.API_V1_STR`,
+            # `prefix=f"{base}/v1"`, `prefix=API_PREFIX` — is a
+            # cross-file reference we can't resolve from the call
+            # site alone. Letting the raw expression flow through
+            # to `router_class.join` used to surface garbage URLs
+            # like `/settings.API_V1_STR/me` (regression seen on
+            # full-stack-fastapi-template). Try one more rescue
+            # path before falling back to empty: when the value
+            # is a bare top-level constant (`API_V1_STR`) imported
+            # via `from … import …`, look up its definition.
+            if lit = raw_value.match(/^['"]([^'"]*)['"]/)
+              prefix = lit[1]
+            elsif resolved = resolve_string_expression(raw_value, source, import_modules)
+              prefix = resolved
+            end
+          end
+
+          # Register router's prefix recursively
+          prefix = router_class.join(prefix)
+          if router_instance_name.count(".") == 0
+            if local_router = include_router_map[file][router_instance_name]?
+              local_router.prefix = combine_router_prefixes(prefix, local_router.prefix)
+              next
             end
 
-            # Register router's prefix recursively
-            prefix = router_class.join(prefix)
-            if router_instance_name.count(".") == 0
-              next unless import_modules.has_key?(router_instance_name)
-              import_module_path = import_modules[router_instance_name].first
+            next unless import_modules.has_key?(router_instance_name)
+            import_module_path = import_modules[router_instance_name].first
 
-              next unless include_router_map.has_key?(import_module_path)
-              configure_router_prefix(import_module_path, include_router_map, prefix)
-            elsif router_instance_name.count(".") == 1
-              module_name, _router_instance_name = router_instance_name.split(".")
-              next unless import_modules.has_key?(module_name)
-              import_module_path = import_modules[module_name].first
+            next unless include_router_map.has_key?(import_module_path)
+            configure_router_prefix(import_module_path, include_router_map, prefix, router_instance_name)
+          elsif router_instance_name.count(".") == 1
+            module_name, imported_router_instance_name = router_instance_name.split(".")
+            next unless import_modules.has_key?(module_name)
+            import_module_path = import_modules[module_name].first
 
-              next unless include_router_map.has_key?(import_module_path)
-              configure_router_prefix(import_module_path, include_router_map, prefix)
-            end
+            next unless include_router_map.has_key?(import_module_path)
+            configure_router_prefix(import_module_path, include_router_map, prefix, imported_router_instance_name)
           end
         end
       end
+    end
+
+    private def extract_include_router_calls(source : ::String, instance_name : ::String) : Array(::String)
+      calls = [] of ::String
+      lines = source.split("\n")
+      lines.each_with_index do |line, index|
+        stripped = line.lstrip
+        next if stripped.starts_with?("#")
+        next unless line.matches?(/\b#{Regex.escape(instance_name)}\s*\.\s*include_router\s*\(/)
+
+        logical_line = coalesce_include_router_call(lines, index, line, instance_name)
+        match = logical_line.match(/\b#{Regex.escape(instance_name)}\s*\.\s*include_router\s*\((.*)\)\s*(?:#.*)?$/m)
+        calls << match[1] if match
+      end
+      calls
+    end
+
+    private def coalesce_include_router_call(codelines : Array(::String),
+                                             index : Int32,
+                                             line : ::String,
+                                             instance_name : ::String) : ::String
+      return line unless line.matches?(/\b#{Regex.escape(instance_name)}\s*\.\s*include_router\s*\(/)
+      return line if python_call_balanced?(line)
+
+      pieces = [line]
+      depth = python_paren_delta(line)
+      i = index + 1
+      while i < codelines.size && depth > 0
+        nxt = codelines[i]
+        pieces << nxt
+        depth += python_paren_delta(nxt)
+        break if depth <= 0
+        i += 1
+      end
+      pieces.join(' ')
+    end
+
+    private def extract_include_router_target(args : ::String) : ::String
+      if router_keyword = extract_python_keyword_expression(args, "router")
+        return router_keyword.strip
+      end
+
+      split_python_arguments(args).each do |arg|
+        stripped = arg.strip
+        next if stripped.empty?
+        break if top_level_keyword_argument?(stripped)
+        return stripped
+      end
+
+      ""
     end
 
     # Best-effort resolver for a non-literal `prefix=` expression in
@@ -563,6 +673,150 @@ module Analyzer::Python
       {attr, path, args}
     end
 
+    private def parse_fastapi_static_mount(line : ::String,
+                                           instance_name : ::String,
+                                           source : ::String,
+                                           import_modules : Hash(::String, Tuple(::String, Int32))) : ::String?
+      match = line.match(/\b#{Regex.escape(instance_name)}\s*\.\s*mount\s*\((.*)\)\s*(?:#.*)?$/m)
+      return unless match
+
+      args = match[1]
+      return unless args.includes?("StaticFiles")
+
+      path_expr = extract_route_path_expression(args)
+      return unless path_expr
+
+      resolve_string_expression(path_expr, source, import_modules)
+    end
+
+    private def resolve_programmatic_handler(args : ::String,
+                                             current_path : ::String,
+                                             source : ::String,
+                                             import_modules : Hash(::String, Tuple(::String, Int32))) : Tuple(::String, ::String)?
+      handler_reference = extract_programmatic_handler_reference(args)
+      return unless handler_reference
+
+      if handler_reference.includes?(".")
+        receiver, function_name = handler_reference.split(".", 2)
+        if import_info = import_modules[receiver]?
+          import_path = import_info.first
+          return {import_path, function_name} unless import_path.empty?
+        end
+
+        sibling_module_path = File.join(File.dirname(current_path), "#{receiver}.py")
+        return {sibling_module_path, function_name} if File.exists?(sibling_module_path)
+
+        return
+      end
+
+      return {current_path, handler_reference} if find_function_def_line(source.split("\n"), handler_reference)
+
+      if import_info = import_modules[handler_reference]?
+        import_path = import_info.first
+        return {import_path, handler_reference} unless import_path.empty?
+      end
+
+      nil
+    end
+
+    private def extract_programmatic_handler_reference(args : ::String) : ::String?
+      if endpoint_expr = extract_python_keyword_expression(args, "endpoint")
+        return clean_programmatic_handler_reference(endpoint_expr)
+      end
+
+      positional_args = [] of ::String
+      split_python_arguments(args).each do |arg|
+        stripped = arg.strip
+        break if top_level_keyword_argument?(stripped)
+        positional_args << stripped
+      end
+
+      return if positional_args.size < 2
+      clean_programmatic_handler_reference(positional_args[1])
+    end
+
+    private def clean_programmatic_handler_reference(expression : ::String) : ::String?
+      reference = expression.strip.split("#", 2)[0].strip
+      return reference if reference.matches?(/^#{PYTHON_VAR_NAME_REGEX}(?:\.#{PYTHON_VAR_NAME_REGEX})?$/)
+
+      nil
+    end
+
+    private def find_function_def_line(lines : Array(::String), function_name : ::String) : Int32?
+      lines.each_with_index do |line, index|
+        return index if line.matches?(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+      end
+
+      nil
+    end
+
+    private def extract_fastapi_handler_params(codelines : Array(::String),
+                                               def_line : Int32,
+                                               route_path : ::String,
+                                               source : ::String,
+                                               import_modules : Hash(::String, Tuple(::String, Int32))) : Array(Param)
+      params = [] of Param
+      function_definition = parse_function_def(codelines, def_line)
+      return params unless function_definition
+
+      path_param_names = [] of ::String
+      route_path.scan(/\{(#{PYTHON_VAR_NAME_REGEX})\}/) do |route_match|
+        path_param_names << route_match[1] if route_match.size > 0
+      end
+
+      function_definition.params.each do |param|
+        next if param.name == "*" || path_param_names.includes?(param.name)
+        next if param.name.in?(%w[self cls])
+        next if fastapi_dependency_param?(param)
+
+        default_value = return_literal_value(param.default)
+        param_type = infer_parameter_type(param.default) unless param.default.empty?
+        if param_type.nil? && !param.type.empty?
+          param_type = param.type
+          param_type = param_type.split("Annotated[", 2)[-1].split(",", 2)[-1] if param_type.includes?("Annotated[")
+          param_type = param_type.split("Union[", 2)[-1] if param_type.includes?("Union[")
+          param_type = infer_parameter_type(param_type, true)
+          param_type = "query" if param_type.nil? && param.type.empty?
+        else
+          param_type = "query" if param_type.nil?
+        end
+
+        if param_type.nil?
+          if /^#{PYTHON_VAR_NAME_REGEX}$/.match(param.type)
+            if param.type.in?(%w[Request dict])
+              function_codeblock = parse_code_block(codelines[def_line..])
+              next if function_codeblock.nil?
+              new_params = find_dictionary_params(function_codeblock, param)
+            elsif import_modules.has_key?(param.type)
+              import_module_path = import_modules[param.type].first
+              next if import_module_path.empty?
+
+              import_module_source = read_file_content(import_module_path)
+              new_params = find_base_model_params(import_module_source, param.type, param.name)
+            else
+              new_params = find_base_model_params(source, param.type, param.name)
+            end
+
+            next if new_params.nil?
+            new_params.each { |model_param| params << model_param }
+          end
+        else
+          params << Param.new(param.name, default_value, param_type)
+        end
+      end
+
+      params
+    end
+
+    private def fastapi_dependency_param?(param : FunctionParameter) : Bool
+      fastapi_dependency_expression?(param.default) ||
+        fastapi_dependency_expression?(param.type)
+    end
+
+    private def fastapi_dependency_expression?(expression : ::String) : Bool
+      expression.includes?("Depends(") || expression.includes?("Security(")
+    end
+
     private def extract_route_path_expression(args : ::String) : ::String?
       split_python_arguments(args).each do |arg|
         stripped = arg.strip
@@ -626,6 +880,13 @@ module Analyzer::Python
       end
       parts << input[start..]
       parts
+    end
+
+    private def static_route_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
     end
 
     # Infers the type of the parameter based on its default value or type annotation
@@ -715,6 +976,26 @@ module Analyzer::Python
                                            line : ::String,
                                            instance_name : ::String) : ::String
       return line unless line.matches?(/\b#{Regex.escape(instance_name)}\s*\.\s*(add_api_route|add_api_websocket_route)\s*\(/)
+      return line if python_call_balanced?(line)
+
+      pieces = [line]
+      depth = python_paren_delta(line)
+      i = index + 1
+      while i < codelines.size && depth > 0
+        nxt = codelines[i]
+        pieces << nxt
+        depth += python_paren_delta(nxt)
+        break if depth <= 0
+        i += 1
+      end
+      pieces.join(' ')
+    end
+
+    private def coalesce_mount_call(codelines : Array(::String),
+                                    index : Int32,
+                                    line : ::String,
+                                    instance_name : ::String) : ::String
+      return line unless line.matches?(/\b#{Regex.escape(instance_name)}\s*\.\s*mount\s*\(/)
       return line if python_call_balanced?(line)
 
       pieces = [line]

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -37,6 +37,7 @@ module Analyzer::Python
       blueprint_prefixes = Hash(::String, ::String).new
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
       register_blueprint = Hash(::String, Hash(::String, ::String)).new
+      blueprint_mounts = Hash(::String, Array(Tuple(::String, ::String, ::String))).new
 
       # Iterate through all Python files in all base paths. Pulls from
       # the detector-built file_map so subtree pruning and --exclude-path
@@ -86,6 +87,15 @@ module Analyzer::Python
                 flask_instance_name = flask_match[1]
                 api_instances[flask_instance_name] ||= ""
                 flask_instances[flask_instance_name] ||= ""
+
+                effective_constructor = if python_paren_delta(original_line) > 0
+                                          join_until_python_call_closes(lines, line_index, original_line)
+                                        else
+                                          original_line
+                                        end
+                if static_url_path = extract_flask_static_url_path(effective_constructor)
+                  result << Endpoint.new(static_route_path(static_url_path), "GET", Details.new(PathInfo.new(path, line_index + 1)))
+                end
               end
               # (Blueprint discovery moved to the tree-sitter pre-pass above.)
 
@@ -155,9 +165,14 @@ module Analyzer::Python
               # Identify Blueprint registration
               register_blueprint_match = line.match /(#{PYTHON_VAR_NAME_REGEX})\.register_blueprint\((#{DOT_NATION})/
               if register_blueprint_match
+                parent_name = register_blueprint_match[1]
+                blueprint_name = register_blueprint_match[2]
                 url_prefix_match = original_line.match /url_prefix\s*=\s*[rf]?['"]([^'"]*)['"]/
+                blueprint_mount_prefix = url_prefix_match ? url_prefix_match[1] : ""
+                blueprint_mounts[path] ||= [] of Tuple(::String, ::String, ::String)
+                blueprint_mounts[path] << {parent_name, blueprint_name, blueprint_mount_prefix}
+
                 if url_prefix_match
-                  blueprint_name = register_blueprint_match[2]
                   resolved = false
                   parser = get_parser(path)
                   if parser.@global_variables.has_key?(blueprint_name)
@@ -210,7 +225,13 @@ module Analyzer::Python
 
               # Identify add_url_rule() registrations for class-based views
               # Match the call generically, then extract rule/view_func from any argument position
-              line.scan(/(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\((.+)\)/) do |_match|
+              effective_add_url_rule = if line.includes?(".add_url_rule(") && python_paren_delta(original_line) > 0
+                                         join_until_python_call_closes(lines, line_index, original_line)
+                                       else
+                                         original_line
+                                       end
+              effective_add_url_rule_stripped = effective_add_url_rule.gsub(" ", "")
+              effective_add_url_rule_stripped.scan(/(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\((.+)\)/m) do |_match|
                 next if _match.size == 0
                 router_name = _match[1]
                 args_str = _match[2]
@@ -218,7 +239,7 @@ module Analyzer::Python
                 # Extract route path from original line to preserve spaces in paths
                 # Try rule= keyword first, then first positional string arg
                 route_path = ""
-                original_args_match = original_line.match /\.add_url_rule\((.+)\)/
+                original_args_match = effective_add_url_rule.match /\.add_url_rule\((.+)\)/m
                 original_args = original_args_match ? original_args_match[1] : args_str
                 rule_match = original_args.match /rule\s*=\s*[rf]?['"]([^'"]*)['"]/
                 if rule_match
@@ -316,7 +337,7 @@ module Analyzer::Python
                 if !class_name.empty?
                   # Extract methods list
                   methods = [] of ::String
-                  methods_match = args_str.match /methods=[\[\(](.*?)[\]\)]/
+                  methods_match = args_str.match /methods=[\[\(](.*?)[\]\)]/m
                   if methods_match
                     methods_str = methods_match[1]
                     methods_str.scan(/['"]([A-Z]+)['"]/) do |method_match|
@@ -336,10 +357,30 @@ module Analyzer::Python
                   #   app.add_url_rule("/x", "name", view_func=fn, methods=["GET", "POST"])
                   # The class-view branch above only fires for
                   # `.as_view(...)` shapes; bare function refs fell
-                  # through. Emit endpoints directly with `route_path`
-                  # and the declared methods (defaulting to GET).
+                  # through. Resolve the function body when it is in
+                  # this file so params/callees match decorator routes.
+                  fn_name = extract_add_url_rule_function_name(args_str)
+                  fn_path = path
+                  fn_source = file_content
+                  fn_lines = lines
+                  fn_def_index = fn_name.empty? || fn_name.includes?(".") ? nil : find_function_def(lines, fn_name)
+                  if fn_def_index.nil? && !fn_name.empty?
+                    import_map_cache ||= find_imported_modules(current_base_path, path, file_content)
+                    if resolved = resolve_external_function_view(fn_name, path, import_map_cache)
+                      fn_path, resolved_name = resolved
+                      if File.exists?(fn_path)
+                        fn_source = fetch_file_content(fn_path)
+                        fn_lines = fn_source.lines
+                        fn_def_index = find_function_def(fn_lines, resolved_name)
+                      end
+                    end
+                  end
+
+                  fn_codeblock = fn_def_index.nil? ? nil : parse_code_block(fn_lines[fn_def_index..])
+                  fn_codeblock_lines = fn_codeblock.nil? ? [] of ::String : fn_codeblock.split("\n")
+
                   fn_methods = [] of ::String
-                  fn_methods_match = args_str.match /methods=[\[\(](.*?)[\]\)]/
+                  fn_methods_match = args_str.match /methods=[\[\(](.*?)[\]\)]/m
                   if fn_methods_match
                     fn_methods_match[1].scan(/['"]([A-Z]+)['"]/) do |method_match|
                       fn_methods << method_match[1]
@@ -354,7 +395,22 @@ module Analyzer::Python
 
                   fn_methods.each do |m|
                     fn_details = Details.new(PathInfo.new(path, line_index + 1))
-                    result << Endpoint.new(fn_full_path, m, fn_details)
+                    fn_params = fn_codeblock_lines.empty? ? [] of Param : get_filtered_params(m, extract_request_params(fn_codeblock_lines))
+                    endpoint = Endpoint.new(fn_full_path, m, fn_params)
+                    endpoint.details = fn_details
+
+                    unless fn_codeblock.nil? || fn_def_index.nil?
+                      push_callees_from(
+                        endpoint,
+                        fn_codeblock,
+                        fn_def_index,
+                        fn_path,
+                        definition_base_path: base_path_for(fn_path),
+                        source: fn_source,
+                      )
+                    end
+
+                    result << endpoint
                   end
                 end
               end
@@ -364,6 +420,7 @@ module Analyzer::Python
       end
 
       # Update the API instances with the blueprint prefixes
+      own_api_instances = clone_path_api_instances(path_api_instances)
       register_blueprint.each do |path, blueprint_info|
         blueprint_info.each do |blueprint_name, blueprint_prefix|
           if path_api_instances.has_key?(path)
@@ -374,6 +431,7 @@ module Analyzer::Python
           end
         end
       end
+      apply_nested_blueprint_prefixes(path_api_instances, own_api_instances, blueprint_mounts)
 
       # Iterate through the routes and extract endpoints
       @routes.each do |router_name, router_info_list|
@@ -505,6 +563,8 @@ module Analyzer::Python
 
           # If no explicit methods, infer from class method definitions
           if methods.empty?
+            methods.concat(extract_class_declared_methods(class_lines, class_def_index, indent))
+
             i = class_def_index + 1
             while i < class_lines.size
               infer_match = class_lines[i].match /(\s*)(async\s+)?def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/
@@ -527,29 +587,8 @@ module Analyzer::Python
             method_name = http_method.downcase
 
             # Find method definition in class
-            method_def_index = -1
-            i = class_def_index + 1
-
-            while i < class_lines.size
-              method_match = class_lines[i].match /(\s*)(async\s+)?def\s+#{method_name}\s*\(/
-              if method_match
-                # Check it's a method of this class (correct indentation)
-                method_indent = method_match[1].size
-                if method_indent > indent
-                  method_def_index = i
-                  break
-                end
-              end
-
-              # Stop if we hit another class at same or higher level
-              class_match = class_lines[i].match /(\s*)class\s+/
-              if class_match && class_match[1].size <= indent
-                break
-              end
-
-              i += 1
-            end
-
+            method_def_index = find_class_method_def(class_lines, class_def_index, indent, method_name)
+            method_def_index = find_class_method_def(class_lines, class_def_index, indent, "dispatch_request") if method_def_index == -1
             next if method_def_index == -1
 
             # Parse method code block
@@ -587,6 +626,94 @@ module Analyzer::Python
       result
     end
 
+    private def extract_class_declared_methods(class_lines : Array(::String), class_def_index : Int32, class_indent : Int32) : Array(::String)
+      methods = [] of ::String
+      i = class_def_index + 1
+      while i < class_lines.size
+        line = class_lines[i]
+        stripped = line.strip
+        unless stripped.empty?
+          indent = line.size - line.lstrip.size
+          break if indent <= class_indent
+
+          if stripped.match(/^methods\s*=/)
+            declaration = collect_python_collection_assignment(class_lines, i, line)
+            declaration.scan(/['"]([A-Za-z]+)['"]/) do |m|
+              method = m[1].upcase
+              methods << method if HTTP_METHODS.any? { |known| known.upcase == method }
+            end
+            break
+          end
+        end
+        i += 1
+      end
+
+      methods.uniq
+    end
+
+    private def collect_python_collection_assignment(lines : Array(::String), start_index : Int32, line : ::String) : ::String
+      return line unless line.includes?("[") || line.includes?("(")
+
+      pieces = [line]
+      depth = python_paren_delta(line) + python_bracket_delta(line)
+      i = start_index + 1
+      while i < lines.size && depth > 0
+        pieces << lines[i]
+        depth += python_paren_delta(lines[i]) + python_bracket_delta(lines[i])
+        i += 1
+      end
+
+      pieces.join(" ")
+    end
+
+    private def python_bracket_delta(line : ::String) : Int32
+      depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      line.each_char do |ch|
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when '['
+          depth += 1
+        when ']'
+          depth -= 1
+        end
+      end
+
+      depth
+    end
+
+    private def find_class_method_def(class_lines : Array(::String), class_def_index : Int32, class_indent : Int32, method_name : ::String) : Int32
+      i = class_def_index + 1
+      while i < class_lines.size
+        method_match = class_lines[i].match /(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/
+        if method_match
+          method_indent = method_match[1].size
+          return i if method_indent > class_indent
+        end
+
+        class_match = class_lines[i].match /(\s*)class\s+/
+        break if class_match && class_match[1].size <= class_indent
+
+        i += 1
+      end
+
+      -1
+    end
+
     # Fetch file content, preferring the detector-populated global
     # cache. The per-analyzer `@file_content_cache` is kept on top to
     # keep Flask's internal lookups (called 2–3× per file across the
@@ -601,6 +728,61 @@ module Analyzer::Python
     # resolver can locate imported modules relative to the right root.
     private def base_path_for(file_path : ::String) : ::String
       base_paths.find { |bp| file_path.starts_with?(bp) } || base_paths[0]? || ""
+    end
+
+    private def extract_flask_static_url_path(constructor_line : ::String) : ::String?
+      match = constructor_line.match(/(?:flask\.)?Flask\s*\((.*)\)\s*$/m)
+      return unless match
+
+      args = match[1]
+      return if args.match(/\bstatic_folder\s*=\s*None\b/)
+      return unless args.includes?("static_url_path")
+
+      static_url_match = args.match(/\bstatic_url_path\s*=\s*[rf]?['"]([^'"]+)['"]/)
+      static_url_match ? static_url_match[1] : nil
+    end
+
+    private def static_route_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
+    end
+
+    private def clone_path_api_instances(path_api_instances : Hash(::String, Hash(::String, ::String))) : Hash(::String, Hash(::String, ::String))
+      cloned = Hash(::String, Hash(::String, ::String)).new
+      path_api_instances.each do |path, api_instances|
+        cloned[path] = api_instances.dup
+      end
+
+      cloned
+    end
+
+    private def apply_nested_blueprint_prefixes(path_api_instances : Hash(::String, Hash(::String, ::String)),
+                                                own_api_instances : Hash(::String, Hash(::String, ::String)),
+                                                blueprint_mounts : Hash(::String, Array(Tuple(::String, ::String, ::String))))
+      blueprint_mounts.each do |path, mounts|
+        api_instances = path_api_instances[path]?
+        next unless api_instances
+
+        own_prefixes = own_api_instances[path]? || api_instances
+        changed = true
+        while changed
+          changed = false
+          mounts.each do |mount|
+            parent_name, child_name, mount_prefix = mount
+            next unless api_instances.has_key?(child_name)
+
+            parent_prefix = api_instances[parent_name]? || ""
+            child_own_prefix = own_prefixes[child_name]? || ""
+            resolved_prefix = File.join(parent_prefix, mount_prefix, child_own_prefix)
+            next if api_instances[child_name] == resolved_prefix
+
+            api_instances[child_name] = resolved_prefix
+            changed = true
+          end
+        end
+      end
     end
 
     # Create a Python parser for a given path and content. The
@@ -652,6 +834,123 @@ module Analyzer::Python
       end
 
       endpoints
+    end
+
+    private def extract_add_url_rule_function_name(args_str : ::String) : ::String
+      if view_func_match = args_str.match(/view_func=(#{DOT_NATION})(?:,|\)|$)/)
+        return view_func_match[1]
+      end
+
+      positional_parts = split_python_call_args(args_str)
+      view_arg = if positional_parts.size >= 3
+                   positional_parts[2]
+                 elsif positional_parts.size == 2
+                   positional_parts[1]
+                 else
+                   ""
+                 end
+      view_arg.matches?(/^#{DOT_NATION}$/) ? view_arg : ""
+    end
+
+    private def resolve_external_function_view(function_ref : ::String,
+                                               current_path : ::String,
+                                               import_modules : Hash(::String, Tuple(::String, Int32))) : Tuple(::String, ::String)?
+      reference = function_ref.strip
+      return if reference.empty?
+
+      if reference.includes?(".")
+        receiver, function_name = reference.split(".", 2)
+        if import_info = import_modules[receiver]?
+          import_path = import_info.first
+          return {import_path, function_name} unless import_path.empty?
+        end
+
+        sibling_module_path = File.join(File.dirname(current_path), "#{receiver}.py")
+        return {sibling_module_path, function_name} if File.exists?(sibling_module_path)
+
+        return
+      end
+
+      if import_info = import_modules[reference]?
+        import_path = import_info.first
+        return {import_path, reference} unless import_path.empty?
+      end
+
+      nil
+    end
+
+    private def split_python_call_args(args_str : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      single_quote = false
+      double_quote = false
+      escaped = false
+
+      args_str.each_char do |ch|
+        if escaped
+          current << ch
+          escaped = false
+          next
+        end
+
+        if ch == '\\'
+          current << ch
+          escaped = true
+          next
+        end
+
+        if single_quote
+          single_quote = false if ch == '\''
+          current << ch
+          next
+        end
+
+        if double_quote
+          double_quote = false if ch == '"'
+          current << ch
+          next
+        end
+
+        case ch
+        when '\''
+          single_quote = true
+        when '"'
+          double_quote = true
+        when '('
+          paren_depth += 1
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+        when '[', '{'
+          bracket_depth += 1
+        when ']', '}'
+          bracket_depth -= 1 if bracket_depth > 0
+        when ','
+          if paren_depth == 0 && bracket_depth == 0
+            part = current.to_s.strip
+            parts << part unless part.empty?
+            current = String::Builder.new
+            next
+          end
+        end
+
+        current << ch
+      end
+
+      part = current.to_s.strip
+      parts << part unless part.empty?
+      parts
+    end
+
+    private def find_function_def(lines : Array(::String), function_name : ::String) : Int32?
+      lines.each_with_index do |line, index|
+        if line.match(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+          return index
+        end
+      end
+
+      nil
     end
 
     # Extracts request parameters from a code block by detecting JSON variable

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -5,7 +5,7 @@ module Analyzer::Python
     # Decorator matching: @get("/path"), @post("/path"), etc. The tail
     # after the path literal is captured so extra kwargs (like methods=)
     # can be inspected for multi-method @route decorators.
-    DECORATOR_REGEX = /@(get|post|put|patch|delete|head|options|route)\s*\(([^)]*)/
+    DECORATOR_REGEX = /@(get|post|put|patch|delete|head|options|route|websocket)\s*\(([^)]*)/
     # Path literal inside a decorator. Litestar accepts both a positional
     # path and an explicit `path=` keyword argument.
     DECORATOR_PATH_REGEX    = /^\s*[rf]?['"]([^'"]*)['"]/
@@ -21,6 +21,10 @@ module Analyzer::Python
 
     def analyze
       python_files = get_files_by_extension(".py")
+      external_handler_prefixes = Hash(::String, Hash(::String, ::String)).new do |hash, key|
+        hash[key] = Hash(::String, ::String).new
+      end
+
       base_paths.each do |current_base_path|
         base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
         python_files.each do |path|
@@ -31,7 +35,26 @@ module Analyzer::Python
           source = read_file_content(path)
           next unless source.includes?("litestar")
 
-          analyze_file(path, source, current_base_path)
+          import_modules = find_imported_modules(current_base_path, path, source)
+          collect_external_handler_prefixes(source, collect_router_prefixes(source), import_modules).each do |handler_path, handler_map|
+            handler_map.each do |handler_name, prefix|
+              external_handler_prefixes[handler_path][handler_name] = prefix
+            end
+          end
+        end
+      end
+
+      base_paths.each do |current_base_path|
+        base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
+        python_files.each do |path|
+          next unless path.starts_with?(base_dir_prefix) || path == current_base_path
+          next if path.includes?("/site-packages/")
+          next if PythonEngine.python_test_path?(path)
+
+          source = read_file_content(path)
+          next unless source.includes?("litestar")
+
+          analyze_file(path, source, current_base_path, external_handler_prefixes[path]? || Hash(::String, ::String).new)
         end
       end
 
@@ -39,10 +62,14 @@ module Analyzer::Python
       result
     end
 
-    private def analyze_file(path : ::String, source : ::String, definition_base_path : ::String)
+    private def analyze_file(path : ::String,
+                             source : ::String,
+                             definition_base_path : ::String,
+                             handler_prefix_overrides : Hash(::String, ::String))
       lines = source.split("\n")
       router_prefixes = collect_router_prefixes(source)
       handler_routers = collect_handler_to_router(source, router_prefixes)
+      controller_prefixes = collect_controller_prefixes(lines)
 
       lines.each_with_index do |line, line_index|
         # Coalesce multi-line decorator calls so paths on
@@ -61,6 +88,7 @@ module Analyzer::Python
           route_path = path_match[1]
 
           methods = [] of ::String
+          websocket_route = decorator == "websocket"
           if decorator == "route"
             http_match = body.match(HTTP_METHOD_KW_REGEX)
             if http_match
@@ -71,19 +99,27 @@ module Analyzer::Python
               end
             end
             methods << "GET" if methods.empty?
+          elsif websocket_route
+            methods << "GET"
           else
             methods << decorator.upcase
           end
 
           handler_name, handler_line = find_handler(lines, line_index)
-          prefix = handler_name ? handler_routers[handler_name]? || "" : ""
+          prefix = handler_name ? handler_prefix_overrides[handler_name]? || handler_routers[handler_name]? || "" : ""
+          if hl = handler_line
+            if controller_info = controller_for_handler(lines, hl, controller_prefixes)
+              controller_name, controller_prefix = controller_info
+              prefix = "#{handler_routers[controller_name]? || ""}#{controller_prefix}"
+            end
+          end
 
           full_path = "#{prefix}#{route_path}"
           full_path = "/#{full_path}" unless full_path.starts_with?("/")
           full_path = full_path.gsub(/\/+/, "/")
           full_path = full_path.gsub(TYPED_PATH_PARAM_REGEX) { |_| "{#{$~[1]}}" }
 
-          path_params = extract_path_params(route_path)
+          path_params = extract_path_params(full_path)
 
           # Parse the handler body once and share between param and
           # callee extraction — both used to call `parse_code_block`
@@ -91,7 +127,7 @@ module Analyzer::Python
           handler_body = if hl = handler_line
                            parse_code_block(lines[hl..])
                          end
-          handler_params = handler_line ? extract_handler_params(lines, handler_line, route_path, handler_body) : [] of Param
+          handler_params = handler_line ? extract_handler_params(lines, handler_line, full_path, handler_body) : [] of Param
 
           # Build once per handler — a decorator can emit multiple
           # endpoints when @route(http_method=[...]) lists several verbs.
@@ -117,6 +153,7 @@ module Analyzer::Python
 
             details = Details.new(PathInfo.new(path, line_index + 1))
             endpoint = Endpoint.new(full_path, method, params, details)
+            endpoint.protocol = "ws" if websocket_route
             handler_callees.each { |c| endpoint.push_callee(c) }
             result << endpoint
           end
@@ -175,7 +212,140 @@ module Analyzer::Python
           mapping[name] = prefix unless mapping.has_key?(name)
         end
       end
+
+      source.scan(/Router\s*\(([^)]*)\)/m) do |match|
+        next if match.size < 2
+        body = match[1]
+        prefix_match = body.match(/path\s*=\s*[rf]?['"]([^'"]*)['"]/)
+        prefix_match ||= body.match(/^\s*[rf]?['"]([^'"]*)['"]/)
+        prefix = prefix_match ? prefix_match[1] : ""
+
+        handlers_match = body.match(/route_handlers\s*=\s*\[([^\]]*)\]/m)
+        next unless handlers_match
+        handlers_match[1].scan(/([a-zA-Z_][a-zA-Z0-9_]*)/) do |m|
+          name = m[1]
+          next if name == "route_handlers"
+          mapping[name] = prefix unless mapping.has_key?(name)
+        end
+      end
+
       mapping
+    end
+
+    private def collect_external_handler_prefixes(source : ::String,
+                                                  router_prefixes : Hash(::String, ::String),
+                                                  import_modules : Hash(::String, Tuple(::String, Int32))) : Hash(::String, Hash(::String, ::String))
+      mapping = Hash(::String, Hash(::String, ::String)).new do |hash, key|
+        hash[key] = Hash(::String, ::String).new
+      end
+
+      source.scan(ROUTER_REGEX) do |match|
+        next if match.size < 3
+        router_name = match[1]
+        body = match[2]
+        prefix = router_prefixes[router_name]? || ""
+        map_external_route_handlers(body, prefix, import_modules, mapping)
+      end
+
+      source.scan(/Router\s*\(([^)]*)\)/m) do |match|
+        next if match.size < 2
+        body = match[1]
+        prefix_match = body.match(/path\s*=\s*[rf]?['"]([^'"]*)['"]/)
+        prefix_match ||= body.match(/^\s*[rf]?['"]([^'"]*)['"]/)
+        prefix = prefix_match ? prefix_match[1] : ""
+        map_external_route_handlers(body, prefix, import_modules, mapping)
+      end
+
+      source.scan(/Litestar\s*\(([^)]*)\)/m) do |match|
+        next if match.size < 2
+        map_external_route_handlers(match[1], "", import_modules, mapping)
+      end
+
+      mapping
+    end
+
+    private def map_external_route_handlers(body : ::String,
+                                            prefix : ::String,
+                                            import_modules : Hash(::String, Tuple(::String, Int32)),
+                                            mapping : Hash(::String, Hash(::String, ::String)))
+      handlers_match = body.match(/route_handlers\s*=\s*\[([^\]]*)\]/m)
+      return unless handlers_match
+
+      handlers_match[1].scan(/(#{PYTHON_VAR_NAME_REGEX})\.(#{PYTHON_VAR_NAME_REGEX})/) do |handler_match|
+        next if handler_match.size < 3
+        module_name = handler_match[1]
+        handler_name = handler_match[2]
+        import_info = import_modules[module_name]?
+        next unless import_info
+
+        handler_path = import_info.first
+        next if handler_path.empty?
+
+        mapping[handler_path][handler_name] = prefix
+      end
+    end
+
+    private def collect_controller_prefixes(lines : Array(::String)) : Hash(::String, ::String)
+      prefixes = Hash(::String, ::String).new
+
+      lines.each_with_index do |line, idx|
+        class_match = line.match(/^\s*class\s+(#{PYTHON_VAR_NAME_REGEX})\s*\(([^)]*)\)/)
+        next unless class_match
+
+        class_name = class_match[1]
+        bases = class_match[2]
+        next unless bases.includes?("Controller")
+
+        prefix = ""
+        if path_match = bases.match(/path\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          prefix = path_match[1]
+        end
+
+        class_indent = line.size - line.lstrip.size
+        body_idx = idx + 1
+        while body_idx < lines.size
+          body_line = lines[body_idx]
+          unless body_line.strip.empty?
+            indent = body_line.size - body_line.lstrip.size
+            break if indent <= class_indent
+
+            if path_attr = body_line.match(/^\s*path\s*=\s*[rf]?['"]([^'"]*)['"]/)
+              prefix = path_attr[1]
+              break
+            end
+          end
+          body_idx += 1
+        end
+
+        prefixes[class_name] = prefix
+      end
+
+      prefixes
+    end
+
+    private def controller_for_handler(lines : Array(::String),
+                                       handler_line : Int32,
+                                       controller_prefixes : Hash(::String, ::String)) : Tuple(::String, ::String)?
+      handler_indent = lines[handler_line].size - lines[handler_line].lstrip.size
+      idx = handler_line - 1
+
+      while idx >= 0
+        line = lines[idx]
+        unless line.strip.empty?
+          indent = line.size - line.lstrip.size
+          if indent < handler_indent
+            if class_match = line.match(/^\s*class\s+(#{PYTHON_VAR_NAME_REGEX})\s*\(/)
+              class_name = class_match[1]
+              if controller_prefixes.has_key?(class_name)
+                return {class_name, controller_prefixes[class_name]}
+              end
+            end
+          end
+        end
+        idx -= 1
+      end
+
+      nil
     end
 
     private def extract_path_params(route_path : ::String) : Array(Param)
@@ -208,6 +378,7 @@ module Analyzer::Python
           next if name.empty? || name == "self" || name == "cls" || name == "*" || name == "request"
           next if name.starts_with?("*")
           next if path_param_names.includes?(name)
+          next if litestar_dependency_param?(fp)
 
           type_hint = fp.type.strip
           param_type = classify_param(type_hint)
@@ -244,7 +415,7 @@ module Analyzer::Python
       stripped = type_hint
       stripped = stripped.split("Annotated[", 2)[-1].split(",", 2)[-1] if stripped.includes?("Annotated[")
 
-      return if stripped.matches?(/\b(Request|State|Dependency|Provide|WebSocket)\b/)
+      return if stripped.matches?(/\b(Request|State|Dependency|Provide|WebSocket|WebsocketListener)\b/)
       return "cookie" if stripped.includes?("Cookie")
       return "header" if stripped.includes?("Header")
       return "form" if stripped.includes?("UploadFile") || stripped.includes?("File(")
@@ -260,6 +431,15 @@ module Analyzer::Python
       return "json" if stripped.match(/^[A-Z][A-Za-z0-9_]*/)
 
       nil
+    end
+
+    private def litestar_dependency_param?(param : FunctionParameter) : Bool
+      litestar_dependency_expression?(param.default) ||
+        litestar_dependency_expression?(param.type)
+    end
+
+    private def litestar_dependency_expression?(expression : ::String) : Bool
+      expression.includes?("Dependency(") || expression.includes?("Provide(")
     end
 
     private def collect_request_attr_params(line : ::String, attr : ::String, noir_type : ::String, params : Array(Param))
@@ -285,7 +465,7 @@ module Analyzer::Python
     private def coalesce_litestar_decorator(lines : Array(::String),
                                             index : Int32,
                                             line : ::String) : ::String
-      return line unless line.matches?(/@(?:get|post|put|patch|delete|head|options|route)\s*\(/)
+      return line unless line.matches?(/@(?:get|post|put|patch|delete|head|options|route|websocket)\s*\(/)
       delta = python_decorator_paren_delta(line)
       return line if delta <= 0
 

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -48,13 +48,10 @@ module Analyzer::Python
           next if PythonEngine.python_test_path?(path)
 
           content = read_file_content(path)
-          next unless content.includes?("pyramid")
+          next unless content.includes?("pyramid") || content.includes?(".add_route") || content.includes?(".add_static_view")
 
-          # config.add_route("name", "/path") — supports multi-line calls and
-          # keyword argument variants like `name="x", pattern="/y"`.
-          content.scan(/\.add_route\s*\(\s*(?:name\s*=\s*)?[rf]?['"]([^'"]+)['"]\s*,\s*(?:pattern\s*=\s*)?[rf]?['"]([^'"]*)['"]/) do |m|
-            route_map[m[1]] = {m[2], path}
-          end
+          extract_route_declarations(content, path, route_map)
+          extract_static_views(content, path)
         end
       end
 
@@ -67,13 +64,15 @@ module Analyzer::Python
           @logger.debug "Analyzing #{path}"
 
           content = read_file_content(path)
-          next unless content.includes?("pyramid")
+          next unless content.includes?("pyramid") || content.includes?(".add_view")
 
           lines = content.lines
           lines.each_with_index do |line, line_index|
             # @view_config(route_name="name", request_method="GET")
             if vc = match_view_config(lines, line_index)
               route_name, methods = vc
+              route_name ||= class_view_defaults_route_name(lines, line_index)
+              next if route_name.nil?
               next unless route_map.has_key?(route_name)
               route_path, _ = route_map[route_name]
 
@@ -124,10 +123,61 @@ module Analyzer::Python
       result
     end
 
+    private def extract_static_views(content : String, path : String)
+      lines = content.lines
+      lines.each_with_index do |line, line_index|
+        next unless line.includes?(".add_static_view")
+
+        static_line = if python_paren_delta(line) > 0
+                        join_until_python_call_closes(lines, line_index, line)
+                      else
+                        line
+                      end
+        call_match = static_line.match(/\.add_static_view\s*\((.+)\)\s*$/m)
+        next unless call_match
+
+        args = split_python_arguments(call_match[1])
+        name = extract_python_keyword_string(args, "name") || args[0]?.try { |arg| extract_python_string(arg) }
+        next if name.nil? || name.empty?
+
+        result << Endpoint.new(static_view_route_path(name), "GET", Details.new(PathInfo.new(path, line_index + 1)))
+      end
+    end
+
+    # config.add_route("name", "/path") plus keyword variants like
+    # name="x", pattern="/y" in either order.
+    private def extract_route_declarations(content : String, path : String, route_map : Hash(String, Tuple(String, String)))
+      content.scan(/\.add_route\s*\((.*?)\)/m) do |m|
+        args = m[1]
+        name = nil
+        pattern = nil
+
+        if name_match = args.match(/\bname\s*=\s*[rf]?['"]([^'"]+)['"]/)
+          name = name_match[1]
+        end
+        if pattern_match = args.match(/\bpattern\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          pattern = pattern_match[1]
+        end
+
+        if name.nil? || pattern.nil?
+          literals = [] of String
+          args.scan(/[rf]?['"]([^'"]*)['"]/) do |literal_match|
+            literals << literal_match[1]
+          end
+          name ||= literals[0]?
+          pattern ||= literals[1]?
+        end
+
+        route_map[name] = {pattern, path} if name && pattern
+      end
+    end
+
     # Look up `@view_config(...)` either on a single line or across
     # continuation lines (the decorator call may span multiple lines).
-    # Returns {route_name, methods} or nil.
-    private def match_view_config(lines : Array(String), line_index : Int32) : Tuple(String, Array(String))?
+    # Returns {route_name, methods} or nil. `route_name` may be nil
+    # when a method-level `@view_config(request_method=...)` relies on
+    # a class-level `@view_defaults(route_name=...)`.
+    private def match_view_config(lines : Array(String), line_index : Int32) : Tuple(String?, Array(String))?
       stripped = lines[line_index].lstrip
       return unless stripped.starts_with?("@view_config") ||
                     stripped.starts_with?("@pyramid.view.view_config") ||
@@ -145,12 +195,58 @@ module Analyzer::Python
       end
 
       rn_match = decorator.match(/route_name\s*=\s*[rf]?['"]([^'"]+)['"]/)
-      return if rn_match.nil?
-      route_name = rn_match[1]
+      route_name = rn_match ? rn_match[1] : nil
 
       methods = extract_methods_from_args(decorator)
       methods = ["GET"] if methods.empty?
       {route_name, methods}
+    end
+
+    private def class_view_defaults_route_name(lines : Array(String), decorator_index : Int32) : String?
+      decorator_indent = lines[decorator_index].size - lines[decorator_index].lstrip.size
+      idx = decorator_index - 1
+
+      while idx >= 0
+        line = lines[idx]
+        unless line.strip.empty?
+          indent = line.size - line.lstrip.size
+          if indent < decorator_indent
+            if line.lstrip.starts_with?("class ")
+              return extract_view_defaults_route_name_above_class(lines, idx)
+            end
+          end
+        end
+        idx -= 1
+      end
+
+      nil
+    end
+
+    private def extract_view_defaults_route_name_above_class(lines : Array(String), class_index : Int32) : String?
+      idx = class_index - 1
+      decorators = [] of String
+
+      while idx >= 0
+        line = lines[idx]
+        stripped = line.lstrip
+        break if stripped.empty?
+        break unless stripped.starts_with?("@") || decorators.size > 0
+
+        decorators.unshift(line)
+        break if stripped.starts_with?("@view_defaults") ||
+                 stripped.starts_with?("@pyramid.view.view_defaults") ||
+                 stripped.starts_with?("@pyramid.view_defaults")
+        idx -= 1
+      end
+
+      decorator = decorators.join(' ')
+      return unless decorator.includes?("view_defaults")
+
+      if route_match = decorator.match(/route_name\s*=\s*[rf]?['"]([^'"]+)['"]/)
+        return route_match[1]
+      end
+
+      nil
     end
 
     # Pull request_method= or request_method=['GET','POST'] out of an
@@ -181,6 +277,89 @@ module Analyzer::Python
       return if first.includes?('=')
       return first if first.match(/^[A-Za-z_][A-Za-z0-9_]*$/)
       nil
+    end
+
+    private def split_python_arguments(args : String) : Array(String)
+      parts = [] of String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      args.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when ','
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+
+    private def extract_python_keyword_string(args : Array(String), keyword : String) : String?
+      args.each do |arg|
+        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        next unless keyword_match
+
+        return extract_python_string(keyword_match[1])
+      end
+
+      nil
+    end
+
+    private def extract_python_string(expression : String) : String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
+
+    private def static_view_route_path(name : String) : String
+      normalized = name.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
     end
 
     # Walk downwards from `line_index` past any further decorators or
@@ -301,10 +480,10 @@ module Analyzer::Python
 
       ACCESSOR_MAP.each do |param_type, accessors|
         accessors.each do |accessor|
-          body.scan(/request\.#{accessor}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
+          body.scan(/(?:self\.)?request\.#{accessor}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
             record.call(m[1], param_type)
           end
-          body.scan(/request\.#{accessor}\.get(?:all|one)?\s*\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
+          body.scan(/(?:self\.)?request\.#{accessor}\.get(?:all|one)?\s*\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
             record.call(m[1], param_type)
           end
         end

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -46,6 +46,8 @@ module Analyzer::Python
     @file_content_cache = Hash(::String, ::String).new
     @parsers = Hash(::String, PythonParser).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, Bool))).new
+    @method_view_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, Array(::String)))).new
+    @function_view_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, Array(::String)))).new
 
     def analyze
       quart_instances = Hash(::String, ::String).new
@@ -53,6 +55,7 @@ module Analyzer::Python
       blueprint_prefixes = Hash(::String, ::String).new
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
       register_blueprint = Hash(::String, Hash(::String, ::String)).new
+      blueprint_mounts = Hash(::String, Array(Tuple(::String, ::String, ::String))).new
 
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
@@ -70,6 +73,7 @@ module Analyzer::Python
           api_instances = Hash(::String, ::String).new
           path_api_instances[path] = api_instances
           import_map_cache : Hash(::String, Tuple(::String, Int32))? = nil
+          view_assignments = Hash(::String, ::String).new
 
           # Tree-sitter pre-pass: harvest every `@<router>.route(...)`,
           # `@<router>.<method>(...)`, and `@<router>.websocket(...)`
@@ -93,7 +97,7 @@ module Analyzer::Python
             api_instances[bp.name] ||= bp.prefix
           end
 
-          lines.each do |original_line|
+          lines.each_with_index do |original_line, line_index|
             line = original_line.gsub(" ", "")
 
             # Identify Quart instance assignments: `app = Quart(__name__)`
@@ -104,13 +108,52 @@ module Analyzer::Python
               quart_instances[quart_instance_name] ||= ""
             end
 
+            if view_assign_match = line.match(/(#{PYTHON_VAR_NAME_REGEX})=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/)
+              view_assignments[view_assign_match[1]] = view_assign_match[2]
+            end
+
+            if line.includes?(".add_url_rule(")
+              effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+              effective_line.scan(/(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\s*\((.*)\)\s*$/m) do |rule_match|
+                next if rule_match.size < 3
+                router_name = rule_match[1]
+                args = rule_match[2]
+                route_path = extract_add_url_rule_path(args)
+                next if route_path.empty?
+
+                class_name = extract_method_view_class(args, view_assignments)
+                methods = extract_add_url_rule_methods(args)
+                if class_name.empty?
+                  function_name = extract_add_url_rule_function_name(args)
+                  next if function_name.empty?
+
+                  route_info = Tuple(Int32, ::String, ::String, ::String, Array(::String)).new(
+                    line_index, path, route_path, function_name, methods
+                  )
+                  @function_view_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, Array(::String))
+                  @function_view_routes[router_name] << route_info
+                else
+                  route_info = Tuple(Int32, ::String, ::String, ::String, Array(::String)).new(
+                    line_index, path, route_path, class_name, methods
+                  )
+                  @method_view_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, Array(::String))
+                  @method_view_routes[router_name] << route_info
+                end
+              end
+            end
+
             # Identify Blueprint registration:
             #   `app.register_blueprint(bp, url_prefix="/api")`
             register_blueprint_match = line.match /(#{PYTHON_VAR_NAME_REGEX})\.register_blueprint\((#{DOT_NATION})/
             if register_blueprint_match
+              parent_name = register_blueprint_match[1]
+              blueprint_name = register_blueprint_match[2]
               url_prefix_match = original_line.match /url_prefix\s*=\s*[rf]?['"]([^'"]*)['"]/
+              blueprint_mount_prefix = url_prefix_match ? url_prefix_match[1] : ""
+              blueprint_mounts[path] ||= [] of Tuple(::String, ::String, ::String)
+              blueprint_mounts[path] << {parent_name, blueprint_name, blueprint_mount_prefix}
+
               if url_prefix_match
-                blueprint_name = register_blueprint_match[2]
                 resolved = false
                 parser = get_parser(path)
                 if parser.@global_variables.has_key?(blueprint_name)
@@ -140,6 +183,7 @@ module Analyzer::Python
 
       # Resolve url_prefix discovered at register_blueprint sites back to
       # the file that declared the Blueprint.
+      own_api_instances = clone_path_api_instances(path_api_instances)
       register_blueprint.each do |path, blueprint_info|
         blueprint_info.each do |blueprint_name, blueprint_prefix|
           if path_api_instances.has_key?(path)
@@ -150,6 +194,7 @@ module Analyzer::Python
           end
         end
       end
+      apply_nested_blueprint_prefixes(path_api_instances, own_api_instances, blueprint_mounts)
 
       # Iterate through the collected route decorations and extract endpoints
       @routes.each do |router_name, router_info_list|
@@ -205,8 +250,380 @@ module Analyzer::Python
         end
       end
 
+      @function_view_routes.each do |router_name, route_infos|
+        route_infos.each do |route_info|
+          line_index, path, route_path, function_name, methods = route_info
+          source = fetch_file_content(path)
+          lines = source.lines
+          api_instances = path_api_instances[path]?
+          prefix = (api_instances && api_instances.has_key?(router_name)) ? api_instances[router_name] : ""
+
+          function_path = path
+          function_source = source
+          function_lines = lines
+          function_def_index = function_name.includes?(".") ? -1 : find_function_def(lines, function_name)
+          if function_def_index < 0
+            import_modules = find_imported_modules(base_path_for(path), path, source)
+            resolved = resolve_external_function_view(function_name, path, import_modules)
+            next unless resolved
+
+            function_path, resolved_name = resolved
+            next unless File.exists?(function_path)
+
+            function_source = fetch_file_content(function_path)
+            function_lines = function_source.lines
+            function_def_index = find_function_def(function_lines, resolved_name)
+            next if function_def_index < 0
+          end
+
+          codeblock = parse_code_block(function_lines[function_def_index..])
+          next if codeblock.nil?
+          codeblock_lines = codeblock.split("\n")
+          route_methods = methods.empty? ? ["GET"] : methods
+          extra_params = "methods=[#{route_methods.map { |m| "'#{m.upcase}'" }.join(",")}]"
+
+          handler_callees = build_callees_from(
+            codeblock,
+            function_def_index,
+            function_path,
+            definition_base_path: base_path_for(function_path),
+            source: function_source,
+          )
+
+          get_endpoints(route_methods.first, route_path, extra_params, codeblock_lines, prefix).each do |route_endpoint|
+            route_endpoint.details = Details.new(PathInfo.new(path, line_index + 1))
+            handler_callees.each { |c| route_endpoint.push_callee(c) }
+            result << route_endpoint
+          end
+        end
+      end
+
+      @method_view_routes.each do |router_name, route_infos|
+        route_infos.each do |route_info|
+          line_index, path, route_path, class_name, methods = route_info
+          source = fetch_file_content(path)
+          lines = source.lines
+          api_instances = path_api_instances[path]?
+          prefix = (api_instances && api_instances.has_key?(router_name)) ? api_instances[router_name] : ""
+
+          class_def_index = find_class_def(lines, class_name)
+          next if class_def_index < 0
+
+          class_indent = lines[class_def_index].size - lines[class_def_index].lstrip.size
+          route_methods = methods.empty? ? infer_method_view_methods(lines, class_def_index, class_indent) : methods
+          route_methods << "GET" if route_methods.empty?
+
+          route_methods.uniq.each do |http_method|
+            method_def_index = find_method_def(lines, class_def_index, class_indent, http_method.downcase)
+            method_def_index = find_method_def(lines, class_def_index, class_indent, "dispatch_request") if method_def_index < 0
+            next if method_def_index < 0
+
+            codeblock = parse_code_block(lines[method_def_index..])
+            next if codeblock.nil?
+            codeblock_lines = codeblock.split("\n")
+            extra_params = "methods=['#{http_method.upcase}']"
+
+            handler_callees = build_callees_from(
+              codeblock,
+              method_def_index,
+              path,
+              definition_base_path: base_path_for(path),
+              source: source,
+            )
+
+            get_endpoints(http_method, route_path, extra_params, codeblock_lines, prefix).each do |route_endpoint|
+              route_endpoint.details = Details.new(PathInfo.new(path, line_index + 1))
+              handler_callees.each { |c| route_endpoint.push_callee(c) }
+              result << route_endpoint
+            end
+          end
+        end
+      end
+
       Fiber.yield
       result
+    end
+
+    private def extract_add_url_rule_path(args : ::String) : ::String
+      if keyword_match = args.match(/(?:rule|path)\s*=\s*[rf]?['"]([^'"]*)['"]/)
+        return keyword_match[1]
+      end
+
+      if positional_match = args.match(/^\s*[rf]?['"]([^'"]*)['"]/)
+        return positional_match[1]
+      end
+
+      ""
+    end
+
+    private def extract_method_view_class(args : ::String, view_assignments : Hash(::String, ::String)) : ::String
+      if direct_match = args.match(/view_func\s*=\s*(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/)
+        return direct_match[1]
+      end
+
+      if variable_match = args.match(/view_func\s*=\s*(#{PYTHON_VAR_NAME_REGEX})/)
+        return view_assignments[variable_match[1]]? || ""
+      end
+
+      if positional_match = args.match(/^\s*[rf]?['"][^'"]*['"]\s*,\s*[rf]?['"][^'"]*['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/)
+        return positional_match[1]
+      end
+
+      if positional_variable_match = args.match(/^\s*[rf]?['"][^'"]*['"]\s*,\s*[rf]?['"][^'"]*['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})(?:\s*,|\s*$)/)
+        return view_assignments[positional_variable_match[1]]? || ""
+      end
+
+      ""
+    end
+
+    private def extract_add_url_rule_function_name(args : ::String) : ::String
+      if view_func_match = args.match(/view_func\s*=\s*(#{DOT_NATION})(?:\s*,|\s*\)|\s*$)/)
+        return view_func_match[1]
+      end
+
+      positional_parts = split_python_call_args(args)
+      view_arg = if positional_parts.size >= 3
+                   positional_parts[2]
+                 elsif positional_parts.size == 2
+                   positional_parts[1]
+                 else
+                   ""
+                 end
+      view_arg.matches?(/^#{DOT_NATION}$/) ? view_arg : ""
+    end
+
+    private def resolve_external_function_view(function_ref : ::String,
+                                               current_path : ::String,
+                                               import_modules : Hash(::String, Tuple(::String, Int32))) : Tuple(::String, ::String)?
+      reference = function_ref.strip
+      return if reference.empty?
+
+      if reference.includes?(".")
+        receiver, function_name = reference.split(".", 2)
+        if import_info = import_modules[receiver]?
+          import_path = import_info.first
+          return {import_path, function_name} unless import_path.empty?
+        end
+
+        sibling_module_path = File.join(File.dirname(current_path), "#{receiver}.py")
+        return {sibling_module_path, function_name} if File.exists?(sibling_module_path)
+
+        return
+      end
+
+      if import_info = import_modules[reference]?
+        import_path = import_info.first
+        return {import_path, reference} unless import_path.empty?
+      end
+
+      nil
+    end
+
+    private def split_python_call_args(args : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      single_quote = false
+      double_quote = false
+      escaped = false
+
+      args.each_char do |ch|
+        if escaped
+          current << ch
+          escaped = false
+          next
+        end
+
+        if ch == '\\'
+          current << ch
+          escaped = true
+          next
+        end
+
+        if single_quote
+          single_quote = false if ch == '\''
+          current << ch
+          next
+        end
+
+        if double_quote
+          double_quote = false if ch == '"'
+          current << ch
+          next
+        end
+
+        case ch
+        when '\''
+          single_quote = true
+        when '"'
+          double_quote = true
+        when '('
+          paren_depth += 1
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+        when '[', '{'
+          bracket_depth += 1
+        when ']', '}'
+          bracket_depth -= 1 if bracket_depth > 0
+        when ','
+          if paren_depth == 0 && bracket_depth == 0
+            part = current.to_s.strip
+            parts << part unless part.empty?
+            current = String::Builder.new
+            next
+          end
+        end
+
+        current << ch
+      end
+
+      part = current.to_s.strip
+      parts << part unless part.empty?
+      parts
+    end
+
+    private def extract_add_url_rule_methods(args : ::String) : Array(::String)
+      methods = [] of ::String
+      methods_match = args.match(/methods\s*=\s*[\[\(](.*?)[\]\)]/m)
+      return methods unless methods_match
+
+      methods_match[1].scan(/['"]([A-Za-z]+)['"]/) do |method_match|
+        method = method_match[1].upcase
+        methods << method if HTTP_METHODS.any? { |hm| hm.upcase == method }
+      end
+      methods
+    end
+
+    private def find_class_def(lines : Array(::String), class_name : ::String) : Int32
+      lines.each_with_index do |line, idx|
+        stripped = line.lstrip
+        class_prefix = "class #{class_name}"
+        if stripped.starts_with?(class_prefix) &&
+           (stripped.size == class_prefix.size || stripped[class_prefix.size].in?('(', ':', ' ', '\t'))
+          return idx
+        end
+      end
+
+      -1
+    end
+
+    private def infer_method_view_methods(lines : Array(::String), class_def_index : Int32, class_indent : Int32) : Array(::String)
+      methods = extract_class_declared_methods(lines, class_def_index, class_indent)
+      i = class_def_index + 1
+      while i < lines.size
+        line = lines[i]
+        if class_match = line.match(/(\s*)class\s+/)
+          break if class_match[1].size <= class_indent
+        end
+
+        if method_match = line.match(/(\s*)(async\s+)?def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/)
+          if method_match[1].size > class_indent
+            method = HTTP_METHODS.find { |http_method| http_method.downcase == method_match[3].downcase }
+            methods << method.upcase if method
+          end
+        end
+        i += 1
+      end
+
+      methods
+    end
+
+    private def extract_class_declared_methods(lines : Array(::String), class_def_index : Int32, class_indent : Int32) : Array(::String)
+      methods = [] of ::String
+      i = class_def_index + 1
+      while i < lines.size
+        line = lines[i]
+        stripped = line.strip
+        unless stripped.empty?
+          indent = line.size - line.lstrip.size
+          break if indent <= class_indent
+
+          if stripped.match(/^methods\s*=/)
+            declaration = collect_python_collection_assignment(lines, i, line)
+            declaration.scan(/['"]([A-Za-z]+)['"]/) do |method_match|
+              method = method_match[1].upcase
+              methods << method if HTTP_METHODS.any? { |known| known.upcase == method }
+            end
+            break
+          end
+        end
+        i += 1
+      end
+
+      methods.uniq
+    end
+
+    private def collect_python_collection_assignment(lines : Array(::String), start_index : Int32, line : ::String) : ::String
+      return line unless line.includes?("[") || line.includes?("(")
+
+      pieces = [line]
+      depth = python_paren_delta(line) + python_bracket_delta(line)
+      i = start_index + 1
+      while i < lines.size && depth > 0
+        pieces << lines[i]
+        depth += python_paren_delta(lines[i]) + python_bracket_delta(lines[i])
+        i += 1
+      end
+
+      pieces.join(" ")
+    end
+
+    private def python_bracket_delta(line : ::String) : Int32
+      depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      line.each_char do |ch|
+        if in_quote
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+        when '['
+          depth += 1
+        when ']'
+          depth -= 1
+        end
+      end
+
+      depth
+    end
+
+    private def find_method_def(lines : Array(::String), class_def_index : Int32, class_indent : Int32, method_name : ::String) : Int32
+      i = class_def_index + 1
+      while i < lines.size
+        line = lines[i]
+        if class_match = line.match(/(\s*)class\s+/)
+          break if class_match[1].size <= class_indent
+        end
+
+        if method_match = line.match(/(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/)
+          return i if method_match[1].size > class_indent
+        end
+        i += 1
+      end
+
+      -1
+    end
+
+    private def find_function_def(lines : Array(::String), function_name : ::String) : Int32
+      lines.each_with_index do |line, index|
+        if line.match(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+          return index
+        end
+      end
+
+      -1
     end
 
     private def fetch_file_content(path : ::String) : ::String
@@ -215,6 +632,42 @@ module Analyzer::Python
 
     private def base_path_for(file_path : ::String) : ::String
       base_paths.find { |bp| file_path.starts_with?(bp) } || base_paths[0]? || ""
+    end
+
+    private def clone_path_api_instances(path_api_instances : Hash(::String, Hash(::String, ::String))) : Hash(::String, Hash(::String, ::String))
+      cloned = Hash(::String, Hash(::String, ::String)).new
+      path_api_instances.each do |path, api_instances|
+        cloned[path] = api_instances.dup
+      end
+
+      cloned
+    end
+
+    private def apply_nested_blueprint_prefixes(path_api_instances : Hash(::String, Hash(::String, ::String)),
+                                                own_api_instances : Hash(::String, Hash(::String, ::String)),
+                                                blueprint_mounts : Hash(::String, Array(Tuple(::String, ::String, ::String))))
+      blueprint_mounts.each do |path, mounts|
+        api_instances = path_api_instances[path]?
+        next unless api_instances
+
+        own_prefixes = own_api_instances[path]? || api_instances
+        changed = true
+        while changed
+          changed = false
+          mounts.each do |mount|
+            parent_name, child_name, mount_prefix = mount
+            next unless api_instances.has_key?(child_name)
+
+            parent_prefix = api_instances[parent_name]? || ""
+            child_own_prefix = own_prefixes[child_name]? || ""
+            resolved_prefix = File.join(parent_prefix, mount_prefix, child_own_prefix)
+            next if api_instances[child_name] == resolved_prefix
+
+            api_instances[child_name] = resolved_prefix
+            changed = true
+          end
+        end
+      end
     end
 
     def create_parser(path : ::String, content : ::String = "") : PythonParser

--- a/src/analyzer/analyzers/python/robyn.cr
+++ b/src/analyzer/analyzers/python/robyn.cr
@@ -21,6 +21,7 @@ module Analyzer::Python
     #     bracket / `.get()` notation.
 
     HTTP_METHOD_DECORATORS = %w[get post put patch delete head options trace]
+    WEBSOCKET_ATTRIBUTES   = {"websocket" => "GET"}
 
     def analyze
       router_prefixes = Hash(::String, ::String).new
@@ -53,7 +54,7 @@ module Analyzer::Python
 
             # Decorator-driven routes via tree-sitter (handles multi-line
             # decorator headers cleanly).
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
+            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, nil, WEBSOCKET_ATTRIBUTES).each do |deco|
               next unless router_prefixes.has_key?(deco.router_name)
               attr = deco.attribute_name.downcase
               next unless attr.in?(HTTP_METHOD_DECORATORS) || attr == "websocket"
@@ -77,6 +78,7 @@ module Analyzer::Python
 
               details = Details.new(PathInfo.new(path, deco.decorator_line + 1))
               endpoint = Endpoint.new(full_path, http_method, params, details)
+              endpoint.protocol = "ws" if attr == "websocket"
               result << endpoint
             end
           end
@@ -91,11 +93,17 @@ module Analyzer::Python
     # Robyn's SubRouter takes the prefix as a positional argument:
     #   SubRouter(__file__, "/api")
     private def collect_router_assignments(lines : Array(::String), router_prefixes : Hash(::String, ::String))
-      lines.each do |line|
+      lines.each_with_index do |line, index|
         if m = line.match(/^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?Robyn\s*\(/)
           router_prefixes[m[1]] = ""
         end
-        if m = line.match(/^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?SubRouter\s*\((.*)/)
+
+        effective_line = if line.includes?("SubRouter") && python_paren_delta(line) > 0
+                           join_until_python_call_closes(lines, index, line)
+                         else
+                           line
+                         end
+        if m = effective_line.match(/^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?SubRouter\s*\((.*)/m)
           name = m[1]
           tail = m[2]
           prefix = extract_subrouter_prefix(tail)
@@ -123,16 +131,42 @@ module Analyzer::Python
       ""
     end
 
-    # `parent.include_router(child)` — Robyn merges the child's routes
-    # under the parent's already-registered prefix. The child's own
-    # prefix stays intact (we don't override it from the include call).
-    # No-op for now — Robyn computes the joined path at runtime by
-    # concatenating the parent app's mount with the SubRouter's prefix,
-    # and we already record the SubRouter's own prefix at construction
-    # time. If a future fixture mounts a SubRouter under a non-root
-    # parent prefix, this is where to compose them.
+    # `parent.include_router(child)` composes nested SubRouter prefixes.
+    # The root Robyn app usually has an empty prefix, but real apps also
+    # nest routers, e.g. `api.include_router(admin)`, which should place
+    # `admin` routes under `/api/admin`.
     private def scan_include_routers(lines : Array(::String), router_prefixes : Hash(::String, ::String))
-      # Intentionally empty — see comment above.
+      includes = [] of Tuple(::String, ::String)
+
+      lines.each_with_index do |line, index|
+        next unless line.includes?(".include_router(")
+
+        effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        effective_line.scan(/\b(#{PYTHON_VAR_NAME_REGEX})\.include_router\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})/) do |m|
+          next if m.size < 3
+          includes << {m[1], m[2]}
+        end
+      end
+
+      changed = true
+      iterations = 0
+      while changed && iterations < includes.size
+        changed = false
+        iterations += 1
+
+        includes.each do |parent, child|
+          parent_prefix = router_prefixes[parent]?
+          child_prefix = router_prefixes[child]?
+          next if parent_prefix.nil? || child_prefix.nil? || parent_prefix.empty?
+          next if child_prefix == parent_prefix || child_prefix.starts_with?("#{parent_prefix}/")
+
+          composed_prefix = normalize_path(join_prefix(parent_prefix, child_prefix))
+          next if composed_prefix == child_prefix
+
+          router_prefixes[child] = composed_prefix
+          changed = true
+        end
+      end
     end
 
     # Robyn uses `:name` for path params; Noir's canonical form is `{name}`.
@@ -201,6 +235,15 @@ module Analyzer::Python
       json_vars = [] of ::String
       body.scan(/([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?:await\s+)?request\.json\s*\(\s*\)/) do |m|
         json_vars << m[1]
+      end
+
+      # Direct one-liners: `request.json()["name"]` /
+      # `request.json().get("name")`.
+      body.scan(/(?:await\s+)?request\.json\s*\(\s*\)\s*\[['"]([^'"]+)['"]\]/) do |m|
+        record.call(m[1], "json")
+      end
+      body.scan(/(?:await\s+)?request\.json\s*\(\s*\)\.get\(['"]([^'"]+)['"]/) do |m|
+        record.call(m[1], "json")
       end
 
       json_vars.each do |var|

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -23,12 +23,16 @@ module Analyzer::Python
     }
 
     @file_content_cache = Hash(::String, ::String).new
-    @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String))).new
+    @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
+    @programmatic_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
+    @programmatic_class_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
+    @static_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String))).new
 
     def analyze
       sanic_instances = Hash(::String, ::String).new
       sanic_instances["app"] ||= "" # Common sanic instance name
       blueprint_prefixes = Hash(::String, ::String).new
+      blueprint_registration_prefixes = Hash(::String, Array(::String)).new
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
 
       # Iterate through all Python files in all base paths. Pulls from
@@ -59,16 +63,17 @@ module Analyzer::Python
               blueprint_prefixes[bp.name] ||= bp.prefix
               api_instances[bp.name] ||= bp.prefix
             end
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |decoration|
+            collect_blueprint_registrations(file_content, blueprint_registration_prefixes)
+            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: {"websocket" => "GET"}).each do |decoration|
               methods_literal = decoration.methods.map { |m| "'#{m}'" }.join(",")
               extra_params = "methods=[#{methods_literal}]"
-              router_info = Tuple(Int32, ::String, ::String, ::String).new(decoration.decorator_line, path, decoration.path, extra_params)
-              @routes[decoration.router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String)
+              router_info = Tuple(Int32, ::String, ::String, ::String, ::String).new(decoration.decorator_line, path, decoration.path, extra_params, decoration.attribute_name)
+              @routes[decoration.router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
               @routes[decoration.router_name] << router_info
             end
 
-            lines.each do |line|
-              line = line.gsub(" ", "") # remove spaces for easier regex matching
+            lines.each_with_index do |original_line, line_index|
+              line = original_line.gsub(" ", "") # remove spaces for easier regex matching
 
               # Identify Sanic instance assignments (tree-sitter extractor
               # doesn't cover this shape yet).
@@ -78,6 +83,28 @@ module Analyzer::Python
                 api_instances[sanic_instance_name] ||= ""
                 sanic_instances[sanic_instance_name] ||= ""
               end
+
+              if line.includes?(".add_route(")
+                effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+                if class_route_info = parse_programmatic_class_route(effective_line)
+                  router_name, route_path, class_name, extra_params = class_route_info
+                  @programmatic_class_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+                  @programmatic_class_routes[router_name] << {line_index, path, route_path, extra_params, class_name}
+                elsif route_info = parse_programmatic_route(effective_line)
+                  router_name, route_path, handler_name, extra_params = route_info
+                  @programmatic_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+                  @programmatic_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
+                end
+              end
+
+              if line.includes?(".static(")
+                effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+                if static_route_info = parse_static_route(effective_line)
+                  router_name, static_path = static_route_info
+                  @static_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String)
+                  @static_routes[router_name] << {line_index, path, static_path}
+                end
+              end
             end
           end
         end
@@ -86,7 +113,7 @@ module Analyzer::Python
       # Iterate through the routes and extract endpoints
       @routes.each do |router_name, router_info_list|
         router_info_list.each do |router_info|
-          line_index, path, route_path, extra_params = router_info
+          line_index, path, route_path, extra_params, route_attr = router_info
           source = fetch_file_content(path)
           lines = source.lines
           definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @base_path
@@ -97,6 +124,7 @@ module Analyzer::Python
           else
             prefix = ""
           end
+          registration_prefixes = blueprint_registration_prefixes[router_name]? || [""]
 
           is_class_router = false
           indent = lines[class_def_index].index("def") || 0
@@ -159,24 +187,434 @@ module Analyzer::Python
 
             # Get the HTTP method from the function name when it is not specified in the route decorator
             method = HTTP_METHODS.find { |http_method| _function_name.downcase == http_method.downcase } || "GET"
-            get_endpoints(method, route_path, extra_params, codeblock_lines, prefix).each do |endpoint|
-              details = Details.new(PathInfo.new(path, line_index + 1))
-              endpoint.details = details
+            registration_prefixes.each do |registration_prefix|
+              full_prefix = join_paths(registration_prefix, prefix)
+              get_endpoints(method, route_path, extra_params, codeblock_lines, full_prefix, route_attr).each do |endpoint|
+                details = Details.new(PathInfo.new(path, line_index + 1))
+                endpoint.details = details
 
-              handler_callees.each { |c| endpoint.push_callee(c) }
+                handler_callees.each { |c| endpoint.push_callee(c) }
 
-              # Add expect params as endpoint params
-              expect_params.each do |expect_param|
-                endpoint.push_param(expect_param)
+                # Add expect params as endpoint params
+                expect_params.each do |expect_param|
+                  endpoint.push_param(expect_param)
+                end
+
+                result << endpoint
               end
+            end
+          end
+        end
+      end
 
+      @programmatic_routes.each do |router_name, router_info_list|
+        router_info_list.each do |route_info|
+          line_index, path, route_path, extra_params, handler_name = route_info
+          source = fetch_file_content(path)
+          lines = source.lines
+          definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @base_path
+          api_instances = path_api_instances[path]
+          prefix = api_instances[router_name]? || ""
+          registration_prefixes = blueprint_registration_prefixes[router_name]? || [""]
+
+          function_def_index = find_function_def(lines, handler_name)
+          handler_path = path
+          handler_source = source
+          handler_lines = lines
+          if function_def_index.nil?
+            import_modules = find_imported_modules(definition_base_path, path, source)
+            resolved = resolve_external_handler(handler_name, path, import_modules)
+            next unless resolved
+
+            handler_path, function_name = resolved
+            next unless File.exists?(handler_path)
+
+            handler_source = fetch_file_content(handler_path)
+            handler_lines = handler_source.lines
+            function_def_index = find_function_def(handler_lines, function_name)
+            next if function_def_index.nil?
+          end
+
+          codeblock = parse_code_block(handler_lines[function_def_index..])
+          next if codeblock.nil?
+          codeblock_lines = codeblock.split("\n")
+          handler_callees = build_callees_from(
+            codeblock,
+            function_def_index,
+            handler_path,
+            definition_base_path: definition_base_path,
+            source: handler_source
+          )
+
+          registration_prefixes.each do |registration_prefix|
+            full_prefix = join_paths(registration_prefix, prefix)
+            get_endpoints("GET", route_path, extra_params, codeblock_lines, full_prefix).each do |endpoint|
+              endpoint.details = Details.new(PathInfo.new(path, line_index + 1))
+              handler_callees.each { |c| endpoint.push_callee(c) }
               result << endpoint
             end
           end
         end
       end
 
+      @programmatic_class_routes.each do |router_name, router_info_list|
+        router_info_list.each do |route_info|
+          line_index, path, route_path, extra_params, class_name = route_info
+          source = fetch_file_content(path)
+          lines = source.lines
+          definition_base_path = base_paths.find { |base_path| path.starts_with?(base_path) } || @base_path
+          api_instances = path_api_instances[path]
+          prefix = api_instances[router_name]? || ""
+          registration_prefixes = blueprint_registration_prefixes[router_name]? || [""]
+
+          class_def_index = find_class_def(lines, class_name)
+          next if class_def_index.nil?
+
+          class_indent = lines[class_def_index].size - lines[class_def_index].lstrip.size
+          methods = extract_methods_from_extra_params(extra_params)
+          methods = find_class_http_methods(lines, class_def_index, class_indent) if methods.empty?
+
+          methods.uniq.each do |http_method|
+            method_def_index = find_class_method_def(lines, class_def_index, class_indent, http_method.downcase)
+            next if method_def_index.nil?
+
+            codeblock = parse_code_block(lines[method_def_index..])
+            next if codeblock.nil?
+            codeblock_lines = codeblock.split("\n")
+            handler_callees = build_callees_from(
+              codeblock,
+              method_def_index,
+              path,
+              definition_base_path: definition_base_path,
+              source: source
+            )
+
+            route_extra_params = "methods=['#{http_method.upcase}']"
+            registration_prefixes.each do |registration_prefix|
+              full_prefix = join_paths(registration_prefix, prefix)
+              get_endpoints(http_method, route_path, route_extra_params, codeblock_lines, full_prefix).each do |endpoint|
+                endpoint.details = Details.new(PathInfo.new(path, line_index + 1))
+                handler_callees.each { |c| endpoint.push_callee(c) }
+                result << endpoint
+              end
+            end
+          end
+        end
+      end
+
+      @static_routes.each do |router_name, static_info_list|
+        static_info_list.each do |static_info|
+          line_index, path, static_path = static_info
+          api_instances = path_api_instances[path]
+          prefix = api_instances[router_name]? || ""
+          registration_prefixes = blueprint_registration_prefixes[router_name]? || [""]
+
+          registration_prefixes.each do |registration_prefix|
+            full_prefix = join_paths(registration_prefix, prefix)
+            endpoint_path = static_route_path(join_paths(full_prefix, static_path))
+            result << Endpoint.new(endpoint_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
+          end
+        end
+      end
+
       result
+    end
+
+    private def parse_static_route(line : ::String) : Tuple(::String, ::String)?
+      call_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.static\s*\((.*)\)\s*$/m)
+      return unless call_match
+
+      router_name = call_match[1]
+      args = split_python_arguments(call_match[2])
+      static_path = extract_keyword_string(args, "uri") ||
+                    extract_keyword_string(args, "path") ||
+                    args[0]?.try { |arg| extract_python_string(arg) } || ""
+      return if static_path.empty?
+
+      {router_name, static_path}
+    end
+
+    private def parse_programmatic_class_route(line : ::String) : Tuple(::String, ::String, ::String, ::String)?
+      call_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m)
+      return unless call_match
+
+      router_name = call_match[1]
+      args = split_python_arguments(call_match[2])
+      class_name = extract_programmatic_handler_class(args)
+      route_path = extract_programmatic_route_path(args)
+      return if class_name.empty? || route_path.empty?
+
+      methods = extract_programmatic_methods(args)
+      extra_params = "methods=[#{methods.map { |method| "'#{method}'" }.join(",")}]"
+      {router_name, route_path, class_name, extra_params}
+    end
+
+    private def parse_programmatic_route(line : ::String) : Tuple(::String, ::String, ::String, ::String)?
+      call_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m)
+      return unless call_match
+
+      router_name = call_match[1]
+      args = split_python_arguments(call_match[2])
+      handler_name = extract_programmatic_handler(args)
+      route_path = extract_programmatic_route_path(args)
+      return if handler_name.empty? || route_path.empty?
+
+      methods = extract_programmatic_methods(args)
+      methods = ["GET"] if methods.empty?
+      extra_params = "methods=[#{methods.map { |method| "'#{method}'" }.join(",")}]"
+      {router_name, route_path, handler_name, extra_params}
+    end
+
+    private def extract_programmatic_handler_class(args : Array(::String)) : ::String
+      handler = extract_keyword_expression(args, "handler") || args[0]?
+      return "" unless handler
+
+      if class_match = handler.strip.match(/^(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/)
+        return class_match[1]
+      end
+
+      ""
+    end
+
+    private def extract_programmatic_handler(args : Array(::String)) : ::String
+      if handler = extract_keyword_expression(args, "handler")
+        return clean_reference(handler)
+      end
+
+      return "" if args.empty?
+      clean_reference(args[0])
+    end
+
+    private def extract_programmatic_route_path(args : Array(::String)) : ::String
+      if uri = extract_keyword_string(args, "uri")
+        return uri
+      end
+      if uri = extract_keyword_string(args, "uri_template")
+        return uri
+      end
+      if path = extract_keyword_string(args, "path")
+        return path
+      end
+
+      return "" if args.size < 2
+      extract_python_string(args[1]) || ""
+    end
+
+    private def extract_programmatic_methods(args : Array(::String)) : Array(::String)
+      expression = extract_keyword_expression(args, "methods")
+      return [] of ::String unless expression
+
+      methods = [] of ::String
+      expression.scan(/['"]([A-Za-z]+)['"]/) do |method_match|
+        methods << method_match[1].upcase
+      end
+      methods
+    end
+
+    private def extract_keyword_expression(args : Array(::String), keyword : ::String) : ::String?
+      args.each do |arg|
+        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        return keyword_match[1].strip if keyword_match
+      end
+
+      nil
+    end
+
+    private def extract_keyword_string(args : Array(::String), keyword : ::String) : ::String?
+      if expression = extract_keyword_expression(args, keyword)
+        return extract_python_string(expression)
+      end
+
+      nil
+    end
+
+    private def extract_python_string(expression : ::String) : ::String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
+
+    private def clean_reference(expression : ::String) : ::String
+      reference = expression.strip
+      return reference if reference.matches?(/^#{PYTHON_VAR_NAME_REGEX}(?:\.#{PYTHON_VAR_NAME_REGEX})*$/)
+
+      ""
+    end
+
+    private def resolve_external_handler(handler_name : ::String,
+                                         current_path : ::String,
+                                         import_modules : Hash(::String, Tuple(::String, Int32))) : Tuple(::String, ::String)?
+      reference = handler_name.strip
+      return if reference.empty?
+
+      if reference.includes?(".")
+        receiver, function_name = reference.split(".", 2)
+        if import_info = import_modules[receiver]?
+          import_path = import_info.first
+          return {import_path, function_name} unless import_path.empty?
+        end
+
+        sibling_module_path = File.join(File.dirname(current_path), "#{receiver}.py")
+        return {sibling_module_path, function_name} if File.exists?(sibling_module_path)
+
+        return
+      end
+
+      if import_info = import_modules[reference]?
+        import_path = import_info.first
+        return {import_path, reference} unless import_path.empty?
+      end
+
+      nil
+    end
+
+    private def split_python_arguments(args : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      args.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when ','
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+
+    private def find_function_def(lines : Array(::String), function_name : ::String) : Int32?
+      lines.each_with_index do |line, index|
+        if line.match(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+          return index
+        end
+      end
+
+      nil
+    end
+
+    private def find_class_def(lines : Array(::String), class_name : ::String) : Int32?
+      lines.each_with_index do |line, index|
+        stripped = line.lstrip
+        class_prefix = "class #{class_name}"
+        if stripped.starts_with?(class_prefix) &&
+           (stripped.size == class_prefix.size || stripped[class_prefix.size].in?('(', ':', ' ', '\t'))
+          return index
+        end
+      end
+
+      nil
+    end
+
+    private def find_class_http_methods(lines : Array(::String), class_def_index : Int32, class_indent : Int32) : Array(::String)
+      methods = [] of ::String
+      i = class_def_index + 1
+      while i < lines.size
+        line = lines[i]
+        if class_match = line.match(/(\s*)class\s+/)
+          break if class_match[1].size <= class_indent
+        end
+
+        if method_match = line.match(/(\s*)(async\s+)?def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/)
+          if method_match[1].size > class_indent
+            method = HTTP_METHODS.find { |known| known.downcase == method_match[3].downcase }
+            methods << method.upcase if method
+          end
+        end
+
+        i += 1
+      end
+
+      methods
+    end
+
+    private def find_class_method_def(lines : Array(::String), class_def_index : Int32, class_indent : Int32, method_name : ::String) : Int32?
+      i = class_def_index + 1
+      while i < lines.size
+        line = lines[i]
+        if class_match = line.match(/(\s*)class\s+/)
+          break if class_match[1].size <= class_indent
+        end
+
+        if method_match = line.match(/(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/)
+          return i if method_match[1].size > class_indent
+        end
+
+        i += 1
+      end
+
+      nil
+    end
+
+    private def extract_methods_from_extra_params(extra_params : ::String) : Array(::String)
+      methods = [] of ::String
+      methods_match = extra_params.match(/methods\s*=\s*\[([^\]]*)\]/)
+      return methods unless methods_match
+
+      methods_match[1].scan(/['"]([^'"]*)['"']/) do |method_match|
+        methods << method_match[1].upcase
+      end
+
+      methods
+    end
+
+    private def collect_blueprint_registrations(source : ::String, registrations : Hash(::String, Array(::String)))
+      source.scan(/\.blueprint\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})(.*?)\)/m) do |match|
+        next if match.size < 3
+        blueprint_name = match[1]
+        tail = match[2]
+        prefix = ""
+        if prefix_match = tail.match(/url_prefix\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          prefix = prefix_match[1]
+        end
+
+        registrations[blueprint_name] ||= [] of ::String
+        registrations[blueprint_name] << prefix unless registrations[blueprint_name].includes?(prefix)
+      end
     end
 
     private def fetch_file_content(path : ::String) : ::String
@@ -192,7 +630,7 @@ module Analyzer::Python
       {[] of Param, Noir::PythonRouteExtractor.find_def_line(lines, line_index, direction)}
     end
 
-    private def get_endpoints(method : String, route_path : String, extra_params : String, codeblock_lines : Array(String), prefix : String = "")
+    private def get_endpoints(method : String, route_path : String, extra_params : String, codeblock_lines : Array(String), prefix : String = "", route_attr : String = "")
       endpoints = [] of Endpoint
       params = [] of Param
 
@@ -263,13 +701,39 @@ module Analyzer::Python
       # Create endpoints for each method
       methods.each do |http_method|
         # Create endpoint with the prefix
-        full_path = prefix.empty? ? route_path : "#{prefix}#{route_path}"
+        full_path = normalize_sanic_path_params(join_paths(prefix, route_path))
         filtered_params = get_filtered_params(http_method, params.dup)
         endpoint = Endpoint.new(full_path, http_method, filtered_params)
+        endpoint.protocol = "ws" if route_attr == "websocket"
         endpoints << endpoint
       end
 
       endpoints
+    end
+
+    private def join_paths(prefix : ::String, path : ::String) : ::String
+      return normalize_path(path) if prefix.empty?
+      return normalize_path(prefix) if path.empty?
+
+      normalize_path("#{prefix}/#{path}")
+    end
+
+    private def static_route_path(path : ::String) : ::String
+      normalized = normalize_path(path)
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
+    end
+
+    private def normalize_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
+    end
+
+    private def normalize_sanic_path_params(path : ::String) : ::String
+      path.gsub(/<([A-Za-z_][A-Za-z0-9_]*)(?::[^>]+)?>/) do |_match|
+        "{#{$1}}"
+      end
     end
 
     # Filters the parameters based on the HTTP method (similar to Flask analyzer)

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -7,7 +7,7 @@ module Analyzer::Python
     # reference. The tail stops at the closing paren on the same line to
     # keep the match cheap; multi-line Route() calls are still covered for
     # the common (path, handler, methods) shape.
-    ROUTE_REGEX = /Route\s*\(\s*[rf]?['"]([^'"]*)['"]([^)]*)/
+    ROUTE_REGEX = /\b(WebSocketRoute|Route)\s*\(\s*[rf]?['"]([^'"]*)['"]([^)]*)/
     # Mount('/prefix', routes=[...]) — only the prefix literal is needed;
     # the routes list is scanned via the ongoing line loop while the mount
     # is on the paren stack.
@@ -41,7 +41,15 @@ module Analyzer::Python
     private def analyze_file(path : ::String, source : ::String, definition_base_path : ::String)
       lines = source.split("\n")
       function_index = build_function_index(lines)
+      class_index = build_class_index(lines)
+      import_modules = find_imported_modules(definition_base_path, path, source)
       handler_cache = {} of ::String => Tuple(Array(Param), Array(Callee))
+      external_handler_cache = {} of ::String => Tuple(Array(Param), Array(Callee))
+      class_handler_cache = {} of ::String => Hash(::String, Tuple(Array(Param), Array(Callee)))
+      websocket_class_handler_cache = {} of ::String => Tuple(Array(Param), Array(Callee))
+      app_prefixes = build_app_prefixes(lines)
+      mounted_route_list_prefixes = build_mounted_route_list_prefixes(lines, app_prefixes)
+      mounted_route_list_ranges = build_mounted_route_list_ranges(lines, mounted_route_list_prefixes)
       # Stack of active Mount prefixes. Each entry stores the paren depth
       # at which the Mount was opened; when the running depth drops below
       # that value the mount has closed and its prefix must be popped.
@@ -56,7 +64,7 @@ module Analyzer::Python
         # never matches the body regex. Coalesce continuation lines
         # into one logical string when the opening paren isn't
         # balanced on this line so the body capture sees the path.
-        effective_line = if line.includes?("Route") && python_paren_delta(line) > 0
+        effective_line = if (line.includes?("Route") || line.includes?("Mount")) && python_paren_delta(line) > 0
                            join_until_python_call_closes(lines, line_index, line)
                          else
                            line
@@ -64,7 +72,98 @@ module Analyzer::Python
         # Lift `path=` keyword to the first positional slot so the
         # existing ROUTE_REGEX (which expects a string right after
         # `Route(`) matches `Route(path="/x", endpoint=h)`.
-        effective_line = effective_line.gsub(/(Route\s*\()\s*path\s*=\s*([rf]?['"][^'"]*['"])/, "\\1\\2,")
+        effective_line = effective_line.gsub(/((?:WebSocketRoute|Route)\s*\()\s*path\s*=\s*([rf]?['"][^'"]*['"])/, "\\1\\2,")
+
+        if effective_line.includes?(".add_route(") || effective_line.includes?(".add_websocket_route(")
+          effective_line.scan(/(#{DOT_NATION})\.add_(websocket_)?route\s*\((.*)\)/m) do |programmatic_match|
+            next if programmatic_match.size < 4
+            receiver = normalize_receiver(programmatic_match[1])
+            websocket_route = !(programmatic_match[2]?).to_s.empty?
+            args = split_python_arguments(programmatic_match[3])
+            route_path = extract_python_keyword_string(args, "path") || args[0]?.try { |arg| extract_python_string(arg) }
+            next unless route_path
+
+            handler_expr = extract_python_keyword_expression(args, "endpoint") || args[1]?.try(&.strip)
+            next unless handler_expr
+            handler_ref = clean_reference(handler_expr)
+            next if handler_ref.empty?
+            handler_name = handler_ref.split(".").last
+
+            methods = websocket_route ? ["GET"] : extract_programmatic_methods(args)
+            methods << "GET" if methods.empty?
+            route_prefixes = app_prefixes[receiver]? || [""]
+
+            route_prefixes.each do |prefix|
+              full_url = normalize_route_url(prefix, route_path)
+              if websocket_route
+                handler_params = [] of Param
+                handler_callees = [] of Callee
+                if class_index.has_key?(handler_name)
+                  handler_params, handler_callees = websocket_class_handler_context_for(lines, class_index, handler_name, path, websocket_class_handler_cache,
+                    definition_base_path: definition_base_path, source: source)
+                else
+                  handler_params, handler_callees = handler_context_for_reference(handler_ref, lines, function_index, path, import_modules, handler_cache, external_handler_cache,
+                    definition_base_path: definition_base_path, source: source)
+                end
+
+                params = extract_path_params(route_path)
+                handler_params.each do |p|
+                  next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                  params << p
+                end
+                endpoint = Endpoint.new(full_url, "GET", params, Details.new(PathInfo.new(path, line_index + 1)))
+                endpoint.protocol = "ws"
+                handler_callees.each { |c| endpoint.push_callee(c) }
+                result << endpoint
+                next
+              end
+
+              if class_index.has_key?(handler_name)
+                class_contexts = class_handler_contexts(lines, class_index, handler_name, path, class_handler_cache,
+                  definition_base_path: definition_base_path, source: source)
+                emit_methods = methods.empty? ? class_contexts.keys : methods
+                emit_methods = ["GET"] if emit_methods.empty?
+
+                emit_methods.uniq.each do |method|
+                  params = extract_path_params(route_path)
+                  handler_callees = [] of Callee
+                  if class_context = class_contexts[method]?
+                    handler_params, handler_callees = class_context
+                    handler_params.each do |p|
+                      next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                      params << p
+                    end
+                  end
+
+                  endpoint = Endpoint.new(full_url, method, params, Details.new(PathInfo.new(path, line_index + 1)))
+                  handler_callees.each { |c| endpoint.push_callee(c) }
+                  result << endpoint
+                end
+              else
+                handler_params, handler_callees = handler_context_for_reference(handler_ref, lines, function_index, path, import_modules, handler_cache, external_handler_cache,
+                  definition_base_path: definition_base_path, source: source)
+                methods.uniq.each do |method|
+                  params = extract_path_params(route_path)
+                  handler_params.each do |p|
+                    next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                    params << p
+                  end
+
+                  endpoint = Endpoint.new(full_url, method, params, Details.new(PathInfo.new(path, line_index + 1)))
+                  handler_callees.each { |c| endpoint.push_callee(c) }
+                  result << endpoint
+                end
+              end
+            end
+          end
+        end
+
+        if static_path = parse_staticfiles_mount_path(effective_line)
+          route_prefixes = mounted_route_prefixes_for_line(line_index, mounted_route_list_ranges) || [mount_stack.map(&.[0]).join]
+          route_prefixes.each do |prefix|
+            result << Endpoint.new(static_route_path(normalize_route_url(prefix, static_path)), "GET", Details.new(PathInfo.new(path, line_index + 1)))
+          end
+        end
 
         effective_line.scan(MOUNT_REGEX) do |match|
           next if match.size < 2
@@ -73,8 +172,10 @@ module Analyzer::Python
 
         effective_line.scan(ROUTE_REGEX) do |match|
           next if match.size < 3
-          route_path = match[1]
-          tail = match[2]
+          route_kind = match[1]
+          route_path = match[2]
+          tail = match[3]
+          websocket_route = route_kind == "WebSocketRoute"
 
           methods = [] of ::String
           methods_match = tail.match(/methods\s*=\s*\[([^\]]*)\]/)
@@ -83,40 +184,103 @@ module Analyzer::Python
               methods << m[1].upcase
             end
           end
-          methods << "GET" if methods.empty?
-
-          prefix = mount_stack.map(&.[0]).join
-          full_url = "#{prefix}#{route_path}"
-          full_url = "/#{full_url}".gsub(/\/+/, "/")
-          full_url = full_url.gsub(TYPED_PATH_PARAM_REGEX) { |_| "{#{$~[1]}}" }
+          explicit_methods = !methods.empty?
 
           path_params = extract_path_params(route_path)
+          route_prefixes = mounted_route_prefixes_for_line(line_index, mounted_route_list_ranges) || [mount_stack.map(&.[0]).join]
 
           handler_params = [] of Param
           handler_callees = [] of Callee
           handler_name = nil
-          if endpoint_keyword_match = tail.match(/endpoint\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)/)
-            handler_name = endpoint_keyword_match[1]
-          elsif positional_match = tail.match(/,\s*([a-zA-Z_][a-zA-Z0-9_]*)/)
-            handler_name = positional_match[1]
+          handler_ref = nil
+          if endpoint_keyword_match = tail.match(/endpoint\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)/)
+            handler_ref = endpoint_keyword_match[1]
+            handler_name = handler_ref.split(".").last
+          elsif positional_match = tail.match(/,\s*([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)/)
+            handler_ref = positional_match[1]
+            handler_name = handler_ref.split(".").last
           end
-          if handler_name
-            handler_params, handler_callees = handler_context_for(lines, function_index, handler_name, path, handler_cache,
+
+          if websocket_route
+            if handler_name
+              if class_index.has_key?(handler_name)
+                handler_params, handler_callees = websocket_class_handler_context_for(lines, class_index, handler_name, path, websocket_class_handler_cache,
+                  definition_base_path: definition_base_path, source: source)
+              else
+                handler_params, handler_callees = handler_context_for_reference(handler_ref || handler_name, lines, function_index, path, import_modules, handler_cache, external_handler_cache,
+                  definition_base_path: definition_base_path, source: source)
+              end
+            end
+
+            route_prefixes.each do |prefix|
+              full_url = normalize_route_url(prefix, route_path)
+              params = [] of Param
+              path_params.each { |p| params << p }
+              handler_params.each do |p|
+                next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                params << p
+              end
+
+              endpoint = Endpoint.new(full_url, "GET", params, Details.new(PathInfo.new(path, line_index + 1)))
+              endpoint.protocol = "ws"
+              handler_callees.each { |c| endpoint.push_callee(c) }
+              result << endpoint
+            end
+            next
+          end
+
+          if handler_name && class_index.has_key?(handler_name)
+            class_contexts = class_handler_contexts(lines, class_index, handler_name, path, class_handler_cache,
+              definition_base_path: definition_base_path, source: source)
+            class_methods = explicit_methods ? methods : class_contexts.keys
+            class_methods = ["GET"] if class_methods.empty?
+
+            route_prefixes.each do |prefix|
+              full_url = normalize_route_url(prefix, route_path)
+              class_methods.uniq.each do |method|
+                params = [] of Param
+                path_params.each { |p| params << p }
+
+                handler_params = [] of Param
+                handler_callees = [] of Callee
+                if class_context = class_contexts[method]?
+                  handler_params, handler_callees = class_context
+                end
+                handler_params.each do |p|
+                  next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                  params << p
+                end
+
+                details = Details.new(PathInfo.new(path, line_index + 1))
+                endpoint = Endpoint.new(full_url, method, params, details)
+                handler_callees.each { |c| endpoint.push_callee(c) }
+                result << endpoint
+              end
+            end
+            next
+          end
+
+          methods << "GET" if methods.empty?
+          if handler_ref || handler_name
+            handler_params, handler_callees = handler_context_for_reference(handler_ref || handler_name.to_s, lines, function_index, path, import_modules, handler_cache, external_handler_cache,
               definition_base_path: definition_base_path, source: source)
           end
 
-          methods.uniq.each do |method|
-            params = [] of Param
-            path_params.each { |p| params << p }
-            handler_params.each do |p|
-              next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
-              params << p
-            end
+          route_prefixes.each do |prefix|
+            full_url = normalize_route_url(prefix, route_path)
+            methods.uniq.each do |method|
+              params = [] of Param
+              path_params.each { |p| params << p }
+              handler_params.each do |p|
+                next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                params << p
+              end
 
-            details = Details.new(PathInfo.new(path, line_index + 1))
-            endpoint = Endpoint.new(full_url, method, params, details)
-            handler_callees.each { |c| endpoint.push_callee(c) }
-            result << endpoint
+              details = Details.new(PathInfo.new(path, line_index + 1))
+              endpoint = Endpoint.new(full_url, method, params, details)
+              handler_callees.each { |c| endpoint.push_callee(c) }
+              result << endpoint
+            end
           end
         end
 
@@ -126,6 +290,248 @@ module Analyzer::Python
           mount_stack.pop
         end
       end
+    end
+
+    private def normalize_route_url(prefix : ::String, route_path : ::String) : ::String
+      full_url = "#{prefix}#{route_path}"
+      full_url = "/#{full_url}".gsub(/\/+/, "/")
+      full_url.gsub(TYPED_PATH_PARAM_REGEX) { |_| "{#{$~[1]}}" }
+    end
+
+    private def parse_staticfiles_mount_path(line : ::String) : ::String?
+      return unless line.includes?("Mount") && line.includes?("StaticFiles")
+
+      if match = line.match(/Mount\s*\(\s*[rf]?['"]([^'"]*)['"]/m)
+        return match[1]
+      end
+
+      nil
+    end
+
+    private def static_route_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
+      normalized == "/" ? "/*" : "#{normalized}/*"
+    end
+
+    private def build_mounted_route_list_prefixes(lines : Array(::String),
+                                                  app_prefixes : Hash(::String, Array(::String))) : Hash(::String, Array(::String))
+      prefixes = Hash(::String, Array(::String)).new do |hash, key|
+        hash[key] = [] of ::String
+      end
+      app_route_lists = build_app_route_lists(lines)
+      route_list_ranges = build_route_list_ranges(lines)
+      mount_edges = [] of Tuple(::String?, ::String, ::String)
+
+      app_route_lists.each do |app_name, route_lists|
+        route_prefixes = app_prefixes[app_name]? || [""]
+        route_lists.each do |route_list|
+          route_prefixes.each do |prefix|
+            add_route_list_prefix(prefixes, route_list, prefix)
+          end
+        end
+      end
+
+      lines.each_with_index do |line, line_index|
+        next unless line.includes?("Mount") && (line.includes?("routes") || line.includes?("app"))
+
+        effective_line = if line.includes?("Mount") && python_paren_delta(line) > 0
+                           join_until_python_call_closes(lines, line_index, line)
+                         else
+                           line
+                         end
+        parent_route_list = route_list_parent_for_line(line_index, route_list_ranges)
+
+        effective_line.scan(/Mount\s*\(\s*[rf]?['"]([^'"]*)['"][^)]*\broutes\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)/m) do |match|
+          next if match.size < 3
+          mount_edges << {parent_route_list, match[2], match[1]}
+        end
+
+        effective_line.scan(/Mount\s*\(\s*[rf]?['"]([^'"]*)['"][^)]*\bapp\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)/m) do |match|
+          next if match.size < 3
+          mount_prefix = match[1]
+          app_name = match[2]
+          route_lists = app_route_lists[app_name]?
+          next unless route_lists
+
+          route_lists.each do |route_list|
+            mount_edges << {parent_route_list, route_list, mount_prefix}
+          end
+        end
+      end
+
+      mount_edges.each do |parent_route_list, route_list, mount_prefix|
+        next if parent_route_list
+        add_route_list_prefix(prefixes, route_list, mount_prefix)
+      end
+
+      changed = true
+      while changed
+        changed = false
+        mount_edges.each do |parent_route_list, route_list, mount_prefix|
+          next unless parent_route_list
+
+          parent_prefixes = prefixes[parent_route_list]?
+          next unless parent_prefixes
+
+          parent_prefixes.each do |parent_prefix|
+            composed_prefix = normalize_route_prefix(parent_prefix, mount_prefix)
+            next if prefixes[route_list].includes?(composed_prefix)
+
+            prefixes[route_list] << composed_prefix
+            changed = true
+          end
+        end
+      end
+
+      prefixes
+    end
+
+    private def add_route_list_prefix(prefixes : Hash(::String, Array(::String)), route_list : ::String, prefix : ::String)
+      normalized = prefix.empty? ? "" : normalize_route_prefix("", prefix)
+      prefixes[route_list] << normalized unless prefixes[route_list].includes?(normalized)
+    end
+
+    private def normalize_route_prefix(parent_prefix : ::String, child_prefix : ::String) : ::String
+      full_prefix = "#{parent_prefix}#{child_prefix}"
+      full_prefix = "/#{full_prefix}".gsub(/\/+/, "/")
+      full_prefix == "/" ? "" : full_prefix
+    end
+
+    private def route_list_parent_for_line(line_index : Int32, route_list_ranges : Hash(::String, Tuple(Int32, Int32))) : ::String?
+      route_list_ranges.each do |route_list, range|
+        start_line, end_line = range
+        return route_list if line_index >= start_line && line_index <= end_line
+      end
+
+      nil
+    end
+
+    private def build_route_list_ranges(lines : Array(::String)) : Hash(::String, Tuple(Int32, Int32))
+      ranges = Hash(::String, Tuple(Int32, Int32)).new
+
+      lines.each_with_index do |line, line_index|
+        assign_match = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)(?:\s*:[^=]+)?\s*=\s*\[/)
+        next unless assign_match
+
+        end_line = line_index
+        bracket_depth = 0
+        index = line_index
+        while index < lines.size
+          bracket_depth += lines[index].count('[') - lines[index].count(']')
+          end_line = index
+          break if bracket_depth <= 0
+          index += 1
+        end
+
+        ranges[assign_match[1]] = {line_index, end_line}
+      end
+
+      ranges
+    end
+
+    private def build_app_prefixes(lines : Array(::String)) : Hash(::String, Array(::String))
+      prefixes = Hash(::String, Array(::String)).new do |hash, key|
+        hash[key] = [] of ::String
+      end
+      mounts = [] of Tuple(::String, ::String)
+
+      lines.each_with_index do |line, line_index|
+        if app_match = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:Starlette|Router)\s*\(/)
+          prefixes[app_match[1]] << "" unless prefixes[app_match[1]].includes?("")
+        end
+
+        next unless line.includes?("Mount") && line.includes?("app")
+
+        effective_line = if line.includes?("Mount") && python_paren_delta(line) > 0
+                           join_until_python_call_closes(lines, line_index, line)
+                         else
+                           line
+                         end
+
+        effective_line.scan(/Mount\s*\(\s*[rf]?['"]([^'"]*)['"][^)]*\bapp\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)/m) do |match|
+          next if match.size < 3
+          mount_prefix = match[1]
+          app_name = match[2]
+          mounts << {mount_prefix, app_name}
+          prefixes[app_name] ||= [] of ::String
+        end
+      end
+
+      mounted_apps = Set(::String).new
+      mounts.each { |_, app_name| mounted_apps << app_name }
+      mounted_apps.each do |app_name|
+        prefixes[app_name].try(&.delete(""))
+      end
+
+      mounts.each do |mount_prefix, app_name|
+        prefixes[app_name] << mount_prefix unless prefixes[app_name].includes?(mount_prefix)
+      end
+
+      prefixes
+    end
+
+    private def build_app_route_lists(lines : Array(::String)) : Hash(::String, Array(::String))
+      app_route_lists = Hash(::String, Array(::String)).new do |hash, key|
+        hash[key] = [] of ::String
+      end
+
+      lines.each_with_index do |line, line_index|
+        next unless line.includes?("Starlette") || line.includes?("Router")
+
+        effective_line = if python_paren_delta(line) > 0
+                           join_until_python_call_closes(lines, line_index, line)
+                         else
+                           line
+                         end
+
+        effective_line.scan(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:Starlette|Router)\s*\([^)]*\broutes\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)/m) do |match|
+          next if match.size < 3
+          app_route_lists[match[1]] << match[2]
+        end
+      end
+
+      app_route_lists
+    end
+
+    private def build_mounted_route_list_ranges(lines : Array(::String),
+                                                mounted_route_list_prefixes : Hash(::String, Array(::String))) : Array(Tuple(Int32, Int32, Array(::String)))
+      ranges = [] of Tuple(Int32, Int32, Array(::String))
+      return ranges if mounted_route_list_prefixes.empty?
+
+      lines.each_with_index do |line, line_index|
+        assign_match = line.match(/^\s*([a-zA-Z_][a-zA-Z0-9_]*)(?:\s*:[^=]+)?\s*=\s*\[/)
+        next unless assign_match
+
+        route_list_name = assign_match[1]
+        prefixes = mounted_route_list_prefixes[route_list_name]?
+        next unless prefixes
+
+        end_line = line_index
+        bracket_depth = 0
+        index = line_index
+        while index < lines.size
+          bracket_depth += lines[index].count('[') - lines[index].count(']')
+          end_line = index
+          break if bracket_depth <= 0
+          index += 1
+        end
+
+        ranges << {line_index, end_line, prefixes}
+      end
+
+      ranges
+    end
+
+    private def mounted_route_prefixes_for_line(line_index : Int32,
+                                                mounted_route_list_ranges : Array(Tuple(Int32, Int32, Array(::String)))) : Array(::String)?
+      mounted_route_list_ranges.each do |range|
+        start_line, end_line, prefixes = range
+        return prefixes if line_index >= start_line && line_index <= end_line
+      end
+
+      nil
     end
 
     private def extract_path_params(route_path : ::String) : Array(Param)
@@ -138,6 +544,110 @@ module Analyzer::Python
       params
     end
 
+    private def extract_programmatic_methods(args : Array(::String)) : Array(::String)
+      methods = [] of ::String
+      expression = extract_python_keyword_expression(args, "methods")
+      return methods unless expression
+
+      expression.scan(/['"]([A-Za-z]+)['"]/) do |method_match|
+        methods << method_match[1].upcase
+      end
+      methods.uniq
+    end
+
+    private def extract_python_keyword_expression(args : Array(::String), keyword : ::String) : ::String?
+      args.each do |arg|
+        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        return keyword_match[1].strip if keyword_match
+      end
+
+      nil
+    end
+
+    private def extract_python_keyword_string(args : Array(::String), keyword : ::String) : ::String?
+      if expression = extract_python_keyword_expression(args, keyword)
+        return extract_python_string(expression)
+      end
+
+      nil
+    end
+
+    private def extract_python_string(expression : ::String) : ::String?
+      string_match = expression.strip.match(/^[rf]?['"]([^'"]*)['"]/)
+      string_match ? string_match[1] : nil
+    end
+
+    private def clean_reference(expression : ::String) : ::String
+      reference = expression.strip
+      reference = reference.split("#", 2)[0].strip
+      reference = reference.split(",", 2)[0].strip
+      reference.matches?(/^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$/) ? reference : ""
+    end
+
+    private def split_python_arguments(args : ::String) : Array(::String)
+      parts = [] of ::String
+      current = String::Builder.new
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_quote : Char? = nil
+      escaped = false
+
+      args.each_char do |ch|
+        if in_quote
+          current << ch
+          if escaped
+            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == in_quote
+            in_quote = nil
+          end
+          next
+        end
+
+        case ch
+        when '\'', '"'
+          in_quote = ch
+          current << ch
+        when '('
+          paren_depth += 1
+          current << ch
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+          current << ch
+        when '['
+          bracket_depth += 1
+          current << ch
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+          current << ch
+        when '{'
+          brace_depth += 1
+          current << ch
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+          current << ch
+        when ','
+          if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+            parts << current.to_s
+            current = String::Builder.new
+          else
+            current << ch
+          end
+        else
+          current << ch
+        end
+      end
+
+      parts << current.to_s
+      parts
+    end
+
+    private def normalize_receiver(receiver : ::String) : ::String
+      receiver.strip.split(".").last
+    end
+
     private def build_function_index(lines : Array(::String)) : Hash(::String, Tuple(Int32, ::String))
       index = {} of ::String => Tuple(Int32, ::String)
       lines.each_with_index do |line, idx|
@@ -148,6 +658,138 @@ module Analyzer::Python
         index[name] = {idx, def_match[2]}
       end
       index
+    end
+
+    private def build_class_index(lines : Array(::String)) : Hash(::String, Int32)
+      index = {} of ::String => Int32
+      lines.each_with_index do |line, idx|
+        class_match = line.match(/^\s*class\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*[\(:]/)
+        next unless class_match
+        index[class_match[1]] ||= idx
+      end
+      index
+    end
+
+    private def class_handler_contexts(lines : Array(::String),
+                                       class_index : Hash(::String, Int32),
+                                       handler_name : ::String,
+                                       path : ::String,
+                                       cache : Hash(::String, Hash(::String, Tuple(Array(Param), Array(Callee)))),
+                                       *,
+                                       definition_base_path : ::String,
+                                       source : ::String) : Hash(::String, Tuple(Array(Param), Array(Callee)))
+      cached = cache[handler_name]?
+      return cached if cached
+
+      contexts = {} of ::String => Tuple(Array(Param), Array(Callee))
+      class_line = class_index[handler_name]?
+      unless class_line
+        cache[handler_name] = contexts
+        return contexts
+      end
+
+      class_indent = lines[class_line].size - lines[class_line].lstrip.size
+      methods_re = "get|post|put|patch|delete|head|options"
+      i = class_line + 1
+      while i < lines.size
+        line = lines[i]
+        unless line.strip.empty?
+          indent = line.size - line.lstrip.size
+          break if indent <= class_indent
+
+          if method_match = line.match(/^\s*(?:async\s+)?def\s+(#{methods_re})\s*\(([^)]*)\)/)
+            method = method_match[1].upcase
+            request_name = extract_request_arg_name(method_match[2])
+            codeblock = parse_code_block(lines[i..])
+            if codeblock
+              params = [] of Param
+              codeblock.split("\n").each do |cl|
+                if request_name
+                  collect_request_attr_params(cl, request_name, "path_params", "path", params)
+                  collect_request_attr_params(cl, request_name, "query_params", "query", params)
+                  collect_request_attr_params(cl, request_name, "headers", "header", params)
+                  collect_request_attr_params(cl, request_name, "cookies", "cookie", params)
+
+                  if cl.matches?(/await\s+#{Regex.escape(request_name)}\.json\s*\(/)
+                    add_unique(params, Param.new("body", "", "json"))
+                  end
+                  if cl.matches?(/await\s+#{Regex.escape(request_name)}\.form\s*\(/)
+                    add_unique(params, Param.new("body", "", "form"))
+                  end
+                end
+
+                collect_request_attr_params(cl, "self.request", "path_params", "path", params)
+                collect_request_attr_params(cl, "self.request", "query_params", "query", params)
+                collect_request_attr_params(cl, "self.request", "headers", "header", params)
+                collect_request_attr_params(cl, "self.request", "cookies", "cookie", params)
+
+                if cl.matches?(/await\s+self\.request\.json\s*\(/)
+                  add_unique(params, Param.new("body", "", "json"))
+                end
+                if cl.matches?(/await\s+self\.request\.form\s*\(/)
+                  add_unique(params, Param.new("body", "", "form"))
+                end
+              end
+              collect_request_body_params(codeblock, request_name, params) if request_name
+              collect_request_body_params(codeblock, "self.request", params)
+
+              callees = build_callees_from(codeblock, i, path,
+                definition_base_path: definition_base_path, source: source)
+              contexts[method] = {params, callees}
+            end
+          end
+        end
+        i += 1
+      end
+
+      cache[handler_name] = contexts
+      contexts
+    end
+
+    private def websocket_class_handler_context_for(lines : Array(::String),
+                                                    class_index : Hash(::String, Int32),
+                                                    handler_name : ::String,
+                                                    path : ::String,
+                                                    cache : Hash(::String, Tuple(Array(Param), Array(Callee))),
+                                                    *,
+                                                    definition_base_path : ::String,
+                                                    source : ::String) : Tuple(Array(Param), Array(Callee))
+      cached = cache[handler_name]?
+      return cached if cached
+
+      params = [] of Param
+      callees = [] of Callee
+      class_line = class_index[handler_name]?
+      unless class_line
+        cache[handler_name] = {params, callees}
+        return cache[handler_name]
+      end
+
+      class_codeblock = parse_code_block(lines[class_line..])
+      unless class_codeblock
+        cache[handler_name] = {params, callees}
+        return cache[handler_name]
+      end
+
+      class_codeblock.split("\n").each do |cl|
+        if method_match = cl.match(/^\s*(?:async\s+)?def\s+(?:on_connect|on_receive|on_disconnect)\s*\(([^)]*)\)/)
+          if request_name = extract_request_arg_name(method_match[1])
+            collect_websocket_params(class_codeblock, request_name, params)
+          end
+        end
+      end
+
+      callees = build_callees_from(class_codeblock, class_line, path,
+        definition_base_path: definition_base_path, source: source)
+      cache[handler_name] = {params, callees}
+      cache[handler_name]
+    end
+
+    private def extract_request_arg_name(args : ::String) : ::String?
+      names = args.split(",").map do |arg|
+        arg.split("=", 2)[0].split(":", 2)[0].strip
+      end.reject(&.empty?)
+      names.find { |name| name != "self" && name != "cls" }
     end
 
     private def handler_context_for(lines : Array(::String),
@@ -178,10 +820,7 @@ module Analyzer::Python
       end
 
       codeblock.split("\n").each do |cl|
-        collect_request_attr_params(cl, request_name, "path_params", "path", params)
-        collect_request_attr_params(cl, request_name, "query_params", "query", params)
-        collect_request_attr_params(cl, request_name, "headers", "header", params)
-        collect_request_attr_params(cl, request_name, "cookies", "cookie", params)
+        collect_websocket_params(cl, request_name, params)
 
         if cl.matches?(/await\s+#{Regex.escape(request_name)}\.json\s*\(/)
           add_unique(params, Param.new("body", "", "json"))
@@ -190,11 +829,60 @@ module Analyzer::Python
           add_unique(params, Param.new("body", "", "form"))
         end
       end
+      collect_request_body_params(codeblock, request_name, params)
 
       callees = build_callees_from(codeblock, idx, path,
         definition_base_path: definition_base_path, source: source)
       cache[handler_name] = {params, callees}
       cache[handler_name]
+    end
+
+    private def handler_context_for_reference(handler_ref : ::String,
+                                              lines : Array(::String),
+                                              function_index : Hash(::String, Tuple(Int32, ::String)),
+                                              path : ::String,
+                                              import_modules : Hash(::String, Tuple(::String, Int32)),
+                                              cache : Hash(::String, Tuple(Array(Param), Array(Callee))),
+                                              external_cache : Hash(::String, Tuple(Array(Param), Array(Callee))),
+                                              *,
+                                              definition_base_path : ::String,
+                                              source : ::String) : Tuple(Array(Param), Array(Callee))
+      clean_ref = clean_reference(handler_ref)
+      return {[] of Param, [] of Callee} if clean_ref.empty?
+
+      unless clean_ref.includes?(".")
+        return handler_context_for(lines, function_index, clean_ref, path, cache,
+          definition_base_path: definition_base_path, source: source)
+      end
+
+      receiver, handler_name = clean_ref.split(".", 2)
+      handler_path = ""
+      if import_info = import_modules[receiver]?
+        handler_path = import_info.first
+      end
+      handler_path = File.join(File.dirname(path), "#{receiver}.py") if handler_path.empty?
+      return {[] of Param, [] of Callee} unless File.exists?(handler_path)
+
+      cache_key = "#{handler_path}:#{handler_name}"
+      cached = external_cache[cache_key]?
+      return cached if cached
+
+      handler_source = read_file_content(handler_path)
+      handler_lines = handler_source.split("\n")
+      handler_function_index = build_function_index(handler_lines)
+      context = handler_context_for(handler_lines, handler_function_index, handler_name, handler_path, {} of ::String => Tuple(Array(Param), Array(Callee)),
+        definition_base_path: definition_base_path, source: handler_source)
+      external_cache[cache_key] = context
+      context
+    end
+
+    private def collect_websocket_params(source : ::String, request_name : ::String, params : Array(Param))
+      source.each_line do |line|
+        collect_request_attr_params(line, request_name, "path_params", "path", params)
+        collect_request_attr_params(line, request_name, "query_params", "query", params)
+        collect_request_attr_params(line, request_name, "headers", "header", params)
+        collect_request_attr_params(line, request_name, "cookies", "cookie", params)
+      end
     end
 
     private def collect_request_attr_params(line : ::String, request_name : ::String, attr : ::String, noir_type : ::String, params : Array(Param))
@@ -203,6 +891,28 @@ module Analyzer::Python
       end
       line.scan(/#{Regex.escape(request_name)}\.#{attr}\.get\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
         add_unique(params, Param.new(m[1], "", noir_type))
+      end
+    end
+
+    private def collect_request_body_params(codeblock : ::String, request_name : ::String, params : Array(Param))
+      request_pattern = Regex.escape(request_name)
+      {
+        "json" => "json",
+        "form" => "form",
+      }.each do |method_name, noir_type|
+        body_vars = [] of ::String
+        codeblock.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{request_pattern}\.#{method_name}\s*\(/) do |m|
+          body_vars << m[1]
+        end
+
+        body_vars.each do |var|
+          codeblock.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
+            add_unique(params, Param.new(m[1], "", noir_type))
+          end
+          codeblock.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\.get\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
+            add_unique(params, Param.new(m[1], "", noir_type))
+          end
+        end
       end
     end
 

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -67,6 +67,12 @@ module Analyzer::Python
                 # Extract URL patterns from this and following lines
                 extract_url_patterns_from_application(lines, line_index, path, api_instances)
               end
+
+              # Tornado apps commonly attach routes after Application()
+              # construction via app.add_handlers(host_pattern, handlers).
+              if line.includes?(".add_handlers(")
+                extract_url_patterns_from_add_handlers(lines, line_index, path)
+              end
             end
           end
         end
@@ -165,6 +171,18 @@ module Analyzer::Python
 
       # Inline list: Application([(...), ...])
       extract_routes_from_lines(lines, start_index, file_path)
+    end
+
+    private def extract_url_patterns_from_add_handlers(lines : Array(::String), start_index : Int32, file_path : ::String)
+      @routes[file_path] ||= [] of Tuple(Int32, ::String, ::String, ::String)
+
+      app_line = join_multiline_call(lines, start_index)
+      if var_match = app_line.match(/\.add_handlers\s*\([^,]+,\s*(#{PYTHON_VAR_NAME_REGEX})\s*[,)]/)
+        extract_routes_from_variable(lines, var_match[1], file_path)
+        return
+      end
+
+      register_routes_from_text(app_line, start_index, file_path)
     end
 
     private def extract_routes_from_variable(lines : Array(::String), var_name : ::String, file_path : ::String)
@@ -282,11 +300,23 @@ module Analyzer::Python
       # Second pass: scan the joined block for tuples whose `(` and
       # path/handler sit on different lines. The per-line scan above
       # only catches single-line and "handler on next line" shapes.
-      block_text = block_pieces.join(" ")
+      register_routes_from_text(block_pieces.join(" "), start_index, file_path)
+    end
+
+    private def register_routes_from_text(block_text : ::String, start_index : Int32, file_path : ::String)
       existing_routes = (@routes[file_path]? || [] of Tuple(Int32, ::String, ::String, ::String))
         .map { |info| {info[2], info[3]} }
         .to_set
       block_text.scan(/\(\s*r?["']([^"']*)["']\s*,\s*([a-zA-Z_][a-zA-Z0-9_.]*)/) do |match|
+        next unless match.size >= 3
+        route_path = match[1]
+        handler_class = match[2]
+        next if existing_routes.includes?({route_path, handler_class})
+        @routes[file_path] << {start_index, "ALL", route_path, handler_class}
+        existing_routes << {route_path, handler_class}
+      end
+
+      block_text.scan(/(?:^|[^a-zA-Z0-9_.])(?:tornado\.web\.)?(?:url|URLSpec)\s*\(\s*r?["']([^"']*)["']\s*,\s*([a-zA-Z_][a-zA-Z0-9_.]*)/) do |match|
         next unless match.size >= 3
         route_path = match[1]
         handler_class = match[2]
@@ -354,21 +384,49 @@ module Analyzer::Python
       lines = read_file_lines(file_path)
 
       class_found = false
+      class_is_websocket = false
       class_indent = 0
       lines.each_with_index do |line, line_index|
         stripped = line.strip
         if (m = stripped.match(CLASS_DEF_REGEX)) && m[1] == handler_class && !class_found
           class_found = true
+          class_is_websocket = stripped.includes?("WebSocketHandler")
           class_indent = indent_level(line)
           next
         end
 
         next unless class_found
 
+        if class_is_websocket &&
+           (stripped.starts_with?("def open(") || stripped.starts_with?("async def open("))
+          params = extract_path_params_from_method_signature(stripped, route_path)
+          extract_params_from_method(lines, line_index, file_path).each do |param|
+            add_unique_param(params, param)
+          end
+          endpoint = Endpoint.new(route_path, "GET", params)
+          endpoint.protocol = "ws"
+
+          if codeblock = parse_code_block(lines[line_index..])
+            push_callees_from(
+              endpoint,
+              codeblock,
+              line_index,
+              file_path,
+              definition_base_path: base_path_for(file_path),
+              source: read_file_content(file_path),
+            )
+          end
+
+          endpoints << endpoint
+        end
+
         # Look for HTTP method handlers (both sync and async)
         HTTP_METHODS.each do |http_method|
           if stripped.starts_with?("def #{http_method}(") || stripped.starts_with?("async def #{http_method}(")
-            params = extract_params_from_method(lines, line_index, file_path)
+            params = extract_path_params_from_method_signature(stripped, route_path)
+            extract_params_from_method(lines, line_index, file_path).each do |param|
+              add_unique_param(params, param)
+            end
             endpoint = Endpoint.new(route_path, http_method.upcase, params)
 
             # Attach 1-hop callees from this method's body. Each
@@ -400,6 +458,57 @@ module Analyzer::Python
       end
 
       class_found
+    end
+
+    private def extract_path_params_from_method_signature(def_line : ::String, route_path : ::String) : Array(Param)
+      params = [] of Param
+
+      route_path.scan(/\{([a-zA-Z_][a-zA-Z0-9_]*)\}/) do |match|
+        add_unique_param(params, Param.new(match[1], "", "path"))
+      end
+
+      route_path.scan(/\(\?P<([a-zA-Z_][a-zA-Z0-9_]*)>/) do |match|
+        add_unique_param(params, Param.new(match[1], "", "path"))
+      end
+      return params unless params.empty?
+
+      capture_count = unnamed_regex_capture_count(route_path)
+      return params if capture_count == 0
+
+      method_arg_names(def_line).first(capture_count).each do |name|
+        add_unique_param(params, Param.new(name, "", "path"))
+      end
+
+      params
+    end
+
+    private def method_arg_names(def_line : ::String) : Array(::String)
+      match = def_line.match(/def\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\(([^)]*)\)/)
+      return [] of ::String unless match
+
+      names = [] of ::String
+      match[1].split(",").each do |arg|
+        name = arg.strip.split("=", 2)[0].split(":", 2)[0].strip
+        while name.starts_with?("*")
+          name = name.lchop("*")
+        end
+        next if name.empty? || name.in?(%w[self cls args kwargs])
+        names << name
+      end
+      names
+    end
+
+    private def unnamed_regex_capture_count(route_path : ::String) : Int32
+      count = 0
+      route_path.scan(/(?:^|[^\\])\((?!\?)/) do
+        count += 1
+      end
+      count
+    end
+
+    private def add_unique_param(params : Array(Param), param : Param)
+      return if params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+      params << param
     end
 
     private def resolve_imports(file_path : ::String) : Hash(::String, Tuple(::String, Int32))


### PR DESCRIPTION
## Summary
- improve Python framework analyzers to reduce endpoint false positives and false negatives across FastAPI, Django, Flask, Quart, Sanic, Aiohttp, Starlette, Falcon, Bottle, Litestar, Pyramid, Robyn, and Tornado
- add regression fixtures for imported handlers/resources, static route declarations, nested router prefixes, DRF router registrations, and programmatic route declarations
- fix review regressions for keyword-form DRF router.register(viewset=...) and FastAPI programmatic route params under parameterized router prefixes

## Tests
- crystal spec spec/functional_test/testers/python/django_spec.cr
- crystal spec spec/functional_test/testers/python/fastapi_spec.cr
- crystal spec spec/functional_test/testers/python
- just build
- just test
- just check