### PR TITLE
Improve OpenAPI output spec compliance

### DIFF
--- a/spec/unit_test/output_builder/oas2_spec.cr
+++ b/spec/unit_test/output_builder/oas2_spec.cr
@@ -116,4 +116,51 @@ describe "OutputBuilderOas2" do
     post_form_op.as_h.has_key?("consumes").should be_true
     post_form_op["consumes"].as_a.should contain(JSON::Any.new("application/x-www-form-urlencoded"))
   end
+
+  it "normalizes Swagger path, method, and host edge cases" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new("https://api.example.com/v1"),
+    }
+    builder = OutputBuilderOas2.new(options)
+    builder.io = IO::Memory.new
+
+    typed_path = Endpoint.new("/users/<int:user_id>", "ANY")
+    typed_path.push_param(Param.new("q", "", "query"))
+
+    mixed_body = Endpoint.new("/mixed", "POST")
+    mixed_body.push_param(Param.new("name", "", "json"))
+    mixed_body.push_param(Param.new("avatar", "", "form"))
+
+    unsupported = Endpoint.new("/jobs", "SUBSCRIBE")
+
+    builder.print([typed_path, mixed_body, unsupported])
+    spec = JSON.parse(builder.io.to_s)
+    paths = spec["paths"]
+
+    spec["host"].as_s.should eq("api.example.com")
+    spec["basePath"].as_s.should eq("/v1")
+    spec["schemes"].as_a.should eq([JSON::Any.new("https")])
+
+    paths.as_h.has_key?("/users/{user_id}").should be_true
+    paths["/users/{user_id}"].as_h.has_key?("any").should be_false
+    %w[get post put patch delete options head trace].each do |method|
+      paths["/users/{user_id}"].as_h.has_key?(method).should be_true
+    end
+
+    get_params = paths["/users/{user_id}"]["get"]["parameters"].as_a
+    get_params.any? { |p| p["in"].as_s == "path" && p["name"].as_s == "user_id" }.should be_true
+
+    mixed_params = paths["/mixed"]["post"]["parameters"].as_a
+    mixed_params.any? { |p| p["in"].as_s == "formData" && p["name"].as_s == "avatar" }.should be_true
+    mixed_params.any? { |p| p["in"].as_s == "body" }.should be_false
+    paths["/mixed"]["post"]["consumes"].as_a.should eq([JSON::Any.new("application/x-www-form-urlencoded")])
+
+    paths["/jobs"].as_h.has_key?("subscribe").should be_false
+    paths["/jobs"]["x-noir-unsupported-methods"].as_a.should contain(JSON::Any.new("SUBSCRIBE"))
+  end
 end

--- a/spec/unit_test/output_builder/oas3_spec.cr
+++ b/spec/unit_test/output_builder/oas3_spec.cr
@@ -128,4 +128,55 @@ describe "OutputBuilderOas3" do
     form_body["content"]["application/x-www-form-urlencoded"]["schema"]["type"].as_s.should eq("object")
     form_body["content"]["application/x-www-form-urlencoded"]["schema"]["properties"].as_h.size.should eq(2)
   end
