### PR TITLE
Reduce FN/FP in AI (LLM) analyzer: prompts, validation guards, ACP token budget

### DIFF
--- a/spec/unit_test/analyzer/analyzers/llm_analyzers/validation_spec.cr
+++ b/spec/unit_test/analyzer/analyzers/llm_analyzers/validation_spec.cr
@@ -1,0 +1,101 @@
+require "../../../../spec_helper"
+require "../../../../../src/analyzer/analyzers/llm_analyzers/unified_ai"
+
+# Test hooks for the deterministic FP/FN guards. These run entirely
+# offline (no LLM call) and assert that hallucinated URLs/params are
+# dropped while legitimate ones survive.
+class Analyzer::AI::Unified
+  def __test_plausible_url(url : String) : Bool
+    plausible_endpoint_url?(url)
+  end
+
+  def __test_plausible_param(name : String) : Bool
+    plausible_param_name?(name)
+  end
+
+  def __test_create_endpoint(json : String) : Endpoint?
+    create_endpoint_from_json(JSON.parse(json), "/tmp/ai_detected")
+  end
+end
+
+private def build_validation_analyzer : Analyzer::AI::Unified
+  options = create_test_options
+  options["base"] = YAML::Any.new([YAML::Any.new(".")])
+  options["ai_provider"] = YAML::Any.new("openai")
+  options["ai_model"] = YAML::Any.new("gpt-4o-mini")
+  options["ai_max_token"] = YAML::Any.new(1024)
+  Analyzer::AI::Unified.new(options)
+end
+
+describe Analyzer::AI::Unified do
+  describe "endpoint url plausibility" do
+    analyzer = build_validation_analyzer
+
+    it "accepts real request paths" do
+      analyzer.__test_plausible_url("/api/v1/users").should be_true
+      analyzer.__test_plausible_url("/users/{id}").should be_true
+      analyzer.__test_plausible_url("/users/:id").should be_true
+      analyzer.__test_plausible_url("/users/<int:id>").should be_true
+      analyzer.__test_plausible_url("/").should be_true
+      analyzer.__test_plausible_url("https://api.example.com/v1/items").should be_true
+    end
+
+    it "rejects URLs that leak whitespace (captured prose or 'METHOD /path')" do
+      analyzer.__test_plausible_url("GET /api/users").should be_false
+      analyzer.__test_plausible_url("/api/users get all users").should be_false
+      analyzer.__test_plausible_url("/api/\nusers").should be_false
+      analyzer.__test_plausible_url("/api/\tusers").should be_false
+    end
+
+    it "rejects empty and placeholder URLs" do
+      analyzer.__test_plausible_url("").should be_false
+      analyzer.__test_plausible_url("url").should be_false
+      analyzer.__test_plausible_url("/endpoint").should be_false
+      analyzer.__test_plausible_url("N/A").should be_false
+      analyzer.__test_plausible_url("none").should be_false
+      analyzer.__test_plausible_url("path/to/endpoint").should be_false
+      analyzer.__test_plausible_url("...").should be_false
+    end
+
+    it "rejects markdown/code noise and oversized URLs" do
+      analyzer.__test_plausible_url("/api/`users`").should be_false
+      analyzer.__test_plausible_url("/#{"a" * 3000}").should be_false
+    end
+  end
+
+  describe "param name plausibility" do
+    analyzer = build_validation_analyzer
+
+    it "accepts identifier-like names" do
+      analyzer.__test_plausible_param("id").should be_true
+      analyzer.__test_plausible_param("user_id").should be_true
+      analyzer.__test_plausible_param("X-Api-Key").should be_true
+    end
+
+    it "rejects names with whitespace or that are oversized" do
+      analyzer.__test_plausible_param("").should be_false
+      analyzer.__test_plausible_param("the user id").should be_false
+      analyzer.__test_plausible_param("a\tb").should be_false
+      analyzer.__test_plausible_param("x" * 200).should be_false
+    end
+  end
+
+  describe "create_endpoint_from_json" do
+    analyzer = build_validation_analyzer
+
+    it "builds a valid endpoint and drops garbage params" do
+      ep = analyzer.__test_create_endpoint(
+        %({"url":"/api/items","method":"post","params":[{"name":"q","param_type":"query","value":""},{"name":"bad name","param_type":"query","value":""}]})
+      )
+      ep = ep.should_not be_nil
+      ep.url.should eq("/api/items")
+      ep.method.should eq("POST")
+      ep.params.map(&.name).should eq(["q"])
+    end
+
+    it "returns nil for a hallucinated url" do
+      analyzer.__test_create_endpoint(%({"url":"GET /api/x","method":"GET","params":[]})).should be_nil
+      analyzer.__test_create_endpoint(%({"url":"endpoint","method":"GET","params":[]})).should be_nil
+    end
+  end
+end

