### PR TITLE
Improve Java Spring/Play/Spark analyzers: cut FP/FN in endpoints, callee, ai-context

### DIFF
--- a/spec/functional_test/fixtures/java/play/app/v1/PostsApi.java
+++ b/spec/functional_test/fixtures/java/play/app/v1/PostsApi.java
@@ -1,0 +1,17 @@
+package v1;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.mvc.Result;
+
+// Controller deliberately parked outside the conventional `controllers`
+// package — Play resolves it by the fully-qualified name in `routes`.
+// Regression guard: its header/body params must still be enriched.
+public class PostsApi extends Controller {
+    public Result create(Http.Request request) {
+        String trace = request.header("X-Posts-Trace").orElse("none");
+        JsonNode json = request.body().asJson();
+        return ok("created");
+    }
+}

--- a/spec/functional_test/fixtures/java/play/conf/routes
+++ b/spec/functional_test/fixtures/java/play/conf/routes
@@ -29,4 +29,6 @@ POST /bytes controllers.MissingController.bytes
 POST /whitespace controllers.MissingController.whitespace
 POST /api/static @controllers.Api.staticPost
 
+POST /v1/posts v1.PostsApi.create(request: Request)
+
 -> /api api.Routes

--- a/spec/functional_test/fixtures/java/spring_callees/src/CatalogApi.java
+++ b/spec/functional_test/fixtures/java/spring_callees/src/CatalogApi.java
@@ -1,0 +1,13 @@
+package com.test;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+// API-first contract: the route lives on the interface (springdoc /
+// OpenAPI style); the behaviour lives on the @Override below.
+@RequestMapping("/api/catalog")
+public interface CatalogApi {
+    @GetMapping("/{id}")
+    String getItem(@PathVariable String id);
+}

--- a/spec/functional_test/fixtures/java/spring_callees/src/CatalogApiController.java
+++ b/spec/functional_test/fixtures/java/spring_callees/src/CatalogApiController.java
@@ -1,0 +1,12 @@
+package com.test;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CatalogApiController implements CatalogApi {
+    @Override
+    public String getItem(String id) {
+        catalogService.load(id);
+        return AuditLog.write("get");
+    }
+}

