### PR TITLE
feat(gin): propagate call-site group prefix into router-builder helpers

### DIFF
--- a/spec/functional_test/fixtures/go/gin_router_builder/go.mod
+++ b/spec/functional_test/fixtures/go/gin_router_builder/go.mod
@@ -1,0 +1,5 @@
+module go
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.1

--- a/spec/functional_test/fixtures/go/gin_router_builder/main.go
+++ b/spec/functional_test/fixtures/go/gin_router_builder/main.go
@@ -1,0 +1,16 @@
+package routes
+
+import "github.com/gin-gonic/gin"
+
+var router = gin.Default()
+
+// getRoutes splits registration across per-resource helpers, each
+// receiving a versioned group. addPingRoutes is reused under /v1 and /v2.
+func getRoutes() {
+	v1 := router.Group("/v1")
+	addUserRoutes(v1)
+	addPingRoutes(v1)
+
+	v2 := router.Group("/v2")
+	addPingRoutes(v2)
+}

--- a/spec/functional_test/fixtures/go/gin_router_builder/ping.go
+++ b/spec/functional_test/fixtures/go/gin_router_builder/ping.go
@@ -1,0 +1,12 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func addPingRoutes(rg *gin.RouterGroup) {
+	ping := rg.Group("/ping")
+	ping.GET("/", func(c *gin.Context) { c.JSON(http.StatusOK, "pong") })
+}

--- a/spec/functional_test/fixtures/go/gin_router_builder/users.go
+++ b/spec/functional_test/fixtures/go/gin_router_builder/users.go
@@ -1,0 +1,15 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func addUserRoutes(rg *gin.RouterGroup) {
+	users := rg.Group("/users")
+
+	users.GET("/", func(c *gin.Context) { c.JSON(http.StatusOK, "users") })
+	users.GET("/comments", func(c *gin.Context) { c.JSON(http.StatusOK, "comments") })
+	users.POST("/", func(c *gin.Context) { c.JSON(http.StatusOK, "create") })
+}

--- a/spec/functional_test/testers/go/gin_router_builder_spec.cr
+++ b/spec/functional_test/testers/go/gin_router_builder_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+# The canonical gin layout splits route registration across
+# `func addXRoutes(rg *gin.RouterGroup)` helpers called from a central
+# function with a versioned group. The prefix (`/v1`) lives at the call
+# site, not in the helper, and the helper's parameter name (`rg`) does
+# NOT match the caller's group variable (`v1`) — so the helper's routes
+# need the call-site prefix grafted on. addPingRoutes is reused under
+# both /v1 and /v2, so it must yield a route for each.
+expected_endpoints = [
+  Endpoint.new("/v1/users/", "GET"),
+  Endpoint.new("/v1/users/", "POST"),
+  Endpoint.new("/v1/users/comments", "GET"),
+  Endpoint.new("/v1/ping/", "GET"),
+  Endpoint.new("/v2/ping/", "GET"),
+]
+
+FunctionalTester.new("fixtures/go/gin_router_builder/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -580,7 +580,6 @@ describe Noir::TreeSitterGoRouteExtractor do
     ].sort)
   end
 
-<<<<<<< HEAD
   it "does not read stdlib net/http Handle/HandleFunc as chi routes" do
     source = <<-GO
       package main
@@ -637,7 +636,9 @@ describe Noir::TreeSitterGoRouteExtractor do
       GO
 
     builders = Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(source)
-    builders.keys.sort.should eq(["addPingRoutes", "addUserRoutes"])
+    ks = builders.keys.to_a
+    ks.sort!
+    ks.should eq(["addPingRoutes", "addUserRoutes"])
     builders["addUserRoutes"].param.should eq("rg")
 
     calls = Noir::TreeSitterGoRouteExtractor.collect_router_builder_callsites(source, builders.keys.to_set)
@@ -648,5 +649,21 @@ describe Noir::TreeSitterGoRouteExtractor do
 
     ping_v2 = Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(source, "addPingRoutes", {"rg" => "/v2"})
     ping_v2.map { |r| {r.verb, r.path} }.should eq([{"GET", "/v2/ping"}])