+
+  it "normalizes OpenAPI path and method edge cases" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new("https://api.example.com"),
+    }
+    builder = OutputBuilderOas3.new(options)
+    builder.io = IO::Memory.new
+
+    typed_path = Endpoint.new("/users/<int:user_id>", "ANY")
+    typed_path.push_param(Param.new("q", "", "query"))
+
+    optional_path = Endpoint.new("/accounts/:id{/:section}", "GET")
+    optional_path.push_param(Param.new("id", "", "path"))
+    optional_path.push_param(Param.new("section", "", "path"))
+    optional_path.push_param(Param.new("section", "", "path"))
+
+    mixed_body = Endpoint.new("/mixed", "POST")
+    mixed_body.push_param(Param.new("name", "", "json"))
+    mixed_body.push_param(Param.new("avatar", "", "form"))
+
+    unsupported = Endpoint.new("/jobs", "SUBSCRIBE")
+
+    builder.print([typed_path, optional_path, mixed_body, unsupported])
+    spec = JSON.parse(builder.io.to_s)
+    paths = spec["paths"]
+
+    paths.as_h.has_key?("/users/{user_id}").should be_true
+    paths["/users/{user_id}"].as_h.has_key?("any").should be_false
+    %w[get post put patch delete options head trace].each do |method|
+      paths["/users/{user_id}"].as_h.has_key?(method).should be_true
+    end
+
+    get_params = paths["/users/{user_id}"]["get"]["parameters"].as_a
+    get_params.any? { |p| p["in"].as_s == "path" && p["name"].as_s == "user_id" }.should be_true
+
+    paths.as_h.has_key?("/accounts/{id}/{section}").should be_true
+    optional_params = paths["/accounts/{id}/{section}"]["get"]["parameters"].as_a
+    optional_params.count { |p| p["in"].as_s == "path" && p["name"].as_s == "section" }.should eq(1)
+
+    content = paths["/mixed"]["post"]["requestBody"]["content"].as_h
+    content.has_key?("application/json").should be_true
+    content.has_key?("application/x-www-form-urlencoded").should be_true
+
+    paths["/jobs"].as_h.has_key?("subscribe").should be_false
+    paths["/jobs"]["x-noir-unsupported-methods"].as_a.should contain(JSON::Any.new("SUBSCRIBE"))
+  end
 end

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -1,61 +1,52 @@
 require "../models/output_builder"
 require "../models/endpoint"
-require "uri"
+require "./oas_common"
 require "json"
 
 class OutputBuilderOas2 < OutputBuilder
+  include OutputBuilderOasCommon
+
   def print(endpoints : Array(Endpoint))
     paths = {} of String => Hash(String, JSON::Any)
 
     endpoints.each do |endpoint|
       parameters = [] of Hash(String, JSON::Any)
-      has_body = false
       consumes = [] of String
       cookie_names = [] of String
+      json_properties = {} of String => JSON::Any
+      has_form = false
 
       endpoint.params.each do |param|
         case param.param_type
         when "json"
           # JSON body parameters should be represented as a body parameter in OAS2
-          has_body = true
+          json_properties[param.name] = JSON::Any.new({
+            "type" => JSON::Any.new("string"),
+          } of String => JSON::Any)
           consumes << "application/json" unless consumes.includes?("application/json")
         when "form"
           # Form data parameters
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("formData"),
-            "type"     => JSON::Any.new("string"),
-            "required" => JSON::Any.new(false),
-          }
+          has_form = true
+          append_unique_parameter(parameters, swagger_parameter(param.name, "formData", false))
           consumes << "application/x-www-form-urlencoded" unless consumes.includes?("application/x-www-form-urlencoded")
         when "header"
           # Header parameters
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("header"),
-            "type"     => JSON::Any.new("string"),
-            "required" => JSON::Any.new(false),
-          }
+          append_unique_parameter(parameters, swagger_parameter(param.name, "header", false))
         when "path"
           # Path parameters
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("path"),
-            "type"     => JSON::Any.new("string"),
-            "required" => JSON::Any.new(true),
-          }
+          append_unique_parameter(parameters, swagger_parameter(param.name, "path", true))
         when "cookie"
           # Collect cookie names for later
           cookie_names << param.name
         else
           # Default to query parameter
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("query"),
-            "type"     => JSON::Any.new("string"),
-            "required" => JSON::Any.new(false),
-          }
+          append_unique_parameter(parameters, swagger_parameter(param.name, "query", false))
         end
+      end
+
+      oas_path = normalize_oas_path(endpoint.url)
+      path_template_names(oas_path).each do |name|
+        append_unique_parameter(parameters, swagger_parameter(name, "path", true))
       end
 
       # Add single Cookie header parameter if cookies exist
@@ -72,15 +63,23 @@ class OutputBuilderOas2 < OutputBuilder
       end
 
       # Add body parameter for JSON content
