### PR TITLE
feat(tagger): expand spring_security detection (CSRF ignoring, security-headers, config CORS)

### DIFF
--- a/docs/content/usage/more_features/tagger/index.ko.md
+++ b/docs/content/usage/more_features/tagger/index.ko.md
@@ -88,8 +88,9 @@ noir scan <BASE_PATH> --use-taggers hunt,oauth
   - `rate-limit` — Rails 8 네이티브 `rate_limit` 매크로로 스로틀링되는 액션. 무차별 대입/남용 노출을 평가할 때 유용한 맥락이며, 인증·복구 표면에서 이것이 부재하면 그 자체가 점검 포인트.
 
   Spring(`spring_security`)의 경우, 인증 태거 `spring_auth`를 보완:
-  - `csrf-protection` — `SecurityFilterChain`에서 CSRF가 비활성화(`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, Kotlin `csrf { disable() }`)된 경우. 해당 체인이 노출하는 상태 변경 엔드포인트(POST/PUT/PATCH/DELETE)에 표시되며, 무상태/토큰 API에서는 흔하지만 항상 검토 가치가 있고, `securityMatcher`가 있으면 그 체인 범위로 한정.
-  - `cors` — 핸들러나 컨트롤러의 `@CrossOrigin` 애너테이션은 브라우저 동일 출처 기본값에서 엔드포인트를 벗어나게 함. 와일드카드 출처(`*`), 특히 자격 증명과 함께 사용된 경우 과도한(permissive) 설정으로 표시.
+  - `csrf-protection` — `SecurityFilterChain`에서 CSRF가 꺼진 경우. 체인 전체 비활성화(`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, Kotlin `csrf { disable() }`)이거나 특정 경로만 선택적으로 제외(`csrf(c -> c.ignoringRequestMatchers("/api/**"))`)된 경우 모두 해당 상태 변경 엔드포인트(POST/PUT/PATCH/DELETE)에 표시. 무상태/토큰 API에서는 흔하지만 항상 검토 가치가 있고, `securityMatcher`가 있으면 그 체인 범위로 한정.
+  - `cors` — 핸들러/컨트롤러의 `@CrossOrigin` 애너테이션 또는 전역 `WebMvcConfigurer` 매핑(`addMapping(...).allowedOrigins("*")`)으로 브라우저 동일 출처 기본값에서 엔드포인트가 벗어난 경우. 와일드카드 출처(`*`), 특히 자격 증명과 함께 사용된 경우 과도한(permissive) 설정으로 표시.
+  - `security-headers` — Spring의 기본 응답 헤더 보호가 약화된 경우: 클릭재킹 보호 해제(`frameOptions().disable()`) 또는 헤더 라이터 전체 비활성화(`headers().disable()` / `headers(HeadersConfigurer::disable)`).
   - `input-validation` — `@Valid` / `@Validated`로 요청 페이로드에 Bean Validation이 적용된 경우. 적용된 지점을 드러내면, 적용되지 않은 공백(`@RequestBody`를 받으면서 검증이 없는 핸들러)도 부재로 드러남.
 
 엔드포인트 레벨 태그는 AI 컨텍스트에도 신호로 전달되어, AI 리뷰어가 사용하는 엔드포인트별 요약을 더욱 풍부하게 만듭니다.

--- a/docs/content/usage/more_features/tagger/index.md
+++ b/docs/content/usage/more_features/tagger/index.md
@@ -88,8 +88,9 @@ Taggers span several kinds of security-relevant signal. Run `noir list taggers` 
   - `rate-limit` — actions throttled by the Rails 8 native `rate_limit` macro; useful context when assessing brute-force / abuse exposure (and its absence on auth/recovery surface is itself a finding).
 
   For Spring (`spring_security`), complementing the `spring_auth` authentication tagger:
