### PR TITLE
feat(tagger): add Rails security framework tagger (CSRF / mass-assignment / rate-limit)

### DIFF
--- a/docs/content/usage/more_features/tagger/index.ko.md
+++ b/docs/content/usage/more_features/tagger/index.ko.md
@@ -82,5 +82,9 @@ noir scan <BASE_PATH> --use-taggers hunt,oauth
   - `api_docs` — API 문서/스키마 엔드포인트(Swagger, OpenAPI, GraphiQL, ReDoc, WSDL). 전체 API 표면을 드러내고 인증 없이 노출되는 경우가 많음. 비인증 노출 및 정보 유출 검토 대상.
   - `account_recovery` — 자격증명 관리·계정 복구 엔드포인트(비밀번호 재설정/변경, 이메일 변경, MFA/OTP, 인증). 전형적인 계정 탈취 표면 — 리셋 토큰 유출, reset 링크 host-header 인젝션, 계정 열거, 레이트리밋 부재 검토 대상.
   - `file_upload` — 파일 업로드 엔드포인트. 무제한 업로드, 경로 탐색, 악성 파일 처리 검토 대상.
+- **프레임워크별 보호 장치 & 위험** — 프레임워크의 안전한 기본값에서 *벗어난 지점*을 해당 액션에 표시하는 프레임워크 인지 태거. Rails(`rails_security`)의 경우:
+  - `csrf-protection` — CSRF 검증이 비활성화(`skip_before_action :verify_authenticity_token`, `skip_forgery_protection`)되었거나 약화(`protect_from_forgery with: :null_session`)된 경우. Rails는 상태 변경 요청을 기본으로 보호하므로, 명시적으로 해제한 지점이 검토 대상.
+  - `mass-assignment` — Strong Parameters가 우회된 경우(`params.permit!`, `params.to_unsafe_h`, 또는 `Model.new(params[:user])`처럼 가공되지 않은 `params[:x]` 해시를 모델 라이터에 전달). 공격자가 제어하는 속성 쓰기(권한 플래그, 소유권 컬럼) 검토 대상.
+  - `rate-limit` — Rails 8 네이티브 `rate_limit` 매크로로 스로틀링되는 액션. 무차별 대입/남용 노출을 평가할 때 유용한 맥락이며, 인증·복구 표면에서 이것이 부재하면 그 자체가 점검 포인트.
 
 엔드포인트 레벨 태그는 AI 컨텍스트에도 신호로 전달되어, AI 리뷰어가 사용하는 엔드포인트별 요약을 더욱 풍부하게 만듭니다.

--- a/docs/content/usage/more_features/tagger/index.md
+++ b/docs/content/usage/more_features/tagger/index.md
@@ -82,5 +82,9 @@ Taggers span several kinds of security-relevant signal. Run `noir list taggers` 
   - `api_docs` — API documentation / schema endpoints (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL); expose the full API surface and are frequently unauthenticated — review for unauthenticated exposure and information disclosure.
   - `account_recovery` — credential-management and account-recovery endpoints (password reset/change, email change, MFA/OTP, verification); the classic account-takeover surface — review for reset-token leakage, host-header injection in reset links, account enumeration, and missing rate limiting.
   - `file_upload` — file upload endpoints; review for unrestricted upload, path traversal, and malicious file handling.
+- **Framework-specific protections & risks** — framework-aware taggers that flag *deviations from a framework's secure defaults* on the actions they affect. For Rails (`rails_security`):
+  - `csrf-protection` — CSRF verification disabled (`skip_before_action :verify_authenticity_token`, `skip_forgery_protection`) or downgraded (`protect_from_forgery with: :null_session`); Rails protects state-changing requests by default, so an explicit opt-out is the case worth reviewing.
+  - `mass-assignment` — Strong Parameters bypassed (`params.permit!`, `params.to_unsafe_h`, or a raw `params[:x]` hash passed to a model writer such as `Model.new(params[:user])`); review for attacker-controlled attribute writes (privilege flags, ownership columns).
+  - `rate-limit` — actions throttled by the Rails 8 native `rate_limit` macro; useful context when assessing brute-force / abuse exposure (and its absence on auth/recovery surface is itself a finding).
 
 Endpoint-level tags also feed the AI context as signals, enriching the per-endpoint summary that AI reviewers consume.

--- a/spec/functional_test/fixtures/ruby/rails_security/Gemfile
+++ b/spec/functional_test/fixtures/ruby/rails_security/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rails"

