### PR TITLE
Fix curl and HTTPie command output

### DIFF
--- a/spec/unit_test/output_builder/curl_spec.cr
+++ b/spec/unit_test/output_builder/curl_spec.cr
@@ -32,6 +32,21 @@ describe "OutputBuilderCurl" do
 
     endpoints = [endpoint1, endpoint2, endpoint3]
     builder.print(endpoints)
-    puts builder.io.to_s
+    output = builder.io.to_s
+    lines = output.split("\n").reject(&.empty?)
+
+    get_line = lines[0]
+    get_line.should eq("curl -i -X 'GET' '/test?id=1' --cookie 'session=abc123'")
+
+    post_line = lines[1]
+    post_line.should start_with("curl -i -X 'POST' '/api/users'")
+    post_line.should contain("--data-raw '{\"username\":\"test\",\"email\":\"test@example.com\"}'")
+    post_line.should contain("-H 'Content-Type: application/json'")
+    post_line.should contain("-H 'x-api-key: key123'")
+
+    put_line = lines[2]
+    put_line.should start_with("curl -i -X 'PUT' '/api/products'")
+    put_line.should contain("--data-raw 'name=Updated Product&price=99.99'")
+    put_line.should contain("-H 'Content-Type: application/x-www-form-urlencoded'")
   end
 end

--- a/spec/unit_test/output_builder/edge_cases_spec.cr
+++ b/spec/unit_test/output_builder/edge_cases_spec.cr
@@ -27,6 +27,7 @@ describe "Output Builders Edge Cases" do
 
     # Should properly escape single quotes for shell
     output.should contain("curl -i -X 'POST'")
+    output.should contain("--data-raw '{\"message\":\"Hello '\\''World'\\''\"")
     output.should contain("Content-Type: application/json")
   end
 
@@ -49,9 +50,36 @@ describe "Output Builders Edge Cases" do
     builder.print([endpoint])
     output = builder.io.to_s
 
-    # Should use HTTPie's JSON syntax
+    # Should use HTTPie's JSON string syntax and shell-escape values
     output.should contain("http 'POST'")
