### PR TITLE
Improve Postman collection analyzer

### DIFF
--- a/spec/unit_test/analyzer/specification/postman_spec.cr
+++ b/spec/unit_test/analyzer/specification/postman_spec.cr
@@ -1,0 +1,176 @@
+require "../../../spec_helper"
+require "../../../../src/models/code_locator"
+require "../../../../src/analyzer/analyzers/specification/postman"
+
+private def analyze_postman(content : String)
+  path = File.tempname("postman", ".json")
+  File.write(path, content)
+  locator = CodeLocator.instance
+  locator.clear "postman-json"
+  locator.push "postman-json", path
+
+  options = create_test_options
+  analyzer = Analyzer::Specification::Postman.new options
+  analyzer.analyze
+ensure
+  locator = CodeLocator.instance
+  locator.clear "postman-json"
+  File.delete(path) if path && File.exists?(path)
+end
+
+private def param_tuples(endpoint : Endpoint)
+  endpoint.params.map { |p| {p.name, p.value, p.param_type} }
+end
+
+describe "Postman Analyzer" do
+  it "resolves collection variables and extracts string requests" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Variable Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "variable": [
+          { "key": "baseUrl", "value": "https://api.example.com/v1" }
+        ],
+        "item": [
+          {
+            "name": "Ping",
+            "request": "{{baseUrl}}/ping?trace=true"
+          }
+        ]
+      }
+      JSON
+
+    endpoints.size.should eq 1
+    endpoint = endpoints.first
+    endpoint.url.should eq "/v1/ping"
+    endpoint.method.should eq "GET"
+    param_tuples(endpoint).should contain({"trace", "true", "query"})
+  end
+
+  it "honors disabled Postman params and derives path variables from raw URLs" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Disabled Param Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "variable": [
+          { "key": "baseUrl", "value": "https://api.example.com/v1" }
+        ],
+        "item": [
+          {
+            "name": "Get User",
+            "request": {
+              "method": "GET",
+              "header": [
+                { "key": "X-Trace", "value": "1" },
+                { "key": "X-Off", "value": "0", "disabled": true },
+                { "key": "Content-Type", "value": "application/json" },
+                { "key": "Cookie", "value": "sid=abc; theme=dark" }
+              ],
+              "url": {
+                "raw": "{{baseUrl}}/users/{{userId}}?page=1&debug=true",
+                "query": [
+                  { "key": "page", "value": "1" },
+                  { "key": "debug", "value": "true", "disabled": true }
+                ]
+              }
+            }
+          }
+        ]
+      }
+      JSON
+
+    endpoints.size.should eq 1
+    endpoint = endpoints.first
+    endpoint.url.should eq "/v1/users/:userId"
+
+    params = param_tuples(endpoint)
+    params.should contain({"page", "1", "query"})
+    params.should contain({"userId", "", "path"})
+    params.should contain({"X-Trace", "1", "header"})
+    params.should contain({"sid", "abc", "cookie"})
+    params.should contain({"theme", "dark", "cookie"})
+    params.should_not contain({"debug", "true", "query"})
+    params.should_not contain({"X-Off", "0", "header"})
+    endpoint.params.any? { |p| p.name == "Content-Type" }.should be_false
+  end
+
+  it "preserves single-brace path variable names" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Single Brace Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": [
+          {
+            "name": "Get User",
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/users/{id}"
+            }
+          }
+        ]
+      }
+      JSON
+
+    endpoints.size.should eq 1
+    endpoint = endpoints.first
+    endpoint.url.should eq "/users/:id"
+    param_tuples(endpoint).should contain({"id", "", "path"})
+  end
+
+  it "skips disabled form fields and extracts GraphQL body variables" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Body Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": [
+          {
+            "name": "Upload",
+            "request": {
+              "method": "POST",
+              "body": {
+                "mode": "formdata",
+                "formdata": [
+                  { "key": "file", "src": "avatar.png" },
+                  { "key": "ignore", "value": "x", "disabled": true }
+                ]
+              },
+              "url": "/upload"
+            }
+          },
+          {
+            "name": "GraphQL",
+            "request": {
+              "method": "POST",
+              "body": {
+                "mode": "graphql",
+                "graphql": {
+                  "query": "query User($id: ID!) { user(id: $id) { id } }",
+                  "variables": "{\\"id\\":\\"123\\"}"
+                }
+              },
+              "url": "/graphql"
+            }
+          }
+        ]
+      }
+      JSON
+
+    upload = endpoints.find!(&.url.==("/upload"))
+    upload_params = param_tuples(upload)
+    upload_params.should contain({"file", "avatar.png", "form"})
+    upload_params.should_not contain({"ignore", "x", "form"})
+
+    graphql = endpoints.find!(&.url.==("/graphql"))
+    graphql_params = param_tuples(graphql)
+    graphql_params.should contain({"query", "query User($id: ID!) { user(id: $id) { id } }", "json"})
+    graphql_params.should contain({"id", "123", "json"})
+  end
+end

