### PR TITLE
feat(tagger): add Rust framework security tagger (CORS/rate-limit/security-headers/body-limit)

### DIFF
--- a/docs/content/usage/more_features/tagger/index.ko.md
+++ b/docs/content/usage/more_features/tagger/index.ko.md
@@ -93,4 +93,10 @@ noir scan <BASE_PATH> --use-taggers hunt,oauth
   - `security-headers` — Spring의 기본 응답 헤더 보호가 약화된 경우: 클릭재킹 보호 해제(`frameOptions().disable()`) 또는 헤더 라이터 전체 비활성화(`headers().disable()` / `headers(HeadersConfigurer::disable)`).
   - `input-validation` — `@Valid` / `@Validated`로 요청 페이로드에 Bean Validation이 적용된 경우. 적용된 지점을 드러내면, 적용되지 않은 공백(`@RequestBody`를 받으면서 검증이 없는 핸들러)도 부재로 드러남.
 
+  Rust 웹 프레임워크(`rust_security`, Actix-Web·Axum/tower-http·Rocket·Loco·Warp 등)의 경우 — Rust에는 암묵적 보안 기본값이 없으므로, 태거는 실제로 연결된 보호 장치(`.wrap(..)`/`.layer(..)` 미들웨어 또는 Loco의 `config/*.yaml`)를 기록하고 위험한 설정을 플래그합니다:
+  - `cors` — CORS 미들웨어. 허용적 설정(`Cors::permissive()`, `CorsLayer::very_permissive()`, `allow_any_origin`, `allow_origins: ["*"]`)은 위험으로 표시하고, 제한된 허용 목록은 정보성으로 기록.
+  - `rate-limit` — 요청 스로틀링(`actix-governor`, `tower_governor`, `actix-limitation`, tower limit 레이어). 감싸는 스코프에 매핑되므로 *보호되지 않은* 라우트가 무엇인지 파악 가능.
+  - `security-headers` — 라우트에 설정된 강화 응답 헤더(HSTS, CSP, `X-Frame-Options`, `X-Content-Type-Options` 등).
+  - `body-limit` — 요청 본문 크기 제한(DoS 완화). 제한이 비활성화(`DefaultBodyLimit::disable()`)된 경우 위험으로 표시.
+
 엔드포인트 레벨 태그는 AI 컨텍스트에도 신호로 전달되어, AI 리뷰어가 사용하는 엔드포인트별 요약을 더욱 풍부하게 만듭니다.

--- a/docs/content/usage/more_features/tagger/index.md
+++ b/docs/content/usage/more_features/tagger/index.md
@@ -93,4 +93,10 @@ Taggers span several kinds of security-relevant signal. Run `noir list taggers` 
   - `security-headers` — Spring's default response-header protections weakened: clickjacking off (`frameOptions().disable()`) or the whole header writer disabled (`headers().disable()` / `headers(HeadersConfigurer::disable)`).
   - `input-validation` — `@Valid` / `@Validated` applies Bean Validation to the request payload; surfacing where it *is* applied also makes the gaps (handlers taking a `@RequestBody` without it) visible by their absence.
 
