### PR TITLE
Improve Kotlin route extraction accuracy

### DIFF
--- a/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
@@ -1,0 +1,74 @@
+require "spec"
+require "../../../src/miniparsers/http4k_extractor_ts"
+
+describe Noir::TreeSitterHttp4kExtractor do
+  it "resolves constant and templated route paths" do
+    source = <<-KT
+      package com.example
+
+      import org.http4k.core.Method.GET
+      import org.http4k.core.Response
+      import org.http4k.core.Status.Companion.OK
+      import org.http4k.routing.bind
+      import org.http4k.routing.routes
+
+      object Paths {
+          const val API = "/api"
+      }
+
+      const val USERS = "/users"
+
+      val app = routes(
+          Paths.API bind routes(
+              (USERS + "/{id}") bind GET to { req -> Response(OK) },
+              "/tenants/$tenantId/items" bind GET to { req -> Response(OK) }
+          )
+      )
+      KT
+
+    constants = Noir::TreeSitterHttp4kExtractor.extract_string_constants(source)
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source, constants)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/users/{id}"},
+      {"GET", "/api/tenants/{tenantId}/items"},
+    ])
+  end
+
+  it "does not resolve route paths from project-wide bare constants" do
+    source = <<-KT
+      import org.http4k.core.Method.GET
+      import org.http4k.core.Response
+      import org.http4k.core.Status.Companion.OK
+      import org.http4k.routing.bind
+      import org.http4k.routing.routes
+
+      val app = routes(
+          USERS bind GET to { req -> Response(OK) }
+      )
+      KT
+
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source, {
+      "USERS" => "/wrong",
+    })
+    routes.should be_empty
+  end
+
+  it "does not drop qualifiers when resolving route constants" do
+    source = <<-KT
+      import org.http4k.core.Method.GET
+      import org.http4k.core.Response
+      import org.http4k.core.Status.Companion.OK
+      import org.http4k.routing.bind
+      import org.http4k.routing.routes
+
+      val app = routes(
+          Other.API bind GET to { req -> Response(OK) }
+      )
+      KT
+
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source, {
+      "API" => "/wrong",
+    })
+    routes.should be_empty
+  end
+end

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -87,6 +87,62 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
     ])
   end
 
+  it "resolves constant and templated route paths" do
+    source = <<-KT
+      package com.example
+
+      object Paths {
+          const val API = "/api"
+      }
+
+      const val USERS = "/users"
+
+      routing {
+          route(Paths.API + "/v1") {
+              get(USERS) { }
+              get("/tenants/$tenantId/items") { }
+          }
+      }
+      KT
+
+    constants = Noir::TreeSitterKotlinKtorRouteExtractor.extract_string_constants(source)
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source, constants)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/v1/users"},
+      {"GET", "/api/v1/tenants/{tenantId}/items"},
+    ])
+  end
+
+  it "does not resolve route paths from project-wide bare constants" do
+    source = <<-KT
+      routing {
+          get(USERS) { }
+          route(API) {
+              get("/nested") { }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source, {
+      "USERS" => "/wrong-users",
+      "API"   => "/wrong-api",
+    })
+    routes.should be_empty
+  end
+
+  it "does not drop qualifiers when resolving route constants" do
+    source = <<-KT
+      routing {
+          get(Other.API) { }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source, {
+      "API" => "/wrong",
+    })
+    routes.should be_empty
+  end
+
   it "treats install(RoutingRoot) as a routing entry point" do
     source = <<-KT
       fun Application.module() {
@@ -181,6 +237,30 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
 
       route = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source).first
       route.header_params.should eq(["X-API-Key", "Authorization"])
+    end
+
+    it "captures common query, header, body, and form access variants" do
+      source = <<-KT
+        routing {
+            post("/profile") {
+                val query = call.request.queryParameters["preview"]
+                val page = call.request.queryParameters.get("page")
+                val id = call.parameters.get("id")
+                val apiKey = call.request.headers.get("X-API-Key")
+                val auth = call.request.header("Authorization")
+                val form = call.receiveParameters()
+                val email = form["email"]
+                val phone = form.get("phone")
+                val body = call.receiveText()
+            }
+        }
+        KT
+
+      route = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source).first
+      route.has_body?.should be_true
+      route.query_params.should eq(["preview", "page", "id"])
+      route.header_params.should eq(["X-API-Key", "Authorization"])
+      route.form_params.should eq(["email", "phone"])
     end
 
     it "ignores params on sibling routes" do

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -10,6 +10,19 @@ module Analyzer::Kotlin
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
+      string_constants = Hash(String, String).new
+      file_list.each do |path|
+        next unless File.exists?(path)
+        next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
+        next if KotlinEngine.test_path?(path)
+
+        Noir::TreeSitterHttp4kExtractor.extract_string_constants(read_file_content(path)).each do |name, value|
+          next unless fully_qualified_constant?(name)
+
+          string_constants[name] ||= value
+        end
+      end
+
       file_list.each do |path|
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
@@ -18,13 +31,17 @@ module Analyzer::Kotlin
         content = read_file_content(path)
         next unless content.includes?(HTTP4K_MARKER)
 