--- a/spec/unit_test/detector/specification/postman_spec.cr
+++ b/spec/unit_test/detector/specification/postman_spec.cr
@@ -64,4 +64,18 @@ describe "Detect Postman Collection" do
 
     instance.detect("not_postman.json", content).should be_false
   end
+
+  it "detects schema-less exports with a Postman id" do
+    content = <<-JSON
+      {
+        "info": {
+          "_postman_id": "12345678-1234-4321-8765-123456789012",
+          "name": "Schema-less Export"
+        },
+        "item": []
+      }
+      JSON
+
+    instance.detect("collection.json", content).should be_true
+  end
 end

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "uri"
 
 module Analyzer::Specification
   class Postman < Analyzer
@@ -16,7 +17,7 @@ module Analyzer::Specification
             begin
               # Process items (requests) in the collection
               if json_obj["item"]?
-                process_items(json_obj["item"], details)
+                process_items(json_obj["item"], details, collect_variables(json_obj["variable"]?))
               end
             rescue e
               @logger.debug "Exception processing #{postman_file}"
@@ -29,18 +30,23 @@ module Analyzer::Specification
       @result
     end
 
-    private def process_items(items, details, folder_path = "")
-      items.as_a.each do |item|
+    private def process_items(items, details, variables : Hash(String, String), folder_path = "")
+      item_array = items.as_a?
+      return unless item_array
+
+      item_array.each do |item|
         begin
+          item_variables = merge_variables(variables, item["variable"]?)
+
           # Check if it's a folder (has nested items) or a request
           if item["item"]?
             # It's a folder, recurse into it
             folder_name = item["name"]?.try(&.to_s) || ""
             new_path = folder_path.empty? ? folder_name : "#{folder_path}/#{folder_name}"
-            process_items(item["item"], details, new_path)
+            process_items(item["item"], details, item_variables, new_path)
           elsif item["request"]?
             # It's a request, process it
-            process_request(item, details)
+            process_request(item, details, item_variables)
           end
         rescue e
           @logger.debug "Exception processing item"
@@ -49,81 +55,47 @@ module Analyzer::Specification
       end
     end
 
-    private def process_request(item, details)
+    private def process_request(item, details, variables : Hash(String, String))
       request = item["request"]
 
-      # Get HTTP method
-      method = "GET"
-      if request.is_a?(JSON::Any) && request["method"]?
-        method = request["method"].to_s.upcase
-      elsif request.is_a?(String)
-        # Simple request format (just a URL string)
+      if request_url = request.as_s?
+        params = [] of Param
+        resolved_url = resolve_vars(request_url, variables)
+        url_path = extract_path_from_url(resolved_url)
+        extract_query_params(resolved_url).each { |param| add_param(params, param) }
+        extract_path_vars(url_path).each { |name| add_param(params, Param.new(name, "", "path")) }
+        @result << Endpoint.new(url_path, "GET", params, details) unless url_path.empty?
         return
       end
+
+      return unless request.as_h?
+
+      # Get HTTP method
+      method = request["method"]?.try(&.as_s?) || "GET"
+      method = method.upcase
+      method = "GET" if method.empty?
 
       # Get URL
       url_path = ""
       params = [] of Param
 
       if request["url"]?
