### PR TITLE
Improve Clojure callee coverage

### DIFF
--- a/spec/functional_test/fixtures/clojure/pedestal_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/pedestal_callees/src/demo/core.clj
@@ -1,0 +1,31 @@
+(ns demo.core
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.route.definition :refer [defroutes]]
+            [io.pedestal.http.route.definition.table :as table]
+            [ring.util.response :as response]))
+
+(defn ^:private list-users [request]
+  (response/ok (user.service/list request)))
+
+(defn create-user [request]
+  (audit.log/write! "create" request)
+  (response/created "/users/1" (user.service/create! request)))
+
+(defn health-handler [_request]
+  (response/ok (health.service/check)))
+
+(defroutes classic-routes
+  [[["/users" {:get #'list-users :post `create-user}]]])
+
+(def helper-routes
+  [(route/get "/health" [] #'health-handler)])
+
+(def table-routes
+  (table/table-routes
+    {:context "/api"}
+    [["/inline" :get (fn [request]
+                      (response/ok (inline.service/run request)))]]))
+
+(def service
+  {::http/routes [classic-routes helper-routes table-routes]})

--- a/spec/functional_test/fixtures/clojure/reitit_callees/project.clj
+++ b/spec/functional_test/fixtures/clojure/reitit_callees/project.clj
@@ -1,0 +1,4 @@
+(defproject reitit-callees-sample "0.1.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [metosin/reitit "0.7.2"]
+                 [ring/ring-core "1.12.2"]])

--- a/spec/functional_test/fixtures/clojure/reitit_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/reitit_callees/src/demo/core.clj
@@ -1,0 +1,25 @@
+(ns demo.core
+  (:require [reitit.ring :as ring]
+            [ring.util.response :as response]))
+
+(defn ^:private list-users [request]
+  (let [users (user.service/list (:params request))]
+    (audit.log/write! "list" users)
+    (response/ok (present-users users))))
+
+(defn create-user [request]
+  (let [payload (payload/from-request request)]
+    (response/created "/users/1" (user.service/create! payload))))
+
+(def routes
+  ["/api"
+   ["/users"
+    {:get {:handler #'list-users}
+     :post {:handler `create-user}}]
+   ["/inline"
+    {:get {:handler (fn [request]
+                     (response/ok (inline.service/run request)))}}]])
+
+(def app
+  (ring/ring-handler
+    (ring/router routes)))

--- a/spec/functional_test/testers/clojure/pedestal_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/pedestal_callees_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+list_endpoint = Endpoint.new("/users", "GET")
+list_endpoint.push_callee(Callee.new("response/ok"))
+list_endpoint.push_callee(Callee.new("user.service/list"))
+
+create_endpoint = Endpoint.new("/users", "POST")
+create_endpoint.push_callee(Callee.new("audit.log/write!"))
+create_endpoint.push_callee(Callee.new("response/created"))
+create_endpoint.push_callee(Callee.new("user.service/create!"))
+
+health_endpoint = Endpoint.new("/health", "GET")
+health_endpoint.push_callee(Callee.new("response/ok"))
+health_endpoint.push_callee(Callee.new("health.service/check"))
+
+inline_endpoint = Endpoint.new("/api/inline", "GET")
+inline_endpoint.push_callee(Callee.new("response/ok"))
+inline_endpoint.push_callee(Callee.new("inline.service/run"))
+
+expected_endpoints = [
+  list_endpoint,
+  create_endpoint,
+  health_endpoint,
+  inline_endpoint,
+]
+
+FunctionalTester.new("fixtures/clojure/pedestal_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/clojure/reitit_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/reitit_callees_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+list_endpoint = Endpoint.new("/api/users", "GET")
+list_endpoint.push_callee(Callee.new("user.service/list"))
+list_endpoint.push_callee(Callee.new("audit.log/write!"))
+list_endpoint.push_callee(Callee.new("response/ok"))
+list_endpoint.push_callee(Callee.new("present-users"))
+
+create_endpoint = Endpoint.new("/api/users", "POST")
+create_endpoint.push_callee(Callee.new("payload/from-request"))
+create_endpoint.push_callee(Callee.new("response/created"))
+create_endpoint.push_callee(Callee.new("user.service/create!"))
+
+inline_endpoint = Endpoint.new("/api/inline", "GET")
+inline_endpoint.push_callee(Callee.new("response/ok"))
+inline_endpoint.push_callee(Callee.new("inline.service/run"))
+
+expected_endpoints = [
+  list_endpoint,
+  create_endpoint,
+  inline_endpoint,
+]
+
+FunctionalTester.new("fixtures/clojure/reitit_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -47,4 +47,32 @@ describe Noir::ClojureCalleeExtractor do
       {"my-service/map", 31},
     ])
   end
+
+  it "collects callees from top-level defn bodies" do
+    source = <<-CLJ
+      (ns demo.core)
+
+      (defn ^:private show-user
+        "Loads a user"
+        [request]
+        (let [user (user.service/find (:id request))]
+          (audit/write! "show" user)
+          (response/ok (present-user user))))
+
+      (defn ^String ^{:private true} ignored []
+        '(quoted/call)
+        #_(discarded/call)
+        (safe/run!))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.function_callees(source, "core.clj")
+
+    callees["show-user"].map { |name, _, line| {name, line} }.should eq([
+      {"user.service/find", 6},
+      {"audit/write!", 7},
+      {"response/ok", 8},
+      {"present-user", 8},
+    ])
+    callees["ignored"].map(&.[0]).should eq(["safe/run!"])
+  end
 end

--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
 
 module Analyzer::Clojure
@@ -33,6 +34,7 @@ module Analyzer::Clojure
     }
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       seen = Set(String).new
       all_files.each do |path|
         next unless clojure_file?(path)
@@ -40,7 +42,8 @@ module Analyzer::Clojure
         content = read_file_content(path)
         next unless pedestal_source?(content)
 
-        walk_forms(content, 0, content.bytesize, "", path, seen)
+        function_callees = include_callee ? Noir::ClojureCalleeExtractor.function_callees(content, path) : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)).new
+        walk_forms(content, 0, content.bytesize, "", path, seen, include_callee, function_callees)
       end
 
       Fiber.yield
@@ -59,7 +62,14 @@ module Analyzer::Clojure
         content.includes?("table-routes")
     end
 
-    private def walk_forms(source : String, start : Int32, limit : Int32, prefix : String, path : String, seen : Set(String))
+    private def walk_forms(source : String,
+                           start : Int32,
+                           limit : Int32,
+                           prefix : String,
+                           path : String,
+                           seen : Set(String),
+                           include_callee : Bool,
+                           function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       while i < limit
         case source.byte_at(i).unsafe_chr
@@ -70,20 +80,20 @@ module Analyzer::Clojure
         when '('
           form_end = find_matching_delimiter(source, i, '(', ')', limit)
           break if form_end <= i
-          handled = process_list(source, i, form_end, prefix, path, seen)
-          walk_forms(source, i + 1, form_end, prefix, path, seen) unless handled
+          handled = process_list(source, i, form_end, prefix, path, seen, include_callee, function_callees)
+          walk_forms(source, i + 1, form_end, prefix, path, seen, include_callee, function_callees) unless handled
           i = form_end + 1
         when '['
           vec_end = find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
-          handled = process_route_vector(source, i, vec_end, prefix, path, seen)
-          walk_forms(source, i + 1, vec_end, prefix, path, seen) unless handled
+          handled = process_route_vector(source, i, vec_end, prefix, path, seen, include_callee, function_callees)
+          walk_forms(source, i + 1, vec_end, prefix, path, seen, include_callee, function_callees) unless handled
           i = vec_end + 1
         when '{'
           map_end = find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
-          handled = process_route_map(source, i, map_end, prefix, path, seen)
-          walk_forms(source, i + 1, map_end, prefix, path, seen) unless handled
+          handled = process_route_map(source, i, map_end, prefix, path, seen, include_callee, function_callees)
+          walk_forms(source, i + 1, map_end, prefix, path, seen, include_callee, function_callees) unless handled
           i = map_end + 1
         else
           i += 1
@@ -92,21 +102,28 @@ module Analyzer::Clojure
     end
 
     private def process_list(source : String, list_start : Int32, list_end : Int32,
-                             prefix : String, path : String, seen : Set(String)) : Bool
+                             prefix : String,
+                             path : String,
+                             seen : Set(String),
+                             include_callee : Bool,
+                             function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
       sym_start = skip_ws_and_comments(source, list_start + 1, list_end)
       symbol, after_symbol = read_symbol(source, sym_start, list_end)
       return false if symbol.empty?
 
       base = base_symbol(symbol)
       if method = helper_method(symbol, base)
-        route_path, _ = first_string_literal(source, after_symbol, list_end)
-        emit_endpoint(source, list_start, join_path(prefix, route_path), method, path, seen) if route_path
+        route_path, route_literal_end = first_string_literal(source, after_symbol, list_end)
+        if route_path
+          handler_range = helper_handler_range(source, route_literal_end + 1, list_end)
+          emit_endpoint(source, list_start, join_path(prefix, route_path), method, path, seen, include_callee, function_callees, handler_range)
+        end
         true
       elsif base == "table-routes"
-        process_table_routes_call(source, after_symbol, list_end, prefix, path, seen)
+        process_table_routes_call(source, after_symbol, list_end, prefix, path, seen, include_callee, function_callees)
         true
       elsif base == "describe-routes" || base == "routify" || base == "expand-routes" || base == "routes-from"
-        walk_forms(source, after_symbol, list_end, prefix, path, seen)
+        walk_forms(source, after_symbol, list_end, prefix, path, seen, include_callee, function_callees)
         true
       else
         false
@@ -119,7 +136,11 @@ module Analyzer::Clojure
     end
 
     private def process_table_routes_call(source : String, start : Int32, limit : Int32,
-                                          prefix : String, path : String, seen : Set(String))
+                                          prefix : String,
+                                          path : String,
+                                          seen : Set(String),
+                                          include_callee : Bool,
+                                          function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = skip_ws_and_comments(source, start, limit)
       current_prefix = prefix
 
@@ -135,22 +156,26 @@ module Analyzer::Clojure
       if i < limit && source.byte_at(i).unsafe_chr == '['
         vec_end = find_matching_delimiter(source, i, '[', ']', limit)
         if vec_end > i
-          process_table_route_entries(source, i + 1, vec_end, current_prefix, path, seen)
+          process_table_route_entries(source, i + 1, vec_end, current_prefix, path, seen, include_callee, function_callees)
           return
         end
       elsif i + 1 < limit && source.byte_at(i).unsafe_chr == '#' && source.byte_at(i + 1).unsafe_chr == '{'
         set_end = find_matching_delimiter(source, i + 1, '{', '}', limit)
         if set_end > i + 1
-          process_table_route_entries(source, i + 2, set_end, current_prefix, path, seen)
+          process_table_route_entries(source, i + 2, set_end, current_prefix, path, seen, include_callee, function_callees)
           return
         end
       end
 
-      walk_forms(source, i, limit, current_prefix, path, seen)
+      walk_forms(source, i, limit, current_prefix, path, seen, include_callee, function_callees)
     end
 
     private def process_table_route_entries(source : String, start : Int32, limit : Int32,
-                                            prefix : String, path : String, seen : Set(String))
+                                            prefix : String,
+                                            path : String,
+                                            seen : Set(String),
+                                            include_callee : Bool,
+                                            function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       current_prefix = prefix
       while i < limit
@@ -161,7 +186,7 @@ module Analyzer::Clojure
         when '['
           vec_end = find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
-          process_route_vector(source, i, vec_end, current_prefix, path, seen)
+          process_route_vector(source, i, vec_end, current_prefix, path, seen, include_callee, function_callees)
           i = vec_end + 1
         when '{'
           map_end = find_matching_delimiter(source, i, '{', '}', limit)
@@ -169,7 +194,7 @@ module Analyzer::Clojure
           if context = extract_context(source, i + 1, map_end)
             current_prefix = join_path(prefix, context)
           else
-            process_route_map(source, i, map_end, current_prefix, path, seen)
+            process_route_map(source, i, map_end, current_prefix, path, seen, include_callee, function_callees)
           end
           i = map_end + 1
         else
@@ -179,11 +204,15 @@ module Analyzer::Clojure
     end
 
     private def process_route_vector(source : String, vec_start : Int32, vec_end : Int32,
-                                     prefix : String, path : String, seen : Set(String)) : Bool
+                                     prefix : String,
+                                     path : String,
+                                     seen : Set(String),
+                                     include_callee : Bool,
+                                     function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
       i = skip_ws_and_comments(source, vec_start + 1, vec_end)
       if i >= vec_end || source.byte_at(i).unsafe_chr != '"'
         if prefix.starts_with?("/")
-          walk_route_vector_body(source, i, vec_end, prefix, path, seen)
+          walk_route_vector_body(source, i, vec_end, prefix, path, seen, include_callee, function_callees)
           return true
         end
 
@@ -204,17 +233,22 @@ module Analyzer::Clojure
       if value_end > body_start
         token = source.byte_slice(body_start, value_end - body_start)
         if method = route_method(token)
-          emit_endpoint(source, body_start, full_path, method, path, seen)
+          handler_range = next_value_range(source, value_end, vec_end)
+          emit_endpoint(source, body_start, full_path, method, path, seen, include_callee, function_callees, handler_range)
           return true
         end
       end
 
-      walk_route_vector_body(source, body_start, vec_end, full_path, path, seen)
+      walk_route_vector_body(source, body_start, vec_end, full_path, path, seen, include_callee, function_callees)
       true
     end
 
     private def walk_route_vector_body(source : String, start : Int32, limit : Int32,
-                                       route_path : String, path : String, seen : Set(String))
+                                       route_path : String,
+                                       path : String,
+                                       seen : Set(String),
+                                       include_callee : Bool,
+                                       function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       while i < limit
         i = skip_ws_and_comments(source, i, limit)
@@ -224,19 +258,19 @@ module Analyzer::Clojure
         when '{'
           map_end = find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
-          process_method_map(source, i + 1, map_end, route_path, path, seen)
-          process_route_map(source, i, map_end, route_path, path, seen)
+          process_method_map(source, i + 1, map_end, route_path, path, seen, include_callee, function_callees)
+          process_route_map(source, i, map_end, route_path, path, seen, include_callee, function_callees)
           i = map_end + 1
         when '['
           vec_end = find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
-          process_route_vector(source, i, vec_end, route_path, path, seen)
+          process_route_vector(source, i, vec_end, route_path, path, seen, include_callee, function_callees)
           i = vec_end + 1
         when '('
           form_end = find_matching_delimiter(source, i, '(', ')', limit)
           break if form_end <= i
-          handled = process_list(source, i, form_end, route_path, path, seen)
-          walk_forms(source, i + 1, form_end, route_path, path, seen) unless handled
+          handled = process_list(source, i, form_end, route_path, path, seen, include_callee, function_callees)
+          walk_forms(source, i + 1, form_end, route_path, path, seen, include_callee, function_callees) unless handled
           i = form_end + 1
         else
           i = end_of_value(source, i, limit)
@@ -245,15 +279,23 @@ module Analyzer::Clojure
     end
 
     private def process_route_map(source : String, map_start : Int32, map_end : Int32,
-                                  prefix : String, path : String, seen : Set(String)) : Bool
+                                  prefix : String,
+                                  path : String,
+                                  seen : Set(String),
+                                  include_callee : Bool,
+                                  function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
       context_prefix = join_path(prefix, extract_context(source, map_start + 1, map_end) || "")
-      verbose = process_verbose_map(source, map_start + 1, map_end, context_prefix, path, seen)
-      path_keyed = process_path_keyed_map(source, map_start + 1, map_end, context_prefix, path, seen)
+      verbose = process_verbose_map(source, map_start + 1, map_end, context_prefix, path, seen, include_callee, function_callees)
+      path_keyed = process_path_keyed_map(source, map_start + 1, map_end, context_prefix, path, seen, include_callee, function_callees)
       verbose || path_keyed
     end
 
     private def process_verbose_map(source : String, start : Int32, limit : Int32,
-                                    prefix : String, path : String, seen : Set(String)) : Bool
+                                    prefix : String,
+                                    path : String,
+                                    seen : Set(String),
+                                    include_callee : Bool,
+                                    function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
       route_path = nil.as(String?)
       route_method = nil.as(String?)
       method_pos = start
@@ -287,22 +329,26 @@ module Analyzer::Clojure
       if range = verbs_range
         v_start, v_end = range
         if v_start < v_end && source.byte_at(v_start).unsafe_chr == '{'
-          process_method_map(source, v_start + 1, v_end - 1, full_path, path, seen)
+          process_method_map(source, v_start + 1, v_end - 1, full_path, path, seen, include_callee, function_callees)
         end
       elsif method = route_method
-        emit_endpoint(source, method_pos, full_path, method, path, seen)
+        emit_endpoint(source, method_pos, full_path, method, path, seen, include_callee, function_callees, nil)
       end
 
       if range = children_range
         c_start, c_end = range
-        walk_forms(source, c_start, c_end, full_path, path, seen)
+        walk_forms(source, c_start, c_end, full_path, path, seen, include_callee, function_callees)
       end
 
       true
     end
 
     private def process_path_keyed_map(source : String, start : Int32, limit : Int32,
-                                       prefix : String, path : String, seen : Set(String)) : Bool
+                                       prefix : String,
+                                       path : String,
+                                       seen : Set(String),
+                                       include_callee : Bool,
+                                       function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
       handled = false
       each_map_entry(source, start, limit) do |key, key_pos, value_start, value_end|
         next unless key.starts_with?('"') && key.ends_with?('"')
@@ -314,12 +360,12 @@ module Analyzer::Clojure
         if value_start < value_end
           case source.byte_at(value_start).unsafe_chr
           when '{'
-            process_method_map(source, value_start + 1, value_end - 1, full_path, path, seen)
-            process_path_keyed_map(source, value_start + 1, value_end - 1, full_path, path, seen)
+            process_method_map(source, value_start + 1, value_end - 1, full_path, path, seen, include_callee, function_callees)
+            process_path_keyed_map(source, value_start + 1, value_end - 1, full_path, path, seen, include_callee, function_callees)
           when '['
-            walk_forms(source, value_start, value_end, full_path, path, seen)
+            walk_forms(source, value_start, value_end, full_path, path, seen, include_callee, function_callees)
           else
-            emit_endpoint(source, key_pos, full_path, "ANY", path, seen)
+            emit_endpoint(source, key_pos, full_path, "ANY", path, seen, include_callee, function_callees, {value_start, value_end})
           end
         end
       end
@@ -327,10 +373,14 @@ module Analyzer::Clojure
     end
 
     private def process_method_map(source : String, start : Int32, limit : Int32,
-                                   route_path : String, path : String, seen : Set(String))
-      each_map_entry(source, start, limit) do |key, key_pos, _value_start, _value_end|
+                                   route_path : String,
+                                   path : String,
+                                   seen : Set(String),
+                                   include_callee : Bool,
+                                   function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+      each_map_entry(source, start, limit) do |key, key_pos, value_start, value_end|
         if method = standard_method(key)
-          emit_endpoint(source, key_pos, route_path, method, path, seen)
+          emit_endpoint(source, key_pos, route_path, method, path, seen, include_callee, function_callees, {value_start, value_end})
         end
       end
     end
@@ -362,7 +412,11 @@ module Analyzer::Clojure
     end
 
     private def emit_endpoint(source : String, offset : Int32, route_path : String, method : String,
-                              path : String, seen : Set(String))
+                              path : String,
+                              seen : Set(String),
+                              include_callee : Bool,
+                              function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)),
+                              handler_range : Tuple(Int32, Int32)?)
       return unless route_path.starts_with?("/")
       key = "#{method}::#{route_path}"
       return if seen.includes?(key)
@@ -372,7 +426,74 @@ module Analyzer::Clojure
       extract_path_param_names(route_path).each do |name|
         add_param_once(endpoint, name, "path")
       end
+      if include_callee && handler_range
+        attach_handler_callees(endpoint, source, handler_range[0], handler_range[1], path, function_callees)
+      end
       @result << endpoint
+    end
+
+    private def helper_handler_range(source : String, start : Int32, limit : Int32) : Tuple(Int32, Int32)?
+      # Pedestal helper routes are usually `(route/get "/path" [] handler)`.
+      first = next_value_range(source, start, limit)
+      return unless first
+      next_value_range(source, first[1], limit)
+    end
+
+    private def next_value_range(source : String, start : Int32, limit : Int32) : Tuple(Int32, Int32)?
+      value_start = skip_ws_and_comments(source, start, limit)
+      return if value_start >= limit
+      value_end = end_of_value(source, value_start, limit)
+      return if value_end <= value_start
+      {value_start, value_end}
+    end
+
+    private def attach_handler_callees(endpoint : Endpoint,
+                                       source : String,
+                                       value_start : Int32,
+                                       value_end : Int32,
+                                       path : String,
+                                       function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+      token, _ = read_form_token(source, value_start, value_end)
+      return if token.empty?
+
+      if token.starts_with?('(')
+        body = source.byte_slice(value_start, value_end - value_start)
+        line = line_number_for(source, value_start)
+        Noir::ClojureCalleeExtractor.attach_to(endpoint, Noir::ClojureCalleeExtractor.callees_for_body(body, path, line))
+      elsif handler_name = normalized_handler_symbol(token)
+        if callees = function_callees[handler_name]?
+          Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
+        else
+          endpoint.push_callee(Callee.new(handler_name, path: path, line: line_number_for(source, value_start)))
+        end
+      end
+    end
+
+    private def normalized_handler_symbol(token : String) : String?
+      name = token
+      if name.starts_with?("#'")
+        name = name[2..]
+      elsif name.starts_with?('\'') || name.starts_with?('`')
+        name = name[1..]
+      end
+
+      return unless handler_symbol?(name)
+      function_name(name)
+    end
+
+    private def handler_symbol?(token : String) : Bool
+      return false if token.starts_with?(':')
+      return false if token.starts_with?('"')
+      return false if {"nil", "true", "false"}.includes?(token)
+      !!token.match(/^[A-Za-z_.*+!?<>=][\w.\-*+!?<>=\/]*$/)
+    end
+
+    private def function_name(symbol : String) : String
+      if index = symbol.rindex('/')
+        symbol[(index + 1)..]
+      else
+        symbol
+      end
     end
 
     private def add_param_once(endpoint : Endpoint, name : String, param_type : String)

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -1,4 +1,5 @@
 require "../../../models/analyzer"
+require "../../../miniparsers/clojure_callee_extractor"
 require "../../../utils/utils"
 
 module Analyzer::Clojure
@@ -32,13 +33,15 @@ module Analyzer::Clojure
     }
 
     def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       all_files.each do |path|
         next unless clojure_file?(path)
 
         content = read_file_content(path)
         next unless reitit_source?(content)
 
-        walk_forms(content, 0, content.bytesize, "", path)
+        function_callees = include_callee ? Noir::ClojureCalleeExtractor.function_callees(content, path) : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)).new
+        walk_forms(content, 0, content.bytesize, "", path, include_callee, function_callees)
       end
 
       Fiber.yield
@@ -59,7 +62,13 @@ module Analyzer::Clojure
     # Iterate forms looking for route-shaped vectors. A vector is
     # route-shaped if its first non-ws element is either a path
     # string (`"/...."`) or another route vector (a list of routes).
-    private def walk_forms(source : String, start : Int32, limit : Int32, prefix : String, path : String)
+    private def walk_forms(source : String,
+                           start : Int32,
+                           limit : Int32,
+                           prefix : String,
+                           path : String,
+                           include_callee : Bool,
+                           function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       while i < limit
         c = source.byte_at(i).unsafe_chr
@@ -71,18 +80,18 @@ module Analyzer::Clojure
         when '('
           form_end = find_matching_delimiter(source, i, '(', ')', limit)
           break if form_end <= i
-          walk_forms(source, i + 1, form_end, prefix, path)
+          walk_forms(source, i + 1, form_end, prefix, path, include_callee, function_callees)
           i = form_end + 1
         when '['
           vec_end = find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
-          handled = try_process_routes(source, i, vec_end, prefix, path)
-          walk_forms(source, i + 1, vec_end, prefix, path) unless handled
+          handled = try_process_routes(source, i, vec_end, prefix, path, include_callee, function_callees)
+          walk_forms(source, i + 1, vec_end, prefix, path, include_callee, function_callees) unless handled
           i = vec_end + 1
         when '{'
           map_end = find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
-          walk_forms(source, i + 1, map_end, prefix, path)
+          walk_forms(source, i + 1, map_end, prefix, path, include_callee, function_callees)
           i = map_end + 1
         else
           i += 1
@@ -90,7 +99,13 @@ module Analyzer::Clojure
       end
     end
 
-    private def try_process_routes(source : String, vec_start : Int32, vec_end : Int32, prefix : String, path : String) : Bool
+    private def try_process_routes(source : String,
+                                   vec_start : Int32,
+                                   vec_end : Int32,
+                                   prefix : String,
+                                   path : String,
+                                   include_callee : Bool,
+                                   function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
       inner_start = vec_start + 1
       i = skip_ws_and_comments(source, inner_start, vec_end)
       return false if i >= vec_end
@@ -102,7 +117,7 @@ module Analyzer::Clojure
         return false if str_end <= i
         route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
         return false unless route_path.starts_with?("/")
-        process_route_vec(source, vec_start, vec_end, prefix, path)
+        process_route_vec(source, vec_start, vec_end, prefix, path, include_callee, function_callees)
         true
       when '['
         # List of routes: [["/a" ...] ["/b" ...]]
@@ -115,14 +130,20 @@ module Analyzer::Clojure
         return false if str_end <= j
         peek = decode_string_literal(source.byte_slice(j, str_end - j + 1))
         return false unless peek.starts_with?("/")
-        process_route_list(source, inner_start, vec_end, prefix, path)
+        process_route_list(source, inner_start, vec_end, prefix, path, include_callee, function_callees)
         true
       else
         false
       end
     end
 
-    private def process_route_list(source : String, start : Int32, limit : Int32, prefix : String, path : String)
+    private def process_route_list(source : String,
+                                   start : Int32,
+                                   limit : Int32,
+                                   prefix : String,
+                                   path : String,
+                                   include_callee : Bool,
+                                   function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       while i < limit
         i = skip_ws_and_comments(source, i, limit)
@@ -131,7 +152,7 @@ module Analyzer::Clojure
         if c == '['
           vec_end = find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
-          process_route_vec(source, i, vec_end, prefix, path)
+          process_route_vec(source, i, vec_end, prefix, path, include_callee, function_callees)
           i = vec_end + 1
         else
           i = end_of_value(source, i, limit)
@@ -139,7 +160,13 @@ module Analyzer::Clojure
       end
     end
 
-    private def process_route_vec(source : String, vec_start : Int32, vec_end : Int32, prefix : String, path : String)
+    private def process_route_vec(source : String,
+                                  vec_start : Int32,
+                                  vec_end : Int32,
+                                  prefix : String,
+                                  path : String,
+                                  include_callee : Bool,
+                                  function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = skip_ws_and_comments(source, vec_start + 1, vec_end)
       return if i >= vec_end
       return unless source.byte_at(i).unsafe_chr == '"'
@@ -149,10 +176,16 @@ module Analyzer::Clojure
 
       route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
       new_prefix = join_path(prefix, route_path)
-      walk_route_body(source, str_end + 1, vec_end, new_prefix, path)
+      walk_route_body(source, str_end + 1, vec_end, new_prefix, path, include_callee, function_callees)
     end
 
-    private def walk_route_body(source : String, start : Int32, limit : Int32, prefix : String, path : String)
+    private def walk_route_body(source : String,
+                                start : Int32,
+                                limit : Int32,
+                                prefix : String,
+                                path : String,
+                                include_callee : Bool,
+                                function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       while i < limit
         i = skip_ws_and_comments(source, i, limit)
@@ -162,12 +195,12 @@ module Analyzer::Clojure
         when '{'
           map_end = find_matching_delimiter(source, i, '{', '}', limit)
           break if map_end <= i
-          process_route_data_map(source, i + 1, map_end, prefix, path)
+          process_route_data_map(source, i + 1, map_end, prefix, path, include_callee, function_callees)
           i = map_end + 1
         when '['
           vec_end = find_matching_delimiter(source, i, '[', ']', limit)
           break if vec_end <= i
-          process_route_vec(source, i, vec_end, prefix, path)
+          process_route_vec(source, i, vec_end, prefix, path, include_callee, function_callees)
           i = vec_end + 1
         else
           i = end_of_value(source, i, limit)
@@ -175,7 +208,13 @@ module Analyzer::Clojure
       end
     end
 
-    private def process_route_data_map(source : String, start : Int32, limit : Int32, route_path : String, path : String)
+    private def process_route_data_map(source : String,
+                                       start : Int32,
+                                       limit : Int32,
+                                       route_path : String,
+                                       path : String,
+                                       include_callee : Bool,
+                                       function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       i = start
       while i < limit
         i = skip_ws_and_comments(source, i, limit)
@@ -192,7 +231,7 @@ module Analyzer::Clojure
         val_end = end_of_value(source, v_start, limit)
 
         if method_name = HTTP_METHODS[key]?
-          emit_endpoint(source, key_start, v_start, val_end, route_path, method_name, path)
+          emit_endpoint(source, key_start, v_start, val_end, route_path, method_name, path, include_callee, function_callees)
         end
 
         i = val_end
@@ -200,7 +239,11 @@ module Analyzer::Clojure
     end
 
     private def emit_endpoint(source : String, key_pos : Int32, v_start : Int32, v_end : Int32,
-                              route_path : String, method : String, path : String)
+                              route_path : String,
+                              method : String,
+                              path : String,
+                              include_callee : Bool,
+                              function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
       endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, key_pos))))
 
       extract_path_param_names(route_path).each do |name|
@@ -214,7 +257,122 @@ module Analyzer::Clojure
         end
       end
 
+      attach_method_callees(endpoint, source, v_start, v_end, path, function_callees) if include_callee
+
       @result << endpoint
+    end
+
+    private def attach_method_callees(endpoint : Endpoint,
+                                      source : String,
+                                      v_start : Int32,
+                                      v_end : Int32,
+                                      path : String,
+                                      function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+      return if v_start >= v_end
+
+      if source.byte_at(v_start).unsafe_chr == '{'
+        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+        return unless map_end > v_start
+        attach_handler_map_callees(source, v_start + 1, map_end, endpoint, path, function_callees)
+      else
+        attach_handler_value(endpoint, source, v_start, v_end, path, function_callees)
+      end
+    end
+
+    private def attach_handler_map_callees(source : String,
+                                           start : Int32,
+                                           limit : Int32,
+                                           endpoint : Endpoint,
+                                           path : String,
+                                           function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+      i = start
+      while i < limit
+        i = skip_ws_and_comments(source, i, limit)
+        break if i >= limit
+        key, after_key = read_symbol(source, i, limit)
+        if key.empty?
+          i = end_of_value(source, i, limit)
+          next
+        end
+
+        v_start = skip_ws_and_comments(source, after_key, limit)
+        break if v_start >= limit
+        val_end = end_of_value(source, v_start, limit)
+
+        attach_handler_value(endpoint, source, v_start, val_end, path, function_callees) if key == ":handler"
+        i = val_end
+      end
+    end
+
+    private def attach_handler_value(endpoint : Endpoint,
+                                     source : String,
+                                     value_start : Int32,
+                                     value_end : Int32,
+                                     path : String,
+                                     function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+      token, _ = read_form_token(source, value_start, value_end)
+      return if token.empty?
+
+      if token.starts_with?('(')
+        body = source.byte_slice(value_start, value_end - value_start)
+        line = line_number_for(source, value_start)
+        Noir::ClojureCalleeExtractor.attach_to(endpoint, Noir::ClojureCalleeExtractor.callees_for_body(body, path, line))
+      elsif handler_name = normalized_handler_symbol(token)
+        if callees = function_callees[handler_name]?
+          Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
+        else
+          endpoint.push_callee(Callee.new(handler_name, path: path, line: line_number_for(source, value_start)))
+        end
+      end
+    end
+
+    private def normalized_handler_symbol(token : String) : String?
+      name = token
+      if name.starts_with?("#'")
+        name = name[2..]
+      elsif name.starts_with?('\'') || name.starts_with?('`')
+        name = name[1..]
+      end
+
+      return unless handler_symbol?(name)
+      function_name(name)
+    end
+
+    private def handler_symbol?(token : String) : Bool
+      return false if token.starts_with?(':')
+      return false if token.starts_with?('"')
+      return false if {"nil", "true", "false"}.includes?(token)
+      !!token.match(/^[A-Za-z_.*+!?<>=][\w.\-*+!?<>=\/]*$/)
+    end
+
+    private def function_name(symbol : String) : String
+      if index = symbol.rindex('/')
+        symbol[(index + 1)..]
+      else
+        symbol
+      end
+    end
+
+    private def read_form_token(source : String, start : Int32, limit : Int32) : Tuple(String, Int32)
+      i = skip_ws_and_comments(source, start, limit)
+      return {"", i} if i >= limit
+
+      case source.byte_at(i).unsafe_chr
+      when '"'
+        e = skip_string(source, i, limit)
+        {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)}
+      when '('
+        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
+      when '['
+        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
+      when '{'
+        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e > i ? {source.byte_slice(i, e - i + 1), skip_ws_and_comments(source, e + 1, limit)} : {"", i}
+      else
+        read_symbol(source, i, limit)
+      end
     end
 
     private def extract_params_from_method_map(source : String, start : Int32, limit : Int32,

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -22,10 +22,124 @@ module Noir::ClojureCalleeExtractor
     dedup_entries(entries)
   end
 
+  def function_callees(source : String, file_path : String) : Hash(String, Array(Entry))
+    result = Hash(String, Array(Entry)).new
+    scan_function_definitions(source, 0, source.bytesize, file_path, result)
+    result
+  end
+
   def attach_to(endpoint : Endpoint, callees : Array(Entry))
     callees.each do |name, path, line|
       endpoint.push_callee(Callee.new(name, path: path, line: line))
     end
+  end
+
+  private def scan_function_definitions(source : String,
+                                        start_index : Int32,
+                                        end_index : Int32,
+                                        file_path : String,
+                                        result : Hash(String, Array(Entry)))
+    i = start_index
+    while i < end_index
+      case source.byte_at(i).unsafe_chr
+      when ';'
+        i = skip_comment(source, i, end_index)
+      when '"'
+        i = skip_string(source, i, end_index) + 1
+      when '\'', '`'
+        i = skip_quoted_form(source, i + 1, end_index)
+      when '#'
+        next_char = i + 1 < end_index ? source.byte_at(i + 1).unsafe_chr : '\0'
+        if next_char == '_'
+          i = skip_quoted_form(source, i + 2, end_index)
+        else
+          i += 1
+        end
+      when '('
+        form_end = find_matching_delimiter(source, i, '(', ')', end_index)
+        break if form_end <= i
+
+        symbol_start = skip_ws_and_comments(source, i + 1, form_end)
+        symbol, after_symbol = read_symbol(source, symbol_start, form_end)
+        base = base_symbol(symbol)
+        if base == "defn" || base == "defn-"
+          collect_defn_callees(source, after_symbol, form_end, file_path, result)
+        else
+          scan_function_definitions(source, after_symbol, form_end, file_path, result) unless quoted_form?(symbol)
+        end
+
+        i = form_end + 1
+      else
+        i += 1
+      end
+    end
+  end
+
+  private def collect_defn_callees(source : String,
+                                   index : Int32,
+                                   form_end : Int32,
+                                   file_path : String,
+                                   result : Hash(String, Array(Entry)))
+    name_start = skip_metadata(source, index, form_end)
+    name, after_name = read_symbol(source, name_start, form_end)
+    return if name.empty?
+
+    body_start = defn_body_start(source, after_name, form_end)
+    return if body_start >= form_end
+
+    body = source.byte_slice(body_start, form_end - body_start)
+    start_line = line_number_for(source, body_start, 1)
+    result[name] = callees_for_body(body, file_path, start_line)
+  end
+
+  private def skip_metadata(source : String, index : Int32, limit : Int32) : Int32
+    i = skip_ws_and_comments(source, index, limit)
+    while i < limit && source.byte_at(i).unsafe_chr == '^'
+      i = skip_metadata_value(source, i + 1, limit)
+      i = skip_ws_and_comments(source, i, limit)
+    end
+    i
+  end
+
+  private def skip_metadata_value(source : String, index : Int32, limit : Int32) : Int32
+    i = skip_ws_and_comments(source, index, limit)
+    return i if i >= limit
+
+    case source.byte_at(i).unsafe_chr
+    when '"'
+      skip_string(source, i, limit) + 1
+    when '{'
+      end_index = find_matching_delimiter(source, i, '{', '}', limit)
+      end_index > i ? end_index + 1 : limit
+    else
+      _, after_symbol = read_symbol(source, i, limit)
+      after_symbol
+    end
+  end
+
+  private def defn_body_start(source : String, index : Int32, limit : Int32) : Int32
+    i = skip_ws_and_comments(source, index, limit)
+
+    # Optional docstring.
+    if i < limit && source.byte_at(i).unsafe_chr == '"'
+      doc_end = skip_string(source, i, limit)
+      i = skip_ws_and_comments(source, doc_end + 1, limit)
+    end
+
+    # Optional attr map.
+    if i < limit && source.byte_at(i).unsafe_chr == '{'
+      map_end = find_matching_delimiter(source, i, '{', '}', limit)
+      i = skip_ws_and_comments(source, map_end + 1, limit) if map_end > i
+    end
+
+    # Single arity: `(defn name [args] body...)`.
+    if i < limit && source.byte_at(i).unsafe_chr == '['
+      args_end = find_matching_delimiter(source, i, '[', ']', limit)
+      return skip_ws_and_comments(source, args_end + 1, limit) if args_end > i
+    end
+
+    # Multi arity: `(defn name ([args] body...) ([args] body...))`.
+    i
   end
 
   private def scan_forms(source : String,


### PR DESCRIPTION
## Summary
- add top-level Clojure defn callee indexing, including metadata-decorated handlers
- attach Reitit and Pedestal handler callees from symbols, quoted vars, syntax quotes, and inline fns
- add focused callee fixtures/specs for Reitit and Pedestal

## Tests
- crystal spec spec/unit_test/miniparser/clojure_callee_extractor_spec.cr spec/functional_test/testers/clojure/reitit_callees_spec.cr spec/functional_test/testers/clojure/pedestal_callees_spec.cr --error-trace
- just test
- just build