-        Noir::TreeSitterHttp4kExtractor.extract_routes(content, include_callees: include_callee).each do |route|
+        Noir::TreeSitterHttp4kExtractor.extract_routes(content, string_constants, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end
 
       Fiber.yield
       @result
+    end
+
+    private def fully_qualified_constant?(name : String) : Bool
+      name.count('.') >= 2
     end
 
     private def build_endpoint(route : Noir::TreeSitterHttp4kExtractor::Route, path : String) : Endpoint

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -9,6 +9,19 @@ module Analyzer::Kotlin
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
+      string_constants = Hash(String, String).new
+      file_list.each do |path|
+        next unless File.exists?(path)
+        next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
+        next if KotlinEngine.test_path?(path)
+
+        Noir::TreeSitterKotlinKtorRouteExtractor.extract_string_constants(read_file_content(path)).each do |name, value|
+          next unless fully_qualified_constant?(name)
+
+          string_constants[name] ||= value
+        end
+      end
+
       file_list.each do |path|
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
@@ -17,7 +30,7 @@ module Analyzer::Kotlin
         content = read_file_content(path)
         next unless potential_ktor_route_file?(content)
 
-        Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content, include_callees: include_callee).each do |route|
+        Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content, string_constants, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end
@@ -30,6 +43,10 @@ module Analyzer::Kotlin
       content.includes?("routing") ||
         content.includes?("io.ktor.server.routing") ||
         content.includes?("Route.")
+    end
+
+    private def fully_qualified_constant?(name : String) : Bool
+      name.count('.') >= 2
     end
 
     private def build_endpoint(route : Noir::TreeSitterKotlinKtorRouteExtractor::Route, path : String) : Endpoint
@@ -48,6 +65,8 @@ module Analyzer::Kotlin
 
       if rt = route.receive_type
         params << Param.new("body", rt, "json")
+      elsif route.has_body?
+        params << Param.new("body", "", "json")
       end
 
       route.query_params.each do |name|
@@ -57,6 +76,10 @@ module Analyzer::Kotlin
 
       route.header_params.each do |name|
         params << Param.new(name, "", "header")
+      end
+
+      route.form_params.each do |name|
+        params << Param.new(name, "", "form")
       end
 
       endpoint = Endpoint.new(route.path, route.verb, params, details)

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -72,32 +72,81 @@ module Noir
       end
     end
 
-    def extract_routes(source : String, *, include_callees : Bool = false) : Array(Route)
+    def extract_routes(source : String, string_constants = Hash(String, String).new, *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
+      local_string_constants = extract_string_constants(source)
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, 0, include_callees)
+        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees)
       end
       routes
     end
 
+    def extract_string_constants(source : String) : Hash(String, String)
+      constants = Hash(String, String).new
+      package_name = ""
+      current_type = ""
+      current_depth = 0
+
+      source.each_line do |line|
+        if package_name.empty?
+          if match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
+            package_name = match[1]
+          end
+        end
+
+        if match = line.match(/^\s*(?:class|object|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/)
+          current_type = match[1]
+          current_depth = 0
+        end
+
+        if match = line.match(/\b(?:const\s+)?val\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*String)?\s*=\s*"([^"]*)"/)
+          name = match[1]
+          value = match[2]
+          constants[name] ||= value
+          unless current_type.empty?
+            constants["#{current_type}.#{name}"] ||= value
+            constants["#{package_name}.#{current_type}.#{name}"] ||= value unless package_name.empty?
+          end
+        end
+
+        unless current_type.empty?
+          current_depth += line.count("{")
+          current_depth -= line.count("}")
+          if current_depth <= 0 && line.includes?("}")
+            current_type = ""
+            current_depth = 0
+          end
+        end
+      end
+
+      constants
+    end
+
     # ---- traversal --------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
