### PR TITLE
feat(axum): aide ApiRouter routes + skip benches/

### DIFF
--- a/spec/functional_test/fixtures/rust/axum_aide/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/axum_aide/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "axum_aide_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+aide = { version = "0.13", features = ["axum"] }

--- a/spec/functional_test/fixtures/rust/axum_aide/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum_aide/src/main.rs
@@ -1,0 +1,36 @@
+// aide's ApiRouter (OpenAPI companion for axum), as used by svix and
+// many production axum APIs. Exercises `.api_route`, `.api_route_with`
+// (with the operation-transform closure), the `*_with` verb
+// constructors, and `.nest_api_service` prefix composition.
+use aide::axum::{
+    routing::{get_with, post_with},
+    ApiRouter,
+};
+use aide::transform::TransformOperation;
+use axum::routing::{get, post};
+
+async fn ping() {}
+async fn redrive() {}
+async fn list_apps() {}
+async fn create_app() {}
+
+fn redrive_op(op: TransformOperation) -> TransformOperation {
+    op.summary("redrive")
+}
+
+fn v1_router() -> ApiRouter {
+    ApiRouter::new().api_route("/app", get(list_apps).post(create_app))
+}
+
+pub fn router() -> ApiRouter {
+    ApiRouter::new()
+        .api_route("/health/ping", get(ping).head(ping))
+        .api_route_with(
+            "/admin/redrive",
+            post_with(redrive, redrive_op),
+            |op| op.tag("Admin"),
+        )
+        .nest_api_service("/api/v1", v1_router())
+}
+
+fn main() {}

