### PR TITLE
feat(tagger): Improve Framework-specific auth taggers (Hono, Ruby, Go, PHP)

### DIFF
--- a/spec/functional_test/fixtures/javascript/hono_auth/app.ts
+++ b/spec/functional_test/fixtures/javascript/hono_auth/app.ts
@@ -1,0 +1,52 @@
+import { Hono } from 'hono'
+import { bearerAuth } from 'hono/bearer-auth'
+import { jwt } from 'hono/jwt'
+import { basicAuth } from 'hono/basic-auth'
+
+const app = new Hono()
+
+// Public route
+app.get('/public', (c) => c.json({ message: 'public' }))
+
+// Using bearerAuth middleware on route
+app.get('/api/secure', bearerAuth({ token: 'secret-token' }), (c) => {
+  return c.json({ data: 'secure' })
+})
+
+// Using jwt middleware via .use() for a prefix
+app.use('/admin/*', jwt({ secret: 'my-secret' }))
+
+app.get('/admin/dashboard', (c) => {
+  const payload = c.var.payload // set by jwt middleware
+  return c.json({ user: payload })
+})
+
+// Basic auth on specific path
+app.use('/basic/*', basicAuth({ username: 'admin', password: 'secret' }))
+
+app.get('/basic/data', (c) => c.json({ ok: true }))
+
+// Custom auth middleware (common pattern)
+const authMiddleware = async (c: any, next: any) => {
+  const auth = c.req.header('Authorization')
+  if (!auth) return c.text('Unauthorized', 401)
+  c.set('user', { id: 1 })
+  await next()
+}
+
+app.use('/protected/*', authMiddleware)
+
+app.get('/protected/profile', (c) => {
+  const user = c.get('user')
+  return c.json({ user })
+})
+
+// Chained inline style (common in Hono)
+app.get('/me', authMiddleware, (c) => {
+  return c.json({ me: true })
+})
+
+// Public health check (no auth nearby)
+app.get('/health', (c) => c.json({ status: 'ok' }))
+
+export default app

--- a/spec/functional_test/fixtures/javascript/hono_auth/package.json
+++ b/spec/functional_test/fixtures/javascript/hono_auth/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hono-auth-fixture",
+  "version": "0.1.0",
+  "dependencies": {
+    "hono": "^4.0.0"
+  }
+}

--- a/spec/functional_test/fixtures/ruby/grape/app.rb
+++ b/spec/functional_test/fixtures/ruby/grape/app.rb
@@ -53,4 +53,37 @@ class API < Grape::API
     get do
     end
   end
+
+  # Auth examples for grape_auth tagger testing
+  before { authenticate! }
+
+  resource :admin do
+    before { require_admin! }
+    get "dashboard" do
+      {ok: true}
+    end
+  end
+
+  http_basic do |username, password|
+    # basic auth example
+  end
+
+  get "secret" do
+    error!('Unauthorized', 401) unless current_user
+    {secret: true}
+  end
+
+  helpers do
+    def authenticate!
+      # ...
+    end
+
+    def require_admin!
+      # ...
+    end
+
+    def current_user
+      # ...
+    end
+  end
 end

--- a/spec/functional_test/fixtures/ruby/roda/app.rb
+++ b/spec/functional_test/fixtures/ruby/roda/app.rb
@@ -51,5 +51,21 @@ class App < Roda
         end
       end
     end
+
+    # Rodauth auth examples for ruby_auth tagger testing
+    r.rodauth
+
+    r.get "dashboard" do
+      rodauth.require_authentication
+      "dashboard"
+    end
+
+    r.get "profile" do
+      if rodauth.logged_in?
+        "profile"
+      else
+        r.halt 401
+      end
+    end
   end
 end

--- a/spec/functional_test/testers/ruby/grape_spec.cr
+++ b/spec/functional_test/testers/ruby/grape_spec.cr
@@ -25,5 +25,5 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/ruby/grape/", {
   :techs     => 1,
