### PR TITLE
Improve C++ Crow/Drogon analyzers: reduce FP/FN, callee & ai-context gaps

### DIFF
--- a/spec/functional_test/fixtures/cpp/crow_routes/app.cpp
+++ b/spec/functional_test/fixtures/cpp/crow_routes/app.cpp
@@ -1,0 +1,53 @@
+#include "crow.h"
+#include "crow/middlewares/cookie_parser.h"
+
+int main()
+{
+    crow::App<crow::CookieParser> app;
+
+    // Static route — must keep only its own body param, not absorb the params
+    // of the route_dynamic registration that follows it.
+    CROW_ROUTE(app, "/static")
+    ([](const crow::request& req) {
+        return crow::response(req.body);
+    });
+
+    // Runtime-string dynamic route.
+    app.route_dynamic("/dynamic")
+    ([](const crow::request& req) {
+        auto foo = req.url_params.get("foo");
+        return crow::response(200);
+    });
+
+    // url_params list/dict accessors.
+    CROW_ROUTE(app, "/list")
+    ([](const crow::request& req) {
+        auto items = req.url_params.get_list("items");
+        auto meta = req.url_params.get_dict("meta");
+        return crow::response(200);
+    });
+
+    // Cookie read through the CookieParser middleware context.
+    CROW_ROUTE(app, "/cookie")
+    ([&](const crow::request& req) {
+        auto& ctx = app.get_context<crow::CookieParser>(req);
+        auto sid = ctx.get_cookie("session");
+        return crow::response(200);
+    });
+
+    // Websocket upgrade endpoint.
+    CROW_WEBSOCKET_ROUTE(app, "/ws")
+      .onmessage([&](crow::websocket::connection& conn, const std::string& data, bool) {
+          conn.send_text(data);
+      });
+
+    /* Commented-out route must be ignored:
+    CROW_ROUTE(app, "/ghost")
+    ([]() {
+        auto secret = req.url_params.get("secret");
+        return "no";
+    });
+    */
+
+    app.port(18080).run();
+}

--- a/spec/functional_test/fixtures/cpp/drogon_controllers/ApiCtrl.h
+++ b/spec/functional_test/fixtures/cpp/drogon_controllers/ApiCtrl.h
@@ -22,6 +22,9 @@ class ApiCtrl : public drogon::HttpController<ApiCtrl>
     ADD_METHOD_TO(ApiCtrl::ping, "/ping", Get, Post);
     // Absolute regex path.
     ADD_METHOD_VIA_REGEX(ApiCtrl::legacy, "/legacy/(.*)", Get);
