### PR TITLE
Improve Grails analyzer: cut endpoint/callee FP/FN vs real OSS apps

### DIFF
--- a/spec/functional_test/fixtures/groovy/grails_modern/build.gradle
+++ b/spec/functional_test/fixtures/groovy/grails_modern/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id "org.grails.grails-web" version "6.1.0"
+}
+
+dependencies {
+    implementation "org.grails:grails-core"
+    implementation "org.grails:grails-web"
+}

--- a/spec/functional_test/fixtures/groovy/grails_modern/grails-app/controllers/UrlMappings.groovy
+++ b/spec/functional_test/fixtures/groovy/grails_modern/grails-app/controllers/UrlMappings.groovy
@@ -1,0 +1,25 @@
+// In Grails 3+ the canonical UrlMappings file lives under
+// `grails-app/controllers/` (it sat in `grails-app/conf/` on 1.x/2.x).
+class UrlMappings {
+    static mappings = {
+        // Default convention mapping — declares no controller/action, so it
+        // is not itself a routable endpoint.
+        "/$controller/$action?/$id?(.$format)?"()
+
+        // GString `${name}` path variable plus an optional content-format
+        // suffix `(.${format})` that must be stripped from the URL.
+        "/image/${imageId}(.${format})"(controller: 'image', action: 'show')
+
+        // Per-verb action dispatch map — one endpoint per HTTP verb.
+        "/api/v1/widget/$id"(controller: 'widget') {
+            action = [GET: 'show', PUT: 'update']
+        }
+
+        // REST resources shortcut → six endpoints.
+        "/api/v1/books"(resources: 'book')
+
+        // Response-code mappings configure error pages, not endpoints.
+        "404"(controller: 'error', action: 'notFound')
+        "500"(view: '/error')
+    }
+}

--- a/spec/functional_test/fixtures/groovy/grails_modern/grails-app/controllers/com/demo/ApiController.groovy
+++ b/spec/functional_test/fixtures/groovy/grails_modern/grails-app/controllers/com/demo/ApiController.groovy
@@ -1,0 +1,41 @@
+package com.demo
+
+// Exercises action-extraction edge cases that must NOT leak helper methods
+// as endpoints. Grails only dispatches to public, non-static controller
+// methods, and never to JavaBean property accessors.
+class ApiController {
+    static allowedMethods = [save: 'POST']
+
+    def index() {
+        render 'ok'
+    }
+
+    def save() {
+        render 'saved'
+    }
+
+    // Typed-return action (Grails 3+) — a real endpoint.
+    List<String> list() {
+        ['a', 'b']
+    }
+
+    // private helper — not an action.
+    private def buildModel() {
+        [:]
+    }
+
+    // protected typed helper — not an action.
+    protected String formatBody() {
+        'body'
+    }
+
+    // static helper — not an action.
+    static int counter() {
+        0
+    }
+
+    // JavaBean getter — a property accessor, not an action.
+    String getDisplayName() {
+        'demo'
+    }
+}

--- a/spec/functional_test/testers/groovy/grails_modern_spec.cr
+++ b/spec/functional_test/testers/groovy/grails_modern_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  # ApiController — public actions only. The private/protected/static helpers
+  # (`buildModel`, `formatBody`, `counter`) and the JavaBean getter
+  # (`getDisplayName`) must not surface as endpoints.
+  Endpoint.new("/api/index", "GET"),
+  Endpoint.new("/api/save", "POST"),
+  Endpoint.new("/api/list", "GET"),
+  # UrlMappings under `grails-app/controllers/` (Grails 3+ layout) is now
+  # scanned. `${imageId}` GString translated to `:imageId`; the `(.${format})`
+  # content-format suffix is stripped.
+  Endpoint.new("/image/:imageId", "GET", [Param.new("imageId", "", "path")]),
+  # `action = [GET: 'show', PUT: 'update']` → one endpoint per verb.
+  Endpoint.new("/api/v1/widget/:id", "GET"),
+  Endpoint.new("/api/v1/widget/:id", "PUT"),
+  # `(resources: 'book')` shortcut → six REST endpoints.
+  Endpoint.new("/api/v1/books", "GET"),
+  Endpoint.new("/api/v1/books", "POST"),
+  Endpoint.new("/api/v1/books/:id", "GET"),
+  Endpoint.new("/api/v1/books/:id", "PUT"),
+  Endpoint.new("/api/v1/books/:id", "PATCH"),
+  Endpoint.new("/api/v1/books/:id", "DELETE"),
+  # `"404"`/`"500"` response-code mappings are error pages, not endpoints.
+]
+
+FunctionalTester.new("fixtures/groovy/grails_modern/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/groovy_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/groovy_callee_extractor_spec.cr
@@ -88,4 +88,27 @@ describe Noir::GroovyCalleeExtractor do
       {"BookService.save", 61},
     ])
   end
