### PR TITLE
Improve OAS specification endpoint extraction

### DIFF
--- a/spec/functional_test/fixtures/specification/oas2_edge_cases/doc.yml
+++ b/spec/functional_test/fixtures/specification/oas2_edge_cases/doc.yml
@@ -1,0 +1,70 @@
+swagger: "2.0"
+info:
+  title: OAS2 Edge Cases
+  version: 1.0.0
+basePath: /api
+consumes:
+  - application/json
+paths:
+  /orders:
+    $ref: "#/x-paths/Orders"
+  /uploads:
+    post:
+      consumes:
+        - multipart/form-data
+      parameters:
+        - $ref: "#/parameters/UploadFile"
+        - name: description
+          in: formData
+          type: string
+      responses:
+        201:
+          description: Uploaded
+x-paths:
+  Orders:
+    parameters:
+      - $ref: "#/parameters/Tenant"
+    get:
+      parameters:
+        - name: state
+          in: query
+          type: string
+      responses:
+        200:
+          description: Orders
+    post:
+      parameters:
+        - name: order
+          in: body
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/OrderCreate"
+      responses:
+        201:
+          description: Created
+parameters:
+  Tenant:
+    name: X-Tenant
+    in: header
+    type: string
+  UploadFile:
+    name: file
+    in: formData
+    type: file
+definitions:
+  OrderCreate:
+    allOf:
+      - type: object
+        properties:
+          name:
+            type: string
+      - oneOf:
+          - type: object
+            properties:
+              expedited:
+                type: boolean
+          - type: object
+            properties:
+              gift_message:
+                type: string

--- a/spec/functional_test/fixtures/specification/oas3_edge_cases/doc.yml
+++ b/spec/functional_test/fixtures/specification/oas3_edge_cases/doc.yml
@@ -1,0 +1,80 @@
+openapi: 3.1.0
+info:
+  title: OAS3 Edge Cases
+  version: 1.0.0
+servers:
+  - url: /api/{version}
+    variables:
+      version:
+        default: v2
+paths:
+  /orders:
+    $ref: "#/components/pathItems/Orders"
+  /reports:
+    post:
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              oneOf:
+                - type: object
+                  properties:
+                    filter:
+                      type: string
+                - type: object
+                  properties:
+                    include_archived:
+                      type: boolean
+      responses:
+        "202":
+          description: Accepted
+components:
+  pathItems:
+    Orders:
+      parameters:
+        - $ref: "#/components/parameters/Tenant"
+      get:
+        parameters:
+          - name: state
+            in: query
+            schema:
+              type: string
+        responses:
+          "200":
+            description: Orders
+      post:
+        requestBody:
+          $ref: "#/components/requestBodies/OrderBody"
+        responses:
+          "201":
+            description: Created
+  parameters:
+    Tenant:
+      name: X-Tenant
+      in: header
+      schema:
+        type: string
+  requestBodies:
+    OrderBody:
+      content:
+        application/merge-patch+json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/OrderPatch"
+  schemas:
+    OrderPatch:
+      allOf:
+        - type: object
+          properties:
+            name:
+              type: string
+        - anyOf:
+            - type: object
+              properties:
+                priority:
+                  type: integer
+            - type: object
+              properties:
+                notes:
+                  type: string

--- a/spec/functional_test/testers/specification/oas2_spec.cr
+++ b/spec/functional_test/testers/specification/oas2_spec.cr
@@ -28,3 +28,23 @@ FunctionalTester.new("fixtures/specification/oas2/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+FunctionalTester.new("fixtures/specification/oas2_edge_cases/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, [
+  Endpoint.new("/api/orders", "GET", [
+    Param.new("X-Tenant", "", "header"),
+    Param.new("state", "", "query"),
+  ]),
+  Endpoint.new("/api/orders", "POST", [
+    Param.new("X-Tenant", "", "header"),
+    Param.new("name", "", "json"),
+    Param.new("expedited", "", "json"),
+    Param.new("gift_message", "", "json"),
+  ]),
+  Endpoint.new("/api/uploads", "POST", [
+    Param.new("file", "", "form"),
+    Param.new("description", "", "form"),
+  ]),
+]).perform_tests

--- a/spec/functional_test/testers/specification/oas3_spec.cr
+++ b/spec/functional_test/testers/specification/oas3_spec.cr
@@ -27,6 +27,15 @@ FunctionalTester.new("fixtures/specification/oas3/no_servers/", {
   :endpoints => 1,
 }, nil).perform_tests
 