+    // Regex with `?` metacharacters must be preserved verbatim (not treated
+    // as a query-string separator).
+    ADD_METHOD_VIA_REGEX(ApiCtrl::grouped, "/grp/(?:a|b)/(.*)?", Get);
     METHOD_LIST_END
 
     void root(const HttpRequestPtr &req,
@@ -46,6 +49,12 @@ class ApiCtrl : public drogon::HttpController<ApiCtrl>
 
     void legacy(const HttpRequestPtr &req,
                 std::function<void(const HttpResponsePtr &)> &&callback)
+    {
+        callback(HttpResponse::newHttpResponse());
+    }
+
+    void grouped(const HttpRequestPtr &req,
+                 std::function<void(const HttpResponsePtr &)> &&callback)
     {
         callback(HttpResponse::newHttpResponse());
     }

--- a/spec/functional_test/fixtures/cpp/drogon_controllers/ApiCtrl.h
+++ b/spec/functional_test/fixtures/cpp/drogon_controllers/ApiCtrl.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <drogon/HttpController.h>
+
+using namespace drogon;
+
+namespace app
+{
+namespace v2
+{
+class ApiCtrl : public drogon::HttpController<ApiCtrl>
+{
+  public:
+    METHOD_LIST_BEGIN
+    // Relative path → prefixed with /app/v2/ApiCtrl
+    METHOD_ADD(ApiCtrl::root, "", Get);
+    // Multi-line macro with a path param and a trailing filter argument.
+    METHOD_ADD(ApiCtrl::show,
+               "/show/{id}",
+               Get,
+               "app::AuthFilter");
+    // Absolute path, two methods.
+    ADD_METHOD_TO(ApiCtrl::ping, "/ping", Get, Post);
+    // Absolute regex path.
+    ADD_METHOD_VIA_REGEX(ApiCtrl::legacy, "/legacy/(.*)", Get);
+    METHOD_LIST_END
+
+    void root(const HttpRequestPtr &req,
+              std::function<void(const HttpResponsePtr &)> &&callback)
+    {
+        auto resp = HttpResponse::newHttpResponse();
+        callback(resp);
+    }
+
+    void show(const HttpRequestPtr &req,
+              std::function<void(const HttpResponsePtr &)> &&callback)
+    {
+        auto user = UserService::find(req->getParameter("q"));
+        callback(HttpResponse::newHttpJsonResponse(renderUser(user)));
+    }
+
+    void ping(const HttpRequestPtr &req,
+              std::function<void(const HttpResponsePtr &)> &&callback)
+    {
+        callback(HttpResponse::newHttpResponse());
+    }
+
+    void legacy(const HttpRequestPtr &req,
+                std::function<void(const HttpResponsePtr &)> &&callback)
+    {
+        callback(HttpResponse::newHttpResponse());
+    }
+};
+}  // namespace v2
+}  // namespace app

--- a/spec/functional_test/fixtures/cpp/drogon_controllers/ChatCtrl.h
+++ b/spec/functional_test/fixtures/cpp/drogon_controllers/ChatCtrl.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <drogon/WebSocketController.h>
+
+using namespace drogon;
+
+class ChatCtrl : public drogon::WebSocketController<ChatCtrl>
+{
+  public:
+    WS_PATH_LIST_BEGIN
+    WS_PATH_ADD("/chat", Get);
+    WS_PATH_LIST_END
+
+    void handleNewMessage(const WebSocketConnectionPtr &,
+                          std::string &&,
+                          const WebSocketMessageType &) override
+    {
+    }
+
+    void handleNewConnection(const HttpRequestPtr &,
+                             const WebSocketConnectionPtr &) override
+    {
+    }
+
+    void handleConnectionClosed(const WebSocketConnectionPtr &) override
+    {
+    }
+};

--- a/spec/functional_test/fixtures/cpp/drogon_controllers/main.cc
+++ b/spec/functional_test/fixtures/cpp/drogon_controllers/main.cc
@@ -1,0 +1,23 @@
+#include <drogon/drogon.h>
+
+using namespace drogon;
+
+int main()
+{
+    // Multi-line registerHandler whose path carries a query-string constraint.
+    app().registerHandler(
+        "/search?q={}",
+        [](const HttpRequestPtr &req,
+           std::function<void(const HttpResponsePtr &)> &&callback) {
+            auto keyword = req->getParameter("q");
+            callback(HttpResponse::newHttpResponse());
+        },
+        {Get});
+
+    /* Commented-out registration must be ignored:
+    app().registerHandler("/ghost", &ghost, {Get});
+    */
+
+    app().run();
+    return 0;
+}

--- a/spec/functional_test/testers/cpp/crow_routes_spec.cr
+++ b/spec/functional_test/testers/cpp/crow_routes_spec.cr
@@ -1,0 +1,53 @@
+require "../../func_spec.cr"
+
+def crow_routes_endpoint(url, method, protocol = "http", params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  endpoint.protocol = protocol
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [
+  # route_dynamic — params stay bounded to this handler.
+  crow_routes_endpoint("/dynamic", "GET", "http", [
+    Param.new("foo", "", "query"),
+  ], [
+    Callee.new("req.url_params.get"),
+  ]),
+  # The static route that precedes route_dynamic must not absorb its `foo`.
+  crow_routes_endpoint("/static", "GET", "http", [
+    Param.new("body", "", "json"),
+  ]),
+  # url_params.get_list / get_dict are query params too.
+  crow_routes_endpoint("/list", "GET", "http", [
+    Param.new("items", "", "query"),
+    Param.new("meta", "", "query"),
+  ]),
+  # CookieParser context get_cookie → cookie param.
+  crow_routes_endpoint("/cookie", "GET", "http", [
+    Param.new("session", "", "cookie"),
+  ]),
+  # Websocket upgrade endpoint.
+  crow_routes_endpoint("/ws", "GET", "ws"),
+]
+
+tester = FunctionalTester.new("fixtures/cpp/crow_routes/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+
+tester.perform_tests
+
+describe "Crow route discovery edge cases" do
+  it "does not leak route_dynamic params into the preceding static route" do
+    static = tester.app.endpoints.find { |e| e.url == "/static" && e.method == "GET" }
+    static.should_not be_nil
+    static.as(Endpoint).params.any? { |p| p.name == "foo" }.should be_false
+  end
+
+  it "ignores routes inside block comments" do
+    tester.app.endpoints.any? { |e| e.url == "/ghost" }.should be_false
+  end
+end

--- a/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
@@ -26,6 +26,8 @@ expected_endpoints = [
   drogon_ctrl_endpoint("/ping", "POST"),
   # ADD_METHOD_VIA_REGEX → absolute regex path.
   drogon_ctrl_endpoint("/legacy/(.*)", "GET"),
+  # Regex `?` metacharacters preserved verbatim (not split as a query string).
+  drogon_ctrl_endpoint("/grp/(?:a|b)/(.*)?", "GET"),
   # WS_PATH_ADD → websocket endpoint.
   drogon_ctrl_endpoint("/chat", "GET", "ws"),
   # Multi-line registerHandler whose query-string constraint becomes a param.
@@ -48,7 +50,15 @@ describe "Drogon controller routing edge cases" do
     tester.app.endpoints.any? { |e| e.url == "/ghost" }.should be_false
   end
 
-  it "strips the query string from the registered path" do
-    tester.app.endpoints.any? { |e| e.url.includes?("?") }.should be_false
+  it "strips the query-string constraint from a registerHandler path" do
+    # `/search?q={}` becomes `/search` with `q` as a query param.
+    tester.app.endpoints.any? { |e| e.url == "/search?q={}" }.should be_false
+    search = tester.app.endpoints.find { |e| e.url == "/search" && e.method == "GET" }
+    search.should_not be_nil
+    search.as(Endpoint).params.any? { |p| p.name == "q" && p.param_type == "query" }.should be_true
+  end
+
+  it "keeps `?` metacharacters in regex routes verbatim" do
+    tester.app.endpoints.any? { |e| e.url == "/grp/(?:a|b)/(.*)?" }.should be_true
   end
 end

--- a/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
@@ -1,0 +1,54 @@
+require "../../func_spec.cr"
+
+def drogon_ctrl_endpoint(url, method, protocol = "http", params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  endpoint.protocol = protocol
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [
+  # METHOD_ADD with an empty pattern → bare controller path prefix.
+  drogon_ctrl_endpoint("/app/v2/ApiCtrl", "GET", "http", [] of Param, [
+    Callee.new("HttpResponse::newHttpResponse"),
+    Callee.new("callback"),
+  ]),
+  # Multi-line METHOD_ADD with a path param; handler reads a query param.
+  drogon_ctrl_endpoint("/app/v2/ApiCtrl/show/{id}", "GET", "http", [
+    Param.new("id", "", "path"),
+    Param.new("q", "", "query"),
+  ], [
+    Callee.new("UserService::find"),
+    Callee.new("renderUser"),
+  ]),
+  # ADD_METHOD_TO → absolute path, two methods.
+  drogon_ctrl_endpoint("/ping", "GET"),
+  drogon_ctrl_endpoint("/ping", "POST"),
+  # ADD_METHOD_VIA_REGEX → absolute regex path.
+  drogon_ctrl_endpoint("/legacy/(.*)", "GET"),
+  # WS_PATH_ADD → websocket endpoint.
+  drogon_ctrl_endpoint("/chat", "GET", "ws"),
+  # Multi-line registerHandler whose query-string constraint becomes a param.
+  drogon_ctrl_endpoint("/search", "GET", "http", [
+    Param.new("q", "", "query"),
+  ]),
+]
+
+tester = FunctionalTester.new("fixtures/cpp/drogon_controllers/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+
+tester.perform_tests
+
+describe "Drogon controller routing edge cases" do
+  it "ignores macros inside block comments" do
+    tester.app.endpoints.any? { |e| e.url == "/ghost" }.should be_false
+  end
+
+  it "strips the query string from the registered path" do
+    tester.app.endpoints.any? { |e| e.url.includes?("?") }.should be_false
+  end
+end

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -8,6 +8,10 @@ module Analyzer::Cpp
     ROUTE_REGEX = /CROW_ROUTE\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]*)"\s*\)/
     # CROW_BP_ROUTE(bp, "/path") — blueprint-scoped route registration.
     BP_ROUTE_REGEX = /CROW_BP_ROUTE\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]*)"\s*\)/
+    # app.route_dynamic("/path") — runtime string route (no compile-time macro).
+    ROUTE_DYNAMIC_REGEX = /\.\s*route_dynamic\s*\(\s*"([^"]*)"\s*\)/
+    # CROW_WEBSOCKET_ROUTE(app, "/path") — websocket upgrade endpoint.
+    WEBSOCKET_REGEX = /CROW_WEBSOCKET_ROUTE\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]*)"\s*\)/
     # .methods("POST"_method, "GET"_method) clause.
     METHODS_REGEX     = /\.methods\s*\(([^)]*)\)/
     METHOD_TOKEN      = /"([A-Za-z]+)"_method/