-      if has_body
-        parameters << {
+      # OAS2 does not allow body and formData parameters in the same operation.
+      # If both are present, keep the formData shape because it preserves the
+      # concrete field names as request parameters.
+      if !json_properties.empty? && !has_form
+        append_unique_parameter(parameters, {
           "name"     => JSON::Any.new("body"),
           "in"       => JSON::Any.new("body"),
           "required" => JSON::Any.new(false),
           "schema"   => JSON::Any.new({
-            "type" => JSON::Any.new("object"),
+            "type"       => JSON::Any.new("object"),
+            "properties" => JSON::Any.new(json_properties),
           } of String => JSON::Any),
-        }
+        } of String => JSON::Any)
+      end
+
+      if has_form
+        consumes.reject! { |content_type| content_type == "application/json" }
       end
 
       # Build operation object
@@ -101,31 +100,38 @@ class OutputBuilderOas2 < OutputBuilder
       add_noir_callees_extension(operation, endpoint)
       add_noir_ai_context_extension(operation, endpoint)
 
-      # Convert path parameters from :param to {param} format for OAS2
-      uri = URI.parse(endpoint.url)
-      oas_path = uri.path.gsub(/:(\w+)/, "{\\1}")
-      oas_path = oas_path.gsub(/<[^:>]+:(\w+)>/, "{\\1}") # Handle <type:param> format
-
       # Initialize path if not exists
       unless paths.has_key?(oas_path)
         paths[oas_path] = {} of String => JSON::Any
       end
 
       # Add method to path
-      paths[oas_path][endpoint.method.downcase] = JSON::Any.new(operation)
+      methods = operation_methods(endpoint.method)
+      if methods.empty?
+        add_unsupported_method_extension(paths[oas_path], endpoint.method)
+      else
+        methods.each do |method|
+          add_operation(paths[oas_path], method, operation)
+        end
+      end
     end
 
+    url_parts = swagger_url_parts(@options["url"]?.try(&.to_s) || "")
     oas2_hash = {
       "swagger" => JSON::Any.new("2.0"),
       "info"    => JSON::Any.new({
         "title"   => JSON::Any.new("Generated by Noir"),
         "version" => JSON::Any.new("1.0.0"),
       } of String => JSON::Any),
-      "basePath" => JSON::Any.new("/"),
-      "schemes"  => JSON::Any.new([JSON::Any.new("http"), JSON::Any.new("https")]),
+      "basePath" => JSON::Any.new(url_parts[:base_path]),
+      "schemes"  => JSON::Any.new(url_parts[:schemes].map { |scheme| JSON::Any.new(scheme) }),
       "produces" => JSON::Any.new([JSON::Any.new("application/json")]),
       "paths"    => JSON::Any.new(paths.transform_values { |v| JSON::Any.new(v) }),
     } of String => JSON::Any
+
+    if host = url_parts[:host]
+      oas2_hash["host"] = JSON::Any.new(host)
+    end
 
     ob_puts JSON::Any.new(oas2_hash).to_pretty_json
   end

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -1,16 +1,16 @@
 require "../models/output_builder"
 require "../models/endpoint"
-require "uri"
+require "./oas_common"
 require "json"
 
 class OutputBuilderOas3 < OutputBuilder
+  include OutputBuilderOasCommon
+
   def print(endpoints : Array(Endpoint))
     paths = {} of String => Hash(String, JSON::Any)
 
     endpoints.each do |endpoint|
       parameters = [] of Hash(String, JSON::Any)
-      has_json_body = false
-      has_form_body = false
       json_properties = {} of String => JSON::Any
       form_properties = {} of String => JSON::Any
 
@@ -18,57 +18,32 @@ class OutputBuilderOas3 < OutputBuilder
         case param.param_type
         when "json"
           # JSON body parameters go into requestBody
-          has_json_body = true
           json_properties[param.name] = JSON::Any.new({
             "type" => JSON::Any.new("string"),
           } of String => JSON::Any)
         when "form"
           # Form data parameters go into requestBody
