### PR TITLE
Resolve Gin/Fiber routes behind .Use(...) middleware chains

### DIFF
--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -161,6 +161,51 @@ describe Noir::TreeSitterGoRouteExtractor do
     ])
   end
 
+  it "peels .Use(...) middleware chains before the verb call" do
+    # Gin's `RouterGroup.Use(...)` / `Engine.Use(...)` return the
+    # receiver, so `r.Use(mw).GET(...)` and
+    # `r.Group("/x").Use(mw).POST(...)` are valid. The verb's operand is
+    # the `.Use(...)` call; without peeling it the routes were dropped.
+    source = <<-GO
+      package main
+      func main() {
+          g := gin.New()
+          g.Use(logMW).GET("/ping", pong)
+          g.Group("/user").Use(authMW).POST("/", createUser)
+          g.Group("/").Use(reqMW).POST("/message", createMsg)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"GET", "/ping"},
+      {"POST", "/message"},
+      {"POST", "/user/"},
+    ].sort)
+  end
+
+  it "collects group declarations whose RHS ends in a .Use(...) chain" do
+    # `v1 := r.Group("/v1").Use(mw)` — the `.Use(...)` wraps the real
+    # `.Group(...)` call. The group name must still bind to `/v1` so the
+    # verb routes registered on `v1` later resolve with the prefix.
+    source = <<-GO
+      package main
+      func main() {
+          r := gin.Default()
+          v1 := r.Group("/v1").Use(authMW)
+          v1.GET("/users", listUsers)
+          v2 := r.Group("/v2").Use(a).Use(b)
+          v2.POST("/items", addItem)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"GET", "/v1/users"},
+      {"POST", "/v2/items"},
+    ].sort)
+  end
+
   it "collects group assignments from var declarations and later assignments" do
     source = <<-GO
       package main

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -81,6 +81,15 @@ module Noir
       "slog",
     }
 
+    # Chain methods that return the receiving router/group unchanged —
+    # middleware registration. Gin's `RouterGroup.Use(...)` and
+    # `Engine.Use(...)` (and Fiber's `app.Use(...)`) return `IRoutes`,
+    # so `r.Use(mw).GET("/x", h)` and `r.Group("/api").Use(mw).POST(...)`
+    # are valid, common shapes. They don't add a path segment, so the
+    # operand walk peels them and resolves the prefix against the
+    # underlying router/group rather than dropping the route entirely.
+    PASSTHROUGH_CHAIN_METHODS = Set{"Use"}
+
     # A static-file route: URL `url_prefix` serves files from disk
     # location `disk_path`.
     struct StaticPath
@@ -808,6 +817,24 @@ module Noir
       return unless parent_node && field_node
       method_name = Noir::TreeSitter.node_text(field_node, source)
 
+      # Peel trailing middleware pass-through calls so
+      # `v1 := r.Group("/v1").Use(mw)` is recognised as a group
+      # declaration for `v1` — the `.Use(...)` wraps the real
+      # `.Group(...)` call without contributing a path segment.
+      while PASSTHROUGH_CHAIN_METHODS.includes?(method_name) &&
+            Noir::TreeSitter.node_type(parent_node) == "call_expression"
+        inner_function = Noir::TreeSitter.field(parent_node, "function")
+        break unless inner_function
+        break unless Noir::TreeSitter.node_type(inner_function) == "selector_expression"
+        inner_parent = Noir::TreeSitter.field(inner_function, "operand")
+        inner_field = Noir::TreeSitter.field(inner_function, "field")
+        break unless inner_parent && inner_field
+        rhs_node = parent_node
+        parent_node = inner_parent
+        field_node = inner_field
+        method_name = Noir::TreeSitter.node_text(field_node, source)
+      end
+
       # Goyave's zero-arg `v1 := api.Group()` is an "alias" declaration —
       # v1 inherits api's prefix without adding its own. We resolve these
       # immediately when the parent prefix is known.
@@ -984,6 +1011,16 @@ module Noir
       return unless field && parent
 
       method_name = Noir::TreeSitter.node_text(field, source)
+
+      # Middleware pass-through (`.Use(...)`): the receiver is returned
+      # unchanged, so skip this link and resolve the prefix against the
+      # parent. Without this, a `r.Group("/x").Use(mw).GET(...)` chain
+      # (the verb's operand is the `.Use(...)` call) would resolve to
+      # nil and the route would be dropped.
+      if PASSTHROUGH_CHAIN_METHODS.includes?(method_name)
+        return router_operand_info(parent, source, groups, group_method, group_aliases, string_values)
+      end
+
       return unless method_name == group_method || group_aliases.includes?(method_name)
 
       prefix = ""


### PR DESCRIPTION
## Summary

The Go route extractor only peeled `.Group(...)` links when resolving a verb call's receiver. Routes whose operand was a `.Use(...)` middleware chain were dropped entirely.

Gin's `RouterGroup.Use` / `Engine.Use` (and Fiber's `app.Use`) return the receiver, so these chains are valid and common in real apps. This already enriches Noir's strong route coverage with a class of registration it was silently skipping.

### Before → After (verified on real apps + minimal repro)

```go
g.Use(mw).GET("/ping", h)                  // missed  -> GET /ping
g.Group("/user").Use(mw).POST("", h)       // missed  -> POST /user/
g.Group("/").Use(mw).POST("/message", h)   // missed  -> POST /message
v1 := r.Group("/v1").Use(mw); v1.GET(...)  // /users  -> GET /v1/users
```

These were observed as false negatives while analyzing **gotify** (Gin) — e.g. `g.Group("/user").Use(authentication.Optional).POST("", ...)` and `g.Group("/").Use(...).POST("/message", ...)`.

## Changes
- Add `PASSTHROUGH_CHAIN_METHODS` (`Use`) — chain methods that return the receiver without contributing a path segment.
- Peel pass-through links in `group_chain_operand_info` (verb-operand walk) and in `collect_group` (group-declaration RHS), recursing to the underlying router/group.

## Testing
- Two new unit tests covering verb-chain and group-declaration `.Use(...)` shapes (incl. multiple `.Use`).
- Full Go functional suite green (1215 examples), route-extractor unit suite green (16 examples).

FP risk is low: the verb decoder still requires the chain to bottom out at a non-`NON_ROUTER_OPERANDS` identifier with a string path and a non-empty handler arg.