-  - `csrf-protection` — CSRF disabled in a `SecurityFilterChain` (`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, or Kotlin `csrf { disable() }`), reported on the state-changing endpoints (POST/PUT/PATCH/DELETE) the affected chain exposes; common for stateless/token APIs but always worth surfacing, and scoped to a chain's `securityMatcher` when present.
-  - `cors` — a `@CrossOrigin` annotation on the handler or controller opts the endpoint out of the browser same-origin default; wildcard origins (`*`), especially combined with credentials, are called out as permissive.
+  - `csrf-protection` — CSRF turned off in a `SecurityFilterChain`, either wholesale (`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`, Kotlin `csrf { disable() }`) or selectively for specific paths (`csrf(c -> c.ignoringRequestMatchers("/api/**"))`), reported on the state-changing endpoints (POST/PUT/PATCH/DELETE) affected; common for stateless/token APIs but always worth surfacing, and scoped to a chain's `securityMatcher` when present.
+  - `cors` — a `@CrossOrigin` annotation on the handler/controller, or a global `WebMvcConfigurer` mapping (`addMapping(...).allowedOrigins("*")`), opts the endpoint out of the browser same-origin default; wildcard origins (`*`), especially combined with credentials, are called out as permissive.
+  - `security-headers` — Spring's default response-header protections weakened: clickjacking off (`frameOptions().disable()`) or the whole header writer disabled (`headers().disable()` / `headers(HeadersConfigurer::disable)`).
   - `input-validation` — `@Valid` / `@Validated` applies Bean Validation to the request payload; surfacing where it *is* applied also makes the gaps (handlers taking a `@RequestBody` without it) visible by their absence.
 
 Endpoint-level tags also feed the AI context as signals, enriching the per-endpoint summary that AI reviewers consume.

--- a/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/AdminController.java
+++ b/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/AdminController.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+    @PostMapping("/users")
+    public String create(@RequestBody String user) {
+        return "created";
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/CorsConfig.java
+++ b/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/CorsConfig.java
@@ -1,0 +1,17 @@
+package com.example;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("*")
+            .allowedMethods("*")
+            .allowCredentials(true);
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/SecurityConfig.java
+++ b/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // CSRF stays ON, but is skipped for inbound webhook paths only.
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/webhook/**"))
+            // Clickjacking protection (X-Frame-Options) turned off globally.
+            .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated());
+        return http.build();
+    }
+}

--- a/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/WebhookController.java
+++ b/spec/functional_test/fixtures/java/spring_security_extras/src/main/java/com/example/WebhookController.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/webhook")
+public class WebhookController {
+
+    @PostMapping("/github")
+    public String github(@RequestBody String payload) {
+        return "ok";
+    }
+}

--- a/spec/unit_test/tagger/framework_taggers/spring_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/spring_security_spec.cr
@@ -15,6 +15,13 @@ require "../../../../src/tagger/tagger"
 # spring_security_scoped/src/main/java/com/example/SecurityConfig.java
 #   chain apiChain: securityMatcher("/api/**") + csrf().disable()
 #   chain webChain: securityMatcher("/web/**"), CSRF left enabled
+#
+# spring_security_extras/src/main/java/com/example/
+#   SecurityConfig.java   csrf ignoringRequestMatchers("/api/webhook/**")
+#                         + headers().frameOptions().disable() (global)
+#   CorsConfig.java       addMapping("/api/**").allowedOrigins("*").allowCredentials(true)
+#   WebhookController.java  10: POST /api/webhook/github
+#   AdminController.java    10: POST /admin/users
 
 private def tag_named(endpoint : Endpoint, name : String) : Tag?
   endpoint.tags.find { |t| t.name == name }
@@ -45,6 +52,13 @@ describe "SpringSecurityTagger" do
 
   scoped_options = create_test_options
   scoped_options["base"] = YAML::Any.new(scoped_base)
+
+  extras_base = "#{__DIR__}/../../../functional_test/fixtures/java/spring_security_extras"
+  webhook_ctrl = "#{extras_base}/src/main/java/com/example/WebhookController.java"
+  admin_ctrl = "#{extras_base}/src/main/java/com/example/AdminController.java"
+
+  extras_options = create_test_options
+  extras_options["base"] = YAML::Any.new(extras_base)
 
   before_each do
     CodeLocator.instance.clear_all
@@ -151,5 +165,73 @@ describe "SpringSecurityTagger" do
     # still applies by URL/method without raising.
     tag_named(endpoint, "csrf-protection").should_not be_nil
     tag_named(endpoint, "cors").should be_nil
+  end
+
+  describe "csrf-protection via ignoringRequestMatchers" do
+    it "flags only the paths CSRF is selectively ignored for" do
+      load_fixture_files(extras_base)
+
+      ignored = build_endpoint(webhook_ctrl, 10, "/api/webhook/github", "POST")
+      SpringSecurityTagger.new(extras_options).perform([ignored])
+      tag = tag_named(ignored, "csrf-protection")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("ignoringRequestMatchers")
+
+      # /admin/users is outside the ignored matcher and the chain is not
+      # otherwise CSRF-disabled, so CSRF stays on → no tag.
+      kept = build_endpoint(admin_ctrl, 10, "/admin/users", "POST")
+      SpringSecurityTagger.new(extras_options).perform([kept])
+      tag_named(kept, "csrf-protection").should be_nil
+    end
+  end
+
+  describe "security-headers" do
+    it "flags clickjacking protection disabled (frameOptions) for every endpoint in scope" do
+      load_fixture_files(extras_base)
+      endpoint = build_endpoint(admin_ctrl, 10, "/admin/users", "POST")
+      SpringSecurityTagger.new(extras_options).perform([endpoint])
+
+      tag = tag_named(endpoint, "security-headers")
+      tag.should_not be_nil
+      tag.not_nil!.tagger.should eq("spring_security")
+      tag.not_nil!.description.should contain("Clickjacking")
+    end
+
+    it "applies to GET endpoints too (headers affect all responses)" do
+      load_fixture_files(extras_base)
+      endpoint = build_endpoint(webhook_ctrl, nil, "/api/webhook/list", "GET")
+      SpringSecurityTagger.new(extras_options).perform([endpoint])
+
+      tag_named(endpoint, "security-headers").should_not be_nil
+    end
+
+    it "is absent when the secure-default headers are left in place" do
+      load_fixture_files(global_base)
+      endpoint = build_endpoint(controller, 12, "/api/posts", "POST")
+      SpringSecurityTagger.new(global_options).perform([endpoint])
+
+      tag_named(endpoint, "security-headers").should be_nil
+    end
+  end
+
+  describe "cors via global WebMvc config" do
+    it "flags a permissive addMapping wildcard + credentials by URL" do
+      load_fixture_files(extras_base)
+      endpoint = build_endpoint(webhook_ctrl, nil, "/api/webhook/github", "POST")
+      SpringSecurityTagger.new(extras_options).perform([endpoint])
+
+      tag = tag_named(endpoint, "cors")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("global WebMvc config")
+      tag.not_nil!.description.should contain("credentials")
+    end
+
+    it "does not flag a URL outside the CORS mapping" do
+      load_fixture_files(extras_base)
+      endpoint = build_endpoint(admin_ctrl, nil, "/admin/users", "POST")
+      SpringSecurityTagger.new(extras_options).perform([endpoint])
+
+      tag_named(endpoint, "cors").should be_nil
+    end
   end
 end

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -10,25 +10,31 @@ require "../../../models/endpoint"
 # secure defaults — that map cleanly onto an endpoint:
 #
 #   * csrf-protection — Spring Security CSRF-protects every state-changing
-#     request by default; an explicit `csrf().disable()`,
-#     `csrf(AbstractHttpConfigurer::disable)` or Kotlin `csrf { disable() }`
-#     in a SecurityFilterChain turns that off. We flag the state-changing
-#     endpoints (POST/PUT/PATCH/DELETE) the affected filter chain exposes.
-#     Disabling CSRF is common and often intentional for token/stateless
-#     REST APIs, but it is always worth surfacing for review.
-#   * cors — a `@CrossOrigin` annotation on the handler or its controller
+#     request by default. We flag the state-changing endpoints
+#     (POST/PUT/PATCH/DELETE) where that is turned off, either wholesale for
+#     a filter chain (`csrf().disable()`, `csrf(AbstractHttpConfigurer::disable)`,
+#     Kotlin `csrf { disable() }`) or selectively for specific paths
+#     (`csrf(c -> c.ignoringRequestMatchers("/api/**"))`). Common and often
+#     intentional for token/stateless APIs, but always worth surfacing.
+#   * cors — a `@CrossOrigin` annotation on the handler/controller, or a
+#     global `WebMvcConfigurer` CORS mapping (`addMapping(...).allowedOrigins("*")`),
 #     opts the endpoint out of the browser same-origin default. Wildcard
-#     origins (`*`), and especially a wildcard combined with credentials,
-#     are called out as permissive.
+#     origins (`*`), especially combined with credentials, are permissive.
+#   * security-headers — Spring Security adds a sensible default header set
+#     (X-Frame-Options DENY, X-Content-Type-Options, Cache-Control, …). We
+#     flag the endpoints where those are weakened: clickjacking protection
+#     off (`frameOptions().disable()`) or the whole header writer disabled
+#     (`headers().disable()` / `headers(HeadersConfigurer::disable)`).
 #   * input-validation — `@Valid` / `@Validated` on the handler applies Bean
 #     Validation to the request payload, the primary Spring input-validation
 #     control. Surfacing where it IS applied also makes the gaps — handlers
 #     taking a body without it — visible by their absence.
 #
-# CSRF is detected from the security config (pre-scanned once, like
-# spring_auth's URL rules). CORS and input-validation are per-endpoint and
-# line-based, walking the handler the endpoint maps to. Cross-file concerns
-# (a custom Filter bean, a global CorsConfigurationSource) are out of scope.
+# CSRF / security-headers / config CORS are detected from the security &
+# MVC config (pre-scanned once, like spring_auth's URL rules). The
+# `@CrossOrigin` and input-validation signals are per-endpoint, line-based
+# walks of the handler the endpoint maps to. Cross-file concerns (a custom
+# Filter bean, a bespoke CorsConfigurationSource) are out of scope.
 class SpringSecurityTagger < FrameworkTagger
   STATE_CHANGING_METHODS = Set{"POST", "PUT", "PATCH", "DELETE"}
 
@@ -39,8 +45,26 @@ class SpringSecurityTagger < FrameworkTagger
 
   # `csrf().disable()` (fluent), `csrf(csrf -> csrf.disable())` /
   # `csrf(AbstractHttpConfigurer::disable)` (lambda/method-ref), and Kotlin
-  # `csrf { disable() }`.
+  # `csrf { disable() }`. Whole-chain disable.
   CSRF_DISABLE = /csrf\s*(?:\(\s*\)\s*\.\s*disable\b|\([^)]*\bdisable|\{[^}]*\bdisable)/
+
+  # `ignoringRequestMatchers(...)` / `ignoringAntMatchers(...)` — CSRF kept on
+  # for the chain but skipped for these (absolute) path patterns. Captured
+  # across line breaks: the arg group stops at the statement's `;`, never
+  # crossing into the next statement. The inner quote scan pulls the path
+  # literal even when wrapped (e.g. `new AntPathRequestMatcher("/api")`).
+  IGNORING_ARGS = /(?:ignoringRequestMatchers|ignoringAntMatchers)\s*\(([^;]*?)\)/
+
+  # Clickjacking protection off: `frameOptions().disable()`,
+  # `frameOptions(f -> f.disable())`, Kotlin `frameOptions { disable() }`.
+  FRAME_OPTIONS_DISABLE = /frameOptions\s*(?:\(\s*\)\s*\.\s*disable\b|\([^)]*\bdisable|\{[^}]*\bdisable)/
+
+  # Whole default header writer off. Restricted to the unambiguous forms —
+  # empty-paren fluent `headers().disable()` and the method-ref
+  # `headers(HeadersConfigurer::disable)` — so a *nested* per-header disable
+  # such as `headers(h -> h.frameOptions(f -> f.disable()))` is NOT mistaken
+  # for an all-headers-off (that one is caught by FRAME_OPTIONS_DISABLE).
+  HEADERS_FULLY_DISABLED = /headers\s*(?:\(\s*\)\s*\.\s*disable\b|\([^)]*::\s*disable)/
 
   # Chain-level request matchers that scope a SecurityFilterChain to a URL
   # subset. `requestMatchers(...)` is deliberately excluded: inside
@@ -52,6 +76,9 @@ class SpringSecurityTagger < FrameworkTagger
     super
     @name = "spring_security"
     @csrf_disable_scopes = [] of String
+    @csrf_ignored_scopes = [] of String
+    @header_weak_scopes = [] of NamedTuple(pattern: String, kind: Symbol)
+    @cors_config_scopes = [] of NamedTuple(pattern: String, credentials: Bool)
   end
 
   def self.target_techs : Array(String)
@@ -59,40 +86,75 @@ class SpringSecurityTagger < FrameworkTagger
   end
 
   def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
-    pre_scan_csrf_config
+    pre_scan_config
     endpoints.each { |endpoint| check_endpoint(endpoint) }
     endpoints
   end
 
-  # ---- CSRF (config-level) ---------------------------------------------
+  # ---- config pre-scan -------------------------------------------------
 
-  private def pre_scan_csrf_config
+  private def pre_scan_config
     @csrf_disable_scopes.clear
+    @csrf_ignored_scopes.clear
+    @header_weak_scopes.clear
+    @cors_config_scopes.clear
+
     [".java", ".kt"].each do |ext|
       collect_files_by_extension(ext).each do |file|
         content = read_file(file)
         next if content.nil?
-        next unless content.includes?("HttpSecurity") || content.includes?("SecurityFilterChain") || content.includes?("WebSecurityConfigurerAdapter")
-        scan_csrf_config(content)
+
+        if content.includes?("HttpSecurity") || content.includes?("SecurityFilterChain") || content.includes?("WebSecurityConfigurerAdapter")
+          scan_security_config(content)
+        end
+        scan_cors_mappings(content) if content.includes?(".addMapping")
       end
     end
+
     @csrf_disable_scopes.uniq!
+    @csrf_ignored_scopes.uniq!
+    @header_weak_scopes.uniq!
+    @cors_config_scopes.uniq!
   end
 
-  private def scan_csrf_config(content : String)
+  private def scan_security_config(content : String)
     split_into_chain_blocks(content).each do |block|
-      next unless block.matches?(CSRF_DISABLE)
-
       matchers = extract_matchers(block)
-      if matchers.size > 0
-        # CSRF disabled for a chain scoped to these URL pattern(s).
-        matchers.each { |m| @csrf_disable_scopes << m }
-      elsif !block.matches?(MATCHER_CALL)
-        # No matcher at all → this chain (and its CSRF-disable) is global.
-        @csrf_disable_scopes << "/**"
+
+      # (a) Whole-chain CSRF disable.
+      record_scoped(@csrf_disable_scopes, matchers, block) if block.matches?(CSRF_DISABLE)
+
+      # (b) CSRF skipped for specific (absolute) paths. Used directly — these
+      #     matchers are not relative to the chain's securityMatcher.
+      extract_ignoring_matchers(block).each { |p| @csrf_ignored_scopes << p }
+
+      # (c) Default security response headers weakened. Whole-writer-off wins
+      #     over the frameOptions-only case when both somehow appear.
+      if block.matches?(HEADERS_FULLY_DISABLED)
+        record_header_scope(:all, matchers, block)
+      elsif block.matches?(FRAME_OPTIONS_DISABLE)
+        record_header_scope(:frame, matchers, block)
       end
-      # else: scoped by a non-literal matcher (e.g. EndpointRequest) we
-      # cannot resolve to a URL — skip rather than over-broaden to global.
+    end
+  end
+
+  # Record a chain-scoped rule: scope to the chain's securityMatcher pattern(s)
+  # when present; treat a matcher-less chain as global `/**`; skip a chain
+  # scoped only by a non-literal matcher (e.g. EndpointRequest) we can't
+  # resolve, rather than over-broadening it to global.
+  private def record_scoped(target : Array(String), matchers : Array(String), block : String)
+    if matchers.size > 0
+      matchers.each { |m| target << m }
+    elsif !block.matches?(MATCHER_CALL)
+      target << "/**"
+    end
+  end
+
+  private def record_header_scope(kind : Symbol, matchers : Array(String), block : String)
+    if matchers.size > 0
+      matchers.each { |m| @header_weak_scopes << {pattern: m, kind: kind} }
+    elsif !block.matches?(MATCHER_CALL)
+      @header_weak_scopes << {pattern: "/**", kind: kind}
     end
   end
 
@@ -121,21 +183,82 @@ class SpringSecurityTagger < FrameworkTagger
     matchers
   end
 
-  private def csrf_disabled_scope_for(endpoint : Endpoint) : String?
+  private def extract_ignoring_matchers(block : String) : Array(String)
+    result = [] of String
+    block.scan(IGNORING_ARGS) do |m|
+      m[1].scan(/"([^"]+)"/) { |q| result << q[1] }
+    end
+    result
+  end
+
+  # `addMapping("/x").allowedOrigins("*")...` in a WebMvcConfigurer. Each
+  # mapping is one `;`-terminated fluent statement, so splitting on `;`
+  # keeps a (possibly multi-line) chain intact. Only a wildcard origin is
+  # permissive enough to flag — a mapping listing specific origins is the
+  # intended, safe use of CORS.
+  private def scan_cors_mappings(content : String)
+    content.split(';').each do |stmt|
+      next unless stmt.includes?(".addMapping")
+      m = stmt.match(/\.addMapping\s*\(\s*"([^"]+)"/)
+      next unless m
+
+      origins_wild = (stmt.includes?("allowedOrigins") || stmt.includes?("allowedOriginPatterns")) && stmt.includes?("\"*\"")
+      next unless origins_wild
+
+      credentials = stmt.includes?("allowCredentials") && stmt.includes?("true")
+      @cors_config_scopes << {pattern: m[1], credentials: credentials}
+    end
+  end
+
+  # ---- per-endpoint resolution ----------------------------------------
+
+  private def csrf_disabled_description_for(endpoint : Endpoint) : String?
     return unless STATE_CHANGING_METHODS.includes?(endpoint.method.upcase)
-    @csrf_disable_scopes.find { |pattern| matches_ant_pattern?(endpoint.url, pattern) }
+    url = endpoint.url
+
+    # Specific ignored paths first — more precise than a chain-wide disable.
+    if scope = @csrf_ignored_scopes.find { |p| matches_ant_pattern?(url, p) }
+      return "CSRF protection disabled for paths matching \"#{scope}\" (csrf ignoringRequestMatchers) — state-changing requests here are not CSRF-validated."
+    end
+
+    if scope = @csrf_disable_scopes.find { |p| matches_ant_pattern?(url, p) }
+      return scope == "/**" ? "CSRF protection disabled globally (Spring Security csrf().disable()) — state-changing requests to this endpoint are not CSRF-validated." : "CSRF protection disabled for the \"#{scope}\" filter chain — state-changing requests to this endpoint are not CSRF-validated."
+    end
+
+    nil
+  end
+
+  private def security_headers_description_for(endpoint : Endpoint) : String?
+    rule = @header_weak_scopes.find { |r| matches_ant_pattern?(endpoint.url, r[:pattern]) }
+    return unless rule
+
+    if rule[:kind] == :all
+      "Spring Security default response headers disabled for this endpoint (headers().disable()) — clickjacking (X-Frame-Options), MIME-sniffing (X-Content-Type-Options) and cache-control protections are all off."
+    else
+      "Clickjacking protection disabled for this endpoint — X-Frame-Options is turned off (frameOptions().disable()), so responses can be embedded in a frame by any site."
+    end
+  end
+
+  private def cors_config_description_for(endpoint : Endpoint) : String?
+    rule = @cors_config_scopes.find { |r| matches_ant_pattern?(endpoint.url, r[:pattern]) }
+    return unless rule
+
+    if rule[:credentials]
+      "Permissive CORS (global WebMvc config) — addMapping(\"#{rule[:pattern]}\") allows all origins (*) with credentials, exposing authenticated responses cross-origin."
+    else
+      "Permissive CORS (global WebMvc config) — addMapping(\"#{rule[:pattern]}\") allows all origins (*)."
+    end
   end
 
   # ---- per-endpoint ----------------------------------------------------
 
   private def check_endpoint(endpoint : Endpoint)
-    if scope = csrf_disabled_scope_for(endpoint)
-      desc = if scope == "/**"
-               "CSRF protection disabled globally (Spring Security csrf().disable()) — state-changing requests to this endpoint are not CSRF-validated."
-             else
-               "CSRF protection disabled for the \"#{scope}\" filter chain — state-changing requests to this endpoint are not CSRF-validated."
-             end
+    if desc = csrf_disabled_description_for(endpoint)
       endpoint.add_tag(Tag.new("csrf-protection", desc, "spring_security"))
+    end
+
+    if desc = security_headers_description_for(endpoint)
+      endpoint.add_tag(Tag.new("security-headers", desc, "spring_security"))
     end
 
     read_source_context(endpoint).each do |ctx|
@@ -152,6 +275,13 @@ class SpringSecurityTagger < FrameworkTagger
       if desc = check_input_validation(lines, idx)
         endpoint.add_tag(Tag.new("input-validation", desc, "spring_security"))
       end
+    end
+
+    # Config-based CORS is annotation-independent. add_tag dedups by
+    # (name, tagger), so an endpoint already tagged from a @CrossOrigin
+    # annotation keeps that (more specific) description.
+    if desc = cors_config_description_for(endpoint)
+      endpoint.add_tag(Tag.new("cors", desc, "spring_security"))
     end
   end
 

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -106,7 +106,7 @@ module NoirTaggers
     },
     spring_security: {
       name:   "Spring Security Tagger",
-      desc:   "Identifies Spring security signals beyond auth (CSRF disabled, CORS policy, input validation)",
+      desc:   "Identifies Spring security signals beyond auth (CSRF disabled, CORS policy, security headers, input validation)",
       runner: SpringSecurityTagger,
     },
     express_auth: {


### PR DESCRIPTION
## Summary

Expands the `spring_security` framework tagger (added in #1851) with three more Spring security signals that map cleanly onto endpoints — broadening detection coverage for security review and the AI context.

## What's new

- **`csrf-protection` — selective CSRF skips.** Beyond whole-chain `csrf().disable()`, now also detects `csrf(c -> c.ignoringRequestMatchers("/api/**"))` / `ignoringAntMatchers(...)` — CSRF stays on for the chain but is *off* for those (absolute) paths. Reported on the matched state-changing endpoints with a distinct description. Multi-line and wrapped (`new AntPathRequestMatcher("…")`) matcher args are parsed.
- **`security-headers` (new tag).** Spring's secure-default response headers weakened:
  - clickjacking off — `frameOptions().disable()` / `frameOptions(f -> f.disable())` / Kotlin `frameOptions { disable() }`
  - whole header writer off — `headers().disable()` / `headers(HeadersConfigurer::disable)`

  Chain-scoped like CSRF, and applied to **all** methods (headers affect every response). The all-headers-off regex is deliberately tightened to the unambiguous empty-paren / method-ref forms so a *nested* per-header disable (`headers(h -> h.frameOptions(f -> f.disable()))`) is not mis-read as all-headers-off — that case is correctly attributed to clickjacking only.
- **`cors` — global WebMvc config.** Beyond `@CrossOrigin`, now also detects a permissive `WebMvcConfigurer` mapping — `addMapping("/api/**").allowedOrigins("*")` (+ `allowCredentials(true)`) — matched by URL. `add_tag` dedup keeps the more specific `@CrossOrigin` description when both apply.

## Design notes

- CSRF / security-headers reuse the existing per-`HttpSecurity`-scope block split, so each signal binds only to its own chain's `securityMatcher` (else global `/**`); a non-literal matcher is skipped rather than over-broadened.
- Config CORS is parsed by splitting on `;` so a multi-line fluent `addMapping(...)` chain stays intact; only a wildcard origin is flagged (specific-origin mappings are the safe, intended use).

## Testing

- `spring_security_extras` fixture exercises all three at once (ignoring matcher scoped to `/api/webhook/**`, global `frameOptions` disable, permissive `/api/**` WebMvc CORS with credentials) plus an in-scope negative (`/admin/users`).
- +6 specs; **all 386 tagger unit specs pass**; `crystal tool format` + `ameba` clean; regex edge cases verified separately; confirmed end-to-end with a real `noir` scan.
- EN + KO docs updated.

```
POST /api/webhook/github -> csrf-protection (ignoringRequestMatchers), security-headers (clickjacking), cors (global WebMvc, credentials)
POST /admin/users        -> security-headers                 (CSRF stays on, outside CORS mapping)
```
