### PR TITLE
Improve Haskell Scotty/Servant/Yesod analyzer accuracy (FN/FP, callees)

### DIFF
--- a/spec/functional_test/fixtures/haskell/servant_callees_applied/package.yaml
+++ b/spec/functional_test/fixtures/haskell/servant_callees_applied/package.yaml
@@ -1,0 +1,6 @@
+name: servant-callees-applied-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - servant
+  - text

--- a/spec/functional_test/fixtures/haskell/servant_callees_applied/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_applied/src/Api.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Api where
+
+import Servant
+import qualified Handlers as H
+
+data Info
+data Rate
+
+type RatesAPI =
+       "rates" :> Get '[JSON] [Rate]
+       -- a full-line comment sitting between routes must not truncate the alias
+  :<|> "rates" :> "all" :> Get '[JSON] [Rate]
+
+type API =
+       "info" :> Get '[JSON] Info   -- a trailing comment on the first route
+
+  :<|> RatesAPI
+
+-- The server is named arbitrarily (not `server` / `apiServer`); it is found via
+-- its `:: Server API` signature. Its leaves are an application (`return x`), a
+-- qualified application (`H.rates s`) and a qualified value (`H.allRates`).
+exchangeServer :: Service -> Server API
+exchangeServer s = return apiInfo :<|> H.rates s :<|> H.allRates
+
+-- A binding whose body carries an inline `::` annotation is still a definition,
+-- so its callees (here `buildInfo`) must be extracted.
+apiInfo :: Info
+apiInfo = buildInfo (Proxy :: Proxy API)

--- a/spec/functional_test/fixtures/haskell/servant_callees_applied/src/Handlers.hs
+++ b/spec/functional_test/fixtures/haskell/servant_callees_applied/src/Handlers.hs
@@ -1,0 +1,11 @@
+module Handlers where
+
+rates :: Service -> Handler [Rate]
+rates s = do
+  found <- lookupRates s
+  return found
+
+allRates :: Handler [Rate]
+allRates = do
+  loaded <- loadAllRates
+  return loaded

