### PR TITLE
Java Struts2/Wicket: 1-hop callee/ai-context, REST deleteConfirm FN, XML line accuracy

### DIFF
--- a/spec/functional_test/fixtures/java/struts2/src/main/java/com/example/actions/admin/DashboardAction.java
+++ b/spec/functional_test/fixtures/java/struts2/src/main/java/com/example/actions/admin/DashboardAction.java
@@ -1,0 +1,17 @@
+package com.example.actions.admin;
+
+import com.opensymphony.xwork2.ActionSupport;
+
+// XML-configured handler for `<action name="dashboard"
+// class="com.example.actions.admin.DashboardAction"/>` in
+// admin-struts.xml. Exercises XML-action callee resolution: the default
+// `execute` method is resolved from the XML `class` attribute and its
+// 1-hop callees attached to the /admin/dashboard endpoint.
+public class DashboardAction extends ActionSupport {
+    private final DashboardService dashboardService = new DashboardService();
+
+    public String execute() {
+        dashboardService.loadStats();
+        return SUCCESS;
+    }
+}

--- a/spec/functional_test/fixtures/java/struts2/src/main/java/com/example/actions/orders/OrdersController.java
+++ b/spec/functional_test/fixtures/java/struts2/src/main/java/com/example/actions/orders/OrdersController.java
@@ -3,7 +3,10 @@ package com.example.actions.orders;
 import com.opensymphony.xwork2.ActionSupport;
 
 public class OrdersController extends ActionSupport {
+    private final OrdersService ordersService = new OrdersService();
+
     public String index() {
+        ordersService.findAll();
         return SUCCESS;
     }
 
@@ -12,6 +15,7 @@ public class OrdersController extends ActionSupport {
     }
 
     public String create() {
+        ordersService.save();
         return SUCCESS;
     }
 
@@ -20,6 +24,11 @@ public class OrdersController extends ActionSupport {
     }
 
     public String destroy() {
+        ordersService.deleteById();
+        return SUCCESS;
+    }
+
+    public String deleteConfirm() {
         return SUCCESS;
     }
 }

--- a/spec/functional_test/fixtures/java/wicket/src/main/java/com/example/PersonsRestResource.java
+++ b/spec/functional_test/fixtures/java/wicket/src/main/java/com/example/PersonsRestResource.java
@@ -7,12 +7,15 @@ import org.wicketstuff.restutils.http.HttpMethod;
 
 @ResourcePath("/scanned")
 public class PersonsRestResource implements IResource {
+    private final PersonService personService = new PersonService();
+
     @MethodMapping("/persons")
     public String listPeople() {
-        return "[]";
+        return personService.findAll();
     }
 
     @MethodMapping(value = "/persons/{personId:\\d+}", httpMethod = HttpMethod.DELETE)
     public void deletePerson(int personId) {
+        personService.deleteById(personId);
     }
 }

--- a/spec/functional_test/fixtures/java/wicket/src/main/java/com/example/PersonsRestResource.java
+++ b/spec/functional_test/fixtures/java/wicket/src/main/java/com/example/PersonsRestResource.java
@@ -3,6 +3,8 @@ package com.example;
 import org.apache.wicket.request.resource.IResource;
 import org.wicketstuff.rest.annotations.MethodMapping;
 import org.wicketstuff.rest.annotations.ResourcePath;
+import org.wicketstuff.rest.annotations.parameters.RequestBody;
+import org.wicketstuff.rest.annotations.parameters.RequestParam;
 import org.wicketstuff.restutils.http.HttpMethod;
 
 @ResourcePath("/scanned")
