### PR TITLE
Go Echo/Gin/Fiber/Beego: FP/FN reduction + callees + analyzer perf

### DIFF
--- a/spec/functional_test/fixtures/go/beego_controller/go.mod
+++ b/spec/functional_test/fixtures/go/beego_controller/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/test-beego-controller
+
+go 1.24.0
+
+require github.com/beego/beego/v2 v2.3.6

--- a/spec/functional_test/fixtures/go/beego_controller/main.go
+++ b/spec/functional_test/fixtures/go/beego_controller/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/beego/beego/v2/server/web"
+)
+
+func main() {
+	ctrl := &UserController{}
+
+	// Mapping-less registration: Beego routes each HTTP-verb-named method
+	// the controller implements. UserController defines Get + Post.
+	web.Router("/users", ctrl)
+
+	// Explicit single-method mappings.
+	web.Router("/users/profile", ctrl, "get:Profile")
+	web.Router("/users/update", ctrl, "post:Update")
+
+	// Multiple methods sharing one controller method.
+	web.Router("/users/batch", ctrl, "get,post:Batch")
+
+	web.Run()
+}
+
+// UserController must satisfy Beego's ControllerInterface.
+type UserController struct {
+	web.Controller
+}
+
+func (c *UserController) Get() {
+	c.Ctx.Output.Body([]byte("list"))
+}
+
+func (c *UserController) Post() {
+	c.Ctx.Output.Body([]byte("create"))
+}
+
+func (c *UserController) Profile() {
+	c.Ctx.Output.Body([]byte("profile"))
+}
+
+func (c *UserController) Update() {
+	c.Ctx.Output.Body([]byte("update"))
+}
+
+func (c *UserController) Batch() {
+	c.Ctx.Output.Body([]byte("batch"))
+}

--- a/spec/functional_test/fixtures/go/huma/main.go
+++ b/spec/functional_test/fixtures/go/huma/main.go
@@ -48,6 +48,12 @@ type DeleteUserInput struct {
 
 type DeleteUserOutput struct{}
 
+type HealthInput struct {
+	Verbose bool `query:"verbose"`
+}
+
+type HealthOutput struct{}
+
 type User struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
@@ -86,6 +92,16 @@ func registerRoutes(api huma.API) {
 		Path:        "/users/{id}",
 	}, func(ctx context.Context, input *DeleteUserInput) (*DeleteUserOutput, error) {
 		return &DeleteUserOutput{}, nil
+	})
+
+	// Huma v2 typed convenience helpers — the path is the SECOND
+	// argument (the first is the API), the verb is the method name.
+	huma.Get(api, "/health", func(ctx context.Context, input *HealthInput) (*HealthOutput, error) {
+		return &HealthOutput{}, nil
+	})
+
+	huma.Patch(api, "/users/{id}", func(ctx context.Context, input *GetUserInput) (*GetUserOutput, error) {
+		return &GetUserOutput{}, nil
 	})
 }
 

