### PR TITLE
Improve Crystal analyzers (Kemal/Amber/Lucky): cut FP, recover FN, fill callee/ai-context gaps

### DIFF
--- a/spec/functional_test/fixtures/crystal/amber/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/amber/src/testapp.cr
@@ -42,6 +42,12 @@ Amber::Server.configure do
     # WebSocket route
     ws "/socket", WebSocketController, :handle
   end
+
+  # Scoped block: every route here is prefixed with "/admin", and the
+  # `resources` macro fans out to the seven RESTful routes.
+  routes :web, "/admin" do
+    resources "/articles", ArticleController
+  end
 end
 
 Amber::Server.start

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/shard.yml
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/shard.yml
@@ -1,0 +1,12 @@
+name: kemal_controller_callees
+version: 0.1.0
+
+targets:
+  kemal_controller_callees:
+    main: src/app.cr
+
+dependencies:
+  kemal:
+    github: kemalcr/kemal
+
+crystal: 1.8.2

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/app.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/app.cr
@@ -18,9 +18,9 @@ module App::Routing
 
   def register_api_routes
     {% begin %}
-      {{namespace = Routes::API}}
+      {{ namespace = Routes::API }}
 
-      get "/api/items/:id", {{namespace}}::Items, :show
+      get "/api/items/:id", {{ namespace }}::Items, :show
     {% end %}
   end
 end

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/app.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/app.cr
@@ -1,0 +1,29 @@
+require "kemal"
+require "./routes/misc"
+require "./routes/api/items"
+
+# invidious-style routing: every route names a controller module and an
+# action method rather than carrying an inline `do … end` block. The
+# handler bodies live in other files, and a chunk of them reference the
+# controller through a compile-time macro variable.
+module App::Routing
+  extend self
+
+  def register_all
+    get "/", Routes::Misc, :home
+    post "/users", Routes::Misc, :create_user
+
+    register_api_routes
+  end
+
+  def register_api_routes
+    {% begin %}
+      {{namespace = Routes::API}}
+
+      get "/api/items/:id", {{namespace}}::Items, :show
+    {% end %}
+  end
+end
+
+App::Routing.register_all
+Kemal.run

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/routes/api/items.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/routes/api/items.cr
@@ -1,0 +1,6 @@
+module Routes::API::Items
+  def self.show(env)
+    id = env.params.url["id"]
+    ItemLookup.find(id)
+  end
+end

--- a/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/routes/misc.cr
+++ b/spec/functional_test/fixtures/crystal/kemal_controller_callees/src/routes/misc.cr
@@ -1,0 +1,11 @@
+module Routes::Misc
+  def self.home(env)
+    payload = HomeService.build
+    env.redirect "/dashboard"
+  end
+
+  def self.create_user(env)
+    data = env.params.json["user"]
+    UserService.create(data)
+  end
+end

--- a/spec/functional_test/fixtures/crystal/lucky/src/actions/home/index.cr
+++ b/spec/functional_test/fixtures/crystal/lucky/src/actions/home/index.cr
@@ -1,6 +1,10 @@
 class Home::Index < ApiAction
   include Api::Auth::SkipRequireAuthToken
 
+  # Lucky's `param` macro declares a query parameter at the class level,
+  # above the route block.
+  param locale : String = "en"
+
   get "/" do
     json({hello: "Hello World from Home::Index"})
   end

--- a/spec/functional_test/fixtures/crystal/lucky/src/actions/posts/index.cr
+++ b/spec/functional_test/fixtures/crystal/lucky/src/actions/posts/index.cr
@@ -1,0 +1,6 @@
+class Posts::Index < BrowserAction
+  # `action do` has no path: Lucky infers `GET /posts` from the class name.
+  action do
+    json PostQuery.new
+  end
+end

--- a/spec/functional_test/fixtures/crystal/lucky/src/actions/posts/show.cr
+++ b/spec/functional_test/fixtures/crystal/lucky/src/actions/posts/show.cr
@@ -1,7 +1,7 @@
 class Posts::Show < BrowserAction
-  # Inferred as `GET /posts/:post_id` (the `:post_id` from the singularized
-  # resource name).
-  action do
+  # `route do` is the other spelling of Lucky's inference macro. Inferred as
+  # `GET /posts/:post_id` (the `:post_id` from the singularized resource).
+  route do
     json PostQuery.new.find(id)
   end
 end

--- a/spec/functional_test/fixtures/crystal/lucky/src/actions/posts/show.cr
+++ b/spec/functional_test/fixtures/crystal/lucky/src/actions/posts/show.cr
@@ -1,0 +1,7 @@
+class Posts::Show < BrowserAction
+  # Inferred as `GET /posts/:post_id` (the `:post_id` from the singularized
+  # resource name).
+  action do
+    json PostQuery.new.find(id)
+  end
+end

