### PR TITLE
feat(tagger): add Spring security framework tagger (CSRF/CORS/input-validation)

### DIFF
--- a/docs/content/usage/more_features/tagger/index.ko.md
+++ b/docs/content/usage/more_features/tagger/index.ko.md
@@ -82,9 +82,14 @@ noir scan <BASE_PATH> --use-taggers hunt,oauth
   - `api_docs` — API 문서/스키마 엔드포인트(Swagger, OpenAPI, GraphiQL, ReDoc, WSDL). 전체 API 표면을 드러내고 인증 없이 노출되는 경우가 많음. 비인증 노출 및 정보 유출 검토 대상.
   - `account_recovery` — 자격증명 관리·계정 복구 엔드포인트(비밀번호 재설정/변경, 이메일 변경, MFA/OTP, 인증). 전형적인 계정 탈취 표면 — 리셋 토큰 유출, reset 링크 host-header 인젝션, 계정 열거, 레이트리밋 부재 검토 대상.
   - `file_upload` — 파일 업로드 엔드포인트. 무제한 업로드, 경로 탐색, 악성 파일 처리 검토 대상.
-- **프레임워크별 보호 장치 & 위험** — 프레임워크의 안전한 기본값에서 *벗어난 지점*을 해당 액션에 표시하는 프레임워크 인지 태거. Rails(`rails_security`)의 경우:
+- **프레임워크별 보호 장치 & 위험** — 프레임워크의 보안 통제와 안전한 기본값에서 *벗어난 지점*을 해당 엔드포인트에 표시하는 프레임워크 인지 태거. Rails(`rails_security`)의 경우:
   - `csrf-protection` — CSRF 검증이 비활성화(`skip_before_action :verify_authenticity_token`, `skip_forgery_protection`)되었거나 약화(`protect_from_forgery with: :null_session`)된 경우. Rails는 상태 변경 요청을 기본으로 보호하므로, 명시적으로 해제한 지점이 검토 대상.
   - `mass-assignment` — Strong Parameters가 우회된 경우(`params.permit!`, `params.to_unsafe_h`, 또는 `Model.new(params[:user])`처럼 가공되지 않은 `params[:x]` 해시를 모델 라이터에 전달). 공격자가 제어하는 속성 쓰기(권한 플래그, 소유권 컬럼) 검토 대상.
   - `rate-limit` — Rails 8 네이티브 `rate_limit` 매크로로 스로틀링되는 액션. 무차별 대입/남용 노출을 평가할 때 유용한 맥락이며, 인증·복구 표면에서 이것이 부재하면 그 자체가 점검 포인트.