--- a/spec/functional_test/testers/java/play_spec.cr
+++ b/spec/functional_test/testers/java/play_spec.cr
@@ -70,6 +70,13 @@ expected_endpoints = [
   Endpoint.new("/api/reports", "POST", [
     Param.new("body", "", "json"),
   ]),
+  # Controller in a non-`controllers` package (`app/v1/PostsApi.java`):
+  # header + body enrichment must still resolve via the `play.mvc`
+  # marker gate, not the package-path convention.
+  Endpoint.new("/v1/posts", "POST", [
+    Param.new("X-Posts-Trace", "", "header"),
+    Param.new("body", "", "json"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/java/play/", {

--- a/spec/functional_test/testers/java/spring_callees_spec.cr
+++ b/spec/functional_test/testers/java/spring_callees_spec.cr
@@ -25,6 +25,11 @@ require "../../func_spec.cr"
 #                               drops the outer `toString` and keeps
 #                               only the inner `getLegacy`, matching
 #                               the Python/Go chained-call noise filter.
+#   - GET  /api/catalog/{id}  — route declared on a springdoc-style
+#                               `*Api` interface; callees are pulled
+#                               from the `@Override` body on the
+#                               concrete controller, not the empty
+#                               interface method.
 expected_endpoints = [
   Endpoint.new("/api/users/", "POST").tap do |ep|
     ep.push_callee(Callee.new("service.save", line: 20))
@@ -39,6 +44,11 @@ expected_endpoints = [
   Endpoint.new("/api/orders/legacy", "GET").tap do |ep|
     ep.push_callee(Callee.new("AuditLog.write", line: 13))
     ep.push_callee(Callee.new("getLegacy", line: 17))
+  end,
+
+  Endpoint.new("/api/catalog/{id}", "GET", [Param.new("id", "", "path")]).tap do |ep|
+    ep.push_callee(Callee.new("catalogService.load", line: 9))
+    ep.push_callee(Callee.new("AuditLog.write", line: 10))
   end,
 ]
 

--- a/spec/functional_test/testers/java/spring_spec.cr
+++ b/spec/functional_test/testers/java/spring_spec.cr
@@ -72,7 +72,7 @@ expected_endpoints = [
   # ItemController.java
   Endpoint.new("/items/{id}", "GET", [Param.new("id", "", "path")]),
   Endpoint.new("/items/json/{id}", "GET", [Param.new("id", "", "path")]),
-  Endpoint.new("/items", "POST", [Param.new("id", "", "form"), Param.new("name", "", "form")]),
+  Endpoint.new("/items", "POST", [Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/items/update/{id}", "PUT", [Param.new("id", "", "path"), Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/items/delete/{id}", "DELETE", [Param.new("id", "", "path")]),
   Endpoint.new("/items/requestmap/put", "PUT"),
@@ -95,7 +95,7 @@ expected_endpoints = [
   ]),
   # ItemController2.java
   Endpoint.new("/items2/{id}", "GET", [Param.new("id", "", "path")]),
-  Endpoint.new("/items2/create", "POST", [Param.new("id", "", "form"), Param.new("name", "", "form")]),
+  Endpoint.new("/items2/create", "POST", [Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/items2/edit/", "PUT", [Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/items2/{id}/thePath", "GET", [Param.new("id", "", "path")]),
   # EmptyController.java
@@ -118,7 +118,7 @@ expected_endpoints = [
   # InventoryClient.java
   Endpoint.new("/api/v2/items/{id}/stock", "PATCH", [Param.new("id", "", "path"), Param.new("quantity", "", "json")]),
   Endpoint.new("/api/v2/items", "GET", [Param.new("category", "", "query")]),
-  Endpoint.new("/api/v2/items", "POST", [Param.new("id", "", "form"), Param.new("name", "", "form")]),
+  Endpoint.new("/api/v2/items", "POST", [Param.new("id", "", "json"), Param.new("name", "", "json")]),
   Endpoint.new("/api/v2/items/{id}", "DELETE", [Param.new("id", "", "path")]),
   # InventoryHttpClient.java — Spring HTTP Interface client.
   Endpoint.new("/api/v3/items/{id}/availability", "GET", [

--- a/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "file_utils"
 require "../../../src/models/logger"
 require "../../../src/miniparsers/java_parameter_extractor_ts"
 
@@ -320,6 +321,75 @@ describe Noir::TreeSitterJavaParameterExtractor do
       )
       params.map(&.name).should eq(["title", "body", "categoryId"])
       params.all? { |p| p.param_type == "json" }.should be_true
+    end
+  end
+
+  describe ".extract_class_supertypes" do
+    it "maps each class to its superclass simple name" do
+      source = <<-JAVA
+        class Owner extends Person {}
+        class Person extends BaseEntity {}
+        class BaseEntity {}
+        class Standalone {}
+        JAVA
+      supers = Noir::TreeSitterJavaParameterExtractor.extract_class_supertypes(source)
+      supers["Owner"].should eq("Person")
+      supers["Person"].should eq("BaseEntity")
+      supers.has_key?("BaseEntity").should be_false
+      supers.has_key?("Standalone").should be_false
+    end
+
+    it "strips package qualifiers and generic arguments" do
+      source = <<-JAVA
+        class Page extends org.example.base.AbstractPage<Item> {}
+        JAVA
+      Noir::TreeSitterJavaParameterExtractor.extract_class_supertypes(source)["Page"].should eq("AbstractPage")
+    end
+  end
+
+  describe "TreeSitterJavaDtoIndex cross-file inheritance" do
+    it "merges inherited fields from a superclass defined in another package" do
+      Noir::TreeSitterJavaDtoIndex.clear_cache!
+      tmp = File.tempname("noir-dto-inherit")
+      Dir.mkdir_p(File.join(tmp, "src/main/java/com/example/web"))
+      Dir.mkdir_p(File.join(tmp, "src/main/java/com/example/model"))
+
+      controller_path = File.join(tmp, "src/main/java/com/example/web/OwnerController.java")
+      owner_path = File.join(tmp, "src/main/java/com/example/web/Owner.java")
+      person_path = File.join(tmp, "src/main/java/com/example/model/Person.java")
+
+      File.write(controller_path, <<-JAVA)
+        package com.example.web;
+        class OwnerController {
+            public String create(Owner owner) { return ""; }
+        }
+        JAVA
+      File.write(owner_path, <<-JAVA)
+        package com.example.web;
+        import com.example.model.Person;
+        public class Owner extends Person {
+            private String city;
+            public String getCity() { return city; }
+            public void setCity(String city) { this.city = city; }
+        }
+        JAVA
+      File.write(person_path, <<-JAVA)
+        package com.example.model;
+        public class Person {
+            private String firstName;
+            private String lastName;
+            public void setFirstName(String firstName) { this.firstName = firstName; }
+            public void setLastName(String lastName) { this.lastName = lastName; }
+        }
+        JAVA
+
+      controller_src = File.read(controller_path)
+      index = Noir::TreeSitterJavaDtoIndex.new.build_for(controller_path, controller_src)
+      index["Owner"]?.should_not be_nil
+      index["Owner"].map(&.name).should eq(["city", "firstName", "lastName"])
+    ensure
+      FileUtils.rm_rf(tmp) if tmp
+      Noir::TreeSitterJavaDtoIndex.clear_cache!
     end
   end
 end

--- a/spec/unit_test/miniparser/jvm_lambda_dsl_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/jvm_lambda_dsl_extractor_ts_spec.cr
@@ -36,7 +36,8 @@ describe Noir::TreeSitterJvmLambdaDslExtractor do
       "post" => "POST",
       "any"  => "ANY",
     },
-    nest_methods: Set{"path"}
+    nest_methods: Set{"path"},
+    router_receivers: Set{"redirect"}
   )
 
   it "resolves constants and concatenations in paths and handler params" do
@@ -316,6 +317,35 @@ describe Noir::TreeSitterJvmLambdaDslExtractor do
       {"GET", "/legacy-home"},
       {"POST", "/legacy-submit"},
       {"ANY", "/legacy-any"},
+    ])
+  end
+
+  it "ignores collection calls that collide with verb method names" do
+    source = <<-JAVA
+      package com.example;
+
+      import static spark.Spark.*;
+      import java.util.HashMap;
+      import java.util.Map;
+
+      public class Application {
+          void register() {
+              Map<String, String> credentials = new HashMap<>();
+              String secret = credentials.get("admin");
+
+              get("/users/:name", (req, res) -> "hi");
+              post("/login", LoginHandler::handle);
+          }
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJvmLambdaDslExtractor.extract_routes(source, spark_config)
+    # `credentials.get("admin")` reads like `get("/admin", ...)` by method
+    # name alone — but its receiver is a Map and it carries no handler, so
+    # it must not surface as a route.
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/users/:name"},
+      {"POST", "/login"},
     ])
   end
 end

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -25,7 +25,7 @@ module Analyzer::Java
 
         if path.ends_with?("routes") || path.ends_with?("routes.conf") || path.includes?("/conf/routes")
           routes_files << path
-        elsif path.ends_with?(".java") && path.includes?("/controllers/")
+        elsif path.ends_with?(".java") && play_controller_file?(path)
           java_files << path
         end
       end
@@ -44,6 +44,20 @@ module Analyzer::Java
 
       Fiber.yield
       @result
+    end
+
+    # Decide whether a `.java` file holds Play actions. The `controllers`
+    # package is the conventional home, but Play resolves actions by the
+    # fully-qualified name written in the `routes` file, so apps freely
+    # park controllers under any package (e.g. `app/v1/post/
+    # PostController.java` referenced as `v1.post.PostController.list`).
+    # Gating on the `play.mvc` marker recovers those — without it their
+    # body/header/cookie params and callees were silently dropped. The
+    # per-method `play_action_method?` filter downstream keeps
+    # non-action classes (filters, actions, helpers) from contributing.
+    private def play_controller_file?(path : String) : Bool
+      return true if path.includes?("/controllers/")
+      read_file_content(path).includes?("play.mvc")
     end
 
     # Parse Java controller files to extract header, cookie, and body parameters

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -36,6 +36,11 @@ module Analyzer::Java
       cookie_methods: Set{"cookie"},
       body_methods: Set{"body", "bodyAsBytes"},
       websocket_methods: Set{"webSocket"},
+      # `redirect.get("/from", "/to")` & friends register redirect
+      # routes with all-string-literal arguments — allowlist the
+      # `redirect` receiver so they survive the route/collection-call
+      # disambiguation in the shared extractor.
+      router_receivers: Set{"redirect"},
     )
 
     def analyze

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -183,9 +183,9 @@ module Analyzer::Java
                 parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
                   root, content, route.class_name, route.method_name
                 )
-                if parameter_format.nil? && route.verb == "POST"
-                  parameter_format = "form"
-                end
+                # The POST form-binding default is applied per-parameter in
+                # the extractor so an explicit `@RequestBody` resolves to
+                # "json" rather than inheriting "form".
 
                 parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
                   root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index
@@ -237,9 +237,8 @@ module Analyzer::Java
                         parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
                           interface_root, entry.source, entry_route.class_name, entry_route.method_name
                         )
-                        if parameter_format.nil? && entry_route.verb == "POST"
-                          parameter_format = "form"
-                        end
+                        # POST form-binding default applied per-parameter in
+                        # the extractor (keeps `@RequestBody` as "json").
 
                         parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
                           interface_root, entry.source, entry_route.class_name, entry_route.method_name,
@@ -249,9 +248,27 @@ module Analyzer::Java
                       end
 
                       details = Details.new(PathInfo.new(entry.path, entry_route.line + 1))
-                      @result << Endpoint.new(
+                      endpoint = Endpoint.new(
                         join_paths(configured_base_path, inherited_path), entry_route.verb, parameters, details
                       )
+
+                      # The route is declared on the interface (springdoc /
+                      # OpenAPI `*Api` contracts), but the behaviour — and
+                      # thus the callees worth surfacing for ai-context —
+                      # lives in the `@Override` method on the concrete
+                      # controller currently being walked. Pull 1-hop
+                      # callees from that implementing body rather than the
+                      # empty interface method.
+                      if include_callee && !(implementation.class_name.empty? || entry_route.method_name.empty?)
+                        Noir::JavaCalleeExtractor.callees_in_method(
+                          root, content, path, implementation.class_name, entry_route.method_name
+                        ).each do |callee_entry|
+                          name, callee_path, callee_line = callee_entry
+                          endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                        end
+                      end
+
+                      @result << endpoint
                     end
                   end
                 end

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -29,7 +29,7 @@ module Analyzer::Scala
           routes_files << path
         elsif path.ends_with?(".scala")
           @scala_paths << path
-          scala_files << path if path.includes?("/controllers/")
+          scala_files << path if play_controller_file?(path)
         end
       end
 
@@ -52,6 +52,19 @@ module Analyzer::Scala
     # All `.scala` paths in the scan, used to resolve SIRD/SimpleRouter
     # classes referenced from `->` include lines that are not routes files.
     @scala_paths = [] of String
+
+    # Decide whether a `.scala` file holds Play controllers. The
+    # `controllers` package is conventional, but Play resolves actions
+    # by the fully-qualified name in the `routes` file, so controllers
+    # routinely live in other packages. Gating on the `play.api.mvc`
+    # marker recovers those — otherwise their header/cookie/body params
+    # and callees are dropped. SIRD/SimpleRouter resolution still walks
+    # every `.scala` path via `@scala_paths`, so this only governs the
+    # controller-method enrichment map.
+    private def play_controller_file?(path : String) : Bool
+      return true if path.includes?("/controllers/")
+      read_file_content(path).includes?("play.api.mvc")
+    end
 
     # Parse Scala controller files to extract header, cookie, and body parameters
     private def parse_controller_files(scala_files : Array(String)) : Hash(String, ControllerMethod)

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -103,6 +103,47 @@ module Noir
       results
     end
 
+    def extract_class_supertypes(source : String) : Hash(String, String)
+      results = Hash(String, String).new
+      Noir::TreeSitter.parse_java(source) do |root|
+        results = extract_class_supertypes_from(root, source)
+      end
+      results
+    end
+
+    # Map each `class` to the simple name of its superclass
+    # (`{"Owner" => "Person"}` for `class Owner extends Person`). Drives
+    # cross-file DTO inheritance: a command object that extends a base
+    # entity binds the parent's fields too, so the index merges them in
+    # via `TreeSitterJavaDtoIndex`. Interfaces are skipped — only the
+    # single `extends` superclass carries bindable fields.
+    def extract_class_supertypes_from(root : LibTreeSitter::TSNode, source : String) : Hash(String, String)
+      results = Hash(String, String).new
+      walk_class_containers(root) do |decl|
+        next unless Noir::TreeSitter.node_type(decl) == "class_declaration"
+        name_node = Noir::TreeSitter.field(decl, "name")
+        next unless name_node
+        super_node = Noir::TreeSitter.field(decl, "superclass")
+        next unless super_node
+        super_name = simple_superclass_name(Noir::TreeSitter.node_text(super_node, source))
+        next if super_name.empty?
+        results[Noir::TreeSitter.node_text(name_node, source)] = super_name
+      end
+      results
+    end
+
+    # `extends com.example.Base<T>` -> `Base`. The tree-sitter
+    # `superclass` node text carries the `extends` keyword, an optional
+    # package qualifier, and optional generic arguments — strip all
+    # three down to the simple type name the field index is keyed on.
+    private def simple_superclass_name(text : String) : String
+      name = text.strip
+      name = name.lchop("extends").strip if name.starts_with?("extends")
+      name = name.split('<', 2).first
+      name = name.split('.').last
+      name.strip
+    end
+
     # Extract parameters for `method_name` on `class_name`. Returns
     # `[]` when the method isn't found. `parameter_format` is the
     # method's default-shape hint (e.g. "form" when `@PostMapping` +
@@ -490,6 +531,14 @@ module Noir
         next unless Noir::TreeSitter.node_type(fp) == "formal_parameter"
         current_format = emit_param_for(fp, method, source, verb, current_format, class_fields, constants, current_class, params)
       end
+
+      # Collapse duplicate `(name, type)` params. A handler binding two
+      # command objects that share an inherited field — e.g. an `Owner`
+      # and a `Pet` both extending a base entity with `id` — otherwise
+      # surfaces `id` once per object, but the wire form carries a
+      # single `id`. Distinct types (path `id` vs query `id`) are kept.
+      seen = Set({String, String}).new
+      params.select! { |param| seen.add?({param.name, param.param_type}) }
       params
     end
 
@@ -559,7 +608,17 @@ module Noir
       when :cookie
         effective_format = "cookie"
       end
-      return effective_format if effective_format.nil?
+      if effective_format.nil?
+        # No parameter annotation and no `consumes` hint. A POST binds an
+        # un-annotated command object / scalar as form data (Spring
+        # `@ModelAttribute` semantics); other verbs carry no implicit
+        # request body, so the parameter isn't a request input. Applying
+        # this per-parameter — rather than pre-seeding the whole method
+        # with "form" — lets an explicit `@RequestBody` on the same POST
+        # resolve to "json" instead of being dragged to "form".
+        return parameter_format unless verb == "POST"
+        effective_format = "form"
+      end
 
       default_value : String? = nil
       parameter_name = arg_name
@@ -764,10 +823,17 @@ module Noir
     # exposed anyway for any test setup that wants explicit
     # determinism.
     @@shared_cache = Hash(String, Index).new
+    # Per-file `class -> superclass simple name` map, cached alongside
+    # the field index so a file is parsed once for both. Drives the
+    # cross-file inheritance merge below.
+    @@shared_super_cache = Hash(String, Hash(String, String)).new
     @@shared_cache_mutex = Mutex.new
 
     def self.clear_cache!
-      @@shared_cache_mutex.synchronize { @@shared_cache.clear }
+      @@shared_cache_mutex.synchronize do
+        @@shared_cache.clear
+        @@shared_super_cache.clear
+      end
     end
 
     def initialize
@@ -793,61 +859,221 @@ module Noir
     # process-wide cache so concurrent analyzers don't double-up.
     def build_for_with_root(path : String, content : String, root : LibTreeSitter::TSNode) : Index
       result = Index.new
+      # `supers[class] = superclass simple name`, `origin[class] = the
+      # file that defined it`. The latter lets the inheritance pass
+      # resolve a superclass through the *subclass's* imports — Owner
+      # imports `model.Person`, even though the controller that pulled
+      # Owner in never mentions the `model` package.
+      supers = Hash(String, String).new
+      origin = Hash(String, String).new
+
       package_name = TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
       imports = TreeSitterJavaParameterExtractor.extract_imports_from(root, content)
 
-      # Seed the shared cache for the current file from the
+      # Seed the shared caches for the current file from the
       # already-parsed root so this and any concurrent analyzer's
       # `related_files` loop reuses it.
       current_fields = TreeSitterJavaParameterExtractor.extract_class_fields_from(root, content)
+      current_supers = TreeSitterJavaParameterExtractor.extract_class_supertypes_from(root, content)
       @@shared_cache_mutex.synchronize do
         @@shared_cache[path] ||= current_fields
+        @@shared_super_cache[path] ||= current_supers
       end
 
       Noir::ImportGraph.related_files(path, package_name, imports, "java") do |file|
-        merge!(result, classes_in(file, path, content))
+        fields, file_supers = load_file(file)
+        absorb!(result, supers, origin, fields, file_supers, file)
       end
 
+      resolve_inheritance!(result, supers, origin)
       result
     end
 
-    private def classes_in(file : String, current_path : String, current_content : String) : Index
-      cached = @@shared_cache_mutex.synchronize { @@shared_cache[file]? }
-      return cached if cached
+    # Pull a file's `{fields, supertypes}` from the shared cache,
+    # parsing it once on a miss. Both maps are populated together so a
+    # DTO file is never parsed twice.
+    private def load_file(file : String) : {Index, Hash(String, String)}
+      cached_fields, cached_supers = @@shared_cache_mutex.synchronize do
+        {@@shared_cache[file]?, @@shared_super_cache[file]?}
+      end
+      return {cached_fields, cached_supers} if cached_fields && cached_supers
 
-      fields = parse_classes_for(file, current_path, current_content)
+      fields = Index.new
+      supertypes = Hash(String, String).new
+      body = file_body(file)
+      Noir::TreeSitter.parse_java(body) do |root|
+        fields = TreeSitterJavaParameterExtractor.extract_class_fields_from(root, body)
+        supertypes = TreeSitterJavaParameterExtractor.extract_class_supertypes_from(root, body)
+      end
 
-      # Multiple analyzers may race here on a cache miss — the
-      # `||=` keeps whichever wrote first; the loser silently
-      # discards its parse. Acceptable cost vs the per-file lock
-      # complexity that strict single-parse would require.
+      # Multiple analyzers may race here on a cache miss — the `||=`
+      # keeps whichever wrote first; the loser silently discards its
+      # parse. Acceptable cost vs the per-file lock complexity that
+      # strict single-parse would require.
       @@shared_cache_mutex.synchronize do
         @@shared_cache[file] ||= fields
-        @@shared_cache[file]
+        @@shared_super_cache[file] ||= supertypes
+        {@@shared_cache[file], @@shared_super_cache[file]}
       end
-    end
-
-    private def parse_classes_for(file : String, current_path : String, current_content : String) : Index
-      body =
-        if file == current_path
-          current_content
-        else
-          # Detector pre-warms a content cache for every scanned
-          # file (size-bounded). Sibling DTO files often live in
-          # that cache already — `nil` falls back to a fresh
-          # `File.read` for files outside the budget.
-          CodeLocator.instance.content_for(file) ||
-            File.read(file, encoding: "utf-8", invalid: :skip)
-        end
-      TreeSitterJavaParameterExtractor.extract_class_fields(body)
     rescue File::NotFoundError
-      Index.new
+      {Index.new, Hash(String, String).new}
     end
 
-    private def merge!(into : Index, src : Index)
-      src.each do |name, fields|
-        into[name] ||= fields
+    private def file_body(file : String) : String
+      # Detector pre-warms a content cache for every scanned file
+      # (size-bounded). Sibling/parent DTO files often live in that
+      # cache already — `nil` falls back to a fresh `File.read` for
+      # files outside the budget.
+      CodeLocator.instance.content_for(file) ||
+        File.read(file, encoding: "utf-8", invalid: :skip)
+    end
+
+    private def absorb!(result : Index,
+                        supers : Hash(String, String),
+                        origin : Hash(String, String),
+                        fields : Index,
+                        file_supers : Hash(String, String),
+                        file : String)
+      fields.each do |name, fs|
+        unless result.has_key?(name)
+          result[name] = fs
+          origin[name] ||= file
+        end
+      end
+      file_supers.each do |name, sup|
+        supers[name] ||= sup
+        origin[name] ||= file
       end
     end
+
+    # Merge inherited fields into each subclass. First pulls in the
+    # files that define still-unresolved superclasses (following
+    # `extends` edges the controller never imported directly), then
+    # folds each `extends` chain into a single flattened field list.
+    private def resolve_inheritance!(result : Index,
+                                     supers : Hash(String, String),
+                                     origin : Hash(String, String))
+      return if supers.empty?
+
+      pull_superclass_files!(result, supers, origin)
+
+      memo = Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)).new
+      (result.keys.to_set | supers.keys.to_set).each do |cls|
+        merged = effective_fields(cls, result, supers, memo, Set(String).new)
+        result[cls] = merged unless merged.empty?
+      end
+    end
+
+    private def pull_superclass_files!(result : Index,
+                                       supers : Hash(String, String),
+                                       origin : Hash(String, String))
+      attempted = Set(String).new
+      pending = supers.keys.to_a
+      iterations = 0
+
+      until pending.empty? || iterations > MAX_INHERITANCE_RESOLUTIONS
+        iterations += 1
+        cls = pending.shift
+        sup = supers[cls]?
+        next unless sup
+        # Already loaded (has fields or a recorded super) — its own
+        # `extends` edge, if any, is queued separately.
+        next if result.has_key?(sup) || supers.has_key?(sup)
+        # Resolve each distinct superclass name at most once, even if
+        # several subclasses share it or its file defines nothing
+        # useful.
+        next unless attempted.add?(sup)
+        file = origin[cls]?
+        next unless file
+
+        pending.concat(load_superclass_files(result, supers, origin, file))
+      end
+    end
+
+    # Walk the subclass file's own related files (siblings + imports)
+    # and absorb any classes not seen yet. Returns the names added so
+    # the caller can chase their `extends` edges in turn.
+    private def load_superclass_files(result : Index,
+                                      supers : Hash(String, String),
+                                      origin : Hash(String, String),
+                                      subclass_file : String) : Array(String)
+      added = [] of String
+      package_name, imports = file_package_imports(subclass_file)
+
+      Noir::ImportGraph.related_files(subclass_file, package_name, imports, "java") do |file|
+        fields, file_supers = load_file(file)
+        fields.each do |name, fs|
+          unless result.has_key?(name)
+            result[name] = fs
+            origin[name] ||= file
+            added << name
+          end
+        end
+        file_supers.each do |name, sup|
+          unless supers.has_key?(name)
+            supers[name] = sup
+            origin[name] ||= file
+            added << name
+          end
+        end
+      end
+
+      added
+    end
+
+    private def file_package_imports(file : String) : {String, Array(Noir::ImportGraph::ImportRef)}
+      package_name = ""
+      imports = [] of Noir::ImportGraph::ImportRef
+      body = file_body(file)
+      Noir::TreeSitter.parse_java(body) do |root|
+        package_name = TreeSitterJavaParameterExtractor.extract_package_name_from(root, body)
+        imports = TreeSitterJavaParameterExtractor.extract_imports_from(root, body)
+      end
+      {package_name, imports}
+    rescue File::NotFoundError
+      {"", [] of Noir::ImportGraph::ImportRef}
+    end
+
+    # Own fields plus the (already-flattened) superclass fields, deduped
+    # by name so an overriding field wins. `visiting` guards against
+    # `extends` cycles; `memo` keeps the walk linear.
+    private def effective_fields(cls : String,
+                                 result : Index,
+                                 supers : Hash(String, String),
+                                 memo : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
+                                 visiting : Set(String)) : Array(TreeSitterJavaParameterExtractor::FieldInfo)
+      if cached = memo[cls]?
+        return cached
+      end
+
+      own = result[cls]? || [] of TreeSitterJavaParameterExtractor::FieldInfo
+      sup = supers[cls]?
+
+      unless sup && sup != cls && !visiting.includes?(cls)
+        memo[cls] = own
+        return own
+      end
+
+      visiting << cls
+      parent = effective_fields(sup, result, supers, memo, visiting)
+      visiting.delete(cls)
+
+      if parent.empty?
+        memo[cls] = own
+        return own
+      end
+
+      names = own.map(&.name).to_set
+      combined = own.dup
+      parent.each do |field|
+        combined << field unless names.includes?(field.name)
+      end
+      memo[cls] = combined
+      combined
+    end
+
+    # Backstop against pathological `extends` graphs — far above any
+    # real DTO hierarchy depth/fan-out.
+    MAX_INHERITANCE_RESOLUTIONS = 512
   end
 end

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -59,6 +59,16 @@ module Noir
       getter cookie_methods : Set(String)
       getter body_methods : Set(String)
       getter body_typed_methods : Set(String)
