### PR TITLE
Recover Django routes from urls.py without a ROOT_URLCONF anchor

### DIFF
--- a/spec/functional_test/fixtures/python/django_app_urls/blog/urls/__init__.py
+++ b/spec/functional_test/fixtures/python/django_app_urls/blog/urls/__init__.py
@@ -1,0 +1,13 @@
+from django.urls import include, path
+
+from blog import views
+
+# A `urls/` package whose `__init__.py` is the app's urlconf and which
+# include()s a sibling module. Exercises the orphan-urlconf fallback's
+# prefix nesting and visited-dedup: `dashboard/` must surface as
+# `/admin/dashboard/` (mounted under the include prefix), not as a
+# second bare `/dashboard/` from processing admin.py as its own root.
+urlpatterns = [
+    path("posts/", views.posts),
+    path("admin/", include("blog.urls.admin")),
+]

--- a/spec/functional_test/fixtures/python/django_app_urls/blog/urls/admin.py
+++ b/spec/functional_test/fixtures/python/django_app_urls/blog/urls/admin.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from blog import views
+
+urlpatterns = [
+    path("dashboard/", views.dashboard),
+]

--- a/spec/functional_test/fixtures/python/django_app_urls/blog/views.py
+++ b/spec/functional_test/fixtures/python/django_app_urls/blog/views.py
@@ -1,0 +1,9 @@
+from django.http import JsonResponse
+
+
+def posts(request):
+    return JsonResponse({"posts": []})
+
+
+def dashboard(request):
+    return JsonResponse({"ok": True})

--- a/spec/functional_test/fixtures/python/django_app_urls/myapp/urls.py
+++ b/spec/functional_test/fixtures/python/django_app_urls/myapp/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from myapp import views
+
+# A reusable Django app ships its own `urls.py` with `urlpatterns`,
+# but no project `settings.py` declaring `ROOT_URLCONF`. Noir must
+# still surface these routes (app-relative) instead of returning
+# nothing.
+urlpatterns = [
+    path("api/ping/", views.ping),
+    path("api/items/", views.items),
+    path("api/items/<int:item_id>/", views.item_detail),
+]

--- a/spec/functional_test/fixtures/python/django_app_urls/myapp/views.py
+++ b/spec/functional_test/fixtures/python/django_app_urls/myapp/views.py
@@ -1,0 +1,13 @@
+from django.http import JsonResponse
+
+
+def ping(request):
+    return JsonResponse({"ok": True})
+
+
+def items(request):
+    return JsonResponse({"items": []})
+
+
+def item_detail(request, item_id):
+    return JsonResponse({"id": item_id})

--- a/spec/functional_test/testers/python/django_app_urls_spec.cr
+++ b/spec/functional_test/testers/python/django_app_urls_spec.cr
@@ -1,15 +1,23 @@
 require "../../func_spec.cr"
 
