### PR TITLE
Add api_docs and account_recovery taggers

### DIFF
--- a/docs/content/usage/more_features/tagger/index.ko.md
+++ b/docs/content/usage/more_features/tagger/index.ko.md
@@ -79,6 +79,8 @@ noir scan <BASE_PATH> --use-taggers hunt,oauth
   - `webhook` — 인바운드 웹훅/콜백 엔드포인트. 서명 검증, 재전송 방어, 아웃바운드 호출의 SSRF 검토 대상.
   - `crypto` — 암호화 연산 엔드포인트(암복호화, 서명, 해시, 키 관리). 약하거나 구식인 알고리즘, 패딩/서명 오라클, 정적 IV/salt 재사용, 키 노출 검토 대상.
   - `debug` — 디버그·진단·내부 전용 엔드포인트(디버그 콘솔/토글, 프로파일러, actuator/management, pprof, heap/thread dump, `/internal` API). 외부에 노출되면 안 되며, 정보 노출 및 위험한 진단 동작 검토 대상.
+  - `api_docs` — API 문서/스키마 엔드포인트(Swagger, OpenAPI, GraphiQL, ReDoc, WSDL). 전체 API 표면을 드러내고 인증 없이 노출되는 경우가 많음. 비인증 노출 및 정보 유출 검토 대상.
+  - `account_recovery` — 자격증명 관리·계정 복구 엔드포인트(비밀번호 재설정/변경, 이메일 변경, MFA/OTP, 인증). 전형적인 계정 탈취 표면 — 리셋 토큰 유출, reset 링크 host-header 인젝션, 계정 열거, 레이트리밋 부재 검토 대상.
   - `file_upload` — 파일 업로드 엔드포인트. 무제한 업로드, 경로 탐색, 악성 파일 처리 검토 대상.
 
 엔드포인트 레벨 태그는 AI 컨텍스트에도 신호로 전달되어, AI 리뷰어가 사용하는 엔드포인트별 요약을 더욱 풍부하게 만듭니다.

--- a/docs/content/usage/more_features/tagger/index.md
+++ b/docs/content/usage/more_features/tagger/index.md
@@ -79,6 +79,8 @@ Taggers span several kinds of security-relevant signal. Run `noir list taggers` 
   - `webhook` — inbound webhook / callback endpoints; verify signature validation, replay protection, and SSRF on outbound calls.
   - `crypto` — cryptographic operation endpoints (encryption/decryption, signing, hashing, key management); review for weak or obsolete algorithms, padding/signing oracles, static IV/salt reuse, and key exposure.
   - `debug` — debug, diagnostic, and internal-only endpoints (debug consoles/toggles, profilers, actuator/management, pprof, heap/thread dumps, `/internal` APIs); should not be publicly reachable — review for information exposure and unsafe diagnostic actions.
+  - `api_docs` — API documentation / schema endpoints (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL); expose the full API surface and are frequently unauthenticated — review for unauthenticated exposure and information disclosure.
+  - `account_recovery` — credential-management and account-recovery endpoints (password reset/change, email change, MFA/OTP, verification); the classic account-takeover surface — review for reset-token leakage, host-header injection in reset links, account enumeration, and missing rate limiting.
   - `file_upload` — file upload endpoints; review for unrestricted upload, path traversal, and malicious file handling.
 
 Endpoint-level tags also feed the AI context as signals, enriching the per-endpoint summary that AI reviewers consume.

--- a/spec/unit_test/tagger/tagger_spec.cr
+++ b/spec/unit_test/tagger/tagger_spec.cr
@@ -298,4 +298,32 @@ describe "Tagger" do
       end
     end
   end
+
+  it "api_docs_tagger" do
+    noir_options = create_test_options
+    expected_endpoints = [
+      Endpoint.new("/swagger-ui.html", "GET"),
+    ]
+    NoirTaggers.run_tagger(expected_endpoints, noir_options, "api_docs")
+    expected_endpoints.each do |endpoint|
+      endpoint.tags.empty?.should be_false
+      endpoint.tags.each do |tag|
+        tag.name.should eq("api_docs")
+      end
+    end
+  end
+
+  it "account_recovery_tagger" do
+    noir_options = create_test_options
+    expected_endpoints = [
+      Endpoint.new("/auth/forgot-password", "POST"),
+    ]
+    NoirTaggers.run_tagger(expected_endpoints, noir_options, "account_recovery")
+    expected_endpoints.each do |endpoint|
+      endpoint.tags.empty?.should be_false
+      endpoint.tags.each do |tag|
+        tag.name.should eq("account_recovery")
+      end
+    end
+  end
 end

