### PR TITLE
test: add unit tests for FastEndpointsAuthTagger, CrystalEngine, and GoEngine

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../src/config_initializer"
+require "../src/utils/utils"
 
 module Noir
   {% unless Noir.has_constant?("VERSION") %}

--- a/spec/unit_test/analyzer/crystal_engine_spec.cr
+++ b/spec/unit_test/analyzer/crystal_engine_spec.cr
@@ -1,0 +1,109 @@
+require "../../spec_helper"
+require "../../../src/analyzer/engines/crystal_engine"
+
+class CrystalEngineSpecHarness < Analyzer::Crystal::CrystalEngine
+  def analyze_file(path : String) : Array(Endpoint)
+    [] of Endpoint
+  end
+
+  def test_normalize_crystal_interpolation(path : String) : String
+    normalize_crystal_interpolation(path)
+  end
+
+  def test_crystal_do_block_open_delta(line : String) : Int32
+    crystal_do_block_open_delta(line)
+  end
+
+  def test_extract_crystal_do_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+    extract_crystal_do_block(lines, start_index)
+  end
+
+  def test_extract_crystal_def_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
+    extract_crystal_def_block(lines, start_index)
+  end
+end
+
+describe Analyzer::Crystal::CrystalEngine do
+  harness = CrystalEngineSpecHarness.new(create_test_options)
+
+  describe "#normalize_crystal_interpolation" do
+    it "replaces Crystal style interpolation with curly braces" do
+      harness.test_normalize_crystal_interpolation("/api/\#{VERSION}/items").should eq("/api/{VERSION}/items")
+      harness.test_normalize_crystal_interpolation("/users/\#{id}").should eq("/users/{id}")
+    end
+
+    it "handles no interpolation gracefully" do
+      harness.test_normalize_crystal_interpolation("/api/v1/items").should eq("/api/v1/items")
+    end
+  end
+
+  describe "#crystal_do_block_open_delta" do
+    it "detects do block start" do
+      harness.test_crystal_do_block_open_delta("get \"/\" do").should eq(1)
+      harness.test_crystal_do_block_open_delta("get \"/\" do |req|").should eq(1)
+    end
+
+    it "returns 0 for do block that is closed on the same line" do
+      harness.test_crystal_do_block_open_delta("get \"/\" do; end").should eq(0)
+    end
+
+    it "detects structural keywords like if, def, class, module" do
+      harness.test_crystal_do_block_open_delta("if true").should eq(1)
+      harness.test_crystal_do_block_open_delta("def hello").should eq(1)
+      harness.test_crystal_do_block_open_delta("class User").should eq(1)
+    end
+  end
+
+  describe "#extract_crystal_do_block" do
+    it "extracts multiline do block successfully" do
+      lines = [
+        "get \"/\" do",
+        "  x = 1",
+        "  y = 2",
+        "end",
+      ]
+      res = harness.test_extract_crystal_do_block(lines, 0)
+      res.should_not be_nil
+      if res
+        body, start_line = res
+        body.should eq("  x = 1\n  y = 2")
+        start_line.should eq(2)
+      end
+    end
+
+    it "handles nested blocks correctly" do
+      lines = [
+        "get \"/\" do",
+        "  if x",
+        "    y = 2",
+        "  end",
+        "end",
+      ]
+      res = harness.test_extract_crystal_do_block(lines, 0)
+      res.should_not be_nil
+      if res
+        body, start_line = res
+        body.should eq("  if x\n    y = 2\n  end")
+        start_line.should eq(2)
+      end
+    end
+  end
+
+  describe "#extract_crystal_def_block" do
+    it "extracts multiline def block successfully" do
+      lines = [
+        "def test_func",
+        "  a = \"hello\"",
+        "  b = \"world\"",
+        "end",
+      ]
+      res = harness.test_extract_crystal_def_block(lines, 0)
+      res.should_not be_nil
+      if res
+        body, start_line = res
+        body.should eq("  a = \"hello\"\n  b = \"world\"")
+        start_line.should eq(2)
+      end
+    end
+  end
+end

