### PR TITLE
Improve Go Chi/Goyave/fasthttp/Mux analyzers: FP/FN reduction + callees

### DIFF
--- a/spec/functional_test/fixtures/go/chi_const_paths/go.mod
+++ b/spec/functional_test/fixtures/go/chi_const_paths/go.mod
@@ -1,0 +1,5 @@
+module chiconst
+
+go 1.21
+
+require github.com/go-chi/chi/v5 v5.0.12

--- a/spec/functional_test/fixtures/go/chi_const_paths/paths.go
+++ b/spec/functional_test/fixtures/go/chi_const_paths/paths.go
@@ -1,0 +1,11 @@
+package app
+
+// Route paths declared as package constants in a sibling file — the
+// dominant real-world chi shape (e.g. drakkan/sftpgo). The analyzer
+// resolves these across the package so the routes that reference them
+// aren't dropped.
+const (
+	healthzPath = "/healthz"
+	tokenPath   = "/api/v2/token"
+	adminPath   = "/api/v2/admins"
+)

--- a/spec/functional_test/fixtures/go/chi_const_paths/server.go
+++ b/spec/functional_test/fixtures/go/chi_const_paths/server.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type Server struct {
+	router chi.Router
+}
+
+func (s *Server) routes() {
+	s.router = chi.NewRouter()
+
+	// Selector-expression receiver (`s.router`) + constant path +
+	// method-value handler.
+	s.router.Get(healthzPath, s.health)
+
+	s.router.Group(func(router chi.Router) {
+		// Bare identifier receiver + constant path + method-value handler.
+		router.Get(tokenPath, s.issueToken)
+		// Concatenation of a path constant and a literal suffix.
+		router.Post(adminPath+"/{username}/reset-password", s.resetPassword)
+	})
+}
+
+func (s *Server) health(w http.ResponseWriter, r *http.Request) {
+	writeOK(w)
+}
+
+func (s *Server) issueToken(w http.ResponseWriter, r *http.Request) {
+	token := newToken()
+	w.Write([]byte(token))
+}
+
+func (s *Server) resetPassword(w http.ResponseWriter, r *http.Request) {
+}
+
+func writeOK(w http.ResponseWriter) {
+	w.Write([]byte("ok"))
+}
+
+func newToken() string {
+	return "t"
+}

--- a/spec/functional_test/fixtures/go/fasthttp_optional/go.mod
+++ b/spec/functional_test/fixtures/go/fasthttp_optional/go.mod
@@ -1,0 +1,8 @@
+module fhopt
+
+go 1.21
+
+require (
+	github.com/fasthttp/router v1.5.0
+	github.com/valyala/fasthttp v1.52.0
+)

--- a/spec/functional_test/fixtures/go/fasthttp_optional/main.go
+++ b/spec/functional_test/fixtures/go/fasthttp_optional/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/fasthttp/router"
+	"github.com/valyala/fasthttp"
+)
+
+func main() {
+	r := router.New()
+	// fasthttp/router path-parameter dialects that must normalize to
+	// the canonical `{name}` placeholder.
+	r.GET("/optional/{name?}", index)         // optional
+	r.GET("/regex/{id:[0-9]+}", index)         // inline regex
+	r.GET("/combo/{slug?:[a-z]+}", index)      // optional + regex
+	fasthttp.ListenAndServe(":8080", r.Handler)
+}
+
+func index(ctx *fasthttp.RequestCtx) {
+	_ = ctx.UserValue("name")
+}

--- a/spec/functional_test/fixtures/go/goyave_groups/go.mod
+++ b/spec/functional_test/fixtures/go/goyave_groups/go.mod
@@ -1,0 +1,5 @@
+module goyavegroups
+
+go 1.21
+
+require goyave.dev/goyave/v5 v5.0.0

--- a/spec/functional_test/fixtures/go/goyave_groups/route.go
+++ b/spec/functional_test/fixtures/go/goyave_groups/route.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"goyave.dev/goyave/v5"
+)
+
+type Controller struct {
+	goyave.Component
+}
+
+// Mirrors go-goyave/goyave-blog-example: a prefixed subrouter, then
+// fluent `Group().SetMeta(...)` / `Group()` children that must inherit
+// the parent prefix. The `.SetMeta(...)` tail has to be peeled so the
+// child binds to `/articles`, not `/`.
+func (c *Controller) RegisterRoutes(router *goyave.Router) {
+	subrouter := router.Subrouter("/articles")
+	subrouter.Get("/", c.Index)
+	subrouter.Get("/{slug}", c.Show)
+
+	authRouter := subrouter.Group().SetMeta("auth", true)
+	authRouter.Post("/", c.Create)
+
+	ownedRouter := authRouter.Group()
+	ownedRouter.Patch("/{articleID:[0-9]+}", c.Update)
+	ownedRouter.Delete("/{articleID:[0-9]+}", c.Delete)
+}
+
+func (c *Controller) Index(response *goyave.Response, request *goyave.Request) {
+	listArticles()
+}
+
+func (c *Controller) Show(response *goyave.Response, request *goyave.Request)   {}
+func (c *Controller) Create(response *goyave.Response, request *goyave.Request) {}
+func (c *Controller) Update(response *goyave.Response, request *goyave.Request) {}
+func (c *Controller) Delete(response *goyave.Response, request *goyave.Request) {}
+
+func listArticles() {}

--- a/spec/functional_test/fixtures/go/mux_method_callees/go.mod
+++ b/spec/functional_test/fixtures/go/mux_method_callees/go.mod
@@ -1,0 +1,5 @@
+module muxmethod
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.1