@@ -16,9 +20,12 @@ module Analyzer::Cpp
     # Path placeholder: <int>, <string>, <uint>, <double>, <path> — and the
     # non-standard but occasionally seen <type:name> form.
     PATH_PARAM_REGEX = /<([^<>:]+)(?::([^<>]+))?>/
-    URL_PARAM_GET    = /url_params\s*\.\s*get(?:\s*<[^>]+>)?\s*\(\s*"([^"]+)"/
-    HEADER_VALUE     = /get_header_value\s*\(\s*"([^"]+)"/
-    BODY_ACCESS      = /\b(req|request)\s*\.\s*body\b/
+    # url_params.get("x") plus the list/dict variants get_list / get_dict.
+    URL_PARAM_GET = /url_params\s*\.\s*get(?:_list|_dict)?(?:\s*<[^>]+>)?\s*\(\s*"([^"]+)"/
+    HEADER_VALUE  = /get_header_value\s*\(\s*"([^"]+)"/
+    # ctx.get_cookie("name") via the CookieParser middleware.
+    COOKIE_GET  = /\bget_cookie\s*\(\s*"([^"]+)"/
+    BODY_ACCESS = /\b(req|request)\s*\.\s*body\b/
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
@@ -41,55 +48,75 @@ module Analyzer::Cpp
 
     private def analyze_file(path : String, include_callee : Bool)
       source = read_file_content(path)
-      return unless source.includes?("CROW_ROUTE") || source.includes?("CROW_BP_ROUTE")
+      return unless source.includes?("CROW_ROUTE") || source.includes?("CROW_BP_ROUTE") ||
+                    source.includes?("CROW_WEBSOCKET_ROUTE") || source.includes?("route_dynamic")
 
+      # Blank comments so commented-out routes (e.g. inside `/* ... */`) and
+      # documentation snippets are not picked up as real endpoints.
+      source = Noir::CppCalleeExtractor.strip_comments(source)
       lines = source.split("\n")
       line_offsets = line_start_offsets(source)
-      last_endpoints = [] of Endpoint
 
       lines.each_with_index do |line, index|
         next if line.lstrip.starts_with?("//")
-        route_match = line.match(ROUTE_REGEX) || line.match(BP_ROUTE_REGEX)
-        if route_match
-          route_path = route_match[1]
 
-          # `.methods(...)` may sit on the same line as CROW_ROUTE or on one
-          # of the following continuation lines before the handler lambda.
-          search_window = line
-          (1..3).each do |offset|
-            break if index + offset >= lines.size
-            next_line = lines[index + offset]
-            break if next_line.match(ROUTE_REGEX) || next_line.match(BP_ROUTE_REGEX)
-            search_window += " " + next_line
-          end
-
-          methods = [] of String
-          if methods_match = search_window.match(METHODS_REGEX)
-            methods = parse_methods(methods_match[1])
-          end
-          methods << "GET" if methods.empty?
-
-          normalized_path, path_params = normalize_path(route_path)
-          details = Details.new(PathInfo.new(path, index + 1))
-          route_offset = line_offsets[index] + (route_match.begin(0) || 0)
-          route_callees = include_callee ? callees_for_route(source, path, route_offset + route_match[0].bytesize) : [] of Noir::CppCalleeExtractor::Entry
-          route_params = params_for_route(source, route_offset + route_match[0].bytesize)
-
-          last_endpoints.clear
-          methods.uniq.each do |method|
-            endpoint = Endpoint.new(normalized_path, method, path_params.dup, details)
-            route_params.each { |param| push_unique(endpoint, param) }
-            Noir::CppCalleeExtractor.attach_to(endpoint, route_callees) if include_callee
-            result << endpoint
-            last_endpoints << endpoint
-          end
-        else
-          next if last_endpoints.empty?
-          collect_params(line).each do |param|
-            last_endpoints.each { |ep| push_unique(ep, param) }
+        websocket = false
+        route_match = line.match(ROUTE_REGEX) || line.match(BP_ROUTE_REGEX) || line.match(ROUTE_DYNAMIC_REGEX)
+        unless route_match
+          if ws_match = line.match(WEBSOCKET_REGEX)
+            route_match = ws_match
+            websocket = true
           end
         end