@@ -12,6 +14,12 @@ public class PersonsRestResource implements IResource {
     @MethodMapping("/persons")
     public String listPeople() {
         return personService.findAll();
+    }
+
+    @MethodMapping(value = "/persons", httpMethod = HttpMethod.POST)
+    public Person createPerson(@RequestBody Person person,
+                               @RequestParam(value = "notify", required = false) boolean notify) {
+        return personService.save(person);
     }
 
     @MethodMapping(value = "/persons/{personId:\\d+}", httpMethod = HttpMethod.DELETE)

--- a/spec/functional_test/testers/java/struts2_spec.cr
+++ b/spec/functional_test/testers/java/struts2_spec.cr
@@ -1,5 +1,15 @@
 require "../../func_spec.cr"
 
+# REST controller index/create/destroy methods invoke a service; assert
+# the 1-hop callees surface so the Struts2 callee/ai-context path stays
+# covered. `deleteConfirm` exercises the REST-plugin confirm-view action.
+orders_index = Endpoint.new("/orders/orders", "GET")
+orders_index.push_callee(Callee.new("ordersService.findAll"))
+orders_create = Endpoint.new("/orders/orders", "POST")
+orders_create.push_callee(Callee.new("ordersService.save"))
+orders_destroy = Endpoint.new("/orders/orders/:id", "DELETE", [Param.new("id", "", "path")])
+orders_destroy.push_callee(Callee.new("ordersService.deleteById"))
+
 expected_endpoints = [
   Endpoint.new("/user/list", "ANY"),
   Endpoint.new("/user/edit", "ANY"),
@@ -10,11 +20,12 @@ expected_endpoints = [
   Endpoint.new("/admin/users/create", "ANY"),
   Endpoint.new("/admin/users/save", "ANY"),
   Endpoint.new("/products/product", "ANY"),
-  Endpoint.new("/orders/orders", "GET"),
+  orders_index,
   Endpoint.new("/orders/orders/:id", "GET", [Param.new("id", "", "path")]),
-  Endpoint.new("/orders/orders", "POST"),
+  Endpoint.new("/orders/orders/:id/deleteConfirm", "GET", [Param.new("id", "", "path")]),
+  orders_create,
   Endpoint.new("/orders/orders/:id", "PUT", [Param.new("id", "", "path")]),
-  Endpoint.new("/orders/orders/:id", "DELETE", [Param.new("id", "", "path")]),
+  orders_destroy,
   Endpoint.new("/person/list-people", "ANY"),
   Endpoint.new("/annotated/default-annotated", "ANY"),
   Endpoint.new("/multi-a/multi-namespace", "ANY"),
@@ -24,4 +35,4 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/struts2/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {"include_callee" => YAML::Any.new(true)}).perform_tests

--- a/spec/functional_test/testers/java/struts2_spec.cr
+++ b/spec/functional_test/testers/java/struts2_spec.cr
@@ -10,12 +10,18 @@ orders_create.push_callee(Callee.new("ordersService.save"))
 orders_destroy = Endpoint.new("/orders/orders/:id", "DELETE", [Param.new("id", "", "path")])
 orders_destroy.push_callee(Callee.new("ordersService.deleteById"))
 
+# XML-configured action: callees are resolved from the `<action
+# class="…">` handler (DashboardAction#execute) referenced in
+# admin-struts.xml, not from a Java-source-discovered route.
+admin_dashboard = Endpoint.new("/admin/dashboard", "ANY")
+admin_dashboard.push_callee(Callee.new("dashboardService.loadStats"))
+
 expected_endpoints = [
   Endpoint.new("/user/list", "ANY"),
   Endpoint.new("/user/edit", "ANY"),
   Endpoint.new("/user/user_*", "ANY", [Param.new("wildcard", "", "path")]),
   Endpoint.new("/user/audit", "ANY"),
-  Endpoint.new("/admin/dashboard", "ANY"),
+  admin_dashboard,
   Endpoint.new("/admin/reports/*", "ANY", [Param.new("wildcard", "", "path")]),
   Endpoint.new("/admin/users/create", "ANY"),
   Endpoint.new("/admin/users/save", "ANY"),

--- a/spec/functional_test/testers/java/wicket_spec.cr
+++ b/spec/functional_test/testers/java/wicket_spec.cr
@@ -11,6 +11,19 @@ scanned_delete = Endpoint.new("/scanned/persons/{personId}", "DELETE", [
 ])
 scanned_delete.push_callee(Callee.new("personService.deleteById"))
 
+# POST handler exercises wicketstuff-rest request-parameter annotations:
+# @RequestBody → json body param, @RequestParam → query param. Asserted
+# on both mount points (/scanned via @ResourcePath, /api via mountResource).
+scanned_create = Endpoint.new("/scanned/persons", "POST", [
+  Param.new("person", "", "json"),
+  Param.new("notify", "", "query"),
+])
+scanned_create.push_callee(Callee.new("personService.save"))
+api_create = Endpoint.new("/api/persons", "POST", [
+  Param.new("person", "", "json"),
+  Param.new("notify", "", "query"),
+])
+
 expected_endpoints = [
   Endpoint.new("/users", "GET"),
   Endpoint.new("/users/{id}", "GET", [
@@ -36,9 +49,11 @@ expected_endpoints = [
   ]),
   Endpoint.new("/DefaultMountPage", "GET"),
   scanned_persons,
+  scanned_create,
   scanned_delete,
   Endpoint.new("/dashboards", "GET"),
   Endpoint.new("/api/persons", "GET"),
+  api_create,
   Endpoint.new("/api/persons/{personId}", "DELETE", [
     Param.new("personId", "", "path"),
   ]),

--- a/spec/functional_test/testers/java/wicket_spec.cr
+++ b/spec/functional_test/testers/java/wicket_spec.cr
@@ -1,5 +1,16 @@
 require "../../func_spec.cr"
 
+# wicketstuff-rest @MethodMapping handlers invoke a service; assert the
+# 1-hop callees surface so the Wicket callee/ai-context path stays
+# covered. The resource is mounted at both /scanned (@ResourcePath) and
+# /api (mountResource), so callees ride along on both.
+scanned_persons = Endpoint.new("/scanned/persons", "GET")
+scanned_persons.push_callee(Callee.new("personService.findAll"))
+scanned_delete = Endpoint.new("/scanned/persons/{personId}", "DELETE", [
+  Param.new("personId", "", "path"),
+])
+scanned_delete.push_callee(Callee.new("personService.deleteById"))
+
 expected_endpoints = [
   Endpoint.new("/users", "GET"),
   Endpoint.new("/users/{id}", "GET", [
@@ -24,10 +35,8 @@ expected_endpoints = [
     Param.new("orderId", "", "path"),
   ]),
   Endpoint.new("/DefaultMountPage", "GET"),
-  Endpoint.new("/scanned/persons", "GET"),
-  Endpoint.new("/scanned/persons/{personId}", "DELETE", [
-    Param.new("personId", "", "path"),
-  ]),
+  scanned_persons,
+  scanned_delete,
   Endpoint.new("/dashboards", "GET"),
   Endpoint.new("/api/persons", "GET"),
   Endpoint.new("/api/persons/{personId}", "DELETE", [
@@ -42,4 +51,4 @@ expected_endpoints = [
 FunctionalTester.new("fixtures/java/wicket/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {"include_callee" => YAML::Any.new(true)}).perform_tests

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -23,8 +23,9 @@ module Analyzer::Java
       getter name : String
       getter method_name : String
       getter line : Int32?
+      getter class_name : String
 
-      def initialize(@name, @method_name, @line)
+      def initialize(@name, @method_name, @line, @class_name = "")
       end
     end
 
@@ -76,6 +77,7 @@ module Analyzer::Java
     end
 
     @include_callee : Bool = false
+    @handler_index : Hash(String, String) = {} of String => String
 
     def analyze
       @include_callee = callees_needed?
@@ -84,12 +86,17 @@ module Analyzer::Java
       convention_config = ConventionConfig.new
       seen = Set(String).new
 
-      config_files.each do |path|
-        parse_struts_config(path, file_list, convention_config, seen)
-      end
-
       java_files = file_list.select do |path|
         File.exists?(path) && path.ends_with?(".java") && !JavaEngine.test_path?(path)
+      end
+
+      # Build a FQCN → source-path index up front so XML `<action
+      # class="…">` handlers can be resolved for callee extraction. Only
+      # needed when callee/ai-context enrichment is requested.
+      build_handler_index(java_files) if @include_callee
+
+      config_files.each do |path|
+        parse_struts_config(path, file_list, convention_config, seen)
       end
 
       package_annotations = package_annotations_for(java_files)
@@ -100,6 +107,51 @@ module Analyzer::Java
 
       Fiber.yield
       @result
+    end
+
+    # Index every top-level Java class by its fully-qualified name so an
+    # XML-configured `<action class="…">` can be resolved back to its
+    # source file for callee extraction. Regex-based to stay cheap; the
+    # index is only built when callee/ai-context enrichment is on.
+    private def build_handler_index(java_files : Array(String))
+      java_files.each do |path|
+        content = read_file_content(path)
+        package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name(content)
+        content.scan(/(?:^|\n)\s*(?:public\s+|protected\s+|private\s+|abstract\s+|final\s+|static\s+)*class\s+([A-Za-z_][A-Za-z0-9_]*)/m) do |match|
+          class_name = match[1]
+          fqcn = package_name.empty? ? class_name : "#{package_name}.#{class_name}"
+          @handler_index[fqcn] ||= path
+        end
+      rescue e : Exception
+        @logger.debug "Failed to index Struts handler #{path}: #{e.message}"
+      end
+    end
+
+    # 1-hop callees for an XML-configured action by resolving its
+    # `class`/`method` (default `execute`) to the handler source. Returns
+    # empty unless enrichment is on and the handler file is indexed.
+    private def xml_action_callees(action : XmlAction) : Array(Callee)
+      callees = [] of Callee
+      return callees unless @include_callee
+      return callees if action.class_name.empty?
+
+      handler_path = @handler_index[action.class_name]?
+      return callees unless handler_path && File.exists?(handler_path)
+
+      simple_name = action.class_name.split('.').last
+      method_name = action.method_name.empty? ? "execute" : action.method_name
+      handler_content = read_file_content(handler_path)
+
+      Noir::TreeSitter.parse_java(handler_content) do |root|
+        Noir::JavaCalleeExtractor.callees_in_method(root, handler_content, handler_path, simple_name, method_name).each do |entry|
+          name, callee_path, callee_line = entry
+          callees << Callee.new(name, path: callee_path, line: callee_line)
+        end
+      end
+      callees
+    rescue e : Exception
+      @logger.debug "Failed to extract Struts XML callees for #{action.class_name}: #{e.message}"
+      [] of Callee
     end
 
     private def struts_config_files(file_list : Array(String)) : Array(String)
@@ -133,7 +185,8 @@ module Analyzer::Java
       packages.each_value do |package_config|
         namespace = package_namespace(package_config, packages, Set(String).new)
         package_config.actions.each do |action|
-          add_route(join_paths(namespace, normalize_action_pattern(action.name)), "ANY", path, action.line)
+          add_route(join_paths(namespace, normalize_action_pattern(action.name)), "ANY", path, action.line,
+            callees: xml_action_callees(action))
         end
       end
     rescue e : Exception
@@ -203,7 +256,8 @@ module Analyzer::Java
         each_xml_child(node, "action") do |action_node|
           action_name = xml_attr(action_node, "name")
           next if action_name.empty?
-          actions << XmlAction.new(action_name, xml_attr(action_node, "method"), xml_line_for(content, action_name, package_offset))
+          actions << XmlAction.new(action_name, xml_attr(action_node, "method"),
+            xml_line_for(content, action_name, package_offset), xml_attr(action_node, "class"))
         end
 
         packages[name] = XmlPackage.new(name, namespace, extends_names, actions)

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -9,13 +9,14 @@ module Analyzer::Java
     STRUTS_CONFIG_BASENAMES = Set{"struts.xml", "struts-plugin.xml", "struts-deferred.xml"}
     DEFAULT_LOCATORS        = ["action", "actions", "struts", "struts2"]
     REST_METHODS            = {
-      "index"   => {"GET", ""},
-      "show"    => {"GET", "/:id"},
-      "edit"    => {"GET", "/:id/edit"},
-      "editNew" => {"GET", "/new"},
-      "create"  => {"POST", ""},
-      "update"  => {"PUT", "/:id"},
-      "destroy" => {"DELETE", "/:id"},
+      "index"         => {"GET", ""},
+      "show"          => {"GET", "/:id"},
+      "edit"          => {"GET", "/:id/edit"},
+      "editNew"       => {"GET", "/new"},
+      "deleteConfirm" => {"GET", "/:id/deleteConfirm"},
+      "create"        => {"POST", ""},
+      "update"        => {"PUT", "/:id"},
+      "destroy"       => {"DELETE", "/:id"},
     }
 
     private struct XmlAction
@@ -74,7 +75,10 @@ module Analyzer::Java
       end
     end
 
+    @include_callee : Bool = false
+
     def analyze
+      @include_callee = callees_needed?
       file_list = all_files()
       config_files = struts_config_files(file_list)
       convention_config = ConventionConfig.new
@@ -190,11 +194,16 @@ module Analyzer::Java
 
         namespace = node["namespace"]?
         extends_names = split_csv(xml_attr(node, "extends"))
+        # Anchor action-line lookups to this package's offset so that an
+        # action name shared across packages (e.g. `delete` in both
+        # `/skill` and `/employee`) resolves to the declaration inside
+        # the owning package rather than the document's first match.
+        package_offset = package_start_offset(content, name)
         actions = [] of XmlAction
         each_xml_child(node, "action") do |action_node|
           action_name = xml_attr(action_node, "name")
           next if action_name.empty?
-          actions << XmlAction.new(action_name, xml_attr(action_node, "method"), xml_line_for(content, action_name))
+          actions << XmlAction.new(action_name, xml_attr(action_node, "method"), xml_line_for(content, action_name, package_offset))
         end
 
         packages[name] = XmlPackage.new(name, namespace, extends_names, actions)
@@ -246,6 +255,25 @@ module Analyzer::Java
       content = read_file_content(path)
       return unless struts_java_source?(content, config)
 
+      # When callee/ai-context enrichment is requested, parse the file
+      # once with tree-sitter and reuse the root for every action route
+      # in the file. On a default scan we skip the parse entirely.
+      if @include_callee
+        Noir::TreeSitter.parse_java(content) do |root|
+          analyze_java_classes(path, config, package_annotations, content, root)
+        end
+      else
+        analyze_java_classes(path, config, package_annotations, content, nil)
+      end
+    rescue e : Exception
+      @logger.debug "Failed to parse Struts Java source #{path}: #{e.message}"
+    end
+
+    private def analyze_java_classes(path : String,
+                                     config : ConventionConfig,
+                                     package_annotations : Hash(String, String),
+                                     content : String,
+                                     root : LibTreeSitter::TSNode?)
       package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name(content)
       classes_in(content, package_name).each do |klass|
         next if klass.abstract?
@@ -262,7 +290,8 @@ module Analyzer::Java
         namespaces.each do |class_namespace|
           class_actions.each do |action_path|
             resolved = action_path.empty? ? join_paths(class_namespace, class_action_base) : resolve_action_path(action_path, class_namespace)
-            add_route(resolved, "ANY", path, klass.line)
+            # A class-level @Action defaults to the `execute` handler.
+            add_route(resolved, "ANY", path, klass.line, callees: callees_for(root, content, path, klass.name, "execute"))
           end
 
           methods.each do |method|
@@ -271,7 +300,7 @@ module Analyzer::Java
 
             action_paths.each do |action_path|
               resolved = action_path.empty? ? join_paths(class_namespace, class_action_base) : resolve_action_path(action_path, class_namespace)
-              add_route(resolved, "ANY", path, method.line)
+              add_route(resolved, "ANY", path, method.line, callees: callees_for(root, content, path, klass.name, method.name))
             end
           end
 
@@ -280,14 +309,35 @@ module Analyzer::Java
 
           base_path = join_paths(class_namespace, class_action_base)
           if rest_controller?(klass, config)
-            add_rest_routes(path, base_path, methods)
+            add_rest_routes(path, base_path, methods, root, content, klass.name)
           else
-            add_route(base_path, "ANY", path, klass.line)
+            # A convention action without an explicit method defaults to `execute`.
+            add_route(base_path, "ANY", path, klass.line, callees: callees_for(root, content, path, klass.name, "execute"))
           end
         end
       end
+    end
+
+    # 1-hop callees out of the action handler method body, mirroring the
+    # Spring analyzer. Returns an empty list unless callee/ai-context
+    # enrichment was requested (`root` is nil on a default scan). The
+    # tree-sitter root is shared across every route in the file.
+    private def callees_for(root : LibTreeSitter::TSNode?,
+                            content : String,
+                            path : String,
+                            class_name : String,
+                            method_name : String) : Array(Callee)
+      callees = [] of Callee
+      return callees if root.nil? || class_name.empty? || method_name.empty?
+
+      Noir::JavaCalleeExtractor.callees_in_method(root, content, path, class_name, method_name).each do |entry|
+        name, callee_path, callee_line = entry
+        callees << Callee.new(name, path: callee_path, line: callee_line)
+      end
+      callees
     rescue e : Exception
-      @logger.debug "Failed to parse Struts Java source #{path}: #{e.message}"
+      @logger.debug "Failed to extract Struts callees for #{class_name}##{method_name}: #{e.message}"
+      [] of Callee
     end
 
     private def struts_java_source?(content : String, config : ConventionConfig) : Bool
@@ -459,14 +509,20 @@ module Analyzer::Java
       klass.name.ends_with?("Controller") && (config.rest_enabled? || config.action_suffixes.includes?("Controller"))
     end
 
-    private def add_rest_routes(path : String, base_path : String, methods : Array(JavaMethod))
+    private def add_rest_routes(path : String,
+                                base_path : String,
+                                methods : Array(JavaMethod),
+                                root : LibTreeSitter::TSNode?,
+                                content : String,
+                                class_name : String)
       methods.each do |method|
         route = REST_METHODS[method.name]?
         next unless route
 
         verb, suffix = route
         params = suffix.includes?(":id") ? [Param.new("id", "", "path")] : [] of Param
-        add_route(join_paths(base_path, suffix), verb, path, method.line, params)
+        add_route(join_paths(base_path, suffix), verb, path, method.line, params,
+          callees: callees_for(root, content, path, class_name, method.name))
       end
     end
 
@@ -517,7 +573,8 @@ module Analyzer::Java
       normalized.empty? ? "" : normalized
     end
 
-    private def add_route(path : String, method : String, file_path : String, line : Int32?, params = [] of Param)
+    private def add_route(path : String, method : String, file_path : String, line : Int32?,
+                          params = [] of Param, callees : Array(Callee) = [] of Callee)
       normalized = normalize_path(path)
       route_params = params.dup
       wildcard_count = normalized.count('*')
@@ -534,7 +591,9 @@ module Analyzer::Java
       key = "#{method} #{normalized}"
       return if @result.any? { |endpoint| "#{endpoint.method} #{endpoint.url}" == key }
 
-      @result << Endpoint.new(normalized, method, route_params, Details.new(PathInfo.new(file_path, line)))
+      endpoint = Endpoint.new(normalized, method, route_params, Details.new(PathInfo.new(file_path, line)))
+      callees.each { |callee| endpoint.push_callee(callee) }
+      @result << endpoint
     end
 
     private def normalize_namespace(namespace : String) : String
@@ -560,11 +619,26 @@ module Analyzer::Java
       value.split(",").map(&.strip).reject(&.empty?)
     end
 
-    private def xml_line_for(content : String, action_name : String) : Int32?
-      if index = content.index(/<action\b[^>]*\bname\s*=\s*["']#{Regex.escape(action_name)}["']/)
+    private def xml_line_for(content : String, action_name : String, from_offset : Int32 = 0) : Int32?
+      pattern = /<action\b[^>]*\bname\s*=\s*["']#{Regex.escape(action_name)}["']/
+      if index = content.index(pattern, from_offset)
+        return line_number_for(content, index)
+      end
+      # Fall back to a document-wide search when the package anchor
+      # didn't land before the declaration (e.g. attributes reordered).
+      if from_offset > 0 && (index = content.index(pattern))
         return line_number_for(content, index)
       end
       nil
+    end
+
+    # Byte offset of a package's opening `<package … name="…">` tag, used
+    # to scope action-line lookups to the declaring package.
+    private def package_start_offset(content : String, package_name : String) : Int32
+      if index = content.index(/<package\b[^>]*\bname\s*=\s*["']#{Regex.escape(package_name)}["']/)
+        return index
+      end
+      0
     end
 
     private def line_number_for(content : String, offset : Int32) : Int32

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -38,7 +38,7 @@ module Analyzer::Java
     REST_LAMBDA_METHODS     = Set{"get", "post", "put", "delete", "patch", "head", "options", "trace"}
 
     alias FileInfo = NamedTuple(path: String, content: String, constants: Hash(String, String))
-    alias RestRoute = NamedTuple(path: String, method: String, file_path: String, line: Int32, callees: Array(Callee))
+    alias RestRoute = NamedTuple(path: String, method: String, file_path: String, line: Int32, callees: Array(Callee), params: Array(Param))
     alias RestMount = NamedTuple(path: String, file_path: String, line: Int32)
 
     @include_callee : Bool = false
@@ -141,7 +141,7 @@ module Analyzer::Java
             if resource_class = rest_resource_class_name(args, rest_routes)
               if routes = rest_routes[resource_class]?
                 routes.each do |route|
-                  add_endpoint(join_mount_paths(normalized, route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees])
+                  add_endpoint(join_mount_paths(normalized, route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees], route[:params])
                 end
                 next
               end
@@ -221,10 +221,12 @@ module Analyzer::Java
       class_name = first_class_name(file[:content])
       return if class_name.empty?
 
-      # First pass collects the route shape + the enclosing handler
-      # method name; callees are filled in a single tree-sitter parse
-      # below (only when callee/ai-context enrichment is requested).
-      pending = [] of NamedTuple(path: String, method: String, line: Int32, method_name: String)
+      # First pass collects the route shape, the enclosing handler method
+      # name, and the handler's request parameters (from wicketstuff-rest
+      # @RequestParam/@HeaderParam/@CookieParam/@RequestBody annotations);
+      # callees are filled in a single tree-sitter parse below (only when
+      # callee/ai-context enrichment is requested).
+      pending = [] of NamedTuple(path: String, method: String, line: Int32, method_name: String, params: Array(Param))
       file[:content].scan(/@(?:[A-Za-z_][A-Za-z0-9_]*\.)*MethodMapping\b/) do |match|
         marker = match.begin(0) || 0
         after = match.end(0) || marker
@@ -239,11 +241,13 @@ module Analyzer::Java
         end
 
         path, method = method_mapping_values(args, file[:constants])
+        method_name, param_list = rest_handler_signature(file[:content], scan_from)
         pending << {
           path:        normalize_mount_path(path),
           method:      method,
           line:        line_for_offset(file[:content], marker),
-          method_name: next_method_name(file[:content], scan_from),
+          method_name: method_name,
+          params:      rest_method_params(param_list),
         }
       end
       return if pending.empty?
@@ -256,6 +260,7 @@ module Analyzer::Java
           file_path: file[:path],
           line:      entry[:line],
           callees:   callee_map[entry[:method_name]]? || [] of Callee,
+          params:    entry[:params],
         }
       end
     end
@@ -290,16 +295,73 @@ module Analyzer::Java
       Hash(String, Array(Callee)).new
     end
 
-    # Name of the method declared immediately after a `@MethodMapping`
-    # annotation. wicketstuff-rest handler methods are public, so we
-    # anchor on the access modifier and capture the identifier that
-    # precedes the parameter list.
-    private def next_method_name(content : String, offset : Int32) : String
+    # Name + raw parameter-list text of the method declared immediately
+    # after a `@MethodMapping` annotation. wicketstuff-rest handler
+    # methods are public, so we anchor on the access modifier and capture
+    # the identifier that precedes the parameter list, then the balanced
+    # `(...)` that follows.
+    private def rest_handler_signature(content : String, offset : Int32) : Tuple(String, String)
       rest = content[offset..]? || ""
-      if match = rest.match(/\b(?:public|protected|private)\b[^;{}=]*?\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
-        return match[1]
+      match = rest.match(/\b(?:public|protected|private)\b[^;{}=]*?\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
+      return {"", ""} unless match
+
+      name = match[1]
+      open_abs = offset + (match.end(0) || 1) - 1
+      close_abs = find_matching_paren(content, open_abs)
+      return {name, ""} unless close_abs
+
+      {name, content[(open_abs + 1)...close_abs]}
+    end
+
+    # Map wicketstuff-rest handler parameters to request parameters.
+    # Path parameters are sourced from the `{...}` placeholders in the
+    # mount URL, so an unannotated method parameter (bound positionally to
+    # a path placeholder) is intentionally skipped here to avoid
+    # duplicates. `@PathParam` is likewise covered by the URL placeholder.
+    private def rest_method_params(param_list : String) : Array(Param)
+      params = [] of Param
+      return params if param_list.strip.empty?
+
+      split_arguments(param_list).each do |raw|
+        decl = raw.strip
+        next if decl.empty?
+
+        java_name = decl.match(/([A-Za-z_][A-Za-z0-9_]*)\s*$/).try(&.[1]) || ""
+
+        if match = decl.match(/@(?:[A-Za-z_][A-Za-z0-9_]*\.)*RequestParam\b\s*\(([^)]*)\)/)
+          name = annotation_first_string(match[1]) || java_name
+          add_rest_param(params, name, "query")
+        elsif match = decl.match(/@(?:[A-Za-z_][A-Za-z0-9_]*\.)*HeaderParam\b\s*\(([^)]*)\)/)
+          name = annotation_first_string(match[1]) || java_name
+          add_rest_param(params, name, "header")
+        elsif match = decl.match(/@(?:[A-Za-z_][A-Za-z0-9_]*\.)*CookieParam\b\s*\(([^)]*)\)/)
+          name = annotation_first_string(match[1]) || java_name
+          add_rest_param(params, name, "cookie")
+        elsif decl.matches?(/@(?:[A-Za-z_][A-Za-z0-9_]*\.)*RequestBody\b/)
+          add_rest_param(params, java_name, "json")
+        end
       end
-      ""
+      params
+    end
+
+    private def add_rest_param(params : Array(Param), name : String, type : String)
+      return if name.empty?
+      return if params.any? { |param| param.name == name && param.param_type == type }
+      params << Param.new(name, "", type)
+    end
+
+    # First string literal in an annotation argument list, handling both
+    # the shorthand `@X("name")` and the explicit `@X(value = "name", …)`
+    # forms.
+    private def annotation_first_string(args : String) : String?
+      stripped = args.strip
+      if value_match = stripped.match(/\bvalue\s*=\s*"((?:\\.|[^"\\])*)"/)
+        return value_match[1]
+      end
+      if literal = stripped.match(/"((?:\\.|[^"\\])*)"/)
+        return literal[1]
+      end
+      nil
     end
 
     private def collect_resource_path_annotations(file : FileInfo,
@@ -337,7 +399,7 @@ module Analyzer::Java
         routes = rest_routes[class_name]?
         if routes && !routes.empty?
           routes.each do |route|
-            add_endpoint(join_mount_paths(mount[:path], route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees])
+            add_endpoint(join_mount_paths(mount[:path], route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees], route[:params])
           end
         else
           add_endpoint(mount[:path], mount[:file_path], mount[:line], seen)
@@ -419,8 +481,14 @@ module Analyzer::Java
       add_endpoint(path, file_path, line, seen, "GET")
     end
 
-    private def add_endpoint(path : String, file_path : String, line : Int32, seen : Set(String), method : String, callees : Array(Callee) = [] of Callee)
-      endpoint = Endpoint.new(path, method, path_params(path), Details.new(PathInfo.new(file_path, line)))
+    private def add_endpoint(path : String, file_path : String, line : Int32, seen : Set(String), method : String, callees : Array(Callee) = [] of Callee, extra_params : Array(Param) = [] of Param)
+      params = path_params(path)
+      extra_params.each do |param|
+        next if params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+        params << param
+      end
+
+      endpoint = Endpoint.new(path, method, params, Details.new(PathInfo.new(file_path, line)))
       key = endpoint_key(endpoint)
       return if seen.includes?(key)
 

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -1,6 +1,7 @@
 require "../../../models/analyzer"
 require "../../engines/java_engine"
 require "../../../miniparsers/java_route_extractor_ts"
+require "../../../miniparsers/java_callee_extractor"
 
 module Analyzer::Java
   class Wicket < Analyzer
@@ -37,10 +38,13 @@ module Analyzer::Java
     REST_LAMBDA_METHODS     = Set{"get", "post", "put", "delete", "patch", "head", "options", "trace"}
 
     alias FileInfo = NamedTuple(path: String, content: String, constants: Hash(String, String))
-    alias RestRoute = NamedTuple(path: String, method: String, file_path: String, line: Int32)
+    alias RestRoute = NamedTuple(path: String, method: String, file_path: String, line: Int32, callees: Array(Callee))
     alias RestMount = NamedTuple(path: String, file_path: String, line: Int32)
 
+    @include_callee : Bool = false
+
     def analyze
+      @include_callee = callees_needed?
       files = java_files_with_content
       page_mounts = Hash(String, Array(String)).new { |hash, key| hash[key] = [] of String }
       rest_routes = Hash(String, Array(RestRoute)).new { |hash, key| hash[key] = [] of RestRoute }
@@ -137,7 +141,7 @@ module Analyzer::Java
             if resource_class = rest_resource_class_name(args, rest_routes)
               if routes = rest_routes[resource_class]?
                 routes.each do |route|
-                  add_endpoint(join_mount_paths(normalized, route[:path]), route[:file_path], route[:line], seen, route[:method])
+                  add_endpoint(join_mount_paths(normalized, route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees])
                 end
                 next
               end
@@ -217,6 +221,10 @@ module Analyzer::Java
       class_name = first_class_name(file[:content])
       return if class_name.empty?
 
+      # First pass collects the route shape + the enclosing handler
+      # method name; callees are filled in a single tree-sitter parse
+      # below (only when callee/ai-context enrichment is requested).
+      pending = [] of NamedTuple(path: String, method: String, line: Int32, method_name: String)
       file[:content].scan(/@(?:[A-Za-z_][A-Za-z0-9_]*\.)*MethodMapping\b/) do |match|
         marker = match.begin(0) || 0
         after = match.end(0) || marker
@@ -226,17 +234,72 @@ module Analyzer::Java
         if scan_from < file[:content].size && file[:content][scan_from] == '('
           if close_idx = find_matching_paren(file[:content], scan_from)
             args = file[:content][(scan_from + 1)...close_idx]
+            scan_from = close_idx + 1
           end
         end
 
         path, method = method_mapping_values(args, file[:constants])
-        rest_routes[class_name] << {
-          path:      normalize_mount_path(path),
-          method:    method,
-          file_path: file[:path],
-          line:      line_for_offset(file[:content], marker),
+        pending << {
+          path:        normalize_mount_path(path),
+          method:      method,
+          line:        line_for_offset(file[:content], marker),
+          method_name: next_method_name(file[:content], scan_from),
         }
       end
+      return if pending.empty?
+
+      callee_map = method_callees_for(file, class_name, pending.map(&.[:method_name]))
+      pending.each do |entry|
+        rest_routes[class_name] << {
+          path:      entry[:path],
+          method:    entry[:method],
+          file_path: file[:path],
+          line:      entry[:line],
+          callees:   callee_map[entry[:method_name]]? || [] of Callee,
+        }
+      end
+    end
+
+    # Parse the file once and return a method-name → 1-hop-callees map for
+    # the requested handler methods. Empty unless callee/ai-context
+    # enrichment was requested. Mirrors the Struts2/Spring callee scope:
+    # call sites inside the same-file handler body, no cross-file
+    # resolution.
+    private def method_callees_for(file : FileInfo,
+                                   class_name : String,
+                                   method_names : Array(String)) : Hash(String, Array(Callee))
+      result = Hash(String, Array(Callee)).new
+      return result unless @include_callee
+
+      Noir::TreeSitter.parse_java(file[:content]) do |root|
+        method_names.uniq.each do |method_name|
+          next if method_name.empty? || result.has_key?(method_name)
+
+          callees = [] of Callee
+          Noir::JavaCalleeExtractor.callees_in_method(root, file[:content], file[:path], class_name, method_name).each do |entry|
+            name, callee_path, callee_line = entry
+            callees << Callee.new(name, path: callee_path, line: callee_line)
+          end
+          result[method_name] = callees
+        end
+      end
+
+      result
+    rescue e : Exception
+      @logger.debug "Failed to extract Wicket callees in #{file[:path]}: #{e.message}"
+      Hash(String, Array(Callee)).new
+    end
+
+    # Name of the method declared immediately after a `@MethodMapping`
+    # annotation. wicketstuff-rest handler methods are public, so we
+    # anchor on the access modifier and capture the identifier that
+    # precedes the parameter list.
+    private def next_method_name(content : String, offset : Int32) : String
+      rest = content[offset..]? || ""
+      if match = rest.match(/\b(?:public|protected|private)\b[^;{}=]*?\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
+        return match[1]
+      end
+      ""
     end
 
     private def collect_resource_path_annotations(file : FileInfo,
@@ -274,7 +337,7 @@ module Analyzer::Java
         routes = rest_routes[class_name]?
         if routes && !routes.empty?
           routes.each do |route|
-            add_endpoint(join_mount_paths(mount[:path], route[:path]), route[:file_path], route[:line], seen, route[:method])
+            add_endpoint(join_mount_paths(mount[:path], route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees])
           end
         else
           add_endpoint(mount[:path], mount[:file_path], mount[:line], seen)
@@ -356,12 +419,13 @@ module Analyzer::Java
       add_endpoint(path, file_path, line, seen, "GET")
     end
 
-    private def add_endpoint(path : String, file_path : String, line : Int32, seen : Set(String), method : String)
+    private def add_endpoint(path : String, file_path : String, line : Int32, seen : Set(String), method : String, callees : Array(Callee) = [] of Callee)
       endpoint = Endpoint.new(path, method, path_params(path), Details.new(PathInfo.new(file_path, line)))
       key = endpoint_key(endpoint)
       return if seen.includes?(key)
 
       seen << key
+      callees.each { |callee| endpoint.push_callee(callee) }
       @result << endpoint
     end
 


### PR DESCRIPTION
## Summary

Hardened the **Apache Struts2** and **Apache Wicket** analyzers by analyzing real open-source applications across three validation cycles, closing the FN / FP / callee-omission gaps that surfaced. Both analyzers already produce a solid endpoint base; this enriches them.

## Validation cycles (real OSS apps)

| Cycle | App | Outcome |
|-------|-----|---------|
| seed | `apache/struts` showcase + rest-showcase | deleteConfirm FN, XML line accuracy, Java-action callees |
| 1 | `apache/roller` (Struts2) | clean validation → motivated XML-handler callee resolution |
| 2 | `wicketstuff/core` restannotations | wicketstuff-rest request-param FN |
| 3 | `apache/syncope`, openlayers3, wicket-mount | mount/`@MountPath` coverage confirmed; dynamic runtime mounts noted as a limitation |

## Struts2

- **Java-action callees (was: always empty).** Emit 1-hop callees for convention `execute`, `@Action` methods, and REST methods — gated on `--include callee` / `--ai-context`, mirroring the Spring analyzer. The AI-context augmentor derives sinks/validators/`unsafe_method` from `endpoint.callees`, so these never fired on Struts apps before.
- **XML-handler callees (was: always empty).** Real Struts2 apps are predominantly XML-configured (`<action class="…" method="…">`). Those endpoints anchored at the XML line and carried no callees. Now: capture the `class` attribute, index FQCN → source path, resolve the handler method (default `execute`), and attach its 1-hop callees pointing at the handler source. Roller went from **0/59 → ~60 routes** with callees.
- **FN — REST `deleteConfirm`.** Recover `GET /:id/deleteConfirm` (documented REST method vocabulary; rest-showcase 8 → 9 endpoints).
- **Line accuracy.** Scope XML `<action>` line lookups to the declaring `<package>` so an action name shared across packages (e.g. `delete` in `/skill` and `/employee`) resolves to its own declaration.

## Wicket

- **wicketstuff-rest callees (was: always empty).** Emit 1-hop callees for `@MethodMapping` handlers, threaded through both `@ResourcePath` and `mountResource` paths. Validated on wicketstuff `PersonsRestResource` (POST → `persons.add`, DELETE → `persons.remove`).
- **FN — request-parameter annotations.** `@MethodMapping` handlers bind inputs via `@RequestBody` (json), `@RequestParam` (query), `@HeaderParam` (header), `@CookieParam` (cookie), but only URL `{...}` path params were surfaced. Every body/query/header/cookie param was a false negative; now extracted from the handler signature and deduped against path params.

## Scope / cost

Tree-sitter parsing (and the Struts2 FQCN index) run **only when** callee/ai-context enrichment is requested, so default scans pay no extra cost. Request-parameter extraction is plain regex and always on (params are core output). Cross-file callee *definition* resolution stays out of scope; the XML→handler link is an explicit config reference, not speculative resolution.

## Validation totals

- rest-showcase 8 → 9; showcase 226 unchanged; wicket-examples 51 unchanged (no regressions / no new FPs).
- Roller: 0/59 → ~60 routes carry callees with `--ai-context`.
- wicketstuff: POST `/personsmanager/persons` now carries its `@RequestBody` json param.
- Full suite green: **18424 examples, 0 failures**. Fixtures + functional specs extended to assert every new behavior (callees, deleteConfirm, XML-handler callees, REST request params).