--- a/spec/functional_test/testers/go/beego_controller_spec.cr
+++ b/spec/functional_test/testers/go/beego_controller_spec.cr
@@ -1,0 +1,26 @@
+require "../../func_spec.cr"
+
+# Controller-style registration (`web.Router("/path", &Ctrl{}, "get:M")`)
+# is Beego's dominant routing idiom. The mapping-less form fans out to
+# every HTTP-verb method the controller implements; explicit mappings
+# resolve to the listed methods. Callees come from walking the named
+# controller method's body — the registration call doesn't pass the
+# handler as an argument, so it's resolved by method name within the
+# package (here every UserController method calls `c.Ctx.Output.Body`).
+main = "spec/functional_test/fixtures/go/beego_controller/main.go"
+
+expected_endpoints = [
+  Endpoint.new("/users", "GET").tap { |ep| ep.push_callee(Callee.new("c.Ctx.Output.Body", main, 30)) },
+  Endpoint.new("/users", "POST").tap { |ep| ep.push_callee(Callee.new("c.Ctx.Output.Body", main, 34)) },
+  Endpoint.new("/users/profile", "GET").tap { |ep| ep.push_callee(Callee.new("c.Ctx.Output.Body", main, 38)) },
+  Endpoint.new("/users/update", "POST").tap { |ep| ep.push_callee(Callee.new("c.Ctx.Output.Body", main, 42)) },
+  Endpoint.new("/users/batch", "GET").tap { |ep| ep.push_callee(Callee.new("c.Ctx.Output.Body", main, 46)) },
+  Endpoint.new("/users/batch", "POST").tap { |ep| ep.push_callee(Callee.new("c.Ctx.Output.Body", main, 46)) },
+]
+
+FunctionalTester.new("fixtures/go/beego_controller/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/huma_spec.cr
+++ b/spec/functional_test/testers/go/huma_spec.cr
@@ -16,6 +16,14 @@ expected_endpoints = [
   Endpoint.new("/users/{id}", "DELETE", [
     Param.new("id", "", "path"),
   ]),
+  # Huma v2 sugar helpers (path is the 2nd argument).
+  Endpoint.new("/health", "GET", [
+    Param.new("verbose", "", "query"),
+  ]),
+  Endpoint.new("/users/{id}", "PATCH", [
+    Param.new("id", "", "path"),
+    Param.new("session", "", "cookie"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/go/huma/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -322,4 +322,98 @@ describe Noir::TreeSitterGoRouteExtractor do
       {"ANY", "/all-builder"},
     ].sort)
   end
+
+  it "does not mint phantom routes from verb-named value helpers" do
+    # A cache's `Put`/`Get` and similar value helpers share a verb name
+    # but take a context/receiver as their first argument, not a URL.
+    # The path must be the FIRST positional argument of a verb call, so
+    # these must produce no routes.
+    source = <<-GO
+      package main
+      func main() {
+          c.Put(context.Background(), "hello", "world", time.Minute)
+          bm.Get(ctx, "name")
+          store.Delete(ctx, "key")
+          r.GET("/real", handler)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/real"}])
+  end
+
+  it "extracts beego controller routes with explicit method mappings" do
+    source = <<-GO
+      package main
+      func main() {
+          web.Router("/health", ctrl, "get:Health")
+          web.Router("/update", ctrl, "post:Update")
+          web.Router("/getOrPost", ctrl, "get,post:GetOrPost")
+          web.Router("/multi", ctrl, "get:Read;delete:Remove")
+          web.Router("/any", ctrl, "*:Any")
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(source)
+    routes.map { |r| {r.verb, r.path, r.handler} }.sort!.should eq([
+      {"ANY", "/any", "Any"},
+      {"DELETE", "/multi", "Remove"},
+      {"GET", "/getOrPost", "GetOrPost"},
+      {"GET", "/health", "Health"},
+      {"GET", "/multi", "Read"},
+      {"POST", "/getOrPost", "GetOrPost"},
+      {"POST", "/update", "Update"},
+    ].sort)
+  end
+
+  it "resolves mapping-less beego controller routes from implemented methods" do
+    source = <<-GO
+      package main
+      func main() {
+          ctrl := &MainController{}
+          web.Router("/", ctrl)
+          web.Router("/inline", &OtherController{})
+      }
+      func (c *MainController) Get()  {}
+      func (c *MainController) Post() {}
+      func (c *MainController) Helper() {}
+      func (c *OtherController) Delete() {}
+      GO
+
+    methods = Noir::TreeSitterGoRouteExtractor.extract_controller_methods(source)
+    methods["MainController"].sort.should eq(["Get", "Post"])
+    methods["OtherController"].should eq(["Delete"])
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(source, methods)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"DELETE", "/inline"},
+      {"GET", "/"},
+      {"POST", "/"},
+    ].sort)
+  end
+
+  it "falls back to GET for beego controllers it can't resolve" do
+    source = <<-GO
+      package main
+      func main() {
+          web.Router("/external", &controllers.UserController{})
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/external"}])
+  end
+
+  it "ignores Router calls on non-beego operands" do
+    source = <<-GO
+      package main
+      func main() {
+          db.Router("/not-a-route", handler)
+          web.Router("/yes", &C{})
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(source)
+    routes.map { |r| r.path }.should eq(["/yes"])
+  end
 end

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -414,6 +414,6 @@ describe Noir::TreeSitterGoRouteExtractor do
       GO
 
     routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(source)
-    routes.map { |r| r.path }.should eq(["/yes"])
+    routes.map(&.path).should eq(["/yes"])
   end
 end

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -404,6 +404,30 @@ describe Noir::TreeSitterGoRouteExtractor do
     routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/external"}])
   end
 
+  it "does not fan out a cross-package controller using a same-named local type" do
+    # A qualified `&controllers.UserController{}` is cross-package; even
+    # though THIS package defines a `UserController` with Get+Post, the
+    # qualified route must take the unresolved fallback (single GET), not
+    # borrow the local type's methods.
+    source = <<-GO
+      package main
+      func main() {
+          web.Router("/local", &UserController{})
+          web.Router("/external", &controllers.UserController{})
+      }
+      func (c *UserController) Get()  {}
+      func (c *UserController) Post() {}
+      GO
+
+    methods = Noir::TreeSitterGoRouteExtractor.extract_controller_methods(source)
+    routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(source, methods)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"GET", "/external"},
+      {"GET", "/local"},
+      {"POST", "/local"},
+    ].sort)
+  end
+
   it "ignores Router calls on non-beego operands" do
     source = <<-GO
       package main

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -14,6 +14,15 @@ module Analyzer::Go
       # use group routes, so we just need file_contents — no fixpoint.
       file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
+      # Per-directory controller-method map so mapping-less
+      # `web.Router("/x", &Ctrl{})` registrations resolve to the exact
+      # HTTP methods the controller implements.
+      package_controller_methods = collect_package_controller_methods(file_contents)
+      # Per-directory controller-method bodies, so a `web.Router` route's
+      # handler (a controller method named in the mapping string) gets its
+      # 1-hop callees walked even though the call doesn't pass it as an
+      # argument. Empty unless callees are requested.
+      package_controller_method_bodies = collect_package_controller_method_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -38,7 +47,12 @@ module Analyzer::Go
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 
+                    # Functional `web.Get("/x", h)` verb routes plus
+                    # controller-style `web.Router("/x", &Ctrl{}, "get:M")`
+                    # registrations — the latter is Beego's dominant idiom.
                     ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content)
+                    controller_methods = ts_controller_methods_for_directory(package_controller_methods, File.dirname(path))
+                    ts_routes += Noir::TreeSitterGoRouteExtractor.extract_beego_routes(content, controller_methods)
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
                       routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
@@ -50,6 +64,7 @@ module Analyzer::Go
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
                     callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+                    controller_method_bodies = ts_controller_method_bodies_for_directory(package_controller_method_bodies, File.dirname(path))
 
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))
@@ -61,6 +76,17 @@ module Analyzer::Go
                             if entries = callees_by_route[route.line]?
                               entries.each do |entry|
                                 name, callee_path, callee_line = entry
+                                new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                              end
+                            elsif callees_needed? && !route.handler.empty? &&
+                                  (bodies = controller_method_bodies[route.handler]?) && bodies.size == 1
+                              # `web.Router` routes carry the controller
+                              # method name in `handler`; the registration
+                              # call doesn't pass it as an argument, so walk
+                              # the method body here. Only when exactly one
+                              # controller in the package defines the name
+                              # (avoids mis-attributing an ambiguous method).
+                              Noir::GoCalleeExtractor.callees_in_body(bodies.first, external_fns).each do |name, callee_path, callee_line|
                                 new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                               end
                             end

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -50,9 +50,15 @@ module Analyzer::Go
                     # Functional `web.Get("/x", h)` verb routes plus
                     # controller-style `web.Router("/x", &Ctrl{}, "get:M")`
                     # registrations — the latter is Beego's dominant idiom.
-                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content)
                     controller_methods = ts_controller_methods_for_directory(package_controller_methods, File.dirname(path))