--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -414,4 +414,21 @@ describe LLM do
       LLM.acp_max_tokens?("https://api.openai.com").should be_nil
     end
   end
+
+  describe "clean_token?" do
+    it "accepts identifier-like and path-like tokens" do
+      LLM.clean_token?("/api/v1/users", 2048).should be_true
+      LLM.clean_token?("user_id", 128).should be_true
+      LLM.clean_token?("X-Api-Key", 128).should be_true
+    end
+
+    it "rejects empty, whitespace, control, backtick, and oversized tokens" do
+      LLM.clean_token?("", 128).should be_false
+      LLM.clean_token?("a b", 128).should be_false
+      LLM.clean_token?("a\tb", 128).should be_false
+      LLM.clean_token?("a\nb", 128).should be_false
+      LLM.clean_token?("a`b", 128).should be_false
+      LLM.clean_token?("x" * 200, 128).should be_false
+    end
+  end
 end

--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -17,6 +17,37 @@ describe LLM do
     LLM::ANALYZE_PROMPT.should contain("Input Code:")
   end
 
+  it "ANALYZE_PROMPT carries FN/FP accuracy guidance" do
+    # Full-path resolution is the biggest false-negative lever; the
+    # "only code that serves it" rule is the biggest false-positive
+    # lever. Assert both survive future prompt edits.
+    LLM::ANALYZE_PROMPT.should contain("FULL request path")
+    LLM::ANALYZE_PROMPT.should contain("SEPARATE endpoint object")
+    LLM::ANALYZE_PROMPT.should contain("Do not invent")
+  end
+
+  it "BUNDLE_ANALYZE_PROMPT carries accuracy guidance and cross-file hint" do
+    LLM::BUNDLE_ANALYZE_PROMPT.should contain("FULL request path")
+    LLM::BUNDLE_ANALYZE_PROMPT.should contain("cross-reference files")
+    LLM::BUNDLE_ANALYZE_PROMPT.should contain("Bundle of files:")
+  end
+
+  it "FILTER_PROMPT biases toward recall" do
+    LLM::FILTER_PROMPT.should contain("Favor recall")
+  end
+
+  it "AGENT_PROMPT instructs full-path resolution and no fabrication" do
+    LLM::AGENT_PROMPT.should contain("FULL request path")
+    LLM::AGENT_PROMPT.should contain("Do not fabricate")
+  end
+
+  it "system prompts steer full-path, per-method, no-fabrication" do
+    LLM::SYSTEM_ANALYZE.should contain("full request paths")
+    LLM::SYSTEM_ANALYZE.should contain("never fabricate")
+    LLM::SYSTEM_BUNDLE.should contain("full request paths")
+    LLM::SYSTEM_FILTER.should contain("Favor recall")
+  end
+
   it "has an ANALYZE_FORMAT constant" do
     LLM::ANALYZE_FORMAT.should_not be_nil
     LLM::ANALYZE_FORMAT.should contain("\"name\": \"analyze_endpoints\"")
@@ -366,6 +397,21 @@ describe LLM do
 
     it "has a top-level default for unknown provider fallback" do
       LLM::MODEL_TOKEN_LIMITS["default"].as(Int32).should eq(4000)
+    end
+  end
+
+  describe "acp_max_tokens?" do
+    it "gives ACP agent providers a generous budget, not the 4000 default" do
+      LLM.acp_max_tokens?("acp:gemini").should eq(LLM::ACP_DEFAULT_MAX_TOKENS)
+      LLM.acp_max_tokens?("acp:codex").should eq(LLM::ACP_DEFAULT_MAX_TOKENS)
+      LLM.acp_max_tokens?("ACP:Claude").should eq(LLM::ACP_DEFAULT_MAX_TOKENS)
+      LLM::ACP_DEFAULT_MAX_TOKENS.should be > 4000
+    end
+
+    it "returns nil for non-ACP providers" do
+      LLM.acp_max_tokens?("openai").should be_nil
+      LLM.acp_max_tokens?("ollama").should be_nil
+      LLM.acp_max_tokens?("https://api.openai.com").should be_nil
     end
   end
 end

