### PR TITLE
Elixir Phoenix/Plug/Bandit: fix detector FN, nested resources, callee & ai-context gaps

### DIFF
--- a/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
@@ -52,6 +52,22 @@ defmodule ElixirPhoenixWeb.Router do
     match :put, "/hooks", PageController, :home
   end
 
+  # Nested resources: the child collection mounts under the parent's
+  # `/:singular_id` member segment, and `only:` placed behind `as:`
+  # must still constrain the generated actions.
+  scope "/admin", ElixirPhoenixWeb do
+    resources "/podcasts", PodcastController, only: [:index, :show] do
+      resources "/episodes", EpisodeController, as: :episode, only: [:index]
+    end
+  end
+
+  # Parenthesised `resources(...)` call form, plus a `singleton: true`
+  # resource whose member routes carry no `/:id` segment.
+  scope "/account", ElixirPhoenixWeb do
+    resources("/session", SessionController, singleton: true, only: [:create, :delete])
+    resources "/keys", KeyController, param: "key_id", only: [:show, :delete]
+  end
+
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:elixir_phoenix, :dev_routes) do
     # If you want to use the LiveDashboard in production, you should put

--- a/spec/functional_test/testers/elixir/phoenix_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_spec.cr
@@ -38,6 +38,17 @@ expected_endpoints = [
   Endpoint.new("/api/hooks", "PUT", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
   Endpoint.new("/dev/dashboard", "GET"),
   Endpoint.new("/dev/mailbox", "GET"),
+  # Nested resources under a scope: child mounts on the parent's
+  # `/:podcast_id` member segment; `only:` behind `as:` still applies.
+  Endpoint.new("/admin/podcasts", "GET"),
+  Endpoint.new("/admin/podcasts/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/podcasts/:podcast_id/episodes", "GET", [Param.new("podcast_id", "", "path")]),
+  # Parenthesised call form + singleton resource (no `/:id` member)
+  Endpoint.new("/account/session", "POST"),
+  Endpoint.new("/account/session", "DELETE"),
+  # `param:` renames the member capture
+  Endpoint.new("/account/keys/:key_id", "GET", [Param.new("key_id", "", "path")]),
+  Endpoint.new("/account/keys/:key_id", "DELETE", [Param.new("key_id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/elixir/phoenix/", {

--- a/spec/unit_test/detector/elixir/phoenix_spec.cr
+++ b/spec/unit_test/detector/elixir/phoenix_spec.cr
@@ -5,7 +5,54 @@ describe "Detect Elixir Phoenix" do
   options = create_test_options
   instance = Detector::Elixir::Phoenix.new options
 
-  it "mix" do
-    instance.detect("mix.exs", "ElixirPhoenix").should be_true
+  it "detects the core phoenix dependency in mix.exs" do
+    mix = <<-MIX
+    defp deps do
+      [
+        {:phoenix, "~> 1.7.1"},
+        {:phoenix_ecto, "~> 4.4"},
+        {:plug_cowboy, "~> 2.5"}
+      ]
+    end
+    MIX
+    instance.detect("mix.exs", mix).should be_true
+  end
+
+  it "does not match sibling phoenix_* deps alone" do
+    mix = <<-MIX
+    defp deps do
+      [
+        {:phoenix_html, "~> 3.3"},
+        {:phoenix_live_view, "~> 0.18"}
+      ]
+    end
+    MIX
+    instance.detect("mix.exs", mix).should be_false
+  end
+
+  it "detects a router via the `use _, :router` convention" do
+    router = <<-EX
+    defmodule MyAppWeb.Router do
+      use MyAppWeb, :router
+
+      scope "/", MyAppWeb do
+        get "/", PageController, :index
+      end
+    end
+    EX
+    instance.detect("lib/my_app_web/router.ex", router).should be_true
+  end
+
+  it "detects a router that uses Phoenix.Router directly" do
+    router = <<-EX
+    defmodule MyAppWeb.Router do
+      use Phoenix.Router
+    end
+    EX
+    instance.detect("lib/my_app_web/router.ex", router).should be_true
+  end
+
+  it "ignores unrelated elixir files" do
+    instance.detect("lib/my_app/foo.ex", "defmodule Foo do\nend\n").should be_false
   end
 end

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -132,7 +132,10 @@ module Analyzer::Elixir
     end
 
     private def statement_open?(buffer : String) : Bool
-      trimmed = buffer.rstrip
+      # Judge continuation on a string-blanked copy so brackets/commas
+      # inside a literal path (`resources "/a[b", Ctrl`) don't read as an
+      # unbalanced, still-open statement.
+      trimmed = Noir::ElixirCalleeExtractor.strip_comment(buffer).rstrip
       return false if trimmed.empty?
       return true if trimmed.ends_with?(",")
       opens = trimmed.count('[') + trimmed.count('(') + trimmed.count('{')
@@ -268,11 +271,16 @@ module Analyzer::Elixir
       while i < limit
         text = strip_trailing_comment(lines[i])
         buffer = buffer.empty? ? text.strip : "#{buffer} #{text.strip}"
-        paren += text.count('(') - text.count(')')
+        # Count parens and look for the block `do` on a string-blanked
+        # copy so a paren or the word `do` inside a default value
+        # (`def f(x \\ "(")`, `def f(mode \\ :do)`) doesn't skew the
+        # depth or fire early.
+        code = Noir::ElixirCalleeExtractor.strip_comment(text)
+        paren += code.count('(') - code.count(')')
         # The block opens at the first top-level `do` once the argument
         # list's parentheses are balanced; the paren guard keeps a `do`
         # buried in a default value or atom inside the args from firing.
-        if paren <= 0 && text.matches?(/\bdo\b(?!:)/)
+        if paren <= 0 && code.matches?(/\bdo\b(?!:)/)
           return {buffer, i}
         end
         i += 1
@@ -605,7 +613,6 @@ module Analyzer::Elixir
     # only affects the placeholder name, never the route structure.
     private def singularize(name : String) : String
       return "#{name[0, name.size - 3]}y" if name.ends_with?("ies") && name.size > 3
-      return name[0, name.size - 2] if name.ends_with?("ses") && name.size > 3
       return name[0, name.size - 1] if name.ends_with?("s") && name.size > 1
       name
     end

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -34,46 +34,138 @@ module Analyzer::Elixir
       in_triple_double = false
       in_triple_single = false
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line.with_index do |line, index|
-          if line.includes?("\"\"\"")
-            line.scan(/"""/).size.times { in_triple_double = !in_triple_double }
-            next
-          end
-          if line.includes?("'''")
-            line.scan(/'''/).size.times { in_triple_single = !in_triple_single }
-            next
-          end
-          next if in_triple_double || in_triple_single
+      content = File.open(path, "r", encoding: "utf-8", invalid: :skip, &.gets_to_end)
+      lines = content.lines
 
-          stripped = line.strip
-          next if stripped.starts_with?("#")
+      index = 0
+      while index < lines.size
+        line = lines[index]
 
-          if !scope_stack.empty?
-            if end_match = line.match(/^(\s*)end\b/)
-              end_indent = end_match[1].size
-              if end_indent == scope_stack.last[:indent]
-                scope_stack.pop
-                next
-              end
+        if line.includes?("\"\"\"")
+          line.scan(/"""/).size.times { in_triple_double = !in_triple_double }
+          index += 1
+          next
+        end
+        if line.includes?("'''")
+          line.scan(/'''/).size.times { in_triple_single = !in_triple_single }
+          index += 1
+          next
+        end
+        if in_triple_double || in_triple_single
+          index += 1
+          next
+        end
+
+        stripped = line.strip
+        if stripped.starts_with?("#")
+          index += 1
+          next
+        end
+
+        if !scope_stack.empty?
+          if end_match = line.match(/^(\s*)end\b/)
+            end_indent = end_match[1].size
+            if end_indent == scope_stack.last[:indent]
+              scope_stack.pop
+              index += 1
+              next
             end
           end
+        end
 
-          if match = line.match(/^(\s*)scope\s*(?:\(\s*)?["']([^"']+)["'](?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
-            scope_stack << {prefix: match[2], module_prefix: match[3]? || "", indent: match[1].size}
-            next
-          end
+        if match = line.match(/^(\s*)scope\s*(?:\(\s*)?["']([^"']+)["'](?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
+          scope_stack << {prefix: match[2], module_prefix: match[3]? || "", indent: match[1].size}
+          index += 1
+          next
+        end
 
-          scope_prefix = current_scope_prefix(scope_stack)
-          scope_module = current_scope_module(scope_stack)
-          line_to_endpoint(line, path, scope_prefix, scope_module).each do |endpoint|
+        scope_prefix = current_scope_prefix(scope_stack)
+        scope_module = current_scope_module(scope_stack)
+
+        # The `resources` macro can span several lines (options such as
+        # `only:`/`except:` are often wrapped onto continuation lines)
+        # and can open a `do` block that nests child resources under a
+        # `/:parent_id` member segment. Both need the whole logical
+        # statement, so assemble it before extracting routes.
+        if line.matches?(/(?:^|[^.\w])resources\s*(?:\(\s*)?["']/)
+          statement, consumed = assemble_statement(lines, index)
+          res_endpoints, nested_prefix = resources_from_statement(statement, scope_prefix, scope_module)
+          res_endpoints.each do |endpoint|
             next if endpoint.method.empty?
             endpoint.details = Details.new(PathInfo.new(path, index + 1))
             endpoints << endpoint
           end
+          if nested_prefix
+            indent = line.size - line.lstrip.size
+            scope_stack << {prefix: nested_prefix, module_prefix: "", indent: indent}
+          end
+          index += consumed
+          next
         end
+
+        line_to_endpoint(line, path, scope_prefix, scope_module).each do |endpoint|
+          next if endpoint.method.empty?
+          endpoint.details = Details.new(PathInfo.new(path, index + 1))
+          endpoints << endpoint
+        end
+        index += 1
       end
       endpoints
+    end
+
+    # Join the line at `start` with any continuation lines so a route
+    # macro split across several physical lines is parsed as one. A
+    # statement is still "open" while its last meaningful character is a
+    # comma or it has more open brackets than closing ones — the shape
+    # Elixir uses to wrap keyword options. Returns the assembled
+    # single-line statement and how many physical lines it consumed.
+    private def assemble_statement(lines : Array(String), start : Int32) : Tuple(String, Int32)
+      buffer = strip_trailing_comment(lines[start]).rstrip
+      consumed = 1
+      while statement_open?(buffer) && (start + consumed) < lines.size
+        nxt = strip_trailing_comment(lines[start + consumed]).strip
+        buffer = "#{buffer} #{nxt}".rstrip
+        consumed += 1
+        break if consumed > 12 # safety bound: route options never wrap this far
+      end
+      {buffer, consumed}
+    end
+
+    private def statement_open?(buffer : String) : Bool
+      trimmed = buffer.rstrip
+      return false if trimmed.empty?
+      return true if trimmed.ends_with?(",")
+      opens = trimmed.count('[') + trimmed.count('(') + trimmed.count('{')
+      closes = trimmed.count(']') + trimmed.count(')') + trimmed.count('}')
+      opens > closes
+    end
+
+    # Drop an Elixir line comment while preserving the string literals
+    # (and their quotes) the `resources` regex depends on — unlike the
+    # callee extractor's `strip_comment`, which discards quotes. A `#`
+    # only opens a comment outside a string, so a `#` inside a quoted
+    # path won't truncate the statement.
+    private def strip_trailing_comment(line : String) : String
+      in_string = false
+      escaped = false
+      quote = '\0'
+      line.each_char_with_index do |char, i|
+        if in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '#'
+          return line[0, i]
+        end
+      end
+      line
     end
 
     def extract_controller_params
@@ -106,36 +198,86 @@ module Analyzer::Elixir
       lines = content.lines
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      # Find all function definitions and extract parameters
-      lines.each_with_index do |line, index|
-        # Match public function definitions only: def action_name(conn, _params) do
-        # Exclude private functions (defp)
-        next if line.match(/^\s*defp\s/)
-        if match = line.match(/^\s*def\s+(\w+)\(conn,/)
-          action_name = match[1]
+      index = 0
+      while index < lines.size
+        line = lines[index]
 
-          matching_endpoints = @result.select do |endpoint|
-            should_extract_params_for_endpoint?(endpoint, controller_name, action_name)
-          end
-          next if matching_endpoints.empty?
-
-          # Find the end of the function block once per controller action.
-          block_end = find_function_end(lines, index)
-          next if block_end == -1
-
-          callees = include_callee ? callees_from_function_block(lines, index, block_end, controller_path) : nil
-
-          matching_endpoints.each do |endpoint|
-            append_code_path(endpoint.details, PathInfo.new(controller_path, index + 1))
-
-            # Extract parameters from the function block
-            params = extract_params_from_function_block(lines, index, block_end, endpoint.method)
-            params.each { |param| endpoint.push_param(param) }
-
-            attach_elixir_callees(endpoint, callees) if callees
-          end
+        if line.matches?(/^\s*defp\s/) || !(name_match = line.match(/^\s*def\s+(\w+)\(/))
+          index += 1
+          next
         end
+        action_name = name_match[1]
+
+        # A controller action's first argument is always the connection,
+        # but the head can pattern-match it (`def edit(conn = %{assigns:
+        # …}, _params)`, `def show(%Plug.Conn{} = conn, params)`) and a
+        # long head can wrap the args across several lines
+        # (`def update(\n  conn,\n  params\n) do`). Assemble the whole
+        # head so the block body is located correctly, then confirm the
+        # first argument really binds `conn` before treating it as an
+        # action.
+        signature, body_start = assemble_def_signature(lines, index)
+        unless signature.matches?(/\(\s*(?:_?conn\b|%[^,)]*\bconn\b)/)
+          index += 1
+          next
+        end
+
+        matching_endpoints = @result.select do |endpoint|
+          should_extract_params_for_endpoint?(endpoint, controller_name, action_name)
+        end
+        if matching_endpoints.empty?
+          index += 1
+          next
+        end
+
+        # Find the end of the function block once per controller action.
+        block_end = find_function_end(lines, body_start)
+        if block_end == -1
+          index += 1
+          next
+        end
+
+        callees = include_callee ? callees_from_function_block(lines, body_start, block_end, controller_path) : nil
+
+        matching_endpoints.each do |endpoint|
+          append_code_path(endpoint.details, PathInfo.new(controller_path, index + 1))
+
+          # Extract parameters from the function block
+          params = extract_params_from_function_block(lines, body_start, block_end, endpoint.method)
+          params.each { |param| endpoint.push_param(param) }
+
+          attach_elixir_callees(endpoint, callees) if callees
+        end
+
+        index += 1
       end
+    end
+
+    # Join a `def` head that may span several physical lines and return
+    # `{assembled_head, body_start}` where `body_start` is the line that
+    # opens the block (`) do` / `do`). Tracks parenthesis depth so the
+    # arg list is closed before the block-opening `do` is recognised
+    # (and the inline `do:` keyword form is ignored). Falls back to the
+    # definition line itself if no block opener turns up within a small
+    # bound.
+    private def assemble_def_signature(lines : Array(String), start : Int32) : Tuple(String, Int32)
+      buffer = ""
+      paren = 0
+      i = start
+      limit = Math.min(lines.size, start + 16)
+      while i < limit
+        text = strip_trailing_comment(lines[i])
+        buffer = buffer.empty? ? text.strip : "#{buffer} #{text.strip}"
+        paren += text.count('(') - text.count(')')
+        # The block opens at the first top-level `do` once the argument
+        # list's parentheses are balanced; the paren guard keeps a `do`
+        # buried in a default value or atom inside the args from firing.
+        if paren <= 0 && text.matches?(/\bdo\b(?!:)/)
+          return {buffer, i}
+        end
+        i += 1
+      end
+      {buffer, start}
     end
 
     def should_extract_params_for_endpoint?(endpoint : Endpoint, controller_name : String, action_name : String) : Bool
@@ -164,14 +306,7 @@ module Analyzer::Elixir
 
       depth = 1
       (start_index + 1...lines.size).each do |i|
-        line = lines[i].strip
-
-        # Count keywords that increase depth (excluding 'fn' which has different end syntax)
-        depth += line.scan(/\b(do|def|defp|case|cond|if|unless)\b/).size
-
-        # Count "end" keywords that decrease depth
-        depth -= line.scan(/\bend\b/).size
-
+        depth += elixir_block_depth_delta(lines[i].strip)
         return i if depth == 0
       end
 
@@ -376,64 +511,103 @@ module Analyzer::Elixir
         end
       end
 
-      # Resources macro - generates standard REST routes
-      if match = line.match(/(?:^|[^.\w])resources\s*(?:\(\s*)?['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)(?:\s*,\s*only:\s*\[([^\]]+)\])?(?:\s*,\s*except:\s*\[([^\]]+)\])?/)
-        base_path = scoped_route_path(scope_prefix, match[1])
-        controller = scoped_controller(scope_module, match[2])
-        only_actions = match[3]?
-        except_actions = match[4]?
+      endpoints
+    end
 
-        if only_actions
-          # Parse only: [:index, :show, :create, etc.]
-          actions = only_actions.scan(/:(\w+)/).map { |m| m[1] }
-        else
-          # Default to all REST actions
-          actions = ["index", "show", "create", "update", "delete", "new", "edit"]
-        end
-        if except_actions
-          excluded = except_actions.scan(/:(\w+)/).map { |m| m[1] }
-          actions = actions.reject { |action| excluded.includes?(action) }
-        end
+    # Expand a (possibly multi-line) `resources` macro into the REST
+    # routes it generates. Returns the endpoints plus, when the macro
+    # opens a `do` block, the relative member prefix (`path/:singular_id`)
+    # that child routes nest under — `nil` for a leaf resource.
+    private def resources_from_statement(statement : String,
+                                         scope_prefix : String,
+                                         scope_module : String) : Tuple(Array(Endpoint), String?)
+      endpoints = Array(Endpoint).new
 
-        actions.each do |action|
-          case action
-          when "index"
-            endpoint = Endpoint.new(base_path, "GET")
-            @route_map["GET::#{base_path}"] = ControllerAction.new(controller, "index")
-            endpoints << endpoint
-          when "show"
-            endpoint = Endpoint.new("#{base_path}/:id", "GET")
-            @route_map["GET::#{base_path}/:id"] = ControllerAction.new(controller, "show")
-            endpoints << endpoint
-          when "create"
-            endpoint = Endpoint.new(base_path, "POST")
-            @route_map["POST::#{base_path}"] = ControllerAction.new(controller, "create")
-            endpoints << endpoint
-          when "update"
-            put_endpoint = Endpoint.new("#{base_path}/:id", "PUT")
-            @route_map["PUT::#{base_path}/:id"] = ControllerAction.new(controller, "update")
-            endpoints << put_endpoint
+      match = statement.match(/(?:^|[^.\w])resources\s*(?:\(\s*)?['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)/)
+      return {endpoints, nil} unless match
 
-            patch_endpoint = Endpoint.new("#{base_path}/:id", "PATCH")
-            @route_map["PATCH::#{base_path}/:id"] = ControllerAction.new(controller, "update")
-            endpoints << patch_endpoint
-          when "delete"
-            endpoint = Endpoint.new("#{base_path}/:id", "DELETE")
-            @route_map["DELETE::#{base_path}/:id"] = ControllerAction.new(controller, "delete")
-            endpoints << endpoint
-          when "new"
-            endpoint = Endpoint.new("#{base_path}/new", "GET")
-            @route_map["GET::#{base_path}/new"] = ControllerAction.new(controller, "new")
-            endpoints << endpoint
-          when "edit"
-            endpoint = Endpoint.new("#{base_path}/:id/edit", "GET")
-            @route_map["GET::#{base_path}/:id/edit"] = ControllerAction.new(controller, "edit")
-            endpoints << endpoint
-          end
+      resource_path = match[1]
+      base_path = scoped_route_path(scope_prefix, resource_path)
+      controller = scoped_controller(scope_module, match[2])
+      # `only:`/`except:` may sit behind other options (`as:`, `param:`,
+      # `name:`), so scan the whole statement rather than anchoring them
+      # to the controller argument.
+      only_actions = statement.match(/\bonly:\s*\[([^\]]+)\]/).try &.[1]
+      except_actions = statement.match(/\bexcept:\s*\[([^\]]+)\]/).try &.[1]
+
+      # A `singleton: true` resource (e.g. a `/session` you always act on
+      # without an id) drops the `/:id` member segment and omits `:index`
+      # from the default action set. A `param:` option renames the member
+      # capture (`param: "tenant_id"` → `/tenants/:tenant_id`).
+      singleton = statement.matches?(/\bsingleton:\s*true\b/)
+      param_name = statement.match(/\bparam:\s*["']?(\w+)["']?/).try(&.[1]) || "id"
+      member = singleton ? base_path : "#{base_path}/:#{param_name}"
+
+      if only_actions
+        actions = only_actions.scan(/:(\w+)/).map { |m| m[1] }
+      elsif singleton
+        actions = ["show", "create", "update", "delete", "new", "edit"]
+      else
+        actions = ["index", "show", "create", "update", "delete", "new", "edit"]
+      end
+      if except_actions
+        excluded = except_actions.scan(/:(\w+)/).map { |m| m[1] }
+        actions = actions.reject { |action| excluded.includes?(action) }
+      end
+
+      actions.each do |action|
+        case action
+        when "index"
+          @route_map["GET::#{base_path}"] = ControllerAction.new(controller, "index")
+          endpoints << Endpoint.new(base_path, "GET")
+        when "show"
+          @route_map["GET::#{member}"] = ControllerAction.new(controller, "show")
+          endpoints << Endpoint.new(member, "GET")
+        when "create"
+          @route_map["POST::#{base_path}"] = ControllerAction.new(controller, "create")
+          endpoints << Endpoint.new(base_path, "POST")
+        when "update"
+          @route_map["PUT::#{member}"] = ControllerAction.new(controller, "update")
+          endpoints << Endpoint.new(member, "PUT")
+          @route_map["PATCH::#{member}"] = ControllerAction.new(controller, "update")
+          endpoints << Endpoint.new(member, "PATCH")
+        when "delete"
+          @route_map["DELETE::#{member}"] = ControllerAction.new(controller, "delete")
+          endpoints << Endpoint.new(member, "DELETE")
+        when "new"
+          @route_map["GET::#{base_path}/new"] = ControllerAction.new(controller, "new")
+          endpoints << Endpoint.new("#{base_path}/new", "GET")
+        when "edit"
+          @route_map["GET::#{member}/edit"] = ControllerAction.new(controller, "edit")
+          endpoints << Endpoint.new("#{member}/edit", "GET")
         end
       end
 
-      endpoints
+      nested_prefix = nil
+      if statement.matches?(/\bdo\s*$/)
+        if singleton
+          nested_prefix = resource_path
+        else
+          # The child collection nests under the parent's member
+          # capture: the explicit `param:` when given, otherwise the
+          # singularized collection name (`/posts` → `:post_id`).
+          nested_param = param_name == "id" ? "#{singularize(resource_path.split('/').reject(&.empty?).last? || resource_path)}_id" : param_name
+          nested_prefix = Noir::URLPath.join(resource_path, ":#{nested_param}")
+        end
+      end
+
+      {endpoints, nested_prefix}
+    end
+
+    # Phoenix names a nested resource's parent capture after the
+    # singularized parent collection (`/posts/:post_id/...`). A small
+    # English inflection covers the common cases; an imperfect singular
+    # only affects the placeholder name, never the route structure.
+    private def singularize(name : String) : String
+      return "#{name[0, name.size - 3]}y" if name.ends_with?("ies") && name.size > 3
+      return name[0, name.size - 2] if name.ends_with?("ses") && name.size > 3
+      return name[0, name.size - 1] if name.ends_with?("s") && name.size > 1
+      name
     end
 
     private def add_standard_route(endpoints : Array(Endpoint),

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -16,11 +16,28 @@ module Analyzer::Elixir
       endpoints = [] of Endpoint
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         content = file.gets_to_end
+        # A Phoenix router is owned by the Phoenix analyzer, which
+        # understands `scope` prefixes, the `resources` macro, and the
+        # controller/action mapping. The bare `get "/path"` regex here
+        # would re-extract those same lines stripped of their scope
+        # prefix and minus every `resources`-generated route — degraded
+        # duplicates that pollute the result. Skip the file and let the
+        # Phoenix analyzer handle it.
+        next endpoints if phoenix_router?(content)
         analyze_content(content, path).each do |endpoint|
           endpoints << endpoint unless endpoint.method.empty?
         end
       end
       endpoints
+    end
+
+    # `use MyAppWeb, :router` (or, rarely, `use Phoenix.Router`) marks a
+    # Phoenix router module. The Plug.Router DSL never uses either, so
+    # this distinguishes the two even though both share `get`/`post`
+    # route macros.
+    private def phoenix_router?(content : String) : Bool
+      content.includes?("Phoenix.Router") ||
+        content.matches?(/\buse\s+[A-Z]\w*(?:\.[A-Z]\w*)*\s*,\s*:router\b/)
     end
 
     def analyze_content(content : String, file_path : String) : Array(Endpoint)
@@ -169,77 +186,70 @@ module Analyzer::Elixir
 
       depth = 1
       (start_index + 1...lines.size).each do |i|
-        line = lines[i].strip
-
-        # Count "do" keywords that increase depth
-        depth += line.scan(/\bdo\b/).size
-
-        # Count "end" keywords that decrease depth
-        depth -= line.scan(/\bend\b/).size
-
+        depth += elixir_block_depth_delta(lines[i].strip)
         return i if depth == 0
       end
 
       -1
     end
 
+    # The route macro must start a fresh token. Without the
+    # `(?:^|[^.\w])` guard the bare verb matched as a substring of any
+    # identifier — `@temp_slot_options "TEMPORARY …"` read as an
+    # `options` route, `Repo.delete "x"` as a `delete` route — flooding
+    # non-router modules with junk endpoints. The captured path is also
+    # required to start with `/`, because the Plug.Router DSL only ever
+    # registers absolute paths; that single constraint drops the
+    # remaining `get "true"`-style false positives.
+    PLUG_ROUTE_MACROS = {
+      "get"     => "GET",
+      "post"    => "POST",
+      "put"     => "PUT",
+      "patch"   => "PATCH",
+      "delete"  => "DELETE",
+      "head"    => "HEAD",
+      "options" => "OPTIONS",
+      "forward" => "FORWARD",
+    }
+
     def line_to_endpoint(line : String) : Array(Endpoint)
       endpoints = Array(Endpoint).new
 
-      # Match Plug.Router style route definitions
-      # get "/path", do: ...
-      line.scan(/get\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "GET")
-      end
-
-      line.scan(/post\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "POST")
-      end
-
-      line.scan(/put\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "PUT")
-      end
-
-      line.scan(/patch\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "PATCH")
-      end
-
-      line.scan(/delete\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "DELETE")
-      end
-
-      line.scan(/head\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "HEAD")
-      end
-
-      line.scan(/options\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "OPTIONS")
-      end
-
-      # Match forward statements: forward "/api", SomeModule
-      line.scan(/forward\s+["\']([^"\']+)["\']/) do |match|
-        endpoints << Endpoint.new("#{match[1]}", "FORWARD")
+      # Match Plug.Router style route definitions, e.g. `get "/path", do: …`
+      PLUG_ROUTE_MACROS.each do |verb, method|
+        pattern = Regex.new("(?:^|[^.\\w])#{verb}\\s+[\"']([^\"']+)[\"']")
+        line.scan(pattern) do |match|
+          path = match[1]
+          endpoints << Endpoint.new(path, method) if plug_route_path?(path)
+        end
       end
 
       # Match match statements with method patterns
       # match "/path", via: [:get, :post]
-      if via_match = line.match(/match\s+["\']([^"\']+)["\'][^:]*via:\s*\[([^\]]+)\]/)
+      if via_match = line.match(/(?:^|[^.\w])match\s+["\']([^"\']+)["\'][^:]*via:\s*\[([^\]]+)\]/)
         path = via_match[1]
-        methods_str = via_match[2]
-        methods_str.scan(/:(\w+)/) do |method_match|
-          endpoints << Endpoint.new(path, method_match[1].upcase)
+        if plug_route_path?(path)
+          via_match[2].scan(/:(\w+)/) do |method_match|
+            endpoints << Endpoint.new(path, method_match[1].upcase)
+          end
         end
       end
 
       # Match simple match statements (defaults to GET)
-      line.scan(/match\s+["\']([^"\']+)["\']/) do |match|
-        # Only add if we didn't already match a via: pattern above
-        unless line.includes?("via:")
-          endpoints << Endpoint.new("#{match[1]}", "GET")
+      unless line.includes?("via:")
+        line.scan(/(?:^|[^.\w])match\s+["\']([^"\']+)["\']/) do |match|
+          path = match[1]
+          endpoints << Endpoint.new(path, "GET") if plug_route_path?(path)
         end
       end
 
       endpoints
+    end
+
+    # Plug.Router only registers absolute paths, so a captured value that
+    # doesn't begin with `/` is a misfire on some other string literal.
+    private def plug_route_path?(path : String) : Bool
+      path.starts_with?('/')
     end
   end
 end

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -26,8 +26,13 @@ module Analyzer::Elixir
     # a `do` that isn't the inline `do:` keyword form, plus each `fn`,
     # minus each `end`.
     protected def elixir_block_depth_delta(line : String) : Int32
-      opens = line.scan(/\bdo\b(?!:)/).size + line.scan(/\bfn\b/).size
-      closes = line.scan(/\bend\b/).size
+      # Count on a string-and-comment-stripped copy so the keywords
+      # `do`/`fn`/`end` appearing inside a literal (`flash(conn, "…the
+      # end")`) or a trailing comment don't shift block depth and
+      # truncate the enclosing function.
+      code = Noir::ElixirCalleeExtractor.strip_comment(line)
+      opens = code.scan(/\bdo\b(?!:)/).size + code.scan(/\bfn\b/).size
+      closes = code.scan(/\bend\b/).size
       opens - closes
     end
 

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -16,6 +16,21 @@ module Analyzer::Elixir
       Noir::ElixirCalleeExtractor.attach_to(endpoint, callees)
     end
 
+    # How much a single line shifts Elixir block nesting depth. Every
+    # block in Elixir closes with `end` and opens with either a `do`
+    # block (`def`/`case`/`if`/`for`/`with`/`receive`/`try`/`cond`/…) or
+    # an anonymous `fn`. Counting the block keyword *and* its `do`
+    # double-counts the opener — `case x do … end` would read as +2/-1 —
+    # which is exactly why a controller action wrapping its body in a
+    # `case … do` never balanced and got dropped. Count the opener once:
+    # a `do` that isn't the inline `do:` keyword form, plus each `fn`,
+    # minus each `end`.
+    protected def elixir_block_depth_delta(line : String) : Int32
+      opens = line.scan(/\bdo\b(?!:)/).size + line.scan(/\bfn\b/).size
+      closes = line.scan(/\bend\b/).size
+      opens - closes
+    end
+
     # No extension filter: Phoenix uses `.ex` only, Plug also accepts
     # `.exs`, so each analyzer filters inside `analyze_file`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil

--- a/src/detector/detectors/elixir/phoenix.cr
+++ b/src/detector/detectors/elixir/phoenix.cr
@@ -2,10 +2,39 @@ require "../../../models/detector"
 
 module Detector::Elixir
   class Phoenix < Detector
-    def detect(filename : String, file_contents : String) : Bool
-      return false unless filename.includes?("mix.exs")
+    # Phoenix routers rarely write `use Phoenix.Router` directly; the
+    # generated convention is `use MyAppWeb, :router`, where the
+    # `:router` clause of the app's `*_web.ex` macro injects
+    # `Phoenix.Router`. Match that `use _, :router` shape so real
+    # routers register even when the literal `Phoenix.Router` never
+    # appears in the file.
+    ROUTER_USE_REGEX = /\buse\s+[A-Z]\w*(?:\.[A-Z]\w*)*\s*,\s*:router\b/
 
-      file_contents.includes?("ElixirPhoenix")
+    def detect(filename : String, file_contents : String) : Bool
+      basename = File.basename(filename)
+
+      # The mix manifest is the most reliable signal: a real Phoenix
+      # project always declares the core `{:phoenix, ...}` dependency.
+      # The previous check looked for the literal `ElixirPhoenix`,
+      # which only ever matched the test fixture's module name, so
+      # every real-world app silently fell through to the Plug
+      # analyzer (losing scope prefixes, `resources` expansion, and
+      # controller param/callee extraction). Require the `{:phoenix,`
+      # tuple specifically so sibling deps like `{:phoenix_ecto, ...}`
+      # or `{:phoenix_live_view, ...}` don't masquerade as the core.
+      if basename == "mix.exs"
+        return file_contents.includes?("{:phoenix,") ||
+          file_contents.includes?("{ :phoenix,")
+      end
+
+      # A router module is an equally strong signal when the mix file
+      # isn't in scope (e.g. `--include-path` runs over `lib/` only).
+      if filename.ends_with?(".ex") || filename.ends_with?(".exs")
+        return file_contents.includes?("Phoenix.Router") ||
+          file_contents.matches?(ROUTER_USE_REGEX)
+      end
+
+      false
     end
 
     def applicable?(filename : String) : Bool


### PR DESCRIPTION
## Summary

Ran noir against a spread of real open-source Elixir apps — **changelog.com, papercups, plausible, hexpm, keila, supabase/realtime, firezone, electric-sql** — and fixed the FN/FP and callee/ai-context gaps that surfaced.

### Detector (the big one)
The Phoenix detector only matched the literal string `ElixirPhoenix` in `mix.exs` — which is just the **test fixture's** module name. So **every real Phoenix app** silently fell through to the Plug analyzer (or went undetected), losing scope prefixes, `resources` expansion, and controller param/callee extraction.

- papercups produced **0 endpoints**; changelog lost its entire `/admin` scope and all `resources` routes (analyzed degraded as Plug).
- Now detects the core `{:phoenix,` dependency and the `use _, :router` / `Phoenix.Router` router convention.

Impact (real apps): papercups 0→269, changelog degraded→265 with correct scope prefixes & nested resources, plausible/hexpm/keila/firezone all detected as Phoenix.

### FP cuts
- **Plug/Bandit no longer re-scan Phoenix router files** — they would emit scope-stripped, `resources`-less duplicate routes.
- **Plug route macros now require a token boundary + absolute path**, so identifiers like `@temp_slot_options "TEMPORARY #{...}"` or `Repo.delete record` stop registering as `OPTIONS`/`DELETE` routes (found in electric-sql).
- **`singleton: true`** resources drop the `/:id` member segment and omit `:index`; **`param:`** renames the member capture (`/tenants/:tenant_id`).

### FN cuts / route accuracy
- **Nested `resources … do`** mount children under the parent's `/:singular_id` member segment (`/podcasts/:podcast_id/episodes`).
- **`resources(...)`** parenthesised call form recognised (papercups).
- **Multi-line `resources` options** honoured — `only:`/`except:` wrapped onto continuation lines, or placed behind `as:`.

### callee & ai-context (no more silent gaps)
- Controller actions that **pattern-match the connection in the head** (`def edit(conn = %{assigns: ...}, _params)`, `%Plug.Conn{} = conn`) and heads **wrapped across several lines** are now linked.
- **Block-depth counting** no longer double-counts `case/if/for/with … do` against its single `end`, so an action wrapping its body in a `case` stops being skipped.

On changelog this lifted controller code-path/callee linkage from **80/265 → 239/265** endpoints (the remainder are LiveView/socket routes and `resources` actions with no defined handler — correctly unlinked).

## Tests
- New fixture coverage: nested resources, `singleton: true`, `param:`, and the parenthesised `resources(...)` call form.
- Full suite: **18427 examples, 0 failures**. Ameba clean.