### PR TITLE
Gotham: compose scope() / with_pipeline_chain() route prefixes

### DIFF
--- a/spec/functional_test/fixtures/rust/gotham_scope/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/gotham_scope/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gotham-scope-example"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gotham = "0.7"
+hyper = "0.14"

--- a/spec/functional_test/fixtures/rust/gotham_scope/src/main.rs
+++ b/spec/functional_test/fixtures/rust/gotham_scope/src/main.rs
@@ -1,0 +1,54 @@
+// Gotham's scoped routing tree: `build_router(|route| { ... })` with
+// `route.scope("/api", |route| { ... })` prepending a path segment,
+// nested scopes composing, and `route.with_pipeline_chain(chain,
+// |route| { ... })` adding middleware without changing the path.
+use gotham::router::builder::*;
+use gotham::router::Router;
+use gotham::state::State;
+use hyper::{Body, Response, StatusCode};
+
+fn index(state: State) -> (State, Response<Body>) {
+    let res = Response::builder().status(StatusCode::OK).body("home".into()).unwrap();
+    (state, res)
+}
+
+fn list_users(state: State) -> (State, Response<Body>) {
+    let res = Response::builder().status(StatusCode::OK).body("users".into()).unwrap();
+    (state, res)
+}
+
+fn create_user(state: State) -> (State, Response<Body>) {
+    let res = Response::builder().status(StatusCode::CREATED).body("created".into()).unwrap();
+    (state, res)
+}
+
+fn show_user(state: State) -> (State, Response<Body>) {
+    let res = Response::builder().status(StatusCode::OK).body("user".into()).unwrap();
+    (state, res)
+}
+
+fn profile(state: State) -> (State, Response<Body>) {
+    // Header access still resolves through the composed route.
+    let auth = state.headers().get("Authorization");
+    let res = Response::builder().status(StatusCode::OK).body("me".into()).unwrap();
+    (state, res)
+}
+
+fn router() -> Router {
+    build_router(default_chain, pipeline_set, |route| {
+        route.get("/").to(index);
+
+        route.scope("/api", |route| {
+            route.get("/users").to(list_users);
+            route.post("/users").to(create_user);
+
+            route.scope("/v2", |route| {
+                route.get("/users/:id").to(show_user);
+            });
+
+            route.with_pipeline_chain(auth_chain, |route| {
+                route.get("/profile").to(profile);
+            });
+        });
+    })
+}

