### PR TITLE
Improve Clojure analyzers (Compojure/Reitit/Pedestal/Ring): cut endpoint/callee/ai-context FP/FN

### DIFF
--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -66,6 +66,11 @@
     (resource
       {:handler (fn [_] "ok")}))
 
+  ; `^metadata` may precede the resource map — the route must still be found.
+  (context "/metered" []
+    (resource
+      ^:audited {:get {:handler (fn [_] "metered")}}))
+
   ; compojure-api restructuring directives declare typed params in the body.
   ; `{y :- Long 1}` is an optional param with a default → still bound as `y`.
   (GET "/calc" []
@@ -77,6 +82,12 @@
     :body-params [message :- s/Str]
     :header-params [authorization :- s/Str]
     (ok message))
+
+  ; Comma-separated, untyped binding names — Clojure treats commas as
+  ; whitespace, so both `a` and `b` must be lifted.
+  (GET "/pair" []
+    :query-params [a, b]
+    (ok))
 
   ; `:path-params` re-declaring the URL param must not duplicate it.
   (PUT "/upload/:id" []

--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -66,6 +66,24 @@
     (resource
       {:handler (fn [_] "ok")}))
 
+  ; compojure-api restructuring directives declare typed params in the body.
+  ; `{y :- Long 1}` is an optional param with a default → still bound as `y`.
+  (GET "/calc" []
+    :query-params [x :- Long, {y :- Long 1}]
+    :return Long
+    (ok (+ x y)))
+
+  (POST "/echo" []
+    :body-params [message :- s/Str]
+    :header-params [authorization :- s/Str]
+    (ok message))
+
+  ; `:path-params` re-declaring the URL param must not duplicate it.
+  (PUT "/upload/:id" []
+    :path-params [id :- Long]
+    :form-params [file :- s/Str]
+    (ok id))
+
   (routes
     (GET "/health" []
       "ok")))

--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -32,6 +32,11 @@
   (GET "/profile/:id" [id q :as {:keys [headers]}]
     {:id id :q q})
 
+  ; Inline regex constraint `:id{[0-9]+}` must normalize to `:id` in the URL,
+  ; and the `:<<` coercion fn (`as-int`) must NOT become a query param.
+  (GET "/orders/:id{[0-9]+}" [id :<< as-int]
+    {:id id})
+
   (context "/api" []
     (POST "/users" request
       request)

--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -48,6 +48,24 @@
     (ANY "/ping" []
       "pong"))
 
+  ; compojure.api.resource: method-keyed map bound to the context path —
+  ; emits GET/POST /widgets, plus a path param from `/widgets/:id`.
+  (context "/widgets" []
+    (resource
+      {:get {:summary "list widgets"
+             :handler (fn [_] "all")}
+       :post {:parameters {:body-params NewWidget}
+              :handler (fn [_] "created")}}))
+
+  (context "/widgets/:id" []
+    (resource
+      {:get {:handler (fn [_] "one")}}))
+
+  ; A bare `:handler` resource (no method key) serves every method → GET.
+  (context "/health-check" []
+    (resource
+      {:handler (fn [_] "ok")}))
+
   (routes
     (GET "/health" []
       "ok")))

--- a/spec/functional_test/fixtures/clojure/compojure_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure_callees/src/demo/core.clj
@@ -28,4 +28,15 @@
   ; Var-quoted handler `#'sym` (the idiomatic hot-reload form) must be
   ; captured as a callee, unlike an ordinary `'quote`.
   (GET "/vars" []
-    (wrap #'handlers/show-vars)))
+    (wrap #'handlers/show-vars))
+
+  ; Arithmetic / comparison operators are not meaningful callees: only the
+  ; real service call should surface.
+  (GET "/calc" []
+    (response/ok (/ (+ 1 2) (math.util/scale 3))))
+
+  ; compojure.api.resource — handlers under each method key become callees.
+  (context "/items" []
+    (resource
+      {:get {:handler (fn [_] (item.service/list-all))}
+       :post {:handler (fn [req] (item.service/create! req))}})))

--- a/spec/functional_test/fixtures/clojure/compojure_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure_callees/src/demo/core.clj
@@ -23,4 +23,9 @@
     "(ignored/string)"
     '(ignored/quoted)
     (quote (ignored/again))
-    (response/ok (safe.service/run!))))
+    (response/ok (safe.service/run!)))
+
+  ; Var-quoted handler `#'sym` (the idiomatic hot-reload form) must be
+  ; captured as a callee, unlike an ordinary `'quote`.
+  (GET "/vars" []
+    (wrap #'handlers/show-vars)))

--- a/spec/functional_test/fixtures/clojure/pedestal_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/pedestal_callees/src/demo/core.clj
@@ -27,5 +27,14 @@
     [["/inline" :get (fn [request]
                       (response/ok (inline.service/run request)))]]))
 
+(def common-interceptors [])
+
+;; Tabular handler built by conj-ing a syntax-quoted handler onto a shared
+;; interceptor vector: `dashboard-page` is the real handler (captured), while
+;; `conj`/`common-interceptors` are plumbing (dropped).
+(def dashboard-routes
+  (table/table-routes
+    #{["/dashboard" :get (conj common-interceptors `dashboard-page)]}))
+
 (def service
-  {::http/routes [classic-routes helper-routes table-routes]})
+  {::http/routes [classic-routes helper-routes table-routes dashboard-routes]})

--- a/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
@@ -36,7 +36,12 @@
      {:patch {:parameters {:path {:id int?}
                            :body {:status string?}
                            :header {:x-request-id string?}}
-              :handler patch-report}}]]])
+              :handler patch-report}}]]
+
+   ; A prefix route-data map with only :middleware (no method, no :handler)
+   ; must NOT emit an endpoint for the prefix itself — only the child does.
+   ["/guarded" {:middleware [wrap-auth]}
+    ["/info" {:get list-info}]]])
 
 (def health-routes
   [["/health"

--- a/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
@@ -27,6 +27,10 @@
                                 :page int?}}
            :handler search}}]
 
