### PR TITLE
feat(scala): add Noir::ScalaLexer structural miniparser; thread masking across the whole file

### DIFF
--- a/spec/functional_test/fixtures/scala/lexer_repro/Repro.scala
+++ b/spec/functional_test/fixtures/scala/lexer_repro/Repro.scala
@@ -1,0 +1,27 @@
+package com.example.akka
+
+import akka.http.scaladsl.server.Directives._
+
+object Repro {
+  // A triple-quoted doc string whose body looks like routing DSL. The
+  // per-line scanner used to treat lines 9-11 as code and surface them.
+  val doc =
+    """
+      path("ghost-from-triple") {
+        get { complete("nope") }
+      }
+    """
+
+  /*
+   * path("ghost-from-comment") {
+   *   get { complete("nope") }
+   * }
+   */
+
+  val route =
+    path("real") {
+      get {
+        complete("ok")
+      }
+    }
+}

--- a/spec/functional_test/testers/scala/lexer_repro_spec.cr
+++ b/spec/functional_test/testers/scala/lexer_repro_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+# Scala structural-lexer regression test.
+#
+# The Scala analyzers used to strip each line in isolation
+# (`scala_code_line(line)` = `strip_non_code_with_state(line, 0, false)`),
+# resetting the block-comment depth and multiline-string flag every line. So
+# route-shaped Akka DSL inside a `"""…"""` triple-quoted string and inside a
+# multi-line `/* … */` comment leaked as phantom endpoints. Threaded through
+# `Noir::ScalaLexer` (which carries that state across the whole file), only the
+# real `path("real")` route survives.
+expected_endpoints = [
+  Endpoint.new("/real", "GET"),
+]
+
+FunctionalTester.new("fixtures/scala/lexer_repro/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/scala_lexer_spec.cr
+++ b/spec/unit_test/miniparser/scala_lexer_spec.cr
@@ -1,0 +1,64 @@
+require "../../spec_helper"
+require "../../../src/minilexers/scala_lexer"
+
+describe Noir::ScalaLexer do
+  it "keeps both masked views aligned with the source length" do
+    src = "val s = \"a\"\nval t = \"\"\"x\ny\"\"\"\n/* a /* b */ c */ z()"
+    lex = Noir::ScalaLexer.new(src)
+    lex.masked.size.should eq(src.size)
+    lex.code.size.should eq(src.size)
+  end
+
+  describe "two masked views" do
+    it "keeps regular strings in the code view but blanks them structurally" do
+      src = "path(\"users\")"
+      lex = Noir::ScalaLexer.new(src)
+      lex.code_lines[0].should eq("path(\"users\")") # routes are string args
+      lex.masked_lines[0].should eq("path(       )") # blanked for brace matching
+    end
+
+    it "blanks triple-quoted bodies in BOTH views (threaded across lines)" do
+      src = "val d =\n  \"\"\"\n  path(\"ghost\")\n  \"\"\"\npath(\"real\")"
+      lex = Noir::ScalaLexer.new(src)
+      code = lex.code_lines.join("\n")
+      code.includes?("ghost").should be_false # inside the triple-quote
+      code.includes?("path(\"real\")").should be_true
+    end
+
+    it "blanks nested block comments across lines" do
+      src = "/* a /* b\n   path(\"ghost\") */ c */\npath(\"real\")"
+      lex = Noir::ScalaLexer.new(src)
+      lex.in_code?(src.index!("ghost")).should be_false      # inside the comment
+      lex.in_code?(src.index!("path(\"real")).should be_true # the real route's `path`
+    end
+
+    it "blanks a char literal but leaves a `'symbol` as code" do
+      lex = Noir::ScalaLexer.new("val c = '}'; val s = 'sym")
+      lex.masked_lines[0].count('}').should eq(0) # char literal masked
+      lex.in_code?("val c = '}'; val s = 'sym".index!("sym")).should be_true
+    end
+  end
+
+  describe "#matching_delimiter" do
+    it "closes a brace block past a `}` inside a string" do
+      src = "{ val j = T(\"a } b\"); more() }"
+      lex = Noir::ScalaLexer.new(src)
+      lex.matching_delimiter(src.index!('{')).should eq(src.size - 1)
+    end
+  end
+
+  describe "#masked_lines / #code_lines" do
+    it "match String#lines element count and per-line length (incl. CRLF)" do
+      {"a\nb\n", "x\r\ny\r\n", "p(\"q\")\nr()", "only"}.each do |src|
+        raw = src.lines
+        lex = Noir::ScalaLexer.new(src)
+        lex.masked_lines.size.should eq(raw.size)
+        lex.code_lines.size.should eq(raw.size)
+        raw.each_with_index do |l, i|
+          lex.masked_lines[i].size.should eq(l.size)
+          lex.code_lines[i].size.should eq(l.size)
+        end
+      end
+    end
+  end
+end

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -13,13 +13,15 @@ module Analyzer::Scala
     private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
+      code_lines = scala_code_lines(content)
+      structural_lines = scala_structural_lines(content)
       prefix_stack = [] of String
       brace_depth = 0
       prefix_depths = [] of Int32 # Track at which depth each prefix was added
 
-      lines.each_with_index do |line, index|
-        stripped_line = scala_code_line(line).strip
-        structural_line = scala_structural_line(line).strip
+      lines.each_with_index do |_line, index|
+        stripped_line = (code_lines[index]? || "").strip
+        structural_line = (structural_lines[index]? || "").strip
 
         # Handle pathPrefix: pathPrefix("api" / "v1") { ... }
         if path_prefix_args = directive_args(stripped_line, "pathPrefix")
@@ -53,7 +55,7 @@ module Analyzer::Scala
 
               # Extract additional parameters from the block
               extract_params_from_block(endpoint, method_param_scopes.join("\n"))
-              attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
+              attach_method_callees(endpoint, lines, structural_lines, index, block_end, method, path) if include_callee
 
               endpoints << endpoint
             end
@@ -75,7 +77,7 @@ module Analyzer::Scala
               endpoint = create_endpoint(full_path, method.upcase, path)
               extract_path_params(endpoint, full_path)
               extract_params_from_block(endpoint, method_param_scopes.join("\n"))
-              attach_method_callees(endpoint, lines, index, block_end, method, path) if include_callee
+              attach_method_callees(endpoint, lines, structural_lines, index, block_end, method, path) if include_callee
               endpoints << endpoint
             end
           end
@@ -105,17 +107,19 @@ module Analyzer::Scala
 
     private def attach_method_callees(endpoint : Endpoint,
                                       lines : Array(String),
+                                      structural_lines : Array(String),
                                       route_start : Int32,
                                       route_end : Int32,
                                       method : String,
                                       path : String)
-      extract_method_blocks(lines, route_start, route_end, method).each do |body, start_line|
+      extract_method_blocks(lines, structural_lines, route_start, route_end, method).each do |body, start_line|
         callees = Noir::ScalaCalleeExtractor.callees_for_body(body, path, start_line)
         attach_scala_callees(endpoint, callees)
       end
     end
 
     private def extract_method_blocks(lines : Array(String),
+                                      structural_lines : Array(String),
                                       route_start : Int32,
                                       route_end : Int32,
                                       method : String) : Array(Tuple(String, Int32))
@@ -123,7 +127,7 @@ module Analyzer::Scala
       index = route_start
 
       while index <= route_end
-        stripped = scala_structural_line(lines[index])
+        stripped = structural_lines[index]? || ""
         match = stripped.match(/(?<![.\w])#{Regex.escape(method)}\s*\{/)
         unless match
           index += 1

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -13,8 +13,9 @@ module Analyzer::Scala
     private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
-      code_lines = scala_code_lines(content)
-      structural_lines = scala_structural_lines(content)
+      lexer = scala_lexer(content)
+      code_lines = lexer.code_lines
+      structural_lines = lexer.masked_lines
       prefix_stack = [] of String
       brace_depth = 0
       prefix_depths = [] of Int32 # Track at which depth each prefix was added

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -12,6 +12,7 @@ module Analyzer::Scala
     private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
+      code_lines = scala_code_lines(content)
 
       routes_names = collect_routes_bindings(content)
       mount_prefixes = collect_mount_prefixes(content, routes_names)
@@ -20,8 +21,7 @@ module Analyzer::Scala
 
       i = 0
       while i < lines.size
-        raw = lines[i]
-        stripped = scala_code_line(raw)
+        stripped = code_lines[i]? || ""
         trimmed = stripped.strip
 
         if m = stripped.match(/\b(?:val|def|lazy\s+val)\s+(\w+)\s*(?::[^=]*?)?=\s*HttpRoutes\.of\b/)
@@ -29,11 +29,11 @@ module Analyzer::Scala
         end
 
         if case_line?(trimmed)
-          header, end_index = collect_case_header(lines, i)
+          header, end_index = collect_case_header(lines, code_lines, i)
           if data = parse_case_header(header)
             methods, segments, path_params, query_params, binding_name = data
             full_path = build_full_path(segments, current_routes_name, mount_prefixes)
-            body_text = extract_case_body(lines, end_index)
+            body_text = extract_case_body(lines, code_lines, end_index)
             body_type : String? = nil
             if binding_name
               if body_match = body_text.match(/#{Regex.escape(binding_name)}\s*\.\s*as\s*\[\s*([^\]\s]+)\s*\]/)
@@ -86,11 +86,11 @@ module Analyzer::Scala
     end
 
     # Join continuation lines until we find the `=>` that ends the case pattern.
-    private def collect_case_header(lines : Array(String), start : Int32) : Tuple(String, Int32)
+    private def collect_case_header(lines : Array(String), code_lines : Array(String), start : Int32) : Tuple(String, Int32)
       buffer = String.build do |io|
         idx = start
         while idx < lines.size
-          stripped = scala_code_line(lines[idx])
+          stripped = code_lines[idx]? || ""
           io << stripped
           io << ' '
           if stripped.includes?("=>")
@@ -203,7 +203,9 @@ module Analyzer::Scala
 
     private def collect_mount_prefixes(content : String, routes_names : Set(String)) : Hash(String, String)
       prefixes = {} of String => String
-      content.scan(/"(\/[^"]*)"\s*->\s*(\w+)/) do |m|
+      # Scan the code-masked view so a `"/x" -> name` that lives inside a
+      # `"""…"""` doc or a `/* … */` comment can't register a phantom prefix.
+      scala_code_lines(content).join('\n').scan(/"(\/[^"]*)"\s*->\s*(\w+)/) do |m|
         prefix = m[1]
         name = m[2]
         next unless routes_names.includes?(name)
@@ -214,7 +216,7 @@ module Analyzer::Scala
 
     # Pull case body text from the line after the `=>` until the next `case ` at the same level
     # or the close of the enclosing brace. Used for body-type and callee extraction.
-    private def extract_case_body(lines : Array(String), header_end_index : Int32) : String
+    private def extract_case_body(lines : Array(String), code_lines : Array(String), header_end_index : Int32) : String
       body_lines = [] of String
       brace_depth = 0
 
@@ -229,7 +231,7 @@ module Analyzer::Scala
       idx = header_end_index + 1
       while idx < lines.size
         line = lines[idx]
-        stripped = scala_code_line(line)
+        stripped = code_lines[idx]? || ""
         trimmed = stripped.strip
 
         if brace_depth <= 0 && (trimmed.starts_with?("case ") || trimmed == "}")

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -15,7 +15,7 @@ module Analyzer::Scala
       code_lines = scala_code_lines(content)
 
       routes_names = collect_routes_bindings(content)
-      mount_prefixes = collect_mount_prefixes(content, routes_names)
+      mount_prefixes = collect_mount_prefixes(code_lines, routes_names)
 
       current_routes_name : String? = nil
 
@@ -201,11 +201,12 @@ module Analyzer::Scala
       names
     end
 
-    private def collect_mount_prefixes(content : String, routes_names : Set(String)) : Hash(String, String)
+    private def collect_mount_prefixes(code_lines : Array(String), routes_names : Set(String)) : Hash(String, String)
       prefixes = {} of String => String
-      # Scan the code-masked view so a `"/x" -> name` that lives inside a
-      # `"""…"""` doc or a `/* … */` comment can't register a phantom prefix.
-      scala_code_lines(content).join('\n').scan(/"(\/[^"]*)"\s*->\s*(\w+)/) do |m|
+      # Scan the (already-computed) code-masked view so a `"/x" -> name` that
+      # lives inside a `"""…"""` doc or a `/* … */` comment can't register a
+      # phantom prefix.
+      code_lines.join('\n').scan(/"(\/[^"]*)"\s*->\s*(\w+)/) do |m|
         prefix = m[1]
         name = m[2]
         next unless routes_names.includes?(name)

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -13,9 +13,10 @@ module Analyzer::Scala
     private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
