### PR TITLE
Improve Python web analyzer route coverage

### DIFF
--- a/spec/functional_test/fixtures/python/django/blog/urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/urls.py
@@ -10,6 +10,7 @@ router = DefaultRouter()
 router.register(r'articles', views.ArticleViewSet, basename='article')
 router.register(r'media', views.MediaViewSet, basename='media')
 router.register(prefix=r'keyword-media', viewset=views.MediaViewSet, basename='keyword-media')
+# router.register(r'commented-media', views.MediaViewSet, basename='commented-media')
 direct_router = DefaultRouter()
 direct_router.register(r'direct-articles', views.ArticleViewSet, basename='direct-article')
 
@@ -46,6 +47,7 @@ extended_patterns = [
 ]
 
 urlpatterns = [
+    # path('commented/', views.local_report_list, name='commented'),
     path('api/', include(router.urls)),
     path('imported-api/', include(api_router.urls)),
     path('local/', include(local_patterns)),
@@ -123,5 +125,7 @@ urlpatterns = [
 ]
 urlpatterns = base_patterns + urlpatterns
 urlpatterns.extend(extended_patterns)
-urlpatterns += direct_router.urls
+urlpatterns.extend(
+    direct_router.urls
+)
 urlpatterns += imported_direct_router.urls

--- a/spec/functional_test/fixtures/python/fastapi/main.py
+++ b/spec/functional_test/fixtures/python/fastapi/main.py
@@ -1,4 +1,5 @@
 import http
+import fastapi
 from typing import FrozenSet, Optional
 
 from fastapi import APIRouter, FastAPI, Path, Query
@@ -6,14 +7,17 @@ from fastapi.staticfiles import StaticFiles
 from api import api
 from api import tenant_api
 
-app : FastAPI = FastAPI()
-local_router = APIRouter(prefix="/local")
+app : fastapi.FastAPI = fastapi.FastAPI()
+local_router : fastapi.APIRouter = fastapi.APIRouter(prefix="/local")
 app.include_router(api, prefix="/api")
 app.include_router(tenant_api, prefix="/api")
 app.include_router(
     router=local_router,
     prefix="/v1",
 )
+# app.include_router(api, prefix="/commented")
+# app.add_api_route("/commented", main, methods=["GET"])
+# app.mount("/commented-static", StaticFiles(directory="public"), name="commented")
 app.mount(
     "/assets",
     StaticFiles(directory="public"),

--- a/spec/functional_test/fixtures/python/flask_advanced/app.py
+++ b/spec/functional_test/fixtures/python/flask_advanced/app.py
@@ -6,9 +6,10 @@ Flask test fixture for advanced features:
 """
 from flask import Flask, Blueprint, request, jsonify
 from flask.views import MethodView, View
+import flask
 import external_views
 
-app = Flask(__name__, static_url_path='/assets', static_folder='public')
+app: flask.Flask = flask.Flask(__name__, static_url_path='/assets', static_folder='public')
 
 # Blueprint with shortcut decorators
 bp = Blueprint('api', __name__, url_prefix='/api')
@@ -152,7 +153,7 @@ user_view = UserAPI.as_view('user_api')
 bp.add_url_rule('/users', view_func=user_view, methods=['GET', 'POST'])
 bp.add_url_rule('/users/<int:user_id>', view_func=user_view, methods=['GET', 'PUT', 'DELETE'])
 
-item_view = ItemAPI.as_view('item_api')
+item_view: View = ItemAPI.as_view('item_api')
 bp.add_url_rule('/items', view_func=item_view, methods=['GET', 'POST'])
 
 async_view = AsyncAPI.as_view('async_api')
@@ -190,12 +191,14 @@ bp.add_url_rule(
 bp.add_url_rule('/registered-search', 'registered_search', registered_search, methods=['GET'])
 bp.add_url_rule(rule='/registered-create', endpoint='registered_create', view_func=registered_create, methods=['POST'])
 bp.add_url_rule('/external-search', view_func=external_views.external_search, methods=['GET'])
+# bp.add_url_rule('/commented', view_func=registered_search, methods=['GET'])
 
 parent_bp.register_blueprint(nested_bp, url_prefix='/child')
 
 # Register blueprint
 app.register_blueprint(bp)
 app.register_blueprint(parent_bp, url_prefix='/mounted')
+# app.register_blueprint(bp, url_prefix='/commented')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/spec/functional_test/fixtures/python/flask_crossfile/app.py
+++ b/spec/functional_test/fixtures/python/flask_crossfile/app.py
@@ -1,10 +1,12 @@
 from flask import Flask
 from blueprints.auth import auth_bp
 from blueprints.items import items_bp
+from blueprints.reports import reports_bp
 
 app = Flask(__name__)
 app.register_blueprint(auth_bp, url_prefix='/api/v1')
 app.register_blueprint(items_bp, url_prefix='/api/v2')
+app.register_blueprint(reports_bp, url_prefix='/api/v3')
 
 if __name__ == "__main__":
     app.run()

--- a/spec/functional_test/fixtures/python/flask_crossfile/blueprints/__init__.py
+++ b/spec/functional_test/fixtures/python/flask_crossfile/blueprints/__init__.py
@@ -1,0 +1,3 @@
+from flask import Blueprint
+
+reports_bp = Blueprint('reports', __name__)

--- a/spec/functional_test/fixtures/python/flask_crossfile/blueprints/reports.py
+++ b/spec/functional_test/fixtures/python/flask_crossfile/blueprints/reports.py
@@ -1,0 +1,6 @@
+from . import reports_bp
+
+
+@reports_bp.route('/reports', methods=['GET'])
+def list_reports():
+    return {"reports": []}

--- a/spec/functional_test/testers/python/flask_crossfile_spec.cr
+++ b/spec/functional_test/testers/python/flask_crossfile_spec.cr
@@ -12,6 +12,7 @@ expected_endpoints = [
   Endpoint.new("/api/v2/items", "POST", [
     Param.new("name", "", "json"),
   ]),
+  Endpoint.new("/api/v3/reports", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/flask_crossfile/", {

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -88,14 +88,18 @@ module Analyzer::Python
                 next if PythonEngine.python_test_path?(file)
                 if file.ends_with? ".py"
                   content = read_file_content(file)
-                  content.scan(REGEX_ROOT_URLCONF) do |match|
-                    next if match.size != 2
-                    dotted_as_urlconf = match[1].split(".")
-                    relative_path = "#{dotted_as_urlconf.join("/")}.py"
+                  content.each_line do |line|
+                    next if line.lstrip.starts_with?("#")
 
-                    Dir.glob("#{escape_glob_path(search_dir)}/**/#{relative_path}") do |filepath|
-                      basepath = filepath.split("/")[..-(dotted_as_urlconf.size + 1)].join("/")
-                      root_django_urls_list << DjangoUrls.new("", filepath, basepath)
+                    line.scan(REGEX_ROOT_URLCONF) do |match|
+                      next if match.size != 2
+                      dotted_as_urlconf = match[1].split(".")
+                      relative_path = "#{dotted_as_urlconf.join("/")}.py"
+
+                      Dir.glob("#{escape_glob_path(search_dir)}/**/#{relative_path}") do |filepath|
+                        basepath = filepath.split("/")[..-(dotted_as_urlconf.size + 1)].join("/")
+                        root_django_urls_list << DjangoUrls.new("", filepath, basepath)
+                      end
                     end
                   end
                 end
@@ -401,6 +405,7 @@ module Analyzer::Python
       lines = content.split("\n")
 
       lines.each_with_index do |line, index|
+        next if line.lstrip.starts_with?("#")
         next unless line.matches?(/\b(?:url|path|re_path|register)\s*\(/)
 
         logical_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
@@ -461,6 +466,7 @@ module Analyzer::Python
       lines = content.split("\n")
 
       lines.each_with_index do |line, index|
+        next if line.lstrip.starts_with?("#")
         next unless line.includes?(".register(")
 
         logical_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
@@ -587,20 +593,21 @@ module Analyzer::Python
 
     private def extract_drf_direct_router_names(content : ::String) : Array(::String)
       router_names = [] of ::String
+      scan_content = content.lines.reject(&.lstrip.starts_with?("#")).join("\n")
 
-      content.scan(/\burlpatterns\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
+      scan_content.scan(/\burlpatterns\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
         router_names << match[1] if match.size == 2
       end
 
-      content.scan(/\burlpatterns\s*\+=\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
+      scan_content.scan(/\burlpatterns\s*\+=\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
         router_names << match[1] if match.size == 2
       end
 
-      content.scan(/\burlpatterns\b[^\n]*\+\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
+      scan_content.scan(/\burlpatterns\b[^\n]*\+\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\b/) do |match|
         router_names << match[1] if match.size == 2
       end
 
-      content.scan(/\burlpatterns\s*\.\s*extend\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\s*\)/) do |match|
+      scan_content.scan(/\burlpatterns\s*\.\s*extend\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\.urls\s*\)/) do |match|
         router_names << match[1] if match.size == 2
       end
 

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -24,9 +24,11 @@ module Analyzer::Python
             import_modules = find_fastapi_imported_modules(current_base_path, path, source)
             codelines = source.split("\n")
             codelines.each_with_index do |original_line, index|
+              next if original_line.lstrip.starts_with?("#")
+
               effective_line = coalesce_constructor_call(codelines, index, original_line, "APIRouter")
               line = effective_line.gsub(" ", "")
-              match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:fastapi\.)?FastAPI\(/
+              match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:fastapi\.)?FastAPI\(/
               if !match.nil?
                 fastapi_instance_name = match[1]
                 unless include_router_map.has_key?(fastapi_instance_name)
@@ -48,7 +50,7 @@ module Analyzer::Python
               end
 
               # https://fastapi.tiangolo.com/tutorial/bigger-applications/
-              match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:fastapi\.)?APIRouter\(/
+              match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:fastapi\.)?APIRouter\(/
               if !match.nil?
                 prefix = ""
                 router_instance_name = match[1]
@@ -81,6 +83,8 @@ module Analyzer::Python
           codelines = source.split("\n")
           router_map.each do |instance_name, router_class|
             codelines.each_with_index do |line, index|
+              next if line.lstrip.starts_with?("#")
+
               # FastAPI route decorators routinely span multiple
               # lines:
               #

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -54,7 +54,7 @@ module Analyzer::Python
 
           file_content = fetch_file_content(path)
           lines = file_content.lines
-          if lines.any?(&.includes?("flask"))
+          if flask_relevant_source?(file_content)
             api_instances = Hash(::String, ::String).new
             path_api_instances[path] = api_instances
             view_assignments = Hash(::String, ::String).new # Maps view_var -> ClassName (per-file scope)
@@ -79,10 +79,12 @@ module Analyzer::Python
             end
 
             lines.each_with_index do |original_line, line_index|
+              next if original_line.lstrip.starts_with?("#")
+
               line = original_line.gsub(" ", "") # remove spaces for easier regex matching
 
               # Identify Flask instance assignments
-              flask_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:flask\.)?Flask\(/
+              flask_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask\.)?Flask\(/
               if flask_match
                 flask_instance_name = flask_match[1]
                 api_instances[flask_instance_name] ||= ""
@@ -112,7 +114,7 @@ module Analyzer::Python
 
               # Api from flask instance
               flask_instances.each do |_flask_instance_name, _prefix|
-                api_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:flask_restx\.)?Api\((app=)?#{_flask_instance_name}/
+                api_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_flask_instance_name}/
                 if api_match
                   api_instance_name = api_match[1]
                   api_instances[api_instance_name] ||= _prefix
@@ -121,7 +123,7 @@ module Analyzer::Python
 
               # Api from blueprint instance
               blueprint_prefixes.each do |_blueprint_instance_name, _prefix|
-                api_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:flask_restx\.)?Api\((app=)?#{_blueprint_instance_name}/
+                api_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_blueprint_instance_name}/
                 if api_match
                   api_instance_name = api_match[1]
                   api_instances[api_instance_name] ||= _prefix
@@ -216,7 +218,7 @@ module Analyzer::Python
 
               # Identify view assignments: view_var = ClassName.as_view('name')
               # Note: spaces are already removed from line at this point
-              view_assign_match = line.match /(#{PYTHON_VAR_NAME_REGEX})=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/
+              view_assign_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/
               if view_assign_match
                 view_var = view_assign_match[1]
                 class_name = view_assign_match[2]
@@ -425,9 +427,8 @@ module Analyzer::Python
         blueprint_info.each do |blueprint_name, blueprint_prefix|
           if path_api_instances.has_key?(path)
             api_instances = path_api_instances[path]
-            if api_instances.has_key?(blueprint_name)
-              api_instances[blueprint_name] = File.join(blueprint_prefix, api_instances[blueprint_name])
-            end
+            own_prefix = api_instances[blueprint_name]? || ""
+            api_instances[blueprint_name] = File.join(blueprint_prefix, own_prefix)
           end
         end
       end
@@ -728,6 +729,14 @@ module Analyzer::Python
     # resolver can locate imported modules relative to the right root.
     private def base_path_for(file_path : ::String) : ::String
       base_paths.find { |bp| file_path.starts_with?(bp) } || base_paths[0]? || ""
+    end
+
+    private def flask_relevant_source?(source : ::String) : Bool
+      return true if source.includes?("flask")
+      return true if source.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
+      return true if source.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
+
+      false
     end
 
     private def extract_flask_static_url_path(constructor_line : ::String) : ::String?


### PR DESCRIPTION
## Summary
- ignore commented Django/FastAPI/Flask route registration patterns to reduce endpoint FPs
- support qualified FastAPI/Flask annotations and cross-file Flask blueprint route modules
- preserve multiline Django DRF direct-router detection with regression fixtures

## Tests
- crystal spec spec/functional_test/testers/python/django_spec.cr spec/functional_test/testers/python/fastapi_spec.cr spec/functional_test/testers/python/flask_advanced_spec.cr spec/functional_test/testers/python/flask_crossfile_spec.cr
- crystal spec spec/unit_test/miniparser/python_route_extractor_ts_spec.cr spec/unit_test/detector/python/fastapi_spec.cr spec/unit_test/detector/python/flask_spec.cr spec/unit_test/detector/python/django_spec.cr
- just test
- just check
- just build
- ./bin/noir -b spec/functional_test/fixtures/python/django -f json | rg "commented|commented-media|/direct-articles/"