+    private def walk(node : LibTreeSitter::TSNode,
+                     source : String,
+                     prefix : String,
+                     routes : Array(Route),
+                     string_constants : Hash(String, String),
+                     local_string_constants : Hash(String, String),
+                     depth : Int32,
+                     include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
 
-      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, depth, include_callees)
+      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees)
         return
       end
 
       if ty == "call_expression" && call_function_name(node, source) == "routes"
-        walk_routes_args(node, source, prefix, routes, depth, include_callees)
+        walk_routes_args(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees)
         return
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1, include_callees)
+        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees)
       end
     end
 
@@ -108,7 +157,14 @@ module Noir
     #
     # Returns true when consumed; false otherwise so the caller can
     # fall through to the generic descent.
-    private def handle_bind(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool) : Bool
+    private def handle_bind(node : LibTreeSitter::TSNode,
+                            source : String,
+                            prefix : String,
+                            routes : Array(Route),
+                            string_constants : Hash(String, String),
+                            local_string_constants : Hash(String, String),
+                            depth : Int32,
+                            include_callees : Bool) : Bool
       lhs, op, rhs = infix_parts(node, source)
       return false unless lhs && rhs
 
@@ -119,12 +175,12 @@ module Noir
         inner_lhs, inner_op, inner_rhs = infix_parts(lhs, source)
         return false unless inner_op == "bind"
         return false unless inner_lhs && inner_rhs
-        return false unless Noir::TreeSitter.node_type(inner_lhs) == "string_literal"
 
         verb = resolve_verb(inner_rhs, source)
         return false unless verb
 
-        path_text = decode_string_literal(inner_lhs, source)
+        path_text = resolve_string_value(inner_lhs, source, string_constants, local_string_constants)
+        return false unless path_text
         full = join_paths(prefix, path_text)
         line = Noir::TreeSitter.node_start_row(node)
 
@@ -155,13 +211,13 @@ module Noir
         routes << Route.new(verb, full, line, has_body, query, header, form, callees)
         true
       when "bind"
-        return false unless Noir::TreeSitter.node_type(lhs) == "string_literal"
         return false unless Noir::TreeSitter.node_type(rhs) == "call_expression"
         return false unless call_function_name(rhs, source) == "routes"
 
-        path_text = decode_string_literal(lhs, source)
+        path_text = resolve_string_value(lhs, source, string_constants, local_string_constants)
+        return false unless path_text
         new_prefix = join_paths(prefix, path_text)
-        walk_routes_args(rhs, source, new_prefix, routes, depth + 1, include_callees)
+        walk_routes_args(rhs, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees)
         true
       else
         false
@@ -172,14 +228,21 @@ module Noir
     # Each argument is a `value_argument` wrapping an
     # `infix_expression` (the binding) or another nested `routes(...)`
     # call.