+
+  it "does not mistake typed declarations for command calls" do
+    body = <<-GROOVY
+      String body = "h1. title"
+      Map model = [:]
+      WikiPage page = WikiPage.get(id)
+      AclClass.list().each { AclClass aclClass ->
+        render aclClass.name
+      }
+      cache true
+      GROOVY
+
+    # `String body =`, `Map model =`, `WikiPage page =` and the typed closure
+    # parameter `AclClass aclClass ->` are declarations, not calls. The real
+    # calls (`WikiPage.get`, `AclClass.list`, `render`, `cache`) survive.
+    callees = Noir::GroovyCalleeExtractor.callees_for_body(body, "BookController.groovy", 70)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"WikiPage.get", 72},
+      {"AclClass.list", 73},
+      {"render", 74},
+      {"cache", 76},
+    ])
+  end
 end

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -20,10 +20,14 @@ module Analyzer::Groovy
   # those restrictions are honored; otherwise actions are emitted as
   # `GET` (the default Grails dispatch verb when no restriction is set).
   #
-  # `grails-app/conf/UrlMappings.groovy` is also scanned for explicit
-  # string-based mappings of the form
+  # `UrlMappings.groovy` is also scanned for explicit string-based mappings
+  # of the form
   #   `get '/api/users'(controller: 'user', action: 'list')`
-  # which are surfaced as additional endpoints.
+  # which are surfaced as additional endpoints. It lives under
+  # `grails-app/conf/` on Grails 1.x/2.x and `grails-app/controllers/` on
+  # Grails 3+; both locations are handled. Per-verb `action = [GET: ..., PUT:
+  # ...]` dispatch maps and `${name}` GString path variables are recognized,
+  # while bare-status-code (`"404"`, `"500"`) error mappings are excluded.
   class Grails < Analyzer
     DEFAULT_METHODS = ["GET"]
     HTTP_METHODS    = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
@@ -95,9 +99,12 @@ module Analyzer::Groovy
     private def url_mappings_path?(path : String) : Bool
       # Grails plugins ship their own `<Name>UrlMappings.groovy` files
       # alongside the canonical `UrlMappings.groovy`, so accept any basename
-      # ending in `UrlMappings.groovy` — but only inside `grails-app/conf/`
-      # so unrelated files with similar names are not picked up.
-      return false unless path.includes?("/grails-app/conf/")
+      # ending in `UrlMappings.groovy`. The canonical location changed across
+      # Grails versions: 1.x/2.x kept it under `grails-app/conf/`, while
+      # Grails 3+ moved it to `grails-app/controllers/`. Accept both so modern
+      # apps (the common case today) are not silently skipped.
+      return false unless path.includes?("/grails-app/conf/") ||
+                          path.includes?("/grails-app/controllers/")
       File.basename(path).ends_with?("UrlMappings.groovy")
     end
 
@@ -199,6 +206,25 @@ module Analyzer::Groovy
       base[0].downcase.to_s + base[1..]
     end
 
+    # JavaBean-style property accessors (`getFoo`, `setFoo`, `isFoo`) follow
+    # the `<get|set|is><UpperCase>` convention. Grails treats these as
+    # property access, never as routable actions, so they must be excluded
+    # from the surfaced endpoint set even though they are public methods.
+    private def accessor_name?(name : String) : Bool
+      name.matches?(/\A(?:get|set|is)[A-Z]/)
+    end
+
+    # Grails only dispatches to *public, non-static* controller methods.
+    # A leading `private`/`protected`/`static` modifier therefore disqualifies
+    # a method from being a routable action. The char-by-char scanner can land
+    # on a method's return-type keyword *after* stepping past its modifier, so
+    # the modifier run is captured and checked here rather than relied upon to
+    # be absent.
+    private def nonpublic_modifier?(modifiers : String?) : Bool
+      return false if modifiers.nil?
+      modifiers.matches?(/\b(?:private|protected|static)\b/)
+    end
+
     alias Action = NamedTuple(name: String, offset: Int32, body: String, body_start: Int32)
 
     private def extract_actions(body : String) : Array(Action)
