### PR TITLE
Improve Dart analyzers: cut FP/FN and recover callees (Dart Frog, Serverpod, Shelf)

### DIFF
--- a/spec/functional_test/fixtures/dart/dart_frog/routes/articles/[id].dart
+++ b/spec/functional_test/fixtures/dart/dart_frog/routes/articles/[id].dart
@@ -1,0 +1,28 @@
+import 'package:dart_frog/dart_frog.dart';
+
+// `onRequest` is dispatched for *every* verb, so unsupported methods are
+// commonly enumerated in fall-through `case` clauses that return
+// `methodNotAllowed`. Those rejected verbs must NOT be surfaced as
+// real endpoints — only GET and PUT below are.
+Future<Response> onRequest(RequestContext context, String id) async {
+  switch (context.request.method) {
+    case HttpMethod.get:
+      return _show(context, id);
+    case HttpMethod.put:
+      return _update(context, id);
+    case HttpMethod.post:
+    case HttpMethod.delete:
+    case HttpMethod.patch:
+    case HttpMethod.head:
+    case HttpMethod.options:
+      return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+}
+
+Future<Response> _show(RequestContext context, String id) async {
+  return Response.json(body: {'id': id});
+}
+
+Future<Response> _update(RequestContext context, String id) async {
+  return Response.json(body: {'id': id, 'updated': true});
+}

--- a/spec/functional_test/fixtures/dart/dart_frog/test/routes/articles_test.dart
+++ b/spec/functional_test/fixtures/dart/dart_frog/test/routes/articles_test.dart
@@ -1,0 +1,19 @@
+import 'package:dart_frog/dart_frog.dart';
+import 'package:test/test.dart';
+
+import '../../routes/articles/[id].dart' as route;
+
+// Dart Frog mirrors the route tree under `test/routes/`. These mock
+// handlers are exercised by `dart test` and must never be surfaced as
+// live endpoints.
+void main() {
+  group('GET /articles/[id]', () {
+    test('responds with 200', () {
+      final context = _MockRequestContext();
+      final response = route.onRequest(context, '1');
+      expect(response, isNotNull);
+    });
+  });
+}
+
+class _MockRequestContext {}

--- a/spec/functional_test/fixtures/dart/dart_frog_callees/routes/proxy.dart
+++ b/spec/functional_test/fixtures/dart/dart_frog_callees/routes/proxy.dart
@@ -1,0 +1,8 @@
+import 'package:dart_frog/dart_frog.dart';
+
+import '../lib/shared_handler.dart';
+
+// Assignment-form handler: `onRequest` is bound to a shared `Handler`
+// rather than declared as a function. The reference must still surface
+// as the route's callee.
+Handler onRequest = sharedHandler;

--- a/spec/functional_test/fixtures/dart/serverpod/lib/server.dart
+++ b/spec/functional_test/fixtures/dart/serverpod/lib/server.dart
@@ -1,0 +1,20 @@
+import 'package:serverpod/serverpod.dart';
+
+import 'src/web/routes/root.dart';
+import 'src/web/routes/webhook.dart';
+
+void run(List<String> args) async {
+  final pod = Serverpod(args, Protocol(), Endpoints());
+
+  // WidgetRoute → GET. Registered at two paths.
+  pod.webServer.addRoute(RootRoute(), '/');
+  pod.webServer.addRoute(RootRoute(), '/index.html');
+
+  // Route with an explicit POST methods set — a webhook.
+  pod.webServer.addRoute(WebhookRoute(), '/webhook');
+
+  // Static file serving is not a handler endpoint and must be skipped.
+  pod.webServer.addRoute(RouteStaticDirectory(serverDirectory: 'static', basePath: '/'), '/static/*');
+
+  await pod.start();
+}

--- a/spec/functional_test/fixtures/dart/serverpod/lib/src/web/routes/root.dart
+++ b/spec/functional_test/fixtures/dart/serverpod/lib/src/web/routes/root.dart
@@ -1,0 +1,11 @@
+import 'package:serverpod/serverpod.dart';
+
+// `WidgetRoute` renders a page on GET. No explicit `methods:` set, so it
+// defaults to GET.
+class RootRoute extends WidgetRoute {
+  @override
+  Future<AbstractWidget> build(Session session, Request request) async {
+    final widget = HomePageWidget();
+    return widget;
+  }
+}

--- a/spec/functional_test/fixtures/dart/serverpod/lib/src/web/routes/webhook.dart
+++ b/spec/functional_test/fixtures/dart/serverpod/lib/src/web/routes/webhook.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+
+import 'package:serverpod/serverpod.dart';
+
+// `Route` with an explicit `methods: {Method.post}` set — surfaced as a
+// single POST endpoint. The `handleCall` body supplies the callees.
+class WebhookRoute extends Route {
+  WebhookRoute() : super(methods: {Method.post});
+
+  @override
+  Future<bool> handleCall(Session session, Request request) async {
+    final rawBody = await utf8.decoder.bind(request.body.read()).join();
+    final payload = jsonDecode(rawBody) as Map<String, dynamic>;
+    await processWebhook(session, payload);
+    return true;
+  }
+}

--- a/spec/functional_test/fixtures/dart/serverpod/test/integration/example_endpoint_test.dart
+++ b/spec/functional_test/fixtures/dart/serverpod/test/integration/example_endpoint_test.dart
@@ -1,0 +1,13 @@
+import 'package:serverpod_test/serverpod_test.dart';
+import 'package:test/test.dart';
+
+// Integration tests exercise endpoints but are not themselves a server
+// surface. They define `Session`-first helpers that must be ignored.
+void main() {
+  group('ExampleEndpoint', () {
+    test('hello returns greeting', () async {
+      Future<String> hello(Session session, String name) async => 'Hello $name';
+      expect(await hello(session, 'x'), equals('Hello x'));
+    });
+  });
+}

--- a/spec/functional_test/fixtures/dart/shelf/bin/server.dart
+++ b/spec/functional_test/fixtures/dart/shelf/bin/server.dart
@@ -2,6 +2,8 @@ import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
 import 'api.dart';
+import 'widgets_controller.dart';
+import 'tasks_controller.dart';
 
 final router = Router()
   ..get('/users', _listUsers)
@@ -10,7 +12,11 @@ final router = Router()
   ..put('/users/<id>', _updateUser)
   ..delete('/users/<id>', _deleteUser)
   ..all('/echo', _echo)
-  ..mount('/api/v1/', apiRouter.call);
+  ..mount('/api/v1/', apiRouter.call)
+  // Class-getter routers mounted under a prefix. Routes must resolve
+  // against the controller class, not the inner local variable.
+  ..mount('/widgets/', WidgetsController().router)
+  ..mount('/tasks/', TasksController().router);
 
 Response _listUsers(Request request) => Response.ok('[]');
 Response _createUser(Request request) => Response.ok('{}');

--- a/spec/functional_test/fixtures/dart/shelf/bin/tasks_controller.dart
+++ b/spec/functional_test/fixtures/dart/shelf/bin/tasks_controller.dart
@@ -1,0 +1,30 @@
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+part 'tasks_controller.g.dart';
+
+// `shelf_router` code-gen style: handlers are declared with
+// `@Route.<verb>('/path')` annotations and wired up by the generated
+// `_$TasksControllerRouter`. The parent mounts this at `/tasks/`.
+class TasksController {
+  @Route.get('/all')
+  Future<Response> index(Request request) async {
+    final tasks = await _repository.fetchAll();
+    return Response.ok(tasks.toString());
+  }
+
+  @Route.post('/<id>/done')
+  Future<Response> markDone(Request request, String id) async {
+    await _repository.complete(id);
+    return Response.ok(id);
+  }
+
+  final _repository = _TaskRepository();
+
+  Router get router => _$TasksControllerRouter(this);
+}
+
+class _TaskRepository {
+  Future<List<String>> fetchAll() async => [];
+  Future<void> complete(String id) async {}
+}

--- a/spec/functional_test/fixtures/dart/shelf/bin/widgets_controller.dart
+++ b/spec/functional_test/fixtures/dart/shelf/bin/widgets_controller.dart
@@ -1,0 +1,19 @@
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+// Imperative router built inside a class getter. It is reached from the
+// outside as `WidgetsController().router`, so when the parent mounts it
+// with `mount('/widgets/', WidgetsController().router)` the routes must
+// pick up the `/widgets` prefix (keyed by the class, not the local
+// `r` variable).
+class WidgetsController {
+  Router get router {
+    final r = Router()
+      ..get('/list', _list)
+      ..get('/<id>', _show);
+    return r;
+  }
+
+  Response _list(Request request) => Response.ok('[]');
+  Response _show(Request request, String id) => Response.ok(id);
+}

--- a/spec/functional_test/fixtures/dart/shelf/test/server_test.dart
+++ b/spec/functional_test/fixtures/dart/shelf/test/server_test.dart
@@ -1,0 +1,12 @@
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+import 'package:test/test.dart';
+
+// `dart test` fixtures often spin up real `Router()` instances. Anything
+// under `test/` is not a production surface and must be ignored.
+void main() {
+  test('routes a request', () {
+    final router = Router()..get('/ignored', (Request request) => Response.ok('x'));
+    expect(router, isNotNull);
+  });
+}

--- a/spec/functional_test/testers/dart/dart_frog_callees_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_callees_spec.cr
@@ -24,6 +24,13 @@ status_callees = [
   Callee.new("HealthService.status", line: 4),
 ]
 
+# `proxy.dart` binds `onRequest` to a shared handler reference; that
+# reference is the route's single callee. No `HttpMethod.*` refs, so it
+# falls back to the standard verb set.
+proxy_callees = [
+  Callee.new("sharedHandler", line: 8),
+]
+
 expected_endpoints = [
   dart_frog_endpoint_with_callees("/users/{id}", "GET", [
     Param.new("id", "", "path"),
@@ -36,6 +43,11 @@ expected_endpoints = [
   dart_frog_endpoint_with_callees("/status", "PUT", [] of Param, status_callees),
   dart_frog_endpoint_with_callees("/status", "DELETE", [] of Param, status_callees),
   dart_frog_endpoint_with_callees("/status", "PATCH", [] of Param, status_callees),
+  dart_frog_endpoint_with_callees("/proxy", "GET", [] of Param, proxy_callees),
+  dart_frog_endpoint_with_callees("/proxy", "POST", [] of Param, proxy_callees),
+  dart_frog_endpoint_with_callees("/proxy", "PUT", [] of Param, proxy_callees),
+  dart_frog_endpoint_with_callees("/proxy", "DELETE", [] of Param, proxy_callees),
+  dart_frog_endpoint_with_callees("/proxy", "PATCH", [] of Param, proxy_callees),
 ]
 
 tester = FunctionalTester.new("fixtures/dart/dart_frog_callees/", {

--- a/spec/functional_test/testers/dart/dart_frog_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_spec.cr
@@ -27,6 +27,12 @@ expected_endpoints = [
   Endpoint.new("/api/health", "PATCH"),
   # `posts/[...slug].dart` — catch-all wildcard collapses to a path param.
   Endpoint.new("/posts/{slug}", "GET", [Param.new("slug", "", "path")]),
+  # `articles/[id].dart` switches on the method: GET and PUT are handled,
+  # the remaining verbs fall through to a `methodNotAllowed` response and
+  # must NOT be reported. (`test/routes/articles_test.dart` is a test
+  # mirror and contributes nothing.)
+  Endpoint.new("/articles/{id}", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/articles/{id}", "PUT", [Param.new("id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/dart/dart_frog/", {

--- a/spec/functional_test/testers/dart/serverpod_spec.cr
+++ b/spec/functional_test/testers/dart/serverpod_spec.cr
@@ -16,9 +16,29 @@ expected_endpoints = [
     Param.new("order", "Order", "json"),
   ]),
   Endpoint.new("/health/ping", "POST"),
+
+  # Web-server routes registered via `pod.webServer.addRoute(...)`.
+  # `RootRoute` (a WidgetRoute) defaults to GET and is mounted at two
+  # paths; `WebhookRoute` declares `methods: {Method.post}`. The
+  # `RouteStaticDirectory` registration is skipped (static file serving),
+  # and the `test/integration` helper is ignored.
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/index.html", "GET"),
+  Endpoint.new("/webhook", "POST"),
 ]
 
-FunctionalTester.new("fixtures/dart/serverpod/", {
+serverpod_tester = FunctionalTester.new("fixtures/dart/serverpod/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+serverpod_tester.perform_tests
+
+it "extracts callees from a Serverpod web-route handler body" do
+  endpoint = serverpod_tester.app.endpoints.find { |found| found.url == "/webhook" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map(&.name).should contain("processWebhook")
+  end
+end

--- a/spec/functional_test/testers/dart/shelf_spec.cr
+++ b/spec/functional_test/testers/dart/shelf_spec.cr
@@ -24,9 +24,47 @@ expected_endpoints = [
   Endpoint.new("/api/v1/items/{itemId}", "GET", [Param.new("itemId", "", "path")]),
   # Direct `apiRouter.patch(...)` outside the cascade.
   Endpoint.new("/api/v1/items/{itemId}", "PATCH", [Param.new("itemId", "", "path")]),
+
+  # `WidgetsController` builds a `Router()` inside a getter and is mounted
+  # at `/widgets/`. The routes must inherit the mount prefix even though
+  # the inner local variable is `r`, not the class name.
+  Endpoint.new("/widgets/list", "GET"),
+  Endpoint.new("/widgets/{id}", "GET", [Param.new("id", "", "path")]),
+
+  # `TasksController` uses the `@Route.<verb>('/path')` code-gen style and
+  # is mounted at `/tasks/`.
+  Endpoint.new("/tasks/all", "GET"),
+  Endpoint.new("/tasks/{id}/done", "POST", [Param.new("id", "", "path")]),
+
+  # (`test/server_test.dart` builds a `Router()` too, but lives under
+  # `test/` and must be ignored.)
 ]
 
 FunctionalTester.new("fixtures/dart/shelf/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+# Callee/AI-context coverage: a bare function-reference handler is
+# recorded as a callee, and `@Route`-annotated handler bodies are
+# scanned for their callees.
+callee_tester = FunctionalTester.new("fixtures/dart/shelf/", {} of Symbol => Int32, [] of Endpoint, {
+  "include_callee" => YAML::Any.new(true),
+})
+callee_tester.perform_tests
+
+it "records bare function-reference handlers as callees" do
+  endpoint = callee_tester.app.endpoints.find { |found| found.url == "/users" && found.method == "GET" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map(&.name).should contain("_listUsers")
+  end
+end
+
+it "extracts callees from @Route-annotated handler bodies" do
+  endpoint = callee_tester.app.endpoints.find { |found| found.url == "/tasks/{id}/done" && found.method == "POST" }
+  endpoint.should_not be_nil
+  endpoint.try do |actual|
+    actual.callees.map(&.name).should contain("_repository.complete")
+  end
+end

--- a/spec/unit_test/analyzer/dart_helper_spec.cr
+++ b/spec/unit_test/analyzer/dart_helper_spec.cr
@@ -1,0 +1,46 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/dart/dart_helper"
+
+describe Analyzer::Dart::Helper do
+  describe ".test_path?" do
+    it "flags Dart Frog test/routes mirror trees" do
+      Analyzer::Dart::Helper.test_path?("/repo/backend/test/routes/index_test.dart", "/repo/backend").should be_true
+    end
+
+    it "flags the standard test/ directory and *_test.dart suffix" do
+      Analyzer::Dart::Helper.test_path?("/repo/test/integration/pay_endpoint_test.dart", "/repo").should be_true
+      Analyzer::Dart::Helper.test_path?("/repo/lib/widget_test.dart", "/repo").should be_true
+    end
+
+    it "does not flag production route files" do
+      Analyzer::Dart::Helper.test_path?("/repo/routes/api/blogs/index.dart", "/repo").should be_false
+      Analyzer::Dart::Helper.test_path?("/repo/lib/src/endpoints/order_endpoint.dart", "/repo").should be_false
+    end
+
+    it "does not treat a base path containing 'test' as a test tree" do
+      Analyzer::Dart::Helper.test_path?("/tmp/test_app/routes/index.dart", "/tmp/test_app").should be_false
+    end
+  end
+
+  describe ".strip_comments" do
+    it "blanks line and block comments but keeps strings and offsets" do
+      source = %(final x = 1; // note\nfinal s = "a // b"; /* c */ final y = 2;)
+      stripped = Analyzer::Dart::Helper.strip_comments(source)
+      stripped.bytesize.should eq source.bytesize
+      stripped.includes?("note").should be_false
+      stripped.includes?("/* c */").should be_false
+      stripped.includes?("a // b").should be_true
+    end
+  end
+
+  describe ".extract_string_literal" do
+    it "reads single and double quoted literals" do
+      Analyzer::Dart::Helper.extract_string_literal(%('/webhook')).should eq("/webhook")
+      Analyzer::Dart::Helper.extract_string_literal(%(  "/index.html"  )).should eq("/index.html")
+    end
+
+    it "returns nil for non-literal expressions" do
+      Analyzer::Dart::Helper.extract_string_literal("RouteRoot()").should be_nil
+    end
+  end
+end

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/dart_callee_extractor"
+require "./dart_helper"
 
 module Analyzer::Dart
   # Dart Frog is a filesystem-routed framework. Routes live under
@@ -43,6 +44,10 @@ module Analyzer::Dart
 
         parallel_analyze(files) do |path|
           next unless path.ends_with?(".dart")
+
+          # Dart Frog mirrors the route tree under `test/routes/`; those
+          # are mock handlers exercised by `dart test`, never live routes.
+          next if Helper.test_path?(path, @base_path)
 
           idx = path.index("/routes/")
           next if idx.nil?
@@ -105,7 +110,24 @@ module Analyzer::Dart
         return Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
       end
 
+      # Assignment form: `Handler onRequest = sharedHandler;` (or
+      # `= fromShelfHandler(router);`). The handler reference itself is
+      # the most useful callee — without this it would be lost entirely.
+      if m = content.match(/\bonRequest\s*=\s*([^;]+);/)
+        rhs = m[1].strip
+        line = Noir::DartCalleeExtractor.line_number_for(content, m.begin(0) || 0)
+        return assignment_callees(rhs, path, line)
+      end
+
       [] of Noir::DartCalleeExtractor::Entry
+    end
+
+    # A bare (possibly dotted) handler reference assigned to `onRequest`.
+    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
+
+    private def assignment_callees(rhs : String, path : String, line : Int32) : Array(Noir::DartCalleeExtractor::Entry)
+      return [{rhs, path, line}] of Noir::DartCalleeExtractor::Entry if rhs.matches?(HANDLER_REFERENCE_REGEX)
+      Noir::DartCalleeExtractor.callees_for_body(rhs, path, line)
     end
 
     # Filesystem path → URL pattern. Drops the `.dart` extension,
@@ -134,16 +156,81 @@ module Analyzer::Dart
       seg
     end
 
+    # Matches `case HttpMethod.<verb>:` clauses inside a method switch.
+    CASE_METHOD_REGEX = /\bcase\s+HttpMethod\.([a-z]+)\s*:/
+    # A clause body that rejects the verb: `methodNotAllowed`,
+    # `MethodNotAllowedResponse()`, or a literal `405` status code.
+    METHOD_NOT_ALLOWED_REGEX = /methodNotAllowed|MethodNotAllowed|statusCode\s*:\s*405|\b405\b/
+
     private def detect_methods(content : String) : Array(String)
+      cleaned = Helper.strip_comments(content)
+
       verbs = [] of String
       HTTP_METHOD_MAP.each do |dart_name, verb|
         # Dart Frog exposes verbs as `HttpMethod.<lowercase>` constants.
         # Both `==` comparison and `case`/`switch` patterns reach here.
-        if content.match(/HttpMethod\.#{dart_name}\b/)
-          verbs << verb
-        end
+        verbs << verb if cleaned.matches?(/HttpMethod\.#{dart_name}\b/)
       end
-      verbs.empty? ? FALLBACK_METHODS : verbs.uniq
+      return FALLBACK_METHODS if verbs.empty?
+
+      # `onRequest` is invoked for every verb, so handlers commonly list
+      # the verbs they *don't* support in fall-through `case` clauses that
+      # return `methodNotAllowed`. Those are not real endpoints — drop
+      # them so we don't over-report.
+      rejected = rejected_verbs(cleaned)
+      kept = verbs.reject { |v| rejected.includes?(v) }
+      kept.empty? ? verbs.uniq : kept.uniq
+    end
+
+    # Walk `case HttpMethod.X:` clauses in order, coalescing empty
+    # fall-through cases into the group that shares their handler body.
+    # Any group whose body resolves to a `methodNotAllowed`/405 response
+    # contributes its verbs to the rejected set.
+    private def rejected_verbs(cleaned : String) : Set(String)
+      rejected = Set(String).new
+      clauses = [] of {verb: String, match_begin: Int32, body_start: Int32}
+      cleaned.scan(CASE_METHOD_REGEX) do |m|
+        verb = HTTP_METHOD_MAP[m[1]]?
+        next unless verb
+        match_begin = m.begin(0)
+        body_start = m.end(0)
+        next unless match_begin && body_start
+        clauses << {verb: verb, match_begin: match_begin, body_start: body_start}
+      end
+
+      pending = [] of String
+      clauses.each_with_index do |clause, idx|
+        pending << clause[:verb]
+        # Bound at the *next clause's* `case` keyword (not its body) so an
+        # empty fall-through case isn't credited with the following
+        # `case ...:` text and mistaken for a real handler body.
+        limit = idx + 1 < clauses.size ? clauses[idx + 1][:match_begin] : cleaned.size
+        body = clause_body(cleaned, clause[:body_start], limit)
+        next if body.strip.empty? # empty case falls through to the next
+
+        if body.matches?(METHOD_NOT_ALLOWED_REGEX)
+          pending.each { |v| rejected << v }
+        end
+        pending.clear
+      end
+
+      rejected
+    end
+
+    # The handler body for a `case` clause runs until the next clause or
+    # the closing brace of the switch — whichever comes first. We bound
+    # at the earliest of a `}`, a `case`, or a `default` keyword so the
+    # last enumerated method-case can't sweep in a trailing `default:`
+    # arm (whose `405`/`methodNotAllowed` would wrongly tar the case).
+    CLAUSE_BOUNDARY_REGEX = /\}|\bcase\b|\bdefault\b/
+
+    private def clause_body(cleaned : String, start : Int32, limit : Int32) : String
+      slice = cleaned[start...limit]
+      if m = slice.match(CLAUSE_BOUNDARY_REGEX)
+        cut = m.begin(0)
+        return slice[0...cut] if cut
+      end
+      slice
     end
   end
 end

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -159,8 +159,11 @@ module Analyzer::Dart
     # Matches `case HttpMethod.<verb>:` clauses inside a method switch.
     CASE_METHOD_REGEX = /\bcase\s+HttpMethod\.([a-z]+)\s*:/
     # A clause body that rejects the verb: `methodNotAllowed`,
-    # `MethodNotAllowedResponse()`, or a literal `405` status code.
-    METHOD_NOT_ALLOWED_REGEX = /methodNotAllowed|MethodNotAllowed|statusCode\s*:\s*405|\b405\b/
+    # `MethodNotAllowedResponse()`, or a literal `405` status code passed
+    # positionally (`Response(405)`) or by name (`statusCode: 405`). We
+    # deliberately avoid a bare `405` so an unrelated `{'code': 405}` in a
+    # real handler body can't be mistaken for a rejection.
+    METHOD_NOT_ALLOWED_REGEX = /methodNotAllowed|MethodNotAllowed|statusCode\s*:\s*405|\(\s*405\b/
 
     private def detect_methods(content : String) : Array(String)
       cleaned = Helper.strip_comments(content)

--- a/src/analyzer/analyzers/dart/dart_helper.cr
+++ b/src/analyzer/analyzers/dart/dart_helper.cr
@@ -1,0 +1,125 @@
+module Analyzer::Dart
+  # Shared helpers for the Dart framework analyzers (Dart Frog, Shelf,
+  # Serverpod). Kept framework-agnostic so each analyzer can opt in
+  # without duplicating path/string conventions.
+  module Helper
+    extend self
+
+    # Standard Dart test-file conventions. The Dart tooling discovers
+    # tests under a project-root `test/` directory and via the
+    # `*_test.dart` suffix; neither ever serves real traffic. Dart Frog
+    # in particular mirrors the route tree under `test/routes/`, so a
+    # naive `/routes/` match would surface every mock handler as a live
+    # endpoint. Centralized so every Dart analyzer can opt in via
+    # `next if Helper.test_path?(path, @base_path)`.
+    #
+    #   * `/test/`, `test/` — Dart's `dart test` discovery root and the
+    #                         Dart Frog `test/routes/` mirror tree
+    #   * `*_test.dart`     — the canonical Dart unit-test suffix
+    def test_path?(path : String, base_path : String? = nil) : Bool
+      relative = relative_for_match(path, base_path)
+      return true if relative.includes?("/test/")
+      return true if relative.starts_with?("test/")
+      File.basename(path).ends_with?("_test.dart")
+    end
+
+    # Replace `//` line and `/* */` block comments with spaces, leaving
+    # string literals and overall byte offsets intact so downstream
+    # regex/offset logic still lines up with the original source.
+    def strip_comments(text : String) : String
+      result = String::Builder.new
+      chars = text.chars
+      i = 0
+      in_string = false
+      string_quote = '\0'
+
+      while i < chars.size
+        c = chars[i]
+
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            result << c
+            result << chars[i + 1]
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '"' || c == '\''
+          in_string = true
+          string_quote = c
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '/'
+          while i < chars.size && chars[i] != '\n'
+            result << ' '
+            i += 1
+          end
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '*'
+          result << "  "
+          i += 2
+          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
+            result << (chars[i] == '\n' ? '\n' : ' ')
+            i += 1
+          end
+          if i + 1 < chars.size
+            result << "  "
+            i += 2
+          end
+          next
+        end
+
+        result << c
+        i += 1
+      end
+
+      result.to_s
+    end
+
+    # Pull the contents of a leading single/double-quoted string literal
+    # from an argument expression, honouring backslash escapes. Returns
+    # nil when the expression doesn't start with a string literal.
+    def extract_string_literal(text : String) : String?
+      stripped = text.strip
+      return if stripped.empty?
+      quote = stripped[0]
+      return unless quote == '"' || quote == '\''
+      i = 1
+      while i < stripped.size
+        c = stripped[i]
+        if c == '\\' && i + 1 < stripped.size
+          i += 2
+          next
+        end
+        return stripped[1...i] if c == quote
+        i += 1
+      end
+      nil
+    end
+
+    private def relative_for_match(path : String, base_path : String?) : String
+      if base_path.nil? || base_path.empty?
+        return File.basename(path)
+      end
+
+      expanded_path = File.expand_path(path)
+      expanded_base = File.expand_path(base_path)
+      unless expanded_path == expanded_base || expanded_path.starts_with?(expanded_base + File::SEPARATOR)
+        return File.basename(path)
+      end
+
+      relative = expanded_path[expanded_base.size..].lchop(File::SEPARATOR)
+      relative.empty? ? File.basename(path) : relative
+    end
+  end
+end

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -45,8 +45,11 @@ module Analyzer::Dart
         next if Helper.test_path?(path, @base_path)
 
         content = read_file_content(path)
-        process_file(path, content, include_callee)
-        collect_web_routes(path, content, include_callee, route_classes, registrations)
+        # Strip comments once and share the cleaned copy between the RPC
+        # scan and the web-route scan.
+        cleaned = strip_dart_comments(content)
+        process_file(path, content, cleaned, include_callee)
+        collect_web_routes(path, content, cleaned, include_callee, route_classes, registrations)
       end
 
       emit_web_routes(route_classes, registrations)
@@ -61,11 +64,10 @@ module Analyzer::Dart
     # both halves here and join them in `emit_web_routes`.
     private def collect_web_routes(path : String,
                                    content : String,
+                                   cleaned : String,
                                    include_callee : Bool,
                                    route_classes : Hash(String, RouteClass),
                                    registrations : Array(Registration))
-      cleaned = strip_dart_comments(content)
-
       cleaned.scan(/class\s+([A-Z][A-Za-z0-9_]*)(?:\s*<[^>]*>)?\s+extends\s+(?:Widget|Component)?Route\b/) do |match|
         class_name = match[1]
         match_end = match.end(0)
@@ -143,7 +145,9 @@ module Analyzer::Dart
 
     private def emit_web_routes(route_classes : Hash(String, RouteClass),
                                 registrations : Array(Registration))
-      registrations.each do |reg|
+      # The same `(class, path)` can be registered more than once (e.g. a
+      # route re-added across environments); emit each surface only once.
+      registrations.uniq.each do |reg|
         info = route_classes[reg[:class_name]]?
         next unless info
         info[:methods].each do |verb|
@@ -155,9 +159,7 @@ module Analyzer::Dart
       end
     end
 
-    private def process_file(path : String, content : String, include_callee : Bool)
-      cleaned = strip_dart_comments(content)
-
+    private def process_file(path : String, content : String, cleaned : String, include_callee : Bool)
       cleaned.scan(/class\s+([A-Z][A-Za-z0-9_]*)(?:\s*<[^>]*>)?\s+extends\s+(?:StreamingEndpoint|Endpoint)\b/) do |match|
         class_name = match[1]
         match_end = match.end(0)

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/dart_callee_extractor"
+require "./dart_helper"
 
 module Analyzer::Dart
   # Serverpod is an RPC-style backend framework. Server endpoints are
@@ -17,19 +18,141 @@ module Analyzer::Dart
   class Serverpod < Analyzer
     HTTP_METHOD         = "POST"
     RESERVED_DART_NAMES = %w[if else for while switch case return try catch finally throw new const final var late void await async assert]
+    # `Method.<verb>` constants accepted by `Route`'s `methods:` set.
+    WEB_METHOD_MAP = {
+      "get"     => "GET",
+      "post"    => "POST",
+      "put"     => "PUT",
+      "patch"   => "PATCH",
+      "delete"  => "DELETE",
+      "head"    => "HEAD",
+      "options" => "OPTIONS",
+    }
     alias MethodParam = NamedTuple(name: String, type: String)
+    alias RouteClass = NamedTuple(methods: Array(String), file: String, line: Int32, callees: Array(Noir::DartCalleeExtractor::Entry))
+    alias Registration = NamedTuple(class_name: String, path: String)
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      route_classes = {} of String => RouteClass
+      registrations = [] of Registration
+
       all_files.each do |path|
         next if File.directory?(path)
         next unless path.ends_with?(".dart")
+        # `test/integration/*_endpoint_test.dart` exercises endpoints but
+        # is not itself a server surface.
+        next if Helper.test_path?(path, @base_path)
 
         content = read_file_content(path)
         process_file(path, content, include_callee)
+        collect_web_routes(path, content, include_callee, route_classes, registrations)
       end
 
+      emit_web_routes(route_classes, registrations)
+
       @result
+    end
+
+    # Serverpod's web server exposes plain HTTP endpoints through `Route`
+    # subclasses wired with `pod.webServer.addRoute(MyRoute(), '/path')`.
+    # These live alongside the RPC endpoints but are easy to miss because
+    # the class and its registration sit in different files. We collect
+    # both halves here and join them in `emit_web_routes`.
+    private def collect_web_routes(path : String,
+                                   content : String,
+                                   include_callee : Bool,
+                                   route_classes : Hash(String, RouteClass),
+                                   registrations : Array(Registration))
+      cleaned = strip_dart_comments(content)
+
+      cleaned.scan(/class\s+([A-Z][A-Za-z0-9_]*)(?:\s*<[^>]*>)?\s+extends\s+(?:Widget|Component)?Route\b/) do |match|
+        class_name = match[1]
+        match_end = match.end(0)
+        match_start = match.begin(0)
+        next unless match_end && match_start
+
+        body_info = extract_braced_block(cleaned, match_end)
+        next unless body_info
+        body, body_start = body_info
+
+        line = line_for_offset(content, match_start)
+        methods = web_route_methods(body)
+        callees = include_callee ? web_handler_callees(path, body, body_start, content) : [] of Noir::DartCalleeExtractor::Entry
+        route_classes[class_name] = {methods: methods, file: path, line: line, callees: callees}
+      end
+
+      cleaned.scan(/\baddRoute\s*\(/) do |match|
+        open_paren = (match.end(0) || 0) - 1
+        close_paren = find_matching_paren(cleaned, open_paren)
+        next unless close_paren
+        args = split_top_level_commas(cleaned[(open_paren + 1)...close_paren])
+        next if args.size < 2
+
+        class_name = registered_class_name(args[0])
+        next unless class_name
+        route_path = Helper.extract_string_literal(args[1])
+        next unless route_path
+        registrations << {class_name: class_name, path: normalize_web_path(route_path)}
+      end
+    end
+
+    # `methods: {Method.post, Method.get}` declared in the constructor.
+    # `Route` defaults to GET when the set is omitted.
+    private def web_route_methods(body : String) : Array(String)
+      verbs = [] of String
+      if m = body.match(/methods\s*:\s*\{([^}]*)\}/)
+        m[1].scan(/Method\.([a-z]+)/) do |mm|
+          verb = WEB_METHOD_MAP[mm[1]]?
+          verbs << verb if verb
+        end
+      end
+      verbs.empty? ? ["GET"] : verbs.uniq
+    end
+
+    private def registered_class_name(arg : String) : String?
+      stripped = arg.strip
+      m = stripped.match(/\A([A-Z][A-Za-z0-9_]*)/)
+      return unless m
+      name = m[1]
+      # `StaticRoute` / `RouteStaticDirectory` serve files, not handlers.
+      return if name.includes?("Static")
+      name
+    end
+
+    private def normalize_web_path(path : String) : String
+      path.starts_with?('/') ? path : "/#{path}"
+    end
+
+    private def web_handler_callees(path : String,
+                                    class_body : String,
+                                    class_body_start : Int32,
+                                    file_content : String) : Array(Noir::DartCalleeExtractor::Entry)
+      m = class_body.match(/\b(?:handleCall|build)\s*\(/)
+      return [] of Noir::DartCalleeExtractor::Entry unless m
+      open_paren = (m.end(0) || 0) - 1
+      close_paren = find_matching_paren(class_body, open_paren)
+      return [] of Noir::DartCalleeExtractor::Entry unless close_paren
+
+      body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, close_paren + 1)
+      return [] of Noir::DartCalleeExtractor::Entry unless body_info
+      body, body_start, _ = body_info
+      start_line = line_for_offset(file_content, class_body_start + body_start)
+      Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    private def emit_web_routes(route_classes : Hash(String, RouteClass),
+                                registrations : Array(Registration))
+      registrations.each do |reg|
+        info = route_classes[reg[:class_name]]?
+        next unless info
+        info[:methods].each do |verb|
+          details = Details.new(PathInfo.new(info[:file], info[:line]))
+          endpoint = Endpoint.new(reg[:path], verb, [] of Param, details)
+          Noir::DartCalleeExtractor.attach_to(endpoint, info[:callees])
+          @result << endpoint
+        end
+      end
     end
 
     private def process_file(path : String, content : String, include_callee : Bool)

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../miniparsers/dart_callee_extractor"
+require "./dart_helper"
 
 module Analyzer::Dart
   # Shelf (`package:shelf_router/shelf_router.dart`) is the foundational
@@ -59,6 +60,9 @@ module Analyzer::Dart
 
         parallel_analyze(files) do |path|
           next unless path.ends_with?(".dart")
+          # Skip `test/` routers — `dart test` fixtures spin up real
+          # `Router()` instances that never serve production traffic.
+          next if Helper.test_path?(path, @base_path)
 
           content = begin
             read_file_content(path)
@@ -109,6 +113,7 @@ module Analyzer::Dart
                           include_callee : Bool) : Hash(String, RouterInfo)
       result = {} of String => RouterInfo
       cleaned = strip_dart_comments(content)
+      classes = class_ranges(cleaned)
 
       cleaned.scan(/(?:^|[;{}=(,\s])(?:final|var|const|late)\s+(?:[A-Za-z_][\w<>,\s\?]*\s+)?([A-Za-z_]\w*)\s*=\s*Router\s*\(\s*\)/) do |match|
         var_name = match[1]
@@ -129,18 +134,184 @@ module Analyzer::Dart
         # strings or comments are ignored.
         scan_direct_calls(cleaned, var_name, content, path, include_callee, routes, mounts)
 
-        existing = result[var_name]?
+        # A router built inside a class (e.g. a `Router get router =>`
+        # getter) is reached from the outside as `ClassName().router`,
+        # so key it under the class name — that's what a parent's
+        # `mount('/prefix', ClassName().router)` resolves against. The
+        # internal local name (`app`, `router`, ...) is only meaningful
+        # within the class and would otherwise be emitted, unmounted, as
+        # a duplicate root with no prefix.
+        key = enclosing_class(classes, end_idx) || var_name
+
+        existing = result[key]?
         if existing
-          result[var_name] = {
+          result[key] = {
             routes: existing[:routes] + routes,
             mounts: existing[:mounts] + mounts,
           }
         else
-          result[var_name] = {routes: routes, mounts: mounts}
+          result[key] = {routes: routes, mounts: mounts}
         end
       end
 
+      # `shelf_router` also supports a code-gen style where handlers are
+      # annotated with `@Route.<verb>('/path')` inside a controller class
+      # and wired up by a generated `_$ClassRouter`. Surface those too.
+      scan_route_annotations(cleaned, content, path, include_callee, classes, result)
+
       result
+    end
+
+    # Matches the official `@Route.<verb>('/path')` annotation and the
+    # `shelf_router_classes` `@Route('VERB', '/path')` variant. Capture 1
+    # is the dotted verb (nil for the string-arg form).
+    ROUTE_ANNOTATION_REGEX = /@Route\s*(?:\.\s*([A-Za-z]+))?\s*\(/
+    ROUTE_PREFIX_REGEX     = /@RoutePrefix\s*\(/
+
+    # Collect `@Route...`-annotated handlers, keyed by their enclosing
+    # controller class so a parent `mount('/p', Ctrl().router)` lines up.
+    private def scan_route_annotations(cleaned : String,
+                                       content : String,
+                                       path : String,
+                                       include_callee : Bool,
+                                       classes : Array(ClassRange),
+                                       result : Hash(String, RouterInfo))
+      prefixes = route_prefixes(cleaned, classes)
+
+      cleaned.scan(ROUTE_ANNOTATION_REGEX) do |m|
+        match_begin = m.begin(0)
+        open_paren = m.end(0).try &.- 1
+        next unless match_begin && open_paren
+        close_paren = find_matching_paren(cleaned, open_paren)
+        next unless close_paren
+
+        args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+        next if args.empty?
+
+        verbs, path_arg = annotation_verbs_and_path(m[1]?, args)
+        next if verbs.empty? || path_arg.nil?
+
+        literal = extract_string_literal(path_arg)
+        next unless literal
+
+        owner = enclosing_class(classes, match_begin)
+        prefix = owner ? prefixes[owner]? : nil
+        route_path = normalize_path(prefix ? join_path(prefix, normalize_path(literal)) : literal)
+
+        line = line_for_offset(content, match_begin)
+        callees = include_callee ? annotation_callees(content, close_paren, path) : [] of Noir::DartCalleeExtractor::Entry
+
+        key = owner || "@route:#{path}"
+        info = result[key]? || {routes: [] of Route, mounts: [] of Mount}
+        routes = info[:routes].dup
+        verbs.each do |verb|
+          routes << {verb: verb, path: route_path, line: line, file: path, callees: callees}
+        end
+        result[key] = {routes: routes, mounts: info[:mounts]}
+      end
+    end
+
+    # `@RoutePrefix('/prefix')` (shelf_router_classes) applies a common
+    # prefix to every annotated route in its class.
+    private def route_prefixes(cleaned : String, classes : Array(ClassRange)) : Hash(String, String)
+      prefixes = {} of String => String
+      cleaned.scan(ROUTE_PREFIX_REGEX) do |m|
+        match_begin = m.begin(0)
+        open_paren = m.end(0).try &.- 1
+        next unless match_begin && open_paren
+        close_paren = find_matching_paren(cleaned, open_paren)
+        next unless close_paren
+        args = split_top_level_args(cleaned[(open_paren + 1)...close_paren])
+        next if args.empty?
+        literal = extract_string_literal(args[0])
+        next unless literal
+        # `@RoutePrefix` sits *above* the `class` keyword, so it isn't
+        # bracketed by any class body — attribute it to the class whose
+        # declaration immediately follows.
+        owner = class_after(classes, match_begin)
+        prefixes[owner] = normalize_path(literal) if owner
+      end
+      prefixes
+    end
+
+    # The class whose body opens soonest after the given offset — used to
+    # bind a leading class annotation (`@RoutePrefix`) to its class.
+    private def class_after(ranges : Array(ClassRange), offset : Int32) : String?
+      best = nil.as(String?)
+      best_start = Int32::MAX
+      ranges.each do |r|
+        next unless r[:start] >= offset
+        if r[:start] < best_start
+          best = r[:name]
+          best_start = r[:start]
+        end
+      end
+      best
+    end
+
+    private def annotation_verbs_and_path(dotted : String?, args : Array(String)) : Tuple(Array(String), String?)
+      if dotted
+        verb = dotted.downcase
+        return {ALL_VERBS.dup, args[0]} if verb == "all"
+        mapped = HTTP_METHOD_MAP[verb]?
+        return {[mapped], args[0]} if mapped
+        return {[] of String, nil}
+      end
+
+      # `@Route('GET', '/path')` — verb is the first string argument.
+      return {[] of String, nil} if args.size < 2
+      verb_lit = extract_string_literal(args[0])
+      return {[] of String, nil} unless verb_lit
+      verb = verb_lit.downcase
+      return {ALL_VERBS.dup, args[1]} if verb == "all"
+      mapped = HTTP_METHOD_MAP[verb]?
+      return {[mapped], args[1]} if mapped
+      {[] of String, nil}
+    end
+
+    private def annotation_callees(content : String,
+                                   annotation_close : Int32,
+                                   path : String) : Array(Noir::DartCalleeExtractor::Entry)
+      body_info = Noir::DartCalleeExtractor.extract_body_after(content, annotation_close + 1)
+      return [] of Noir::DartCalleeExtractor::Entry unless body_info
+
+      body, body_start, _ = body_info
+      start_line = Noir::DartCalleeExtractor.line_number_for(content, body_start)
+      Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
+    end
+
+    alias ClassRange = NamedTuple(name: String, start: Int32, finish: Int32)
+
+    # Locate every `class Name { ... }` block and its byte range so a
+    # `Router()` instantiation can be attributed to its enclosing class.
+    private def class_ranges(cleaned : String) : Array(ClassRange)
+      ranges = [] of ClassRange
+      cleaned.scan(/\bclass\s+([A-Za-z_]\w*)/) do |m|
+        name = m[1]
+        header_end = m.end(0)
+        next unless header_end
+        open = Noir::DartCalleeExtractor.find_next_code_char(cleaned, '{', header_end)
+        next unless open
+        close = Noir::DartCalleeExtractor.find_matching_delimiter(cleaned, open, '{', '}')
+        next unless close
+        ranges << {name: name, start: open, finish: close}
+      end
+      ranges
+    end
+
+    # Innermost class whose body brackets the given offset, if any.
+    private def enclosing_class(ranges : Array(ClassRange), offset : Int32) : String?
+      best = nil.as(String?)
+      best_size = Int32::MAX
+      ranges.each do |r|
+        next unless offset >= r[:start] && offset <= r[:finish]
+        size = r[:finish] - r[:start]
+        if size < best_size
+          best = r[:name]
+          best_size = size
+        end
+      end
+      best
     end
 
     private def scan_cascades(cleaned : String,
@@ -229,27 +400,37 @@ module Analyzer::Dart
         return unless child
         mounts << {prefix: normalize_path(literal), child: child}
       when "all"
-        callees = include_callee && args.size >= 2 ? handler_callees(args[1], file_content, close_paren, path) : [] of Noir::DartCalleeExtractor::Entry
+        callees = include_callee && args.size >= 2 ? handler_callees(args[1], file_content, close_paren, path, line) : [] of Noir::DartCalleeExtractor::Entry
         ALL_VERBS.each do |verb|
           routes << {verb: verb, path: normalize_path(literal), line: line, file: path, callees: callees}
         end
       else
         verb = HTTP_METHOD_MAP[method]?
         return unless verb
-        callees = include_callee && args.size >= 2 ? handler_callees(args[1], file_content, close_paren, path) : [] of Noir::DartCalleeExtractor::Entry
+        callees = include_callee && args.size >= 2 ? handler_callees(args[1], file_content, close_paren, path, line) : [] of Noir::DartCalleeExtractor::Entry
         routes << {verb: verb, path: normalize_path(literal), line: line, file: path, callees: callees}
       end
     end
 
-    # Best-effort callee extraction for inline handler lambdas. Returns
-    # an empty list for plain function references (those resolve via the
-    # cross-file callee resolution stage later).
+    # Matches a bare handler reference (`getNotes`, `_echo`,
+    # `health_check.handler`) passed as the second argument to a route.
+    HANDLER_REFERENCE_REGEX = /\A[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\z/
+
+    # Best-effort callee extraction for the route handler. Inline lambdas
+    # have their body scanned for callees; a plain function reference
+    # (Dart can't resolve these cross-file yet) is itself recorded as the
+    # single callee so the handler still surfaces in AI context.
     private def handler_callees(handler_arg : String,
                                 file_content : String,
                                 close_paren : Int32,
-                                path : String) : Array(Noir::DartCalleeExtractor::Entry)
+                                path : String,
+                                line : Int32) : Array(Noir::DartCalleeExtractor::Entry)
       stripped = handler_arg.strip
-      return [] of Noir::DartCalleeExtractor::Entry unless stripped.starts_with?('(')
+
+      unless stripped.starts_with?('(')
+        return [] of Noir::DartCalleeExtractor::Entry unless stripped.matches?(HANDLER_REFERENCE_REGEX)
+        return [{stripped, path, line}] of Noir::DartCalleeExtractor::Entry
+      end
 
       body_info = Noir::DartCalleeExtractor.extract_body_after(file_content, close_paren - handler_arg.size)
       return [] of Noir::DartCalleeExtractor::Entry unless body_info


### PR DESCRIPTION
## Summary

Accuracy sweep of the three Dart framework analyzers (Dart Frog, Serverpod, Shelf), validated against **16 real open-source apps**. Reduces false positives/negatives and fills callee / AI-context gaps so the already-solid Dart context base captures more of what real apps expose.

Measured impact across the sample set:

| repo | before | after | note |
|---|---:|---:|---|
| df_fullstack | 117 | 37 | **−80 FP** (`methodNotAllowed` arms) |
| df_ecommerce / mahasiswa / todo | — | — | **−test-path FPs** |
| sh_crud / sh_classes | 0 / 0 | 5 / 4 | **+FN** (`@Route` annotations) |
| sp_stripe / bills / discord / tracking | — | +9 | **web routes recovered** (incl. `POST /webhook`) |
| sh_tutorial / sh_apiexample | 5 / 5 | 5 / 5 | mount prefix corrected (`/films/*`, `/users/*`) |

## Changes

**Shared**
- New `Analyzer::Dart::Helper` (`dart_helper.cr`): `test_path?`, `strip_comments`, `extract_string_literal`; required by all three analyzers.

**FP reductions**
- Gate Dart test trees (`test/routes/` mirror + `*_test.dart`) in all three analyzers.
- **Dart Frog**: drop verbs whose `switch` case falls through to a `methodNotAllowed`/`405` response. Clause body is bounded at the earliest `}`/`case`/`default` so a trailing `default: 405` no longer tars the last real case.

**FN recovery**
- **Shelf**: key class-getter routers by their enclosing class so `mount('/p/', Ctrl().router)` inherits the prefix (also fixes a latent same-var-name collision).
- **Shelf**: support the official `@Route.<verb>('/path')` code-gen annotations, the `@Route('VERB','/path')` variant, and `@RoutePrefix`.
- **Serverpod**: surface web-server routes registered via `pod.webServer.addRoute(MyRoute(), '/path')` (`extends Route`/`WidgetRoute`), with methods read from `super(methods: {...})` (default GET); `*Static*` route classes skipped.

**Callee / AI-context**
- **Shelf**: record bare function-reference handlers (`..get('/x', getNotes)`) as callees.
- **Dart Frog**: record assignment-form handlers (`Handler onRequest = sharedHandler;`).

## Tests
- Extended `dart_frog` / `shelf` / `serverpod` / `dart_frog_callees` fixtures with the real-world idioms above and added `spec/unit_test/analyzer/dart_helper_spec.cr`.
- Full suite green (`crystal spec`), `crystal tool format --check` clean.

## Known follow-ups (not in this PR)
- `df_blog` real Dart Frog routes get deduped away by an OAS3 `openapi.json` (cross-analyzer dedup picks the OAS3 duplicate); the analyzer finds them standalone.
- Repo-specific `context.HttpMethodPost` extension getters fall back to the default verb set.
- Dart is not yet in ImportGraph, so function-ref handlers are recorded by name only (no cross-file resolution).