### PR TITLE
Improve PHP framework route extraction

### DIFF
--- a/spec/functional_test/fixtures/php/laravel/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel/routes/web.php
@@ -20,6 +20,8 @@ Route::get('/', function () {
 });
 
 Route::get('/dashboard', [UserController::class, 'dashboard'])->name('dashboard');
+Route::view('/terms', 'terms');
+Route::redirect('/legacy-dashboard', '/dashboard');
 
 Route::get('/users', [UserController::class, 'index']);
 Route::post('/users', [UserController::class, 'store']);
@@ -27,7 +29,14 @@ Route::get('/users/{id}', [UserController::class, 'show']);
 Route::put('/users/{id}', [UserController::class, 'update']);
 Route::delete('/users/{id}', [UserController::class, 'destroy']);
 
+// Route::resource('phantoms', ProductController::class)
 Route::resource('products', ProductController::class);
+Route::resource('photos', ProductController::class)
+    ->only(['index', 'show'])
+    ->parameters(['photos' => 'photo']);
+Route::apiResource('admin/widgets', ProductController::class)
+    ->except(['destroy'])
+    ->parameters(['widgets' => 'widget']);
 
 Route::group(['prefix' => 'admin'], function () {
     Route::get('/settings', function () {

--- a/spec/functional_test/fixtures/php/symfony/config/routes.yaml
+++ b/spec/functional_test/fixtures/php/symfony/config/routes.yaml
@@ -21,3 +21,7 @@ api_search:
 webhooks_receive:
     path: /webhooks/{provider}
     methods: [POST]
+
+api.status-check:
+    path: /api/status-check
+    methods: GET

--- a/spec/functional_test/testers/php/laravel_spec.cr
+++ b/spec/functional_test/testers/php/laravel_spec.cr
@@ -6,6 +6,8 @@ expected_endpoints = [
   # Core Laravel routes that are definitely working
   Endpoint.new("/", "GET"),
   Endpoint.new("/dashboard", "GET"),
+  Endpoint.new("/terms", "GET"),
+  Endpoint.new("/legacy-dashboard", "GET"),
   Endpoint.new("/users", "GET"),
   Endpoint.new("/users", "POST"),
   Endpoint.new("/health", "GET"),
@@ -18,6 +20,11 @@ expected_endpoints = [
   Endpoint.new("/webhook", "POST"),
   Endpoint.new("/products", "GET"),
   Endpoint.new("/products", "POST"),
+  Endpoint.new("/photos", "GET"),
+  Endpoint.new("/photos/{photo}", "GET", [Param.new("photo", "", "path")]),
+  Endpoint.new("/admin/widgets", "GET"),
+  Endpoint.new("/admin/widgets/{widget}", "GET", [Param.new("widget", "", "path")]),
+  Endpoint.new("/admin/widgets/{widget}", "PATCH", [Param.new("widget", "", "path")]),
   Endpoint.new("/user", "GET"),
   Endpoint.new("/admin/settings", "GET"),
   Endpoint.new("/admin/settings", "POST"),
@@ -32,5 +39,5 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/laravel/", {
   :techs     => 2,  # Detection still sees both php_laravel and php_pure
-  :endpoints => 53, # Analysis suppresses redundant php_pure and unprefixed group endpoints
+  :endpoints => 62, # Analysis suppresses redundant php_pure and unprefixed group endpoints
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/php/symfony_callees_spec.cr
+++ b/spec/functional_test/testers/php/symfony_callees_spec.cr
@@ -83,7 +83,7 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,
-  :endpoints => 20,
+  :endpoints => 21,
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/php/symfony_spec.cr
+++ b/spec/functional_test/testers/php/symfony_spec.cr
@@ -65,9 +65,10 @@ expected_endpoints = [
   Endpoint.new("/webhooks/{provider}", "POST", [
     Param.new("provider", "", "path"),
   ]),
+  Endpoint.new("/api/status-check", "GET"),
 ]
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,  # Detection still sees php_symfony and php_pure
-  :endpoints => 20, # Analysis suppresses redundant php_pure file endpoints
+  :endpoints => 21, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -9,6 +9,13 @@ module Analyzer::Php
       end
     end
 
+    private struct ResourceRouteCall
+      getter resource, statement, start_pos
+
+      def initialize(@resource : String, @statement : String, @start_pos : Int32)
+      end
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
@@ -196,27 +203,66 @@ module Analyzer::Php
         end
       end
 
-      # 2. Resource routes
-      resource_matches = content.scan(/Route::resource\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi)
-      resource_matches.each do |match|
-        next if inside_laravel_group_body?(match.begin(0), route_groups) ||
-                inside_php_skip_range?(match.begin(0), skip_ranges)
-
-        resource_name = match[1]
-        full_resource_path = build_full_path(prefix, resource_name)
-        route_line = base_line + newline_count_before(content, match.begin(0))
-        endpoints.concat(create_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line))
+      static_route_regex = /Route::(view|redirect|permanentRedirect)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
+      pos = 0
+      while route_match = content.match(static_route_regex, pos)
+        if inside_laravel_group_body?(route_match.begin(0), route_groups) ||
+           inside_php_skip_range?(route_match.begin(0), skip_ranges)
+          pos = route_match.end(0)
+        else
+          route_path = route_match[2]
+          full_path = build_full_path(prefix, route_path)
+          route_line = base_line + newline_count_before(content, route_match.begin(0))
+          params = extract_brace_path_params(full_path)
+          details = Details.new(PathInfo.new(file_path, route_line))
+          endpoints << Endpoint.new(full_path, "GET", params, details.dup)
+          pos = route_match.end(0)
+        end
       end
 
-      api_resource_matches = content.scan(/Route::apiResource\s*\(\s*['"]([^'"]+)['"][^)]*\)/mi)
-      api_resource_matches.each do |match|
-        next if inside_laravel_group_body?(match.begin(0), route_groups) ||
-                inside_php_skip_range?(match.begin(0), skip_ranges)
+      chained_static_route_regex = /Route::((?:\w+\s*\([^;]*?\)\s*->\s*)+)(view|redirect|permanentRedirect)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
+      pos = 0
+      while route_match = content.match(chained_static_route_regex, pos)
+        if inside_laravel_group_body?(route_match.begin(0), route_groups) ||
+           inside_php_skip_range?(route_match.begin(0), skip_ranges)
+          pos = route_match.end(0)
+        else
+          route_prefix = extract_group_prefix("Route::#{route_match[1]}")
+          route_path = route_match[3]
+          full_path = build_full_path(build_full_path(prefix, route_prefix), route_path)
+          route_line = base_line + newline_count_before(content, route_match.begin(0))
+          params = extract_brace_path_params(full_path)
+          details = Details.new(PathInfo.new(file_path, route_line))
+          endpoints << Endpoint.new(full_path, "GET", params, details.dup)
+          pos = route_match.end(0)
+        end
+      end
 
-        resource_name = match[1]
+      # 2. Resource routes
+      resource_calls = extract_resource_route_calls(content, "resource", skip_ranges)
+      resource_calls.each do |call|
+        next if inside_laravel_group_body?(call.start_pos, route_groups) ||
+                inside_php_skip_range?(call.start_pos, skip_ranges)
+
+        resource_name = call.resource
         full_resource_path = build_full_path(prefix, resource_name)
-        route_line = base_line + newline_count_before(content, match.begin(0))
-        endpoints.concat(create_api_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line))
+        route_line = base_line + newline_count_before(content, call.start_pos)
+        actions = resource_actions_for_statement(call.statement, api: false)
+        param_name = resource_param_name_for_statement(resource_name, call.statement)
+        endpoints.concat(create_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line, actions, param_name))
+      end
+
+      api_resource_calls = extract_resource_route_calls(content, "apiResource", skip_ranges)
+      api_resource_calls.each do |call|
+        next if inside_laravel_group_body?(call.start_pos, route_groups) ||
+                inside_php_skip_range?(call.start_pos, skip_ranges)
+
+        resource_name = call.resource
+        full_resource_path = build_full_path(prefix, resource_name)
+        route_line = base_line + newline_count_before(content, call.start_pos)
+        actions = resource_actions_for_statement(call.statement, api: true)
+        param_name = resource_param_name_for_statement(resource_name, call.statement)
+        endpoints.concat(create_api_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line, actions, param_name))
       end
 
       # 3. Group routes (recursive). Extract group bodies before scanning nested
@@ -471,24 +517,21 @@ module Analyzer::Php
       groups.any? { |group| pos >= group.body_start && pos < group.body_end }
     end
 
-    private def create_resource_endpoints(resource : String, file_path : String, line : Int32? = nil) : Array(Endpoint)
+    private def create_resource_endpoints(resource : String,
+                                          file_path : String,
+                                          line : Int32? = nil,
+                                          actions : Array(String) = RESOURCE_ACTIONS,
+                                          param_name : String = resource_param_name) : Array(Endpoint)
       endpoints = [] of Endpoint
       details = Details.new(PathInfo.new(file_path, line))
 
       # Standard Laravel resource routes
-      resource_routes = [
-        {"/#{resource}", "GET"},           # index
-        {"/#{resource}/create", "GET"},    # create
-        {"/#{resource}", "POST"},          # store
-        {"/#{resource}/{id}", "GET"},      # show
-        {"/#{resource}/{id}/edit", "GET"}, # edit
-        {"/#{resource}/{id}", "PUT"},      # update
-        {"/#{resource}/{id}", "PATCH"},    # update
-        {"/#{resource}/{id}", "DELETE"},   # destroy
-      ]
+      resource_routes = resource_route_templates(resource, param_name, api: false)
 
       resource_routes.each do |route_info|
-        path, method = route_info
+        action, path, method = route_info
+        next unless actions.includes?(action)
+
         params = extract_brace_path_params(path)
         endpoints << Endpoint.new(path, method, params, details)
       end
@@ -496,27 +539,173 @@ module Analyzer::Php
       endpoints
     end
 
-    private def create_api_resource_endpoints(resource : String, file_path : String, line : Int32? = nil) : Array(Endpoint)
+    private def create_api_resource_endpoints(resource : String,
+                                              file_path : String,
+                                              line : Int32? = nil,
+                                              actions : Array(String) = API_RESOURCE_ACTIONS,
+                                              param_name : String = resource_param_name) : Array(Endpoint)
       endpoints = [] of Endpoint
       details = Details.new(PathInfo.new(file_path, line))
 
       # API resource routes (excludes create and edit forms)
-      api_resource_routes = [
-        {"/#{resource}", "GET"},         # index
-        {"/#{resource}", "POST"},        # store
-        {"/#{resource}/{id}", "GET"},    # show
-        {"/#{resource}/{id}", "PUT"},    # update
-        {"/#{resource}/{id}", "PATCH"},  # update
-        {"/#{resource}/{id}", "DELETE"}, # destroy
-      ]
+      api_resource_routes = resource_route_templates(resource, param_name, api: true)
 
       api_resource_routes.each do |route_info|
-        path, method = route_info
+        action, path, method = route_info
+        next unless actions.includes?(action)
+
         params = extract_brace_path_params(path)
         endpoints << Endpoint.new(path, method, params, details)
       end
 
       endpoints
+    end
+
+    RESOURCE_ACTIONS     = ["index", "create", "store", "show", "edit", "update", "destroy"]
+    API_RESOURCE_ACTIONS = ["index", "store", "show", "update", "destroy"]
+
+    private def resource_route_templates(resource : String, param_name : String, api : Bool) : Array(Tuple(String, String, String))
+      templates = [
+        {"index", "/#{resource}", "GET"},
+        {"store", "/#{resource}", "POST"},
+        {"show", "/#{resource}/{#{param_name}}", "GET"},
+        {"update", "/#{resource}/{#{param_name}}", "PUT"},
+        {"update", "/#{resource}/{#{param_name}}", "PATCH"},
+        {"destroy", "/#{resource}/{#{param_name}}", "DELETE"},
+      ]
+
+      unless api
+        templates.insert(1, {"create", "/#{resource}/create", "GET"})
+        templates.insert(4, {"edit", "/#{resource}/{#{param_name}}/edit", "GET"})
+      end
+
+      templates
+    end
+
+    private def extract_resource_route_calls(content : String,
+                                             method_name : String,
+                                             skip_ranges : Array(Range(Int32, Int32))) : Array(ResourceRouteCall)
+      calls = [] of ResourceRouteCall
+      regex = Regex.new("Route::#{method_name}\\s*\\(\\s*['\"]([^'\"]+)['\"]", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE)
+      pos = 0
+
+      while route_match = content.match(regex, pos)
+        if inside_php_skip_range?(route_match.begin(0), skip_ranges)
+          pos = route_match.end(0)
+        else
+          statement_end = find_php_statement_end(content, route_match.begin(0))
+          statement = content[route_match.begin(0)...statement_end]
+          calls << ResourceRouteCall.new(route_match[1], statement, route_match.begin(0))
+          pos = statement_end > route_match.end(0) ? statement_end : route_match.end(0)
+        end
+      end
+
+      calls
+    end
+
+    private def find_php_statement_end(content : String, start_pos : Int32) : Int32
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      in_string = false
+      in_line_comment = false
+      in_block_comment = false
+      escaped = false
+      quote = '\0'
+      pos = start_pos
+
+      while pos < content.size
+        char = content[pos]
+        next_char = content[pos + 1]?
+
+        if in_line_comment
+          in_line_comment = false if char == '\n'
+        elsif in_block_comment
+          if char == '*' && next_char == '/'
+            in_block_comment = false
+            pos += 1
+          end
+        elsif in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '/' && next_char == '/'
+          in_line_comment = true
+          pos += 1
+        elsif char == '/' && next_char == '*'
+          in_block_comment = true
+          pos += 1
+        elsif char == '#'
+          in_line_comment = true
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '('
+          paren_depth += 1
+        elsif char == ')'
+          paren_depth -= 1 if paren_depth > 0
+        elsif char == '['
+          bracket_depth += 1
+        elsif char == ']'
+          bracket_depth -= 1 if bracket_depth > 0
+        elsif char == '{'
+          brace_depth += 1
+        elsif char == '}'
+          brace_depth -= 1 if brace_depth > 0
+        elsif char == ';' && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+          return pos + 1
+        end
+
+        pos += 1
+      end
+
+      content.size
+    end
+
+    private def resource_actions_for_statement(statement : String, api : Bool) : Array(String)
+      actions = api ? API_RESOURCE_ACTIONS.dup : RESOURCE_ACTIONS.dup
+
+      if only = extract_resource_action_filter(statement, "only")
+        return actions.select { |action| only.includes?(action) }
+      end
+
+      if except = extract_resource_action_filter(statement, "except")
+        return actions.reject { |action| except.includes?(action) }
+      end
+
+      actions
+    end
+
+    private def extract_resource_action_filter(statement : String, filter_name : String) : Array(String)?
+      match = statement.match(Regex.new("->\\s*#{filter_name}\\s*\\((.*?)\\)", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE))
+      return unless match
+
+      actions = [] of String
+      match[1].scan(/['"]([^'"]+)['"]/).each do |action_match|
+        actions << action_match[1].downcase
+      end
+      actions.empty? ? nil : actions
+    end
+
+    private def resource_param_name_for_statement(resource : String, statement : String) : String
+      if match = statement.match(/->\s*parameters\s*\(\s*\[([^\]]+)\]\s*\)/mi)
+        last_segment = resource.split('/').last
+        match[1].scan(/['"]([^'"]+)['"]\s*=>\s*['"]([^'"]+)['"]/).each do |param_match|
+          key = param_match[1]
+          value = param_match[2]
+          return value if key == resource || key == last_segment
+        end
+      end
+
+      resource_param_name
+    end
+
+    private def resource_param_name : String
+      "id"
     end
 
     private def extract_methods_from_array(methods_str : String) : Array(String)

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -212,22 +212,24 @@ module Analyzer::Php
           #   path: /api/users/{id}
           #   methods: [GET, POST]
 
