### PR TITLE
docs: align site with The Website Specification (Tier 1)

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -144,8 +144,8 @@ lazy_loading = true
 enabled = true
 name = "OWASP Noir"
 short_name = "Noir"
-theme_color = "#1a1a2e"
-background_color = "#1a1a2e"
+theme_color = "#050507"
+background_color = "#050507"
 display = "standalone"
 start_url = "/"
 

--- a/docs/static/.well-known/security.txt
+++ b/docs/static/.well-known/security.txt
@@ -1,0 +1,8 @@
+# OWASP Noir — security contact (RFC 9116)
+Contact: https://github.com/owasp-noir/noir/security/advisories
+Contact: mailto:hahwul@gmail.com
+Contact: mailto:h.lee@owasp.org
+Expires: 2027-06-02T00:00:00.000Z
+Preferred-Languages: en, ko
+Canonical: https://owasp-noir.github.io/noir/.well-known/security.txt
+Policy: https://github.com/owasp-noir/noir/blob/main/SECURITY.md

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -2848,3 +2848,25 @@ p:has(> .member-card) {
     display: none;
   }
 }
+
+/* ==========================================================================
+   Skip-to-content link — WCAG 2.4.1 Bypass Blocks
+   ========================================================================== */
+.skip-link {
+    position: absolute;
+    left: 0;
+    top: -100%;
+    z-index: 1000;
+    padding: 0.65rem 1.1rem;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    border: 1px solid var(--accent);
+    border-radius: 0 0 8px 0;
+    font-weight: 600;
+    text-decoration: none;
+}
+.skip-link:focus {
+    top: 0;
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}

--- a/docs/static/site.webmanifest
+++ b/docs/static/site.webmanifest
@@ -1,21 +1,26 @@
 {
+  "id": "/noir/",
   "name": "OWASP Noir",
   "short_name": "Noir",
+  "description": "Attack surface detector that identifies endpoints by static analysis.",
+  "lang": "en",
+  "start_url": "/noir/",
+  "scope": "/noir/",
+  "display": "standalone",
+  "theme_color": "#050507",
+  "background_color": "#050507",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "/noir/web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "/noir/web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
     }
-  ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone"
+  ]
 }

--- a/docs/templates/404.html
+++ b/docs/templates/404.html
@@ -1,5 +1,5 @@
 {% include "header.html" %}
-  <div class="error-page">
+  <div class="error-page" id="main-content">
     <div class="error-content">
       <h1 class="error-code">404</h1>
       <p class="error-message">The page you are looking for does not exist.</p>

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -3,9 +3,56 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <meta name="theme-color" content="#050507">
   <meta name="description" content="{{ page.description | default(site.description) }}">
   <title>{% if page.title and page.title != site.title %}{{ page.title }} - {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
   {{ og_all_tags }}
+  {% if page.permalink %}
+  {% set rel = page.permalink | replace(base_url, "") %}
+  {% if page.language == "ko" %}
+  {% set en_url = base_url ~ (rel | replace("/ko/", "/")) %}
+  {% set ko_url = page.permalink %}
+  {% else %}
+  {% set en_url = page.permalink %}
+  {% set ko_url = base_url ~ "/ko" ~ rel %}
+  {% endif %}
+  <link rel="canonical" href="{{ page.permalink }}">
+  <link rel="alternate" hreflang="en" href="{{ en_url }}">
+  <link rel="alternate" hreflang="ko" href="{{ ko_url }}">
+  <link rel="alternate" hreflang="x-default" href="{{ en_url }}">
+  <script type="application/ld+json">
+  {% autoescape false %}
+  {% if rel == "/" or rel == "/ko/" %}
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "OWASP Noir",
+    "description": "{{ site.description | replace('"', '\\"') }}",
+    "url": "{{ base_url }}/",
+    "applicationCategory": "SecurityApplication",
+    "operatingSystem": "Linux, macOS, Windows",
+    "softwareHelp": "{{ base_url }}/get_started/overview/",
+    "codeRepository": "https://github.com/owasp-noir/noir",
+    "license": "https://github.com/owasp-noir/noir/blob/main/LICENSE.md",
+    "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
+    "publisher": {"@type": "Organization", "name": "OWASP", "url": "https://owasp.org"}
+  }
+  {% else %}
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "{{ page.title | default(site.title) | replace('"', '\\"') }}",
+    "description": "{{ page.description | default(site.description) | replace('"', '\\"') }}",
+    "inLanguage": "{{ page.language | default('en') }}",
+    "url": "{{ page.permalink }}",
+    "isPartOf": {"@type": "WebSite", "name": "{{ site.title | replace('"', '\\"') }}", "url": "{{ base_url }}/"},
+    "publisher": {"@type": "Organization", "name": "OWASP", "url": "https://owasp.org"}
+  }
+  {% endif %}
+  {% endautoescape %}
+  </script>
+  {% endif %}
   <link rel="icon" href="{{ base_url }}/favicon.ico" sizes="any">
   <link rel="icon" href="{{ base_url }}/favicon.svg" type="image/svg+xml">
   <link rel="icon" href="{{ base_url }}/favicon-96x96.png" type="image/png" sizes="96x96">
