### PR TITLE
Improve Scala Akka and Play analyzers

### DIFF
--- a/spec/functional_test/fixtures/scala/akka/WebServer.scala
+++ b/spec/functional_test/fixtures/scala/akka/WebServer.scala
@@ -94,6 +94,24 @@ object WebServer {
               complete(s"Search results for: $query")
             }
           }
+        },
+        pathPrefix("orders") {
+          pathEndOrSingleSlash {
+            get(complete("orders")) ~
+            (post & entity(as[Item])) { item =>
+              complete(s"Created order: ${item.name}")
+            }
+          } ~
+          pathPrefix(JavaUUID) { orderId =>
+            pathSingleSlash {
+              delete(complete(s"Deleted order $orderId"))
+            } ~
+            (get & path("price")) {
+              parameter('currency) { currency =>
+                complete(s"Price for $orderId in $currency")
+              }
+            }
+          }
         }
       )
 

--- a/spec/functional_test/fixtures/scala/play/app/controllers/HomeController.scala
+++ b/spec/functional_test/fixtures/scala/play/app/controllers/HomeController.scala
@@ -80,3 +80,14 @@ class Assets extends BaseController {
     Ok(s"Asset $path/$file")
   }
 }
+
+class Admin extends BaseController {
+  def stats(request: Request, format: Option[String]) = AuthenticatedAction { request =>
+    val trace = request.headers.get("X-Trace-Id")
+    Ok(s"admin stats $format")
+  }
+
+  def enqueue(id: Long) = Action.async(parse.json) { implicit request =>
+    Future.successful(Ok(s"queued $id"))
+  }
+}

--- a/spec/functional_test/fixtures/scala/play/conf/admin.routes
+++ b/spec/functional_test/fixtures/scala/play/conf/admin.routes
@@ -1,0 +1,2 @@
+GET /stats controllers.Admin.stats(request: Request, format: Option[String] ?= "json")
+POST /jobs/:id controllers.Admin.enqueue(id: Long)

