### PR TITLE
Improve Rails and Sinatra endpoint extraction

### DIFF
--- a/spec/functional_test/fixtures/ruby/sinatra/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra/app.rb
@@ -40,4 +40,23 @@ namespace "/api" do
   post("/widgets") do
     request.env["HTTP_X_TRACE_ID"]
   end
+
+  route :get, :post, "/route_widgets" do
+    params.fetch(:token)
+  end
+
+  route :get, "/verb_named/:post" do
+    params[:id]
+  end
+end
+
+namespace "/v2" {
+  get "/widgets" do
+    params.fetch("cursor")
+  end
+}
+
+def helper_noise
+  params[:should_not_attach]
+  request.env["HTTP_SHOULD_NOT_ATTACH"]
 end

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -22,6 +22,7 @@ expected_endpoints = [
   Endpoint.new("/admin/reports/1", "GET"),
   Endpoint.new("/admin/reports", "POST"),
   Endpoint.new("/admin/reports/1", "PUT"),
+  Endpoint.new("/admin/reports/1", "PATCH"),
   Endpoint.new("/admin/reports/1", "DELETE"),
 
   # member/collection actions on namespaced resource. #1359: action-scoped
@@ -81,6 +82,7 @@ expected_endpoints = [
   Endpoint.new("/internal/statements/1", "GET"),
   Endpoint.new("/internal/statements", "POST"),
   Endpoint.new("/internal/statements/1", "PUT"),
+  Endpoint.new("/internal/statements/1", "PATCH"),
 
   # resources :scans, controller: "billing/scans", only: [:index]
   Endpoint.new("/scans", "GET"),
@@ -108,6 +110,7 @@ expected_endpoints = [
   Endpoint.new("/posts/1", "GET"),
   Endpoint.new("/posts", "POST"),
   Endpoint.new("/posts/1", "PUT"),
+  Endpoint.new("/posts/1", "PATCH"),
   Endpoint.new("/posts/1", "DELETE"),
   Endpoint.new("/posts/1/comments", "GET"),
   Endpoint.new("/posts/1/comments/1", "GET"),
@@ -154,18 +157,18 @@ expected_endpoints = [
 # /scans/1) and devise_for emits its full route set.
 total_endpoints = 1 +  # root
                   2 +  # `#{base_c_route}` interpolation resolved to 2 routes
-                  5 +  # admin/reports
+                  6 +  # admin/reports
                   4 +  # admin/refunds member (change_status, purge, update_metadata) + collection (new_list)
                   1 +  # admin/monitor/heartbeat (namespaced `to:`)
                   2 +  # namespace path override reports
                   2 +  # scope module/path explicit routes
                   1 +  # controller block route
                   2 +  # api/items only:[index,show]
-                  4 +  # internal/statements except:[destroy]
+                  5 +  # internal/statements except:[destroy]
                   1 +  # /scans only:[index] via controller override
                   2 +  # multiline resources options
                   3 +  # inline collection/member/new custom routes
-                  5 +  # posts
+                  6 +  # posts
                   4 +  # posts/1/comments + nested likes from concern
                   2 +  # /up + /ping
                   20 + # devise_for :users

--- a/spec/functional_test/testers/ruby/rails_monorepo_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_monorepo_spec.cr
@@ -15,6 +15,7 @@ expected_endpoints = [
     Param.new("context", "", "json"),
   ]),
   Endpoint.new("/posts/1", "PUT"),
+  Endpoint.new("/posts/1", "PATCH"),
   Endpoint.new("/posts/1", "DELETE"),
   Endpoint.new("/up", "GET"),
 ]

--- a/spec/functional_test/testers/ruby/rails_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_spec.cr
@@ -18,6 +18,10 @@ expected_endpoints = [
     Param.new("title", "", "json"),
     Param.new("context", "", "json"),
   ]),
+  Endpoint.new("/posts/1", "PATCH", [
+    Param.new("title", "", "json"),
+    Param.new("context", "", "json"),
+  ]),
   Endpoint.new("/posts/1", "DELETE"),
   Endpoint.new("/up", "GET"),
   Endpoint.new("/service-worker", "GET"),

--- a/spec/functional_test/testers/ruby/sinatra_spec.cr
+++ b/spec/functional_test/testers/ruby/sinatra_spec.cr
@@ -13,9 +13,21 @@ expected_endpoints = [
   Endpoint.new("/api/widgets", "POST", [
     Param.new("HTTP_X_TRACE_ID", "", "header"),
   ]),
+  Endpoint.new("/api/route_widgets", "GET", [
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/api/route_widgets", "POST", [
+    Param.new("token", "", "query"),
+  ]),
+  Endpoint.new("/api/verb_named/:post", "GET", [
+    Param.new("id", "", "query"),
+  ]),
+  Endpoint.new("/v2/widgets", "GET", [
+    Param.new("cursor", "", "query"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/ruby/sinatra/", {
   :techs     => 1,
-  :endpoints => 4,
+  :endpoints => 8,
 }, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -819,6 +819,7 @@ module Analyzer::Ruby
           methods << "POST"
         when "update"
           methods << "PUT"
+          methods << "PATCH"
         when "destroy"
           methods << "DELETE"
         end

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -15,7 +15,8 @@ module Analyzer::Ruby
         next if RubyEngine.ruby_test_path?(path)
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           lines = file.each_line.to_a
-          last_endpoint = Endpoint.new("", "")
+          active_route_endpoints = [] of Endpoint
+          active_route_depth = nil.as(Int32?)
           prefix_stack = [] of NamedTuple(depth: Int32, path: String)
           depth = 0
           lines.each_with_index do |line, index|
@@ -28,24 +29,42 @@ module Analyzer::Ruby
             stripped = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: true).strip
             next if stripped.empty? || stripped.starts_with?('#')
 
-            if ns = stripped.match(/^namespace\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s+do\b/)
+            if ns = stripped.match(/^namespace\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s*(?:do\b|\{)/)
               prefix_stack << {depth: depth + 1, path: ns[1]}
             end
 
-            endpoint = line_to_endpoint(line)
-            unless endpoint.method.empty?
-              endpoint.url = sinatra_prefixed_path(prefix_stack, endpoint.url)
-              details = Details.new(PathInfo.new(path, index + 1))
-              endpoint.details = details
-              attach_route_callees(endpoint, lines, index, path) if include_callee
-              @result << endpoint
-              last_endpoint = endpoint
+            route_endpoints = line_to_endpoints(stripped)
+            unless route_endpoints.empty?
+              route_endpoints.each do |endpoint|
+                endpoint.url = sinatra_prefixed_path(prefix_stack, endpoint.url)
+                details = Details.new(PathInfo.new(path, index + 1))
+                endpoint.details = details
+                attach_route_callees(endpoint, lines, index, path) if include_callee
+                @result << endpoint
+              end
+
+              if sinatra_block_opens(stripped) > sinatra_block_closes(stripped)
+                active_route_endpoints = route_endpoints
+                active_route_depth = depth + 1
+              else
+                active_route_endpoints = [] of Endpoint
+                active_route_depth = nil
+              end
             end
 
-            param = line_to_param(line)
-            unless param.name.empty?
-              unless last_endpoint.method.empty?
-                last_endpoint.push_param(param)
+            line_to_params(stripped).each do |param|
+              target_endpoints = if route_endpoints.empty?
+                                   if (route_depth = active_route_depth) && !active_route_endpoints.empty? && depth >= route_depth
+                                     active_route_endpoints
+                                   else
+                                     [] of Endpoint
+                                   end
+                                 else
+                                   route_endpoints
+                                 end
+
+              target_endpoints.each do |endpoint|
+                endpoint.push_param(param)
               end
             end
 
@@ -53,11 +72,57 @@ module Analyzer::Ruby
             while !prefix_stack.empty? && prefix_stack.last[:depth] > depth
               prefix_stack.pop
             end
+            if (route_depth = active_route_depth) && depth < route_depth
+              active_route_endpoints = [] of Endpoint
+              active_route_depth = nil
+            end
           end
         end
       end
 
       @result
+    end
+
+    private def line_to_endpoints(content : String) : Array(Endpoint)
+      route_endpoints = route_call_to_endpoints(content)
+      return route_endpoints unless route_endpoints.empty?
+
+      endpoint = line_to_endpoint(content)
+      endpoint.method.empty? ? ([] of Endpoint) : [endpoint]
+    end
+
+    private def route_call_to_endpoints(content : String) : Array(Endpoint)
+      leading = content.lstrip
+      return [] of Endpoint unless leading.starts_with?("route")
+      return [] of Endpoint if leading.size > 5 && (leading[5].alphanumeric? || leading[5] == '_')
+
+      path = nil.as(String?)
+      verb_source = leading
+      leading.scan(/['"]([^'"]+)['"]/) do |m|
+        candidate = m[1]
+        if candidate.starts_with?("/")
+          path = candidate
+          verb_source = leading[0, m.begin(0) || 0]
+          break
+        end
+      end
+      return [] of Endpoint unless route_path = path
+
+      verbs = [] of String
+      verb_source.scan(/:(get|post|put|patch|delete|head|options)\b/i) do |m|
+        verbs << m[1].upcase
+      end
+      verb_source.scan(/['"](GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)['"]/i) do |m|
+        verbs << m[1].upcase
+      end
+      verb_source.scan(/%[iw][\[\(]([^\]\)]*)[\]\)]/) do |m|
+        m[1].split(/\s+/).each do |verb|
+          normalized = verb.strip.lchop(":").upcase
+          verbs << normalized if HTTP_VERBS.includes?(normalized.downcase)
+        end
+      end
+
+      verbs.uniq.map { |verb| Endpoint.new(route_path, verb) }
     end
 
     private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
@@ -69,32 +134,43 @@ module Analyzer::Ruby
     end
 
     def line_to_param(content : String) : Param
-      if content.includes? "param["
-        param = content.split("param[")[1].split("]")[0].gsub("\"", "").gsub("'", "").gsub(":", "")
-        return Param.new(param, "", "query")
+      line_to_params(content).first? || Param.new("", "", "")
+    end
+
+    private def line_to_params(content : String) : Array(Param)
+      params = [] of Param
+
+      content.scan(/param\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "query") unless name.empty?
       end
 
-      if content.includes? "params["
-        param = content.split("params[")[1].split("]")[0].gsub("\"", "").gsub("'", "").gsub(":", "")
-        return Param.new(param, "", "query")
+      content.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "query") unless name.empty?
       end
 
-      if content.includes? "request.env["
-        param = content.split("request.env[")[1].split("]")[0].gsub("\"", "").gsub("'", "")
-        return Param.new(param, "", "header")
+      content.scan(/params\.fetch\s*\(\s*(?::(\w+)|['"]([^'"]+)['"])/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "query") unless name.empty?
       end
 
-      if content.includes? "headers["
-        param = content.split("headers[")[1].split("]")[0].gsub("\"", "").gsub("'", "").gsub(":", "")
-        return Param.new(param, "", "header")
+      content.scan(/request\.env\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+        name = m[1].strip
+        params << Param.new(name, "", "header") unless name.empty?
       end
 
-      if content.includes? "cookies["
-        param = content.split("cookies[")[1].split("]")[0].gsub("\"", "").gsub("'", "").gsub(":", "")
-        return Param.new(param, "", "cookie")
+      content.scan(/headers\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "header") unless name.empty?
       end
 
-      Param.new("", "", "")
+      content.scan(/cookies\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+        name = (m[1]? || m[2]?).to_s.strip
+        params << Param.new(name, "", "cookie") unless name.empty?
+      end
+
+      params
     end
 
     private def sinatra_prefixed_path(prefix_stack : Array(NamedTuple(depth: Int32, path: String)), path : String) : String


### PR DESCRIPTION
## Summary
- emit PATCH endpoints for Rails resource update actions
- support Sinatra route multi-verb declarations and brace-style namespace blocks
- scope Sinatra params to the active route block to avoid leaking params into unrelated endpoints
- avoid treating named path params like :post as route verbs

## Tests
- crystal spec spec/functional_test/testers/ruby/rails_spec.cr spec/functional_test/testers/ruby/rails_monorepo_spec.cr spec/functional_test/testers/ruby/rails_advanced_spec.cr spec/functional_test/testers/ruby/sinatra_spec.cr spec/functional_test/testers/ruby/sinatra_callees_spec.cr
- just test
- just build
- just check