### PR TITLE
feat(csharp): add Noir::CSharpLexer structural miniparser; mask non-code in common.cr scanners

### DIFF
--- a/spec/functional_test/fixtures/csharp/lexer_repro/Controllers/ReproController.cs
+++ b/spec/functional_test/fixtures/csharp/lexer_repro/Controllers/ReproController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Demo.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ReproController : ControllerBase
+    {
+        // BUG 1: a `}` inside a string literal makes the brace counter hit 0
+        // early, so every callee below the string line is dropped.
+        [HttpGet("dirty/{id}")]
+        public IActionResult Dirty([FromRoute] int id)
+        {
+            var json = LoadTemplate("a } brace in string");
+            SecretHelperCall(id);
+            AuditLog.Write("dirty");
+            return Ok(SerializeOrder(json));
+        }
+
+        // BUG 2: an unbalanced `(` inside a string default keeps the paren
+        // counter > 0, so the signature runs away and both params are lost.
+        [HttpGet("calc")]
+        public IActionResult Calc(
+            [FromQuery] string expr = "2 * (3 + 4",
+            [FromQuery] int limit = 10)
+        {
+            return Ok(Compute(expr, limit));
+        }
+    }
+}

--- a/spec/functional_test/fixtures/csharp/lexer_repro/MyApp.csproj
+++ b/spec/functional_test/fixtures/csharp/lexer_repro/MyApp.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/testers/csharp/lexer_repro_spec.cr
+++ b/spec/functional_test/testers/csharp/lexer_repro_spec.cr
@@ -1,0 +1,38 @@
+require "../../func_spec.cr"
+
+# C# structural-lexer regression test.
+#
+# The shared line-based scanners in `csharp/common.cr` used to count `{`/`}`
+# and `(`/`)` over raw lines with no string masking, so:
+#   * a `}` inside a string literal truncated the method block, dropping every
+#     callee below it (here SecretHelperCall / AuditLog.Write / Ok /
+#     SerializeOrder were lost, only LoadTemplate survived), and
+#   * a `(` inside a string default value made the signature run away, dropping
+#     both parameters and the body's callees.
+# Routed through `Noir::CSharpLexer#masked_lines`, the counters now run over
+# code only and recover all of them.
+dirty = Endpoint.new("/api/Repro/dirty/{id}", "GET", [
+  Param.new("id", "", "path"),
+])
+dirty.push_callee(Callee.new("LoadTemplate", line: 14))
+dirty.push_callee(Callee.new("SecretHelperCall", line: 15))
+dirty.push_callee(Callee.new("AuditLog.Write", line: 16))
+dirty.push_callee(Callee.new("Ok", line: 17))
+dirty.push_callee(Callee.new("SerializeOrder", line: 17))
+
+calc = Endpoint.new("/api/Repro/calc", "GET", [
+  Param.new("expr", "", "query"),
+  Param.new("limit", "", "query"),
+])
+calc.push_callee(Callee.new("Ok", line: 27))
+calc.push_callee(Callee.new("Compute", line: 27))
+
+FunctionalTester.new("fixtures/csharp/lexer_repro/", {
+  :techs     => 1,
+  :endpoints => 2,
+}, [
+  dirty,
+  calc,
+], {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/miniparser/csharp_lexer_spec.cr
+++ b/spec/unit_test/miniparser/csharp_lexer_spec.cr
@@ -1,0 +1,88 @@
+require "../../spec_helper"
+require "../../../src/minilexers/csharp_lexer"
+
+describe Noir::CSharpLexer do
+  it "keeps the masked buffer aligned with the source length" do
+    src = "var v = @\"a \"\"b\"\" }\"; var r = \"\"\"raw } \"\"\"; c = '}';"
+    Noir::CSharpLexer.new(src).masked.size.should eq(src.size)
+  end
+
+  describe "string masking" do
+    it "blanks a `}` and `(` inside a regular string" do
+      src = "var j = T(\"a } b ( c\");"
+      m = Noir::CSharpLexer.new(src).masked_lines[0]
+      m.count('}').should eq(0)
+      m.count('(').should eq(1) # only the real T( paren survives
+      m.count(')').should eq(1)
+    end
+
+    it "handles verbatim strings (doubled quote escapes, backslash literal)" do
+      src = "var p = @\"C:\\temp \"\"q\"\" }x\"; ok();"
+      lex = Noir::CSharpLexer.new(src)
+      lex.in_code?(src.index!("}x")).should be_false
+      lex.in_code?(src.index!("ok")).should be_true
+    end
+
+    it "handles interpolated strings including a nested string in a hole" do
+      src = "var s = $\"id={foo(\"}\")}-end\"; after();"
+      lex = Noir::CSharpLexer.new(src)
+      lex.in_code?(src.index!("foo")).should be_false  # inside the interpolation
+      lex.in_code?(src.index!("after")).should be_true # the literal ended correctly
+    end
+
+    it "handles C# 11 raw string literals with a quote fence" do
+      src = "var r = \"\"\" a } \" \"\" }\"\" b \"\"\"; tail();"
+      lex = Noir::CSharpLexer.new(src)
+      lex.in_code?(src.index!("tail")).should be_true
+      lex.masked_lines[0].count('}').should eq(0)
+    end
+
+    it "blanks a char literal so a brace char is not counted" do
+      Noir::CSharpLexer.new("c = '}'; d = '\\''; e();").masked_lines[0].count('}').should eq(0)
+    end
+  end
+
+  describe "#matching_delimiter" do
+    it "closes a method block past a `}` inside a string" do
+      src = "{ var j = T(\"a } b\"); More(); }"
+      lex = Noir::CSharpLexer.new(src)
+      lex.matching_delimiter(src.index!('{')).should eq(src.size - 1)
+    end
+
+    it "does not let `/*/` self-close a block comment" do
+      src = "/*/ Route(\"x\") */ ok();"
+      lex = Noir::CSharpLexer.new(src)
+      lex.in_code?(src.index!("Route")).should be_false
+      lex.in_code?(src.index!("ok")).should be_true
+    end
+  end
+
+  describe "#masked_lines" do
+    it "matches String#lines element count and per-line length (incl. CRLF)" do
+      {"a\nb\n", "x\r\ny()\r\n", "p => Q(\"x;y\");\nN();", "only"}.each do |src|
+        raw = src.lines
+        ml = Noir::CSharpLexer.new(src).masked_lines
+        ml.size.should eq(raw.size)
+        raw.each_with_index { |l, i| ml[i].size.should eq(l.size) }
+      end
+    end
+  end
+
+  describe "#statement_end" do
+    it "ignores a `;` inside a string literal" do
+      src = "var x = T(\"a;b\"); next();"
+      lex = Noir::CSharpLexer.new(src)
+      src[0...lex.statement_end(0)].should eq("var x = T(\"a;b\");")
+    end
+  end
+
+  describe "#tokens" do
+    it "produces a structural stream with idents, punctuation and string spans" do
+      src = "app.MapGet(\"/x\", H);"
+      kinds = Noir::CSharpLexer.new(src).tokens.map(&.kind)
+      kinds.should eq([
+        :ident, :dot, :ident, :lparen, :string, :comma, :ident, :rparen, :semicolon,
+      ])
+    end
+  end
+end

--- a/spec/unit_test/miniparser/csharp_lexer_spec.cr
+++ b/spec/unit_test/miniparser/csharp_lexer_spec.cr
@@ -30,6 +30,16 @@ describe Noir::CSharpLexer do
       lex.in_code?(src.index!("after")).should be_true # the literal ended correctly
     end
 
+    it "skips nested verbatim/raw strings inside an interpolation hole" do
+      # The `}` inside the nested `@"…"` / `"""…"""` must not terminate the
+      # outer interpolated string early.
+      verbatim = "var s = $\"x{Path(@\"a\"\"}\"\"b\")}y\"; tail();"
+      Noir::CSharpLexer.new(verbatim).in_code?(verbatim.index!("tail")).should be_true
+
+      raw = "var s = $\"x{F(\"\"\"a}\"\" }\"\"\" )}y\"; done();"
+      Noir::CSharpLexer.new(raw).in_code?(raw.index!("done")).should be_true
+    end
+
     it "handles C# 11 raw string literals with a quote fence" do
       src = "var r = \"\"\" a } \" \"\" }\"\" b \"\"\"; tail();"
       lex = Noir::CSharpLexer.new(src)

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -50,12 +50,13 @@ module Analyzer::CSharp
       return [] of Param unless block.includes?("Bind(")
 
       params = [] of Param
+      masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
       lines.each_with_index do |line, index|
         next unless line.includes?("Bind(")
         next unless line.includes?("public") || line.includes?("private") || line.includes?("protected") || line.includes?("internal") || line.includes?("static")
 
-        _, end_idx = build_signature(lines, index)
-        body = extract_method_block(lines, end_idx)
+        _, end_idx = build_signature(lines, masked_lines, index)
+        body = extract_method_block(lines, masked_lines, end_idx)
         params.concat(extract_params_from_block(body))
       end
 
@@ -142,6 +143,7 @@ module Analyzer::CSharp
 
       controller_route = extract_controller_route(content)
       lines = content.lines
+      masked_lines = Noir::CSharpLexer.new(content).masked_lines
 
       http_method = "GET"
       action_route = ""
@@ -174,12 +176,12 @@ module Analyzer::CSharp
         end
 
         if in_class && potential_action_signature?(line)
-          signature, end_index = build_signature(lines, i)
+          signature, end_index = build_signature(lines, masked_lines, i)
           if !non_action_attribute && action_method?(signature, explicit_endpoint_attribute)
             action_name = extract_action_name(signature)
             unless action_name.empty?
               parameters = extract_parameters(signature, http_method)
-              body_block, body_line, skip_first = extract_callable_body(lines, end_index)
+              body_block, body_line, skip_first = extract_callable_body(lines, masked_lines, end_index)
               body_params = extract_params_from_block(body_block)
               parameters = merge_params(parameters, body_params, http_method)
               effective_action_route = action_route

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -71,6 +71,7 @@ module Analyzer::CSharp
       return unless content.includes?("Controller") && content.includes?("ActionResult")
 
       lines = content.lines
+      masked_lines = Noir::CSharpLexer.new(content).masked_lines
       controller_name = extract_controller_name(content)
       return if controller_name.empty?
 
@@ -113,7 +114,7 @@ module Analyzer::CSharp
 
         # Check for action method definition
         if line.includes?("public") && line.includes?("(") && (line.includes?("ActionResult") || explicit_endpoint_attribute)
-          signature, end_index = build_signature(lines, i)
+          signature, end_index = build_signature(lines, masked_lines, i)
           action_name = extract_action_name(signature)
           parameters = extract_parameters(signature, http_method)
 
@@ -122,7 +123,7 @@ module Analyzer::CSharp
             url = build_url(controller_route_prefix, action_route, controller_name, action_name)
             details = Details.new(PathInfo.new(file, i + 1))
             endpoint = Endpoint.new(url, http_method, details)
-            body_block = extract_method_block(lines, end_index)
+            body_block = extract_method_block(lines, masked_lines, end_index)
 
             parameters.each do |param|
               endpoint.params << param

--- a/src/analyzer/analyzers/csharp/carter.cr
+++ b/src/analyzer/analyzers/csharp/carter.cr
@@ -37,11 +37,12 @@ module Analyzer::CSharp
     end
 
     private def each_add_routes_block(lines : Array(String), &)
+      masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
       i = 0
       while i < lines.size
         line = lines[i]
         if add_routes_signature?(line)
-          _, end_index = build_signature(lines, i)
+          _, end_index = build_signature(lines, masked_lines, i)
           body_start = end_index
           block_lines, body_end = collect_method_body_lines(lines, body_start)
           yield block_lines, body_start
@@ -251,12 +252,13 @@ module Analyzer::CSharp
       return [] of Param unless block.includes?("Bind(") || block.includes?("BindAsync(")
 
       params = [] of Param
+      masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
       lines.each_with_index do |line, index|
         next unless line.includes?("Bind(") || line.includes?("BindAsync(")
         next unless line.includes?("public") || line.includes?("private") || line.includes?("protected") || line.includes?("internal") || line.includes?("static")
 
-        _, end_idx = build_signature(lines, index)
-        body = extract_method_block(lines, end_idx)
+        _, end_idx = build_signature(lines, masked_lines, index)
+        body = extract_method_block(lines, masked_lines, end_idx)
         params.concat(extract_params_from_block(body))
       end
 

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -1,4 +1,5 @@
 require "../../../miniparsers/csharp_callee_extractor"
+require "../../../minilexers/csharp_lexer"
 
 module Analyzer::CSharp::Common
   # Standard .NET test-source conventions:
@@ -69,14 +70,19 @@ module Analyzer::CSharp::Common
     SERVICE_TYPE_SUFFIXES.any? { |suffix| base.ends_with?(suffix) }
   end
 
-  protected def build_signature(lines : Array(String), start_index : Int32) : Tuple(String, Int32)
+  # `masked` is the string/comment-blanked twin of `lines` (from
+  # `CSharpLexer#masked_lines`). Delimiter counting runs over `masked` so a
+  # `(` inside a string default (`expr = "2 * (3 + 4"`) can't keep the paren
+  # counter open and run the signature away, while the returned text is built
+  # from the real `lines`.
+  protected def build_signature(lines : Array(String), masked : Array(String), start_index : Int32) : Tuple(String, Int32)
     signature = lines[start_index]
-    paren_count = signature.count('(') - signature.count(')')
+    paren_count = masked[start_index].count('(') - masked[start_index].count(')')
     index = start_index + 1
 
     while paren_count > 0 && index < lines.size
       signature += " " + lines[index]
-      paren_count += lines[index].count('(') - lines[index].count(')')
+      paren_count += masked[index].count('(') - masked[index].count(')')
       index += 1
     end
 
@@ -148,13 +154,17 @@ module Analyzer::CSharp::Common
   # close paren so an expression body (`(int id) => Repo.Find(id)`) doesn't
   # leak the call's own arguments into the parameter list.
   protected def extract_balanced_param_list(signature : String) : String?
-    open = signature.index('(')
+    # Count parens over the masked signature so a `(`/`)` inside a string
+    # default value doesn't unbalance the parameter-list bounds. The masked
+    # twin is character-aligned with `signature`, so the slice indices apply.
+    masked = Noir::CSharpLexer.new(signature).masked
+    open = masked.index('(')
     return unless open
 
     depth = 0
     i = open
-    while i < signature.size
-      case signature[i]
+    while i < masked.size
+      case masked[i]
       when '('
         depth += 1
       when ')'
@@ -166,7 +176,10 @@ module Analyzer::CSharp::Common
     nil
   end
 
-  protected def extract_method_block(lines : Array(String), start_index : Int32) : String
+  # Counts braces over `masked` (string/comment-blanked) so a `}` inside a
+  # string literal (`var json = T("a } b");`) can't terminate the block early
+  # and drop every callee below it. The emitted text comes from raw `lines`.
+  protected def extract_method_block(lines : Array(String), masked : Array(String), start_index : Int32) : String
     io = String::Builder.new
     brace = 0
     started = false
@@ -174,17 +187,18 @@ module Analyzer::CSharp::Common
 
     while index < lines.size
       line = lines[index]
-      brace += line.count('{') - line.count('}')
-      started ||= brace > 0 || line.includes?("{")
+      m = masked[index]
+      brace += m.count('{') - m.count('}')
+      started ||= brace > 0 || m.includes?("{")
       io << line
       io << '\n'
-      if started && brace <= 0 && line.includes?("}")
+      if started && brace <= 0 && m.includes?("}")
         break
       end
       # Expression-bodied member (`=> expr;`): there is no brace block, so the
       # statement terminator ends it. Without this guard the scanner would run
       # to end-of-file and swallow every following member.
-      if !started && line.includes?(";")
+      if !started && m.includes?(";")
         break
       end
       index += 1
@@ -198,30 +212,33 @@ module Analyzer::CSharp::Common
   # (`=> expr;`). Returns `{block, start_line_index, skip_first_line}` —
   # the caller passes `skip_first_line` through to the callee scanner so a
   # brace body's own declaration line isn't recorded as a self-callee.
-  protected def extract_callable_body(lines : Array(String), start_index : Int32) : Tuple(String, Int32, Bool)
+  protected def extract_callable_body(lines : Array(String), masked : Array(String), start_index : Int32) : Tuple(String, Int32, Bool)
     i = start_index
     while i < lines.size
-      line = lines[i]
-      if line.includes?("{")
+      m = masked[i]
+      if m.includes?("{")
         # Brace body: hand the `{`-line to the scanner with skip_first so
         # the method name on that line isn't recorded as its own callee.
-        return {extract_method_block(lines, i), i, true}
-      elsif arrow = line.index("=>")
+        return {extract_method_block(lines, masked, i), i, true}
+      elsif arrow = m.index("=>")
         # Expression body: crop everything up to and including `=>` on the
-        # first line, then read until the statement terminator.
+        # first line, then read until the statement terminator. Delimiter
+        # depth and the `;` terminator are read from `masked` so braces/parens
+        # and semicolons inside string literals don't end the body early.
         io = String::Builder.new
         depth = 0
         j = i
         while j < lines.size
           raw = lines[j]
+          mraw = masked[j]
           text = j == i ? raw[(arrow + 2)..]? || "" : raw
           io << text << '\n'
-          depth += raw.count('(') - raw.count(')') + raw.count('{') - raw.count('}')
-          break if depth <= 0 && raw.includes?(";")
+          depth += mraw.count('(') - mraw.count(')') + mraw.count('{') - mraw.count('}')
+          break if depth <= 0 && mraw.includes?(";")
           j += 1
         end
         return {io.to_s, i, false}
-      elsif line.includes?(";")
+      elsif m.includes?(";")
         # Abstract/interface declaration with no body.
         return {"", i, false}
       end

--- a/src/analyzer/analyzers/csharp/fastendpoints.cr
+++ b/src/analyzer/analyzers/csharp/fastendpoints.cr
@@ -162,10 +162,11 @@ module Analyzer::CSharp
 
     private def extract_configure_block(class_block : String) : String?
       lines = class_block.lines
+      masked_lines = Noir::CSharpLexer.new(class_block).masked_lines
       lines.each_with_index do |line, index|
         next unless line.includes?("Configure") && line.includes?("(") && line.includes?(")")
         next unless line.includes?("override") || line.includes?("public") || line.includes?("protected")
-        method_block = extract_method_block(lines, index)
+        method_block = extract_method_block(lines, masked_lines, index)
         return method_block
       end
       nil

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -241,12 +241,13 @@ module Analyzer::CSharp::MinimalApiSupport
     return [] of Param unless block.includes?("Bind(") || block.includes?("BindAsync(")
 
     params = [] of Param
+    masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
     lines.each_with_index do |line, index|
       next unless line.includes?("Bind(") || line.includes?("BindAsync(")
       next unless line.includes?("public") || line.includes?("private") || line.includes?("protected") || line.includes?("internal") || line.includes?("static")
 
-      _, end_idx = build_signature(lines, index)
-      body = extract_method_block(lines, end_idx)
+      _, end_idx = build_signature(lines, masked_lines, index)
+      body = extract_method_block(lines, masked_lines, end_idx)
       params.concat(extract_params_from_block(body))
     end
 
@@ -507,6 +508,7 @@ module Analyzer::CSharp::MinimalApiSupport
   # registration call itself and assignment/call sites.
   private def locate_method_definition(name : String, lines : Array(String)) : Tuple(String, String, Int32, Bool)?
     decl = /(?:public|private|internal|protected|static|async)\b[^;={(]*\b#{Regex.escape(name)}\s*\(/
+    masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
 
     lines.each_with_index do |line, idx|
       next unless line.includes?(name)
@@ -514,8 +516,8 @@ module Analyzer::CSharp::MinimalApiSupport
       # The `Map*("/x", Name)` line also references the handler — skip it.
       next if line.matches?(/\bMap(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
 
-      sig, end_idx = build_signature(lines, idx)
-      block, body_idx, skip_first = extract_callable_body(lines, end_idx)
+      sig, end_idx = build_signature(lines, masked_lines, idx)
+      block, body_idx, skip_first = extract_callable_body(lines, masked_lines, end_idx)
       return if block.empty?
       return {sig, block, body_idx + 1, skip_first}
     end
@@ -573,18 +575,19 @@ module Analyzer::CSharp::MinimalApiSupport
     end
     return [] of String unless def_idx
 
+    masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
     defline = lines[def_idx]
     name_pos = defline.index(/\b#{Regex.escape(type_name)}\b/)
     paren = defline.index('(', name_pos || 0)
     if name_pos && paren && paren > name_pos
-      return split_csharp_parameters(gather_balanced_parens(lines, def_idx, paren))
+      return split_csharp_parameters(gather_balanced_parens(lines, masked_lines, def_idx, paren))
     end
 
     defs = [] of String
     # Capture any binding attributes that precede the property (they may sit
     # on their own line, e.g. `[FromHeader(Name = "X-Tenant")]`) so the
     # member keeps its `header`/`query` classification and explicit name.
-    extract_method_block(lines, def_idx).scan(/((?:\[[^\]]*\]\s*)*)(?:public|internal)\s+([\w<>\[\]\?\.]+)\s+([A-Za-z_]\w*)\s*\{\s*get/) do |m|
+    extract_method_block(lines, masked_lines, def_idx).scan(/((?:\[[^\]]*\]\s*)*)(?:public|internal)\s+([\w<>\[\]\?\.]+)\s+([A-Za-z_]\w*)\s*\{\s*get/) do |m|
       attrs = m[1].gsub(/\s+/, " ").strip
       defs << "#{attrs} #{m[2].strip} #{m[3]}".strip
     end
@@ -593,21 +596,25 @@ module Analyzer::CSharp::MinimalApiSupport
 
   # Collects the text inside a parenthesised group that opens at `open_pos`
   # on `lines[start_index]`, spanning subsequent lines until balanced.
-  private def gather_balanced_parens(lines : Array(String), start_index : Int32, open_pos : Int32) : String
+  private def gather_balanced_parens(lines : Array(String), masked : Array(String), start_index : Int32, open_pos : Int32) : String
     io = String::Builder.new
     depth = 0
     i = start_index
     started = false
     while i < lines.size
       line = lines[i]
+      mline = masked[i]
       from = i == start_index ? open_pos : 0
       (from...line.size).each do |k|
+        # Count over the masked twin so a `(`/`)` inside a string default
+        # value (`prop = "f(x"`) can't unbalance the group; emit raw text.
+        mch = k < mline.size ? mline[k] : ' '
         ch = line[k]
-        if ch == '('
+        if mch == '('
           depth += 1
           started = true
           next if depth == 1
-        elsif ch == ')'
+        elsif mch == ')'
           depth -= 1
           return io.to_s if depth == 0
         end

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -611,17 +611,17 @@ module Analyzer::CSharp::MinimalApiSupport
       (from...line_chars.size).each do |k|
         # Count over the masked twin so a `(`/`)` inside a string default
         # value (`prop = "f(x"`) can't unbalance the group; emit raw text.
-        mch = k < mline_chars.size ? mline_chars[k] : ' '
-        ch = line_chars[k]
-        if mch == '('
+        masked_char = k < mline_chars.size ? mline_chars[k] : ' '
+        raw_char = line_chars[k]
+        if masked_char == '('
           depth += 1
           started = true
           next if depth == 1
-        elsif mch == ')'
+        elsif masked_char == ')'
           depth -= 1
           return io.to_s if depth == 0
         end
-        io << ch if started && depth >= 1
+        io << raw_char if started && depth >= 1
       end
       io << ' '
       break if started && depth <= 0

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -602,14 +602,17 @@ module Analyzer::CSharp::MinimalApiSupport
     i = start_index
     started = false
     while i < lines.size
-      line = lines[i]
-      mline = masked[i]
+      # Index over `Array(Char)` (O(1)) rather than `String#[](Int)`, which is
+      # O(n) per access on multi-byte lines and made this O(n^2) on long
+      # CJK signatures — the very regression the lexer work targets.
+      line_chars = lines[i].chars
+      mline_chars = masked[i].chars
       from = i == start_index ? open_pos : 0
-      (from...line.size).each do |k|
+      (from...line_chars.size).each do |k|
         # Count over the masked twin so a `(`/`)` inside a string default
         # value (`prop = "f(x"`) can't unbalance the group; emit raw text.
-        mch = k < mline.size ? mline[k] : ' '
-        ch = line[k]
+        mch = k < mline_chars.size ? mline_chars[k] : ' '
+        ch = line_chars[k]
         if mch == '('
           depth += 1
           started = true

--- a/src/minilexers/csharp_lexer.cr
+++ b/src/minilexers/csharp_lexer.cr
@@ -193,6 +193,16 @@ module Noir
       escaped = false
       while i < @size
         c = @chars[i]
+
+        # A string opening inside a `{ … }` interpolation hole is a nested
+        # string, NOT the end of the outer literal. Skip the whole nested
+        # literal — regular, verbatim `@"`, raw `"""`, or `$`-prefixed — so its
+        # quotes and braces can't change interp_depth or terminate early.
+        if interpolated && interp_depth > 0 && c == '"' && !escaped
+          i = mask_nested_hole_string(i)
+          next
+        end
+
         @masked << (c == '\n' ? '\n' : ' ')
         if escaped
           escaped = false
@@ -233,15 +243,9 @@ module Noir
           end
           interp_depth -= 1 if interp_depth > 0
         elsif c == '"'
-          if interp_depth == 0
-            i += 1
-            break
-          else
-            # A `"` inside a `{ }` interpolation hole opens a nested string;
-            # skip it so its quotes/braces don't end the outer literal.
-            i = skip_nested_string(i + 1)
-          end
-          next
+          # interp_depth == 0 here — the hole case is handled above.
+          i += 1
+          break
         end
 
         i += 1
@@ -282,15 +286,64 @@ module Noir
       @size
     end
 
-    # `start` is just past the nested opening `"`. Mask a regular string up to
-    # and including its closing quote; returns the index after it.
-    private def skip_nested_string(start : Int32) : Int32
-      i = start
+    # `quote_pos` is the opening `"` of a string nested inside an interpolation
+    # hole. Mask the whole nested literal (recognising a `@` verbatim prefix via
+    # lookbehind and a `"""` raw fence) and return the index just past it.
+    private def mask_nested_hole_string(quote_pos : Int32) : Int32
+      verbatim = quote_pos > 0 && @chars[quote_pos - 1] == '@'
+
+      run = 0
+      j = quote_pos
+      while j < @size && @chars[j] == '"'
+        run += 1
+        j += 1
+      end
+
+      if run >= 3 # raw nested string: close on the next run of `run` quotes
+        run.times { @masked << ' ' }
+        i = quote_pos + run
+        while i < @size
+          if @chars[i] == '"'
+            r = 0
+            while i + r < @size && @chars[i + r] == '"'
+              r += 1
+            end
+            if r >= run
+              run.times { @masked << ' ' }
+              return i + run
+            end
+            r.times { @masked << ' ' }
+            i += r
+          else
+            @masked << (@chars[i] == '\n' ? '\n' : ' ')
+            i += 1
+          end
+        end
+        return @size
+      end
+
+      if run == 2 && !verbatim # empty "" string
+        @masked << ' '
+        @masked << ' '
+        return quote_pos + 2
+      end
+
+      @masked << ' ' # opening quote
+      i = quote_pos + 1
       escaped = false
       while i < @size
         c = @chars[i]
         @masked << (c == '\n' ? '\n' : ' ')
-        if escaped
+        if verbatim
+          if c == '"'
+            if i + 1 < @size && @chars[i + 1] == '"'
+              @masked << ' ' # doubled (escaped) quote
+              i += 2
+              next
+            end
+            return i + 1
+          end
+        elsif escaped
           escaped = false
         elsif c == '\\'
           escaped = true

--- a/src/minilexers/csharp_lexer.cr
+++ b/src/minilexers/csharp_lexer.cr
@@ -1,0 +1,458 @@
+module Noir
+  # A single token produced by `CSharpLexer#tokens`. `start`/`end` are
+  # character indices into the original source (`end` exclusive); `line` is
+  # the 1-based line of `start`.
+  struct CSharpToken
+    getter kind : Symbol
+    getter value : String
+    getter start : Int32
+    getter end : Int32
+    getter line : Int32
+
+    def initialize(@kind : Symbol, @value : String, @start : Int32, @end : Int32, @line : Int32)
+    end
+
+    def to_s(io : IO) : Nil
+      io << @kind << '(' << @value << ')'
+    end
+  end
+
+  # CSharpLexer is a hand-rolled structural lexer for C# source, modelled on
+  # `Noir::PhpLexer`. The C# analyzers count `{`/`}`/`(`/`)` per line with no
+  # string awareness (`line.count('{') - line.count('}')`), so a single `}` or
+  # `(` inside a string literal truncates a method block (dropping callees) or
+  # makes a signature run away (dropping parameters). This lexer masks every
+  # non-code region in one linear pass so those counters can run over code only.
+  #
+  # Handles the C# string zoo:
+  #   * regular     `"…"`           backslash escapes
+  #   * verbatim    `@"…"`          `""` is an escaped quote, `\` is literal
+  #   * interpolated `$"…{expr}…"`  `{{`/`}}` are literal braces; a `"` inside a
+  #                                 `{ }` hole opens a nested string
+  #   * combined    `$@"…"` / `@$"…"`
+  #   * raw         `"""…"""`       (and `$"""…"""`) variable-length quote fence
+  #   * char        `'x'` / `'\}'` / `'"'`
+  #   * comments    `//…` and `/* … */`
+  #
+  # Every literal is masked to spaces (newlines preserved, length unchanged), so
+  # the structural helpers below are plain depth counters over `@masked`. The
+  # source is materialised once into an `Array(Char)` for O(1) indexing, keeping
+  # the scan O(n) on multi-byte (e.g. CJK-commented) source.
+  class CSharpLexer
+    getter masked : Array(Char)
+
+    @chars : Array(Char)
+    @size : Int32
+    @spans : Array(Tuple(Symbol, Int32, Int32))
+    @tokens : Array(CSharpToken)?
+    @skip_ranges : Array(Range(Int32, Int32))?
+    @masked_lines : Array(String)?
+
+    def initialize(source : String)
+      @chars = source.chars
+      @size = @chars.size
+      @masked = Array(Char).new(@size)
+      @spans = [] of Tuple(Symbol, Int32, Int32)
+      @tokens = nil
+      @skip_ranges = nil
+      @masked_lines = nil
+      scan
+    end
+
+    private def ident_char?(c : Char) : Bool
+      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
+    end
+
+    private def ident_start?(c : Char) : Bool
+      c == '_' || c.ascii_letter? || c.ord >= 0x80
+    end
+
+    private def scan
+      i = 0
+      while i < @size
+        c = @chars[i]
+        nxt = i + 1 < @size ? @chars[i + 1] : '\0'
+
+        if c == '/' && nxt == '/'
+          i = mask_line_comment(i)
+        elsif c == '/' && nxt == '*'
+          i = mask_block_comment(i)
+        elsif c == '\''
+          i = mask_char_literal(i)
+        elsif c == '"'
+          i = mask_string(i, i, false, false)
+        elsif c == '@' || c == '$'
+          i = dispatch_prefixed_string(i)
+        else
+          @masked << c
+          i += 1
+        end
+      end
+    end
+
+    # `@` and `$` may prefix a string (`@"`, `$"`, `$@"`, `@$"`) or be ordinary
+    # code (`@class` verbatim identifier, a stray `$`). Only treat the run as a
+    # string when a `"` follows it.
+    private def dispatch_prefixed_string(start : Int32) : Int32
+      j = start
+      verbatim = false
+      interpolated = false
+      while j < @size && (@chars[j] == '@' || @chars[j] == '$')
+        verbatim = true if @chars[j] == '@'
+        interpolated = true if @chars[j] == '$'
+        j += 1
+      end
+      if j < @size && @chars[j] == '"'
+        mask_string(start, j, verbatim, interpolated)
+      else
+        @masked << @chars[start]
+        start + 1
+      end
+    end
+
+    private def mask_line_comment(start : Int32) : Int32
+      i = start
+      while i < @size && @chars[i] != '\n'
+        @masked << ' '
+        i += 1
+      end
+      @spans << {:comment, start, i}
+      i
+    end
+
+    private def mask_block_comment(start : Int32) : Int32
+      # Blank the `/*` opener first, then scan for `*/` from after it so `/*/`
+      # is not mis-read as self-closing.
+      @masked << ' '
+      @masked << ' '
+      i = start + 2
+      while i < @size
+        if @chars[i] == '*' && i + 1 < @size && @chars[i + 1] == '/'
+          @masked << ' '
+          @masked << ' '
+          i += 2
+          break
+        end
+        @masked << (@chars[i] == '\n' ? '\n' : ' ')
+        i += 1
+      end
+      @spans << {:comment, start, i}
+      i
+    end
+
+    # `start` points at the opening `'`. Masks a char literal, honouring a
+    # single backslash escape (`'\''`, `'\\'`, `'\}'`).
+    private def mask_char_literal(start : Int32) : Int32
+      @masked << ' '
+      i = start + 1
+      escaped = false
+      while i < @size
+        c = @chars[i]
+        @masked << (c == '\n' ? '\n' : ' ')
+        if escaped
+          escaped = false
+        elsif c == '\\'
+          escaped = true
+        elsif c == '\''
+          i += 1
+          break
+        end
+        i += 1
+      end
+      @spans << {:string, start, i}
+      i
+    end
+
+    # `start` is the first prefix char (or the quote when unprefixed);
+    # `quote_pos` is the opening `"`. Dispatches to raw / verbatim / regular
+    # masking and records one `:string` span spanning the whole literal.
+    private def mask_string(start : Int32, quote_pos : Int32, verbatim : Bool, interpolated : Bool) : Int32
+      (start...quote_pos).each { @masked << ' ' }
+
+      unless verbatim
+        run = 0
+        j = quote_pos
+        while j < @size && @chars[j] == '"'
+          run += 1
+          j += 1
+        end
+        if run >= 3
+          return mask_raw_string(start, quote_pos, run)
+        end
+        if run == 2
+          @masked << ' '
+          @masked << ' '
+          @spans << {:string, start, quote_pos + 2}
+          return quote_pos + 2
+        end
+      end
+
+      @masked << ' ' # opening quote
+      i = quote_pos + 1
+      interp_depth = 0
+      escaped = false
+      while i < @size
+        c = @chars[i]
+        @masked << (c == '\n' ? '\n' : ' ')
+        if escaped
+          escaped = false
+          i += 1
+          next
+        end
+
+        if verbatim
+          if c == '"'
+            if i + 1 < @size && @chars[i + 1] == '"'
+              @masked << ' ' # the doubled (escaped) quote
+              i += 2
+              next
+            end
+            i += 1
+            break
+          end
+        else
+          if c == '\\'
+            escaped = true
+            i += 1
+            next
+          end
+        end
+
+        if interpolated && c == '{'
+          if i + 1 < @size && @chars[i + 1] == '{'
+            @masked << ' '
+            i += 2
+            next
+          end
+          interp_depth += 1
+        elsif interpolated && c == '}'
+          if i + 1 < @size && @chars[i + 1] == '}'
+            @masked << ' '
+            i += 2
+            next
+          end
+          interp_depth -= 1 if interp_depth > 0
+        elsif c == '"'
+          if interp_depth == 0
+            i += 1
+            break
+          else
+            # A `"` inside a `{ }` interpolation hole opens a nested string;
+            # skip it so its quotes/braces don't end the outer literal.
+            i = skip_nested_string(i + 1)
+          end
+          next
+        end
+
+        i += 1
+      end
+
+      @spans << {:string, start, i}
+      i
+    end
+
+    # Mask a C# 11 raw string literal: opened by `fence` quotes (>= 3), closed
+    # by the first run of `fence` quotes. Content (including `"`, `{`, `}`) is
+    # literal and fully masked.
+    private def mask_raw_string(start : Int32, quote_pos : Int32, fence : Int32) : Int32
+      fence.times { @masked << ' ' }
+      i = quote_pos + fence
+      while i < @size
+        if @chars[i] == '"'
+          run = 0
+          j = i
+          while j < @size && @chars[j] == '"'
+            run += 1
+            j += 1
+          end
+          if run >= fence
+            fence.times { @masked << ' ' }
+            i += fence
+            @spans << {:string, start, i}
+            return i
+          end
+          run.times { @masked << ' ' }
+          i += run
+        else
+          @masked << (@chars[i] == '\n' ? '\n' : ' ')
+          i += 1
+        end
+      end
+      @spans << {:string, start, @size}
+      @size
+    end
+
+    # `start` is just past the nested opening `"`. Mask a regular string up to
+    # and including its closing quote; returns the index after it.
+    private def skip_nested_string(start : Int32) : Int32
+      i = start
+      escaped = false
+      while i < @size
+        c = @chars[i]
+        @masked << (c == '\n' ? '\n' : ' ')
+        if escaped
+          escaped = false
+        elsif c == '\\'
+          escaped = true
+        elsif c == '"'
+          return i + 1
+        end
+        i += 1
+      end
+      i
+    end
+
+    # ---- structural helpers (character indices) ----------------------------
+
+    def matching_delimiter(open_pos : Int32) : Int32?
+      return unless 0 <= open_pos && open_pos < @size
+      open = @masked[open_pos]
+      close = case open
+              when '(' then ')'
+              when '[' then ']'
+              when '{' then '}'
+              else          return
+              end
+      depth = 0
+      i = open_pos
+      while i < @size
+        c = @masked[i]
+        if c == open
+          depth += 1
+        elsif c == close
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+      nil
+    end
+
+    # Index just after the top-level `;` at or after `start_pos`, or the source
+    # size when none is found.
+    def statement_end(start_pos : Int32) : Int32
+      paren = 0
+      bracket = 0
+      brace = 0
+      i = start_pos < 0 ? 0 : start_pos
+      while i < @size
+        case @masked[i]
+        when '(' then paren += 1
+        when ')' then paren -= 1 if paren > 0
+        when '[' then bracket += 1
+        when ']' then bracket -= 1 if bracket > 0
+        when '{' then brace += 1
+        when '}' then brace -= 1 if brace > 0
+        when ';'
+          return i + 1 if paren == 0 && bracket == 0 && brace == 0
+        end
+        i += 1
+      end
+      @size
+    end
+
+    def skip_ranges : Array(Range(Int32, Int32))
+      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
+    end
+
+    def in_code?(pos : Int32) : Bool
+      return false unless 0 <= pos && pos < @size
+      @spans.none? { |(_, s, e)| s <= pos && pos < e }
+    end
+
+    # The masked source split into lines, parallel to `source.lines`. Strings,
+    # comments and char literals are blanked, so the C# analyzers can run their
+    # existing per-line `line.count('{')` / `line.count('(')` counters over
+    # `masked_lines[i]` (structure) while emitting `lines[i]` (real text).
+    def masked_lines : Array(String)
+      @masked_lines ||= begin
+        # Mirror `String#lines` (chomp: drop the trailing empty segment when the
+        # source ends in `\n`) so masked_lines[i] aligns 1:1 with content.lines[i].
+        out = [] of String
+        line_start = 0
+        i = 0
+        while i < @size
+          if @chars[i] == '\n'
+            # Chomp the `\r` of a `\r\n` so each line matches `String#lines`.
+            finish = i > line_start && @chars[i - 1] == '\r' ? i - 1 : i
+            out << @masked[line_start...finish].join
+            line_start = i + 1
+          end
+          i += 1
+        end
+        out << @masked[line_start...@size].join if line_start < @size
+        out
+      end
+    end
+
+    # ---- token stream ------------------------------------------------------
+
+    def tokens : Array(CSharpToken)
+      @tokens ||= build_tokens
+    end
+
+    private def build_tokens : Array(CSharpToken)
+      result = [] of CSharpToken
+      span_idx = 0
+      spans = @spans
+      i = 0
+      line = 1
+      line_cursor = 0
+      line_for = ->(pos : Int32) do
+        while line_cursor < pos
+          line += 1 if @chars[line_cursor] == '\n'
+          line_cursor += 1
+        end
+        line
+      end
+
+      while i < @size
+        if span_idx < spans.size && spans[span_idx][1] == i
+          kind, s, e = spans[span_idx]
+          result << CSharpToken.new(kind, @chars[s...e].join, s, e, line_for.call(s))
+          span_idx += 1
+          i = e
+          next
+        end
+
+        c = @masked[i]
+        if c.ascii_whitespace?
+          i += 1
+        elsif ident_start?(c)
+          start = i
+          while i < @size && ident_char?(@masked[i])
+            i += 1
+          end
+          result << CSharpToken.new(:ident, @chars[start...i].join, start, i, line_for.call(start))
+        else
+          kind, len = punct_at(i)
+          if kind
+            result << CSharpToken.new(kind, @chars[i...i + len].join, i, i + len, line_for.call(i))
+            i += len
+          else
+            i += 1
+          end
+        end
+      end
+      result
+    end
+
+    private def punct_at(i : Int32) : Tuple(Symbol?, Int32)
+      c = @masked[i]
+      n = i + 1 < @size ? @masked[i + 1] : '\0'
+      case
+      when c == '=' && n == '>' then {:arrow, 2}
+      when c == '('             then {:lparen, 1}
+      when c == ')'             then {:rparen, 1}
+      when c == '['             then {:lbracket, 1}
+      when c == ']'             then {:rbracket, 1}
+      when c == '{'             then {:lbrace, 1}
+      when c == '}'             then {:rbrace, 1}
+      when c == ';'             then {:semicolon, 1}
+      when c == ','             then {:comma, 1}
+      when c == '.'             then {:dot, 1}
+      else                           {nil, 1}
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds **`Noir::CSharpLexer`** (the C# analogue of `Noir::PhpLexer`) and routes the shared line-based scanners in `csharp/common.cr` through it. This enriches C# callee/parameter extraction by counting structural delimiters over **code only**.

The shared scanners counted `{`/`}`/`(`/`)` over raw lines with no string awareness (`line.count('{') - line.count('}')`), so:
- a `}` inside a string literal made `extract_method_block` hit brace 0 early and **truncate the method body, dropping every callee below it**, and
- a `(` inside a string default made `build_signature` / `extract_balanced_param_list` / `gather_balanced_parens` run away, **dropping the whole parameter list**.

`Noir::CSharpLexer` masks every non-code region in one linear pass into an `Array(Char)` of the same length, handling the full C# string zoo:
- regular `"…"` (backslash escapes)
- verbatim `@"…"` (`""` escapes a quote, `\` is literal)
- interpolated `$"…{expr}…"` (with nested strings inside `{ }` holes, `{{`/`}}` literal)
- combined `$@"…"` / `@$"…"`
- C# 11 raw `"""…"""` (variable-length quote fence)
- char literals `'}'`, `'\''`, and `//` / `/* */` comments

It exposes `masked_lines` (1:1 with `String#lines`), `matching_delimiter`, `statement_end`, `skip_ranges`, `in_code?` and a token stream. `build_signature`, `extract_method_block`, `extract_callable_body`, `extract_balanced_param_list` and `gather_balanced_parens` now count over the masked twin (one lexer built per file, reused) while emitting the real text — so all 5 analyzers (aspnet_core_mvc / aspnet_mvc / carter / fastendpoints / minimal_api) are fixed at the shared layer.

## Measured impact (new `lexer_repro` fixture, before → after)

**Accuracy (FN reduction):**

| Endpoint | Metric | before | after |
|---|---|---|---|
| `GET /dirty/{id}` | callees | `[LoadTemplate]` | `[LoadTemplate, SecretHelperCall, AuditLog.Write, Ok, SerializeOrder]` |
| `GET /calc` | callees | `[]` | `[Ok, Compute]` |
| `GET /calc` | params | `[]` | `[expr, limit]` |

Net **+6 callees / +2 params** recovered (a `}`-in-string body truncation and a `(`-in-string signature runaway).

**Performance:** `extract_balanced_param_list`'s char scan was `O(n^2)` on multi-byte source (`String#[](Int)` is `O(n)` per access). Over the lexer's `Array(Char)` it is `O(n)`. On a 21 KB CJK signature the balanced-paren scan drops from **~149 ms to ~0.16 ms (~950×)**.

## Validation

- Full unit suite **2877** + all C# functional specs **589** (incl. **11** new lexer unit specs + the `lexer_repro` regression) green
- `ameba` + `crystal tool format --check` clean
- Alignment invariant (`masked.size == source.size`) fuzzed **0/5000** across all string forms

Sibling to the PHP lexer (#1855); the same design is queued for Scala next.