+   ; Bare `:handler` (no method key) responds to every method — emit GET.
+   ["/status"
+    {:handler status-handler}]
+
    ["/admin"
     ["/reports/:id"
      {:patch {:parameters {:path {:id int?}

--- a/spec/functional_test/fixtures/clojure/reitit_callees/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/reitit_callees/src/demo/core.clj
@@ -18,7 +18,17 @@
      :post {:handler `create-user}}]
    ["/inline"
     {:get {:handler (fn [request]
-                     (response/ok (inline.service/run request)))}}]])
+                     (response/ok (inline.service/run request)))}}]
+
+   ; Method map carries no handler — the route-data `:handler` is what reitit
+   ; dispatches to, so it must surface as the GET endpoint's callee.
+   ["/items/:id"
+    {:get {:parameters {:path {:id int?}}}
+     :handler get-item}]
+
+   ; Bare `:handler` (no method) — emit a GET endpoint with its callee.
+   ["/health"
+    {:handler health-check}]])
 
 (def app
   (ring/ring-handler

--- a/spec/functional_test/testers/clojure/compojure_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_callees_spec.cr
@@ -30,12 +30,27 @@ vars_endpoint = Endpoint.new("/vars", "GET")
 vars_endpoint.push_callee(Callee.new("wrap", line: 31))
 vars_endpoint.push_callee(Callee.new("handlers/show-vars", line: 31))
 
+# Operators (`/`, `+`) are filtered; only the real service call surfaces.
+calc_endpoint = Endpoint.new("/calc", "GET")
+calc_endpoint.push_callee(Callee.new("response/ok", line: 36))
+calc_endpoint.push_callee(Callee.new("math.util/scale", line: 36))
+
+# compojure.api.resource: each method's `:handler` body yields its callees.
+items_get_endpoint = Endpoint.new("/items", "GET")
+items_get_endpoint.push_callee(Callee.new("item.service/list-all", line: 41))
+
+items_post_endpoint = Endpoint.new("/items", "POST")
+items_post_endpoint.push_callee(Callee.new("item.service/create!", line: 42))
+
 expected_endpoints = [
   show_endpoint,
   create_endpoint,
   delete_endpoint,
   quoted_endpoint,
   vars_endpoint,
+  calc_endpoint,
+  items_get_endpoint,
+  items_post_endpoint,
 ]
 
 FunctionalTester.new("fixtures/clojure/compojure_callees/", {

--- a/spec/functional_test/testers/clojure/compojure_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_callees_spec.cr
@@ -26,11 +26,16 @@ quoted_endpoint = Endpoint.new("/quoted", "GET")
 quoted_endpoint.push_callee(Callee.new("response/ok", line: 26))
 quoted_endpoint.push_callee(Callee.new("safe.service/run!", line: 26))
 
+vars_endpoint = Endpoint.new("/vars", "GET")
+vars_endpoint.push_callee(Callee.new("wrap", line: 31))
+vars_endpoint.push_callee(Callee.new("handlers/show-vars", line: 31))
+
 expected_endpoints = [
   show_endpoint,
   create_endpoint,
   delete_endpoint,
   quoted_endpoint,
+  vars_endpoint,
 ]
 
 FunctionalTester.new("fixtures/clojure/compojure_callees/", {

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -43,6 +43,18 @@ expected_endpoints = [
     Param.new("id", "", "path"),
   ]),
   Endpoint.new("/health-check", "GET"),
+  Endpoint.new("/calc", "GET", [
+    Param.new("x", "", "query"),
+    Param.new("y", "", "query"),
+  ]),
+  Endpoint.new("/echo", "POST", [
+    Param.new("message", "", "json"),
+    Param.new("authorization", "", "header"),
+  ]),
+  Endpoint.new("/upload/:id", "PUT", [
+    Param.new("id", "", "path"),
+    Param.new("file", "", "form"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/clojure/compojure/", {

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -37,6 +37,12 @@ expected_endpoints = [
   ]),
   Endpoint.new("/health", "GET"),
   Endpoint.new("/api/ping", "ANY"),
+  Endpoint.new("/widgets", "GET"),
+  Endpoint.new("/widgets", "POST"),
+  Endpoint.new("/widgets/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/health-check", "GET"),
 ]
 
 FunctionalTester.new("fixtures/clojure/compojure/", {

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -43,6 +43,7 @@ expected_endpoints = [
     Param.new("id", "", "path"),
   ]),
   Endpoint.new("/health-check", "GET"),
+  Endpoint.new("/metered", "GET"),
   Endpoint.new("/calc", "GET", [
     Param.new("x", "", "query"),
     Param.new("y", "", "query"),
@@ -50,6 +51,10 @@ expected_endpoints = [
   Endpoint.new("/echo", "POST", [
     Param.new("message", "", "json"),
     Param.new("authorization", "", "header"),
+  ]),
+  Endpoint.new("/pair", "GET", [
+    Param.new("a", "", "query"),
+    Param.new("b", "", "query"),
   ]),
   Endpoint.new("/upload/:id", "PUT", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -27,6 +27,9 @@ expected_endpoints = [
     Param.new("id", "", "path"),
     Param.new("q", "", "query"),
   ]),
+  Endpoint.new("/orders/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
   Endpoint.new("/api/users", "POST"),
   Endpoint.new("/api/admin/users/:id", "DELETE", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/clojure/pedestal_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/pedestal_callees_spec.cr
@@ -17,11 +17,16 @@ inline_endpoint = Endpoint.new("/api/inline", "GET")
 inline_endpoint.push_callee(Callee.new("response/ok"))
 inline_endpoint.push_callee(Callee.new("inline.service/run"))
 
+# Syntax-quoted handler in a conj-built interceptor vector.
+dashboard_endpoint = Endpoint.new("/dashboard", "GET")
+dashboard_endpoint.push_callee(Callee.new("dashboard-page"))
+
 expected_endpoints = [
   list_endpoint,
   create_endpoint,
   health_endpoint,
   inline_endpoint,
+  dashboard_endpoint,
 ]
 
 FunctionalTester.new("fixtures/clojure/pedestal_callees/", {

--- a/spec/functional_test/testers/clojure/reitit_callees_spec.cr
+++ b/spec/functional_test/testers/clojure/reitit_callees_spec.cr
@@ -15,10 +15,20 @@ inline_endpoint = Endpoint.new("/api/inline", "GET")
 inline_endpoint.push_callee(Callee.new("response/ok"))
 inline_endpoint.push_callee(Callee.new("inline.service/run"))
 
+items_endpoint = Endpoint.new("/api/items/:id", "GET", [
+  Param.new("id", "", "path"),
+])
+items_endpoint.push_callee(Callee.new("get-item"))
+
+health_endpoint = Endpoint.new("/api/health", "GET")
+health_endpoint.push_callee(Callee.new("health-check"))
+
 expected_endpoints = [
   list_endpoint,
   create_endpoint,
   inline_endpoint,
+  items_endpoint,
+  health_endpoint,
 ]
 
 FunctionalTester.new("fixtures/clojure/reitit_callees/", {

--- a/spec/functional_test/testers/clojure/reitit_spec.cr
+++ b/spec/functional_test/testers/clojure/reitit_spec.cr
@@ -17,6 +17,7 @@ expected_endpoints = [
     Param.new("q", "", "query"),
     Param.new("page", "", "query"),
   ]),
+  Endpoint.new("/api/status", "GET"),
   Endpoint.new("/api/admin/reports/:id", "PATCH", [
     Param.new("id", "", "path"),
     Param.new("status", "", "json"),

--- a/spec/functional_test/testers/clojure/reitit_spec.cr
+++ b/spec/functional_test/testers/clojure/reitit_spec.cr
@@ -18,6 +18,7 @@ expected_endpoints = [
     Param.new("page", "", "query"),
   ]),
   Endpoint.new("/api/status", "GET"),
+  Endpoint.new("/api/guarded/info", "GET"),
   Endpoint.new("/api/admin/reports/:id", "PATCH", [
     Param.new("id", "", "path"),
     Param.new("status", "", "json"),

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -50,6 +50,25 @@ describe Noir::ClojureCalleeExtractor do
     ])
   end
 
+  it "skips arithmetic/comparison operators and binding macros" do
+    body = <<-CLJ
+      (if-let [u (db/find id)]
+        (response/ok (/ (+ (:a u) (:b u)) (math/scale 2)))
+        (when-some [d (db/default)]
+          (response/ok (= d (compute/value d)))))
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 1)
+    callees.map(&.[0]).should eq([
+      "db/find",
+      "response/ok",
+      "math/scale",
+      "db/default",
+      "response/ok",
+      "compute/value",
+    ])
+  end
+
   it "keeps namespaced callees that share reserved base names" do
     body = <<-CLJ
       (let [items (db/filter params)]

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -69,6 +69,20 @@ describe Noir::ClojureCalleeExtractor do
     ])
   end
 
+  it "captures syntax-quoted handler symbols and drops collection plumbing" do
+    body = <<-CLJ
+      (conj common-interceptors `home-page)
+      (into [] `app.handlers/show)
+      `(ignored template)
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 1)
+    callees.map(&.[0]).should eq([
+      "home-page",
+      "app.handlers/show",
+    ])
+  end
+
   it "keeps namespaced callees that share reserved base names" do
     body = <<-CLJ
       (let [items (db/filter params)]

--- a/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/clojure_callee_extractor_spec.cr
@@ -34,6 +34,22 @@ describe Noir::ClojureCalleeExtractor do
     ])
   end
 
+  it "captures var-quoted handler references but still skips plain quotes" do
+    body = <<-CLJ
+      (wrap #'user-ctl/default)
+      (route #'show-handler)
+      '(ignored/quoted)
+      CLJ
+
+    callees = Noir::ClojureCalleeExtractor.callees_for_body(body, "core.clj", 40)
+    callees.map { |name, _, line| {name, line} }.should eq([
+      {"wrap", 40},
+      {"user-ctl/default", 40},
+      {"route", 41},
+      {"show-handler", 41},
+    ])
+  end
+
   it "keeps namespaced callees that share reserved base names" do
     body = <<-CLJ
       (let [items (db/filter params)]

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -25,6 +25,15 @@ module Analyzer::Clojure
       ":options" => "OPTIONS",
       ":any"     => "ANY",
     }
+    # compojure-api restructuring directives that name request params with a
+    # `[name :- Schema ...]` binding vector in the route body.
+    RESTRUCTURING_PARAMS = {
+      ":query-params"  => "query",
+      ":body-params"   => "json",
+      ":path-params"   => "path",
+      ":form-params"   => "form",
+      ":header-params" => "header",
+    }
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
 
     def analyze
@@ -121,6 +130,10 @@ module Analyzer::Clojure
         end
       end
 
+      # compojure-api routes declare typed params via `:query-params`/etc.
+      # directives in the body rather than the binding vector.
+      extract_restructuring_params(source, route_body_start(source, path_end + 1, form_end), form_end, endpoint)
+
       attach_route_callees(endpoint, source, path_end + 1, form_end, path) if include_callee
 
       @result << endpoint
@@ -134,6 +147,96 @@ module Analyzer::Clojure
       start_line = line_number_for(source, body_start)
       callees = Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line)
       Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    # Scan a route body for compojure-api restructuring directives
+    # (`:query-params [x :- Long]`, `:body-params`, …) and lift their bound
+    # names into endpoint params. Only top-level body forms are inspected, so
+    # keywords nested inside the handler expression are never mistaken for
+    # directives.
+    private def extract_restructuring_params(source : String, body_start : Int32, form_end : Int32, endpoint : Endpoint)
+      i = body_start
+      while i < form_end
+        i = skip_ws_and_comments(source, i, form_end)
+        break if i >= form_end
+
+        if source.byte_at(i).unsafe_chr == ':'
+          keyword, after_kw = read_symbol(source, i, form_end)
+          value_start = skip_ws_and_comments(source, after_kw, form_end)
+          value_end = resource_end_of_value(source, value_start, form_end)
+
+          if (ptype = RESTRUCTURING_PARAMS[keyword]?) &&
+             value_start < value_end && source.byte_at(value_start).unsafe_chr == '['
+            bind_end = find_matching_delimiter(source, value_start, '[', ']', value_end)
+            if bind_end > value_start
+              binding_param_names(source, value_start + 1, bind_end).each do |name|
+                add_param_once(endpoint, name, ptype)
+              end
+            end
+          end
+
+          i = value_end
+        else
+          i = resource_end_of_value(source, i, form_end)
+        end
+      end
+    end
+
+    # Extract the bound names from a compojure-api binding vector body such as
+    # `x :- Long, y :- (describe Long "..")`. A symbol followed by `:-` is a
+    # bound name; the schema form after `:-` is skipped. Map-destructuring and
+    # `&` rest-bindings are ignored.
+    private def binding_param_names(source : String, start : Int32, limit : Int32) : Array(String)
+      forms = [] of String
+      i = start
+      while i < limit
+        i = skip_ws_and_comments(source, i, limit)
+        break if i >= limit
+        form_end = resource_end_of_value(source, i, limit)
+        break if form_end <= i
+        forms << source.byte_slice(i, form_end - i).strip
+        i = form_end
+      end
+
+      names = [] of String
+      j = 0
+      while j < forms.size
+        token = forms[j]
+        if j + 1 < forms.size && forms[j + 1] == ":-"
+          names << token if param_symbol?(token)
+          j += 3 # name, `:-`, schema
+        elsif token == "&"
+          j += 2 # `&`, rest-binding name
+        elsif token.starts_with?('{')
+          # Optional param with default: `{y :- Long 1}` binds `y`.
+          if name = optional_param_name(token)
+            names << name
+          end
+          j += 1
+        else
+          names << token if param_symbol?(token)
+          j += 1
+        end
+      end
+      names.uniq
+    end
+
+    private def optional_param_name(token : String) : String?
+      if m = token.match(/\A\{\s*([A-Za-z_][\w\-!?*<>]*)\s+:-/)
+        m[1]
+      end
+    end
+
+    private def param_symbol?(token : String) : Bool
+      return false if token.empty?
+      return false if token == ":-" || token.starts_with?(':')
+      !!token.match(/\A[A-Za-z_][\w\-!?*<>]*\z/)
+    end
+
+    private def add_param_once(endpoint : Endpoint, name : String, param_type : String)
+      return if name.empty?
+      return if endpoint.params.any? { |p| p.name == name && p.param_type == param_type }
+      endpoint.push_param(Param.new(name, "", param_type))
     end
 
     # `(resource {...})` (compojure.api.resource). The resource map keys the

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -247,6 +247,12 @@ module Analyzer::Clojure
     private def add_resource(source : String, args_start : Int32, form_end : Int32,
                              prefix : String, path : String, include_callee : Bool) : Bool
       i = skip_ws_and_comments(source, args_start, form_end)
+      # An optional `^metadata` form may precede the resource map
+      # (`(resource ^:foo {...})`); skip the metadata and its value.
+      while i < form_end && source.byte_at(i).unsafe_chr == '^'
+        i = resource_end_of_value(source, i + 1, form_end)
+        i = skip_ws_and_comments(source, i, form_end)
+      end
       return false if i >= form_end
       return false unless source.byte_at(i).unsafe_chr == '{'
 
@@ -554,7 +560,9 @@ module Analyzer::Clojure
       i = index
       while i < limit
         char = source.byte_at(i).unsafe_chr
-        break if whitespace?(char) || {'(', ')', '[', ']', '{', '}', '"', ';'}.includes?(char)
+        # Commas are whitespace in Clojure, so they terminate a symbol just
+        # like spaces (keeps `[x, y]` from reading `x,` as one token).
+        break if whitespace?(char) || char == ',' || {'(', ')', '[', ']', '{', '}', '"', ';'}.includes?(char)
         i += 1
       end
 
@@ -565,7 +573,7 @@ module Analyzer::Clojure
       i = index
       while i < limit
         char = source.byte_at(i).unsafe_chr
-        if whitespace?(char)
+        if whitespace?(char) || char == ','
           i += 1
         elsif char == ';'
           i = skip_comment(source, i, limit)

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -14,6 +14,17 @@ module Analyzer::Clojure
       "OPTIONS" => "OPTIONS",
       "ANY"     => "ANY",
     }
+    # compojure.api.resource method keys (keyword form inside the resource map).
+    RESOURCE_METHODS = {
+      ":get"     => "GET",
+      ":post"    => "POST",
+      ":put"     => "PUT",
+      ":delete"  => "DELETE",
+      ":patch"   => "PATCH",
+      ":head"    => "HEAD",
+      ":options" => "OPTIONS",
+      ":any"     => "ANY",
+    }
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
 
     def analyze
@@ -36,7 +47,10 @@ module Analyzer::Clojure
     end
 
     private def compojure_source?(content : String) : Bool
-      content.includes?("compojure.core") || content.includes?("defroutes") || content.includes?("(context")
+      content.includes?("compojure.core") ||
+        content.includes?("compojure.api") ||
+        content.includes?("defroutes") ||
+        content.includes?("(context")
     end
 
     private def scan_forms(source : String, start_index : Int32, end_index : Int32, prefix : String, path : String, include_callee : Bool)
@@ -64,6 +78,14 @@ module Analyzer::Clojure
             scan_forms(source, after_symbol, form_end, next_prefix, path, include_callee)
           when "defroutes", "routes"
             scan_forms(source, after_symbol, form_end, prefix, path, include_callee)
+          when "resource"
+            # compojure.api.resource: `(resource {:get {...} :post {...}})`
+            # binds method handlers to the enclosing context path rather than
+            # a route string. Falls back to plain recursion when the argument
+            # is not a resource map (e.g. `(resource db Schema)`).
+            unless add_resource(source, after_symbol, form_end, prefix, path, include_callee)
+              scan_forms(source, after_symbol, form_end, prefix, path, include_callee)
+            end
           else
             if route_method = ROUTE_METHODS[base]?
               add_route(source, i, after_symbol, form_end, prefix, path, route_method, include_callee)
@@ -112,6 +134,140 @@ module Analyzer::Clojure
       start_line = line_number_for(source, body_start)
       callees = Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line)
       Noir::ClojureCalleeExtractor.attach_to(endpoint, callees)
+    end
+
+    # `(resource {...})` (compojure.api.resource). The resource map keys the
+    # HTTP methods it serves; the path is the enclosing context prefix. Returns
+    # false when the first argument is not a map so the caller can fall back to
+    # ordinary recursion. Each method value is itself a map that may carry a
+    # `:handler`; a top-level `:handler` (no method key) serves every method.
+    private def add_resource(source : String, args_start : Int32, form_end : Int32,
+                             prefix : String, path : String, include_callee : Bool) : Bool
+      i = skip_ws_and_comments(source, args_start, form_end)
+      return false if i >= form_end
+      return false unless source.byte_at(i).unsafe_chr == '{'
+
+      map_end = find_matching_delimiter(source, i, '{', '}', form_end)
+      return false if map_end <= i
+
+      route_path = prefix.empty? ? "/" : prefix
+      data_handler = resource_value_range(source, i + 1, map_end, ":handler")
+
+      method_found = false
+      each_resource_entry(source, i + 1, map_end) do |key, key_pos, value_start, value_end|
+        if method = RESOURCE_METHODS[key]?
+          method_found = true
+          handler_range = resource_value_range(source, value_start, value_end, ":handler") || data_handler
+          emit_resource_endpoint(source, key_pos, route_path, method, path, include_callee, handler_range)
+        end
+      end
+
+      if !method_found && (dh = data_handler)
+        emit_resource_endpoint(source, dh[0], route_path, "GET", path, include_callee, dh)
+      end
+
+      true
+    end
+
+    private def emit_resource_endpoint(source : String, offset : Int32, route_path : String, method : String,
+                                       path : String, include_callee : Bool, handler_range : Tuple(Int32, Int32)?)
+      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, offset))))
+      extract_path_param_names(route_path).each do |name|
+        endpoint.push_param(Param.new(name, "", "path"))
+      end
+
+      if include_callee && handler_range
+        body = source.byte_slice(handler_range[0], handler_range[1] - handler_range[0])
+        start_line = line_number_for(source, handler_range[0])
+        Noir::ClojureCalleeExtractor.attach_to(endpoint,
+          Noir::ClojureCalleeExtractor.callees_for_body(body, path, start_line))
+      end
+
+      @result << endpoint
+    end
+
+    # Find the value byte-range of a top-level keyword key. When the scanned
+    # span itself is a `{...}` map (a method-value map), descend into it; nested
+    # values are skipped via `resource_end_of_value`.
+    private def resource_value_range(source : String, start : Int32, limit : Int32, target_key : String) : Tuple(Int32, Int32)?
+      i = skip_ws_and_comments(source, start, limit)
+      return if i >= limit
+
+      inner_start = i
+      inner_limit = limit
+      if source.byte_at(i).unsafe_chr == '{'
+        map_end = find_matching_delimiter(source, i, '{', '}', limit)
+        return if map_end <= i
+        inner_start = i + 1
+        inner_limit = map_end
+      end
+
+      result = nil.as(Tuple(Int32, Int32)?)
+      each_resource_entry(source, inner_start, inner_limit) do |key, _key_pos, value_start, value_end|
+        result = {value_start, value_end} if result.nil? && key == target_key
+      end
+      result
+    end
+
+    private def each_resource_entry(source : String, start : Int32, limit : Int32, &)
+      i = start
+      while i < limit
+        i = skip_ws_and_comments(source, i, limit)
+        break if i >= limit
+        key_pos = i
+        key, after_key = read_symbol(source, i, limit)
+        if key.empty?
+          i = resource_end_of_value(source, i, limit)
+          next
+        end
+
+        value_start = skip_ws_and_comments(source, after_key, limit)
+        break if value_start >= limit
+        value_end = resource_end_of_value(source, value_start, limit)
+        yield key, key_pos, value_start, value_end
+        i = value_end
+      end
+    end
+
+    private def resource_end_of_value(source : String, start : Int32, limit : Int32) : Int32
+      i = skip_ws_and_comments(source, start, limit)
+      return i if i >= limit
+
+      case source.byte_at(i).unsafe_chr
+      when '"'
+        e = skip_string(source, i, limit)
+        e >= i ? e + 1 : limit
+      when '('
+        e = find_matching_delimiter(source, i, '(', ')', limit)
+        e > i ? e + 1 : limit
+      when '['
+        e = find_matching_delimiter(source, i, '[', ']', limit)
+        e > i ? e + 1 : limit
+      when '{'
+        e = find_matching_delimiter(source, i, '{', '}', limit)
+        e > i ? e + 1 : limit
+      when '\'', '`'
+        resource_end_of_value(source, i + 1, limit)
+      when '#'
+        nxt = i + 1 < limit ? source.byte_at(i + 1).unsafe_chr : '\0'
+        case nxt
+        when '{', '('
+          inner_close = nxt == '{' ? '}' : ')'
+          e = find_matching_delimiter(source, i + 1, nxt, inner_close, limit)
+          e > i + 1 ? e + 1 : limit
+        when '"'
+          e = skip_string(source, i + 1, limit)
+          e >= i + 1 ? e + 1 : limit
+        when '_'
+          resource_end_of_value(source, i + 2, limit)
+        else
+          _, after = read_symbol(source, i, limit)
+          after
+        end
+      else
+        _, after = read_symbol(source, i, limit)
+        after > i ? after : i + 1
+      end
     end
 
     private def route_body_start(source : String, index : Int32, limit : Int32) : Int32

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -59,6 +59,7 @@ module Analyzer::Clojure
           case base
           when "context"
             context_path, _ = first_string_literal(source, after_symbol, form_end)