-    output.should contain(":=")
+    output.should contain("'message=Hello '\\''World'\\'''")
+    output.should_not contain("message:=")
+  end
+
+  it "prints httpie form requests as form data" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHttpie.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/api/test", "POST")
+    endpoint.push_param(Param.new("display_name", "Jane Doe", "form"))
+    endpoint.push_param(Param.new("note", "rock and roll", "form"))
+    endpoint.push_param(Param.new("token", "a+b", "form"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("http --form 'POST' '/api/test'")
+    output.should contain("'display_name=Jane Doe'")
+    output.should contain("'note=rock and roll'")
+    output.should contain("'token=a+b'")
+    output.should_not contain("'token=a b'")
   end
 
   it "handles special characters in powershell" do

--- a/spec/unit_test/output_builder/httpie_spec.cr
+++ b/spec/unit_test/output_builder/httpie_spec.cr
@@ -48,14 +48,15 @@ describe "OutputBuilderHttpie" do
     post_line = lines[1]
     post_line.should start_with("http 'POST'")
     post_line.should contain("/api/users")
-    # HTTPie uses key:=value syntax for JSON fields
-    (post_line.should contain("username:=")) || (post_line.should contain("email:="))
+    # HTTPie uses key=value syntax for JSON string fields
+    post_line.should contain("'username=test'")
+    post_line.should contain("'email=test@example.com'")
     post_line.should contain("x-api-key")
 
     # Check PUT request with form data
     put_line = lines[2]
-    put_line.should start_with("http 'PUT'")
+    put_line.should start_with("http --form 'PUT'")
     put_line.should contain("/api/products")
-    put_line.should contain("name=")
+    put_line.should contain("'name=Updated Product'")
   end
 end

--- a/src/output_builder/curl.cr
+++ b/src/output_builder/curl.cr
@@ -6,35 +6,37 @@ class OutputBuilderCurl < OutputBuilder
     endpoints.each do |endpoint|
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
-      # Properly quote and escape the URL
-      cmd = "curl -i -X '#{escape_shell(endpoint.method)}' '#{escape_shell(baked[:url])}'"
+      parts = ["curl", "-i", "-X", shell_quote(endpoint.method), shell_quote(baked[:url])]
 
       unless baked[:body].empty?
         if baked[:body_type] == "json"
-          # For JSON, use single quotes to avoid shell interpolation issues
-          cmd += " -d '#{escape_shell(baked[:body])}'"
-          cmd += " -H 'Content-Type: application/json'"
+          parts << "--data-raw"
+          parts << shell_quote(baked[:body])
+          parts << "-H"
+          parts << shell_quote("Content-Type: application/json")
         else
-          # For form data, escape properly
-          cmd += " -d '#{escape_shell(baked[:body])}'"
-          cmd += " -H 'Content-Type: application/x-www-form-urlencoded'"
+          parts << "--data-raw"
+          parts << shell_quote(baked[:body])
+          parts << "-H"
+          parts << shell_quote("Content-Type: application/x-www-form-urlencoded")
         end
       end
 
       baked[:header].each do |header|
-        cmd += " -H '#{escape_shell(header)}'"
+        parts << "-H"
+        parts << shell_quote(header)
       end
 
       baked[:cookie].each do |cookie|
-        cmd += " --cookie '#{escape_shell(cookie)}'"
+        parts << "--cookie"
+        parts << shell_quote(cookie)
       end
 
-      ob_puts cmd
+      ob_puts parts.join(" ")
     end
   end
 
-  # Escape special characters for shell (using single quotes)
-  private def escape_shell(str : String) : String
-    str.gsub("'", "'\\''")
+  private def shell_quote(str : String) : String
+    "'#{str.gsub("'", "'\\''")}'"
   end
 end

--- a/src/output_builder/httpie.cr
+++ b/src/output_builder/httpie.cr
@@ -1,77 +1,66 @@
 require "../models/output_builder"
 require "../models/endpoint"
 require "json"
-require "uri"
 
 class OutputBuilderHttpie < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
-      # Quote the URL properly
-      cmd = "http '#{escape_shell(endpoint.method)}' '#{escape_shell(baked[:url])}'"
+      parts = ["http"]
+      request_items = [] of String
 
-      # For HTTPie, we need to handle JSON differently
       unless baked[:body].empty?
         if baked[:body_type] == "json"
-          # Parse JSON and convert to HTTPie's key:=value syntax
           begin
             json_data = JSON.parse(baked[:body])
             if json_data.as_h?
               json_data.as_h.each do |key, value|
-                # Use := for JSON fields (only use to_json for non-string types)
                 if value.raw.is_a?(String)
-                  escaped_value = escape_shell(value.as_s)
-                  cmd += " #{key}:='#{escaped_value}'"
+                  request_items << shell_quote("#{key}=#{value.as_s}")
                 else
-                  escaped_value = escape_shell(value.to_json)
-                  cmd += " #{key}:='#{escaped_value}'"
+                  request_items << shell_quote("#{key}:=#{value.to_json}")
                 end
               end
             else
-              # For arrays and primitives, HTTPie can handle them directly
-              cmd += " '#{escape_shell(baked[:body])}'"
+              parts << "--raw"
+              parts << shell_quote(baked[:body])
+              request_items << shell_quote("Content-Type:application/json")
             end
           rescue
-            # If parsing fails, use the body as-is
-            cmd += " '#{escape_shell(baked[:body])}'"
+            parts << "--raw"
+            parts << shell_quote(baked[:body])
+            request_items << shell_quote("Content-Type:application/json")
           end
         else
-          # For form data, use key=value syntax
+          parts << "--form"
           form_parts = baked[:body].split('&')
           form_parts.each do |part|
             if part.includes?('=')
-              key_value = part.split('=', 2)
-              # URL decode the value before escaping for HTTPie
-              begin
-                decoded_value = URI.decode_www_form(key_value[1])
-                cmd += " #{key_value[0]}='#{escape_shell(decoded_value)}'"
-              rescue
-                # If decoding fails, use the value as-is
-                cmd += " #{key_value[0]}='#{escape_shell(key_value[1])}'"
-              end
+              request_items << shell_quote(part)
             end
           end
         end
       end
 
-      # Headers: use Header:Value format (no quotes around the header directive)
+      parts << shell_quote(endpoint.method)
+      parts << shell_quote(baked[:url])
+      parts.concat(request_items)
+
       baked[:header].each do |header|
-        cmd += " '#{escape_shell(header)}'"
+        parts << shell_quote(header)
       end
 
-      # Cookies: add as Cookie header
       unless baked[:cookie].empty?
         cookie_value = baked[:cookie].join("; ")
-        cmd += " 'Cookie:#{escape_shell(cookie_value)}'"
+        parts << shell_quote("Cookie:#{cookie_value}")
       end
 
-      ob_puts cmd
+      ob_puts parts.join(" ")
     end
   end
 
-  # Escape special characters for shell (using single quotes)
-  private def escape_shell(str : String) : String
-    str.gsub("'", "'\\''")
+  private def shell_quote(str : String) : String
+    "'#{str.gsub("'", "'\\''")}'"
   end
 end


### PR DESCRIPTION
## Summary
- build curl commands from quoted argv parts and use --data-raw for request bodies
- emit HTTPie JSON string fields with key=value and raw JSON values with key:=json
- emit HTTPie form bodies with --form while preserving literal plus signs

## Tests
- crystal spec spec/unit_test/output_builder/curl_spec.cr
- crystal spec spec/unit_test/output_builder/httpie_spec.cr
- crystal spec spec/unit_test/output_builder/edge_cases_spec.cr
- just test
- just build
- just check