### PR TITLE
Improve Insomnia endpoint extraction

### DIFF
--- a/spec/functional_test/fixtures/specification/insomnia/edgecases/collection.yaml
+++ b/spec/functional_test/fixtures/specification/insomnia/edgecases/collection.yaml
@@ -1,0 +1,74 @@
+type: collection.insomnia.rest/5.0
+name: Insomnia Edge Cases
+meta:
+  id: wrk_edge
+  created: 1771459200000
+  modified: 1771459200000
+environments:
+  data:
+    hosts:
+      api: https://api.example.com
+    token: edge-token
+collection:
+  - name: HTTP
+    meta:
+      id: fld_http
+    children:
+      - name: User detail
+        meta:
+          id: req_user_detail
+        method: GET
+        url: "{{ _.hosts.api }}/users/{userId}?include=posts"
+        parameters:
+          - name: page
+            value: "1"
+          - name: disabled
+            value: skip
+            disabled: true
+        pathParameters:
+          - name: userId
+            value: "42"
+        headers:
+          - name: ""
+            value: skip
+          - name: Host
+            value: api.example.com
+        authentication:
+          type: bearer
+          token: "{{ token }}"
+      - name: Session
+        meta:
+          id: req_session
+        method: POST
+        url: /sessions/{{ session_id }}
+        body:
+          mimeType: application/json
+          text: '{"username":"alice","password":"secret"}'
+      - name: Host without scheme
+        meta:
+          id: req_host_without_scheme
+        method: GET
+        url: localhost:3000/status
+      - name: Relative without leading slash
+        meta:
+          id: req_relative_without_slash
+        method: GET
+        url: api/v1/relative
+      - name: Diagnostics trace
+        meta:
+          id: req_diagnostics_trace
+        method: TRACE
+        url: https://api.example.com/diagnostics
+      - name: WebSocket is not HTTP
+        meta:
+          id: ws-req_socket
+        url: ws://localhost:3000/socket
+        headers:
+          - name: X-Socket
+            value: skip
+      - name: GRPC is not HTTP
+        meta:
+          id: grpc_req
+        url: grpc://localhost:50051/example.Service/Call
+        body:
+          text: "{}"

--- a/spec/functional_test/testers/specification/insomnia_spec.cr
+++ b/spec/functional_test/testers/specification/insomnia_spec.cr
@@ -43,3 +43,25 @@ FunctionalTester.new("fixtures/specification/insomnia/folders/", {
   :techs     => 1,
   :endpoints => 2,
 }, nil).perform_tests
+
+edge_endpoints = [
+  Endpoint.new("/users/{userId}", "GET", [
+    Param.new("include", "", "query"),
+    Param.new("page", "1", "query"),
+    Param.new("userId", "42", "path"),
+    Param.new("Authorization", "Bearer edge-token", "header"),
+  ]),
+  Endpoint.new("/sessions/:session_id", "POST", [
+    Param.new("session_id", "", "path"),
+    Param.new("username", "", "json"),
+    Param.new("password", "", "json"),
+  ]),
+  Endpoint.new("/status", "GET"),
+  Endpoint.new("/api/v1/relative", "GET"),
+  Endpoint.new("/diagnostics", "TRACE"),
+]
+
+FunctionalTester.new("fixtures/specification/insomnia/edgecases/", {
+  :techs     => 1,
+  :endpoints => edge_endpoints.size,
+}, edge_endpoints).perform_tests

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -1,7 +1,10 @@
 require "../../../models/analyzer"
+require "../../../utils/http_symbols"
 
 module Analyzer::Specification
   class Insomnia < Analyzer
+    HTTP_METHODS = ALLOWED_HTTP_METHODS
+
     def analyze
       locator = CodeLocator.instance
 
@@ -61,13 +64,7 @@ module Analyzer::Specification
       resources.each do |resource|
         next unless resource["_type"]?.try(&.as_s?) == "environment"
         if data = resource["data"]?.try(&.as_h?)