+  end
+
+  it "collects inline Group call-site as direct prefix for router builders" do
+    source = <<-GO
+      package routes
+      func getRoutes() {
+          addUserRoutes(router.Group("/v1"))
+      }
+      func addUserRoutes(rg *gin.RouterGroup) {
+          rg.GET("/u", h)
+      }
+      GO
+
+    builders = Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(source)
+    calls = Noir::TreeSitterGoRouteExtractor.collect_router_builder_callsites(source, builders.keys.to_set)
+    calls.should eq([{"addUserRoutes", "/v1"}])
   end
 end

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -580,6 +580,7 @@ describe Noir::TreeSitterGoRouteExtractor do
     ].sort)
   end
 
+<<<<<<< HEAD
   it "does not read stdlib net/http Handle/HandleFunc as chi routes" do
     source = <<-GO
       package main
@@ -614,5 +615,38 @@ describe Noir::TreeSitterGoRouteExtractor do
 
     routes = Noir::TreeSitterGoRouteExtractor.extract_chi_routes(source, Set{"subResource.Routes"})
     routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/health"}])
+  end
+
+  it "detects gin router-builder helpers and grafts call-site prefixes" do
+    source = <<-GO
+      package routes
+      func getRoutes() {
+          v1 := router.Group("/v1")
+          addUserRoutes(v1)
+          addPingRoutes(v1)
+          v2 := router.Group("/v2")
+          addPingRoutes(v2)
+      }
+      func addUserRoutes(rg *gin.RouterGroup) {
+          users := rg.Group("/users")
+          users.GET("/", h)
+      }
+      func addPingRoutes(rg *gin.RouterGroup) {
+          rg.GET("/ping", h)
+      }
+      GO
+
+    builders = Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(source)
+    builders.keys.sort.should eq(["addPingRoutes", "addUserRoutes"])
+    builders["addUserRoutes"].param.should eq("rg")
+
+    calls = Noir::TreeSitterGoRouteExtractor.collect_router_builder_callsites(source, builders.keys.to_set)
+    calls.sort.should eq([{"addPingRoutes", "v1"}, {"addPingRoutes", "v2"}, {"addUserRoutes", "v1"}])
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(source, "addUserRoutes", {"rg" => "/v1"})
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/v1/users/"}])
+
+    ping_v2 = Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(source, "addPingRoutes", {"rg" => "/v2"})
+    ping_v2.map { |r| {r.verb, r.path} }.should eq([{"GET", "/v2/ping"}])
   end
 end

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -55,7 +55,6 @@ module Analyzer::Go
           # route, and it determines which function bodies to exclude from
           # the free-floating TS extraction pass below. The target may be
           # a plain function (`adminRouter()`) or a struct value-method
-<<<<<<< HEAD
           # (`todosResource{}.Routes()`); each contributes a *skip key*
           # (qualified by receiver type for methods, so a same-named
           # `Routes()` on another type — or a top-level router builder

--- a/src/analyzer/analyzers/go/chi.cr
+++ b/src/analyzer/analyzers/go/chi.cr
@@ -55,6 +55,7 @@ module Analyzer::Go
           # route, and it determines which function bodies to exclude from
           # the free-floating TS extraction pass below. The target may be
           # a plain function (`adminRouter()`) or a struct value-method
+<<<<<<< HEAD
           # (`todosResource{}.Routes()`); each contributes a *skip key*
           # (qualified by receiver type for methods, so a same-named
           # `Routes()` on another type — or a top-level router builder

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -72,7 +72,7 @@ module Analyzer::Go
                     if content.includes?("*gin.RouterGroup")
                       Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(content).each do |fn, rb|
                         pset = dir_builder_prefixes[fn]?
-                        next unless pset && !pset.empty?
+                        next if pset.nil? || pset.empty?
                         next if cross_file_groups.has_key?(rb.param)
                         suppress_ranges << (rb.start_row..rb.end_row)
                         expand_builders << {fn, rb, pset}
@@ -111,7 +111,7 @@ module Analyzer::Go
                       # Skip lines inside an expanded router-builder body — its
                       # routes (and any params) are emitted, with the call-site
                       # prefix applied, by the expansion pass below.
-                      next if suppress_ranges.any? { |r| r.includes?(index) }
+                      next if suppress_ranges.any?(&.includes?(index))
 
                       details = Details.new(PathInfo.new(path, index + 1))
 
@@ -140,30 +140,7 @@ module Analyzer::Go
                         end
                       end
 