@@ -238,8 +264,7 @@ module Analyzer::Groovy
           if m
             modifier = m[1]?
             name = m[2]
-            is_private = modifier && modifier.lstrip.starts_with?("private")
-            unless is_private || SKIP_ACTION_NAMES.includes?(name)
+            unless nonpublic_modifier?(modifier) || SKIP_ACTION_NAMES.includes?(name) || accessor_name?(name)
               if action_body = extract_braced_block(body, i + (m.end(0) || 0))
                 action_body_text, action_body_start = action_body
                 actions << {name: name, offset: i, body: action_body_text, body_start: action_body_start}
@@ -254,10 +279,10 @@ module Analyzer::Groovy
           # Grails 3+ allows actions with explicit return types. We
           # require the trailing `{` to avoid matching field declarations
           # like `String name = "x"` or method calls.
-          m2 = rest.match(/\A(public\s+|protected\s+)?([A-Z][A-Za-z0-9_]*(?:\s*<[^<>]+>)?(?:\s*\[\s*\])?)\s+([a-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:throws\s+[A-Za-z0-9_,\s.]+)?\s*\{/)
+          m2 = rest.match(/\A((?:(?:public|protected|private|static|final|synchronized)\s+)*)([A-Z][A-Za-z0-9_]*(?:\s*<[^<>]+>)?(?:\s*\[\s*\])?)\s+([a-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:throws\s+[A-Za-z0-9_,\s.]+)?\s*\{/)
           if m2
             name = m2[3]
-            unless SKIP_ACTION_NAMES.includes?(name)
+            unless nonpublic_modifier?(m2[1]?) || SKIP_ACTION_NAMES.includes?(name) || accessor_name?(name)
               open_brace = i + (m2.end(0) || 1) - 1
               if action_body = extract_braced_block(body, open_brace)
                 action_body_text, action_body_start = action_body
@@ -273,10 +298,10 @@ module Analyzer::Groovy
           # `int count(...) { ... }`. Distinct from the uppercase-return
           # pattern above to avoid colliding with field declarations and
           # `def` actions.
-          m3 = rest.match(/\A(public\s+|protected\s+)?(void|int|long|boolean|byte|short|float|double|char)\s+([a-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:throws\s+[A-Za-z0-9_,\s.]+)?\s*\{/)
+          m3 = rest.match(/\A((?:(?:public|protected|private|static|final|synchronized)\s+)*)(void|int|long|boolean|byte|short|float|double|char)\s+([a-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:throws\s+[A-Za-z0-9_,\s.]+)?\s*\{/)
           if m3
             name = m3[3]
-            unless SKIP_ACTION_NAMES.includes?(name)
+            unless nonpublic_modifier?(m3[1]?) || SKIP_ACTION_NAMES.includes?(name) || accessor_name?(name)
               open_brace = i + (m3.end(0) || 1) - 1
               if action_body = extract_braced_block(body, open_brace)
                 action_body_text, action_body_start = action_body
@@ -410,6 +435,11 @@ module Analyzer::Groovy
       # mappings.
       simple_pattern = /(?:^|\n)\s*(?:name\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?(['"])([^'"]+)\1\s*\(([^)]*?)\)/m
       remaining.scan(simple_pattern) do |match|
+        # Response-code mappings (`"404"(...)`, `"500"(...)`) reuse the same
+        # paren-form syntax but the "path" is an HTTP status code, not a URL.
+        # They are error-page handlers, not addressable endpoints.
+        next if status_code_mapping?(match[2])
+
         url_pattern = prefix + match[2]
         body_args = match[3]
         line = line_for_offset(content, match.begin(0) || 0)
@@ -437,6 +467,20 @@ module Analyzer::Groovy
 
         next unless body_args.includes?("controller:") || body_args.includes?("action:") ||
                     body_args.includes?("view:") || body_args.includes?("uri:")
+
+        # A trailing closure block may declare per-verb action dispatch via
+        # `action = [GET: "show", PUT: "apiUpdate"]`. When present, surface one
+        # endpoint per HTTP verb rather than the single GET fallback.
+        verbs = action_map_verbs_after(remaining, match.end(0))
+        if verbs
+          verbs.each do |verb|
+            @result << Endpoint.new(translate_pattern(url_pattern), verb,
+              extract_path_params(url_pattern),
+              Details.new(PathInfo.new(path, line)))
+          end
+          next
+        end
+
         verb = extract_method_arg(body_args) || "GET"
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),
@@ -446,6 +490,7 @@ module Analyzer::Groovy
       # Closure-form mapping: `'/path' { controller = 'foo'; method = 'POST' }`.
       closure_pattern = /(?:^|\n)\s*(['"])([^'"]+)\1\s*\{([^}]*)\}/m
       remaining.scan(closure_pattern) do |match|
+        next if status_code_mapping?(match[2])
         url_pattern = prefix + match[2]
         body_block = match[3]
         next unless body_block.match(/\b(controller|action|method|view)\s*=/)
@@ -526,16 +571,60 @@ module Analyzer::Groovy
       HTTP_METHODS.includes?(verb) ? verb : nil
     end
 
+    # Grails response-code mappings (`"404"(...)`, `"500" { ... }`) carry a
+    # bare HTTP status code where a URL would normally go. They configure
+    # error pages, not routable endpoints, so they must not be surfaced.
+    private def status_code_mapping?(raw : String) : Bool
+      raw.matches?(/\A\d{3}\z/)
+    end
+
+    # Parses the `action = [GET: "show", PUT: "apiUpdate"]` per-verb dispatch
+    # map from a closure block that trails a paren-form mapping. `match_end`
+    # is the offset just past the closing `)` of the paren form; we only look
+    # ahead when the very next token is the opening `{` of that block.
+    private def action_map_verbs_after(text : String, match_end : Int32?) : Array(String)?
+      return unless match_end
+      return if match_end >= text.size
+
+      lead = text[match_end..].match(/\A\s*\{/)
+      return unless lead
+
+      brace_pos = match_end + (lead.end(0) || 1) - 1
+      close = find_matching_brace(text, brace_pos)
+      return unless close
+
+      block = text[(brace_pos + 1)...close]
+      map_match = block.match(/\baction\s*=\s*\[([^\]]*)\]/)
+      return unless map_match
+
+      verbs = [] of String
+      map_match[1].scan(/([A-Za-z]+)\s*:/) do |vm|
+        verb = vm[1].upcase
+        verbs << verb if HTTP_METHODS.includes?(verb) && !verbs.includes?(verb)
+      end
+      verbs.empty? ? nil : verbs
+    end
+
     private def translate_pattern(pattern : String) : String
-      pattern.gsub(/\$([A-Za-z_][A-Za-z0-9_]*)\??/) { |_, m| ":#{m[1]}" }
+      # `$name` and `${name}` path variables both map to `:name`.
+      strip_format_suffix(pattern)
+        .gsub(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?\??/) { |_, m| ":#{m[1]}" }
     end
 
     private def extract_path_params(pattern : String) : Array(Param)
       params = [] of Param
-      pattern.scan(/\$([A-Za-z_][A-Za-z0-9_]*)/) do |m|
+      strip_format_suffix(pattern).scan(/\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?/) do |m|
         params << Param.new(m[1], "", "path")
       end
       params
+    end
+
+    # Drops the optional Grails content-format suffix `(.$format)?` /
+    # `(.${type})` so it does not leak into the surfaced URL as a literal
+    # `(.:format)` segment. The suffix denotes optional content negotiation
+    # (`.json`, `.xml`), not an actual path component.
+    private def strip_format_suffix(pattern : String) : String
+      pattern.gsub(/\(\.\$\{?[A-Za-z_][A-Za-z0-9_]*\}?\)\??/, "")
     end
 
     private def extract_braced_block(text : String, start : Int32) : Tuple(String, Int32)?

--- a/src/miniparsers/groovy_callee_extractor.cr
+++ b/src/miniparsers/groovy_callee_extractor.cr
@@ -48,7 +48,7 @@ module Noir::GroovyCalleeExtractor
 
       candidates << {position, match[1]}
     end
-    scan_candidates(line, COMMAND_CALL_REGEX, candidates)
+    scan_command_candidates(line, candidates)
     scan_candidates(line, KEYWORD_COMMAND_CALL_REGEX, candidates)
     scan_candidates(line, ASSIGN_CALL_REGEX, candidates)
 
@@ -63,6 +63,24 @@ module Noir::GroovyCalleeExtractor
   private def scan_candidates(line : String, regex : Regex, candidates : Array(Tuple(Int32, String)))
     line.scan(regex) do |match|
       candidates << {match.begin(1) || 0, match[1]}
+    end
+  end
+
+  # Command-style calls (`render foo`, `cache true`, `AuditLog.write 'x'`) share
+  # their surface syntax with typed variable/parameter declarations, where the
+  # captured "command" is really the declared type:
+  #   * locals:        `String body = "..."`, `Map m = [:]`
+  #   * closure params: `list.each { WikiPage page -> ... }`
+  # Neither is a call, so drop a candidate whose argument is `<identifier> =`
+  # (local) or `<identifier> ->` (closure param) — shapes a declaration takes
+  # and a genuine command argument never does.
+  private def scan_command_candidates(line : String, candidates : Array(Tuple(Int32, String)))
+    line.scan(COMMAND_CALL_REGEX) do |match|
+      position = match.begin(1) || 0
+      after = line[(match.end(1) || position)..]
+      next if after.matches?(/\A\s+[A-Za-z_$][A-Za-z0-9_$]*\s*(?:=(?!=)|->)/)
+
+      candidates << {position, match[1]}
     end
   end
 


### PR DESCRIPTION
## Summary

Sweep of the Groovy/Grails analyzer (`endpoints`, `callee`, `ai-context`) validated against **34 real open-source Grails apps** scanned with `./bin/noir` — the grails.org website, grails-petclinic, and the spring-security-core / -oauth2 plugin example apps.

This builds on the already-solid Grails AI-context base rather than fixing a gap: it sharpens accuracy where real apps use idioms the fixtures didn't cover (modern file layout, GString routes, per-verb dispatch maps, helper methods).

### Measured effect across the 34 apps
- **−81 false-positive endpoints**, **+30 previously-missed endpoints**, **0 legitimate endpoints dropped** (every removal verified to be a non-public/accessor method, status-code mapping, or a malformed URL replaced by its clean form).
- **−134 false-positive callees** (type-declaration noise), only clean re-attributions added.

## Endpoint changes
- **UrlMappings location (biggest FN).** Scan `UrlMappings.groovy` under `grails-app/controllers/` (the Grails 3+ home), not only `grails-app/conf/`. Modern apps keep it in `controllers/`, so their mappings — REST `resources`, OAuth routes, namespaced URLs — were entirely missed.
- **Status-code mappings (FP).** Exclude bare `"404"(...)` / `"500" { ... }` — these wire up error pages, not routable URLs.
- **Per-verb dispatch maps (FN).** Honor `action = [GET: "show", PUT: "update"]` on paren-form mappings, emitting one endpoint per verb instead of GET-only.
- **GString routes (FP/correctness).** Translate `${name}` (not just `$name`) and strip the optional content-format suffix `(.$format)?` / `(.${type})`, so URLs no longer leak `{imageId}` / `(.{type})` fragments.
- **Non-action methods (FP).** Drop `private`/`protected`/`static` methods (Grails dispatches only public instance methods) and JavaBean accessors (`getX`/`setX`/`isX`). The char-scanner previously matched a method's return-type keyword after stepping past its access modifier.

## Callee / ai-context changes
- Stop treating typed declarations as command-style calls: `String body = ...`, `Map m = [:]`, and typed closure params `list.each { WikiPage page -> ... }` no longer surface the type name as a callee.

## Tests
- New `grails_modern` functional fixture (Grails 3+ layout) covering the controllers/ UrlMappings location, status-code exclusion, GString + format-suffix, `action = [...]` multi-verb, and helper/accessor exclusion.
- Callee unit-spec cases for the declaration/closure-param exclusion.
- Full suite green: unit (2796) + functional (16081), ameba clean.