### PR TITLE
feat(ruby): Ruby analyzer FP/FN + perf sweep (rails/sinatra/grape/roda/hanami)

### DIFF
--- a/spec/functional_test/fixtures/ruby/grape/app.rb
+++ b/spec/functional_test/fixtures/ruby/grape/app.rb
@@ -47,6 +47,19 @@ class API < Grape::API
     end
   end
 
+  resource :articles do
+    # `requires :title` declares a json body param.
+    params do
+      requires :title
+    end
+    post do
+      token_header = "X-Token"
+      headers[token_header]   # bare variable subscript — must NOT become a param
+      headers["X-Request-Id"] # string literal — surfaces as a header param
+      params[:title]          # already declared json — must NOT re-add as query
+    end
+  end
+
   version "v2", using: :path
 
   resource :status do

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/config/routes.rb
@@ -22,6 +22,11 @@ module Testapp
       end
 
       resource :account, only: %i[show]
+
+      post "/widgets/:id/build",
+           to: "widgets.build"
     end
+
+    mount Sidekiq::Web, at: "/sidekiq"
   end
 end

--- a/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/widgets/build.rb
+++ b/spec/functional_test/fixtures/ruby/hanami_advanced/slices/main/actions/widgets/build.rb
@@ -1,0 +1,15 @@
+module Main
+  module Actions
+    module Widgets
+      class Build < Main::Action
+        params do
+          required(:quantity).filled(:integer)
+        end
+
+        def handle(request, response)
+          response.render(request.params[:id])
+        end
+      end
+    end
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -94,10 +94,11 @@ Rails.application.routes.draw do
   get "feed(.:format)", to: "monitor#ping"
   get "report(/:section)/rss", to: "monitor#ping"
 
-  # Unresolved `#{...}` interpolation (a `.each` loop variable, like
-  # Redmine's repository routes) must normalize to a `{placeholder}` and
-  # never leak raw Ruby into the URL. The `.each do` block is also a
-  # transparent scope — the route after it keeps the root prefix.
+  # A `%w[...].each do |action|` loop over a literal list (like Redmine's
+  # repository routes) unrolls to one route per element with `#{action}`
+  # substituted — never leaking raw Ruby or a fabricated `{action}` path
+  # param into the URL. The `.each do` block is also a transparent scope —
+  # the route after it keeps the root prefix.
   %w[browse annotate].each do |action|
     get "repo/:id/#{action}", to: "monitor#ping"
   end

--- a/spec/functional_test/fixtures/ruby/sinatra/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra/app.rb
@@ -73,6 +73,10 @@ namespace "/admin" do
     params[:since]
   end
 end
+get "/files/*" do
+  params[:splat]
+  params[:real]
+end
 
 def helper_noise
   params[:should_not_attach]

--- a/spec/functional_test/testers/ruby/grape_spec.cr
+++ b/spec/functional_test/testers/ruby/grape_spec.cr
@@ -20,6 +20,13 @@ expected_endpoints = [
     Param.new("account_id", "", "path"),
     Param.new("expand", "", "query"),
   ]),
+  # `requires :title` -> json (NOT duplicated as query by the later
+  # `params[:title]` read); `headers["X-Request-Id"]` literal -> header;
+  # the bare-variable `headers[token_header]` subscript is NOT captured.
+  Endpoint.new("/articles", "POST", [
+    Param.new("title", "", "json"),
+    Param.new("X-Request-Id", "", "header"),
+  ]),
   Endpoint.new("/v2/status", "GET"),
   # Symbol verb path (`get :ping`) is a literal segment, not a `{ping}` param.
   Endpoint.new("/v2/status/ping", "GET"),
@@ -27,5 +34,5 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/ruby/grape/", {
   :techs     => 1,
-  :endpoints => 12,
+  :endpoints => 13,
 }, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/ruby/hanami_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/hanami_advanced_spec.cr