-                      ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
-                        if line.includes?("#{pattern}(")
-                          add_param_to_endpoint(get_param(line), last_endpoint)
-                        end
-                      end
-
-                      # Body bindings: `c.BindJSON`, `c.ShouldBindJSON`,
-                      # `c.BindXML`, `c.ShouldBindXML`, `c.BindYAML`, etc.
-                      # all populate the request body. Emit a single "body"
-                      # indicator so downstream consumers know a body is
-                      # expected; the bound struct's fields stay opaque
-                      # without a deeper static-type pass.
-                      if line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
-                        add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
-                      end
-
-                      if line.includes?("Cookie(") &&
-                         !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
-                        match = line.match(/Cookie\(\"(.*)\"\)/)
-                        if match
-                          cookie_name = match[1]
-                          last_endpoint.params << Param.new(cookie_name, "", "cookie")
-                        end
-                      end
+                      add_gin_param_patterns(line, last_endpoint)
                     end
 
                     # Expansion pass: emit each suppressed router-builder's
@@ -173,15 +150,26 @@ module Analyzer::Go
                     # `addPingRoutes(v2)` — yields both `/v1/ping` and
                     # `/v2/ping`.)
                     expand_builders.each do |fn, rb, pset|
+                      builder_emitted = [] of Endpoint
                       pset.each do |prefix|
                         Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(
                           content, fn, {rb.param => prefix}, handle_method: "Handle"
                         ).each do |route|
                           rdetails = Details.new(PathInfo.new(path, route.line + 1))
                           Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
-                            result << Endpoint.new(route.path, verb, rdetails)
+                            ep = Endpoint.new(route.path, verb, rdetails)
+                            result << ep
+                            builder_emitted << ep
                           end
                         end
+                      end
+                      # Attach any Gin params (Query/Bind/Cookie/Param) and
+                      # (future) callees from the builder function body to the
+                      # expanded endpoints. Mirrors chi's attach_router_function_params
+                      # for Mount-expanded routes so that helpers with c.Query etc.
+                      # inside produce correct params on the prefixed endpoints.
+                      if !builder_emitted.empty?
+                        attach_gin_builder_params(builder_emitted, content, rb.start_row, rb.end_row)
                       end
                     end
                   end
@@ -199,6 +187,71 @@ module Analyzer::Go
       resolve_public_dirs(public_dirs)
 
       result
+    end
+
+    private def add_gin_param_patterns(line : String, target : Endpoint)
+      ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
+        if line.includes?("#{pattern}(")
+          add_param_to_endpoint(get_param(line), target)
+        end
+      end
+      if line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
+        add_param_to_endpoint(Param.new("body", "", "json"), target)
+      end
+      if line.includes?("Cookie(") &&
+         !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
+        match = line.match(/Cookie\(\"(.*)\"\)/)
+        if match
+          target.params << Param.new(match[1], "", "cookie")
+        end
+      end
+    end
+
+    private def add_gin_param_patterns_to_many(line : String, targets : Array(Endpoint))
+      return if targets.empty?
+      ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
+        if line.includes?("#{pattern}(")
+          p = get_param(line)
+          targets.each { |t| add_param_to_endpoint(p, t) }
+        end
+      end
+      if line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
+        b = Param.new("body", "", "json")
+        targets.each { |t| add_param_to_endpoint(b, t) }
+      end
+      if line.includes?("Cookie(") &&
+         !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
+        match = line.match(/Cookie\(\"(.*)\"\)/)
+        if match
+          c = Param.new(match[1], "", "cookie")
+          targets.each { |t| t.params << c }
+        end
+      end
+    end
+
+    private def attach_gin_builder_params(emitted : Array(Endpoint), content : String, start_row : Int32, end_row : Int32)
+      return if emitted.empty?
+      lines = content.lines
+      eps_by_line = Hash(Int32, Array(Endpoint)).new { |h, k| h[k] = [] of Endpoint }
+      emitted.each do |ep|
+        ep.details.code_paths.each do |cp|
+          if ln = cp.line
+            eps_by_line[ln.to_i - 1] << ep
+          end
+        end
+      end
+      return if eps_by_line.empty?
+      currents = [] of Endpoint
+      (start_row..[end_row, lines.size - 1].min).each do |i|
+        line = lines[i]?
+        next unless line
+        if eps = eps_by_line[i]?
+          currents = eps
+        end
+        if !currents.empty?
+          add_gin_param_patterns_to_many(line, currents)
+        end
+      end
     end
 
     # Builds `{dir => {builder_fn => set(prefixes)}}` for the package by
@@ -224,15 +277,29 @@ module Analyzer::Go
 
         group_map = package_groups[dir]? || Hash(String, String).new
         prefixes = Hash(String, Set(String)).new
+        unresolved = Set(String).new
         paths.each do |p|
           content = file_contents[p]?
           next unless content
           Noir::TreeSitterGoRouteExtractor.collect_router_builder_callsites(content, builders).each do |fn, arg|
-            if prefix = group_map[arg]?
+            prefix = group_map[arg]?
+            if prefix.nil? && arg.starts_with?("/")
+              prefix = arg
+            end
+            if prefix
               (prefixes[fn] ||= Set(String).new) << prefix
+            else
+              # Unresolved or complex arg (including "__unresolved__" marker).
+              # This builder has at least one call site that didn't resolve
+              # to a known group prefix — guard will prevent expansion for it.
+              unresolved << fn
             end
           end
         end
+        # Only keep prefixes for builders where *every* call site resolved.
+        # Mixed (some resolved + some direct/root/complex) fall back to
+        # whole-file pass to avoid losing routes from the unresolved calls.
+        prefixes.reject! { |fn, _| unresolved.includes?(fn) }
         result[dir] = prefixes unless prefixes.empty?
       end
 

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -158,16 +158,22 @@ module Analyzer::Go
                           rdetails = Details.new(PathInfo.new(path, route.line + 1))
                           Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
                             ep = Endpoint.new(route.path, verb, rdetails)
+                            if entries = callees_by_route[route.line]?
+                              entries.each do |entry|
+                                name, callee_path, callee_line = entry
+                                ep.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                              end
+                            end
                             result << ep
                             builder_emitted << ep
                           end
                         end
                       end
-                      # Attach any Gin params (Query/Bind/Cookie/Param) and
-                      # (future) callees from the builder function body to the
-                      # expanded endpoints. Mirrors chi's attach_router_function_params
-                      # for Mount-expanded routes so that helpers with c.Query etc.
-                      # inside produce correct params on the prefixed endpoints.
+                      # Attach any Gin params (Query/Bind/Cookie/Param) and callees
+                      # from the builder function body to the expanded endpoints.
+                      # Mirrors chi's attach_router_function_params for Mount-expanded
+                      # routes (callees were attached in the emit above using the
+                      # precomputed callees_by_route; params via the dedicated attach).
                       if !builder_emitted.empty?
                         attach_gin_builder_params(builder_emitted, content, rb.start_row, rb.end_row)
                       end
@@ -242,13 +248,32 @@ module Analyzer::Go
       end
       return if eps_by_line.empty?
       currents = [] of Endpoint
+      in_inline = false
+      brace_count = 0
       (start_row..[end_row, lines.size - 1].min).each do |i|
         line = lines[i]?
         next unless line
+        apply_now = false
         if eps = eps_by_line[i]?
           currents = eps
+          apply_now = true
+          if line.includes?("func(")
+            in_inline = true
+            brace_count = line.count("{") - line.count("}")
+            if brace_count <= 0
+              in_inline = false
+              brace_count = 0
+            end
+          end
+        elsif in_inline
+          brace_count += line.count("{") - line.count("}")
+          if brace_count <= 0
+            in_inline = false
+            brace_count = 0
+          end
+          apply_now = true
         end
-        if !currents.empty?
+        if !currents.empty? && apply_now
           add_gin_param_patterns_to_many(line, currents)
         end
       end

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -4,6 +4,10 @@ module Analyzer::Go
   class Gin < GoEngine
     IMPORT_MARKER = "github.com/gin-gonic/gin"
 
+    # Shared read-only fallback for directories with no resolved
+    # router-builder prefixes (never mutated).
+    EMPTY_BUILDER_PREFIXES = Hash(String, Set(String)).new
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -13,6 +17,13 @@ module Analyzer::Go
       # O(1) lookup into `package_function_bodies` rather than re-
       # walking every sibling source file.
       package_function_bodies = collect_package_function_bodies(file_contents)
+      # Cross-file router-builder prefix resolution: `{dir => {builder_fn
+      # => set(call-site prefixes)}}`. Resolves the canonical gin layout
+      # where `func addXRoutes(rg *gin.RouterGroup)` helpers are called
+      # from a central function with a versioned group (`addUserRoutes(
+      # router.Group("/v1"))`). The prefix lives at the call site, so it
+      # must be grafted onto the helper's routes.
+      builder_prefixes_by_dir = resolve_router_builder_prefixes(file_contents, package_groups)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         WaitGroup.wait do |wg|
@@ -42,6 +53,32 @@ module Analyzer::Go
                     # /GetHeader/Cookie) to the most recently declared route —
                     # matching the legacy `last_endpoint` semantics.
                     cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
+
+                    # Router-builder expansion: graft call-site prefixes onto
+                    # the routes of `func addXRoutes(rg *gin.RouterGroup)`
+                    # helpers DEFINED in this file. Only "case b" helpers are
+                    # expanded — those whose group parameter name is NOT
+                    # already a key in the package group map. ("Case a" helpers
+                    # whose parameter name happens to match a caller's group
+                    # variable, e.g. both named `v1`, are already resolved by
+                    # the whole-file pass below, so they're left untouched to
+                    # keep their params/callees.) Expanded helpers' bodies are
+                    # suppressed in the whole-file pass to avoid emitting the
+                    # prefix-less variant alongside the corrected one.
+                    dir = File.dirname(path)
+                    dir_builder_prefixes = builder_prefixes_by_dir[dir]? || EMPTY_BUILDER_PREFIXES
+                    expand_builders = [] of Tuple(String, Noir::TreeSitterGoRouteExtractor::RouterBuilder, Set(String))
+                    suppress_ranges = [] of Range(Int32, Int32)
+                    if content.includes?("*gin.RouterGroup")
+                      Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(content).each do |fn, rb|
+                        pset = dir_builder_prefixes[fn]?
+                        next unless pset && !pset.empty?
+                        next if cross_file_groups.has_key?(rb.param)
+                        suppress_ranges << (rb.start_row..rb.end_row)
+                        expand_builders << {fn, rb, pset}
+                      end
+                    end
+
                     # Gin also accepts `r.Handle(method, path, handler)`
                     # alongside the verb shortcuts (`r.GET`, etc.),
                     # so opt into the method-first decoder so those
@@ -71,6 +108,11 @@ module Analyzer::Go
                     end
 
                     lines.each_with_index do |line, index|
+                      # Skip lines inside an expanded router-builder body — its
+                      # routes (and any params) are emitted, with the call-site
+                      # prefix applied, by the expansion pass below.
+                      next if suppress_ranges.any? { |r| r.includes?(index) }
+
                       details = Details.new(PathInfo.new(path, index + 1))
 
                       # Emit endpoints for any verb route that begins on this
@@ -123,6 +165,25 @@ module Analyzer::Go
                         end
                       end
                     end
+
+                    # Expansion pass: emit each suppressed router-builder's
+                    # routes once per resolved call-site prefix, with the
+                    # group parameter bound to that prefix. (A helper called
+                    # from two versioned groups — `addPingRoutes(v1)` and
+                    # `addPingRoutes(v2)` — yields both `/v1/ping` and
+                    # `/v2/ping`.)
+                    expand_builders.each do |fn, rb, pset|
+                      pset.each do |prefix|
+                        Noir::TreeSitterGoRouteExtractor.extract_routes_from_function(
+                          content, fn, {rb.param => prefix}, handle_method: "Handle"
+                        ).each do |route|
+                          rdetails = Details.new(PathInfo.new(path, route.line + 1))
+                          Noir::TreeSitterGoRouteExtractor.fan_out_verbs(route.verb).each do |verb|
+                            result << Endpoint.new(route.path, verb, rdetails)
+                          end
+                        end
+                      end
+                    end
                   end
                 rescue File::NotFoundError
                   logger.debug "File not found: #{path}"
@@ -136,6 +197,44 @@ module Analyzer::Go
       end
 
       resolve_public_dirs(public_dirs)
+
+      result
+    end
+
+    # Builds `{dir => {builder_fn => set(prefixes)}}` for the package by
+    # (1) collecting every `func F(rg *gin.RouterGroup)` helper across the
+    # directory's files and (2) resolving each call site `F(arg)` to the
+    # prefix `arg` denotes via the directory group map. A helper called
+    # with several different groups accumulates each prefix.
+    private def resolve_router_builder_prefixes(file_contents : Hash(String, String),
+                                                package_groups : Hash(String, Hash(String, String))) : Hash(String, Hash(String, Set(String)))
+      result = Hash(String, Hash(String, Set(String))).new
+      files_by_dir = Hash(String, Array(String)).new
+      file_contents.each_key { |p| (files_by_dir[File.dirname(p)] ||= [] of String) << p }
+
+      files_by_dir.each do |dir, paths|
+        builders = Set(String).new
+        paths.each do |p|
+          content = file_contents[p]?
+          next unless content
+          next unless content.includes?("*gin.RouterGroup")
+          Noir::TreeSitterGoRouteExtractor.collect_router_group_builders(content).each_key { |fn| builders << fn }
+        end
+        next if builders.empty?
+
+        group_map = package_groups[dir]? || Hash(String, String).new
+        prefixes = Hash(String, Set(String)).new
+        paths.each do |p|
+          content = file_contents[p]?
+          next unless content
+          Noir::TreeSitterGoRouteExtractor.collect_router_builder_callsites(content, builders).each do |fn, arg|
+            if prefix = group_map[arg]?
+              (prefixes[fn] ||= Set(String).new) << prefix
+            end
+          end
+        end
+        result[dir] = prefixes unless prefixes.empty?
+      end
 
       result
     end

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -257,6 +257,10 @@ module Noir::TreeSitter
     LibTreeSitter.ts_node_start_point(node).row.to_i
   end
 
+  def self.node_end_row(node : LibTreeSitter::TSNode) : Int32
+    LibTreeSitter.ts_node_end_point(node).row.to_i
+  end
+
   def self.field(node : LibTreeSitter::TSNode, name : String) : LibTreeSitter::TSNode?
     child = LibTreeSitter.ts_node_child_by_field_name(node, name.to_unsafe, name.bytesize.to_u32)
     LibTreeSitter.ts_node_is_null(child) ? nil : child

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -350,16 +350,46 @@ module Noir
         walk(root) do |node|
           next unless Noir::TreeSitter.node_type(node) == "call_expression"
           fn = Noir::TreeSitter.field(node, "function")
-          next unless fn && Noir::TreeSitter.node_type(fn) == "identifier"
-          name = Noir::TreeSitter.node_text(fn, source)
-          next unless builders.includes?(name)
+          next unless fn
+          fn_name = Noir::TreeSitter.node_text(fn, source).split(".").last
+          next unless builders.includes?(fn_name)
+          name = fn_name
           args = Noir::TreeSitter.field(node, "arguments")
           next unless args
           first_arg = nil
           Noir::TreeSitter.each_named_child(args) { |a| first_arg ||= a }
           next unless first_arg
-          next unless Noir::TreeSitter.node_type(first_arg) == "identifier"
-          calls << {name, Noir::TreeSitter.node_text(first_arg, source)}
+          arg_text = if Noir::TreeSitter.node_type(first_arg) == "identifier"
+                       Noir::TreeSitter.node_text(first_arg, source)
+                     elsif Noir::TreeSitter.node_type(first_arg) == "call_expression"
+                       # Support inline `addX(router.Group("/v1"))` — treat the
+                       # literal prefix as the "arg" key (resolve will see it
+                       # starts with / and use directly).
+                       gfn = Noir::TreeSitter.field(first_arg, "function")
+                       if gfn && Noir::TreeSitter.node_text(gfn, source).split(".").last == "Group"
+                         gargs = Noir::TreeSitter.field(first_arg, "arguments")
+                         if gargs
+                           lit = nil
+                           Noir::TreeSitter.each_named_child(gargs) do |ga|
+                             if s = string_expr_text(ga, source, {} of String => String)
+                               if s.starts_with?("/")
+                                 lit = s
+                                 break
+                               end
+                             end
+                           end
+                           lit
+                         end
+                       end
+                     end
+          if arg_text
+            calls << {name, arg_text}
+          else
+            # Non-identifier, non-inline-Group arg (e.g. expr, func result,
+            # root router, etc.) — record so caller can apply "all sites must
+            # resolve" guard and fall back to whole-file pass.
+            calls << {name, "__unresolved__"}
+          end
         end
       end
       calls

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -281,6 +281,133 @@ module Noir
       group_prefixes
     end
 
+    # A Gin "router-builder" helper — `func F(rg *gin.RouterGroup) {...}`
+    # — whose body registers routes onto the passed-in group. `param` is
+    # the group parameter's name; `start_row`/`end_row` bound the
+    # declaration so the caller can suppress the (prefix-less) routes the
+    # whole-file pass would otherwise emit for it.
+    struct RouterBuilder
+      getter param : String
+      getter start_row : Int32
+      getter end_row : Int32
+
+      def initialize(@param, @start_row, @end_row)
+      end
+    end
+
+    # Detects top-level Gin router-builder helpers. The canonical gin
+    # project layout splits registration across `func addXRoutes(rg
+    # *gin.RouterGroup)` helpers called from a central `getRoutes()` with
+    # a versioned group (`addUserRoutes(router.Group("/v1"))`). The group
+    # prefix lives at the call site, not in the helper, so the helper's
+    # routes need that prefix grafted on (see `extract_routes_from_function`).
+    # Returns `{func_name => RouterBuilder}`; only functions with exactly
+    # one `*gin.RouterGroup` parameter qualify (an ambiguous count can't be
+    # bound to a single prefix).
+    def collect_router_group_builders(source : String) : Hash(String, RouterBuilder)
+      result = Hash(String, RouterBuilder).new
+      Noir::TreeSitter.parse_go(source) do |root|
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "function_declaration"
+          name_node = Noir::TreeSitter.field(node, "name")
+          params = Noir::TreeSitter.field(node, "parameters")
+          next unless name_node && params
+          param = router_group_param_name(params, source)
+          next unless param
+          result[Noir::TreeSitter.node_text(name_node, source)] =
+            RouterBuilder.new(param, Noir::TreeSitter.node_start_row(node), Noir::TreeSitter.node_end_row(node))
+        end
+      end
+      result
+    end
+
+    # Returns the sole `*gin.RouterGroup` parameter's name, or nil when
+    # the function has zero or more than one such parameter.
+    private def router_group_param_name(params : LibTreeSitter::TSNode, source : String) : String?
+      found = nil
+      count = 0
+      Noir::TreeSitter.each_named_child(params) do |decl|
+        next unless Noir::TreeSitter.node_type(decl) == "parameter_declaration"
+        type_node = Noir::TreeSitter.field(decl, "type")
+        name_node = Noir::TreeSitter.field(decl, "name")
+        next unless type_node && name_node
+        final = Noir::TreeSitter.node_text(type_node, source).lchop('*').split('.').last
+        next unless final == "RouterGroup"
+        count += 1
+        found = Noir::TreeSitter.node_text(name_node, source)
+      end
+      count == 1 ? found : nil
+    end
+
+    # Finds calls to any of the named builder functions and returns
+    # `[{func_name, first_arg_identifier}]`. The first argument names the
+    # group passed in (`addUserRoutes(v1)` -> `{"addUserRoutes", "v1"}`),
+    # which the caller resolves to a prefix via the package group map.
+    def collect_router_builder_callsites(source : String, builders : Set(String)) : Array(Tuple(String, String))
+      calls = [] of Tuple(String, String)
+      return calls if builders.empty?
+      Noir::TreeSitter.parse_go(source) do |root|
+        walk(root) do |node|
+          next unless Noir::TreeSitter.node_type(node) == "call_expression"
+          fn = Noir::TreeSitter.field(node, "function")
+          next unless fn && Noir::TreeSitter.node_type(fn) == "identifier"
+          name = Noir::TreeSitter.node_text(fn, source)
+          next unless builders.includes?(name)
+          args = Noir::TreeSitter.field(node, "arguments")
+          next unless args
+          first_arg = nil
+          Noir::TreeSitter.each_named_child(args) { |a| first_arg ||= a }
+          next unless first_arg
+          next unless Noir::TreeSitter.node_type(first_arg) == "identifier"
+          calls << {name, Noir::TreeSitter.node_text(first_arg, source)}
+        end
+      end
+      calls
+    end
+
+    # Extracts the verb routes registered inside one named function's body,
+    # seeding `external_groups` with the function's group parameter bound to
+    # a call-site prefix (`{rg => "/v1"}`). This grafts the call-site prefix
+    # onto routes a router-builder helper registers on its parameter group
+    # (`users := rg.Group("/users"); users.GET("/")` -> `/v1/users/`). Route
+    # line numbers stay relative to `source` so code paths remain accurate.
+    def extract_routes_from_function(source : String, func_name : String,
+                                     external_groups : Hash(String, String),
+                                     handle_method : String? = nil) : Array(Route)
+      routes = [] of Route
+      Noir::TreeSitter.parse_go(source) do |root|
+        string_values = collect_string_values(root, source)
+        find_function_body_node(root, source, func_name) do |body|
+          group_prefixes = external_groups.dup
+          walk(body) do |node|
+            next unless group_assignment_node?(node)
+            collect_group(node, source, group_prefixes, "Group", [] of String, string_values)
+          end
+          walk(body) do |node|
+            next unless Noir::TreeSitter.node_type(node) == "call_expression"
+            if route = decode_verb_call(node, source, group_prefixes, [] of String, "Group", [] of String, string_values)
+              routes << route
+            elsif handle_method && (route = decode_handle_call(node, source, group_prefixes, handle_method))
+              routes << route
+            end
+          end
+        end
+      end
+      dedupe_routes(routes)
+    end
+
+    private def find_function_body_node(node : LibTreeSitter::TSNode, source : String, name : String, &block : LibTreeSitter::TSNode ->)
+      if Noir::TreeSitter.node_type(node) == "function_declaration"
+        if (nn = Noir::TreeSitter.field(node, "name")) && Noir::TreeSitter.node_text(nn, source) == name
+          if body = Noir::TreeSitter.field(node, "body")
+            yield body
+            return
+          end
+        end
+      end
+      Noir::TreeSitter.each_named_child(node) { |c| find_function_body_node(c, source, name, &block) }
+    end
+
     # Collects Beego controller types and the HTTP-verb-named methods they
     # implement, keyed by the (package-unqualified) type name. Used to
     # resolve mapping-less `web.Router("/path", &Ctrl{})` registrations


### PR DESCRIPTION
Stacked on #1864 → #1863 (base retargets to `main` as those merge).

## Problem

The canonical gin layout (used by gin's own `examples/group-routes`) splits registration across `func addXRoutes(rg *gin.RouterGroup)` helpers invoked with a versioned group:

```go
v1 := router.Group("/v1")
addUserRoutes(v1)   // func addUserRoutes(rg *gin.RouterGroup) { users := rg.Group("/users"); users.GET("/", h) }
addPingRoutes(v1)
v2 := router.Group("/v2")
addPingRoutes(v2)
```

The prefix lives at the **call site** and the helper's parameter name (`rg`) does not match the caller's group variable (`v1`). So routes came out as `/users/` instead of `/v1/users/`, and the second `addPingRoutes(v2)` call's `/v2/ping` was missed entirely.

## Fix

New extractor helpers `collect_router_group_builders` / `collect_router_builder_callsites` / `extract_routes_from_function`, plus gin.cr `resolve_router_builder_prefixes`, resolve each builder's call-site prefixes and emit one route set per prefix (so a helper reused under `/v1` and `/v2` yields both).

## Safety (no regression on existing apps)

Only **"case b"** helpers are expanded — those whose group parameter name is NOT already a key in the package group map. **"Case a"** helpers whose parameter happens to match the caller's group variable (e.g. both named `v1`, as in **go-admin** and the existing `gin_engine_param_collision` fixture) are left to the established name-coincidence path, keeping their params/callees. Expanded builder bodies are line-range-suppressed in the whole-file pass to avoid emitting the prefix-less variant alongside the corrected one.

## Validation
- gin-gonic/examples `group-routes`: 4 prefix-less → 5 correct (`/v1/users/`, `/v1/users/comments`, `/v1/users/pictures`, `/v1/ping/`, `/v2/ping/`).
- **go-admin: 175 → 175** (case-a untouched); gin-vue-admin unchanged by this PR; sponge (indirect registry) safely not-expanded, no FP.
- New `node_end_row` tree-sitter helper, `gin_router_builder` fixture + unit test (fail on base); full suite green (functional 16481, unit 2906).

### Known follow-ups (deliberately out of scope)
Inline-group-arg call sites `addX(router.Group("/v1"))` (only group-var args resolved); indirect registries (`[]func(*gin.RouterGroup)` + generic register, e.g. sponge); expanded-route params/callees (matches the chi Mount-expansion precedent).