### PR TITLE
C# ASP.NET Core: cut DI-service FPs, recover method-group & modern-controller endpoints

### DIFF
--- a/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api_methodgroup/MethodGroupDemo.csproj
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api_methodgroup/MethodGroupDemo.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api_methodgroup/Program.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_minimal_api_methodgroup/Program.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+// Method-group handler: route lives on the Map line, parameters and body
+// live in the referenced method. The analyzer resolves it for both.
+app.MapGet("/products", GetProducts)
+   .WithName("ListProducts")
+   .Produces<IResult>();
+
+app.MapGet("/products/{id:int}", GetProductById);
+app.MapPost("/products", CreateProduct);
+
+// [AsParameters] bundle whose type is declared in this file: the query/
+// header members expand, the injected service member is dropped.
+app.MapGet("/search", Search);
+
+// Services injected straight into a lambda are not request parameters.
+app.MapGet("/inventory", (IProductRepository repository, AppDbContext db, ILogger<Program> logger) =>
+{
+    return Results.Ok(repository.All());
+});
+
+app.MapPost("/orders", ([FromHeader(Name = "x-request-id")] Guid requestId, CreateOrderRequest order, ISender sender) =>
+{
+    sender.Send(order);
+    return Results.Accepted();
+});
+
+app.Run();
+
+static IResult GetProducts(IProductRepository repository, int? page, [FromQuery] string? sort)
+{
+    var items = repository.Query(page, sort);
+    return Results.Ok(items);
+}
+
+static IResult GetProductById([FromServices] IProductRepository repository, int id)
+{
+    var item = repository.Find(id);
+    return Results.Ok(item);
+}
+
+static IResult CreateProduct(CreateProductRequest request, IProductRepository repository)
+{
+    repository.Add(request);
+    return Results.Created($"/products/{request.Name}", request);
+}
+
+static IResult Search([AsParameters] ProductSearch query, IProductRepository repository)
+{
+    return Results.Ok(repository.Search(query));
+}
+
+record CreateOrderRequest(string Sku, int Quantity);
+record CreateProductRequest(string Name, decimal Price);
+
+class ProductSearch
+{
+    public string? Term { get; set; }
+    public int Page { get; set; }
+
+    [FromHeader(Name = "X-Tenant")]
+    public string? Tenant { get; set; }
+
+    public IProductRepository? Repository { get; set; }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Controllers/UsersController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc/Controllers/UsersController.cs
@@ -32,6 +32,12 @@ namespace Demo.Controllers
             return repository.List(filter);
         }
 