--- a/spec/unit_test/optimizer/llm_optimizer_spec.cr
+++ b/spec/unit_test/optimizer/llm_optimizer_spec.cr
@@ -3,6 +3,14 @@ require "../../../src/optimizer/llm_optimizer"
 require "../../../src/models/endpoint"
 require "../../../src/models/logger"
 
+# Expose the private LLM-response application path so the FP/FN guards
+# on the correction step can be tested without a live adapter.
+class LLMEndpointOptimizer
+  def __test_apply(endpoint : Endpoint, response : String) : Endpoint
+    apply_llm_optimizations(endpoint, response)
+  end
+end
+
 describe "LLMEndpointOptimizer" do
   options = create_test_options
   logger = NoirLogger.new(false, false, false, false)
@@ -98,6 +106,29 @@ describe "LLMEndpointOptimizer" do
       result[0].params.size.should eq(2)
       result[0].params[0].name.should eq("id")
       result[0].params[1].name.should eq("post_id")
+    end
+  end
+
+  describe "LLM response correction guards" do
+    guard_logger = NoirLogger.new(false, false, false, false)
+
+    it "applies a clean URL rewrite and drops garbage params" do
+      optimizer = LLMEndpointOptimizer.new(guard_logger, create_test_options)
+      endpoint = Endpoint.new("/users/USR123", "GET")
+      response = %({"optimized_url":"/users/{id}","optimized_params":[{"name":"id","param_type":"path","value":""},{"name":"bad name","param_type":"query","value":""}]})
+
+      result = optimizer.__test_apply(endpoint, response)
+      result.url.should eq("/users/{id}")
+      result.params.map(&.name).should eq(["id"])
+    end
+
+    it "rejects a corrupting URL rewrite that leaks whitespace" do
+      optimizer = LLMEndpointOptimizer.new(guard_logger, create_test_options)
+      endpoint = Endpoint.new("/users/{id}", "GET")
+      response = %({"optimized_url":"/GET /users/{id}","optimized_params":[]})
+
+      result = optimizer.__test_apply(endpoint, response)
+      result.url.should eq("/users/{id}")
     end
   end
 

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -305,20 +305,12 @@ module Analyzer::AI
     # high-precision: it removes false positives without dropping any
     # legitimate endpoint.
     private def plausible_endpoint_url?(url : String) : Bool
-      return false if url.empty?
-      return false if url.size > MAX_ENDPOINT_URL_LENGTH
-      # A served path never contains raw whitespace (encoded as %20) or
-      # control characters. Their presence means the model captured a
-      # sentence or a code fragment, not a route.
-      return false if url.each_char.any? { |c| c.ascii_whitespace? || c.control? }
-      # Backticks are markdown/code noise, never part of a path.
-      return false if url.includes?('`')
+      return false unless LLM.clean_token?(url, MAX_ENDPOINT_URL_LENGTH)
       # `lstrip('/')` collapses an all-slash URL to "" — that is the
       # root path ("/"), which is a legitimate endpoint, so only the
       # placeholder-token comparison uses the stripped form.
       bare = url.lstrip('/').downcase
-      return false if PLACEHOLDER_URLS.includes?(bare)
-      true
+      !PLACEHOLDER_URLS.includes?(bare)
     end
 
     # A parameter name is an identifier-ish token. Drop names that carry
@@ -326,10 +318,7 @@ module Analyzer::AI
     # are absurdly long — both are false-positive params that would
     # otherwise ride along on an otherwise-valid endpoint.
     private def plausible_param_name?(name : String) : Bool
-      return false if name.empty?
-      return false if name.size > MAX_PARAM_NAME_LENGTH
-      return false if name.each_char.any? { |c| c.ascii_whitespace? || c.control? }
-      true
+      LLM.clean_token?(name, MAX_PARAM_NAME_LENGTH)
     end
 
     private def create_param_from_json(param : JSON::Any) : Param?

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -22,10 +22,22 @@ module Analyzer::AI
     AGENT_DEFAULT_FILE_PATTERN         = "*.{go,py,js,ts,java,rb,php,cs,cr,kt,rs,swift,scala,graphql}"
     VALID_METHODS                      = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
     VALID_PARAM_TYPES                  = ["query", "json", "form", "header", "cookie", "path"]
