### PR TITLE
fix: resolve concurrent fiber scheduler crashes and spinner deadlocks

### DIFF
--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -254,6 +254,9 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   selected_techs = filter_redundant_generic_techs(techs).select { |t| analyzer.has_key?(t) }
   mutex = Mutex.new
 
+  # Pre-build extension index synchronously to avoid concurrent mutation in multiple threads/fibers
+  CodeLocator.instance.build_extension_index
+
   WaitGroup.wait do |wg|
     selected_techs.each do |tech|
       wg.spawn do

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -22,12 +22,12 @@ module Analyzer::Cpp
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, CPP_EXTENSIONS)
+        locator = CodeLocator.instance
+        files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
 
-        parallel_analyze(channel) do |path|
+        parallel_analyze(files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
           analyze_file(path, include_callee)

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -27,12 +27,12 @@ module Analyzer::Cpp
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, CPP_EXTENSIONS)
+        locator = CodeLocator.instance
+        files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
 
-        parallel_analyze(channel) do |path|
+        parallel_analyze(files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
           next unless CPP_EXTENSIONS.any? { |ext| path.ends_with?(ext) }

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -38,12 +38,10 @@ module Analyzer::Dart
       result = [] of Endpoint
       mutex = Mutex.new
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_filtered_files(channel, ".dart")
+        files = get_files_by_extension(".dart")
 
-        parallel_analyze(channel) do |path|
+        parallel_analyze(files) do |path|
           next unless path.ends_with?(".dart")
 
           idx = path.index("/routes/")

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -54,12 +54,10 @@ module Analyzer::Dart
       mutex = Mutex.new
       routers = {} of String => RouterInfo
 
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_filtered_files(channel, ".dart")
+        files = get_files_by_extension(".dart")
 
-        parallel_analyze(channel) do |path|
+        parallel_analyze(files) do |path|
           next unless path.ends_with?(".dart")
 
           content = begin

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -17,9 +17,13 @@ module Analyzer::Go
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -75,9 +75,13 @@ module Analyzer::Go
 
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -16,9 +16,13 @@ module Analyzer::Go
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -13,9 +13,13 @@ module Analyzer::Go
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/gf.cr
+++ b/src/analyzer/analyzers/go/gf.cr
@@ -16,9 +16,13 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -15,9 +15,13 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -17,9 +17,13 @@ module Analyzer::Go
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -19,9 +19,15 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, [".go", ".api"])
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            [".go", ".api"].each do |ext|
+              get_files_by_extension(ext).each { |file| channel.send(file) }
+            end
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -19,9 +19,13 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/httprouter.cr
+++ b/src/analyzer/analyzers/go/httprouter.cr
@@ -33,9 +33,13 @@ module Analyzer::Go
 
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -59,10 +59,14 @@ module Analyzer::Go
 
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         mutex = Mutex.new
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/iris.cr
+++ b/src/analyzer/analyzers/go/iris.cr
@@ -14,9 +14,13 @@ module Analyzer::Go
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -19,9 +19,13 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/go/pocketbase.cr
+++ b/src/analyzer/analyzers/go/pocketbase.cr
@@ -16,9 +16,13 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
-        populate_channel_with_filtered_files(channel, ".go")
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            get_files_by_extension(".go").each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -25,9 +25,13 @@ module Analyzer::Java
       service_with_routes_index = collect_service_with_routes_index
 
       begin
-        populate_channel_with_files(channel)
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            all_files.each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -11,9 +11,13 @@ module Analyzer::Java
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_files(channel)
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            all_files.each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -42,9 +42,13 @@ module Analyzer::Java
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
-        populate_channel_with_files(channel)
-
         WaitGroup.wait do |wg|
+          # Producer — tracked by the WaitGroup
+          wg.spawn do
+            all_files.each { |file| channel.send(file) }
+            channel.close
+          end
+
           @options["concurrency"].to_s.to_i.times do
             wg.spawn do
               loop do

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -63,9 +63,13 @@ module Analyzer::Python
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       search_dir = @base_path
 
-      populate_channel_with_files(channel)
-
       WaitGroup.wait do |wg|
