### PR TITLE
feat(php): add Noir::PhpLexer structural miniparser; route Laravel through it

### DIFF
--- a/spec/functional_test/fixtures/php/laravel_heredoc/composer.json
+++ b/spec/functional_test/fixtures/php/laravel_heredoc/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "laravel/laravel",
+    "type": "project",
+    "keywords": ["framework", "laravel"],
+    "require": {
+        "php": "^8.1",
+        "laravel/framework": "^10.10"
+    }
+}

--- a/spec/functional_test/fixtures/php/laravel_heredoc/routes/web.php
+++ b/spec/functional_test/fixtures/php/laravel_heredoc/routes/web.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\WidgetController;
+
+// A heredoc whose body *looks* like routing code. None of these may surface
+// as endpoints, and the stray `{ } ;` must not corrupt the brace/statement
+// scanner for the real routes that follow it.
+$template = <<<HTML
+<div data-handler="Route::get('/heredoc-fake', fn() => 1);">
+  { unbalanced ; braces } plus a fake Route::post('/heredoc-fake-2', 'x');
+</div>
+HTML;
+
+// A plain string literal that embeds a route-shaped call.
+$doc = "Route::get('/string-fake', 'noop')";
+
+Route::group(['prefix' => 'admin'], function () {
+    // Heredoc *inside* a group closure: its braces/semicolons previously
+    // closed the group body early, dropping or mis-prefixing the real route.
+    $sql = <<<SQL
+        SELECT * FROM widgets WHERE meta = '{ "a": 1 }'; -- } ; {
+    SQL;
+
+    Route::get('/widgets', [WidgetController::class, 'index']);
+});
+
+Route::post('/notify', function () {
+    return response()->json(['ok' => true]);
+});