-    IGNORE_EXTENSIONS                  = [".css", ".xml", ".json", ".yml", ".yaml", ".md", ".jpg", ".jpeg", ".png", ".gif", ".svg", ".ico",
-                                          ".eot", ".ttf", ".woff", ".woff2", ".otf", ".mp3", ".mp4", ".avi", ".mov", ".webm", ".zip", ".tar",
-                                          ".gz", ".7z", ".rar", ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".txt", ".csv",
-                                          ".log", ".sql", ".bak", ".swp", ".jar"] of String
+    MAX_ENDPOINT_URL_LENGTH            = 2048
+    MAX_PARAM_NAME_LENGTH              =  128
+    # Bare URL tokens the LLM emits when it has nothing real to report
+    # (schema echoes, "no endpoint" stand-ins). Compared case-folded
+    # against the whole path with a single leading slash stripped, so a
+    # legitimate nested route like `/example/users` is never rejected —
+    # only a URL that IS one of these placeholders is dropped.
+    PLACEHOLDER_URLS = Set{
+      "url", "uri", "endpoint", "n/a", "na", "none", "null", "nil",
+      "undefined", "your_endpoint", "your-endpoint", "path/to/endpoint",
+      "...", "<url>", "<endpoint>", "<path>",
+    }
+    IGNORE_EXTENSIONS = [".css", ".xml", ".json", ".yml", ".yaml", ".md", ".jpg", ".jpeg", ".png", ".gif", ".svg", ".ico",
+                         ".eot", ".ttf", ".woff", ".woff2", ".otf", ".mp3", ".mp4", ".avi", ".mov", ".webm", ".zip", ".tar",
+                         ".gz", ".7z", ".rar", ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx", ".txt", ".csv",
+                         ".log", ".sql", ".bak", ".swp", ".jar"] of String
 
     @provider : String
     @model : String
@@ -191,7 +203,28 @@ module Analyzer::AI
 
       begin
         filtered = JSON.parse(response.to_s)
-        filtered["files"].as_a.map(&.as_s)
+        selected = filtered["files"].as_a.map(&.as_s)
+
+        # Keep only real, in-scope source files. The model sometimes
+        # echoes directories, hallucinated paths, or ignorable assets;
+        # analyzing those is wasted work and can mask the recall guard
+        # below.
+        selected = selected.select do |path|
+          File.file?(path) &&
+            !ignore_extensions.includes?(File.extname(path)) &&
+            path_within_base?(path)
+        end
+
+        # Recall guard: an over-aggressive (or empty/garbage) filter
+        # would silently zero out AI results — every endpoint in the
+        # dropped files becomes a false negative. Fall back to scanning
+        # all source files rather than returning nothing.
+        if selected.empty?
+          logger.debug_sub "AI::Filter returned no usable files; analyzing all source files"
+          return get_all_source_files
+        end
+
+        selected
       rescue e : Exception
         logger.debug "Error parsing filter response: #{e.message}"
         get_all_source_files
@@ -254,7 +287,7 @@ module Analyzer::AI
 
     private def create_endpoint_from_json(ep : JSON::Any, default_path : String) : Endpoint?
       url = extract_endpoint_url(ep)
-      return if url.empty?
+      return unless plausible_endpoint_url?(url)
 
       method = normalize_http_method(safe_json_string(ep, "method", "GET"))
       path_info = build_path_info(ep, default_path)
@@ -264,17 +297,52 @@ module Analyzer::AI
       Endpoint.new(url, method, params, details)
     end
 