+        next unless route_match
+
+        route_path = route_match[1]
+        normalized_path, path_params = normalize_path(route_path)
+        details = Details.new(PathInfo.new(path, index + 1))
+        route_offset = line_offsets[index] + (route_match.begin(0) || 0)
+        search_start = route_offset + route_match[0].bytesize
+
+        # The websocket handler is a chain of `.onopen/.onmessage/...` lambdas
+        # rather than a single request handler, so we register the upgrade
+        # endpoint without trying to mine request params from it.
+        if websocket
+          endpoint = Endpoint.new(normalized_path, "GET", path_params.dup, details)
+          endpoint.protocol = "ws"
+          result << endpoint
+          next
+        end
+
+        # `.methods(...)` may sit on the same line as the route or on one of the
+        # following continuation lines before the handler lambda.
+        search_window = line
+        (1..3).each do |offset|
+          break if index + offset >= lines.size
+          next_line = lines[index + offset]
+          break if route_line?(next_line)
+          search_window += " " + next_line
+        end
+
+        methods = [] of String
+        if methods_match = search_window.match(METHODS_REGEX)
+          methods = parse_methods(methods_match[1])
+        end
+        methods << "GET" if methods.empty?
+
+        route_callees = include_callee ? callees_for_route(source, path, search_start) : [] of Noir::CppCalleeExtractor::Entry
+        route_params = params_for_route(source, search_start)
+
+        methods.uniq.each do |method|
+          endpoint = Endpoint.new(normalized_path, method, path_params.dup, details)
+          route_params.each { |param| push_unique(endpoint, param) }
+          Noir::CppCalleeExtractor.attach_to(endpoint, route_callees) if include_callee
+          result << endpoint
+        end
       end
+    end
+
+    private def route_line?(line : String) : Bool
+      !!(line.match(ROUTE_REGEX) || line.match(BP_ROUTE_REGEX) ||
+        line.match(ROUTE_DYNAMIC_REGEX) || line.match(WEBSOCKET_REGEX))
     end
 
     private def callees_for_route(source : String, path : String, search_start : Int32) : Array(Noir::CppCalleeExtractor::Entry)
@@ -112,6 +139,8 @@ module Analyzer::Cpp
       offsets = [
         source.index("CROW_ROUTE", search_start),
         source.index("CROW_BP_ROUTE", search_start),
+        source.index("CROW_WEBSOCKET_ROUTE", search_start),
+        source.index("route_dynamic", search_start),
       ].compact
       offsets.min? || source.bytesize
     end
@@ -184,6 +213,9 @@ module Analyzer::Cpp
       end
       line.scan(HEADER_VALUE) do |m|
         params << Param.new(m[1], "", "header")
+      end
+      line.scan(COOKIE_GET) do |m|
+        params << Param.new(m[1], "", "cookie")
       end
       if line.match(BODY_ACCESS)
         params << Param.new("body", "", "json")

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -192,7 +192,7 @@ module Analyzer::Cpp
                                     via_regex : Bool = false,
                                     protocol : String = "http")
       clean_path, path_params, query_params = normalize_drogon_path(raw_path, via_regex)
-      methods = parse_methods(method_args.reject { |a| a.lstrip.starts_with?('"') }.join(","))
+      methods = parse_methods(method_args.reject(&.lstrip.starts_with?('"')).join(","))
       line_number = Noir::CppCalleeExtractor.line_number_for(content, call_start)
 
       if handler && !handler[1].empty?

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -7,6 +7,9 @@ module Analyzer::Cpp
     CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp"]
     alias HandlerTarget = Tuple(String?, String)
     alias SourceRange = Tuple(Int32, Int32)
+    # A controller class body span plus the URL prefix Drogon derives from its
+    # fully-qualified name (namespaces + class), e.g. `api::v1::ApiTest` → `/api/v1/ApiTest`.
+    alias ControllerScope = Tuple(Int32, Int32, String)
 
     HTTP_METHODS = {
       "Get"     => "GET",
@@ -21,9 +24,7 @@ module Analyzer::Cpp
     # `{Get, Post}` method list: brace block whose first token is a verb.
     METHOD_BLOCK = /\{\s*((?:drogon::)?(?:Get|Post|Put|Delete|Patch|Head|Options)\b[^{}]*)\}/
 
-    REGEX_REGISTER_HANDLER = /app\(\)\s*\.?\s*registerHandler\s*\(\s*"([^"]+)"/
-    REGEX_PATH_ADD         = /PATH_ADD\s*\(\s*"([^"]+)"\s*,\s*([^)]+)\)/
-    REGEX_ADD_METHOD       = /ADD_METHOD_TO\s*\(\s*([^,]+)\s*,\s*"([^"]+)"\s*,\s*([^)]+)\)/
+    REGEX_REGISTER_HANDLER = /app\(\)\s*\.?\s*registerHandler(?:ViaRegex)?\s*\(\s*"([^"]+)"/
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
@@ -43,7 +44,9 @@ module Analyzer::Cpp
                       content.includes?("PATH_LIST_BEGIN") ||
                       content.includes?("PATH_ADD") ||
                       content.includes?("METHOD_LIST_BEGIN") ||