+FunctionalTester.new("fixtures/specification/oas3/no_servers/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, [
+  Endpoint.new("https://api.example.com/gems", "GET"),
+], {
+  "url" => YAML::Any.new("https://api.example.com"),
+}).perform_tests
+
 FunctionalTester.new("fixtures/specification/oas3/multiple_docs/", {
   :techs     => 1,
   :endpoints => 2,
@@ -79,3 +88,36 @@ FunctionalTester.new("fixtures/specification/oas3/param_in_path/", {
     Param.new("cookie", "", "cookie"),
   ]),
 ]).perform_tests
+
+edge_case_endpoints = [
+  Endpoint.new("/api/v2/orders", "GET", [
+    Param.new("X-Tenant", "", "header"),
+    Param.new("state", "", "query"),
+  ]),
+  Endpoint.new("/api/v2/orders", "POST", [
+    Param.new("X-Tenant", "", "header"),
+    Param.new("name", "", "json"),
+    Param.new("priority", "", "json"),
+    Param.new("notes", "", "json"),
+  ]),
+  Endpoint.new("/api/v2/reports", "POST", [
+    Param.new("filter", "", "json"),
+    Param.new("include_archived", "", "json"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/specification/oas3_edge_cases/", {
+  :techs     => 1,
+  :endpoints => edge_case_endpoints.size,
+}, edge_case_endpoints).perform_tests
+
+edge_case_url_endpoints = edge_case_endpoints.map do |endpoint|
+  Endpoint.new("https://api.example.com#{endpoint.url}", endpoint.method, endpoint.params)
+end
+
+FunctionalTester.new("fixtures/specification/oas3_edge_cases/", {
+  :techs     => 1,
+  :endpoints => edge_case_url_endpoints.size,
+}, edge_case_url_endpoints, {
+  "url" => YAML::Any.new("https://api.example.com"),
+}).perform_tests

--- a/spec/unit_test/analyzer/specification/oas3_spec.cr
+++ b/spec/unit_test/analyzer/specification/oas3_spec.cr
@@ -1,0 +1,37 @@
+require "../../../spec_helper"
+require "../../../../src/analyzer/analyzers/specification/oas3"
+
+private def oas3_analyzer(url : String = "") : Analyzer::Specification::Oas3
+  options = create_test_options
+  options["url"] = YAML::Any.new(url)
+  Analyzer::Specification::Oas3.new(options)
+end
+
+describe "OAS3 Analyzer" do
+  it "prepends --url when an absolute server matches the target host" do
+    servers = JSON.parse(%([{"url":"https://api.example.com/v1"}]))
+    analyzer = oas3_analyzer("https://api.example.com")
+
+    analyzer.get_base_path(servers).should eq("https://api.example.com/v1")
+  end
+
+  it "prepends --url to relative server paths and expands server variables" do
+    servers = YAML.parse(<<-YAML
+      - url: /api/{version}
+        variables:
+          version:
+            default: v2
+      YAML
+    )
+    analyzer = oas3_analyzer("https://api.example.com")
+
+    analyzer.get_base_path(servers).should eq("https://api.example.com/api/v2")
+  end
+
+  it "uses --url as the fallback base when no server matches" do
+    servers = JSON.parse(%([{"url":"https://other.example.com/v1"}]))
+    analyzer = oas3_analyzer("https://api.example.com")
+
+    analyzer.get_base_path(servers).should eq("https://api.example.com")
+  end
+end

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -54,6 +54,16 @@ describe "EndpointOptimizer" do
       result[1].url.should eq("/api/data")
     end
 
+    it "does not corrupt absolute URLs while normalizing slashes" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("https://api.example.com/v1/users", "GET"),
+      ]
+
+      result = optimizer.optimize_endpoints(endpoints)
+      result[0].url.should eq("https://api.example.com/v1/users")
+    end
+
     it "strips Spring inline regex constraints from path variables" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -30,47 +30,85 @@ module Analyzer::Specification
       node
     end
 
+    private def add_param(params : Array(Param), name : String, param_type : String)
+      return if name.empty?
+      param = Param.new(name, "", param_type)
+      params << param unless params.includes?(param)
+    end
+
     # Walks a body schema and emits a Param per top-level property.
-    private def collect_body_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param))
+    private def collect_body_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref = schema["$ref"]?.try(&.as_s?)
+        return if seen.includes?(ref)
+        seen << ref
         if resolved = resolve_ref_json(root, ref)
