### PR TITLE
Clean up labeler rules and repo labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -55,8 +55,14 @@
 🐳 docker:
   - changed-files:
       - any-glob-to-any-file: Dockerfile
-🤖 llm:
+🤖 ai-analyzer:
   - changed-files:
       - any-glob-to-any-file:
           - src/llm/**
           - src/analyzer/analyzers/llm_analyzers/**
+🧩 ai-context:
+  - changed-files:
+      - any-glob-to-any-file: src/ai_context/**
+🪝 callee:
+  - changed-files:
+      - any-glob-to-any-file: src/miniparsers/*_callee_extractor.cr


### PR DESCRIPTION
## Description

Tidies up the PR labeler config and the repo's label set.

### `.github/labeler.yml`
- Rename `🤖 llm` rule → `🤖 ai-analyzer` (globs unchanged: `src/llm/**`, `src/analyzer/analyzers/llm_analyzers/**`)
- Add `🧩 ai-context` → `src/ai_context/**`
- Add `🪝 callee` → `src/miniparsers/*_callee_extractor.cr`

### Repo labels (applied directly via `gh`)
- Renamed `🤖 llm` → `🤖 ai-analyzer`
- Created `🧩 ai-context` and `🪝 callee`
- Removed the auto-registered per-language labels: `go`, `java`, `javascript`, `python`, `ruby`, `rust`

### Notes
- `callee` intentionally overlaps with `🥢 mini-lexer` (`src/miniparsers/**`); callee-extractor PRs will carry both.
- Dependabot may recreate `python`/`javascript`/`ruby` ecosystem labels on its next run.