-                      content.includes?("ADD_METHOD_TO")
+                      content.includes?("METHOD_ADD") ||
+                      content.includes?("ADD_METHOD_TO") ||
+                      content.includes?("ADD_METHOD_VIA_REGEX")
 
           analyze_file(path, content, include_callee)
         end
@@ -55,6 +58,9 @@ module Analyzer::Cpp
     end
 
     def analyze_file(path : String, content : String, include_callee : Bool = false)
+      # Blank out comments first so commented-out routes and documentation
+      # examples (e.g. `/** ADD_METHOD_TO(...) */`) are never mistaken for code.
+      content = Noir::CppCalleeExtractor.strip_comments(content)
       lines = content.split("\n")
       file_params = extract_params(lines)
 
@@ -62,11 +68,7 @@ module Analyzer::Cpp
         @result << endpoint
       end
 
-      extract_block_endpoints(path, lines, "PATH_LIST_BEGIN", "PATH_LIST_END", REGEX_PATH_ADD, file_params).each do |endpoint|
-        @result << endpoint
-      end
-
-      extract_add_method_endpoints(path, content, lines, file_params, include_callee).each do |endpoint|
+      extract_macro_endpoints(path, content, file_params, include_callee).each do |endpoint|
         @result << endpoint
       end
     end
@@ -79,7 +81,9 @@ module Analyzer::Cpp
       # lambda bodies between the path and the method list without needing a
       # full-blown C++ parser.
       content.scan(REGEX_REGISTER_HANDLER) do |match|
-        route = normalize_path(match[1])
+        raw_route = match[1]
+        via_regex = (match[0].includes?("registerHandlerViaRegex"))
+        clean_path, path_params, query_params = normalize_drogon_path(raw_route, via_regex)
         rest = match.post_match
         window = rest.size > 4000 ? rest[0, 4000] : rest
 
@@ -89,15 +93,17 @@ module Analyzer::Cpp
                     ["GET"]
                   end
 
-        line_number = find_line_number(lines, "registerHandler", match[1])
         match_start = match.begin(0) || 0
+        line_number = Noir::CppCalleeExtractor.line_number_for(content, match_start)
         callees = include_callee ? callees_for_block_after(content, path, match_start) : [] of Noir::CppCalleeExtractor::Entry
         route_params = params_for_register_handler(content, match_start)
 
         methods.each do |m|
           details = Details.new(PathInfo.new(path, line_number))
-          endpoint = Endpoint.new(route, m, details)
-          route_params.each { |p| endpoint.push_param(p) }
+          endpoint = Endpoint.new(clean_path, m, details)
+          path_params.each { |p| add_endpoint_param(endpoint, p) }
+          query_params.each { |p| add_endpoint_param(endpoint, p) }
+          route_params.each { |p| add_endpoint_param(endpoint, p) }
           Noir::CppCalleeExtractor.attach_to(endpoint, callees) if include_callee
           endpoints << endpoint
         end
@@ -106,77 +112,198 @@ module Analyzer::Cpp
       endpoints
     end
 