-                    ts_routes += Noir::TreeSitterGoRouteExtractor.extract_beego_routes(content, controller_methods)
+                    beego_routes = Noir::TreeSitterGoRouteExtractor.extract_beego_routes(content, controller_methods)
+                    # Track which lines are `web.Router` registrations so the
+                    # controller-method callee fallback below only fires for
+                    # them — never for a `web.Get` verb route whose handler
+                    # text happens to collide with a method name.
+                    beego_router_lines = Set(Int32).new
+                    beego_routes.each { |r| beego_router_lines << r.line }
+                    ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content) + beego_routes
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
                       routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
@@ -78,7 +84,8 @@ module Analyzer::Go
                                 name, callee_path, callee_line = entry
                                 new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                               end
-                            elsif callees_needed? && !route.handler.empty? &&
+                            elsif callees_needed? && beego_router_lines.includes?(route.line) &&
+                                  !route.handler.empty? &&
                                   (bodies = controller_method_bodies[route.handler]?) && bodies.size == 1
                               # `web.Router` routes carry the controller
                               # method name in `handler`; the registration

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -7,7 +7,7 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
-      package_groups, file_contents = collect_package_groups_ts
+      package_groups, file_contents = collect_package_groups_ts(import_marker: IMPORT_MARKER)
       # Pre-pass for cross-file identifier-handler resolution. Built
       # once per analyze() so each per-file callee pass only does an
       # O(1) lookup into `package_function_bodies` rather than re-

--- a/src/analyzer/analyzers/go/fiber.cr
+++ b/src/analyzer/analyzers/go/fiber.cr
@@ -7,7 +7,7 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
-      package_groups, file_contents = collect_package_groups_ts
+      package_groups, file_contents = collect_package_groups_ts(import_marker: IMPORT_MARKER)
       # Pre-pass for cross-file identifier-handler resolution (see Gin).
       package_function_bodies = collect_package_function_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -7,7 +7,7 @@ module Analyzer::Go
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
-      package_groups, file_contents = collect_package_groups_ts
+      package_groups, file_contents = collect_package_groups_ts(import_marker: IMPORT_MARKER)
       # Pre-pass for cross-file identifier-handler resolution. Built
       # once per analyze() so each per-file callee pass only does an
       # O(1) lookup into `package_function_bodies` rather than re-

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -20,6 +20,22 @@ module Analyzer::Go
       "cookie" => "cookie",
     }
 
+    # Huma v2's typed convenience helpers — `huma.Get(api, "/path",
+    # handler)` and friends — register an operation without the verbose
+    # `huma.Register(api, huma.Operation{...}, handler)` literal. The verb
+    # is the method name; the path is the SECOND argument (the first is
+    # the API/group). Mapped here so the call walker can decode them
+    # alongside `huma.Register`.
+    SUGAR_VERBS = {
+      "huma.Get"     => "GET",
+      "huma.Post"    => "POST",
+      "huma.Put"     => "PUT",
+      "huma.Patch"   => "PATCH",
+      "huma.Delete"  => "DELETE",
+      "huma.Head"    => "HEAD",
+      "huma.Options" => "OPTIONS",
+    }
+
     private struct StructField
       property name : String
       property tag : String
@@ -113,28 +129,47 @@ module Analyzer::Go
         walk_calls(root) do |call|
           func = Noir::TreeSitter.field(call, "function")
           next if func.nil?
-          next unless Noir::TreeSitter.node_text(func, source) == "huma.Register"
+          func_text = Noir::TreeSitter.node_text(func, source)
+          sugar_verb = SUGAR_VERBS[func_text]?
+          next unless func_text == "huma.Register" || sugar_verb
 
           args = Noir::TreeSitter.field(call, "arguments")
           next if args.nil?
 
-          op_node = nil_arg = nil
-          handler_node = nil_arg
-          arg_index = 0
-          Noir::TreeSitter.each_named_child(args) do |arg|
-            case arg_index
-            when 1
-              op_node = arg
-            when 2
-              handler_node = arg
+          # `route_path` keeps an empty-string default (a sugar call with
+          # too few args leaves it unset); `method` is assigned on every
+          # branch below, so it needs no initializer.
+          route_path = ""
+          handler_node : LibTreeSitter::TSNode? = nil
+
+          if sugar_verb
+            # huma.Get(api, "/path", handler) — path@1, handler@2.
+            method = sugar_verb
+            arg_index = 0
+            Noir::TreeSitter.each_named_child(args) do |arg|
+              case arg_index
+              when 1 then route_path = decode_string_value(arg, source) || ""
+              when 2 then handler_node = arg
+              end
+              arg_index += 1
             end
-            arg_index += 1
+          else
+            # huma.Register(api, huma.Operation{...}, handler) —
+            # Operation literal@1, handler@2.
+            op_node : LibTreeSitter::TSNode? = nil
+            arg_index = 0
+            Noir::TreeSitter.each_named_child(args) do |arg|
+              case arg_index
+              when 1 then op_node = arg
+              when 2 then handler_node = arg
+              end
+              arg_index += 1
+            end
+            operation_arg = op_node
+            next if operation_arg.nil?
+            method, route_path = decode_operation(operation_arg, source)
           end
 
-          operation_arg = op_node
-          next if operation_arg.nil?
-
-          method, route_path = decode_operation(operation_arg, source)
           next if method.empty? || route_path.empty?
 
           row = Noir::TreeSitter.node_start_row(call) + 1

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -39,7 +39,15 @@ module Analyzer::Go
     # The fixpoint handles the `routes.go` calling `v1.GET(...)` under a
     # `v1 := r.Group("/v1")` declared in `main.go` case — iterate until
     # no new entries land. In-file declarations win over external ones.
-    def collect_package_groups_ts(group_method : String = "Group") : Tuple(Hash(String, Hash(String, String)), Hash(String, String))
+    # `import_marker`, when given, restricts the cross-file group/engine
+    # pre-pass to files that actually import the framework. Group
+    # variables (`v1 := r.Group("/v1")`) and root-engine bindings only
+    # ever appear in framework-importing files, so skipping the rest
+    # avoids parsing unrelated `.go` files — a large saving in mixed
+    # repos (e.g. an example monorepo where most dirs use other routers).
+    # `file_contents` is still populated for every file so the per-file
+    # route pass and callee pre-pass keep their read cache.
+    def collect_package_groups_ts(group_method : String = "Group", import_marker : String? = nil) : Tuple(Hash(String, Hash(String, String)), Hash(String, String))
       package_groups = Hash(String, Hash(String, String)).new
       files_by_dir = Hash(String, Array(String)).new
       file_contents = Hash(String, String).new
