### PR TITLE
Java Armeria/JSP/Spring: FP/FN reduction + analyzer perf

### DIFF
--- a/spec/functional_test/fixtures/java/armeria/src/AnnotatedService.java
+++ b/spec/functional_test/fixtures/java/armeria/src/AnnotatedService.java
@@ -62,6 +62,14 @@ public class AnnotatedService {
         return HttpResponse.of("");
     }
 
+    // Rest-path capture: `{*filePath}` binds the remainder of the path to
+    // the `filePath` path variable — not a query parameter, and the name
+    // must not carry the leading asterisk.
+    @Get("/annotated/files/{*filePath}")
+    public HttpResponse serveFile(@Param String filePath) {
+        return HttpResponse.of("file");
+    }
+
     // Inner class for RequestObject
     public static class User {
         public String name;

--- a/spec/functional_test/fixtures/java/armeria/src/DocExampleService.java
+++ b/spec/functional_test/fixtures/java/armeria/src/DocExampleService.java
@@ -1,0 +1,38 @@
+package org.apache.skywalking.oap.server.webapp;
+
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+
+/**
+ * Demonstrates that builder chains living inside documentation must not
+ * be picked up as real routes. The block comment below shows example
+ * wiring that should be ignored by the analyzer:
+ *
+ * <pre>{@code
+ * Server.builder()
+ *       .service("/doc-comment-route", new OapProxyService())
+ *       .service("/api/comment-thrift", HealthCheckService.of())
+ *       .build()
+ *       .start();
+ * }</pre>
+ */
+public class DocExampleService {
+    // A Java text block carrying the same example must also be ignored.
+    public static final String EXAMPLE = """
+        Server.builder()
+              .service("/doc-textblock-route", new OapProxyService())
+              .build()
+              .start();
+        """;
+
+    public static void main(String[] args) throws Exception {
+        // The only real route in this file.
+        Server
+            .builder()
+            .service("/real/ping", HealthCheckService.of())
+            .build()
+            .start()
+            .join();
+    }
+}

--- a/spec/functional_test/fixtures/java/jsp/attribute.jsp
+++ b/spec/functional_test/fixtures/java/jsp/attribute.jsp
@@ -1,3 +1,9 @@
 <%
+    // Application-set attribute — a real, user-meaningful parameter.
     Object userId = request.getAttribute("userId");
+
+    // Container-managed attributes — populated by the servlet engine,
+    // never by user input. These must NOT surface as parameters.
+    Object sessionId = request.getAttribute("javax.servlet.request.ssl_session_id");
+    Object certs = request.getAttribute("jakarta.servlet.request.X509Certificate");
 %>

--- a/spec/functional_test/fixtures/java/spring/src/AbstractCrudController.java
+++ b/spec/functional_test/fixtures/java/spring/src/AbstractCrudController.java
@@ -1,0 +1,19 @@
+package com.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+// Abstract base controller: never mapped on its own, so `/list` and
+// `/{id}` must NOT surface without a concrete subclass prefix. The
+// routes only exist through CrudReportController below.
+public abstract class AbstractCrudController {
+    @GetMapping("/list")
+    public String list() {
+        return "list";
+    }
+
+    @GetMapping("/{id}")
+    public String get(@PathVariable("id") String id) {
+        return id;
+    }
+}

--- a/spec/functional_test/fixtures/java/spring/src/CrudReportController.java
+++ b/spec/functional_test/fixtures/java/spring/src/CrudReportController.java
@@ -1,0 +1,18 @@
+package com.test;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// Concrete controller inheriting the base CRUD routes under `/crud`:
+//   GET  /crud/list   (inherited)
+//   GET  /crud/{id}   (inherited, with path param)
+//   POST /crud        (own)
+@RestController
+@RequestMapping("/crud")
+public class CrudReportController extends AbstractCrudController {
+    @PostMapping
+    public String create() {
+        return "created";
+    }
+}

--- a/spec/functional_test/testers/java/armeria_spec.cr
+++ b/spec/functional_test/testers/java/armeria_spec.cr
@@ -140,6 +140,12 @@ expected_endpoints << annotated_search_get
 annotated_health_head = Endpoint.new("/annotated/health", "HEAD")
 expected_endpoints << annotated_health_head
 
+# GET /annotated/files/{*filePath} — rest-path capture binds `filePath`
+# as a single path param (no `*filePath`, no spurious query param).
+annotated_files_get = Endpoint.new("/annotated/files/{*filePath}", "GET")
+annotated_files_get.push_param(Param.new("filePath", "", "path"))
+expected_endpoints << annotated_files_get
+
 # OPTIONS /annotated/cors with header: Origin
 annotated_cors_options = Endpoint.new("/annotated/cors", "OPTIONS")
 annotated_cors_options.push_param(Param.new("Origin", "", "header"))

--- a/spec/functional_test/testers/java/armeria_spec.cr
+++ b/spec/functional_test/testers/java/armeria_spec.cr
@@ -161,6 +161,12 @@ mounted_create_post = Endpoint.new("/mounted/create", "POST")
 mounted_create_post.push_param(Param.new("title", "", "json"))
 expected_endpoints << mounted_create_post
 
+# DocExampleService.java: only the real builder route is detected.
+# The Server.builder() chains inside the Javadoc comment and the Java
+# text block (/doc-comment-route, /api/comment-thrift, /doc-textblock-route)
+# must NOT surface as endpoints.
+expected_endpoints << Endpoint.new("/real/ping", "ANY")
+
 FunctionalTester.new("fixtures/java/armeria/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/spec/functional_test/testers/java/spring_spec.cr
+++ b/spec/functional_test/testers/java/spring_spec.cr
@@ -126,6 +126,12 @@ expected_endpoints = [
     Param.new("region", "", "query"),
   ]),
   Endpoint.new("/api/v3/items/bulk", "POST", [Param.new("tenant", "", "query")]),
+  # CrudReportController.java extends AbstractCrudController.java — the
+  # abstract base's @GetMapping routes are inherited under the `/crud`
+  # prefix, and the base must NOT emit un-prefixed `/list` or `/{id}`.
+  Endpoint.new("/crud", "POST"),
+  Endpoint.new("/crud/list", "GET"),
+  Endpoint.new("/crud/{id}", "GET", [Param.new("id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/java/spring/", {

--- a/spec/unit_test/analyzer/analyzer_jsp_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_jsp_spec.cr
@@ -1,0 +1,38 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/java/jsp.cr"
+
+describe "JSP param extraction" do
+  options = create_test_options
+  instance = Analyzer::Java::Jsp.new(options)
+
+  it "extracts getParameter as a query param" do
+    params = instance.extract_params(%q(<%= request.getParameter("username") %>))
+    params.map(&.name).should contain("username")
+  end
+
+  it "extracts a user-meaningful getAttribute as a query param" do
+    params = instance.extract_params(%q(<% Object userId = request.getAttribute("userId"); %>))
+    params.map(&.name).should contain("userId")
+  end
+
+  # Container/framework-managed request attributes are populated by the
+  # servlet engine or filters, never by user input. They previously
+  # leaked into the parameter list (e.g. `javax.servlet.request.*` on
+  # TLS info JSPs) and must be filtered out.
+  it "ignores container-managed servlet attributes" do
+    content = <<-JSP
+      <%= request.getAttribute("javax.servlet.request.ssl_session_id") %>
+      <%= request.getAttribute("jakarta.servlet.request.X509Certificate") %>
+      <%= request.getAttribute("org.springframework.web.servlet.HandlerMapping.bestMatchingPattern") %>
+      JSP
+    instance.extract_params(content).should be_empty
+  end
+
+  it "classifies known internal attribute namespaces" do
+    instance.internal_servlet_attribute?("javax.servlet.request.key_size").should be_true
+    instance.internal_servlet_attribute?("jakarta.servlet.forward.request_uri").should be_true
+    instance.internal_servlet_attribute?("org.apache.catalina.something").should be_true
+    instance.internal_servlet_attribute?("userId").should be_false
+    instance.internal_servlet_attribute?("customAttribute").should be_false
+  end
+end

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -160,6 +160,37 @@ describe "EndpointOptimizer" do
       result[1].params[0].name.should eq("post_id")
     end
 
+    it "names catch-all path variables without the leading asterisk" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/files/{*path}", "GET"), # Spring / Armeria / ASP.NET
+        Endpoint.new("/static/{*remaining}/raw", "GET"),
+      ]
+
+      result = optimizer.add_path_parameters(endpoints)
+      result[0].params.size.should eq(1)
+      result[0].params[0].name.should eq("path")
+      result[0].params[0].param_type.should eq("path")
+
+      result[1].params.size.should eq(1)
+      result[1].params[0].name.should eq("remaining")
+    end
+
+    it "ignores bare glob splats that are not real parameter names" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/glob/**", "GET"),      # Armeria glob: captures `*`, not a name
+        Endpoint.new("/assets/*file", "GET"), # named splat is still a parameter
+      ]
+
+      result = optimizer.add_path_parameters(endpoints)
+      result[0].params.size.should eq(0)
+
+      result[1].params.size.should eq(1)
+      result[1].params[0].name.should eq("file")
+      result[1].params[0].param_type.should eq("path")
+    end
+
     it "extracts parameters from angle bracket patterns" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -59,7 +59,19 @@ module Analyzer::Java
                                 else
                                   Hash(String, String).new
                                 end
+                    # Built lazily on the first builder-chain match: marks
+                    # char offsets that live inside a string literal or
+                    # comment so we can ignore `Server.builder()...build()`
+                    # chains that only appear in documentation strings or
+                    # `@Description` examples (a real FP source in Kotlin
+                    # docs and Java text blocks).
+                    non_code_mask = nil.as(Array(Bool)?)
                     content.scan(REGEX_SERVER_CODE_BLOCK) do |server_codeblock_match|
+                      start = server_codeblock_match.begin(0)
+                      if start
+                        mask = (non_code_mask ||= build_non_code_mask(content))
+                        next if start < mask.size && mask[start]
+                      end
                       server_codeblock = server_codeblock_match[0]
 
                       collect_service_routes(server_codeblock, constants, details, service_with_routes_index)
@@ -568,6 +580,84 @@ module Analyzer::Java
       tail = expr[start..]?.to_s.strip
       args << tail unless tail.empty?
       args
+    end
+
+    # Marks character offsets that fall inside a string literal or a
+    # comment. Used to reject `Server.builder()...build()` chains that
+    # only appear inside documentation — e.g. an `@Description` value or
+    # a Java text block / Kotlin raw string showing example code. Handles
+    # `//` line comments, `/* */` block comments, triple-quoted strings,
+    # double-quoted strings and char literals (with `\` escapes).
+    private def build_non_code_mask(content : String) : Array(Bool)
+      chars = content.chars
+      n = chars.size
+      mask = Array(Bool).new(n, false)
+      i = 0
+      while i < n
+        c = chars[i]
+        nxt = i + 1 < n ? chars[i + 1] : '\0'
+
+        if c == '/' && nxt == '/'
+          while i < n && chars[i] != '\n'
+            mask[i] = true
+            i += 1
+          end
+          next
+        end
+
+        if c == '/' && nxt == '*'
+          mask[i] = true
+          mask[i + 1] = true
+          i += 2
+          while i < n
+            if chars[i] == '*' && i + 1 < n && chars[i + 1] == '/'
+              mask[i] = true
+              mask[i + 1] = true
+              i += 2
+              break
+            end
+            mask[i] = true
+            i += 1
+          end
+          next
+        end
+
+        if c == '"' && nxt == '"' && i + 2 < n && chars[i + 2] == '"'
+          mask[i] = mask[i + 1] = mask[i + 2] = true
+          i += 3
+          while i < n
+            if chars[i] == '"' && i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '"'
+              mask[i] = mask[i + 1] = mask[i + 2] = true
+              i += 3
+              break
+            end
+            mask[i] = true
+            i += 1
+          end
+          next
+        end
+
+        if c == '"' || c == '\''
+          mask[i] = true
+          i += 1
+          while i < n
+            ch = chars[i]
+            if ch == '\\'
+              mask[i] = true
+              mask[i + 1] = true if i + 1 < n
+              i += 2
+              next
+            end
+            mask[i] = true
+            i += 1
+            break if ch == c
+          end
+          next
+        end
+
+        i += 1
+      end
+      mask
     end
 
     private def find_matching_delimiter(code : String,

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -980,7 +980,10 @@ module Analyzer::Java
       return params unless fparams
 
       path_param_names = Set(String).new
-      url_path.scan(/\{(\w+)\}/) do |match|
+      # `\*?` also matches Armeria's rest-path capture `{*name}` so a
+      # matching `@Param name` is recognised as a path variable rather
+      # than emitted as a spurious query parameter.
+      url_path.scan(/\{\*?(\w+)\}/) do |match|
         path_param_names << match[1] if match.size > 1
       end
 
@@ -1097,8 +1100,9 @@ module Analyzer::Java
     end
 
     # Extract path parameters from URLs like /users/{userId} or /items/{itemId}/comments
+    # (`\*?` also captures the rest-path form `{*name}` as `name`).
     private def extract_path_parameters(url : String, endpoint : Endpoint)
-      url.scan(/\{(\w+)\}/) do |match|
+      url.scan(/\{\*?(\w+)\}/) do |match|
         if match.size > 0
           param_name = match[1]
           # Only add if not already present

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -54,18 +54,19 @@ module Analyzer::Java
                     # Server.builder()-style routes (regex-scoped — the
                     # builder chain isn't worth a dedicated TS walk yet).
                     details = Details.new(PathInfo.new(path))
-                    constants = if path.ends_with?(".java")
-                                  Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content)
-                                else
-                                  Hash(String, String).new
-                                end
-                    # Built lazily on the first builder-chain match: marks
-                    # char offsets that live inside a string literal or
-                    # comment so we can ignore `Server.builder()...build()`
-                    # chains that only appear in documentation strings or
-                    # `@Description` examples (a real FP source in Kotlin
-                    # docs and Java text blocks).
+                    # Both the string-constant table (a full tree-sitter
+                    # parse) and the non-code mask (a char walk) are only
+                    # needed once a `Server.builder()...build()` chain is
+                    # actually present. Most files are annotated services
+                    # with no builder chain at all, so build both lazily
+                    # on the first match to avoid parsing every file twice.
+                    #
+                    # The mask marks char offsets inside string literals or
+                    # comments, letting us drop builder chains that only
+                    # appear in documentation (e.g. a Kotlin `@Description`
+                    # value or a Java text block) — a real FP source.
                     non_code_mask = nil.as(Array(Bool)?)
+                    constants = nil.as(Hash(String, String)?)
                     content.scan(REGEX_SERVER_CODE_BLOCK) do |server_codeblock_match|
                       start = server_codeblock_match.begin(0)
                       if start
@@ -74,8 +75,9 @@ module Analyzer::Java
                       end
                       server_codeblock = server_codeblock_match[0]
 
-                      collect_service_routes(server_codeblock, constants, details, service_with_routes_index)
-                      collect_builder_routes(server_codeblock, constants, details)
+                      resolved_constants = constants ||= (path.ends_with?(".java") ? Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content) : Hash(String, String).new)
+                      collect_service_routes(server_codeblock, resolved_constants, details, service_with_routes_index)
+                      collect_builder_routes(server_codeblock, resolved_constants, details)
                     end
                   end
                 rescue File::NotFoundError

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -97,10 +97,31 @@ module Analyzer::Java
       servlet_methods
     end
 
-    private def extract_params(content : String) : Array(Param)
+    # Container- and framework-managed request attributes. These are
+    # populated by the servlet engine, filters or the MVC layer — never
+    # by user input — so `request.getAttribute("javax.servlet....")`
+    # must not be reported as a request parameter.
+    INTERNAL_ATTRIBUTE_PREFIXES = [
+      "javax.servlet.", "jakarta.servlet.",
+      "javax.faces.", "jakarta.faces.",
+      "org.springframework.", "org.apache.",
+      "org.eclipse.jetty.", "org.glassfish.",
+      "com.sun.", "weblogic.", "io.undertow.",
+    ]
+
+    def internal_servlet_attribute?(name : String) : Bool
+      INTERNAL_ATTRIBUTE_PREFIXES.any? { |prefix| name.starts_with?(prefix) }
+    end
+
+    def extract_params(content : String) : Array(Param)
       params = [] of Param
 
-      content.scan(/request\s*\.\s*get(?:Parameter|ParameterValues|Attribute)\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+      content.scan(/request\s*\.\s*get(?:Parameter|ParameterValues)\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+        add_param(params, match[1], "query")
+      end
+
+      content.scan(/request\s*\.\s*getAttribute\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+        next if internal_servlet_attribute?(match[1])
         add_param(params, match[1], "query")
       end
 
@@ -273,7 +294,12 @@ module Analyzer::Java
       request_receivers.each do |receiver|
         receiver_pattern = Regex.escape(receiver)
 
-        content.scan(/#{receiver_pattern}\s*\.\s*get(?:Parameter|ParameterValues|Attribute)\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+        content.scan(/#{receiver_pattern}\s*\.\s*get(?:Parameter|ParameterValues)\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+          add_param(params, match[1], request_param_type)
+        end
+
+        content.scan(/#{receiver_pattern}\s*\.\s*getAttribute\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+          next if internal_servlet_attribute?(match[1])
           add_param(params, match[1], request_param_type)
         end
 

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -362,12 +362,12 @@ module Analyzer::Java
         next if JavaEngine.test_path?(path)
 
         content = read_file_content(path)
-        # Only Java interface declarations carry inheritable controller
-        # routes here (Feign, Spring HTTP Interface, and OpenAPI-style
-        # `*Api` interfaces). Files with no `interface` keyword — the
-        # bulk of controller classes — can't contribute, so skip the
-        # parse before the annotation gate below.
-        next unless content.includes?("interface")
+        # Inheritable routes come from Java interfaces (Feign, Spring HTTP
+        # Interface, OpenAPI-style `*Api`) and from `abstract` base
+        # classes that concrete controllers extend. Files with neither
+        # keyword — the bulk of controller classes — can't contribute, so
+        # skip the parse before the annotation gate below.
+        next unless content.includes?("interface") || content.includes?("abstract")
         next unless content.includes?(spring_web_bind_package) || http_exchange_bindings?(content, http_exchange_package) ||
                     content.includes?("@RequestMapping") ||
                     content.includes?("@GetMapping") || content.includes?("@PostMapping")

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -333,6 +333,11 @@ module Analyzer::Java
 
         content = read_file_content(path)
         next unless content.includes?(spring_web_bind_package)
+        # Composed (meta) mapping annotations are declared as Java
+        # annotation types (`@interface`). A file without one cannot
+        # contribute to this index, so skip the tree-sitter parse for
+        # the (overwhelming) majority of regular controller classes.
+        next unless content.includes?("@interface")
 
         Noir::TreeSitter.parse_java(content) do |root|
           package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
@@ -357,6 +362,12 @@ module Analyzer::Java
         next if JavaEngine.test_path?(path)
 
         content = read_file_content(path)
+        # Only Java interface declarations carry inheritable controller
+        # routes here (Feign, Spring HTTP Interface, and OpenAPI-style
+        # `*Api` interfaces). Files with no `interface` keyword — the
+        # bulk of controller classes — can't contribute, so skip the
+        # parse before the annotation gate below.
+        next unless content.includes?("interface")
         next unless content.includes?(spring_web_bind_package) || http_exchange_bindings?(content, http_exchange_package) ||
                     content.includes?("@RequestMapping") ||
                     content.includes?("@GetMapping") || content.includes?("@PostMapping")

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -184,6 +184,13 @@ module Noir
           return
         end
 
+        # An `abstract` base is never mapped directly — its routes only
+        # exist through a concrete subclass (resolved separately via the
+        # inherited-route index). Walk into it for nested types but don't
+        # emit its own method routes, otherwise an un-prefixed phantom
+        # endpoint (e.g. `GET /list` for `BaseController.list`) leaks.
+        is_abstract = ty == "class_declaration" && abstract_class?(node, source)
+
         class_name = class_simple_name(node, source)
         mapping = class_mapping(node, source, constants, class_name, meta_mappings)
         class_prefixes = mapping.paths
@@ -201,7 +208,7 @@ module Noir
           Noir::TreeSitter.each_named_child(body) do |member|
             case Noir::TreeSitter.node_type(member)
             when "method_declaration"
-              collect_method_routes(member, source, class_name, prefixes, verbs, params, routes, constants, meta_mappings)
+              collect_method_routes(member, source, class_name, prefixes, verbs, params, routes, constants, meta_mappings) unless is_abstract
             when "class_declaration", "interface_declaration"
               walk_classes(member, source, prefixes, verbs, params, routes, constants, meta_mappings)
             end
@@ -223,20 +230,26 @@ module Noir
                                       depth : Int32 = 0)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
+      # Both interfaces and `abstract` base classes can declare routes
+      # that a concrete controller inherits, so index either under its
+      # simple name.
       ty = Noir::TreeSitter.node_type(node)
-      if ty == "interface_declaration"
-        interface_name = class_simple_name(node, source)
-        mapping = class_mapping(node, source, constants, interface_name, meta_mappings)
+      indexable = ty == "interface_declaration" || (ty == "class_declaration" && abstract_class?(node, source))
+      if indexable
+        type_name = class_simple_name(node, source)
+        mapping = class_mapping(node, source, constants, type_name, meta_mappings)
         prefixes = mapping.paths
         prefixes = [""] if prefixes.empty?
 
         if body = Noir::TreeSitter.field(node, "body")
           Noir::TreeSitter.each_named_child(body) do |member|
             next unless Noir::TreeSitter.node_type(member) == "method_declaration"
-            collect_method_routes(member, source, interface_name, prefixes, mapping.verbs, mapping.params, routes[interface_name], constants, meta_mappings)
+            collect_method_routes(member, source, type_name, prefixes, mapping.verbs, mapping.params, routes[type_name], constants, meta_mappings)
           end
         end
-        return
+        # Interfaces never enclose a controller; an abstract class might
+        # nest one, so keep descending for the class case.
+        return if ty == "interface_declaration"
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
@@ -254,6 +267,13 @@ module Noir
 
       if Noir::TreeSitter.node_type(node) == "class_declaration"
         interface_names = implemented_interface_names(node, source)
+        # A concrete controller can also inherit `@*Mapping` methods from
+        # an `abstract` base class (generic CRUD bases are common). Treat
+        # the superclass exactly like an implemented interface — its
+        # routes are resolved from the same index.
+        if superclass = superclass_name(node, source)
+          interface_names << superclass unless interface_names.includes?(superclass)
+        end
         if !interface_names.empty? && spring_controller_class?(node, source)
           class_name = class_simple_name(node, source)
           mapping = class_mapping(node, source, constants, class_name, meta_mappings)
@@ -332,6 +352,50 @@ module Noir
       end
       names.uniq!
       names
+    end
+
+    # An `abstract class` is never instantiated as a controller, so its
+    # `@*Mapping` methods are only ever served through a concrete
+    # subclass. We use this both to suppress the base's standalone routes
+    # and to index it as an inheritable route source.
+    private def abstract_class?(decl : LibTreeSitter::TSNode, source : String) : Bool
+      return false unless mods = find_modifiers(decl)
+      Noir::TreeSitter.node_text(mods, source).split.includes?("abstract")
+    end
+
+    # Simple name of the `extends` superclass, or nil. Type-parameter
+    # bounds (`<T extends Number>`) are stripped first so they aren't
+    # mistaken for the superclass, and the body `{` is located after the
+    # `class` keyword so a `{}` inside a class-level annotation argument
+    # doesn't truncate the header early.
+    private def superclass_name(class_decl : LibTreeSitter::TSNode, source : String) : String?
+      header = Noir::TreeSitter.node_text(class_decl, source)
+      keyword = header.index(/\bclass\b/) || 0
+      if body_start = header.index('{', keyword)
+        header = header[...body_start]
+      end
+      header = strip_angle_sections(header)
+      return unless match = header.match(/\bextends\s+([A-Za-z_][A-Za-z0-9_.]*)/)
+
+      type_name = match[1]
+      if idx = type_name.rindex('.')
+        type_name[(idx + 1)..]
+      else
+        type_name
+      end
+    end
+
+    private def strip_angle_sections(text : String) : String
+      String.build do |io|
+        depth = 0
+        text.each_char do |ch|
+          case ch
+          when '<' then depth += 1
+          when '>' then depth -= 1 if depth > 0
+          else          io << ch if depth == 0
+          end
+        end
+      end
     end
 
     private def split_top_level_commas(text : String) : Array(String)

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -363,38 +363,23 @@ module Noir
       Noir::TreeSitter.node_text(mods, source).split.includes?("abstract")
     end
 
-    # Simple name of the `extends` superclass, or nil. Type-parameter
-    # bounds (`<T extends Number>`) are stripped first so they aren't
-    # mistaken for the superclass, and the body `{` is located after the
-    # `class` keyword so a `{}` inside a class-level annotation argument
-    # doesn't truncate the header early.
+    # Simple name of the `extends` superclass, or nil. Read straight from
+    # the tree-sitter `superclass` field so neither class-level annotation
+    # arguments nor `<T extends Number>` type-parameter bounds can confuse
+    # the parse; generic arguments on the parent type (`Parent<T>`) are
+    # stripped, and a qualified name keeps only its last segment.
     private def superclass_name(class_decl : LibTreeSitter::TSNode, source : String) : String?
-      header = Noir::TreeSitter.node_text(class_decl, source)
-      keyword = header.index(/\bclass\b/) || 0
-      if body_start = header.index('{', keyword)
-        header = header[...body_start]
-      end
-      header = strip_angle_sections(header)
-      return unless match = header.match(/\bextends\s+([A-Za-z_][A-Za-z0-9_.]*)/)
+      return unless superclass = Noir::TreeSitter.field(class_decl, "superclass")
+      return unless LibTreeSitter.ts_node_named_child_count(superclass) > 0
 
-      type_name = match[1]
-      if idx = type_name.rindex('.')
-        type_name[(idx + 1)..]
+      type_node = LibTreeSitter.ts_node_named_child(superclass, 0_u32)
+      name = strip_generic_arguments(Noir::TreeSitter.node_text(type_node, source))
+      return if name.empty?
+
+      if idx = name.rindex('.')
+        name[(idx + 1)..]
       else
-        type_name
-      end
-    end
-
-    private def strip_angle_sections(text : String) : String
-      String.build do |io|
-        depth = 0
-        text.each_char do |ch|
-          case ch
-          when '<' then depth += 1
-          when '>' then depth -= 1 if depth > 0
-          else          io << ch if depth == 0
-          end
-        end
+        name
       end
     end
 

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -285,7 +285,12 @@ class EndpointOptimizer
       # Handle {param} patterns
       scans = endpoint.url.scan(/\/\{([^}]+)\}/).flatten
       scans.each do |match|
-        param = match[1].split(":")[0]
+        # Strip a leading `*` from catch-all path variables. Spring,
+        # Armeria and ASP.NET all spell the rest-of-path capture as
+        # `{*name}` (e.g. `/files/{*path}`); the parameter is named
+        # `name`, not `*name`.
+        param = match[1].split(":")[0].lstrip('*')
+        next if param.empty?
         new_value = apply_pvalue("path", param, "")
         unless new_value.empty?
           new_endpoint.url = new_endpoint.url.gsub("{#{match[1]}}", new_value)
@@ -355,6 +360,11 @@ class EndpointOptimizer
       # Handle /*param patterns (wildcard/glob parameters)
       scans = endpoint.url.scan(/\/\*([^\/]+)/).flatten
       scans.each do |match|
+        # Only named splats are parameters (`/files/*path` -> `path`).
+        # A bare glob like Armeria's `glob:/glob/**` captures `*`, and
+        # a gRPC resource template leaves a trailing `}` — neither is a
+        # real parameter name.
+        next unless valid_path_param_name?(match[1])
         new_value = apply_pvalue("path", match[1], "")
         unless new_value.empty?
           new_endpoint.url = new_endpoint.url.gsub("*#{match[1]}", new_value)


### PR DESCRIPTION
## Summary

Tested the Java **Armeria / JSP / Spring** analyzers against real open-source repositories (line/armeria, spring-projects/spring-boot, spring-petclinic, bodgeit, WebGoat-Legacy) and fixed accuracy (FP/FN) issues for Endpoint / Callee / AI-context identification, plus two Java-analyzer performance wins.

Six self-contained commits.

### Accuracy (FP/FN)

- **Armeria builder-chain doc FP** — `Server.builder()...build()` was matched inside string literals/comments, so a Kotlin `@Description` value containing example wiring leaked phantom routes (`ANY /hello`, `/api/thrift`, `/monitor/l7check`). Skip any match whose start offset falls inside a string/comment via a lazily-built non-code mask.
- **JSP container-attribute FP** — `request.getAttribute("javax.servlet.request.ssl_session_id")` and friends were reported as query params on TLS-info JSPs. Filter known container/framework namespaces (`javax.servlet.`, `jakarta.servlet.`, `org.springframework.`, `org.apache.`, …); application attributes like `userId` stay (intentional, per the existing `attribute.jsp` fixture).
- **Catch-all / glob path-param names (global optimizer)** — `{*path}` (Spring/Armeria/ASP.NET) produced a param literally named `*path`; Armeria's bare glob `**` and gRPC resource templates produced junk params (`*`, `}`). Strip the leading `*` from `{*name}` and guard the splat branch with `valid_path_param_name?`. The Armeria analyzer now also maps `@Param` of a `{*name}` capture to the path var (no duplicate query param).
- **Spring abstract base controller inheritance** — a `@RestController` extending an `abstract` base inherited the base's `@*Mapping` methods under the subclass prefix; noir missed those and instead leaked the base's un-prefixed phantoms (`GET /list` instead of `GET /users/list`). Mirrors the existing interface-inheritance machinery for class inheritance (index abstract bases, treat `extends` like `implements`, suppress the abstract class's own routes). Concrete-base inheritance intentionally out of scope.

### Performance (Java analyzers)

- **Spring index pre-passes gated** — the meta-annotation and interface-route index passes tree-sitter-parsed nearly every controller. Meta mappings only come from `@interface` defs and inheritable routes only from `interface`/`abstract` decls, so cheap substring gates cut spring-boot pre-pass parses 292 → 17 (~29% faster on a controller-dense scan, byte-identical output).
- **Armeria lazy string-constants** — `extract_string_constants` (a full parse) ran for every `.java` file even with no `Server.builder()` chain; now built lazily on the first builder hit. Full line/armeria scan ~35% faster, identical output.

## Verification

- Full spec suite: **18,010 examples, 0 failures**.
- Output equivalence confirmed on real repos (spring-boot 27→27, armeria 32→32 — no routes lost); spring-petclinic MVC 17/17 clean; WebFlux functional routing, `@RequestMapping(method=…)`, multi-path `@GetMapping({...})`, JSP forms + web.xml jsp-file mappings all verified accurate.
- Regression tests added: Armeria (doc-string + rest-path fixtures), JSP unit spec, optimizer unit tests (catch-all/glob), Spring abstract-base fixture.

## Known remaining (not in this PR)

- Armeria Kotlin annotated services (`@Get` on `.kt`) — tree-sitter-java can't parse Kotlin.
- Armeria `regex:`/`glob:` path representation glues the scheme onto the service prefix, and `(?<name>)` still dups one path param.