### PR TITLE
feat(chi): MethodFunc/HandleFunc routes + Mount struct-method resource pattern

### DIFF
--- a/spec/functional_test/fixtures/go/chi_resource/go.mod
+++ b/spec/functional_test/fixtures/go/chi_resource/go.mod
@@ -1,0 +1,5 @@
+module go
+
+go 1.21
+
+require github.com/go-chi/chi/v5 v5.0.10

--- a/spec/functional_test/fixtures/go/chi_resource/main.go
+++ b/spec/functional_test/fixtures/go/chi_resource/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func main() {
+	r := chi.NewRouter()
+
+	r.Get("/", index)
+	// MethodFunc: HTTP method as the first string argument.
+	r.MethodFunc("GET", "/health", health)
+	r.MethodFunc("POST", "/submit", submit)
+	// HandleFunc / Handle: match every HTTP method.
+	r.HandleFunc("/everything", everything)
+
+	// Mount struct value-method routers (chi's REST "resource" pattern).
+	r.Mount("/todos", todosResource{}.Routes())
+	r.Mount("/users", usersResource{}.Routes())
+
+	http.ListenAndServe(":3333", r)
+}
+
+func index(w http.ResponseWriter, r *http.Request)      {}
+func health(w http.ResponseWriter, r *http.Request)     {}
+func submit(w http.ResponseWriter, r *http.Request)     {}
+func everything(w http.ResponseWriter, r *http.Request) {}

--- a/spec/functional_test/fixtures/go/chi_resource/todos.go
+++ b/spec/functional_test/fixtures/go/chi_resource/todos.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type todosResource struct{}
+
+func (rs todosResource) Routes() chi.Router {
+	r := chi.NewRouter()
+	r.Get("/", rs.List)
+	r.Post("/", rs.Create)
+	r.Route("/{id}", func(r chi.Router) {
+		r.Get("/", rs.Get)
+		r.Delete("/", rs.Delete)
+	})
+	return r
+}
+
+func (rs todosResource) List(w http.ResponseWriter, r *http.Request)   {}
+func (rs todosResource) Create(w http.ResponseWriter, r *http.Request) {}
+func (rs todosResource) Get(w http.ResponseWriter, r *http.Request)    {}
+func (rs todosResource) Delete(w http.ResponseWriter, r *http.Request) {}

--- a/spec/functional_test/fixtures/go/chi_resource/users.go
+++ b/spec/functional_test/fixtures/go/chi_resource/users.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type usersResource struct{}
+
+func (rs usersResource) Routes() chi.Router {
+	r := chi.NewRouter()
+	r.Get("/", rs.List)
+	r.Route("/{id}", func(r chi.Router) {
+		r.Put("/", rs.Update)
+	})
+	return r
+}
+
+func (rs usersResource) List(w http.ResponseWriter, r *http.Request)   {}
+func (rs usersResource) Update(w http.ResponseWriter, r *http.Request) {}

--- a/spec/functional_test/testers/go/chi_resource_spec.cr
+++ b/spec/functional_test/testers/go/chi_resource_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+# Covers chi's net/http registrations and the idiomatic REST "resource"
+# pattern:
+#   * r.MethodFunc("GET", "/health", h)  — method as the first string arg
+#   * r.HandleFunc("/everything", h)     — matches every HTTP method (ANY)
+#   * r.Mount("/todos", todosResource{}.Routes()) — struct value-method
+#     router mounted under a prefix, with the body living in a sibling
+#     file. The receiver type disambiguates two resources that both
+#     expose a `Routes()` method (todos vs users).
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/health", "GET"),
+  Endpoint.new("/submit", "POST"),
+  # HandleFunc fans out across the full HTTP method set.
+  Endpoint.new("/everything", "GET"),
+  Endpoint.new("/everything", "POST"),
+  Endpoint.new("/everything", "PUT"),
+  Endpoint.new("/everything", "PATCH"),
+  Endpoint.new("/everything", "DELETE"),
+  Endpoint.new("/everything", "HEAD"),
+  Endpoint.new("/everything", "OPTIONS"),
+  # todosResource.Routes() mounted at /todos.
+  Endpoint.new("/todos/", "GET"),
+  Endpoint.new("/todos/", "POST"),
+  Endpoint.new("/todos/{id}/", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/todos/{id}/", "DELETE", [Param.new("id", "", "path")]),
+  # usersResource.Routes() mounted at /users — resolved to its own body
+  # by receiver type, not the first `Routes()` method found.
+  Endpoint.new("/users/", "GET"),
+  Endpoint.new("/users/{id}/", "PUT", [Param.new("id", "", "path")]),
+]
+
+FunctionalTester.new("fixtures/go/chi_resource/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -558,4 +558,25 @@ describe Noir::TreeSitterGoRouteExtractor do
     routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
     routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/ok"}])
   end
+
+  it "decodes chi MethodFunc/HandleFunc/Handle net-http registrations" do
+    source = <<-GO
+      package main
+      func main() {
+          r := chi.NewRouter()
+          r.Route("/api", func(r chi.Router) {
+              r.MethodFunc("GET", "/health", health)
+              r.HandleFunc("/everything", everything)
+          })
+          r.Handle("/metrics", promhttp.Handler())
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_chi_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"ANY", "/api/everything"},
+      {"ANY", "/metrics"},
+      {"GET", "/api/health"},
+    ].sort)
+  end
 end

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -579,4 +579,40 @@ describe Noir::TreeSitterGoRouteExtractor do
       {"GET", "/api/health"},
     ].sort)
   end