-          has_form_body = true
           form_properties[param.name] = JSON::Any.new({
             "type" => JSON::Any.new("string"),
           } of String => JSON::Any)
         when "header"
           # Header parameters
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("header"),
-            "required" => JSON::Any.new(false),
-            "schema"   => JSON::Any.new({
-              "type" => JSON::Any.new("string"),
-            } of String => JSON::Any),
-          }
+          append_unique_parameter(parameters, openapi_parameter(param.name, "header", false))
         when "path"
           # Path parameters
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("path"),
-            "required" => JSON::Any.new(true),
-            "schema"   => JSON::Any.new({
-              "type" => JSON::Any.new("string"),
-            } of String => JSON::Any),
-          }
+          append_unique_parameter(parameters, openapi_parameter(param.name, "path", true))
         when "cookie"
           # Cookie parameters (supported in OAS3)
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("cookie"),
-            "required" => JSON::Any.new(false),
-            "schema"   => JSON::Any.new({
-              "type" => JSON::Any.new("string"),
-            } of String => JSON::Any),
-          }
+          append_unique_parameter(parameters, openapi_parameter(param.name, "cookie", false))
         else
           # Default to query parameter
-          parameters << {
-            "name"     => JSON::Any.new(param.name),
-            "in"       => JSON::Any.new("query"),
-            "required" => JSON::Any.new(false),
-            "schema"   => JSON::Any.new({
-              "type" => JSON::Any.new("string"),
-            } of String => JSON::Any),
-          }
+          append_unique_parameter(parameters, openapi_parameter(param.name, "query", false))
         end
+      end
+
+      oas_path = normalize_oas_path(endpoint.url)
+      path_template_names(oas_path).each do |name|
+        append_unique_parameter(parameters, openapi_parameter(name, "path", true))
       end
 
       # Build operation object
@@ -88,41 +63,37 @@ class OutputBuilderOas3 < OutputBuilder
         "parameters" => JSON::Any.new(parameters.map { |p| JSON::Any.new(p) }),
       } of String => JSON::Any
 
+      request_content = {} of String => JSON::Any
+
       # Add requestBody for JSON content