-    private def extract_block_endpoints(path : String, lines : Array(String), begin_marker : String, end_marker : String, pattern : Regex, file_params : Array(Param)) : Array(Endpoint)
+    # Handles the controller-style routing macros, all of which may span
+    # several lines (Drogon's own clang-format wraps them). Each macro call is
+    # located by name and its arguments parsed against balanced parentheses, so
+    # multi-line invocations are extracted reliably:
+    #
+    #   METHOD_ADD(Ctrl::fn, "/path", Get)        — relative to the controller path
+    #   ADD_METHOD_TO(Ctrl::fn, "/path", Get)     — absolute path
+    #   ADD_METHOD_VIA_REGEX(Ctrl::fn, "/re", Get)— absolute regex path
+    #   PATH_ADD("/path", Get)                    — HttpSimpleController, absolute path
+    private def extract_macro_endpoints(path : String, content : String, file_params : Array(Param), include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
-      in_block = false
+      scopes = controller_scopes(content)
 
-      lines.each_with_index do |line, index|
-        if line.includes?(begin_marker)
-          in_block = true
-          next
-        end
+      # METHOD_ADD: path is relative to the controller class path prefix.
+      each_macro_call(content, "METHOD_ADD") do |args, call_start|
+        next if args.size < 2
+        raw_path = unquote(args[1])
+        next unless raw_path
+        handler = normalize_handler_target(args[0])
+        full = join_controller_path(prefix_for(scopes, call_start), raw_path)
+        add_macro_endpoints(endpoints, path, content, full, args[2..], handler, file_params, include_callee, call_start)
+      end
 
-        if line.includes?(end_marker)
-          in_block = false
-          next
-        end
+      # ADD_METHOD_TO: absolute path.
+      each_macro_call(content, "ADD_METHOD_TO") do |args, call_start|
+        next if args.size < 2
+        raw_path = unquote(args[1])
+        next unless raw_path
+        handler = normalize_handler_target(args[0])
+        add_macro_endpoints(endpoints, path, content, raw_path, args[2..], handler, file_params, include_callee, call_start)
+      end
 
-        next unless in_block
+      # ADD_METHOD_VIA_REGEX: absolute regex path.
+      each_macro_call(content, "ADD_METHOD_VIA_REGEX") do |args, call_start|
+        next if args.size < 2
+        raw_path = unquote(args[1])
+        next unless raw_path
+        handler = normalize_handler_target(args[0])
+        add_macro_endpoints(endpoints, path, content, raw_path, args[2..], handler, file_params, include_callee, call_start, via_regex: true)
+      end
 
-        if match = line.match(pattern)
-          route = normalize_path(match[1])
-          methods = parse_methods(match[2])
+      # PATH_ADD: HttpSimpleController, absolute path, no handler reference.
+      each_macro_call(content, "PATH_ADD") do |args, call_start|
+        next if args.empty?
+        raw_path = unquote(args[0])
+        next unless raw_path
+        add_macro_endpoints(endpoints, path, content, raw_path, args[1..], nil, file_params, include_callee, call_start)
+      end
 
-          methods.each do |m|
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint = Endpoint.new(route, m, details)
-            file_params.each { |p| endpoint.push_param(p) }
-            endpoints << endpoint
-          end
-        end
+      # WS_PATH_ADD: WebSocketController, absolute path, upgrade is an HTTP GET.
+      each_macro_call(content, "WS_PATH_ADD") do |args, call_start|
+        next if args.empty?
+        raw_path = unquote(args[0])
+        next unless raw_path
+        add_macro_endpoints(endpoints, path, content, raw_path, args[1..], nil, file_params, include_callee, call_start, protocol: "ws")
+      end
+
+      # WS_ADD_PATH_VIA_REGEX: WebSocketController, absolute regex path.
+      each_macro_call(content, "WS_ADD_PATH_VIA_REGEX") do |args, call_start|
+        next if args.empty?
+        raw_path = unquote(args[0])
+        next unless raw_path
+        add_macro_endpoints(endpoints, path, content, raw_path, args[1..], nil, file_params, include_callee, call_start, via_regex: true, protocol: "ws")
       end
 
       endpoints
     end
 
-    private def extract_add_method_endpoints(path : String,
-                                             content : String,
-                                             lines : Array(String),
-                                             file_params : Array(Param),
-                                             include_callee : Bool) : Array(Endpoint)
-      endpoints = [] of Endpoint
-      in_block = false
+    private def add_macro_endpoints(endpoints : Array(Endpoint),
+                                    path : String,
+                                    content : String,
+                                    raw_path : String,
+                                    method_args : Array(String),
+                                    handler : HandlerTarget?,
+                                    file_params : Array(Param),
+                                    include_callee : Bool,
+                                    call_start : Int32,
+                                    via_regex : Bool = false,
+                                    protocol : String = "http")
+      clean_path, path_params, query_params = normalize_drogon_path(raw_path, via_regex)
+      methods = parse_methods(method_args.reject { |a| a.lstrip.starts_with?('"') }.join(","))
+      line_number = Noir::CppCalleeExtractor.line_number_for(content, call_start)
 
-      lines.each_with_index do |line, index|
-        if line.includes?("METHOD_LIST_BEGIN")
-          in_block = true
-          next
-        end
-
-        if line.includes?("METHOD_LIST_END")
-          in_block = false
-          next
-        end
-
-        next unless in_block
-
-        if match = line.match(REGEX_ADD_METHOD)
-          handler_target = normalize_handler_target(match[1])
-          route = normalize_path(match[2])
-          methods = parse_methods(match[3])
-          callees = include_callee ? callees_for_handler(content, path, handler_target) : [] of Noir::CppCalleeExtractor::Entry
-
-          methods.each do |m|
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint = Endpoint.new(route, m, details)
-            file_params.each { |p| endpoint.push_param(p) }
-            Noir::CppCalleeExtractor.attach_to(endpoint, callees) if include_callee
-            endpoints << endpoint
-          end
-        end
+      if handler && !handler[1].empty?
+        handler_params = params_for_handler(content, handler)
+        handler_callees = include_callee ? callees_for_handler(content, path, handler) : [] of Noir::CppCalleeExtractor::Entry
+      else
+        # HttpSimpleController (PATH_ADD) has a single fixed handler, so the
+        # best available signal is the parameters seen anywhere in the file.
+        handler_params = file_params
+        handler_callees = [] of Noir::CppCalleeExtractor::Entry
       end
 
-      endpoints
+      methods.each do |m|
+        details = Details.new(PathInfo.new(path, line_number))
+        endpoint = Endpoint.new(clean_path, m, details)
+        endpoint.protocol = protocol unless protocol == "http"
+        path_params.each { |p| add_endpoint_param(endpoint, p) }
+        query_params.each { |p| add_endpoint_param(endpoint, p) }
+        handler_params.each { |p| add_endpoint_param(endpoint, p) }
+        Noir::CppCalleeExtractor.attach_to(endpoint, handler_callees) if include_callee
+        endpoints << endpoint
+      end
+    end
+
+    private def each_macro_call(content : String, macro_name : String, &block : Array(String), Int32 ->)
+      content.scan(/\b#{macro_name}\s*\(/) do |match|
+        call_start = match.begin(0) || 0
+        open_paren = Noir::CppCalleeExtractor.find_next_code_char(content, '(', call_start)
+        next unless open_paren
+
+        close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
+        next unless close_paren
+
+        args = split_top_level_args(content[(open_paren + 1)...close_paren])
+        block.call(args, call_start)
+      end
+    end
+
+    private def unquote(raw : String) : String?
+      s = raw.strip
+      return unless s.size >= 2 && s.starts_with?('"') && s.ends_with?('"')
+      s[1...-1]
+    end
+
+    # Drogon prefixes METHOD_ADD paths with the controller's fully-qualified
+    # name (namespaces joined by `/`, then the class name). Empty patterns map
+    # to the bare prefix; relative patterns are appended with a separator.
+    private def join_controller_path(prefix : String?, pattern : String) : String
+      if prefix.nil?
+        return pattern.starts_with?("/") ? pattern : "/#{pattern}"
+      end
+
+      if pattern.empty?
+        prefix
+      elsif pattern.starts_with?("/")
+        prefix + pattern
+      else
+        "#{prefix}/#{pattern}"
+      end
+    end
+
+    private def prefix_for(scopes : Array(ControllerScope), pos : Int32) : String?
+      best : ControllerScope? = nil
+      scopes.each do |scope|
+        open_brace, close_brace, _ = scope
+        next unless pos > open_brace && pos < close_brace
+        best = scope if best.nil? || (close_brace - open_brace) < (best[1] - best[0])
+      end
+      best.try &.[2]
+    end
+
+    # Collects every class/struct body in the file together with the URL prefix
+    # Drogon would derive for a controller of that name.
+    private def controller_scopes(content : String) : Array(ControllerScope)
+      scopes = [] of ControllerScope
+      content.scan(/\b(?:class|struct)\s+([A-Za-z_][A-Za-z0-9_]*)\b/) do |match|
+        class_start = match.begin(0) || 0
+        open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', class_start)
+        next unless open_brace
+
+        # Skip forward declarations (`class Foo;`) and `using`/typedef noise.
+        semicolon = Noir::CppCalleeExtractor.find_next_code_char(content, ';', class_start)
+        next if semicolon && semicolon < open_brace
+
+        close_brace = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_brace, '{', '}')
+        next unless close_brace
+
+        namespaces = enclosing_namespaces(content, class_start)
+        prefix = "/" + (namespaces + [match[1]]).join("/")
+        scopes << {open_brace, close_brace, prefix}
+      end
+      scopes
+    end
+
+    private def enclosing_namespaces(content : String, target : Int32) : Array(String)
+      found = [] of Tuple(Int32, String)
+      content.scan(/\bnamespace\s+([A-Za-z_][A-Za-z0-9_]*(?:\s*::\s*[A-Za-z_][A-Za-z0-9_]*)*)\s*\{/) do |match|
+        ns_start = match.begin(0) || 0
+        open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', ns_start)
+        next unless open_brace
+        next if open_brace >= target
+
+        close_brace = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_brace, '{', '}')
+        next unless close_brace
+        next unless target > open_brace && target < close_brace
+
+        found << {open_brace, match[1].gsub(/\s+/, "")}
+      end
+
+      found.sort_by!(&.[0])
+      found.flat_map { |_, name| name.split("::") }
     end
 
     private def callees_for_block_after(content : String, path : String, search_start : Int32) : Array(Noir::CppCalleeExtractor::Entry)
@@ -405,16 +532,65 @@ module Analyzer::Cpp
       methods
     end
 
-    # Normalize `/path/{id:int}` → `/path/{id}`; leaves plain `{id}` alone.
-    private def normalize_path(path : String) : String
-      path.gsub(/\{([^{}:]+):[^{}]+\}/) { "{#{$1}}" }
+    # Splits a Drogon path pattern into a clean URL, its path params, and any
+    # query params declared via the `?key={}` suffix. Placeholder bodies are
+    # normalized to readable names:
+    #   {}            → param1, param2, …   (positional)
+    #   {1} / {2}     → param1, param2, …   (positional index)
+    #   {int p1}      → p1                  (type + name)
+    #   {3:p3}        → p3                  (index : name)
+    #   {id}          → id                  (named)
+    private def normalize_drogon_path(raw : String, via_regex : Bool = false) : Tuple(String, Array(Param), Array(Param))
+      path_part, _, query = raw.partition('?')
+      query_params = extract_query_params(query)
+
+      return {path_part, [] of Param, query_params} if via_regex
+
+      path_params = [] of Param
+      counter = 0
+      clean = path_part.gsub(/\{([^{}]*)\}/) do
+        name = clean_param_name($1)
+        if name.nil?
+          counter += 1
+          name = "param#{counter}"
+        end
+        path_params << Param.new(name, "", "path")
+        "{#{name}}"
+      end
+
+      {clean, path_params, query_params}
     end
 
-    private def find_line_number(lines : Array(String), marker : String, route : String) : Int32
-      lines.each_with_index do |line, index|
-        return index + 1 if line.includes?(marker) && line.includes?(route)
+    private def clean_param_name(inner : String) : String?
+      s = inner.strip
+      return if s.empty?
+
+      # Drogon's colon form is ambiguous: `{id:int}` is name:type (use the
+      # name), while `{4:p4}` is index:name (use the name after the index).
+      if s.includes?(':')
+        before, _, after = s.partition(':')
+        before = before.strip
+        after = after.strip
+        s = before.matches?(/\A\d+\z/) ? after : before
       end
-      1
+
+      # `{int p1}` (type + name) collapses to the trailing identifier.
+      s = s.split(/\s+/).last if s.includes?(' ')
+
+      return if s.empty? || s.matches?(/\A\d+\z/)
+      s
+    end
+
+    private def extract_query_params(query : String) : Array(Param)
+      params = [] of Param
+      return params if query.empty?
+
+      query.split('&').each do |pair|
+        key = pair.split('=', 2).first.strip
+        next if key.empty?
+        add_unique_param(params, Param.new(key, "", "query"))
+      end
+      params
     end
 
     private def extract_params(lines : Array(String)) : Array(Param)
@@ -454,6 +630,12 @@ module Analyzer::Cpp
       return if param.name.empty?
       return if params.any? { |p| p.name == param.name && p.param_type == param.param_type }
       params << param
+    end
+
+    private def add_endpoint_param(endpoint : Endpoint, param : Param)
+      return if param.name.empty?
+      return if endpoint.params.any? { |p| p.name == param.name && p.param_type == param.param_type }
+      endpoint.push_param(param)
     end
   end
 end

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -541,10 +541,13 @@ module Analyzer::Cpp
     #   {3:p3}        → p3                  (index : name)
     #   {id}          → id                  (named)
     private def normalize_drogon_path(raw : String, via_regex : Bool = false) : Tuple(String, Array(Param), Array(Param))
+      # Regex routes are kept verbatim: `?` is a quantifier / `(?:...)` group,
+      # not the query-string separator, so neither splitting nor placeholder
+      # rewriting applies.
+      return {raw, [] of Param, [] of Param} if via_regex
+
       path_part, _, query = raw.partition('?')
       query_params = extract_query_params(query)
-
-      return {path_part, [] of Param, query_params} if via_regex
 
       path_params = [] of Param
       counter = 0

--- a/src/miniparsers/cpp_callee_extractor.cr
+++ b/src/miniparsers/cpp_callee_extractor.cr
@@ -137,6 +137,60 @@ module Noir::CppCalleeExtractor
     1 + source.to_slice[0, index].count('\n'.ord.to_u8)
   end
 
+  # Returns a copy of `source` with every `//` and `/* */` comment replaced by
+  # spaces. String/char literals are preserved verbatim and newlines are kept,
+  # so byte offsets and line numbers stay identical to the original. This lets
+  # macro/route scanners run without matching commented-out (or documentation)
+  # code. ASCII-oriented, matching the rest of the offset handling here.
+  def strip_comments(source : String) : String
+    bytes = source.to_slice.dup
+    size = bytes.size
+    i = 0
+
+    while i < size
+      char = bytes[i].unsafe_chr
+
+      if char == '"' || char == '\''
+        quote = char
+        i += 1
+        while i < size
+          c = bytes[i].unsafe_chr
+          if c == '\\'
+            i += 2
+            next
+          elsif c == quote
+            break
+          end
+          i += 1
+        end
+        i += 1
+      elsif char == '/' && i + 1 < size && bytes[i + 1].unsafe_chr == '/'
+        while i < size && bytes[i].unsafe_chr != '\n'
+          bytes[i] = ' '.ord.to_u8
+          i += 1
+        end
+      elsif char == '/' && i + 1 < size && bytes[i + 1].unsafe_chr == '*'
+        bytes[i] = ' '.ord.to_u8
+        bytes[i + 1] = ' '.ord.to_u8
+        i += 2
+        while i < size
+          if bytes[i].unsafe_chr == '*' && i + 1 < size && bytes[i + 1].unsafe_chr == '/'
+            bytes[i] = ' '.ord.to_u8
+            bytes[i + 1] = ' '.ord.to_u8
+            i += 2
+            break
+          end
+          bytes[i] = ' '.ord.to_u8 unless bytes[i].unsafe_chr == '\n'
+          i += 1
+        end
+      else
+        i += 1
+      end
+    end
+
+    String.new(bytes)
+  end
+
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
     candidates = [] of Tuple(Int32, String)
 


### PR DESCRIPTION
## Summary

Improves the C++ **Crow** and **Drogon** analyzers, validated against real OSS (`CrowCpp/Crow` examples, `drogonframework/drogon` examples + integration tests). Reduces false positives/negatives and fills callee / ai-context gaps.

## Drogon

- **`METHOD_ADD` support (biggest FN).** The most common Drogon controller macro was 100% unhandled, and the block handling was line-by-line so multi-line macros were missed too. Rewrote extraction to locate each macro by name and parse its arguments against balanced parentheses — multi-line-safe — covering `METHOD_ADD`, `ADD_METHOD_TO`, `ADD_METHOD_VIA_REGEX`, `PATH_ADD`, `WS_PATH_ADD`, `WS_ADD_PATH_VIA_REGEX`. The `api_v1_ApiTest` controller went **0 → 21** endpoints; the full drogon sample tree **46 → ~100**.
- **Controller path prefix.** `METHOD_ADD` paths are prefixed with the fully-qualified controller name (namespaces + class, e.g. `/app/v2/ApiCtrl`), per `HttpController::registerMethod`. `ADD_METHOD_TO` and the regex variants stay absolute.
- **Path normalization.** Split the `?key={}` query-string suffix into query params and clean placeholders: `{}` / `{1}` → positional `paramN`, `{int p1}` → `p1`, `{4:p4}` → `p4`, `{id:int}` → `id` (semantics verified against `HttpControllersRouter.cc`).
- **Line numbers.** Multi-line `registerHandler` calls used to report line `1`; now offset-based and accurate.
- **WebSocket.** `WS_PATH_ADD` / `WS_ADD_PATH_VIA_REGEX` → endpoints with `protocol="ws"`.

## Crow

- **`route_dynamic` (FP + FN).** `app.route_dynamic("/x")` was unrecognized, so its handler's params leaked into the *preceding* `CROW_ROUTE` (e.g. `/add_json` wrongly received `/params`'s query params) via an unbounded line-by-line fallback. Now recognized, and the unbounded fallback is removed in favor of block-scoped param extraction.
- **WebSocket / cookie / list-dict (FN).** `CROW_WEBSOCKET_ROUTE` → `protocol="ws"`; `get_cookie(...)` → cookie param; `url_params.get_list` / `get_dict` → query params.

## Shared

- **Block-comment false positives.** Added `Noir::CppCalleeExtractor.strip_comments` (length/offset-preserving, keeps string literals so path args survive) and run both analyzers on the comment-blanked copy. Commented-out routes and `/** ... */` documentation examples (Crow `/templatt`, Drogon `/some/path`) are no longer emitted.

## callee / ai-context

`METHOD_ADD` endpoints now resolve same-file handler bodies for callees and params (e.g. `/SayHello/` → `[newHttpResponse, callback]`). Cross-file handler resolution (header declares the macro, body lives in a `.cc`) remains a known limitation.

## Tests

- New regression fixtures + specs: `fixtures/cpp/crow_routes/` and `fixtures/cpp/drogon_controllers/`.
- Full suite: **18316 examples, 0 failures**. `crystal tool format` clean.

## Known limitations (out of scope)

- Cross-file Drogon handler bodies (ImportGraph territory).
- Crow blueprint prefix resolution (`register_blueprint` nesting) — raw route reported.