-          data.each do |k, v|
-            if s = v.as_s?
-              env[k] = s
-            elsif v.as_i64? || v.as_f? || v.as_bool?
-              env[k] = v.to_s
-            end
-          end
+          collect_json_env_values(env, data)
         end
       end
       env
@@ -75,9 +72,14 @@ module Analyzer::Specification
 
     private def process_v4_request(request : JSON::Any, env : Hash(String, String), details : Details)
       method = (request["method"]?.try(&.as_s?) || "GET").upcase
+      return unless HTTP_METHODS.includes?(method)
       url_raw = resolve_vars(request["url"]?.try(&.as_s?) || "", env)
       url_path = extract_path_from_url(url_raw)
       params = [] of Param
+
+      extract_query_param_names(url_raw).each do |name|
+        add_param(params, name, "", "query")
+      end
 
       # Query string parameters
       if parameters = request["parameters"]?.try(&.as_a?)
@@ -85,7 +87,7 @@ module Analyzer::Specification
           next unless name = p["name"]?.try(&.as_s?)
           next if p["disabled"]?.try(&.as_bool?) == true
           value = p["value"]?.try(&.as_s?) || ""
-          params << Param.new(name, value, "query")
+          add_param(params, name, value, "query")
         end
       end
 
@@ -94,15 +96,27 @@ module Analyzer::Specification
         headers.each do |h|
           next unless name = h["name"]?.try(&.as_s?)
           next if h["disabled"]?.try(&.as_bool?) == true
-          next if name.downcase == "content-type"
+          next if skipped_header?(name)
           value = h["value"]?.try(&.as_s?) || ""
-          params << Param.new(name, value, "header")
+          add_param(params, name, value, "header")
         end
       end
 
       # Path variables `:name` placeholders (Insomnia uses `:name` in URLs).
       extract_path_vars(url_path).each do |name|
-        params << Param.new(name, "", "path") unless params.any? { |p| p.name == name && p.param_type == "path" }
+        add_param(params, name, "", "path")
+      end
+
+      if path_parameters = request["pathParameters"]?.try(&.as_a?)
+        path_parameters.each do |p|
+          next unless name = p["name"]?.try(&.as_s?)
+          value = p["value"]?.try(&.as_s?) || ""
+          add_param(params, name, value, "path")
+        end
+      end
+
+      if auth = request["authentication"]?
+        process_json_auth(auth, params)
       end
 
       # Body
@@ -115,17 +129,11 @@ module Analyzer::Specification
     end
 
     private def process_v4_body(body : JSON::Any, params : Array(Param))
-      mime = body["mimeType"]?.try(&.as_s?) || ""
+      mime = (body["mimeType"]?.try(&.as_s?) || "").downcase
       case
       when mime.includes?("application/json")
         if text = body["text"]?.try(&.as_s?)
-          begin
-            parsed = JSON.parse(text)
-            if h = parsed.as_h?
-              h.each { |k, _| params << Param.new(k, "", "json") }
-            end
-          rescue
-          end
+          process_json_body_text(text, params)
         end
       when mime.includes?("x-www-form-urlencoded"), mime.includes?("multipart/form-data")
         if form_params = body["params"]?.try(&.as_a?)
@@ -133,7 +141,7 @@ module Analyzer::Specification
             next unless name = fp["name"]?.try(&.as_s?)
             next if fp["disabled"]?.try(&.as_bool?) == true
             value = fp["value"]?.try(&.as_s?) || ""
-            params << Param.new(name, value, "form")
+            add_param(params, name, value, "form")
           end
         end
       end
@@ -164,12 +172,12 @@ module Analyzer::Specification
       candidates.each do |node|
         data = node["data"]? || node
         if h = data.as_h?
-          h.each do |k, v|
-            key = k.to_s
-            if s = v.as_s?
-              env[key] = s
-            elsif v.as_i64? || v.as_f? || v.as_bool?
-              env[key] = v.to_s
+          collect_yaml_env_values(env, h)
+        end
+        if sub_envs = node["subEnvironments"]?.try(&.as_a?)
+          sub_envs.each do |sub_env|
+            if sub_data = sub_env["data"]?.try(&.as_h?)
+              collect_yaml_env_values(env, sub_data)
             end
           end
         end