--- a/spec/functional_test/fixtures/ruby/rails_security/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_security/app/controllers/posts_controller.rb
@@ -1,0 +1,17 @@
+class PostsController < ApplicationController
+  def index
+    render json: Post.all
+  end
+
+  def create
+    post = Post.new(post_params)
+    post.save
+    render json: post
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body)
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_security/app/controllers/users_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_security/app/controllers/users_controller.rb
@@ -1,0 +1,20 @@
+class UsersController < ApplicationController
+  protect_from_forgery with: :null_session
+  skip_before_action :verify_authenticity_token, only: [:create]
+
+  def index
+    render json: User.all
+  end
+
+  def create
+    user = User.new(params[:user])
+    user.save
+    render json: user
+  end
+
+  def update
+    user = User.find(params[:id])
+    user.update(params.permit!)
+    render json: user
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_security/app/controllers/webhooks_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_security/app/controllers/webhooks_controller.rb
@@ -1,0 +1,13 @@
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  rate_limit to: 10, within: 1.minute, only: :create
+
+  def create
+    payload = JSON.parse(request.body.read)
+    render json: { ok: true }
+  end
+
+  def index
+    render json: { up: true }
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_security/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_security/config/routes.rb
@@ -1,0 +1,6 @@
+Rails.application.routes.draw do
+  resources :users, only: [:index, :create, :update]
+  resources :posts, only: [:index, :create]
+
+  resources :webhooks, only: [:index, :create]
+end