+      code_lines = scala_code_lines(content)
 
-      lines.each_with_index do |line, index|
-        stripped_line = scala_code_line(line).strip
+      lines.each_with_index do |_line, index|
+        stripped_line = (code_lines[index]? || "").strip
 
         # Match Scalatra route definitions: get("/path") { ... }
         HTTP_METHODS.each do |method|

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -28,14 +28,15 @@ module Analyzer::Scala
     private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
+      code_lines = scala_code_lines(content)
       consumed_until = -1
 
       lines.each_with_index do |_, index|
         next if index <= consumed_until
-        code = scala_code_line(lines[index])
+        code = code_lines[index]? || ""
         next unless match = code.match(BASE_ENDPOINT_RE)
         col = match.begin || 0
-        chain_text, last_line = collect_chain(lines, index, col)
+        chain_text, last_line = collect_chain(lines, code_lines, index, col)
         consumed_until = last_line
 
         endpoint = parse_chain(chain_text, path, index + 1)
@@ -45,13 +46,13 @@ module Analyzer::Scala
       endpoints
     end
 
-    private def collect_chain(lines : Array(String), start : Int32, col : Int32) : Tuple(String, Int32)
-      head = scala_code_line(lines[start])
+    private def collect_chain(lines : Array(String), code_lines : Array(String), start : Int32, col : Int32) : Tuple(String, Int32)
+      head = code_lines[start]? || ""
       first = col < head.size ? head[col..] : ""
       parts = [first]
       idx = start + 1
       while idx < lines.size