-    private def walk_routes_args(call : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool)
+    private def walk_routes_args(call : LibTreeSitter::TSNode,
+                                 source : String,
+                                 prefix : String,
+                                 routes : Array(Route),
+                                 string_constants : Hash(String, String),
+                                 local_string_constants : Hash(String, String),
+                                 depth : Int32,
+                                 include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       args = call_value_arguments(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "value_argument"
         Noir::TreeSitter.each_named_child(arg) do |child|
-          walk(child, source, prefix, routes, depth + 1, include_callees)
+          walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees)
         end
       end
     end
@@ -326,12 +389,44 @@ module Noir
     private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
       buf = String.build do |io|
         Noir::TreeSitter.each_named_child(node) do |child|
-          if Noir::TreeSitter.node_type(child) == "string_content"
+          case Noir::TreeSitter.node_type(child)
+          when "string_content"
             io << Noir::TreeSitter.node_text(child, source)
+          when "interpolated_identifier", "interpolated_expression"
+            io << '{'
+            io << Noir::TreeSitter.node_text(child, source).strip
+            io << '}'
           end
         end
       end
       buf
+    end
+
+    private def resolve_string_value(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     string_constants : Hash(String, String),
+                                     local_string_constants : Hash(String, String)) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        decode_string_literal(node, source)
+      when "simple_identifier"
+        local_string_constants[Noir::TreeSitter.node_text(node, source)]?
+      when "navigation_expression"
+        text = Noir::TreeSitter.node_text(node, source)
+        local_string_constants[text]? || string_constants[text]?
+      when "parenthesized_expression"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          return resolve_string_value(child, source, string_constants, local_string_constants)
+        end
+      when "additive_expression"
+        parts = [] of String
+        Noir::TreeSitter.each_named_child(node) do |child|
+          part = resolve_string_value(child, source, string_constants, local_string_constants)
+          return unless part
+          parts << part
+        end
+        parts.join
+      end
     end
 
     private def join_paths(prefix : String, suffix : String) : String

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -70,35 +70,87 @@ module Noir
       getter path : String
       getter line : Int32 # 0-based line of the verb call
       getter receive_type : String?
+      getter? has_body : Bool
       getter query_params : Array(String)
       getter header_params : Array(String)
+      getter form_params : Array(String)
       # 1-hop callees out of the handler lambda body. `path` is left
       # for the caller to fill in (the route extractor doesn't carry
       # the file path itself); each tuple is (callee_name, line_1_based).
       getter callees : Array(Tuple(String, Int32))
 
-      def initialize(@verb, @path, @line, @receive_type, @query_params, @header_params, @callees)
+      def initialize(@verb, @path, @line, @receive_type, @has_body, @query_params, @header_params, @form_params, @callees)
       end
     end
 
-    def extract_routes(source : String, *, include_callees : Bool = false) : Array(Route)
+    def extract_routes(source : String, string_constants = Hash(String, String).new, *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
+      local_string_constants = extract_string_constants(source)
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, 0, include_callees, false)
+        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees, false)
       end
       routes
     end
 
+    def extract_string_constants(source : String) : Hash(String, String)
+      constants = Hash(String, String).new
+      package_name = ""
+      current_type = ""
+      current_depth = 0
+
+      source.each_line do |line|
+        if package_name.empty?
+          if match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
+            package_name = match[1]
+          end
+        end
+
+        if match = line.match(/^\s*(?:class|object|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/)
+          current_type = match[1]
+          current_depth = 0
+        end
+
+        if match = line.match(/\b(?:const\s+)?val\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*String)?\s*=\s*"([^"]*)"/)
+          name = match[1]
+          value = match[2]
+          constants[name] ||= value
+          unless current_type.empty?
+            constants["#{current_type}.#{name}"] ||= value
+            constants["#{package_name}.#{current_type}.#{name}"] ||= value unless package_name.empty?
+          end
+        end
+
+        unless current_type.empty?
+          current_depth += line.count("{")
+          current_depth -= line.count("}")
+          if current_depth <= 0 && line.includes?("}")
+            current_type = ""
+            current_depth = 0
+          end
+        end
+      end
+
+      constants
+    end
+
     # ---- traversal ----------------------------------------------------
 
-    private def walk(node : LibTreeSitter::TSNode, source : String, prefix : String, routes : Array(Route), depth : Int32, include_callees : Bool, active : Bool)
+    private def walk(node : LibTreeSitter::TSNode,
+                     source : String,
+                     prefix : String,
+                     routes : Array(Route),
+                     string_constants : Hash(String, String),
+                     local_string_constants : Hash(String, String),
+                     depth : Int32,
+                     include_callees : Bool,
+                     active : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
 
       if ty == "function_declaration" && route_extension_function?(node, source)
         if body = function_body_statements(node)
-          walk(body, source, prefix, routes, depth + 1, include_callees, true)
+          walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
         end
         return
       end
@@ -107,33 +159,42 @@ module Noir
         name = call_name(node, source)
         case
         when active && HTTP_VERB_NAMES.has_key?(name)
-          emit_route(node, source, name, prefix, routes, include_callees)
+          emit_route(node, source, name, prefix, routes, string_constants, local_string_constants, include_callees)
           return
         when active && name == "route"
-          path_arg = call_string_argument(node, source)
+          path_arg = call_string_argument(node, source, string_constants, local_string_constants)
+          return if path_arg.nil? && call_has_value_arguments?(node)
           new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
           if body = call_lambda_body(node)
             if method = call_http_method_argument(node, source)
               emit_method_route(node, body, source, method, new_prefix, routes, include_callees) if has_handle_call?(body, source)
             end
-            walk(body, source, new_prefix, routes, depth + 1, include_callees, true)
+            walk(body, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
           end
           return
         when name == "routing" || routing_install_call?(node, source) || (active && PASSTHROUGH_NAMES.includes?(name))
           if body = call_lambda_body(node)
-            walk(body, source, prefix, routes, depth + 1, include_callees, true)
+            walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, depth + 1, include_callees, active)
+        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, active)
       end
     end
 