+            context_path = normalize_route_path(context_path) if context_path
             next_prefix = context_path ? join_path(prefix, context_path) : prefix
             scan_forms(source, after_symbol, form_end, next_prefix, path, include_callee)
           when "defroutes", "routes"
@@ -80,8 +81,9 @@ module Analyzer::Clojure
 
     private def add_route(source : String, form_start : Int32, args_start : Int32, form_end : Int32,
                           prefix : String, path : String, method : String, include_callee : Bool)
-      route_path, path_end = first_string_literal(source, args_start, form_end)
-      return unless route_path
+      raw_route_path, path_end = first_string_literal(source, args_start, form_end)
+      return unless raw_route_path
+      route_path = normalize_route_path(raw_route_path)
 
       full_path = join_path(prefix, route_path)
       endpoint = Endpoint.new(full_path, method, Details.new(PathInfo.new(path, line_number_for(source, form_start))))
@@ -139,6 +141,14 @@ module Analyzer::Clojure
       names
     end
 
+    # Compojure allows an inline regex constraint on a path param:
+    # `:id{[0-9]+}` binds `id` and validates it against `[0-9]+`. The
+    # constraint is routing metadata, not part of the matched URL, so strip
+    # it to keep the endpoint path clean (`/user/:id`, not `/user/:id{[0-9]+}`).
+    private def normalize_route_path(route_path : String) : String
+      route_path.gsub(/(:[A-Za-z_][\w\-]*)\{[^{}]*\}/, "\\1")
+    end
+
     private def extract_query_param_names(binding : String, path_param_names : Array(String)) : Array(String)
       # `{:keys [...]}` style request-map destructuring — extract keys directly.
       return extract_keys_from_map(binding, path_param_names) if binding.starts_with?('{')