--- a/spec/unit_test/tagger/framework_taggers/rails_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/rails_security_spec.cr
@@ -1,0 +1,137 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+# Fixture line references
+#
+# webhooks_controller.rb
+#   1: class WebhooksController < ApplicationController
+#   2:   skip_before_action :verify_authenticity_token
+#   3:   rate_limit to: 10, within: 1.minute, only: :create
+#   5:   def create
+#  10:   def index
+#
+# users_controller.rb
+#   1: class UsersController < ApplicationController
+#   2:   protect_from_forgery with: :null_session
+#   3:   skip_before_action :verify_authenticity_token, only: [:create]
+#   5:   def index
+#   9:   def create   ->  user = User.new(params[:user])
+#  15:   def update   ->  user.update(params.permit!)
+#
+# posts_controller.rb (control: default CSRF + Strong Parameters)
+#   2:   def index
+#   6:   def create   ->  Post.new(post_params)
+
+private def tag_named(endpoint : Endpoint, name : String) : Tag?
+  endpoint.tags.find { |t| t.name == name }
+end
+
+private def build_endpoint(path : String, line : Int32, method : String = "POST") : Endpoint
+  details = Details.new(PathInfo.new(path, line))
+  details.technology = "ruby_rails"
+  Endpoint.new("/x", method, [] of Param, details)
+end
+
+describe "RailsSecurityTagger" do
+  fixture_base = "#{__DIR__}/../../../functional_test/fixtures/ruby/rails_security"
+  webhooks = "#{fixture_base}/app/controllers/webhooks_controller.rb"
+  users = "#{fixture_base}/app/controllers/users_controller.rb"
+  posts = "#{fixture_base}/app/controllers/posts_controller.rb"
+
+  options = create_test_options
+  options["base"] = YAML::Any.new(fixture_base)
+
+  it "exposes ruby_rails as its only target tech" do
+    RailsSecurityTagger.target_techs.should eq(["ruby_rails"])
+  end
+
+  describe "csrf-protection" do
+    it "flags skip_before_action :verify_authenticity_token (disabled)" do
+      endpoint = build_endpoint(webhooks, 5)
+      RailsSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "csrf-protection")
+      tag.should_not be_nil
+      tag.not_nil!.tagger.should eq("rails_security")
+      tag.not_nil!.description.should contain("disabled")
+    end
+
+    it "flags protect_from_forgery with: :null_session (downgraded)" do
+      endpoint = build_endpoint(users, 5) # index, only inherits null_session
+      RailsSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "csrf-protection")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("null_session")
+    end
+
+    it "honours only: so the skip applies just to the named action" do
+      # create is in only: [:create] -> disabled (nearest macro wins)
+      create_ep = build_endpoint(users, 9)
+      RailsSecurityTagger.new(options).perform([create_ep])
+      tag_named(create_ep, "csrf-protection").not_nil!.description.should contain("disabled")
+
+      # update is not in only: [:create] -> falls through to null_session
+      update_ep = build_endpoint(users, 15)
+      RailsSecurityTagger.new(options).perform([update_ep])
+      tag_named(update_ep, "csrf-protection").not_nil!.description.should contain("null_session")
+    end
+
+    it "does not flag a controller relying on the Rails default" do
+      endpoint = build_endpoint(posts, 2) # index
+      RailsSecurityTagger.new(options).perform([endpoint])
+      tag_named(endpoint, "csrf-protection").should be_nil
+    end
+  end
+
+  describe "rate-limit" do
+    it "flags a rate_limit macro scoped to the action via only:" do
+      endpoint = build_endpoint(webhooks, 5) # create (only: :create)
+      RailsSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "rate-limit")
+      tag.should_not be_nil
+      tag.not_nil!.tagger.should eq("rails_security")
+    end
+
+    it "does not flag an action outside the rate_limit only: filter" do
+      endpoint = build_endpoint(webhooks, 10) # index
+      RailsSecurityTagger.new(options).perform([endpoint])
+      tag_named(endpoint, "rate-limit").should be_nil
+    end
+  end
+
+  describe "mass-assignment" do
+    it "flags a raw params hash passed to a model writer" do
+      endpoint = build_endpoint(users, 9) # User.new(params[:user])
+      RailsSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "mass-assignment")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("model writer")
+    end
+
+    it "flags params.permit!" do
+      endpoint = build_endpoint(users, 15) # user.update(params.permit!)
+      RailsSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "mass-assignment")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("permit!")
+    end
+
+    it "does not flag a strong-parameters action" do
+      endpoint = build_endpoint(posts, 6) # Post.new(post_params)
+      RailsSecurityTagger.new(options).perform([endpoint])
+      tag_named(endpoint, "mass-assignment").should be_nil
+    end
+  end
+
+  it "applies multiple independent tags to one action" do
+    endpoint = build_endpoint(webhooks, 5) # create: CSRF disabled + rate limited
+    RailsSecurityTagger.new(options).perform([endpoint])
+
+    tag_named(endpoint, "csrf-protection").should_not be_nil
+    tag_named(endpoint, "rate-limit").should_not be_nil
+  end
+end

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -1,0 +1,203 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+# Rails-specific security tagger.
+#
+# `ruby_auth` already classifies authentication (Devise/Pundit/CanCanCan/…),
+# so this tagger covers the other Rails controller-level security signals
+# that map cleanly onto an action and are *deviations from the framework
+# default* — i.e. worth a reviewer's attention rather than ambient noise:
+#
+#   * csrf-protection — CSRF disabled (`skip_before_action
+#     :verify_authenticity_token`, `skip_forgery_protection`) or downgraded
+#     (`protect_from_forgery with: :null_session`). Rails protects every
+#     state-changing request by default, so an explicit opt-out is the
+#     interesting case.
+#   * mass-assignment — Strong Parameters bypassed (`params.permit!`,
+#     `params.to_unsafe_h`, or a raw `params[:x]` hash handed to a model
+#     writer like `Model.new(params[:user])`).
+#   * rate-limit — Rails 8 native `rate_limit` throttle on the action.
+#
+# Like `ruby_auth`, detection is single-file and line-based: it walks the
+# controller the action lives in. Cross-file concerns (a `null_session`
+# base controller inherited by children, a Rack::Attack initializer) are
+# out of scope by design — those live outside the action's own file.
+class RailsSecurityTagger < FrameworkTagger
+  # Class-level macros that turn CSRF verification OFF for (some) actions.
+  CSRF_DISABLE_PATTERNS = [
+    {/skip_before_action\s+:verify_authenticity_token/, "verify_authenticity_token skipped"},
+    {/skip_forgery_protection/, "skip_forgery_protection"},
+  ]
+
+  # `protect_from_forgery with: :null_session` keeps the filter but lets a
+  # forged request through with a blank session instead of rejecting it —
+  # the usual choice for token/API controllers, and worth flagging because
+  # cookie-session callers lose CSRF rejection.
+  CSRF_NULL_SESSION_PATTERN = /protect_from_forgery\s+.*with:\s*:null_session/
+
+  # Rails 8 `rate_limit to: N, within: T[, only:/except:]` declared like a
+  # before_action at class scope.
+  RATE_LIMIT_PATTERN = /\brate_limit\s+(?:to|within|by|with|store|name|only|except):/
+
+  # Strong-Parameters escape hatches in an action body.
+  MASS_ASSIGN_BANG_PATTERNS = [
+    {/params\.permit!/, "params.permit!"},
+    {/params\.to_unsafe_h(?:ash)?\b/, "params.to_unsafe_h"},
+  ]
+
+  # A raw `params[:x]` hash passed straight into a model writer (no
+  # intervening `.permit`). `find`/`where` take a scalar id, so they are
+  # deliberately excluded — only attribute-setting writers are risky.
+  MASS_ASSIGN_WRITER_PATTERN =
+    /\.(?:new|create|create!|update|update!|update_attributes|update_attributes!|assign_attributes)\s*\(\s*params\[/
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "rails_security"
+  end
+
+  def self.target_techs : Array(String)
+    ["ruby_rails"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    endpoints.each do |endpoint|
+      check_endpoint(endpoint)
+    end
+    endpoints
+  end
+
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      # Skip stale/out-of-range line refs: a line beyond the content we read
+      # would crash the lines[idx] walks below with IndexError.
+      next if line_num < 1 || line_num > lines.size
+      line_idx = line_num - 1
+
+      action_name = extract_action_name(lines, line_idx)
+
+      # Each concern is independent — an action can be CSRF-disabled AND
+      # rate-limited AND mass-assigning — so collect all that apply rather
+      # than returning on the first hit.
+      if desc = check_csrf(lines, line_idx, action_name)
+        endpoint.add_tag(Tag.new("csrf-protection", desc, "rails_security"))
+      end
+
+      if desc = check_rate_limit(lines, line_idx, action_name)
+        endpoint.add_tag(Tag.new("rate-limit", desc, "rails_security"))
+      end
+
+      if desc = check_mass_assignment(lines, line_idx)
+        endpoint.add_tag(Tag.new("mass-assignment", desc, "rails_security"))
+      end
+    end
+  end
+
+  # Walk backwards from the action to its enclosing class, looking for a
+  # CSRF disable/downgrade macro. The nearest matching macro wins.
+  private def check_csrf(lines : Array(String), action_line : Int32, action_name : String?) : String?
+    idx = action_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      CSRF_DISABLE_PATTERNS.each do |pattern, label|
+        if current.matches?(pattern) && macro_applies?(current, action_name)
+          return "CSRF protection disabled (#{label}) — state-changing requests to this action are not CSRF-validated."
+        end
+      end
+
+      if current.matches?(CSRF_NULL_SESSION_PATTERN) && macro_applies?(current, action_name)
+        return "CSRF protection downgraded to null_session — forged requests proceed with an empty session instead of being rejected (typical for token/API controllers)."
+      end
+
+      break if current.starts_with?("class ")
+      idx -= 1
+    end
+
+    nil
+  end
+
+  # Rails 8 `rate_limit` is a class-level macro like before_action; walk
+  # back to the class and honour only:/except:.
+  private def check_rate_limit(lines : Array(String), action_line : Int32, action_name : String?) : String?
+    idx = action_line
+    while idx >= 0
+      current = lines[idx].strip
+
+      if current.matches?(RATE_LIMIT_PATTERN) && macro_applies?(current, action_name)
+        return "Rate limited by Rails rate_limit — request volume to this action is throttled per client."
+      end
+
+      break if current.starts_with?("class ")
+      idx -= 1
+    end
+
+    nil
+  end
+
+  # Scan the action body forward for Strong-Parameters bypasses.
+  private def check_mass_assignment(lines : Array(String), action_line : Int32) : String?
+    idx = action_line + 1
+    end_idx = [action_line + 25, lines.size - 1].min
+
+    while idx <= end_idx
+      current = lines[idx].strip
+      # Stop at the next method definition (left the action body).
+      break if current.starts_with?("def ") && idx > action_line
+
+      MASS_ASSIGN_BANG_PATTERNS.each do |pattern, label|
+        if current.matches?(pattern)
+          return "Mass assignment risk — Strong Parameters bypassed via #{label}, allowing arbitrary model attributes to be set."
+        end
+      end
+
+      if current.matches?(MASS_ASSIGN_WRITER_PATTERN)
+        return "Mass assignment risk — a raw params hash is passed to a model writer without Strong Parameters filtering."
+      end
+
+      idx += 1
+    end
+
+    nil
+  end
+
+  private def extract_action_name(lines : Array(String), line_idx : Int32) : String?
+    return if line_idx < 0 || line_idx >= lines.size
+    match = lines[line_idx].strip.match(/def\s+(\w+)/)
+    match ? match[1] : nil
+  end
+
+  # A class-level macro with `only:`/`except:` filters applies to the action
+  # only if the action is (only:) / is not (except:) named in the filter.
+  # With no filter it applies to every action. An unknown action name is
+  # treated conservatively: skip for only:, keep for except:.
+  private def macro_applies?(line : String, action_name : String?) : Bool
+    if line.includes?("only:")
+      action_in_filter?(line, action_name)
+    elsif line.includes?("except:")
+      !action_in_filter?(line, action_name)
+    else
+      true
+    end
+  end
+
+  # Detect the action across the symbol/string/`%i[]`/`%w[]` filter forms:
+  #   only: :create | only: [:create, :update] | only: %i[create update]
+  #   except: "create" | except: ["create"]
+  private def action_in_filter?(line : String, action_name : String?) : Bool
+    return false if action_name.nil?
+    return true if line.includes?(":#{action_name}")
+    return true if line.includes?("\"#{action_name}\"")
+    return true if line.includes?("'#{action_name}'")
+    if m = line.match(/%[iIwW]\[([^\]]*)\]/)
+      return m[1].split.includes?(action_name)
+    end
+    false
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -139,6 +139,11 @@ module NoirTaggers
       desc:   "Identifies Ruby authentication patterns (Devise, Pundit, CanCanCan, Warden)",
       runner: RubyAuthTagger,
     },
+    rails_security: {
+      name:   "Rails Security Tagger",
+      desc:   "Identifies Rails controller security signals (CSRF protection, mass assignment, rate limiting)",
+      runner: RailsSecurityTagger,
+    },
     php_auth: {
       name:   "PHP Auth Tagger",
       desc:   "Identifies PHP authentication patterns (Laravel, Symfony, CakePHP)",


### PR DESCRIPTION
## Summary

Extends the framework-specific taggers for **Rails**. `ruby_auth` already classifies authentication (Devise/Pundit/CanCanCan/Warden); this PR adds `RailsSecurityTagger` (`rails_security`), targeting `ruby_rails`, which flags the *other* controller-level security signals — specifically **deviations from Rails' secure defaults** on the actions they affect, so a reviewer's attention lands where it matters rather than on ambient noise.

### New tags

| tag | when it fires | why it matters |
|-----|---------------|----------------|
| `csrf-protection` | `skip_before_action :verify_authenticity_token`, `skip_forgery_protection` (disabled) or `protect_from_forgery with: :null_session` (downgraded) | Rails protects state-changing requests by default — an explicit opt-out is the case worth reviewing |
| `mass-assignment` | `params.permit!`, `params.to_unsafe_h`, or a raw `params[:x]` hash passed to a model writer (`Model.new(params[:user])`, `.update(...)`, `.assign_attributes(...)`, …) | Strong Parameters bypassed → attacker-controlled attribute writes (privilege flags, ownership columns) |
| `rate-limit` | Rails 8 native `rate_limit to:/within:/only:` macro on the action | brute-force / abuse exposure context; absence on auth/recovery surface is itself a finding |

### How it works

Detection mirrors `ruby_auth`: single-file, line-based controller walk.

- **Class-level macros** (`csrf-protection`, `rate-limit`) — walk backward from the action `def` to its `class`, honouring `only:`/`except:` filters across the symbol/string/`%i[]`/`%w[]` forms. Nearest matching macro wins.
- **Action-body** (`mass-assignment`) — forward scan of the action body until the next `def`.
- Each concern is independent, so one action can carry several tags at once (e.g. `csrf-protection` + `rate-limit`).

Cross-file concerns (a `null_session` base controller inherited by children, a Rack::Attack initializer) are out of scope by design — consistent with `ruby_auth`'s single-file model.

## Test plan

- New `spec/unit_test/tagger/framework_taggers/rails_security_spec.cr` (11 examples) covering disabled/null_session CSRF, `only:` gating + nearest-macro-wins, `rate_limit` scoping, `params.permit!` / raw-writer mass-assignment, and the strong-parameters / default-CSRF negatives.
- New `rails_security` fixture (RESTful controllers + routes).
- Full unit suite green (`2812 examples, 0 failures`); `crystal tool format --check` + `ameba` clean.
- Verified end-to-end:

```
$ noir scan spec/functional_test/fixtures/ruby/rails_security --use-taggers rails_security
GET    /users      -> [csrf-protection]                  # null_session
POST   /users      -> [csrf-protection, mass-assignment] # skip only:[:create] + Model.new(params[:user])
PUT    /users/1    -> [csrf-protection, mass-assignment] # null_session + params.permit!
POST   /webhooks   -> [csrf-protection, rate-limit]      # skip-all + rate_limit only::create
GET    /posts      -> []                                 # default CSRF + strong params (no noise)
```

Registered in `noir list taggers` and runs under `--use-taggers all`.