-    private def emit_route(node : LibTreeSitter::TSNode, source : String, name : String, prefix : String, routes : Array(Route), include_callees : Bool)
-      path_arg = call_string_argument(node, source)
+    private def emit_route(node : LibTreeSitter::TSNode,
+                           source : String,
+                           name : String,
+                           prefix : String,
+                           routes : Array(Route),
+                           string_constants : Hash(String, String),
+                           local_string_constants : Hash(String, String),
+                           include_callees : Bool)
+      path_arg = call_string_argument(node, source, string_constants, local_string_constants)
+      return if path_arg.nil? && call_has_value_arguments?(node)
       return unless path_arg || call_has_lambda?(node)
 
       verb = HTTP_VERB_NAMES[name]
@@ -141,14 +202,17 @@ module Noir
       line = Noir::TreeSitter.node_start_row(node)
 
       receive_type : String? = nil
+      has_body = false
       query_params = [] of String
       header_params = [] of String
+      form_params = [] of String
       callees = [] of Tuple(String, Int32)
 
       if body = call_lambda_body(node)
-        scan_handler_body(body, source, query_params, header_params).tap do |rt|
+        scan_handler_body(body, source, query_params, header_params, form_params).tap do |rt|
           receive_type = rt
         end
+        has_body = !!receive_type || handler_reads_body?(body, source)
         # KotlinCalleeExtractor uses `(name, file_path, line)` so it can
         # mirror the Java/Python/Go shape, but Ktor's route extractor
         # doesn't carry the file path — drop the placeholder here and
@@ -162,7 +226,7 @@ module Noir
         end
       end
 
-      routes << Route.new(verb, full_path, line, receive_type, query_params, header_params, callees)
+      routes << Route.new(verb, full_path, line, receive_type, has_body, query_params, header_params, form_params, callees)
     end
 
     private def emit_method_route(node : LibTreeSitter::TSNode,
@@ -175,7 +239,9 @@ module Noir
       line = Noir::TreeSitter.node_start_row(node)
       query_params = [] of String
       header_params = [] of String
-      receive_type = scan_handler_body(body, source, query_params, header_params)
+      form_params = [] of String
+      receive_type = scan_handler_body(body, source, query_params, header_params, form_params)
+      has_body = !!receive_type || handler_reads_body?(body, source)
 
       callees = [] of Tuple(String, Int32)
       if include_callees
@@ -185,7 +251,7 @@ module Noir
         end
       end
 
-      routes << Route.new(verb, full_path, line, receive_type, query_params, header_params, callees)
+      routes << Route.new(verb, full_path, line, receive_type, has_body, query_params, header_params, form_params, callees)
     end
 
     # ---- call shape helpers ------------------------------------------
@@ -221,7 +287,10 @@ module Noir
 
     # Pull the first `string_literal` argument, if any, from the inner
     # call. Used for `get("/x")` and `route("/api")`.
-    private def call_string_argument(call : LibTreeSitter::TSNode, source : String) : String?
+    private def call_string_argument(call : LibTreeSitter::TSNode,
+                                     source : String,
+                                     string_constants : Hash(String, String),
+                                     local_string_constants : Hash(String, String)) : String?
       first = first_named_child(call)
       return unless first
       return unless Noir::TreeSitter.node_type(first) == "call_expression"
@@ -238,8 +307,8 @@ module Noir
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "value_argument"
         Noir::TreeSitter.each_named_child(arg) do |child|
-          if Noir::TreeSitter.node_type(child) == "string_literal"
-            return decode_string_literal(child, source)
+          if value = resolve_string_value(child, source, string_constants, local_string_constants)
+            return value
           end
         end
       end
@@ -352,6 +421,32 @@ module Noir
       false
     end
 
+    private def call_has_value_arguments?(call : LibTreeSitter::TSNode) : Bool
+      if call_node_has_value_arguments?(call)
+        return true
+      end
+
+      first = first_named_child(call)
+      if first && Noir::TreeSitter.node_type(first) == "call_expression"
+        return true if call_node_has_value_arguments?(first)
+      end
+
+      false
+    end
+
+    private def call_node_has_value_arguments?(call : LibTreeSitter::TSNode) : Bool
+      Noir::TreeSitter.each_named_child(call) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "call_suffix"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          next unless Noir::TreeSitter.node_type(sub) == "value_arguments"
+          Noir::TreeSitter.each_named_child(sub) do |arg|
+            return true if Noir::TreeSitter.node_type(arg) == "value_argument"
+          end
+        end
+      end
+      false
+    end
+
     private def has_handle_call?(node : LibTreeSitter::TSNode, source : String, depth : Int32 = 0) : Bool
       return false if depth > Noir::TreeSitter::MAX_AST_DEPTH
       if Noir::TreeSitter.node_type(node) == "call_expression" && call_name(node, source) == "handle"
@@ -448,9 +543,11 @@ module Noir
     private def scan_handler_body(node : LibTreeSitter::TSNode,
                                   source : String,
                                   query_params : Array(String),
-                                  header_params : Array(String)) : String?
+                                  header_params : Array(String),
+                                  form_params : Array(String)) : String?
       receive_type : String? = nil