-# Regression: a reusable Django app (or any project scanned at the
-# app level) ships `urls.py` with `urlpatterns` but no project
-# `settings.py` declaring `ROOT_URLCONF`. The ROOT_URLCONF-anchored
-# pass finds no root, so before the orphan-urlconf fallback the whole
-# app mapped to zero endpoints. Paths are app-relative because there
-# is no host project to supply a mount prefix.
+# Regression: a reusable Django app (or any project scanned at the app
+# level) ships `urls.py` / a `urls/` package with `urlpatterns` but no
+# project `settings.py` declaring `ROOT_URLCONF`. The ROOT_URLCONF-
+# anchored pass finds no root, so before the orphan-urlconf fallback
+# the whole app mapped to zero endpoints. Paths are app-relative
+# because there is no host project to supply a mount prefix.
+#
+# `blog/urls/__init__.py` also `include()`s a sibling module, locking
+# in the fallback's prefix nesting and visited-dedup: the sibling's
+# `dashboard/` surfaces once as `/admin/dashboard/` (mounted under the
+# include prefix), never as a bare `/dashboard/` from processing
+# `admin.py` as its own root — the `:endpoints => 5` count enforces it.
 extracted_endpoints = [
   Endpoint.new("/api/ping/", "GET"),
   Endpoint.new("/api/items/", "GET"),
   Endpoint.new("/api/items/<int:item_id>/", "GET"),
+  Endpoint.new("/posts/", "GET"),
+  Endpoint.new("/admin/dashboard/", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/django_app_urls/", {

--- a/spec/functional_test/testers/python/django_app_urls_spec.cr
+++ b/spec/functional_test/testers/python/django_app_urls_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+# Regression: a reusable Django app (or any project scanned at the
+# app level) ships `urls.py` with `urlpatterns` but no project
+# `settings.py` declaring `ROOT_URLCONF`. The ROOT_URLCONF-anchored
+# pass finds no root, so before the orphan-urlconf fallback the whole
+# app mapped to zero endpoints. Paths are app-relative because there
+# is no host project to supply a mount prefix.
+extracted_endpoints = [
+  Endpoint.new("/api/ping/", "GET"),
+  Endpoint.new("/api/items/", "GET"),
+  Endpoint.new("/api/items/<int:item_id>/", "GET"),
+]
+
+FunctionalTester.new("fixtures/python/django_app_urls/", {
+  :techs     => 1,
+  :endpoints => extracted_endpoints.size,
+}, extracted_endpoints).perform_tests

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -43,6 +43,24 @@ module Analyzer::Python
         end
       end
 
+      # Fall back to scanning `urls.py` modules directly when the
+      # ROOT_URLCONF-anchored pass above produced nothing. Reusable
+      # Django apps and libraries (Wagtail, DRF, …) — and any project
+      # scanned at the app level — ship `urls.py` files with
+      # `urlpatterns` but no project `settings.py` declaring
+      # `ROOT_URLCONF`, so the anchored pass finds no root and the
+      # whole app silently maps to zero endpoints. Treating each
+      # unvisited, non-test `urls.py` as its own routing root recovers
+      # those routes (app-relative, since there is no host-project
+      # mount prefix to apply). Gated on an empty result so every
+      # project that DOES expose a ROOT_URLCONF keeps its fully
+      # prefixed paths and sees no behavior change.
+      if endpoints.empty?
+        extract_endpoints_from_orphan_urlconfs.each do |endpoint|
+          endpoints << endpoint
+        end
+      end
+
       # Find static files
       begin
         static_prefix = "#{@base_path}/static/"
@@ -52,6 +70,51 @@ module Analyzer::Python
         end
       rescue e
         logger.debug e
+      end
+
+      endpoints
+    end
+
+    # Treat every unvisited, non-test `urls.py` (or `urls/` package
+    # module) carrying a `urlpatterns` as its own routing root. Used
+    # only as a fallback when no ROOT_URLCONF anchor exists, so the
+    # paths are app-relative — there is no host project to supply a
+    # mount prefix. `extract_endpoints` marks each file (and anything
+    # it `include()`s) visited, so a module pulled in by another is
+    # not processed twice.
+    private def extract_endpoints_from_orphan_urlconfs : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      candidates = all_files.select do |file|
+        next false unless file.ends_with?(".py")
+        next false if file.includes?("/site-packages/")
+        next false if PythonEngine.python_test_path?(file, @base_path)
+        next false if @visited_url_paths.has_key?(file)
+        File.basename(file) == "urls.py" || file.includes?("/urls/")
+      end
+
+      # Shallower paths first so a parent urlconf is processed before
+      # the modules it includes, keeping include() prefixes attached
+      # to the more specific routes where a parent exists in-tree.
+      candidates.sort_by! { |file| {file.count('/'), file} }
+
+      # Dotted include() targets (`include("app.sub.urls")`) and
+      # `from app.sub import urls` resolve against the scan root.
+      @django_base_path = @base_path
+
+      candidates.each do |file|
+        next if @visited_url_paths.has_key?(file)
+        begin
+          content = read_file_content(file)
+        rescue
+          next
+        end
+        next unless content.includes?("urlpatterns")
+
+        django_urls = DjangoUrls.new("", file, @base_path)
+        extract_endpoints(django_urls).each do |endpoint|
+          endpoints << endpoint
+        end
       end
 
       endpoints

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -89,7 +89,6 @@ module Analyzer::Python
         next false unless file.ends_with?(".py")
         next false if file.includes?("/site-packages/")
         next false if PythonEngine.python_test_path?(file, @base_path)
-        next false if @visited_url_paths.has_key?(file)
         File.basename(file) == "urls.py" || file.includes?("/urls/")
       end
 
@@ -102,8 +101,19 @@ module Analyzer::Python
       # `from app.sub import urls` resolve against the scan root.
       @django_base_path = @base_path
 
+      # Dedup by canonical (expanded) path. `all_files` entries and the
+      # paths `extract_endpoints` records when it follows an `include()`
+      # can spell the same file differently (`./` prefix, trailing or
+      # doubled slashes) depending on how the base path was passed, so a
+      # plain string compare would re-process a module a parent urlconf
+      # already pulled in — surfacing its routes a second time without
+      # the include() prefix.
+      visited = Set(::String).new
+      @visited_url_paths.each_key { |key| visited << File.expand_path(key) }
+
       candidates.each do |file|
-        next if @visited_url_paths.has_key?(file)
+        expanded = File.expand_path(file)
+        next if visited.includes?(expanded)
         begin
           content = read_file_content(file)
         rescue
@@ -115,6 +125,7 @@ module Analyzer::Python
         extract_endpoints(django_urls).each do |endpoint|
           endpoints << endpoint
         end
+        @visited_url_paths.each_key { |key| visited << File.expand_path(key) }
       end
 
       endpoints


### PR DESCRIPTION
## Summary

The Django analyzer discovered endpoints **only** by following `ROOT_URLCONF` from a project `settings.py`. Reusable Django apps and libraries (Wagtail, DRF) — and any project scanned at the app level — ship `urls.py` modules with `urlpatterns` but no such settings, so the entire app silently mapped to **zero endpoints**.

This adds a fallback that, **only when the ROOT_URLCONF-anchored pass finds nothing**, treats each unvisited, non-test `urls.py` as its own routing root. Paths are app-relative (there is no host project to supply a mount prefix). `extract_endpoints` marks each file and anything it `include()`s as visited, so a module pulled in by another is not processed twice.

The `endpoints.empty?` gate means every project that *does* expose a `ROOT_URLCONF` keeps its fully-prefixed paths and sees **no behavior change**.

## Verified on real-world repos

| repo | before | after |
|---|---|---|
| wagtail | 0 | **171** |
| django-rest-framework | 0 | **2** |
| bakerydemo | 12 | 12 (unchanged) |
| django-oscar | 8 | 8 (unchanged) |
| Netflix/dispatch (FastAPI) | 298 | 298 (unchanged) |
| microblog (Flask) | 35 | 35 (unchanged) |

Full Python functional suite stays green (1782 examples, 0 failures). Adds a regression fixture (`spec/functional_test/fixtures/python/django_app_urls/`) + tester covering the orphan-urlconf case.

## Commits
- Recover Django routes from urls.py without a ROOT_URLCONF anchor
- Add regression test for Django urls.py without ROOT_URLCONF