--- a/spec/functional_test/fixtures/haskell/yesod/src/config/routes.yesodroutes
+++ b/spec/functional_test/fixtures/haskell/yesod/src/config/routes.yesodroutes
@@ -1,3 +1,7 @@
-/search SearchR GET
-/files/*Texts FilesR GET
-/feed/+Texts FeedR GET POST
+-- Columns are padded with multiple spaces, the common alignment style in
+-- real Yesod routes files. The token splitter must collapse the run of spaces
+-- into a single separator (regression: it used to stringify an empty builder
+-- twice and abort the whole analyzer).
+/search          SearchR   GET
+/files/*Texts    FilesR    GET
+/feed/+Texts     FeedR     GET POST

--- a/spec/functional_test/testers/haskell/servant_callees_applied_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_callees_applied_spec.cr
@@ -1,0 +1,58 @@
+require "../../func_spec.cr"
+
+def applied_endpoint_with_callees(url, method, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+# `/info` is served by `return apiInfo`; `apiInfo`'s body carries an inline
+# `Proxy :: Proxy API` annotation, which must not stop it being treated as a
+# definition.
+info_callees = [
+  Callee.new("buildInfo", line: 31),
+]
+
+# `H.rates s` — a qualified, applied server leaf resolves to the `rates` handler.
+rates_callees = [
+  Callee.new("lookupRates", line: 5),
+]
+
+# `H.allRates` — a qualified server leaf resolves to the `allRates` handler.
+all_rates_callees = [
+  Callee.new("loadAllRates", line: 10),
+]
+
+expected_endpoints = [
+  applied_endpoint_with_callees("/info", "GET", info_callees),
+  applied_endpoint_with_callees("/rates", "GET", rates_callees),
+  applied_endpoint_with_callees("/rates/all", "GET", all_rates_callees),
+]
+
+tester = FunctionalTester.new("fixtures/haskell/servant_callees_applied/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+tester.perform_tests
+
+it "resolves Servant callees through a non-conventional server name and applied leaves" do
+  info = tester.app.endpoints.find { |found| found.url == "/info" && found.method == "GET" }
+  info.should_not be_nil
+  info.try do |actual|
+    actual.callees.map(&.name).should eq(info_callees.map(&.name))
+  end
+
+  rates = tester.app.endpoints.find { |found| found.url == "/rates" && found.method == "GET" }
+  rates.should_not be_nil
+  rates.try do |actual|
+    actual.callees.map(&.name).should eq(rates_callees.map(&.name))
+  end
+
+  all_rates = tester.app.endpoints.find { |found| found.url == "/rates/all" && found.method == "GET" }
+  all_rates.should_not be_nil
+  all_rates.try do |actual|
+    actual.callees.map(&.name).should eq(all_rates_callees.map(&.name))
+  end
+end

--- a/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
@@ -40,6 +40,22 @@ describe Noir::HaskellCalleeExtractor do
     ])
   end
 
+  it "treats a binding with an inline body annotation as a definition" do
+    source = <<-HASKELL
+      apiInfo :: Info
+      apiInfo = buildInfo (Proxy :: Proxy API)
+
+      typed = decode payload :: Maybe Value
+      HASKELL
+
+    bodies = Noir::HaskellCalleeExtractor.function_bodies(source, "Api.hs")
+    bodies.map { |body| body[:name] }.should eq(["apiInfo", "typed"])
+
+    apiinfo = bodies.find { |body| body[:name] == "apiInfo" }.not_nil!
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(apiinfo[:body], apiinfo[:path], apiinfo[:start_line])
+    callees.map { |name, _, _| name }.should contain("buildInfo")
+  end
+
   it "extracts direct calls from Haskell handler bodies" do
     body = <<-HASKELL
       do

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -160,6 +160,26 @@ describe "EndpointOptimizer" do
       result[1].params[0].name.should eq("post_id")
     end
 
+    it "does not duplicate a path param the analyzer already recorded with a type" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      # Haskell's Servant/Yesod analyzers store the captured type in the param
+      # `value` (e.g. `Capture "id" Int`). The URL-derived param has an empty
+      # value, so an exact-struct dedup used to miss it and add a duplicate.
+      endpoints = [
+        Endpoint.new("/users/:id", "GET", [Param.new("id", "Int", "path")]),
+        Endpoint.new("/sites/{site_id}", "GET", [Param.new("site_id", "SiteId", "path")]),
+        Endpoint.new("/files/*path", "GET", [Param.new("path", "Text", "path")]),
+      ]
+
+      result = optimizer.add_path_parameters(endpoints)
+      result.each_with_index do |endpoint, idx|
+        path_params = endpoint.params.select { |param| param.param_type == "path" }
+        path_params.size.should eq(1)
+        # The analyzer-supplied type must survive (no empty-value clobber).
+        path_params[0].value.should_not eq("")
+      end
+    end
+
     it "names catch-all path variables without the leading asterisk" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -122,10 +122,18 @@ module Analyzer::Haskell
           j = i + 1
           while j < lines.size
             next_line = lines[j]
-            stripped = next_line.lstrip
-            if stripped.empty?
-              break
-            elsif starts_with_whitespace?(next_line) || stripped.starts_with?(":<|>") || stripped.starts_with?(":>")
+            if next_line.lstrip.empty?
+              # A blank line — which may be a stripped full-line comment sitting
+              # between routes — does not necessarily terminate the alias. Peek
+              # past the blank run: keep collecting only when a real
+              # continuation line follows, otherwise the declaration has ended.
+              k = j + 1
+              while k < lines.size && lines[k].lstrip.empty?
+                k += 1
+              end
+              break unless k < lines.size && continuation_line?(lines[k])
+              j = k
+            elsif continuation_line?(next_line)
               body_parts << next_line
               j += 1
             else
@@ -147,6 +155,12 @@ module Analyzer::Haskell
       first = line[0]?
       return false unless first
       first == ' ' || first == '\t'
+    end
+
+    private def continuation_line?(line : String) : Bool
+      return true if starts_with_whitespace?(line)
+      stripped = line.lstrip
+      stripped.starts_with?(":<|>") || stripped.starts_with?(":>")
     end
 
     private def strip_haskell_comments(text : String) : String
@@ -286,7 +300,7 @@ module Analyzer::Haskell
                                       endpoint_count : Int32,
                                       handler_bodies : HandlerBodies,
                                       server_bindings : ServerBindings) : Array(String)?
-      server_candidate_names(api_name).each do |server_name|
+      server_candidate_names(api_name, api_source, server_bindings).each do |server_name|
         binding = body_for_path(server_name, api_source, handler_bodies)
         next unless binding
         next unless root_server_matches_api?(server_name, api_source, api_name, server_bindings)
@@ -296,7 +310,13 @@ module Analyzer::Haskell
         leaves = flatten_server_expression(binding[:body], handler_bodies, server_bindings, binding[:path], visited)
         next unless leaves
         next unless leaves.size == endpoint_count
-        next unless leaves.all? { |leaf| !unique_handler_body(leaf, handler_bodies).nil? }
+        # The server is already confirmed by its `:: Server <api>` binding and an
+        # exact leaf/endpoint count match, so require only that at least one leaf
+        # names a known function (proving the flatten landed on real handlers).
+        # Handlers that are imported, point-free, or collide across modules then
+        # simply contribute no callees rather than sinking the whole server —
+        # `attach_servant_callees` resolves each leaf independently.
+        next unless leaves.any? { |leaf| handler_bodies.has_key?(leaf) }
 
         return leaves
       end
@@ -304,12 +324,22 @@ module Analyzer::Haskell
       nil
     end
 
-    private def server_candidate_names(api_name : String) : Array(String)
+    private def server_candidate_names(api_name : String,
+                                       api_source : String,
+                                       server_bindings : ServerBindings) : Array(String)
       candidates = ["server", "#{lower_camel(api_name)}Server"]
 
       if api_name.ends_with?("API")
         prefix = api_name[0...(api_name.size - "API".size)]
         candidates << "#{lower_camel(prefix)}Server" unless prefix.empty?
+      end
+
+      # Servers are frequently named arbitrarily (`exchangeServer`, `appToServer`)
+      # rather than following the `<api>Server` convention. Any binding in the
+      # same file whose `:: Server <api>` / `:: ServerT <api>` signature targets
+      # this API is a valid server root regardless of its name.
+      server_bindings.each do |key, target|
+        candidates << key[1] if key[0] == api_source && target == api_name
       end
 
       candidates.uniq
@@ -344,8 +374,8 @@ module Analyzer::Haskell
                                     server_bindings : ServerBindings,
                                     current_path : String,
                                     visited : Set(Tuple(String, String))) : Array(String)?
-      name = unwrap_parens(part.strip)
-      return unless simple_value_name?(name)
+      name = leaf_value_name(unwrap_parens(part.strip))
+      return unless name
 
       binding = body_for_path(name, current_path, handler_bodies)
       if binding
@@ -363,6 +393,33 @@ module Analyzer::Haskell
       return if server_like_name?(name) || server_binding_name?(name, server_bindings)
 
       [name]
+    end
+
+    # Resolve a single server expression down to the value name that identifies
+    # its handler. A bare name is returned as-is; an application keeps its head
+    # function (`Handler.rates s` -> `rates`, `mkHandler cfg` -> `mkHandler`).
+    # `hoistServer`/`enter` wrap the real server in their last argument, and
+    # `return x`/`pure x` produce a constant response from `x`.
+    private def leaf_value_name(expr : String) : String?
+      return expr if simple_value_name?(expr)
+
+      tokens = expr.split(/\s+/).reject(&.empty?)
+      return if tokens.empty?
+
+      head = qualified_tail(tokens[0])
+      if {"hoistServer", "hoistServerWithContext", "enter"}.includes?(head) && tokens.size >= 2
+        head = qualified_tail(tokens[-1])
+      elsif {"return", "pure"}.includes?(head) && tokens.size >= 2
+        head = qualified_tail(tokens[1])
+      end
+
+      simple_value_name?(head) ? head : nil
+    end
+
+    # Strip a module qualifier and stray parentheses: `Mod.Sub.fn` -> `fn`,
+    # `(handler` -> `handler`.
+    private def qualified_tail(token : String) : String
+      token.strip.gsub(/[()]/, "").split('.').last
     end
 
     private def root_server_matches_api?(server_name : String,

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -234,28 +234,35 @@ module Analyzer::Haskell
     private def split_route_tokens(line : String) : Array(String)
       tokens = [] of String
       current = String::Builder.new
+      has_content = false
       brace_depth = 0
 
       line.each_char do |char|
         if char == '{'
           brace_depth += 1
           current << char
+          has_content = true
         elsif char == '}'
           brace_depth -= 1 if brace_depth > 0
           current << char
+          has_content = true
         elsif char.whitespace? && brace_depth == 0
-          token = current.to_s
-          unless token.empty?
-            tokens << token
+          # Flush the pending token. Guard on `has_content` so a `String::Builder`
+          # is only stringified once — consecutive whitespace (common in
+          # alignment-padded routes files) would otherwise call `to_s` twice on
+          # the same builder and raise.
+          if has_content
+            tokens << current.to_s
             current = String::Builder.new
+            has_content = false
           end
         else
           current << char
+          has_content = true
         end
       end
 
-      token = current.to_s
-      tokens << token unless token.empty?
+      tokens << current.to_s if has_content
       tokens
     end
 

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -38,13 +38,21 @@ module Noir::HaskellCalleeExtractor
       end
 
       name = match[1]
-      if skip_callee?(name) || line.includes?("::")
+      if skip_callee?(name)
         index += 1
         next
       end
 
       equals_index = line.index('=')
       unless equals_index
+        index += 1
+        next
+      end
+
+      # A `::` before the `=` marks a type signature (`foo :: (C a) => a`), not a
+      # definition. Only inspect the head; an inline annotation in the body
+      # (e.g. `apiSwagger = toSwagger (Proxy :: Proxy API)`) is a real binding.
+      if line[0...equals_index].includes?("::")
         index += 1
         next
       end

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -297,7 +297,7 @@ class EndpointOptimizer
         end
 
         new_param = Param.new(param, "", "path")
-        unless new_endpoint.params.includes?(new_param)
+        unless path_param_present?(new_endpoint.params, param)
           new_endpoint.params << new_param
         end
       end
@@ -318,7 +318,7 @@ class EndpointOptimizer
         end
 
         new_param = Param.new(param, "", "path")
-        unless new_endpoint.params.includes?(new_param)
+        unless path_param_present?(new_endpoint.params, param)
           new_endpoint.params << new_param
         end
       end
@@ -352,7 +352,7 @@ class EndpointOptimizer
         end
 
         new_param = Param.new(param, "", "path")
-        unless new_endpoint.params.includes?(new_param)
+        unless path_param_present?(new_endpoint.params, param)
           new_endpoint.params << new_param
         end
       end
@@ -371,7 +371,7 @@ class EndpointOptimizer
         end
 
         new_param = Param.new(match[1], "", "path")
-        unless new_endpoint.params.includes?(new_param)
+        unless path_param_present?(new_endpoint.params, match[1])
           new_endpoint.params << new_param
         end
       end
@@ -386,6 +386,15 @@ class EndpointOptimizer
   # a glob, a type expression) is not a real parameter name.
   private def valid_path_param_name?(name : String) : Bool
     !name.empty? && !!name.match(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+  end
+
+  # A URL cannot carry two path params with the same name, so dedup by name
+  # alone. An exact-struct check is too strict: analyzers that record a type
+  # in the param `value` (e.g. Haskell's Servant/Yesod store `Capture "id" Int`
+  # as `Param("id", "Int", "path")`) would otherwise not match the empty-value
+  # param this pass derives from the URL, producing a duplicate.
+  private def path_param_present?(params : Array(Param), name : String) : Bool
+    params.any? { |param| param.param_type == "path" && param.name == name }
   end
 
   # Drop a literal format/extension suffix that shares the segment with the


### PR DESCRIPTION
## Summary

A focused accuracy pass over the already-solid Haskell analyzers, validated by running noir against 9+ real open-source apps across all three frameworks — `scotty-realworld`, `trypurescript`, `exchange-rates`, `servant-persistent`, `servant-cookbook`, `example-servant-minimal`, `carnival`, `haskellers`, `yesodweb-com` — plus the `scotty`/`servant` framework repos. Five issues surfaced and are fixed here, lifting both endpoint recall and the richness of the callee/AI-context layer.

## Fixes

### Yesod — whole-analyzer crash on alignment-padded routes (highest impact)
`split_route_tokens` called `String::Builder#to_s` twice when a routes line had a run of consecutive spaces (the common column-alignment style, e.g. `/auth   AuthR   Auth   getAuth`): the empty token between spaces left the builder un-reset, so the next `to_s` raised `Can only invoke 'to_s' once on String::Builder` and aborted the *entire* analyzer. `carnival` and `haskellers` went from **0 endpoints to 21 and 83**. (`yesodweb-com` used single spaces, so it never triggered.) Fixed with a `has_content` flag so an empty builder is never stringified.

### Servant — API type truncated at the first comment / blank line
`extract_type_aliases` broke alias-body collection on the first blank line. Full-line comments become blank after comment-stripping, so a `type Api = route :<|> {- comment -} route ...` with interspersed comments or blank lines was truncated at the first one. Now peeks past blank runs and keeps collecting while a real continuation (`:>` / `:<|>` / indentation) follows. On servant's own `ClientTestUtils` this recovered **5 → 24 endpoints**.

### Path-parameter duplication (FP, Servant + Yesod)
The optimizer's `add_path_parameters` deduped via exact `Param` struct equality, but the Haskell analyzers store the captured *type* in the param `value` (`Capture "id" Int` → `Param("id","Int","path")`) while the URL-derived param carries an empty value — so every typed path param got a duplicate empty-value twin. Now dedups path params by name (a URL can't carry two same-named path params). Cross-cutting optimizer change; strictly removes spurious duplicates for all frameworks.

### Callee extractor — inline `::` annotations dropped definitions
`function_bodies` skipped any definition whose line contained `::`, which also dropped real bindings carrying an inline annotation (`apiInfo = buildInfo (Proxy :: Proxy API)`). Now only a `::` *before* the `=` marks a type signature.

### Servant callees — richer server resolution
Enriches the handler→endpoint linkage so more endpoints carry callees:
- discover the server by its `:: Server <api>` / `:: ServerT <api>` binding target, not just the `<api>Server` name convention (handles `exchangeServer`, `appToServer`, …);
- resolve applied/qualified server leaves (`H.rates s` → `rates`), `hoistServer`/`enter` last-arg, and `return x` / `pure x`;
- relax the leaf guard from all-unique to any-known so a handler name that collides across modules (e.g. `currencies` defined in two modules) no longer drops the whole server's callees.

## Known follow-ups (not in this PR)
- NamedRoutes / record-based APIs (`data X mode = X { f :: mode :- ... }`, modern Servant ≥ 0.19) are still unsupported — a real FN, but absent from every real app tested (only present in servant's own test files).
- A server expression embedded inline in `serve api (h1 :<|> files)` with no `:: Server` binding (e.g. `servant-persistent`'s `hoistServer` indirection) still resolves no callees.

## Tests
- New `servant_callees_applied` fixture: binding-based server discovery + applied/qualified leaves + inline-`::` body + comment recovery, all in one.
- Yesod routes fixture switched to multi-space alignment as a crash regression.
- Unit tests for the path-param dedup and the inline-`::` body extraction.
- Format + ameba clean; full suite green (**18418 examples, 0 failures**).