@@ -187,8 +195,12 @@ module Analyzer::Specification
             end
           end
 
-          # Treat any node with a `url` field as a request entry.
+          # v5 also stores WebSocket, Socket.IO, gRPC, and MCP nodes with
+          # URLs but without HTTP methods. Only HTTP request nodes are
+          # endpoints for this analyzer.
           next unless item["url"]?
+          next unless method = item["method"]?.try(&.as_s?)
+          next unless HTTP_METHODS.includes?(method.upcase)
           process_v5_request(item, env, details)
         rescue e
           @logger.debug "Exception processing insomnia v5 item"
@@ -198,10 +210,15 @@ module Analyzer::Specification
     end
 
     private def process_v5_request(item : YAML::Any, env : Hash(String, String), details : Details)
-      method = (item["method"]?.try(&.as_s?) || "GET").upcase
+      method = (item["method"]?.try(&.as_s?) || "").upcase
+      return unless HTTP_METHODS.includes?(method)
       url_raw = resolve_vars(item["url"]?.try(&.as_s?) || "", env)
       url_path = extract_path_from_url(url_raw)
       params = [] of Param
+
+      extract_query_param_names(url_raw).each do |name|
+        add_param(params, name, "", "query")
+      end
 
       if parameters_node = item["parameters"]?
         if parameters = parameters_node.as_a?
@@ -209,7 +226,7 @@ module Analyzer::Specification
             next unless name = p["name"]?.try(&.as_s?)
             next if p["disabled"]?.try(&.as_bool?) == true
             value = p["value"]?.try(&.as_s?) || ""
-            params << Param.new(name, value, "query")
+            add_param(params, name, value, "query")
           end
         end
       end
@@ -219,15 +236,29 @@ module Analyzer::Specification
           headers.each do |h|
             next unless name = h["name"]?.try(&.as_s?)
             next if h["disabled"]?.try(&.as_bool?) == true
-            next if name.downcase == "content-type"
+            next if skipped_header?(name)
             value = h["value"]?.try(&.as_s?) || ""
-            params << Param.new(name, value, "header")
+            add_param(params, name, value, "header")
           end
         end
       end
 
       extract_path_vars(url_path).each do |name|
-        params << Param.new(name, "", "path") unless params.any? { |p| p.name == name && p.param_type == "path" }
+        add_param(params, name, "", "path")
+      end
+
+      if path_parameters_node = item["pathParameters"]?
+        if path_parameters = path_parameters_node.as_a?
+          path_parameters.each do |p|
+            next unless name = p["name"]?.try(&.as_s?)
+            value = p["value"]?.try(&.as_s?) || ""
+            add_param(params, name, value, "path")
+          end
+        end
+      end
+
+      if auth = item["authentication"]?
+        process_yaml_auth(auth, params)
       end
 
       if body_node = item["body"]?
@@ -239,17 +270,11 @@ module Analyzer::Specification
     end
 
     private def process_v5_body(body : YAML::Any, params : Array(Param))
-      mime = body["mimeType"]?.try(&.as_s?) || ""
+      mime = (body["mimeType"]?.try(&.as_s?) || "").downcase
       case
       when mime.includes?("application/json")
         if text = body["text"]?.try(&.as_s?)
-          begin
-            parsed = JSON.parse(text)
-            if h = parsed.as_h?
-              h.each { |k, _| params << Param.new(k, "", "json") }
-            end
-          rescue
-          end
+          process_json_body_text(text, params)
         end
       when mime.includes?("x-www-form-urlencoded"), mime.includes?("multipart/form-data")
         if form_params_node = body["params"]?
@@ -258,7 +283,7 @@ module Analyzer::Specification
               next unless name = fp["name"]?.try(&.as_s?)
               next if fp["disabled"]?.try(&.as_bool?) == true
               value = fp["value"]?.try(&.as_s?) || ""