--- a/spec/functional_test/fixtures/scala/play/conf/routes
+++ b/spec/functional_test/fixtures/scala/play/conf/routes
@@ -21,3 +21,5 @@ GET /assets/*file controllers.Assets.at(path="/public", file)
 POST /multipart controllers.MissingController.multipart
 POST /xml controllers.MissingController.xml
 POST /whitespace controllers.MissingController.whitespace
+
+-> /admin admin.Routes

--- a/spec/functional_test/testers/scala/akka_spec.cr
+++ b/spec/functional_test/testers/scala/akka_spec.cr
@@ -24,6 +24,13 @@ expected_endpoints = [
     Param.new("X-API-Key", "", "header"),
   ]),
   Endpoint.new("/search", "POST", [Param.new("q", "", "query")]),
+  Endpoint.new("/orders", "GET"),
+  Endpoint.new("/orders", "POST", [Param.new("body", "Item", "json")]),
+  Endpoint.new("/orders/{orderId}", "DELETE", [Param.new("orderId", "", "path")]),
+  Endpoint.new("/orders/{orderId}/price", "GET", [
+    Param.new("orderId", "", "path"),
+    Param.new("currency", "", "query"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/scala/akka/", {

--- a/spec/functional_test/testers/scala/play_callees_spec.cr
+++ b/spec/functional_test/testers/scala/play_callees_spec.cr
@@ -14,7 +14,7 @@ post_data.push_callee(Callee.new("Json.toJson"))
 
 FunctionalTester.new("fixtures/scala/play/", {
   :techs     => 1,
-  :endpoints => 17,
+  :endpoints => 19,
 }, [index, protected_endpoint, post_data], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/scala/play_spec.cr
+++ b/spec/functional_test/testers/scala/play_spec.cr
@@ -41,6 +41,14 @@ expected_endpoints = [
   Endpoint.new("/whitespace", "POST", [
     Param.new("body", "", "json"),
   ]),
+  Endpoint.new("/admin/stats", "GET", [
+    Param.new("format", "json", "query"),
+    Param.new("X-Trace-Id", "", "header"),
+  ]),
+  Endpoint.new("/admin/jobs/:id", "POST", [
+    Param.new("id", "", "path"),
+    Param.new("body", "", "json"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/scala/play/", {

--- a/spec/unit_test/analyzer/analyzer_scala_akka_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_scala_akka_spec.cr
@@ -101,4 +101,44 @@ describe "scala akka route extraction" do
     File.delete(temp_file) if temp_file && File.exists?(temp_file)
     Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
   end
+
+  it "keeps params scoped to inline sibling method directives" do
+    options = create_test_options
+    instance = Analyzer::Scala::Akka.new(options)
+
+    temp_dir = File.tempname("scala_akka_inline_params_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "Routes.scala")
+
+    File.write(temp_file, <<-SCALA)
+      import akka.http.scaladsl.server.Directives._
+
+      object Routes {
+        val route =
+          pathPrefix("orders") {
+            pathEndOrSingleSlash {
+              get(complete("orders")) ~
+              (post & entity(as[Order])) { order =>
+                complete("created")
+              }
+            }
+          }
+      }
+      SCALA
+
+    endpoints = instance.analyze_file(temp_file)
+    get_endpoint = endpoints.find { |e| e.method == "GET" && e.url == "/orders" }
+    post_endpoint = endpoints.find { |e| e.method == "POST" && e.url == "/orders" }
+
+    get_endpoint.should_not be_nil
+    post_endpoint.should_not be_nil
+
+    if get_endpoint && post_endpoint
+      get_endpoint.params.any? { |p| p.name == "body" }.should be_false
+      post_endpoint.params.map { |p| {p.name, p.param_type} }.should contain({"body", "json"})
+    end
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
 end

--- a/spec/unit_test/analyzer/analyzer_scala_play_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_scala_play_spec.cr
@@ -62,4 +62,50 @@ describe "scala play analyzer" do
     Dir.delete(conf_dir) if conf_dir && Dir.exists?(conf_dir)
     Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
   end
+
+  it "resolves included routes relative to the including routes file" do
+    options = create_test_options
+
+    temp_dir = File.tempname("scala_play_multi_module_test")
+    module_a_conf = File.join(temp_dir, "module-a", "conf")
+    module_b_conf = File.join(temp_dir, "module-b", "conf")
+    Dir.mkdir_p(module_a_conf)
+    Dir.mkdir_p(module_b_conf)
+
+    a_routes = File.join(module_a_conf, "routes")
+    a_admin_routes = File.join(module_a_conf, "admin.routes")
+    b_routes = File.join(module_b_conf, "routes")
+    b_admin_routes = File.join(module_b_conf, "admin.routes")
+
+    File.write(a_routes, "-> /admin admin.Routes\n")
+    File.write(a_admin_routes, "GET /a controllers.Admin.a\n")
+    File.write(b_routes, "-> /admin admin.Routes\n")
+    File.write(b_admin_routes, "GET /b controllers.Admin.b\n")
+
+    CodeLocator.instance.clear_all
+    CodeLocator.instance.register_file(a_routes, File.read(a_routes))
+    CodeLocator.instance.register_file(a_admin_routes, File.read(a_admin_routes))
+    CodeLocator.instance.register_file(b_routes, File.read(b_routes))
+    CodeLocator.instance.register_file(b_admin_routes, File.read(b_admin_routes))
+
+    options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+    endpoints = Analyzer::Scala::Play.new(options).analyze
+
+    endpoints.map(&.url).should contain("/admin/a")
+    endpoints.map(&.url).should contain("/admin/b")
+    endpoints.map(&.url).should_not contain("/a")
+    endpoints.map(&.url).should_not contain("/b")
+  ensure
+    CodeLocator.instance.clear_all
+    [a_routes, a_admin_routes, b_routes, b_admin_routes].each do |path|
+      File.delete(path) if path && File.exists?(path)
+    end
+    Dir.delete(module_a_conf) if module_a_conf && Dir.exists?(module_a_conf)
+    Dir.delete(module_b_conf) if module_b_conf && Dir.exists?(module_b_conf)
+    module_a = temp_dir ? File.join(temp_dir, "module-a") : nil
+    module_b = temp_dir ? File.join(temp_dir, "module-b") : nil
+    Dir.delete(module_a) if module_a && Dir.exists?(module_a)
+    Dir.delete(module_b) if module_b && Dir.exists?(module_b)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
 end

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -42,15 +42,17 @@ module Analyzer::Scala
 
           block_content = block[0]
           block_end = block[2]
+          route_scope = "#{stripped_line}\n#{block_content}"
 
           HTTP_METHODS.each do |method|
-            if block_content =~ /\b#{method}\s*\{/
+            method_param_scopes = extract_method_param_scopes(route_scope, method)
+            unless method_param_scopes.empty?
               endpoint = create_endpoint(full_path, method.upcase, path)
 
               extract_path_params(endpoint, full_path)
 
               # Extract additional parameters from the block
-              extract_params_from_block(endpoint, block_content)
+              extract_params_from_block(endpoint, method_param_scopes.join("\n"))
               attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
 
               endpoints << endpoint
@@ -58,19 +60,21 @@ module Analyzer::Scala
           end
         end
 
-        if stripped_line.includes?("pathEnd") || stripped_line.includes?("pathEndOrSingleSlash")
+        if stripped_line.includes?("pathEnd") || stripped_line.includes?("pathEndOrSingleSlash") || stripped_line.includes?("pathSingleSlash")
           full_path = prefix_stack.empty? ? "/" : prefix_stack.join("")
           block = extract_block_from_index(lines, index)
           next unless block
 
           block_content = block[0]
           block_end = block[2]
+          route_scope = "#{stripped_line}\n#{block_content}"
 
           HTTP_METHODS.each do |method|
-            if block_content =~ /\b#{method}\s*\{/
+            method_param_scopes = extract_method_param_scopes(route_scope, method)
+            unless method_param_scopes.empty?
               endpoint = create_endpoint(full_path, method.upcase, path)
               extract_path_params(endpoint, full_path)
-              extract_params_from_block(endpoint, block_content)
+              extract_params_from_block(endpoint, method_param_scopes.join("\n"))
               attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
               endpoints << endpoint
             end
@@ -146,12 +150,42 @@ module Analyzer::Scala
         endpoint.push_param(Param.new(match[1], "", "query"))
       end
 
+      # Extract symbol parameters: parameter('name) { ... }
+      block.scan(/parameter\s*\(\s*'(\w+)/) do |match|
+        param_name = match[1]
+        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+          endpoint.push_param(Param.new(param_name, "", "query"))
+        end
+      end
+
+      # Extract Symbol("name") parameters.
+      block.scan(/parameter\s*\(\s*Symbol\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+        param_name = match[1]
+        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+          endpoint.push_param(Param.new(param_name, "", "query"))
+        end
+      end
+
       # Extract multiple parameters: parameters("name", "age") or parameters("name", "age".optional)
       if params_match = block.match(/parameters\s*\(([^)]+)\)/)
         params_content = params_match[1]
         params_content.scan(/['"](\w+)['"]/) do |match|
           param_name = match[1]
           # Avoid duplicating parameters already added
+          unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+            endpoint.push_param(Param.new(param_name, "", "query"))
+          end
+        end
+
+        params_content.scan(/'(\w+)/) do |match|
+          param_name = match[1]
+          unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+            endpoint.push_param(Param.new(param_name, "", "query"))
+          end
+        end
+
+        params_content.scan(/Symbol\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+          param_name = match[1]
           unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
             endpoint.push_param(Param.new(param_name, "", "query"))
           end
@@ -181,11 +215,142 @@ module Analyzer::Scala
       match[1]
     end
 
+    private def extract_method_param_scopes(content : String, method : String) : Array(String)
+      scopes = [] of String
+      regex = /(?<![.\w])#{Regex.escape(method)}(?![\w])/
+      search_from = 0
+
+      while match = content.match(regex, search_from)
+        method_start = match.begin || search_from
+        method_end = match.end || method_start
+        next_index = skip_whitespace(content, method_end)
+
+        if next_index < content.size
+          case content[next_index]
+          when '{'
+            if block = balanced_slice(content, next_index, '{', '}')
+              scopes << block
+            end
+          when '('
+            if args = balanced_slice(content, next_index, '(', ')')
+              scope = args
+              after_args = skip_whitespace(content, next_index + args.size)
+              if after_args < content.size && content[after_args] == '{'
+                if block = balanced_slice(content, after_args, '{', '}')
+                  scope = "#{scope}\n#{block}"
+                end
+              end
+              scopes << scope
+            end
+          else
+            if chain_block = chained_directive_scope(content, method_start)
+              scopes << chain_block
+            end
+          end
+        elsif method_end == content.size
+          scopes << method
+        end
+
+        search_from = method_end
+      end
+
+      scopes
+    end
+
+    private def chained_directive_scope(content : String, method_start : Int32) : String?
+      opening_brace = next_unquoted_char(content, '{', method_start)
+      return unless opening_brace
+
+      header = content[method_start...opening_brace]
+      return unless header.includes?("&")
+      block = balanced_slice(content, opening_brace, '{', '}') || content[opening_brace..]
+
+      "#{header}\n#{block}"
+    end
+
+    private def skip_whitespace(content : String, index : Int32) : Int32
+      i = index
+      while i < content.size && content[i].whitespace?
+        i += 1
+      end
+      i
+    end
+
+    private def next_unquoted_char(content : String, needle : Char, start : Int32) : Int32?
+      in_string = false
+      quote = '\0'
+      escape = false
+      i = start
+
+      while i < content.size
+        char = content[i]
+        if in_string
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            in_string = false
+          end
+        else
+          case char
+          when '"', '\''
+            in_string = true
+            quote = char
+          else
+            return i if char == needle
+            return if char == '~' || char == ','
+          end
+        end
+        i += 1
+      end
+
+      nil
+    end
+
+    private def balanced_slice(content : String, start : Int32, open_char : Char, close_char : Char) : String?
+      return unless start < content.size && content[start] == open_char
+
+      depth = 0
+      in_string = false
+      quote = '\0'
+      escape = false
+      i = start
+
+      while i < content.size
+        char = content[i]
+        if in_string
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            in_string = false
+          end
+        else
+          case char
+          when '"', '\''
+            in_string = true
+            quote = char
+          else
+            depth += 1 if char == open_char
+            if char == close_char
+              depth -= 1
+              return content[start..i] if depth == 0
+            end
+          end
+        end
+        i += 1
+      end
+
+      nil
+    end
+
     private def akka_path_from_args(args : String, param_names : Array(String)) : String
       segments = [] of String
       param_index = 0
 
-      args.scan(/"([^"]+)"|(IntNumber|LongNumber|Segment|Remaining|JavaUUID)/) do |match|
+      args.scan(/"([^"]+)"|(IntNumber|LongNumber|DoubleNumber|HexIntNumber|Segment|Segments|Remaining|RemainingPath|Rest|JavaUUID)/) do |match|
         if literal = match[1]?
           segments.concat(literal.split('/').reject(&.empty?))
         elsif match[2]?

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -33,10 +33,14 @@ module Analyzer::Scala
 
       # Parse controller files to build method map
       controller_methods = parse_controller_files(scala_files)
+      routes_by_key = index_routes_files(routes_files)
+      included_routes = collect_included_routes(routes_files, routes_by_key)
+      top_level_routes = routes_files.reject { |path| included_routes.includes?(path) }
+      top_level_routes = routes_files if top_level_routes.empty?
 
       # Process each routes file
-      routes_files.each do |routes_path|
-        process_routes_file(routes_path, controller_methods)
+      top_level_routes.each do |routes_path|
+        process_routes_file(routes_path, controller_methods, routes_by_key, "", Set(String).new)
       end
 
       Fiber.yield
@@ -72,9 +76,11 @@ module Analyzer::Scala
           # Get content from class start
           class_content = content[class_start_idx..]
 
-          # Find all def methods in the class
-          # Match method signatures: def methodName = Action { ... } or def methodName(params) = Action { ... }
-          method_regex = /def\s+(\w+)(?:\s*\([^)]*\))?\s*=\s*Action/
+          # Find all def methods in the class. Route files decide whether a
+          # method is externally reachable, so parsing custom ActionBuilder
+          # wrappers here improves controller parameter enrichment without
+          # adding standalone endpoints.
+          method_regex = /def\s+(\w+)(?:\s*\([^)]*\))?(?:\s*:\s*[^=]+)?\s*=/
           class_content.scan(method_regex) do |match|
             method_name = match[1]
             full_method_name = package_name.empty? ? "#{class_name}.#{method_name}" : "#{package_name}.#{class_name}.#{method_name}"
@@ -133,14 +139,23 @@ module Analyzer::Scala
 
     # Extract method body from content
     private def extract_method_body(content : String, method_name : String) : MethodBody?
-      # Find method start - Scala methods with Action
-      # Handles: Action { ... }, Action { request => ... }, Action.async { ... }, Action(parse.json) { ... }
-      method_start_regex = /def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?\s*=\s*Action(?:\s*\.async)?(?:\s*\([^)]*\))?(?:\s*\.async)?\s*\{\s*(?:\w+\s*=>\s*)?/
+      # Find method start and the first action block. Handles `Action`,
+      # `Action.async`, parser variants, and custom action builders such as
+      # `AuthenticatedAction { request => ... }`.
+      method_start_regex = /def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?(?:\s*:\s*[^=]+)?\s*=/
       match = content.match(method_start_regex)
       return unless match
 
-      start_index = match.end
-      return unless start_index
+      search_start = match.end
+      return unless search_start
+
+      opening_brace = content.index('{', search_start)
+      return unless opening_brace
+
+      next_method = content.index(/\ndef\s+\w+/, search_start)
+      return if next_method && next_method < opening_brace
+
+      start_index = opening_brace + 1
 
       # Find matching closing brace
       brace_count = 1
@@ -155,14 +170,22 @@ module Analyzer::Scala
         end_index += 1
       end
 
-      signature = match[0]
+      signature_start = match.begin || 0
+      signature = content[signature_start..opening_brace]
       body = content[start_index...end_index - 1]
       {signature: signature, body: body}
     end
 
     # Process a Play routes file
-    private def process_routes_file(path : String, controller_methods : Hash(String, ControllerMethod))
-      content = File.read(path)
+    private def process_routes_file(path : String,
+                                    controller_methods : Hash(String, ControllerMethod),
+                                    routes_by_key : Hash(String, Array(String)),
+                                    prefix : String,
+                                    seen : Set(String))
+      return if seen.includes?(path)
+
+      seen << path
+      content = read_file_content(path)
       lines = content.split('\n')
 
       lines.each_with_index do |line, index|
@@ -171,11 +194,20 @@ module Analyzer::Scala
         # Skip comments and empty lines
         next if stripped_line.empty? || stripped_line.starts_with?("#")
 
+        if include_match = stripped_line.match(/^->\s+([^\s]+)\s+(.+)$/)
+          include_prefix = include_match[1]
+          include_target = include_match[2]
+          if included_path = resolve_included_routes_file(include_target, routes_by_key, path)
+            process_routes_file(included_path, controller_methods, routes_by_key, join_paths(prefix, include_prefix), seen)
+          end
+          next
+        end
+
         # Match route definitions: METHOD /path controller.action
         # Example: GET /users/:id controllers.Users.show(id: Long)
         if route_match = stripped_line.match(/^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+([^\s]+)\s+(.+)/)
           method = route_match[1]
-          route_path = route_match[2]
+          route_path = join_paths(prefix, route_match[2])
           action = route_match[3]
 
           endpoint = create_endpoint(route_path, method, path, index + 1)
@@ -192,6 +224,83 @@ module Analyzer::Scala
           @result << endpoint
         end
       end
+
+      seen.delete(path)
+    end
+
+    private def index_routes_files(routes_files : Array(String)) : Hash(String, Array(String))
+      index = Hash(String, Array(String)).new { |hash, key| hash[key] = [] of String }
+
+      routes_files.each do |path|
+        basename = File.basename(path)
+        index[basename] << path
+
+        if basename == "routes" || basename == "routes.conf"
+          index["Routes"] << path
+          index["router.Routes"] << path
+        elsif match = basename.match(/^(.+)\.routes$/)
+          name = match[1]
+          index[name] << path
+          index["#{name}.Routes"] << path
+        end
+      end
+
+      index
+    end
+
+    private def collect_included_routes(routes_files : Array(String), routes_by_key : Hash(String, Array(String))) : Set(String)
+      included = Set(String).new
+
+      routes_files.each do |path|
+        read_file_content(path).each_line do |line|
+          stripped = line.strip
+          next if stripped.empty? || stripped.starts_with?("#")
+          next unless include_match = stripped.match(/^->\s+[^\s]+\s+(.+)$/)
+
+          if included_path = resolve_included_routes_file(include_match[1], routes_by_key, path)
+            included << included_path
+          end
+        end
+      end
+
+      included
+    end
+
+    private def resolve_included_routes_file(target : String,
+                                             routes_by_key : Hash(String, Array(String)),
+                                             including_path : String) : String?
+      key = target.split(/\s|\(/).first.strip
+      key = key.lchop("@")
+      candidates = [key]
+
+      if key.ends_with?(".Routes")
+        candidates << key[0...(key.size - ".Routes".size)]
+      else
+        candidates << "#{key}.Routes"
+      end
+
+      including_dir = File.dirname(including_path)
+      candidates.each do |candidate|
+        paths = routes_by_key[candidate]?
+        next unless paths
+
+        if local_path = paths.find { |path| File.dirname(path) == including_dir }
+          return local_path
+        end
+      end
+
+      candidates.each do |candidate|
+        paths = routes_by_key[candidate]?
+        return paths.first if paths && paths.size == 1
+      end
+
+      nil
+    end
+
+    private def join_paths(prefix : String, suffix : String) : String
+      return suffix if prefix.empty?
+      return prefix.rstrip('/') if suffix.empty?
+      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
 
     # Extract path parameters from route pattern
@@ -226,40 +335,153 @@ module Analyzer::Scala
       if params_match = action.match(/\((.*)\)/)
         params_str = params_match[1]
 
-        # Split by comma for simple parsing (note: doesn't handle nested structures perfectly)
-        params_str.split(',').each do |param_def|
+        split_route_action_params(params_str).each do |param_def|
           param_def = param_def.strip
           next if param_def.empty?
 
-          # Skip named parameters with literal values (e.g., path="/public")
-          # But don't skip optional parameters with defaults (e.g., name: String ?= "default")
-          next if param_def.match(/^\w+\s*=\s*"/)
+          if route_param = route_action_param(param_def)
+            param_name, param_type, default_value = route_param
+            next if request_route_param_type?(param_type)
+            next if endpoint.params.any? { |p| p.name == param_name && p.param_type == "path" }
+            next if endpoint.params.any? { |p| p.name == param_name }
 
-          # Extract parameter name and type
-          # Formats: "id: Long", "name: String ?= default", "category: Option[String]"
-          # Match parameter name followed by colon and any type (including generics)
-          if param_match = param_def.match(/^(\w+)\s*:\s*/)
-            param_name = param_match[1]
-
-            # Check if it's already a path parameter
-            is_path_param = endpoint.params.any? { |p| p.name == param_name && p.param_type == "path" }
-
-            unless is_path_param
-              # Add as query parameter
-              unless endpoint.params.any? { |p| p.name == param_name }
-                endpoint.push_param(Param.new(param_name, "", "query"))
-              end
-            end
+            endpoint.push_param(Param.new(param_name, default_value, "query"))
           end
         end
       end