--- a/spec/functional_test/testers/php/laravel_heredoc_spec.cr
+++ b/spec/functional_test/testers/php/laravel_heredoc_spec.cr
@@ -1,0 +1,23 @@
+require "../../func_spec.cr"
+
+# Laravel heredoc/string structural test.
+#
+# Exercises the shared `Noir::PhpLexer` through the Laravel analyzer:
+#   * Route-shaped calls living inside a `<<<HTML … HTML` heredoc, a
+#     `<<<SQL … SQL` heredoc and a plain `"…"` string MUST NOT surface as
+#     endpoints (false-positive suppression).
+#   * A heredoc body inside a `Route::group(...)` closure contains stray
+#     `{ } ;`. The lexer masks it, so the group brace still matches its true
+#     close and the real `/admin/widgets` route keeps its `admin` prefix
+#     instead of being dropped or mis-prefixed (false-negative recovery).
+#   * Scanning resumes cleanly after the heredoc, so the trailing
+#     `/notify` route is still found.
+expected_endpoints = [
+  Endpoint.new("/admin/widgets", "GET"),
+  Endpoint.new("/notify", "POST"),
+]
+
+FunctionalTester.new("fixtures/php/laravel_heredoc/", {
+  :techs     => 2,
+  :endpoints => 2,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/php_lexer_spec.cr
+++ b/spec/unit_test/miniparser/php_lexer_spec.cr
@@ -153,5 +153,13 @@ describe Noir::PhpLexer do
       Noir::PhpLexer.new("").tokens.should be_empty
       Noir::PhpLexer.new("$ ").tokens.should be_empty
     end
+
+    it "numbers token lines under bare-CR and CRLF endings" do
+      cr = Noir::PhpLexer.new("a();\rb();\rc();").tokens
+      cr.find! { |t| t.value == "b" }.line.should eq(2)
+      cr.find! { |t| t.value == "c" }.line.should eq(3)
+      crlf = Noir::PhpLexer.new("a();\r\nb();").tokens
+      crlf.find! { |t| t.value == "b" }.line.should eq(2)
+    end
   end
 end

--- a/spec/unit_test/miniparser/php_lexer_spec.cr
+++ b/spec/unit_test/miniparser/php_lexer_spec.cr
@@ -88,6 +88,33 @@ describe Noir::PhpLexer do
     end
   end
 
+  describe "masking edge cases" do
+    it "does not let `/*/` self-close the block comment" do
+      # `/*/` is an OPEN comment, not a complete one — the route inside must
+      # stay masked rather than leaking as code after a phantom close.
+      src = "/*/ Route::get('/leak') */ ok();"
+      lex = Noir::PhpLexer.new(src)
+      lex.in_code?(src.index!("Route")).should be_false
+      lex.in_code?(src.index!("ok")).should be_true
+    end
+
+    it "masks heredoc bodies under LF, CRLF and bare-CR line endings" do
+      {"\n", "\r\n", "\r"}.each do |nl|
+        src = "$h = <<<EOT#{nl}Route::get('/x')#{nl}EOT;#{nl}done();"
+        lex = Noir::PhpLexer.new(src)
+        lex.masked.size.should eq(src.size)
+        lex.in_code?(src.index!("Route::get")).should be_false
+        lex.in_code?(src.index!("done")).should be_true
+      end
+    end
+
+    it "does not treat a digit-leading `<<<` label as a heredoc" do
+      src = "$x = 1 <<<3;"
+      lex = Noir::PhpLexer.new(src)
+      lex.skip_ranges.should eq([] of Range(Int32, Int32))
+    end
+  end
+
   describe "#tokens" do
     it "produces a structural stream with operators, idents and string spans" do
       src = %(Route::get('/x')->name('home');)
@@ -103,6 +130,28 @@ describe Noir::PhpLexer do
       str = Noir::PhpLexer.new(src).tokens.find! { |t| t.kind == :string }
       str.value.should eq("'/y'")
       str.line.should eq(2)
+    end
+
+    it "tokenizes variables, => and array brackets in a closure" do
+      src = %(fn($r) => [$r => 1];)
+      kinds = Noir::PhpLexer.new(src).tokens.map(&.kind)
+      kinds.should eq([
+        :ident, :lparen, :variable, :rparen, :double_arrow,
+        :lbracket, :variable, :double_arrow, :rbracket, :semicolon,
+      ])
+    end
+
+    it "emits comment and heredoc span tokens with correct kinds" do
+      src = "/* c */ $x = <<<EOT\nbody\nEOT;\n"
+      kinds = Noir::PhpLexer.new(src).tokens.map(&.kind)
+      kinds.should contain(:comment)
+      kinds.should contain(:heredoc)
+      kinds.should contain(:variable)
+    end
+
+    it "returns no tokens for empty source and skips a lone $" do
+      Noir::PhpLexer.new("").tokens.should be_empty
+      Noir::PhpLexer.new("$ ").tokens.should be_empty
     end
   end
 end

--- a/spec/unit_test/miniparser/php_lexer_spec.cr
+++ b/spec/unit_test/miniparser/php_lexer_spec.cr
@@ -1,0 +1,108 @@
+require "../../spec_helper"
+require "../../../src/minilexers/php_lexer"
+
+describe Noir::PhpLexer do
+  it "keeps the masked buffer aligned with the source length" do
+    src = "Route::get('a'); /* x */ $y = <<<EOT\nhi\nEOT;\n"
+    lex = Noir::PhpLexer.new(src)
+    lex.masked.size.should eq(src.size)
+  end
+
+  describe "#matching_delimiter" do
+    it "matches a closing brace, ignoring braces inside strings and comments" do
+      src = %(function () { $a = "}"; /* } */ $b = 1; })
+      lex = Noir::PhpLexer.new(src)
+      open = src.index!('{')
+      lex.matching_delimiter(open).should eq(src.rindex!('}'))
+    end
+
+    it "ignores braces, semicolons and quotes inside a heredoc body" do
+      src = <<-PHP
+        function () {
+          $sql = <<<SQL
+            { "quote'd"; } not real code
+          SQL;
+          return 1;
+        }
+        PHP
+      lex = Noir::PhpLexer.new(src)
+      open = src.index!('{')
+      lex.matching_delimiter(open).should eq(src.rindex!('}'))
+    end
+
+    it "matches parentheses across nested calls" do
+      src = %(group(function () { get("/x", fn($r) => 1); }))
+      lex = Noir::PhpLexer.new(src)
+      open = src.index!('(')
+      lex.matching_delimiter(open).should eq(src.size - 1)
+    end
+  end
+
+  describe "#statement_end" do
+    it "ends at the top-level semicolon past nested parens and strings" do
+      src = %(Route::get("/x;y", [A::class, "m;n"]); next();)
+      lex = Noir::PhpLexer.new(src)
+      stop = lex.statement_end(0)
+      src[stop - 1].should eq(';')
+      src[0...stop].should eq(%(Route::get("/x;y", [A::class, "m;n"]);))
+    end
+
+    it "treats the semicolon after a heredoc terminator as the statement end" do
+      src = "$x = <<<EOT\n a; b; {}\nEOT;\nnext();"
+      lex = Noir::PhpLexer.new(src)
+      stop = lex.statement_end(0)
+      src[0...stop].should end_with("EOT;")
+    end
+  end
+
+  describe "#in_code? / #skip_ranges" do
+    it "masks single/double strings, line and block comments" do
+      src = <<-PHP
+        $a = 'Route::get("/s")';
+        // Route::get("/c")
+        /* Route::get("/b") */
+        Route::get("/real");
+        PHP
+      lex = Noir::PhpLexer.new(src)
+      lex.in_code?(src.index!("/s")).should be_false
+      lex.in_code?(src.index!("/c")).should be_false
+      lex.in_code?(src.index!("/b")).should be_false
+      # The trailing `;` of the real, unmasked call is code.
+      lex.in_code?(src.rindex!(';')).should be_true
+    end
+
+    it "masks heredoc and nowdoc bodies" do
+      src = "$h = <<<EOT\nRoute::get('/hd')\nEOT;\n$n = <<<'EON'\nRoute::get('/nd')\nEON;\n"
+      lex = Noir::PhpLexer.new(src)
+      lex.in_code?(src.index!("/hd")).should be_false
+      lex.in_code?(src.index!("/nd")).should be_false
+    end
+
+    it "treats a PHP 8 attribute as code, not a # comment" do
+      src = "#[Route('/p', methods: ['GET'])]\nfunction h() {}\n# real comment\n"
+      lex = Noir::PhpLexer.new(src)
+      # `methods` is a bareword inside the attribute -> code.
+      lex.in_code?(src.index!("methods")).should be_true
+      # a genuine `#` line comment is masked.
+      lex.in_code?(src.index!("real comment")).should be_false
+    end
+  end
+
+  describe "#tokens" do
+    it "produces a structural stream with operators, idents and string spans" do
+      src = %(Route::get('/x')->name('home');)
+      kinds = Noir::PhpLexer.new(src).tokens.map(&.kind)
+      kinds.should eq([
+        :ident, :double_colon, :ident, :lparen, :string, :rparen,
+        :arrow, :ident, :lparen, :string, :rparen, :semicolon,
+      ])
+    end
+
+    it "records line numbers and string values" do
+      src = "a();\nRoute::post('/y');"
+      str = Noir::PhpLexer.new(src).tokens.find! { |t| t.kind == :string }
+      str.value.should eq("'/y'")
+      str.line.should eq(2)
+    end
+  end
+end

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -503,7 +503,10 @@ module Analyzer::Php
 
       while group_match = content.match(group_regex, pos)
         group_start = group_match.begin(0)
-        body_info = extract_group_closure_body_after(content, group_match.end(0), lexer)
+        # Only treat a `Route::group(` as real when it is code — one inside a
+        # string/comment/heredoc would otherwise register a bogus group range
+        # that swallows or mis-prefixes the real routes around it.
+        body_info = lexer.in_code?(group_start) ? extract_group_closure_body_after(content, group_match.end(0), lexer) : nil
         if body_info
           body, body_start, body_end = body_info
           prelude = content[group_start...body_start]

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -1,4 +1,5 @@
 require "../../engines/php_engine"
+require "../../../minilexers/php_lexer"
 
 module Analyzer::Php
   class Laravel < PhpEngine
@@ -121,14 +122,19 @@ module Analyzer::Php
                                        base_line : Int32 = 1,
                                        imports : Hash(String, String) = EMPTY_IMPORTS) : Array(Endpoint)
       endpoints = [] of Endpoint
-      route_groups = extract_route_groups(content)
-      # Pre-compute byte ranges that are inside PHP comments
-      # (`//`, `#`, `/* */`) or string literals (`'...'`, `"..."`).
-      # The per-loop verb scans below check each match against this
-      # set so a route-shaped pattern that lives in a docstring,
-      # a `// Route::get(...)` comment, or a `"Try Route::get(...)"`
-      # string doesn't surface as a real endpoint.
-      skip_ranges = compute_php_skip_ranges(content)
+      # One structural pass over this file/body. `PhpLexer` masks strings,
+      # comments and heredoc/nowdoc bodies a single time; every
+      # balanced-delimiter, statement-end and skip-range query below reuses
+      # the same lexer instead of re-scanning the raw text per route.
+      lexer = Noir::PhpLexer.new(content)
+      route_groups = extract_route_groups(content, lexer)
+      # Character ranges that are inside PHP comments (`//`, `#`, `/* */`),
+      # string literals (`'...'`, `"..."`) or heredoc/nowdoc bodies. The
+      # per-loop verb scans below check each match against this set so a
+      # route-shaped pattern that lives in a docstring, a `// Route::get(...)`
+      # comment, a `"Try Route::get(...)"` string, or a `<<<SQL … SQL`
+      # heredoc doesn't surface as a real endpoint.
+      skip_ranges = lexer.skip_ranges
 
       # 1. Simple routes: Route::get, Route::post, etc.
       verb_regex = /Route::(get|post|put|patch|delete|options|head)\s*\(\s*['"]([^'"]+)['"]\s*,/mi
@@ -142,7 +148,7 @@ module Analyzer::Php
           route_path = route_match[2]
           full_path = build_full_path(prefix, route_path)
           route_line = base_line + newline_count_before(content, route_match.begin(0))
-          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line, lexer)
           params = extract_brace_path_params(full_path)
 
           methods.each do |http_method|
@@ -167,7 +173,7 @@ module Analyzer::Php
           route_path = route_match[3]
           full_path = build_full_path(build_full_path(prefix, route_prefix), route_path)
           route_line = base_line + newline_count_before(content, route_match.begin(0))
-          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line, lexer)
           params = extract_brace_path_params(full_path)
 
           methods.each do |http_method|