+    # Reject obviously-hallucinated URLs before they become endpoints.
+    # The LLM occasionally returns prose, a "METHOD /path" description, a
+    # schema echo, or a stray placeholder instead of a real path; those
+    # leak whitespace, control chars, or match a known placeholder token.
+    # Real request paths carry none of these signals, so this stays
+    # high-precision: it removes false positives without dropping any
+    # legitimate endpoint.
+    private def plausible_endpoint_url?(url : String) : Bool
+      return false if url.empty?
+      return false if url.size > MAX_ENDPOINT_URL_LENGTH
+      # A served path never contains raw whitespace (encoded as %20) or
+      # control characters. Their presence means the model captured a
+      # sentence or a code fragment, not a route.
+      return false if url.each_char.any? { |c| c.ascii_whitespace? || c.control? }
+      # Backticks are markdown/code noise, never part of a path.
+      return false if url.includes?('`')
+      # `lstrip('/')` collapses an all-slash URL to "" — that is the
+      # root path ("/"), which is a legitimate endpoint, so only the
+      # placeholder-token comparison uses the stripped form.
+      bare = url.lstrip('/').downcase
+      return false if PLACEHOLDER_URLS.includes?(bare)
+      true
+    end
+
+    # A parameter name is an identifier-ish token. Drop names that carry
+    # whitespace/control chars (the model captured a description) or that
+    # are absurdly long — both are false-positive params that would
+    # otherwise ride along on an otherwise-valid endpoint.
+    private def plausible_param_name?(name : String) : Bool
+      return false if name.empty?
+      return false if name.size > MAX_PARAM_NAME_LENGTH
+      return false if name.each_char.any? { |c| c.ascii_whitespace? || c.control? }
+      true
+    end
+
     private def create_param_from_json(param : JSON::Any) : Param?
       case param.raw
       when String
         name = param.as_s.strip
-        return if name.empty?
+        return unless plausible_param_name?(name)
         Param.new(name, "", "query")
       when Hash
         name = safe_json_string(param, "name", "").strip
         name = safe_json_string(param, "key", "").strip if name.empty?
         name = safe_json_string(param, "param", "").strip if name.empty?
-        return if name.empty?
+        return unless plausible_param_name?(name)
 
         param_type = safe_json_string(param, "param_type", "").strip
         param_type = safe_json_string(param, "type", "").strip if param_type.empty?
@@ -759,7 +827,13 @@ module Analyzer::AI
     end
 
     private def call_llm_with_cache(kind : String, system_prompt : String, payload : String, format : String, adapter : LLM::Adapter) : String
-      disk_key = LLM::Cache.key(@provider, @model, kind, format, payload)
+      # Fold the system prompt into the cache key. The remote request
+      # is driven by both the system and user prompts, so keying on the
+      # payload alone would replay a stale response after a system-prompt
+      # change (e.g. tightened FP/FN guidance) until the user manually
+      # cleared the cache. The system prompt is only mixed into the key,
+      # never sent twice.
+      disk_key = LLM::Cache.key(@provider, @model, kind, format, "#{system_prompt}\n#{payload}")
 
       if cached = LLM::Cache.fetch(disk_key)
         return cached

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -538,6 +538,21 @@ module LLM
     provider.downcase.starts_with?("acp:") ? ACP_DEFAULT_MAX_TOKENS : nil
   end
 
+  # Shared shape check for LLM-supplied endpoint URLs and parameter
+  # names. A served path or an identifier never carries raw whitespace,
+  # control characters, or markdown backticks, and stays within a sane
+  # length bound — their presence means the model captured prose or a
+  # code fragment instead. Both the AI analyzer (identification) and
+  # the LLM optimizer (correction) call this so a hallucinated value
+  # can't ride through either phase. Token-specific rules (placeholder
+  # words for URLs) stay at the call site.
+  def self.clean_token?(value : String, max_length : Int32) : Bool
+    return false if value.empty?
+    return false if value.size > max_length
+    return false if value.includes?('`')
+    !value.each_char.any? { |c| c.ascii_whitespace? || c.control? }
+  end
+
   # Estimate the number of tokens in a string
   # This is a rough estimate using 1 token ≈ 4 characters for English text
   def self.estimate_tokens(text : String) : Int32

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -4,17 +4,36 @@ module LLM
   SHARED_RULES       = "Output only JSON. No explanations. method in [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD]. param_type in [query, json, form, header, cookie, path]."
   AGENT_SHARED_RULES = "Output only JSON. No markdown fences. Use only the defined action names. Do not guess endpoints without reading code."
 