--- a/spec/unit_test/tagger/taggers/account_recovery_spec.cr
+++ b/spec/unit_test/tagger/taggers/account_recovery_spec.cr
@@ -1,0 +1,153 @@
+require "../../../spec_helper"
+require "../../../../src/utils/*"
+require "../../../../src/models/endpoint.cr"
+require "../../../../src/models/logger.cr"
+require "../../../../src/models/tagger.cr"
+require "../../../../src/tagger/taggers/account_recovery.cr"
+require "yaml"
+
+def default_tagger_options
+  {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+  }
+end
+
+describe "AccountRecoveryTagger" do
+  describe "initialization" do
+    it "creates tagger with name" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+      tagger.name.should eq("account_recovery")
+    end
+  end
+
+  describe "perform" do
+    it "tags a forgot-password endpoint" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/auth/forgot-password", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("account_recovery")
+    end
+
+    it "tags a Devise-style /users/password endpoint" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/password", "PUT")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("account_recovery")
+    end
+
+    it "tags an MFA enrollment endpoint" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/account/mfa/enable", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("account_recovery")
+    end
+
+    it "tags a password change via parameters regardless of path" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/settings", "PATCH", [
+        Param.new("current_password", "", "json"),
+        Param.new("new_password", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("account_recovery")
+    end
+
+    it "tags an email verification endpoint via two weak tokens" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/verify-email", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("account_recovery")
+    end
+
+    it "tags an email-change endpoint (account-takeover vector)" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      change = Endpoint.new("/change-email", "POST")
+      update = Endpoint.new("/settings/update-email", "POST")
+
+      tagger.perform([change, update])
+
+      change.tags.size.should eq(1)
+      change.tags[0].name.should eq("account_recovery")
+      update.tags.size.should eq(1)
+    end
+
+    it "tags /account/recovery via the weak pair" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/account/recovery", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("account_recovery")
+    end
+
+    it "does not tag disaster/data-recovery infrastructure endpoints" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      disaster = Endpoint.new("/disaster-recovery", "POST")
+      data = Endpoint.new("/data/recovery/jobs", "GET")
+
+      tagger.perform([disaster, data])
+
+      disaster.tags.size.should eq(0)
+      data.tags.size.should eq(0)
+    end
+
+    it "does not tag API-credential rotation routes" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/credentials/reset", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag a bare /reset on an unrelated resource" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/dashboard/reset", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag a benign endpoint" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/products", "GET", [
+        Param.new("page", "1", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+  end
+end

--- a/spec/unit_test/tagger/taggers/api_docs_spec.cr
+++ b/spec/unit_test/tagger/taggers/api_docs_spec.cr
@@ -1,0 +1,112 @@
+require "../../../spec_helper"
+require "../../../../src/utils/*"
+require "../../../../src/models/endpoint.cr"
+require "../../../../src/models/logger.cr"
+require "../../../../src/models/tagger.cr"
+require "../../../../src/tagger/taggers/api_docs.cr"
+require "yaml"
+
+def default_tagger_options
+  {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+  }
+end
+
+describe "ApiDocsTagger" do
+  describe "initialization" do
+    it "creates tagger with name" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+      tagger.name.should eq("api_docs")
+    end
+  end
+
+  describe "perform" do
+    it "tags a Swagger UI endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/swagger-ui.html", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "tags a Spring /v3/api-docs endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/v3/api-docs", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "tags an openapi.json spec endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/openapi.json", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "tags a GraphiQL explorer endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/graphiql", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "tags a drf-spectacular /api/schema endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/schema/", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "does not tag a bare schema segment without api/openapi context" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/graphql/schema", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag a generic /docs documentation path" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/docs/getting-started", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag a benign endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/products", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -81,6 +81,16 @@ module NoirTaggers
       desc:   "Identifies debug, diagnostic, and internal-only endpoints (debug consoles, profilers, actuator, pprof, internal APIs)",
       runner: DebugTagger,
     },
+    api_docs: {
+      name:   "API Docs Tagger",
+      desc:   "Identifies API documentation/schema endpoints (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL)",
+      runner: ApiDocsTagger,
+    },
+    account_recovery: {
+      name:   "Account Recovery Tagger",
+      desc:   "Identifies credential-management and account-recovery endpoints (password reset/change, MFA/OTP, verification)",
+      runner: AccountRecoveryTagger,
+    },
   }
 
   HasFrameworkTaggers = {

--- a/src/tagger/taggers/account_recovery.cr
+++ b/src/tagger/taggers/account_recovery.cr
@@ -1,0 +1,79 @@
+require "../../models/tagger"
+require "../../models/endpoint"
+
+# Flags credential-management and account-recovery endpoints — password
+# reset/change, forgot-password, email change, MFA/2FA enrollment, OTP,
+# and account verification/recovery. These are the classic account-
+# takeover surface: review for reset-token leakage, host-header
+# injection in reset links, account enumeration, missing rate limiting,
+# and weak step-up verification.
+class AccountRecoveryTagger < Tagger
+  # Path segments that on their own mark a credential/recovery action.
+  # `password`/`mfa`/`otp`/`forgot` are not benign as a standalone path
+  # component. `recover`/`recovery` are intentionally *not* here — they
+  # collide with disaster/backup/data recovery — and are matched in the
+  # weak tier instead (so `/account/recovery` tags but `/disaster-recovery`
+  # does not).
+  STRONG_PATH_PARTS = Set{
+    "password", "passwd", "forgot", "mfa", "2fa", "totp", "otp",
+  }
+
+  # Parameter names that mark a credential change or a recovery/step-up
+  # code regardless of the route.
+  STRONG_PARAM_NAMES = Set{
+    "new_password", "old_password", "current_password",
+    "password_confirmation", "password_confirm", "reset_token",
+    "reset_password_token", "otp", "otp_code", "mfa_code", "totp_code",
+    "verification_code", "recovery_code", "confirmation_token",
+  }
+
+  # Weaker, generic action words. Tag only when two *distinct* weak
+  # tokens co-occur (e.g. `/verify-email`, `/change-email`,
+  # `/account/recovery`), so a bare `/reset` or `/confirm` on an
+  # unrelated resource is not flagged. `change`/`update` pair with
+  # `email`/`username` to catch the email-change ATO vector.
+  WEAK_PATH_PARTS = Set{
+    "verify", "verification", "confirm", "confirmation", "resend",
+    "reset", "email", "username", "change", "update", "phone",
+    "account", "recover", "recovery",
+  }
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "account_recovery"
+  end
+
+  def perform(endpoints : Array(Endpoint))
+    endpoints.each do |endpoint|
+      param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set
+      url_segments = url_parts(endpoint.url)
+
+      has_strong = !(STRONG_PARAM_NAMES & param_names).empty? ||
+                   url_segments.any? { |part| STRONG_PATH_PARTS.includes?(part) }
+
+      weak_tokens = Set(String).new
+      url_segments.each do |part|
+        weak_tokens << part if WEAK_PATH_PARTS.includes?(part)
+      end
+
+      check = has_strong || weak_tokens.size >= 2
+
+      if check
+        tag = Tag.new(
+          "account_recovery",
+          "Credential-management or account-recovery endpoint (password reset/change, email change, MFA/OTP, verification); classic account-takeover surface — review for reset-token leakage, host-header injection in reset links, account enumeration, and missing rate limiting.",
+          "AccountRecovery"
+        )
+        endpoint.add_tag(tag)
+      end
+    end
+  end
+
+  private def url_parts(url : String) : Array(String)
+    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+  end
+
+  private def normalize_param_name(name : String) : String
+    name.downcase.tr("-", "_")
+  end
+end

--- a/src/tagger/taggers/api_docs.cr
+++ b/src/tagger/taggers/api_docs.cr
@@ -1,0 +1,55 @@
+require "../../models/tagger"
+require "../../models/endpoint"
+
+# Flags API documentation / schema endpoints — Swagger UI, OpenAPI/JSON
+# specs, GraphiQL, ReDoc, RapiDoc, WSDL/WADL, Spring `…/api-docs`. These
+# expose the full API surface (every route, parameter, and model) and
+# are very frequently reachable without authentication, so they are a
+# high-value recon target and an information-disclosure risk.
+class ApiDocsTagger < Tagger
+  # Matched against slash/dot-delimited segments (hyphens and
+  # underscores kept inside a segment) so `/swagger-ui.html`,
+  # `/v3/api-docs`, and `/openapi.json` are all recognized while a
+  # generic `/docs` documentation site is not (FastAPI apps are still
+  # caught via `/openapi.json` / `/redoc`).
+  DOC_SEGMENTS = Set{
+    "swagger", "swagger-ui", "swaggerui", "swagger-resources",
+    "openapi", "openapi3", "redoc", "graphiql", "rapidoc",
+    "wsdl", "wadl", "api-docs", "api_docs", "apidocs",
+    "asyncapi", "api-json", "api-yaml", "apispec", "apispec_1",
+  }
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "api_docs"
+  end
+
+  def perform(endpoints : Array(Endpoint))
+    endpoints.each do |endpoint|
+      segments = doc_segments(endpoint.url)
+      check = segments.any? { |seg| DOC_SEGMENTS.includes?(seg) } ||
+              api_schema?(segments)
+
+      if check
+        tag = Tag.new(
+          "api_docs",
+          "API documentation / schema endpoint (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL); exposes the full API surface and is frequently reachable without authentication — review for unauthenticated exposure and information disclosure.",
+          "ApiDocs"
+        )
+        endpoint.add_tag(tag)
+      end
+    end
+  end
+
+  private def doc_segments(url : String) : Array(String)
+    url.downcase.split(/[\/.]+/).reject(&.empty?)
+  end
+
+  # `schema` is too generic to match on its own (GraphQL `/schema`,
+  # resource schema routes), so only flag it alongside an `api`/`openapi`
+  # segment — the drf-spectacular `/api/schema/` shape.
+  private def api_schema?(segments : Array(String)) : Bool
+    segments.includes?("schema") &&
+      (segments.includes?("api") || segments.includes?("openapi"))
+  end
+end


### PR DESCRIPTION
## Summary

Extends the security-context tagger set (after #1797, #1798, #1799) with two endpoint classifiers focused on **recon** and **account-takeover** surfaces. Both are enabled via `-T` / `--use-taggers`, and flow into the AI context as signals automatically.

## `api_docs`

Flags API documentation / schema endpoints — Swagger UI, OpenAPI/JSON specs, GraphiQL, ReDoc, RapiDoc, WSDL/WADL, AsyncAPI, NestJS `api-json`/`api-yaml`, flasgger `apispec`, Spring `/v3/api-docs`, and drf-spectacular `/api/schema`. These expose the full API surface (every route, parameter, and model) and are frequently reachable without authentication.

- Matched on **slash/dot segments** (hyphens/underscores kept inside a segment), so `/swagger-ui.html`, `/v3/api-docs`, and `/openapi.json` hit while a generic `/docs` documentation site does **not** (FastAPI is still caught via `/openapi.json` + `/redoc`).
- `schema` is matched **only alongside an `api`/`openapi` segment** (drf-spectacular `/api/schema/`), never bare — so `/graphql/schema` and resource `/schema` routes don't false-positive.

## `account_recovery`

Flags credential-management and account-recovery endpoints — password reset/change, forgot-password, email change, MFA/2FA, OTP, verification. The classic ATO surface (reset-token leakage, host-header injection in reset links, account enumeration, missing rate limiting).

- Strong single tokens (`password`, `passwd`, `forgot`, `mfa`, `2fa`, `totp`, `otp`) and credential-change / recovery-code params tag directly.
- `recover`/`recovery` sit in the **weak tier**: `/account/recovery` tags via the `account`+`recovery` pair, while `/disaster-recovery` and `/data/recovery` (infra, not accounts) do **not**.
- `change`/`update` pair with `email`/`username` to catch the **email-change takeover vector** (`/change-email`, `/update-email`).

Both taggers' tiering and exclusions came out of adversarial FP/FN review passes; the headline fixes prevent `/disaster-recovery` and `/credentials/reset` false positives and recover the `/change-email` and DRF `/api/schema` cases.

## Testing

- New `api_docs_spec.cr` and `account_recovery_spec.cr` with positive, negative, and FP/FN-guard regressions (`/api/schema` scoping, `/graphql/schema` negative, `/disaster-recovery`/`/credentials/reset` negatives, `/change-email`/`/account/recovery` positives).
- Registry integration tests in `tagger_spec.cr`.
- `just check` (format + ameba, 1231 files) — clean.
- `just test` — unit **2632** + functional **15068**, 0 failures.
- End-to-end scan confirms all the above on a real Sinatra fixture.

## Docs

`api_docs` and `account_recovery` added to the "Tag categories" section in `docs/content/usage/more_features/tagger/index.md` (+ `.ko.md`).