@@ -152,6 +162,11 @@ module Analyzer::Clojure
       # request map — keys inside are existing symbols, not query params.
       # Strip those maps before any further harvesting.
       inner_clean = inner.gsub(/:(?:as|or)\s*\{[^{}]*\}/, " ")
+
+      # Compojure's `:<<` applies a coercion fn to the preceding binding,
+      # e.g. `[id :<< as-int]`. The symbol after `:<<` is the coercion fn,
+      # not a request param — drop both the operator and its fn.
+      inner_clean = inner_clean.gsub(/:<<\s+[^\s\[\]{}()]+/, " ")
 
       # Vector binding may carry inline destructuring sub-maps like
       # `[foo {:keys [bar]}]`. Capture inline `:keys`/`:strs`/`:syms`

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -53,10 +53,11 @@ module Analyzer::Clojure
     end
 
     private def reitit_source?(content : String) : Bool
-      content.includes?("reitit.core") ||
-        content.includes?("reitit.ring") ||
-        content.includes?("reitit.http") ||
-        content.includes?("metosin/reitit")
+      # Any `reitit.*` namespace marks a reitit file. Route data is often
+      # split across namespaces that only pull a coercion/middleware ns
+      # (`reitit.coercion.spec`, `reitit.ring.coercion`, …) rather than the
+      # core/ring/http entry points, so match the family broadly.
+      content.includes?("reitit.") || content.includes?("metosin/reitit")
     end
 
     # Iterate forms looking for route-shaped vectors. A vector is