+        [HttpGet("search")]
+        public IActionResult Search(string keyword, IUserRepository repository)
+        {
+            return Ok(repository.List(keyword));
+        }
+
         [NonAction]
         public Task<UserDto> LoadUser([FromQuery] string id)
         {

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/ArticlesController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/ArticlesController.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Demo.Controllers
+{
+    // C# 12 primary constructor + attribute-routed controller deriving from the
+    // framework Controller base. Actions are expression-bodied and delegate to
+    // MediatR — the prevailing "thin controller" style.
+    [Route("articles")]
+    public class ArticlesController(IMediator mediator) : Controller
+    {
+        [HttpGet]
+        public Task<ArticlesEnvelope> List(
+            [FromQuery] string tag,
+            [FromQuery] int? limit,
+            CancellationToken cancellationToken
+        ) => mediator.Send(new ListQuery(tag, limit), cancellationToken);
+
+        [HttpGet("{slug}")]
+        public Task<ArticleEnvelope> Get(string slug, CancellationToken cancellationToken) =>
+            mediator.Send(new DetailsQuery(slug), cancellationToken);
+
+        [HttpPost]
+        public Task<ArticleEnvelope> Create(
+            [FromBody] CreateArticleCommand command,
+            CancellationToken cancellationToken
+        ) => mediator.Send(command, cancellationToken);
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/UsersController.cs
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/Controllers/UsersController.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Demo.Controllers
+{
+    // POCO controller: no `: Controller` / `: ControllerBase` base class. ASP.NET
+    // Core still treats it as a controller by the `Controller` name suffix.
+    [Route("users")]
+    public class UsersController(IMediator mediator)
+    {
+        [HttpPost]
+        public Task<UserEnvelope> Create(
+            [FromBody] RegisterCommand command,
+            CancellationToken cancellationToken
+        ) => mediator.Send(command, cancellationToken);
+
+        [HttpPost("login")]
+        public Task<UserEnvelope> Login(
+            [FromBody] LoginCommand command,
+            CancellationToken cancellationToken
+        ) => mediator.Send(command, cancellationToken);
+    }
+}

--- a/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/MyApp.csproj
+++ b/spec/functional_test/fixtures/csharp/aspnet_core_mvc_modern/MyApp.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/testers/csharp/aspnet_core_minimal_api_methodgroup_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_minimal_api_methodgroup_spec.cr
@@ -1,0 +1,82 @@
+require "../../func_spec.cr"
+
+# Method-group handlers (`MapGet("/x", Handler)`), `[AsParameters]` bundle
+# expansion and dependency-injected service dropping — the dominant style in
+# modern minimal APIs (eShop, vertical-slice / REPR).
+list_products = Endpoint.new("/products", "GET", [
+  Param.new("page", "", "query"),
+  Param.new("sort", "", "query"),
+])
+list_products.push_callee(Callee.new("repository.Query"))
+list_products.push_callee(Callee.new("Results.Ok"))
+
+get_product = Endpoint.new("/products/{id}", "GET", [
+  Param.new("id", "", "path"),
+])
+get_product.push_callee(Callee.new("repository.Find"))
+
+create_product = Endpoint.new("/products", "POST", [
+  Param.new("request", "", "json"),
+])
+create_product.push_callee(Callee.new("repository.Add"))
+
+search = Endpoint.new("/search", "GET", [
+  Param.new("Term", "", "query"),
+  Param.new("Page", "", "query"),
+  Param.new("X-Tenant", "", "header"),
+])
+
+inventory = Endpoint.new("/inventory", "GET")
+inventory.push_callee(Callee.new("repository.All"))
+
+create_order = Endpoint.new("/orders", "POST", [
+  Param.new("x-request-id", "", "header"),
+  Param.new("order", "", "json"),
+])
+create_order.push_callee(Callee.new("sender.Send"))
+
+expected_endpoints = [
+  list_products,
+  get_product,
+  create_product,
+  search,
+  inventory,
+  create_order,
+]
+
+tester = FunctionalTester.new("fixtures/csharp/aspnet_core_minimal_api_methodgroup/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+
+tester.perform_tests
+
+describe "ASP.NET Core Minimal API method-group analyzer edge cases" do
+  it "drops DI services injected into a lambda handler" do
+    inv = tester.app.endpoints.find { |e| e.url == "/inventory" && e.method == "GET" }
+    inv.should_not be_nil
+    inv.as(Endpoint).params.empty?.should be_true
+  end
+
+  it "drops the injected service member when expanding [AsParameters]" do
+    s = tester.app.endpoints.find { |e| e.url == "/search" && e.method == "GET" }
+    s.should_not be_nil
+    s.as(Endpoint).params.any? { |p| p.name.downcase == "repository" }.should be_false
+  end
+
+  it "does not record binding attributes or route metadata as callees" do
+    order = tester.app.endpoints.find { |e| e.url == "/orders" && e.method == "POST" }
+    order.should_not be_nil
+    names = order.as(Endpoint).callees.map(&.name)
+    names.any? { |n| n == "FromHeader" }.should be_false
+  end
+
+  it "does not record fluent route-builder metadata as callees" do
+    products = tester.app.endpoints.find { |e| e.url == "/products" && e.method == "GET" }
+    products.should_not be_nil
+    names = products.as(Endpoint).callees.map(&.name)
+    names.any? { |n| n == "WithName" || n == "Produces" }.should be_false
+  end
+end

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_modern_spec.cr
@@ -1,0 +1,66 @@
+require "../../func_spec.cr"
+
+# Modern controller styles: C# 12 primary constructors, POCO controllers with
+# no `: Controller` base, and expression-bodied actions delegating to MediatR.
+articles_list = Endpoint.new("/articles", "GET", [
+  Param.new("tag", "", "query"),
+  Param.new("limit", "", "query"),
+])
+articles_list.push_callee(Callee.new("mediator.Send"))
+
+article_get = Endpoint.new("/articles/{slug}", "GET", [
+  Param.new("slug", "", "path"),
+])
+
+article_create = Endpoint.new("/articles", "POST", [
+  Param.new("command", "", "json"),
+])
+
+users_create = Endpoint.new("/users", "POST", [
+  Param.new("command", "", "json"),
+])
+
+users_login = Endpoint.new("/users/login", "POST", [
+  Param.new("command", "", "json"),
+])
+
+expected_endpoints = [
+  articles_list,
+  article_get,
+  article_create,
+  users_create,
+  users_login,
+]
+
+tester = FunctionalTester.new("fixtures/csharp/aspnet_core_mvc_modern/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+
+tester.perform_tests
+
+describe "ASP.NET Core MVC modern controller edge cases" do
+  it "resolves actions on a primary-constructor controller" do
+    list = tester.app.endpoints.find { |e| e.url == "/articles" && e.method == "GET" }
+    list.should_not be_nil
+  end
+
+  it "resolves actions on a POCO controller with no base class" do
+    login = tester.app.endpoints.find { |e| e.url == "/users/login" && e.method == "POST" }
+    login.should_not be_nil
+  end
+
+  it "drops the ambient CancellationToken from expression-bodied actions" do
+    list = tester.app.endpoints.find { |e| e.url == "/articles" && e.method == "GET" }
+    list.should_not be_nil
+    list.as(Endpoint).params.any? { |p| p.name == "cancellationToken" }.should be_false
+  end
+
+  it "records callees from an expression-bodied action body" do
+    list = tester.app.endpoints.find { |e| e.url == "/articles" && e.method == "GET" }
+    list.should_not be_nil
+    list.as(Endpoint).callees.map(&.name).any? { |n| n == "mediator.Send" }.should be_true
+  end
+end

--- a/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
+++ b/spec/functional_test/testers/csharp/aspnet_core_mvc_spec.cr
@@ -31,6 +31,9 @@ expected_endpoints = [
   Endpoint.new("/api/Users/raw", "GET", [
     Param.new("filter", "", "query"),
   ]),
+  Endpoint.new("/api/Users/search", "GET", [
+    Param.new("keyword", "", "query"),
+  ]),
   Endpoint.new("/api/Users/{id}", "PUT", [
     Param.new("id", "", "path"),
     Param.new("name", "", "json"),
@@ -132,6 +135,12 @@ describe "ASP.NET Core MVC analyzer edge cases" do
     raw = tester.app.endpoints.find { |e| e.url == "/api/Users/raw" && e.method == "GET" }
     raw.should_not be_nil
     raw.as(Endpoint).params.any? { |p| p.name == "repository" }.should be_false
+  end
+
+  it "drops an interface-typed action parameter that has no explicit [FromServices]" do
+    search = tester.app.endpoints.find { |e| e.url == "/api/Users/search" && e.method == "GET" }
+    search.should_not be_nil
+    search.as(Endpoint).params.any? { |p| p.name == "repository" }.should be_false
   end
 
   it "does not report NonAction task-returning helpers as endpoints" do

--- a/spec/unit_test/analyzer/csharp_common_service_type_spec.cr
+++ b/spec/unit_test/analyzer/csharp_common_service_type_spec.cr
@@ -1,0 +1,42 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/csharp/common.cr"
+
+describe Analyzer::CSharp::Common do
+  describe ".csharp_service_type?" do
+    it "treats interface-typed parameters as DI services" do
+      Analyzer::CSharp::Common.csharp_service_type?("IRepository").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("IMapper").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("ISender").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("IAntiforgery").should be_true
+      # Generic interfaces collapse to their base name first.
+      Analyzer::CSharp::Common.csharp_service_type?("IRepository<CatalogItem>").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("ILogger<Program>").should be_true
+    end
+
+    it "treats well-known service suffixes as DI services" do
+      Analyzer::CSharp::Common.csharp_service_type?("CatalogContext").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("HooksRepository").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("OrderService").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("AppDbContext").should be_true
+    end
+
+    it "treats known framework types as services" do
+      Analyzer::CSharp::Common.csharp_service_type?("HttpContext").should be_true
+      Analyzer::CSharp::Common.csharp_service_type?("CancellationToken").should be_true
+    end
+
+    it "keeps form-upload interfaces as request inputs" do
+      Analyzer::CSharp::Common.csharp_service_type?("IFormFile").should be_false
+      Analyzer::CSharp::Common.csharp_service_type?("IFormFileCollection").should be_false
+    end
+
+    it "does not flag request DTOs or value types" do
+      Analyzer::CSharp::Common.csharp_service_type?("CreateOrderRequest").should be_false
+      Analyzer::CSharp::Common.csharp_service_type?("CatalogItem").should be_false
+      Analyzer::CSharp::Common.csharp_service_type?("string").should be_false
+      Analyzer::CSharp::Common.csharp_service_type?("int").should be_false
+      # Acronym value types (I-P-A) must not be caught by the interface rule.
+      Analyzer::CSharp::Common.csharp_service_type?("IPAddress").should be_false
+    end
+  end
+end

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -179,7 +179,7 @@ module Analyzer::CSharp
             action_name = extract_action_name(signature)
             unless action_name.empty?
               parameters = extract_parameters(signature, http_method)
-              body_block = extract_method_block(lines, end_index)
+              body_block, body_line, skip_first = extract_callable_body(lines, end_index)
               body_params = extract_params_from_block(body_block)
               parameters = merge_params(parameters, body_params, http_method)
               effective_action_route = action_route
@@ -196,7 +196,7 @@ module Analyzer::CSharp
                   endpoint.params << param
                 end
 
-                attach_csharp_callees(endpoint, body_block, file, end_index + 1, include_callee, skip_first_line: true)
+                attach_csharp_callees(endpoint, body_block, file, body_line + 1, include_callee, skip_first_line: skip_first)
                 @result << endpoint
               end
 
@@ -312,7 +312,17 @@ module Analyzer::CSharp
     end
 
     private def extract_controller_name(content : String) : String
-      match = content.match(/class\s+(\w+)Controller\s*:\s*[\w<>\s,]*Controller\w*/)
+      # Any class whose name ends in `Controller` is a controller in ASP.NET
+      # Core, regardless of its base list — so we no longer require a
+      # `: Controller`/`: ControllerBase` suffix. This covers:
+      #   * POCO controllers with no base class (`class UsersController { }`),
+      #   * custom base classes (`: BaseApiController`),
+      #   * C# 12 primary constructors (`class ArticlesController(IMediator m)`),
+      #   * generic controllers (`class CrudController<T>`).
+      # The enclosing file is already filtered to `*Controller.cs`, so the
+      # match is unambiguous. `\b` after `Controller` avoids matching
+      # `FooControllerOptions`-style helper types.
+      match = content.match(/\bclass\s+(\w+)Controller\b/)
       return "" unless match
       match[1]
     end
@@ -326,10 +336,10 @@ module Analyzer::CSharp
     private def extract_parameters(signature : String, http_method : String) : Array(Param)
       parameters = [] of Param
 
-      match = signature.match(/\((.*)\)/m)
-      return parameters unless match
+      param_list = extract_balanced_param_list(signature)
+      return parameters unless param_list
 
-      param_list = match[1].strip
+      param_list = param_list.strip
       return parameters if param_list.empty?
 
       default_param_type = default_param_type(http_method)
@@ -341,6 +351,16 @@ module Analyzer::CSharp
 
         if match = cleaned_def.match(/(\w+)\s*(?:=\s*[^,]+)?\s*$/)
           param_name = match[1]
+
+          # A complex/interface action parameter with no explicit `[FromX]`
+          # attribute that names a DI service (an injected repository, the
+          # DbContext, a MediatR sender, …) is not request input — model
+          # binding never produces one. Dropping it removes a recurring FP.
+          if param_type.nil?
+            type_token = cleaned_def.sub(/\b#{Regex.escape(param_name)}\b\s*(?:=\s*[^,]+)?\s*$/, "").strip.split(/\s+/).last?
+            next if type_token && Common.csharp_service_type?(type_token)
+          end
+
           parameters << Param.new(param_name, "", param_type || default_param_type)
         end
       end

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -24,6 +24,51 @@ module Analyzer::CSharp::Common
     base.ends_with?("Test.cs")
   end
 
+  # `IFormFile`/`IFormFileCollection`/`IFormCollection` are interfaces but
+  # bind from the request body (file upload / form), not from DI — keep
+  # them as request inputs even though they match the interface rule below.
+  SERVICE_FORM_INPUT_TYPES = Set{"IFormFile", "IFormFileCollection", "IFormCollection"}
+
+  # Concrete framework types that are always resolved from DI / the
+  # request pipeline rather than bound from user input.
+  KNOWN_SERVICE_TYPES = Set{
+    "CancellationToken", "HttpContext", "HttpRequest", "HttpResponse",
+    "ClaimsPrincipal", "IServiceProvider", "LinkGenerator", "ILoggerFactory",
+    "IConfiguration", "IWebHostEnvironment", "IHostEnvironment",
+  }
+
+  # High-precision suffixes that mark a type as a dependency-injected
+  # collaborator. Deliberately conservative: suffixes that collide with
+  # common domain/entity names (e.g. `Client`, `Provider`, `Factory`) are
+  # left out so request DTOs aren't dropped by mistake. Interface-typed
+  # DI is caught separately by the `I<Pascal>` rule.
+  SERVICE_TYPE_SUFFIXES = %w[
+    Repository Service Services Manager Mediator Mapper Accessor
+    Dispatcher Publisher DbContext Context Logger
+  ]
+
+  # Heuristic for whether a parameter's *type* names a dependency-injected
+  # service (DbContext, repository, MediatR sender, mapper, …) rather than a
+  # value bound from the request. ASP.NET Core can't be statically resolved
+  # against its DI container, so we lean on near-universal naming
+  # conventions in real code:
+  #
+  #   * Interfaces (`I` + PascalCase) are never deserialized from a request
+  #     body and never bound from the query string — they're DI or special
+  #     pipeline types. The `[a-z]` third-char guard keeps acronym value
+  #     types like `IPAddress` (I-P-A) out of the net.
+  #   * A small set of concrete framework types and service suffixes.
+  #
+  # Returns false for the form-upload interfaces, which *are* request inputs.
+  def self.csharp_service_type?(type_name : String) : Bool
+    base = type_name.gsub(/<.*>/, "").split('.').last.strip
+    return false if base.empty?
+    return false if SERVICE_FORM_INPUT_TYPES.includes?(base)
+    return true if KNOWN_SERVICE_TYPES.includes?(base)
+    return true if base.matches?(/\AI[A-Z][a-z]/)
+    SERVICE_TYPE_SUFFIXES.any? { |suffix| base.ends_with?(suffix) }
+  end
+
   protected def build_signature(lines : Array(String), start_index : Int32) : Tuple(String, Int32)
     signature = lines[start_index]
     paren_count = signature.count('(') - signature.count(')')
@@ -44,9 +89,28 @@ module Analyzer::CSharp::Common
     generic_depth = 0
     paren_depth = 0
     bracket_depth = 0
+    brace_depth = 0
+    in_string = false
+    escaped = false
 
     param_list.each_char do |char|
+      # Inside a string literal commas/brackets are data, not structure —
+      # e.g. a route literal `"/a,b"` or a `new[] { "GET", "POST" }` arg.
+      if in_string
+        current << char
+        if escaped
+          escaped = false
+        elsif char == '\\'
+          escaped = true
+        elsif char == '"'
+          in_string = false
+        end
+        next
+      end
+
       case char
+      when '"'
+        in_string = true
       when '<'
         generic_depth += 1
       when '>'
@@ -59,8 +123,12 @@ module Analyzer::CSharp::Common
         bracket_depth += 1
       when ']'
         bracket_depth -= 1 if bracket_depth > 0
+      when '{'
+        brace_depth += 1
+      when '}'
+        brace_depth -= 1 if brace_depth > 0
       when ','
-        if generic_depth == 0 && paren_depth == 0 && bracket_depth == 0
+        if generic_depth == 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
           params << current.to_s.strip
           current = String::Builder.new
           next
@@ -73,6 +141,29 @@ module Analyzer::CSharp::Common
     tail = current.to_s.strip
     params << tail unless tail.empty?
     params
+  end
+
+  # Returns the substring inside the first balanced parameter-list parens of
+  # a method signature. Unlike a greedy `\((.*)\)`, this stops at the matching
+  # close paren so an expression body (`(int id) => Repo.Find(id)`) doesn't
+  # leak the call's own arguments into the parameter list.
+  protected def extract_balanced_param_list(signature : String) : String?
+    open = signature.index('(')
+    return unless open
+
+    depth = 0
+    i = open
+    while i < signature.size
+      case signature[i]
+      when '('
+        depth += 1
+      when ')'
+        depth -= 1
+        return signature[(open + 1)...i] if depth == 0
+      end
+      i += 1
+    end
+    nil
   end
 
   protected def extract_method_block(lines : Array(String), start_index : Int32) : String
@@ -90,10 +181,53 @@ module Analyzer::CSharp::Common
       if started && brace <= 0 && line.includes?("}")
         break
       end
+      # Expression-bodied member (`=> expr;`): there is no brace block, so the
+      # statement terminator ends it. Without this guard the scanner would run
+      # to end-of-file and swallow every following member.
+      if !started && line.includes?(";")
+        break
+      end
       index += 1
     end
 
     io.to_s
+  end
+
+  # Extracts a method's body starting from the line where its signature
+  # closes. Handles both brace bodies (`{ ... }`) and expression bodies
+  # (`=> expr;`). Returns `{block, start_line_index, skip_first_line}` —
+  # the caller passes `skip_first_line` through to the callee scanner so a
+  # brace body's own declaration line isn't recorded as a self-callee.
+  protected def extract_callable_body(lines : Array(String), start_index : Int32) : Tuple(String, Int32, Bool)
+    i = start_index
+    while i < lines.size
+      line = lines[i]
+      if line.includes?("{")
+        # Brace body: hand the `{`-line to the scanner with skip_first so
+        # the method name on that line isn't recorded as its own callee.
+        return {extract_method_block(lines, i), i, true}
+      elsif arrow = line.index("=>")
+        # Expression body: crop everything up to and including `=>` on the
+        # first line, then read until the statement terminator.
+        io = String::Builder.new
+        depth = 0
+        j = i
+        while j < lines.size
+          raw = lines[j]
+          text = j == i ? raw[(arrow + 2)..]? || "" : raw
+          io << text << '\n'
+          depth += raw.count('(') - raw.count(')') + raw.count('{') - raw.count('}')
+          break if depth <= 0 && raw.includes?(";")
+          j += 1
+        end
+        return {io.to_s, i, false}
+      elsif line.includes?(";")
+        # Abstract/interface declaration with no body.
+        return {"", i, false}
+      end
+      i += 1
+    end
+    {"", start_index, false}
   end
 
   protected def attach_csharp_callees(endpoint : Endpoint,

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -69,12 +69,27 @@ module Analyzer::CSharp::MinimalApiSupport
     extra_params.concat(extract_bind_params_from_file(block, file_lines))
     extra_params.concat(extract_delegate_params(block, route, methods.first))
 
+    # Method-group handlers — `MapGet("/items", GetItems)` — carry the route
+    # on the `Map` line but keep their parameters and body in the referenced
+    # method. Resolve it so params, callees and ai-context aren't lost. The
+    # dominant style in modern minimal APIs (eShop, vertical-slice/REPR).
+    callee_block = block
+    callee_line = line
+    callee_skip_first = false
+    if handler = resolve_handler_method(block, file_lines)
+      sig, handler_block, handler_line, skip_first = handler
+      extra_params.concat(handler_signature_params(sig, route, methods.first, file_lines))
+      callee_block = handler_block
+      callee_line = handler_line
+      callee_skip_first = skip_first
+    end
+
     endpoints = [] of Endpoint
     methods.each do |method|
       endpoint = build_endpoint_from_route(route, method, file, line, extra_params)
       next unless endpoint
 
-      attach_csharp_callees(endpoint, block, file, line, include_callee)
+      attach_csharp_callees(endpoint, callee_block, file, callee_line, include_callee, skip_first_line: callee_skip_first)
       endpoints << endpoint
     end
     endpoints
@@ -342,7 +357,11 @@ module Analyzer::CSharp::MinimalApiSupport
     return true if param_type == "service"
     return true if SERVICE_BINDING_TYPES.includes?(type_name)
     return true if full_definition.includes?("HttpContext") || full_definition.includes?("HttpRequest") || full_definition.includes?("HttpResponse")
-    type_name.starts_with?("ILogger")
+    return true if type_name.starts_with?("ILogger")
+    # DbContexts, repositories, MediatR senders, mappers and other DI
+    # collaborators injected straight into the handler delegate are not
+    # request-bound values.
+    Common.csharp_service_type?(type_name)
   end
 
   private def default_delegate_param_type(type_name : String, http_method : String) : String
@@ -420,5 +439,211 @@ module Analyzer::CSharp::MinimalApiSupport
     end
 
     keys.uniq
+  end
+
+  # --- Method-group handler resolution -------------------------------------
+
+  # Resolves a `MapGet("/x", HandlerMethod)` style registration to the
+  # referenced method's signature + body. Returns
+  # `{signature, body, body_start_line, skip_first_line}` or nil when the
+  # handler is a lambda (already handled) or can't be found in this file.
+  private def resolve_handler_method(block : String, lines : Array(String)) : Tuple(String, String, Int32, Bool)?
+    name = handler_method_name(block)
+    return unless name
+    locate_method_definition(name, lines)
+  end
+
+  # Pulls the handler argument out of the `Map*(...)` call and returns its
+  # method name when it's a method group (a bare/qualified identifier), or
+  # nil for lambdas, string literals and inline expressions.
+  private def handler_method_name(block : String) : String?
+    args = map_call_arguments(block)
+    return if args.size < 2
+
+    handler = args.last.strip
+    return if handler.empty?
+    return if handler.includes?("=>")   # lambda
+    return if handler.starts_with?('"') # string literal
+    return if handler.starts_with?("new")
+    return unless handler.matches?(/\A@?[A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)*\z/)
+
+    handler.gsub(/\s+/, "").lchop('@').split('.').last
+  end
+
+  # Top-level argument list of the first `Map*` invocation in the block,
+  # split on commas while respecting nested parens/brackets/braces/generics
+  # and string literals.
+  private def map_call_arguments(block : String) : Array(String)
+    m = block.match(/\bMap(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
+    return [] of String unless m
+
+    open = block.index('(', m.begin)
+    return [] of String unless open
+
+    depth = 0
+    i = open
+    close = -1
+    while i < block.size
+      case block[i]
+      when '('
+        depth += 1
+      when ')'
+        depth -= 1
+        if depth == 0
+          close = i
+          break
+        end
+      end
+      i += 1
+    end
+    return [] of String if close < 0
+
+    split_csharp_parameters(block[(open + 1)...close])
+  end
+
+  # Finds a method declaration by name in the file and returns its
+  # signature, body block, body start line (1-based) and whether the
+  # callee scanner should skip the first body line. Skips the
+  # registration call itself and assignment/call sites.
+  private def locate_method_definition(name : String, lines : Array(String)) : Tuple(String, String, Int32, Bool)?
+    decl = /(?:public|private|internal|protected|static|async)\b[^;={(]*\b#{Regex.escape(name)}\s*\(/
+
+    lines.each_with_index do |line, idx|
+      next unless line.includes?(name)
+      next unless line.matches?(decl)
+      # The `Map*("/x", Name)` line also references the handler — skip it.
+      next if line.matches?(/\bMap(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
+
+      sig, end_idx = build_signature(lines, idx)
+      block, body_idx, skip_first = extract_callable_body(lines, end_idx)
+      return if block.empty?
+      return {sig, block, body_idx + 1, skip_first}
+    end
+
+    nil
+  end
+
+  # Builds params from a resolved handler's signature, reusing the delegate
+  # binding rules and expanding `[AsParameters]` bundle types.
+  private def handler_signature_params(signature : String, route : String, http_method : String, lines : Array(String)) : Array(Param)
+    list = extract_balanced_param_list(signature)
+    return [] of Param unless list
+
+    list = list.strip
+    return [] of Param if list.empty?
+
+    route_params = extract_route_placeholders(route)
+    params = [] of Param
+    split_csharp_parameters(list).each do |pdef|
+      if pdef.includes?("[AsParameters]") || pdef.includes?("[AsParameters ")
+        params.concat(expand_as_parameters(pdef, lines, route_params, http_method))
+      elsif param = delegate_param_to_noir_param(pdef, route_params, http_method)
+        params << param
+      end
+    end
+    params.uniq(&.name)
+  end
+
+  # `[AsParameters] SomeType arg` binds each public member of `SomeType`
+  # from the query/route/header — never the body. Expand to those members,
+  # dropping the DI-service members (a bundle like `CatalogServices` yields
+  # nothing, which is exactly right).
+  private def expand_as_parameters(param_def : String, lines : Array(String), route_params : Array(String), http_method : String) : Array(Param)
+    cleaned = param_def.gsub(/\[[^\]]*\]\s*/, "").strip
+    type_token = cleaned.split(/\s+/).first?
+    return [] of Param unless type_token
+
+    base = type_token.gsub(/<.*>/, "").split('.').last
+    return [] of Param if base.empty?
+    return [] of Param if Common.csharp_service_type?(base)
+
+    params = [] of Param
+    as_parameters_member_defs(base, lines).each do |member|
+      param = as_parameters_member_to_param(member, route_params, http_method)
+      params << param if param
+    end
+    params.uniq(&.name)
+  end
+
+  # Returns the member definitions (primary-constructor params or public
+  # auto-properties) of a record/class/struct used with `[AsParameters]`.
+  private def as_parameters_member_defs(type_name : String, lines : Array(String)) : Array(String)
+    def_idx = lines.index do |l|
+      l.matches?(/\b(?:record|class|struct)\s+#{Regex.escape(type_name)}\b/)
+    end
+    return [] of String unless def_idx
+
+    defline = lines[def_idx]
+    name_pos = defline.index(/\b#{Regex.escape(type_name)}\b/)
+    paren = defline.index('(', name_pos || 0)
+    if name_pos && paren && paren > name_pos
+      return split_csharp_parameters(gather_balanced_parens(lines, def_idx, paren))
+    end
+
+    defs = [] of String
+    # Capture any binding attributes that precede the property (they may sit
+    # on their own line, e.g. `[FromHeader(Name = "X-Tenant")]`) so the
+    # member keeps its `header`/`query` classification and explicit name.
+    extract_method_block(lines, def_idx).scan(/((?:\[[^\]]*\]\s*)*)(?:public|internal)\s+([\w<>\[\]\?\.]+)\s+([A-Za-z_]\w*)\s*\{\s*get/) do |m|
+      attrs = m[1].gsub(/\s+/, " ").strip
+      defs << "#{attrs} #{m[2].strip} #{m[3]}".strip
+    end
+    defs
+  end
+
+  # Collects the text inside a parenthesised group that opens at `open_pos`
+  # on `lines[start_index]`, spanning subsequent lines until balanced.
+  private def gather_balanced_parens(lines : Array(String), start_index : Int32, open_pos : Int32) : String
+    io = String::Builder.new
+    depth = 0
+    i = start_index
+    started = false
+    while i < lines.size
+      line = lines[i]
+      from = i == start_index ? open_pos : 0
+      (from...line.size).each do |k|
+        ch = line[k]
+        if ch == '('
+          depth += 1
+          started = true
+          next if depth == 1
+        elsif ch == ')'
+          depth -= 1
+          return io.to_s if depth == 0
+        end
+        io << ch if started && depth >= 1
+      end
+      io << ' '
+      break if started && depth <= 0
+      i += 1
+    end
+    io.to_s
+  end
+
+  # Maps a single `[AsParameters]` member to a Param. Defaults to query
+  # (members bind from query/route/header, never the body) and honours an
+  # explicit `[FromHeader]`/`[FromQuery]`/`[FromRoute]` on the member.
+  private def as_parameters_member_to_param(member_def : String, route_params : Array(String), http_method : String) : Param?
+    explicit_name = extract_explicit_binding_name(member_def)
+    param_type = binding_attribute_type(member_def)
+    cleaned = member_def.gsub(/\[[^\]]*\]\s*/, "").strip
+    cleaned = cleaned.sub(/=.*/, "").strip
+    cleaned = cleaned.gsub(/\b(ref|out|in|params)\b/, "").strip
+    return if cleaned.empty?
+
+    name_match = cleaned.match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/)
+    return unless name_match
+
+    name = explicit_name || name_match[1]
+    type_name = cleaned[0...(cleaned.size - name_match[1].size)].strip
+      .gsub(/\?$/, "")
+      .split(/\s+/).last? || ""
+    type_name = type_name.split('.').last
+
+    return if service_binding?(type_name, cleaned, param_type)
+    return if param_type == "service"
+
+    param_type ||= route_params.includes?(name) ? "path" : "query"
+    Param.new(name, "", param_type)
   end
 end

--- a/src/miniparsers/csharp_callee_extractor.cr
+++ b/src/miniparsers/csharp_callee_extractor.cr
@@ -6,7 +6,7 @@ module Noir::CSharpCalleeExtractor
   alias Entry = Tuple(String, String, Int32)
 
   RESERVED = Set{
-    "as", "await", "base", "case", "catch", "checked", "default",
+    "as", "async", "await", "base", "case", "catch", "checked", "default",
     "delegate", "do", "else", "event", "explicit", "finally",
     "fixed", "for", "foreach", "if", "implicit", "is", "lock",
     "nameof", "new", "operator", "return", "sizeof", "switch",
@@ -15,7 +15,33 @@ module Noir::CSharpCalleeExtractor
 
   ROUTE_BUILDER_METHODS = Set{
     "Map", "MapGet", "MapPost", "MapPut", "MapDelete", "MapPatch",
-    "MapHead", "MapOptions", "MapMethods",
+    "MapHead", "MapOptions", "MapMethods", "MapGroup",
+  }
+
+  # Fluent route-builder metadata calls (`.WithName(...)`, `.Produces(...)`,
+  # `[ProducesResponseType(...)]`, …) and API-versioning helpers configure
+  # the endpoint registration — they aren't handler behavior, so they're
+  # noise in the callee/ai-context surface. Matched on the trailing segment.
+  ROUTE_METADATA_METHODS = Set{
+    "WithName", "WithSummary", "WithDescription", "WithTags", "WithOpenApi",
+    "WithMetadata", "WithDisplayName", "WithGroupName", "WithOrder",
+    "Produces", "ProducesProblem", "ProducesValidationProblem",
+    "ProducesResponseType", "Accepts", "RequireAuthorization", "AllowAnonymous",
+    "RequireCors", "RequireHost", "RequireRateLimiting", "DisableRateLimiting",
+    "CacheOutput", "DisableAntiforgery", "ExcludeFromDescription",
+    "AddEndpointFilter", "AddEndpointFilterFactory", "WithRequestTimeout",
+    "MapToApiVersion", "HasApiVersion", "HasDeprecatedApiVersion",
+    "IsApiVersionNeutral", "ReportApiVersions", "WithApiVersionSet",
+    "NewVersionedApi",
+  }
+
+  # Parameter-binding / documentation attributes (`[FromHeader(...)]`,
+  # `[AsParameters]`, `[Description(...)]`, …). They sit inside a lambda's
+  # parameter list, so the line scanner sees them as calls — they aren't.
+  BINDING_ATTRIBUTES = Set{
+    "FromQuery", "FromRoute", "FromBody", "FromHeader", "FromForm",
+    "FromServices", "FromKeyedServices", "AsParameters", "Description",
+    "DefaultValue", "Required", "BindRequired", "BindNever",
   }
 
   CALL_REGEX = /((?:[A-Za-z_][\w]*)(?:\s*\.\s*[A-Za-z_][\w]*)*)\s*(?:<[^>\n]+>)?\s*\(/
@@ -66,6 +92,8 @@ module Noir::CSharpCalleeExtractor
     last = name.split('.').last
     return true if RESERVED.includes?(last)
     return true if ROUTE_BUILDER_METHODS.includes?(last)
+    return true if ROUTE_METADATA_METHODS.includes?(last)
+    return true if BINDING_ATTRIBUTES.includes?(last)
 
     false
   end


### PR DESCRIPTION
## Summary

Improves the **ASP.NET Core MVC** and **Minimal API** analyzers. Validated against real open-source projects — `dotnet/eShop`, `dotnet-architecture/eShopOnWeb`, the RealWorld **conduit** app, and the Clean Architecture templates — to reduce false positives, false negatives, and missing `callee`/`ai-context`. This builds on the already-solid C# analyzer base.

## What changed

### FP reduction — DI services were leaking in as params
Real minimal APIs inject collaborators straight into the handler delegate (`CatalogContext context`, `IRepository<CatalogItem> repo`, `IMapper`, `ISender`, `IAntiforgery`, `HooksRepository`, …). These were surfacing as `query`/`json`/`form` params.

- New shared `Common.csharp_service_type?` heuristic: interface convention (`I<Pascal>`), a small set of high-precision service suffixes, and known framework types. Used in the Minimal API delegate/handler binding **and** MVC action params.
- Form-upload interfaces (`IFormFile`, `IFormFileCollection`) stay request inputs.

_eShopOnWeb before:_ `GET /api/catalog-brands (catalogBrandRepository:query)` → _after:_ `GET /api/catalog-brands ()`. Same fix removed `context`, `grantUrlTester`, `antiforgery`, `hooksRepository`, … across eShop.

### FN + callee recovery — Minimal API method groups
`MapGet("/items", GetAllItems)` is the dominant modern style (eShop, vertical-slice/REPR). The route was resolved but params and body were lost.

- Resolve the method group to its definition: pull params from the signature, expand same-file `[AsParameters]` bundles (service members dropped — a `CatalogServices` bundle correctly yields nothing), and attach callees/ai-context from the method body.

_eShop Catalog (C#-only) before:_ most endpoints had only path params + a `context` FP → _after:_ `product`, `productToUpdate`, `ids`, `name/type/brand`, … recovered, real handler-body callees attached.

### FN + callee recovery — modern MVC controllers
- Recognize **POCO controllers** (no `: Controller` base), **C# 12 primary-constructor** controllers, and generic controllers.
- Balanced-paren parameter extraction + expression-bodied action handling (`=> mediator.Send(...)`).

_conduit went from **0 → 19 endpoints**_, all with correct params and callees, after recognizing primary-constructor/POCO controllers and expression bodies.

### Callee / ai-context quality
- Drop route-builder metadata (`WithName`, `Produces`, `MapGroup`, API-versioning helpers), binding attributes (`[FromHeader]`, `[AsParameters]`, `[Description]`) and the `async` keyword from the callee surface.

## Tests
- New fixtures + specs: `aspnet_core_minimal_api_methodgroup` (method group, `[AsParameters]`, DI-service drop) and `aspnet_core_mvc_modern` (primary-ctor, POCO, expression-bodied).
- New unit spec for `Common.csharp_service_type?`.
- Extended the existing MVC fixture/spec with an attribute-less interface-service drop case.
- Full suite green (`crystal spec`), `crystal tool format` + `ameba` clean.