### PR TITLE
Servant: support NamedRoutes record APIs + fix guard body extraction

### DIFF
--- a/spec/functional_test/fixtures/haskell/servant_named_routes/package.yaml
+++ b/spec/functional_test/fixtures/haskell/servant_named_routes/package.yaml
@@ -1,0 +1,6 @@
+name: servant-named-routes-fixture
+version: 0.1.0.0
+dependencies:
+  - base
+  - servant
+  - text

--- a/spec/functional_test/fixtures/haskell/servant_named_routes/src/Api.hs
+++ b/spec/functional_test/fixtures/haskell/servant_named_routes/src/Api.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Api where
+
+import Servant
+import Servant.API.Generic ((:-))
+
+data Item
+data Detail
+
+-- A record-based (NamedRoutes / Servant.API.Generic) API. Each field is a route
+-- declared as `field :: mode :- <route>`. `otherRoutes` nests another record via
+-- `NamedRoutes`, prefixed by the captured `itemId`.
+data Routes mode = Routes
+  { version :: mode :- "version" :> Get '[JSON] Item
+  , listItems :: mode :- "items" :> QueryParam "page" Int :> Get '[JSON] [Item]
+  , createItem :: mode :- "items" :> ReqBody '[JSON] Item :> Post '[JSON] Item
+  , itemRoutes :: mode :- "items" :> Capture "itemId" Int :> NamedRoutes ItemRoutes
+  }
+
+newtype ItemRoutes mode = ItemRoutes
+  { detail :: mode :- "detail" :> Get '[JSON] Detail
+  }
+
+type API = NamedRoutes Routes