+  For Rust web frameworks (`rust_security`, covering Actix-Web, Axum/tower-http, Rocket, Loco, Warp, …) — Rust has no implicit secure defaults, so the tagger records the protections actually wired up (via `.wrap(..)`/`.layer(..)` middleware, or Loco's `config/*.yaml`) and flags the dangerous configurations:
+  - `cors` — CORS middleware. Permissive configs (`Cors::permissive()`, `CorsLayer::very_permissive()`, `allow_any_origin`, `allow_origins: ["*"]`) are flagged as a risk; restricted allow-lists are recorded as informational.
+  - `rate-limit` — request throttling (`actix-governor`, `tower_governor`, `actix-limitation`, tower's limit layers); maps onto the scope it wraps, so you can see which routes are *not* protected.
+  - `security-headers` — hardening response headers set on the route (HSTS, CSP, `X-Frame-Options`, `X-Content-Type-Options`, …).
+  - `body-limit` — request body size cap (DoS mitigation); a disabled limit (`DefaultBodyLimit::disable()`) is flagged as a risk.
+
 Endpoint-level tags also feed the AI context as signals, enriching the per-endpoint summary that AI reviewers consume.

--- a/spec/functional_test/fixtures/rust/rust_security/actix/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rust_security/actix/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-security-actix-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4.9"
+actix-cors = "0.7"
+actix-governor = "0.6"

--- a/spec/functional_test/fixtures/rust/rust_security/actix/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rust_security/actix/src/main.rs
@@ -1,0 +1,60 @@
+use actix_web::{web, App, HttpServer, HttpResponse, get, post};
+use actix_web::middleware::DefaultHeaders;
+use actix_cors::Cors;
+use actix_governor::{Governor, GovernorConfigBuilder};
+
+// Public endpoint, only covered by app-wide middleware.
+#[get("/health")]
+async fn health() -> HttpResponse {
+    HttpResponse::Ok().body("ok")
+}
+
+#[get("/api/users")]
+async fn list_users() -> HttpResponse {
+    HttpResponse::Ok().body("users")
+}
+
+// Lives under the rate-limited /admin scope.
+#[post("/admin/import")]
+async fn admin_import(body: String) -> HttpResponse {
+    HttpResponse::Ok().body("imported")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let governor_conf = GovernorConfigBuilder::default().finish().unwrap();
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Cors::permissive())
+            .wrap(
+                DefaultHeaders::new()
+                    .add(("X-Frame-Options", "DENY"))
+                    .add(("Content-Security-Policy", "default-src 'self'")),
+            )
+            .app_data(web::JsonConfig::default().limit(4096))
+            .service(health)
+            .service(list_users)
+            .service(
+                web::scope("/admin")
+                    .wrap(Governor::new(&governor_conf))
+                    .service(admin_import),
+            )
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test-only app: a permissive CORS here must NOT leak onto the real
+    // endpoints above.
+    fn build_test_app() {
+        let _app = App::new()
+            .wrap(Cors::permissive())
+            .app_data(web::PayloadConfig::new(usize::MAX));
+    }
+}

--- a/spec/functional_test/fixtures/rust/rust_security/axum/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rust_security/axum/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust-security-axum-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+tower-http = { version = "0.6", features = ["cors", "set-header", "limit"] }
+tower_governor = "0.4"
+http = "1"

--- a/spec/functional_test/fixtures/rust/rust_security/axum/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rust_security/axum/src/main.rs
@@ -1,0 +1,31 @@
+use axum::{routing::get, routing::post, Router};
+use axum::extract::DefaultBodyLimit;
+use tower_http::cors::CorsLayer;
+use tower_http::set_header::SetResponseHeaderLayer;
+use tower_governor::GovernorLayer;
+use http::header;
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+async fn upload() -> &'static str {
+    "uploaded"
+}
+
+fn app() -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/upload", post(upload))
+        // Wide-open CORS: any origin accepted.
+        .layer(CorsLayer::very_permissive())
+        // Rate limiting via tower_governor.
+        .layer(GovernorLayer::default())
+        // HSTS hardening header.
+        .layer(SetResponseHeaderLayer::overriding(
+            header::STRICT_TRANSPORT_SECURITY,
+            "max-age=31536000",
+        ))
+        // Body size limit removed entirely — DoS risk.
+        .layer(DefaultBodyLimit::disable())
+}

--- a/spec/functional_test/fixtures/rust/rust_security/loco/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rust_security/loco/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-security-loco-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+loco-rs = "0.13"
+axum = "0.7"
+serde = { version = "1", features = ["derive"] }

--- a/spec/functional_test/fixtures/rust/rust_security/loco/config/development.yaml
+++ b/spec/functional_test/fixtures/rust/rust_security/loco/config/development.yaml
@@ -1,0 +1,21 @@
+logger:
+  enable: true
+  level: debug
+
+server:
+  binding: localhost
+  port: 5150
+  middlewares:
+    limit_payload:
+      enable: true
+      body_limit: 5mb
+    cors:
+      enable: true
+      allow_origins:
+        - "*"
+    secure_headers:
+      enable: true
+      preset: github
+    # Disabled middleware must not be tagged.
+    compression:
+      enable: false

--- a/spec/functional_test/fixtures/rust/rust_security/loco/src/controllers/notes.rs
+++ b/spec/functional_test/fixtures/rust/rust_security/loco/src/controllers/notes.rs
@@ -1,0 +1,23 @@
+use axum::extract::Json;
+use loco_rs::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct NoteData {
+    title: String,
+    body: String,
+}
+
+async fn index() -> Result<impl IntoResponse> {
+    format::json(())
+}
+
+async fn create(Json(data): Json<NoteData>) -> Result<impl IntoResponse> {
+    format::json(())
+}
+
+pub fn routes() -> Routes {
+    Routes::new()
+        .prefix("/api/notes")
+        .add("/", get(index).post(create))
+}

--- a/spec/functional_test/fixtures/rust/rust_security/test_only/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rust_security/test_only/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-security-testonly-fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4.9"
+actix-cors = "0.7"

--- a/spec/functional_test/fixtures/rust/rust_security/test_only/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rust_security/test_only/src/main.rs
@@ -1,0 +1,21 @@
+use actix_web::{web, App, get, HttpResponse};
+use actix_cors::Cors;
+
+// The only production endpoint. It has NO security middleware in real
+// code — every protection below lives in a #[cfg(test)] module and must
+// be ignored by the tagger.
+#[get("/widget")]
+async fn widget() -> HttpResponse {
+    HttpResponse::Ok().body("w")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build() {
+        let _app = App::new()
+            .wrap(Cors::permissive())
+            .app_data(web::JsonConfig::default().limit(64));
+    }
+}