-        url = request["url"]
-
-        # Check if URL is a simple string (v2.0.0 format) or object (v2.1.0 format)
-        begin
-          url_string = url.as_s
-          # URL is a string
-          url_path = extract_path_from_url(url_string)
-        rescue
-          # URL is an object
-          # Extract path
-          if url["path"]?
-            if url["path"].as_a?
-              url_path = "/" + url["path"].as_a.map(&.to_s).join("/")
-            elsif url["path"].as_s?
-              url_path = url["path"].to_s
-            end
-          elsif url["raw"]?
-            url_path = extract_path_from_url(url["raw"].to_s)
-          end
-
-          # Extract query parameters
-          if url["query"]?
-            url["query"].as_a.each do |query_param|
-              if query_param["key"]?
-                param_name = query_param["key"].to_s
-                param_value = query_param["value"]?.try(&.to_s) || ""
-                params << Param.new(param_name, param_value, "query")
-              end
-            rescue
-            end
-          end
-
-          # Extract path variables
-          if url["variable"]?
-            url["variable"].as_a.each do |path_var|
-              if path_var["key"]?
-                param_name = path_var["key"].to_s
-                param_value = path_var["value"]?.try(&.to_s) || ""
-                params << Param.new(param_name, param_value, "path")
-              end
-            rescue
-            end
-          end
-        end
+        url_path = process_url(request["url"], variables, params)
       end
 
       # Extract headers
       if request["header"]?
-        request["header"].as_a.each do |header|
-          if header["key"]?
-            param_name = header["key"].to_s
-            param_value = header["value"]?.try(&.to_s) || ""
+        request["header"].as_a?.try &.each do |header|
+          next if disabled?(header)
+
+          if param_name = header["key"]?.try(&.as_s?)
+            param_value = scalar_to_s(header["value"]?) || ""
             # Skip common headers that are not user-controllable
             unless param_name.downcase == "content-type"
-              params << Param.new(param_name, param_value, "header")
+              add_param(params, Param.new(param_name, param_value, "header"))
+              extract_cookie_params(param_value).each { |param| add_param(params, param) } if param_name.downcase == "cookie"
             end
           end
-        rescue
         end
       end
 
@@ -136,12 +108,12 @@ module Analyzer::Specification
         when "raw"
           # Try to parse as JSON
           if body["raw"]?
-            raw_content = body["raw"].to_s
+            raw_content = scalar_to_s(body["raw"]?) || ""
             begin
               json_body = JSON.parse(raw_content)
               if json_body.as_h?
                 json_body.as_h.each do |key, value|
-                  params << Param.new(key, value.to_s, "json")
+                  add_param(params, Param.new(key, value.to_s, "json"))
                 end
               end
             rescue
@@ -150,24 +122,43 @@ module Analyzer::Specification
           end
         when "urlencoded"
           if body["urlencoded"]?
-            body["urlencoded"].as_a.each do |form_param|
-              if form_param["key"]?
-                param_name = form_param["key"].to_s
-                param_value = form_param["value"]?.try(&.to_s) || ""
-                params << Param.new(param_name, param_value, "form")
+            body["urlencoded"].as_a?.try &.each do |form_param|
+              next if disabled?(form_param)
+
+              if param_name = form_param["key"]?.try(&.as_s?)
+                param_value = scalar_to_s(form_param["value"]?) || ""
+                add_param(params, Param.new(param_name, param_value, "form"))
               end
-            rescue
             end
           end
         when "formdata"
           if body["formdata"]?
-            body["formdata"].as_a.each do |form_param|
-              if form_param["key"]?
-                param_name = form_param["key"].to_s
-                param_value = form_param["value"]?.try(&.to_s) || ""
-                params << Param.new(param_name, param_value, "form")
+            body["formdata"].as_a?.try &.each do |form_param|
+              next if disabled?(form_param)
+
+              if param_name = form_param["key"]?.try(&.as_s?)
+                param_value = scalar_to_s(form_param["value"]?) || scalar_to_s(form_param["src"]?) || ""
+                add_param(params, Param.new(param_name, param_value, "form"))
               end
-            rescue
+            end
+          end
+        when "graphql"
+          if graphql = body["graphql"]?
+            if query = scalar_to_s(graphql["query"]?)
+              add_param(params, Param.new("query", query, "json"))
+            end
+
+            if variables_raw = scalar_to_s(graphql["variables"]?)
+              begin
+                parsed_variables = JSON.parse(variables_raw)
+                if variables_hash = parsed_variables.as_h?
+                  variables_hash.each do |key, value|
+                    add_param(params, Param.new(key, value.to_s, "json"))
+                  end
+                end
+              rescue
+                add_param(params, Param.new("variables", variables_raw, "json"))
+              end
             end
           end
         end
@@ -182,21 +173,240 @@ module Analyzer::Specification
       @logger.debug_sub e
     end
 
