### PR TITLE
Stop reused engine/local names from polluting Go cross-file group prefixes

### DIFF
--- a/spec/functional_test/fixtures/go/gin_engine_param_collision/a_handlers.go
+++ b/spec/functional_test/fixtures/go/gin_engine_param_collision/a_handlers.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// registerSysJobRouter reuses the name `r` as a *local* group variable.
+// In the engine entrypoint (z_router.go) `r` is the *gin.Engine root.
+// The two must not be conflated across files, or `r`'s "/sysjob" prefix
+// leaks onto `v1 := r.Group("/api/v1")` and pollutes every route.
+func registerSysJobRouter(v1 *gin.RouterGroup) {
+	r := v1.Group("/sysjob")
+	r.GET("/list", func(c *gin.Context) { c.JSON(http.StatusOK, nil) })
+	r.POST("/create", func(c *gin.Context) { c.JSON(http.StatusOK, nil) })
+
+	v1.GET("/job/start", func(c *gin.Context) { c.JSON(http.StatusOK, nil) })
+}

--- a/spec/functional_test/fixtures/go/gin_engine_param_collision/go.mod
+++ b/spec/functional_test/fixtures/go/gin_engine_param_collision/go.mod
@@ -1,0 +1,5 @@
+module ginenginecollision
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.1

--- a/spec/functional_test/fixtures/go/gin_engine_param_collision/z_router.go
+++ b/spec/functional_test/fixtures/go/gin_engine_param_collision/z_router.go
@@ -1,0 +1,8 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+func registerRoutes(r *gin.Engine) {
+	v1 := r.Group("/api/v1")
+	registerSysJobRouter(v1)
+}

--- a/spec/functional_test/testers/go/gin_engine_param_collision_spec.cr
+++ b/spec/functional_test/testers/go/gin_engine_param_collision_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+# Regression: a handler file reuses the variable name `r` as a *local*
+# group (`r := v1.Group("/sysjob")`), while the engine entrypoint uses
+# `r` as the `*gin.Engine` root (`v1 := r.Group("/api/v1")`). The flat
+# per-package group map used to conflate the two, leaking `/sysjob` onto
+# `v1` and polluting every route as `/sysjob/api/v1/...`. Root engine
+# names are now excluded from the cross-file group map, so each file
+# resolves its own `r` locally and the prefixes stay correct.
+expected_endpoints = [
+  Endpoint.new("/api/v1/sysjob/list", "GET"),
+  Endpoint.new("/api/v1/sysjob/create", "POST"),
+  Endpoint.new("/api/v1/job/start", "GET"),
+]
+
+FunctionalTester.new("fixtures/go/gin_engine_param_collision/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -161,6 +161,35 @@ describe Noir::TreeSitterGoRouteExtractor do
     ])
   end
 
+  it "detects root engine/router names from constructors and engine-typed params" do
+    source = <<-GO
+      package main
+
+      func boot() {
+          r := gin.New()
+          e := echo.New()
+          mux := chi.NewRouter()
+          v1 := r.Group("/api/v1")
+          v1.GET("/users", h)
+      }
+
+      func register(app *gin.Engine, grp *gin.RouterGroup) {
+          grp.GET("/posts", h)
+      }
+      GO
+
+    names = Noir::TreeSitterGoRouteExtractor.extract_engine_names(source)
+    # Constructors (r/e/mux) and the *gin.Engine param (app) are roots;
+    # `grp` is a *gin.RouterGroup (a real group param) and `v1` is a
+    # derived group — neither is an engine.
+    names.includes?("r").should be_true
+    names.includes?("e").should be_true
+    names.includes?("mux").should be_true
+    names.includes?("app").should be_true
+    names.includes?("grp").should be_false
+    names.includes?("v1").should be_false
+  end
+
   it "peels .Use(...) middleware chains before the verb call" do
     # Gin's `RouterGroup.Use(...)` / `Engine.Use(...)` return the
     # receiver, so `r.Use(mw).GET(...)` and

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -63,6 +63,43 @@ module Analyzer::Go
       end
 
       files_by_dir.each do |dir, paths|