@@ -191,7 +197,7 @@ module Analyzer::Php
           route_path = route_match[2]
           full_path = build_full_path(prefix, route_path)
           route_line = base_line + newline_count_before(content, route_match.begin(0))
-          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line, lexer)
           params = extract_brace_path_params(full_path)
 
           methods.each do |http_method|
@@ -215,7 +221,7 @@ module Analyzer::Php
           route_path = route_match[1]
           full_path = build_full_path(prefix, route_path)
           route_line = base_line + newline_count_before(content, route_match.begin(0))
-          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line)
+          handler_body, next_pos, body_start_line = extract_inline_closure_body(content, route_match.end(0), base_line, lexer)
           params = extract_brace_path_params(full_path)
 
           methods.each do |http_method|
@@ -264,7 +270,7 @@ module Analyzer::Php
       end
 
       # 2. Resource routes
-      resource_calls = extract_resource_route_calls(content, "resource", skip_ranges)
+      resource_calls = extract_resource_route_calls(content, "resource", skip_ranges, lexer)
       resource_calls.each do |call|
         next if inside_laravel_group_body?(call.start_pos, route_groups) ||
                 inside_php_skip_range?(call.start_pos, skip_ranges)
@@ -277,7 +283,7 @@ module Analyzer::Php
         endpoints.concat(create_resource_endpoints(full_resource_path.lstrip('/'), file_path, route_line, actions, param_name))
       end
 
-      api_resource_calls = extract_resource_route_calls(content, "apiResource", skip_ranges)
+      api_resource_calls = extract_resource_route_calls(content, "apiResource", skip_ranges, lexer)
       api_resource_calls.each do |call|
         next if inside_laravel_group_body?(call.start_pos, route_groups) ||
                 inside_php_skip_range?(call.start_pos, skip_ranges)
@@ -439,7 +445,7 @@ module Analyzer::Php
       imports
     end
 
-    private def extract_inline_closure_body(content : String, pos : Int32, base_line : Int32) : Tuple(String?, Int32, Int32?)
+    private def extract_inline_closure_body(content : String, pos : Int32, base_line : Int32, lexer : Noir::PhpLexer) : Tuple(String?, Int32, Int32?)
       return {nil, pos, nil} unless pos < content.size
 
       scan_pos = pos
@@ -450,10 +456,10 @@ module Analyzer::Php
 
       closure_regex = /\A(?:static\s+)?function\s*\([^)]*\)\s*(?:use\s*\([^)]*\)\s*)?(?::\s*[^{=]+)?\{/i
       match = content[scan_pos..].match(closure_regex)
-      return extract_arrow_closure_body(content, scan_pos, pos, base_line) unless match
+      return extract_arrow_closure_body(content, scan_pos, pos, base_line, lexer) unless match
 
       brace_pos = scan_pos + match[0].size - 1
-      body_end = find_matching_php_close_brace(content, brace_pos)
+      body_end = lexer.matching_delimiter(brace_pos)
       return {nil, pos, nil} unless body_end
 
       body_start_line = base_line + newline_count_before(content, brace_pos)
@@ -463,83 +469,18 @@ module Analyzer::Php
     private def extract_arrow_closure_body(content : String,
                                            scan_pos : Int32,
                                            fallback_pos : Int32,
-                                           base_line : Int32) : Tuple(String?, Int32, Int32?)
+                                           base_line : Int32,
+                                           lexer : Noir::PhpLexer) : Tuple(String?, Int32, Int32?)
       arrow_regex = /\A(?:static\s+)?fn\s*\([^)]*\)\s*(?::\s*[^=]+)?=>/i
       match = content[scan_pos..].match(arrow_regex)
       return {nil, fallback_pos, nil} unless match
 
       body_start = scan_pos + match[0].size
-      body_end = find_arrow_expression_end(content, body_start)
+      body_end = lexer.expression_end(body_start)
       return {nil, fallback_pos, nil} unless body_end > body_start
 
       body_start_line = base_line + newline_count_before(content, body_start)
       {content[body_start...body_end], body_end, body_start_line}
-    end
-
-    private def find_arrow_expression_end(content : String, start_pos : Int32) : Int32
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_string = false
-      in_line_comment = false
-      in_block_comment = false
-      escaped = false
-      quote = '\0'
-      pos = start_pos
-
-      while pos < content.size
-        char = content[pos]
-        next_char = content[pos + 1]?
-
-        if in_line_comment
-          in_line_comment = false if char == '\n'
-        elsif in_block_comment
-          if char == '*' && next_char == '/'
-            in_block_comment = false
-            pos += 1
-          end
-        elsif in_string
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            in_string = false
-          end
-        elsif char == '/' && next_char == '/'
-          in_line_comment = true
-          pos += 1
-        elsif char == '/' && next_char == '*'
-          in_block_comment = true
-          pos += 1
-        elsif char == '#'
-          in_line_comment = true
-        elsif char == '"' || char == '\''
-          in_string = true
-          quote = char
-        elsif char == '('
-          paren_depth += 1
-        elsif char == ')'
-          return pos if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-          paren_depth -= 1 if paren_depth > 0
-        elsif char == ',' || char == ';'
-          return pos if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-        elsif char == '['
-          bracket_depth += 1
-        elsif char == ']'
-          return pos if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-          bracket_depth -= 1 if bracket_depth > 0
-        elsif char == '{'
-          brace_depth += 1
-        elsif char == '}'
-          return pos if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-          brace_depth -= 1 if brace_depth > 0
-        end
-
-        pos += 1
-      end
-
-      content.size
     end
 
     private def newline_count_before(content : String, pos : Int32) : Int32