--- a/spec/functional_test/fixtures/go/mux_method_callees/server.go
+++ b/spec/functional_test/fixtures/go/mux_method_callees/server.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type API struct{}
+
+func (a *API) ListUsers(w http.ResponseWriter, r *http.Request) {
+	users := fetchUsers()
+	w.Write([]byte(users))
+}
+
+func (a *API) GetUser(w http.ResponseWriter, r *http.Request) {
+	_ = mux.Vars(r)["id"]
+}
+
+// Middleware wrapper — handlers are commonly registered wrapped
+// (gophish's `mid.Use(as.Foo, ...)`); the real handler is the first
+// argument and must be unwrapped for callee resolution.
+func wrap(h http.HandlerFunc) http.HandlerFunc {
+	return h
+}
+
+func main() {
+	a := &API{}
+	r := mux.NewRouter()
+	// Bare method-value handler.
+	r.HandleFunc("/users", a.ListUsers).Methods("GET")
+	// Wrapped method-value handler.
+	r.HandleFunc("/users/{id}", wrap(a.GetUser)).Methods("GET")
+	http.ListenAndServe(":8080", r)
+}
+
+func fetchUsers() string {
+	return ""
+}

--- a/spec/functional_test/testers/go/chi_const_paths_spec.cr
+++ b/spec/functional_test/testers/go/chi_const_paths_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+# Regression test: chi apps routinely register routes with a constant or
+# variable path argument (`const tokenPath = "/api/v2/token"` declared in
+# a sibling file, used as `r.Get(tokenPath, h)`) and hang the router off a
+# struct field (`s.router.Get(...)`). drakkan/sftpgo registers ~hundreds of
+# routes this way; before this fix noir surfaced none of them.
+#
+# Coverage:
+#   - GET /healthz   — selector receiver (`s.router`) + constant path +
+#                      method-value handler (callee resolves through the
+#                      method body to `writeOK`).
+#   - GET /api/v2/token
+#                    — bare receiver inside a `Group(func(r){...})` closure
+#                      + constant path + method-value handler.
+#   - POST /api/v2/admins/{username}/reset-password
+#                    — `adminPath + "/{username}/reset-password"`
+#                      concatenation of a path constant and a literal.
+expected_endpoints = [
+  Endpoint.new("/healthz", "GET").tap do |ep|
+    ep.push_callee(Callee.new("writeOK"))
+  end,
+  Endpoint.new("/api/v2/token", "GET").tap do |ep|
+    ep.push_callee(Callee.new("newToken"))
+    ep.push_callee(Callee.new("w.Write"))
+  end,
+  Endpoint.new("/api/v2/admins/{username}/reset-password", "POST", [
+    Param.new("username", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/chi_const_paths/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/fasthttp_optional_spec.cr
+++ b/spec/functional_test/testers/go/fasthttp_optional_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Regression test: fasthttp/router path-parameter dialects must normalize
+# to the canonical `{name}` placeholder. The optional marker (`{name?}`)
+# and the optional+regex form (`{slug?:[a-z]+}`) previously leaked the `?`
+# into the param name and kept the regex body in the URL.
+#
+# Coverage:
+#   - GET /optional/{name}  — `{name?}`        optional
+#   - GET /regex/{id}       — `{id:[0-9]+}`    inline regex
+#   - GET /combo/{slug}     — `{slug?:[a-z]+}` optional + regex
+expected_endpoints = [
+  Endpoint.new("/optional/{name}", "GET", [
+    Param.new("name", "", "path"),
+  ]),
+  Endpoint.new("/regex/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/combo/{slug}", "GET", [
+    Param.new("slug", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/fasthttp_optional/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/goyave_groups_spec.cr
+++ b/spec/functional_test/testers/go/goyave_groups_spec.cr
@@ -1,0 +1,41 @@
+require "../../func_spec.cr"
+
+# Regression test: goyave's fluent router builder chains configuration
+# methods that return the same `*Router` (`subrouter.Group().SetMeta(...)`).
+# The `.SetMeta(...)` tail must be peeled so the assigned subrouter binds
+# to the parent prefix; otherwise every route under it falls back to `/`.
+# Mirrors go-goyave/goyave-blog-example.
+#
+# Coverage:
+#   - GET /articles/                — direct subrouter route (callee
+#                                     resolves through the controller
+#                                     method to `listArticles`).
+#   - GET /articles/{slug}          — path param under the prefix.
+#   - POST /articles/               — `Group().SetMeta(...)` child inherits
+#                                     `/articles`.
+#   - PATCH/DELETE /articles/{articleID}
+#                                   — nested `Group()` child also inherits
+#                                     `/articles`; the `{id:regex}` form is
+#                                     normalized to `{articleID}`.
+expected_endpoints = [
+  Endpoint.new("/articles/", "GET").tap do |ep|
+    ep.push_callee(Callee.new("listArticles"))
+  end,
+  Endpoint.new("/articles/{slug}", "GET", [
+    Param.new("slug", "", "path"),
+  ]),
+  Endpoint.new("/articles/", "POST"),
+  Endpoint.new("/articles/{articleID}", "PATCH", [
+    Param.new("articleID", "", "path"),
+  ]),
+  Endpoint.new("/articles/{articleID}", "DELETE", [
+    Param.new("articleID", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/goyave_groups/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/go/mux_method_callees_spec.cr
+++ b/spec/functional_test/testers/go/mux_method_callees_spec.cr
@@ -1,0 +1,31 @@
+require "../../func_spec.cr"
+
+# Regression test: gorilla/mux handlers are almost always method values
+# (`a.ListUsers`) or wrapped method values (`mid.Use(as.Foo, ...)` in
+# gophish). Both used to yield zero callees. Method-value handlers now
+# resolve through the package method-body map, and wrapper calls are
+# peeled to their underlying handler.
+#
+# Coverage:
+#   - GET /users      — bare method-value handler `a.ListUsers`
+#                       (callees `fetchUsers`, `w.Write`).
+#   - GET /users/{id} — wrapped method-value handler `wrap(a.GetUser)`
+#                       (callee `mux.Vars` from the unwrapped method body).
+expected_endpoints = [
+  Endpoint.new("/users", "GET").tap do |ep|
+    ep.push_callee(Callee.new("fetchUsers"))
+    ep.push_callee(Callee.new("w.Write"))
+  end,
+  Endpoint.new("/users/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("mux.Vars"))
+  end,
+]
+
+FunctionalTester.new("fixtures/go/mux_method_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -27,6 +27,10 @@ module Analyzer::Go
       package_files = Hash(String, Array(String)).new
       file_contents_cache = Hash(String, String).new
       file_lines_cache = Hash(String, Array(String)).new
+      # Directories that hold at least one chi-importing file. Route-path
+      # constants (`const tokenPath = "/api/v2/token"`) are resolved only
+      # for these so unrelated packages don't pay for an extra parse.
+      chi_dirs = Set(String).new
 
       get_files_by_extension(".go").each do |scan_path|
         next if File.directory?(scan_path)
@@ -36,6 +40,7 @@ module Analyzer::Go
           package_files[dir] << scan_path
 
           content = read_file_content(scan_path)
+          chi_dirs << dir if content.includes?(IMPORT_MARKER)
           # Cache contents for every Go file in the package — the
           # cross-file callee map and Mount-expansion walker both
           # need handler/helper functions that live in non-chi
@@ -72,6 +77,37 @@ module Analyzer::Go
       # that as a follow-up; for now Mount endpoints keep an empty
       # callees list.
       package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies_if(callees_needed?, file_contents_cache)
+      # Method-value handlers (`s.handleOIDCRedirect`, `router.Get(p,
+      # h.Show)`) resolve to their method bodies so callees aren't empty
+      # when chi apps hang handlers off a server/controller struct.
+      package_method_bodies = Noir::GoCalleeExtractor.package_method_bodies_if(callees_needed?, file_contents_cache)
+
+      # Per-directory string-constant map so a route registered in one
+      # file (`server.go`: `r.Get(tokenPath, h)`) resolves a path
+      # constant declared in a sibling file (`httpd.go`:
+      # `const tokenPath = "/api/v2/token"`). Conflicting redefinitions
+      # across files are dropped so an ambiguous name never resolves to
+      # the wrong path.
+      package_string_values = Hash(String, Hash(String, String)).new
+      chi_dirs.each do |dir|
+        next unless files = package_files[dir]?
+        merged = Hash(String, String).new
+        ambiguous = Set(String).new
+        files.each do |fp|
+          content = file_contents_cache[fp]?
+          next unless content
+          Noir::TreeSitterGoRouteExtractor.extract_string_values(content).each do |name, value|
+            next if ambiguous.includes?(name)
+            if (existing = merged[name]?) && existing != value
+              merged.delete(name)
+              ambiguous << name
+            else
+              merged[name] = value
+            end
+          end
+        end
+        package_string_values[dir] = merged unless merged.empty?
+      end
 
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
@@ -102,7 +138,8 @@ module Analyzer::Go
                   # bodies of functions that are expanded via Mount (those
                   # are handled below to get their `/admin` prefix).
                   ts_routes = Noir::TreeSitterGoRouteExtractor
-                    .extract_chi_routes(content, mounted_functions)
+                    .extract_chi_routes(content, mounted_functions,
+                      package_string_values[dir]? || Hash(String, String).new)
                   routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                   ts_routes.each do |r|
                     routes_by_line[r.line] ||= [] of Noir::TreeSitterGoRouteExtractor::Route
@@ -117,7 +154,8 @@ module Analyzer::Go
                   route_rows = Set(Int32).new
                   routes_by_line.each_key { |row| route_rows << row }
                   external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, dir)
-                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+                  external_methods = Noir::GoCalleeExtractor.method_bodies_for_directory(package_method_bodies, dir)
+                  callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
 
                   state = ChiRouteState.new
                   last_endpoint = Endpoint.new("", "")

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -29,6 +29,9 @@ module Analyzer::Go
           end
         end
         package_function_bodies = Noir::GoCalleeExtractor.package_function_bodies_if(callees_needed?, file_contents)
+        # Resolve method-value handlers (`h.Index`) to their bodies too,
+        # so callees aren't empty when handlers hang off a struct.
+        package_method_bodies = Noir::GoCalleeExtractor.package_method_bodies_if(callees_needed?, file_contents)
 
         base_paths.each do |current_base_path|
           base_dir_prefix = current_base_path.ends_with?("/") ? current_base_path : "#{current_base_path}/"
@@ -59,15 +62,17 @@ module Analyzer::Go
               route_rows = Set(Int32).new
               routes_by_line.each_key { |row| route_rows << row }
               external_fns = Noir::GoCalleeExtractor.function_bodies_for_directory(package_function_bodies, File.dirname(path))
-              callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+              external_methods = Noir::GoCalleeExtractor.method_bodies_for_directory(package_method_bodies, File.dirname(path))
+              callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
 
               content.each_line.with_index do |line, index|
                 details = Details.new(PathInfo.new(path, index + 1))
 
                 if ts_hits = routes_by_line[index]?
                   ts_hits.each do |route|
+                    clean_path = normalize_fasthttp_path(route.path)
                     Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                      endpoint = Endpoint.new(route.path, verb, details)
+                      endpoint = Endpoint.new(clean_path, verb, details)
                       if entries = callees_by_route[route.line]?
                         entries.each do |entry|
                           name, callee_path, callee_line = entry
@@ -97,6 +102,18 @@ module Analyzer::Go
       end
 
       result
+    end
+
+    # Normalize fasthttp/router path-parameter syntax into the canonical
+    # `{name}` placeholder. fasthttp/router accepts optional params
+    # (`{name?}`), inline regex constraints (`{name:[0-9]+}`), and the
+    # two combined (`{name?:[a-zA-Z]+}`). The optimizer's generic
+    # `{name:regex}` stripper only matches identifier-then-colon, so the
+    # `?` optional marker leaks through as part of the param name
+    # (`name?`) and the URL keeps its regex body. Strip both here so the
+    # surfaced URL and the path-param names are clean.
+    private def normalize_fasthttp_path(path : String) : String
+      path.gsub(/\{([a-zA-Z0-9_]+)\??(?::[^{}]+)?\}/) { "{#{$1}}" }
     end
 
     private def analyze_route_line(line : String, details : Details) : Endpoint

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -14,6 +14,10 @@ module Analyzer::Go
       # than piggy-backing on `collect_package_groups_ts`.
       file_contents = read_package_file_contents
       package_function_bodies = collect_package_function_bodies(file_contents)
+      # Goyave handlers are controller method values (`ctrl.Index`,
+      # `ctrl.Show`); resolve them to their method bodies so callees and
+      # ai-context aren't empty.
+      package_method_bodies = collect_package_controller_method_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -59,7 +63,8 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+                    external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
 
                     # `router.Static(&fs, "/prefix", false)` — the first
                     # `/`-prefixed string arg is both URL prefix and (with

--- a/src/analyzer/analyzers/go/mux.cr
+++ b/src/analyzer/analyzers/go/mux.cr
@@ -17,6 +17,10 @@ module Analyzer::Go
       # HandleFunc call_expression itself, so the row-keyed callee
       # lookup matches it cleanly.
       package_function_bodies = collect_package_function_bodies(file_contents)
+      # Mux handlers are almost always method values (`as.Campaigns`) or
+      # wrapped method values (`mid.Use(as.Users, ...)`); resolve them to
+      # their method bodies so callees/ai-context aren't empty.
+      package_method_bodies = collect_package_controller_method_bodies(file_contents)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         WaitGroup.wait do |wg|
@@ -56,7 +60,8 @@ module Analyzer::Go
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
-                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
+                    external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, File.dirname(path))
+                    callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
 
                     # Mux static-file: `r.PathPrefix("/x/").Handler(... http.Dir("./x/") ...)`
                     Noir::TreeSitterGoRouteExtractor.extract_mux_statics(content).each do |sp|

--- a/src/miniparsers/go_callee_extractor.cr
+++ b/src/miniparsers/go_callee_extractor.cr
@@ -93,6 +93,33 @@ module Noir::GoCalleeExtractor
     package_bodies[dir]? || Hash(String, FunctionBody).new
   end
 
+  # Per-directory `{method_name => [FunctionBody, ...]}` map so a
+  # method-value handler (`as.Campaigns`, `ctrl.Index`) can be resolved
+  # to its method body for callee extraction. Module-level twin of
+  # `GoEngine#collect_package_controller_method_bodies` for analyzers
+  # (Chi) that don't inherit from `GoEngine`. Returns an empty map
+  # immediately when `enabled` is false so default scans pay nothing.
+  def package_method_bodies_if(enabled : Bool, file_contents : Hash(String, String)) : Hash(String, Hash(String, Array(FunctionBody)))
+    bodies = Hash(String, Hash(String, Array(FunctionBody))).new
+    return bodies unless enabled
+    file_contents.each do |path, content|
+      next unless content.includes?("func (")
+      methods = collect_method_bodies(content, path)
+      next if methods.empty?
+      dir = File.dirname(path)
+      dir_map = (bodies[dir] ||= Hash(String, Array(FunctionBody)).new)
+      methods.each do |name, list|
+        (dir_map[name] ||= [] of FunctionBody).concat(list)
+      end
+    end
+    bodies
+  end
+
+  # Returns the per-directory method-body map, or an empty map.
+  def method_bodies_for_directory(package_method_bodies : Hash(String, Hash(String, Array(FunctionBody))), dir : String) : Hash(String, Array(FunctionBody))
+    package_method_bodies[dir]? || Hash(String, Array(FunctionBody)).new
+  end
+
   # Returns top-level function declarations in `source`, keyed by name.
   # `file_path` is recorded on each `FunctionBody` so callees emitted by
   # later re-parsing can report a useful path.
@@ -121,18 +148,25 @@ module Noir::GoCalleeExtractor
                             source : String,
                             file_path : String,
                             route_rows : Set(Int32),
-                            external_functions : Hash(String, FunctionBody))
+                            external_functions : Hash(String, FunctionBody),
+                            external_methods : Hash(String, Array(FunctionBody)) = Hash(String, Array(FunctionBody)).new)
     return Hash(Int32, Array(Tuple(String, String, Int32))).new unless enabled
-    callees_for_routes(source, file_path, route_rows, external_functions)
+    callees_for_routes(source, file_path, route_rows, external_functions, external_methods)
   end
 
   # For each call_expression at a row in `route_rows`, find the handler
   # argument, walk its body, and return the 1-hop callees keyed by row.
   # Each entry is a tuple `{name, callee_file_path, file_line_1_based}`.
+  #
+  # `external_methods` maps a (package-unqualified) method name to the
+  # bodies that define it, so a method-value handler (`as.Campaigns`,
+  # `s.handleOIDCRedirect` — the dominant shape in gorilla/mux and chi
+  # apps) resolves to its method body when the name is unambiguous.
   def callees_for_routes(source : String,
                          file_path : String,
                          route_rows : Set(Int32),
-                         external_functions : Hash(String, FunctionBody))
+                         external_functions : Hash(String, FunctionBody),
+                         external_methods : Hash(String, Array(FunctionBody)) = Hash(String, Array(FunctionBody)).new)
     by_route = Hash(Int32, Array(Tuple(String, String, Int32))).new
     return by_route if route_rows.empty?
 
@@ -167,9 +201,27 @@ module Noir::GoCalleeExtractor
             end
           elsif extern = external_functions[name]?
             callees.concat(calls_in_external(extern, external_functions))
+          elsif (methods = external_methods[name]?) && methods.size == 1
+            # A bare identifier that resolves to a single same-package
+            # method (rare, but `Handle("/x", Foo)` where `Foo` is a
+            # method value lifted to package scope).
+            callees.concat(calls_in_external(methods.first, external_functions))
+          end
+        when "selector_expression"
+          # Method-value handler: `as.Campaigns`, `s.handleOIDCRedirect`,
+          # `ctrl.Index`. Resolve by the field (method) name against the
+          # package method-body map; only attribute when the name is
+          # unambiguous so a shared method name across two receiver types
+          # can't mis-attribute callees.
+          field = Noir::TreeSitter.field(handler_arg, "field")
+          if field
+            method_name = Noir::TreeSitter.node_text(field, source)
+            if (methods = external_methods[method_name]?) && methods.size == 1
+              callees.concat(calls_in_external(methods.first, external_functions))
+            end
           end
         else
-          # selector_expression / method values — out of scope for now.
+          # other shapes (index/lambda results) — out of scope.
         end
 
         by_route[row] = callees unless callees.empty?
@@ -191,14 +243,34 @@ module Noir::GoCalleeExtractor
     args = Noir::TreeSitter.field(call_node, "arguments")
     return unless args
     handler_only = handler_only_call?(call_node, source)
-    seen_path = false
+
+    if handler_only
+      # `.Handler(h)` / `.HandlerFunc(h)` builder calls: the handler is
+      # the first non-string argument.
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        ty = Noir::TreeSitter.node_type(arg)
+        next if ty == "interpreted_string_literal" || ty == "raw_string_literal"
+        return arg
+      end
+      return
+    end
+
+    # Verb/registration calls are path-first (`r.Get("/x", h)`). Treat the
+    # FIRST positional argument as the path — a string literal in most
+    # apps, but just as often a path constant/variable
+    # (`r.Get(tokenPath, h)`) or a concatenation — then take the next
+    # non-string argument as the handler. Keying off "first arg = path"
+    # rather than "first string literal = path" is what lets callee
+    # resolution survive constant route paths.
+    first = true
     Noir::TreeSitter.each_named_child(args) do |arg|
-      ty = Noir::TreeSitter.node_type(arg)
-      if ty == "interpreted_string_literal" || ty == "raw_string_literal"
-        seen_path = true
+      if first
+        first = false
         next
       end
-      return arg if seen_path || handler_only
+      ty = Noir::TreeSitter.node_type(arg)
+      next if ty == "interpreted_string_literal" || ty == "raw_string_literal"
+      return arg
     end
     nil
   end
@@ -218,24 +290,34 @@ module Noir::GoCalleeExtractor
     end
   end
 
-  private def unwrap_handler_arg(arg : LibTreeSitter::TSNode, source : String) : LibTreeSitter::TSNode
+  # Peel handler-wrapping calls down to the underlying handler so callee
+  # resolution sees the real function. Covers the common wrappers in
+  # gorilla/mux and chi apps:
+  #
+  #   * `http.HandlerFunc(h)`                         -> `h`
+  #   * `mid.Use(as.Foo, mid.RequireLogin)`           -> `as.Foo`
+  #   * `http.StripPrefix("/x", fileServer)`          -> `fileServer`
+  #   * nested combinations (`mid.Use(http.HandlerFunc(h), ...)`)
+  #
+  # The rule is: a call_expression handler unwraps to its first non-string
+  # argument (the handler position; string args are prefixes/keys). The
+  # walk is depth-capped so a pathological chain can't recurse forever.
+  private def unwrap_handler_arg(arg : LibTreeSitter::TSNode, source : String, depth : Int32 = 0) : LibTreeSitter::TSNode
+    return arg if depth > 4
     return arg unless Noir::TreeSitter.node_type(arg) == "call_expression"
-
-    function = Noir::TreeSitter.field(arg, "function")
-    return arg unless function
-    return arg unless Noir::TreeSitter.node_type(function) == "selector_expression"
-
-    field = Noir::TreeSitter.field(function, "field")
-    return arg unless field
-    return arg unless Noir::TreeSitter.node_text(field, source) == "HandlerFunc"
 
     args = Noir::TreeSitter.field(arg, "arguments")
     return arg unless args
+
+    inner : LibTreeSitter::TSNode? = nil
     Noir::TreeSitter.each_named_child(args) do |child|
-      return child unless Noir::TreeSitter.node_type(child) == "interpreted_string_literal" ||
-                          Noir::TreeSitter.node_type(child) == "raw_string_literal"
+      ty = Noir::TreeSitter.node_type(child)
+      next if ty == "interpreted_string_literal" || ty == "raw_string_literal"
+      inner = child
+      break
     end
-    arg
+    return arg unless found = inner
+    unwrap_handler_arg(found, source, depth + 1)
   end
 
   # Walk `body_node` for call expressions and append `(name, file_path,

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -82,13 +82,27 @@ module Noir
     }
 
     # Chain methods that return the receiving router/group unchanged —
-    # middleware registration. Gin's `RouterGroup.Use(...)` and
-    # `Engine.Use(...)` (and Fiber's `app.Use(...)`) return `IRoutes`,
-    # so `r.Use(mw).GET("/x", h)` and `r.Group("/api").Use(mw).POST(...)`
-    # are valid, common shapes. They don't add a path segment, so the
-    # operand walk peels them and resolves the prefix against the
-    # underlying router/group rather than dropping the route entirely.
-    PASSTHROUGH_CHAIN_METHODS = Set{"Use"}
+    # middleware / metadata registration. Gin's `RouterGroup.Use(...)`
+    # and `Engine.Use(...)` (and Fiber's `app.Use(...)`) return
+    # `IRoutes`, so `r.Use(mw).GET("/x", h)` and
+    # `r.Group("/api").Use(mw).POST(...)` are valid, common shapes.
+    #
+    # Goyave's router exposes a fluent builder whose configuration
+    # methods (`SetMeta`, `Middleware`, `CORS`, ...) all return the same
+    # `*Router`, so `authRouter := subrouter.Group().SetMeta(k, v)` binds
+    # `authRouter` to the group's prefix — the `.SetMeta(...)` tail must
+    # be peeled to reach the prefix-bearing `.Group()` call underneath
+    # (otherwise the parent prefix is lost and every route under
+    # `authRouter` falls back to `/`).
+    #
+    # None of these add a path segment, so the operand walk peels them
+    # and resolves the prefix against the underlying router/group rather
+    # than dropping the route (or its prefix) entirely.
+    PASSTHROUGH_CHAIN_METHODS = Set{
+      "Use",
+      # Goyave fluent-builder configuration methods (all return *Router).
+      "SetMeta", "RemoveMeta", "Middleware", "GlobalMiddleware", "CORS",
+    }
 
     # Beego registers controllers with `web.Router("/path", &Ctrl{},
     # "get:Method;post:Other")`. The receiver is the `web` package (v2,
@@ -432,8 +446,25 @@ module Noir
     end
 
     def extract_chi_routes(source : String,
-                           skip_functions : Set(String) = Set(String).new) : Array(Route)
-      extract_scoped_routes(source, ScopedConfig.new, skip_functions)
+                           skip_functions : Set(String) = Set(String).new,
+                           external_string_values : Hash(String, String) = Hash(String, String).new) : Array(Route)
+      extract_scoped_routes(source, ScopedConfig.new, skip_functions, external_string_values)
+    end
+
+    # Collects `<name> := "literal"` / `const <name> = "literal"` string
+    # bindings from `source`, keyed by name. Real chi/mux apps routinely
+    # declare route paths as package constants
+    # (`const tokenPath = "/api/v2/token"`) and register them with
+    # `r.Get(tokenPath, h)`; the analyzer merges these per-package so the
+    # scoped walker can resolve a constant/variable path argument to its
+    # literal value. Conflicting redefinitions are dropped by
+    # `collect_string_values`.
+    def extract_string_values(source : String) : Hash(String, String)
+      result = Hash(String, String).new
+      Noir::TreeSitter.parse_go(source) do |root|
+        result = collect_string_values(root, source)
+      end
+      result
     end
 
     # Gf-style: `.Group("/api", func(){...})` pushes prefix, inline
@@ -505,11 +536,17 @@ module Noir
 
     private def extract_scoped_routes(source : String,
                                       config : ScopedConfig,
-                                      skip_functions : Set(String) = Set(String).new) : Array(Route)
+                                      skip_functions : Set(String) = Set(String).new,
+                                      external_string_values : Hash(String, String) = Hash(String, String).new) : Array(Route)
       routes = [] of Route
       local_groups = Hash(String, String).new
       Noir::TreeSitter.parse_go(source) do |root|
-        walk_chi(root, source, [] of String, local_groups, routes, skip_functions, config)
+        # Same-file string constants/vars win over package-level ones;
+        # both feed the scoped walker so a `r.Get(tokenPath, h)` whose
+        # path is a constant resolves to its literal value.
+        string_values = external_string_values.dup
+        collect_string_values(root, source).each { |k, v| string_values[k] = v }
+        walk_chi(root, source, [] of String, local_groups, routes, skip_functions, config, string_values)
       end
       routes
     end
@@ -518,10 +555,11 @@ module Noir
     # (typically a function body captured elsewhere). Uses chi defaults.
     def walk_chi_public(node : LibTreeSitter::TSNode,
                         source : String,
-                        sink : Array(Route))
+                        sink : Array(Route),
+                        string_values : Hash(String, String) = Hash(String, String).new)
       local_groups = Hash(String, String).new
       skip = Set(String).new
-      walk_chi(node, source, [] of String, local_groups, sink, skip, ScopedConfig.new)
+      walk_chi(node, source, [] of String, local_groups, sink, skip, ScopedConfig.new, string_values)
     end
 
     private def walk_chi(node : LibTreeSitter::TSNode,
@@ -530,7 +568,8 @@ module Noir
                          local_groups : Hash(String, String),
                          routes : Array(Route),
                          skip_functions : Set(String),
-                         config : ScopedConfig)
+                         config : ScopedConfig,
+                         string_values : Hash(String, String) = Hash(String, String).new)
       ty = Noir::TreeSitter.node_type(node)
 
       # Skip `func <skipped>() { ... }` bodies entirely — their routes are
@@ -546,14 +585,14 @@ module Noir
       # here because the binding is name-scoped: sibling calls on the
       # outer receiver still refer to the outer prefix.
       if ty == "short_var_declaration"
-        bind_local_group(node, source, local_groups, config)
+        bind_local_group(node, source, local_groups, config, string_values)
       end
 
       if ty == "call_expression"
-        kind = classify_chi_call(node, source, config)
+        kind = classify_chi_call(node, source, config, string_values)
         case kind
         when ChiCall::Route
-          if info = unpack_chi_scope_call(node, source, expect_prefix: true)
+          if info = unpack_chi_scope_call(node, source, string_values, expect_prefix: true)
             new_prefix, body, closure = info
             prefix_stack.push(new_prefix)
             # Register the closure's first router param (e.g. `group` in
@@ -566,7 +605,7 @@ module Noir
             active_prefix = prefix_stack.join
             saved_binding = local_groups[param_name]? if param_name
             local_groups[param_name] = active_prefix if param_name
-            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config)
+            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config, string_values)
             if param_name
               if saved_binding.nil?
                 local_groups.delete(param_name)
@@ -578,18 +617,18 @@ module Noir
             return
           end
         when ChiCall::Group
-          if info = unpack_chi_scope_call(node, source, expect_prefix: false)
+          if info = unpack_chi_scope_call(node, source, string_values, expect_prefix: false)
             _, body, _ = info
-            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config)
+            walk_chi(body, source, prefix_stack, local_groups, routes, skip_functions, config, string_values)
             return
           end
         when ChiCall::Verb
-          if route = decode_chi_verb_call(node, source, prefix_stack, local_groups, config)
+          if route = decode_chi_verb_call(node, source, prefix_stack, local_groups, config, string_values)
             routes << route
           end
           return
         when ChiCall::Bind
-          if route = decode_chi_bind_call(node, source, prefix_stack, local_groups, config)
+          if route = decode_chi_bind_call(node, source, prefix_stack, local_groups, config, string_values)
             routes << route
           end
           return
@@ -597,7 +636,7 @@ module Noir
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_chi(child, source, prefix_stack, local_groups, routes, skip_functions, config)
+        walk_chi(child, source, prefix_stack, local_groups, routes, skip_functions, config, string_values)
       end
     end
 
@@ -606,7 +645,8 @@ module Noir
     private def bind_local_group(decl : LibTreeSitter::TSNode,
                                  source : String,
                                  local_groups : Hash(String, String),
-                                 config : ScopedConfig)
+                                 config : ScopedConfig,
+                                 string_values : Hash(String, String) = Hash(String, String).new)
       left = Noir::TreeSitter.field(decl, "left")
       right = Noir::TreeSitter.field(decl, "right")
       return unless left && right