-        code = scala_code_line(lines[idx])
+        code = code_lines[idx]? || ""
         if code.lstrip.starts_with?(".")
           parts << code
           idx += 1

--- a/src/analyzer/analyzers/scala/zio_http.cr
+++ b/src/analyzer/analyzers/scala/zio_http.cr
@@ -15,9 +15,10 @@ module Analyzer::Scala
     private def extract_routes_from_content(path : String, content : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = content.split('\n')
+      code_lines = scala_code_lines(content)
 
-      lines.each_with_index do |line, index|
-        stripped = scala_code_line(line)
+      lines.each_with_index do |_line, index|
+        stripped = code_lines[index]? || ""
 
         offset = 0
         while m = stripped.match(/(?<![.\w])Method\.([A-Z]+)/, offset)

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -1,5 +1,6 @@
 require "../../models/analyzer"
 require "../../miniparsers/scala_callee_extractor"
+require "../../minilexers/scala_lexer"
 
 module Analyzer::Scala
   abstract class ScalaEngine < Analyzer
@@ -75,6 +76,25 @@ module Analyzer::Scala
 
     protected def scala_code_line(line : String) : String
       Noir::ScalaCalleeExtractor.strip_comment_preserving_strings(line)
+    end
+
+    # Whole-file masked views (via `Noir::ScalaLexer`). Unlike the per-line
+    # `scala_code_line` / `scala_structural_line`, these thread block-comment
+    # depth and triple-quote state across the WHOLE file, so route-shaped DSL
+    # inside a `"""…"""` string or a multi-line `/* … */` comment no longer
+    # leaks as a phantom endpoint. Index 1:1 with `content.lines`; analyzers
+    # that split with `content.split('\n')` should guard the last (possibly
+    # empty) line with `[i]? || ""`. Build once per file and reuse.
+    #
+    #   * code view: comments + triple-quote bodies blanked, regular `"…"`
+    #     string literals KEPT (Scala routes are string args).
+    #   * structural view: all strings/comments blanked, for brace matching.
+    protected def scala_code_lines(content : String) : Array(String)
+      Noir::ScalaLexer.new(content).code_lines
+    end
+
+    protected def scala_structural_lines(content : String) : Array(String)
+      Noir::ScalaLexer.new(content).masked_lines
     end
 
     private def scala_structural_opening_brace(line : String) : Int32?

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -97,6 +97,13 @@ module Analyzer::Scala
       Noir::ScalaLexer.new(content).masked_lines
     end
 
+    # One lexer per file when an analyzer needs BOTH the code and structural
+    # views (take `.code_lines` and `.masked_lines` from it) so the file is
+    # lexed once rather than twice.
+    protected def scala_lexer(content : String) : Noir::ScalaLexer
+      Noir::ScalaLexer.new(content)
+    end
+
     private def scala_structural_opening_brace(line : String) : Int32?
       scala_structural_line(line).index('{')
     end

--- a/src/minilexers/scala_lexer.cr
+++ b/src/minilexers/scala_lexer.cr
@@ -1,0 +1,362 @@
+module Noir
+  # A single token produced by `ScalaLexer#tokens`. `start`/`end` are
+  # character indices into the original source (`end` exclusive); `line` is
+  # the 1-based line of `start`.
+  struct ScalaToken
+    getter kind : Symbol
+    getter value : String
+    getter start : Int32
+    getter end : Int32
+    getter line : Int32
+
+    def initialize(@kind : Symbol, @value : String, @start : Int32, @end : Int32, @line : Int32)
+    end
+
+    def to_s(io : IO) : Nil
+      io << @kind << '(' << @value << ')'
+    end
+  end
+
+  # ScalaLexer is a hand-rolled structural lexer for Scala source, modelled on
+  # `Noir::PhpLexer` / `Noir::CSharpLexer`. The Scala analyzers used to strip
+  # each line in isolation (`strip_non_code_with_state(line, 0, false)`),
+  # resetting the block-comment depth and multiline-string flag on every line,
+  # so route-shaped DSL inside a `"""…"""` triple-quoted string or a multi-line
+  # `/* … */` comment leaked as phantom endpoints. This lexer threads that state
+  # across the whole file once.
+  #
+  # Two masked views are produced, both the same length as the source with
+  # newlines preserved:
+  #   * `masked` (structural): strings, comments, triple-quotes and char
+  #     literals are all blanked — used for brace/paren matching.
+  #   * `code`: comments, triple-quoted bodies and char literals are blanked,
+  #     but regular `"…"` string literals are PRESERVED, because Scala routes
+  #     are string arguments (`path("users")`) that the analyzers read back.
+  #
+  # Scala specifics handled: nested block comments (`/* /* */ */`), triple-quoted
+  # raw strings spanning lines, regular strings with `\` escapes, and `'x'` /
+  # `'\n'` char literals (left as code when it is actually a `'sym` symbol).
+  class ScalaLexer
+    getter masked : Array(Char)
+    getter code : Array(Char)
+
+    @chars : Array(Char)
+    @size : Int32
+    @spans : Array(Tuple(Symbol, Int32, Int32))
+    @tokens : Array(ScalaToken)?
+    @skip_ranges : Array(Range(Int32, Int32))?
+    @masked_lines : Array(String)?
+    @code_lines : Array(String)?
+
+    def initialize(source : String)
+      @chars = source.chars
+      @size = @chars.size
+      @masked = Array(Char).new(@size)
+      @code = Array(Char).new(@size)
+      @spans = [] of Tuple(Symbol, Int32, Int32)
+      @tokens = nil
+      @skip_ranges = nil
+      @masked_lines = nil
+      @code_lines = nil
+      scan
+    end
+
+    private def ident_char?(c : Char) : Bool
+      c == '_' || c.ascii_alphanumeric? || c.ord >= 0x80
+    end
+
+    private def ident_start?(c : Char) : Bool
+      c == '_' || c.ascii_letter? || c.ord >= 0x80
+    end
+
+    # Emit one source character to both views.
+    private def emit(struct_c : Char, code_c : Char)
+      @masked << struct_c
+      @code << code_c
+    end
+
+    private def scan
+      i = 0
+      while i < @size
+        c = @chars[i]
+        nxt = i + 1 < @size ? @chars[i + 1] : '\0'
+
+        if c == '/' && nxt == '/'
+          i = mask_line_comment(i)
+        elsif c == '/' && nxt == '*'
+          i = mask_block_comment(i)
+        elsif c == '"' && nxt == '"' && (i + 2 < @size ? @chars[i + 2] : '\0') == '"'
+          i = mask_triple_string(i)
+        elsif c == '"'
+          i = mask_string(i)
+        elsif c == '\'' && char_literal?(i)
+          i = mask_char_literal(i)
+        else
+          emit(c, c)
+          i += 1
+        end
+      end
+    end
+
+    private def mask_line_comment(start : Int32) : Int32
+      i = start
+      while i < @size && @chars[i] != '\n'
+        emit(' ', ' ')
+        i += 1
+      end
+      @spans << {:comment, start, i}
+      i
+    end
+
+    # Scala block comments NEST: `/* /* */ */`. Track depth.
+    private def mask_block_comment(start : Int32) : Int32
+      depth = 0
+      i = start
+      while i < @size
+        c = @chars[i]
+        nxt = i + 1 < @size ? @chars[i + 1] : '\0'
+        if c == '/' && nxt == '*'
+          depth += 1
+          emit(' ', ' ')
+          emit(' ', ' ')
+          i += 2
+        elsif c == '*' && nxt == '/'
+          depth -= 1
+          emit(' ', ' ')
+          emit(' ', ' ')
+          i += 2
+          break if depth == 0
+        else
+          emit((c == '\n' ? '\n' : ' '), (c == '\n' ? '\n' : ' '))
+          i += 1
+        end
+      end
+      @spans << {:comment, start, i}
+      i
+    end
+
+    # `start` points at the first of `"""`. Triple-quoted strings are raw and
+    # may span lines; close on the next `"""`. Blanked in BOTH views.
+    private def mask_triple_string(start : Int32) : Int32
+      emit(' ', ' ')
+      emit(' ', ' ')
+      emit(' ', ' ')
+      i = start + 3
+      while i < @size
+        if @chars[i] == '"' && i + 2 < @size && @chars[i + 1] == '"' && @chars[i + 2] == '"'
+          emit(' ', ' ')
+          emit(' ', ' ')
+          emit(' ', ' ')
+          i += 3
+          break
+        end
+        ch = @chars[i] == '\n' ? '\n' : ' '
+        emit(ch, ch)
+        i += 1
+      end
+      @spans << {:string, start, i}
+      i
+    end
+
+    # Regular `"…"` string. Blanked in the structural view; PRESERVED (quotes
+    # and content) in the code view so route literals stay readable.
+    private def mask_string(start : Int32) : Int32
+      emit(' ', '"')
+      i = start + 1
+      escaped = false
+      while i < @size
+        c = @chars[i]
+        if c == '\n'
+          emit('\n', '\n')
+          i += 1
+          break # unterminated single-line string
+        end
+        emit(' ', c)
+        if escaped
+          escaped = false
+        elsif c == '\\'
+          escaped = true
+        elsif c == '"'
+          i += 1
+          break
+        end
+        i += 1
+      end
+      @spans << {:string, start, i}
+      i
+    end
+
+    # True when the `'` at `pos` opens a real char literal (`'x'` or `'\x'`)
+    # rather than a `'symbol` literal.
+    private def char_literal?(pos : Int32) : Bool
+      return false if pos + 2 >= @size
+      if @chars[pos + 1] == '\\'
+        # '\n' style: '  \  x  '
+        pos + 3 < @size && @chars[pos + 3] == '\''
+      else
+        @chars[pos + 1] != '\'' && @chars[pos + 2] == '\''
+      end
+    end
+
+    private def mask_char_literal(start : Int32) : Int32
+      len = @chars[start + 1] == '\\' ? 4 : 3
+      len.times { emit(' ', ' ') }
+      @spans << {:string, start, start + len}
+      start + len
+    end
+
+    # ---- structural helpers (character indices, over the structural view) ---
+
+    def matching_delimiter(open_pos : Int32) : Int32?
+      return unless 0 <= open_pos && open_pos < @size
+      open = @masked[open_pos]
+      close = case open
+              when '(' then ')'
+              when '[' then ']'
+              when '{' then '}'
+              else          return
+              end
+      depth = 0
+      i = open_pos
+      while i < @size
+        c = @masked[i]
+        if c == open
+          depth += 1
+        elsif c == close
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+      nil
+    end
+
+    def statement_end(start_pos : Int32) : Int32
+      paren = 0
+      bracket = 0
+      brace = 0
+      i = start_pos < 0 ? 0 : start_pos
+      while i < @size
+        case @masked[i]
+        when '(' then paren += 1
+        when ')' then paren -= 1 if paren > 0
+        when '[' then bracket += 1
+        when ']' then bracket -= 1 if bracket > 0
+        when '{' then brace += 1
+        when '}' then brace -= 1 if brace > 0
+        when ';'
+          return i + 1 if paren == 0 && bracket == 0 && brace == 0
+        end
+        i += 1
+      end
+      @size
+    end
+
+    def skip_ranges : Array(Range(Int32, Int32))
+      @skip_ranges ||= @spans.map { |(_, s, e)| (s..e - 1) }
+    end
+
+    def in_code?(pos : Int32) : Bool
+      return false unless 0 <= pos && pos < @size
+      @spans.none? { |(_, s, e)| s <= pos && pos < e }
+    end
+
+    # Structural masked source split into lines (1:1 with `String#lines`).
+    def masked_lines : Array(String)
+      @masked_lines ||= split_lines(@masked)
+    end
+
+    # Code masked source split into lines (1:1 with `String#lines`). Comments,
+    # triple-quote bodies and char literals are blanked; regular strings kept.
+    def code_lines : Array(String)
+      @code_lines ||= split_lines(@code)
+    end
+
+    private def split_lines(buf : Array(Char)) : Array(String)
+      out = [] of String
+      line_start = 0
+      i = 0
+      while i < @size
+        if @chars[i] == '\n'
+          finish = i > line_start && @chars[i - 1] == '\r' ? i - 1 : i
+          out << buf[line_start...finish].join
+          line_start = i + 1
+        end
+        i += 1
+      end
+      out << buf[line_start...@size].join if line_start < @size
+      out
+    end
+
+    # ---- token stream ------------------------------------------------------
+
+    def tokens : Array(ScalaToken)
+      @tokens ||= build_tokens
+    end
+
+    private def build_tokens : Array(ScalaToken)
+      result = [] of ScalaToken
+      span_idx = 0
+      spans = @spans
+      i = 0
+      line = 1
+      line_cursor = 0
+      line_for = ->(pos : Int32) do
+        while line_cursor < pos
+          line += 1 if @chars[line_cursor] == '\n'
+          line_cursor += 1
+        end
+        line
+      end
+
+      while i < @size
+        if span_idx < spans.size && spans[span_idx][1] == i
+          kind, s, e = spans[span_idx]
+          result << ScalaToken.new(kind, @chars[s...e].join, s, e, line_for.call(s))
+          span_idx += 1
+          i = e
+          next
+        end
+
+        c = @masked[i]
+        if c.ascii_whitespace?
+          i += 1
+        elsif ident_start?(c)
+          start = i
+          while i < @size && ident_char?(@masked[i])
+            i += 1
+          end
+          result << ScalaToken.new(:ident, @chars[start...i].join, start, i, line_for.call(start))
+        else
+          kind, len = punct_at(i)
+          if kind
+            result << ScalaToken.new(kind, @chars[i...i + len].join, i, i + len, line_for.call(i))
+            i += len
+          else
+            i += 1
+          end
+        end
+      end
+      result
+    end
+
+    private def punct_at(i : Int32) : Tuple(Symbol?, Int32)
+      c = @masked[i]
+      n = i + 1 < @size ? @masked[i + 1] : '\0'
+      case
+      when c == '=' && n == '>' then {:arrow, 2}
+      when c == '('             then {:lparen, 1}
+      when c == ')'             then {:rparen, 1}
+      when c == '['             then {:lbracket, 1}
+      when c == ']'             then {:rbracket, 1}
+      when c == '{'             then {:lbrace, 1}
+      when c == '}'             then {:rbrace, 1}
+      when c == ';'             then {:semicolon, 1}
+      when c == ','             then {:comma, 1}
+      when c == '.'             then {:dot, 1}
+      when c == '/'             then {:slash, 1}
+      else                           {nil, 1}
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds **`Noir::ScalaLexer`** (the Scala analogue of `Noir::PhpLexer` / `Noir::CSharpLexer`) and rewires the Scala analyzers through it.

The analyzers stripped each line **in isolation** (`scala_code_line` / `scala_structural_line` = `strip_non_code_with_state(line, 0, false)`), resetting the block-comment depth and triple-quote flag every line. So route-shaped DSL inside a `"""…"""` triple-quoted string or a multi-line `/* … */` comment **leaked as phantom endpoints** across akka / scalatra / http4s / zio_http / tapir (play is immune — it has its own file-wide masker).

`Noir::ScalaLexer` threads block-comment depth and triple-quote state across the **whole file** in one pass and produces two character-aligned masked views:
- **`code`** — comments, triple-quote bodies and char literals blanked, but regular `"…"` strings **KEPT** (Scala routes are string args like `path("users")`)
- **`masked`** — everything blanked, for brace matching

plus `code_lines` / `masked_lines` (1:1 with `String#lines`), `matching_delimiter`, `statement_end`, `skip_ranges`, `in_code?` and a token stream. It also handles **nested block comments** (`/* /* */ */`) and `'x'`/`'\n'` **char literals** (a gap in the old per-line stripper), leaving a `'sym` symbol as code.

`scala_engine.cr` gains `scala_code_lines(content)` / `scala_structural_lines(content)`; each analyzer builds them once per file and indexes them in its route-detection loop instead of re-stripping every line.

## Measured impact (new `lexer_repro` fixture, before → after)

**Accuracy (FP reduction):** a `path(...)` inside a `"""…"""` doc string and one inside a `/* … */` comment stop surfacing.

| | before | after |
|---|---|---|
| `GET /ghost-from-triple` | ❌ phantom | gone |
| `GET /ghost-from-comment` | ❌ phantom | gone |
| `GET /real` | ✓ | ✓ |
| total | 3 (2 phantom) | **1 real** |

Net **−2 false positives, 0 false negatives**.

**Performance:** the old per-line strippers index with `String#[](Int)` (`O(n)` per access on multi-byte → `O(line^2)` per CJK line) and run twice per line; the lexer materialises an `Array(Char)` once. On a 130 KB CJK Scala file the masking drops from **~15 ms to ~1.8 ms (~8.5×)**.

## Safety

The lexer is **behaviour-identical** to threading the proven `strip_non_code_with_state` over the whole file: both masked views match it **line-for-line across all 14 Scala fixtures (0 diffs)**, so the only change is the cross-line state fix.

- Full unit suite **2873** + all Scala functional specs **476** (incl. **7** new lexer unit specs + the `lexer_repro` regression) green
- `ameba` + `crystal tool format --check` clean
- Alignment invariant fuzzed **0/4000**

Sibling to the PHP (#1855) and C# (#1856) lexers.