-  SYSTEM_FILTER  = "#{SHARED_RULES} Given a list of file paths, return JSON with property files: string[] of likely endpoints (no directories)."
-  SYSTEM_ANALYZE = "#{SHARED_RULES} Given source code, return JSON with endpoints: [{url, method, params:[{name, param_type, value}]}]."
-  SYSTEM_BUNDLE  = "#{SHARED_RULES} Given a bundle of files, include endpoints from ALL files; return the same JSON schema."
+  # Shared accuracy guidance injected into the endpoint-extraction
+  # prompts. Centralised so the classic, bundle, and agentic paths all
+  # apply the same FN/FP rules:
+  #   - Full-path resolution kills the biggest false-negative source
+  #     (sub-routes whose prefix lives in a parent router/controller).
+  #   - One-object-per-method stops verb collapsing.
+  #   - The "only code that actually serves it" rule kills the biggest
+  #     false-positive source (example/comment/test/outbound URLs).
+  ENDPOINT_GUIDANCE = <<-RULES
+    Accuracy rules:
+    - Report the FULL request path a client calls. Resolve and prepend every route prefix, router/blueprint group, controller base path, or mount point (e.g. group "/api/v1" + route "/users" => "/api/v1/users").
+    - Emit a SEPARATE endpoint object for each HTTP method a route handles; never merge methods.
+    - Capture every parameter with the correct param_type: query, json (request body), form, header, cookie, or path (a URL placeholder such as {id} or :id).
+    - Include only endpoints THIS code defines or serves. Ignore URLs that appear only in comments, documentation, string examples, tests, or outbound calls to third-party services.
+    - Do not invent, guess, or pad endpoints. If the code defines none, return an empty endpoints list.
+    RULES
+
+  SYSTEM_FILTER  = "#{SHARED_RULES} Given a list of file paths, return JSON with property files: string[] of files that may define or serve endpoints (no directories). Favor recall: when unsure, include the file."
+  SYSTEM_ANALYZE = "#{SHARED_RULES} Given source code, return JSON with endpoints: [{url, method, params:[{name, param_type, value}]}]. Report full request paths (resolve route prefixes), one object per HTTP method, and never fabricate endpoints."
+  SYSTEM_BUNDLE  = "#{SHARED_RULES} Given a bundle of files, include endpoints from ALL files; return the same JSON schema. Report full request paths (resolve route prefixes), one object per HTTP method, and never fabricate endpoints."
   SYSTEM_AGENT   = "#{AGENT_SHARED_RULES} You are OWASP Noir Advanced Endpoint Discovery Agent. Use iterative tool actions until enough evidence is collected, then finalize."
 
   FILTER_PROMPT = <<-PROMPT
-    Analyze the following list of file paths and identify which files are likely to represent endpoints, including API endpoints, web pages, or static resources.
+    Analyze the following list of file paths and identify which files are likely to define or serve endpoints, including API endpoints, web pages, route/controller definitions, or static resources.
 
     Guidelines:
     - Focus only on individual files.
     - Do not include directories.
+    - Favor recall over precision: when a file might define routes, controllers, handlers, or served content, include it. Missing a route-bearing file loses endpoints permanently.
+    - Exclude only files that clearly cannot serve endpoints (lock files, build artifacts, images, binaries).
     - Do not include any explanations, comments, or additional text.
     - Output only the JSON result.
     - Return the result strictly in valid JSON format according to the schema provided below.
@@ -48,7 +67,9 @@ module LLM
   ANALYZE_PROMPT = <<-PROMPT
     Analyze the provided source code to extract details about the endpoints and their parameters.
 
-    Guidelines:
+    #{ENDPOINT_GUIDANCE}
+
+    Output format:
     - The "method" field should strictly use one of these values: "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD".
     - The "param_type" must strictly use one of these values: "query", "json", "form", "header", "cookie", "path".
     - Do not include any explanations, comments, or additional text.
@@ -113,7 +134,10 @@ module LLM
   BUNDLE_ANALYZE_PROMPT = <<-PROMPT
     Analyze the following bundle of source code files to extract details about the endpoints and their parameters.
 
-    Guidelines:
+    #{ENDPOINT_GUIDANCE}
+    - A route prefix may be declared in one file and consumed in another within the same bundle; cross-reference files to resolve the full path.
+
+    Output format:
     - The "method" field should strictly use one of these values: "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD".
     - The "param_type" must strictly use one of these values: "query", "json", "form", "header", "cookie", "path".
     - Include endpoints from ALL files in the bundle.
@@ -139,6 +163,9 @@ module LLM
     - First inspect project structure with list_directory or grep.
     - Never assume endpoint existence from filenames only.
     - Read source files before finalizing.
+    - Resolve the FULL request path: follow route prefixes, router/blueprint groups, controller base paths, and mount points back to their declaration before recording a URL.
+    - Emit a separate endpoint for each HTTP method a route handles, and capture query/json/form/header/cookie/path parameters.
+    - Include only endpoints the code actually serves; ignore URLs found only in comments, docs, tests, or outbound third-party calls. Do not fabricate endpoints.
     - Use finalize only when confident enough.
     - Keep endpoint method to [GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD].
     - Use param_type in [query, json, form, header, cookie, path].