@@ -633,7 +673,7 @@ module Noir
       # already handled by the walker.
       return if chi_closure_arg(rhs_node)
 
-      path = chi_first_string_arg(rhs_node, source)
+      path = chi_first_string_arg(rhs_node, source, string_values)
       return unless path
 
       var_name = Noir::TreeSitter.node_text(var_name_node, source)
@@ -667,7 +707,8 @@ module Noir
 
     # Classify a call_expression so `walk_chi` knows whether to descend
     # into a scoped body, emit a route, or keep walking children.
-    private def classify_chi_call(call : LibTreeSitter::TSNode, source : String, config : ScopedConfig) : ChiCall
+    private def classify_chi_call(call : LibTreeSitter::TSNode, source : String, config : ScopedConfig,
+                                  string_values : Hash(String, String) = Hash(String, String).new) : ChiCall
       function = Noir::TreeSitter.field(call, "function")
       return ChiCall::None unless function
       return ChiCall::None unless Noir::TreeSitter.node_type(function) == "selector_expression"
@@ -678,7 +719,7 @@ module Noir
       if name == config.prefix_method
         # (string, closure) -> push prefix. This also handles gf's
         # `.Group("/api", func(){...})`.
-        if chi_first_string_arg(call, source) && chi_closure_arg(call)
+        if chi_first_string_arg(call, source, string_values) && chi_closure_arg(call)
           return ChiCall::Route
         end
       end