--- a/spec/unit_test/tagger/framework_taggers/rust_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/rust_security_spec.cr
@@ -1,0 +1,179 @@
+require "../../../spec_helper"
+require "../../../../src/tagger/tagger"
+
+# Fixture line references
+#
+# actix/src/main.rs
+#    8: async fn health()        -> GET /health
+#   13: async fn list_users()    -> GET /api/users
+#   19: async fn admin_import()  -> POST /admin/import   (under /admin scope)
+#   App::new() wraps: Cors::permissive(), DefaultHeaders (X-Frame-Options,
+#   Content-Security-Policy), JsonConfig.limit; the /admin scope wraps
+#   Governor::new(). A #[cfg(test)] module also wraps Cors::permissive().
+#
+# axum/src/main.rs
+#   app() layers: CorsLayer::very_permissive(), GovernorLayer,
+#   SetResponseHeaderLayer(STRICT_TRANSPORT_SECURITY),
+#   DefaultBodyLimit::disable()  (all app-wide, prefix "/").
+#
+# loco/config/development.yaml
+#   server.middlewares: limit_payload (enable), cors (allow_origins "*"),
+#   secure_headers (enable), compression (enable: false).
+#
+# test_only/src/main.rs
+#    8: async fn widget() -> GET /widget; all middleware is #[cfg(test)].
+
+private def load_fixture(base : String) : Hash(String, YAML::Any)
+  CodeLocator.instance.clear_all
+  options = create_test_options
+  options["base"] = YAML::Any.new(base)
+
+  locator = CodeLocator.instance
+  Dir.glob("#{base}/**/*").each do |file|
+    next if File.directory?(file)
+    locator.push("file_map", file)
+  end
+  options
+end
+
+private def tag_named(endpoint : Endpoint, name : String) : Tag?
+  endpoint.tags.find { |t| t.name == name }
+end
+
+private def build_endpoint(path : String, line : Int32, url : String, method : String, tech : String) : Endpoint
+  details = Details.new(PathInfo.new(path, line))
+  details.technology = tech
+  Endpoint.new(url, method, [] of Param, details)
+end
+
+describe "RustSecurityTagger" do
+  fixtures = "#{__DIR__}/../../../functional_test/fixtures/rust/rust_security"
+
+  describe "target techs" do
+    it "covers the major Rust web frameworks" do
+      techs = RustSecurityTagger.target_techs
+      techs.should contain("rust_actix_web")
+      techs.should contain("rust_axum")
+      techs.should contain("rust_loco")
+    end
+  end
+
+  describe "actix-web (source middleware)" do
+    actix_base = "#{fixtures}/actix"
+    main_path = "#{actix_base}/src/main.rs"
+
+    it "flags app-wide permissive CORS on every endpoint" do
+      options = load_fixture(actix_base)
+      endpoint = build_endpoint(main_path, 8, "/health", "GET", "rust_actix_web")
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "cors")
+      tag.should_not be_nil
+      tag.not_nil!.tagger.should eq("rust_security")
+      tag.not_nil!.description.should contain("Permissive")
+    end
+
+    it "flags app-wide security headers and body limit" do
+      options = load_fixture(actix_base)
+      endpoint = build_endpoint(main_path, 13, "/api/users", "GET", "rust_actix_web")
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      tag_named(endpoint, "security-headers").should_not be_nil
+      tag_named(endpoint, "body-limit").should_not be_nil
+    end
+
+    it "scopes rate limiting to the /admin scope only" do
+      options = load_fixture(actix_base)
+
+      admin = build_endpoint(main_path, 19, "/admin/import", "POST", "rust_actix_web")
+      RustSecurityTagger.new(options).perform([admin])
+      tag_named(admin, "rate-limit").should_not be_nil
+
+      health = build_endpoint(main_path, 8, "/health", "GET", "rust_actix_web")
+      RustSecurityTagger.new(options).perform([health])
+      tag_named(health, "rate-limit").should be_nil
+    end
+  end
+
+  describe "axum / tower-http (source middleware)" do
+    axum_base = "#{fixtures}/axum"
+    main_path = "#{axum_base}/src/main.rs"
+
+    it "flags very_permissive CORS as a risk" do
+      options = load_fixture(axum_base)
+      endpoint = build_endpoint(main_path, 8, "/health", "GET", "rust_axum")
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "cors")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("Permissive")
+    end
+
+    it "flags a disabled body limit as a risk" do
+      options = load_fixture(axum_base)
+      endpoint = build_endpoint(main_path, 12, "/upload", "POST", "rust_axum")
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      tag = tag_named(endpoint, "body-limit")
+      tag.should_not be_nil
+      tag.not_nil!.description.should contain("disabled")
+    end
+
+    it "detects rate limiting and HSTS security header via tower layers" do
+      options = load_fixture(axum_base)
+      endpoint = build_endpoint(main_path, 8, "/health", "GET", "rust_axum")
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      tag_named(endpoint, "rate-limit").should_not be_nil
+      headers = tag_named(endpoint, "security-headers")
+      headers.should_not be_nil
+      headers.not_nil!.description.should contain("HSTS")
+    end
+  end
+
+  describe "Loco (YAML config middleware)" do
+    loco_base = "#{fixtures}/loco"
+
+    it "maps limit_payload / cors / secure_headers onto every endpoint" do
+      options = load_fixture(loco_base)
+      # Loco controllers live elsewhere; the endpoint just needs a tech.
+      details = Details.new
+      details.technology = "rust_loco"
+      endpoint = Endpoint.new("/api/notes", "GET", [] of Param, details)
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      tag_named(endpoint, "body-limit").should_not be_nil
+      tag_named(endpoint, "security-headers").should_not be_nil
+
+      cors = tag_named(endpoint, "cors")
+      cors.should_not be_nil
+      cors.not_nil!.description.should contain("Permissive")
+    end
+  end
+
+  describe "test-module isolation" do
+    test_base = "#{fixtures}/test_only"
+    main_path = "#{test_base}/src/main.rs"
+
+    it "ignores middleware defined inside #[cfg(test)] modules" do
+      options = load_fixture(test_base)
+      endpoint = build_endpoint(main_path, 8, "/widget", "GET", "rust_actix_web")
+      RustSecurityTagger.new(options).perform([endpoint])
+
+      endpoint.tags.empty?.should be_true
+    end
+  end
+
+  it "handles empty code_paths gracefully" do
+    options = load_fixture("#{fixtures}/actix")
+    details = Details.new
+    details.technology = "rust_actix_web"
+    endpoint = Endpoint.new("/unknown", "GET", [] of Param, details)
+
+    RustSecurityTagger.new(options).perform([endpoint])
+    # App-wide source middleware still applies even without code_paths,
+    # because protections are pre-scanned from the file map, not the
+    # endpoint's own path.
+    endpoint.tags.empty?.should be_false
+  end
+end

