### PR TITLE
Improve Django route extraction precision

### DIFF
--- a/spec/functional_test/fixtures/python/django/blog/imported_urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/imported_urls.py
@@ -1,0 +1,10 @@
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    path(route='keyword-route/', view=views.keyword_route, name='keyword_route'),
+    path('inline/', include([
+        path('nested/', views.inline_nested, name='inline_nested'),
+    ])),
+]

--- a/spec/functional_test/fixtures/python/django/blog/urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path, re_path
 from rest_framework.routers import DefaultRouter
 from django.views.decorators.cache import cache_page
 
+from . import imported_urls as imported_blog_urls
 from . import views
 from .api_router import api_router, direct_imported_router as imported_direct_router
 
@@ -50,6 +51,7 @@ urlpatterns = [
     # path('commented/', views.local_report_list, name='commented'),
     path('api/', include(router.urls)),
     path('imported-api/', include(api_router.urls)),
+    path('module-include/', include(imported_blog_urls)),
     path('local/', include(local_patterns)),
     path('namespaced/', include((namespace_patterns, app_name), namespace='nested')),
     path(

--- a/spec/functional_test/fixtures/python/django/blog/views.py
+++ b/spec/functional_test/fixtures/python/django/blog/views.py
@@ -464,6 +464,14 @@ def extended_report(request):
 
     return HttpResponse("extended")
 
+async def keyword_route(request):
+    value = request.GET.get('value')
+    return HttpResponse(value)
+
+def inline_nested(request):
+    nested = request.GET.get('nested')
+    return HttpResponse(nested)
+
 def server_error_view(request, template_name='blog/error_page.html'):
     return render(request,
                   template_name,

--- a/spec/functional_test/testers/python/django_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_callees_spec.cr
@@ -22,12 +22,7 @@ require "../../func_spec.cr"
 helpers_path = "./spec/functional_test/fixtures/python/django_callees/helpers.py"
 
 expected_endpoints = [
-  # Django's `request.POST.get(...)` registers as a form param, and
-  # `form` type accepts GET as well (existing REQUEST_PARAM_TYPE_MAP
-  # behavior), so both GET and POST endpoints carry the same name.
-  Endpoint.new("/users", "GET", [
-    Param.new("name", "", "form"),
-  ]).tap do |ep|
+  Endpoint.new("/users", "GET").tap do |ep|
     ep.push_callee(Callee.new("request.POST.get", line: 8))
     ep.push_callee(Callee.new("save_user", helpers_path, 1))
     ep.push_callee(Callee.new("audit_log", helpers_path, 5))

--- a/spec/functional_test/testers/python/django_drf_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_drf_callees_spec.cr
@@ -1,0 +1,25 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/api/articles/", "GET", [
+    Param.new("status", "", "query"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("request.query_params.get", line: 32))
+    ep.push_callee(Callee.new("HttpResponse", line: 33))
+  end,
+
+  Endpoint.new("/api/articles/{article_id}/publish/", "POST", [
+    Param.new("reason", "", "form"),
+    Param.new("article_id", "", "path"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("request.data.get", line: 41))
+    ep.push_callee(Callee.new("HttpResponse", line: 42))
+  end,
+]
+
+tester = FunctionalTester.new("fixtures/python/django/", {
+  :techs => 1,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests

--- a/spec/functional_test/testers/python/django_spec.cr
+++ b/spec/functional_test/testers/python/django_spec.cr
@@ -45,6 +45,12 @@ expected_endpoints = [
     Param.new("state", "", "form"),
     Param.new("media_id", "", "path"),
   ]),
+  Endpoint.new("/module-include/keyword-route/", "GET", [
+    Param.new("value", "", "query"),
+  ]),
+  Endpoint.new("/module-include/inline/nested/", "GET", [
+    Param.new("nested", "", "query"),
+  ]),
   Endpoint.new("/direct-articles/", "GET", [
     Param.new("status", "", "query"),
   ]),
@@ -86,7 +92,7 @@ expected_endpoints = [
   Endpoint.new("/combined/", "GET", [
     Param.new("owner", "", "query"),
   ]),
-  Endpoint.new("/extended/", "GET", [Param.new("token", "", "form")]),
+  Endpoint.new("/extended/", "GET"),
   Endpoint.new("/extended/", "POST", [Param.new("token", "", "form")]),
   Endpoint.new("/", "GET"),
   Endpoint.new("/page/<int:page>/", "GET", [
@@ -127,7 +133,7 @@ expected_endpoints = [
   Endpoint.new("/upload", "GET", [Param.new("sign", "", "query"), Param.new("sign", "", "query"), Param.new("X_FORWARDED_FOR", "", "header"), Param.new("X_REAL_IP", "", "header")]),
   Endpoint.new("/upload", "POST", [Param.new("sign", "", "query"), Param.new("X_FORWARDED_FOR", "", "header"), Param.new("X_REAL_IP", "", "header")]),
   Endpoint.new("/not_found", "GET", [Param.new("app_type", "", "cookie")]),
-  Endpoint.new("/test", "GET", [Param.new("test_param", "", "form")]),
+  Endpoint.new("/test", "GET"),
   Endpoint.new("/test", "POST", [Param.new("test_param", "", "form")]),
   Endpoint.new("/test", "PUT", [Param.new("test_param", "", "form")]),
   Endpoint.new("/test", "PATCH", [Param.new("test_param", "", "form")]),

--- a/spec/unit_test/analyzer/python_engine_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "../../../src/models/code_locator"
 require "../../../src/analyzer/engines/python_engine"
 
 class PythonEngineSpecHarness < Analyzer::Python::PythonEngine
@@ -18,6 +19,16 @@ class PythonEngineSpecHarness < Analyzer::Python::PythonEngine
 end
 
 describe Analyzer::Python::PythonEngine do
+  it "treats singular Python test fixture directories as non-production code" do
+    Analyzer::Python::PythonEngine.python_test_path?("/repo/wagtail/test/urls.py", "/repo/wagtail").should be_true
+    Analyzer::Python::PythonEngine.python_test_path?("/repo/src/oscar/test/factories/urls.py", "/repo/src/oscar").should be_true
+  end
+
+  it "does not treat parent test directories outside the scan root as Python tests" do
+    Analyzer::Python::PythonEngine.python_test_path?("/tmp/test/myapp/app/views.py", "/tmp/test/myapp").should be_false
+    Analyzer::Python::PythonEngine.python_test_path?("/tmp/test/myapp/tests/views.py", "/tmp/test/myapp").should be_true
+  end
+
   it "keeps call-site coordinates when a Python callee definition is unreachable" do
     options = create_test_options
     options["include_callee"] = YAML::Any.new(true)

--- a/spec/unit_test/miniparser/import_graph_spec.cr
+++ b/spec/unit_test/miniparser/import_graph_spec.cr
@@ -318,6 +318,34 @@ describe Noir::ImportGraph::Python do
       end
     end
 
+    it "resolves aliased imported modules before classifying package type" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "pkg"))
+        target = File.join(root, "pkg", "urls.py")
+        from_file = File.join(root, "main.py")
+        File.write(target, "")
+        content = "from pkg import urls as pkg_urls\n"
+        File.write(from_file, content)
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file, content)
+        result["pkg_urls"].should eq({target, Noir::ImportGraph::Python::PackageType::FILE})
+      end
+    end
+
+    it "resolves aliased relative modules" do
+      with_tmpdir do |root|
+        Dir.mkdir_p(File.join(root, "pkg"))
+        target = File.join(root, "pkg", "urls.py")
+        from_file = File.join(root, "pkg", "main.py")
+        File.write(target, "")
+        content = "from . import urls as local_urls\n"
+        File.write(from_file, content)
+
+        result = Noir::ImportGraph::Python.find_imported_modules(root, from_file, content)
+        result["local_urls"].should eq({target, Noir::ImportGraph::Python::PackageType::FILE})
+      end
+    end
+
     it "resolves relative imports `from . import x` against the file's directory" do
       with_tmpdir do |root|
         Dir.mkdir_p(File.join(root, "pkg"))

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -41,7 +41,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -37,7 +37,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -25,7 +25,7 @@ module Analyzer::Python
     # Map request parameter types to HTTP methods
     REQUEST_PARAM_TYPE_MAP = {
       "query"  => nil,
-      "form"   => ["GET", "POST", "PUT", "PATCH"],
+      "form"   => ["POST", "PUT", "PATCH"],
       "cookie" => nil,
       "header" => nil,
     }
@@ -85,7 +85,8 @@ module Analyzer::Python
                 # such phantom endpoints. Standard test conventions
                 # (`tests/` dir, `tests.py`, `test_*.py`, `*_test.py`)
                 # are unambiguous in Python codebases.
-                next if PythonEngine.python_test_path?(file)
+                next if PythonEngine.python_test_path?(file, @base_path)
+                next unless django_settings_path?(file)
                 if file.ends_with? ".py"
                   content = read_file_content(file)
                   content.each_line do |line|
@@ -94,9 +95,7 @@ module Analyzer::Python
                     line.scan(REGEX_ROOT_URLCONF) do |match|
                       next if match.size != 2
                       dotted_as_urlconf = match[1].split(".")
-                      relative_path = "#{dotted_as_urlconf.join("/")}.py"
-
-                      Dir.glob("#{escape_glob_path(search_dir)}/**/#{relative_path}") do |filepath|
+                      resolve_root_urlconf_paths(file, dotted_as_urlconf, search_dir).each do |filepath|
                         basepath = filepath.split("/")[..-(dotted_as_urlconf.size + 1)].join("/")
                         root_django_urls_list << DjangoUrls.new("", filepath, basepath)
                       end
@@ -112,6 +111,33 @@ module Analyzer::Python
       end
 
       root_django_urls_list.uniq
+    end
+
+    private def django_settings_path?(path : ::String) : Bool
+      base = File.basename(path)
+      return true if base == "settings.py"
+      return true if base.ends_with?("_settings.py")
+      path.includes?("/settings/")
+    end
+
+    private def resolve_root_urlconf_paths(settings_file : ::String,
+                                           dotted_as_urlconf : Array(::String),
+                                           search_dir : ::String) : Array(::String)
+      relative_path = "#{dotted_as_urlconf.join("/")}.py"
+
+      if dotted_as_urlconf.size == 1
+        candidates = [
+          File.join(File.dirname(settings_file), relative_path),
+          File.join(search_dir, relative_path),
+        ]
+        return candidates.select { |path| File.exists?(path) }.uniq!
+      end
+
+      paths = [] of ::String
+      Dir.glob("#{escape_glob_path(search_dir)}/**/#{relative_path}") do |filepath|
+        paths << filepath
+      end
+      paths.uniq
     end
 
     # Extract endpoints from a Django URL configuration file
@@ -164,6 +190,24 @@ module Analyzer::Python
             end
           end
           next if new_django_urls
+
+          if imported_urlconf_path = extract_imported_include_target(view, package_map)
+            new_django_urls = DjangoUrls.new("#{django_urls.prefix}#{route}", imported_urlconf_path, django_urls.basepath)
+            unless @visited_url_paths.has_key? new_django_urls.filepath
+              extract_endpoints(new_django_urls).each do |endpoint|
+                append_code_path(endpoint.details, PathInfo.new(imported_urlconf_path))
+                endpoints << endpoint
+              end
+            end
+            next
+          end
+
+          if inline_patterns = extract_inline_include_patterns(view)
+            extract_local_urlpattern_endpoints(django_urls, route, inline_patterns, package_map, route_path, urlpattern_lists, import_aliases, drf_router_registrations).each do |endpoint|
+              endpoints << endpoint
+            end
+            next
+          end
 
           if local_patterns = extract_local_include_target(view)
             if pattern_content = urlpattern_lists[local_patterns]?
@@ -403,8 +447,15 @@ module Analyzer::Python
     private def extract_route_mappings(content : ::String) : Array(Tuple(::String, ::String))
       mappings = [] of Tuple(::String, ::String)
       lines = content.split("\n")
+      inline_include_depth = 0
 
       lines.each_with_index do |line, index|
+        if inline_include_depth > 0
+          inline_include_depth += python_bracket_delta(line)
+          inline_include_depth = 0 if inline_include_depth < 0
+          next
+        end
+
         next if line.lstrip.starts_with?("#")
         next unless line.matches?(/\b(?:url|path|re_path|register)\s*\(/)
 
@@ -416,9 +467,25 @@ module Analyzer::Python
         next if args.size < 2
 
         route = extract_python_string(args[0])
+        route ||= extract_python_keyword_string(args, "route")
+        route ||= extract_python_keyword_string(args, "regex")
         next unless route
 
-        mappings << {route, args[1].strip}
+        view_expr = extract_python_keyword_expression(args, "view")
+        view_expr ||= args[1]?.try do |candidate|
+          if keyword_view = candidate.match(/^\s*view\s*=\s*(.+)$/m)
+            keyword_view[1].strip
+          else
+            candidate.strip
+          end
+        end
+        view_expr ||= ""
+        mappings << {route, view_expr}
+
+        if line.includes?("include([")
+          include_start = line.index("include([") || 0
+          inline_include_depth = python_bracket_delta(line[include_start..])
+        end
       end
 
       mappings
@@ -503,6 +570,27 @@ module Analyzer::Python
       include_match[1]
     end
 
+    private def extract_inline_include_patterns(view : ::String) : ::String?
+      include_match = view.match(/\binclude\s*\(\s*(\[[\s\S]*\])\s*(?:,\s*namespace\s*=|\))?/m)
+      include_match ? include_match[1] : nil
+    end
+
+    private def extract_imported_include_target(view : ::String, package_map) : ::String?
+      include_match = view.match(/\binclude\s*\(\s*(?:\(\s*)?([A-Za-z_][A-Za-z0-9_]*)\b/)
+      return unless include_match
+
+      target_name = include_match[1]
+      return if view.includes?("#{target_name}.urls")
+      imported = package_map[target_name]?
+      return unless imported
+
+      filepath, package_type = imported
+      return unless package_type == PackageType::FILE
+      return unless File.exists?(filepath)
+
+      filepath
+    end
+
     private def extract_local_urlpattern_endpoints(django_urls : DjangoUrls,
                                                    mount_route : ::String,
                                                    pattern_content : ::String,
@@ -525,6 +613,24 @@ module Analyzer::Python
             end
             next
           end
+        end
+
+        if inline_patterns = extract_inline_include_patterns(view)
+          extract_local_urlpattern_endpoints(django_urls, nested_mount, inline_patterns, package_map, route_path, urlpattern_lists, import_aliases, drf_router_registrations).each do |endpoint|
+            endpoints << endpoint
+          end
+          next
+        end
+
+        if imported_urlconf_path = extract_imported_include_target(view, package_map)
+          new_django_urls = DjangoUrls.new(join_url_parts(django_urls.prefix, nested_mount).lchop("/"), imported_urlconf_path, django_urls.basepath)
+          unless @visited_url_paths.has_key? new_django_urls.filepath
+            extract_endpoints(new_django_urls).each do |endpoint|
+              append_code_path(endpoint.details, PathInfo.new(imported_urlconf_path))
+              endpoints << endpoint
+            end
+          end
+          next
         end
 
         if router_name = extract_drf_router_include_target(view)
@@ -776,7 +882,7 @@ module Analyzer::Python
       content_lines = content.split "\n"
 
       # Function Based View
-      function_start_index = content.index /def\s+#{function_or_class_name}\s*\(/
+      function_start_index = content.index /(?:async\s+)?def\s+#{function_or_class_name}\s*\(/
       if !function_start_index.nil?
         function_codeblock = parse_code_block(content[function_start_index..])
         if !function_codeblock.nil?
@@ -972,6 +1078,13 @@ module Analyzer::Python
                 drf_action.params << param
               end
             end
+            drf_action.callees = build_callees_from(
+              codeblock,
+              body_start_line + offset + 1,
+              filepath,
+              definition_base_path: @django_base_path,
+              source: content
+            )
           end
 
           actions.reject! { |existing| existing.name == drf_action.name && existing.method == drf_action.method && existing.detail == drf_action.detail }
@@ -985,7 +1098,9 @@ module Analyzer::Python
         params << Param.new(lookup_param, "", "path") if action.detail
         params = dedupe_params(params)
         details = Details.new(PathInfo.new(filepath, action.definition_line || class_definition_line))
-        endpoints << Endpoint.new(endpoint_path, action.method, params, details)
+        endpoint = Endpoint.new(endpoint_path, action.method, params, details)
+        action.callees.each { |callee| endpoint.push_callee(callee) }
+        endpoints << endpoint
       end
 
       endpoints
@@ -1326,7 +1441,7 @@ module Analyzer::Python
     end
 
     class DjangoDrfAction
-      property name, method, detail, path, params, definition_line
+      property name, method, detail, path, params, definition_line, callees
 
       @definition_line : Int32?
 
@@ -1335,7 +1450,8 @@ module Analyzer::Python
                      @detail : Bool,
                      @path : ::String,
                      @params = [] of Param,
-                     @definition_line = nil)
+                     @definition_line = nil,
+                     @callees = [] of Callee)
       end
     end
   end

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -34,7 +34,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           analyze_file(path, current_base_path)

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -18,7 +18,7 @@ module Analyzer::Python
           python_files.each do |path|
             next unless path.starts_with?(base_dir_prefix) || path == current_base_path
             next if path.includes?("/site-packages/")
-            next if PythonEngine.python_test_path?(path)
+            next if PythonEngine.python_test_path?(path, @base_path)
             source = read_file_content(path)
 
             import_modules = find_fastapi_imported_modules(current_base_path, path, source)

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -49,7 +49,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           file_content = fetch_file_content(path)

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -30,7 +30,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
 
           source = read_file_content(path)
           next unless source.includes?("litestar")
@@ -49,7 +49,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
 
           source = read_file_content(path)
           next unless source.includes?("litestar")

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -45,7 +45,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
 
           content = read_file_content(path)
           next unless content.includes?("pyramid") || content.includes?(".add_route") || content.includes?(".add_static_view")
@@ -60,7 +60,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           content = read_file_content(path)

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -63,7 +63,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           file_content = fetch_file_content(path)

--- a/src/analyzer/analyzers/python/robyn.cr
+++ b/src/analyzer/analyzers/python/robyn.cr
@@ -36,7 +36,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             file_content = file.gets_to_end

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -44,7 +44,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -25,7 +25,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
 
           source = read_file_content(path)
           next unless source.includes?("starlette")

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -41,7 +41,7 @@ module Analyzer::Python
         python_files.each do |path|
           next unless path.starts_with?(base_dir_prefix) || path == current_base_path
           next if path.includes?("/site-packages/")
-          next if PythonEngine.python_test_path?(path)
+          next if PythonEngine.python_test_path?(path, @base_path)
           @logger.debug "Analyzing #{path}"
 
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -18,20 +18,38 @@ module Analyzer::Python
     # under any of these patterns ships with `python -m pytest` or
     # `python -m unittest` and never serves real traffic in
     # production. Centralized so every analyzer can opt in via
-    # `next if PythonEngine.python_test_path?(path)`.
+    # `next if PythonEngine.python_test_path?(path, @base_path)`.
     #
-    #   * `/tests/`          — pytest discovery default (Django,
-    #                          Litestar, FastAPI all use it)
+    #   * `/tests/`, `/test/` — pytest discovery defaults and common
+    #                           framework fixture packages (Django,
+    #                           Litestar, FastAPI all use variants)
     #   * `tests.py`         — the legacy Django per-app test module
     #   * `test_*.py`        — unittest / pytest default discovery
     #   * `*_test.py`        — pytest-go style suffix (rare in Python,
     #                          but cheap to include)
-    def self.python_test_path?(path : String) : Bool
-      return true if path.includes?("/tests/")
+    def self.python_test_path?(path : String, base_path : String? = nil) : Bool
+      relative_path = path_for_test_convention_match(path, base_path)
+      return true if relative_path.includes?("/tests/")
+      return true if relative_path.starts_with?("tests/")
+      return true if relative_path.includes?("/test/")
+      return true if relative_path.starts_with?("test/")
       base = File.basename(path)
       return true if base == "tests.py"
       return true if base.starts_with?("test_") && base.ends_with?(".py")
       base.ends_with?("_test.py")
+    end
+
+    private def self.path_for_test_convention_match(path : String, base_path : String?) : String
+      if base_path.nil? || base_path.empty?
+        return File.basename(path)
+      end
+
+      expanded_path = File.expand_path(path)
+      expanded_base = File.expand_path(base_path)
+      return File.basename(path) unless expanded_path == expanded_base || expanded_path.starts_with?(expanded_base + File::SEPARATOR)
+
+      relative = expanded_path[expanded_base.size..].lchop(File::SEPARATOR)
+      relative.empty? ? File.basename(path) : relative
     end
 
     # Parses the definition of a function from the source lines starting at a given index

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -331,7 +331,15 @@ module Noir::ImportGraph::Python
 
     py_path = ""
     is_positive_travel = false
-    dotted_as_names_split = dotted_as_names.split(".")
+    alias_name = nil
+    import_path = dotted_as_names.strip
+    if import_path.includes?(" as ")
+      import_path, alias_name = import_path.split(/\s+as\s+/, 2)
+      import_path = import_path.strip
+      alias_name = alias_name.strip
+    end
+
+    dotted_as_names_split = import_path.split(".")
 
     dotted_as_names_split.each_with_index do |names, index|
       travel_package_path = File.join(package_path, names)
@@ -354,7 +362,6 @@ module Noir::ImportGraph::Python
         import = name.strip
         next if import.empty?
 
-        alias_name = nil
         if import.includes?(" as ")
           import, alias_name = import.split(" as ")
         end


### PR DESCRIPTION
## Summary
- reduce Django ROOT_URLCONF false positives by resolving bare URLConf modules relative to settings files
- resolve imported and inline Django include() URLConfs, keyword route/view args, async views, and DRF ViewSet callees
- scope Python test-directory filtering to the scan root so parent /test/ paths do not skip production files

## Validation
- just test
- just check
- just build