### PR TITLE
Improve detector scan feedback and add spinner opt-out

### DIFF
--- a/spec/unit_test/cli/help_command_spec.cr
+++ b/spec/unit_test/cli/help_command_spec.cr
@@ -63,6 +63,7 @@ describe Noir::CLI::HelpCommand do
         out.should contain(cmd)
       end
       out.should contain("--no-color")
+      out.should contain("--no-spinner")
       out.should contain("-v, --version")
       out.should contain("-h, --help")
     end

--- a/spec/unit_test/config_initializer_spec.cr
+++ b/spec/unit_test/config_initializer_spec.cr
@@ -49,6 +49,12 @@ describe ConfigInitializer do
     end
   end
 
+  it "coerces no_spinner config to Bool" do
+    with_noir_home("no_spinner: yes\n") do |options|
+      options["no_spinner"].should be_true
+    end
+  end
+
   it "normalizes a bare-string passive_scan_path into a single-element array" do
     with_noir_home("passive_scan_path: ./team-rules\n") do |options|
       arr = options["passive_scan_path"].as_a

--- a/spec/unit_test/models/logger_spec.cr
+++ b/spec/unit_test/models/logger_spec.cr
@@ -101,6 +101,18 @@ describe "NoirLogger" do
       logger = NoirLogger.new(debug: false, verbose: true, colorize: false, no_log: false)
       logger.verbose_sub("verbose sub message")
     end
+
+    it "supports loading blocks" do
+      logger = NoirLogger.new(debug: false, verbose: false, colorize: false, no_log: false)
+      value = logger.loading("loading message") { 42 }
+      value.should eq(42)
+    end
+
+    it "supports loading blocks in no_log mode" do
+      logger = NoirLogger.new(debug: false, verbose: false, colorize: false, no_log: true)
+      value = logger.loading("loading message") { 42 }
+      value.should eq(42)
+    end
   end
 
   describe "colorize option" do

--- a/spec/unit_test/models/logger_spec.cr
+++ b/spec/unit_test/models/logger_spec.cr
@@ -113,6 +113,12 @@ describe "NoirLogger" do
       value = logger.loading("loading message") { 42 }
       value.should eq(42)
     end
+
+    it "supports disabling loading spinners" do
+      logger = NoirLogger.new(debug: false, verbose: false, colorize: true, no_log: false, no_spinner: true)
+      value = logger.loading("loading message") { 42 }
+      value.should eq(42)
+    end
   end
 
   describe "colorize option" do

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -24,6 +24,11 @@ describe "default_options" do
     noir_options["ai_context"].should be_false
   end
 
+  it "has loading spinners enabled by default" do
+    noir_options = create_test_options
+    noir_options["no_spinner"].should be_false
+  end
+
   # Concurrency is auto-scaled to the host's CPU count, clamped to the
   # [4, 32] window. The exact value depends on the box the suite runs
   # on, so the spec asserts the window rather than a literal.
@@ -38,6 +43,21 @@ describe "default_options" do
 end
 
 describe "run_options_parser" do
+  it "supports --no-spinner" do
+    original_argv = ARGV.dup
+
+    ARGV.clear
+    ARGV.concat(["--no-spinner"])
+
+    begin
+      noir_options = run_options_parser()
+      noir_options["no_spinner"].should be_true
+    ensure
+      ARGV.clear
+      ARGV.concat(original_argv)
+    end
+  end
+
   it "supports multiple -b flags" do
     # Save original ARGV
     original_argv = ARGV.dup

--- a/src/cli/commands/help.cr
+++ b/src/cli/commands/help.cr
@@ -86,6 +86,7 @@ module Noir::CLI::HelpCommand
 
       #{green.call("GLOBAL FLAGS:")}
         --no-color     Strip ANSI color from every command's output (NO_COLOR env also works)
+        --no-spinner   Disable loading spinner animations while keeping normal logs
         -v, --version  Print the noir version and exit (alias for `noir version`)
         -h, --help     Show this overview, or, after a verb, that command's help
 

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -248,8 +248,11 @@ module Noir::CLI::ScanCommand
       app.logger.info "Running Noir with Diff mode."
     end
 