--- a/src/tagger/framework_taggers/rust/rust_security.cr
+++ b/src/tagger/framework_taggers/rust/rust_security.cr
@@ -1,0 +1,386 @@
+require "../../../models/framework_tagger"
+require "../../../models/endpoint"
+
+# Rust-specific security tagger.
+#
+# `rust_auth` already classifies *authentication* (request guards,
+# extractors, auth middleware), so this tagger covers the other
+# framework-level *security protections* that a reviewer wants to know
+# are (or are not) in front of an endpoint. Each protection maps onto a
+# tag whose description says whether the configuration is hardened or a
+# risk:
+#
+#   * cors             — CORS middleware. Permissive configs (any origin,
+#                        wildcard) are flagged as a risk; restricted
+#                        allow-lists are recorded as informational.
+#   * rate-limit       — request throttling (actix-governor /
+#                        tower_governor / actix-limitation / tower limit).
+#   * security-headers — hardening response headers (HSTS, CSP,
+#                        X-Frame-Options, X-Content-Type-Options, …).
+#   * body-limit       — request body size cap (DoS mitigation). A
+#                        disabled limit is flagged as a risk.
+#
+# Detection is two-pronged:
+#
+#   1. Source middleware — every `.rs` file is pre-scanned for the
+#      builder calls above. The enclosing Actix `web::scope("/x")` (if
+#      any) gives the URL prefix the protection applies to; app-wide
+#      middleware (`App::new().wrap(..)`, `Router::new().layer(..)`)
+#      maps to `/` so it tags every endpoint. Test modules
+#      (`#[cfg(test)]`) and `tests/`/`benches/`/`examples/` files are
+#      skipped so test-only middleware can't taint real endpoints.
+#
+#   2. Loco config — Loco wires its middleware in `config/*.yaml`
+#      (`middlewares: { cors:, limit_payload:, secure_headers: }`)
+#      rather than in code, so those files are parsed too and applied
+#      app-wide.
+#
+# Scope mapping errs toward false *negatives* (a too-narrow prefix tags
+# fewer endpoints) rather than false positives, in keeping with the
+# rest of Noir's tagging.
+class RustSecurityTagger < FrameworkTagger
+  # A single detected protection: the tag to emit, its human description,
+  # the URL prefix it guards, and whether it is a risk (risk variants win
+  # dedup so the reviewer sees the alarming description, not the benign).
+  record Protection,
+    tag : String,
+    description : String,
+    prefix : String,
+    risk : Bool
+
+  # --- CORS -----------------------------------------------------------
+  # Permissive: any origin is accepted. The classic finding.
+  CORS_PERMISSIVE_PATTERNS = [
+    {/Cors::permissive\s*\(/, "Cors::permissive()"},
+    {/CorsLayer::permissive\s*\(/, "CorsLayer::permissive()"},
+    {/CorsLayer::very_permissive\s*\(/, "CorsLayer::very_permissive()"},
+    {/\.allow_any_origin\s*\(/, ".allow_any_origin()"},
+    {/\.send_wildcard\s*\(/, ".send_wildcard()"},
+    {/\.allow_origin\s*\(\s*Any\b/, ".allow_origin(Any)"},
+    {/\.allowed_origin\s*\(\s*"\*"/, %(allowed_origin("*"))},
+  ]
+
+  # Configured (restricted) CORS — present but not wide open.
+  CORS_PRESENT_PATTERNS = [
+    {/Cors::default\s*\(/, "actix-cors"},
+    {/CorsLayer::new\s*\(/, "tower-http CorsLayer"},
+    {/\.allowed_origin\s*\(/, "actix-cors allow-list"},
+    {/\.allow_origin\s*\(/, "tower-http allow-list"},
+    {/\bCorsOptions\b/, "rocket-cors"},
+  ]
+
+  # --- Rate limiting --------------------------------------------------
+  # Match the *application* of a limiter (`.wrap`/`.layer`) or a Layer
+  # type that is only ever applied — never a bare `GovernorConfigBuilder`
+  # value, which is config and would mis-map an app-wide tag onto every
+  # endpoint even when the limiter is wrapped onto one scope.
+  RATE_LIMIT_PATTERNS = [
+    {/\.(?:wrap|layer|route_layer|attach)\s*\(\s*&?\s*[\w:]*Governor\b/, "governor"},
+    {/\bGovernorLayer\b/, "tower_governor"},
+    {/\bRateLimitLayer\b/, "tower RateLimitLayer"},
+    {/\.(?:wrap|layer)\s*\(\s*&?\s*[\w:]*RateLimiter\b/, "rate limiter"},
+    {/\bactix_limitation\b/, "actix-limitation"},
+  ]
+
+  # --- Security response headers --------------------------------------
+  # The header name — as a quoted literal (`"X-Frame-Options"`) or the
+  # `http` crate's `HeaderName` constant (`X_FRAME_OPTIONS`) — is a
+  # strong signal the app sets it (request-side reads of these are rare).
+  # Framework-agnostic: works for Actix `DefaultHeaders`, tower-http
+  # `SetResponseHeaderLayer`, and helmet-style crates alike.
+  SECURITY_HEADER_PATTERNS = [
+    {/"[Ss]trict-[Tt]ransport-[Ss]ecurity"|\bSTRICT_TRANSPORT_SECURITY\b/, "Strict-Transport-Security (HSTS)"},
+    {/"[Cc]ontent-[Ss]ecurity-[Pp]olicy"|\bCONTENT_SECURITY_POLICY\b/, "Content-Security-Policy"},
+    {/"[Xx]-[Ff]rame-[Oo]ptions"|\bX_FRAME_OPTIONS\b/, "X-Frame-Options"},
+    {/"[Xx]-[Cc]ontent-[Tt]ype-[Oo]ptions"|\bX_CONTENT_TYPE_OPTIONS\b/, "X-Content-Type-Options"},
+    {/"[Rr]eferrer-[Pp]olicy"|\bREFERRER_POLICY\b/, "Referrer-Policy"},
+    {/"[Pp]ermissions-[Pp]olicy"|\bPERMISSIONS_POLICY\b/, "Permissions-Policy"},
+  ]
+
+  # --- Request body size limit ----------------------------------------
+  BODY_LIMIT_DISABLED_PATTERNS = [
+    {/DefaultBodyLimit::disable\s*\(/, "DefaultBodyLimit::disable()"},
+  ]
+
+  BODY_LIMIT_PATTERNS = [
+    {/DefaultBodyLimit::max\s*\(/, "axum DefaultBodyLimit"},
+    {/\bDefaultBodyLimit\b/, "axum DefaultBodyLimit"},
+    {/\bRequestBodyLimitLayer\b/, "tower-http RequestBodyLimitLayer"},
+    {/\bPayloadConfig\b/, "actix PayloadConfig"},
+    {/\b(?:Json|Form|Payload)Config\b[^=]*\.limit\s*\(/, "actix config limit"},
+  ]
+
+  def initialize(options : Hash(String, YAML::Any))
+    super
+    @name = "rust_security"
+    @protections = [] of Protection
+  end
+
+  # Kept in lock-step with `rust_auth` (the guard-support invariant in
+  # techs_spec requires every framework-tagger target to be a
+  # guard-supported tech, which currently excludes Salvo/Poem).
+  def self.target_techs : Array(String)
+    [
+      "rust_axum", "rust_rocket", "rust_actix_web",
+      "rust_loco", "rust_rwf", "rust_tide",
+      "rust_warp", "rust_gotham",
+    ]
+  end
+
+  def perform(endpoints : Array(Endpoint)) : Array(Endpoint)
+    pre_scan_protections
+
+    # Risk variants first so they win the (name, tagger) dedup in
+    # Endpoint#add_tag — a reviewer should see "permissive CORS", not
+    # "CORS configured", when both touch the same endpoint. The tag and
+    # description are tie-breakers: `sort_by!` is not stable, so without
+    # them two same-tag, same-risk protections (e.g. an `X-Frame-Options`
+    # and a `Content-Security-Policy` line both → `security-headers`)
+    # could surface a different description run-to-run, making scan
+    # output non-deterministic.
+    @protections.sort_by! { |p| {p.risk ? 0 : 1, p.tag, p.description} }
+
+    endpoints.each { |endpoint| apply_protections(endpoint) }
+    endpoints
+  end
+
+  private def pre_scan_protections
+    @protections.clear
+
+    collect_files_by_extension(".rs").each do |file|
+      next if test_path?(file)
+      content = read_file(file)
+      next if content.nil?
+      scan_rust_source(content)
+    end
+
+    # Loco (and similar) configure middleware in YAML, not code.
+    (collect_files_by_extension(".yaml") + collect_files_by_extension(".yml")).uniq!.each do |file|
+      next unless file.includes?("/config/")
+      content = read_file(file)
+      next if content.nil?
+      scan_loco_config(content)
+    end
+
+    @protections.uniq!
+  end
+
+  # Integration tests / benches / examples define throwaway apps whose
+  # middleware must not leak onto real endpoints.
+  private def test_path?(path : String) : Bool
+    path.includes?("/tests/") ||
+      path.includes?("/benches/") ||
+      path.includes?("/examples/")
+  end
+
+  private def scan_rust_source(content : String)
+    lines = content.split("\n")
+
+    # `#[cfg(test)]` module skipping via brace depth.
+    brace_depth = 0
+    in_test = false
+    test_base = 0
+    pending_test = false
+
+    lines.each_with_index do |line, idx|
+      stripped = line.strip
+
+      if stripped.matches?(/#\[cfg\([^)]*\btest\b[^)]*\)\]/)
+        pending_test = true
+      end
+
+      opens = count_char(stripped, '{')
+      closes = count_char(stripped, '}')
+
+      if pending_test && stripped.includes?("{")
+        in_test = true
+        test_base = brace_depth
+        pending_test = false
+      end
+
+      unless in_test || stripped.starts_with?("//")
+        detect_line_protections(lines, idx, stripped)
+      end
+
+      brace_depth += opens - closes
+      if in_test && brace_depth <= test_base
+        in_test = false
+      end
+    end
+  end
+
+  private def detect_line_protections(lines : Array(String), idx : Int32, stripped : String)
+    # `resolve_chain_prefix` is only invoked from a branch that already
+    # matched, so the walk-up cost is paid solely on middleware lines.
+
+    # CORS — permissive wins over a generic "present" match on the same line.
+    if m = match_first(stripped, CORS_PERMISSIVE_PATTERNS)
+      add_protection("cors", resolve_chain_prefix(lines, idx), true,
+        "Permissive CORS (#{m}) — cross-origin requests are accepted from any origin, so any website can read responses to credentialed requests. Confirm this is intended for the endpoints it covers.")
+    elsif m = match_first(stripped, CORS_PRESENT_PATTERNS)
+      add_protection("cors", resolve_chain_prefix(lines, idx), false,
+        "CORS configured (#{m}) — cross-origin access is restricted to an explicit origin allow-list.")
+    end
+
+    if m = match_first(stripped, RATE_LIMIT_PATTERNS)
+      add_protection("rate-limit", resolve_chain_prefix(lines, idx), false,
+        "Rate limited (#{m}) — request volume to this endpoint is throttled per client, mitigating brute-force and abuse.")
+    end
+
+    if m = match_first(stripped, SECURITY_HEADER_PATTERNS)
+      add_protection("security-headers", resolve_chain_prefix(lines, idx), false,
+        "Security response header set (#{m}) — the response is hardened against clickjacking / MIME-sniffing / protocol-downgrade attacks.")
+    end
+
+    if m = match_first(stripped, BODY_LIMIT_DISABLED_PATTERNS)
+      add_protection("body-limit", resolve_chain_prefix(lines, idx), true,
+        "Request body size limit disabled (#{m}) — unbounded request bodies are accepted, a memory-exhaustion denial-of-service risk.")
+    elsif m = match_first(stripped, BODY_LIMIT_PATTERNS)
+      add_protection("body-limit", resolve_chain_prefix(lines, idx), false,
+        "Request body size limited (#{m}) — oversized request bodies are rejected, mitigating memory-exhaustion DoS.")
+    end
+  end
+
+  # Loco's `config/*.yaml` `server.middlewares:` block. Each protection
+  # is app-wide (prefix `/`).
+  private def scan_loco_config(content : String)
+    lines = content.split("\n")
+
+    lines.each_with_index do |line, idx|
+      next if line.lstrip.starts_with?("#")
+      key = line.match(/^(\s*)(cors|limit_payload|secure_headers):\s*$/)
+      next if key.nil?
+
+      indent = key[1].size
+      kind = key[2]
+      block = collect_yaml_block(lines, idx, indent)
+
+      # An explicit `enable: false` means the middleware is off — skip.
+      next if block.any?(&.matches?(/\benable:\s*false\b/))
+
+      case kind
+      when "cors"
+        if loco_cors_permissive?(block)
+          add_protection("cors", "/", true,
+            "Permissive CORS (Loco config allow_origins: \"*\") — cross-origin requests are accepted from any origin.")
+        else
+          add_protection("cors", "/", false,
+            "CORS configured (Loco middleware) — cross-origin access is governed by the Loco CORS middleware.")
+        end
+      when "limit_payload"
+        add_protection("body-limit", "/", false,
+          "Request body size limited (Loco limit_payload middleware) — oversized request bodies are rejected.")
+      when "secure_headers"
+        add_protection("security-headers", "/", false,
+          "Security response headers set (Loco secure_headers middleware) — responses carry hardening headers (CSP, X-Frame-Options, …).")
+      end
+    end
+  end
+
+  # A Loco `cors:` block is permissive when its origin list is (or
+  # contains) `*` — either an inline `allow_origins: ["*"]` or a `- "*"`
+  # list item.
+  private def loco_cors_permissive?(block : Array(String)) : Bool
+    block.any? do |line|
+      line.matches?(/allow_origins:\s*\[?\s*["']?\*/) ||
+        line.matches?(/^-\s*["']?\*["']?\s*$/)
+    end
+  end
+
+  # Gather a YAML mapping value's nested lines (those indented deeper than
+  # the key) as stripped strings for cheap per-line checks.
+  private def collect_yaml_block(lines : Array(String), key_idx : Int32, key_indent : Int32) : Array(String)
+    buf = [] of String
+    idx = key_idx + 1
+    while idx < lines.size
+      line = lines[idx]
+      stripped = line.strip
+      if stripped.empty?
+        idx += 1
+        next
+      end
+      indent = line.size - line.lstrip.size
+      break if indent <= key_indent
+      buf << stripped
+      idx += 1
+    end
+    buf
+  end
+
+  # Walk upward from a middleware call to the nearest enclosing Actix
+  # `web::scope("/x")`, or `/` when the call sits on an app/router head.
+  # A found scope always wins; otherwise we fall back to `/`.
+  #
+  # Caveat (Axum/Tower): when a `.layer(..)` is applied to a sub-router
+  # that is built in its own statement/function and only later mounted
+  # with `nest("/x", sub)`, the walk-up reaches `Router::new(` and
+  # resolves `/` — i.e. it tags the whole app even though the layer only
+  # covers `/x`. That is a false *positive* (over-broad), unlike the
+  # Actix path which errs toward false negatives. We accept it because
+  # the alternative (data-flow tracking a router variable across
+  # statements) is out of scope for a line-based tagger, and an
+  # over-broad "protected" signal is rarer in practice than the inline
+  # `Router::new().route(..).layer(..)` form this resolves correctly.
+  private def resolve_chain_prefix(lines : Array(String), idx : Int32) : String
+    i = idx
+    steps = 0
+    while i >= 0 && steps <= 25
+      s = lines[i].strip
+
+      if m = s.match(/web::(?:scope|resource)\s*\(\s*"([^"]*)"/)
+        return normalize_prefix(m[1])
+      end
+
+      if s.includes?("App::new(") || s.includes?("Router::new(") ||
+         s.includes?("HttpServer::new(") || s.matches?(/\bcfg\.service\s*\(/) ||
+         s.includes?("ServiceConfig")
+        return "/"
+      end
+
+      i -= 1
+      steps += 1
+    end
+
+    "/"
+  end
+
+  private def normalize_prefix(raw : String) : String
+    p = raw.strip
+    return "/" if p.empty? || p == "/"
+    p = "/" + p unless p.starts_with?("/")
+    p = p.rstrip("/")
+    p.empty? ? "/" : p
+  end
+
+  private def match_first(line : String, patterns : Array(Tuple(Regex, String))) : String?
+    patterns.each do |pattern, label|
+      return label if line.matches?(pattern)
+    end
+    nil
+  end
+
+  private def add_protection(tag : String, prefix : String, risk : Bool, description : String)
+    @protections << Protection.new(tag, description, prefix, risk)
+  end
+
+  private def count_char(str : String, char : Char) : Int32
+    str.count(char)
+  end
+
+  private def apply_protections(endpoint : Endpoint)
+    url = endpoint.url
+    @protections.each do |protection|
+      next unless url_under_prefix?(url, protection.prefix)
+      endpoint.add_tag(Tag.new(protection.tag, protection.description, "rust_security"))
+    end
+  end
+
+  # `/` (or empty) matches everything. Otherwise require a real path
+  # boundary so `/api` does not match `/apiv2`.
+  private def url_under_prefix?(url : String, prefix : String) : Bool
+    return true if prefix == "/" || prefix.empty?
+    return true if url == prefix
+    boundary = prefix.ends_with?("/") ? prefix : prefix + "/"
+    url.starts_with?(boundary)
+  end
+end

--- a/src/tagger/tagger.cr
+++ b/src/tagger/tagger.cr
@@ -124,6 +124,11 @@ module NoirTaggers
       desc:   "Identifies Rust authentication patterns (guards, extractors, middleware)",
       runner: RustAuthTagger,
     },
+    rust_security: {
+      name:   "Rust Security Tagger",
+      desc:   "Identifies Rust framework security protections (CORS, rate limiting, security headers, body-size limits)",
+      runner: RustSecurityTagger,
+    },
     flask_auth: {
       name:   "Flask Auth Tagger",
       desc:   "Identifies Flask authentication patterns (flask-login, flask-jwt, flask-httpauth)",


### PR DESCRIPTION
## Summary

Adds `rust_security`, a non-auth **framework security tagger** for Rust web frameworks — the Rust counterpart to `rails_security` / `spring_security` / `go_security`. It complements `rust_auth` (which classifies authentication) by surfacing the *other* security middleware in front of an endpoint, so AI reviewers and humans can see which routes are hardened and which carry a risky configuration.

Rust ships no implicit secure defaults, so the tagger records the protections actually wired up (and flags the dangerous ones), framed as enrichment of the existing per-endpoint context.

### Tags

| tag | detects | risk variant |
|-----|---------|--------------|
| `cors` | `actix-cors`, `tower-http` `CorsLayer`, rocket-cors, Loco config | permissive (`Cors::permissive()`, `CorsLayer::very_permissive()`, `allow_any_origin`, `allow_origins: ["*"]`) |
| `rate-limit` | `actix-governor`, `tower_governor`, `actix-limitation`, tower limit layers | — |
| `security-headers` | HSTS / CSP / `X-Frame-Options` / `X-Content-Type-Options` / … (quoted literals **and** `http`-crate consts) | — |
| `body-limit` | axum `DefaultBodyLimit`, `RequestBodyLimitLayer`, actix `PayloadConfig` / `*Config.limit()` | disabled (`DefaultBodyLimit::disable()`) |

### How it works

- **Two-pronged discovery**: (1) `.rs` source middleware (`.wrap(..)` / `.layer(..)`), and (2) Loco's `config/*.yaml` `server.middlewares:` block (`limit_payload` / `cors` / `secure_headers`), applied app-wide.
- **Scope mapping**: walks up from the middleware call to the nearest Actix `web::scope("/x")` (→ that prefix) or the `App::new` / `Router::new` head (→ `/`, app-wide). Errs toward false-negatives (a too-narrow prefix tags fewer routes) rather than false positives, consistent with the rest of Noir's tagging. Prefix matching is path-boundary-aware (`/api` ≠ `/apiv2`).
- **Noise control**: `#[cfg(test)]` modules (brace-depth tracked) and `tests/` / `benches/` / `examples/` files are skipped so test-only middleware can't taint real endpoints. Rate-limit detection requires an application site (`.wrap`/`.layer`) so a bare `GovernorConfigBuilder` value isn't mistaken for app-wide protection. Risk variants win the per-endpoint tag dedup.
- Targets the same 8 guard-supported Rust techs as `rust_auth` (axum/rocket/actix_web/loco/rwf/tide/warp/gotham).

### Tests & docs

- New spec `spec/unit_test/tagger/framework_taggers/rust_security_spec.cr` (10 examples) over Actix / Axum-tower / Loco-YAML / cfg(test)-isolation fixtures.
- End-to-end verified (`noir scan --use-taggers rust_security`) on all fixtures; full suite green, `ameba` clean.
- Tagger docs updated (EN + KO).