@@ -63,6 +71,13 @@ module Analyzer::Go
       end
 
       files_by_dir.each do |dir, paths|
+        relevant = if import_marker
+                     paths.select { |p| (c = file_contents[p]?) && c.includes?(import_marker) }
+                   else
+                     paths
+                   end
+        next if relevant.empty?
+
         # Detect group-variable names that resolve to DIFFERENT prefixes
         # across files of the same package. These are almost always
         # function-local names (`r`, `g`, `api`, ...) reused across
@@ -77,19 +92,23 @@ module Analyzer::Go
         # package: `/dept/api/v1/...`.) Each file still re-derives these
         # names locally during route extraction, so same-file resolution
         # is unaffected.
+        #
+        # Root engine/router names (`r := gin.New()`, `func(r
+        # *gin.Engine)`) are folded into the same parse and likewise added
+        # to `ambiguous` so a same-named local group in a sibling file
+        # (e.g. `r := v1.Group("/sysjob")`) can't leak its prefix onto the
+        # root and pollute `v1 := r.Group("/api/v1")` (observed:
+        # `/sysjob/api/v1/...`).
         ambiguous = Set(String).new
         local_values = Hash(String, String).new
-        paths.each do |path|
+        own_groups_by_file = Hash(String, Hash(String, String)).new
+        relevant.each do |path|
           content = file_contents[path]?
           next if content.nil?
-          # Root engine/router names (`r := gin.New()`,
-          # `func(r *gin.Engine)`) must never carry a cross-file prefix.
-          # A same-named local group in a sibling file (e.g.
-          # `r := v1.Group("/sysjob")`) would otherwise leak its prefix
-          # onto the root and pollute `v1 := r.Group("/api/v1")`
-          # (observed: `/sysjob/api/v1/...`).
-          Noir::TreeSitterGoRouteExtractor.extract_engine_names(content).each { |n| ambiguous << n }
-          Noir::TreeSitterGoRouteExtractor.extract_groups(content, group_method: group_method).each do |k, v|
+          names, own = Noir::TreeSitterGoRouteExtractor.extract_engine_names_and_groups(content, group_method)
+          names.each { |n| ambiguous << n }
+          own_groups_by_file[path] = own
+          own.each do |k, v|
             next if ambiguous.includes?(k)
             if (existing = local_values[k]?) && existing != v
               ambiguous << k
@@ -101,18 +120,29 @@ module Analyzer::Go
         end
 
         groups = Hash(String, String).new
-        loop do
-          prev_size = groups.size
-          paths.each do |path|
-            content = file_contents[path]?
-            next if content.nil?
-            found = Noir::TreeSitterGoRouteExtractor.extract_groups(content, groups, group_method)
-            found.each do |k, v|
-              next if ambiguous.includes?(k)
-              groups[k] ||= v
-            end
+        if relevant.size == 1
+          # A single-file package can't propagate prefixes across files,
+          # so its own-file groups (already parsed above) are final — skip
+          # the cross-file fixpoint and its redundant re-parse entirely.
+          own = own_groups_by_file[relevant.first]?
+          own.try &.each do |k, v|
+            next if ambiguous.includes?(k)
+            groups[k] = v
           end
-          break if groups.size == prev_size
+        else
+          loop do
+            prev_size = groups.size
+            relevant.each do |path|
+              content = file_contents[path]?
+              next if content.nil?
+              found = Noir::TreeSitterGoRouteExtractor.extract_groups(content, groups, group_method)
+              found.each do |k, v|
+                next if ambiguous.includes?(k)
+                groups[k] ||= v
+              end
+            end
+            break if groups.size == prev_size
+          end
         end
         package_groups[dir] = groups unless groups.empty?
       end
@@ -152,6 +182,66 @@ module Analyzer::Go
     # or an empty map when the directory has no captured functions.
     def ts_function_bodies_for_directory(package_function_bodies : Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody)), dir : String) : Hash(String, Noir::GoCalleeExtractor::FunctionBody)
       package_function_bodies[dir]? || Hash(String, Noir::GoCalleeExtractor::FunctionBody).new
+    end
+
+    # --- Beego controller-method pre-pass --------------------------------
+    #
+    # Builds a per-directory `{controller_type => [http_verb_methods]}` map
+    # so mapping-less `web.Router("/x", &Ctrl{})` registrations resolve to
+    # the exact methods the controller implements. Keyed by directory
+    # because Beego controllers and their router registrations share a Go
+    # package (== directory); a controller defined in a sibling file is
+    # still found.
+    def collect_package_controller_methods(file_contents : Hash(String, String)) : Hash(String, Hash(String, Array(String)))
+      result = Hash(String, Hash(String, Array(String))).new
+      file_contents.each do |path, content|
+        # Cheap gate: a file with controller methods must contain a method
+        # receiver. gofmt always writes those as `func (recv Type) Name(`,
+        # so files without `func (` can't define controller methods and
+        # are skipped before paying for a tree-sitter parse.
+        next unless content.includes?("func (")
+        methods = Noir::TreeSitterGoRouteExtractor.extract_controller_methods(content)
+        next if methods.empty?
+        dir = File.dirname(path)
+        dir_map = (result[dir] ||= Hash(String, Array(String)).new)
+        methods.each do |type_name, names|
+          list = (dir_map[type_name] ||= [] of String)
+          names.each { |n| list << n unless list.includes?(n) }
+        end
+      end
+      result
+    end
+
+    # Returns the cross-file controller-method map for the given
+    # directory, or an empty map.
+    def ts_controller_methods_for_directory(package_controller_methods : Hash(String, Hash(String, Array(String))), dir : String) : Hash(String, Array(String))
+      package_controller_methods[dir]? || Hash(String, Array(String)).new
+    end
+
+    # Per-directory `{method_name => [FunctionBody, ...]}` map for
+    # controller-style routes whose handler is referenced by method name
+    # (Beego's `web.Router("/x", &Ctrl{}, "get:Method")`). Lets the
+    # analyzer walk the controller method's body for callees even though
+    # the registration call doesn't pass the handler as an argument.
+    # Gated on `callees_needed?` so default scans pay nothing.
+    def collect_package_controller_method_bodies(file_contents : Hash(String, String)) : Hash(String, Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)))
+      result = Hash(String, Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))).new
+      return result unless callees_needed?
+      file_contents.each do |path, content|
+        next unless content.includes?("func (")
+        methods = Noir::GoCalleeExtractor.collect_method_bodies(content, path)
+        next if methods.empty?
+        dir = File.dirname(path)
+        dir_map = (result[dir] ||= Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)).new)
+        methods.each do |name, list|
+          (dir_map[name] ||= [] of Noir::GoCalleeExtractor::FunctionBody).concat(list)
+        end
+      end
+      result
+    end
+
+    def ts_controller_method_bodies_for_directory(package_controller_method_bodies : Hash(String, Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))), dir : String) : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))
+      package_controller_method_bodies[dir]? || Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)).new
     end
 
     # Read every `.go` file once into a `{path => source}` hash. Used by

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -268,11 +268,13 @@ module Noir::GoCalleeExtractor
     end
   end
 