@@ -215,6 +216,13 @@ module Analyzer::Clojure
                                        path : String,
                                        include_callee : Bool,
                                        function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+      # A route-data-level `:handler` (sibling to the method keys) is the
+      # handler reitit uses for any method without its own. Locate it first so
+      # method endpoints can fall back to it and so a method-less `:handler`
+      # still produces an endpoint.
+      data_handler = find_value_range(source, start, limit, ":handler")
+
+      method_found = false
       i = start
       while i < limit
         i = skip_ws_and_comments(source, i, limit)
@@ -231,60 +239,24 @@ module Analyzer::Clojure
         val_end = end_of_value(source, v_start, limit)
 
         if method_name = HTTP_METHODS[key]?
-          emit_endpoint(source, key_start, v_start, val_end, route_path, method_name, path, include_callee, function_callees)
+          method_found = true
+          emit_endpoint(source, key_start, v_start, val_end, route_path, method_name, path, include_callee, function_callees, data_handler)
         end
 
         i = val_end
       end
-    end
 
-    private def emit_endpoint(source : String, key_pos : Int32, v_start : Int32, v_end : Int32,
-                              route_path : String,
-                              method : String,
-                              path : String,
-                              include_callee : Bool,
-                              function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
-      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, key_pos))))
-
-      extract_path_param_names(route_path).each do |name|
-        endpoint.push_param(Param.new(name, "", "path"))
-      end
-
-      if v_start < v_end && source.byte_at(v_start).unsafe_chr == '{'
-        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
-        if map_end > v_start
-          extract_params_from_method_map(source, v_start + 1, map_end, endpoint, route_path)
-        end
-      end
-
-      attach_method_callees(endpoint, source, v_start, v_end, path, function_callees) if include_callee
-
-      @result << endpoint
-    end
-
-    private def attach_method_callees(endpoint : Endpoint,
-                                      source : String,
-                                      v_start : Int32,
-                                      v_end : Int32,
-                                      path : String,
-                                      function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
-      return if v_start >= v_end
-
-      if source.byte_at(v_start).unsafe_chr == '{'
-        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
-        return unless map_end > v_start
-        attach_handler_map_callees(source, v_start + 1, map_end, endpoint, path, function_callees)
-      else
-        attach_handler_value(endpoint, source, v_start, v_end, path, function_callees)
+      # `["/path" {:handler h}]` (no method key) responds to every method.
+      # Emit a single GET endpoint so the route is not dropped entirely.
+      if !method_found && (dh = data_handler)
+        emit_endpoint(source, dh[0], dh[0], dh[1], route_path, "GET", path, include_callee, function_callees, nil)
       end
     end
 
-    private def attach_handler_map_callees(source : String,
-                                           start : Int32,
-                                           limit : Int32,
-                                           endpoint : Endpoint,
-                                           path : String,
-                                           function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)))
+    # Find the value byte-range of a top-level `target_key` in a map at
+    # `[start, limit)`. Nested maps are skipped via `end_of_value`, so only
+    # first-level keys are inspected.
+    private def find_value_range(source : String, start : Int32, limit : Int32, target_key : String) : Tuple(Int32, Int32)?
       i = start
       while i < limit
         i = skip_ws_and_comments(source, i, limit)