@@ -687,7 +728,7 @@ module Noir
         # (closure only) -> middleware group that doesn't change prefix.
         # Excludes Gin-style `.Group("/x")` which is handled by
         # `extract_routes`, not this walker.
-        if chi_closure_arg(call) && !chi_first_string_arg(call, source)
+        if chi_closure_arg(call) && !chi_first_string_arg(call, source, string_values)
           return ChiCall::Group
         end
       end
@@ -713,7 +754,8 @@ module Noir
                                      source : String,
                                      prefix_stack : Array(String),
                                      local_groups : Hash(String, String),
-                                     config : ScopedConfig) : Route?
+                                     config : ScopedConfig,
+                                     string_values : Hash(String, String) = Hash(String, String).new) : Route?
       function = Noir::TreeSitter.field(call, "function")
       return unless function
       operand = Noir::TreeSitter.field(function, "operand")
@@ -729,7 +771,14 @@ module Noir
         when "interpreted_string_literal", "raw_string_literal"
           raw_path = decode_string_literal(arg, source) if raw_path.nil?
         else
-          handler_text = Noir::TreeSitter.node_text(arg, source) if handler_text.empty? && !raw_path.nil?
+          # A constant/variable first argument is still the bind path
+          # (`s.BindHandler(rootPath, h)`); resolve it before falling
+          # back to treating the arg as the handler.
+          if raw_path.nil? && (resolved_path = string_expr_text(arg, source, string_values))
+            raw_path = resolved_path
+          elsif handler_text.empty? && !raw_path.nil?
+            handler_text = Noir::TreeSitter.node_text(arg, source)
+          end
         end
       end
       return unless raw_path
