### PR TITLE
Rust: skip raw strings when scanning #[cfg(test)] region braces

### DIFF
--- a/spec/unit_test/analyzer/rust_engine_spec.cr
+++ b/spec/unit_test/analyzer/rust_engine_spec.cr
@@ -33,4 +33,54 @@ describe Analyzer::Rust::RustEngine do
       body.should contain("RealService::run")
     end
   end
+
+  describe ".collect_cfg_test_regions" do
+    it "treats braces inside a raw string as opaque so the region spans the whole block" do
+      source = <<-RUST
+      fn real() {
+          Router::with_path("/real").get(real_handler);
+      }
+
+      #[cfg(test)]
+      mod tests {
+          #[test]
+          fn renders() {
+              let raw = r#"{ "openapi": { "paths": {} } }"#;
+              Router::with_path("/test-only").get(test_handler);
+          }
+      }
+      RUST
+
+      regions = Analyzer::Rust::RustEngine.collect_cfg_test_regions(source)
+      regions.size.should eq(1)
+      start_byte, end_byte = regions[0]
+
+      # The test-only route is registered *after* the brace-laden raw
+      # string; without raw-string handling the region would close early
+      # at a `}` inside the JSON and leak that route as an endpoint.
+      test_route = source.byte_index("/test-only").not_nil!
+      (test_route >= start_byte && test_route < end_byte).should be_true
+
+      # The production route above the block stays outside the region.
+      real_route = source.byte_index("/real").not_nil!
+      (real_route >= start_byte && real_route < end_byte).should be_false
+    end
+
+    it "still closes a cfg(test) block that contains no raw strings" do
+      source = <<-RUST
+      #[cfg(test)]
+      mod tests {
+          fn t() { let x = 1; }
+      }
+
+      fn after() {}
+      RUST
+
+      regions = Analyzer::Rust::RustEngine.collect_cfg_test_regions(source)
+      regions.size.should eq(1)
+      start_byte, end_byte = regions[0]
+      after_byte = source.byte_index("fn after").not_nil!
+      (after_byte >= end_byte).should be_true
+    end
+  end
 end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -109,6 +109,11 @@ module Analyzer::Rust
         case c
         when '"'.ord  then i = skip_string_literal(bytes, i)
         when '\''.ord then i = skip_char_or_lifetime(bytes, i)
+        when 'r'.ord, 'b'.ord
+          # Raw strings (`r"…"`, `r#"…"#`, `br#"…"#`) routinely embed `{`
+          # / `}` — e.g. a JSON body in a `#[cfg(test)]` test — and must
+          # be skipped whole or the brace matcher mis-counts depth.
+          i = try_skip_raw_string(bytes, i) || i + 1
         when '/'.ord
           if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
             i = skip_line_comment(bytes, i)
@@ -132,6 +137,11 @@ module Analyzer::Rust
         case c
         when '"'.ord  then i = skip_string_literal(bytes, i); next
         when '\''.ord then i = skip_char_or_lifetime(bytes, i); next
+        when 'r'.ord, 'b'.ord
+          if nb = try_skip_raw_string(bytes, i)
+            i = nb
+            next
+          end
         when '/'.ord
           if i + 1 < bytes.size && bytes[i + 1] == '/'.ord
             i = skip_line_comment(bytes, i); next
@@ -144,6 +154,45 @@ module Analyzer::Rust
         i += 1
       end
       depth == 0 ? i - 1 : nil
+    end
+
+    # If `from` begins a Rust raw string literal — `r"…"`, `r#"…"#`,
+    # `r##"…"##`, or the byte-string `br"…"` / `br#"…"#` forms — return
+    # the index just past its terminator; otherwise `nil`. The closer is
+    # a `"` followed by exactly the same number of `#` as the opener, so
+    # interior quotes and braces are consumed verbatim. In valid Rust an
+    # `r` / `br` immediately followed by `#`* `"` is unambiguously a raw
+    # string (a bare `r#ident` raw identifier has no quote), so ordinary
+    # identifiers and byte/binary literals (`b'x'`, `b"x"`, `0b10`) fall
+    # through to `nil`.
+    private def self.try_skip_raw_string(bytes : Slice(UInt8), from : Int32) : Int32?
+      i = from
+      if bytes[i] == 'b'.ord
+        i += 1
+        return unless i < bytes.size && bytes[i] == 'r'.ord
+      end
+      return unless i < bytes.size && bytes[i] == 'r'.ord
+      i += 1
+      hashes = 0
+      while i < bytes.size && bytes[i] == '#'.ord
+        hashes += 1
+        i += 1
+      end
+      return unless i < bytes.size && bytes[i] == '"'.ord
+      i += 1
+      while i < bytes.size
+        if bytes[i] == '"'.ord
+          j = i + 1
+          k = 0
+          while k < hashes && j < bytes.size && bytes[j] == '#'.ord
+            k += 1
+            j += 1
+          end
+          return j if k == hashes
+        end
+        i += 1
+      end
+      bytes.size
     end
 
     private def self.skip_string_literal(bytes : Slice(UInt8), from : Int32) : Int32


### PR DESCRIPTION
## Summary

Shared-engine fix surfaced while sweeping real Rust OSS apps (follow-up to #1829 / #1831).

`RustEngine.collect_cfg_test_regions` locates each `#[cfg(test)]` block by brace-counting, skipping string/char/comment content so a `{` inside `"foo {"` doesn't shift the depth. It did **not** skip Rust **raw strings** (`r"…"`, `r#"…"#`, `br#"…"#`). A raw string embedding unbalanced braces — e.g. a JSON literal in a serde round-trip test — closed the region early at a `}` inside the string, so everything after it in the test module looked like production code and **test-only route registrations leaked as endpoints**.

This affects every Rust analyzer (axum, actix, rocket, salvo, …). Concretely, on `salvo-rs/salvo` it dropped four phantom endpoints from `crates/oapi/src/openapi.rs`'s `#[cfg(test)] mod tests` block (router builders used to exercise `merge_router`):

```rust
#[cfg(test)]
mod tests {
    fn renders() {
        let raw_json = r#"{ "openapi": "3.1.0", "paths": {} }"#;  // <- braces here closed the region early
        let router = Router::with_path("/pets/{id}").get(get_pet_by_id);  // <- leaked as an endpoint
    }
}
```

## Fix

Add `try_skip_raw_string`, which recognises the `r` / `br` + `#`\* + `"` opener and consumes through the matching `"` + `#`\* closer, and call it from both brace scanners (`find_block_open_brace`, `find_matching_close_brace`). A bare `r#ident` raw identifier (no quote) and byte/binary literals (`b'x'`, `b"x"`, `0b10`) correctly fall through to ordinary handling.

## Tests

- New unit tests on `collect_cfg_test_regions`: a raw string full of braces keeps the region spanning the whole block (and excludes the production route above it); a brace-only block without raw strings still closes correctly.
- Full Rust suite green (1629 examples across analyzer/miniparser/functional), `crystal tool format` + ameba clean.