+        # Producer — tracked by the WaitGroup
+        wg.spawn do
+          all_files.each { |file| channel.send(file) }
+          channel.close
+        end
+
         @options["concurrency"].to_s.to_i.times do
           wg.spawn do
             loop do

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -17,12 +17,8 @@ module Analyzer::Crystal
     # Subclasses that need a custom scan shape can override `analyze`
     # (e.g. Amber/Kemal run a public-dir post-pass after the file walk).
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".cr"
           next if path.includes?("lib")

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -19,12 +19,8 @@ module Analyzer::Elixir
     # No extension filter: Phoenix uses `.ex` only, Plug also accepts
     # `.exs`, so each analyzer filters inside `analyze_file`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
 

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -15,12 +15,8 @@ module Analyzer::Javascript
     #
     # Name-consistent with the other engines' `parallel_file_scan` helpers.
     protected def parallel_file_scan(extensions : Array(String) = DEFAULT_EXTENSIONS, &block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
           next unless extensions.any? { |ext| path.ends_with?(ext) }

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -14,12 +14,8 @@ module Analyzer::Perl
     # No extension filter at the engine layer: Perl ships in `.pl`, `.pm`,
     # `.psgi`, and `.t` files, so each analyzer filters inside `analyze_file`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
 

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -22,12 +22,8 @@ module Analyzer::Php
     # extension/pathname filters inside the block because Symfony matches
     # `.php` *and* YAML route files, Laravel checks `routes/*.php`, etc.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
           next if PhpEngine.test_path?(path)

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -85,12 +85,8 @@ module Analyzer::Ruby
     #
     # Name-consistent with the other engines' `parallel_file_scan` helpers.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
 

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -35,12 +35,8 @@ module Analyzer::Rust
     # and call this helper directly; the default `analyze` above is the
     # simpler path.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".rs"
           next if RustEngine.test_path?(path)

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -15,12 +15,8 @@ module Analyzer::Scala
     # `.scala` extension filter baked in. Subclasses that need a custom
     # scan shape can override `analyze` and call this helper directly.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".scala"
 

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -25,12 +25,8 @@ module Analyzer::Swift
     # `.swift` extension filter baked in. Subclasses that need a custom
     # scan shape can override `analyze` and call this helper directly.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
-      channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-
       begin
-        populate_channel_with_files(channel)
-
-        parallel_analyze(channel) do |path|
+        parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".swift"
           # Swift Package Manager convention parks tests under

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -64,8 +64,21 @@ class Analyzer
     any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
   end
 
-  def parallel_analyze(channel : Channel(String), &block : String -> Nil)
+  # Preferred overload: accepts a file list and creates both the
+  # producer and worker fibers inside a single WaitGroup so every
+  # fiber is tracked.  The bare-`spawn` producer in the channel-based
+  # overload below was an orphan that could trigger "can't resume a
+  # running fiber" under Crystal ≥1.20's M:N scheduler when multiple
+  # analyzers ran concurrently.
+  def parallel_analyze(files : Array(String), &block : String -> Nil)
+    channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
     WaitGroup.wait do |wg|
+      # Producer — tracked by the WaitGroup
+      wg.spawn do
+        files.each { |file| channel.send(file) }
+        channel.close
+      end
+
       worker_count = @options["concurrency"].to_s.to_i
       worker_count = MAX_ANALYZER_WORKERS if worker_count > MAX_ANALYZER_WORKERS
       worker_count = 1 if worker_count < 1
@@ -115,9 +128,14 @@ class FileAnalyzer < Analyzer
 
   def analyze
     channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
-    populate_channel_with_files(channel)
 
     WaitGroup.wait do |wg|
+      # Producer — tracked by the WaitGroup
+      wg.spawn do
+        all_files.each { |file| channel.send(file) }
+        channel.close
+      end
+
       @options["concurrency"].to_s.to_i.times do
         wg.spawn do
           loop do

--- a/src/models/code_locator.cr
+++ b/src/models/code_locator.cr
@@ -23,6 +23,8 @@ class CodeLocator
   @content_cache_used : Int64
   @content_cache_skipped : Int32
 
+  @lock : Mutex
+
   def initialize
     options = {"debug" => "false", "verbose" => "false", "color" => "true", "nolog" => "false"}
     @is_debug = any_to_bool(options["debug"])
@@ -41,6 +43,7 @@ class CodeLocator
     @content_cache_budget = resolve_content_cache_budget
     @content_cache_used = 0_i64
     @content_cache_skipped = 0
+    @lock = Mutex.new
   end
 
   private def resolve_content_cache_budget : Int64
@@ -115,15 +118,18 @@ class CodeLocator
   # Build extension index from file_map for fast lookups
   def build_extension_index
     return if @extension_index_built
-    @extension_index.clear
-    files = @a_map["file_map"]?
-    return unless files
-    files.each do |file|
-      ext = File.extname(file)
-      @extension_index[ext] ||= Array(String).new
-      @extension_index[ext] << file
+    @lock.synchronize do
+      return if @extension_index_built
+      @extension_index.clear
+      files = @a_map["file_map"]?
+      return unless files
+      files.each do |file|
+        ext = File.extname(file)
+        @extension_index[ext] ||= Array(String).new
+        @extension_index[ext] << file
+      end
+      @extension_index_built = true
     end
-    @extension_index_built = true
   end
 
   # Get files by extension using the index (O(1) lookup)

--- a/src/models/file_helper.cr
+++ b/src/models/file_helper.cr
@@ -57,40 +57,6 @@ module FileHelper
     end
   end
 
-  # Helper to populate a channel from file list instead of using Dir.glob
-  def populate_channel_with_files(channel : Channel(String))
-    files = all_files
-    spawn do
-      files.each do |file|
-        channel.send(file)
-      end
-      channel.close
-    end
-  end
-
-  # Helper to populate a channel with only files matching the given extension
-  def populate_channel_with_filtered_files(channel : Channel(String), extension : String)
-    files = get_files_by_extension(extension)
-    spawn do
-      files.each do |file|
-        channel.send(file)
-      end
-      channel.close
-    end
-  end
-
-  # Helper to populate a channel with files matching any of the given extensions
-  def populate_channel_with_filtered_files(channel : Channel(String), extensions : Array(String))
-    locator = CodeLocator.instance
-    files = extensions.flat_map { |ext| locator.files_by_extension(ext) }
-    spawn do
-      files.each do |file|
-        channel.send(file)
-      end
-      channel.close
-    end
-  end
-
   # Helper to get public directories content from anywhere in the project
   def get_public_dir_files(base_path : String, folder : String) : Array(String)
     # Get all files in the project

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -1,5 +1,9 @@
 require "colorize"
 
+lib LibC
+  fun usleep(useconds : UInt32) : Int32
+end
+
 class NoirLogger
   SPINNER_FRAMES      = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
   SHIMMER_COLORS      = [159, 255, 250, 247, 245]
@@ -16,6 +20,8 @@ class NoirLogger
     HEADING
   end
 
+  @stdout_busy : Atomic(Int8)
+
   def initialize(debug : Bool, verbose : Bool, colorize : Bool, no_log : Bool, no_spinner : Bool = false)
     @debug = debug
     @verbose = verbose
@@ -24,6 +30,7 @@ class NoirLogger
     @no_spinner = no_spinner
     @output_mutex = Mutex.new
     @spinner_active = false
+    @stdout_busy = Atomic(Int8).new(0_i8)
   end
 
   def log(level : LogLevel, message : String)
@@ -65,22 +72,33 @@ class NoirLogger
 
     stop = Atomic(Int8).new(0_i8)
 
-    @output_mutex.synchronize do
-      @spinner_active = true
+    # Set @spinner_active thread-safely
+    while @stdout_busy.compare_and_set(0_i8, 1_i8, :acquire_release, :acquire)[1] == false
+      Fiber.yield
     end
+    @spinner_active = true
+    @stdout_busy.set(0_i8)
 
     thread = Thread.new do
       index = 0
       while stop.get == 0_i8
-        render_spinner(message, index)
-        index += 1
-        sleep 60.milliseconds
+        # Non-blocking lock try
+        _, success = @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)
+        if success
+          render_spinner(message, index)
+          index += 1
+          @stdout_busy.set(0_i8)
+        end
+        LibC.usleep(60000_u32)
       end
 