@@ -755,8 +804,9 @@ module Noir
     # parameter list (for binding the subrouter name into local_groups).
     private def unpack_chi_scope_call(call : LibTreeSitter::TSNode,
                                       source : String,
+                                      string_values : Hash(String, String),
                                       expect_prefix : Bool) : Tuple(String, LibTreeSitter::TSNode, LibTreeSitter::TSNode)?
-      prefix = expect_prefix ? chi_first_string_arg(call, source) : ""
+      prefix = expect_prefix ? chi_first_string_arg(call, source, string_values) : ""
       return if prefix.nil?
       closure = chi_closure_arg(call)
       return unless closure
@@ -765,13 +815,19 @@ module Noir
       {prefix, body, closure}
     end
 
-    private def chi_first_string_arg(call : LibTreeSitter::TSNode, source : String) : String?
+    private def chi_first_string_arg(call : LibTreeSitter::TSNode,
+                                     source : String,
+                                     string_values : Hash(String, String) = Hash(String, String).new) : String?
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
-        case Noir::TreeSitter.node_type(arg)
-        when "interpreted_string_literal", "raw_string_literal"
-          return decode_string_literal(arg, source)
+        # Resolve the first string-valued argument: a literal, or a
+        # constant/variable/concatenation that `string_values` can pin
+        # down (e.g. `const apiBase = "/api/v2"` used as `r.Route(apiBase,
+        # ...)`). With an empty `string_values` map this still only
+        # matches literals, preserving the original behaviour.
+        if s = string_expr_text(arg, source, string_values)
+          return s
         end
       end
       nil