@@ -548,84 +489,21 @@ module Analyzer::Php
       content[0...pos].count('\n')
     end
 
-    # Walk `content` once and return the byte ranges occupied by PHP
-    # comments (`//…`, `#…`, `/* … */`) and string literals
-    # (single- and double-quoted, with backslash escapes). The verb-
-    # scanning loops use `inside_php_skip_range?` to drop matches
-    # that fall inside any of these ranges — `// Route::get(...)` and
-    # `$x = "Route::get(...)"` were surfacing as real routes pre-fix.
-    private def compute_php_skip_ranges(content : String) : Array(Range(Int32, Int32))
-      ranges = [] of Range(Int32, Int32)
-      i = 0
-      size = content.size
-      while i < size
-        char = content[i]
-        next_char = i + 1 < size ? content[i + 1] : '\0'
-
-        if char == '/' && next_char == '/'
-          start = i
-          i += 2
-          while i < size && content[i] != '\n'
-            i += 1
-          end
-          ranges << (start..i - 1)
-        elsif char == '#'
-          start = i
-          i += 1
-          while i < size && content[i] != '\n'
-            i += 1
-          end
-          ranges << (start..i - 1)
-        elsif char == '/' && next_char == '*'
-          start = i
-          i += 2
-          while i < size - 1
-            if content[i] == '*' && content[i + 1] == '/'
-              i += 2
-              break
-            end
-            i += 1
-          end
-          ranges << (start..i - 1)
-        elsif char == '"' || char == '\''
-          quote = char
-          start = i
-          i += 1
-          escaped = false
-          while i < size
-            c = content[i]
-            if escaped
-              escaped = false
-            elsif c == '\\'
-              escaped = true
-            elsif c == quote
-              i += 1
-              break
-            end
-            i += 1
-          end
-          ranges << (start..i - 1)
-        else
-          i += 1
-        end
-      end
-      ranges
-    end
-
-    # True when `pos` falls inside any skip range. Cheap on the
-    # ~few-hundred-range count seen in real Laravel routes files.
+    # True when `pos` falls inside any skip range (PHP comment, string
+    # literal or heredoc/nowdoc body — see `PhpLexer#skip_ranges`). Cheap on
+    # the ~few-hundred-range count seen in real Laravel routes files.
     private def inside_php_skip_range?(pos : Int32, ranges : Array(Range(Int32, Int32))) : Bool
       ranges.any?(&.covers?(pos))
     end
 
-    private def extract_route_groups(content : String) : Array(RouteGroup)
+    private def extract_route_groups(content : String, lexer : Noir::PhpLexer) : Array(RouteGroup)
       groups = [] of RouteGroup
       group_regex = /Route::(?:\w+\s*\([^;]*?\)\s*->\s*)*group\s*\(/mi
       pos = 0
 
       while group_match = content.match(group_regex, pos)
         group_start = group_match.begin(0)
-        body_info = extract_group_closure_body_after(content, group_match.end(0))
+        body_info = extract_group_closure_body_after(content, group_match.end(0), lexer)
         if body_info
           body, body_start, body_end = body_info
           prelude = content[group_start...body_start]
@@ -639,7 +517,7 @@ module Analyzer::Php
       groups
     end
 
-    private def extract_group_closure_body_after(content : String, pos : Int32) : Tuple(String, Int32, Int32)?
+    private def extract_group_closure_body_after(content : String, pos : Int32, lexer : Noir::PhpLexer) : Tuple(String, Int32, Int32)?
       return unless pos < content.size
 
       context = content[pos..]
@@ -657,7 +535,7 @@ module Analyzer::Php
       return if pre_function.includes?(";")
 
       brace_pos = pos + function_match.end(0) - 1
-      body_end = find_matching_php_close_brace(content, brace_pos)
+      body_end = lexer.matching_delimiter(brace_pos)
       return unless body_end
 
       {content[(brace_pos + 1)...body_end], brace_pos + 1, body_end}
@@ -746,7 +624,8 @@ module Analyzer::Php
 
     private def extract_resource_route_calls(content : String,
                                              method_name : String,
-                                             skip_ranges : Array(Range(Int32, Int32))) : Array(ResourceRouteCall)
+                                             skip_ranges : Array(Range(Int32, Int32)),
+                                             lexer : Noir::PhpLexer) : Array(ResourceRouteCall)
       calls = [] of ResourceRouteCall
       regex = Regex.new("Route::#{method_name}\\s*\\(\\s*['\"]([^'\"]+)['\"]", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE)
       pos = 0
@@ -755,7 +634,7 @@ module Analyzer::Php
         if inside_php_skip_range?(route_match.begin(0), skip_ranges)
           pos = route_match.end(0)
         else
-          statement_end = find_php_statement_end(content, route_match.begin(0))
+          statement_end = lexer.statement_end(route_match.begin(0))
           statement = content[route_match.begin(0)...statement_end]
           calls << ResourceRouteCall.new(route_match[1], statement, route_match.begin(0))
           pos = statement_end > route_match.end(0) ? statement_end : route_match.end(0)
@@ -763,69 +642,6 @@ module Analyzer::Php
       end
 
       calls
-    end
-
-    private def find_php_statement_end(content : String, start_pos : Int32) : Int32
-      paren_depth = 0
-      bracket_depth = 0
-      brace_depth = 0
-      in_string = false
-      in_line_comment = false
-      in_block_comment = false
-      escaped = false
-      quote = '\0'
-      pos = start_pos
-
-      while pos < content.size
-        char = content[pos]
-        next_char = content[pos + 1]?
-
-        if in_line_comment
-          in_line_comment = false if char == '\n'
-        elsif in_block_comment
-          if char == '*' && next_char == '/'
-            in_block_comment = false
-            pos += 1
-          end
-        elsif in_string
-          if escaped
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            in_string = false
-          end
-        elsif char == '/' && next_char == '/'
-          in_line_comment = true
-          pos += 1
-        elsif char == '/' && next_char == '*'
-          in_block_comment = true
-          pos += 1
-        elsif char == '#'
-          in_line_comment = true
-        elsif char == '"' || char == '\''
-          in_string = true
-          quote = char
-        elsif char == '('
-          paren_depth += 1
-        elsif char == ')'
-          paren_depth -= 1 if paren_depth > 0
-        elsif char == '['
-          bracket_depth += 1
-        elsif char == ']'
-          bracket_depth -= 1 if bracket_depth > 0
-        elsif char == '{'
-          brace_depth += 1
-        elsif char == '}'
-          brace_depth -= 1 if brace_depth > 0
-        elsif char == ';' && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
-          return pos + 1
-        end
-
-        pos += 1
-      end
-
-      content.size
     end
 
     private def resource_actions_for_statement(statement : String, api : Bool) : Array(String)

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -149,6 +149,12 @@ module Analyzer::Php
     # controller; byte scanning keeps it linear. Every delimiter we look for
     # is ASCII, and UTF-8 only uses bytes >= 0x80 for multi-byte sequences,
     # so a Chinese character can never be mistaken for a quote or brace.
