### PR TITLE
feat(tagger): add go_security framework tagger (CSRF/headers/rate-limit/body-limit/timeout/CORS/secure-cookies)

### DIFF
--- a/docs/content/usage/more_features/tagger/index.ko.md
+++ b/docs/content/usage/more_features/tagger/index.ko.md
@@ -99,4 +99,13 @@ noir scan <BASE_PATH> --use-taggers hunt,oauth
   - `security-headers` — 라우트에 설정된 강화 응답 헤더(HSTS, CSP, `X-Frame-Options`, `X-Content-Type-Options` 등).
   - `body-limit` — 요청 본문 크기 제한(DoS 완화). 제한이 비활성화(`DefaultBodyLimit::disable()`)된 경우 위험으로 표시.
 
+  Go 웹 프레임워크(`go_security`)의 경우, 각 엔드포인트에 매핑되는 것은 *보호 미들웨어*입니다. Rails와 달리 Go는 이런 보호를 기본으로 제공하지 않으므로, 그 *존재*(그리고 상태 변경 라우트에서의 부재)가 곧 신호입니다. 그룹 단위 `.Use(...)`, 전역 래퍼, 인라인 라우트 미들웨어로부터 Echo·Gin·Fiber·Chi 등 전반에서 탐지합니다:
+  - `csrf-protection` — 라우트의 CSRF 미들웨어(Echo `middleware.CSRF`, Fiber `csrf.New`, gorilla/csrf `csrf.Protect`, gin-csrf, `nosurf`). 쿠키 인증 기반 상태 변경 라우트에서 부재하면 검토 대상.
+  - `security-headers` — 응답 강화 미들웨어(Echo `middleware.Secure`, Fiber `helmet`, unrolled/gin-contrib `secure`). HSTS / `X-Frame-Options` / nosniff / XSS 보호 헤더 설정.
+  - `rate-limit` — 스로틀링 미들웨어(Echo `RateLimiter`, chi `Throttle`, Fiber/ulule `limiter`, go-chi/httprate, tollbooth). 무차별 대입/남용 노출을 매핑.
+  - `body-limit` — 요청 본문 크기 제한(Echo `BodyLimit`, gin-contrib/size). DoS/자원 고갈 방어 장치.
+  - `timeout` — 요청 타임아웃 미들웨어(Echo/chi `middleware.Timeout`, Fiber `timeout`). 느린 요청/자원 고갈 방어 장치.
+  - `cors` — CORS 미들웨어(Echo `middleware.CORS`, Fiber/gin-contrib/go-chi/rs `cors`, gorilla `handlers.CORS`). 알려진 permissive 생성자(`cors.Default()`, `cors.AllowAll()`)는 모든 origin 허용으로 플래깅. 헤더 파라미터 기반 `cors` 태거를 보완.
+  - `secure-cookies` — 쿠키 기밀성/무결성 미들웨어(Fiber `encryptcookie`).
+
 엔드포인트 레벨 태그는 AI 컨텍스트에도 신호로 전달되어, AI 리뷰어가 사용하는 엔드포인트별 요약을 더욱 풍부하게 만듭니다.

--- a/docs/content/usage/more_features/tagger/index.md
+++ b/docs/content/usage/more_features/tagger/index.md
@@ -99,4 +99,13 @@ Taggers span several kinds of security-relevant signal. Run `noir list taggers` 
   - `security-headers` — hardening response headers set on the route (HSTS, CSP, `X-Frame-Options`, `X-Content-Type-Options`, …).
   - `body-limit` — request body size cap (DoS mitigation); a disabled limit (`DefaultBodyLimit::disable()`) is flagged as a risk.
 
+  For Go web frameworks (`go_security`) the protective middleware is what gets mapped onto each endpoint — unlike Rails, Go ships none of it on by default, so its *presence* (and absence on a state-changing route) is the signal. Detected from group-level `.Use(...)`, global wrappers, and inline route middleware across Echo, Gin, Fiber, Chi, and friends:
+  - `csrf-protection` — CSRF middleware on the route (`middleware.CSRF` for Echo, `csrf.New` for Fiber, `csrf.Protect` for gorilla/csrf, gin-csrf, `nosurf`); its absence on cookie-authenticated state-changing routes is the case worth reviewing.
+  - `security-headers` — response-hardening middleware (Echo `middleware.Secure`, Fiber `helmet`, unrolled/gin-contrib `secure`) setting HSTS / `X-Frame-Options` / nosniff / XSS protections.
+  - `rate-limit` — throttling middleware (Echo `RateLimiter`, chi `Throttle`, Fiber/ulule `limiter`, go-chi/httprate, tollbooth); maps brute-force / abuse exposure.
+  - `body-limit` — request-body size cap (Echo `BodyLimit`, gin-contrib/size); a DoS / resource-exhaustion guard.
+  - `timeout` — request-timeout middleware (Echo/chi `middleware.Timeout`, Fiber `timeout`); a slow-request / resource-exhaustion guard.
+  - `cors` — CORS middleware (Echo `middleware.CORS`, Fiber/gin-contrib/go-chi/rs `cors`, gorilla `handlers.CORS`); known-permissive constructors (`cors.Default()`, `cors.AllowAll()`) are flagged as allowing all origins. Complements the header-param-based `cors` tagger.
+  - `secure-cookies` — cookie confidentiality/integrity middleware (Fiber `encryptcookie`).
+
 Endpoint-level tags also feed the AI context as signals, enriching the per-endpoint summary that AI reviewers consume.