@@ -794,7 +850,8 @@ module Noir
                                      source : String,
                                      prefix_stack : Array(String),
                                      local_groups : Hash(String, String),
-                                     config : ScopedConfig) : Route?
+                                     config : ScopedConfig,
+                                     string_values : Hash(String, String) = Hash(String, String).new) : Route?
       function = Noir::TreeSitter.field(call, "function")
       return unless function
       return unless Noir::TreeSitter.node_type(function) == "selector_expression"
@@ -852,23 +909,60 @@ module Noir
         break
       end
 
-      return unless Noir::TreeSitter.node_type(operand) == "identifier"
-      router_name = Noir::TreeSitter.node_text(operand, source)
-      return if NON_ROUTER_OPERANDS.includes?(router_name)
+      # The verb receiver is usually a bare identifier (`r.Get(...)`), but
+      # real apps just as often hang the router off a struct field
+      # (`s.router.Get(...)`). Accept both; for the selector form, guard on
+      # the final segment so non-router fields (`req.Header.Get(...)`,
+      # `s.cache.Get(...)`) can't mint phantom routes.
+      operand_is_selector = false
+      case Noir::TreeSitter.node_type(operand)
+      when "identifier"
+        router_name = Noir::TreeSitter.node_text(operand, source)
+        return if NON_ROUTER_OPERANDS.includes?(router_name)
+      when "selector_expression"
+        final_field = Noir::TreeSitter.field(operand, "field")
+        return unless final_field
+        return if NON_ROUTER_OPERANDS.includes?(Noir::TreeSitter.node_text(final_field, source))
+        router_name = Noir::TreeSitter.node_text(operand, source)
+        operand_is_selector = true
+      else
+        return
+      end
 
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
       raw_path = nil