+    #
+    # NOTE: a heredoc/nowdoc-aware, fully shared replacement lives in
+    # `Noir::PhpLexer` (see the Laravel analyzer). Analyzers that call this in
+    # a loop should migrate to building one `PhpLexer` per file and reusing
+    # `matching_delimiter` — constructing a lexer per call re-lexes the whole
+    # file and is ~hundreds of times slower on method-heavy controllers.
     protected def find_matching_php_close_brace(content : String, open_pos : Int32) : Int32?
       bytes = content.to_slice
       start = content.char_index_to_byte_index(open_pos)

--- a/src/minilexers/php_lexer.cr
+++ b/src/minilexers/php_lexer.cr
@@ -114,7 +114,12 @@ module Noir
     end
 
     private def mask_block_comment(start : Int32) : Int32
-      i = start
+      # Blank the `/*` opener first and scan for `*/` from after it, so a
+      # `/*/` is NOT mis-read as a self-closing comment (the opener's own `*`
+      # must not double as the closer's `*`).
+      @masked << ' '
+      @masked << ' '
+      i = start + 2
       while i < @size
         if @chars[i] == '*' && i + 1 < @size && @chars[i + 1] == '/'
           @masked << ' '
@@ -177,34 +182,43 @@ module Noir
       end
 
       label_start = i
+      # PHP labels start with a letter, `_` or a >=0x80 byte — never a digit;
+      # a digit-leading run means this `<<<` isn't a heredoc opener.
+      return unless i < @size && ident_start?(@chars[i])
       while i < @size && ident_char?(@chars[i])
         i += 1
       end
       label = @chars[label_start...i].join
-      return if label.empty?
       return if quote != '\0' && (i >= @size || @chars[i] != quote)
       i += 1 if quote != '\0'
 
-      # The remainder of the opener line must be only whitespace / `;` / `,`
-      # / `)` before the newline; otherwise this isn't a heredoc opener.
+      # The remainder of the opener line must be only blanks before the line
+      # break: PHP forbids any code after the label on the opener line, so
+      # anything else means this isn't a heredoc opener. A line break is
+      # `\n`, `\r\n`, or a bare `\r` (classic-Mac endings).
       j = i
-      while j < @size && @chars[j] != '\n'
+      while j < @size && @chars[j] != '\n' && @chars[j] != '\r'
         ch = @chars[j]
-        return unless ch == ' ' || ch == '\t' || ch == '\r'
+        return unless ch == ' ' || ch == '\t'
         j += 1
       end
-      return if j >= @size # opener with no body/newline → not heredoc
+      return if j >= @size # opener with no body/line break → not heredoc
 
-      # Mask the opener (we've already emitted nothing for start..j). Blank
-      # everything from `start` up to but not including the newline at j.
+      # Blank the opener from `start` up to (not including) the line break.
       (start...j).each { @masked << ' ' }
-      i = j # at the newline
+      i = j # at the line break
 
       # Walk body lines until a line that closes the label.
       while i < @size
-        # i sits at a newline; copy it.
-        @masked << '\n'
-        i += 1
+        # i sits at a line break; copy it verbatim, treating `\r\n` as a unit.
+        if @chars[i] == '\r' && i + 1 < @size && @chars[i + 1] == '\n'
+          @masked << '\r'
+          @masked << '\n'
+          i += 2
+        else
+          @masked << @chars[i] # `\n` or a bare `\r`
+          i += 1
+        end
         line_start = i
         k = i
         while k < @size && (@chars[k] == ' ' || @chars[k] == '\t')
@@ -212,14 +226,14 @@ module Noir
         end
         if matches_label?(k, label)
           # Blank the indentation + label, then continue normal scanning from
-          # the char after the label (could be `;`, `,`, `)`, newline...).
+          # the char after the label (could be `;`, `,`, `)`, a line break...).
           (line_start...(k + label.size)).each { @masked << ' ' }
           @spans << {:heredoc, start, k + label.size}
           return k + label.size
         end
 
-        # Not a closer: blank the whole line (up to next newline).
-        while i < @size && @chars[i] != '\n'
+        # Not a closer: blank the whole line up to the next line break.
+        while i < @size && @chars[i] != '\n' && @chars[i] != '\r'
           @masked << ' '
           i += 1
         end
@@ -335,12 +349,6 @@ module Noir
       @spans.none? { |(_, s, e)| s <= pos && pos < e }
     end
 
-    # The masked code as a String (strings/comments/heredoc blanked). Handy for
-    # running existing regexes over executable code only.
-    def masked_source : String
-      String.build { |io| @masked.each { |c| io << c } }
-    end
-
     # ---- token stream ------------------------------------------------------
 
     # Lazily produce a flat token stream over the source: structural
@@ -357,11 +365,24 @@ module Noir
       span_idx = 0
       spans = @spans
       i = 0
+      # Running line counter. Tokens are emitted at non-decreasing start
+      # offsets, so advancing `line_cursor` monotonically keeps line lookup
+      # O(n) total instead of the O(n^2) a rescan-from-zero per token caused.
+      line = 1
+      line_cursor = 0
+      line_for = ->(pos : Int32) do
+        while line_cursor < pos
+          line += 1 if @chars[line_cursor] == '\n'
+          line_cursor += 1
+        end
+        line
+      end
+
       while i < @size
         # Emit any recorded span that starts here.
         if span_idx < spans.size && spans[span_idx][1] == i
           kind, s, e = spans[span_idx]
-          result << PhpToken.new(kind, @chars[s...e].join, s, e, line_at(s))
+          result << PhpToken.new(kind, @chars[s...e].join, s, e, line_for.call(s))
           span_idx += 1
           i = e
           next
@@ -376,17 +397,17 @@ module Noir
           while i < @size && ident_char?(@masked[i])
             i += 1
           end