+
+  it "does not read stdlib net/http Handle/HandleFunc as chi routes" do
+    source = <<-GO
+      package main
+      func main() {
+          r := chi.NewRouter()
+          r.Get("/", index)
+          http.HandleFunc("/legacy", legacy)
+          http.Handle("/metrics", promhttp.Handler())
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_chi_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/"}])
+  end
+
+  it "skips only the receiver-matched mounted method body, not a same-named method" do
+    # `subResource.Routes()` is the mount target; `server.Routes()` is a
+    # top-level builder used directly and must keep its routes.
+    source = <<-GO
+      package main
+      func (s server) Routes() chi.Router {
+          r := chi.NewRouter()
+          r.Get("/health", s.Health)
+          return r
+      }
+      func (s subResource) Routes() chi.Router {
+          r := chi.NewRouter()
+          r.Get("/item", s.Item)
+          return r
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_chi_routes(source, Set{"subResource.Routes"})
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/health"}])
+  end
 end

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -543,4 +543,19 @@ describe Noir::TreeSitterGoRouteExtractor do
       {"POST", "/many"},
     ].sort)
   end
+
+  it "does not treat zap.Any logging field constructors as routes" do
+    source = <<-GO
+      package main
+      func main() {
+          r := gin.Default()
+          r.GET("/ok", handler)
+          global.GVA_LOG.Info("msg", zap.Any("error", err))
+          slog.Any("mode", val)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/ok"}])
+  end
 end

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -55,14 +55,16 @@ module Analyzer::Go
           # route, and it determines which function bodies to exclude from
           # the free-floating TS extraction pass below. The target may be
           # a plain function (`adminRouter()`) or a struct value-method
-          # (`todosResource{}.Routes()`) — both contribute a declaration
-          # *name* whose body must be skipped in the free pass.
+          # (`todosResource{}.Routes()`); each contributes a *skip key*
+          # (qualified by receiver type for methods, so a same-named
+          # `Routes()` on another type — or a top-level router builder
+          # also named `Routes()` — is not skipped by accident).
           next unless content.includes?(".Mount(")
           content.each_line do |scan_line|
             next unless scan_line.includes?(".Mount(")
             if target = parse_mount_target(scan_line)
               package_mounted_functions[dir] ||= Set(String).new
-              package_mounted_functions[dir] << target[:func_name]
+              package_mounted_functions[dir] << mount_skip_key(target)
             end
           end
         rescue File::NotFoundError
@@ -183,9 +185,13 @@ module Analyzer::Go
                       # can be a mount target whose body must be skipped so
                       # its routes are attributed only to the Mount-expanded
                       # (prefixed) endpoints, never the free-floating pass.
+                      # Methods are keyed by `Receiver.Method` so an
+                      # unmounted same-named method (e.g. a top-level
+                      # `func (s server) Routes()` used directly) keeps its
+                      # routes — and the `.Mount(...)` calls inside it.
                       decl_name = nil
-                      if func_match = line.match(/func\s+\([^)]*\)\s+([a-zA-Z_]\w*)\s*\(/)
-                        decl_name = func_match[1]
+                      if func_match = line.match(/func\s+\(\s*\w+\s+\*?([\w.]+)\)\s+([a-zA-Z_]\w*)\s*\(/)
+                        decl_name = "#{func_match[1].split('.').last}.#{func_match[2]}"
                       elsif func_match = line.match(/func\s+([a-zA-Z_]\w*)\s*\(/)
                         decl_name = func_match[1]
                       end
@@ -359,20 +365,34 @@ module Analyzer::Go
     # found. Returns nil for unsupported targets (e.g. a bare variable
     # receiver `s.Routes()` whose concrete type can't be read locally).
     private def parse_mount_target(line : String) : NamedTuple(prefix: String, func_name: String, recv_type: String?)?
-      match = line.match(/[a-zA-Z]\w*\.Mount\(\s*"([^"]+)"\s*,\s*([^(]+)\(\)/)
-      return unless match
-      prefix = match[1]
-      expr = match[2].strip
-      # `Type{}.Method` / `pkg.Type{...}.Method` / `&Type{}.Method`
-      if m = expr.match(/\A&?\s*([\w.]+)\s*\{[^{}]*\}\s*\.\s*(\w+)\z/)
-        recv_type = m[1].split('.').last
-        return {prefix: prefix, func_name: m[2], recv_type: recv_type}
+      # Value-receiver method: `Mount("/x", Type{}.Routes())` /
+      # `pkg.Type{...}.Routes()`.
+      if m = line.match(/\.Mount\(\s*"([^"]+)"\s*,\s*([\w.]+)\s*\{[^{}]*\}\s*\.\s*(\w+)\s*\(\s*\)/)
+        return {prefix: m[1], func_name: m[3], recv_type: m[2].split('.').last}
       end
-      # Plain function symbol.
-      if m = expr.match(/\A(\w+)\z/)
-        return {prefix: prefix, func_name: m[1], recv_type: nil}
+      # Pointer-receiver method: `Mount("/x", (&Type{}).Routes())` — the
+      # only valid Go syntax for a pointer-receiver resource (`.` binds
+      # tighter than `&`, so the parens are required).
+      if m = line.match(/\.Mount\(\s*"([^"]+)"\s*,\s*\(\s*&\s*([\w.]+)\s*\{[^{}]*\}\s*\)\s*\.\s*(\w+)\s*\(\s*\)/)
+        return {prefix: m[1], func_name: m[3], recv_type: m[2].split('.').last}
+      end
+      # Plain function symbol: `Mount("/x", adminRouter())`.
+      if m = line.match(/\.Mount\(\s*"([^"]+)"\s*,\s*(\w+)\s*\(\s*\)/)
+        return {prefix: m[1], func_name: m[2], recv_type: nil}
       end
       nil
+    end
+
+    # Skip key for a parsed mount target: a method target is keyed by
+    # `Receiver.Method` so the free pass skips only the exact mounted
+    # method body, while a plain-function target is keyed by its bare
+    # name. Mirrors the keys produced when scanning declarations.
+    private def mount_skip_key(target : NamedTuple(prefix: String, func_name: String, recv_type: String?)) : String
+      if rt = target[:recv_type]
+        "#{rt}.#{target[:func_name]}"
+      else
+        target[:func_name]
+      end
     end
 
     # Extracts endpoints from a router function definition, searching across

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -53,14 +53,16 @@ module Analyzer::Go
           # Mount targets still need a regex sweep — the name that appears
           # in `r.Mount("/admin", adminRouter())` is a *symbol*, not a
           # route, and it determines which function bodies to exclude from
-          # the free-floating TS extraction pass below.
+          # the free-floating TS extraction pass below. The target may be
+          # a plain function (`adminRouter()`) or a struct value-method
+          # (`todosResource{}.Routes()`) — both contribute a declaration
+          # *name* whose body must be skipped in the free pass.
           next unless content.includes?(".Mount(")
           content.each_line do |scan_line|
-            if scan_line.includes?(".Mount(")
-              if scan_match = scan_line.match(/[a-zA-Z]\w*\.Mount\(\s*"([^"]+)"\s*,\s*([^(]+)\(\)/)
-                package_mounted_functions[dir] ||= Set(String).new
-                package_mounted_functions[dir] << scan_match[2].strip
-              end
+            next unless scan_line.includes?(".Mount(")
+            if target = parse_mount_target(scan_line)
+              package_mounted_functions[dir] ||= Set(String).new
+              package_mounted_functions[dir] << target[:func_name]
             end
           end
         rescue File::NotFoundError
@@ -176,27 +178,34 @@ module Analyzer::Go
                       next
                     end
                     if !mounted_functions.empty? && line.strip.starts_with?("func ")
-                      if func_match = line.match(/func\s+([a-zA-Z_]\w*)\s*\(/)
-                        if mounted_functions.includes?(func_match[1])
-                          in_mounted_func = true
-                          mounted_func_brace_count = line.count("{") - line.count("}")
-                          if mounted_func_brace_count <= 0
-                            in_mounted_func = false
-                          end
-                          next
+                      # Match both plain functions (`func adminRouter(`) and
+                      # methods (`func (rs todosResource) Routes(`); either
+                      # can be a mount target whose body must be skipped so
+                      # its routes are attributed only to the Mount-expanded
+                      # (prefixed) endpoints, never the free-floating pass.
+                      decl_name = nil
+                      if func_match = line.match(/func\s+\([^)]*\)\s+([a-zA-Z_]\w*)\s*\(/)
+                        decl_name = func_match[1]
+                      elsif func_match = line.match(/func\s+([a-zA-Z_]\w*)\s*\(/)
+                        decl_name = func_match[1]
+                      end
+                      if decl_name && mounted_functions.includes?(decl_name)
+                        in_mounted_func = true
+                        mounted_func_brace_count = line.count("{") - line.count("}")
+                        if mounted_func_brace_count <= 0
+                          in_mounted_func = false
                         end
+                        next
                       end
                     end
 
                     details = Details.new(PathInfo.new(path, index + 1))
 
                     if line.includes?(".Mount(")
-                      if match = line.match(/[a-zA-Z]\w*\.Mount\(\s*"([^"]+)"\s*,\s*([^(]+)\(\)/)
-                        mount_prefix = match[1]
-                        router_function = match[2]
-                        endpoints = analyze_router_function(path, router_function, package_files, file_contents_cache, file_lines_cache)
+                      if target = parse_mount_target(line)
+                        endpoints = analyze_router_function(path, target[:func_name], package_files, file_contents_cache, file_lines_cache, target[:recv_type])
                         endpoints.each do |ep|
-                          ep.url = mount_prefix + ep.url
+                          ep.url = target[:prefix] + ep.url
                           result << ep
                         end
                       end
@@ -337,17 +346,49 @@ module Analyzer::Go
       Param.new(param_name, "", param_type)
     end
 
+    # Parses a `.Mount("/prefix", target())` line into its mount prefix
+    # and the declaration that builds the sub-router. Two target shapes
+    # are recognized:
+    #   * plain function   — `r.Mount("/admin", adminRouter())`
+    #     -> {func_name: "adminRouter", recv_type: nil}
+    #   * struct value-method (chi's idiomatic REST "resource" pattern) —
+    #     `r.Mount("/todos", todosResource{}.Routes())`
+    #     -> {func_name: "Routes", recv_type: "todosResource"}
+    # The receiver type is kept so two resources that both expose a
+    # `Routes()` method resolve to their own bodies, not the first one
+    # found. Returns nil for unsupported targets (e.g. a bare variable
+    # receiver `s.Routes()` whose concrete type can't be read locally).
+    private def parse_mount_target(line : String) : NamedTuple(prefix: String, func_name: String, recv_type: String?)?
+      match = line.match(/[a-zA-Z]\w*\.Mount\(\s*"([^"]+)"\s*,\s*([^(]+)\(\)/)
+      return unless match
+      prefix = match[1]
+      expr = match[2].strip
+      # `Type{}.Method` / `pkg.Type{...}.Method` / `&Type{}.Method`
+      if m = expr.match(/\A&?\s*([\w.]+)\s*\{[^{}]*\}\s*\.\s*(\w+)\z/)
+        recv_type = m[1].split('.').last
+        return {prefix: prefix, func_name: m[2], recv_type: recv_type}
+      end
+      # Plain function symbol.
+      if m = expr.match(/\A(\w+)\z/)
+        return {prefix: prefix, func_name: m[1], recv_type: nil}
+      end
+      nil
+    end
+
     # Extracts endpoints from a router function definition, searching across
     # all .go files in the same directory (Go package) if not found in the
     # given file.
     #
     # Uses the tree-sitter walker too, but scoped down to just the target
     # function's declaration so the returned routes are relative to the
-    # function body — caller slaps on the Mount prefix.
+    # function body — caller slaps on the Mount prefix. When `recv_type`
+    # is given, the target is a method (`func (r Type) Name()`) and only
+    # the declaration on that receiver type is matched.
     def analyze_router_function(file_path : String, func_name : String,
                                 package_files : Hash(String, Array(String))? = nil,
                                 file_contents_cache : Hash(String, String)? = nil,
-                                file_lines_cache : Hash(String, Array(String))? = nil) : Array(Endpoint)
+                                file_lines_cache : Hash(String, Array(String))? = nil,
+                                recv_type : String? = nil) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       # Search: given file first, then other files in the same directory.
@@ -368,7 +409,7 @@ module Analyzer::Go
               next
             end
 
-        routes = extract_router_function_routes(content, func_name)
+        routes = extract_router_function_routes(content, func_name, recv_type)
         next if routes.empty?
 
         # Capture routes' original line numbers on the endpoint details.
@@ -392,12 +433,13 @@ module Analyzer::Go
     end
 
     # Walks the full tree-sitter tree for `source`, isolating the body of
-    # `func <func_name>(...)` and returning only the routes registered
+    # `func <func_name>(...)` (or method `func (r <recv_type>) <func_name>()`
+    # when `recv_type` is given) and returning only the routes registered
     # there.
-    private def extract_router_function_routes(source : String, func_name : String) : Array(Noir::TreeSitterGoRouteExtractor::Route)
+    private def extract_router_function_routes(source : String, func_name : String, recv_type : String? = nil) : Array(Noir::TreeSitterGoRouteExtractor::Route)
       hits = [] of Noir::TreeSitterGoRouteExtractor::Route
       Noir::TreeSitter.parse_go(source) do |root|
-        find_func_declaration(root, source, func_name) do |body|
+        find_func_declaration(root, source, func_name, recv_type) do |body|
           # Re-run the chi walker against the isolated body. skip_functions
           # is empty because any nested func literal inside is the inline
           # handler which the walker already ignores by convention.
@@ -409,10 +451,16 @@ module Analyzer::Go
       hits
     end
 
-    private def find_func_declaration(node : LibTreeSitter::TSNode, source : String, name : String, &block : LibTreeSitter::TSNode ->)
-      if Noir::TreeSitter.node_type(node) == "function_declaration"
+    private def find_func_declaration(node : LibTreeSitter::TSNode, source : String, name : String, recv_type : String? = nil, &block : LibTreeSitter::TSNode ->)
+      node_ty = Noir::TreeSitter.node_type(node)
+      # A plain function (`func Name()`) matches when no receiver type was
+      # requested; a method (`func (r Type) Name()`) matches only when its
+      # receiver type equals `recv_type`.
+      wanted_ty = recv_type ? "method_declaration" : "function_declaration"
+      if node_ty == wanted_ty
         if name_node = Noir::TreeSitter.field(node, "name")
-          if Noir::TreeSitter.node_text(name_node, source) == name
+          if Noir::TreeSitter.node_text(name_node, source) == name &&
+             (recv_type.nil? || method_receiver_type(node, source) == recv_type)
             if body = Noir::TreeSitter.field(node, "body")
               yield body
               return
@@ -421,8 +469,25 @@ module Analyzer::Go
         end
       end
       Noir::TreeSitter.each_named_child(node) do |child|
-        find_func_declaration(child, source, name, &block)
+        find_func_declaration(child, source, name, recv_type, &block)
       end
+    end
+
+    # Returns the (package-unqualified, pointer-stripped) receiver type name
+    # of a `method_declaration` — `func (rs todosResource) Routes()` ->
+    # "todosResource", `func (s *Server) Routes()` -> "Server".
+    private def method_receiver_type(node : LibTreeSitter::TSNode, source : String) : String?
+      receiver = Noir::TreeSitter.field(node, "receiver")
+      return unless receiver
+      type_name = nil
+      Noir::TreeSitter.each_named_child(receiver) do |decl|
+        next unless Noir::TreeSitter.node_type(decl) == "parameter_declaration"
+        if type_node = Noir::TreeSitter.field(decl, "type")
+          type_name = Noir::TreeSitter.node_text(type_node, source)
+        end
+      end
+      return unless type_name
+      type_name.lchop('*').split('.').last
     end
 
     # Reattach the line-based param extractor to mount-expanded endpoints.

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -85,6 +85,15 @@ module Noir
       # surfaces as a phantom `Any /error` route fanned across all 7
       # HTTP verbs (observed in gin-vue-admin: `/error`, `/mode`).
       "zap",
+      # The stdlib net/http package: `http.Handle("/x", h)` /
+      # `http.HandleFunc("/x", h)` register on the default ServeMux and
+      # collide with chi's identically-named all-methods registrations
+      # (chi `net_http_methods` path). `http` is never a chi router, so
+      # exclude it — otherwise every `http.Handle`/`http.HandleFunc` in a
+      # chi app (promhttp metrics, pprof, …) fans out to 7 phantom verbs.
+      # (`http.Get`/`http.Post` client calls are already dropped by the
+      # scheme / handler-arg guards.)
+      "http",
     }
 
     # Chain methods that return the receiving router/group unchanged —
@@ -959,13 +968,24 @@ module Noir
       ty = Noir::TreeSitter.node_type(node)
 
       # Skip `func <skipped>() { ... }` bodies entirely — their routes are
-      # emitted by a separate analysis pass (e.g. Mount expansion). Both
-      # plain functions (`func adminRouter()`) and methods
-      # (`func (rs todosResource) Routes()`) can be mount targets, so
-      # match on the declaration name for either node type.
+      # emitted by a separate analysis pass (e.g. Mount expansion). A plain
+      # function (`func adminRouter()`) is keyed by its bare name; a method
+      # (`func (rs todosResource) Routes()`) is keyed by `Receiver.Method`
+      # so ONLY the exact mounted method body is skipped — a same-named
+      # method on another type, or a top-level router builder also named
+      # `Routes()` used directly, keeps its routes (and the `.Mount`
+      # calls inside it).
       if (ty == "function_declaration" || ty == "method_declaration") && !skip_functions.empty?
         if name_node = Noir::TreeSitter.field(node, "name")
-          return if skip_functions.includes?(Noir::TreeSitter.node_text(name_node, source))
+          name = Noir::TreeSitter.node_text(name_node, source)
+          skip_key = if ty == "method_declaration"
+                       if (recv = Noir::TreeSitter.field(node, "receiver")) && (rt = receiver_type_name(recv, source))
+                         "#{rt}.#{name}"
+                       end
+                     else
+                       name
+                     end
+          return if skip_key && skip_functions.includes?(skip_key)
         end
       end
 

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -469,19 +469,27 @@ module Noir
       getter? chain_prefix : Bool
       getter bind_methods : Array(String)
       getter bind_method_verb : String
+      getter? net_http_methods : Bool
 
       def initialize(@prefix_method = "Route",
                      @middleware_method = "Group",
                      @chain_prefix = false,
                      @bind_methods = [] of String,
-                     @bind_method_verb = "ALL")
+                     @bind_method_verb = "ALL",
+                     @net_http_methods = false)
       end
     end
 
+    # net/http-style registrations chi exposes alongside the verb
+    # shortcuts: `r.MethodFunc("GET", "/x", h)` (method as the first
+    # string arg, incl. custom verbs from `chi.RegisterMethod`) and
+    # `r.HandleFunc("/x", h)` / `r.Handle("/x", h)` (match ANY method).
+    # Gated behind `ScopedConfig#net_http_methods?` so the gf walker —
+    # which shares this recognizer — is untouched.
     def extract_chi_routes(source : String,
                            skip_functions : Set(String) = Set(String).new,
                            external_string_values : Hash(String, String) = Hash(String, String).new) : Array(Route)
-      extract_scoped_routes(source, ScopedConfig.new, skip_functions, external_string_values)
+      extract_scoped_routes(source, ScopedConfig.new(net_http_methods: true), skip_functions, external_string_values)
     end
 
     # Collects `<name> := "literal"` / `const <name> = "literal"` string
@@ -928,14 +936,16 @@ module Noir
     end
 
     # Exposes the closure-scoped walker against an arbitrary node
-    # (typically a function body captured elsewhere). Uses chi defaults.
+    # (typically a function body captured elsewhere). Uses chi defaults
+    # incl. the net/http registrations (MethodFunc/HandleFunc/Handle) so a
+    # Mount-expanded router function body is parsed like any chi file.
     def walk_chi_public(node : LibTreeSitter::TSNode,
                         source : String,
                         sink : Array(Route),
                         string_values : Hash(String, String) = Hash(String, String).new)
       local_groups = Hash(String, String).new
       skip = Set(String).new
-      walk_chi(node, source, [] of String, local_groups, sink, skip, ScopedConfig.new, string_values)
+      walk_chi(node, source, [] of String, local_groups, sink, skip, ScopedConfig.new(net_http_methods: true), string_values)
     end
 
     private def walk_chi(node : LibTreeSitter::TSNode,
@@ -949,8 +959,11 @@ module Noir
       ty = Noir::TreeSitter.node_type(node)
 
       # Skip `func <skipped>() { ... }` bodies entirely — their routes are
-      # emitted by a separate analysis pass (e.g. Mount expansion).
-      if ty == "function_declaration" && !skip_functions.empty?
+      # emitted by a separate analysis pass (e.g. Mount expansion). Both
+      # plain functions (`func adminRouter()`) and methods
+      # (`func (rs todosResource) Routes()`) can be mount targets, so
+      # match on the declaration name for either node type.
+      if (ty == "function_declaration" || ty == "method_declaration") && !skip_functions.empty?
         if name_node = Noir::TreeSitter.field(node, "name")
           return if skip_functions.includes?(Noir::TreeSitter.node_text(name_node, source))
         end
@@ -1005,6 +1018,16 @@ module Noir
           return
         when ChiCall::Bind
           if route = decode_chi_bind_call(node, source, prefix_stack, local_groups, config, string_values)
+            routes << route
+          end
+          return
+        when ChiCall::MethodFunc
+          if route = decode_chi_methodfunc_call(node, source, prefix_stack, local_groups, string_values)
+            routes << route
+          end
+          return
+        when ChiCall::HandleAll
+          if route = decode_chi_handle_all_call(node, source, prefix_stack, local_groups, string_values)
             routes << route
           end
           return
@@ -1079,6 +1102,8 @@ module Noir
       Group
       Verb
       Bind
+      MethodFunc
+      HandleAll
     end
 
     # Classify a call_expression so `walk_chi` knows whether to descend
@@ -1117,6 +1142,16 @@ module Noir
       when "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
            "Get", "Post", "Put", "Delete", "Patch", "Head", "Options"
         return ChiCall::Verb
+      end
+
+      if config.net_http_methods?
+        # `r.MethodFunc("GET", "/x", h)` — method as the first string
+        # arg (the route path is the second). Also covers custom verbs
+        # registered via `chi.RegisterMethod`.
+        return ChiCall::MethodFunc if name == "MethodFunc"
+        # `r.HandleFunc("/x", h)` / `r.Handle("/x", h)` — match every
+        # HTTP method (chi fans these over the full method set).
+        return ChiCall::HandleAll if name == "HandleFunc" || name == "Handle"
       end
 
       ChiCall::None
@@ -1172,6 +1207,105 @@ module Noir
         handler_text,
         Noir::TreeSitter.node_start_row(call),
       )
+    end
+
+    # Resolve the verb-call receiver to a router name, rejecting known
+    # non-router operands. Accepts a bare identifier (`r.Get(...)`) and
+    # a struct-field selector (`s.router.Get(...)`), guarding the final
+    # field of the selector against `NON_ROUTER_OPERANDS`. Returns nil
+    # for any other operand shape (call chains, etc.).
+    private def chi_router_operand_name(operand : LibTreeSitter::TSNode, source : String) : String?
+      case Noir::TreeSitter.node_type(operand)
+      when "identifier"
+        name = Noir::TreeSitter.node_text(operand, source)
+        return if NON_ROUTER_OPERANDS.includes?(name)
+        name
+      when "selector_expression"
+        final_field = Noir::TreeSitter.field(operand, "field")
+        return unless final_field
+        return if NON_ROUTER_OPERANDS.includes?(Noir::TreeSitter.node_text(final_field, source))
+        Noir::TreeSitter.node_text(operand, source)
+      end
+    end
+
+    # Decode `r.MethodFunc("GET", "/path", handler)` — chi's net/http
+    # registration whose FIRST string arg is the HTTP method and second
+    # is the route path. The method may be a custom verb registered via
+    # `chi.RegisterMethod` (LINK/WOOHOO/...), so it is emitted verbatim.
+    private def decode_chi_methodfunc_call(call : LibTreeSitter::TSNode,
+                                           source : String,
+                                           prefix_stack : Array(String),
+                                           local_groups : Hash(String, String),
+                                           string_values : Hash(String, String) = Hash(String, String).new) : Route?
+      function = Noir::TreeSitter.field(call, "function")
+      return unless function
+      operand = Noir::TreeSitter.field(function, "operand")
+      return unless operand
+      router_name = chi_router_operand_name(operand, source)
+      return unless router_name
+
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      method = nil
+      raw_path = nil
+      handler_text = ""
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        s = string_expr_text(arg, source, string_values)
+        if method.nil?
+          # First arg must be a string method ("GET", "WOOHOO", ...).
+          return if s.nil?
+          method = s
+        elsif raw_path.nil?
+          return if s.nil?
+          raw_path = s
+        elsif handler_text.empty?
+          handler_text = Noir::TreeSitter.node_text(arg, source)
+        end
+      end
+      return unless (m = method) && (path = raw_path)
+      return unless path.starts_with?("/")
+      return if handler_text.empty?
+
+      base_prefix = local_groups[router_name]? || prefix_stack.join
+      resolved = base_prefix.empty? ? path : join_paths(base_prefix, path)
+      Route.new(router_name, m.upcase, resolved, path, handler_text, Noir::TreeSitter.node_start_row(call))
+    end
+
+    # Decode `r.HandleFunc("/path", h)` / `r.Handle("/path", h)` — chi
+    # registers these for EVERY HTTP method, so they are emitted with a
+    # fan-out "ANY" verb (the analyzer expands it to each method).
+    private def decode_chi_handle_all_call(call : LibTreeSitter::TSNode,
+                                           source : String,
+                                           prefix_stack : Array(String),
+                                           local_groups : Hash(String, String),
+                                           string_values : Hash(String, String) = Hash(String, String).new) : Route?
+      function = Noir::TreeSitter.field(call, "function")
+      return unless function
+      operand = Noir::TreeSitter.field(function, "operand")
+      return unless operand
+      router_name = chi_router_operand_name(operand, source)
+      return unless router_name
+
+      args = Noir::TreeSitter.field(call, "arguments")
+      return unless args
+      raw_path = nil
+      handler_text = ""
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        s = string_expr_text(arg, source, string_values)
+        if raw_path.nil?
+          return if s.nil?
+          raw_path = s
+        elsif handler_text.empty?
+          handler_text = Noir::TreeSitter.node_text(arg, source)
+        end
+      end
+      return unless (path = raw_path)
+      return unless path.starts_with?("/")
+      return if handler_text.empty?
+
+      base_prefix = local_groups[router_name]? || prefix_stack.join
+      resolved = base_prefix.empty? ? path : join_paths(base_prefix, path)
+      Route.new(router_name, "ANY", resolved, path, handler_text, Noir::TreeSitter.node_start_row(call))
     end
 
     # Extract `{prefix, body_block, closure_node}` from a Route/Group call.

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -1319,7 +1319,7 @@ module Noir
           handler_text = Noir::TreeSitter.node_text(arg, source)
         end
       end
-      return unless (path = raw_path)
+      return unless path = raw_path
       return unless path.starts_with?("/")
       return if handler_text.empty?
 

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -79,6 +79,12 @@ module Noir
       # would otherwise read as `Any /key`. Pocketbase parks
       # several `slog.Any("subscriptions", ...)` calls per file.
       "slog",
+      # uber-go/zap — the most widely used structured logger in Go —
+      # exposes the field constructor `zap.Any("key", value)`. Without
+      # this guard `global.GVA_LOG.Info(..., zap.Any("error", err))`
+      # surfaces as a phantom `Any /error` route fanned across all 7
+      # HTTP verbs (observed in gin-vue-admin: `/error`, `/mode`).
+      "zap",
     }
 
     # Chain methods that return the receiving router/group unchanged —


### PR DESCRIPTION
Stacked on #1863 (base will retarget to `main` once that merges).

## Two FN classes found validating the chi extractor against real OSS (go-chi/chi `_examples`)

### 1. net/http registrations were unrecognized
- `r.MethodFunc("GET", "/x", h)` — HTTP method as the first string arg (incl. custom verbs registered via `chi.RegisterMethod`)
- `r.HandleFunc("/x", h)` / `r.Handle("/x", h)` — match every HTTP method (emitted as ANY → fanned out)

Gated behind a new `ScopedConfig#net_http_methods?` flag so the **shared GoFrame (gf) walker is untouched**.

### 2. Mount struct-method "resource" pattern dropped its prefix
`r.Mount("/todos", todosResource{}.Routes())` is the idiomatic chi REST resource pattern (struct value-method returning a router, per the chi README). The mount prefix was dropped entirely — routes surfaced as `/{id}/` instead of `/todos/{id}/` — and a second resource mounted via the **same** `Routes()` method name (`usersResource`) was lost outright.

`parse_mount_target` now reads the `Type{}.Method` form and resolves the method declaration **by receiver type**, so `todos` vs `users` map to their own bodies.

## Validation
- chi-examples: **25 → 41** endpoints, all correct; the 6 prefix-less `/{id}/` rows are replaced by correctly-prefixed `/todos/`·`/users/` variants.
- gf (GoFrame) specs unaffected (shared walker gated).
- New `chi_resource` fixture + unit test (fail on base); full suite green (functional 16481, unit 2906).