+
+  Spring(`spring_security`)의 경우, 인증 태거 `spring_auth`를 보완:
+  - `csrf-protection` — `SecurityFilterChain`에서 CSRF가 비활성화(`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, Kotlin `csrf { disable() }`)된 경우. 해당 체인이 노출하는 상태 변경 엔드포인트(POST/PUT/PATCH/DELETE)에 표시되며, 무상태/토큰 API에서는 흔하지만 항상 검토 가치가 있고, `securityMatcher`가 있으면 그 체인 범위로 한정.
+  - `cors` — 핸들러나 컨트롤러의 `@CrossOrigin` 애너테이션은 브라우저 동일 출처 기본값에서 엔드포인트를 벗어나게 함. 와일드카드 출처(`*`), 특히 자격 증명과 함께 사용된 경우 과도한(permissive) 설정으로 표시.
+  - `input-validation` — `@Valid` / `@Validated`로 요청 페이로드에 Bean Validation이 적용된 경우. 적용된 지점을 드러내면, 적용되지 않은 공백(`@RequestBody`를 받으면서 검증이 없는 핸들러)도 부재로 드러남.
 
 엔드포인트 레벨 태그는 AI 컨텍스트에도 신호로 전달되어, AI 리뷰어가 사용하는 엔드포인트별 요약을 더욱 풍부하게 만듭니다.

--- a/docs/content/usage/more_features/tagger/index.md
+++ b/docs/content/usage/more_features/tagger/index.md
@@ -82,9 +82,14 @@ Taggers span several kinds of security-relevant signal. Run `noir list taggers` 
   - `api_docs` — API documentation / schema endpoints (Swagger, OpenAPI, GraphiQL, ReDoc, WSDL); expose the full API surface and are frequently unauthenticated — review for unauthenticated exposure and information disclosure.
   - `account_recovery` — credential-management and account-recovery endpoints (password reset/change, email change, MFA/OTP, verification); the classic account-takeover surface — review for reset-token leakage, host-header injection in reset links, account enumeration, and missing rate limiting.
   - `file_upload` — file upload endpoints; review for unrestricted upload, path traversal, and malicious file handling.
-- **Framework-specific protections & risks** — framework-aware taggers that flag *deviations from a framework's secure defaults* on the actions they affect. For Rails (`rails_security`):
+- **Framework-specific protections & risks** — framework-aware taggers that flag a framework's security controls and *deviations from its secure defaults* on the endpoints they affect. For Rails (`rails_security`):
   - `csrf-protection` — CSRF verification disabled (`skip_before_action :verify_authenticity_token`, `skip_forgery_protection`) or downgraded (`protect_from_forgery with: :null_session`); Rails protects state-changing requests by default, so an explicit opt-out is the case worth reviewing.
   - `mass-assignment` — Strong Parameters bypassed (`params.permit!`, `params.to_unsafe_h`, or a raw `params[:x]` hash passed to a model writer such as `Model.new(params[:user])`); review for attacker-controlled attribute writes (privilege flags, ownership columns).
   - `rate-limit` — actions throttled by the Rails 8 native `rate_limit` macro; useful context when assessing brute-force / abuse exposure (and its absence on auth/recovery surface is itself a finding).
+
+  For Spring (`spring_security`), complementing the `spring_auth` authentication tagger:
+  - `csrf-protection` — CSRF disabled in a `SecurityFilterChain` (`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, or Kotlin `csrf { disable() }`), reported on the state-changing endpoints (POST/PUT/PATCH/DELETE) the affected chain exposes; common for stateless/token APIs but always worth surfacing, and scoped to a chain's `securityMatcher` when present.
+  - `cors` — a `@CrossOrigin` annotation on the handler or controller opts the endpoint out of the browser same-origin default; wildcard origins (`*`), especially combined with credentials, are called out as permissive.
+  - `input-validation` — `@Valid` / `@Validated` applies Bean Validation to the request payload; surfacing where it *is* applied also makes the gaps (handlers taking a `@RequestBody` without it) visible by their absence.
 
 Endpoint-level tags also feed the AI context as signals, enriching the per-endpoint summary that AI reviewers consume.