-              params << Param.new(name, value, "form")
+              add_param(params, name, value, "form")
             end
           end
         end
@@ -272,27 +297,64 @@ module Analyzer::Specification
     # parser can still strip them out.
     private def resolve_vars(input : String, env : Hash(String, String)) : String
       return input if input.empty? || env.empty?
-      input.gsub(/\{\{\s*(?:_\.)?([A-Za-z0-9_]+)\s*\}\}/) do |match|
+      input.gsub(/\{\{\s*(?:_\.)?([A-Za-z0-9_.-]+)\s*\}\}/) do |match|
         name = $1
         env.fetch(name, match)
       end
     end
 
     private def extract_path_from_url(url_string : String) : String
-      return "" if url_string.empty?
-      begin
-        uri = URI.parse(url_string)
-        path = uri.path
-        return path if path && !path.empty?
-      rescue
+      stripped = url_string.strip
+      return "" if stripped.empty?
+
+      if stripped =~ /^https?:\/\//i
+        begin
+          uri = URI.parse(stripped)
+          path = uri.path
+          return normalize_path(path.empty? ? "/" : path)
+        rescue
+        end
+      elsif stripped =~ /^[A-Za-z][A-Za-z0-9+.-]*:\/\//
+        return ""
       end
 
       # No scheme — treat as path-only or host-prefixed.