+      # Receiver names (the `object` in `recv.get(...)`) that mark a
+      # verb call as a genuine route registration even when it carries
+      # no functional handler argument. Spark's redirect API
+      # (`redirect.get("/from", "/to")`) is the canonical case — its
+      # arguments are all string literals, so without an explicit
+      # allowlist it's indistinguishable from a colliding collection
+      # call like `map.put("k", "v")`. Matched against the receiver's
+      # last dotted segment, so both `redirect.get(...)` and
+      # `Spark.redirect.get(...)` resolve to `redirect`.
+      getter router_receivers : Set(String)
 
       def initialize(@verb_methods,
                      @nest_methods,
@@ -71,7 +81,8 @@ module Noir
                      @cookie_methods = Set(String).new,
                      @body_methods = Set(String).new,
                      @body_typed_methods = Set(String).new,
-                     @websocket_methods = Set(String).new)
+                     @websocket_methods = Set(String).new,
+                     @router_receivers = Set(String).new)
       end
     end
 
@@ -167,6 +178,8 @@ module Noir
                            method_bodies : Hash(String, LibTreeSitter::TSNode),
                            include_callees : Bool,
                            protocol : String = "http")
+      return unless route_invocation?(call, source, config)
+
       path_arg = first_string_argument(call, source, constants)
       if path_arg.nil?
         return if prefix.empty? || !pathless_handler_argument?(call)