-          collect_body_props_json(root, resolved, param_type, params)
+          collect_body_props_json(root, resolved, param_type, params, seen)
         end
         return
       end
 
+      if items = schema["items"]?
+        collect_body_props_json(root, items, param_type, params, seen)
+      end
+
       if props = schema["properties"]?.try(&.as_h?)
         props.each do |name, _|
-          params << Param.new(name.to_s, "", param_type)
+          add_param(params, name.to_s, param_type)
         end
       end
 
       if all_of = schema["allOf"]?.try(&.as_a?)
-        all_of.each { |s| collect_body_props_json(root, s, param_type, params) }
+        all_of.each { |s| collect_body_props_json(root, s, param_type, params, seen) }
+      end
+
+      if one_of = schema["oneOf"]?.try(&.as_a?)
+        one_of.each { |s| collect_body_props_json(root, s, param_type, params, seen) }
+      end
+
+      if any_of = schema["anyOf"]?.try(&.as_a?)
+        any_of.each { |s| collect_body_props_json(root, s, param_type, params, seen) }
       end
     end
 
-    private def collect_body_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param))
+    private def collect_body_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
       if ref_node = schema[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
+          return if seen.includes?(ref)
+          seen << ref
           if resolved = resolve_ref_yaml(root, ref)
-            collect_body_props_yaml(root, resolved, param_type, params)
+            collect_body_props_yaml(root, resolved, param_type, params, seen)
           end
         end
         return
       end
 
+      if items_node = schema[YAML::Any.new("items")]?
+        collect_body_props_yaml(root, items_node, param_type, params, seen)
+      end
+
       if props_node = schema[YAML::Any.new("properties")]?
         if props = props_node.as_h?
           props.each do |name, _|
-            params << Param.new(name.to_s, "", param_type)
+            add_param(params, name.to_s, param_type)
           end
         end
       end
 
       if all_of_node = schema[YAML::Any.new("allOf")]?
         if all_of = all_of_node.as_a?
-          all_of.each { |s| collect_body_props_yaml(root, s, param_type, params) }
+          all_of.each { |s| collect_body_props_yaml(root, s, param_type, params, seen) }
+        end
+      end
+
+      if one_of_node = schema[YAML::Any.new("oneOf")]?
+        if one_of = one_of_node.as_a?
+          one_of.each { |s| collect_body_props_yaml(root, s, param_type, params, seen) }
+        end
+      end
+
+      if any_of_node = schema[YAML::Any.new("anyOf")]?
+        if any_of = any_of_node.as_a?
+          any_of.each { |s| collect_body_props_yaml(root, s, param_type, params, seen) }
         end
       end
     end
@@ -106,11 +144,11 @@ module Analyzer::Specification
         return if name.empty?
         case location
         when "query"
-          params << Param.new(name, "", "query")
+          add_param(params, name, "query")
         when "header"
-          params << Param.new(name, "", "header")
+          add_param(params, name, "header")
         when "form", "formData"
-          params << Param.new(name, "", "form")
+          add_param(params, name, "form")
         end
       end
     end
@@ -136,13 +174,32 @@ module Analyzer::Specification
         return if name.empty?
         case location
         when "query"
-          params << Param.new(name, "", "query")
+          add_param(params, name, "query")
         when "header"
-          params << Param.new(name, "", "header")
+          add_param(params, name, "header")
         when "form", "formData"
-          params << Param.new(name, "", "form")
+          add_param(params, name, "form")
         end
       end
+    end
+
+    private def resolve_path_item_json(root : JSON::Any, path_obj : JSON::Any, seen : Set(String) = Set(String).new) : JSON::Any
+      return path_obj unless path_obj_h = path_obj.as_h?
+      return path_obj unless ref = path_obj_h["$ref"]?.try(&.as_s?)
+      return path_obj if seen.includes?(ref)
+      seen << ref
+      resolved = resolve_ref_json(root, ref)
+      resolved ? resolve_path_item_json(root, resolved, seen) : path_obj
+    end
+
+    private def resolve_path_item_yaml(root : YAML::Any, path_obj : YAML::Any, seen : Set(String) = Set(String).new) : YAML::Any
+      return path_obj unless path_obj_h = path_obj.as_h?
+      return path_obj unless ref_node = path_obj_h[YAML::Any.new("$ref")]?
+      return path_obj unless ref = ref_node.as_s?
+      return path_obj if seen.includes?(ref)
+      seen << ref
+      resolved = resolve_ref_yaml(root, ref)
+      resolved ? resolve_path_item_yaml(root, resolved, seen) : path_obj
     end
 
     private def consumes_json(root : JSON::Any, method_obj : JSON::Any) : Array(String)
@@ -203,19 +260,21 @@ module Analyzer::Specification
       begin
         paths = json_obj["paths"].as_h
         paths.each do |path, path_obj|
-          path_level_params = [] of Param
-          if path_obj_h = path_obj.as_h?
+          path_item = resolve_path_item_json(json_obj, path_obj)
+          path_level_params = [] of JSON::Any
+          if path_obj_h = path_item.as_h?
             if shared = path_obj_h["parameters"]?.try(&.as_a?)
-              shared.each do |param_obj|
-                extract_param_json(json_obj, param_obj, [] of String, path_level_params)
-              end
+              path_level_params.concat(shared)
             end
           end
 
-          path_obj.as_h.each do |method, method_obj|
+          path_item.as_h.each do |method, method_obj|
             next unless HTTP_METHODS.includes?(method.to_s.downcase)
-            params = path_level_params.dup
+            params = [] of Param
             consumes = consumes_json(json_obj, method_obj)
+            path_level_params.each do |param_obj|
+              extract_param_json(json_obj, param_obj, consumes, params)
+            end
 
             if method_params = method_obj["parameters"]?.try(&.as_a?)
               method_params.each do |param_obj|
@@ -260,21 +319,23 @@ module Analyzer::Specification
       begin
         paths = yaml_obj["paths"].as_h
         paths.each do |path, path_obj|
-          path_level_params = [] of Param
-          if path_obj_h = path_obj.as_h?
+          path_item = resolve_path_item_yaml(yaml_obj, path_obj)
+          path_level_params = [] of YAML::Any
+          if path_obj_h = path_item.as_h?
             if shared_node = path_obj_h[YAML::Any.new("parameters")]?
               if shared = shared_node.as_a?
-                shared.each do |param_obj|
-                  extract_param_yaml(yaml_obj, param_obj, [] of String, path_level_params)
-                end
+                path_level_params.concat(shared)
               end
             end
           end
 
-          path_obj.as_h.each do |method, method_obj|
+          path_item.as_h.each do |method, method_obj|
             next unless HTTP_METHODS.includes?(method.to_s.downcase)
-            params = path_level_params.dup
+            params = [] of Param
             consumes = consumes_yaml(yaml_obj, method_obj)
+            path_level_params.each do |param_obj|
+              extract_param_yaml(yaml_obj, param_obj, consumes, params)
+            end
 
             if method_params_node = method_obj[YAML::Any.new("parameters")]?
               if method_params = method_params_node.as_a?

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -1,34 +1,32 @@
 require "../../../models/analyzer"
+require "uri"
 
 module Analyzer::Specification
   class Oas3 < Analyzer
     HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head", "trace"}
 
-    def get_base_path(servers)
-      base_path = @url
-      servers.as_a.each do |server_obj|
-        if server_obj["url"].to_s.starts_with?("http")
-          user_uri = URI.parse(@url)
-          source_uri = URI.parse(server_obj["url"].to_s)
-          if user_uri.host == source_uri.host
-            base_path = @url + source_uri.path
-            break
-          end
-        end
-      end
+    def get_base_path(servers : JSON::Any)
+      server_base_path(servers.as_a.map { |server_obj| server_url_json(server_obj) })
+    end
 
-      base_path
+    def get_base_path(servers : YAML::Any)
+      server_base_path(servers.as_a.map { |server_obj| server_url_yaml(server_obj) })
     end
 
     # Maps an OAS3 request-body content type to a Noir param type.
     private def param_type_for_content(content_type : String) : String?
-      case content_type
-      when .starts_with?("application/json")
+      media_type = content_type.split(';', 2).first.strip.downcase
+      case media_type
+      when "application/json"
         "json"
       when "application/x-www-form-urlencoded"
         "form"
       when .starts_with?("multipart/form-data")
         "form"
+      else
+        if media_type.ends_with?("+json")
+          "json"
+        end
       end
     end
 
@@ -57,6 +55,69 @@ module Analyzer::Specification
       node
     end
 
+    private def add_param(params : Array(Param), name : String, param_type : String)
+      return if name.empty?
+      param = Param.new(name, "", param_type)
+      params << param unless params.includes?(param)
+    end
+
+    private def server_url_json(server_obj : JSON::Any) : String
+      url = server_obj["url"]?.try(&.as_s?) || ""
+      if variables = server_obj["variables"]?.try(&.as_h?)
+        variables.each do |name, variable_obj|
+          default = variable_obj["default"]?.try(&.as_s?)
+          url = url.gsub("{#{name}}", default) if default
+        end
+      end
+      url
+    end
+
+    private def server_url_yaml(server_obj : YAML::Any) : String
+      url = server_obj[YAML::Any.new("url")]?.try(&.as_s?) || ""
+      if variables_node = server_obj[YAML::Any.new("variables")]?
+        if variables = variables_node.as_h?
+          variables.each do |name, variable_obj|
+            default = variable_obj[YAML::Any.new("default")]?.try(&.as_s?)
+            url = url.gsub("{#{name}}", default) if default
+          end
+        end
+      end
+      url
+    end
+
+    private def server_base_path(server_urls : Array(String)) : String
+      server_urls.each do |server_url|
+        next if server_url.empty?
+
+        if server_url.starts_with?("http")
+          next if @url.empty?
+          user_uri = URI.parse(@url)
+          source_uri = URI.parse(server_url)
+          return combine_base_url(source_uri.path) if user_uri.host == source_uri.host
+        elsif server_url.starts_with?("/")
+          return combine_base_url(server_url)
+        else
+          return combine_base_url("/#{server_url}")
+        end
+      rescue
+        next
+      end
+
+      @url
+    end
+
+    private def combine_base_url(path : String) : String
+      return @url if path.empty?
+      return path if @url.empty?
+      if @url.ends_with?("/") && path.starts_with?("/")
+        @url + path[1..]
+      elsif !@url.ends_with?("/") && !path.starts_with?("/")
+        "#{@url}/#{path}"
+      else
+        @url + path
+      end
+    end
+
     # Walks an OAS3 schema, emitting one Param per top-level property.
     # Follows `$ref` and flattens `allOf` so referenced/composed schemas
     # surface their members.
@@ -70,14 +131,26 @@ module Analyzer::Specification
         return
       end
 
+      if items = schema["items"]?
+        collect_schema_props_json(root, items, param_type, params, seen)
+      end
+
       if props = schema["properties"]?.try(&.as_h?)
         props.each do |name, _|
-          params << Param.new(name.to_s, "", param_type)
+          add_param(params, name.to_s, param_type)
         end
       end
 
       if all_of = schema["allOf"]?.try(&.as_a?)
         all_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
+      end
+
+      if one_of = schema["oneOf"]?.try(&.as_a?)
+        one_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
+      end
+
+      if any_of = schema["anyOf"]?.try(&.as_a?)
+        any_of.each { |s| collect_schema_props_json(root, s, param_type, params, seen) }
       end
     end
 
@@ -93,10 +166,14 @@ module Analyzer::Specification
         return
       end
 
+      if items_node = schema[YAML::Any.new("items")]?
+        collect_schema_props_yaml(root, items_node, param_type, params, seen)
+      end
+
       if props_node = schema[YAML::Any.new("properties")]?
         if props = props_node.as_h?
           props.each do |name, _|
-            params << Param.new(name.to_s, "", param_type)
+            add_param(params, name.to_s, param_type)
           end
         end
       end
@@ -104,6 +181,18 @@ module Analyzer::Specification
       if all_of_node = schema[YAML::Any.new("allOf")]?
         if all_of = all_of_node.as_a?
           all_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
+        end
+      end
+
+      if one_of_node = schema[YAML::Any.new("oneOf")]?
+        if one_of = one_of_node.as_a?
+          one_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
+        end
+      end
+
+      if any_of_node = schema[YAML::Any.new("anyOf")]?
+        if any_of = any_of_node.as_a?
+          any_of.each { |s| collect_schema_props_yaml(root, s, param_type, params, seen) }
         end
       end
     end
@@ -121,11 +210,11 @@ module Analyzer::Specification
       return if name.empty?
       case location
       when "query"
-        params << Param.new(name, "", "query")
+        add_param(params, name, "query")
       when "header"
-        params << Param.new(name, "", "header")
+        add_param(params, name, "header")
       when "cookie"
-        params << Param.new(name, "", "cookie")
+        add_param(params, name, "cookie")
       end
     end
 
@@ -144,12 +233,31 @@ module Analyzer::Specification
       return if name.empty?
       case location
       when "query"
-        params << Param.new(name, "", "query")
+        add_param(params, name, "query")
       when "header"
-        params << Param.new(name, "", "header")
+        add_param(params, name, "header")
       when "cookie"
-        params << Param.new(name, "", "cookie")
+        add_param(params, name, "cookie")
       end
+    end
+
+    private def resolve_path_item_json(root : JSON::Any, path_obj : JSON::Any, seen : Set(String) = Set(String).new) : JSON::Any
+      return path_obj unless path_obj_h = path_obj.as_h?
+      return path_obj unless ref = path_obj_h["$ref"]?.try(&.as_s?)
+      return path_obj if seen.includes?(ref)
+      seen << ref
+      resolved = resolve_ref_json(root, ref)
+      resolved ? resolve_path_item_json(root, resolved, seen) : path_obj
+    end
+
+    private def resolve_path_item_yaml(root : YAML::Any, path_obj : YAML::Any, seen : Set(String) = Set(String).new) : YAML::Any
+      return path_obj unless path_obj_h = path_obj.as_h?
+      return path_obj unless ref_node = path_obj_h[YAML::Any.new("$ref")]?
+      return path_obj unless ref = ref_node.as_s?
+      return path_obj if seen.includes?(ref)
+      seen << ref
+      resolved = resolve_ref_yaml(root, ref)
+      resolved ? resolve_path_item_yaml(root, resolved, seen) : path_obj
     end
 
     private def extract_request_body_json(root : JSON::Any, request_body : JSON::Any, params : Array(Param))
@@ -239,8 +347,9 @@ module Analyzer::Specification
     private def process_paths_json(json_obj : JSON::Any, base_path : String, details : Details, source : String)
       paths = json_obj["paths"].as_h
       paths.each do |path, path_obj|
+        path_item = resolve_path_item_json(json_obj, path_obj)
         path_level_params = [] of Param
-        if path_obj_h = path_obj.as_h?
+        if path_obj_h = path_item.as_h?
           if shared = path_obj_h["parameters"]?.try(&.as_a?)
             shared.each do |param_obj|
               extract_param_json(json_obj, param_obj, path_level_params)
@@ -248,7 +357,7 @@ module Analyzer::Specification
           end
         end
 
-        path_obj.as_h.each do |method, method_obj|
+        path_item.as_h.each do |method, method_obj|
           next unless HTTP_METHODS.includes?(method.to_s.downcase)
           params = path_level_params.dup
 
@@ -287,8 +396,9 @@ module Analyzer::Specification
     private def process_paths_yaml(yaml_obj : YAML::Any, base_path : String, details : Details, source : String)
       paths = yaml_obj["paths"].as_h
       paths.each do |path, path_obj|
+        path_item = resolve_path_item_yaml(yaml_obj, path_obj)
         path_level_params = [] of Param
-        if path_obj_h = path_obj.as_h?
+        if path_obj_h = path_item.as_h?
           if shared_node = path_obj_h[YAML::Any.new("parameters")]?
             if shared = shared_node.as_a?
               shared.each do |param_obj|
@@ -298,7 +408,7 @@ module Analyzer::Specification
           end
         end
 
-        path_obj.as_h.each do |method, method_obj|
+        path_item.as_h.each do |method, method_obj|
           next unless HTTP_METHODS.includes?(method.to_s.downcase)
           params = path_level_params.dup
 

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -207,13 +207,15 @@ class EndpointOptimizer
 
       # Duplicate check
       unless tiny_tmp.url.empty?
+        absolute_url = tiny_tmp.url.matches?(/\A[a-zA-Z][a-zA-Z0-9+.\-]*:\/\//)
+
         # Check start with slash
-        if tiny_tmp.url[0] != "/"
+        if !absolute_url && tiny_tmp.url[0] != "/"
           tiny_tmp.url = "/#{tiny_tmp.url}"
         end
 
         # Check double slash
-        tiny_tmp.url = tiny_tmp.url.gsub_repeatedly("//", "/")
+        tiny_tmp.url = tiny_tmp.url.gsub_repeatedly("//", "/") unless absolute_url
 
         key = {tiny_tmp.method, tiny_tmp.url}
 


### PR DESCRIPTION
## Summary
- resolve OAS2/OAS3 path item refs and expand array/composed request-body schemas
- support OAS3 relative servers, server variables, and application/*+json request bodies
- preserve --url prefixing for OAS3 server and no-server specs, including absolute URL optimizer handling

## Tests
- crystal spec spec/functional_test/testers/specification/oas2_spec.cr
- crystal spec spec/functional_test/testers/specification/oas3_spec.cr
- crystal spec spec/unit_test/analyzer/specification/oas3_spec.cr spec/unit_test/optimizer/optimizer_spec.cr
- just test
- just build
- just check