### PR TITLE
Add claude-opus-4-8 and grok-build-0.1 model token limits

### DIFF
--- a/docs/content/usage/ai_providers/openrouter/index.ko.md
+++ b/docs/content/usage/ai_providers/openrouter/index.ko.md
@@ -18,7 +18,7 @@ sort_by = "weight"
 ```bash
 noir scan ./myapp \
      --ai-provider=openrouter \
-     --ai-model=anthropic/claude-opus-4-7 \
+     --ai-model=anthropic/claude-opus-4-8 \
      --ai-key=sk-or-...
 ```
 

--- a/docs/content/usage/ai_providers/openrouter/index.md
+++ b/docs/content/usage/ai_providers/openrouter/index.md
@@ -20,7 +20,7 @@ Run Noir with OpenRouter:
 ```bash
 noir scan ./myapp \
      --ai-provider=openrouter \
-     --ai-model=anthropic/claude-opus-4-7 \
+     --ai-model=anthropic/claude-opus-4-8 \
      --ai-key=sk-or-...
 ```
 

--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -109,6 +109,10 @@ describe LLM do
         xai["grok-4.1-fast"].should eq(2000000)
       end
 
+      it "includes grok-build-0.1 with 256000 tokens" do
+        xai["grok-build-0.1"].should eq(256000)
+      end
+
       it "has default of 8000" do
         xai["default"].should eq(8000)
       end
@@ -147,6 +151,10 @@ describe LLM do
 
       it "includes claude-opus-4-7 with 200000 tokens" do
         anthropic["claude-opus-4-7"].should eq(200000)
+      end
+
+      it "includes claude-opus-4-8 with 1000000 tokens" do
+        anthropic["claude-opus-4-8"].should eq(1000000)
       end
 
       it "has default of 100000" do

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -353,6 +353,7 @@ module LLM
       "grok-4.3"                  => 2000000,
       "grok-code-fast"            => 2000000,
       "grok-code-fast-1"          => 2000000,
+      "grok-build-0.1"            => 256000,
       "default"                   => 8000,
     },
     "anthropic" => {
@@ -375,6 +376,7 @@ module LLM
       "claude-opus-4-5"    => 200000,
       "claude-opus-4-6"    => 200000,
       "claude-opus-4-7"    => 200000,
+      "claude-opus-4-8"    => 1000000,
       "default"            => 100000,
     },
     "azure" => {


### PR DESCRIPTION
## Description

Extends the AI provider model catalog in `MODEL_TOKEN_LIMITS` with two newly released models, keeping Noir's already-broad AI context coverage current with the latest provider lineups.

- **`anthropic` / `claude-opus-4-8`** → `1000000` — Claude Opus 4.8 ships a 1M-token context window by default on the Claude API ([Anthropic docs](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-8)).
- **`xai` / `grok-build-0.1`** → `256000` — xAI's agentic coding model with a 256k-token context window ([xAI docs](https://docs.x.ai/developers/models/grok-build-0.1)).

## Changes

- `src/llm/prompt.cr` — add both entries to the `anthropic` and `xai` token-limit maps.
- `spec/unit_test/llm/prompt_spec.cr` — add coverage asserting the new token limits.

## Testing

```
crystal spec spec/unit_test/llm/prompt_spec.cr
# 75 examples, 0 failures, 0 errors, 0 pending
```