@@ -493,6 +520,24 @@ module LLM
     "default" => 4000,
   }
 
+  # Bundling budget for ACP agent providers ("acp:gemini",
+  # "acp:codex", "acp:claude", …). These proxy to large-context
+  # frontier models whose exact id we don't control, so they aren't
+  # keys in MODEL_TOKEN_LIMITS. Falling through to the generic 4000-
+  # token global default would shard a project into many tiny bundles
+  # and break the cross-file context the bundle analyzer relies on to
+  # resolve route prefixes (a false-negative source). 128k is a safe
+  # lower bound across the current ACP agents.
+  ACP_DEFAULT_MAX_TOKENS = 128_000
+
+  # Returns the ACP bundling budget for an `acp:<agent>` provider, or
+  # nil for non-ACP providers. Kept as a standalone pure function so it
+  # stays testable even though `get_max_tokens` is monkeypatched in the
+  # analyzer specs.
+  def self.acp_max_tokens?(provider : String) : Int32?
+    provider.downcase.starts_with?("acp:") ? ACP_DEFAULT_MAX_TOKENS : nil
+  end
+
   # Estimate the number of tokens in a string
   # This is a rough estimate using 1 token ≈ 4 characters for English text
   def self.estimate_tokens(text : String) : Int32
@@ -506,6 +551,13 @@ module LLM
   # Get the maximum token limit for a given provider and model
   def self.get_max_tokens(provider : String, model : String) : Int32
     provider = provider.downcase
+
+    # ACP agent providers don't appear in MODEL_TOKEN_LIMITS; give them
+    # a generous, model-agnostic bundling budget instead of the tiny
+    # global default.
+    if acp = acp_max_tokens?(provider)
+      return acp
+    end
 
     # Extract just the provider name if URL was provided
     if provider.includes?("://") || provider.includes?(".")

--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -242,16 +242,15 @@ class LLMEndpointOptimizer < EndpointOptimizer
 
   # A rewritten URL must look like a served path: no raw whitespace,
   # control chars, or markdown noise, and within a sane length bound.
+  # Shares the shape check with Analyzer::AI::Unified so the correction
+  # phase can't reintroduce what the identification phase rejected.
   private def plausible_rewrite_url?(url : String) : Bool
-    return false if url.size > MAX_REWRITE_URL_LENGTH
-    return false if url.includes?('`')
-    !url.each_char.any? { |c| c.ascii_whitespace? || c.control? }
+    LLM.clean_token?(url, MAX_REWRITE_URL_LENGTH)
   end
 
   # A param name is an identifier-ish token, not a sentence.
   private def valid_optimized_param_name?(name : String) : Bool
-    return false if name.empty? || name.size > MAX_OPTIMIZED_PARAM_NAME
-    !name.each_char.any? { |c| c.ascii_whitespace? || c.control? }
+    LLM.clean_token?(name, MAX_OPTIMIZED_PARAM_NAME)
   end
 
   # LLM response format for optimization. The canonical prompt text

--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -143,7 +143,12 @@ class LLMEndpointOptimizer < EndpointOptimizer
     # Apply URL optimizations if suggested
     if optimization_data.has_key?("optimized_url")
       new_url = optimization_data["optimized_url"].as_s
-      if new_url != endpoint.url && !new_url.empty? && new_url.starts_with?("/")
+      # Only accept a rewrite that is a real path. Without this guard a
+      # model that returns prose, a code fragment, or a "/GET /x"-style
+      # string (anything that merely starts with "/") would clobber a
+      # correct URL — corrupting the endpoint (a false positive) and
+      # losing the original (a false negative) in one step.
+      if new_url != endpoint.url && !new_url.empty? && new_url.starts_with?("/") && plausible_rewrite_url?(new_url)
         @logger.debug_sub "  - URL optimized: #{endpoint.url} → #{new_url}"
         optimized_endpoint.url = new_url
       end
@@ -155,6 +160,11 @@ class LLMEndpointOptimizer < EndpointOptimizer
       optimization_data["optimized_params"].as_a.each do |param_data|
         param_obj = param_data.as_h
         name = param_obj["name"].as_s
