### PR TITLE
Improve Swift Hummingbird route detection accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ ameba.sh
 # tree-sitter build artifacts (compiled on demand from vendored source)
 src/ext/tree_sitter/**/*.o
 
+# SwiftPM build artifacts (SourceKit regenerates these inside Swift fixtures)
+.build/
+.swiftpm/
+
 # Ignore for Hwaro
 /docs/public/
 

--- a/spec/functional_test/fixtures/swift/hummingbird_controllers/Package.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_controllers/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "HummingbirdControllers",
+    platforms: [
+       .macOS(.v14)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        // A vapor-org ecosystem package — must NOT make this a Vapor app.
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+            ]
+        ),
+    ]
+)

--- a/spec/functional_test/fixtures/swift/hummingbird_controllers/Sources/App/Application+build.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_controllers/Sources/App/Application+build.swift
@@ -1,0 +1,22 @@
+import Hummingbird
+
+func buildApplication() -> some ApplicationProtocol {
+    let router = Router()
+
+    // Look-alike `.get`/`.delete` calls on non-router receivers — must
+    // never be reported as endpoints.
+    _ = environment.get("LOG_LEVEL")
+    _ = sessionStorage.get(key: "session")
+    _ = try await repository.delete(id: identifier)
+
+    router.get("health") { _, _ in .ok }              // GET /health
+    router.on("status", method: .HEAD) { _, _ in .ok } // HEAD /status
+    router.ws("socket") { _, _ in .upgrade([:]) }      // GET /socket
+
+    // RouteCollection controller mounted at an explicit path.
+    router.addRoutes(UserController().endpoints, atPath: "/users")
+    // Controller bound to a router group.
+    TodoController().addRoutes(to: router.group("api/todos"))
+
+    return Application(router: router)
+}

--- a/spec/functional_test/fixtures/swift/hummingbird_controllers/Sources/App/Controllers.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_controllers/Sources/App/Controllers.swift
@@ -1,0 +1,41 @@
+import Hummingbird
+
+// `addRoutes(to:)` + a fluent builder chain whose `use:` handlers are
+// referenced through `self.`. The "/api/todos" prefix is lifted from the
+// call site in Application+build.swift.
+struct TodoController<Context: RequestContext> {
+    func addRoutes(to group: RouterGroup<Context>) {
+        group
+            .get(use: self.list)              // GET    /api/todos
+            .get(":id", use: self.get)        // GET    /api/todos/:id
+            .post(use: self.create)           // POST   /api/todos
+            .patch(":id", use: self.update)   // PATCH  /api/todos/:id
+            .delete(":id", use: self.delete)  // DELETE /api/todos/:id
+    }
+
+    func list(_ request: Request, context: Context) async throws -> [Todo] { [] }
+    func get(_ request: Request, context: Context) async throws -> Todo? { nil }
+    func create(_ request: Request, context: Context) async throws -> Todo { Todo() }
+    func update(_ request: Request, context: Context) async throws -> Todo { Todo() }
+    func delete(_ request: Request, context: Context) async throws -> HTTPResponse.Status { .ok }
+}
+
+// `RouteCollection` mounted via `addRoutes(_:atPath:)`; routes inherit the
+// "/users" prefix. The trailing-closure builder chain must resume across
+// each closure body.
+struct UserController {
+    var endpoints: RouteCollection<AppRequestContext> {
+        let routes = RouteCollection(context: AppRequestContext.self)
+        routes.post(use: self.signup)         // POST /users
+        routes.get(":id", use: self.profile)  // GET  /users/:id
+
+        routes.group("session")
+            .add(middleware: SessionMiddleware())
+            .post("login") { _, _ in .ok }     // POST /users/session/login
+            .post("logout") { _, _ in .ok }    // POST /users/session/logout
+        return routes
+    }
+
+    func signup(_ request: Request, context: AppRequestContext) async throws -> User { User() }
+    func profile(_ request: Request, context: AppRequestContext) async throws -> User { User() }
+}