+      path_was_literal = false
       handler_text = ""
       Noir::TreeSitter.each_named_child(args) do |arg|
         case Noir::TreeSitter.node_type(arg)
         when "interpreted_string_literal", "raw_string_literal"
-          raw_path = decode_string_literal(arg, source) if raw_path.nil?
+          if raw_path.nil?
+            raw_path = decode_string_literal(arg, source)
+            path_was_literal = true
+          end
         else
-          handler_text = Noir::TreeSitter.node_text(arg, source) if handler_text.empty? && !raw_path.nil?
+          # Resolve a constant/variable/concatenation path argument
+          # (`r.Get(tokenPath, h)`, `r.Post(adminPath+"/x", h)`) before
+          # treating a non-string arg as the handler.
+          if raw_path.nil? && (resolved_path = string_expr_text(arg, source, string_values))
+            raw_path = resolved_path
+          elsif handler_text.empty? && !raw_path.nil?
+            handler_text = Noir::TreeSitter.node_text(arg, source)
+          end
         end
       end
       return unless raw_path
+
+      # Tighten the broadened cases (selector receiver or a path resolved
+      # from a non-literal) so they can't surface noise: a real chi/gf
+      # route always starts with `/` and always carries a handler. The
+      # original literal-path + identifier-receiver shape keeps its
+      # historical leniency untouched.
+      if operand_is_selector || !path_was_literal
+        return if handler_text.empty?
+        return unless raw_path.starts_with?("/")
+      end
 
       # Prefer the local binding (closure param / `v1 := group.Group(...)`)
       # when it exists, since Go scope rules say the nearest binding wins.