--- a/spec/unit_test/analyzer/go_engine_spec.cr
+++ b/spec/unit_test/analyzer/go_engine_spec.cr
@@ -1,0 +1,81 @@
+require "../../spec_helper"
+require "../../../src/analyzer/engines/go_engine"
+
+class GoEngineSpecHarness < Analyzer::Go::GoEngine
+  def test_add_param_to_endpoint(param : Param, endpoint : Endpoint)
+    add_param_to_endpoint(param, endpoint)
+  end
+
+  def test_add_static_path_if_valid(static_path : Hash(String, String), public_dirs : Array(Hash(String, String)))
+    add_static_path_if_valid(static_path, public_dirs)
+  end
+end
+
+describe Analyzer::Go::GoEngine do
+  harness = GoEngineSpecHarness.new(create_test_options)
+
+  describe ".go_test_file?" do
+    it "returns true for test files ending with _test.go" do
+      Analyzer::Go::GoEngine.go_test_file?("main_test.go").should be_true
+      Analyzer::Go::GoEngine.go_test_file?("path/to/server_test.go").should be_true
+    end
+
+    it "returns true for path components starting with _" do
+      Analyzer::Go::GoEngine.go_test_file?("path/_examples/main.go").should be_true
+      Analyzer::Go::GoEngine.go_test_file?("_testdata/fixture.go").should be_true
+    end
+
+    it "returns false for standard production files" do
+      Analyzer::Go::GoEngine.go_test_file?("main.go").should be_false
+      Analyzer::Go::GoEngine.go_test_file?("path/to/server.go").should be_false
+    end
+  end
+
+  describe "#add_param_to_endpoint" do
+    it "adds parameter to endpoint when all properties are valid" do
+      endpoint = Endpoint.new("/api/users", "GET")
+      param = Param.new("id", "", "query")
+
+      harness.test_add_param_to_endpoint(param, endpoint)
+
+      endpoint.params.size.should eq(1)
+      endpoint.params[0].name.should eq("id")
+    end
+
+    it "ignores empty parameters" do
+      endpoint = Endpoint.new("/api/users", "GET")
+      param = Param.new("", "", "query")
+
+      harness.test_add_param_to_endpoint(param, endpoint)
+
+      endpoint.params.size.should eq(0)
+    end
+  end
+
+  describe "#add_static_path_if_valid" do
+    it "adds static path mapping if both static_path and file_path are present" do
+      public_dirs = [] of Hash(String, String)
+      mapping = {
+        "static_path" => "/assets",
+        "file_path"   => "public/assets",
+      }
+
+      harness.test_add_static_path_if_valid(mapping, public_dirs)
+
+      public_dirs.size.should eq(1)
+      public_dirs[0]["static_path"].should eq("/assets")
+    end
+
+    it "does not add static path mapping if static_path is empty" do
+      public_dirs = [] of Hash(String, String)
+      mapping = {
+        "static_path" => "",
+        "file_path"   => "public/assets",
+      }
+
+      harness.test_add_static_path_if_valid(mapping, public_dirs)
+
+      public_dirs.size.should eq(0)
+    end
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/fastendpoints_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/fastendpoints_auth_spec.cr
@@ -1,0 +1,39 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "FastEndpointsAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/csharp/fastendpoints"
+  create_user_path = "#{fixture_base}/Endpoints/CreateUserEndpoint.cs"
+  ping_path = "#{fixture_base}/Endpoints/PingEndpoint.cs"
+
+  it "detects Roles protection on actions" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(create_user_path, 8))
+    details.technology = "cs_fastendpoints"
+    endpoint = Endpoint.new("/users", "POST", [] of Param, details)
+
+    tagger = FastEndpointsAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("fastendpoints_auth")
+    endpoint.tags[0].description.should contain("Roles")
+  end
+
+  it "respects AllowAnonymous" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    details = Details.new(PathInfo.new(ping_path, 7))
+    details.technology = "cs_fastendpoints"
+    endpoint = Endpoint.new("/ping", "GET", [] of Param, details)
+
+    tagger = FastEndpointsAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end


### PR DESCRIPTION
This PR introduces unit tests for several previously untested components in `owasp-noir`:

1. **`FastEndpointsAuthTagger`** - Verifies role-based protection detection and `AllowAnonymous` handling.
2. **`CrystalEngine`** - Tests string interpolation normalization and block structure/method body extraction.
3. **`GoEngine`** - Tests test-file routing, parameter handling, and static asset mapping.

All 17 new test cases successfully pass, increasing unit test coverage across frameworks and core engines. Additionally, `spec_helper.cr` has been updated to import `src/utils/utils.cr` directly so that individual framework tagger specs can now be compiled and executed in isolation.