-      @output_mutex.synchronize do
-        clear_spinner_line
-        @spinner_active = false
+      # Spin-acquire for final cleanup
+      while @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)[1] == false
+        LibC.usleep(100_u32)
       end
+      clear_spinner_line
+      @spinner_active = false
+      @stdout_busy.set(0_i8)
     end
 
     begin
@@ -156,17 +174,22 @@ class NoirLogger
     frame = SPINNER_FRAMES[index % SPINNER_FRAMES.size]
     line = shimmer("#{frame} #{message}", index)
 
-    @output_mutex.synchronize do
-      STDERR.print "\r\e[2K#{line}"
-      STDERR.flush
-    end
+    STDERR.print "\r\e[2K#{line}"
+    STDERR.flush
   end
 
   private def write_stderr_line(message : String)
-    @output_mutex.synchronize do
-      clear_spinner_line if @spinner_active
-      STDERR.puts message
+    # Spin-acquire for the main fiber (cooperative yielding)
+    while @stdout_busy.compare_and_set(0_i8, 1_i8, :acquire_release, :acquire)[1] == false
+      Fiber.yield
     end
+
+    clear_spinner_line if @spinner_active
+    STDERR.puts message
+    STDERR.flush
+
+    @stdout_busy.set(0_i8)
+    nil
   end
 
   private def clear_spinner_line


### PR DESCRIPTION
- Refactor parallel_analyze to accept a files list and spawn both the producer and workers inside a single, tracked WaitGroup block.
- Update 9 language engines and custom framework adapters (Go, Java, Python, C++, Dart) to use the new tracked files-based parallel_analyze.
- Remove obsolete untracked channel-based parallel scan APIs and unsafe file helper routines.
- Pre-build CodeLocator extension index synchronously on the main thread before starting parallel analyzers.
- Secure CodeLocator#build_extension_index using a Mutex spinlock to prevent concurrent mutation race conditions under multi-threading.
- Resolve logger spinner fiber crashes and deadlocks by replacing the cooperative Mutex within the raw OS thread with an atomic spinlock (@stdout_busy) and non-blocking skipped frames, completely decoupling spinner rendering from the fiber scheduler.