--- a/spec/functional_test/fixtures/java/spring_security/src/main/java/com/example/ApiController.java
+++ b/spec/functional_test/fixtures/java/spring_security/src/main/java/com/example/ApiController.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import org.springframework.web.bind.annotation.*;
+import javax.validation.Valid;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/api")
+public class ApiController {
+
+    @PostMapping("/posts")
+    public String createPost(@Valid @RequestBody PostDto dto) {
+        return "created";
+    }
+
+    @PutMapping("/posts/{id}")
+    public String updatePost(@PathVariable Long id, @RequestBody PostDto dto) {
+        return "updated";
+    }
+
+    @GetMapping("/posts")
+    public String listPosts() {
+        return "list";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_security/src/main/java/com/example/SecurityConfig.java
+++ b/spec/functional_test/fixtures/java/spring_security/src/main/java/com/example/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            );
+        return http.build();
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_security_scoped/src/main/java/com/example/SecurityConfig.java
+++ b/spec/functional_test/fixtures/java/spring_security_scoped/src/main/java/com/example/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.example;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    // Stateless REST chain: CSRF disabled, scoped to /api/**.
+    @Bean
+    @Order(1)
+    public SecurityFilterChain apiChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/api/**")
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+        return http.build();
+    }
+
+    // Session-based web chain: CSRF stays enabled (Spring default), scoped
+    // to /web/**.
+    @Bean
+    @Order(2)
+    public SecurityFilterChain webChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/web/**")
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+        return http.build();
+    }
+}

--- a/spec/unit_test/tagger/framework_taggers/spring_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/spring_security_spec.cr
@@ -1,0 +1,155 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+# Fixture line references
+#
+# spring_security/src/main/java/com/example/SecurityConfig.java
+#   14: .csrf(csrf -> csrf.disable())   (global — no securityMatcher)
+#
+# spring_security/src/main/java/com/example/ApiController.java
+#    7: @CrossOrigin(origins = "*")     (class-level, wildcard)
+#   12:     public String createPost(@Valid @RequestBody PostDto dto) {
+#   17:     public String updatePost(@PathVariable Long id, @RequestBody PostDto dto) {
+#   22:     public String listPosts() {
+#
+# spring_security_scoped/src/main/java/com/example/SecurityConfig.java
+#   chain apiChain: securityMatcher("/api/**") + csrf().disable()
+#   chain webChain: securityMatcher("/web/**"), CSRF left enabled
+
+private def tag_named(endpoint : Endpoint, name : String) : Tag?
+  endpoint.tags.find { |t| t.name == name }
+end
+
+private def load_fixture_files(fixture_base : String)
+  locator = CodeLocator.instance
+  Dir.glob("#{fixture_base}/**/*").each do |file|
+    next if File.directory?(file)
+    locator.push("file_map", file)
+  end
+end
+
+private def build_endpoint(path : String, line : Int32?, url : String, method : String) : Endpoint
+  details = line ? Details.new(PathInfo.new(path, line)) : Details.new
+  details.technology = "java_spring"
+  Endpoint.new(url, method, [] of Param, details)
+end
+
+describe "SpringSecurityTagger" do
+  global_base = "#{__DIR__}/../../../functional_test/fixtures/java/spring_security"
+  controller = "#{global_base}/src/main/java/com/example/ApiController.java"
+
+  scoped_base = "#{__DIR__}/../../../functional_test/fixtures/java/spring_security_scoped"
+
+  global_options = create_test_options
+  global_options["base"] = YAML::Any.new(global_base)
+
+  scoped_options = create_test_options
+  scoped_options["base"] = YAML::Any.new(scoped_base)
+
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "exposes java_spring and kotlin_spring as its target techs" do
+    SpringSecurityTagger.target_techs.should eq(["java_spring", "kotlin_spring"])
+  end
+
+  describe "csrf-protection" do
+    it "flags a state-changing endpoint when CSRF is disabled globally" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 12, "/api/posts", "POST")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag = tag_named(endpoint, "csrf-protection")
+      tag.should_not be_nil
+      tag.not_nil!.tagger.should eq("spring_security")
+      tag.not_nil!.description.should contain("globally")
+    end
+
+    it "flags PUT as well as POST" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 17, "/api/posts/1", "PUT")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag_named(endpoint, "csrf-protection").should_not be_nil
+    end
+
+    it "does not flag a GET endpoint (CSRF protection only guards state-changing requests)" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 22, "/api/posts", "GET")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag_named(endpoint, "csrf-protection").should be_nil
+    end
+
+    it "scopes a securityMatcher-bound csrf disable to the matched URLs only" do
+      load_fixture_files(scoped_base)
+
+      in_scope = build_endpoint(controller, nil, "/api/posts", "POST")
+      SpringSecurityTagger.new(scoped_options).perform([in_scope])
+      scoped_tag = tag_named(in_scope, "csrf-protection")
+      scoped_tag.should_not be_nil
+      scoped_tag.not_nil!.description.should contain("/api/**")
+
+      # /web/** keeps CSRF enabled — the disable in apiChain must not leak.
+      out_of_scope = build_endpoint(controller, nil, "/web/login", "POST")
+      SpringSecurityTagger.new(scoped_options).perform([out_of_scope])
+      tag_named(out_of_scope, "csrf-protection").should be_nil
+    end
+  end
+
+  describe "cors" do
+    it "flags a class-level @CrossOrigin wildcard as permissive" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 12, "/api/posts", "POST")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag = tag_named(endpoint, "cors")
+      tag.should_not be_nil
+      tag.not_nil!.tagger.should eq("spring_security")
+      tag.not_nil!.description.should contain("Permissive")
+      tag.not_nil!.description.should contain("controller")
+    end
+  end
+
+  describe "input-validation" do
+    it "flags a handler whose body is @Valid-annotated" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 12, "/api/posts", "POST")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag = tag_named(endpoint, "input-validation")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("Bean Validation")
+    end
+
+    it "does not flag a handler taking a @RequestBody without @Valid" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 17, "/api/posts/1", "PUT")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag_named(endpoint, "input-validation").should be_nil
+    end
+  end
+
+  it "applies multiple independent tags to one handler" do
+    load_fixture_files(global_base)
+    endpoint = build_endpoint(controller, 12, "/api/posts", "POST")
+    SpringSecurityTagger.new(global_options).perform([endpoint])
+
+    tag_named(endpoint, "csrf-protection").should_not be_nil
+    tag_named(endpoint, "cors").should_not be_nil
+    tag_named(endpoint, "input-validation").should_not be_nil
+  end
+
+  it "handles empty code_paths gracefully (CSRF still resolves by URL)" do
+    load_fixture_files(global_base)
+    endpoint = build_endpoint(controller, nil, "/api/posts", "POST")
+    SpringSecurityTagger.new(global_options).perform([endpoint])
+
+    # No code_path → no annotation walk, but the config-level CSRF rule
+    # still applies by URL/method without raising.
+    tag_named(endpoint, "csrf-protection").should_not be_nil
+    tag_named(endpoint, "cors").should be_nil
+  end
+end

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -1,0 +1,260 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+# Spring-specific security tagger.
+#
+# `spring_auth` already classifies authentication/authorization
+# (@PreAuthorize/@Secured/@RolesAllowed annotations and HttpSecurity URL
+# rules). This tagger covers the *other* Spring security signals a reviewer
+# cares about — the protections Spring ships and the deviations from its
+# secure defaults — that map cleanly onto an endpoint:
+#
+#   * csrf-protection — Spring Security CSRF-protects every state-changing
+#     request by default; an explicit `csrf().disable()`,
+#     `csrf(AbstractHttpConfigurer::disable)` or Kotlin `csrf { disable() }`
+#     in a SecurityFilterChain turns that off. We flag the state-changing
+#     endpoints (POST/PUT/PATCH/DELETE) the affected filter chain exposes.
+#     Disabling CSRF is common and often intentional for token/stateless
+#     REST APIs, but it is always worth surfacing for review.
+#   * cors — a `@CrossOrigin` annotation on the handler or its controller
+#     opts the endpoint out of the browser same-origin default. Wildcard
+#     origins (`*`), and especially a wildcard combined with credentials,
+#     are called out as permissive.
+#   * input-validation — `@Valid` / `@Validated` on the handler applies Bean
+#     Validation to the request payload, the primary Spring input-validation
+#     control. Surfacing where it IS applied also makes the gaps — handlers
+#     taking a body without it — visible by their absence.
+#
+# CSRF is detected from the security config (pre-scanned once, like
+# spring_auth's URL rules). CORS and input-validation are per-endpoint and
+# line-based, walking the handler the endpoint maps to. Cross-file concerns
+# (a custom Filter bean, a global CorsConfigurationSource) are out of scope.
+class SpringSecurityTagger < FrameworkTagger
+  STATE_CHANGING_METHODS = Set{"POST", "PUT", "PATCH", "DELETE"}
+
+  # A SecurityFilterChain bean / WebSecurityConfigurerAdapter.configure body
+  # delimits one HttpSecurity scope. A CSRF-disable and any chain-level
+  # securityMatcher are associated within the same scope/block.
+  SCOPE_BOUNDARY = /SecurityFilterChain\b|configure\s*\(\s*(?:final\s+)?HttpSecurity/
+
+  # `csrf().disable()` (fluent), `csrf(csrf -> csrf.disable())` /
+  # `csrf(AbstractHttpConfigurer::disable)` (lambda/method-ref), and Kotlin
+  # `csrf { disable() }`.
+  CSRF_DISABLE = /csrf\s*(?:\(\s*\)\s*\.\s*disable\b|\([^)]*\bdisable|\{[^}]*\bdisable)/
+
+  # Chain-level request matchers that scope a SecurityFilterChain to a URL
+  # subset. `requestMatchers(...)` is deliberately excluded: inside
+  # `authorizeHttpRequests {…}` it scopes an authorization rule, not the
+  # chain, and treating those as CSRF scopes would mis-attribute the rule.
+  MATCHER_CALL = /\b(?:securityMatcher|antMatcher)\s*\(/
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "spring_security"
+    @csrf_disable_scopes = [] of String
+  end
+
+  def self.target_techs : Array(String)
+    ["java_spring", "kotlin_spring"]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    pre_scan_csrf_config
+    endpoints.each { |endpoint| check_endpoint(endpoint) }
+    endpoints
+  end
+
+  # ---- CSRF (config-level) ---------------------------------------------
+
+  private def pre_scan_csrf_config
+    @csrf_disable_scopes.clear
+    [".java", ".kt"].each do |ext|
+      collect_files_by_extension(ext).each do |file|
+        content = read_file(file)
+        next if content.nil?
+        next unless content.includes?("HttpSecurity") || content.includes?("SecurityFilterChain") || content.includes?("WebSecurityConfigurerAdapter")
+        scan_csrf_config(content)
+      end
+    end
+    @csrf_disable_scopes.uniq!
+  end
+
+  private def scan_csrf_config(content : String)
+    split_into_chain_blocks(content).each do |block|
+      next unless block.matches?(CSRF_DISABLE)
+
+      matchers = extract_matchers(block)
+      if matchers.size > 0
+        # CSRF disabled for a chain scoped to these URL pattern(s).
+        matchers.each { |m| @csrf_disable_scopes << m }
+      elsif !block.matches?(MATCHER_CALL)
+        # No matcher at all → this chain (and its CSRF-disable) is global.
+        @csrf_disable_scopes << "/**"
+      end
+      # else: scoped by a non-literal matcher (e.g. EndpointRequest) we
+      # cannot resolve to a URL — skip rather than over-broaden to global.
+    end
+  end
+
+  # Split a config file into one block per HttpSecurity scope so a
+  # CSRF-disable is associated only with its own filter chain's matcher.
+  private def split_into_chain_blocks(content : String) : Array(String)
+    blocks = [] of String
+    current = [] of String
+    content.each_line do |raw|
+      if raw.matches?(SCOPE_BOUNDARY) && !current.empty?
+        blocks << current.join("\n")
+        current = [] of String
+      end
+      current << raw
+    end
+    blocks << current.join("\n") unless current.empty?
+    blocks
+  end
+
+  private def extract_matchers(block : String) : Array(String)
+    matchers = [] of String
+    block.each_line do |raw|
+      next unless raw.matches?(MATCHER_CALL)
+      raw.scan(/"([^"]+)"/) { |m| matchers << m[1] }
+    end
+    matchers
+  end
+
+  private def csrf_disabled_scope_for(endpoint : Endpoint) : String?
+    return unless STATE_CHANGING_METHODS.includes?(endpoint.method.upcase)
+    @csrf_disable_scopes.find { |pattern| matches_ant_pattern?(endpoint.url, pattern) }
+  end
+
+  # ---- per-endpoint ----------------------------------------------------
+
+  private def check_endpoint(endpoint : Endpoint)
+    if scope = csrf_disabled_scope_for(endpoint)
+      desc = if scope == "/**"
+               "CSRF protection disabled globally (Spring Security csrf().disable()) — state-changing requests to this endpoint are not CSRF-validated."
+             else
+               "CSRF protection disabled for the \"#{scope}\" filter chain — state-changing requests to this endpoint are not CSRF-validated."
+             end
+      endpoint.add_tag(Tag.new("csrf-protection", desc, "spring_security"))
+    end
+
+    read_source_context(endpoint).each do |ctx|
+      line = ctx.line
+      next if line.nil?
+      lines = ctx.full_content.split("\n")
+      next if line < 1 || line > lines.size
+      idx = line - 1
+
+      if desc = check_cross_origin(lines, idx)
+        endpoint.add_tag(Tag.new("cors", desc, "spring_security"))
+      end
+
+      if desc = check_input_validation(lines, idx)
+        endpoint.add_tag(Tag.new("input-validation", desc, "spring_security"))
+      end
+    end
+  end
+
+  # `@CrossOrigin` on the handler (walk the annotation block above it) or on
+  # the controller class (applies to every handler in the file).
+  private def check_cross_origin(lines : Array(String), method_idx : Int32) : String?
+    # Method-level: the contiguous annotation block directly above the
+    # handler. Mirrors spring_auth's backward walk — stop at the previous
+    # member/class boundary so we don't bleed into another handler.
+    idx = method_idx - 1
+    while idx >= 0 && idx >= method_idx - 15
+      current = lines[idx].strip
+      if current.empty?
+        idx -= 1
+        next
+      end
+      break if current.starts_with?("public ") || current.starts_with?("private ") || current.starts_with?("protected ")
+      break if current.starts_with?("class ") || current.starts_with?("}") || current.ends_with?("}")
+
+      return describe_cross_origin(current) if current.includes?("@CrossOrigin")
+      idx -= 1
+    end
+
+    # Class-level: a @CrossOrigin sitting on the controller declaration.
+    if class_line = class_level_annotation(lines, "@CrossOrigin")
+      return describe_cross_origin(class_line, class_level: true)
+    end
+
+    nil
+  end
+
+  private def describe_cross_origin(line : String, class_level : Bool = false) : String
+    scope = class_level ? "controller" : "handler"
+    # No parenthesised args → Spring's @CrossOrigin defaults to allowing all
+    # origins.
+    unless line.includes?("(")
+      return "Cross-origin requests enabled on this #{scope} via @CrossOrigin with no origin restriction (defaults to allowing all origins)."
+    end
+
+    wildcard = line.includes?("\"*\"") || line.includes?("'*'")
+    credentials = line.includes?("allowCredentials") && line.includes?("true")
+    if wildcard && credentials
+      "Permissive CORS on this #{scope} — @CrossOrigin allows all origins (*) with credentials, exposing authenticated responses cross-origin."
+    elsif wildcard
+      "Permissive CORS on this #{scope} — @CrossOrigin allows all origins (*)."
+    else
+      "Cross-origin requests enabled on this #{scope} via @CrossOrigin."
+    end
+  end
+
+  # `@Valid` / `@Validated` applied to the handler's parameters (scan the
+  # signature up to the body brace) or `@Validated` on the controller class.
+  private def check_input_validation(lines : Array(String), method_idx : Int32) : String?
+    idx = method_idx
+    end_idx = [method_idx + 10, lines.size - 1].min
+    while idx <= end_idx
+      current = lines[idx]
+      if current.includes?("@Valid") || current.includes?("@Validated")
+        return "Request payload validated by Bean Validation (@Valid/@Validated)."
+      end
+      # The first body brace closes the signature — stop before scanning the
+      # method body so a `@Valid` used deeper inside cannot leak in.
+      break if current.includes?("{")
+      idx += 1
+    end
+
+    if class_level_annotation(lines, "@Validated")
+      return "Controller annotated @Validated — Bean Validation is applied to this handler's parameters."
+    end
+
+    nil
+  end
+
+  # Find an annotation (`@CrossOrigin`/`@Validated`) that decorates the class
+  # declaration: it must be immediately followed — skipping other annotations
+  # and blank lines — by a `class` line. Returns the annotation line text.
+  private def class_level_annotation(lines : Array(String), annotation_name : String) : String?
+    lines.each_with_index do |raw, i|
+      stripped = raw.strip
+      next unless stripped.starts_with?(annotation_name)
+      j = i + 1
+      while j < lines.size
+        nxt = lines[j].strip
+        if nxt.empty? || nxt.starts_with?("@")
+          j += 1
+          next
+        end
+        return stripped if nxt.includes?("class ")
+        break
+      end
+    end
+    nil
+  end
+
+  # Ant-style pattern match (`/**` → any depth, `*` → one segment), prefix
+  # anchored like spring_auth so `/api/**` matches `/api/posts/1`.
+  private def matches_ant_pattern?(url : String, pattern : String) : Bool
+    regex_str = pattern.gsub("**", "DOUBLE_STAR")
+      .gsub("*", "[^/]*")
+      .gsub("DOUBLE_STAR", ".*")
+    url.matches?(/^#{regex_str}/)
+  rescue ex
+    @logger.debug "SpringSecurityTagger: failed to match ant pattern '#{pattern}': #{ex.message}"
+    false
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -104,6 +104,11 @@ module NoirTaggers
       desc:   "Identifies Spring Security patterns (annotations, security config)",
       runner: SpringAuthTagger,
     },
+    spring_security: {
+      name:   "Spring Security Tagger",
+      desc:   "Identifies Spring security signals beyond auth (CSRF disabled, CORS policy, input validation)",
+      runner: SpringSecurityTagger,
+    },
     express_auth: {
       name:   "Express Auth Tagger",
       desc:   "Identifies Express.js authentication patterns (Passport, JWT, auth middleware)",


### PR DESCRIPTION
## Summary

Adds `spring_security`, a Java/Kotlin framework tagger that surfaces **Spring security signals beyond authentication** — mirroring how `rails_security` complements `ruby_auth`. `spring_auth` already classifies authn/authz (`@PreAuthorize`/`@Secured`/`@RolesAllowed` + `HttpSecurity` URL rules); this tagger covers the protections Spring ships and the deviations from its secure defaults that map cleanly onto an endpoint.

This is enrichment of Noir's already-solid Spring AI context — these tags feed the per-endpoint AI summary as additional security signals.

## Tags

- **`csrf-protection`** — CSRF disabled in a `SecurityFilterChain` (`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, lambda forms, Kotlin `csrf { disable() }`), reported on the **state-changing** endpoints (POST/PUT/PATCH/DELETE) the affected chain exposes. Common/intentional for token/stateless REST APIs but always worth surfacing. Scoped to a chain's `securityMatcher(...)` when present, else treated as global.
- **`cors`** — a `@CrossOrigin` annotation on the handler or its controller opts the endpoint out of the browser same-origin default. Wildcard origins (`*`), and especially wildcard + credentials, are called out as **permissive**.
- **`input-validation`** — `@Valid` / `@Validated` applying Bean Validation to the request payload (the primary Spring input-validation control). Surfacing where it *is* applied makes the gaps (a `@RequestBody` handler without it) visible by their absence.

## Design

- Targets `java_spring` and `kotlin_spring`.
- CSRF is **pre-scanned** from security config once (like `spring_auth`'s URL rules), splitting each config file into per-`HttpSecurity`-scope blocks so a `csrf().disable()` is associated only with its own chain's matcher. A chain matched by a non-literal matcher (e.g. `EndpointRequest.toAnyEndpoint()`) is skipped rather than over-broadened to global — avoids the actuator-chain false positive.
- CORS and input-validation are per-endpoint, line-based walks of the handler (annotation block above + signature), with class-level `@CrossOrigin`/`@Validated` detection.

## Testing

- New unit spec (`spring_security_spec.cr`, 10 examples) covering global vs. `securityMatcher`-scoped CSRF, GET exclusion, permissive CORS, `@Valid` present/absent, multi-tag, and empty `code_paths`.
- Fixtures: `spring_security/` (global disable + wildcard CORS + `@Valid`) and `spring_security_scoped/` (two chains, only `/api/**` disables CSRF).
- All 380 tagger unit specs pass; `crystal tool format` + `ameba` clean; verified end-to-end with a real `noir` scan.
- EN + KO docs updated.

## Example

```
POST /api/posts       -> csrf-protection, cors, input-validation
PUT  /api/posts/{id}  -> csrf-protection, cors        (no @Valid)
GET  /api/posts       -> cors                         (GET: no CSRF concern)
```