@@ -504,6 +517,49 @@ module Noir
                                        source : String,
                                        constants : Hash(String, String)) : Bool
       !!first_string_argument(call, source, constants) || pathless_handler_argument?(call)
+    end
+
+    # Guard against collisions between verb method names and ordinary
+    # collection / builder calls that happen to share them — e.g.
+    # `usernamePasswords.put("foo", "bar")` (a `Map.put`) reads exactly
+    # like `put("/foo", handler)` once you only look at the method name
+    # and a string argument. A call is a genuine route when ANY holds:
+    #
+    #   * it's unqualified (`get("/x", ...)`) — `import static
+    #     spark.Spark.*` style, never a method on a user object;
+    #   * it carries a functional handler argument (lambda, method
+    #     reference, anonymous class, or class literal) — collection
+    #     mutators pass plain values, never handlers;
+    #   * its receiver is an allowlisted router (Spark's `redirect`),
+    #     which lets the all-string-literal redirect forms through.
+    private def route_invocation?(call : LibTreeSitter::TSNode,
+                                  source : String,
+                                  config : Config) : Bool
+      receiver = Noir::TreeSitter.field(call, "object")
+      return true unless receiver
+      return true if functional_handler_argument?(call)
+      config.router_receivers.includes?(receiver_key(receiver, source))
+    end
+
+    # Last dotted segment of the receiver expression: `redirect` for
+    # both `redirect.get(...)` and `service.redirect.get(...)`.
+    private def receiver_key(receiver : LibTreeSitter::TSNode, source : String) : String
+      Noir::TreeSitter.node_text(receiver, source).split('.').last.strip
+    end
+
+    private def functional_handler_argument?(call : LibTreeSitter::TSNode) : Bool
+      args = argument_list_node(call)
+      return false unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        case Noir::TreeSitter.node_type(arg)
+        when "lambda_expression", "method_reference",
+             "object_creation_expression", "class_literal"
+          return true
+        end
+      end
+
+      false
     end
 
     private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String