+    end
+
+    private def split_route_action_params(params_str : String) : Array(String)
+      params = [] of String
+      start = 0
+      depth = 0
+      in_string = false
+      quote = '\0'
+      escape = false
+
+      params_str.each_char_with_index do |char, index|
+        if in_string
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            in_string = false
+          end
+          next
+        end
+
+        case char
+        when '"', '\''
+          in_string = true
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+        when ','
+          next unless depth == 0
+
+          params << params_str[start...index].strip
+          start = index + 1
+        end
+      end
+
+      tail = params_str[start..]?.to_s.strip
+      params << tail unless tail.empty?
+      params
+    end
+
+    private def route_action_param(param_def : String) : Tuple(String, String?, String)?
+      optional_default_index = top_level_operator_index(param_def, "?=")
+      fixed_value_index = top_level_operator_index(param_def, "=")
+      return if fixed_value_index && optional_default_index.nil?
+
+      declaration_end = optional_default_index || param_def.size
+      declaration = param_def[0...declaration_end].strip
+      return if declaration.empty?
+
+      default_value = ""
+      if optional_default_index
+        raw_default = param_def[(optional_default_index + 2)..].strip
+        default_value = normalize_route_default_value(raw_default)
+      end
+
+      if colon = declaration.index(':')
+        name = declaration[0...colon].strip
+        type_name = declaration[(colon + 1)..].strip
+        return if name.empty?
+        return {name, type_name.empty? ? nil : type_name, default_value}
+      end
+
+      name = declaration.strip
+      return unless name.match(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+      {name, nil, default_value}
+    end
+
+    private def top_level_operator_index(text : String, operator : String) : Int32?
+      depth = 0
+      in_string = false
+      quote = '\0'
+      escape = false
+      i = 0
+
+      while i <= text.size - operator.size
+        char = text[i]
+
+        if in_string
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            in_string = false
+          end
+          i += 1
+          next
+        end
+
+        case char
+        when '"', '\''
+          in_string = true
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+        else
+          return i if depth == 0 && text.byte_slice(i, operator.size) == operator
+        end
+        i += 1
+      end
+
+      nil
+    end
+
+    private def normalize_route_default_value(raw_default : String) : String
+      value = raw_default.strip
+      return "" if value.empty?
+
+      if value.size >= 2 && ((value.starts_with?('"') && value.ends_with?('"')) || (value.starts_with?("'") && value.ends_with?("'")))
+        return value[1..-2]
+      end
+
+      value
+    end
+
+    private def request_route_param_type?(param_type : String?) : Bool
+      return false unless param_type
+
+      normalized = param_type.gsub(/\s+/, "")
+      normalized == "Request" || normalized == "RequestHeader" || normalized == "MessagesRequest" ||
+        normalized.ends_with?(".Request") || normalized.ends_with?(".RequestHeader") || normalized.ends_with?(".MessagesRequest")
     end
 
     # Extract header, cookie, and body parameters from controller method
     private def extract_controller_params(endpoint : Endpoint, action : String, controller_methods : Hash(String, ControllerMethod))
       # Extract controller method name from action
       # Example: controllers.Users.show(id: Long) -> controllers.Users.show
-      method_name = action.split("(").first.strip
+      method_name = action.split("(").first.strip.lchop("@")
 
       # Look up the controller method
       if method_info = controller_methods[method_name]?
@@ -291,7 +513,7 @@ module Analyzer::Scala
     end
 
     private def line_number_for_method_body(content : String, class_start_idx : Int32, method_name : String) : Int32
-      if method_start = content.index(/def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?\s*=\s*Action/, class_start_idx)
+      if method_start = content.index(/def\s+#{Regex.escape(method_name)}(?:\s*\([^)]*\))?(?:\s*:\s*[^=]+)?\s*=/, class_start_idx)
         return content[0, method_start].count('\n') + 1
       end
 


### PR DESCRIPTION
## Summary
- scope Akka HTTP parameter extraction to the matched method directive and support inline/chained directives
- support Play subrouter includes with directory-local resolution to avoid cross-module route mixups
- add Scala Akka/Play regression fixtures for inline routes, symbol params, custom action builders, and included routes

## Validation
- just test
- just build
- just check