--- a/spec/functional_test/testers/rust/gotham_scope_spec.cr
+++ b/spec/functional_test/testers/rust/gotham_scope_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+# Gotham scoped routing: `route.scope("/api", |route| { ... })` prepends
+# a segment, nested scopes compose (`/api/v2/...`), and
+# `route.with_pipeline_chain(chain, |route| { ... })` adds middleware
+# without changing the path. Handler-body enrichment (the Authorization
+# header) still resolves through the composed route.
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/users", "POST"),
+  Endpoint.new("/api/v2/users/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/api/profile", "GET", [Param.new("Authorization", "", "header")]),
+]
+
+FunctionalTester.new("fixtures/rust/gotham_scope/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -25,16 +25,43 @@ module Analyzer::Rust
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = build_function_index(root, source)
+        walk_with_prefix(root, source, "", path, function_index, include_callee, endpoints)
+      end
 
-        walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "call_expression"
-          route = decode_to_call(node, source)
-          next unless route
+      endpoints
+    end
+
+    # Recursive descent that threads the current path prefix. Gotham's
+    # `build_router(|route| { ... })` groups routes under
+    # `route.scope("/api", |route| { ... })` closures (which prepend a
+    # path segment) and `route.with_pipeline_chain(chain, |route| { ... })`
+    # closures (which only add middleware). A flat walk reported the
+    # inner path verbatim — `/users` instead of `/api/users`. We now
+    # descend into each closure carrying the accumulated prefix.
+    private def walk_with_prefix(node : LibTreeSitter::TSNode,
+                                 source : String,
+                                 prefix : String,
+                                 path : String,
+                                 function_index : Hash(String, LibTreeSitter::TSNode),
+                                 include_callee : Bool,
+                                 endpoints : Array(Endpoint))
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        if scope = decode_scope(node, source)
+          seg, block = scope
+          walk_with_prefix(block, source, join_paths(prefix, seg), path, function_index, include_callee, endpoints)
+          return
+        end
+        if block = decode_pipeline_closure(node, source)
+          walk_with_prefix(block, source, prefix, path, function_index, include_callee, endpoints)
+          return
+        end
+        if route = decode_to_call(node, source)
           route_path, method, handler_name = route
+          full_path = join_paths(prefix, route_path)
 
           details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
-          endpoint = Endpoint.new(route_path, method, details)
-          extract_path_params(route_path, endpoint)
+          endpoint = Endpoint.new(full_path, method, details)
+          extract_path_params(full_path, endpoint)
 
           if handler_function = function_index[handler_name]?
             scan_function(handler_function, source, endpoint)
@@ -45,7 +72,63 @@ module Analyzer::Rust
         end
       end
 
-      endpoints
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_with_prefix(child, source, prefix, path, function_index, include_callee, endpoints)
+      end
+    end
+
+    # `route.scope("/seg", |route| { ... })` → `{seg, closure_body}`.
+    private def decode_scope(call : LibTreeSitter::TSNode, source : String) : Tuple(String, LibTreeSitter::TSNode)?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      field = Noir::TreeSitter.field(fn_node, "field")
+      return unless field && Noir::TreeSitter.node_text(field, source) == "scope"
+
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      seg = first_string_literal_text(args, source)
+      return unless seg
+      block = closure_body(args)
+      return unless block
+      {seg, block}
+    end
+
+    # Pipeline-grouping closures (`with_pipeline_chain`, `with_pipeline`)
+    # wrap routes with middleware without changing the path. Returns the
+    # closure body so the caller can descend with the same prefix.
+    private def decode_pipeline_closure(call : LibTreeSitter::TSNode, source : String) : LibTreeSitter::TSNode?
+      fn_node = Noir::TreeSitter.field(call, "function")
+      return unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
+      field = Noir::TreeSitter.field(fn_node, "field")
+      return unless field
+      name = Noir::TreeSitter.node_text(field, source)
+      return unless name == "with_pipeline_chain" || name == "with_pipeline"
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      closure_body(args)
+    end
+
+    # Body block of the first closure argument in an `arguments` node.
+    private def closure_body(args : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "closure_expression"
+        body = Noir::TreeSitter.field(arg, "body")
+        return body if body && Noir::TreeSitter.node_type(body) == "block"
+        Noir::TreeSitter.each_named_child(arg) do |child|
+          return child if Noir::TreeSitter.node_type(child) == "block"
+        end
+      end
+      nil
+    end
+
+    private def join_paths(prefix : String, route_path : String) : String
+      return ensure_leading_slash(route_path) if prefix.empty?
+      combined = "/#{prefix.strip('/')}/#{route_path.lstrip('/')}".rstrip('/')
+      combined.empty? ? "/" : combined
+    end
+
+    private def ensure_leading_slash(route_path : String) : String
+      route_path.starts_with?("/") ? route_path : "/#{route_path}"
     end
 
     # `.<verb>("/x").to(handler)` → `{path, METHOD, handler_name}` or


### PR DESCRIPTION
## Summary

Final framework in the real-OSS Rust sweep (after Loco #1829, Salvo #1831, raw-string #1833, RWF #1837).

Gotham builds its routing tree with `build_router(|route| { ... })`, where `route.scope("/api", |route| { ... })` prepends a path segment (nesting to compose) and `route.with_pipeline_chain(chain, |route| { ... })` adds middleware without changing the path. The analyzer walked routes flat and reported the **inner** path verbatim — `/users` instead of `/api/users`.

## Fix

Replace the flat route walk with a prefix-threading recursive descent:
- entering `.scope("/seg", closure)` → recurse into the closure body with the accumulated prefix,
- `.with_pipeline_chain(...)` / `.with_pipeline(...)` → recurse with the prefix unchanged,
- `.verb(path).to(handler)` → emit at `prefix + path`.

Handler-body param/callee (ai-context) enrichment is unchanged and still resolves through composed routes.

## Results on `colinbankier/realworld-gotham`

| before | after |
|---|---|
| `POST /users` | `POST /api/users` |
| `POST /users/login` | `POST /api/users/login` |
| `GET /user` | `GET /api/user` (also inside `with_pipeline_chain`) |
| `GET /` | `GET /` (no scope, unchanged) |

## Tests

- New `gotham_scope` fixture + spec: root route, single scope, nested scope with a path param (`/api/v2/users/:id`), and a `with_pipeline_chain` pass-through that still extracts a handler-body `Authorization` header.
- Existing `gotham_spec` / `gotham_callees_spec` (builder-chain style, empty prefix) unchanged and green.
- Full Rust suite green (1138 examples), `crystal tool format` + ameba clean.

## Note

Scanning the upstream `gotham` framework repo (which bundles many independent example apps under one tree) shows a small endpoint-count drop purely from noir's global method+url dedup: once the `scopes` example's routes compose to `/checkout/address`, they coincide with the separate `http_verbs` example's literal `/checkout/address` and dedup to one. That can't happen within a single real app.