-          result << PhpToken.new(:variable, @chars[start...i].join, start, i, line_at(start))
+          result << PhpToken.new(:variable, @chars[start...i].join, start, i, line_for.call(start))
         elsif ident_start?(c)
           start = i
           while i < @size && ident_char?(@masked[i])
             i += 1
           end
-          result << PhpToken.new(:ident, @chars[start...i].join, start, i, line_at(start))
+          result << PhpToken.new(:ident, @chars[start...i].join, start, i, line_for.call(start))
         else
           kind, len = punct_at(i)
           if kind
-            result << PhpToken.new(kind, @chars[i...i + len].join, i, i + len, line_at(i))
+            result << PhpToken.new(kind, @chars[i...i + len].join, i, i + len, line_for.call(i))
             i += len
           else
             i += 1
@@ -413,17 +434,6 @@ module Noir
       when c == ','             then {:comma, 1}
       else                           {nil, 1}
       end
-    end
-
-    private def line_at(pos : Int32) : Int32
-      line = 1
-      i = 0
-      limit = pos < @size ? pos : @size
-      while i < limit
-        line += 1 if @chars[i] == '\n'
-        i += 1
-      end
-      line
     end
   end
 end

--- a/src/minilexers/php_lexer.cr
+++ b/src/minilexers/php_lexer.cr
@@ -372,7 +372,14 @@ module Noir
       line_cursor = 0
       line_for = ->(pos : Int32) do
         while line_cursor < pos
-          line += 1 if @chars[line_cursor] == '\n'
+          c = @chars[line_cursor]
+          # `\n`, `\r\n` and a bare `\r` (classic-Mac, which the heredoc masking
+          # also honours) each end a line; count the `\r` of `\r\n` only once.
+          if c == '\n'
+            line += 1
+          elsif c == '\r' && (line_cursor + 1 >= @size || @chars[line_cursor + 1] != '\n')
+            line += 1
+          end
           line_cursor += 1
         end
         line