--- a/spec/functional_test/testers/crystal/amber_spec.cr
+++ b/spec/functional_test/testers/crystal/amber_spec.cr
@@ -9,6 +9,16 @@ expected_endpoints = [
   Endpoint.new("/socket", "GET"), # WebSocket endpoint
   Endpoint.new("/test.html", "GET"),
   Endpoint.new("/style.css", "GET"),
+  # `routes :web, "/admin" do resources "/articles", … end` expands to the
+  # seven RESTful routes, each prefixed with the "/admin" scope.
+  Endpoint.new("/admin/articles", "GET"),
+  Endpoint.new("/admin/articles/new", "GET"),
+  Endpoint.new("/admin/articles", "POST"),
+  Endpoint.new("/admin/articles/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/articles/:id/edit", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/articles/:id", "PUT", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/articles/:id", "PATCH", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/articles/:id", "DELETE", [Param.new("id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/crystal/amber/", {

--- a/spec/functional_test/testers/crystal/kemal_controller_callees_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_controller_callees_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+# invidious-style Kemal routing: routes dispatch to `Controller, :action`
+# handlers defined in other files (no inline `do … end` block). The callees
+# must be resolved cross-file through the action index, including routes
+# whose controller is named via a compile-time macro variable.
+home = Endpoint.new("/", "GET").tap do |ep|
+  ep.push_callee(Callee.new("HomeService.build", line: 3))
+  ep.push_callee(Callee.new("env.redirect", line: 4))
+end
+
+users_create = Endpoint.new("/users", "POST").tap do |ep|
+  ep.push_callee(Callee.new("env.params.json", line: 8))
+  ep.push_callee(Callee.new("UserService.create", line: 9))
+end
+
+# `{{namespace = Routes::API}}` + `{{namespace}}::Items` resolves to
+# `Routes::API::Items`, so this route still carries its handler's callees.
+items_show = Endpoint.new("/api/items/:id", "GET", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("env.params.url", line: 3))
+  ep.push_callee(Callee.new("ItemLookup.find", line: 4))
+end
+
+expected_endpoints = [
+  home,
+  users_create,
+  items_show,
+]
+
+FunctionalTester.new("fixtures/crystal/kemal_controller_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("crystal_kemal"),
+}).perform_tests

--- a/spec/functional_test/testers/crystal/lucky_spec.cr
+++ b/spec/functional_test/testers/crystal/lucky_spec.cr
@@ -1,7 +1,7 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
-  Endpoint.new("/", "GET"),
+  Endpoint.new("/", "GET", [Param.new("locale", "", "query")]),
   Endpoint.new("/secret.html", "GET"),
   Endpoint.new("/api/me", "GET", [
     Param.new("q", "", "query"),

--- a/spec/functional_test/testers/crystal/lucky_spec.cr
+++ b/spec/functional_test/testers/crystal/lucky_spec.cr
@@ -14,6 +14,10 @@ expected_endpoints = [
     Param.new("name1", "", "cookie"),
     Param.new("name2", "", "cookie"),
   ]),
+  # `action do` routes inferred from the action class name (Lucky's
+  # resourceful routing).
+  Endpoint.new("/posts", "GET"),
+  Endpoint.new("/posts/:post_id", "GET", [Param.new("post_id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/crystal/lucky/", {

--- a/spec/unit_test/analyzer/crystal_engine_spec.cr
+++ b/spec/unit_test/analyzer/crystal_engine_spec.cr
@@ -21,6 +21,20 @@ class CrystalEngineSpecHarness < Analyzer::Crystal::CrystalEngine
   def test_extract_crystal_def_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?
     extract_crystal_def_block(lines, start_index)
   end
+
+  def test_valid_crystal_route_path?(path : String) : Bool
+    valid_crystal_route_path?(path)
+  end
+
+  def test_collect_actions(lines : Array(String), path : String) : ActionIndex
+    index = ActionIndex.new
+    collect_actions_into(index, lines, path)
+    index
+  end
+
+  def test_resolve_action_callees(index : ActionIndex, controller : String, action : String)
+    resolve_action_callees(index, controller, action)
+  end
 end
 
 describe Analyzer::Crystal::CrystalEngine do
@@ -104,6 +118,61 @@ describe Analyzer::Crystal::CrystalEngine do
         body.should eq("  a = \"hello\"\n  b = \"world\"")
         start_line.should eq(2)
       end
+    end
+  end
+
+  describe "#valid_crystal_route_path?" do
+    it "accepts genuine route paths (root, params, glob, interpolation)" do
+      harness.test_valid_crystal_route_path?("/").should be_true
+      harness.test_valid_crystal_route_path?("/users/:id").should be_true
+      harness.test_valid_crystal_route_path?("/posts/*").should be_true
+      harness.test_valid_crystal_route_path?("{VERSION}/items").should be_true
+    end
+
+    it "rejects captures from string args and prose" do
+      # `method: "get", template: "…"`, `nested_arrays("post")`, the word
+      # "post" in a sentence — all surface as non-path captures.
+      harness.test_valid_crystal_route_path?(", template:").should be_false
+      harness.test_valid_crystal_route_path?(")[").should be_false
+      harness.test_valid_crystal_route_path?("Fortunes").should be_false
+      harness.test_valid_crystal_route_path?("").should be_false
+    end
+  end
+
+  describe "#collect_actions_into" do
+    # A controller method whose body opens an `XML.build do … end` block and
+    # contains a literal "end" string used to throw off do/end depth counting
+    # and drop every method defined after it. Indentation tracking is immune.
+    lines = [
+      "module Invidious::Routes::API::Manifest",
+      "  def self.get_dash_video_id(env)",
+      "    body = String.build do |str|",
+      "      str << \"end\"",
+      "    end",
+      "  end",
+      "",
+      "  def self.get_dash_video_playback(env)",
+      "    Manifest.render(env)",
+      "  end",
+      "end",
+    ]
+    index = harness.test_collect_actions(lines, "manifest.cr")
+
+    it "indexes every method regardless of body complexity" do
+      index.has_key?("get_dash_video_id").should be_true
+      index.has_key?("get_dash_video_playback").should be_true
+    end
+
+    it "resolves a relatively-named controller by namespace suffix" do
+      callees = harness.test_resolve_action_callees(index, "Routes::API::Manifest", "get_dash_video_playback")
+      callees.should_not be_nil
+      if callees
+        callees.map(&.[0]).should contain("Manifest.render")
+      end
+    end
+
+    it "returns nil when no controller/action matches" do
+      harness.test_resolve_action_callees(index, "Routes::Other", "missing").should be_nil
     end
   end
 end

--- a/spec/unit_test/analyzer/crystal_engine_spec.cr
+++ b/spec/unit_test/analyzer/crystal_engine_spec.cr
@@ -35,6 +35,10 @@ class CrystalEngineSpecHarness < Analyzer::Crystal::CrystalEngine
   def test_resolve_action_callees(index : ActionIndex, controller : String, action : String)
     resolve_action_callees(index, controller, action)
   end
+
+  def test_crystal_dependency_path?(path : String) : Bool
+    crystal_dependency_path?(path)
+  end
 end
 
 describe Analyzer::Crystal::CrystalEngine do
@@ -173,6 +177,21 @@ describe Analyzer::Crystal::CrystalEngine do
 
     it "returns nil when no controller/action matches" do
       harness.test_resolve_action_callees(index, "Routes::Other", "missing").should be_nil
+    end
+  end
+
+  describe "#crystal_dependency_path?" do
+    it "skips the shards lib/ dependency directory" do
+      harness.test_crystal_dependency_path?("/app/lib/kemal/src/kemal.cr").should be_true
+      harness.test_crystal_dependency_path?("lib/foo/bar.cr").should be_true
+    end
+
+    it "keeps app dirs that merely contain the substring 'lib'" do
+      # Regression: a real Amber app under `amber-library/` surfaced 0
+      # routes because the old `path.includes?(\"lib\")` matched "library".
+      harness.test_crystal_dependency_path?("/app/amber-library/config/routes.cr").should be_false
+      harness.test_crystal_dependency_path?("/app/glib/src/app.cr").should be_false
+      harness.test_crystal_dependency_path?("/app/src/routes.cr").should be_false
     end
   end
 end

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -2,6 +2,29 @@ require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
   class Amber < CrystalEngine
+    # `routes :web, "/admin" do … end` — the optional second argument is a
+    # path scope that prefixes every route declared inside the block.
+    ROUTES_SCOPE_PATTERN = /^(\s*)routes\s+:\w+(?:\s*,\s*["']([^"']*)["'])?\s+do\b/
+    # `namespace "/admin" do … end` — Amber's DSL scope macro.
+    NAMESPACE_PATTERN = /^(\s*)namespace\s+["']([^"']*)["']\s+do\b/
+    # `resources "/posts", PostController[, only: …][, except: …]`.
+    RESOURCES_PATTERN = /^\s*resources\s+["']([^"']+)["']\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*(.*)$/
+
+    # Amber's `resources` macro expands to the seven RESTful routes below
+    # (update is registered for both PUT and PATCH). `resource` (singular)
+    # shares the same action set; the `:id` segment is auto-detected as a
+    # path param downstream, so we only emit the verb + URL + action here.
+    RESOURCE_ROUTES = [
+      {"GET", "", :index},
+      {"GET", "/new", :new},
+      {"POST", "", :create},
+      {"GET", "/:id", :show},
+      {"GET", "/:id/edit", :edit},
+      {"PUT", "/:id", :update},
+      {"PATCH", "/:id", :update},
+      {"DELETE", "/:id", :destroy},
+    ]
+
     @is_public : Bool = true
     @public_folders : Array(String) = [] of String
 
@@ -25,9 +48,47 @@ module Analyzer::Crystal
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
       last_endpoint = Endpoint.new("", "")
 
+      # Stack of `{prefix, indent}` for open `routes "/scope"`/`namespace`
+      # blocks. The path scope is the concatenation of every open prefix.
+      scope_stack = [] of NamedTuple(prefix: String, indent: Int32)
+
       lines.each_with_index do |line, index|
+        stripped = Noir::CrystalCalleeExtractor.strip_comment(line)
+
+        # Open a scope block (routes-with-scope or namespace).
+        if match = stripped.match(ROUTES_SCOPE_PATTERN)
+          scope_stack << {prefix: match[2]? || "", indent: match[1].size}
+          next
+        end
+        if match = stripped.match(NAMESPACE_PATTERN)
+          scope_stack << {prefix: match[2], indent: match[1].size}
+          next
+        end
+
+        # Close the innermost scope when an `end` lines up with its indent.
+        unless scope_stack.empty?
+          if end_match = stripped.match(/^(\s*)end\b/)
+            if end_match[1].size == scope_stack.last[:indent]
+              scope_stack.pop
+              next
+            end
+          end
+        end
+
+        scope_prefix = scope_stack.reduce("") { |acc, ns| Noir::URLPath.join(acc, ns[:prefix]) }
+
+        # `resources`/`resource` macros expand to several RESTful routes.
+        if match = stripped.match(RESOURCES_PATTERN)
+          expand_resources(match[1], match[2], match[3], scope_prefix, path, index, actions, include_callee).each do |ep|
+            endpoints << ep
+            last_endpoint = ep
+          end
+          next
+        end
+
         endpoint = line_to_endpoint(line)
-        unless endpoint.method.empty?
+        if !endpoint.method.empty? && valid_crystal_route_path?(endpoint.url)
+          endpoint.url = Noir::URLPath.join(scope_prefix, endpoint.url) unless scope_prefix.empty?
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint.details = details
           attach_route_callees(endpoint, line, actions) if include_callee
@@ -128,6 +189,55 @@ module Analyzer::Crystal
       end
     end
 
+    # Expand a `resources "/posts", PostController` macro into its RESTful
+    # routes, prefixing each with the active scope and wiring callees from
+    # the matching controller action when available (same-file controllers).
+    private def expand_resources(resource : String,
+                                 controller : String,
+                                 opts : String,
+                                 scope_prefix : String,
+                                 path : String,
+                                 index : Int32,
+                                 actions : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)),
+                                 include_callee : Bool) : Array(Endpoint)
+      result = [] of Endpoint
+      # `resources "/posts"` and `resources "posts"` both map to `/posts`.
+      base = resource.strip.strip("/")
+      return result if base.empty?
+
+      allowed = resource_actions(opts)
+      base_path = Noir::URLPath.join(scope_prefix, "/#{base}")
+
+      RESOURCE_ROUTES.each do |method, suffix, action|
+        next unless allowed.includes?(action)
+        url = suffix.empty? ? base_path : Noir::URLPath.join(base_path, suffix)
+        endpoint = Endpoint.new(url, method)
+        endpoint.details = Details.new(PathInfo.new(path, index + 1))
+        if include_callee
+          if callees = actions[controller_action_key(controller, action.to_s)]?
+            attach_crystal_callees(endpoint, callees)
+          end
+        end
+        result << endpoint
+      end
+
+      result
+    end
+
+    # Resolve the active resource actions, honouring `only:`/`except:`.
+    private def resource_actions(opts : String) : Array(Symbol)
+      all = [:index, :new, :create, :show, :edit, :update, :destroy]
+      if match = opts.match(/\bonly:\s*\[([^\]]*)\]/)
+        names = match[1].scan(/:(\w+)/).map { |m| m[1] }
+        return all.select { |action| names.includes?(action.to_s) }
+      end
+      if match = opts.match(/\bexcept:\s*\[([^\]]*)\]/)
+        names = match[1].scan(/:(\w+)/).map { |m| m[1] }
+        return all.reject { |action| names.includes?(action.to_s) }
+      end
+      all
+    end
+
     private def controller_action_key(controller : String, action : String) : String
       "#{controller}##{action}"
     end
@@ -226,33 +336,6 @@ module Analyzer::Crystal
 
     def line_to_endpoint(content : String) : Endpoint
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
-
-      # Amber route definitions with controller and action - simplified patterns
-      if content.includes?("get \"/\"") && content.includes?("ApplicationController")
-        return Endpoint.new("/", "GET")
-      end
-
-      if content.includes?("post \"/users\"") && content.includes?("ApplicationController")
-        return Endpoint.new("/users", "POST")
-      end
-
-      if content.includes?("get \"/posts/:id\"") && content.includes?("ApplicationController")
-        return Endpoint.new("/posts/:id", "GET")
-      end
-
-      if content.includes?("get \"/search\"") && content.includes?("ApplicationController")
-        return Endpoint.new("/search", "GET")
-      end
-
-      if content.includes?("post \"/upload\"") && content.includes?("ApplicationController")
-        return Endpoint.new("/upload", "POST")
-      end
-
-      if content.includes?("ws \"/socket\"") && content.includes?("WebSocketController")
-        endpoint = Endpoint.new("/socket", "GET")
-        endpoint.protocol = "ws"
-        return endpoint
-      end
 
       # Amber route definitions with controller and action
       content.scan(/(?:^|[^.\w])get\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -6,11 +6,23 @@ module Analyzer::Crystal
     NAMESPACE_PATTERN = /^(\s*)(?:(\w+)\.)?namespace\s+["'](.+?)["']/
     MOUNT_PATTERN     = /^\s*mount\s+["'](.+?)["']\s*,\s*(\w+)/
     ROUTER_PATTERN    = /^\s*(\w+)\s*=\s*Kemal::Router\.new/
+    # Compile-time macro var assignment, e.g. `{{namespace = Routes::API::V1}}`.
+    # invidious sets it once, then registers 50+ routes as
+    # `get "/…", {{namespace}}::Videos, :videos` — substituting it back lets
+    # those routes resolve their controller and carry callees.
+    MACRO_VAR_PATTERN = /\{\{\s*(\w+)\s*=\s*([A-Za-z_][\w:]*)\s*\}\}/
 
     @is_public : Bool = true
     @public_folders : Array(String) = [] of String
+    @action_index : ActionIndex = ActionIndex.new
 
     def analyze
+      # Apps like invidious register routes as `get "/", Routes::Misc, :home`
+      # with the handler defined in a separate controller file. Build the
+      # cross-file action index up front so those routes can carry callees.
+      if any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+        @action_index = build_crystal_action_index(all_files)
+      end
       super
       collect_public_dir_endpoints
       @result
@@ -21,9 +33,11 @@ module Analyzer::Crystal
       lines = File.read_lines(path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      # Pre-scan: build mount_map (variable_name => mount_path)
+      # Pre-scan: build mount_map (variable_name => mount_path) and resolve
+      # compile-time macro variables used in controller references.
       mount_map = {} of String => String
       router_vars = Set(String).new
+      macro_vars = {} of String => String
 
       lines.each do |line|
         if match = line.match(ROUTER_PATTERN)
@@ -31,6 +45,11 @@ module Analyzer::Crystal
         end
         if match = line.match(MOUNT_PATTERN)
           mount_map[match[2]] = match[1]
+        end
+        if include_callee
+          if match = line.match(MACRO_VAR_PATTERN)
+            macro_vars[match[1]] = match[2]
+          end
         end
       end
 
@@ -86,7 +105,7 @@ module Analyzer::Crystal
 
         # Parse endpoint
         endpoint = line_to_endpoint(line)
-        unless endpoint.method.empty?
+        if !endpoint.method.empty? && valid_crystal_route_path?(endpoint.url)
           # Build full path with namespace prefixes and mount path
           route_path = endpoint.url
           full_path = route_path
@@ -109,7 +128,7 @@ module Analyzer::Crystal
           endpoint.url = full_path
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint.details = details
-          attach_route_callees(endpoint, lines, index, path) if include_callee
+          attach_route_callees(endpoint, lines, index, path, macro_vars) if include_callee
           endpoints << endpoint
           last_endpoint = endpoint
         end
@@ -128,13 +147,34 @@ module Analyzer::Crystal
       endpoints
     end
 
-    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)
-      route_body = extract_crystal_do_block(lines, index)
-      return unless route_body
+    private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String, macro_vars : Hash(String, String))
+      # Preferred source: the inline `do … end` route block.
+      if route_body = extract_crystal_do_block(lines, index)
+        body, body_start_line = route_body
+        callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+        attach_crystal_callees(endpoint, callees)
+        return
+      end
 
-      body, body_start_line = route_body
-      callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
-      attach_crystal_callees(endpoint, callees)
+      # Fallback: `get "/path", Controller, :action` dispatches to a handler
+      # in another file — resolve it through the cross-file action index.
+      if target = extract_route_target(substitute_macro_vars(lines[index], macro_vars))
+        controller, action = target
+        if callees = resolve_action_callees(@action_index, controller, action)
+          attach_crystal_callees(endpoint, callees)
+        end
+      end
+    end
+
+    private def extract_route_target(line : String) : Tuple(String, String)?
+      if match = line.match(/\b(?:get|post|put|delete|patch|head|options|ws)\s+['"][^'"]+['"]\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*,\s*:(\w+)/)
+        {match[1], match[2]}
+      end
+    end
+
+    private def substitute_macro_vars(line : String, macro_vars : Hash(String, String)) : String
+      return line if macro_vars.empty? || !line.includes?("{{")
+      line.gsub(/\{\{\s*(\w+)\s*\}\}/) { |whole| macro_vars[$~[1]]? || whole }
     end
 
     private def collect_public_dir_endpoints

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -20,11 +20,29 @@ module Analyzer::Crystal
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       last_endpoint = Endpoint.new("", "")
 
+      # Lucky's `param name : Type` macro declares a query parameter at the
+      # class level, above the route block. Buffer declarations and flush
+      # them onto the next route; reset at each class boundary so a guide
+      # file with several example actions doesn't cross-attach params.
+      pending_params = [] of Param
+
       lines.each_with_index do |line, index|
+        stripped = Noir::CrystalCalleeExtractor.strip_comment(line)
+
+        if stripped.match(/^\s*(?:abstract\s+)?class\b/)
+          pending_params.clear
+        end
+
+        if decl = lucky_param_declaration(stripped)
+          pending_params << decl
+        end
+
         endpoint = line_to_endpoint(line)
-        unless endpoint.method.empty?
+        if !endpoint.method.empty? && valid_crystal_route_path?(endpoint.url)
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint.details = details
+          pending_params.each { |p| endpoint.push_param(p) }
+          pending_params.clear
           attach_route_callees(endpoint, lines, index, path) if include_callee
           endpoints << endpoint
           last_endpoint = endpoint
@@ -39,6 +57,15 @@ module Analyzer::Crystal
       end
 
       endpoints
+    end
+
+    # `param name : Type` / `param name : Type = default` — Lucky's query
+    # parameter declaration macro. Requires the `name :` shape so prose such
+    # as "the param to determine the page" never matches.
+    private def lucky_param_declaration(content : String) : Param?
+      if match = content.match(/^\s*param\s+(\w+)\s*:/)
+        Param.new(match[1], "", "query")
+      end
     end
 
     private def attach_route_callees(endpoint : Endpoint, lines : Array(String), index : Int32, path : String)

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -25,16 +25,38 @@ module Analyzer::Crystal
       # them onto the next route; reset at each class boundary so a guide
       # file with several example actions doesn't cross-attach params.
       pending_params = [] of Param
+      # Track the enclosing action class so `action`/`nested_route` (which
+      # carry no path) can infer their route from the class name.
+      current_class = ""
 
       lines.each_with_index do |line, index|
         stripped = Noir::CrystalCalleeExtractor.strip_comment(line)
 
-        if stripped.match(/^\s*(?:abstract\s+)?class\b/)
+        if class_match = stripped.match(/^\s*(?:abstract\s+)?class\s+([A-Z]\w*(?:::[A-Z]\w*)*)/)
+          current_class = class_match[1]
+          pending_params.clear
+        elsif stripped.match(/^\s*(?:abstract\s+)?class\b/)
+          current_class = ""
           pending_params.clear
         end
 
         if decl = lucky_param_declaration(stripped)
           pending_params << decl
+        end
+
+        # `action do … end` / `nested_route do … end` infer the verb and
+        # path from the action class name (Lucky's RouteInferrer). This is
+        # the resourceful style real apps use instead of explicit `get "/…"`.
+        if inferred = infer_lucky_action_route(stripped, current_class)
+          method, url = inferred
+          endpoint = Endpoint.new(url, method)
+          endpoint.details = Details.new(PathInfo.new(path, index + 1))
+          pending_params.each { |p| endpoint.push_param(p) }
+          pending_params.clear
+          attach_route_callees(endpoint, lines, index, path) if include_callee
+          endpoints << endpoint
+          last_endpoint = endpoint
+          next
         end
 
         endpoint = line_to_endpoint(line)
@@ -65,6 +87,67 @@ module Analyzer::Crystal
     private def lucky_param_declaration(content : String) : Param?
       if match = content.match(/^\s*param\s+(\w+)\s*:/)
         Param.new(match[1], "", "query")
+      end
+    end
+
+    RESOURCEFUL_ACTIONS = %w[index show new create edit update delete]
+
+    # When a line opens an `action do` / `nested_route do` block inside an
+    # action class, infer the route the way Lucky's `RouteInferrer` does:
+    # split the class name, the last piece is the resourceful action, the
+    # piece before it is the resource. `nested_route` additionally folds in
+    # the parent resource as `/parent/:parent_id`. Returns `{method, url}`.
+    private def infer_lucky_action_route(content : String, current_class : String) : Tuple(String, String)?
+      return if current_class.empty?
+      match = content.match(/^\s*(action|nested_route)\b.*\bdo\b/)
+      return unless match
+      nested = match[1] == "nested_route"
+
+      pieces = current_class.split("::").map(&.underscore)
+      return if pieces.size < 2
+
+      action_name = pieces.last
+      return unless RESOURCEFUL_ACTIONS.includes?(action_name)
+      resource = pieces[-2]
+      return if nested && pieces.size < 3
+      parent = nested ? pieces[-3] : ""
+
+      method = case action_name
+               when "delete" then "DELETE"
+               when "create" then "POST"
+               when "update" then "PUT"
+               else               "GET"
+               end
+
+      namespace_pieces = pieces.reject { |p| p == action_name || p == resource }
+      namespace_pieces = namespace_pieces.reject { |p| p == parent } if nested
+      parent_pieces = nested ? [parent, ":#{lucky_singularize(parent)}_id"] : [] of String
+
+      resource_pieces = case action_name
+                        when "index", "create" then [resource]
+                        when "new"             then [resource, "new"]
+                        when "edit"            then [resource, ":#{lucky_singularize(resource)}_id", "edit"]
+                        else # show, update, delete
+                          [resource, ":#{lucky_singularize(resource)}_id"]
+                        end
+
+      url = "/" + (namespace_pieces + parent_pieces + resource_pieces).reject(&.empty?).join("/")
+      {method, url}
+    end
+
+    # Minimal inflector for the `:resource_id` path-param name. Lucky uses
+    # Wordsmith; these rules cover the regular plurals real resources use.
+    private def lucky_singularize(word : String) : String
+      return word if word.empty?
+      if word.ends_with?("ies")
+        "#{word[0..-4]}y"
+      elsif word.ends_with?("ses") || word.ends_with?("xes") || word.ends_with?("zes") ||
+            word.ends_with?("ches") || word.ends_with?("shes")
+        word[0..-3]
+      elsif word.ends_with?("s") && !word.ends_with?("ss")
+        word[0..-2]
+      else
+        word
       end
     end
 

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -92,14 +92,17 @@ module Analyzer::Crystal
 
     RESOURCEFUL_ACTIONS = %w[index show new create edit update delete]
 
-    # When a line opens an `action do` / `nested_route do` block inside an
-    # action class, infer the route the way Lucky's `RouteInferrer` does:
-    # split the class name, the last piece is the resourceful action, the
-    # piece before it is the resource. `nested_route` additionally folds in
-    # the parent resource as `/parent/:parent_id`. Returns `{method, url}`.
+    # When a line opens a `route do` / `action do` / `nested_route do` block
+    # inside an action class, infer the route the way Lucky's `RouteInferrer`
+    # does: split the class name, the last piece is the resourceful action,
+    # the piece before it is the resource. Lucky exposes the inference under
+    # both `route` and `action` (real apps use either); `nested_route`
+    # additionally folds in the parent as `/parent/:parent_id`. The leading
+    # `route\b` won't match `routes`/`route_prefix`/`route_style`, and a
+    # non-resourceful class name infers nothing. Returns `{method, url}`.
     private def infer_lucky_action_route(content : String, current_class : String) : Tuple(String, String)?
       return if current_class.empty?
-      match = content.match(/^\s*(action|nested_route)\b.*\bdo\b/)
+      match = content.match(/^\s*(action|nested_route|route)\b.*\bdo\b/)
       return unless match
       nested = match[1] == "nested_route"
 

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -69,7 +69,7 @@ module Analyzer::Crystal
       get_files_by_extension(".cr").each do |path|
         next if File.directory?(path)
         next unless File.exists?(path)
-        next if path.includes?("lib")
+        next if crystal_dependency_path?(path)
 
         collect_handler_callees_from_lines(read_source_lines(path), path, actions)
       rescue e

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -21,7 +21,7 @@ module Analyzer::Crystal
         parallel_analyze(all_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path) && File.extname(path) == ".cr"
-          next if path.includes?("lib")
+          next if crystal_dependency_path?(path)
           # Crystal's standard test directory is `spec/`, and test
           # files always end in `_spec.cr`. Crystal framework repos
           # (lucky, marten, amber, kemal) park hundreds of route
@@ -54,6 +54,15 @@ module Analyzer::Crystal
         normalized = root.ends_with?("/") ? root : "#{root}/"
         path.starts_with?("#{normalized}spec/")
       end
+    end
+
+    # Shards installs dependencies under a `lib/` directory; skip them.
+    # Match the `lib/` path SEGMENT, not the bare substring "lib", so
+    # application directories like `library/`, `glib/`, or a project
+    # literally named `amber-library` aren't silently dropped (that bug
+    # made a real Amber app surface 0 routes — only public files).
+    protected def crystal_dependency_path?(path : String) : Bool
+      path.includes?("/lib/") || path.starts_with?("lib/")
     end
 
     # Crystal `"…"` strings interpolate `#{expr}`. The Kemal/Lucky/
@@ -106,7 +115,7 @@ module Analyzer::Crystal
       paths.each do |path|
         next if File.directory?(path)
         next unless File.exists?(path) && File.extname(path) == ".cr"
-        next if path.includes?("lib")
+        next if crystal_dependency_path?(path)
         begin
           collect_actions_into(index, File.read_lines(path), path)
         rescue e

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -68,8 +68,105 @@ module Analyzer::Crystal
       path.gsub(/\#\{([^}]+)\}/) { |_| "{#{$~[1].strip}}" }
     end
 
+    # A genuine Kemal/Lucky/Amber route path always begins with `/`
+    # (root, nested, or a glob like `/*`), a normalized interpolation
+    # `{…}` (see `normalize_crystal_interpolation`), or a bare glob `*`.
+    #
+    # The verb regexes (`get "…"`, `post "…"`, …) are deliberately loose
+    # so they catch every routing style, but that also lets them fire on
+    # the verb appearing inside a string or sentence rather than as a
+    # routing call — `method: "get", template: "…"`, `nested_arrays("post")`,
+    # the macro literal `{"get", "post"}`, or the word "post" in prose.
+    # Those produce captures that start with `,`, `)`, `>`, whitespace, or
+    # a letter, surfacing as junk endpoints like `/, template:` or `/)[`.
+    # Real apps (invidious, lucky's guide site) hit this constantly, so
+    # reject anything whose first character isn't a path lead-in.
+    protected def valid_crystal_route_path?(path : String) : Bool
+      return false if path.empty?
+      first = path[0]
+      first == '/' || first == '*' || first == '{'
+    end
+
     protected def attach_crystal_callees(endpoint : Endpoint, callees : Array(Noir::CrystalCalleeExtractor::Entry))
       Noir::CrystalCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    # method name => list of `{full_namespace, callees}` definitions.
+    alias ActionIndex = Hash(String, Array(Tuple(String, Array(Noir::CrystalCalleeExtractor::Entry))))
+
+    # Cross-file controller/action index for the `verb "/path", Controller,
+    # :action` routing style — invidious registers every Kemal route as
+    # `get "/", Routes::Misc, :home` with the handler `def self.home(env)`
+    # living in another file, and Amber's route table works the same way.
+    # Without this, those apps surface routes with zero callees (no inline
+    # `do` block to read). Built once per project and only when callee/
+    # ai-context extraction is requested, so default scans pay nothing.
+    protected def build_crystal_action_index(paths : Array(String)) : ActionIndex
+      index = ActionIndex.new
+      paths.each do |path|
+        next if File.directory?(path)
+        next unless File.exists?(path) && File.extname(path) == ".cr"
+        next if path.includes?("lib")
+        begin
+          collect_actions_into(index, File.read_lines(path), path)
+        rescue e
+          logger.debug "crystal action index #{path}: #{e}"
+        end
+      end
+      index
+    end
+
+    # Resolve the callees of `Controller#action` against the index. The
+    # route names the controller relatively (`Routes::Misc`), the index
+    # keys it fully (`Invidious::Routes::Misc`), so match by suffix.
+    protected def resolve_action_callees(index : ActionIndex,
+                                         controller : String,
+                                         action : String) : Array(Noir::CrystalCalleeExtractor::Entry)?
+      if entries = index[action]?
+        if match = entries.find { |ns, _| ns == controller || ns.ends_with?("::#{controller}") }
+          return match[1]
+        end
+      end
+      nil
+    end
+
+    # Track the enclosing module/class by indentation rather than by
+    # counting `do`/`end`. Method bodies in real controllers are full of
+    # heredocs, `{% … %}` macros, and `XML.build do … end` blocks that
+    # throw off keyword-based depth counting and prematurely "close" the
+    # module, dropping every method defined after them. Indentation is the
+    # one signal those constructs can't corrupt: a namespace stays open
+    # until a line dedents to or past the column where it was declared.
+    protected def collect_actions_into(index : ActionIndex, lines : Array(String), path : String) : Nil
+      namespace_stack = [] of NamedTuple(name: String, indent: Int32)
+
+      lines.each_with_index do |raw, i|
+        line = Noir::CrystalCalleeExtractor.strip_comment(raw)
+        content = line.lstrip
+        next if content.empty?
+        indent = line.size - content.size
+
+        # Anything at this column or shallower has closed the namespaces
+        # opened deeper than it.
+        while !namespace_stack.empty? && namespace_stack.last[:indent] >= indent
+          namespace_stack.pop
+        end
+
+        if ns = content.match(/^(?:abstract\s+)?(?:module|class|struct)\s+([A-Z]\w*(?:::[A-Z]\w*)*)/)
+          namespace_stack << {name: ns[1], indent: indent}
+          next
+        end
+
+        if def_match = content.match(/^(?:(?:private|protected)\s+)?def\s+(?:self\.)?([A-Za-z_]\w*[!?=]?)/)
+          next if namespace_stack.empty?
+          if method_body = extract_crystal_def_block(lines, i)
+            body, body_start_line = method_body
+            callees = Noir::CrystalCalleeExtractor.callees_for_body(body, path, body_start_line)
+            full_ns = namespace_stack.map(&.[:name]).join("::")
+            (index[def_match[1]] ||= Array(Tuple(String, Array(Noir::CrystalCalleeExtractor::Entry))).new) << {full_ns, callees}
+          end
+        end
+      end
     end
 
     protected def extract_crystal_do_block(lines : Array(String), start_index : Int32) : Tuple(String, Int32)?

--- a/src/models/file_helper.cr
+++ b/src/models/file_helper.cr
@@ -2,6 +2,13 @@
 # instead of using Dir.glob, improving efficiency by reusing files already scanned
 
 module FileHelper
+  # Version-control / OS placeholder files that sit inside `public/`
+  # directories (often to keep an otherwise-empty dir in git) but are
+  # never served as real endpoints. Matched by exact basename so genuine
+  # static files keep flowing through — e.g. `.well-known/dnt-policy.txt`
+  # (basename `dnt-policy.txt`) is unaffected.
+  PUBLIC_FILE_IGNORE = Set{".gitkeep", ".keep", ".gitignore", ".DS_Store", ".placeholder"}
+
   # Get all files from CodeLocator
   def all_files : Array(String)
     locator = CodeLocator.instance
@@ -53,6 +60,7 @@ module FileHelper
     files.select do |file|
       next false unless file.starts_with?(base_path)
       next false if File.directory?(file)
+      next false if PUBLIC_FILE_IGNORE.includes?(File.basename(file))
       project_public_roots.any? { |root| file.starts_with?(root + "/") }
     end
   end
@@ -69,6 +77,8 @@ module FileHelper
     public_dir_files = files.select do |file|
       # Ignore directories
       next false if File.directory?(file)
+      # Ignore VC/OS placeholder files (never served).
+      next false if PUBLIC_FILE_IGNORE.includes?(File.basename(file))
 
       # Case 1: Folder is a full path
       if normalized_folder.includes?("/")


### PR DESCRIPTION
## Summary

Crystal's Kemal/Amber/Lucky analyzers already produce a solid endpoint + AI-context base; this pass enriches it by running noir against real-world apps and closing the gaps that surfaced. Survey targets:

- **Kemal** — [iv-org/invidious](https://github.com/iv-org/invidious), [getmango/Mango](https://github.com/getmango/Mango)
- **Lucky** — [luckyframework/website](https://github.com/luckyframework/website) (guide site)
- **Amber** — freyamade/nocturne, faustinoaq/pet-tracker, ChangJoo-Park/amber-microblog, konstantine-v/amber-ticketing

## Cross-framework (Kemal/Lucky/Amber)

**Reject route captures that aren't paths.** The verb regexes (`get "…"`, `post "…"`, …) are intentionally loose so they catch every routing style, but they also fired on the verb appearing *inside a string or sentence*:

| Source | Bad endpoint |
| --- | --- |
| `method: "get", template: "…"` | `GET /, template:` |
| `nested_arrays("post")["tags"]` | `POST /)[` |
| `{"get", "post", …}` (macro literal) | `GET /,` |
| `["post"]` | `POST /][` |
| the word "post" in prose | `POST /Fortunes` |

A real route path always starts with `/`, `*`, or a normalized `{…}` interpolation. New shared `valid_crystal_route_path?` drops the rest. **invidious 212 → 208** (−4 FP), **Lucky site 95 → 90** (−5 FP); Mango and the Amber apps unaffected.

## Amber

- **`resources` macro expansion (large FN).** `resources "/posts", PostController` was completely unhandled. It now fans out to the 7 RESTful routes (`index`/`new`/`create`/`show`/`edit`/`update` [PUT **and** PATCH]/`destroy`), honouring `only:`/`except:`. Expansion mirrors Amber's own `src/amber/dsl/router.cr`. **pet-tracker 4 → 12, microblog 12 → 36.**
- **`routes :web, "/admin" do … end` scope prefix.** The optional second argument is a path scope applied to every route in the block; it was ignored, so nocturne's `/admin/*` and `/nocturne/admin/*` routes were all reported at the wrong path. `routes :admin do` (pipeline valve only, no scope string) correctly yields no prefix. `namespace "/x" do` supported too.
- Dropped redundant fixture-specific hardcoded route cases (the generic regex already covers them).

## Lucky

- **`param name : Type` macro → query parameter (FN).** A class-level declaration above the route block. Declarations are buffered onto the next route and reset at each class boundary, so guide files with many example actions don't cross-attach.

## Kemal

- **Cross-file `Controller, :action` callees (biggest AI-context gap).** invidious registers every route as `get "/", Routes::Misc, :home`, with the handler defined in another file and no inline `do` block — so it produced **0 callees on 208 endpoints**. A new cross-file, **indentation-based** controller/action index (do/end counting drifts on heredocs / `XML.build do` / `{% %}` bodies and silently drops methods) resolves the handler body, including controllers named through a `{{namespace}}` compile-time macro variable. **invidious went from 0 to 173 / 174 real routes carrying callees** (the 1 miss is a `:: Authenticated` typo in invidious source; the other zero-callee endpoints are static assets). Built only when callee/ai-context extraction is requested, so default scans pay nothing. Mango's inline-`do`-block path is unchanged (65/65).

## Tests

- New functional fixture `fixtures/crystal/kemal_controller_callees/` (cross-file dispatch + macro-var).
- Extended the Amber fixture (scoped `resources`) and Lucky fixture (`param`).
- Unit tests for `valid_crystal_route_path?`, the indentation-based action index (the drift regression), and namespace-suffix resolution.
- Full suite: **18456 examples, 0 failures**. `crystal tool format` + `ameba` clean.

## Follow-ups (not in this PR)

- Wire the cross-file action index into Amber too (resources/route callees are still same-file via `collect_controller_actions`; the engine index is ready to reuse).

---

## Follow-up OSS cycles (more apps)

Three more rounds against fresh real apps surfaced four additional issues, now folded into this PR:

**Cross-Crystal FN — `lib/` filter matched the substring, not the path segment.**
`path.includes?("lib")` skipped any file whose path merely *contained* "lib", so a real Amber app cloned as `amber-library/` (or any `glib/`, `calibrate/`) had **every route file skipped** and surfaced only public files (3 endpoints; real count 21). Now matches the `lib/` directory segment via a shared `crystal_dependency_path?` (engine scan, action index, Marten).

**Cross-framework FP — version-control placeholders served as endpoints.**
`.gitkeep`, `.keep`, `.gitignore`, `.DS_Store`, `.placeholder` inside `public/` were emitted as `GET` endpoints (`/fonts/.gitkeep`, `/videojs/.gitignore`, `/resources/.keep`). Filtered by exact basename in the shared `FileHelper` collectors — `.well-known/...` keeps flowing. invidious 208→207, nocturne 54→53, northwind 9→7.

**Lucky FN (large) — resourceful routing via `action do` / `route do` / `nested_route do`.**
Lucky actions usually skip the path and infer the verb + URL from the class name (`Lists::Show` → `GET /lists/:list_id`). The analyzer only knew explicit `get "/path"`, so resourceful apps were nearly invisible — **checklists 1 → 12, kindmetrics 76 → 84**. Ported Lucky's `RouteInferrer` (both the `action` and `route` spellings, plus `nested_route` parent folding). The `do` block is inline, so callees attach too (checklists 12/12 with `--include-callee`).

Validated clean against Mango (65), lucky_bits (30), lucky_jumpstart (23), kindmetrics (84), and confirmed libraries (kave, lucky_honeypot) correctly yield 0. Updated fixtures + unit tests; full suite **18464 examples, 0 failures**.