-  # Re-parse a sibling-file function body for cross-file identifier
-  # handler resolution. Wraps the captured `function_declaration` text
-  # in a `package` line so tree-sitter Go can parse it as a complete
-  # `source_file`; the wrap adds exactly one row, which we subtract via
-  # `start_row - 1` to map walked rows back to the original file.
+  # Re-parse a sibling-file function/method body for cross-file handler
+  # resolution. Wraps the captured declaration text in a `package` line so
+  # tree-sitter Go can parse it as a complete `source_file`; the wrap adds
+  # exactly one row, which we subtract via `start_row - 1` to map walked
+  # rows back to the original file. Handles both `function_declaration`
+  # (bare-identifier handlers) and `method_declaration` (controller-method
+  # handlers, e.g. Beego's `web.Router("/x", &Ctrl{}, "get:Method")`).
   private def calls_in_external(fn : FunctionBody,
                                 external_functions : Hash(String, FunctionBody)) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
@@ -280,7 +282,8 @@ module Noir::GoCalleeExtractor
     line_offset = fn.start_row - 1
     Noir::TreeSitter.parse_go(wrapped) do |root|
       Noir::TreeSitter.each_named_child(root) do |child|
-        next unless Noir::TreeSitter.node_type(child) == "function_declaration"
+        ty = Noir::TreeSitter.node_type(child)
+        next unless ty == "function_declaration" || ty == "method_declaration"
         if body = Noir::TreeSitter.field(child, "body")
           walk_calls_in_node(body, wrapped, fn.file_path, sink, line_offset, external_functions)
           break
@@ -288,6 +291,38 @@ module Noir::GoCalleeExtractor
       end
     end
     sink