-  :endpoints => 9,
+  :endpoints => 11,
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/ruby/roda_spec.cr
+++ b/spec/functional_test/testers/ruby/roda_spec.cr
@@ -30,6 +30,8 @@ expected_endpoints = [
     Param.new("org_id", "", "path"),
     Param.new("project_id", "", "path"),
   ]),
+  Endpoint.new("/dashboard", "GET"),
+  Endpoint.new("/profile", "GET"),
 ]
 
 FunctionalTester.new("fixtures/ruby/roda/", {

--- a/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
@@ -119,3 +119,32 @@ describe "GoAuthTagger" do
     endpoint.tags.empty?.should be_true
   end
 end
+
+# Verify new Go framework targets (Hertz, Iris, GF) are supported by the same tagger
+describe "GoAuthTagger (expanded targets)" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/go/gin_auth"
+  main_path = "#{fixture_base}/main.go"
+
+  %w[go_hertz go_iris go_gf].each do |tech|
+    it "accepts and runs with technology=#{tech}" do
+      noir_options = create_test_options
+      noir_options["base"] = YAML::Any.new(fixture_base)
+
+      locator = CodeLocator.instance
+      Dir.glob("#{fixture_base}/**/*").each do |file|
+        next if File.directory?(file)
+        locator.push("file_map", file)
+      end
+
+      details = Details.new(PathInfo.new(main_path, 29))
+      details.technology = tech
+      endpoint = Endpoint.new("/dashboard", "GET", [] of Param, details)
+
+      tagger = GoAuthTagger.new(noir_options)
+      tagger.perform([endpoint])
+
+      endpoint.tags.empty?.should be_false
+      endpoint.tags[0].tagger.should eq("go_auth")
+    end
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/hono_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/hono_auth_spec.cr
@@ -1,0 +1,108 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+describe "HonoAuthTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/javascript/hono_auth"
+  app_path = "#{fixture_base}/app.ts"
+
+  # app.ts line reference (see actual fixture):
+  #  12: app.get('/api/secure', bearerAuth(...), ...)
+  #  17: app.use('/admin/*', jwt(...))
+  #  19: app.get('/admin/dashboard'...
+  #  25: app.use('/basic/*', basicAuth(...))
+  #  37: app.use('/protected/*', authMiddleware)
+  #  39: app.get('/protected/profile'...
+  #  45: app.get('/me', authMiddleware, ...)
+  #  50: app.get('/health'...
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "detects bearerAuth middleware on route" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 12))
+    details.technology = "js_hono"
+    endpoint = Endpoint.new("/api/secure", "GET", [] of Param, details)
+
+    tagger = HonoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("hono_auth")
+    endpoint.tags[0].description.should contain("bearerAuth")
+  end
+
+  it "detects jwt middleware via app.use prefix scope" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 19))
+    details.technology = "js_hono"
+    endpoint = Endpoint.new("/admin/dashboard", "GET", [] of Param, details)
+
+    tagger = HonoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("jwt")
+  end
+
+  it "detects custom authMiddleware chained on route" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 45))
+    details.technology = "js_hono"
+    endpoint = Endpoint.new("/me", "GET", [] of Param, details)
+
+    tagger = HonoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].description.should contain("authMiddleware")
+  end
+
+  it "does not tag public health endpoint" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(fixture_base)
+
+    locator = CodeLocator.instance
+    Dir.glob("#{fixture_base}/**/*").each do |file|
+      next if File.directory?(file)
+      locator.push("file_map", file)
+    end
+
+    details = Details.new(PathInfo.new(app_path, 50))
+    details.technology = "js_hono"
+    endpoint = Endpoint.new("/health", "GET", [] of Param, details)
+
+    tagger = HonoAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/php_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/php_auth_spec.cr
@@ -58,3 +58,44 @@ describe "PhpAuthTagger" do
     endpoint.tags.empty?.should be_true
   end
 end