@@ -299,9 +271,88 @@ module Analyzer::Clojure
         break if v_start >= limit
         val_end = end_of_value(source, v_start, limit)
 
-        attach_handler_value(endpoint, source, v_start, val_end, path, function_callees) if key == ":handler"
+        return {v_start, val_end} if key == target_key
         i = val_end
       end
+      nil
+    end
+
+    private def emit_endpoint(source : String, key_pos : Int32, v_start : Int32, v_end : Int32,
+                              route_path : String,
+                              method : String,
+                              path : String,
+                              include_callee : Bool,
+                              function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)),
+                              data_handler : Tuple(Int32, Int32)? = nil)
+      endpoint = Endpoint.new(route_path, method, Details.new(PathInfo.new(path, line_number_for(source, key_pos))))
+
+      extract_path_param_names(route_path).each do |name|
+        endpoint.push_param(Param.new(name, "", "path"))
+      end
+
+      if v_start < v_end && source.byte_at(v_start).unsafe_chr == '{'
+        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+        if map_end > v_start
+          extract_params_from_method_map(source, v_start + 1, map_end, endpoint, route_path)
+        end
+      end
+
+      attach_method_callees(endpoint, source, v_start, v_end, path, function_callees, data_handler) if include_callee
+
+      @result << endpoint
+    end
+
+    private def attach_method_callees(endpoint : Endpoint,
+                                      source : String,
+                                      v_start : Int32,
+                                      v_end : Int32,
+                                      path : String,
+                                      function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)),
+                                      data_handler : Tuple(Int32, Int32)? = nil)
+      return if v_start >= v_end
+
+      if source.byte_at(v_start).unsafe_chr == '{'
+        map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+        return unless map_end > v_start
+        attached = attach_handler_map_callees(source, v_start + 1, map_end, endpoint, path, function_callees)
+        # `{:get {:parameters ...}}` carries no method-level handler; fall back
+        # to the route-data `:handler` reitit would dispatch to.
+        if !attached && (dh = data_handler)
+          attach_handler_value(endpoint, source, dh[0], dh[1], path, function_callees)
+        end
+      else
+        attach_handler_value(endpoint, source, v_start, v_end, path, function_callees)
+      end
+    end
+
+    private def attach_handler_map_callees(source : String,
+                                           start : Int32,
+                                           limit : Int32,
+                                           endpoint : Endpoint,
+                                           path : String,
+                                           function_callees : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry))) : Bool
+      attached = false
+      i = start
+      while i < limit
+        i = skip_ws_and_comments(source, i, limit)
+        break if i >= limit
+        key, after_key = read_symbol(source, i, limit)
+        if key.empty?
+          i = end_of_value(source, i, limit)
+          next
+        end
+
+        v_start = skip_ws_and_comments(source, after_key, limit)
+        break if v_start >= limit
+        val_end = end_of_value(source, v_start, limit)
+
+        if key == ":handler"
+          attach_handler_value(endpoint, source, v_start, val_end, path, function_callees)
+          attached = true
+        end
+        i = val_end
+      end
+      attached
     end
 
     private def attach_handler_value(endpoint : Endpoint,

--- a/src/detector/detectors/clojure/compojure.cr
+++ b/src/detector/detectors/clojure/compojure.cr
@@ -14,6 +14,10 @@ module Detector::Clojure
 
       if CLOJURE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
         return true if file_contents.includes?("compojure.core")
+        # compojure-api (`compojure.api.sweet`/`.core`/`.resource`) shares the
+        # GET/POST/context macros and adds the `resource` DSL — files often
+        # pull only this ns rather than `compojure.core`.
+        return true if file_contents.includes?("compojure.api")
         return true if file_contents.includes?("defroutes") && file_contents.match(/\([A-Z]+?\s+"/)
       end
 

--- a/src/detector/detectors/clojure/reitit.cr
+++ b/src/detector/detectors/clojure/reitit.cr
@@ -16,9 +16,10 @@ module Detector::Clojure
       end
 
       if CLOJURE_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
-        return true if file_contents.includes?("reitit.core")
-        return true if file_contents.includes?("reitit.ring")
-        return true if file_contents.includes?("reitit.http")
+        # Any `reitit.*` namespace import marks a reitit file — routes are
+        # frequently defined in namespaces that only pull a coercion or
+        # middleware ns rather than the core/ring/http entry points.
+        return true if file_contents.includes?("reitit.")
       end
 
       false

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -161,6 +161,16 @@ module Noir::ClojureCalleeExtractor
         next_char = i + 1 < end_index ? source.byte_at(i + 1).unsafe_chr : '\0'
         if next_char == '_'
           i = skip_quoted_form(source, i + 2, end_index)
+        elsif next_char == '\''
+          # Var-quote `#'handler` resolves a var — a deliberate function
+          # reference (the idiomatic Ring/Compojure handler form, e.g.
+          # `(wrap #'user-ctl/default)`). Record the var'd symbol as a callee
+          # rather than skipping it like an ordinary quote.
+          symbol, after_symbol = read_symbol(source, i + 2, end_index)
+          unless skip_callee?(symbol)
+            entries << {symbol, file_path, line_number_for(source, i, start_line)}
+          end
+          i = after_symbol
         else
           i += 1
         end

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -18,6 +18,12 @@ module Noir::ClojureCalleeExtractor
     # Arithmetic / comparison operators are clojure.core primitives, not
     # meaningful handler callees — they only add noise to AI context.
     "+", "-", "*", "/", "=", "==", "<", ">", "<=", ">=", "not=",
+    # Collection plumbing (clojure.core). These shuffle data — building
+    # interceptor chains, assembling response maps — rather than expressing
+    # handler logic, so they are noise in AI context.
+    "conj", "conj!", "into", "merge", "merge-with", "concat", "cons",
+    "assoc", "assoc!", "assoc-in", "dissoc", "update", "update-in",
+    "get", "get-in", "select-keys", "vec", "set", "seq", "keys", "vals",
   }
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
@@ -159,7 +165,12 @@ module Noir::ClojureCalleeExtractor
         i = skip_comment(source, i, end_index)
       when '"'
         i = skip_string(source, i, end_index) + 1
-      when '\'', '`'
+      when '`'
+        # Syntax-quote of a bare symbol (`` `ns/handler ``) is the idiomatic
+        # Pedestal tabular-route handler reference — capture it. Syntax-quoted
+        # collections/strings stay code templates and are skipped.
+        i = scan_quoted_symbol(source, i, end_index, file_path, start_line, entries)
+      when '\''
         i = skip_quoted_form(source, i + 1, end_index)
       when '#'
         next_char = i + 1 < end_index ? source.byte_at(i + 1).unsafe_chr : '\0'
@@ -231,6 +242,33 @@ module Noir::ClojureCalleeExtractor
       symbol[(index + 1)..]
     else
       symbol
+    end
+  end
+
+  # Handle a syntax-quote `` ` `` at `index`. When it quotes a bare symbol
+  # (a route-handler reference) the symbol is recorded as a callee; quoted
+  # collections/strings are skipped as code templates. Returns the index past
+  # the quoted form.
+  private def scan_quoted_symbol(source : String,
+                                 index : Int32,
+                                 limit : Int32,
+                                 file_path : String,
+                                 start_line : Int32,
+                                 entries : Array(Entry)) : Int32
+    i = skip_ws_and_comments(source, index + 1, limit)
+    return i if i >= limit
+
+    case source.byte_at(i).unsafe_chr
+    when '(', '[', '{', '"', '~'
+      skip_quoted_form(source, index + 1, limit)
+    else
+      symbol, after = read_symbol(source, i, limit)
+      # Auto-gensyms (`foo#`) only occur in macro templates, never as handler
+      # references — leave them out.
+      unless skip_callee?(symbol) || symbol.ends_with?('#')
+        entries << {symbol, file_path, line_number_for(source, index, start_line)}
+      end
+      after > i ? after : i + 1
     end
   end
 

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -7,13 +7,17 @@ module Noir::ClojureCalleeExtractor
 
   RESERVED = Set{
     "def", "defn", "defmacro", "fn", "let", "letfn", "if", "if-not",
-    "when", "when-not", "when-let", "when-first", "cond", "condp",
+    "if-let", "if-some", "when", "when-not", "when-let", "when-some",
+    "when-first", "while", "cond", "condp",
     "case", "do", "doseq", "dotimes", "for", "loop", "recur",
     "try", "catch", "finally", "throw", "quote", "var", "new",
     "set!", "and", "or", "not", "->", "->>", "as->", "cond->",
     "cond->>", "some->", "some->>", "doto", ".", "..", "comment",
     "str", "println", "print", "prn", "list", "vector", "hash-map",
     "map", "filter", "reduce", "partial", "comp", "identity",
+    # Arithmetic / comparison operators are clojure.core primitives, not
+    # meaningful handler callees — they only add noise to AI context.
+    "+", "-", "*", "/", "=", "==", "<", ">", "<=", ">=", "not=",
   }
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
@@ -204,7 +208,10 @@ module Noir::ClojureCalleeExtractor
   end
 
   private def reserved_symbol?(symbol : String, expected : String? = nil) : Bool
-    if symbol.includes?('/')
+    # `/` is the bare division operator, not a namespaced symbol — the `/`
+    # it contains is the whole name. Treat it as an ordinary base symbol so
+    # it can match the RESERVED entry rather than being read as a namespace.
+    if symbol.includes?('/') && symbol != "/"
       return false unless symbol.starts_with?("clojure.core/")
 
       base = base_symbol(symbol)


### PR DESCRIPTION
## Description

Improves the four Clojure analyzers (Compojure, Reitit, Pedestal, Ring) and the shared Clojure callee extractor, cutting FP/FN in **endpoints, callees, and ai-context**. Each change was found and validated against real open-source apps (seancorfield/usermanager-example, PrestanceDesign/usermanager-reitit-example, metosin/reitit examples, metosin/compojure-api, clojars/clojars-web, yogthos/memory-hole, cognitect-labs/vase, pedestal samples, kit, duct, system-ring).

Done as 5 incremental rounds:

### Compojure / compojure-api
- **Path-regex FP**: inline constraint `:id{[0-9]+}` now normalizes to `:id` in the URL (also for `context` prefixes) instead of leaking the constraint syntax.
- **`:<<` coercion FP**: `[id :<< as-int]` no longer emits the coercion fn `as-int` as a query param.
- **`resource` DSL (FN)**: `(resource {:get {...} :post {...}})` (compojure.api.resource) now emits an endpoint per method key bound to the enclosing context path; a bare `:handler` serves every method (→ GET); handler callees and prefix path params are attached.
- **Detection (FN)**: compojure-api files are recognized by the `compojure.api` namespace, so a standalone app with no `project.clj` scans (thingie example `0 → 39` endpoints; resources `0 → 5`).
- **Restructuring params (FN)**: `:query-params` / `:body-params` (json) / `:path-params` / `:form-params` / `:header-params` `[name :- Schema]` directives in route bodies are lifted into params, including optional `{y :- Long 1}` and complex schema forms; `&`/map-destructuring skipped; de-duplicated against path/binding params.

### Reitit
- **Bare `:handler` (FN)**: a route-data map with a bare `:handler` (no method key) now emits a GET endpoint instead of being dropped (e.g. `/`, `/reset`, `/user/list` in usermanager-reitit-example: `3 → 7` endpoints).
- **Callee fallback (FN)**: a method endpoint whose method map carries no handler of its own (`{:get {:parameters ...}} :handler h`) now resolves its callee to the route-data `:handler`.
- **Detection (FN)**: the file gate and detector match any `reitit.*` namespace, so route data in coercion/middleware-only namespaces is scanned (ring-example `0 → 6`).

### Pedestal / shared callee extractor
- **Var-quote handlers (FN)**: `#'handler` references (`(wrap #'user-ctl/default)`) are captured as callees.
- **Syntax-quote handlers (FN)**: `` `ns/handler `` references — the idiomatic Pedestal tabular-route form `(conj common-interceptors `home-page)` — are captured (omnext-todo now resolves to `home-page`/`about-page`/`handle-demand` instead of the `conj` plumbing).
- **Callee noise FP**: arithmetic/comparison operators (`+ - * / = == < > <= >= not=`), binding macros (`if-let`/`if-some`/`when-some`/`while`), and collection plumbing (`conj`/`into`/`merge`/`assoc`/`get`/…) are dropped from callees.

### ai-context impact
Recovered callees feed downstream signals — e.g. `GET /user/delete/:id` now raises `unsafe_method` (a safe-method endpoint invoking a state-changing `delete-by-id`) and `idor`, neither of which existed before.

## Testing
- New functional + unit fixtures cover every case above (path-regex, `:<<`, resource endpoints/callees, restructuring params, bare/fallback `:handler`, var-quote & syntax-quote handler callees, operator/collection-op filtering, prefix-data-map no-FP guard).
- Full suite green: **functional 16120, unit 2798, 0 failures**; `ameba` 0 failures; `crystal tool format --check` clean.
- Synthetic probes + a broad OSS sweep (clojars-web 31, compojure-api 218, vase, duct, kit, pedestal samples) show no weird URLs and no crashes.

Known accepted limitation: reitit route data living in a namespace with **zero** `reitit.*` reference (e.g. reitit ring-example `plain.clj`) stays undetected per-file.