+  end
+
+  # Public entry for walking a captured function/method body and
+  # returning its 1-hop callees. Used by analyzers (Beego controller
+  # routing) that resolve a handler to a `FunctionBody` outside the
+  # standard route-row flow.
+  def callees_in_body(fn : FunctionBody,
+                      external_functions : Hash(String, FunctionBody) = Hash(String, FunctionBody).new) : Array(Tuple(String, String, Int32))
+    calls_in_external(fn, external_functions)
+  end
+
+  # Collects top-level `method_declaration` bodies keyed by method name.
+  # The value is a list because a name can be defined on several receiver
+  # types in one package; callers that need an unambiguous resolution
+  # should require `size == 1`. Used to attach callees to controller-style
+  # routes whose handler is referenced by method name only.
+  def collect_method_bodies(source : String, file_path : String) : Hash(String, Array(FunctionBody))
+    bodies = Hash(String, Array(FunctionBody)).new
+    Noir::TreeSitter.parse_go(source) do |root|
+      Noir::TreeSitter.each_named_child(root) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "method_declaration"
+        name_node = Noir::TreeSitter.field(child, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        (bodies[name] ||= [] of FunctionBody) << FunctionBody.new(
+          Noir::TreeSitter.node_text(child, source),
+          file_path,
+          Noir::TreeSitter.node_start_row(child),
+        )
+      end
+    end
+    bodies
   end
 
   # Render a callee's textual name. Identifiers come back verbatim;

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -1560,16 +1560,22 @@ module Noir
       composite_literal_type_name(node, source)
     end
 
-    # Find a `composite_literal` at or under `node` and return its type
-    # name with any package qualifier and pointer stripped
-    # (`&pkg.Ctrl{}` → `Ctrl`).
+    # Find a `composite_literal` at or under `node` and return its
+    # (pointer-stripped) LOCAL type name. A package-qualified literal
+    # (`&pkg.Ctrl{}`) returns nil: in Go a qualified type always lives in
+    # another package, so its methods are never in this directory's
+    # controller-method map. Returning nil routes such a route to the
+    # unresolved-controller fallback instead of mis-matching a local type
+    # that happens to share the final identifier (`Ctrl`).
     private def composite_literal_type_name(node : LibTreeSitter::TSNode,
                                             source : String) : String?
       comp = find_composite_literal(node)
       return unless comp
       type_node = Noir::TreeSitter.field(comp, "type") || first_named_child(comp)
       return unless type_node
-      final_type_identifier(type_node, source)
+      text = Noir::TreeSitter.node_text(type_node, source).lchop('*')
+      return if text.includes?('.')
+      text
     end
 
     private def find_composite_literal(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -1484,8 +1484,13 @@ module Noir
       else
         methods = ctrl_type.try { |t| controller_methods[t]? }
         if methods && !methods.empty?
-          methods.map do |m|
-            Route.new("web", BEEGO_CONTROLLER_HTTP_METHODS[m], route_path, route_path, m, line)
+          # `compact_map` + `[m]?` is defensive: `controller_methods`
+          # only carries HTTP-verb-named methods today, but a non-verb
+          # name would otherwise raise on the direct lookup.
+          methods.compact_map do |m|
+            if verb = BEEGO_CONTROLLER_HTTP_METHODS[m]?
+              Route.new("web", verb, route_path, route_path, m, line)
+            end
           end
         else
           # Unresolved controller type: surface the endpoint under GET so

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -90,6 +90,29 @@ module Noir
     # underlying router/group rather than dropping the route entirely.
     PASSTHROUGH_CHAIN_METHODS = Set{"Use"}
 
+    # Beego registers controllers with `web.Router("/path", &Ctrl{},
+    # "get:Method;post:Other")`. The receiver is the `web` package (v2,
+    # `github.com/beego/beego/v2/server/web`) or the legacy `beego`
+    # package alias (v1, `github.com/astaxie/beego`). Restricting the
+    # operand to these two names keeps `something.Router(...)` calls on
+    # unrelated types from minting phantom endpoints.
+    BEEGO_ROUTER_OPERANDS = Set{"web", "beego"}
+
+    # When a `web.Router` call carries no method-mapping string, Beego
+    # auto-maps incoming requests to controller methods whose names match
+    # an HTTP verb (Go-cased). Maps the receiver-method name to the HTTP
+    # verb it serves so a mapping-less registration emits exactly the
+    # methods the controller actually implements.
+    BEEGO_CONTROLLER_HTTP_METHODS = {
+      "Get"     => "GET",
+      "Post"    => "POST",
+      "Put"     => "PUT",
+      "Delete"  => "DELETE",
+      "Patch"   => "PATCH",
+      "Head"    => "HEAD",
+      "Options" => "OPTIONS",
+    }
+
     # A static-file route: URL `url_prefix` serves files from disk
     # location `disk_path`.
     struct StaticPath
@@ -202,6 +225,71 @@ module Noir
       group_prefixes
     end
 
+    # Collects Beego controller types and the HTTP-verb-named methods they
+    # implement, keyed by the (package-unqualified) type name. Used to
+    # resolve mapping-less `web.Router("/path", &Ctrl{})` registrations
+    # into the concrete set of methods the controller serves. Built once
+    # per package directory by the Beego analyzer (controllers and their
+    # router registrations usually share a package).
+    #
+    # Only HTTP-verb method names are recorded — a `MainController` that
+    # defines `Get`, `Health`, `Update` contributes `{"MainController" =>
+    # ["Get"]}`, because Beego's default mapping only routes verb-named
+    # methods; `Health`/`Update` are reachable solely via an explicit
+    # `"get:Health"` mapping string.
+    def extract_controller_methods(source : String) : Hash(String, Array(String))
+      result = Hash(String, Array(String)).new
+      Noir::TreeSitter.parse_go(source) do |root|
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "method_declaration"
+          receiver = Noir::TreeSitter.field(node, "receiver")
+          name_node = Noir::TreeSitter.field(node, "name")
+          next unless receiver && name_node
+          method_name = Noir::TreeSitter.node_text(name_node, source)
+          next unless BEEGO_CONTROLLER_HTTP_METHODS.has_key?(method_name)
+          type_name = receiver_type_name(receiver, source)
+          next unless type_name
+          list = (result[type_name] ||= [] of String)
+          list << method_name unless list.includes?(method_name)
+        end
+      end
+      result
+    end
+
+    # Extracts Beego controller-style routes:
+    #
+    #   web.Router("/health", ctrl, "get:Health")          -> GET /health
+    #   web.Router("/x", c, "get,post:Handle")             -> GET /x, POST /x
+    #   web.Router("/x", c, "get:Read;post:Write")         -> GET /x, POST /x
+    #   web.Router("/any", c, "*:Any")                     -> ANY /any (fan-out)
+    #   web.Router("/", &MainController{})                 -> verb routes
+    #                                                         for each HTTP
+    #                                                         method the
+    #                                                         controller
+    #                                                         implements
+    #
+    # `controller_methods` (see `extract_controller_methods`) supplies the
+    # method set for the mapping-less form; when the controller type can't
+    # be resolved (e.g. a cross-package `&controllers.User{}`), the route
+    # falls back to a single GET so the endpoint is still surfaced rather
+    # than dropped. The Route's `handler` carries the controller-method
+    # name so the analyzer can attribute it as a callee.
+    def extract_beego_routes(source : String,
+                             controller_methods : Hash(String, Array(String)) = Hash(String, Array(String)).new) : Array(Route)
+      routes = [] of Route
+      Noir::TreeSitter.parse_go(source) do |root|
+        string_values = collect_string_values(root, source)
+        var_types = collect_controller_var_types(root, source)
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          decode_beego_router_call(node, source, controller_methods, var_types, string_values).each do |route|
+            routes << route
+          end
+        end
+      end
+      dedupe_routes(routes)
+    end
+
     # Framework constructors that mint a *root* router/engine — the
     # receiver they're assigned to carries no path prefix. A name bound
     # to one of these is the application root, never a sub-group.
@@ -240,6 +328,33 @@ module Noir
         end
       end
       names
+    end
+
+    # Single-parse combination of `extract_engine_names` +
+    # `extract_groups` (with an empty external map). The Go engine's
+    # group pre-pass needs BOTH per file — the root-engine names to
+    # exclude from cross-file propagation and the file's own group
+    # declarations — so folding them into one tree-sitter parse halves
+    # the pre-pass parse count. Behaviour is identical to calling the two
+    # extractors separately; only the parse is shared.
+    def extract_engine_names_and_groups(source : String,
+                                        group_method : String = "Group",
+                                        group_aliases : Array(String) = [] of String) : Tuple(Set(String), Hash(String, String))
+      names = Set(String).new
+      group_prefixes = Hash(String, String).new
+      Noir::TreeSitter.parse_go(source) do |root|
+        string_values = collect_string_values(root, source)
+        walk(root) do |node|
+          case Noir::TreeSitter.node_type(node)
+          when "short_var_declaration", "assignment_statement", "var_spec"
+            collect_engine_assignment(node, source, names)
+            collect_group(node, source, group_prefixes, group_method, group_aliases, string_values)
+          when "parameter_declaration"
+            collect_engine_param(node, source, names)
+          end
+        end
+      end
+      {names, group_prefixes}
     end
 
     # `<name> := <pkg>.New()` / `.Default()` / `.NewRouter()` → root name.
@@ -1025,14 +1140,25 @@ module Noir
 
       raw_path = nil
       handler_text = ""
+      arg_index = 0
       Noir::TreeSitter.each_named_child(args) do |arg|
-        if raw_path.nil?
+        if arg_index == 0
+          # The route path must be the FIRST positional argument of a verb
+          # call (`r.GET("/path", handler)` across Gin/Echo/Fiber/Beego/
+          # Hertz/Iris). Bailing when arg0 isn't a string rejects
+          # value-returning helpers that merely share a verb name — a
+          # cache's `c.Put(ctx, "key", val)`, a store's `s.Get(ctx, "id")`,
+          # etc. — whose first arg is a context/receiver, not a URL.
+          # Previously the scan walked past the non-string first arg and
+          # latched onto a later string literal, surfacing phantom routes
+          # like `PUT /key` (observed across beego cache examples).
           raw_path = string_expr_text(arg, source, string_values)
-        else
+        elsif handler_text.empty?
           # First non-string positional arg after the path is treated as
           # the handler — matches Gin/Echo/Fiber calling conventions.
-          handler_text = Noir::TreeSitter.node_text(arg, source) if handler_text.empty? && !raw_path.nil?
+          handler_text = Noir::TreeSitter.node_text(arg, source)
         end
+        arg_index += 1
       end
 
       return unless raw_path
@@ -1310,6 +1436,166 @@ module Noir
       verbs.uniq.map do |verb|
         Route.new(router_name, verb, resolved, raw_path, handler_text, registration_line, query_params.dup)
       end
+    end
+
+    # Decode a single `web.Router(...)` / `beego.Router(...)` call into
+    # zero or more routes (one per resolved HTTP method).
+    private def decode_beego_router_call(call : LibTreeSitter::TSNode,
+                                         source : String,
+                                         controller_methods : Hash(String, Array(String)),
+                                         var_types : Hash(String, String),
+                                         string_values : Hash(String, String)) : Array(Route)
+      empty = [] of Route
+      function = Noir::TreeSitter.field(call, "function")
+      return empty unless function
+      return empty unless Noir::TreeSitter.node_type(function) == "selector_expression"
+      operand = Noir::TreeSitter.field(function, "operand")
+      field = Noir::TreeSitter.field(function, "field")
+      return empty unless operand && field
+      return empty unless Noir::TreeSitter.node_type(operand) == "identifier"
+      return empty unless BEEGO_ROUTER_OPERANDS.includes?(Noir::TreeSitter.node_text(operand, source))
+      return empty unless Noir::TreeSitter.node_text(field, source) == "Router"
+
+      args = Noir::TreeSitter.field(call, "arguments")
+      return empty unless args
+
+      path = nil
+      controller_node : LibTreeSitter::TSNode? = nil
+      mapping = nil
+      idx = 0
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        case idx
+        when 0 then path = string_expr_text(arg, source, string_values)
+        when 1 then controller_node = arg
+        when 2 then mapping = string_expr_text(arg, source, string_values)
+        end
+        idx += 1
+      end
+      route_path = path
+      return empty if route_path.nil? || route_path.empty?
+
+      line = Noir::TreeSitter.node_start_row(call)
+      ctrl_type = controller_node.try { |n| controller_type_name(n, source, var_types) }
+
+      if mapping && !mapping.empty?
+        parse_beego_mapping(mapping).map do |verb, fn|
+          Route.new("web", verb, route_path, route_path, fn, line)
+        end
+      else
+        methods = ctrl_type.try { |t| controller_methods[t]? }
+        if methods && !methods.empty?
+          methods.map do |m|
+            Route.new("web", BEEGO_CONTROLLER_HTTP_METHODS[m], route_path, route_path, m, line)
+          end
+        else
+          # Unresolved controller type: surface the endpoint under GET so
+          # it isn't dropped entirely. Beego controllers almost always
+          # implement `Get()`, so GET is the safest single-method guess.
+          [Route.new("web", "GET", route_path, route_path, ctrl_type || "", line)]
+        end
+      end
+    end
+
+    # Parse a Beego method-mapping string into `{HTTP_VERB, func_name}`
+    # pairs. Format: `"get:Method;post,put:Other"` — `;`-separated
+    # segments, each `methods:funcname`, methods `,`-separated, `*`
+    # meaning "any method".
+    private def parse_beego_mapping(mapping : String) : Array(Tuple(String, String))
+      result = [] of Tuple(String, String)
+      mapping.split(';').each do |segment|
+        segment = segment.strip
+        next if segment.empty?
+        colon = segment.index(':')
+        next unless colon
+        methods = segment[0...colon]
+        fn = segment[(colon + 1)..].strip
+        methods.split(',').each do |m|
+          m = m.strip
+          next if m.empty?
+          result << ({m == "*" ? "ANY" : m.upcase, fn})
+        end
+      end
+      result
+    end
+
+    # Scan the file for `name := &Ctrl{}` / `name := Ctrl{}` bindings so a
+    # later `web.Router("/x", name)` can resolve `name`'s controller type.
+    private def collect_controller_var_types(root : LibTreeSitter::TSNode,
+                                             source : String) : Hash(String, String)
+      var_types = Hash(String, String).new
+      walk(root) do |node|
+        next unless group_assignment_node?(node)
+        left = Noir::TreeSitter.field(node, "left")
+        right = Noir::TreeSitter.field(node, "right")
+        if Noir::TreeSitter.node_type(node) == "var_spec"
+          left = Noir::TreeSitter.field(node, "name")
+          right = Noir::TreeSitter.field(node, "value")
+        end
+        next unless left && right
+        name_node = identifier_or_first_child(left)
+        rhs = first_named_child(right)
+        next unless name_node && rhs
+        next unless Noir::TreeSitter.node_type(name_node) == "identifier"
+        type_name = composite_literal_type_name(rhs, source)
+        next unless type_name
+        var_types[Noir::TreeSitter.node_text(name_node, source)] ||= type_name
+      end
+      var_types
+    end
+
+    # Resolve a controller argument node to its (unqualified) type name.
+    # `identifier` → look up the var binding; anything wrapping a
+    # `composite_literal` (`&Ctrl{}`, `Ctrl{}`) → the literal's type.
+    private def controller_type_name(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     var_types : Hash(String, String)) : String?
+      if Noir::TreeSitter.node_type(node) == "identifier"
+        return var_types[Noir::TreeSitter.node_text(node, source)]?
+      end
+      composite_literal_type_name(node, source)
+    end
+
+    # Find a `composite_literal` at or under `node` and return its type
+    # name with any package qualifier and pointer stripped
+    # (`&pkg.Ctrl{}` → `Ctrl`).
+    private def composite_literal_type_name(node : LibTreeSitter::TSNode,
+                                            source : String) : String?
+      comp = find_composite_literal(node)
+      return unless comp
+      type_node = Noir::TreeSitter.field(comp, "type") || first_named_child(comp)
+      return unless type_node
+      final_type_identifier(type_node, source)
+    end
+
+    private def find_composite_literal(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      return node if Noir::TreeSitter.node_type(node) == "composite_literal"
+      result : LibTreeSitter::TSNode? = nil
+      Noir::TreeSitter.each_named_child(node) do |child|
+        if found = find_composite_literal(child)
+          result = found
+          break
+        end
+      end
+      result
+    end
+
+    # Type name of a method receiver: `(c *MainController)` → `MainController`.
+    private def receiver_type_name(receiver : LibTreeSitter::TSNode,
+                                   source : String) : String?
+      Noir::TreeSitter.each_named_child(receiver) do |decl|
+        next unless Noir::TreeSitter.node_type(decl) == "parameter_declaration"
+        type_node = Noir::TreeSitter.field(decl, "type")
+        next unless type_node
+        return final_type_identifier(type_node, source)
+      end
+      nil
+    end
+
+    # Strip a leading `*` (pointer) and any package qualifier, returning
+    # the final identifier of a type expression: `*pkg.Foo` → `Foo`.
+    private def final_type_identifier(type_node : LibTreeSitter::TSNode,
+                                      source : String) : String
+      Noir::TreeSitter.node_text(type_node, source).lchop('*').split('.').last
     end
 
     private def dedupe_routes(routes : Array(Route)) : Array(Route)


### PR DESCRIPTION
## Summary

Tested the Go **Echo / Gin / Fiber / Beego** analyzers against real open-source repos (`gin-gonic/examples`, `labstack/echox`, `gofiber/recipes`, `beego/beego-example`, `go-admin-team/go-admin`) and reduced **endpoint / callee / AI-context** false positives & negatives, plus sped up the Go group pre-pass. This enriches the already-solid Go AI-context base rather than fixing a gap.

> Note: example-collection repos (echox, fiber-recipes, gin-examples) are poor for FN counting because noir global-dedupes by `(method, url)` — dozens of independent `GET /` example apps collapse to one. Cohesive single apps (go-admin) were used for FN, example repos only for structural pattern gaps.

## Endpoints

- **Beego `web.Router` controller routing (FN, largest).** `web.Router("/x", &Ctrl{}, "get:Method")` was entirely missed (only `web.Get` verb-style was handled). Now parses the mapping string (`"get:H;post,put:X"`, `*`→ANY, comma/semicolon lists); the mapping-less form resolves the controller's HTTP-verb-named methods via a per-directory `type→methods` map; an unresolved cross-package controller falls back to a single GET. **beego-example 3 → 36 endpoints** (the prior 3 were all FPs).
- **Verb-call first-arg (FP, all Go frameworks).** The route path must be the **first** positional argument (true for Gin/Echo/Fiber/Beego/Hertz/Iris), so value helpers that merely share a verb name — `cache.Put(ctx, "key", val)`, `store.Get(ctx, "id")` — no longer surface phantom routes like `PUT /key`.
- **Huma v2 sugar helpers (FN + regression recovery).** The first-arg fix removed the Fiber pass's *incidental* catch of `huma.Get(api, "/books/{id}", h)` (path is the 2nd arg). The Huma analyzer now handles `huma.Get/Post/Put/Patch/Delete/Head/Options` alongside `huma.Register`, so these are correctly attributed to Huma.

## Callees

- **Beego controller-method callees.** `web.Router` routes had no callees (the handler isn't a call argument). The named controller method's body is now walked (resolved within the package, single-definition ambiguity guard). **beego-example: 35/36 endpoints now carry callees; all 36 gain AI-context.**

## Performance (group pre-pass)

Measured via a temporary `parse_go` counter: `collect_package_groups_ts` parsed each `.go` file ~4× (engine-names + groups separately, then the fixpoint re-parses every file each iteration). Three fixes — (1) gate the pre-pass on the framework import marker, (2) fold engine-name + group extraction into a single parse, (3) skip the cross-file fixpoint for single-file packages:

| repo | parses | scan time | endpoints |
|------|--------|-----------|-----------|
| go-admin | 697 → 291 (**-58%**) | **-28%** | 155 (unchanged) |
| fiber-recipes | 1878 → 1017 (**-46%**) | **-28%** | 172 (unchanged) |
| gin-examples | — | **-37%** | 48 (unchanged) |

All real-repo endpoint sets are byte-identical before/after (parity diff 0).

## Tests

- New `fixtures/go/beego_controller/` + spec (endpoints + callees).
- Extended the Huma fixture/spec with sugar-method calls.
- +5 route-extractor unit tests (first-arg FP guard, beego mapping / mapping-less / fallback / non-beego operand).
- Full suite: **18229 examples, 0 failures**; `crystal tool format` clean; ameba clean.

## Follow-ups (not in this PR)

- **go-admin callee FN:** 154/155 endpoints lack callees because handlers are method-values on **cross-package** receivers (`dataApi.GetPage`). Resolving needs cross-package type+method resolution (ImportGraph territory) — deferred.
- Beego `web.AutoRouter` / `web.NewNamespace` / `NSRouter` namespacing still unhandled.