+        # Detect group-variable names that resolve to DIFFERENT prefixes
+        # across files of the same package. These are almost always
+        # function-local names (`r`, `g`, `api`, ...) reused across
+        # separate handler functions, not genuinely shared package
+        # groups. Each name's binding is computed from its OWN file only
+        # (empty external map) so the decision is immune to cross-file
+        # pollution. Conflicting names are excluded from the shared map
+        # below — propagating them would let one function's local binding
+        # contaminate another's routes. (Observed in go-admin:
+        # `r := v1.Group("/dept")` in one handler file leaked a spurious
+        # `/dept` prefix onto `v1` and therefore onto every route in the
+        # package: `/dept/api/v1/...`.) Each file still re-derives these
+        # names locally during route extraction, so same-file resolution
+        # is unaffected.
+        ambiguous = Set(String).new
+        local_values = Hash(String, String).new
+        paths.each do |path|
+          content = file_contents[path]?
+          next if content.nil?
+          # Root engine/router names (`r := gin.New()`,
+          # `func(r *gin.Engine)`) must never carry a cross-file prefix.
+          # A same-named local group in a sibling file (e.g.
+          # `r := v1.Group("/sysjob")`) would otherwise leak its prefix
+          # onto the root and pollute `v1 := r.Group("/api/v1")`
+          # (observed: `/sysjob/api/v1/...`).
+          Noir::TreeSitterGoRouteExtractor.extract_engine_names(content).each { |n| ambiguous << n }
+          Noir::TreeSitterGoRouteExtractor.extract_groups(content, group_method: group_method).each do |k, v|
+            next if ambiguous.includes?(k)
+            if (existing = local_values[k]?) && existing != v
+              ambiguous << k
+              local_values.delete(k)
+            else
+              local_values[k] = v
+            end
+          end
+        end
+
         groups = Hash(String, String).new
         loop do
           prev_size = groups.size
@@ -70,7 +107,10 @@ module Analyzer::Go
             content = file_contents[path]?
             next if content.nil?
             found = Noir::TreeSitterGoRouteExtractor.extract_groups(content, groups, group_method)
-            found.each { |k, v| groups[k] ||= v }
+            found.each do |k, v|
+              next if ambiguous.includes?(k)
+              groups[k] ||= v
+            end
           end
           break if groups.size == prev_size
         end

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -202,6 +202,91 @@ module Noir
       group_prefixes
     end
 
+    # Framework constructors that mint a *root* router/engine — the
+    # receiver they're assigned to carries no path prefix. A name bound
+    # to one of these is the application root, never a sub-group.
+    ENGINE_CONSTRUCTORS = Set{"New", "Default", "NewRouter"}
+
+    # Engine/root type names (final identifier of the parameter type,
+    # pointer stripped). A parameter of one of these types is the root
+    # router handed in by the caller — `gin.Engine`, `echo.Echo`,
+    # `fiber.App`, `chi.Mux`/`mux.Router` (the last shares `Router` with
+    # group types, so it's intentionally omitted to avoid excluding
+    # genuine group params).
+    ENGINE_PARAM_TYPES = Set{"Engine", "Echo", "App", "Mux"}
+
+    # Collects names that denote a *root* engine/router rather than a
+    # path-bearing group:
+    #
+    #   r := gin.New()            / r := gin.Default()
+    #   r := chi.NewRouter()      / e := echo.New()
+    #   func setup(r *gin.Engine) / func setup(e *echo.Echo)
+    #
+    # The cross-file group pre-pass excludes these so a same-named local
+    # group in a sibling file (e.g. `r := v1.Group("/sysjob")`) can't
+    # leak a prefix onto the root and contaminate every route in the
+    # package. Each file still resolves its own `r` locally during route
+    # extraction; this only governs what crosses file boundaries.
+    def extract_engine_names(source : String) : Set(String)
+      names = Set(String).new
+      Noir::TreeSitter.parse_go(source) do |root|
+        walk(root) do |node|
+          case Noir::TreeSitter.node_type(node)
+          when "short_var_declaration", "assignment_statement", "var_spec"
+            collect_engine_assignment(node, source, names)
+          when "parameter_declaration"
+            collect_engine_param(node, source, names)
+          end
+        end
+      end
+      names
+    end
+
+    # `<name> := <pkg>.New()` / `.Default()` / `.NewRouter()` → root name.
+    private def collect_engine_assignment(node : LibTreeSitter::TSNode,
+                                          source : String,
+                                          names : Set(String))
+      left = Noir::TreeSitter.field(node, "left")
+      right = Noir::TreeSitter.field(node, "right")
+      if Noir::TreeSitter.node_type(node) == "var_spec"
+        left = Noir::TreeSitter.field(node, "name")
+        right = Noir::TreeSitter.field(node, "value")
+      end
+      return unless left && right
+
+      name_node = identifier_or_first_child(left)
+      rhs_node = first_named_child(right)
+      return unless name_node && rhs_node
+      return unless Noir::TreeSitter.node_type(name_node) == "identifier"
+      return unless Noir::TreeSitter.node_type(rhs_node) == "call_expression"
+
+      function = Noir::TreeSitter.field(rhs_node, "function")
+      return unless function
+      return unless Noir::TreeSitter.node_type(function) == "selector_expression"
+      field = Noir::TreeSitter.field(function, "field")
+      return unless field
+      return unless ENGINE_CONSTRUCTORS.includes?(Noir::TreeSitter.node_text(field, source))
+
+      names << Noir::TreeSitter.node_text(name_node, source)
+    end
+
+    # `func f(<name> *gin.Engine)` / `(<name> *echo.Echo)` → root name.
+    private def collect_engine_param(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     names : Set(String))
+      name_node = Noir::TreeSitter.field(node, "name")
+      type_node = Noir::TreeSitter.field(node, "type")
+      return unless name_node && type_node
+      return unless Noir::TreeSitter.node_type(name_node) == "identifier"
+
+      type_text = Noir::TreeSitter.node_text(type_node, source)
+      # Strip pointer / package qualifier: `*gin.Engine` -> `Engine`.
+      final = type_text.lchop('*').split('.').last
+      return unless ENGINE_PARAM_TYPES.includes?(final)
+
+      names << Noir::TreeSitter.node_text(name_node, source)
+    end
+
     # Chi-style extractor: walks the AST with a prefix stack so
     # `r.Route("/api", func(r chi.Router) { r.Get("/users", h) })`
     # resolves to `/api/users`. Handles arbitrarily-nested `.Route` blocks