--- a/spec/functional_test/fixtures/go/echo_security/go.mod
+++ b/spec/functional_test/fixtures/go/echo_security/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/test-go-echo-security
+
+go 1.24.1
+
+require github.com/labstack/echo/v4 v4.11.1

--- a/spec/functional_test/fixtures/go/echo_security/main.go
+++ b/spec/functional_test/fixtures/go/echo_security/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func main() {
+	e := echo.New()
+
+	// Global security middleware — applies to every route.
+	e.Use(middleware.Secure())
+	e.Use(middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(20)))
+
+	// Public route (inherits the global Secure + RateLimiter).
+	e.GET("/health", func(c echo.Context) error {
+		return c.String(http.StatusOK, "OK")
+	})
+
+	// CSRF-protected group.
+	web := e.Group("/web")
+	web.Use(middleware.CSRF())
+	web.POST("/transfer", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	// Body-size cap on an upload group.
+	upload := e.Group("/upload")
+	upload.Use(middleware.BodyLimit("2M"))
+	upload.POST("/file", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	// Timeout-guarded API group.
+	api := e.Group("/api")
+	api.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{Timeout: 5 * time.Second}))
+	api.GET("/report", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	// CORS-enabled (permissive) group.
+	pub := e.Group("/pub")
+	pub.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"*"},
+	}))
+	pub.GET("/feed", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	// Inline route-level CSRF middleware (trailing arg on the route call).
+	e.POST("/admin/reset", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	}, middleware.CSRF())
+
+	e.Logger.Fatal(e.Start(":8080"))
+}

--- a/spec/functional_test/fixtures/go/fiber_security/go.mod
+++ b/spec/functional_test/fixtures/go/fiber_security/go.mod
@@ -1,0 +1,5 @@
+module github.com/hahwul/test-go-fiber-security
+
+go 1.20
+
+require github.com/gofiber/fiber/v2 v2.52.13

--- a/spec/functional_test/fixtures/go/fiber_security/main.go
+++ b/spec/functional_test/fixtures/go/fiber_security/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/csrf"
+	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
+	"github.com/gofiber/fiber/v2/middleware/helmet"
+	"github.com/gofiber/fiber/v2/middleware/limiter"
+)
+
+func main() {
+	app := fiber.New()
+
+	// Global Fiber security middleware — applies to every route.
+	app.Use(helmet.New())
+	app.Use(encryptcookie.New(encryptcookie.Config{Key: "secret-thirty-two-character-key!"}))
+
+	app.Get("/status", func(c *fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	// Rate-limited + CSRF-protected API group.
+	api := app.Group("/api")
+	api.Use(limiter.New())
+	api.Use(csrf.New())
+	api.Post("/orders", func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusCreated)
+	})
+
+	// CORS-enabled group.
+	open := app.Group("/open")
+	open.Use(cors.New())
+	open.Get("/data", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{})
+	})
+
+	app.Listen(":3000")
+}