### PR DESCRIPTION
Sweeps endpoint / callee / ai-context FP & FN across the Java **Spring**, **Play**, and **Spark** analyzers, validated against real OSS apps (`spring-petclinic`, `spring-boot-realworld-example-app`, `spring-petclinic-rest`, `playframework/play-samples`, `perwendel/spark` examples).

These build on an already-solid AI-context base — each change tightens what the analyzers already do well rather than papering over a gap.

## Spark (shared JVM lambda-DSL extractor)
- **FP:** collection/builder calls that collide with verb method names no longer become routes. `usernamePasswords.put("foo", "bar")` (a `Map.put`) used to surface as `PUT /foo`. A verb call now counts as a route only when it is unqualified, carries a *functional handler* argument (lambda / method reference / anonymous class / class literal), or targets an allowlisted router receiver. Spark's redirect API (`redirect.get("/from", "/to")` — all string-literal args) is kept via a new `router_receivers` config.

## Play (Java + Scala)
- **FN:** controllers parked outside the conventional `controllers` package (e.g. `app/v1/post/PostController.java`, resolved by fully-qualified name in the `routes` file) were dropped, losing their header/cookie/body params **and** callees. Collection is now gated on the `play.mvc` / `play.api.mvc` marker instead of the package path.

## Spring
- **FN (DTO inheritance):** a command object that extends a base entity now binds the parent's fields too — `Owner extends Person` recovers `firstName`/`lastName`, `Pet extends NamedEntity` recovers `name`. `TreeSitterJavaDtoIndex` follows `extends` edges through the subclass's own imports and merges flattened fields cross-file.
- **FN (ai-context callees):** springdoc / OpenAPI API-first controllers (`@RestController implements OwnersApi`) had empty callees because the route lives on the interface. Callees are now pulled from the `@Override` body on the concrete controller.
- **FP (param type):** `@RequestBody` params are typed `json` instead of `form`. The POST form-binding default is applied per-parameter so an explicit `@RequestBody` resolves to json, while un-annotated `@ModelAttribute`-style command objects stay form.
- **FP (dedup):** duplicate `(name, type)` params are collapsed when a handler binds two command objects sharing an inherited field.

## Tests
- **Unit:** Map.put/get collision suppression; class supertype extraction; cross-file DTO inheritance merge.
- **Functional:** Play controller in a non-`controllers` package; Spring interface-implementation callees; `@RequestBody` POST → json.

Full suite green: `2799` unit + `16059` functional examples, 0 failures.