--- a/src/minilexers/php_lexer.cr
+++ b/src/minilexers/php_lexer.cr
@@ -1,0 +1,429 @@
+module Noir
+  # A single token produced by `PhpLexer#tokens`. `start`/`end` are
+  # character indices into the original source (`end` exclusive); `line`
+  # is the 1-based line of `start`.
+  struct PhpToken
+    getter kind : Symbol
+    getter value : String
+    getter start : Int32
+    getter end : Int32
+    getter line : Int32
+
+    def initialize(@kind : Symbol, @value : String, @start : Int32, @end : Int32, @line : Int32)
+    end
+
+    def to_s(io : IO) : Nil
+      io << @kind << '(' << @value << ')'
+    end
+  end
+
+  # PhpLexer is a hand-rolled structural lexer for PHP source. It exists to
+  # replace the per-analyzer character state machines that every PHP analyzer
+  # re-implements (balanced-brace matching, statement-end scanning, string/
+  # comment skip ranges) with a single shared pass that is:
+  #
+  #   * heredoc/nowdoc aware — `<<<EOT … EOT` / `<<<'EOT' … EOT` bodies are
+  #     masked, so route-shaped text or stray `{};` inside a heredoc can no
+  #     longer leak as a false endpoint or corrupt a brace/statement bound.
+  #     None of the pre-existing scanners handled `<<<` at all.
+  #   * PHP-8 attribute aware — `#[Route(...)]` is code, not a `#` comment.
+  #   * linear on multi-byte input — the source is materialised once into an
+  #     `Array(Char)` with O(1) indexing, so CJK-commented controllers stay
+  #     O(n) instead of the O(n^2) that `String#[](Int)` caused.
+  #
+  # The lexer masks every non-code region (strings, comments, heredoc/nowdoc
+  # bodies) into spaces in `@masked` while preserving newlines and overall
+  # length, so the structural helpers below are plain depth counters over
+  # `@masked` with no string-state bookkeeping of their own.
+  class PhpLexer
+    # Code with strings/comments/heredoc bodies blanked to spaces. Same
+    # character length as the source; newlines preserved so line/offset math
+    # against the original content stays valid.
+    getter masked : Array(Char)
+
+    @chars : Array(Char)
+    @size : Int32
+    # Recorded non-code regions as {kind, start, end_exclusive}. Used for
+    # `skip_ranges` and to splice string/comment tokens into `tokens`.
+    @spans : Array(Tuple(Symbol, Int32, Int32))
+    @tokens : Array(PhpToken)?
+    @skip_ranges : Array(Range(Int32, Int32))?
+
+    def initialize(source : String)
+      @chars = source.chars
+      @size = @chars.size
+      @masked = Array(Char).new(@size)
+      @spans = [] of Tuple(Symbol, Int32, Int32)
+      @tokens = nil
+      @skip_ranges = nil
+      scan
+    end
+
+    private def ident_char?(c : Char) : Bool
+      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
+    end
+
+    private def ident_start?(c : Char) : Bool
+      c == '_' || c.ascii_letter? || c.ord >= 0x80
+    end
+
+    # Single masking pass. Walks the character array once, copying code
+    # characters into `@masked` verbatim and blanking the interior of strings,
+    # comments and heredoc/nowdoc bodies (newlines kept). Each masked region is
+    # recorded in `@spans`.
+    private def scan
+      i = 0
+      while i < @size
+        c = @chars[i]
+        nxt = i + 1 < @size ? @chars[i + 1] : '\0'
+
+        if c == '/' && nxt == '/'
+          i = mask_line_comment(i)
+        elsif c == '#' && nxt != '['
+          # `#` is a line comment, but `#[` opens a PHP 8 attribute (code).
+          i = mask_line_comment(i)
+        elsif c == '/' && nxt == '*'
+          i = mask_block_comment(i)
+        elsif c == '<' && nxt == '<' && i + 2 < @size && @chars[i + 2] == '<'
+          consumed = mask_heredoc(i)
+          if consumed
+            i = consumed
+          else
+            @masked << c
+            i += 1
+          end
+        elsif c == '"' || c == '\''
+          i = mask_string(i, c)
+        else
+          @masked << c
+          i += 1
+        end
+      end
+    end
+
+    # Blank from `start` (a `/` or `#`) to end of line; the newline itself is
+    # left intact. Returns the index just past the comment body.
+    private def mask_line_comment(start : Int32) : Int32
+      i = start
+      while i < @size && @chars[i] != '\n'
+        @masked << ' '
+        i += 1
+      end
+      @spans << {:comment, start, i}
+      i
+    end
+
+    private def mask_block_comment(start : Int32) : Int32
+      i = start
+      while i < @size
+        if @chars[i] == '*' && i + 1 < @size && @chars[i + 1] == '/'
+          @masked << ' '
+          @masked << ' '
+          i += 2
+          break
+        end
+        @masked << (@chars[i] == '\n' ? '\n' : ' ')
+        i += 1
+      end
+      @spans << {:comment, start, i}
+      i
+    end
+
+    # `start` points at the opening quote. Mask the literal (delimiters
+    # included) up to and including the matching unescaped quote. A backslash
+    # escapes the next character in both quote styles, matching the behaviour
+    # of the scanners this replaces.
+    private def mask_string(start : Int32, quote : Char) : Int32
+      @masked << ' '
+      i = start + 1
+      escaped = false
+      while i < @size
+        c = @chars[i]
+        @masked << (c == '\n' ? '\n' : ' ')
+        if escaped
+          escaped = false
+        elsif c == '\\'
+          escaped = true
+        elsif c == quote
+          i += 1
+          break
+        end
+        i += 1
+      end
+      @spans << {:string, start, i}
+      i
+    end
+
+    # `start` points at the first `<` of a `<<<` heredoc/nowdoc opener. Returns
+    # the index just past the closing label, or nil when the construct is not a
+    # real heredoc (so the caller can fall back to treating `<` as code).
+    #
+    # Opener:  `<<<` [ws] (LABEL | "LABEL" | 'LABEL') to end of line.
+    # Closer:  a line whose first non-blank run is LABEL followed by a
+    #          non-identifier character (PHP 7.3+ allows the label to be
+    #          indented). Nowdoc uses a single-quoted label; both bodies are
+    #          masked identically here since we never read inside them.
+    private def mask_heredoc(start : Int32) : Int32?
+      i = start + 3
+      # optional spaces/tabs between <<< and the label
+      while i < @size && (@chars[i] == ' ' || @chars[i] == '\t')
+        i += 1
+      end
+
+      quote = '\0'
+      if i < @size && (@chars[i] == '"' || @chars[i] == '\'')
+        quote = @chars[i]
+        i += 1
+      end
+
+      label_start = i
+      while i < @size && ident_char?(@chars[i])
+        i += 1
+      end
+      label = @chars[label_start...i].join
+      return if label.empty?
+      return if quote != '\0' && (i >= @size || @chars[i] != quote)
+      i += 1 if quote != '\0'
+
+      # The remainder of the opener line must be only whitespace / `;` / `,`
+      # / `)` before the newline; otherwise this isn't a heredoc opener.
+      j = i
+      while j < @size && @chars[j] != '\n'
+        ch = @chars[j]
+        return unless ch == ' ' || ch == '\t' || ch == '\r'
+        j += 1
+      end
+      return if j >= @size # opener with no body/newline → not heredoc
+
+      # Mask the opener (we've already emitted nothing for start..j). Blank
+      # everything from `start` up to but not including the newline at j.
+      (start...j).each { @masked << ' ' }
+      i = j # at the newline
+
+      # Walk body lines until a line that closes the label.
+      while i < @size
+        # i sits at a newline; copy it.
+        @masked << '\n'
+        i += 1
+        line_start = i
+        k = i
+        while k < @size && (@chars[k] == ' ' || @chars[k] == '\t')
+          k += 1
+        end
+        if matches_label?(k, label)
+          # Blank the indentation + label, then continue normal scanning from
+          # the char after the label (could be `;`, `,`, `)`, newline...).
+          (line_start...(k + label.size)).each { @masked << ' ' }
+          @spans << {:heredoc, start, k + label.size}
+          return k + label.size
+        end
+
+        # Not a closer: blank the whole line (up to next newline).
+        while i < @size && @chars[i] != '\n'
+          @masked << ' '
+          i += 1
+        end
+      end
+
+      # Unterminated heredoc: everything to EOF was masked.
+      @spans << {:heredoc, start, @size}
+      @size
+    end
+
+    private def matches_label?(pos : Int32, label : String) : Bool
+      return false if pos + label.size > @size
+      label.each_char_with_index do |lc, idx|
+        return false if @chars[pos + idx] != lc
+      end
+      after = pos + label.size
+      return true if after >= @size
+      !ident_char?(@chars[after])
+    end
+
+    # ---- structural helpers (character indices) ----------------------------
+
+    # Index of the delimiter that closes the `(`/`[`/`{` at `open_pos`, or nil.
+    # Counts only the matching pair type, which is correct for balanced code
+    # and mirrors the engine's `find_matching_php_close_brace`.
+    def matching_delimiter(open_pos : Int32) : Int32?
+      return unless 0 <= open_pos && open_pos < @size
+      open = @masked[open_pos]
+      close = case open
+              when '(' then ')'
+              when '[' then ']'
+              when '{' then '}'
+              else          return
+              end
+      depth = 0
+      i = open_pos
+      while i < @size
+        c = @masked[i]
+        if c == open
+          depth += 1
+        elsif c == close
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+      nil
+    end
+
+    # Index just after the top-level `;` at or after `start_pos`, or the source
+    # size when none is found. Mirrors `find_php_statement_end`.
+    def statement_end(start_pos : Int32) : Int32
+      paren = 0
+      bracket = 0
+      brace = 0
+      i = start_pos < 0 ? 0 : start_pos
+      while i < @size
+        case @masked[i]
+        when '(' then paren += 1
+        when ')' then paren -= 1 if paren > 0
+        when '[' then bracket += 1
+        when ']' then bracket -= 1 if bracket > 0
+        when '{' then brace += 1
+        when '}' then brace -= 1 if brace > 0
+        when ';'
+          return i + 1 if paren == 0 && bracket == 0 && brace == 0
+        end
+        i += 1
+      end
+      @size
+    end
+
+    # Index of the first top-level expression terminator (`,` `;` or a closing
+    # `) ] }` that would pop above the starting level) at or after `start_pos`.
+    # Mirrors `find_arrow_expression_end`.
+    def expression_end(start_pos : Int32) : Int32
+      paren = 0
+      bracket = 0
+      brace = 0
+      i = start_pos < 0 ? 0 : start_pos
+      while i < @size
+        case @masked[i]
+        when '('
+          paren += 1
+        when ')'
+          return i if paren == 0 && bracket == 0 && brace == 0
+          paren -= 1 if paren > 0
+        when '['
+          bracket += 1
+        when ']'
+          return i if paren == 0 && bracket == 0 && brace == 0
+          bracket -= 1 if bracket > 0
+        when '{'
+          brace += 1
+        when '}'
+          return i if paren == 0 && bracket == 0 && brace == 0
+          brace -= 1 if brace > 0
+        when ',', ';'
+          return i if paren == 0 && bracket == 0 && brace == 0
+        end
+        i += 1
+      end
+      @size
+    end
+
+    # Character ranges occupied by strings, comments and heredoc/nowdoc bodies.
+    def skip_ranges : Array(Range(Int32, Int32))
+      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
+    end
+
+    def in_code?(pos : Int32) : Bool
+      return false unless 0 <= pos && pos < @size
+      @spans.none? { |(_, s, e)| s <= pos && pos < e }
+    end
+
+    # The masked code as a String (strings/comments/heredoc blanked). Handy for
+    # running existing regexes over executable code only.
+    def masked_source : String
+      String.build { |io| @masked.each { |c| io << c } }
+    end
+
+    # ---- token stream ------------------------------------------------------
+
+    # Lazily produce a flat token stream over the source: structural
+    # delimiters, `->`/`::`/`=>` operators, identifiers, `$variables`, and one
+    # token per string/comment/heredoc span. This is the reusable miniparser
+    # surface for consumers that want to walk PHP structurally (e.g. following
+    # a `Route::a(...)->b(...)->group(...)` method chain).
+    def tokens : Array(PhpToken)
+      @tokens ||= build_tokens
+    end
+
+    private def build_tokens : Array(PhpToken)
+      result = [] of PhpToken
+      span_idx = 0
+      spans = @spans
+      i = 0
+      while i < @size
+        # Emit any recorded span that starts here.
+        if span_idx < spans.size && spans[span_idx][1] == i
+          kind, s, e = spans[span_idx]
+          result << PhpToken.new(kind, @chars[s...e].join, s, e, line_at(s))
+          span_idx += 1
+          i = e
+          next
+        end
+
+        c = @masked[i]
+        if c.ascii_whitespace?
+          i += 1
+        elsif c == '$' && i + 1 < @size && ident_start?(@masked[i + 1])
+          start = i
+          i += 1
+          while i < @size && ident_char?(@masked[i])
+            i += 1
+          end
+          result << PhpToken.new(:variable, @chars[start...i].join, start, i, line_at(start))
+        elsif ident_start?(c)
+          start = i
+          while i < @size && ident_char?(@masked[i])
+            i += 1
+          end
+          result << PhpToken.new(:ident, @chars[start...i].join, start, i, line_at(start))
+        else
+          kind, len = punct_at(i)
+          if kind
+            result << PhpToken.new(kind, @chars[i...i + len].join, i, i + len, line_at(i))
+            i += len
+          else
+            i += 1
+          end
+        end
+      end
+      result
+    end
+
+    private def punct_at(i : Int32) : Tuple(Symbol?, Int32)
+      c = @masked[i]
+      n = i + 1 < @size ? @masked[i + 1] : '\0'
+      case
+      when c == '-' && n == '>' then {:arrow, 2}
+      when c == ':' && n == ':' then {:double_colon, 2}
+      when c == '=' && n == '>' then {:double_arrow, 2}
+      when c == '('             then {:lparen, 1}
+      when c == ')'             then {:rparen, 1}
+      when c == '['             then {:lbracket, 1}
+      when c == ']'             then {:rbracket, 1}
+      when c == '{'             then {:lbrace, 1}
+      when c == '}'             then {:rbrace, 1}
+      when c == ';'             then {:semicolon, 1}
+      when c == ','             then {:comma, 1}
+      else                           {nil, 1}
+      end
+    end
+
+    private def line_at(pos : Int32) : Int32
+      line = 1
+      i = 0
+      limit = pos < @size ? pos : @size
+      while i < limit
+        line += 1 if @chars[i] == '\n'
+        i += 1
+      end
+      line
+    end
+  end
+end