-      if has_json_body
-        operation["requestBody"] = JSON::Any.new({
-          "required" => JSON::Any.new(false),
-          "content"  => JSON::Any.new({
-            "application/json" => JSON::Any.new({
-              "schema" => JSON::Any.new({
-                "type"       => JSON::Any.new("object"),
-                "properties" => JSON::Any.new(json_properties),
-              } of String => JSON::Any),
-            } of String => JSON::Any),
+      unless json_properties.empty?
+        request_content["application/json"] = JSON::Any.new({
+          "schema" => JSON::Any.new({
+            "type"       => JSON::Any.new("object"),
+            "properties" => JSON::Any.new(json_properties),
           } of String => JSON::Any),
         } of String => JSON::Any)
-      elsif has_form_body
-        # Add requestBody for form data
+      end
+
+      # Add requestBody for form data
+      unless form_properties.empty?
+        request_content["application/x-www-form-urlencoded"] = JSON::Any.new({
+          "schema" => JSON::Any.new({
+            "type"       => JSON::Any.new("object"),
+            "properties" => JSON::Any.new(form_properties),
+          } of String => JSON::Any),
+        } of String => JSON::Any)
+      end
+
+      unless request_content.empty?
         operation["requestBody"] = JSON::Any.new({
           "required" => JSON::Any.new(false),
-          "content"  => JSON::Any.new({
-            "application/x-www-form-urlencoded" => JSON::Any.new({
-              "schema" => JSON::Any.new({
-                "type"       => JSON::Any.new("object"),
-                "properties" => JSON::Any.new(form_properties),
-              } of String => JSON::Any),
-            } of String => JSON::Any),
-          } of String => JSON::Any),
+          "content"  => JSON::Any.new(request_content),
         } of String => JSON::Any)
       end
 
       add_noir_callees_extension(operation, endpoint)
       add_noir_ai_context_extension(operation, endpoint)
-
-      # Convert path parameters from :param to {param} format for OAS3
-      uri = URI.parse(endpoint.url)
-      oas_path = uri.path.gsub(/:(\w+)/, "{\\1}")
-      oas_path = oas_path.gsub(/<[^:>]+:(\w+)>/, "{\\1}") # Handle <type:param> format
 
       # Initialize path if not exists
       unless paths.has_key?(oas_path)
@@ -130,7 +101,14 @@ class OutputBuilderOas3 < OutputBuilder
       end
 
       # Add method to path
-      paths[oas_path][endpoint.method.downcase] = JSON::Any.new(operation)
+      methods = operation_methods(endpoint.method)
+      if methods.empty?
+        add_unsupported_method_extension(paths[oas_path], endpoint.method)
+      else
+        methods.each do |method|
+          add_operation(paths[oas_path], method, operation)
+        end
+      end
     end
 
     oas3_hash = {

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -1,0 +1,164 @@
+require "json"
+require "uri"
+
+module OutputBuilderOasCommon
+  VALID_OPERATION_METHODS = Set{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+  ANY_OPERATION_METHODS   = %w[get post put patch delete options head trace]
+
+  private def normalize_oas_path(raw_url : String) : String
+    uri = URI.parse(raw_url)
+    path = uri.path
+    path = "/" if path.empty?
+
+    # Express-style optional segments (`/:id{/:op}`) are not representable as
+    # optional in OpenAPI path templates. Drop the route-syntax braces so the
+    # emitted path remains a valid template instead of `/users/{id}{/{op}}`.
+    path = path.gsub(/\{\/:(\w+)\}/, "/:\\1")
+    path = path.gsub(/\{\/([^{}]+)\}/, "/\\1")
+
+    # Convert typed placeholders before the generic :param pass; otherwise
+    # `<int:id>` becomes `<int{id}>` and can no longer be normalized.
+    path = path.gsub(/<[^:>]+:(\w+)>/, "{\\1}")
+    path = path.gsub(/<(\w+)>/, "{\\1}")
+    path = path.gsub(/\*(\w+)/, "{\\1}")
+    path = path.gsub(/:(\w+)/, "{\\1}")
+
+    path.starts_with?("/") ? path : "/#{path}"
+  end
+
+  private def path_template_names(path : String) : Array(String)
+    names = path.scan(/\{([^{}\/]+)\}/).map { |match| match[1] }
+    names.uniq!
+    names
+  end
+
+  private def operation_methods(method : String) : Array(String)
+    normalized = method.downcase
+    return [normalized] if VALID_OPERATION_METHODS.includes?(normalized)
+    return ANY_OPERATION_METHODS if {"any", "all", "forward", "use"}.includes?(normalized)
+
+    [] of String
+  end
+
+  private def add_unsupported_method_extension(path_item : Hash(String, JSON::Any), method : String)
+    methods = [] of String
+    if existing = path_item["x-noir-unsupported-methods"]?
+      methods = existing.as_a.map(&.as_s)
+    end
+
+    methods << method unless methods.includes?(method)
+    path_item["x-noir-unsupported-methods"] = JSON::Any.new(methods.map { |m| JSON::Any.new(m) })
+  end
+
+  private def parameter_key(parameter : Hash(String, JSON::Any)) : String
+    "#{parameter["in"].as_s}\0#{parameter["name"].as_s}"
+  end
+
+  private def append_unique_parameter(parameters : Array(Hash(String, JSON::Any)), parameter : Hash(String, JSON::Any))
+    key = parameter_key(parameter)
+    return if parameters.any? { |existing| parameter_key(existing) == key }
+
+    parameters << parameter
+  end
+
+  private def merge_parameters(existing : Array(JSON::Any), incoming : Array(JSON::Any)) : Array(JSON::Any)
+    merged = [] of Hash(String, JSON::Any)
+
+    (existing + incoming).each do |parameter|
+      append_unique_parameter(merged, parameter.as_h)
+    end
+
+    merged.map { |parameter| JSON::Any.new(parameter) }
+  end
+
+  private def merge_request_body(existing : JSON::Any?, incoming : JSON::Any?) : JSON::Any?
+    return incoming unless existing
+    return existing unless incoming
+
+    existing_hash = existing.as_h.dup
+    incoming_hash = incoming.as_h
+
+    if existing_content = existing_hash["content"]?
+      if incoming_content = incoming_hash["content"]?
+        content = existing_content.as_h.dup
+        incoming_content.as_h.each do |media_type, media_value|
+          content[media_type] = media_value unless content.has_key?(media_type)
+        end
+        existing_hash["content"] = JSON::Any.new(content)
+      end
+    elsif incoming_content = incoming_hash["content"]?
+      existing_hash["content"] = incoming_content
+    end
+
+    JSON::Any.new(existing_hash)
+  end
+
+  private def merge_operations(existing : JSON::Any, incoming : Hash(String, JSON::Any)) : JSON::Any
+    merged = existing.as_h.dup
+
+    if existing_parameters = merged["parameters"]?
+      incoming_parameters = incoming["parameters"]?.try(&.as_a) || [] of JSON::Any
+      merged["parameters"] = JSON::Any.new(merge_parameters(existing_parameters.as_a, incoming_parameters))
+    elsif incoming_parameters = incoming["parameters"]?
+      merged["parameters"] = incoming_parameters
+    end
+
+    if request_body = merge_request_body(merged["requestBody"]?, incoming["requestBody"]?)
+      merged["requestBody"] = request_body
+    end
+
+    incoming.each do |key, value|
+      next if {"parameters", "requestBody"}.includes?(key)
+      merged[key] = value unless merged.has_key?(key)
+    end
+
+    JSON::Any.new(merged)
+  end
+
+  private def add_operation(path_item : Hash(String, JSON::Any), method : String, operation : Hash(String, JSON::Any))
+    if existing = path_item[method]?
+      path_item[method] = merge_operations(existing, operation)
+    else
+      path_item[method] = JSON::Any.new(operation)
+    end
+  end
+
+  private def schema_string : JSON::Any
+    JSON::Any.new({
+      "type" => JSON::Any.new("string"),
+    } of String => JSON::Any)
+  end
+
+  private def openapi_parameter(name : String, location : String, required : Bool) : Hash(String, JSON::Any)
+    {
+      "name"     => JSON::Any.new(name),
+      "in"       => JSON::Any.new(location),
+      "required" => JSON::Any.new(required),
+      "schema"   => schema_string,
+    } of String => JSON::Any
+  end
+
+  private def swagger_parameter(name : String, location : String, required : Bool) : Hash(String, JSON::Any)
+    {
+      "name"     => JSON::Any.new(name),
+      "in"       => JSON::Any.new(location),
+      "type"     => JSON::Any.new("string"),
+      "required" => JSON::Any.new(required),
+    } of String => JSON::Any
+  end
+
+  private def swagger_url_parts(raw_url : String) : NamedTuple(host: String?, base_path: String, schemes: Array(String))
+    return {host: nil, base_path: "/", schemes: %w[http https]} if raw_url.empty?
+
+    uri = URI.parse(raw_url)
+    schemes = if scheme = uri.scheme
+                [scheme]
+              else
+                %w[http https]
+              end
+    base_path = uri.path.empty? ? "/" : uri.path
+    base_path = "/" unless base_path.starts_with?("/")
+
+    {host: uri.host, base_path: base_path, schemes: schemes}
+  end
+end


### PR DESCRIPTION
## Summary
- normalize OAS2/OAS3 path templates and supported operation methods
- preserve unsupported methods via x-noir-unsupported-methods instead of invalid operation keys
- dedupe and backfill path parameters, handle mixed body/form edge cases, and reflect OAS2 URL parts

## Tests
- crystal spec spec/unit_test/output_builder/oas2_spec.cr spec/unit_test/output_builder/oas3_spec.cr
- just test
- just build
- just check