### PR DESCRIPTION
## Summary

Noir's Go cross-file group resolution keeps one binding per variable name across a whole package (first-seen wins). That conflates names that mean different things in different functions/files, and one function's local group could leak its prefix onto the package root.

```go
// z_router.go — r is the *gin.Engine root
func registerRoutes(r *gin.Engine) { v1 := r.Group("/api/v1"); registerSysJob(v1) }

// a_handlers.go — r is a local group inside a helper
func registerSysJob(v1 *gin.RouterGroup) { r := v1.Group("/sysjob"); r.GET("/list", h) }
```

Depending on file-processing order, `r`'s `/sysjob` binding leaked onto `v1 := r.Group("/api/v1")`, so **every route in the package came out prefixed** as `/sysjob/api/v1/...` instead of `/api/v1/sysjob/...`.

### Observed on real apps
Analyzing **go-admin** (Gin) produced false-positive paths like `/dept/api/v1/dept/`, `/sysjob/api/v1/sysjob/`, `/dept/api/v1/config/` — a spurious leading `/dept` or `/sysjob` on the whole package. This became widespread once `.Use(...)` chains started binding these local group vars (#1803), so it rides on top of that FN improvement.

## Fix
Exclude names that can't represent one stable package-level group from the **cross-file** map (each file still re-derives them locally during route extraction, so same-file resolution and the legitimate cross-file group case are unchanged):

- **Root engine/router names** — `r := gin.New()` / `gin.Default()` / `chi.NewRouter()` / `echo.New()`, or a `*gin.Engine` / `*echo.Echo` parameter. New `TreeSitterGoRouteExtractor.extract_engine_names`.
- **Conflicting names** — a variable bound to different prefixes across files (decided from each file's *own* bindings, so the detection is immune to the cross-file pollution it guards against).

This removes the bogus prefixes while **keeping** the routes #1803 newly surfaced. On go-admin the package-wide `/dept` and `/sysjob` pollution is gone; routes resolve to the correct `/api/v1/...`.

## Testing
- Unit coverage for `extract_engine_names` (constructors + engine-typed params; real group params are not flagged).
- New `gin_engine_param_collision` functional fixture, deterministically polluted before the fix (`/sysjob/api/v1/...`) and correct after (`/api/v1/sysjob/...`).
- Full Go suite green (1247 examples); re-verified gotify / photoprism / memos / gin+echo examples show no double-prefix pollution and no lost routes.