-      walk_handler(node, source, query_params, header_params, 0) do |type|
+      form_vars = Set(String).new
+      walk_handler(node, source, query_params, header_params, form_params, form_vars, 0) do |type|
         receive_type ||= type
       end
       receive_type
@@ -460,6 +557,8 @@ module Noir
                              source : String,
                              query_params : Array(String),
                              header_params : Array(String),
+                             form_params : Array(String),
+                             form_vars : Set(String),
                              depth : Int32,
                              &block : String ->)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
@@ -467,12 +566,33 @@ module Noir
       ty = Noir::TreeSitter.node_type(node)
 
       case ty
+      when "property_declaration"
+        if receive_parameters_assignment?(node, source)
+          if name = property_name(node, source)
+            form_vars << name
+          end
+        end
       when "call_expression"
         if call_is_call_receive?(node, source)
           if type_arg = call_receive_type_argument(node, source)
             block.call(type_arg)
           end
           return
+        elsif call_reads_request_body?(node, source)
+          block.call("")
+          return
+        elsif name = call_string_parameter(node, source)
+          first = first_named_child(node)
+          if first
+            chain = navigation_chain(first, source)
+            if chain == ["call", "parameters", "get"] || chain == ["call", "request", "queryParameters", "get"]
+              query_params << name
+            elsif chain == ["call", "request", "headers", "get"] || chain == ["call", "request", "header"]
+              header_params << name
+            elsif chain.size == 2 && form_vars.includes?(chain.first) && chain.last == "get"
+              form_params << name
+            end
+          end
         end
       when "indexing_expression"
         target = first_named_child(node)
@@ -482,16 +602,24 @@ module Noir
             if name = indexing_string_key(node, source)
               query_params << name
             end
+          elsif chain == ["call", "request", "queryParameters"]
+            if name = indexing_string_key(node, source)
+              query_params << name
+            end
           elsif chain == ["call", "request", "headers"]
             if name = indexing_string_key(node, source)
               header_params << name
+            end
+          elsif chain.size == 1 && form_vars.includes?(chain.first)
+            if name = indexing_string_key(node, source)
+              form_params << name
             end
           end
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_handler(child, source, query_params, header_params, depth + 1, &block)
+        walk_handler(child, source, query_params, header_params, form_params, form_vars, depth + 1, &block)
       end
     end
 
@@ -499,7 +627,61 @@ module Noir
       first = first_named_child(call)
       return false unless first
       return false unless Noir::TreeSitter.node_type(first) == "navigation_expression"