--- a/spec/functional_test/testers/swift/hummingbird_controllers_spec.cr
+++ b/spec/functional_test/testers/swift/hummingbird_controllers_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+# Exercises the controller-oriented Hummingbird routing styles:
+#   * `addRoutes(to: router.group("api/todos"))` + fluent builder chains
+#   * `RouteCollection` mounted via `addRoutes(_:atPath:)`
+#   * builder chains that resume across trailing closures
+#   * `.on(method:)`, HEAD and `.ws` verbs
+# The fixture also contains non-router `.get(...)`/`.delete(...)` calls
+# (environment.get, storage.get, repository.delete) that must NOT surface
+# as endpoints, and a `vapor/*` ecosystem dependency that must NOT tag the
+# project as Vapor.
+expected_endpoints = [
+  Endpoint.new("/health", "GET"),
+  Endpoint.new("/status", "HEAD"),
+  Endpoint.new("/socket", "GET"),
+  Endpoint.new("/users", "POST"),
+  Endpoint.new("/users/:id", "GET"),
+  Endpoint.new("/users/session/login", "POST"),
+  Endpoint.new("/users/session/logout", "POST"),
+  Endpoint.new("/api/todos", "GET"),
+  Endpoint.new("/api/todos/:id", "GET"),
+  Endpoint.new("/api/todos", "POST"),
+  Endpoint.new("/api/todos/:id", "PATCH"),
+  Endpoint.new("/api/todos/:id", "DELETE"),
+]
+
+FunctionalTester.new("fixtures/swift/hummingbird_controllers/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/analyzer/analyzer_swift_hummingbird_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_swift_hummingbird_spec.cr
@@ -84,4 +84,67 @@ describe "swift hummingbird analyzer" do
     File.delete(temp_file) if temp_file && File.exists?(temp_file)
     Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
   end
+
+  it "ignores look-alike calls on non-router receivers" do
+    options = create_test_options
+    instance = Analyzer::Swift::Hummingbird.new(options)
+
+    temp_dir = File.tempname("swift_hummingbird_receiver_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Hummingbird
+
+      func routes(_ router: Router<BasicRequestContext>) {
+          let level = environment.get("LOG_LEVEL")
+          let token = sessionStorage.get(key: "session")
+          _ = try await repository.delete(id: identifier)
+          _ = try await database.schema("todos").delete()
+
+          router.get("ping") { _, _ in "pong" }
+      }
+      SWIFT
+
+    endpoints = instance.analyze_file(temp_file)
+    endpoints.map(&.url).should eq(["/ping"])
+    endpoints.map(&.method).should eq(["GET"])
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
+
+  it "resolves fluent builder chains, .on, head and ws verbs" do
+    options = create_test_options
+    instance = Analyzer::Swift::Hummingbird.new(options)
+
+    temp_dir = File.tempname("swift_hummingbird_chain_test")
+    Dir.mkdir_p(temp_dir)
+    temp_file = File.join(temp_dir, "routes.swift")
+
+    File.write(temp_file, <<-SWIFT)
+      import Hummingbird
+
+      func routes(_ router: Router<BasicRequestContext>) {
+          router.group("api")
+              .get("items", use: listItems)
+              .post("items", use: createItems)
+
+          router.on("legacy", method: .GET) { _, _ in "ok" }
+          router.head("health") { _, _ in .ok }
+          router.ws("live") { _, _ in .upgrade([:]) }
+      }
+      SWIFT
+
+    endpoints = instance.analyze_file(temp_file)
+    pairs = endpoints.map { |e| {e.method, e.url} }
+    pairs.should contain({"GET", "/api/items"})
+    pairs.should contain({"POST", "/api/items"})
+    pairs.should contain({"GET", "/legacy"})
+    pairs.should contain({"HEAD", "/health"})
+    pairs.should contain({"GET", "/live"})
+  ensure
+    File.delete(temp_file) if temp_file && File.exists?(temp_file)
+    Dir.delete(temp_dir) if temp_dir && Dir.exists?(temp_dir)
+  end
 end

--- a/spec/unit_test/detector/swift/vapor_spec.cr
+++ b/spec/unit_test/detector/swift/vapor_spec.cr
@@ -1,0 +1,37 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/swift/*"
+
+describe "Detect Swift Vapor" do
+  options = create_test_options
+  instance = Detector::Swift::Vapor.new options
+
+  it "detects the Vapor framework dependency" do
+    package = <<-SWIFT
+      dependencies: [
+          .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),
+      ]
+      SWIFT
+    instance.detect("Package.swift", package).should be_true
+  end
+
+  it "detects a Vapor product reference" do
+    package = <<-SWIFT
+      dependencies: [ .package(url: "https://github.com/example/web.git", from: "1.0.0") ]
+      .product(name: "Vapor", package: "vapor")
+      SWIFT
+    instance.detect("Package.swift", package).should be_true
+  end
+
+  it "does not treat vapor-org ecosystem packages as Vapor" do
+    # Hummingbird apps routinely depend on these; matching the bare
+    # "vapor" substring used to tag them as Vapor and emit phantom routes.
+    package = <<-SWIFT
+      dependencies: [
+          .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+          .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.7.0"),
+          .package(url: "https://github.com/vapor/jwt-kit.git", from: "5.0.0"),
+      ]
+      SWIFT
+    instance.detect("Package.swift", package).should be_false
+  end
+end

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -6,72 +6,715 @@ module Analyzer::Swift
     # Maximum number of lines to look ahead for function parameters
     LOOKAHEAD_LIMIT = 20
 
-    # Patterns for route definitions in Hummingbird:
-    # router.get("path") { ... }
-    # router.post("path") { ... }
-    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\(/
+    # Route-registration methods exposed by Hummingbird's `RouterMethods`
+    # protocol. They all return `Self`, which is what makes the fluent
+    # builder chain (`group.get(...).post(...)`) possible.
+    HTTP_METHODS = %w[get post put patch delete head]
+
     ROUTE_BODY_LOOKAHEAD_LIMIT = 5
-    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.group\s*\(/
-    GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group\s*\(/
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
+
+    # `let group = router.group("path")` / `var api = router.group("v1")`
+    GROUP_ASSIGN_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.group\s*\(/
+    # `let router = Router()` — establishes a root router-like receiver.
+    ROUTER_ASSIGN_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*Router\s*[(<]/
+    # `let routes = RouteCollection(context: ...)` — a mountable route group.
+    ROUTE_COLLECTION_ASSIGN_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*\.)?RouteCollection\s*[(<]/
+    # `router.group("admin") { admin in ... }` — closure-scoped group.
+    GROUP_CLOSURE_PATTERN = /([A-Za-z_]\w*)\.group\s*\(/
+    # A function parameter typed as a router/router-group/router-methods.
+    ROUTER_PARAM_PATTERN = /([A-Za-z_]\w*)\s*:\s*(?:some\s+|any\s+|inout\s+)*(?:Router|RouterGroup|RouterMethods)\b/
+    # Type declarations whose body can host a RouteCollection handler.
+    TYPE_DECL_PATTERN = /\b(?:struct|class|extension|actor|enum)\s+([A-Za-z_]\w*)/
+
+    # A route hit discovered by the chain scanner.
+    record RouteHit,
+      method : String,
+      path : String,
+      line_index : Int32,
+      handler : String?
+
+    # Prefixes bound to RouteCollection-style handlers via their call
+    # sites. Keyed by enclosing type name and by free-function name so
+    # `Controller(...).addRoutes(to: router.group("api/todos"))` lifts the
+    # `/api/todos` prefix onto routes defined inside `addRoutes`.
+    @controller_prefix_by_type = {} of String => String
+    @controller_prefix_by_func = {} of String => String
+
+    # Project-wide pre-pass: resolve RouteCollection prefixes before the
+    # per-file scan so controller bodies in one file can pick up the
+    # prefix declared at a call site in another.
+    def analyze
+      build_controller_prefixes
+      super
+    end
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      stripped_lines = strip_code_lines(lines)
+      include_callee = callees_needed?
       handler_bodies = named_handler_bodies(lines)
-      prefix_by_receiver = {} of String => String
-      group_prefix_stack = [] of Tuple(String, Int32)
-      brace_depth = 0
 
-      lines.each_with_index do |line, index|
-        stripped_line = code_line(line)
-        register_group_assignment(stripped_line, prefix_by_receiver)
-        register_group_closure(stripped_line, prefix_by_receiver, group_prefix_stack, brace_depth)
+      hits = collect_route_hits(stripped_lines, lines)
 
-        match = route_definition_line?(stripped_line) ? stripped_line.match(ROUTE_PATTERN) : nil
-        unless match
-          brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
-          next
-        end
-
+      hits.each do |hit|
         begin
-          receiver = match[1]
-          method = match[2].upcase
-          args = call_arguments(stripped_line, match.end(0) || 0)
-          next unless args
+          details = Details.new(PathInfo.new(path, hit.line_index + 1))
+          endpoint = Endpoint.new(hit.path, hit.method, details)
+          extract_path_params(hit.path, endpoint)
 
-          route_args = args[0]
-          route_path = join_paths(prefix_for_receiver(receiver, prefix_by_receiver), parse_route_path(route_args))
-
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(route_path, method, details)
-
-          extract_path_params(route_path, endpoint)
-          extract_function_params(lines, index + 1, endpoint)
-          extract_named_handler_params(lines[index], handler_bodies, endpoint)
-          attach_route_callees(lines, index, path, endpoint, handler_bodies) if include_callee
+          if handler = hit.handler
+            extract_named_handler_params(handler, handler_bodies, endpoint)
+            attach_named_handler_callees(handler, handler_bodies, path, endpoint) if include_callee
+          else
+            extract_function_params(lines, hit.line_index + 1, endpoint)
+            attach_route_callees(lines, hit.line_index, path, endpoint, handler_bodies) if include_callee
+          end
 
           endpoints << endpoint
         rescue e
           logger.debug "Error processing endpoint: #{e.message}"
-        ensure
-          brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
         end
       end
 
       endpoints
     end
 
-    # Parse route path from route arguments
-    # Examples:
-    # "hello" -> /hello
-    # "users/:id" -> /users/:id
-    # "api/users/:userID" -> /api/users/:userID
+    # ------------------------------------------------------------------
+    # Chain-aware route discovery
+    # ------------------------------------------------------------------
+
+    # Scan the (comment/string-stripped) source for route registrations.
+    # Detection is receiver-aware: a `.get(...)`/`.post(...)` call only
+    # counts when its receiver is router-like (a tracked router/group
+    # variable, a router-typed function parameter, or a continuation of
+    # an already-open router chain). This is what keeps `env.get(...)`,
+    # `storage.get(key:)` and friends out of the endpoint list.
+    private def collect_route_hits(stripped_lines : Array(String), original_lines : Array(String)) : Array(RouteHit)
+      hits = [] of RouteHit
+      prefix_by_receiver = {} of String => String
+      group_prefix_stack = [] of Tuple(String, Int32)
+      param_stack = [] of Tuple(String, Int32)
+      type_stack = [] of Tuple(String, Int32, String)
+      brace_depth = 0
+      active_prefix : String? = nil
+      active_paren_depth = 0
+      # A builder chain whose route step ended in a trailing closure
+      # (`.post("x") { ... }`) is suspended across the closure body so the
+      # next leading-dot step (`.post("y") { ... }`) re-attaches to it.
+      suspended_prefix : String? = nil
+      suspended_depth = 0
+
+      stripped_lines.each_with_index do |line, index|
+        original = original_lines[index]
+        type_prefix = type_stack.last?.try(&.[2]) || ""
+
+        # Register router-like receivers introduced on this line *before*
+        # scanning, so same-line closures (`router.group("api") { api in
+        # api.get(...) }`) can resolve the freshly-bound receiver.
+        register_router_assignment(line, type_prefix, prefix_by_receiver)
+        register_group_assignment(line, original, prefix_by_receiver)
+        register_group_closure(line, original, prefix_by_receiver, group_prefix_stack, brace_depth)
+        register_router_param(line, prefix_by_receiver, param_stack, type_stack, brace_depth)
+
+        # Manage a chain suspended across a trailing closure body. Once the
+        # body has closed (brace depth is back to the suspend level), the
+        # next leading-dot step resumes it; any other statement clears it.
+        if suspended_prefix
+          if brace_depth < suspended_depth
+            suspended_prefix = nil
+          elsif brace_depth == suspended_depth && !line.strip.empty?
+            if line.lstrip.starts_with?('.')
+              active_prefix = suspended_prefix if active_prefix.nil?
+            end
+            suspended_prefix = nil
+          end
+        end
+
+        cursor = 0
+
+        # Continuation of a chain opened on a previous line.
+        if active_prefix && (active_paren_depth > 0 || line.lstrip.starts_with?('.'))
+          result = scan_chain_segment(line, original, index, active_prefix, active_paren_depth, 0, hits)
+          if result[:closed]
+            suspended_prefix, suspended_depth = result[:prefix], brace_depth
+            active_prefix = nil
+            active_paren_depth = 0
+            cursor = result[:stop]
+          else
+            active_prefix = result[:prefix]
+            active_paren_depth = result[:paren_depth]
+            brace_depth = update_scopes(line, brace_depth, group_prefix_stack, param_stack, type_stack, prefix_by_receiver)
+            next
+          end
+        else
+          active_prefix = nil
+          active_paren_depth = 0
+        end
+
+        # Start (and possibly restart, for one-liners) chains on this line.
+        started = false
+        loop do
+          start = find_chain_start(line, cursor, prefix_by_receiver, type_prefix)
+          break unless start
+
+          started = true
+          result = scan_chain_segment(line, original, index, start[:prefix], 0, start[:start_col], hits)
+          if result[:closed]
+            suspended_prefix, suspended_depth = result[:prefix], brace_depth
+            cursor = result[:stop] + 1
+            active_prefix = nil
+            active_paren_depth = 0
+            break if cursor >= line.size
+          else
+            active_prefix = result[:prefix]
+            active_paren_depth = result[:paren_depth]
+            break
+          end
+        end
+
+        # A line that is just a bare router-like receiver (e.g. `group`
+        # before a leading-dot builder chain), or that ends in a
+        # `RouteCollection(...)` constructor, opens a chain so the following
+        # `.get(...)`/`.post(...)` continuations attach to it.
+        if !started && active_prefix.nil?
+          if bare = bare_receiver(line, prefix_by_receiver)
+            active_prefix = bare
+            active_paren_depth = 0
+          elsif trailing_route_collection?(line)
+            active_prefix = type_prefix
+            active_paren_depth = 0
+          end
+        end
+
+        brace_depth = update_scopes(line, brace_depth, group_prefix_stack, param_stack, type_stack, prefix_by_receiver)
+      end
+
+      hits
+    end
+
+    # Locate the first router-like receiver that opens a chain at or after
+    # `from`. Returns the column of the `.` that begins the method call so
+    # the chain scanner can pick up from there.
+    private def find_chain_start(line : String, from : Int32, prefix_by_receiver : Hash(String, String), type_prefix : String)
+      offset = from
+      while offset < line.size
+        slice = line[offset..]
+        match = slice.match(/(?<![.\w])([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|patch|delete|head|on|ws|group)\s*\(/)
+        break unless match
+
+        receiver = match[1]
+        receiver_begin = offset + (match.begin(1) || 0)
+        if router_like?(receiver, prefix_by_receiver)
+          dot_col = receiver_begin + receiver.size
+          return {prefix: prefix_for_receiver(receiver, prefix_by_receiver), start_col: dot_col}
+        end
+
+        offset = receiver_begin + receiver.size
+      end
+
+      # A `RouteCollection(context:).get(...)...` builder mounted into the
+      # router elsewhere (via `addRoutes(_:atPath:)`). The constructor ends
+      # in `)`, so the receiver-name scan above can't see it; pick it up by
+      # walking to the close paren and checking for a trailing `.method(`.
+      offset = from
+      while marker = line.index("RouteCollection", offset)
+        open = line.index('(', marker)
+        if open && (args = call_arguments(line, open + 1))
+          after = args[1] + 1
+          if line[after..]?.try(&.lstrip).try(&.starts_with?('.'))
+            dot_col = after + (line[after..].size - line[after..].lstrip.size)
+            return {prefix: type_prefix, start_col: dot_col}
+          end
+        end
+        offset = marker + "RouteCollection".size
+      end
+
+      nil
+    end
+
+    # A line consisting solely of a router-like receiver token (the head
+    # of a multi-line builder chain). Returns its prefix, or nil.
+    private def bare_receiver(line : String, prefix_by_receiver : Hash(String, String)) : String?
+      trimmed = line.strip
+      return if trimmed.empty?
+      return unless trimmed.match(/^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*$/)
+      return unless router_like?(trimmed, prefix_by_receiver)
+
+      prefix_for_receiver(trimmed, prefix_by_receiver)
+    end
+
+    # True when a line ends with a `RouteCollection(...)` constructor (the
+    # head of a `return RouteCollection(context:)` builder whose `.get`/
+    # `.post` steps continue on the following leading-dot lines).
+    private def trailing_route_collection?(line : String) : Bool
+      marker = line.rindex("RouteCollection")
+      return false unless marker
+
+      open = line.index('(', marker)
+      return false unless open
+
+      args = call_arguments(line, open + 1)
+      return false unless args
+
+      (line[(args[1] + 1)..]? || "").strip.empty?
+    end
+
+    # Walk a single physical line of a router chain starting at `start_col`.
+    # Updates the running prefix on `.group(...)` segments and records a
+    # `RouteHit` for each HTTP-verb / `.on(...)` call. Returns the prefix,
+    # the carried paren depth and whether a trailing closure (`{`) closed
+    # the chain head on this line.
+    private def scan_chain_segment(line : String,
+                                   original : String,
+                                   index : Int32,
+                                   prefix : String,
+                                   paren_depth : Int32,
+                                   start_col : Int32,
+                                   hits : Array(RouteHit))
+      i = start_col
+      closed = false
+      stop = line.size
+
+      while i < line.size
+        char = line[i]
+
+        if paren_depth > 0
+          case char
+          when '(', '['
+            paren_depth += 1
+          when ')', ']'
+            paren_depth -= 1
+          end
+          i += 1
+          next
+        end
+
+        case char
+        when '{'
+          closed = true
+          stop = i
+          break
+        when '('
+          paren_depth += 1
+          i += 1
+        when '['
+          paren_depth += 1
+          i += 1
+        when ')', ']'
+          paren_depth -= 1 if paren_depth > 0
+          i += 1
+        when '.'
+          method_match = line[i..].match(/^\.([A-Za-z_]\w*)\s*(\(|\{)/)
+          unless method_match
+            i += 1
+            next
+          end
+
+          method = method_match[1]
+          # `.get { ... }` / `.post { ... }` — a verb with a trailing
+          # closure and no path argument registers a root-relative route.
+          if method_match[2] == "{"
+            if verb = route_verb(method)
+              hits << RouteHit.new(verb, join_paths(prefix, "/"), index, nil)
+            end
+            i += (method_match.end(0) || 1) - 1
+            next
+          end
+
+          open_paren = i + (method_match.end(0) || 0) - 1
+          # Structure comes from the stripped line, but argument *content*
+          # (the path literal) must be read from the original source.
+          args = call_arguments(original, open_paren + 1)
+
+          unless args
+            # Arguments spill onto following lines; account for the open
+            # paren and let the continuation handling pick them up.
+            paren_depth += 1
+            i = open_paren + 1
+            next
+          end
+
+          args_str = args[0]
+          prefix = handle_chain_method(method, args_str, prefix, index, hits)
+          i = args[1] + 1
+        else
+          i += 1
+        end
+      end
+
+      {prefix: prefix, paren_depth: paren_depth, closed: closed, stop: stop}
+    end
+
+    # Apply one method call from a chain: `.group` extends the prefix,
+    # HTTP verbs and `.on` emit route hits, anything else is ignored.
+    private def handle_chain_method(method : String,
+                                    args_str : String,
+                                    prefix : String,
+                                    index : Int32,
+                                    hits : Array(RouteHit)) : String
+      case method
+      when "group"
+        join_paths(prefix, parse_route_path(args_str))
+      when "on"
+        path = join_paths(prefix, parse_route_path(args_str))
+        handler = handler_from_args(args_str)
+        on_methods(args_str).each do |http_method|
+          hits << RouteHit.new(http_method, path, index, handler)
+        end
+        prefix
+      else
+        if verb = route_verb(method)
+          path = join_paths(prefix, parse_route_path(args_str))
+          hits << RouteHit.new(verb, path, index, handler_from_args(args_str))
+        end
+        prefix
+      end
+    end
+
+    # Map a builder method name to its HTTP verb. `ws` registers a
+    # WebSocket upgrade, which is served over an HTTP GET.
+    private def route_verb(method : String) : String?
+      return method.upcase if HTTP_METHODS.includes?(method)
+      return "GET" if method == "ws"
+      nil
+    end
+
+    # Extract HTTP method(s) from an `.on(...)` argument list.
+    # Handles `method: .GET`, `method: .get`, `method: [.GET, .POST]`
+    # and `method: HTTPRequest.Method.get`.
+    private def on_methods(args_str : String) : Array(String)
+      methods = [] of String
+      if marker = args_str.index("method:")
+        rest = args_str[(marker + 7)..]
+        rest.scan(/\.([A-Za-z]+)/) do |m|
+          token = m[1].upcase
+          methods << token if HTTP_METHODS.includes?(token.downcase) || token == "OPTIONS" || token == "TRACE" || token == "CONNECT"
+        end
+      end
+      methods
+    end
+
+    # The named handler referenced via `use:` (e.g. `use: self.create`
+    # yields "create"). Closures return nil so the caller knows to read
+    # the inline body instead.
+    private def handler_from_args(args_str : String) : String?
+      if match = args_str.match(/\buse:\s*(?:self\.)?([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)/)
+        return match[1].split('.').last
+      end
+      nil
+    end
+
+    private def router_like?(receiver : String, prefix_by_receiver : Hash(String, String)) : Bool
+      receiver.split('.').any? { |part| prefix_by_receiver.has_key?(part) }
+    end
+
+    # ------------------------------------------------------------------
+    # Receiver registration
+    # ------------------------------------------------------------------
+
+    private def register_router_assignment(line : String, type_prefix : String, prefix_by_receiver : Hash(String, String))
+      # `let router = Router()` roots at "/"; `let routes = RouteCollection(...)`
+      # inherits the prefix its enclosing controller is mounted at.
+      if match = line.match(ROUTER_ASSIGN_PATTERN)
+        prefix_by_receiver[match[1]] = ""
+      elsif match = line.match(ROUTE_COLLECTION_ASSIGN_PATTERN)
+        prefix_by_receiver[match[1]] = type_prefix
+      end
+    end
+
+    private def register_group_assignment(line : String, original : String, prefix_by_receiver : Hash(String, String))
+      match = line.match(GROUP_ASSIGN_PATTERN)
+      return unless match
+
+      variable = match[1]
+      base = match[2]
+      args = call_arguments(original, match.end(0) || 0)
+      return unless args
+
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
+    end
+
+    private def register_group_closure(line : String,
+                                       original : String,
+                                       prefix_by_receiver : Hash(String, String),
+                                       group_prefix_stack : Array(Tuple(String, Int32)),
+                                       brace_depth : Int32)
+      match = line.match(GROUP_CLOSURE_PATTERN)
+      return unless match
+
+      base = match[1]
+      return unless router_like?(base, prefix_by_receiver)
+
+      args = call_arguments(original, match.end(0) || 0)
+      return unless args
+
+      after_call = line[(args[1] + 1)..]? || ""
+      closure_match = after_call.match(/^\s*\{\s*([A-Za-z_]\w*)\s+in/)
+      return unless closure_match
+
+      variable = closure_match[1]
+      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
+      group_prefix_stack << {variable, brace_depth + 1}
+    end
+
+    # Register a router/router-group function parameter (e.g. the `group`
+    # in `func addRoutes(to group: RouterGroup<Context>)`) as a router-like
+    # receiver, lifting any prefix resolved for the enclosing type or
+    # free function from the controller pre-pass.
+    private def register_router_param(line : String,
+                                      prefix_by_receiver : Hash(String, String),
+                                      param_stack : Array(Tuple(String, Int32)),
+                                      type_stack : Array(Tuple(String, Int32, String)),
+                                      brace_depth : Int32)
+      func_match = line.match(FUNCTION_SIGNATURE_PATTERN)
+      return unless func_match
+
+      param_match = line.match(ROUTER_PARAM_PATTERN)
+      return unless param_match
+
+      param = param_match[1]
+      func_name = func_match[1]
+      type_name = type_stack.last?.try(&.[0])
+
+      prefix = ""
+      if type_name && (bound = @controller_prefix_by_type[type_name]?)
+        prefix = bound
+      elsif bound = @controller_prefix_by_func[func_name]?
+        prefix = bound
+      end
+
+      prefix_by_receiver[param] = prefix
+      param_stack << {param, brace_depth + 1}
+    end
+
+    # Track brace depth and unwind scope-bound receivers (closure groups,
+    # router params) and type declarations as their blocks close.
+    private def update_scopes(line : String,
+                              brace_depth : Int32,
+                              group_prefix_stack : Array(Tuple(String, Int32)),
+                              param_stack : Array(Tuple(String, Int32)),
+                              type_stack : Array(Tuple(String, Int32, String)),
+                              prefix_by_receiver : Hash(String, String)) : Int32
+      if match = line.match(TYPE_DECL_PATTERN)
+        if line.includes?('{')
+          bound = @controller_prefix_by_type[match[1]]? || ""
+          type_stack << {match[1], brace_depth + 1, bound}
+        end
+      end
+
+      depth = brace_depth + line.count('{') - line.count('}')
+
+      while !group_prefix_stack.empty? && depth < group_prefix_stack.last[1]
+        variable, _ = group_prefix_stack.pop
+        prefix_by_receiver.delete(variable)
+      end
+
+      while !param_stack.empty? && depth < param_stack.last[1]
+        variable, _ = param_stack.pop
+        prefix_by_receiver.delete(variable)
+      end
+
+      while !type_stack.empty? && depth < type_stack.last[1]
+        type_stack.pop
+      end
+
+      depth
+    end
+
+    # ------------------------------------------------------------------
+    # Controller (RouteCollection) prefix resolution — cross-file pre-pass
+    # ------------------------------------------------------------------
+
+    private def build_controller_prefixes
+      files = swift_source_files
+      return if files.empty?
+
+      route_methods = Set{"addRoutes"}     # `addRoutes` is the RouteCollection built-in
+      assignments = {} of String => String # variable -> constructed type
+
+      files.each do |path|
+        lines = strip_code_lines(File.read_lines(path, encoding: "utf-8", invalid: :skip))
+        lines.each do |line|
+          if (func = line.match(FUNCTION_SIGNATURE_PATTERN)) && line.match(ROUTER_PARAM_PATTERN)
+            route_methods << func[1]
+          end
+          if assign = line.match(/\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\s*[(<]/)
+            assignments[assign[1]] = assign[2]
+          end
+        end
+      end
+
+      files.each do |path|
+        register_controller_call_sites(path, route_methods, assignments)
+      end
+    end
+
+    private def register_controller_call_sites(path : String,
+                                               method_set : Set(String),
+                                               assignments : Hash(String, String))
+      original_lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      stripped_lines = strip_code_lines(original_lines)
+
+      merge_logical_lines(stripped_lines, original_lines) do |stripped, original|
+        method_set.each do |func_name|
+          search_from = 0
+          while marker = stripped.index(".#{func_name}", search_from)
+            search_from = marker + func_name.size + 1
+            # Require the call to be exactly `.<func>(` — guards against
+            # partial matches like `.addRoutesLater(`.
+            open = stripped.index('(', marker)
+            next unless open && stripped[(marker + 1)...open].strip == func_name
+
+            args = call_arguments(original, open + 1)
+            next unless args
+
+            args_str = args[0]
+            before = original[0...marker]
+
+            prefix = at_path_prefix(args_str) || labeled_group_prefix(args_str) || chain_group_prefix(before)
+
+            controller = positional_controller_type(args_str, assignments) ||
+                         resolve_type(receiver_before(before), assignments)
+
+            if controller
+              @controller_prefix_by_type[controller] ||= prefix
+            end
+            @controller_prefix_by_func[func_name] ||= prefix
+          end
+        end
+      end
+    end
+
+    # Merge physical lines into logical statements: a line continues the
+    # previous one while parentheses/brackets stay open or the next line
+    # begins with a leading dot (fluent-chain continuation).
+    private def merge_logical_lines(stripped_lines : Array(String), original_lines : Array(String), &)
+      i = 0
+      n = stripped_lines.size
+      while i < n
+        buf_s = [stripped_lines[i]]
+        buf_o = [original_lines[i]]
+        depth = paren_delta(stripped_lines[i])
+        j = i
+        while j + 1 < n && (depth > 0 || stripped_lines[j + 1].lstrip.starts_with?('.'))
+          j += 1
+          buf_s << stripped_lines[j]
+          buf_o << original_lines[j]
+          depth += paren_delta(stripped_lines[j])
+        end
+        yield buf_s.join("\n"), buf_o.join("\n")
+        i = j + 1
+      end
+    end
+
+    private def paren_delta(line : String) : Int32
+      line.count('(') + line.count('[') - line.count(')') - line.count(']')
+    end
+
+    # `atPath: "/todos"` mount label -> "/todos".
+    private def at_path_prefix(args : String) : String?
+      if match = args.match(/\batPath:\s*["']([^"']*)["']/)
+        return parse_route_path("\"#{match[1]}\"")
+      end
+      nil
+    end
+
+    # `to: router.group("api/todos")` -> "/api/todos"; `to: router` -> "".
+    private def labeled_group_prefix(args : String) : String?
+      if match = args.match(/\bto:\s*([A-Za-z_][\w.]*(?:\s*\([^)]*\))?(?:\.[A-Za-z_]\w*\s*\([^)]*\))*)/)
+        return chain_group_prefix(match[1])
+      end
+      nil
+    end
+
+    # Join every `.group("x")` literal found in a receiver expression.
+    private def chain_group_prefix(expr : String) : String
+      prefix = ""
+      expr.scan(/\bgroup\s*\(\s*["']([^"']*)["']/) do |m|
+        prefix = join_paths(prefix, parse_route_path("\"#{m[1]}\""))
+      end
+      prefix
+    end
+
+    # The first positional argument's controller type, e.g.
+    # `TodoController(...).endpoints` -> "TodoController",
+    # `controller.routes` -> resolved type of `controller`.
+    private def positional_controller_type(args : String, assignments : Hash(String, String)) : String?
+      first = first_positional_arg(args)
+      return unless first
+      return if first.includes?(':') && !first.includes?('(')
+
+      if match = first.match(/^([A-Za-z_]\w*)\s*(?:<[^>]*>)?\s*\(/)
+        return match[1]
+      end
+      if match = first.match(/^([A-Za-z_]\w*)\s*\./)
+        return assignments[match[1]]?
+      end
+      nil
+    end
+
+    # The text of the first positional argument (nil if the first argument
+    # is labeled, e.g. `to:`/`atPath:`).
+    private def first_positional_arg(args : String) : String?
+      depth = 0
+      slice = ""
+      args.each_char do |char|
+        case char
+        when '(', '[', '<' then depth += 1
+        when ')', ']', '>' then depth -= 1
+        when ','
+          break if depth == 0
+        end
+        slice += char
+      end
+      slice = slice.strip
+      return if slice.empty?
+      # A leading `label:` marks this as a non-positional argument.
+      return if slice.match(/^[A-Za-z_]\w*\s*:/) && !slice.match(/^[A-Za-z_]\w*\s*\(/)
+      slice
+    end
+
+    # The receiver expression to the left of a `.method(` call.
+    private def receiver_before(before : String) : String
+      if match = before.match(/([A-Za-z_]\w*)(?:<[^>]*>)?(?:\([^()]*\))?\s*$/)
+        return match[1]
+      end
+      ""
+    end
+
+    private def resolve_type(receiver : String, assignments : Hash(String, String)) : String?
+      return if receiver.empty?
+      # `TodoController(...).addRoutes(...)` keeps the type verbatim; a bare
+      # lowercase variable resolves through its constructor assignment.
+      if receiver[0].uppercase?
+        receiver
+      else
+        assignments[receiver]?
+      end
+    end
+
+    private def swift_source_files : Array(String)
+      all_files.select do |path|
+        File.exists?(path) && !File.directory?(path) &&
+          File.extname(path) == ".swift" &&
+          !swift_test_path?(path) && !swift_vendor_path?(path)
+      end
+    rescue
+      [] of String
+    end
+
+    # ------------------------------------------------------------------
+    # Path / parameter helpers
+    # ------------------------------------------------------------------
+
+    # Parse route path from route arguments. The path is the first quoted
+    # string; `{id}`-style segments are normalized to `:id`.
     def parse_route_path(route_args : String) : String
-      # Match the first quoted string (the path)
       if match = route_args.match(/["']([^"']+)["']/)
         path = match[1]
+        path = path.gsub(/\{(\w+)\}/, ":\\1")
         path = "/" + path unless path.starts_with?("/")
         return path
       end
@@ -87,7 +730,7 @@ module Analyzer::Swift
       end
     end
 
-    # Extract parameters from function body
+    # Extract parameters from an inline closure body.
     def extract_function_params(lines : Array(String), start_index : Int32, endpoint : Endpoint)
       in_function = false
       brace_count = 0
@@ -127,14 +770,8 @@ module Analyzer::Swift
     private def route_definition?(line : String) : Bool
       (line.includes?(".get(") || line.includes?(".post(") ||
         line.includes?(".put(") || line.includes?(".delete(") ||
-        line.includes?(".patch("))
-    end
-
-    # Check if a line is a route definition but not a parameter access
-    private def route_definition_line?(line : String) : Bool
-      route_definition?(line) &&
-        !line.includes?("context.parameters") &&
-        !line.includes?("request.uri.queryParameters")
+        line.includes?(".patch(") || line.includes?(".head(") ||
+        line.includes?(".on("))
     end
 
     private def attach_route_callees(lines : Array(String),
@@ -143,12 +780,20 @@ module Analyzer::Swift
                                      endpoint : Endpoint,
                                      handler_bodies : Hash(String, Tuple(String, Int32)))
       body, start_line = route_body(lines, route_index)
-      if body.empty?
-        body, start_line = named_handler_body(lines[route_index], route_index, handler_bodies)
-      end
       return if body.empty?
 
       callees = Noir::SwiftCalleeExtractor.callees_for_body(body, path, start_line)
+      Noir::SwiftCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    private def attach_named_handler_callees(handler_name : String,
+                                             handler_bodies : Hash(String, Tuple(String, Int32)),
+                                             path : String,
+                                             endpoint : Endpoint)
+      body = handler_bodies[handler_name]?
+      return unless body
+
+      callees = Noir::SwiftCalleeExtractor.callees_for_body(body[0], path, body[1])
       Noir::SwiftCalleeExtractor.attach_to(endpoint, callees)
     end
 
@@ -157,7 +802,7 @@ module Analyzer::Swift
       opening_brace = structural_opening_brace(lines[opening_index])
       unless opening_brace
         ((route_index + 1)...[route_index + ROUTE_BODY_LOOKAHEAD_LIMIT, lines.size].min).each do |index|
-          break if route_definition_line?(lines[index])
+          break if route_definition?(strip_code_line(lines[index]))
 
           if brace_index = structural_opening_brace(lines[index])
             opening_index = index
@@ -168,84 +813,12 @@ module Analyzer::Swift
       end
       return {"", route_index + 2} unless opening_brace
 
-      route_line = lines[opening_index]
-      first_fragment = route_line[(opening_brace + 1)..]? || ""
-      clean_fragment, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first_fragment, 0, false)
-      body_lines = [] of String
-      brace_count = 1 + clean_fragment.count('{') - clean_fragment.count('}')
-
-      if brace_count <= 0
-        closing_brace = clean_fragment.rindex('}')
-        first_fragment = first_fragment[0...closing_brace] if closing_brace
-        return {first_fragment, opening_index + 1}
-      end
-
-      body_lines << first_fragment
-      index = opening_index + 1
-
-      while index < lines.size && brace_count > 0
-        line = lines[index]
-        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
-          line,
-          block_comment_depth,
-          in_multiline_string
-        )
-        opens = stripped.count('{')
-        closes = stripped.count('}')
-        next_brace_count = brace_count + opens - closes
-
-        if next_brace_count <= 0
-          if line.strip != "}"
-            closing_brace = stripped.rindex('}')
-            body_lines << (closing_brace ? line[0...closing_brace] : line)
-          end
-          break
-        end
-
-        body_lines << line
-        brace_count = next_brace_count
-
-        index += 1
-      end
-
-      {body_lines.join("\n"), opening_index + 1}
+      body_after_opening_brace(lines, opening_index, opening_brace)
     end
 
     private def structural_opening_brace(line : String) : Int32?
       stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
       stripped.index('{')
-    end
-
-    private def register_group_assignment(line : String, prefix_by_receiver : Hash(String, String))
-      match = line.match(GROUP_ASSIGN_PATTERN)
-      return unless match
-
-      variable = match[1]
-      base = match[2]
-      args = call_arguments(line, match.end(0) || 0)
-      return unless args
-
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
-    end
-
-    private def register_group_closure(line : String,
-                                       prefix_by_receiver : Hash(String, String),
-                                       group_prefix_stack : Array(Tuple(String, Int32)),
-                                       brace_depth : Int32)
-      match = line.match(GROUP_CLOSURE_PATTERN)
-      return unless match
-
-      base = match[1]
-      args = call_arguments(line, match.end(0) || 0)
-      return unless args
-
-      after_call = line[(args[1] + 1)..]? || ""
-      closure_match = after_call.match(/^\s*\{\s*([A-Za-z_]\w*)\s+in/)
-      return unless closure_match
-
-      variable = closure_match[1]
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), parse_route_path(args[0]))
-      group_prefix_stack << {variable, brace_depth + 1}
     end
 
     private def call_arguments(line : String, args_start : Int32) : Tuple(String, Int32)?
@@ -284,21 +857,6 @@ module Analyzer::Swift
       nil
     end
 
-    private def update_group_depth(line : String,
-                                   brace_depth : Int32,
-                                   group_prefix_stack : Array(Tuple(String, Int32)),
-                                   prefix_by_receiver : Hash(String, String)) : Int32
-      structural, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
-      depth = brace_depth + structural.count('{') - structural.count('}')
-
-      while !group_prefix_stack.empty? && depth < group_prefix_stack.last[1]
-        variable, _ = group_prefix_stack.pop
-        prefix_by_receiver.delete(variable)
-      end
-
-      depth
-    end
-
     private def prefix_for_receiver(receiver : String, prefix_by_receiver : Hash(String, String)) : String
       receiver.split('.').reverse_each do |part|
         if prefix = prefix_by_receiver[part]?
@@ -322,16 +880,30 @@ module Analyzer::Swift
       normalized.gsub(%r{/+}, "/")
     end
 
-    private def code_line(line : String) : String
-      line.split("//", 2).first
+    private def strip_code_line(line : String) : String
+      stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, 0, false)
+      stripped
     end
 
-    private def extract_named_handler_params(route_line : String,
+    # Strip comments and string contents across the whole file so brace,
+    # paren and method scanning never trips over `}` inside a string or a
+    # multi-line comment.
+    private def strip_code_lines(lines : Array(String)) : Array(String)
+      block_comment_depth = 0
+      in_multiline_string = false
+      lines.map do |line|
+        stripped, block_comment_depth, in_multiline_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+          line,
+          block_comment_depth,
+          in_multiline_string
+        )
+        stripped
+      end
+    end
+
+    private def extract_named_handler_params(handler_name : String,
                                              handler_bodies : Hash(String, Tuple(String, Int32)),
                                              endpoint : Endpoint)
-      handler_name = route_handler_name(route_line)
-      return unless handler_name
-
       body = handler_bodies[handler_name]?
       return unless body
 
@@ -380,7 +952,7 @@ module Analyzer::Swift
         end
       end
 
-      # Extract path parameters from context.parameters.require or context.parameters.get
+      # Extract path parameters from context.parameters.require / .get
       if line.includes?("context.parameters.require(") ||
          line.includes?("context.parameters.get(")
         match = line.match(/context\.parameters\.(require|get)\(["']([^"']+)["']\)/)
@@ -392,24 +964,6 @@ module Analyzer::Swift
           end
         end
       end
-    end
-
-    private def named_handler_body(route_line : String,
-                                   route_index : Int32,
-                                   handler_bodies : Hash(String, Tuple(String, Int32))) : Tuple(String, Int32)
-      handler_name = route_handler_name(route_line)
-      return {"", route_index + 2} unless handler_name
-
-      handler_bodies[handler_name]? || {"", route_index + 2}
-    end
-
-    private def route_handler_name(route_line : String) : String?
-      stripped, _, _ = Noir::SwiftCalleeExtractor.strip_non_code_with_state(route_line, 0, false)
-      if match = stripped.match(/\buse:\s*([A-Za-z_]\w*)/)
-        return match[1]
-      end
-
-      nil
     end
 
     private def named_handler_bodies(lines : Array(String)) : Hash(String, Tuple(String, Int32))

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -22,6 +22,18 @@ module Analyzer::Swift
       SwiftEngine.swift_test_path?(path)
     end
 
+    # SwiftPM parks resolved dependency sources under `.build/` (and Xcode
+    # under `.swiftpm/`). Scanning them pulls every transitive package's
+    # routes into the report — pure noise against the project under test.
+    def self.swift_vendor_path?(path : String) : Bool
+      path.includes?("/.build/") || path.starts_with?(".build/") ||
+        path.includes?("/.swiftpm/") || path.starts_with?(".swiftpm/")
+    end
+
+    private def swift_vendor_path?(path : String) : Bool
+      SwiftEngine.swift_vendor_path?(path)
+    end
+
     # `.swift` extension filter baked in. Subclasses that need a custom
     # scan shape can override `analyze` and call this helper directly.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
@@ -37,6 +49,7 @@ module Analyzer::Swift
           # XCTest-style `*Tests.swift` filenames carry the same
           # signal — pick them both up.
           next if swift_test_path?(path)
+          next if swift_vendor_path?(path)
 
           begin
             block.call(path)

--- a/src/detector/detectors/swift/vapor.cr
+++ b/src/detector/detectors/swift/vapor.cr
@@ -6,14 +6,16 @@ module Detector::Swift
       # Check if this is a Package.swift file
       return false unless filename.includes?("Package.swift")
 
-      # Look for vapor package dependency with more specific pattern
-      # Matches patterns like: .package(url: "https://github.com/vapor/vapor.git", ...)
-      check = file_contents.includes?("dependencies")
-      check = check && (file_contents.includes?("vapor/vapor") ||
-                        (file_contents.includes?("vapor") &&
-                         file_contents.includes?(".package(")))
+      # Require the Vapor framework itself, not just any package from the
+      # `vapor/*` org. Hummingbird apps routinely pull `vapor/fluent-kit`,
+      # `vapor/fluent-sqlite-driver`, `vapor/jwt-kit`, etc. — matching a
+      # bare "vapor" substring there falsely tagged those projects as Vapor
+      # and produced phantom endpoints from the Vapor analyzer.
+      return false unless file_contents.includes?("dependencies")
 
-      check
+      file_contents.includes?("vapor/vapor") ||
+        file_contents.includes?(%(package: "vapor")) ||
+        file_contents.includes?(%(name: "Vapor"))
     end
 
     def applicable?(filename : String) : Bool


### PR DESCRIPTION
## Summary

Reworks the Hummingbird analyzer to be **receiver-aware** and **chain-aware**, closing large FN/FP gaps surfaced by running noir against the [hummingbird-examples](https://github.com/hummingbird-project/hummingbird-examples) apps. This enriches the AI/endpoint context noir already produces for Swift by covering the controller and fluent-builder routing styles real Hummingbird apps overwhelmingly use.

The previous analyzer treated any `x.get("s")` as a route, so it both **invented** endpoints and **missed** the dominant real-world patterns. For example, `auth-cognito` reported 3 phantom routes from `env.get(...)` and nothing real; `todos-fluent` reported only `GET /health` + a bogus `DELETE /` and missed all six `/api/todos` routes.

## FP reduction (receiver-aware)
A `.get`/`.post`/… call is only a route when its receiver is **router-like**: a tracked `Router()` / `RouteCollection()` / `.group(...)` variable, a `Router`/`RouterGroup`/`RouterMethods` function parameter, or a continuation of an already-open router chain. This removes false endpoints from `environment.get("LOG_LEVEL")`, `storage.get(key:)`, `repository.delete(id:)`, `database.schema(...).delete()`, etc.

## FN reduction (chain-aware + cross-file binding)
- **Fluent builder chains** across leading-dot continuations (`group.get(use:).get(":id", use:).post(use:)`), chains that **resume across trailing closures** (`.post("x") { } .post("y") { }`), and the **no-arg closure form** (`.post { }`).
- `use: self.handler` resolution, `.on(path, method:)`, **HEAD**, and WebSocket **`.ws`**.
- **RouteCollection controllers** mounted via `addRoutes(_:atPath:)` and the `Controller(...).addRoutes(to: router.group("api/todos"))` style — a cross-file pre-pass lifts the mount prefix (`atPath:` / `to:` group / bound receiver) onto the controller body.

## Also
- **Skip SwiftPM vendored sources** (`.build/`, `.swiftpm/`) in the Swift engine so resolved dependency routes don't pollute the report (benefits Vapor/Kitura too).
- **Tighten the Vapor detector** to the actual Vapor framework, so Hummingbird apps depending on `vapor/fluent-*` / `vapor/jwt-kit` aren't mis-tagged as Vapor (which had emitted phantom endpoints into Hummingbird projects).

## Validation against hummingbird-examples
Representative results after the change (all verified correct against source):

| app | before | after |
|---|---|---|
| todos-fluent | `GET /health`, `DELETE /` (FP) | 6 `/api/todos` CRUD + `/health` |
| auth-cognito | 3 FPs from `env.get` | 0 FPs (uses the declarative DSL — follow-up) |
| auth-otp | 1 | 9 (`/api/users`, `/api/users/totp/*`) |
| todos-postgres-tutorial | `GET /health` | 7 (RouteCollection) |
| sessions / auth-jwt / auth-srp / html-form / websocket-* | mostly 0 or FPs | correct |

Out of scope (separate follow-up): the `HummingbirdRouter` **declarative result-builder DSL** (`RouterBuilder { Get(...) RouteGroup(...) }`, `RouterController.body`) used by `auth-cognito` and `webauthn`.

## Tests
- New controller functional fixture (`fixtures/swift/hummingbird_controllers`) covering builder chains, RouteCollection + atPath, closure-resume, `.on`/HEAD/`.ws`, the receiver FP guards, and a `vapor/*` ecosystem dep that must stay tagged Hummingbird-only.
- Analyzer unit tests for the receiver guard and verb handling; a Vapor detector unit test.
- Full suite green: `2639` unit + `15094` functional examples.