### PR DESCRIPTION
Sweeps the four Go frameworks against real open-source apps and closes the FN/FP and callee/ai-context gaps surfaced. Enriches the already-solid Go AI-context base so a reviewer gets full routes + handler callees instead of empty shells.

Validated against: **drakkan/sftpgo** (chi), **gophish** (mux), **go-goyave/goyave-blog-example** (goyave), **fasthttp/router** examples, **go-chi** examples, **gorilla/mux**.

## Chi
- **Constant/variable route paths.** Apps overwhelmingly declare paths as package constants (`const tokenPath = "/api/v2/token"`) and register `r.Get(tokenPath, h)`. The scoped walker now resolves path args through a per-package string-constant map (sibling-file aware; conflicting redefinitions dropped).
- **Struct-field router receivers** (`s.router.Get(...)`), guarded on the final selector segment so `req.Header.Get(...)` / `s.cache.Get(...)` can't mint phantom routes; broadened cases also require a handler arg and a `/`-leading path.
- Net: **drakkan/sftpgo 0 → 162 chi endpoints.**

## Goyave
- Peel the fluent builder's self-returning config methods (`SetMeta`, `RemoveMeta`, `Middleware`, `GlobalMiddleware`, `CORS`) when resolving group declarations, so `authRouter := subrouter.Group().SetMeta(...)` inherits the parent prefix instead of falling back to `/`. (goyave-blog-example `/articles/{articleID}` etc. now correct.)

## fasthttp
- Normalize fasthttp/router optional path params (`{name?}`, `{slug?:[a-z]+}`) to canonical `{name}` — the optimizer's generic `{name:regex}` stripper missed the `?` marker, leaking `name?` into param names and the regex into URLs.

## Callees / AI-context
- Resolve method-value handlers (`as.Campaigns`, `ctrl.Index`, `s.handleOIDCRedirect`) to their method bodies via a per-package method-body map (unambiguous names only), wired into chi/mux/goyave/fasthttp.
- Peel handler wrappers (`mid.Use(as.Foo, ...)`, `http.HandlerFunc(h)`, `http.StripPrefix(...)`) to the underlying handler.
- Treat the first positional arg of a route call as the path, so callee resolution survives constant route paths.
- Net: **gophish 0 → 336 endpoints-with-callees**; **sftpgo chi 1 → 162.**

## Tests
- New functional fixtures + specs: `chi_const_paths`, `goyave_groups`, `fasthttp_optional`, `mux_method_callees`.
- Full suite green (unit 2766, functional 15692, 0 failures); ameba + `crystal tool format` clean.