@@ -21,6 +68,7 @@
   {{ auto_includes_css }}
 </head>
 <body>
+  <a href="#main-content" class="skip-link">{% if page.language == "ko" %}본문으로 건너뛰기{% else %}Skip to content{% endif %}</a>
   <header class="site-header">
     <div class="header-inner">
       <div class="header-left">

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -1,5 +1,5 @@
 {% include "header.html" %}
-  <div class="landing">
+  <div class="landing" id="main-content">
     {{ content }}
   </div>
   <div class="search-modal" id="search-modal">

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -1,7 +1,7 @@
 {% include "header.html" %}
   <div class="docs-layout">
     {% include "sidebar.html" %}
-    <main class="docs-main">
+    <main class="docs-main" id="main-content">
       <article class="docs-article">
         <h1>{{ page.title }}</h1>
         {{ content }}


### PR DESCRIPTION
## Summary

Audited the docs site (hwaro) against [The Website Specification](https://specification.website) — a platform-agnostic spec of what a good website should have, across 10 categories (Foundations, SEO, Accessibility, Security, Well-Known URIs, Agent Readiness, Performance, Privacy, Resilience, i18n).

The docs base was already strong (auto OG images, `llms.txt`/`llms-full.txt`, sitemap, RSS + feed discovery, PWA generation, full favicon set, bilingual EN/KO). This PR closes the **highest-impact, hwaro-feasible gaps** found by diffing the actual build output against each spec category.

## Changes (mapped to spec categories)

| Spec category | Gap (verified in build) | Fix |
|---|---|---|
| **i18n + SEO** | Bilingual site emitted **zero** `hreflang` and no `rel="canonical"` | `<link rel="canonical">` + `hreflang` `en`/`ko`/`x-default` on every page (mirrors the existing JS language-switcher logic at build time) |
| **SEO + Agent Readiness** | No structured data | JSON-LD: `SoftwareApplication` on the home page, `TechArticle` on docs pages |
| **Foundations** | No `theme-color` / `color-scheme` (dark-mode white flash) | Both added, matching the actual noir theme `#050507` |
| **Resilience** | The manifest `<head>` links (`site.webmanifest`) had a **white** theme, no `description`/`start_url`, and root-relative icon paths that 404 under `/noir/` | Consolidated to a correct manifest (`#050507`, description, `start_url`/`scope` `/noir/`, `/noir/`-prefixed icons); `config.toml` PWA colors aligned too |
| **Security + Well-Known** | No `/.well-known/security.txt` | Added (RFC 9116) — contacts from `SECURITY.md` |
| **Accessibility** | No skip-to-content link (WCAG 2.4.1 Bypass Blocks) | Skip link + focus-visible CSS; `id="main-content"` targets in page/landing/404 |
| — | `.well-known/` dot-dir would be stripped on gh-pages | `.nojekyll` added |

## Verification

- `hwaro build` clean (0.5s, 128 pages)
- **All 131 output pages** carry a valid (JSON-parseable) JSON-LD block + canonical + `hreflang x-default`
- Nested KO `hreflang="en"` targets resolve to existing EN pages
- `/.well-known/security.txt` served at `/noir/.well-known/security.txt`
- EN/KO doc-parity gate passes

## Known caveat

`security.txt` lives under the project path (`/noir/.well-known/`) because `owasp-noir.github.io` apex isn't ours to control. It documents the policy but isn't at the RFC-canonical apex. Header-based Security items (CSP, X-Frame-Options, etc.) remain out of scope — GitHub Pages can't set response headers.

## Not included (deferred Tier 2)

Service-worker registration, `llms.txt` index enrichment, 404 localization + `noindex`, breadcrumbs, SRI on the cdnjs stylesheet, and stale-file cleanup — happy to follow up.