--- a/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
@@ -1,0 +1,229 @@
+require "file_utils"
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+# echo_security/main.go line reference:
+#  15: e.Use(middleware.Secure())                 -> global security-headers
+#  16: e.Use(middleware.RateLimiter(...))          -> global rate-limit
+#  19: e.GET("/health", ...)                       -> public (globals only)
+#  24: web := e.Group("/web")
+#  25: web.Use(middleware.CSRF())                  -> /web csrf-protection
+#  26: web.POST("/transfer", ...)
+#  31: upload := e.Group("/upload")
+#  32: upload.Use(middleware.BodyLimit("2M"))      -> /upload body-limit
+#  33: upload.POST("/file", ...)
+#  38: api := e.Group("/api")
+#  39: api.Use(middleware.TimeoutWithConfig(...))  -> /api timeout
+#  40: api.GET("/report", ...)
+#  45: pub := e.Group("/pub")
+#  46: pub.Use(middleware.CORSWithConfig(...))     -> /pub cors
+#  49: pub.GET("/feed", ...)
+#  54: e.POST("/admin/reset", ..., middleware.CSRF()) -> inline csrf-protection
+#
+# fiber_security/main.go line reference:
+#  16: app.Use(helmet.New())                       -> global security-headers
+#  17: app.Use(encryptcookie.New(...))             -> global secure-cookies
+#  19: app.Get("/status", ...)                     -> globals only
+#  24: api := app.Group("/api")
+#  25: api.Use(limiter.New())                       -> /api rate-limit
+#  26: api.Use(csrf.New())                          -> /api csrf-protection
+#  27: api.Post("/orders", ...)
+#  33: open.Use(cors.New())                         -> /open cors
+#  34: open.Get("/data", ...)
+
+private def tag_named(endpoint : Endpoint, name : String) : Tag?
+  endpoint.tags.find { |t| t.name == name }
+end
+
+private def seed_file_map(fixture_base : String)
+  locator = CodeLocator.instance
+  locator.clear_all
+  Dir.glob("#{fixture_base}/**/*").each do |file|
+    next if File.directory?(file)
+    locator.push("file_map", file)
+  end
+end
+
+private def go_endpoint(path : String, line : Int32, url : String, method : String, tech : String) : Endpoint
+  details = Details.new(PathInfo.new(path, line))
+  details.technology = tech
+  Endpoint.new(url, method, [] of Param, details)
+end
+
+describe "GoSecurityTagger" do
+  echo_base = "#{__DIR__}/../../../functional_test/fixtures/go/echo_security"
+  echo_main = "#{echo_base}/main.go"
+  fiber_base = "#{__DIR__}/../../../functional_test/fixtures/go/fiber_security"
+  fiber_main = "#{fiber_base}/main.go"
+
+  echo_opts = create_test_options
+  echo_opts["base"] = YAML::Any.new(echo_base)
+
+  it "targets the Go web framework techs" do
+    techs = GoSecurityTagger.target_techs
+    techs.should contain("go_echo")
+    techs.should contain("go_gin")
+    techs.should contain("go_fiber")
+    techs.should contain("go_chi")
+  end
+
+  describe "Echo: global middleware (.Use at the root)" do
+    it "applies security-headers + rate-limit to a public route" do
+      seed_file_map(echo_base)
+      endpoint = go_endpoint(echo_main, 19, "/health", "GET", "go_echo")
+      GoSecurityTagger.new(echo_opts).perform([endpoint])
+
+      tag_named(endpoint, "security-headers").should_not be_nil
+      tag_named(endpoint, "rate-limit").should_not be_nil
+      # The group scopes must not bleed onto /health.
+      tag_named(endpoint, "csrf-protection").should be_nil
+      tag_named(endpoint, "body-limit").should be_nil
+      tag_named(endpoint, "timeout").should be_nil
+      tag_named(endpoint, "cors").should be_nil
+    end
+  end
+
+  describe "Echo: group-scoped middleware" do
+    it "tags csrf-protection on the /web group, plus inherited globals" do
+      seed_file_map(echo_base)
+      endpoint = go_endpoint(echo_main, 26, "/web/transfer", "POST", "go_echo")
+      GoSecurityTagger.new(echo_opts).perform([endpoint])
+
+      csrf = tag_named(endpoint, "csrf-protection")
+      csrf.should_not be_nil
+      csrf.not_nil!.tagger.should eq("go_security")
+      csrf.not_nil!.description.should contain("CSRF")
+      tag_named(endpoint, "security-headers").should_not be_nil
+      tag_named(endpoint, "rate-limit").should_not be_nil
+      tag_named(endpoint, "body-limit").should be_nil
+    end
+
+    it "tags body-limit on the /upload group" do
+      seed_file_map(echo_base)
+      endpoint = go_endpoint(echo_main, 33, "/upload/file", "POST", "go_echo")
+      GoSecurityTagger.new(echo_opts).perform([endpoint])
+
+      tag_named(endpoint, "body-limit").should_not be_nil
+      tag_named(endpoint, "csrf-protection").should be_nil
+    end
+
+    it "tags timeout on the /api group" do
+      seed_file_map(echo_base)
+      endpoint = go_endpoint(echo_main, 40, "/api/report", "GET", "go_echo")
+      GoSecurityTagger.new(echo_opts).perform([endpoint])
+
+      tag_named(endpoint, "timeout").should_not be_nil
+      tag_named(endpoint, "csrf-protection").should be_nil
+    end
+
+    it "tags cors on the /pub group" do
+      seed_file_map(echo_base)
+      endpoint = go_endpoint(echo_main, 49, "/pub/feed", "GET", "go_echo")
+      GoSecurityTagger.new(echo_opts).perform([endpoint])
+
+      tag_named(endpoint, "cors").should_not be_nil
+      tag_named(endpoint, "timeout").should be_nil
+    end
+  end
+
+  describe "Echo: inline route-level middleware" do
+    it "tags csrf-protection from a trailing middleware arg on the route call" do
+      seed_file_map(echo_base)
+      endpoint = go_endpoint(echo_main, 54, "/admin/reset", "POST", "go_echo")
+      GoSecurityTagger.new(echo_opts).perform([endpoint])
+
+      csrf = tag_named(endpoint, "csrf-protection")
+      csrf.should_not be_nil
+      csrf.not_nil!.description.should contain("inline")
+      tag_named(endpoint, "security-headers").should_not be_nil
+      tag_named(endpoint, "rate-limit").should_not be_nil
+      tag_named(endpoint, "body-limit").should be_nil
+    end
+  end
+
+  describe "Fiber framework family" do
+    fiber_opts = create_test_options
+    fiber_opts["base"] = YAML::Any.new(fiber_base)
+
+    it "tags global helmet (security-headers) + encryptcookie (secure-cookies)" do
+      seed_file_map(fiber_base)
+      endpoint = go_endpoint(fiber_main, 19, "/status", "GET", "go_fiber")
+      GoSecurityTagger.new(fiber_opts).perform([endpoint])
+
+      tag_named(endpoint, "security-headers").should_not be_nil
+      tag_named(endpoint, "secure-cookies").should_not be_nil
+      tag_named(endpoint, "rate-limit").should be_nil
+    end
+
+    it "tags rate-limit (limiter) + csrf (csrf.New) on the /api group" do
+      seed_file_map(fiber_base)
+      endpoint = go_endpoint(fiber_main, 27, "/api/orders", "POST", "go_fiber")
+      GoSecurityTagger.new(fiber_opts).perform([endpoint])
+
+      tag_named(endpoint, "rate-limit").should_not be_nil
+      tag_named(endpoint, "csrf-protection").should_not be_nil
+      tag_named(endpoint, "security-headers").should_not be_nil
+      tag_named(endpoint, "secure-cookies").should_not be_nil
+    end
+
+    it "tags cors (cors.New) on the /open group only" do
+      seed_file_map(fiber_base)
+      endpoint = go_endpoint(fiber_main, 34, "/open/data", "GET", "go_fiber")
+      GoSecurityTagger.new(fiber_opts).perform([endpoint])
+
+      tag_named(endpoint, "cors").should_not be_nil
+      tag_named(endpoint, "csrf-protection").should be_nil
+    end
+  end
+
+  it "handles empty code_paths gracefully" do
+    seed_file_map(echo_base)
+    details = Details.new
+    details.technology = "go_echo"
+    endpoint = Endpoint.new("/nowhere", "GET", [] of Param, details)
+
+    GoSecurityTagger.new(echo_opts).perform([endpoint])
+    # Globals from the pre-scan still match by URL prefix even without a
+    # code_path, but the run must not raise.
+    endpoint.tags.empty?.should be_false
+  end
+
+  it "does not over-match a sibling prefix (/web vs /website)" do
+    seed_file_map(echo_base)
+    endpoint = go_endpoint(echo_main, 19, "/website", "GET", "go_echo")
+    GoSecurityTagger.new(echo_opts).perform([endpoint])
+    tag_named(endpoint, "csrf-protection").should be_nil
+  end
+
+  it "scopes a closure-style group's middleware to its prefix only" do
+    tmpdir = File.tempname("go_sec_closure")
+    Dir.mkdir_p(tmpdir)
+    file = File.join(tmpdir, "main.go")
+    File.write(file, [
+      "func main() {",
+      "    r := chi.NewRouter()",
+      "    r.Get(\"/open\", openHandler)",
+      "    r.Route(\"/admin\", func(r chi.Router) {",
+      "        r.Use(csrf.Protect(key))",
+      "        r.Get(\"/panel\", panelHandler)",
+      "    })",
+      "}",
+    ].join("\n"))
+
+    opts = create_test_options
+    opts["base"] = YAML::Any.new(tmpdir)
+    seed_file_map(tmpdir)
+
+    # /admin/panel is inside the closure -> csrf-protection.
+    admin = go_endpoint(file, 6, "/admin/panel", "GET", "go_chi")
+    GoSecurityTagger.new(opts).perform([admin])
+    tag_named(admin, "csrf-protection").should_not be_nil
+
+    # /open is outside the closure -> no csrf-protection leak.
+    open = go_endpoint(file, 3, "/open", "GET", "go_chi")
+    GoSecurityTagger.new(opts).perform([open])
+    tag_named(open, "csrf-protection").should be_nil
+
+    FileUtils.rm_rf(tmpdir)
+  end
+end

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -1,0 +1,250 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+# Go security-middleware tagger.
+#
+# `go_auth` already classifies *authentication* middleware (JWT/session/…).
+# This tagger covers the other security middleware Go web frameworks expose —
+# the protections a reviewer wants mapped onto each endpoint because, unlike
+# Rails, Go frameworks ship none of them on by default. Their *presence* is
+# the signal: which routes carry CSRF tokens, security headers, a rate limit,
+# or a request-body cap, and (by their absence on a state-changing route)
+# which don't.
+#
+# Detection mirrors `go_auth`: a pre-scan records group-level `.Use(...)`
+# middleware against the group's URL prefix, then each endpoint is matched
+# against inline middleware on its own route call and against the
+# prefix-scoped group middleware. Everything is line-based and best-effort.
+#
+# Precision over recall: the indirect form (`mw := limiter.New(...)` then a
+# bare `api.Use(mw)`) is deliberately *not* resolved — a false "protected"
+# tag is worse for a security review than a miss, so only middleware named
+# directly at the registration site is tagged. Cross-file middleware
+# factories are likewise out of scope by design.
+class GoSecurityTagger < FrameworkTagger
+  # Security middleware constructors/identifiers, each mapped to the tag it
+  # produces. Patterns are tied to the concrete constructor (`middleware.CSRF`,
+  # `csrf.New`, `helmet.New`, …) so a plain local called `secure` or `limiter`
+  # can't trip them. `wrapper: true` marks the net/http-style helpers
+  # (gorilla/csrf, unrolled/secure, nosurf) that wrap the root handler rather
+  # than register via `.Use` — those apply globally.
+  SECURITY_MIDDLEWARE = [
+    # --- CSRF protection ---
+    {pattern: /middleware\.CSRF(?:WithConfig)?\s*\(/, tag: "csrf-protection", desc: "Echo CSRF middleware", wrapper: false},
+    {pattern: /\bcsrf\.New\s*\(/, tag: "csrf-protection", desc: "Fiber CSRF middleware", wrapper: false},
+    {pattern: /\bcsrf\.Protect\s*\(/, tag: "csrf-protection", desc: "gorilla/csrf protection", wrapper: true},
+    {pattern: /\bcsrf\.Middleware\s*\(/, tag: "csrf-protection", desc: "gin-csrf middleware", wrapper: false},
+    {pattern: /\bnosurf\.New(?:Pure)?\s*\(/, tag: "csrf-protection", desc: "nosurf CSRF middleware", wrapper: true},
+    # --- Security response headers (XSS/clickjacking/HSTS/nosniff/…) ---
+    {pattern: /middleware\.Secure(?:WithConfig)?\s*\(/, tag: "security-headers", desc: "Echo Secure (security headers) middleware", wrapper: false},
+    {pattern: /\bhelmet\.New\s*\(/, tag: "security-headers", desc: "Fiber Helmet (security headers) middleware", wrapper: false},
+    {pattern: /\bsecure\.New\s*\(/, tag: "security-headers", desc: "secure (security headers) middleware", wrapper: true},
+    # --- Rate limiting / throttling ---
+    {pattern: /middleware\.RateLimiter(?:WithConfig)?\s*\(/, tag: "rate-limit", desc: "Echo RateLimiter middleware", wrapper: false},
+    {pattern: /middleware\.Throttle(?:Backlog)?\s*\(/, tag: "rate-limit", desc: "go-chi Throttle middleware", wrapper: false},
+    {pattern: /\blimiter\.New\s*\(/, tag: "rate-limit", desc: "rate-limiter middleware", wrapper: false},
+    {pattern: /\bhttprate\.(?:Limit|LimitByIP|LimitByRealIP|LimitAll)\s*\(/, tag: "rate-limit", desc: "go-chi/httprate rate limiting", wrapper: false},
+    {pattern: /\btollbooth\.(?:LimitHandler|LimitFuncHandler|LimitByKeys)\s*\(/, tag: "rate-limit", desc: "tollbooth rate limiting", wrapper: false},
+    # --- Request body size cap (DoS guard) ---
+    {pattern: /middleware\.BodyLimit\s*\(/, tag: "body-limit", desc: "Echo BodyLimit (request body size cap) middleware", wrapper: false},
+    {pattern: /\blimits\.RequestSizeLimiter\s*\(/, tag: "body-limit", desc: "gin-contrib/size request body size cap", wrapper: false},
+    # --- Request timeout (resource-exhaustion guard) ---
+    {pattern: /middleware\.Timeout(?:WithConfig)?\s*\(/, tag: "timeout", desc: "request timeout middleware", wrapper: false},
+    {pattern: /\btimeout\.New(?:WithContext)?\s*\(/, tag: "timeout", desc: "Fiber timeout middleware", wrapper: false},
+    # --- CORS (cross-origin resource sharing) ---
+    {pattern: /middleware\.CORS(?:WithConfig)?\s*\(/, tag: "cors", desc: "Echo CORS middleware (review allowed origins/credentials)", wrapper: false},
+    {pattern: /\bcors\.New\s*\(/, tag: "cors", desc: "CORS middleware (review allowed origins/credentials)", wrapper: true},
+    {pattern: /\bcors\.Default\s*\(/, tag: "cors", desc: "gin-contrib/cors Default() — permissive: all origins allowed", wrapper: false},
+    {pattern: /\bcors\.AllowAll\s*\(/, tag: "cors", desc: "rs/cors AllowAll() — permissive: all origins allowed", wrapper: true},
+    {pattern: /\bhandlers\.CORS\s*\(/, tag: "cors", desc: "gorilla/handlers CORS (review allowed origins/credentials)", wrapper: true},
+    # --- Cookie confidentiality/integrity ---
+    {pattern: /\bencryptcookie\.New\s*\(/, tag: "secure-cookies", desc: "Fiber encrypted-cookie middleware", wrapper: false},
+  ] of NamedTuple(pattern: Regex, tag: String, desc: String, wrapper: Bool)
+
+  # A `.Use(...)` / `.Pre(...)` middleware registration call.
+  USE_CALL = /(\w+)\.(?:Use|Pre)\s*\(/
+
+  # A route-definition call. Used only to *exclude* route lines from the
+  # global-wrapper branch (inline route middleware is handled per-endpoint),
+  # so an over-broad verb set here is safe.
+  ROUTE_DEF = /\b(?:GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD|CONNECT|TRACE|Get|Post|Put|Delete|Patch|Options|Head|Connect|Trace|Any|All|Handle|HandleFunc|Match|Add)\s*\(/
+
+  # `name := parent.Group("/seg")` style group declaration (no closure arg).
+  ASSIGN_GROUP = /(\w+)\s*:?=\s*(\w+)\.Group\s*\(\s*"([^"]*)"/
+
+  # `parent.Group("/seg", func(...)` / `.Route` / `.Party` closure group.
+  CLOSURE_GROUP = /(\w+)\.(?:Group|Route|Party|PartyFunc|Mount)\s*\(\s*"([^"]*)"\s*,\s*func/
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "go_security"
+    @middleware_scopes = [] of NamedTuple(prefix: String, tag: String, description: String)
+  end
+
+  def self.target_techs : Array(String)
+    [
+      "go_echo", "go_gin", "go_chi", "go_fiber",
+      "go_beego", "go_mux", "go_fasthttp",
+      "go_gozero", "go_goyave",
+      "go_hertz", "go_iris", "go_gf",
+    ]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    pre_scan_middleware_scopes
+    endpoints.each { |endpoint| check_endpoint(endpoint) }
+    endpoints
+  end
+
+  # Phase 1: walk every .go file and record where security middleware is
+  # registered, resolved to the URL prefix it guards.
+  private def pre_scan_middleware_scopes
+    @middleware_scopes.clear
+
+    collect_files_by_extension(".go").each do |file|
+      content = read_file(file)
+      next if content.nil?
+      scan_group_middleware(content)
+    end
+
+    @middleware_scopes.uniq!
+  end
+
+  private def scan_group_middleware(content : String)
+    # variable name -> resolved URL prefix (assignment-style groups)
+    group_vars = {} of String => String
+    # active closure-group prefixes, with the brace depth they live above
+    scope_stack = [] of NamedTuple(threshold: Int32, prefix: String)
+    depth = 0
+
+    content.each_line do |line|
+      stripped = line.strip
+
+      # Closure group: push its prefix; it stays active until braces unwind.
+      if m = stripped.match(CLOSURE_GROUP)
+        base = resolve_receiver(m[1], group_vars, scope_stack)
+        scope_stack << {threshold: depth, prefix: join_prefix(base, m[2])}
+      end
+
+      # Assignment group: remember the variable's prefix for later `.Use`.
+      if m = stripped.match(ASSIGN_GROUP)
+        base = resolve_receiver(m[2], group_vars, scope_stack)
+        group_vars[m[1]] = join_prefix(base, m[3])
+      end
+
+      register_security_scopes(stripped, group_vars, scope_stack)
+
+      # Update brace depth and retire any closure scopes that just closed.
+      depth += line.count('{') - line.count('}')
+      while !scope_stack.empty? && depth <= scope_stack.last[:threshold]
+        scope_stack.pop
+      end
+    end
+  end
+
+  private def register_security_scopes(stripped : String, group_vars, scope_stack)
+    use_receiver = stripped.match(USE_CALL).try &.[1]
+
+    SECURITY_MIDDLEWARE.each do |mw|
+      next unless stripped.matches?(mw[:pattern])
+
+      if use_receiver
+        # `receiver.Use(middleware.X())` — scope to the receiver's group.
+        prefix = prefix_for(resolve_receiver(use_receiver, group_vars, scope_stack))
+      elsif mw[:wrapper] && !stripped.matches?(ROUTE_DEF)
+        # net/http wrapper around the root handler — applies globally. Route
+        # lines are skipped (their inline middleware is tagged per-endpoint).
+        prefix = prefix_for(current_scope(scope_stack))
+      else
+        next
+      end
+
+      @middleware_scopes << {prefix: prefix, tag: mw[:tag], description: mw[:desc]}
+    end
+  end
+
+  # Phase 2: tag each endpoint from inline route middleware + group scopes.
+  private def check_endpoint(endpoint : Endpoint)
+    endpoint.details.code_paths.each do |path_info|
+      content = read_file(path_info.path)
+      next if content.nil?
+
+      lines = content.split("\n")
+      line_num = path_info.line
+      next if line_num.nil?
+      next if line_num < 1 || line_num > lines.size
+
+      tag_inline_route_middleware(endpoint, lines, line_num - 1)
+    end
+
+    @middleware_scopes.each do |scope|
+      next unless prefix_covers?(scope[:prefix], endpoint.url)
+      endpoint.add_tag(Tag.new(scope[:tag], scope[:description], "go_security"))
+    end
+  end
+
+  # Scan only the current route call's own lines (paren-balanced from the
+  # route line) for trailing route-level middleware such as Echo's
+  # `e.POST(path, handler, middleware.CSRF())`. Bounding to the route call's
+  # extent keeps a following sibling's `group.Use(...)` from leaking in.
+  private def tag_inline_route_middleware(endpoint : Endpoint, lines : Array(String), start_idx : Int32)
+    # The route call always opens its paren on its own line. If the line ref
+    # doesn't (a stale/misaligned location), bail rather than scan forward —
+    # otherwise the loop would run to `limit` and could pick up a following
+    # group's `.Use(...)` and tag the wrong endpoint.
+    return unless lines[start_idx].includes?('(')
+
+    depth = 0
+    opened = false
+    idx = start_idx
+    limit = [start_idx + 12, lines.size - 1].min
+
+    while idx <= limit
+      line = lines[idx]
+
+      SECURITY_MIDDLEWARE.each do |mw|
+        if line.matches?(mw[:pattern])
+          endpoint.add_tag(Tag.new(mw[:tag], "#{mw[:desc]} (inline on route)", "go_security"))
+        end
+      end
+
+      depth += line.count('(') - line.count(')')
+      opened = true if line.includes?('(')
+      break if opened && depth <= 0
+      idx += 1
+    end
+  end
+
+  # Resolve a receiver token to its URL prefix: a tracked group variable, the
+  # innermost active closure group, or "" (the root router / global scope).
+  private def resolve_receiver(receiver : String?, group_vars, scope_stack) : String
+    return current_scope(scope_stack) if receiver.nil?
+    if gp = group_vars[receiver]?
+      gp
+    else
+      current_scope(scope_stack)
+    end
+  end
+
+  private def current_scope(scope_stack) : String
+    scope_stack.empty? ? "" : scope_stack.last[:prefix]
+  end
+
+  private def prefix_for(prefix : String) : String
+    prefix.empty? ? "/" : prefix
+  end
+
+  # Join a base prefix and a new path segment into a normalized URL prefix:
+  #   ("", "/web") -> "/web"   ("/api", "v1") -> "/api/v1"
+  private def join_prefix(base : String, seg : String) : String
+    parts = "#{base}/#{seg}".split("/").reject(&.empty?)
+    parts.empty? ? "/" : "/" + parts.join("/")
+  end
+
+  # Segment-aware prefix match so "/web" guards "/web/x" but not "/website".
+  # The root scope "/" guards every endpoint.
+  private def prefix_covers?(prefix : String, url : String) : Bool
+    return true if prefix == "/"
+    url == prefix || url.starts_with?("#{prefix}/")
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -119,6 +119,11 @@ module NoirTaggers
       desc:   "Identifies Go authentication patterns (middleware, JWT, session)",
       runner: GoAuthTagger,
     },
+    go_security: {
+      name:   "Go Security Tagger",
+      desc:   "Identifies Go security middleware (CSRF, security headers, rate limiting, body-size limits)",
+      runner: GoSecurityTagger,
+    },
     rust_auth: {
       name:   "Rust Auth Tagger",
       desc:   "Identifies Rust authentication patterns (guards, extractors, middleware)",


### PR DESCRIPTION
## Summary

Adds `go_security`, a non-auth framework security tagger for Go web frameworks — the Go counterpart to `rails_security` (#1846) and `spring_security` (#1851). It complements the existing `go_auth` tagger (which classifies authentication middleware) by mapping the **other** protective middleware onto each endpoint.

Unlike Rails (secure-by-default → tag deviations), Go ships none of these protections on by default, so the **presence** of protective middleware (and its absence on a state-changing route) is the signal a reviewer wants. This enriches the per-endpoint AI context with concrete "what is this route protected by" facts.

## Tags (7)

| Tag | Detected from |
|-----|---------------|
| `csrf-protection` | Echo `middleware.CSRF`, Fiber `csrf.New`, gorilla `csrf.Protect`, gin-csrf `csrf.Middleware`, `nosurf` |
| `security-headers` | Echo `middleware.Secure`, Fiber `helmet`, unrolled/gin-contrib `secure.New` |
| `rate-limit` | Echo `RateLimiter`, chi `middleware.Throttle`, Fiber/ulule `limiter.New`, go-chi/httprate, tollbooth |
| `body-limit` | Echo `middleware.BodyLimit`, gin-contrib/size |
| `timeout` | Echo/chi `middleware.Timeout`, Fiber `timeout.New` |
| `cors` | Echo `middleware.CORS`, Fiber/gin-contrib/go-chi/rs `cors.New`, gorilla `handlers.CORS` — `cors.Default()`/`cors.AllowAll()` flagged **permissive** |
| `secure-cookies` | Fiber `encryptcookie.New` |

`cors`/`rate-limit`/`security-headers`/`body-limit` reuse the cross-language tag vocabulary shared with `rust_security`/`spring_security`. The middleware-based `cors` tag complements the existing header-param `cors` tagger (which only fires when an endpoint carries an `Origin`/`Access-Control-*` header param), so the two are not redundant.

## Design

Architecture mirrors `go_auth`, with improved scope resolution. A pre-scan resolves each `.Use(...)` registration to the URL prefix it guards via:
- **assignment-group var map** — `api := e.Group("/x"); api.Use(...)`
- **closure-group brace-depth stack** — chi `r.Route("/x", func(r){ r.Use(...) })`
- **root `.Use` → `/`** global, plus net/http wrapper detection (`csrf.Protect`/`secure.New`/gorilla `handlers.CORS`, skipped on route-definition lines)
- **inline route-level middleware** — Echo `e.POST(path, h, middleware.CSRF())`, tagged via a paren-balanced forward scan of the route call only (won't leak a sibling's `.Use`)

Endpoint matching is **segment-aware** (`prefix_covers?`: `/web` guards `/web/x` but not `/website`). The indirect form (`mw := limiter.New(); api.Use(mw)`) is **deliberately not resolved** — for a security tool a false "protected" tag is worse than a miss, so only middleware named directly at the registration site is tagged. `Recover`/panic-recovery is deliberately excluded as it's near-ubiquitous (noise).

## Tests

- New unit spec `go_security_spec.cr` (13 examples): Echo global/group/inline + Fiber family + closure-scope isolation + sibling-prefix non-overmatch.
- Full tagger suite green (383 examples), ameba clean, formatted.
- End-to-end verified through the real detector→analyzer→tagger pipeline on the new `echo_security` + `fiber_security` fixtures:

```
Echo:  GET  /api/report   -> [rate-limit, security-headers, timeout]
       GET  /pub/feed      -> [cors, rate-limit, security-headers]
Fiber: POST /api/orders    -> [csrf-protection, rate-limit, secure-cookies, security-headers]
       GET  /open/data     -> [cors, secure-cookies, security-headers]
```

## Known follow-up

- Multi-line CORS config wildcard (`AllowOrigins: []string{"*"}`) is not yet flagged permissive — only the known-permissive constructors are.