--- a/spec/functional_test/testers/rust/axum_aide_spec.cr
+++ b/spec/functional_test/testers/rust/axum_aide_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+# aide's `ApiRouter` (OpenAPI companion for axum). Covers `.api_route`,
+# `.api_route_with` (path + method-router + transform closure), the
+# `*_with` verb constructors (`post_with`), the multi-verb `get(h).head(h)`
+# method-router, and `.nest_api_service("/api/v1", v1_router())` prefix
+# composition through a same-file router-returning function.
+expected_endpoints = [
+  Endpoint.new("/health/ping", "GET"),
+  Endpoint.new("/health/ping", "HEAD"),
+  Endpoint.new("/admin/redrive", "POST"),
+  Endpoint.new("/api/v1/app", "GET"),
+  Endpoint.new("/api/v1/app", "POST"),
+]
+
+FunctionalTester.new("fixtures/rust/axum_aide/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_axum"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -131,6 +131,10 @@ module Analyzer::Rust
     # axum apps (static-file mounts, SPA fallbacks, websocket upgrades).
     ROUTER_EMIT_NAMES = Set{
       "route", "route_service", "nest_service", "fallback", "fallback_service",
+      # aide's `ApiRouter` (OpenAPI companion, used by svix and many
+      # axum apps) mirrors `.route` with `.api_route(path, mr)` and
+      # `.api_route_with(path, mr, transform_closure)`.
+      "api_route", "api_route_with",
     }
 
     BUILDER_ROUTE_EMIT_NAMES = Set{
@@ -210,9 +214,14 @@ module Analyzer::Rust
       walk_router_builders(receiver, source, prefix, test_regions, mounted_router_names, &block)
     end
 
+    # `.nest("/p", router)` and aide's `.nest_api_service("/p", router)`
+    # both mount a sub-router under a path prefix.
+    NEST_NAMES = Set{"nest", "nest_api_service"}
+
     private def extract_nest_call(call : LibTreeSitter::TSNode,
                                   source : String) : Tuple(String, LibTreeSitter::TSNode)?
-      return unless field_call_name(call, source) == "nest"
+      name = field_call_name(call, source)
+      return unless name && NEST_NAMES.includes?(name)
       args = named_arguments(call)
       return unless args.size >= 2
       prefix = string_literal_text(args[0], source)
@@ -391,7 +400,11 @@ module Analyzer::Rust
       return unless kind
 
       case kind
-      when "route"
+      when "route", "api_route", "api_route_with"
+        # `.route(path, mr)`, aide `.api_route(path, mr)`, and
+        # `.api_route_with(path, mr, transform)` all carry the path in
+        # arg 0 and the method-router in arg 1 (the trailing transform
+        # closure of `api_route_with` is ignored).
         args = Noir::TreeSitter.field(call, "arguments")
         return unless args
         named = named_children(args)
@@ -468,20 +481,21 @@ module Analyzer::Rust
         break unless fn_node
         case Noir::TreeSitter.node_type(fn_node)
         when "identifier", "scoped_identifier"
-          # Innermost: `get(handler)`.
-          verb = Noir::TreeSitter.node_text(fn_node, source).split("::").last.downcase
-          if HTTP_VERBS.includes?(verb)
-            handlers.unshift({verb.upcase, first_callable_argument(cursor, source)})
+          # Innermost: `get(handler)` or aide's `get_with(handler, op)`.
+          verb = normalize_method_verb(Noir::TreeSitter.node_text(fn_node, source).split("::").last)
+          if verb
+            handlers.unshift({verb, first_callable_argument(cursor, source)})
           end
           break
         when "field_expression"
-          # Chained: `<inner>.post(...)`. Field is the verb. Non-verb
-          # layers (`.layer(...)`, `.route_layer(...)`) are transparent.
+          # Chained: `<inner>.post(...)` / `.post_with(...)`. Field is
+          # the verb. Non-verb layers (`.layer(...)`, `.route_layer(...)`)
+          # are transparent.
           field = Noir::TreeSitter.field(fn_node, "field")
           if field
-            verb = Noir::TreeSitter.node_text(field, source).downcase
-            if HTTP_VERBS.includes?(verb)
-              handlers.unshift({verb.upcase, first_callable_argument(cursor, source)})
+            verb = normalize_method_verb(Noir::TreeSitter.node_text(field, source))
+            if verb
+              handlers.unshift({verb, first_callable_argument(cursor, source)})
             end
           end
           inner = Noir::TreeSitter.field(fn_node, "value")
@@ -494,6 +508,16 @@ module Analyzer::Rust
 
       handlers << {"GET", nil.as(String?)} if handlers.empty?
       handlers
+    end
+
+    # Map a method-router constructor name to its canonical HTTP verb,
+    # or `nil` if it isn't one. Handles plain axum verbs (`get`, `post`,
+    # … `any`) and aide's operation-annotated `*_with` variants
+    # (`get_with`, `post_with`, …). Returns the upcased verb.
+    private def normalize_method_verb(name : String) : String?
+      verb = name.downcase
+      verb = verb[0...-"_with".size] if verb.ends_with?("_with")
+      HTTP_VERBS.includes?(verb) ? verb.upcase : nil
     end
 
     private def first_callable_argument(call : LibTreeSitter::TSNode, source : String) : String?

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -63,6 +63,11 @@ module Analyzer::Rust
     # the shared engine so the rest of the Rust family benefits.
     def self.test_path?(path : String) : Bool
       return true if path.includes?("/tests/")
+      # Cargo's `benches/` directory holds `cargo bench` harnesses
+      # (`Router::new().route(...)` scaffolding for throughput tests),
+      # never production endpoints — axum/tide park route-building
+      # benchmarks here. Exclude it like `tests/`.
+      return true if path.includes?("/benches/")
       base = File.basename(path)
       base.ends_with?("_test.rs") || base.ends_with?("_tests.rs")
     end


### PR DESCRIPTION
## Summary

axum analyzer FP/FN sweep against real OSS apps (svix-webhooks, atuin, the axum repo). svix and many production axum APIs route through **aide's `ApiRouter`** (the OpenAPI companion), whose registration methods the analyzer didn't recognize.

## Changes
- **aide `.api_route(path, mr)` / `.api_route_with(path, mr, transform)`** recognized as route registrations (trailing transform closure ignored).
- **aide verb constructors `get_with` / `post_with` / …** decoded alongside plain `get` / `post` (shared `normalize_method_verb` strips `_with`; handler is the first arg, the operation-transform fn is skipped).
- **`.nest_api_service("/prefix", router())`** mounted like `.nest(...)` so nested ApiRouter routes inherit the prefix.
- **`RustEngine.test_path?` now excludes `/benches/`** (Cargo benchmark harnesses), matching the `/tests/` rule — benefits every Rust analyzer.

## Results (real OSS apps)
| app | metric | before | after |
|---|---|---|---|
| svix-webhooks | `rust_axum` endpoints | 14 | **60** (GT ~74) |
| axum repo | total (benches FP) | 91 | 88 |
| tide repo | total (benches FP) | 21 | 17 |

svix gap to ~74 is the cross-file `/api/v1` prefix, consistent with the per-file design. New `axum_aide` fixture + spec; all rust functional specs pass.