### PR TITLE
Improve Hanami route and callee extraction

### DIFF
--- a/spec/functional_test/fixtures/ruby/hanami_advanced/Gemfile
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "hanami", "~> 2.0"

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/app/actions/health/ready.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/app/actions/health/ready.rb
@@ -1,0 +1,11 @@
+module Testapp
+  module Actions
+    module Health
+      class Ready < Testapp::Action
+        def handle(request, response)
+          response.render HealthCheck.ready
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/app/actions/home/show.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/app/actions/home/show.rb
@@ -1,0 +1,11 @@
+module Testapp
+  module Actions
+    module Home
+      class Show < Testapp::Action
+        def handle(request, response)
+          response.render HomePage.render
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/app/actions/secure/show.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/app/actions/secure/show.rb
@@ -1,0 +1,19 @@
+module Testapp
+  module Actions
+    module Secure
+      class Show < Testapp::Action
+        plug :authenticate
+
+        def handle(request, response)
+          response.render SecureRenderer.render
+        end
+
+        private
+
+        def authenticate(request, response)
+          TokenVerifier.verify(request.headers["Authorization"])
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/config/routes.rb
@@ -1,0 +1,8 @@
+namespace "users" do
+  post "/", to: "users#create"
+  post "/login", to: "users#login"
+end
+
+namespace "articles" do
+  get "/:slug", to: "articles#show"
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/controllers/articles/show.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/controllers/articles/show.rb
@@ -1,0 +1,13 @@
+module Api
+  module Controllers
+    module Articles
+      class Show
+        include Api::Action
+
+        def call(params)
+          ArticleRepository.find_by_slug(params.get(:slug))
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/controllers/users/create.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/controllers/users/create.rb
@@ -1,0 +1,19 @@
+module Api
+  module Controllers
+    module Users
+      class Create
+        include Api::Action
+
+        params do
+          required(:user).schema do
+            required(:username).filled
+          end
+        end
+
+        def call(params)
+          UserRepository.create(params.get(:user, :username))
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/controllers/users/login.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/apps/api/controllers/users/login.rb
@@ -1,0 +1,13 @@
+module Api
+  module Controllers
+    module Users
+      class Login
+        include Api::Action
+
+        def call(params)
+          Authenticator.login(params.get(:email), params.get(:password))
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/config/routes.rb
@@ -1,0 +1,27 @@
+module Testapp
+  class Routes < Hanami::Routes
+    root to: "home.show"
+    get "/#{API_PREFIX}/items", to: "health.ready"
+    get "/secure", to: "secure.show"
+
+    scope "/api" do
+      get "/health", to: "health.ready"
+    end
+
+    scope "/block" do
+      get "/inline" do
+        "ok"
+      end
+
+      get "/after", to: "health.ready"
+    end
+
+    slice :main, at: "/" do
+      resources :cafes, only: %i[show] do
+        resources :reviews, only: %i[new create]
+      end
+
+      resource :account, only: %i[show]
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/account/show.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/account/show.rb
@@ -1,0 +1,11 @@
+module Main
+  module Actions
+    module Account
+      class Show < Main::Action
+        def handle(request, response)
+          response.render actor(request).account
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/cafes/reviews/create.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/cafes/reviews/create.rb
@@ -1,0 +1,19 @@
+module Main
+  module Actions
+    module Cafes
+      module Reviews
+        class Create < Main::Action
+          params do
+            required(:content).filled(:string)
+            required(:rating).filled(:integer)
+          end
+
+          def handle(request, response)
+            result = CreateReview.call(request.params.to_h)
+            response.render result
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/cafes/reviews/new.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/cafes/reviews/new.rb
@@ -1,0 +1,13 @@
+module Main
+  module Actions
+    module Cafes
+      module Reviews
+        class New < Main::Action
+          def handle(request, response)
+            response.render ReviewForm.build(request.params[:cafe_id])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/cafes/show.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/cafes/show.rb
@@ -1,0 +1,12 @@
+module Main
+  module Actions
+    module Cafes
+      class Show < Main::Action
+        def handle(request, response)
+          cafe = CafeRepo.find(request.params[:id])
+          response.render cafe
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/testers/ruby/hanami_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/hanami_advanced_spec.cr
@@ -1,0 +1,98 @@
+require "../../func_spec.cr"
+
+root = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("HomePage.render"))
+end
+
+health = Endpoint.new("/api/health", "GET").tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("HealthCheck.ready"))
+end
+
+interpolated = Endpoint.new("/{API_PREFIX}/items", "GET", [
+  Param.new("API_PREFIX", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("HealthCheck.ready"))
+end
+
+secure = Endpoint.new("/secure", "GET", [
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("SecureRenderer.render"))
+  ep.push_callee(Callee.new("TokenVerifier.verify"))
+end
+
+block_inline = Endpoint.new("/block/inline", "GET")
+
+block_after = Endpoint.new("/block/after", "GET").tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("HealthCheck.ready"))
+end
+
+cafe_show = Endpoint.new("/cafes/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("CafeRepo.find"))
+end
+
+review_new = Endpoint.new("/cafes/:cafe_id/reviews/new", "GET", [
+  Param.new("cafe_id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ReviewForm.build"))
+end
+
+review_create = Endpoint.new("/cafes/:cafe_id/reviews", "POST", [
+  Param.new("cafe_id", "", "path"),
+  Param.new("content", "", "json"),
+  Param.new("rating", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("CreateReview.call"))
+end
+
+account_show = Endpoint.new("/account", "GET").tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("actor"))
+end
+
+users_create = Endpoint.new("/users", "POST", [
+  Param.new("user", "", "json"),
+  Param.new("username", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserRepository.create"))
+end
+
+users_login = Endpoint.new("/users/login", "POST").tap do |ep|
+  ep.push_callee(Callee.new("Authenticator.login"))
+end
+
+article_show = Endpoint.new("/articles/:slug", "GET", [
+  Param.new("slug", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ArticleRepository.find_by_slug"))
+end
+
+expected_endpoints = [
+  root,
+  interpolated,
+  secure,
+  health,
+  block_inline,
+  block_after,
+  cafe_show,
+  review_new,
+  review_create,
+  account_show,
+  users_create,
+  users_login,
+  article_show,
+]
+
+FunctionalTester.new("fixtures/ruby/hanami_advanced/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/ruby/hanami_spec.cr
+++ b/spec/functional_test/testers/ruby/hanami_spec.cr
@@ -1,6 +1,7 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
+  Endpoint.new("/", "GET"),
   Endpoint.new("/books", "GET", [
     Param.new("page", "", "query"),
     Param.new("limit", "", "query"),

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -2,6 +2,17 @@ require "../../engines/ruby_engine"
 
 module Analyzer::Ruby
   class Hanami < RubyEngine
+    HANAMI_HTTP_VERBS = HTTP_VERBS + ["trace"]
+
+    struct RouteFrame
+      property path, slice, action_prefix
+
+      def initialize(@path : String = "", @slice : String? = nil, @action_prefix : String = "")
+      end
+    end
+
+    record RouteEndpoint, endpoint : Endpoint, target : String?
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       framework_roots = discover_framework_roots("config/routes.rb")
@@ -11,37 +22,72 @@ module Analyzer::Ruby
         path = "#{framework_root}/config/routes.rb"
         next unless File.exists?(path)
 
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          file.each_line.with_index do |line, index|
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint = line_to_endpoint(line, details)
-            unless endpoint.method.empty?
-              # Extract action path from route
-              action_path = extract_action_path(line, framework_root)
-              unless action_path.empty?
-                # Scan action file for parameters
-                scan_action_file(endpoint, action_path, include_callee)
-              end
-
-              @result << endpoint
-            end
-          end
-        end
+        parse_routes_file(path, framework_root, include_callee)
       end
 
       @result
     end
 
-    def extract_action_path(content : String, framework_root : String = @base_path) : String
-      # Extract action from to: parameter, e.g., to: "books.index" -> app/actions/books/index.rb
-      content.scan(/to:\s*['"](.+?)['"]/) do |match|
-        if match.size > 1
-          action = match[1]
-          # Convert "books.index" to "app/actions/books/index.rb"
-          return "#{framework_root}/app/actions/#{action.gsub(".", "/")}.rb"
+    private def parse_routes_file(path : String, framework_root : String, include_callee : Bool)
+      stack = [] of RouteFrame
+
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+        file.each_line.with_index do |raw_line, index|
+          line = Noir::RubyCalleeExtractor.strip_comment(raw_line, preserve_strings: true).strip
+          next if line.empty?
+
+          if closes_block?(line)
+            stack.pop unless stack.empty?
+            next
+          end
+
+          opens_block = opens_route_block?(line)
+          details = Details.new(PathInfo.new(path, index + 1))
+
+          if neutral_block?(line)
+            stack << RouteFrame.new if opens_block
+            next
+          end
+
+          if frame = slice_frame(line)
+            stack << frame if opens_block
+            next
+          end
+
+          if frame = prefix_frame(line, ["namespace", "scope"])
+            stack << frame if opens_block
+            next
+          end
+
+          if resource = resource_call(line)
+            routes, nested_frame = expand_resource(resource, stack, details)
+            routes.each { |route| attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee) }
+            @result.concat(routes.map(&.endpoint))
+            stack << nested_frame if opens_block
+            next
+          end
+
+          if route = root_endpoint(line, stack, details)
+            attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee)
+            @result << route.endpoint
+            stack << RouteFrame.new if opens_block
+            next
+          end
+
+          if route = verb_endpoint(line, stack, details)
+            attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee)
+            @result << route.endpoint
+            stack << RouteFrame.new if opens_block
+          end
         end
       end
-      ""
+    end
+
+    def extract_action_path(content : String, framework_root : String = @base_path) : String
+      target = extract_action_target(content)
+      return "" unless target
+
+      find_action_path(target, framework_root, nil)
     end
 
     def scan_action_file(endpoint : Endpoint, action_path : String, include_callee : Bool = false)
@@ -54,6 +100,275 @@ module Analyzer::Ruby
 
       scan_action_params(endpoint, lines)
       attach_handle_callees(endpoint, action_path, lines) if include_callee
+    end
+
+    private def attach_action_context(endpoint : Endpoint, target : String?, framework_root : String,
+                                      stack : Array(RouteFrame), include_callee : Bool)
+      return unless target
+
+      action_path = find_action_path(target, framework_root, current_slice(stack))
+      scan_action_file(endpoint, action_path, include_callee) unless action_path.empty?
+    end
+
+    private def root_endpoint(line : String, stack : Array(RouteFrame), details : Details) : RouteEndpoint?
+      return unless line.match(/^root(?:\s|\(|\{|$)/)
+
+      endpoint = Endpoint.new(join_paths(current_path_prefix(stack), "/"), "GET", details)
+      RouteEndpoint.new(endpoint, extract_action_target(line))
+    end
+
+    private def verb_endpoint(line : String, stack : Array(RouteFrame), details : Details) : RouteEndpoint?
+      HANAMI_HTTP_VERBS.each do |verb|
+        next unless line.starts_with?(verb)
+        next if line.size > verb.size && (line[verb.size].alphanumeric? || line[verb.size] == '_')
+
+        if m = line.match(/^#{verb}\s*\(?\s*['"]([^'"]*)['"](.*)$/)
+          endpoint = Endpoint.new(join_paths(current_path_prefix(stack), normalize_route_path(m[1])), verb.upcase, details)
+          return RouteEndpoint.new(endpoint, extract_action_target(m[2]))
+        end
+      end
+
+      nil
+    end
+
+    private def neutral_block?(line : String) : Bool
+      !!line.match(/^(?:class|module)\b/) || !!line.match(/^define\s+do\b/)
+    end
+
+    private def opens_route_block?(line : String) : Bool
+      !!line.match(/\bdo\b/) && !line.match(/\bend\b/)
+    end
+
+    private def closes_block?(line : String) : Bool
+      line == "end" || line.starts_with?("end ") || line.starts_with?("end;")
+    end
+
+    private def slice_frame(line : String) : RouteFrame?
+      return unless call = route_call(line, ["slice"])
+
+      name = parse_first_route_name(call)
+      return unless name
+
+      at = parse_options(call)["at"]? || name
+      RouteFrame.new(at, name, "")
+    end
+
+    private def prefix_frame(line : String, names : Array(String)) : RouteFrame?
+      return unless call = route_call(line, names)
+
+      path = ""
+      options = parse_options(call)
+      if first = parse_first_route_name(call)
+        path = first
+      end
+      path = options["path"]? || path
+
+      RouteFrame.new(path)
+    end
+
+    private def route_call(line : String, names : Array(String)) : String?
+      names.each do |name|
+        next unless line.starts_with?(name)
+        next if line.size > name.size && (line[name.size].alphanumeric? || line[name.size] == '_')
+
+        return line[name.size, line.size - name.size].strip
+      end
+
+      nil
+    end
+
+    private def resource_call(line : String) : NamedTuple(kind: String, name: String, options: Hash(String, String))?
+      return unless call = route_call(line, ["resources", "resource"])
+      kind = line.starts_with?("resources") ? "resources" : "resource"
+      name = parse_first_route_name(call)
+      return unless name
+
+      {kind: kind, name: name, options: parse_options(call)}
+    end
+
+    private def expand_resource(resource, stack : Array(RouteFrame), details : Details) : Tuple(Array(RouteEndpoint), RouteFrame)
+      routes = [] of RouteEndpoint
+      resource_name = resource[:name]
+      singular = singularize_resource(resource_name)
+      action_prefix = join_action_parts(current_action_prefix(stack), resource_name)
+      actions = resource_actions(resource[:kind], resource[:options])
+
+      resource_routes(resource[:kind], resource_name, singular).each do |action, method, path_suffix|
+        next unless actions.includes?(action)
+
+        endpoint = Endpoint.new(join_paths(current_path_prefix(stack), path_suffix), method, details.dup)
+        routes << RouteEndpoint.new(endpoint, join_action_parts(action_prefix, action))
+      end
+
+      nested_path = if resource[:kind] == "resources"
+                      join_paths(resource_name, ":#{singular}_id")
+                    else
+                      resource_name
+                    end
+      nested_frame = RouteFrame.new(nested_path, nil, action_prefix)
+
+      {routes, nested_frame}
+    end
+
+    private def resource_routes(kind : String, resource_name : String, singular : String)
+      if kind == "resource"
+        [
+          {"show", "GET", resource_name},
+          {"new", "GET", "#{resource_name}/new"},
+          {"create", "POST", resource_name},
+          {"edit", "GET", "#{resource_name}/edit"},
+          {"update", "PATCH", resource_name},
+          {"destroy", "DELETE", resource_name},
+        ]
+      else
+        [
+          {"index", "GET", resource_name},
+          {"new", "GET", "#{resource_name}/new"},
+          {"create", "POST", resource_name},
+          {"show", "GET", "#{resource_name}/:id"},
+          {"edit", "GET", "#{resource_name}/:id/edit"},
+          {"update", "PATCH", "#{resource_name}/:id"},
+          {"destroy", "DELETE", "#{resource_name}/:id"},
+        ]
+      end
+    end
+
+    private def resource_actions(kind : String, options : Hash(String, String)) : Set(String)
+      defaults = if kind == "resource"
+                   Set{"show", "new", "create", "edit", "update", "destroy"}
+                 else
+                   Set{"index", "new", "create", "show", "edit", "update", "destroy"}
+                 end
+
+      if only = options["only"]?
+        return Set(String).new(parse_action_names(only))
+      end
+
+      if except = options["except"]?
+        parse_action_names(except).each { |action| defaults.delete(action) }
+      end
+
+      defaults
+    end
+
+    private def parse_options(args : String) : Hash(String, String)
+      options = {} of String => String
+
+      args.scan(/(\w+):\s*("[^"]*"|'[^']*'|%i\[[^\]]+\]|\[[^\]]+\]|:\w+)/) do |match|
+        key = match[1]
+        value = match[2].strip
+        options[key] = unquote_option(value)
+      end
+
+      options
+    end
+
+    private def parse_first_route_name(args : String) : String?
+      if m = args.match(/^\s*(?::([A-Za-z_][\w]*)|['"]([^'"]+)['"])/)
+        return (m[1]? || m[2]?).to_s
+      end
+
+      nil
+    end
+
+    private def parse_action_names(value : String) : Array(String)
+      names = [] of String
+      value.scan(/:([A-Za-z_][\w]*)|([A-Za-z_][\w]*)/) do |match|
+        name = match[1]? || match[2]?
+        next unless name
+        next if name == "i"
+
+        names << name
+      end
+      names
+    end
+
+    private def unquote_option(value : String) : String
+      value = value.strip
+      if (value.starts_with?("'") && value.ends_with?("'")) || (value.starts_with?("\"") && value.ends_with?("\""))
+        return value[1, value.size - 2]
+      end
+      return value[1, value.size - 1] if value.starts_with?(":")
+
+      value
+    end
+
+    private def current_path_prefix(stack : Array(RouteFrame)) : String
+      parts = stack.map(&.path).reject(&.empty?)
+      join_paths(parts)
+    end
+
+    private def current_slice(stack : Array(RouteFrame)) : String?
+      stack.reverse_each do |frame|
+        return frame.slice if frame.slice
+      end
+
+      nil
+    end
+
+    private def current_action_prefix(stack : Array(RouteFrame)) : String
+      parts = stack.map(&.action_prefix).reject(&.empty?)
+      join_action_parts(parts)
+    end
+
+    private def join_paths(parts : Array(String)) : String
+      normalized = parts.flat_map(&.split('/')).reject(&.empty?)
+      normalized.empty? ? "/" : "/#{normalized.join("/")}"
+    end
+
+    private def join_paths(prefix : String, suffix : String) : String
+      join_paths([prefix, suffix])
+    end
+
+    private def normalize_route_path(path : String) : String
+      path.gsub(/\#\{([^}]+)\}/) { |_| "{#{$~[1].strip}}" }
+    end
+
+    private def join_action_parts(parts : Array(String)) : String
+      parts.flat_map(&.split(/[.\/]/)).reject(&.empty?).join(".")
+    end
+
+    private def join_action_parts(prefix : String, suffix : String) : String
+      join_action_parts([prefix, suffix])
+    end
+
+    private def singularize_resource(name : String) : String
+      return name[0, name.size - 3] + "y" if name.ends_with?("ies") && name.size > 3
+      return name[0, name.size - 1] if name.ends_with?("s") && name.size > 1
+
+      name
+    end
+
+    private def extract_action_target(content : String) : String?
+      if match = content.match(/to:\s*['"](.+?)['"]/)
+        return match[1]
+      end
+
+      nil
+    end
+
+    private def find_action_path(target : String, framework_root : String, slice : String?) : String
+      action = normalize_action_target(target)
+      candidates = [] of String
+
+      if slice
+        candidates << "#{framework_root}/slices/#{slice}/actions/#{action}.rb"
+        candidates << "#{framework_root}/slices/#{slice}/lib/actions/#{action}.rb"
+        candidates << "#{framework_root}/slices/#{slice}/controllers/#{action}.rb"
+        candidates << "#{framework_root}/apps/#{slice}/controllers/#{action}.rb"
+      end
+
+      candidates << "#{framework_root}/app/actions/#{action}.rb"
+      candidates << "#{framework_root}/app/controllers/#{action}.rb"
+      candidates << "#{framework_root}/actions/#{action}.rb"
+      candidates << "#{framework_root}/controllers/#{action}.rb"
+      candidates << "#{framework_root}/lib/actions/#{action}.rb"
+
+      candidates.find { |path| File.exists?(path) } || ""
+    end
+
+    private def normalize_action_target(target : String) : String
+      target.gsub("::", "/").gsub("#", "/").gsub(".", "/")
     end
 
     private def scan_action_params(endpoint : Endpoint, lines : Array(String))
@@ -152,19 +467,25 @@ module Analyzer::Ruby
     end
 
     private def attach_handle_callees(endpoint : Endpoint, action_path : String, lines : Array(String))
-      if block = extract_handle_body(lines)
+      if block = extract_action_body(lines, ["handle", "call"])
         body, body_start_line = block
         callees = Noir::RubyCalleeExtractor.callees_for_body(body, action_path, body_start_line)
         attach_ruby_callees(endpoint, callees)
       end
+
+      extract_plug_bodies(lines).each do |plug_body, plug_body_start_line|
+        callees = Noir::RubyCalleeExtractor.callees_for_body(plug_body, action_path, plug_body_start_line)
+        attach_ruby_callees(endpoint, callees)
+      end
     end
 
-    private def extract_handle_body(lines : Array(String)) : Tuple(String, Int32)?
+    private def extract_action_body(lines : Array(String), names : Array(String)) : Tuple(String, Int32)?
       index = 0
 
       while index < lines.size
         stripped = Noir::RubyCalleeExtractor.strip_comment(lines[index]).strip
-        if match = stripped.match(/^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?handle\b/)
+        name_pattern = names.join("|")
+        if match = stripped.match(/^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?(?:#{name_pattern})\b/)
           inline_body, closed_on_def_line = inline_def_body(stripped, match[0])
           body_lines = [] of String
           body_start_line = inline_body ? index + 1 : index + 2
@@ -197,6 +518,18 @@ module Analyzer::Ruby
 
         index += 1
       end
+    end
+
+    private def extract_plug_bodies(lines : Array(String)) : Array(Tuple(String, Int32))
+      plug_names = [] of String
+      lines.each do |line|
+        stripped = Noir::RubyCalleeExtractor.strip_comment(line).strip
+        if match = stripped.match(/^plug\s+:([A-Za-z_]\w*[!?=]?)/)
+          plug_names << match[1]
+        end
+      end
+
+      plug_names.compact_map { |name| extract_action_body(lines, [name]) }
     end
 
     private def inline_def_body(line : String, match_text : String) : Tuple(String?, Bool)


### PR DESCRIPTION
## Summary
- Expand Ruby Hanami route parsing for root, scope/namespace, slices, resources/resource, nested resources, and block-form routes
- Resolve Hanami v2 app/slice actions and Hanami v1 app controllers for params, callees, and AI context
- Add advanced Hanami fixtures covering interpolation normalization, scoped route blocks, plug callees, slices, resources, and v1 namespaces

## Test
- just build
- just test
- just check