+
+# Light coverage for newly added PHP targets (Slim, Yii, CodeIgniter)
+describe "PhpAuthTagger (expanded targets)" do
+  slim_base = "#{__DIR__}/../../../functional_test/fixtures/php/slim"
+  slim_path = "#{slim_base}/index.php"
+
+  it "runs without error on php_slim technology" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(slim_base)
+
+    # Line 28 in slim fixture has X-Auth-Token header access (manual auth pattern)
+    details = Details.new(PathInfo.new(slim_path, 28))
+    details.technology = "php_slim"
+    endpoint = Endpoint.new("/users/{id}", "GET", [] of Param, details)
+
+    tagger = PhpAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    # We don't assert a tag (fixture has manual header read, not strong declarative auth),
+    # but the tagger must not crash and must accept the tech.
+    true.should be_true
+  end
+
+  it "runs without error on php_yii and php_codeigniter technologies" do
+    noir_options = create_test_options
+    # Reuse slim dir as base (no real Yii/CI files needed for smoke test)
+    noir_options["base"] = YAML::Any.new(slim_base)
+
+    ["php_yii", "php_codeigniter"].each do |tech|
+      details = Details.new(PathInfo.new(slim_path, 10))
+      details.technology = tech
+      endpoint = Endpoint.new("/test", "GET", [] of Param, details)
+
+      tagger = PhpAuthTagger.new(noir_options)
+      # Should not raise
+      tagger.perform([endpoint])
+    end
+
+    true.should be_true
+  end
+end

--- a/spec/unit_test/tagger/framework_taggers/ruby_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ruby_auth_spec.cr
@@ -60,3 +60,45 @@ describe "RubyAuthTagger" do
     endpoint.tags.empty?.should be_true
   end
 end
+
+# Additional tests for Grape + Roda support (B target)
+describe "RubyAuthTagger (Grape/Roda)" do
+  grape_base = "#{__DIR__}/../../../functional_test/fixtures/ruby/grape"
+  grape_path = "#{grape_base}/app.rb"
+
+  roda_base = "#{__DIR__}/../../../functional_test/fixtures/ruby/roda"
+  roda_path = "#{roda_base}/app.rb"
+
+  it "detects Grape before { authenticate! } and helpers" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(grape_base)
+
+    details = Details.new(PathInfo.new(grape_path, 62)) # admin/dashboard get with before
+    details.technology = "ruby_grape"
+    endpoint = Endpoint.new("/admin/dashboard", "GET", [] of Param, details)
+
+    tagger = RubyAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("ruby_auth")
+  end
+
+  it "detects Roda rodauth.require_authentication and logged_in?" do
+    noir_options = create_test_options
+    noir_options["base"] = YAML::Any.new(roda_base)
+
+    details = Details.new(PathInfo.new(roda_path, 58)) # dashboard route with rodauth.require_authentication
+    details.technology = "ruby_roda"
+    endpoint = Endpoint.new("/dashboard", "GET", [] of Param, details)
+
+    tagger = RubyAuthTagger.new(noir_options)
+    tagger.perform([endpoint])
+
+    endpoint.tags.empty?.should be_false
+    endpoint.tags[0].name.should eq("auth")
+    endpoint.tags[0].tagger.should eq("ruby_auth")
+    endpoint.tags[0].description.should match(/Rodauth|rodauth/i)
+  end
+end

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -36,6 +36,10 @@ class GoAuthTagger < FrameworkTagger
     /\b[Aa]dmin[Oo]nly\b/,
     /\b[Rr]ole[Cc]heck\b/,
     /\b[Pp]ermission[Cc]heck\b/,
+    # Hertz / Iris / GF specific
+    /\bHertzAuth\b/,
+    /\bIrisAuth\b/,
+    /\bGF[Aa]uth\b/,
   ]
 
   def initialize(options : Hash(String, YAML::Any))