-      navigation_chain(first, source) == ["call", "receive"]
+      chain = navigation_chain(first, source)
+      chain == ["call", "receive"] || chain == ["call", "receiveNullable"]
+    end
+
+    private def call_reads_request_body?(call : LibTreeSitter::TSNode, source : String) : Bool
+      first = first_named_child(call)
+      return false unless first
+      return false unless Noir::TreeSitter.node_type(first) == "navigation_expression"
+      chain = navigation_chain(first, source)
+      chain == ["call", "receiveText"] || chain == ["call", "receiveChannel"] || chain == ["call", "receiveStream"]
+    end
+
+    private def handler_reads_body?(node : LibTreeSitter::TSNode, source : String) : Bool
+      body_reader?(node, source, 0)
+    end
+
+    private def body_reader?(node : LibTreeSitter::TSNode, source : String, depth : Int32) : Bool
+      return false if depth > Noir::TreeSitter::MAX_AST_DEPTH
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        if call_is_call_receive?(node, source) || call_reads_request_body?(node, source)
+          return true
+        end
+      end
+      Noir::TreeSitter.each_named_child(node) do |child|
+        return true if body_reader?(child, source, depth + 1)
+      end
+      false
+    end
+
+    private def receive_parameters_assignment?(node : LibTreeSitter::TSNode, source : String) : Bool
+      Noir::TreeSitter.each_named_child(node) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "call_expression"
+        first = first_named_child(child)
+        next unless first
+        next unless Noir::TreeSitter.node_type(first) == "navigation_expression"
+        return true if navigation_chain(first, source) == ["call", "receiveParameters"]
+      end
+      false
+    end
+
+    private def property_name(node : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "variable_declaration"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          return Noir::TreeSitter.node_text(sub, source) if Noir::TreeSitter.node_type(sub) == "simple_identifier"
+        end
+      end
+      nil
+    end
+
+    private def call_string_parameter(call : LibTreeSitter::TSNode, source : String) : String?
+      first = first_named_child(call)
+      return unless first
+      return unless Noir::TreeSitter.node_type(first) == "navigation_expression"
+      first_string_argument(call, source)
     end
 
     # Pull the `<T>` from `call.receive<T>()`. The `call_suffix` of
@@ -599,6 +781,49 @@ module Noir
         end
       end
       nil
+    end
+
+    private def first_string_argument(call : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(call) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "call_suffix"
+        Noir::TreeSitter.each_named_child(child) do |sub|
+          next unless Noir::TreeSitter.node_type(sub) == "value_arguments"
+          Noir::TreeSitter.each_named_child(sub) do |arg|
+            next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+            Noir::TreeSitter.each_named_child(arg) do |value|
+              return decode_string_literal(value, source) if Noir::TreeSitter.node_type(value) == "string_literal"
+            end
+          end
+        end
+      end
+      nil
+    end
+
+    private def resolve_string_value(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     string_constants : Hash(String, String),
+                                     local_string_constants : Hash(String, String)) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal"
+        decode_string_literal(node, source)
+      when "simple_identifier"
+        local_string_constants[Noir::TreeSitter.node_text(node, source)]?
+      when "navigation_expression"
+        text = Noir::TreeSitter.node_text(node, source)
+        local_string_constants[text]? || string_constants[text]?
+      when "parenthesized_expression"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          return resolve_string_value(child, source, string_constants, local_string_constants)
+        end
+      when "additive_expression"
+        parts = [] of String
+        Noir::TreeSitter.each_named_child(node) do |child|
+          part = resolve_string_value(child, source, string_constants, local_string_constants)
+          return unless part
+          parts << part
+        end
+        parts.join
+      end
     end
 
     private def join_paths(prefix : String, suffix : String) : String

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -806,8 +806,13 @@ module Noir
     private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
       buf = String.build do |io|
         Noir::TreeSitter.each_named_child(node) do |child|
-          if Noir::TreeSitter.node_type(child) == "string_content"
+          case Noir::TreeSitter.node_type(child)
+          when "string_content"
             io << Noir::TreeSitter.node_text(child, source)
+          when "interpolated_identifier", "interpolated_expression"
+            io << '{'
+            io << Noir::TreeSitter.node_text(child, source).strip
+            io << '}'
           end
         end
       end


### PR DESCRIPTION
## Summary
- resolve Kotlin route path constants for Ktor and http4k without leaking bare constants across files
- preserve qualified constant names and avoid emitting routes for unresolved path arguments
- add Ktor/http4k coverage for templated paths, constant collisions, and common Ktor parameter/body accessors

## Tests
- just build
- crystal spec --no-debug spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr spec/unit_test/miniparser/http4k_extractor_ts_spec.cr spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr spec/functional_test/testers/kotlin/spring_spec.cr spec/functional_test/testers/kotlin/ktor_spec.cr spec/functional_test/testers/kotlin/http4k_spec.cr
- crystal tool format --check && crystal run --no-debug lib/ameba/bin/ameba.cr
- crystal spec --no-debug spec/unit_test && crystal spec --no-debug spec/functional_test