### PR TITLE
Improve tagger coverage and accuracy

### DIFF
--- a/spec/unit_test/tagger/taggers/file_upload_spec.cr
+++ b/spec/unit_test/tagger/taggers/file_upload_spec.cr
@@ -151,5 +151,55 @@ describe "FileUploadTagger" do
       endpoint.tags.size.should eq(1)
       endpoint.tags[0].name.should eq("file_upload")
     end
+
+    it "tags PATCH endpoint with avatar body parameter" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/me/avatar", "PATCH", [
+        Param.new("avatar", "", "body"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("file_upload")
+    end
+
+    it "tags multipart content-type header values" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/profile", "POST", [
+        Param.new("Content-Type", "multipart/form-data; boundary=abc", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("file_upload")
+    end
+
+    it "does not tag non-multipart content-type headers" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/profile", "POST", [
+        Param.new("Content-Type", "application/json", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag GET media endpoints as uploads" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/123/avatar", "GET", [
+        Param.new("avatar", "", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/jwt_spec.cr
+++ b/spec/unit_test/tagger/taggers/jwt_spec.cr
@@ -133,5 +133,43 @@ describe "JwtTagger" do
       endpoint.tags.size.should eq(1)
       endpoint.tags[0].name.should eq("jwt")
     end
+
+    it "tags bearer authorization values without a second token parameter" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/profile", "GET", [
+        Param.new("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("jwt")
+    end
+
+    it "tags auth routes with custom token header names" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/login", "POST", [
+        Param.new("x-api-token", "", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("jwt")
+    end
+
+    it "does not tag CSRF-only token parameters" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/auth/session", "POST", [
+        Param.new("csrf_token", "", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/oauth_spec.cr
+++ b/spec/unit_test/tagger/taggers/oauth_spec.cr
@@ -57,7 +57,7 @@ describe "OAuthTagger" do
     it "tags with exactly 3 matching parameters" do
       tagger = OAuthTagger.new(default_tagger_options)
 
-      endpoint = Endpoint.new("/oauth/token", "POST", [
+      endpoint = Endpoint.new("/api/integrations/token", "POST", [
         Param.new("grant_type", "client_credentials", "form"),
         Param.new("client_id", "my-app", "form"),
         Param.new("client_secret", "secret", "form"),
@@ -101,10 +101,9 @@ describe "OAuthTagger" do
       endpoint2.tags.size.should eq(0)
     end
 
-    it "is case-sensitive for parameter matching" do
+    it "normalizes parameter names for matching" do
       tagger = OAuthTagger.new(default_tagger_options)
 
-      # OAuth parameter names are case-sensitive
       endpoint = Endpoint.new("/oauth/token", "POST", [
         Param.new("GRANT_TYPE", "authorization_code", "form"),
         Param.new("CODE", "abc123", "form"),
@@ -113,7 +112,65 @@ describe "OAuthTagger" do
 
       tagger.perform([endpoint])
 
-      # Should not match because case doesn't match
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "tags OAuth authorization endpoints with OIDC parameters" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/oauth2/authorize", "GET", [
+        Param.new("response_type", "code", "query"),
+        Param.new("client_id", "my-app", "query"),
+        Param.new("redirect_uri", "https://example.com/callback", "query"),
+        Param.new("scope", "openid profile", "query"),
+        Param.new("state", "abc123", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "tags OAuth token endpoints using PKCE verifier without client secret" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/oauth/token", "POST", [
+        Param.new("grant-type", "authorization_code", "form"),
+        Param.new("code_verifier", "pkce-secret", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "does not tag generic token routes with weak OAuth parameters" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/token", "POST", [
+        Param.new("code", "123456", "form"),
+        Param.new("state", "ready", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag non-OAuth endpoints with weak OAuth-like parameter names" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/promotions", "POST", [
+        Param.new("code", "SPRING", "form"),
+        Param.new("state", "published", "form"),
+        Param.new("scope", "regional", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
       endpoint.tags.size.should eq(0)
     end
   end

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -2,7 +2,15 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class FileUploadTagger < Tagger
-  WORDS = ["file", "upload", "attachment", "document", "image", "multipart", "content-type", "filename", "content-disposition"]
+  WORDS = Set{
+    "file", "files", "upload", "attachment", "attachments", "document", "documents",
+    "image", "images", "photo", "photos", "avatar", "media", "multipart",
+    "content_type", "filename", "content_disposition",
+  }
+
+  UPLOAD_PARAM_TYPES = Set{"file", "form", "body", "json"}
+  UPLOAD_METHODS     = Set{"POST", "PUT", "PATCH"}
+  UPLOAD_PATH_PARTS  = Set{"upload", "uploads", "attach", "attachment", "attachments", "import", "imports", "avatar", "photo", "photos", "media"}
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -11,28 +19,40 @@ class FileUploadTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
+      has_upload_param = endpoint.params.any? { |param| upload_param?(param) }
+      is_upload_url = upload_url?(endpoint.url)
+      is_upload_method = UPLOAD_METHODS.includes?(endpoint.method.upcase)
+      has_multipart_header = endpoint.params.any? { |param| multipart_header?(param) }
 
-      endpoint.params.each do |param|
-        tmp_params.push param.name.to_s.downcase
-      end
-
-      # Check URL path for upload indicators
-      url_lower = endpoint.url.downcase
-      is_upload_url = url_lower.includes?("upload") || url_lower.includes?("attach") || url_lower.includes?("import")
-
-      words_set = Set.new(WORDS)
-      tmp_params_set = Set.new(tmp_params)
-      intersection = words_set & tmp_params_set
-
-      # Check that at least one parameter matches and method is POST/PUT or URL indicates upload
-      is_upload_method = endpoint.method == "POST" || endpoint.method == "PUT"
-      check = (intersection.size.to_i >= 1 && is_upload_method) || (is_upload_url && is_upload_method)
+      check = is_upload_method && (has_upload_param || is_upload_url || has_multipart_header)
 
       if check
         tag = Tag.new("file_upload", "File upload endpoint potentially vulnerable to unrestricted file upload, path traversal, or malicious file execution.", "FileUpload")
         endpoint.add_tag(tag)
       end
     end
+  end
+
+  private def upload_param?(param : Param) : Bool
+    name = normalize_param_name(param.name)
+    return false unless UPLOAD_PARAM_TYPES.includes?(param.param_type)
+
+    WORDS.includes?(name) || name.ends_with?("_file") || name.ends_with?("_files")
+  end
+
+  private def multipart_header?(param : Param) : Bool
+    name = normalize_param_name(param.name)
+    value = param.value.downcase
+    (name == "content_type" && value.includes?("multipart/form-data")) ||
+      (name == "content_disposition" && value.includes?("filename="))
+  end
+
+  private def upload_url?(url : String) : Bool
+    parts = url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+    parts.any? { |part| UPLOAD_PATH_PARTS.includes?(part) }
+  end
+
+  private def normalize_param_name(name : String) : String
+    name.downcase.tr("-", "_")
   end
 end

--- a/src/tagger/taggers/jwt.cr
+++ b/src/tagger/taggers/jwt.cr
@@ -2,7 +2,17 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class JwtTagger < Tagger
-  WORDS = ["token", "jwt", "bearer", "refresh_token", "access_token", "id_token", "authorization"]
+  STRONG_NAMES = Set{
+    "jwt", "bearer", "authorization", "access_token", "refresh_token", "id_token",
+    "auth_token", "api_token", "x_api_token", "x_access_token",
+  }
+
+  EXCLUDED_TOKEN_NAMES = Set{
+    "csrf_token", "xsrf_token", "authenticity_token", "anti_csrf_token",
+    "captcha_token", "recaptcha_token", "turnstile_token",
+  }
+
+  AUTH_PATH_PARTS = Set{"auth", "authenticate", "authentication", "login", "signin", "sign_in", "token", "refresh", "jwt"}
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -11,27 +21,46 @@ class JwtTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
+      signals = endpoint.params.count { |param| jwt_signal?(param) }
+      has_bearer_value = endpoint.params.any? { |param| bearer_or_jwt_value?(param.value) }
+      is_auth_url = auth_url?(endpoint.url)
 
-      endpoint.params.each do |param|
-        tmp_params.push param.name.to_s.downcase
-      end
-
-      # Check URL path for JWT indicators
-      url_lower = endpoint.url.downcase
-      is_jwt_url = url_lower.includes?("/token") || url_lower.includes?("/auth") || url_lower.includes?("/jwt") || url_lower.includes?("/refresh")
-
-      words_set = Set.new(WORDS)
-      tmp_params_set = Set.new(tmp_params)
-      intersection = words_set & tmp_params_set
-
-      # Check that at least two parameters match or URL indicates JWT handling
-      check = intersection.size.to_i >= 2 || (is_jwt_url && intersection.size.to_i >= 1)
+      # Require either an unmistakable token value, multiple token/auth
+      # signals, or an auth-like route plus a non-CSRF token parameter.
+      check = has_bearer_value || signals >= 2 || (is_auth_url && signals >= 1)
 
       if check
         tag = Tag.new("jwt", "JWT endpoint for token-based authentication, requiring validation of signature, expiration, and claims.", "JWT")
         endpoint.add_tag(tag)
       end
     end
+  end
+
+  private def jwt_signal?(param : Param) : Bool
+    name = normalize_param_name(param.name)
+    return false if EXCLUDED_TOKEN_NAMES.includes?(name)
+    return true if STRONG_NAMES.includes?(name)
+    return true if name == "token"
+    return true if name.ends_with?("_token") && !name.includes?("csrf") && !name.includes?("captcha")
+
+    false
+  end
+
+  private def bearer_or_jwt_value?(value : String) : Bool
+    value_lower = value.downcase
+    return true if value_lower.starts_with?("bearer ")
+
+    # Compact JWTs are three base64url-ish segments. Keep this strict
+    # enough to avoid tagging arbitrary dotted values.
+    !!value.match(/\AeyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\z/)
+  end
+
+  private def normalize_param_name(name : String) : String
+    name.downcase.tr("-", "_")
+  end
+
+  private def auth_url?(url : String) : Bool
+    parts = url.downcase.tr("-", "_").split(/[\/\.]+/).reject(&.empty?)
+    parts.any? { |part| AUTH_PATH_PARTS.includes?(part) }
   end
 end

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -2,7 +2,13 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class OAuthTagger < Tagger
-  WORDS = ["grant_type", "code", "redirect_uri", "redirect_url", "client_id", "client_secret"]
+  WORDS = Set{
+    "grant_type", "code", "redirect_uri", "redirect_url", "client_id", "client_secret",
+    "response_type", "scope", "state", "code_challenge", "code_challenge_method",
+    "code_verifier", "refresh_token", "access_token", "id_token", "nonce", "audience",
+  }
+
+  OAUTH_PATH_PARTS = Set{"oauth", "oauth2", "authorize", "authorization", "token", "callback"}
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -11,23 +17,58 @@ class OAuthTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
+      param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set
+      intersection = WORDS & param_names
 
-      endpoint.params.each do |param|
-        tmp_params.push param.name.to_s
-      end
-
-      words_set = Set.new(WORDS)
-      tmp_params_set = Set.new(tmp_params)
-      intersection = words_set & tmp_params_set
-
-      # Check that at least three parameters match.
-      check = intersection.size.to_i >= 3
+      # OAuth authorization endpoints commonly use response_type +
+      # client_id + redirect_uri, while token endpoints can rely on
+      # HTTP Basic auth and expose only grant_type + code/verifier.
+      check = strong_oauth_params?(param_names) ||
+              (oauth_url?(endpoint.url) && intersection.size >= 3) ||
+              (oauth_url?(endpoint.url) && oauth_authorization_params?(param_names)) ||
+              (oauth_url?(endpoint.url) && oauth_token_params?(param_names))
 
       if check
         tag = Tag.new("oauth", "Suspected OAuth endpoint for granting 3rd party access.", "Oauth")
         endpoint.add_tag(tag)
       end
     end
+  end
+
+  private def normalize_param_name(name : String) : String
+    name.downcase.tr("-", "_")
+  end
+
+  private def oauth_url?(url : String) : Bool
+    parts = url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+    parts.any? { |part| OAUTH_PATH_PARTS.includes?(part) }
+  end
+
+  private def oauth_authorization_params?(param_names : Set(String)) : Bool
+    param_names.includes?("client_id") &&
+      (param_names.includes?("redirect_uri") || param_names.includes?("redirect_url")) &&
+      (param_names.includes?("response_type") || param_names.includes?("scope") || param_names.includes?("state"))
+  end
+
+  private def strong_oauth_params?(param_names : Set(String)) : Bool
+    oauth_authorization_params?(param_names) || strong_oauth_token_params?(param_names)
+  end
+
+  private def strong_oauth_token_params?(param_names : Set(String)) : Bool
+    return false unless param_names.includes?("grant_type")
+
+    param_names.includes?("client_secret") ||
+      param_names.includes?("code_verifier") ||
+      param_names.includes?("refresh_token") ||
+      (param_names.includes?("client_id") && param_names.includes?("code"))
+  end
+
+  private def oauth_token_params?(param_names : Set(String)) : Bool
+    return false unless param_names.includes?("grant_type")
+
+    param_names.includes?("client_id") ||
+      param_names.includes?("code") ||
+      param_names.includes?("code_verifier") ||
+      param_names.includes?("refresh_token")
   end
 end


### PR DESCRIPTION
## Summary
- expand OAuth detection for OIDC/PKCE while gating weak generic params by URL or strong OAuth parameter combinations
- broaden JWT token signal detection while excluding CSRF/captcha-style tokens
- improve file upload tagging for avatar/photo/media, PATCH, file/body params, and multipart headers

## Tests
- crystal spec spec/unit_test/tagger/taggers/oauth_spec.cr spec/unit_test/tagger/taggers/jwt_spec.cr spec/unit_test/tagger/taggers/file_upload_spec.cr
- just test
- just check
- just build