-    app.logger.info "Detecting technologies in the base directory."
-    app.detect
+    app.logger.loading "Detecting technologies in the base directory." do
+      app.detect
+    end
+
+    analysis_message = "Starting code analysis."
 
     if app.techs.empty?
       app.logger.warning "No technologies detected."
@@ -288,10 +291,12 @@ module Noir::CLI::ScanCommand
       app.techs = app.techs.reject do |tech|
         exclude_techs.any? { |t| NoirTechs.similar_to_tech(t).includes?(tech) }
       end
-      app.logger.info "Starting code analysis based on the detected technologies."
+      analysis_message = "Starting code analysis based on the detected technologies."
     end
 
-    app.analyze
+    app.logger.loading analysis_message do
+      app.analyze
+    end
     app.logger.success "Identified #{app.endpoints.size} endpoints in total."
 
     elapsed = Time.instant - start_time

--- a/src/completions.cr
+++ b/src/completions.cr
@@ -33,6 +33,7 @@ private SCAN_FLAGS = %w[
   --include-callee
   --ai-context
   --no-color
+  --no-spinner
   --no-log
   -P --passive-scan
   --passive-scan-path
@@ -162,6 +163,7 @@ def generate_zsh_completion_script
             '--ai-context[Include AI review context (guards,sinks,...)]::list:(guards sinks validators signals callee)' \\
             '--exclude-path[Exclude files by glob]:pattern:' \\
             '--no-color[Disable color output]' \\
+            '--no-spinner[Disable loading spinner animations]' \\
             '--no-log[Show only results]' \\
             '(-P --passive-scan)'{-P,--passive-scan}'[Enable passive security scan]' \\
             '--passive-scan-path[Custom passive rules path]:path:_files' \\
@@ -374,6 +376,7 @@ def generate_fish_completion_script
     complete -c noir      -l ai-native-tools-allowlist -d 'Provider allowlist for native tool-calling' -r
     complete -c noir      -l ai-max-token          -d 'Max tokens per request' -r
     complete -c noir      -l no-color              -d 'Disable color output'
+    complete -c noir      -l no-spinner            -d 'Disable loading spinner animations'
     complete -c noir      -l no-log                -d 'Show only results'
     complete -c noir -s P -l passive-scan          -d 'Enable passive scan'
     complete -c noir      -l passive-scan-path           -d 'Custom passive rules path' -r -F
@@ -439,7 +442,7 @@ def generate_elvish_completion_script
       --set-pvalue-form --set-pvalue-json --set-pvalue-path
       --status-codes --exclude-codes --exclude-path
       --include --include-path --include-techs --include-callee
-      --ai-context --no-color --no-log
+      --ai-context --no-color --no-spinner --no-log
       -P --passive-scan --passive-scan-path --passive-scan-severity
       --passive-scan-auto-update --passive-scan-no-update-check
       -T --use-all-taggers --use-taggers

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -19,6 +19,7 @@ class ConfigInitializer
     include_callee
     ai_context
     nolog
+    no_spinner
     send_req
     all_taggers
     status_codes
@@ -203,6 +204,7 @@ class ConfigInitializer
       "include_callee"               => YAML::Any.new(false),
       "ai_context"                   => YAML::Any.new(false),
       "nolog"                        => YAML::Any.new(false),
+      "no_spinner"                   => YAML::Any.new(false),
       "output"                       => YAML::Any.new(""),
       "export_es"                    => YAML::Any.new(""),
       "probe_via"                    => YAML::Any.new(""),
@@ -304,6 +306,9 @@ class ConfigInitializer
 
       # Whether to disable logging
       nolog: #{options["nolog"]}
+
+      # Whether to disable loading spinners while keeping normal logs
+      no_spinner: #{options["no_spinner"]}
 
       # The output file to write to
       output: "#{options["output"]}"

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -236,7 +236,14 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     end
   end
 
-  channel = Channel(Tuple(String, String)).new(Analyzer::DEFAULT_CONTENT_CHANNEL_CAPACITY)
+  # Resolve the severity threshold and prune the rule set once,
+  # before the reader/workers spawn. The previous shape did this
+  # lookup and comparison inside the per-file hot loop, costing one
+  # Hash lookup + downcase per (file × rule).
+  min_severity = options["passive_scan_severity"]?.try(&.to_s) || "high"
+  active_passive_scans = NoirPassiveScan.filter_rules_by_severity(passive_scans, min_severity)
+
+  channel = Channel(Tuple(String, String, Array(Int32))).new(Analyzer::DEFAULT_CONTENT_CHANNEL_CAPACITY)
   locator = CodeLocator.instance
   wg = WaitGroup.new
 
@@ -248,6 +255,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   spawn do
     begin
       skipped_files = 0
+      skipped_content_reads = 0
       total_files = 0
       skipped_ignored_dirs = 0
 
@@ -355,14 +363,35 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 end
               end
 
-              if skip_reason = MediaFilter.skip_check(full_path, info: info)
+              if skip_reason = MediaFilter.skip_check(full_path, info: info, sniff_binary: false)
                 logger.debug "Skipping #{full_path}: #{skip_reason}"
                 skipped_files += 1
                 next
               end
 
+              candidate_detector_indices = [] of Int32
+              detector_list.each_with_index do |detector, idx|
+                candidate_detector_indices << idx if detector.applicable?(full_path)
+              end
+
+              if candidate_detector_indices.empty? && active_passive_scans.empty?
+                # Keep the path visible to analyzers without paying to
+                # read/cache content that neither detection nor passive
+                # scan will inspect. Analyzer reads still fall back to
+                # File.read when a file was not cached here.
+                locator.push("file_map", full_path)
+                skipped_content_reads += 1
+                next
+              end
+
               content = File.read(full_path, encoding: "utf-8", invalid: :skip)
-              channel.send({full_path, content})
+              if content.to_slice.includes?(0_u8)
+                logger.debug "Skipping #{full_path}: binary content (file is text-extension but bytes look binary)"
+                skipped_files += 1
+                next
+              end
+
+              channel.send({full_path, content, candidate_detector_indices})
               # Register the path in file_map and (budget permitting)
               # cache the content so analyzers can skip the re-read.
               locator.register_file(full_path, content)
@@ -383,6 +412,9 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       if skipped_exclude_path > 0
         logger.info "Skipped #{skipped_exclude_path} files matching --exclude-path patterns"
       end
+      if skipped_content_reads > 0
+        logger.debug "Avoided content reads for #{skipped_content_reads} file(s) with no applicable detectors"
+      end
 
       stats = locator.content_cache_stats
       if stats[:budget] > 0
@@ -395,9 +427,6 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       wg.done
     end
   end
-
-  # Log how many files were added to the file_map
-  logger.debug "Added #{locator.all("file_map").size} files to file_map"
 
   # Threads for receiving and processing the contents from the channel
   concurrency = options["concurrency"].to_s.to_i
@@ -412,16 +441,6 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # never persist.
   detected_flags = Array(AtomicFlag).new(detector_list.size) { AtomicFlag.new }
 
-  # Resolve the severity threshold and prune the rule set once,
-  # before workers spawn. The previous shape did this lookup and
-  # comparison inside the per-file hot loop, costing one Hash
-  # lookup + downcase per (file × rule). With monorepo scans
-  # easily hitting 10k+ files and a few hundred rules, this is a
-  # noticeable accumulated cost for an answer that never changes
-  # mid-scan.
-  min_severity = options["passive_scan_severity"]?.try(&.to_s) || "high"
-  active_passive_scans = NoirPassiveScan.filter_rules_by_severity(passive_scans, min_severity)
-
   concurrency.times do
     wg.add(1)
     spawn do
@@ -430,22 +449,16 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
           begin
             file_content = channel.receive?
             break if file_content.nil?
-            file, content = file_content
+            file, content, candidate_detector_indices = file_content
             logger.debug "Detecting: #{file}"
 
-            detector_list.each_with_index do |detector, idx|
+            candidate_detector_indices.each do |idx|
+              detector = detector_list[idx]
               # Skip detectors that have already matched, unless
               # the detector signals it has side effects in
               # `detect` (`idempotent? == false`) — see
               # `Detector#idempotent?` for the contract.
               next if detector.idempotent? && detected_flags[idx].get
-              # Cheap filename precheck: most detectors gate on a
-              # fixed extension or path component. Skipping the
-              # `detect` dispatch (and the regex / `includes?`
-              # work inside it) for non-applicable files cuts the
-              # detector pass on language-heavy trees by an order
-              # of magnitude.
-              next unless detector.applicable?(file)
               if detector.detect(file, content)
                 detected_flags[idx].set
                 newly_added = false
@@ -484,5 +497,6 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   end
 
   wg.wait
+  logger.debug "Added #{locator.all("file_map").size} files to file_map"
   {techs.uniq, passive_result}
 end

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -1,6 +1,10 @@
 require "colorize"
 
 class NoirLogger
+  SPINNER_FRAMES      = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+  SHIMMER_COLORS      = [159, 255, 250, 247, 245]
+  SHIMMER_BAND_RADIUS = SHIMMER_COLORS.size - 1
+
   enum LogLevel
     DEBUG
     VERBOSE
@@ -17,6 +21,8 @@ class NoirLogger
     @verbose = verbose
     @color_mode = colorize
     @no_log = no_log
+    @output_mutex = Mutex.new
+    @spinner_active = false
   end
 
   def log(level : LogLevel, message : String)
@@ -41,9 +47,47 @@ class NoirLogger
                "★".colorize(:yellow).toggle(@color_mode)
              end
 
-    STDERR.puts "#{prefix} #{message}"
+    write_stderr_line "#{prefix} #{message}"
 
     exit(1) if level == LogLevel::FATAL
+  end
+
+  def loading(message : String, &)
+    if @no_log
+      return yield
+    end
+
+    unless spinner_enabled?
+      info(message)
+      return yield
+    end
+
+    stop = Atomic(Int8).new(0_i8)
+
+    @output_mutex.synchronize do
+      @spinner_active = true
+    end
+
+    thread = Thread.new do
+      index = 0
+      while stop.get == 0_i8
+        render_spinner(message, index)
+        index += 1
+        sleep 60.milliseconds
+      end
+
+      @output_mutex.synchronize do
+        clear_spinner_line
+        @spinner_active = false
+      end
+    end
+
+    begin
+      yield
+    ensure
+      stop.set(1_i8)
+      thread.join
+    end
   end
 
   def puts(message)
@@ -68,7 +112,7 @@ class NoirLogger
 
   def sub(message)
     return if @no_log
-    STDERR.puts "  " + message
+    write_stderr_line "  " + message
   end
 
   def warning(message)
@@ -86,7 +130,7 @@ class NoirLogger
 
   def debug_sub(message)
     return if @no_log || !@debug
-    STDERR.puts "  " + message.to_s
+    write_stderr_line "  " + message.to_s
   end
 
   def verbose(message)
@@ -96,10 +140,57 @@ class NoirLogger
 
   def verbose_sub(message)
     return if @no_log || !@verbose
-    STDERR.puts "  " + message
+    write_stderr_line "  " + message
   end
 
   def fatal(message)
     log(LogLevel::FATAL, message)
+  end
+
+  private def spinner_enabled? : Bool
+    @color_mode && STDERR.tty?
+  end
+
+  private def render_spinner(message : String, index : Int32)
+    frame = SPINNER_FRAMES[index % SPINNER_FRAMES.size]
+    line = shimmer("#{frame} #{message}", index)
+
+    @output_mutex.synchronize do
+      STDERR.print "\r\e[2K#{line}"
+      STDERR.flush
+    end
+  end
+
+  private def write_stderr_line(message : String)
+    @output_mutex.synchronize do
+      clear_spinner_line if @spinner_active
+      STDERR.puts message
+    end
+  end
+
+  private def clear_spinner_line
+    STDERR.print "\r\e[2K"
+    STDERR.flush
+  end
+
+  private def shimmer(text : String, index : Int32) : String
+    chars = text.chars
+    return text if chars.empty?
+
+    travel = chars.size + SHIMMER_BAND_RADIUS * 2
+    highlight = index % travel - SHIMMER_BAND_RADIUS
+
+    String.build do |io|
+      chars.each_with_index do |char, char_index|
+        distance = (char_index - highlight).abs
+        color = if distance <= SHIMMER_BAND_RADIUS
+                  SHIMMER_COLORS[distance]
+                else
+                  SHIMMER_COLORS.last
+                end
+        io << "\e[38;5;" << color << "m" << char
+      end
+      io << "\e[0m"
+    end
   end
 end

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -16,11 +16,12 @@ class NoirLogger
     HEADING
   end
 
-  def initialize(debug : Bool, verbose : Bool, colorize : Bool, no_log : Bool)
+  def initialize(debug : Bool, verbose : Bool, colorize : Bool, no_log : Bool, no_spinner : Bool = false)
     @debug = debug
     @verbose = verbose
     @color_mode = colorize
     @no_log = no_log
+    @no_spinner = no_spinner
     @output_mutex = Mutex.new
     @spinner_active = false
   end
@@ -148,7 +149,7 @@ class NoirLogger
   end
 
   private def spinner_enabled? : Bool
-    @color_mode && STDERR.tty?
+    @color_mode && !@no_spinner && STDERR.tty?
   end
 
   private def render_spinner(message : String, index : Int32)

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -25,6 +25,7 @@ class NoirRunner
   @is_verbose : Bool
   @is_color : Bool
   @is_log : Bool
+  @no_spinner : Bool
   @concurrency : Int32
   @config_file : String
   @noir_home : String
@@ -68,9 +69,10 @@ class NoirRunner
     @is_verbose = any_to_bool(@options["verbose"])
     @is_color = any_to_bool(@options["color"])
     @is_log = any_to_bool(@options["nolog"])
+    @no_spinner = any_to_bool(@options["no_spinner"])
     @concurrency = @options["concurrency"].to_s.to_i
 
-    @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
+    @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log, @no_spinner
 
     if ai_context_enabled?
       @options["include_callee"] = YAML::Any.new(true)

--- a/src/options.cr
+++ b/src/options.cr
@@ -296,6 +296,9 @@ def run_options_parser
     parser.on "--no-color", "Disable color output" do
       noir_options["color"] = YAML::Any.new(false)
     end
+    parser.on "--no-spinner", "Disable loading spinner animations" do
+      noir_options["no_spinner"] = YAML::Any.new(true)
+    end
     parser.on "--no-log", "Show only results" do
       noir_options["nolog"] = YAML::Any.new(true)
     end

--- a/src/utils/media_filter.cr
+++ b/src/utils/media_filter.cr
@@ -111,7 +111,7 @@ module MediaFilter
   # When the caller has already obtained a `File::Info` (e.g. the
   # detector walker stats each entry with `follow_symlinks: false`), it
   # can be passed as `info` to skip the size stat entirely.
-  def self.skip_check(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil) : String?
+  def self.skip_check(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil, sniff_binary : Bool = true) : String?
     extension = File.extname(file_path).downcase
     return "media file (#{extension})" if MEDIA_EXTENSION_SET.includes?(extension)
 
@@ -141,7 +141,7 @@ module MediaFilter
     # Sample the first 512 bytes — that's enough to spot the NUL-byte
     # signature of binary blobs (object files, packed assets, etc.)
     # without re-reading the whole file content.
-    if binary_content_signature?(file_path)
+    if sniff_binary && binary_content_signature?(file_path)
       return "binary content (file is text-extension but bytes look binary)"
     end
 
@@ -167,13 +167,13 @@ module MediaFilter
   # Combined check - returns true if file should be skipped. Prefer
   # {skip_check} on hot paths: it returns the reason in the same call
   # so the caller does not re-stat to log.
-  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil) : Bool
-    !skip_check(file_path, max_size, info).nil?
+  def self.should_skip_file?(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil, sniff_binary : Bool = true) : Bool
+    !skip_check(file_path, max_size, info, sniff_binary).nil?
   end
 
   # Get a human-readable reason why a file was skipped. Kept for
   # backwards compatibility; new callers should use {skip_check}.
-  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil) : String?
-    skip_check(file_path, max_size, info)
+  def self.skip_reason(file_path : String, max_size : Int32 = MAX_FILE_SIZE, info : File::Info? = nil, sniff_binary : Bool = true) : String?
+    skip_check(file_path, max_size, info, sniff_binary)
   end
 end


### PR DESCRIPTION
## Summary
- improve detector scan performance by skipping irrelevant media files
- add animated loading feedback for long detector scans
- add `--no-spinner` / `no_spinner` to disable spinner animations independently of color output

## Tests
- `just build`
- `just test`
- `just check`