-      stripped = url_string.sub(/^https?:\/\//, "")
-      if stripped.includes?("/")
-        return "/" + stripped.split("/", 2)[1].split("?")[0]
+      without_query = stripped.split("?", 2)[0].split("#", 2)[0]
+      path = without_query
+      unless path.starts_with?("/")
+        if looks_host_prefixed?(path)
+          parts = path.split("/", 2)
+          return "/" if parts.size == 1
+          path = "/" + parts[1]
+        else
+          path = "/" + path
+        end
       end
-      stripped.starts_with?("/") ? stripped : ""
+      normalize_path(path)
+    end
+
+    private def extract_query_param_names(url_string : String) : Array(String)
+      query = ""
+      begin
+        uri = URI.parse(url_string)
+        query = uri.query || ""
+      rescue
+      end
+
+      if query.empty?
+        idx = url_string.index('?')
+        if idx
+          query = url_string[(idx + 1)..].split("#", 2)[0]
+        end
+      end
+
+      names = [] of String
+      query.split('&').each do |pair|
+        next if pair.empty?
+        name = pair.split('=', 2).first.strip
+        names << name unless name.empty?
+      end
+      names
     end
 
     private def extract_path_vars(path : String) : Array(String)
@@ -300,7 +362,119 @@ module Analyzer::Specification
       path.scan(/:([A-Za-z_][A-Za-z0-9_]*)/) do |m|
         vars << m[1]
       end
+      path.scan(/\{([A-Za-z_][A-Za-z0-9_]*)\}/) do |m|
+        vars << m[1]
+      end
       vars
+    end
+
+    private def looks_host_prefixed?(value : String) : Bool
+      first = value.split("/", 2).first
+      first.includes?(".") || first.includes?(":") || first.downcase == "localhost" || first.includes?("{{")
+    end
+
+    private def normalize_path(path : String) : String
+      normalized = path.empty? ? "/" : path
+      normalized = "/" + normalized unless normalized.starts_with?("/")
+      normalized.gsub(/\{\{\s*(?:_\.)?([A-Za-z0-9_.-]+)\s*\}\}/) do
+        ":#{normalize_var_name($1)}"
+      end
+    end
+
+    private def normalize_var_name(name : String) : String
+      normalized = name.gsub(/[^A-Za-z0-9_]/, "_")
+      normalized = normalized.lstrip('_')
+      normalized = normalized.rstrip('_')
+      normalized.empty? ? "param" : normalized
+    end
+
+    private def add_param(params : Array(Param), name : String, value : String, param_type : String)
+      normalized = name.strip
+      return if normalized.empty?
+      return if params.any? { |p| p.name == normalized && p.param_type == param_type }
+      params << Param.new(normalized, value, param_type)
+    end
+
+    private def skipped_header?(name : String) : Bool
+      normalized = name.strip.downcase
+      normalized.empty? || normalized == "content-type" || normalized == "content-length" || normalized == "host"
+    end
+
+    private def process_json_body_text(text : String, params : Array(Param))
+      parsed = JSON.parse(text)
+      if h = parsed.as_h?
+        h.each { |k, _| add_param(params, k, "", "json") }
+      end
+    rescue
+    end
+
+    private def process_json_auth(auth : JSON::Any, params : Array(Param))
+      return if auth["disabled"]?.try(&.as_bool?) == true
+      type = auth["type"]?.try(&.as_s?) || ""
+      process_auth_fields(
+        type,
+        auth["key"]?.try(&.as_s?) || "",
+        auth["value"]?.try(&.as_s?) || "",
+        auth["addTo"]?.try(&.as_s?) || "",
+        auth["token"]?.try(&.as_s?) || "",
+        auth["prefix"]?.try(&.as_s?) || "",
+        params
+      )
+    end
+
+    private def process_yaml_auth(auth : YAML::Any, params : Array(Param))
+      return if auth["disabled"]?.try(&.as_bool?) == true
+      type = auth["type"]?.try(&.as_s?) || ""
+      process_auth_fields(
+        type,
+        auth["key"]?.try(&.as_s?) || "",
+        auth["value"]?.try(&.as_s?) || "",
+        auth["addTo"]?.try(&.as_s?) || "",
+        auth["token"]?.try(&.as_s?) || "",
+        auth["prefix"]?.try(&.as_s?) || "",
+        params
+      )
+    end
+
+    private def process_auth_fields(type : String, key : String, value : String, add_to : String, token : String, prefix : String, params : Array(Param))
+      case type.downcase
+      when "apikey"
+        param_type = add_to.downcase.includes?("query") ? "query" : "header"
+        add_param(params, key, value, param_type)
+      when "bearer"
+        auth_prefix = prefix.empty? ? "Bearer" : prefix
+        auth_value = token.empty? ? "" : "#{auth_prefix} #{token}"
+        add_param(params, "Authorization", auth_value, "header")
+      when "basic", "digest", "oauth1", "oauth2", "hawk", "ntlm", "iam", "asap", "singletoken"
+        add_param(params, "Authorization", "", "header")
+      end
+    end
+
+    private def collect_json_env_values(env : Hash(String, String), data : Hash(String, JSON::Any), prefix = "")
+      data.each do |k, v|
+        key = prefix.empty? ? k : "#{prefix}.#{k}"
+        if s = v.as_s?
+          env[key] = s
+        elsif v.as_i64? || v.as_f? || v.as_bool?
+          env[key] = v.to_s
+        elsif h = v.as_h?
+          collect_json_env_values(env, h, key)
+        end
+      end
+    end
+
+    private def collect_yaml_env_values(env : Hash(String, String), data : Hash(YAML::Any, YAML::Any), prefix = "")
+      data.each do |k, v|
+        key_part = k.to_s
+        key = prefix.empty? ? key_part : "#{prefix}.#{key_part}"
+        if s = v.as_s?
+          env[key] = s
+        elsif v.as_i64? || v.as_f? || v.as_bool?
+          env[key] = v.to_s
+        elsif h = v.as_h?
+          collect_yaml_env_values(env, h, key)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- filter Insomnia v5 non-HTTP URL nodes to reduce endpoint false positives
- extract query/path/auth parameters from v4/v5 exports, including nested env vars and templated path params
- add Insomnia edgecase fixture coverage, including TRACE support from the shared HTTP method list

## Verification
- crystal spec --error-trace spec/functional_test/testers/specification/insomnia_spec.cr
- just build
- just check

## Notes
- `just test` unit phase passed, but the functional phase hung locally for 12+ minutes in existing Python Flask `apply_nested_blueprint_prefixes`; I terminated the stuck local process after sampling it. This appears unrelated to the Insomnia changes.