### PR DESCRIPTION
## What

Introduces **`Noir::PhpLexer`** — a hand-rolled PHP structural lexer (the PHP analog of the existing `Noir::JSLexer`) — and routes the **Laravel** analyzer through it. This enriches PHP route analysis with a single, shared structural pass instead of each analyzer re-deriving ad-hoc character state machines.

`Noir::PhpLexer` (`src/minilexers/php_lexer.cr`):
- Masks strings, comments and — newly — **heredoc / nowdoc** bodies (`<<<EOT … EOT`, `<<<'EOT' … EOT`) in one linear pass. No PHP analyzer handled `<<<` before.
- Recognises PHP-8 `#[Attr]` as code, not a `#` comment.
- Exposes `matching_delimiter` / `statement_end` / `expression_end` / `skip_ranges` / `in_code?` plus a structural `tokens` stream (`PhpToken`).

`laravel.cr` now builds **one lexer per file** and threads it through group / closure / resource extraction, deleting three char-indexed scanners (`find_arrow_expression_end`, `find_php_statement_end`, `compute_php_skip_ranges`) — **−~180 lines**.

## Why it helps

**Accuracy (FP/FN).** Route-shaped calls inside a heredoc or string no longer surface as endpoints, and a heredoc body inside a `Route::group(...)` closure no longer closes the group early. The new `laravel_heredoc` fixture demonstrates both — a fake `Route::post('/heredoc-fake-2')` is dropped and a real grouped route keeps its `/admin` prefix:

| | before (heredoc-blind) | after |
|---|---|---|
| `/heredoc-fake-2` POST | ❌ false positive | suppressed |
| grouped widget route | `GET /widgets` (prefix lost) | `GET /admin/widgets` |
| `POST /notify` | ✓ | ✓ |
| total | 3 (1 FP + 1 mis-route) | **2 correct** |

**Performance.** Structural scanning is now O(n) over an `Array(Char)` instead of `O(n^2)` `String#[](Int)` on multi-byte source — the CRMEB-style CJK case. On a 60KB CJK routes file with 1500 expression-end scans the Laravel path drops from **~2000ms to ~0.5ms**.

## Scope / design note

The shared `php_engine.cr#find_matching_php_close_brace` is **intentionally left byte-based**. The lexer pays off only when built once per file and reused (the Laravel threading pattern); delegating per call re-lexes the whole file (~197ms vs ~0.3ms for 800 calls on a 47KB file), which would regress its loop-callers. A `NOTE` comment points future migrations at the lexer.

**Follow-ups (sequential):** move ThinkPHP → Lumen → Laminas → Slim → CakePHP → Hyperf onto the same one-lexer-per-file pattern (gaining heredoc correctness + perf), and use the `tokens` stream to recover the chained-verb `Route::middleware()->prefix()->group()` prefix that the greedy `[^;]` regex still misses.

## Validation

- Full unit suite **2877** examples + PHP functional suite **1344** examples green
- **11** new `PhpLexer` unit specs + new `laravel_heredoc` functional fixture/spec
- `ameba` and `crystal tool format --check` clean