@@ -74,6 +74,16 @@ article_show = Endpoint.new("/articles/:slug", "GET", [
   ep.push_callee(Callee.new("ArticleRepository.find_by_slug"))
 end
 
+widgets_build = Endpoint.new("/widgets/:id/build", "POST", [
+  Param.new("id", "", "path"),
+  Param.new("quantity", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("response.render"))
+  ep.push_callee(Callee.new("request.params"))
+end
+
+sidekiq = Endpoint.new("/sidekiq", "GET")
+
 expected_endpoints = [
   root,
   interpolated,
@@ -88,6 +98,8 @@ expected_endpoints = [
   users_create,
   users_login,
   article_show,
+  widgets_build,
+  sidekiq,
 ]
 
 FunctionalTester.new("fixtures/ruby/hanami_advanced/", {

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -140,9 +140,13 @@ expected_endpoints = [
     Param.new("X-Ping", "", "header"),
   ]),
 
-  # Unresolved `#{action}` loop-variable interpolation collapses to a
-  # `{placeholder}` instead of leaking raw Ruby into the URL.
-  Endpoint.new("/repo/:id/{action}", "GET", [
+  # `%w[browse annotate].each do |action|` unrolls to one route per literal
+  # element with `#{action}` substituted — never leaking raw Ruby or a
+  # fabricated `{action}` path param into the URL.
+  Endpoint.new("/repo/:id/browse", "GET", [
+    Param.new("X-Ping", "", "header"),
+  ]),
+  Endpoint.new("/repo/:id/annotate", "GET", [
     Param.new("X-Ping", "", "header"),
   ]),
 
@@ -193,7 +197,7 @@ total_endpoints = 1 +  # root
                   4 +  # posts/1/comments + nested likes from concern
                   2 +  # /up + /ping
                   2 +  # optional-segment routes /feed + /report/rss
-                  1 +  # %w[...].each loop route with normalized #{action}
+                  2 +  # %w[browse annotate].each unrolled to /repo/:id/browse + /annotate
                   20 + # devise_for :users
                   1 +  # mount sidekiq
                   1 +  # multiline parenthesized get

--- a/spec/functional_test/testers/ruby/sinatra_spec.cr
+++ b/spec/functional_test/testers/ruby/sinatra_spec.cr
@@ -31,9 +31,12 @@ expected_endpoints = [
   Endpoint.new("/admin/audit", "GET", [
     Param.new("since", "", "query"),
   ]),
+  Endpoint.new("/files/*", "GET", [
+    Param.new("real", "", "query"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/ruby/sinatra/", {
   :techs     => 1,
-  :endpoints => 10,
+  :endpoints => 11,
 }, expected_endpoints).perform_tests

--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -129,8 +129,8 @@ describe "Endpoint equality" do
       endpoint = Endpoint.new("/p", "GET")
       endpoint.push_param(Param.new("id", "", "query"))
       endpoint.push_param(Param.new("id", "later", "query")) # dup (name, type) — dropped
-      endpoint.push_param(Param.new("id", "", "path"))        # same name, different type — kept
-      endpoint.push_param(Param.new("name", "", "query"))     # different name — kept
+      endpoint.push_param(Param.new("id", "", "path"))       # same name, different type — kept
+      endpoint.push_param(Param.new("name", "", "query"))    # different name — kept
 
       endpoint.params.size.should eq 3
       endpoint.params.count { |p| p.name == "id" && p.param_type == "query" }.should eq 1

--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -124,6 +124,20 @@ describe "Endpoint equality" do
     end
   end
 
+  describe "#push_param" do
+    it "dedups by (name, param_type) but keeps distinct params" do
+      endpoint = Endpoint.new("/p", "GET")
+      endpoint.push_param(Param.new("id", "", "query"))
+      endpoint.push_param(Param.new("id", "later", "query")) # dup (name, type) — dropped
+      endpoint.push_param(Param.new("id", "", "path"))        # same name, different type — kept
+      endpoint.push_param(Param.new("name", "", "query"))     # different name — kept
+
+      endpoint.params.size.should eq 3
+      endpoint.params.count { |p| p.name == "id" && p.param_type == "query" }.should eq 1
+      endpoint.params.count { |p| p.name == "id" && p.param_type == "path" }.should eq 1
+    end
+  end
+
   describe "#add_tag" do
     it "dedups by (name, tagger) but keeps distinct tags" do
       endpoint = Endpoint.new("/tagged", "GET")

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -199,7 +199,7 @@ describe "EndpointOptimizer" do
 
       ruby_params = result[0].params
       ruby_params.count { |p| p.name == "id" }.should eq(1)
-      ruby_params.find { |p| p.name == "id" }.not_nil!.param_type.should eq("path")
+      ruby_params.find! { |p| p.name == "id" }.param_type.should eq("path")
       ruby_params.any? { |p| p.name == "token" && p.param_type == "query" }.should be_true
 
       result[1].params.count { |p| p.name == "id" }.should eq(2) # path + query both kept

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -180,6 +180,31 @@ describe "EndpointOptimizer" do
       end
     end
 
+    it "reconciles ruby path params against same-named query/body params" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      ruby_details = Details.new
+      ruby_details.technology = "ruby_rails"
+      other_details = Details.new
+      other_details.technology = "lucky"
+
+      endpoints = [
+        # Rack frameworks merge path captures into params, so the body
+        # `params[:id]` for /users/:id IS the path value — drop the query dup.
+        Endpoint.new("/users/:id", "GET", [Param.new("id", "", "query"), Param.new("token", "", "query")], ruby_details),
+        # Non-ruby (Lucky) keeps separate typed path/query buckets — keep both.
+        Endpoint.new("/users/:id", "GET", [Param.new("id", "", "query")], other_details),
+      ]
+
+      result = optimizer.add_path_parameters(endpoints)
+
+      ruby_params = result[0].params
+      ruby_params.count { |p| p.name == "id" }.should eq(1)
+      ruby_params.find { |p| p.name == "id" }.not_nil!.param_type.should eq("path")
+      ruby_params.any? { |p| p.name == "token" && p.param_type == "query" }.should be_true
+
+      result[1].params.count { |p| p.name == "id" }.should eq(2) # path + query both kept
+    end
+
     it "names catch-all path variables without the leading asterisk" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/spec/unit_test/tagger/framework_taggers/ruby_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/ruby_auth_spec.cr
@@ -73,7 +73,7 @@ describe "RubyAuthTagger (Grape/Roda)" do
     noir_options = create_test_options
     noir_options["base"] = YAML::Any.new(grape_base)
 
-    details = Details.new(PathInfo.new(grape_path, 68)) # admin/dashboard get with before
+    details = Details.new(PathInfo.new(grape_path, 81)) # admin/dashboard get with before
     details.technology = "ruby_grape"
     endpoint = Endpoint.new("/admin/dashboard", "GET", [] of Param, details)
 

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -4,6 +4,20 @@ module Analyzer::Ruby
   class Grape < RubyEngine
     GRAPE_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
+    # Crystal recompiles an interpolated regex literal (`/^#{verb}.../`)
+    # on every evaluation — ~11000x slower than a precompiled one — so
+    # matching the verb DSL inside the per-line loop used to recompile
+    # 14 regexes for every line of every Grape file. Build the per-verb
+    # patterns once at load time instead. `_WITH_PATH` matches
+    # `get '/users' do` (capturing the path literal/symbol); `_BARE_DO`
+    # matches the path-less `get do` form.
+    GRAPE_VERB_WITH_PATH = GRAPE_VERBS.to_h do |verb|
+      {verb, /^#{verb}\b(?:\s+(['":][\w\/\-:]+[\'""]?))?(?:\s*,[^#]*?)?\s*do\b/}
+    end
+    GRAPE_VERB_BARE_DO = GRAPE_VERBS.to_h do |verb|
+      {verb, /^#{verb}\s+do\b/}
+    end
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -79,7 +93,13 @@ module Analyzer::Ruby
 
         verb_handled = false
         GRAPE_VERBS.each do |verb|
-          if m = stripped.match(/^#{verb}\b(?:\s+(['":][\w\/\-:]+[\'""]?))?(?:\s*,[^#]*?)?\s*do\b/)
+          # Cheap prefix gate before the (precompiled) anchored regexes:
+          # skips the regex work entirely for the vast majority of lines
+          # that don't open with a verb keyword.
+          next unless stripped.starts_with?(verb)
+          next if stripped.size > verb.size && (stripped[verb.size].alphanumeric? || stripped[verb.size] == '_')
+
+          if m = stripped.match(GRAPE_VERB_WITH_PATH[verb])
             raw_match = (m[1]? || "").to_s
             raw_path = grape_literal_or_param_path(raw_match)
             ep_path = build_path(class_prefix, version_prefix, prefix_segments, raw_path)
@@ -104,7 +124,7 @@ module Analyzer::Ruby
             break
           end
 
-          if m = stripped.match(/^#{verb}\s+do\b/)
+          if m = stripped.match(GRAPE_VERB_BARE_DO[verb])
             ep_path = build_path(class_prefix, version_prefix, prefix_segments, "")
             details = Details.new(PathInfo.new(path, index + 1))
             endpoint = Endpoint.new(ep_path, verb.upcase, details)
@@ -130,20 +150,21 @@ module Analyzer::Ruby
         next if verb_handled
 
         if le = last_endpoint
-          line.scan(/\bparams\[['"]?:?([\w-]+)['"]?\]/) do |match|
-            if match.size > 1
-              push_grape_param(le, Param.new(match[1], "", "query"))
-            end
+          # Require a symbol (`:name`) or string (`'name'`/`"name"`) key.
+          # The old `['"]?:?` made both optional, so a bare-variable
+          # subscript like `headers[key]` (where `key` is a local) was
+          # mis-captured as a literal header named `key`.
+          line.scan(/\bparams\[\s*(?::([\w-]+)|['"]([\w-]+)['"])\s*\]/) do |match|
+            name = (match[1]? || match[2]?).to_s
+            push_grape_param(le, Param.new(name, "", "query")) unless name.empty?
           end
-          line.scan(/\bheaders\[['"]?:?([\w-]+)['"]?\]/) do |match|
-            if match.size > 1
-              push_grape_param(le, Param.new(match[1], "", "header"))
-            end
+          line.scan(/\bheaders\[\s*(?::([\w-]+)|['"]([\w-]+)['"])\s*\]/) do |match|
+            name = (match[1]? || match[2]?).to_s
+            push_grape_param(le, Param.new(name, "", "header")) unless name.empty?
           end
-          line.scan(/\bcookies\[['"]?:?([\w-]+)['"]?\]/) do |match|
-            if match.size > 1
-              push_grape_param(le, Param.new(match[1], "", "cookie"))
-            end
+          line.scan(/\bcookies\[\s*(?::([\w-]+)|['"]([\w-]+)['"])\s*\]/) do |match|
+            name = (match[1]? || match[2]?).to_s
+            push_grape_param(le, Param.new(name, "", "cookie")) unless name.empty?
           end
         end
 
@@ -176,6 +197,11 @@ module Analyzer::Ruby
 
     private def push_grape_param(endpoint : Endpoint, param : Param)
       return if param.param_type == "query" && endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == "path" }
+      # A `params do; requires :x; end` block already declared `:x` as a
+      # body (json/form) param; a later `params[:x]` read in the handler
+      # body must not re-add it as a separate `query` param. The declared
+      # type wins.
+      return if param.param_type == "query" && endpoint.params.any? { |existing| existing.name == param.name && (existing.param_type == "json" || existing.param_type == "form" || existing.param_type == "formData") }
       return if endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
       endpoint.push_param(param)
     end

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -197,11 +197,10 @@ module Analyzer::Ruby
 
     private def push_grape_param(endpoint : Endpoint, param : Param)
       return if param.param_type == "query" && endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == "path" }
-      # A `params do; requires :x; end` block already declared `:x` as a
-      # body (json/form) param; a later `params[:x]` read in the handler
-      # body must not re-add it as a separate `query` param. The declared
-      # type wins.
-      return if param.param_type == "query" && endpoint.params.any? { |existing| existing.name == param.name && (existing.param_type == "json" || existing.param_type == "form" || existing.param_type == "formData") }
+      # A `params do; requires :x; end` block already declared `:x` as a json
+      # body param; a later `params[:x]` read in the handler body must not
+      # re-add it as a separate `query` param. The declared type wins.
+      return if param.param_type == "query" && endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == "json" }
       return if endpoint.params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
       endpoint.push_param(param)
     end

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -32,10 +32,7 @@ module Analyzer::Ruby
       stack = [] of RouteFrame
 
       File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line.with_index do |raw_line, index|
-          line = Noir::RubyCalleeExtractor.strip_comment(raw_line, preserve_strings: true).strip
-          next if line.empty?
-
+        hanami_logical_lines(file).each do |line, index|
           if closes_block?(line)
             stack.pop unless stack.empty?
             next
@@ -43,6 +40,11 @@ module Analyzer::Ruby
 
           opens_block = opens_route_block?(line)
           details = Details.new(PathInfo.new(path, index + 1))
+
+          if mounted = mount_endpoint(line, stack, details)
+            @result << mounted
+            next
+          end
 
           if neutral_block?(line)
             stack << RouteFrame.new if opens_block
@@ -81,6 +83,51 @@ module Analyzer::Ruby
           end
         end
       end
+    end
+
+    # Join continuation lines so a route whose options spill onto the next
+    # line is parsed as one statement. Hanami routes routinely wrap a long
+    # `to:`/`as:` tail:
+    #   post "/extensions/:extension_id/build",
+    #        to: "extensions.builds.create"
+    # Without joining, the verb line carries no `to:` so the action file is
+    # never opened and all of the route's params/callees are dropped.
+    # Returns {logical_line, first_line_index} pairs; comments are stripped
+    # and strings preserved, mirroring the per-line parse.
+    private def hanami_logical_lines(file) : Array(Tuple(String, Int32))
+      result = [] of Tuple(String, Int32)
+      buffer = ""
+      buffer_index = 0
+
+      file.each_line.with_index do |raw_line, index|
+        line = Noir::RubyCalleeExtractor.strip_comment(raw_line, preserve_strings: true).strip
+        next if line.empty?
+
+        if buffer.empty?
+          buffer = line
+          buffer_index = index
+        else
+          buffer = "#{buffer} #{line}"
+        end
+
+        next if buffer.ends_with?(",")
+        result << {buffer, buffer_index}
+        buffer = ""
+      end
+
+      result << {buffer, buffer_index} unless buffer.empty?
+      result
+    end
+
+    # `mount RackApp, at: "/path"` mounts a sub-app at a prefix (Sidekiq::Web,
+    # a sub-router). Emit a best-effort GET at the mount prefix so the
+    # mounted surface isn't invisible — same shape as the Rails analyzer.
+    private def mount_endpoint(line : String, stack : Array(RouteFrame), details : Details) : Endpoint?
+      return unless line.starts_with?("mount")
+      return if line.size > 5 && (line[5].alphanumeric? || line[5] == '_')
+      return unless m = line.match(/\bat:\s*['"]([^'"]+)['"]/)
+
+      Endpoint.new(join_paths(current_path_prefix(stack), m[1]), "GET", details)
     end
 
     def extract_action_path(content : String, framework_root : String = @base_path) : String

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -123,9 +123,8 @@ module Analyzer::Ruby
     # a sub-router). Emit a best-effort GET at the mount prefix so the
     # mounted surface isn't invisible — same shape as the Rails analyzer.
     private def mount_endpoint(line : String, stack : Array(RouteFrame), details : Details) : Endpoint?
-      return unless line.starts_with?("mount")
-      return if line.size > 5 && (line[5].alphanumeric? || line[5] == '_')
-      return unless m = line.match(/\bat:\s*['"]([^'"]+)['"]/)
+      return unless call = route_call(line, ["mount"])
+      return unless m = call.match(/\bat:\s*['"]([^'"]+)['"]/)
 
       Endpoint.new(join_paths(current_path_prefix(stack), m[1]), "GET", details)
     end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -652,7 +652,7 @@ module Analyzer::Ruby
         content.each_line do |raw|
           line = strip_inline_comment(raw)
           next unless line.includes?("mount")
-          if m = line.match(/\bmount\s+(?:::)?([A-Z][A-Za-z0-9_:]*)\s*(?:,\s*at:\s*|=>\s*)['"]([^'"]+)['"]/)
+          if m = line.match(/\bmount\b\s*\(?\s*(?:::)?([A-Z][A-Za-z0-9_:]*)\s*(?:,\s*at:\s*|=>\s*)['"]([^'"]+)['"]/)
             const = m[1]
             map[const] = normalize_mount_prefix(m[2]) unless map.has_key?(const)
           end

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -179,7 +179,7 @@ module Analyzer::Ruby
         # Handle `end` (top of stack pops one). Closing a
         # `use_doorkeeper` block is where its routes are emitted, now
         # that any `skip_controllers`/`controllers` config is known.
-        if line == "end" || line.starts_with?("end ") || line.starts_with?("end;") || line.starts_with?("end#")
+        if end_line?(line)
           unless stack.empty?
             popped = stack.pop
             if popped.kind == :doorkeeper
@@ -585,7 +585,19 @@ module Analyzer::Ruby
     # so it is left for the normal parser (its block opens a neutral frame).
     LOOP_OPENER = /^%([wi])[\[\(\{]([^\]\)\}]*)[\]\)\}]\s*\.each(?:_with_index)?\s+do\s*\|\s*([a-z_]\w*)[^|]*\|\s*$/
 
-    private def expand_static_loops(lines : Array(String)) : Array(String)
+    # noir scans arbitrary untrusted repos, so loop unrolling must not be a DoS
+    # vector — expansion is multiplicative (elements ^ nesting). A crafted
+    # `routes.rb` with deep nesting or a huge `%w[...]` list could otherwise
+    # blow up CPU/memory. Real apps use tiny shallow lists (discourse's biggest
+    # is the 2-element `%w[users u]`), so modest caps preserve all genuine
+    # recall while bounding the worst case. Over a limit, the block is passed
+    # through unexpanded (the pre-unrolling behavior — a transparent frame).
+    MAX_LOOP_DEPTH  =      3
+    MAX_LOOP_VALUES =    100
+    MAX_LOOP_OUTPUT = 20_000
+
+    private def expand_static_loops(lines : Array(String), depth : Int32 = 0) : Array(String)
+      return lines if depth > MAX_LOOP_DEPTH
       return lines unless lines.any?(&.matches?(LOOP_OPENER))
 
       result = [] of String
@@ -598,24 +610,34 @@ module Analyzer::Ruby
 
           # Walk to the `end` that closes this `.each do`, mirroring the main
           # parser's one-block-open-per-line / `end`-pops-one model.
-          depth = 1
+          block_depth = 1
           body = [] of String
           cursor = index + 1
-          while cursor < lines.size && depth > 0
+          while cursor < lines.size && block_depth > 0
             body_line = lines[cursor]
             if end_line?(body_line)
-              depth -= 1
-              break if depth == 0
+              block_depth -= 1
+              break if block_depth == 0
             elsif opens_do_block?(body_line) || opens_keyword_block?(body_line)
-              depth += 1
+              block_depth += 1
             end
             body << body_line
             cursor += 1
           end
 
-          expanded_body = expand_static_loops(body)
-          values.each do |value|
-            expanded_body.each { |unrolled| result << substitute_loop_var(unrolled, var, value) }
+          if values.size > MAX_LOOP_VALUES || result.size > MAX_LOOP_OUTPUT
+            # Over budget: emit the block verbatim so the main parser handles
+            # it as a neutral frame instead of unrolling an attacker-sized fan-out.
+            (index..cursor).each { |i| result << lines[i] if i < lines.size }
+          else
+            expanded_body = expand_static_loops(body, depth + 1)
+            # Precompile the substitution once per loop var (Crystal recompiles
+            # an interpolated regex literal on every match).
+            pattern = Regex.new("\\#\\{\\s*#{Regex.escape(var)}\\s*\\}")
+            values.each do |value|
+              break if result.size > MAX_LOOP_OUTPUT
+              expanded_body.each { |unrolled| result << unrolled.gsub(pattern, value) }
+            end
           end
           index = cursor + 1 # skip the closing `end`
         else
@@ -625,10 +647,6 @@ module Analyzer::Ruby
       end
 
       result
-    end
-
-    private def substitute_loop_var(line : String, var : String, value : String) : String
-      line.gsub(/\#\{\s*#{Regex.escape(var)}\s*\}/, value)
     end
 
     private def end_line?(line : String) : Bool

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -362,8 +362,11 @@ module Analyzer::Ruby
             url_segment = options["path"]? || name
             singular = (kind_kw == "resource")
             child_path = singular ? url_segment : "#{url_segment}/1"
+            # A `module:` on the resources line also scopes nested
+            # resources/routes inside its block, so carry it on the frame's
+            # controller_subdir for children to inherit.
             stack << Frame.new(:resources, path: child_path, resource_name: name,
-              controller_path: existing_controller_path)
+              controller_path: existing_controller_path, controller_subdir: options["module"]? || "")
           end
           next
         end
@@ -408,12 +411,18 @@ module Analyzer::Ruby
             next
           end
 
-          # `get "path"` / `get "path" => "..."` / `get "path", to: "..."`
-          if sm = rest.match(/^\s*['"]([^'"]+)['"]/)
+          # `get "path"` / `get "path" => "..."` / `get "path", to: "..."`.
+          # The path literal may be empty (`get "" => "admin#index"` maps a
+          # namespace to its bare prefix), so accept `*` not `+`.
+          if sm = rest.match(/^\s*['"]([^'"]*)['"]/)
             path = normalize_ruby_interpolation(strip_optional_route_segments(sm[1]))
             prefix = current_path_prefix_for_route(stack, route_scope)
             path_part = path.starts_with?("/") ? path : "/#{path}"
             url = prefix.empty? ? path_part : "/#{prefix}#{path_part}"
+            # `get ""` / `get "/"` inside a namespace/scope composes to a
+            # bare `/prefix/`; collapse the redundant trailing slash so the
+            # URL matches the real route (`/admin`, not `/admin/`).
+            url = url.rchop('/') if url.size > 1 && url.ends_with?('/')
 
             ctrl_action = parse_controller_action(rest, current_controller_scope(stack))
             action_params = [] of Param
@@ -451,11 +460,12 @@ module Analyzer::Ruby
         # same path/controller#action.
         if call = route_call(line, ["match"])
           rest = call[1]
-          if sm = rest.match(/^\s*['"]([^'"]+)['"]/)
+          if sm = rest.match(/^\s*['"]([^'"]*)['"]/)
             path = normalize_ruby_interpolation(strip_optional_route_segments(sm[1]))
             prefix = current_path_prefix_for_route(stack, parse_options(rest)["on"]?)
             path_part = path.starts_with?("/") ? path : "/#{path}"
             url = prefix.empty? ? path_part : "/#{prefix}#{path_part}"
+            url = url.rchop('/') if url.size > 1 && url.ends_with?('/')
 
             match_verbs = parse_match_verbs(rest)
             ctrl_action = parse_controller_action(rest, current_controller_scope(stack))
@@ -704,6 +714,15 @@ module Analyzer::Ruby
                                      options : Hash(String, String)) : String?
       singular = (kind_kw == "resource")
       controller_subdir = current_controller_subdir(stack)
+      # `module:` on a `resources`/`resource` line nests the controller
+      # under an extra namespace directory WITHOUT changing the URL —
+      # `resources :accounts, module: :lists` is served by
+      # `Lists::AccountsController` (app/controllers/.../lists/accounts_controller.rb).
+      # The namespace/scope `module:` is already folded into the stack via
+      # `controller_subdir`; the per-line one is not, so apply it here.
+      if line_module = options["module"]?
+        controller_subdir = controller_subdir.empty? ? line_module : "#{controller_subdir}/#{line_module}"
+      end
       ctrl_override = options["controller"]?
       file_base = if ctrl_override
                     ctrl_override.includes?('/') ? ctrl_override : (controller_subdir.empty? ? ctrl_override : "#{controller_subdir}/#{ctrl_override}")
@@ -721,6 +740,10 @@ module Analyzer::Ruby
       unless ctrl_override
         candidates << "#{framework_root}/app/controllers/#{file_base}s_controller.rb"
         candidates << "#{framework_root}/app/controllers/#{file_base}es_controller.rb"
+        # Irregular y->ies plural: a singular `resource :directory` is backed
+        # by `DirectoriesController` (directories_controller.rb), never
+        # `directorys`/`directoryes`.
+        candidates << "#{framework_root}/app/controllers/#{file_base.rchop('y')}ies_controller.rb" if file_base.ends_with?('y')
       end
 
       existing_controller_path = candidates.find { |c| File.exists?(c) }
@@ -1063,6 +1086,15 @@ module Analyzer::Ruby
             pm[1].split(',').each do |raw|
               name = raw.gsub(/[:\s'"]/, "")
               next if name.empty? || this_method.empty?
+              # A permit list entry is always a lowercase symbol/string key
+              # (`:title`, `tag_ids`). Splat-of-constant args
+              # (`permit(*PERMITTED_PARAMS)`, `permit(:a, *Filter::KEYS)`)
+              # and the garbage left by naive comma-splitting of nested
+              # `key: [...]` forms survive the quote/colon strip as
+              # `*PERMITTED_PARAMS` / `*FilterKEYS` / `address[city`. Drop
+              # anything that isn't a clean identifier so those don't leak
+              # in as fabricated param names.
+              next unless name.matches?(/\A[a-z_][a-z0-9_]*\z/)
               params_body_by_action[this_method] ||= [] of Param
               params_body_by_action[this_method] << Param.new(name, "", param_type)
               params_query_by_action[this_method] ||= [] of Param
@@ -1245,14 +1277,25 @@ module Analyzer::Ruby
     private def build_helper_call_map(method_bodies : Hash(String, Array(String)), defined_actions : Set(String)) : Hash(String, Array(String))
       helper_calls = Hash(String, Array(String)).new
 
+      # Tokenize each method body once into the set of identifiers it
+      # references, then test action names by set membership. The previous
+      # shape compiled an interpolated `/\b#{candidate}\b/` and rescanned
+      # the whole body for every (method × action) pair — O(M·A) recompiled
+      # regexes per controller, quadratic in the action count. Whole-token
+      # set membership is equivalent to the `\b…\b` word-boundary match for
+      # identifier names while running in O(M·body + M·A).
       method_bodies.each do |method_name, body_lines|
-        body = body_lines.join("\n")
+        tokens = Set(String).new
+        body_lines.each do |line|
+          line.scan(/[A-Za-z_]\w*[!?=]?/) { |m| tokens << m[0] }
+        end
+
+        matches = [] of String
         defined_actions.each do |candidate|
           next if candidate == method_name
-          next unless body.matches?(/\b#{Regex.escape(candidate)}\b/)
-          helper_calls[method_name] ||= [] of String
-          helper_calls[method_name] << candidate unless helper_calls[method_name].includes?(candidate)
+          matches << candidate if tokens.includes?(candidate)
         end
+        helper_calls[method_name] = matches unless matches.empty?
       end
 
       helper_calls

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -86,8 +86,16 @@ module Analyzer::Ruby
       stack : Array(Frame)
 
     @controller_data_cache = Hash(String, ControllerData).new
+    # Maps a mountable-engine constant (e.g. `DiscoursePoll::Engine`) to the
+    # path it is mounted at (`/polls`). A Rails engine's `routes.draw` block
+    # holds engine-relative paths; the `mount` that anchors them usually
+    # lives in a different file (a plugin.rb, the host app's routes), so we
+    # resolve it cross-file once up front.
+    @engine_mount_prefixes = Hash(String, String).new
 
     def analyze
+      @engine_mount_prefixes = build_engine_mount_map
+
       framework_roots = discover_framework_roots("config/routes.rb")
       framework_roots = [@base_path] if framework_roots.empty?
 
@@ -200,6 +208,21 @@ module Analyzer::Ruby
         # Outermost: Rails.application.routes.draw do ... end
         if line.starts_with?("Rails.application.routes.draw")
           stack << Frame.new(:neutral) if opens_block
+          next
+        end
+
+        # Mountable engine: `SomeEngine.routes.draw do ... end`. Its routes
+        # are relative to where the host `mount`s the engine, so resolve the
+        # mount prefix (built cross-file in @engine_mount_prefixes) and push
+        # it as a scope. Unknown mounts (engine shipped as a library, host
+        # not in scan) fall back to a transparent frame — same as before.
+        if opens_block && (em = line.match(/^(?:::)?([A-Z][A-Za-z0-9_:]*)\.routes\.draw\b/))
+          mount_prefix = @engine_mount_prefixes[em[1]]?
+          if mount_prefix && !mount_prefix.empty?
+            stack << Frame.new(:scope, path: mount_prefix)
+          else
+            stack << Frame.new(:neutral)
+          end
           next
         end
 
@@ -583,6 +606,39 @@ module Analyzer::Ruby
 
     private def end_line?(line : String) : Bool
       line == "end" || line.starts_with?("end ") || line.starts_with?("end;") || line.starts_with?("end#")
+    end
+
+    # Scan the files that declare engine mounts (`config/routes.rb`,
+    # `plugin.rb` — discourse pins every plugin's `mount X::Engine, at:`
+    # there) and build the engine-constant -> mount-path map. Forms handled:
+    #   mount X::Engine, at: "/p"        mount X::Engine => "/p"
+    #   Discourse::Application.routes.append { mount X::Engine, at: "/p" }
+    private def build_engine_mount_map : Hash(String, String)
+      map = Hash(String, String).new
+      all_files.each do |file|
+        base = File.basename(file)
+        next unless base == "plugin.rb" || base.ends_with?("routes.rb")
+        next unless File.exists?(file)
+        content = read_file_content(file)
+        next unless content.includes?("mount")
+
+        content.each_line do |raw|
+          line = strip_inline_comment(raw)
+          next unless line.includes?("mount")
+          if m = line.match(/\bmount\s+(?:::)?([A-Z][A-Za-z0-9_:]*)\s*(?:,\s*at:\s*|=>\s*)['"]([^'"]+)['"]/)
+            const = m[1]
+            map[const] = normalize_mount_prefix(m[2]) unless map.has_key?(const)
+          end
+        end
+      end
+      map
+    end
+
+    private def normalize_mount_prefix(at : String) : String
+      prefix = at.strip
+      return "" if prefix.empty? || prefix == "/"
+      prefix = prefix.rchop('/') if prefix.size > 1 && prefix.ends_with?('/')
+      prefix.lchop('/')
     end
 
     private def logical_route_lines(routes_path : String) : Array(String)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -145,7 +145,7 @@ module Analyzer::Ruby
       # `controllers foo: 'bar'` remaps the implementing controller.
       doorkeeper_skip = Set(String).new
       doorkeeper_controllers = Hash(String, String).new
-      logical_route_lines(routes_path).each do |raw_line|
+      expand_static_loops(logical_route_lines(routes_path)).each do |raw_line|
         line = raw_line.strip
         next if line.empty?
 
@@ -521,6 +521,68 @@ module Analyzer::Ruby
       end.join("|")
 
       "#{path}##{stack_key}"
+    end
+
+    # A `%w[...].each do |var|` / `%i[...].each_with_index do |var, i|`
+    # block over a STATIC literal list unrolls to one copy of its body per
+    # element with the loop variable's `#{var}` interpolations substituted.
+    # discourse alone wraps ~46 routes in `%w[users u].each` — without this,
+    # `get "#{root_path}/..."` leaks `{root_path}` into ~130 endpoints (a
+    # fabricated path param) AND the real /users + /u variants are lost.
+    #
+    # Only literal `%w`/`%i` receivers are expanded: a dynamic
+    # `Model.scopes.each do |s|` cannot be resolved to values at parse time,
+    # so it is left for the normal parser (its block opens a neutral frame).
+    LOOP_OPENER = /^%([wi])[\[\(\{]([^\]\)\}]*)[\]\)\}]\s*\.each(?:_with_index)?\s+do\s*\|\s*([a-z_]\w*)[^|]*\|\s*$/
+
+    private def expand_static_loops(lines : Array(String)) : Array(String)
+      return lines unless lines.any? { |l| l.matches?(LOOP_OPENER) }
+
+      result = [] of String
+      index = 0
+      while index < lines.size
+        line = lines[index]
+        if m = line.match(LOOP_OPENER)
+          var = m[3]
+          values = m[2].split(/\s+/).reject(&.empty?)
+
+          # Walk to the `end` that closes this `.each do`, mirroring the main
+          # parser's one-block-open-per-line / `end`-pops-one model.
+          depth = 1
+          body = [] of String
+          cursor = index + 1
+          while cursor < lines.size && depth > 0
+            body_line = lines[cursor]
+            if end_line?(body_line)
+              depth -= 1
+              break if depth == 0
+            elsif opens_do_block?(body_line) || opens_keyword_block?(body_line)
+              depth += 1
+            end
+            body << body_line
+            cursor += 1
+          end
+
+          expanded_body = expand_static_loops(body)
+          values.each do |value|
+            expanded_body.each { |body_line| result << substitute_loop_var(body_line, var, value) }
+          end
+          index = cursor + 1 # skip the closing `end`
+        else
+          result << line
+          index += 1
+        end
+      end
+
+      result
+    end
+
+    private def substitute_loop_var(line : String, var : String, value : String) : String
+      line.gsub(/\#\{\s*#{Regex.escape(var)}\s*\}/, value)
+    end
+
+    private def end_line?(line : String) : Bool
+      line == "end" || line.starts_with?("end ") || line.starts_with?("end;") || line.starts_with?("end#")
     end
 
     private def logical_route_lines(routes_path : String) : Array(String)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -586,7 +586,7 @@ module Analyzer::Ruby
     LOOP_OPENER = /^%([wi])[\[\(\{]([^\]\)\}]*)[\]\)\}]\s*\.each(?:_with_index)?\s+do\s*\|\s*([a-z_]\w*)[^|]*\|\s*$/
 
     private def expand_static_loops(lines : Array(String)) : Array(String)
-      return lines unless lines.any? { |l| l.matches?(LOOP_OPENER) }
+      return lines unless lines.any?(&.matches?(LOOP_OPENER))
 
       result = [] of String
       index = 0
@@ -615,7 +615,7 @@ module Analyzer::Ruby
 
           expanded_body = expand_static_loops(body)
           values.each do |value|
-            expanded_body.each { |body_line| result << substitute_loop_var(body_line, var, value) }
+            expanded_body.each { |unrolled| result << substitute_loop_var(unrolled, var, value) }
           end
           index = cursor + 1 # skip the closing `end`
         else

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -434,6 +434,33 @@ module Analyzer::Ruby
             next
           end
 
+          # `get :action, to: "ctrl#action"` outside any resource block —
+          # e.g. inside a bare `namespace :apps`. The symbol is a literal
+          # path segment (`/api/v1/apps/verify_credentials`), not a resource
+          # action. Requires an explicit destination so a bare `get :foo`
+          # with no controller context isn't fabricated into a route.
+          if (am = rest.match(/^\s*:(\w+)\b/)) && explicit_route_destination?(rest)
+            segment = am[1]
+            prefix = current_path_prefix_for_route(stack, route_scope)
+            url = prefix.empty? ? "/#{segment}" : "/#{prefix}/#{segment}"
+
+            ctrl_action = parse_controller_action(rest, current_controller_scope(stack))
+            ctrl_path = nil.as(String?)
+            action_name = nil.as(String?)
+            action_params = [] of Param
+            if ctrl_action
+              ctrl_name, action = ctrl_action
+              ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
+              action_name = action
+              action_params = params_for_action(ctrl_path, action, verb)
+            end
+
+            endpoint = Endpoint.new(url, verb, action_params, details)
+            attach_callees_for_action(endpoint, ctrl_path, action_name) if action_name
+            @result << endpoint
+            next
+          end
+
           # `get "path"` / `get "path" => "..."` / `get "path", to: "..."`.
           # The path literal may be empty (`get "" => "admin#index"` maps a
           # namespace to its bare prefix), so accept `*` not `+`.

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -4,6 +4,21 @@ module Analyzer::Ruby
   class Roda < RubyEngine
     HTTP_METHOD_MATCHERS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
+    # Precompile the per-verb routing-tree regexes once at load time.
+    # Crystal recompiles an interpolated regex literal on every match, so
+    # the `r.<verb>` matchers used to rebuild 21 regexes for every line of
+    # every route block. `_BLOCK` = `r.get "x" do |..|`/`{`, `_STRING` =
+    # `r.get "path"`, `_BARE` = `r.get` (do/brace/slash/eol).
+    RODA_VERB_BLOCK = HTTP_METHOD_MATCHERS.to_h do |verb|
+      {verb, /\br\.#{verb}\s+(.+?)\s*(?:do\b\s*(?:\|([^|]*)\|)?|\{\s*(?:\|([^|]*)\|)?)/}
+    end
+    RODA_VERB_STRING = HTTP_METHOD_MATCHERS.to_h do |verb|
+      {verb, /\br\.#{verb}\s+['"]([^'"]+)['"]/}
+    end
+    RODA_VERB_BARE = HTTP_METHOD_MATCHERS.to_h do |verb|
+      {verb, /\br\.#{verb}\b\s*(?:do\b|\{|\/|$)/}
+    end
+
     alias PrefixEntry = NamedTuple(depth: Int32, segments: Array(String), path_params: Array(String))
 
     def analyze
@@ -93,8 +108,12 @@ module Analyzer::Ruby
         return @result.size - 1
       end
 
+      # Every routing matcher below requires the `r.` request receiver, so
+      # skip the whole verb sweep for lines that cannot contain one.
+      return -1 unless line.includes?("r.")
+
       HTTP_METHOD_MATCHERS.each do |verb|
-        if m = line.match(/\br\.#{verb}\s+(.+?)\s*(?:do\b\s*(?:\|([^|]*)\|)?|\{\s*(?:\|([^|]*)\|)?)/)
+        if m = line.match(RODA_VERB_BLOCK[verb])
           segments, path_params = parse_on_args(m[1], m[2]? || m[3]?)
           unless segments.empty? && path_params.empty?
             url = build_url(collect_segments(prefix_stack), nil, segments)
@@ -107,7 +126,7 @@ module Analyzer::Ruby
           end
         end
 
-        if m = line.match(/\br\.#{verb}\s+['"]([^'"]+)['"]/)
+        if m = line.match(RODA_VERB_STRING[verb])
           url = build_url(collect_segments(prefix_stack), m[1], nil)
           ep = build_endpoint(url, verb.upcase, path, index)
           apply_path_params(ep, prefix_stack)
@@ -116,7 +135,7 @@ module Analyzer::Ruby
           return @result.size - 1
         end
 
-        if line =~ /\br\.#{verb}\b\s*(?:do\b|\{|\/|$)/
+        if line =~ RODA_VERB_BARE[verb]
           url = build_url(collect_segments(prefix_stack), nil, nil)
           url = "/" if url.empty?
           ep = build_endpoint(url, verb.upcase, path, index)

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -139,17 +139,23 @@ module Analyzer::Ruby
       line_to_params(content).first? || Param.new("", "", "")
     end
 
+    # `params[:splat]` (the `*` wildcard matches) and `params[:captures]`
+    # (regex route captures) are Sinatra's framework bindings for the
+    # route pattern itself, not user-supplied query fields — the `*`/regex
+    # segment is already modeled in the URL.
+    SINATRA_RESERVED_PARAMS = Set{"splat", "captures"}
+
     private def line_to_params(content : String) : Array(Param)
       params = [] of Param
 
       content.scan(/param\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
         name = (m[1]? || m[2]?).to_s.strip
-        params << Param.new(name, "", "query") unless name.empty?
+        params << Param.new(name, "", "query") unless name.empty? || SINATRA_RESERVED_PARAMS.includes?(name)
       end
 
       content.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
         name = (m[1]? || m[2]?).to_s.strip
-        params << Param.new(name, "", "query") unless name.empty?
+        params << Param.new(name, "", "query") unless name.empty? || SINATRA_RESERVED_PARAMS.includes?(name)
       end
 
       content.scan(/params\.fetch\s*\(\s*(?::(\w+)|['"]([^'"]+)['"])/) do |m|

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -50,7 +50,14 @@ struct Endpoint
     @tags << tag
   end
 
+  # Dedup by (name, param_type) like push_callee/add_tag do for their
+  # collections. A handler that reads the same input twice
+  # (`params[:id]` on two lines, a path param re-read in the body) used
+  # to surface the identical Param multiple times in the raw `params`
+  # list and the text output. `params_to_hash`/`==` already collapse on
+  # name+type, so deduping here only trims redundant entries.
   def push_param(param : Param)
+    return if @params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
     @params << param
   end
 

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -376,6 +376,24 @@ class EndpointOptimizer
         end
       end
 
+      # Reconcile path params against same-named query/body params for
+      # Ruby frameworks. Rack/Rails frameworks (Rails, Sinatra, Hanami,
+      # Roda, Grape) merge captured path segments into a single `params`
+      # hash, so a handler that reads `params[:id]` for a `/users/:id`
+      # route is reading the path value — not a separate query/body field.
+      # Once the path type is known, the duplicate non-path entry is
+      # redundant. This is NOT done globally: frameworks with separate
+      # path/query/body buckets (Lucky's typed params, Express
+      # `req.params` vs `req.query`) legitimately carry both.
+      tech = new_endpoint.details.technology
+      if tech && tech.starts_with?("ruby_")
+        path_names = new_endpoint.params.compact_map { |p| p.param_type == "path" ? p.name : nil }
+        unless path_names.empty?
+          path_name_set = path_names.to_set
+          new_endpoint.params.reject! { |p| p.param_type != "path" && path_name_set.includes?(p.name) }
+        end
+      end
+
       final << new_endpoint
     end
 

--- a/typos.toml
+++ b/typos.toml
@@ -21,6 +21,10 @@ wrk = "wrk"
 mis = "mis"
 falsk = "falsk"
 nin = "nin"
+# `directorys`/`directoryes` appear in a comment in rails.cr as examples of
+# the *incorrect* plural forms (contrasted with the y->ies rule).
+directorys = "directorys"
+directoryes = "directoryes"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Summary

A FP/FN accuracy + performance sweep across all five Ruby analyzers (Rails, Sinatra, Grape, Roda, Hanami), validated against a corpus of real OSS apps: **discourse, mastodon, spree, gollum, resque, terminus (Hanami 2), grape-on-rack, grape-on-rails, html2rss-web**, plus the framework repos. Builds on the earlier Ruby pass (#1826).

All findings were discovered by comparing noir's output to each app's real route definitions and adversarially verified against source before fixing.

## Performance

Crystal recompiles an interpolated regex literal (`/^#{verb}/`) on **every** match — ~11000× slower than a precompiled one (measured with `Benchmark.ips`).

- **Grape / Roda**: per-verb route regexes precompiled into constants + cheap prefix / `r.` receiver gates. A synthetic 8k-line Roda route file drops **0.57s → 0.02s**.
- **Rails** `build_helper_call_map`: an `O(methods × actions)` recompiled-regex scan replaced by tokenizing each method body once into a `Set`. discourse Rails analysis 0.94s → 0.81s.

## Accuracy

**Shared (gated, full-suite-safe):**
- `Endpoint#push_param` now dedups by `(name, param_type)` — the existing `add_tag` comment already assumed this. Removes duplicate params across **all** analyzers.
- `optimizer.add_path_parameters`: for `ruby_*` techs only, drop a query/body param that duplicates a same-named **path** param (Rack frameworks merge captured path segments into `params`). Deliberately **not** global — Lucky / Express / Flask keep separate path vs query buckets.

**Rails:**
- Honor `module:` on a `resources`/`resource` line for controller resolution (+ nested inheritance).
- **Cross-file mountable-engine prefixes**: scan `plugin.rb` / `*routes.rb` for `mount X::Engine, at:/=>` (incl. `routes.append { mount … }` and the paren form) into a const→prefix map, applied when `X::Engine.routes.draw` opens. discourse: **181** bare engine-relative routes corrected (`/vote` → `/polls/vote`, `/api/channels/:id` → `/chat/api/channels/:id`, `/ai-bot/…` → `/discourse-ai/ai-bot/…`).
- **Unroll static `%w[]/%i[].each do |var|` route loops** as a logical-lines pre-pass — discourse stopped leaking `{root_path}` into ~130 endpoints and recovered the real `/users` + `/u` variants.
- `get :symbol, to:` routes inside a bare `namespace`/`scope` (mastodon `verify_credentials`, `measures`, …).
- Filter `permit(*CONST)` / `::` splat-constant param noise; collapse trailing slash on `get '/'`; accept empty-path `get ''` (namespace root); try the `y→ies` plural controller.

**Grape:** require a `:sym`/`'str'` key in `params/headers/cookies` subscripts (no bare-variable phantom like `headers[key]`); drop a query param duplicating a declared `params do` json field.

**Sinatra:** skip the reserved `params[:splat]` / `[:captures]` wildcard bindings.

**Hanami:** join comma-continuation lines so a multi-line `to:` no longer drops the route's action params/callees (terminus); emit a best-effort GET for `mount RackApp, at:`.

## Validation

| app | tech | before | after |
|---|---|---:|---:|
| discourse | rails | 1542 | **1695** |
| mastodon | rails | 635 | **679** |
| spree | rails | 122 | 122 (trailing-slash FP removed) |
| terminus | hanami | 114 | 115 (+ recovered action params/callees) |
| gollum/resque | sinatra | 23/24 | 23/24 (duplicate & cross-type param FPs removed) |
| grape-on-rack/rails | grape | 17/6 | 17/6 (phantom header + query/json dup removed) |

- **All 19343 functional + unit specs pass.** `crystal tool format` clean, `ameba` clean.
- One `rails_advanced` fixture updated: it previously asserted the *buggy* `{action}` collapse for a `%w[…].each` loop; it now asserts the correct unrolled routes.
- Independent reviewer pass: 0 correctness bugs.

## Deliberately deferred (low corpus value or high risk)

Rails controller superclass-inheritance merge; spree engine-namespace controller dir (`app/controllers/spree/`); Grape cross-file `mount` prefix; Roda named request receiver (`router.on`) + modular `Module.call(r)` mounts; Sinatra `%r{}` regex routes; dynamic-loop suppression. A full Ruby minilexer was evaluated and found unnecessary — no heredoc/percent-literal FP/FN surfaced in the corpus.
