### PR TITLE
Improve Rails implicit route context

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
@@ -21,6 +21,18 @@ class PostsController < ApplicationController
     render json: serialize_preview(preview)
   end
 
+  def implicit_preview
+    draft = PreviewBuilder.build(params[:draft])
+    AuditLog.write("implicit")
+    render json: serialize_preview(draft)
+  end
+
+  def implicit_preview_legacy
+    draft = PreviewBuilder.build(params[:draft])
+    AuditLog.write("legacy")
+    render json: serialize_preview(draft)
+  end
+
   private
 
   def post_params

--- a/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
@@ -8,4 +8,7 @@ Rails.application.routes.draw do
   get "status", to: "monitor#status"
   get "ping", to: "monitor#ping"
   get "ready", to: "monitor#ready"
+
+  post "posts/implicit_preview", format: "json"
+  post "posts/implicit_preview_legacy", :format => "json"
 end

--- a/spec/functional_test/testers/ruby/rails_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_callees_spec.cr
@@ -26,6 +26,20 @@ preview_endpoint = Endpoint.new("/posts/preview", "GET").tap do |ep|
   ep.push_callee(Callee.new("serialize_preview", line: 21))
 end
 
+implicit_preview_endpoint = Endpoint.new("/posts/implicit_preview", "POST").tap do |ep|
+  ep.push_callee(Callee.new("PreviewBuilder.build", line: 25))
+  ep.push_callee(Callee.new("AuditLog.write", line: 26))
+  ep.push_callee(Callee.new("render", line: 27))
+  ep.push_callee(Callee.new("serialize_preview", line: 27))
+end
+
+legacy_implicit_preview_endpoint = Endpoint.new("/posts/implicit_preview_legacy", "POST").tap do |ep|
+  ep.push_callee(Callee.new("PreviewBuilder.build", line: 31))
+  ep.push_callee(Callee.new("AuditLog.write", line: 32))
+  ep.push_callee(Callee.new("render", line: 33))
+  ep.push_callee(Callee.new("serialize_preview", line: 33))
+end
+
 status_endpoint = Endpoint.new("/status", "GET").tap do |ep|
   ep.push_callee(Callee.new("Health.check", line: 3))
   ep.push_callee(Callee.new("render", line: 4))
@@ -47,6 +61,8 @@ expected_endpoints = [
   show_endpoint,
   create_endpoint,
   preview_endpoint,
+  implicit_preview_endpoint,
+  legacy_implicit_preview_endpoint,
   status_endpoint,
   ping_endpoint,
   ready_endpoint,

--- a/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/ruby_callee_extractor_spec.cr
@@ -56,9 +56,32 @@ describe Noir::RubyCalleeExtractor do
 
     callees = Noir::RubyCalleeExtractor.callees_for_body(body, "posts_controller.rb", 40)
     callees.map { |name, _, line| {name, line} }.should eq([
-      {"format.html", 40},
       {"redirect_to", 40},
       {"post_url", 40},
+    ])
+  end
+
+  it "skips Rails format DSL and simple attribute readers" do
+    body = <<-RUBY
+      @story.user_id
+      story.id
+      format.json { render json: story_url(@story) }
+      request.remote_ip
+      respond_to do |format|
+        format.html
+      end
+      response.status = 204
+      @story.save
+      @story.valid?
+      RUBY
+
+    callees = Noir::RubyCalleeExtractor.callees_for_body(body, "stories_controller.rb", 50)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"render", 52},
+      {"story_url", 52},
+      {"response.status", 57},
+      {"@story.save", 58},
+      {"@story.valid?", 59},
     ])
   end
 end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -358,6 +358,11 @@ module Analyzer::Ruby
               ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
               action_name = action
               action_params = params_for_action(ctrl_path, action, verb)
+            elsif inferred = infer_implicit_controller_action(path, rest, current_controller_scope(stack))
+              ctrl_name, action = inferred
+              ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
+              action_name = action
+              action_params = params_for_action(ctrl_path, action, verb)
             elsif parent = parent_resources_frame(stack)
               if action = infer_action_from_path(path)
                 ctrl_path = parent.controller_path
@@ -393,6 +398,10 @@ module Analyzer::Ruby
             action_name = nil.as(String?)
             if ctrl_action
               ctrl_name, action = ctrl_action
+              ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
+              action_name = action
+            elsif inferred = infer_implicit_controller_action(path, rest, current_controller_scope(stack))
+              ctrl_name, action = inferred
               ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
               action_name = action
             end
@@ -1170,6 +1179,51 @@ module Analyzer::Ruby
         end
       end
       nil