+        # Drop names that carry whitespace/control chars or are absurdly
+        # long — the model captured a description, not an identifier.
+        # Mirrors the guard Analyzer::AI::Unified applies to its own
+        # responses so the correction step can't reintroduce param FPs.
+        next unless valid_optimized_param_name?(name)
         # Normalize whatever string the LLM returns to one of the
         # canonical param types so we don't end up with rogue values
         # like "uri" or "Querystring" propagating into the endpoint
@@ -219,13 +229,29 @@ class LLMEndpointOptimizer < EndpointOptimizer
     end
   end
 
-  VALID_PARAM_TYPES = %w[query json form header cookie path]
+  VALID_PARAM_TYPES        = %w[query json form header cookie path]
+  MAX_REWRITE_URL_LENGTH   = 2048
+  MAX_OPTIMIZED_PARAM_NAME =  128
 
   # Coerce an LLM-supplied param_type string to one of the canonical
   # values; anything outside the list falls back to "query".
   private def normalize_param_type(raw : String) : String
     normalized = raw.downcase
     VALID_PARAM_TYPES.includes?(normalized) ? normalized : "query"
+  end
+
+  # A rewritten URL must look like a served path: no raw whitespace,
+  # control chars, or markdown noise, and within a sane length bound.
+  private def plausible_rewrite_url?(url : String) : Bool
+    return false if url.size > MAX_REWRITE_URL_LENGTH
+    return false if url.includes?('`')
+    !url.each_char.any? { |c| c.ascii_whitespace? || c.control? }
+  end
+
+  # A param name is an identifier-ish token, not a sentence.
+  private def valid_optimized_param_name?(name : String) : Bool
+    return false if name.empty? || name.size > MAX_OPTIMIZED_PARAM_NAME
+    !name.each_char.any? { |c| c.ascii_whitespace? || c.control? }
   end
 
   # LLM response format for optimization. The canonical prompt text


### PR DESCRIPTION
## Summary

Improves the accuracy of `Analyzer::AI` (the LLM analyzer) across both the **endpoint-identification phase** and the **final correction phase**, reducing false negatives and false positives.

### Identification — prompt hardening (`src/llm/prompt.cr`)
- Shared `ENDPOINT_GUIDANCE` injected into the analyze/bundle prompts and folded into `SYSTEM_ANALYZE` / `SYSTEM_BUNDLE` / `AGENT_PROMPT`:
  - Report the **FULL request path** — resolve & prepend route prefixes, router/blueprint groups, controller base paths, and mount points (the biggest FN source: sub-routes whose prefix lives in a parent file).
  - Emit **one endpoint per HTTP method**; capture every `param_type`.
  - Include only endpoints the code **actually serves** — ignore comment/doc/test/outbound URLs (the biggest FP source); never fabricate.
- `FILTER_PROMPT` / `SYSTEM_FILTER` now bias toward **recall** so route-bearing files are not dropped.

### Correction — deterministic guards
- `unified_ai`: `plausible_endpoint_url?` drops hallucinated URLs before they become endpoints (raw whitespace/control chars, backtick, oversize, or a whole-URL placeholder token). The placeholder set is intentionally **tight** (no `example`/`todo`/`test`) so real single-segment routes aren't turned into FNs; root `/` stays valid. `plausible_param_name?` drops garbage param names.
- `llm_optimizer`: mirrors both guards so the LLM "optimize" step can't overwrite a correct URL with garbage (which would be an FP for the new URL **and** an FN for the lost original).

### Other
- `filter_paths_with_llm` keeps only existing, in-base, non-ignored files and **falls back to scanning all source files when the filtered set is empty**, so an over-aggressive filter can't silently zero out AI results.
- **ACP token budget**: `acp:gemini` / `acp:codex` / `acp:claude` fell through to the global `4000` default → tiny bundles → broken cross-file prefix resolution. New `LLM.acp_max_tokens?` returns `128k`.
- `call_llm_with_cache` folds the system prompt into the cache key so prompt changes take effect without a manual `noir cache clear`.

## Testing
- New `validation_spec` (url/param plausibility + `create_endpoint_from_json`), `prompt_spec` guidance + `acp_max_tokens?` assertions, `llm_optimizer_spec` correction-guard cases.
- Full unit suite **2753 examples, 0 failures**; ameba and `crystal tool format` clean.
- Verified end-to-end with `--ai-provider=acp:gemini` on the gin fixture: group prefixes resolved (`/group/users`, `/group/v1/migration`, `POST /admin`), no false positives, `max tokens: 128000`.