@@ -49,6 +53,7 @@ class GoAuthTagger < FrameworkTagger
       "go_echo", "go_gin", "go_chi", "go_fiber",
       "go_beego", "go_mux", "go_fasthttp",
       "go_gozero", "go_goyave",
+      "go_hertz", "go_iris", "go_gf",
     ]
   end
 

--- a/src/tagger/framework_taggers/javascript/hono_auth.cr
+++ b/src/tagger/framework_taggers/javascript/hono_auth.cr
@@ -1,0 +1,180 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+class HonoAuthTagger < FrameworkTagger
+  # Hono official auth middleware
+  HONO_AUTH_MIDDLEWARE = [
+    {/\bbearerAuth\s*\(/, "Hono bearerAuth middleware"},
+    {/\bjwt\s*\(/, "Hono jwt middleware"},
+    {/\bbasicAuth\s*\(/, "Hono basicAuth middleware"},
+  ]
+
+  # Custom or third-party auth middleware names commonly used with Hono
+  CUSTOM_AUTH_NAMES = [
+    /\bauthMiddleware\b/i,
+    /\bauthGuard\b/i,
+    /\brequireAuth\b/i,
+    /\bverifyToken\b/i,
+    /\bcheckAuth\b/i,
+    /\bensureAuth\b/i,
+    /\bwithAuth\b/i,
+  ]
+
+  # Context user extraction after auth (secondary signal)
+  CONTEXT_USER_PATTERNS = [
+    /c\.var\.(user|payload|auth|session)/,
+    /c\.get\s*\(\s*['"](user|payload|auth|session)/,
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "hono_auth"
+    @use_auth_scopes = [] of {prefix: String, description: String}
+  end
+
+  def self.target_techs : Array(String)
+    ["js_hono"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    pre_scan_use_auth
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def pre_scan_use_auth
+    @use_auth_scopes.clear
+
+    extensions = [".ts", ".js", ".tsx", ".jsx", ".mjs", ".cjs"]
+    extensions.each do |ext|
+      files = get_files_by_prefix_and_extension(@base_path, ext)
+      files.each do |file|
+        content = read_file(file)
+        next if content.nil?
+
+        lines = content.split("\n")
+        lines.each do |line|
+          stripped = line.strip
+
+          # Match app.use('/prefix', authMiddleware) or app.use(auth)
+          if stripped =~ /(?:app|router|hono)\.use\s*\(\s*['"]([^'"]+)['"]\s*,/
+            prefix = $1
+            if has_auth_middleware_in_line?(stripped)
+              @use_auth_scopes << {prefix: prefix, description: "Protected by Hono app.use() auth on #{prefix}"}
+            end
+          end
+
+          # app.use('/prefix/*', ...)
+          if stripped =~ /(?:app|router|hono)\.use\s*\(\s*['"]([^'"]+\*)['"]\s*,/
+            prefix = $1.gsub("*", "")
+            if has_auth_middleware_in_line?(stripped)
+              @use_auth_scopes << {prefix: prefix, description: "Protected by Hono app.use() auth on #{prefix}"}
+            end
+          end
+
+          # Global app.use(auth)
+          if stripped =~ /(?:app|router|hono)\.use\s*\(\s*(?!['"])/
+            if has_auth_middleware_in_line?(stripped)
+              @use_auth_scopes << {prefix: "/", description: "Protected by Hono global auth middleware"}
+            end
+          end
+        end
+      end
+    end
+  end
+
+  private def has_auth_middleware_in_line?(line : String) : Bool
+    HONO_AUTH_MIDDLEWARE.each do |pattern, _|
+      return true if line.matches?(pattern)
+    end
+    CUSTOM_AUTH_NAMES.each do |pattern|
+      return true if line.matches?(pattern)
+    end
+    false
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      line_idx = line_num - 1
+
+      # Check route definition + small surrounding window for chained middleware
+      description = check_route_and_nearby(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "hono_auth"))
+        return
+      end
+
+      # Check for context user extraction in handler body (secondary)
+      description = check_context_user(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by Hono auth (#{description})", "hono_auth"))
+        return
+      end
+    end
+
+    # Check prefix-based use() scopes
+    description = check_use_scopes(endpoint)
+    if description
+      endpoint.add_tag(Tag.new("auth", description, "hono_auth"))
+    end
+  end
+
+  private def check_route_and_nearby(lines : Array(String), line_idx : Int32) : String?
+    # Look at the route line and up to 2 lines above (for chained or options object)
+    start_idx = [line_idx - 2, 0].max
+    (start_idx..line_idx).each do |i|
+      current = lines[i]
+
+      HONO_AUTH_MIDDLEWARE.each do |pattern, desc|
+        if current.matches?(pattern)
+          return desc
+        end
+      end
+
+      CUSTOM_AUTH_NAMES.each do |pattern|
+        if current.matches?(pattern)
+          # Try to extract a nice name
+          if m = current.match(/\b([a-zA-Z_]*[Aa]uth[a-zA-Z_]*)\b/)
+            return "Hono #{m[1]} middleware"
+          end
+          return "custom Hono auth middleware"
+        end
+      end
+    end
+    nil
+  end
+
+  private def check_context_user(lines : Array(String), line_idx : Int32) : String?
+    end_idx = [line_idx + 8, lines.size - 1].min
+    (line_idx..end_idx).each do |i|
+      current = lines[i]
+      CONTEXT_USER_PATTERNS.each do |pattern|
+        if current.matches?(pattern)
+          return "context user extraction"
+        end
+      end
+    end
+    nil
+  end
+
+  private def check_use_scopes(endpoint : Endpoint) : String?
+    url = endpoint.url
+    @use_auth_scopes.each do |scope|
+      prefix = scope[:prefix]
+      # Normalize Hono /* prefixes and do proper prefix matching
+      normalized = prefix.gsub(/\/\*$/, "/")
+      if url.starts_with?(normalized) || url.starts_with?(prefix)
+        return scope[:description]
+      end
+    end
+    nil
+  end
+end

--- a/src/tagger/framework_taggers/php/php_auth.cr
+++ b/src/tagger/framework_taggers/php/php_auth.cr
@@ -52,13 +52,33 @@ class PhpAuthTagger < FrameworkTagger
     {/\$_SERVER\[['"]PHP_AUTH_USER['"]/, "PHP HTTP Basic Auth"},
   ]
 
+  # Slim / Yii / CodeIgniter additional patterns
+  SLIM_YII_CI_PATTERNS = [
+    # Slim
+    {/\->add\s*\(\s*['"]?auth/i, "Slim auth middleware"},
+    {/\bAuthorization\b.*header/i, "Slim Authorization header check"},
+    # Yii
+    {/\bAccessControl\b/, "Yii AccessControl filter"},
+    {/\bAuthMethod\b/, "Yii AuthMethod"},
+    {/\bHttpBearerAuth\b/, "Yii HttpBearerAuth"},
+    {/\bCompositeAuth\b/, "Yii CompositeAuth"},
+    {/\bbeforeAction\b.*auth/i, "Yii beforeAction auth"},
+    # CodeIgniter (4+ filters, controller before)
+    {/->before\s*\(\s*['"]?auth/i, "CodeIgniter before auth filter"},
+    {/\$this->beforeFilter/i, "CodeIgniter beforeFilter"},
+    {/\bauthFilter\b/i, "CodeIgniter authFilter"},
+  ]
+
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "php_auth"
   end
 
   def self.target_techs : Array(String)
-    ["php_laravel", "php_symfony", "php_cakephp", "php_pure"]
+    [
+      "php_laravel", "php_symfony", "php_cakephp", "php_pure",
+      "php_slim", "php_yii", "php_codeigniter",
+    ]
   end
 
   def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
@@ -78,8 +98,9 @@ class PhpAuthTagger < FrameworkTagger
       next if line_num.nil?
       line_idx = line_num - 1
 
-      # Check route-level middleware (Laravel)
-      description = check_patterns_near_line(lines, line_idx, LARAVEL_ROUTE_MIDDLEWARE, 3)
+      # Check route-level middleware (Laravel + Slim groups etc.)
+      route_patterns = LARAVEL_ROUTE_MIDDLEWARE + SLIM_YII_CI_PATTERNS
+      description = check_patterns_near_line(lines, line_idx, route_patterns, 3)
       if description
         endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "php_auth"))
         return
@@ -170,7 +191,7 @@ class PhpAuthTagger < FrameworkTagger
       brace_count += current.count('{') - current.count('}')
       break if brace_count < 0
 
-      all_patterns = LARAVEL_AUTH_CHECKS + CAKEPHP_PATTERNS + GENERIC_PATTERNS
+      all_patterns = LARAVEL_AUTH_CHECKS + CAKEPHP_PATTERNS + GENERIC_PATTERNS + SLIM_YII_CI_PATTERNS
       all_patterns.each do |pattern, desc|
         return desc if stripped.matches?(pattern)
       end

--- a/src/tagger/framework_taggers/ruby/ruby_auth.cr
+++ b/src/tagger/framework_taggers/ruby/ruby_auth.cr
@@ -38,6 +38,27 @@ class RubyAuthTagger < FrameworkTagger
     {/before\s+:authorize/, "Hanami authorize"},
   ]
 
+  # Grape patterns (before blocks, http_basic, helpers)
+  GRAPE_AUTH_PATTERNS = [
+    {/before\s+do.*authenticate/, "Grape before authenticate"},
+    {/before\s*\{\s*authenticate!/, "Grape authenticate!"},
+    {/before\s*\{\s*require_auth/, "Grape require_auth"},
+    {/http_basic\s+do/, "Grape http_basic auth"},
+    {/helpers\s+do.*authenticate/, "Grape helpers authenticate"},
+    {/\.error!\s*\(\s*['"]Unauthorized/, "Grape error! unauthorized"},
+  ]
+
+  # Roda / Rodauth patterns
+  RODA_AUTH_PATTERNS = [
+    {/rodauth\.require_authentication/, "Rodauth require_authentication"},
+    {/rodauth\.require_auth/, "Rodauth require_auth"},
+    {/rodauth\.logged_in\?/, "Rodauth logged_in?"},
+    {/rodauth\.authenticated\?/, "Rodauth authenticated?"},
+    {/r\.rodauth/, "Roda rodauth plugin"},
+    {/r\.halt\s+401/, "Roda 401 halt"},
+    {/authorize!/, "Roda authorize!"},
+  ]
+
   # skip_before_action marks public overrides
   SKIP_PATTERNS = [
     /skip_before_action\s+:authenticate/,
@@ -50,7 +71,7 @@ class RubyAuthTagger < FrameworkTagger
   end
 
   def self.target_techs : Array(String)
-    ["ruby_rails", "ruby_sinatra", "ruby_hanami"]
+    ["ruby_rails", "ruby_sinatra", "ruby_hanami", "ruby_grape", "ruby_roda"]
   end
 
   def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
@@ -86,6 +107,20 @@ class RubyAuthTagger < FrameworkTagger
 
       # Check Sinatra/Rack patterns in context
       description = check_sinatra_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ruby_auth"))
+        return
+      end
+
+      # Check Grape patterns (before blocks, http_basic, etc.)
+      description = check_grape_auth(lines, line_idx)
+      if description
+        endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ruby_auth"))
+        return
+      end
+
+      # Check Roda/Rodauth patterns
+      description = check_roda_auth(lines, line_idx)
       if description
         endpoint.add_tag(Tag.new("auth", "Protected by #{description}", "ruby_auth"))
         return
@@ -193,5 +228,40 @@ class RubyAuthTagger < FrameworkTagger
     line = lines[line_idx].strip
     match = line.match(/def\s+(\w+)/)
     match ? match[1] : nil
+  end
+
+  private def check_grape_auth(lines : Array(String), route_line : Int32) : String?
+    # Grape uses before { } blocks, often near the top of the class or inside resource/namespace
+    start_idx = [route_line - 20, 0].max
+
+    (start_idx...route_line).each do |idx|
+      current = lines[idx].strip
+
+      GRAPE_AUTH_PATTERNS.each do |pattern, desc|
+        if current.matches?(pattern)
+          return desc
+        end
+      end
+    end
+
+    nil
+  end
+
+  private def check_roda_auth(lines : Array(String), route_line : Int32) : String?
+    # Roda uses route blocks; rodauth calls are usually inside the handler or just above
+    start_idx = [route_line - 12, 0].max
+    end_idx = [route_line + 8, lines.size - 1].min
+
+    (start_idx..end_idx).each do |idx|
+      current = lines[idx].strip
+
+      RODA_AUTH_PATTERNS.each do |pattern, desc|
+        if current.matches?(pattern)
+          return desc
+        end
+      end
+    end
+
+    nil
   end
 end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -154,6 +154,11 @@ module NoirTaggers
       desc:   "Identifies Crystal framework authentication patterns (Kemal, Amber, Lucky)",
       runner: CrystalAuthTagger,
     },
+    hono_auth: {
+      name:   "Hono Auth Tagger",
+      desc:   "Identifies Hono authentication patterns (bearerAuth, jwt, basicAuth, custom middleware)",
+      runner: HonoAuthTagger,
+    },
   }
 
   def self.taggers


### PR DESCRIPTION
## Summary

This PR delivers the four high-priority improvements to Framework-specific auth taggers:

- **A. Hono** — New dedicated `HonoAuthTagger` (bearerAuth, jwt, basicAuth, scoped `app.use`, custom middleware, `c.var`/`c.get` context extraction).
- **B. Ruby** — Extended `RubyAuthTagger` to cover `ruby_grape` and `ruby_roda` (before blocks, `http_basic`, rodauth, `error!` guards, etc.).
- **C. Go** — Added `go_hertz`, `go_iris`, and `go_gf` as supported targets for `GoAuthTagger`.
- **D. PHP** — Added `php_slim`, `php_yii`, and `php_codeigniter` as supported targets for `PhpAuthTagger`.

(E: `js_misc_auth` deepening work was tracked separately as an issue.)

## Changes

- New dedicated Hono tagger + fixture + unit tests
- Pattern/target expansions in Ruby/Go/PHP auth taggers
- Fixture updates and test additions (including endpoint count fixes for grape/roda)
- All changes pass `just build`, full `just test`, and `just check`

## Code Review Notes

- Follows existing `FrameworkTagger` patterns (pre-scan for scope middleware + per-endpoint checks) used by `express_auth`, `go_auth`, `spring_auth`, etc.
- PHP coverage for the new frameworks is intentionally lighter because many real codebases in those ecosystems rely on manual header/session checks rather than declarative middleware. The new targets at least prevent silent no-op behavior.
- Hono received a full dedicated tagger (highest impact) due to rapid adoption in edge/Bun/Deno/Cloudflare environments.
- No major refactors — changes are additive and low-risk.

## Testing

- `just build` ✅
- `just test` ✅ (unit + 14,655+ functional examples, 0 failures)
- `just check` ✅ (format + ameba lint, 0 failures)

## Related

- Separate enhancement for `js_misc_auth` (Fastify/Koa/Restify depth + consideration for Hono/Elysia dedicated taggers) will be filed as a follow-up issue.
