### PR TITLE
fix(go): stop reading zap.Any logging fields as Gin .Any() routes

### DIFF
--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -543,4 +543,19 @@ describe Noir::TreeSitterGoRouteExtractor do
       {"POST", "/many"},
     ].sort)
   end
+
+  it "does not treat zap.Any logging field constructors as routes" do
+    source = <<-GO
+      package main
+      func main() {
+          r := gin.Default()
+          r.GET("/ok", handler)
+          global.GVA_LOG.Info("msg", zap.Any("error", err))
+          slog.Any("mode", val)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/ok"}])
+  end
 end

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -79,6 +79,12 @@ module Noir
       # would otherwise read as `Any /key`. Pocketbase parks
       # several `slog.Any("subscriptions", ...)` calls per file.
       "slog",
+      # uber-go/zap — the most widely used structured logger in Go —
+      # exposes the field constructor `zap.Any("key", value)`. Without
+      # this guard `global.GVA_LOG.Info(..., zap.Any("error", err))`
+      # surfaces as a phantom `Any /error` route fanned across all 7
+      # HTTP verbs (observed in gin-vue-admin: `/error`, `/mode`).
+      "zap",
     }
 
     # Chain methods that return the receiving router/group unchanged —


### PR DESCRIPTION
## Problem

uber-go/zap's field constructor `zap.Any("key", value)` was decoded by the Go verb extractor as a Gin `.Any()` route registration. The decoder matched the bare method name `.Any` + first string literal without rejecting the `zap` package receiver, and `.Any` fans out across all 7 HTTP methods.

Result: a single logging call like `global.GVA_LOG.Info("...", zap.Any("error", err))` minted a phantom `/error` endpoint × 7 verbs. Found while validating the Go analyzers against real OSS apps — **gin-vue-admin** produced phantom `/error` and `/mode` endpoints (14 false-positive rows) from `zap.Any(...)` calls.

## Fix

`slog` was already guarded in `NON_ROUTER_OPERANDS` (with the exact same `slog.Any` rationale); `zap` — Go's most widely used structured logger — was simply missing. Add it.

## Validation

- gin-vue-admin: 236 → 222 endpoints (−14 phantom `zap.Any` rows); no real route lost.
- New unit test in `go_route_extractor_ts_spec.cr` (fails on `main`).
- Full suite green: functional 16481, unit 2906.

Part of a Go-analyzer accuracy sweep vs real OSS (gin/echo/fiber/chi/mux/hertz). Follow-up PRs: chi MethodFunc/HandleFunc/Mount-resource, gin router-builder prefix propagation.