-          route_matches = content.scan(/^\s*\w+:\s*\n\s*path:\s*["']?([^"'\n]+)["']?(?:\n\s*methods:\s*\[([^\]]+)\])?/m)
-          route_matches.each do |match|
-            route_path = match[1]
-            methods_str = match[2]?
+          yaml = YAML.parse(content)
+          if routes = yaml.as_h?
+            routes.each_value do |route|
+              route_h = route.as_h?
+              next unless route_h
 
-            if methods_str
-              methods = methods_str.split(",").map(&.strip.gsub(/["'\[\]]/, ""))
-            else
-              methods = ["GET"]
-            end
+              route_path = route_h[YAML::Any.new("path")]?.try(&.as_s?)
+              next unless route_path
 
-            params = extract_brace_path_params(route_path)
-            details = Details.new(PathInfo.new(path))
+              methods = extract_yaml_methods(route_h[YAML::Any.new("methods")]?)
+              methods = ["GET"] if methods.empty?
 
-            methods.each do |method|
-              endpoints << Endpoint.new(route_path, method.upcase, params, details)
+              params = extract_brace_path_params(route_path)
+              details = Details.new(PathInfo.new(path))
+
+              methods.each do |method|
+                endpoints << Endpoint.new(route_path, method.upcase, params, details)
+              end
             end
           end
         end
@@ -236,6 +238,18 @@ module Analyzer::Php
       end
 
       endpoints
+    end
+
+    private def extract_yaml_methods(node : YAML::Any?) : Array(String)
+      return [] of String unless node
+
+      if methods = node.as_a?
+        methods.compact_map(&.as_s?).reject(&.empty?)
+      elsif method = node.as_s?
+        method.empty? ? [] of String : [method]
+      else
+        [] of String
+      end
     end
 
     private def attach_method_callees(endpoint : Endpoint, method_body : Tuple(String, Int32)?, path : String)


### PR DESCRIPTION
## Summary
- detect Laravel view/redirect shorthand routes
- respect Laravel resource/apiResource only, except, and parameters chains
- parse Symfony YAML routes with YAML parser to support dotted route names and scalar methods
- cover skipped resource-like matches in comments before real routes

## Tests
- crystal spec spec/functional_test/testers/php/laravel_spec.cr --error-trace
- crystal spec spec/functional_test/testers/php/*_spec.cr
- crystal spec spec/unit_test
- crystal spec spec/functional_test
- just build