--- a/spec/functional_test/testers/haskell/servant_named_routes_spec.cr
+++ b/spec/functional_test/testers/haskell/servant_named_routes_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+# Record-based `NamedRoutes` API: routes declared as record fields
+# (`field :: mode :- <route>`), reached through `type API = NamedRoutes Routes`,
+# including a nested record (`NamedRoutes ItemRoutes`) under a captured segment.
+expected_endpoints = [
+  Endpoint.new("/version", "GET"),
+  Endpoint.new("/items", "GET", [
+    Param.new("page", "Int", "query"),
+  ]),
+  Endpoint.new("/items", "POST", [
+    Param.new("body", "Item", "body"),
+  ]),
+  Endpoint.new("/items/:itemId/detail", "GET", [
+    Param.new("itemId", "Int", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/haskell/servant_named_routes/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/haskell_callee_extractor_spec.cr
@@ -56,6 +56,21 @@ describe Noir::HaskellCalleeExtractor do
     callees.map { |name, _, _| name }.should contain("buildInfo")
   end
 
+  it "extracts the body past a same-line guard comparison" do
+    # The binding `=` follows a `==` guard; splitting on the first `=` would
+    # capture `= 0 = handleZero n` instead of the real body.
+    source = <<-HASKELL
+      classify n | n == 0 = handleZero n
+      HASKELL
+
+    bodies = Noir::HaskellCalleeExtractor.function_bodies(source, "X.hs")
+    body = bodies.first
+    body[:name].should eq("classify")
+    callees = Noir::HaskellCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
+    names = callees.map { |name, _, _| name }
+    names.should contain("handleZero")
+  end
+
   it "extracts direct calls from Haskell handler bodies" do
     body = <<-HASKELL
       do

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -29,6 +29,18 @@ module Analyzer::Haskell
             line:   entry[:line],
           }
         end
+
+        # Record-based (`NamedRoutes`) APIs declare each route as a record field
+        # `field :: mode :- <route>`. Treat the record as a pseudo type alias
+        # whose body is the fields joined with `:<|>`, so the existing
+        # expansion/processing pipeline handles it like any other API.
+        extract_record_routes(content).each do |entry|
+          type_aliases[entry[:name]] = {
+            body:   entry[:body],
+            source: path,
+            line:   entry[:line],
+          }
+        end
       end
 
       reference_counts = Hash(String, Int32).new(0)
@@ -41,7 +53,7 @@ module Analyzer::Haskell
       type_aliases.each do |name, entry|
         next if reference_counts[name] > 0
 
-        expanded = expand_references(entry[:body], type_aliases)
+        expanded = strip_named_routes(expand_references(entry[:body], type_aliases))
         next unless contains_servant_signature?(expanded)
 
         endpoints = process_api_body(entry[:source], entry[:line], expanded)
@@ -149,6 +161,114 @@ module Analyzer::Haskell
       end
 
       results
+    end
+
+    # Extract `Servant.API.Generic` record-route declarations:
+    #
+    #   data RecordRoutes mode = RecordRoutes
+    #     { version :: mode :- "version" :> Get '[JSON] Int
+    #     , echo    :: mode :- "echo" :> Capture "s" String :> Get '[JSON] String
+    #     }
+    #
+    # Each `field :: mode :- <route>` carries one route; the record is returned
+    # as a pseudo type alias whose body is the routes joined with `:<|>`, so the
+    # downstream alias machinery (reference counting, expansion, processing)
+    # treats it exactly like a `type X = ...` API.
+    private def extract_record_routes(content : String) : Array(NamedTuple(name: String, body: String, line: Int32))
+      results = [] of NamedTuple(name: String, body: String, line: Int32)
+      cleaned = strip_haskell_comments(content)
+      lines = cleaned.lines
+
+      i = 0
+      while i < lines.size
+        match = lines[i].match(/^(?:data|newtype)\s+([A-Z][A-Za-z0-9_']*)\s+[a-z][A-Za-z0-9_']*\b/)
+        unless match
+          i += 1
+          next
+        end
+
+        name = match[1]
+        start_line = i + 1
+
+        # Collect from the declaration through the closing brace of the record.
+        open_index = find_record_open_brace(lines, i)
+        unless open_index
+          i += 1
+          next
+        end
+
+        block, next_index = collect_record_block(lines, open_index)
+        routes = record_field_routes(block)
+        if routes.size > 0
+          results << {name: name, body: routes.join(" :<|> "), line: start_line}
+        end
+        i = next_index
+      end
+
+      results
+    end
+
+    # Locate the `{` that opens the record's field list, scanning at most a few
+    # lines past the `data`/`newtype` head (the brace is often on the next line).
+    private def find_record_open_brace(lines : Array(String), decl_index : Int32) : Int32?
+      i = decl_index
+      limit = Math.min(lines.size, decl_index + 4)
+      while i < limit
+        return i if lines[i].includes?('{')
+        # Stop if another top-level declaration starts before any brace.
+        return if i > decl_index && !lines[i].lstrip.empty? && !starts_with_whitespace?(lines[i]) && !lines[i].lstrip.starts_with?("=")
+        i += 1
+      end
+      nil
+    end
+
+    # Return the text between the record's outermost `{` and matching `}` plus
+    # the index of the line after the closing brace.
+    private def collect_record_block(lines : Array(String), open_index : Int32) : Tuple(String, Int32)
+      buffer = String::Builder.new
+      depth = 0
+      started = false
+      i = open_index
+      while i < lines.size
+        line = lines[i]
+        line.each_char do |char|
+          if char == '{'
+            depth += 1
+            started = true
+            next
+          elsif char == '}'
+            depth -= 1
+            next if depth <= 0
+          end
+          buffer << char if started && depth >= 1
+        end
+        if started && depth <= 0
+          return {buffer.to_s, i + 1}
+        end
+        buffer << '\n' if started
+        i += 1
+      end
+      {buffer.to_s, i}
+    end
+
+    # Split a record body into its per-field route types, keeping only fields of
+    # the form `name :: mode :- <route>` and returning the `<route>` part.
+    private def record_field_routes(block : String) : Array(String)
+      routes = [] of String
+      split_top_level(block, ",").each do |field|
+        idx = field.index(":-")
+        next unless idx
+        route = field[(idx + 2)..].strip
+        routes << route unless route.empty?
+      end
+      routes
+    end
+
+    # Drop the `NamedRoutes` combinator keyword. After expansion a nested record
+    # reference reads `... :> NamedRoutes (<expanded body>)`; removing the bare
+    # word leaves `... :> (<expanded body>)`, a plain nested route.
+    private def strip_named_routes(body : String) : String
+      body.gsub(/\bNamedRoutes\b/, " ")
     end
 
     private def starts_with_whitespace?(line : String) : Bool
@@ -495,11 +615,31 @@ module Analyzer::Haskell
       [route]
     end
 
+    # Split a route into its `:>` segments, recursing into parenthesised
+    # sub-chains. `:>` is right-associative, so `A :> (B :> C)` is the same route
+    # as `A :> B :> C`; a nested `NamedRoutes` record expands to a parenthesised
+    # `:>` chain that must be spliced in rather than treated as one opaque
+    # segment.
+    private def flatten_route_segments(raw : String) : Array(String)
+      result = [] of String
+      split_top_level(raw, ":>").each do |segment|
+        seg = unwrap_parens(segment.strip)
+        next if seg.empty?
+
+        if split_top_level(seg, ":>").size > 1
+          result.concat(flatten_route_segments(seg))
+        else
+          result << seg
+        end
+      end
+      result
+    end
+
     private def process_route(source : String, line_number : Int32, route : String) : Endpoint?
       raw = unwrap_parens(route.strip)
       return if raw.empty?
 
-      segments = split_top_level(raw, ":>")
+      segments = flatten_route_segments(raw)
 
       url_parts = [] of String
       params = [] of Param

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -43,7 +43,10 @@ module Noir::HaskellCalleeExtractor
         next
       end
 
-      equals_index = line.index('=')
+      # Find the definition `=`, skipping comparison/arrow operators that also
+      # contain `=` (`==`, `>=`, `<=`, `/=`, `=>`, `=<<`). Otherwise a guard such
+      # as `f x | x == 0 = ...` would split on the `==` and mis-extract the body.
+      equals_index = definition_equals_index(line)
       unless equals_index
         index += 1
         next
@@ -148,6 +151,23 @@ module Noir::HaskellCalleeExtractor
 
   private def same_function_equation?(line : String, name : String) : Bool
     !!line.match(/^#{Regex.escape(name)}\b.*=/)
+  end
+
+  # Index of the binding `=`, skipping operators that merely contain `=`
+  # (`==`, `>=`, `<=`, `/=`, `!=`, `=>`, `=<<`). Returns nil when the line has no
+  # standalone definition `=` (e.g. it is only a comparison expression).
+  private def definition_equals_index(line : String) : Int32?
+    index = 0
+    while index < line.size
+      if line[index] == '='
+        prev = index > 0 ? line[index - 1] : ' '
+        nxt = index + 1 < line.size ? line[index + 1] : ' '
+        adjacent = {'=', '<', '>', '/', '!'}
+        return index unless adjacent.includes?(prev) || nxt == '=' || nxt == '>' || nxt == '<'
+      end
+      index += 1
+    end
+    nil
   end
 
   private def skip_callee?(name : String) : Bool


### PR DESCRIPTION
## Summary

Follow-up to #1836, addressing that PR's own review notes. Adds the headline TODO — **NamedRoutes / record-based APIs** (modern Servant ≥ 0.19, `Servant.API.Generic`) — plus two correctness cleanups surfaced in review.

## Changes

### NamedRoutes / record-based API support (FN)
Record APIs declare each route as a record field:

```haskell
data Routes mode = Routes
  { version :: mode :- "version" :> Get '[JSON] Item
  , listItems :: mode :- "items" :> QueryParam "page" Int :> Get '[JSON] [Item]
  , itemRoutes :: mode :- "items" :> Capture "itemId" Int :> NamedRoutes ItemRoutes
  }
type API = NamedRoutes Routes
```

A `data/newtype X mode = Ctor { field :: mode :- <route>, ... }` record is now extracted as a pseudo type alias whose body is the fields joined with `:<|>`, so the existing reference-counting / expansion / processing pipeline treats it exactly like a `type X = ...` API. Nested `NamedRoutes Sub` references expand the sub-record (prefixed by the path so far), and the bare `NamedRoutes` combinator keyword is stripped after expansion. Only records that actually carry `:-` fields are treated as APIs, so plain data records (`data User = User { name :: Text }`) are ignored.

### `:>` is right-associative — flatten nested segments
`process_route` now flattens `:>` segments recursively: `A :> (B :> C)` is the same route as `A :> B :> C`. A nested record expands to a parenthesised `:>` chain, which previously stayed opaque (so the inner `Get` was never seen). This is what recovers `/items/:itemId/detail` from a nested record.

### Guard body extraction (callee accuracy)
The callee extractor located the binding `=` with `line.index('=')`, which on a same-line guard `f x | x == 0 = handleZero n` split on the `==` and mis-extracted the body. It now finds the definition `=` by skipping operators that merely contain `=` (`==`, `>=`, `<=`, `/=`, `=>`, `=<<`).

## Validation
- On servant's own `ClientTestUtils` the record routes are recovered (`/version`, `/echo/:string`, `/other/:someParam/something`), lifting that file 24 → 27 endpoints.
- Existing real servant apps unchanged (exchange-rates 3, servant-persistent 4, example-servant-minimal 2; no duplicate path params).

## Tests
- New `servant_named_routes` fixture: top-level `type API = NamedRoutes Routes`, query/body/path params, and a nested record under a captured segment.
- Unit test for the same-line-guard body extraction.
- Format + ameba clean; full suite green (**18822 examples, 0 failures**).

## Still open (future)
- NamedRoutes **callees**: the server is a record value (`Routes { version = h, ... }`) served via `genericServe`; resolving handlers from record construction is not wired up yet (endpoints are recovered, callees are not).
- Inline server expression in a `serve api (h :<|> files)` call with no `:: Server` binding (servant-persistent's `hoistServer` indirection).