### PR TITLE
Fix Spring route trailing slash and expand Lombok @RequestBody DTO params

### DIFF
--- a/spec/functional_test/testers/java/spring_hunt_ai_context_spec.cr
+++ b/spec/functional_test/testers/java/spring_hunt_ai_context_spec.cr
@@ -19,7 +19,7 @@ describe "--ai-context Hunt signals on Spring fixtures" do
 
     endpoints = app.endpoints
 
-    create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/items/" }.ai_context
+    create_context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/items" }.ai_context
     create_context = create_context.should_not be_nil
     create_context.signals.map(&.kind).should_not contain("idor")
     create_context.signals.map(&.kind).should_not contain("identifier_input")

--- a/spec/functional_test/testers/java/spring_spec.cr
+++ b/spec/functional_test/testers/java/spring_spec.cr
@@ -56,7 +56,7 @@ expected_endpoints = [
     Param.new("id", "", "path"),
     Param.new("view", "", "query"),
   ]),
-  Endpoint.new("/api/catalog/", "POST", [
+  Endpoint.new("/api/catalog", "POST", [
     Param.new("title", "", "json"),
     Param.new("count", "", "json"),
   ]),
@@ -72,7 +72,7 @@ expected_endpoints = [
   # ItemController.java
   Endpoint.new("/items/{id}", "GET", [Param.new("id", "", "path")]),
   Endpoint.new("/items/json/{id}", "GET", [Param.new("id", "", "path")]),
-  Endpoint.new("/items/", "POST", [Param.new("id", "", "form"), Param.new("name", "", "form")]),
+  Endpoint.new("/items", "POST", [Param.new("id", "", "form"), Param.new("name", "", "form")]),
   Endpoint.new("/items/update/{id}", "PUT", [Param.new("id", "", "path"), Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/items/delete/{id}", "DELETE", [Param.new("id", "", "path")]),
   Endpoint.new("/items/requestmap/put", "PUT"),
@@ -99,22 +99,22 @@ expected_endpoints = [
   Endpoint.new("/items2/edit/", "PUT", [Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/items2/{id}/thePath", "GET", [Param.new("id", "", "path")]),
   # EmptyController.java
-  Endpoint.new("/empty/", "GET", [Param.new("tenant", "", "query")]),
+  Endpoint.new("/empty", "GET", [Param.new("tenant", "", "query")]),
   Endpoint.new("/empty/filtered", "GET", [
     Param.new("tenant", "", "query"),
     Param.new("mode", "full", "query"),
     Param.new("X-Client", "mobile", "header"),
   ]),
   # MyController.java
-  Endpoint.new("/api/v1/test/", "GET"),
+  Endpoint.new("/api/v1/test", "GET"),
   # TApiResponses.java
-  Endpoint.new("/multi/annotation/", "GET"),
+  Endpoint.new("/multi/annotation", "GET"),
   # TRequestHeader.java
-  Endpoint.new("/request/header/", "GET"),
+  Endpoint.new("/request/header", "GET"),
   # DuplicateParameter.java
   Endpoint.new("/duplicate/parameter/{token}/test", "DELETE", [Param.new("token", "", "path")]),
   # ThrowsMultiException.java
-  Endpoint.new("/throws/multi/exception/", "GET"),
+  Endpoint.new("/throws/multi/exception", "GET"),
   # InventoryClient.java
   Endpoint.new("/api/v2/items/{id}/stock", "PATCH", [Param.new("id", "", "path"), Param.new("quantity", "", "json")]),
   Endpoint.new("/api/v2/items", "GET", [Param.new("category", "", "query")]),

--- a/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
@@ -115,6 +115,52 @@ describe Noir::TreeSitterJavaParameterExtractor do
       results["A"].first.name.should eq("a")
       results["B"].first.name.should eq("b")
     end
+
+    it "treats every field on a Lombok @Data class as setter-backed" do
+      # Lombok synthesises the setters at compile time, so the source
+      # has none — without special-casing the annotation a `@Data` DTO
+      # would expand to zero body params.
+      source = <<-JAVA
+        import lombok.Data;
+        @Data
+        class PhotoRequest {
+            private String title;
+            private String url;
+            private Long albumId;
+        }
+        JAVA
+
+      fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(source)["PhotoRequest"]
+      fields.map(&.name).should eq(["title", "url", "albumId"])
+      fields.all?(&.has_setter?).should be_true
+    end
+
+    it "recognises @Setter and @Value as field-binding annotations" do
+      ["@Setter", "@Value"].each do |lombok_ann|
+        source = lombok_ann + "\nclass Dto {\n    private String name;\n}\n"
+        fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(source)["Dto"]
+        fields.find!(&.name.== "name").has_setter?.should be_true
+      end
+    end
+
+    it "excludes static fields (constants are never request params)" do
+      # `serialVersionUID` and `public static` config keys must not be
+      # surfaced as body parameters, even on a Lombok @Data class where
+      # every instance field becomes settable.
+      source = <<-JAVA
+        import lombok.Data;
+        @Data
+        class Category {
+            private static final long serialVersionUID = 1L;
+            public static final String TYPE = "category";
+            private Long id;
+            private String name;
+        }
+        JAVA
+
+      fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(source)["Category"]
+      fields.map(&.name).should eq(["id", "name"])
+    end
   end
 
   describe ".extract_consumes" do
@@ -245,6 +291,35 @@ describe Noir::TreeSitterJavaParameterExtractor do
         Hash(String, Array(Noir::TreeSitterJavaParameterExtractor::FieldInfo)).new
       )
       params.should be_empty
+    end
+
+    it "expands a Lombok @RequestBody DTO into one param per field" do
+      # End-to-end: a `@Data` request DTO has no source-level setters,
+      # yet every field must surface as a body param. Regression guard
+      # for the common Spring shape where this previously yielded `[]`.
+      dto_source = <<-JAVA
+        import lombok.Data;
+        @Data
+        class PostRequest {
+            private String title;
+            private String body;
+            private Long categoryId;
+        }
+        JAVA
+      class_fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(dto_source)
+
+      controller = <<-JAVA
+        class PostController {
+            @PostMapping("/posts")
+            public String add(@RequestBody PostRequest req) { return ""; }
+        }
+        JAVA
+
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        controller, "PostController", "add", "POST", "json", class_fields
+      )
+      params.map(&.name).should eq(["title", "body", "categoryId"])
+      params.all? { |p| p.param_type == "json" }.should be_true
     end
   end
 end

--- a/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_route_extractor_ts_spec.cr
@@ -167,9 +167,11 @@ describe Noir::TreeSitterJavaRouteExtractor do
       JAVA
 
     routes = Noir::TreeSitterJavaRouteExtractor.extract_routes(source)
+    # A bare method path on `/api` collapses to `/api` (no trailing
+    # slash) — Spring absorbs the empty segment into the class prefix.
     routes.map { |r| {r.verb, r.path} }.should eq([
       {"GET", ""},
-      {"GET", "/api/"},
+      {"GET", "/api"},
       {"GET", "/health"},
       {"GET", "/api/health"},
     ])

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -156,11 +156,12 @@ describe Noir::TreeSitterKotlinRouteExtractor do
     routes.map(&.path).should eq(["/api/users"])
   end
 
-  it "emits prefix/ when the method path is empty" do
+  it "collapses an empty method path onto the class prefix" do
     # Kotlin Spring controllers routinely do
     # `@RequestMapping("/api/article")` on the class and `@GetMapping`
-    # (no path arg) on a method, expecting `/api/article/` for the
-    # handler. Matches the Java Spring behaviour pinned down in #1291.
+    # (no path arg) on a method. Spring absorbs the empty segment, so
+    # the handler maps to `/api/article` (no trailing slash). Matches
+    # the Java Spring behaviour.
     source = <<-KT
       @RequestMapping("/api/article")
       class ArticleController {
@@ -170,7 +171,7 @@ describe Noir::TreeSitterKotlinRouteExtractor do
       KT
 
     routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
-    routes.map(&.path).should eq(["/api/article/"])
+    routes.map(&.path).should eq(["/api/article"])
   end
 
   it "extracts Spring Cloud Gateway PredicateSpec helper routes" do

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -30,6 +30,15 @@ module Noir
     # `request.getParameter("x")` / `request.getHeader("x")` calls.
     SERVLET_REQUEST_TYPES = Set{"HttpServletRequest"}
 
+    # Lombok class-level annotations that synthesise setters (or an
+    # all-args constructor) for every instance field at compile time.
+    # The generated members never appear in source, so a DTO annotated
+    # with one of these binds its fields from a request body even though
+    # no explicit `setX(...)` method is visible. Treat every non-static
+    # field on such a class as settable — otherwise the extremely common
+    # `@Data`-annotated Spring DTO yields zero body parameters.
+    LOMBOK_FIELD_BINDING_ANNOTATIONS = Set{"Data", "Setter", "Value"}
+
     # Spring `HttpHeaders` constant → canonical header name. Matches
     # the table the legacy analyzer maintained; necessary because
     # tree-sitter reports the constant as a `field_access` node
@@ -87,7 +96,8 @@ module Noir
         class_name = Noir::TreeSitter.node_text(name_node, source)
         body = Noir::TreeSitter.field(decl, "body")
         next unless body
-        fields = collect_class_fields(body, source)
+        lombok_setters = lombok_field_binding?(decl, source)
+        fields = collect_class_fields(body, source, lombok_setters)
         results[class_name] = fields unless fields.empty?
       end
       results
@@ -370,7 +380,9 @@ module Noir
 
     # ---- class field introspection ------------------------------------
 
-    private def collect_class_fields(body : LibTreeSitter::TSNode, source : String) : Array(FieldInfo)
+    private def collect_class_fields(body : LibTreeSitter::TSNode,
+                                     source : String,
+                                     lombok_setters : Bool = false) : Array(FieldInfo)
       # First pass: collect field declarations.
       declared = [] of Tuple(String, String, String) # name, access, init_value
       setter_targets = Set(String).new
@@ -378,6 +390,12 @@ module Noir
       Noir::TreeSitter.each_named_child(body) do |member|
         case Noir::TreeSitter.node_type(member)
         when "field_declaration"
+          # Static fields are class constants (`serialVersionUID`,
+          # `public static final` config keys), never instance state a
+          # request body populates — skip them. This also keeps Lombok
+          # `@Data` from promoting constants to params, since Lombok
+          # never synthesises accessors for static fields.
+          next if field_static?(member, source)
           access = modifier_access(member, source)
           type_node = Noir::TreeSitter.field(member, "type")
           _ = type_node
@@ -403,8 +421,32 @@ module Noir
       end
 
       declared.map do |name, access, init|
-        FieldInfo.new(name, access, setter_targets.includes?(name), init)
+        has_setter = lombok_setters || setter_targets.includes?(name)
+        FieldInfo.new(name, access, has_setter, init)
       end
+    end
+
+    # True when `decl` carries a Lombok class annotation that synthesises
+    # field accessors (`@Data` / `@Setter` / `@Value`). Such a class
+    # exposes every instance field to request-body binding even though no
+    # `setX(...)` method is written out in source.
+    private def lombok_field_binding?(decl : LibTreeSitter::TSNode, source : String) : Bool
+      each_annotation_on(decl, source) do |name|
+        return true if LOMBOK_FIELD_BINDING_ANNOTATIONS.includes?(name)
+      end
+      false
+    end
+
+    # True when a `field_declaration`'s modifier list includes `static`.
+    private def field_static?(decl : LibTreeSitter::TSNode, source : String) : Bool
+      mods = find_modifiers(decl)
+      return false unless mods
+      count = LibTreeSitter.ts_node_child_count(mods)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_child(mods, i.to_u32)
+        return true if Noir::TreeSitter.node_text(child, source) == "static"
+      end
+      false
     end
 
     # Return the first access modifier keyword in `decl`'s modifiers,

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -1180,9 +1180,9 @@ module Noir
     # `/items/{id}` even though neither segment has a leading slash.
     #
     # Empty method path (`@PostMapping` with no argument, or
-    # `@GetMapping("")`) emits `prefix/` — matches Spring's runtime
-    # behaviour and the legacy analyzer's `File.join("/prefix", "")`
-    # trailing-slash convention.
+    # `@GetMapping("")`) collapses onto the class prefix — Spring absorbs
+    # the empty segment, so `@RequestMapping("/api")` + `@GetMapping`
+    # maps to `/api`, not `/api/` (see the empty-path branch below).
     private def join_paths(prefix : String, path : String) : String
       return path if prefix.empty?
       # A bare method mapping (`@GetMapping` / `@GetMapping("")`) on a

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -1185,7 +1185,16 @@ module Noir
     # trailing-slash convention.
     private def join_paths(prefix : String, path : String) : String
       return path if prefix.empty?
-      return "#{prefix.rstrip('/')}/" if path.empty?
+      # A bare method mapping (`@GetMapping` / `@GetMapping("")`) on a
+      # class mapped to `/api/polls` resolves to `/api/polls` in Spring,
+      # NOT `/api/polls/` — the empty segment is absorbed into the class
+      # prefix. Mirror the jaxrs/quarkus/micronaut extractors and drop
+      # the trailing slash here; only a class prefix that is itself all
+      # slashes (`@RequestMapping("/")`) keeps the root `/`.
+      if path.empty?
+        trimmed = prefix.rstrip('/')
+        return trimmed.empty? ? "/" : trimmed
+      end
       trimmed_prefix = prefix.rstrip('/')
       trimmed_path = path.lstrip('/')
       "#{trimmed_prefix}/#{trimmed_path}"

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -824,7 +824,16 @@ module Noir
     # a class-prefixed route emits `/prefix/`.
     private def join_paths(prefix : String, path : String) : String
       return path if prefix.empty?
-      return "#{prefix.rstrip('/')}/" if path.empty?
+      # A bare method mapping (`@GetMapping` with no path arg) on a class
+      # mapped to `/api/article` resolves to `/api/article` in Spring —
+      # the empty segment is absorbed, not turned into `/api/article/`.
+      # An explicit `@GetMapping("/")` still carries its own `/` segment
+      # and falls through to the last branch. Only an all-slash class
+      # prefix (`@RequestMapping("/")`) keeps the root `/`.
+      if path.empty?
+        trimmed = prefix.rstrip('/')
+        return trimmed.empty? ? "/" : trimmed
+      end
       "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
     end
   end

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -819,9 +819,10 @@ module Noir
       buf
     end
 
-    # Trailing-slash semantics match Spring's runtime and mirror the
-    # Java extractor: `prefix + "" = prefix/` so `@GetMapping("")` on
-    # a class-prefixed route emits `/prefix/`.
+    # Empty-path semantics mirror the Java extractor: a bare method
+    # mapping collapses onto the class prefix, so `@RequestMapping("/api")`
+    # + `@GetMapping` (no path) maps to `/api`, not `/api/` (see the
+    # empty-path branch below).
     private def join_paths(prefix : String, path : String) : String
       return path if prefix.empty?
       # A bare method mapping (`@GetMapping` with no path arg) on a class


### PR DESCRIPTION
## Summary

Two endpoint/parameter accuracy fixes found by running noir against several open-source Spring apps (spring-petclinic, piggymetrics, spring-boot-blog-rest-api, polls-app, spring-reactive-sample, …) and diffing the output against the controller source. Both reduce false positives / false negatives on real codebases.

### 1. Endpoint FP — trailing slash on a bare method mapping
A class-level `@RequestMapping("/api/polls")` combined with a method mapping that has **no path** (`@GetMapping` or `@GetMapping("")`) resolved to `/api/polls/` instead of `/api/polls`.

- Spring absorbs the empty method segment into the class prefix → the registered path has **no** trailing slash.
- The sibling JAX-RS / Quarkus / Micronaut extractors already drop the slash; the Java + Kotlin route extractors were the outliers.
- Fix is scoped to the empty-path branch of `join_paths`. An all-slash class prefix (`@RequestMapping("/")`) still keeps the root `/`, and an explicit `@GetMapping("/")` keeps its own segment (unaffected).

Observed effect: `GET /api/polls/` → `GET /api/polls`, `POST /api/photos/` → `POST /api/photos`, etc. — trailing-slash endpoints across the surveyed apps dropped to zero.

### 2. Body param FN — Lombok DTOs yielded no parameters
`@RequestBody` DTO expansion only surfaced fields that are `public` or have an explicit `setX(...)` method in source. A DTO annotated with Lombok `@Data` / `@Setter` / `@Value` has its setters synthesised at compile time, so **every field was dropped** — the most common modern Spring request DTO produced an empty params list (e.g. `POST /api/photos` → `[]`).

- Treat each **non-static** field on a `@Data` / `@Setter` / `@Value` class as settable.
- Exclude **static** fields (`serialVersionUID`, `public static final` constants) — they are never request parameters (previously a `public static` field could even be mis-emitted).
- `extract_class_fields` is shared by the Spring, JAX-RS, Quarkus, Micronaut, Dropwizard, Armeria and Struts2 analyzers, so all of them gain Lombok DTO coverage.

Observed effect on `spring-boot-blog-rest-api`: POST endpoints with empty params went from several to **0/23**; `signin`/`signup`/`photos`/`posts` bodies now expand fully. Entity-backed bodies also surface their `id`/relationship fields — the genuine mass-assignment surface.

## Tests
- New unit coverage for Lombok `@Data`/`@Setter`/`@Value` field binding, static-field exclusion, and end-to-end `@RequestBody` expansion.
- Updated the Spring/Kotlin fixtures + functional specs that pinned the old trailing-slash output.
- Full suite: `17681 examples, 0 failures, 0 errors`.

## Scope notes
Callee (1-hop), STOMP/WebSocket, Spring Cloud Gateway, and Feign-client detection were checked against the same apps and were already accurate — no changes needed there.