+    end
+
+    # Rails allows compact declarations such as `post "stories/preview"`
+    # which route to `StoriesController#preview`. These still need controller
+    # resolution so params/callees/AI context attach to the emitted endpoint.
+    private def infer_implicit_controller_action(path : String, rest : String,
+                                                 scoped_controller : String? = nil) : Tuple(String, String)?
+      return if explicit_route_destination?(rest)
+
+      segments = static_route_segments(path)
+      return if segments.empty?
+
+      if scoped_controller
+        action = segments.last
+        return unless valid_action_name?(action)
+        return {scoped_controller, action}
+      end
+
+      return if segments.size < 2
+      action = segments.last
+      return unless valid_action_name?(action)
+
+      {segments[0, segments.size - 1].join("/"), action}
+    end
+
+    private def explicit_route_destination?(rest : String) : Bool
+      !!rest.match(/^\s*['"][^'"]+['"]\s*=>/) ||
+        !!rest.match(/\bto\s*:/) ||
+        !!rest.match(/:?to\s*=>/) ||
+        !!rest.match(/:?controller\s*(?:=>|:)/) ||
+        !!rest.match(/:?action\s*(?:=>|:)/)
+    end
+
+    private def static_route_segments(path : String) : Array(String)
+      path.lchop('/').split('/').map do |segment|
+        segment = segment.split('.', 2)[0]
+        return [] of String if segment.empty?
+        return [] of String if segment.includes?(':') || segment.includes?('*')
+        return [] of String if segment.includes?('(') || segment.includes?(')')
+        segment
+      end
+    end
+
+    private def valid_action_name?(name : String) : Bool
+      !!name.match(/\A[A-Za-z_]\w*[!?=]?\z/)
     end
 
     # Resolve `ctrl#action` to a controller file. When the route lives inside a

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -13,8 +13,18 @@ module Noir::RubyCalleeExtractor
     "true", "undef", "unless", "until", "when", "while", "yield",
   }
 
-  RECEIVER_CALL_REGEX = /((?:@{1,2})?[A-Za-z_][\w]*(?:::[A-Za-z_][\w]*)*(?:\.[A-Za-z_][\w]*[!?=]?)+)\s*(?:\(|\b|$)/
+  RECEIVER_CALL_REGEX = /((?:@{1,2})?[A-Za-z_][\w]*(?:::[A-Za-z_][\w]*)*(?:\.[A-Za-z_][\w]*[!?=]?)+)\s*(\()?/
   BARE_CALL_REGEX     = /(?<![.\w:])([a-z_][\w]*[!?=]?)(?:\s*\(|(?=\s+(?:[:'"]|@{1,2}[A-Za-z_]|[A-Za-z_][\w]*[!?=]?)))/
+  RAILS_FORMAT_CALLS  = Set{"html", "json", "js", "xml", "rss", "atom", "turbo_stream", "api"}
+  RAILS_RESPONSE_DSL  = Set{"respond_to"}
+  REQUEST_ACCESSORS   = Set{"get", "post", "put", "patch", "delete", "xhr", "xhr?", "remote_ip", "raw_post"}
+  ATTRIBUTE_READERS   = Set{
+    "id", "ids", "uuid", "guid", "token", "key",
+    "name", "username", "title", "description", "text", "body", "message",
+    "url", "uri", "path", "email", "status", "state", "type", "role",
+    "score", "size", "length", "first", "last", "active",
+    "attributes", "safe_attributes", "password", "password_confirmation", "scheme_name",
+  }
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
@@ -35,7 +45,8 @@ module Noir::RubyCalleeExtractor
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
     line.scan(RECEIVER_CALL_REGEX) do |match|
       name = match[1]
-      next if skip_callee?(name)
+      has_parens = !!match[2]?
+      next if skip_callee?(name, has_parens)
 
       entries << {name, file_path, line_number}
     end
@@ -48,11 +59,40 @@ module Noir::RubyCalleeExtractor
     end
   end
 
-  private def skip_callee?(name : String) : Bool
+  private def skip_callee?(name : String, has_parens : Bool = false) : Bool
     return true if name.empty?
 
     last = name.split('.').last
-    RESERVED.includes?(last)
+    return true if RESERVED.includes?(last)
+    return true if RAILS_RESPONSE_DSL.includes?(last)
+    return true if request_accessor_callee?(name, last)
+    return true if rails_format_callee?(name, last, has_parens)
+    return true if attribute_reader_callee?(name, last, has_parens)
+
+    false
+  end
+
+  private def rails_format_callee?(name : String, last : String, has_parens : Bool) : Bool
+    return false if has_parens
+    name.starts_with?("format.") && RAILS_FORMAT_CALLS.includes?(last)
+  end
+
+  private def request_accessor_callee?(name : String, last : String) : Bool
+    name.starts_with?("request.") && REQUEST_ACCESSORS.includes?(last)
+  end
+
+  private def attribute_reader_callee?(name : String, last : String, has_parens : Bool) : Bool
+    return false if has_parens
+    return false if name.starts_with?("response.")
+    return false if last.ends_with?("?") || last.ends_with?("!") || last.ends_with?("=")
+    ATTRIBUTE_READERS.includes?(last) ||
+      last.starts_with?("is_") ||
+      last.ends_with?("_id") ||
+      last.ends_with?("_ids") ||
+      last.ends_with?("_ip") ||
+      last.ends_with?("_name") ||
+      last.ends_with?("_at") ||
+      last.ends_with?("_attributes")
   end
 
   def strip_comment(line : String, preserve_strings : Bool = false) : String


### PR DESCRIPTION
## Summary
- infer Rails controller/action for compact routes without explicit `to:`, including old hash-rocket options like `:format => "json"`
- attach params and callees for those implicit Rails routes
- reduce Ruby callee noise from Rails format/response DSL, request accessors, and simple attribute readers

## Testing
- `just build`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache-pr-78952 just test`
- `just check`