### PR TITLE
fix: replace native Thread.new spinner with fiber to prevent "can't resume running fiber" panic

### DIFF
--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -69,7 +69,7 @@ class NoirLogger
       @spinner_active = true
     end
 
-    thread = Thread.new do
+    spawn do
       index = 0
       while stop.get == 0_i8
         render_spinner(message, index)
@@ -87,7 +87,10 @@ class NoirLogger
       yield
     ensure
       stop.set(1_i8)
-      thread.join
+      # The animation fiber will exit on its next iteration or after its current
+      # sleep. Subsequent log output (which goes through the mutex) will clear
+      # any in-flight spinner frame via clear_spinner_line when @spinner_active
+      # is still true. No native thread is used, avoiding scheduler/GC races.
     end
   end
 


### PR DESCRIPTION
The loading spinner in \`NoirLogger#loading\` used \`Thread.new\` + \`thread.join\`. When enabled (tty + color, i.e. normal interactive runs), this created a second native thread with its own Crystal scheduler while the primary thread performed heavy concurrent work:

- \`analysis_endpoints\` using \`WaitGroup.wait { wg.spawn ... }\` across multiple detected technologies
- Ruby (and other) engines using nested \`parallel_file_scan\` → channel sender spawn + another \`WaitGroup\` worker pool
- Detector phase, many file reads, allocations, etc.

Combined with Boehm GC stop-the-world pauses, this could corrupt fiber scheduler state, leading to the fatal:

\`\`\`
FATAL: can't resume a running fiber: #<Fiber:... main>
\`\`\`

The crash was intermittent and most easily triggered by running \`noir scan\` repeatedly on projects that activate multiple analyzers (the Ruby multi-framework fixture was the reliable repro).

### Fix

Replaced the spinner with a plain \`spawn\` fiber using the same \`Atomic\` stop flag and \`@output_mutex\`-protected rendering. All scheduling now stays on the primary thread's scheduler, which is the model expected by \`WaitGroup\`, channels, the analyzer engines, etc.

- Spinner UX/behavior is unchanged.
- Subsequent log output still cleanly removes any in-flight spinner frame via the existing mutex paths.
- No more native threads competing with the fiber runtime + GC.

### Testing
- Reproduced the crash reliably before the fix (under \`script -q\` to force tty + spinner).
- After the fix: 15+ consecutive runs with spinner active → no crashes.
- \`just build\`, \`just test\` (full suite, 16k+ examples), \`crystal tool format\` all pass.
- Verified basic functionality on the crystal fixture as recommended in AGENTS.md.

Fixes the fiber scheduler corruption when the progress spinner is active.