-    private def extract_path_from_url(url_string : String) : String
-      # Extract path from a full URL string
-      begin
-        uri = URI.parse(url_string)
-        return uri.path || "/"
-      rescue
-        # If parsing fails, try to extract path manually
-        # Remove protocol if present
-        url = url_string.sub(/^https?:\/\//, "")
-        # Remove host and port
-        if url.includes?("/")
-          return "/" + url.split("/", 2)[1].split("?")[0]
+    private def process_url(url : JSON::Any, variables : Hash(String, String), params : Array(Param)) : String
+      if url_string = url.as_s?
+        resolved_url = resolve_vars(url_string, variables)
+        extract_query_params(resolved_url).each { |param| add_param(params, param) }
+        url_path = extract_path_from_url(resolved_url)
+        extract_path_vars(url_path).each { |name| add_param(params, Param.new(name, "", "path")) }
+        return url_path
+      end
+
+      return "" unless url.as_h?
+
+      raw = resolve_vars(url["raw"]?.try(&.as_s?) || "", variables)
+      url_path = ""
+
+      if path_node = url["path"]?
+        url_path = extract_path_from_path_node(path_node, variables)
+      end
+      url_path = extract_path_from_url(raw) if url_path.empty? && !raw.empty?
+
+      if query_array = url["query"]?.try(&.as_a?)
+        query_array.each do |query_param|
+          next if disabled?(query_param)
+
+          if param_name = query_param["key"]?.try(&.as_s?)
+            param_value = scalar_to_s(query_param["value"]?) || ""
+            add_param(params, Param.new(param_name, param_value, "query"))
+          end
+        end
+      elsif !raw.empty?
+        extract_query_params(raw).each { |param| add_param(params, param) }
+      end
+
+      if variable_array = url["variable"]?.try(&.as_a?)
+        variable_array.each do |path_var|
+          next if disabled?(path_var)
+
+          if param_name = path_var["key"]?.try(&.as_s?)
+            param_value = scalar_to_s(path_var["value"]?) || ""
+            add_param(params, Param.new(param_name, param_value, "path"))
+          end
         end
       end
-      "/"
+
+      extract_path_vars(url_path).each { |name| add_param(params, Param.new(name, "", "path")) }
+      url_path
+    end
+
+    private def extract_path_from_url(url_string : String) : String
+      stripped = url_string.strip
+      return "" if stripped.empty?
+
+      begin
+        uri = URI.parse(stripped)
+        if path = uri.path
+          return normalize_path(path) unless path.empty?
+        end
+      rescue
+      end
+
+      if scheme_idx = stripped.index("://")
+        rest = stripped[(scheme_idx + 3)..]
+        slash_idx = rest.index("/")
+        return "/" unless slash_idx
+
+        return normalize_path(rest[slash_idx..])
+      end
+
+      pathish = strip_query_and_fragment(stripped)
+      return normalize_path(pathish) if pathish.starts_with?("/")
+
+      parts = pathish.split("/", 2)
+      first = parts[0]
+      if parts.size == 2
+        return normalize_path("/#{parts[1]}") if host_like_segment?(first)
+        return normalize_path(pathish)
+      end
+
+      return "" if unresolved_variable_segment?(first)
+      host_like_segment?(first) ? "/" : normalize_path(pathish)
+    end
+
+    private def extract_path_from_path_node(path_node : JSON::Any, variables : Hash(String, String)) : String
+      if path = path_node.as_s?
+        return normalize_path(resolve_vars(path, variables))
+      end
+
+      segments = [] of String
+      if path_array = path_node.as_a?
+        path_array.each do |segment|
+          value = scalar_to_s(segment) || segment.to_s
+          resolve_vars(value, variables).split("/").each do |part|
+            stripped = part.strip
+            segments << stripped unless stripped.empty?
+          end
+        end
+      end
+
+      segments.empty? ? "" : normalize_path("/#{segments.join("/")}")
+    end
+
+    private def extract_query_params(url_string : String) : Array(Param)
+      params = [] of Param
+      query_idx = url_string.index("?")
+      return params unless query_idx
+
+      fragment_idx = url_string.index("#", query_idx)
+      query = fragment_idx ? url_string[(query_idx + 1)...fragment_idx] : url_string[(query_idx + 1)..]
+      return params if query.empty?
+
+      begin
+        URI::Params.parse(query).each do |key, value|
+          params << Param.new(key, value, "query") unless key.empty?
+        end
+      rescue
+      end
+      params
+    end
+
+    private def extract_cookie_params(header_value : String) : Array(Param)
+      params = [] of Param
+      header_value.split(";").each do |part|
+        key_value = part.split("=", 2)
+        name = key_value[0].strip
+        next if name.empty?
+
+        value = key_value.size == 2 ? key_value[1].strip : ""
+        params << Param.new(name, value, "cookie")
+      end
+      params
+    end
+
+    private def extract_path_vars(path : String) : Array(String)
+      vars = [] of String
+      path.scan(/:([A-Za-z_][A-Za-z0-9_.-]*)/) do |m|
+        vars << m[1]
+      end
+      path.scan(/\{([A-Za-z_][A-Za-z0-9_.-]*)\}/) do |m|
+        vars << m[1]
+      end
+      vars.uniq
+    end
+
+    private def normalize_path(path : String) : String
+      stripped = strip_query_and_fragment(path.strip)
+      return "" if stripped.empty?
+
+      normalized = stripped.gsub(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/) do
+        ":#{$1.split(".").last}"
+      end
+      normalized = normalized.gsub(/\{([A-Za-z_][A-Za-z0-9_.-]*)\}/) { ":#{$1}" }
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
+    end
+
+    private def strip_query_and_fragment(value : String) : String
+      end_idx = value.size
+      if query_idx = value.index("?")
+        end_idx = Math.min(end_idx, query_idx)
+      end
+      if fragment_idx = value.index("#")
+        end_idx = Math.min(end_idx, fragment_idx)
+      end
+      value[0...end_idx]
+    end
+
+    private def host_like_segment?(segment : String) : Bool
+      return true if unresolved_variable_segment?(segment)
+      downcased = segment.downcase
+      downcased == "localhost" || segment.includes?(".") || segment.includes?(":")
+    end
+
+    private def unresolved_variable_segment?(segment : String) : Bool
+      segment.matches?(/\A\{\{\s*[^}]+\s*\}\}\z/)
+    end
+
+    private def collect_variables(node : JSON::Any?) : Hash(String, String)
+      variables = {} of String => String
+      return variables unless node
+      variable_array = node.as_a?
+      return variables unless variable_array
+
+      variable_array.each do |variable|
+        next if disabled?(variable)
+
+        key = variable["key"]?.try(&.as_s?) || variable["name"]?.try(&.as_s?)
+        next unless key
+
+        value = scalar_to_s(variable["value"]?) || scalar_to_s(variable["initialValue"]?)
+        variables[key] = value if value
+      end
+
+      variables
+    end
+
+    private def merge_variables(parent : Hash(String, String), node : JSON::Any?) : Hash(String, String)
+      merged = parent.dup
+      collect_variables(node).each do |key, value|
+        merged[key] = value
+      end
+      merged
+    end
+
+    private def resolve_vars(input : String, variables : Hash(String, String)) : String
+      return input if input.empty? || variables.empty?
+
+      resolved = input
+      3.times do
+        previous = resolved
+        resolved = resolved.gsub(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/) do |match|
+          name = $1
+          variables.fetch(name, variables.fetch(name.split(".").last, match))
+        end
+        break if resolved == previous
+      end
+      resolved
+    end
+
+    private def scalar_to_s(value : JSON::Any?) : String?
+      return unless value
+      return value.as_s if value.as_s?
+      return value.to_s if value.as_i64? || value.as_f? || value.as_bool?
+      nil
+    end
+
+    private def disabled?(node : JSON::Any) : Bool
+      disabled = node["disabled"]?
+      return false unless disabled
+      disabled.as_bool? == true || disabled.as_s? == "true"
+    end
+
+    private def add_param(params : Array(Param), param : Param)
+      return if param.name.empty?
+      return if params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+      params << param
     end
   end
 end

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -14,9 +14,14 @@ module Detector::Specification
             schema = data["info"]["schema"].as_s
             if schema.includes?("schema.getpostman.com") || schema.includes?("schema.postman.com")
               check = true
-              locator = CodeLocator.instance
-              locator.push("postman-json", filename)
             end
+          elsif data["info"]? && data["info"]["_postman_id"]? && data["item"]?.try(&.as_a?)
+            check = true
+          end
+
+          if check
+            locator = CodeLocator.instance
+            locator.push("postman-json", filename)
           end
         rescue
         end


### PR DESCRIPTION
## Summary
- resolve Postman collection/folder/item variables when extracting request URLs
- support string request URLs, raw query params, disabled params, cookies, GraphQL bodies, and path-variable normalization
- detect schema-less Postman exports with _postman_id

## Tests
- crystal spec spec/unit_test/analyzer/specification/postman_spec.cr spec/unit_test/detector/specification/postman_spec.cr --error-trace
- just build
- just test
- just check