### PR TITLE
feat(warp): path! macro + filter-returning helper fns

### DIFF
--- a/spec/functional_test/fixtures/rust/warp_path_macro/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/warp_path_macro/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "warp_path_macro_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+warp = "0.3"

--- a/spec/functional_test/fixtures/rust/warp_path_macro/src/main.rs
+++ b/spec/functional_test/fixtures/rust/warp_path_macro/src/main.rs
@@ -1,0 +1,39 @@
+// warp's `path!` macro (the idiomatic multi-segment form) plus
+// filter-returning helper functions whose tail expression IS the route.
+use warp::Filter;
+
+async fn list_todos() {}
+async fn create_todo() {}
+async fn update_todo() {}
+
+// let-bound routes using path! with literal + typed segments.
+fn build() {
+    let _hello = warp::path!("hello" / "from" / "warp").map(|| "hi");
+    let _sum = warp::path!("sum" / u32 / u32).and(warp::get()).map(|a, b| a + b);
+}
+
+// filter-returning helper functions (tail expression is the route).
+pub fn todos_list() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("todos")
+        .and(warp::get())
+        .and_then(list_todos)
+}
+
+pub fn todos_create() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("todos")
+        .and(warp::post())
+        .and_then(create_todo)
+}
+
+pub fn todos_update() -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("todos" / u64)
+        .and(warp::put())
+        .and_then(update_todo)
+}
+
+// A non-route helper filter: no path -> must NOT become an endpoint.
+fn with_auth() -> impl Filter<Extract = (), Error = warp::Rejection> + Clone {
+    warp::header::exact("authorization", "Bearer x")
+}
+
+fn main() {}

--- a/spec/functional_test/testers/rust/warp_path_macro_spec.cr
+++ b/spec/functional_test/testers/rust/warp_path_macro_spec.cr
@@ -1,0 +1,24 @@
+require "../../func_spec.cr"
+
+# warp's `path!` macro (literal + typed segments) and filter-returning
+# helper functions whose tail expression IS the route. A non-route
+# helper filter (`with_auth`, no path) must not become an endpoint.
+expected_endpoints = [
+  Endpoint.new("/hello/from/warp", "GET"),
+  Endpoint.new("/sum/:param1/:param2", "GET", [
+    Param.new("param1", "", "path"),
+    Param.new("param2", "", "path"),
+  ]),
+  Endpoint.new("/todos", "GET"),
+  Endpoint.new("/todos", "POST"),
+  Endpoint.new("/todos/:param", "PUT", [
+    Param.new("param", "", "path"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/rust/warp_path_macro/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_warp"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -34,14 +34,27 @@ module Analyzer::Rust
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = build_function_index(root, source)
+        seen = Set(Int32).new
 
         walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "let_declaration"
-          value = Noir::TreeSitter.field(node, "value")
+          # Two route-bearing positions: a `let route = warp::path(...)`
+          # binding, and a filter-returning helper
+          # `fn list() -> impl Filter { warp::path!(...).and(...) }`
+          # whose tail expression IS the route (todos-style apps).
+          value =
+            case Noir::TreeSitter.node_type(node)
+            when "let_declaration"
+              Noir::TreeSitter.field(node, "value")
+            when "function_item"
+              function_tail_expression(node)
+            end
           next unless value
           next unless warp_chain?(value, source)
+          byte = LibTreeSitter.ts_node_start_byte(value).to_i
+          next if seen.includes?(byte)
+          seen.add(byte)
 
-          endpoint = build_endpoint(value, source, path, Noir::TreeSitter.node_start_row(node) + 1)
+          endpoint = build_endpoint(value, source, path, Noir::TreeSitter.node_start_row(value) + 1)
           next unless endpoint
 
           if include_callee
@@ -84,6 +97,15 @@ module Analyzer::Rust
 
       walk(value) do |node|
         case Noir::TreeSitter.node_type(node)
+        when "macro_invocation"
+          # `warp::path!("todos" / u64 / "items")` — the idiomatic
+          # multi-segment form. tree-sitter leaves the args as a flat
+          # `token_tree`; string literals are path segments and type
+          # tokens (`u64`, `String`, `Uuid`, …) are path params.
+          if path_macro?(node, source)
+            seg_count = parse_path_macro(node, source, path_parts, params)
+            has_path_end = true if seg_count > 0
+          end
         when "call_expression"
           fn_text = call_function_text(node, source)
           next unless fn_text
@@ -150,6 +172,91 @@ module Analyzer::Rust
       route = path_parts.empty? ? "/" : "/" + path_parts.join("/")
       details = Details.new(PathInfo.new(file_path, row))
       Endpoint.new(route, method, params, details)
+    end
+
+    # The trailing (no-semicolon) expression of a function body block —
+    # the value the function returns. Returns `nil` when the function
+    # ends in a statement (so we don't treat `warp::serve(...).run()` and
+    # other side-effecting tails as routes; the empty-path guard in
+    # build_endpoint also filters those, but this keeps the walk tight).
+    private def function_tail_expression(function : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body && Noir::TreeSitter.node_type(body) == "block"
+      tail = nil.as(LibTreeSitter::TSNode?)
+      Noir::TreeSitter.each_named_child(body) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "line_comment", "block_comment"
+          # skip
+        else
+          tail = child
+        end
+      end
+      return unless tail
+      case Noir::TreeSitter.node_type(tail)
+      when "expression_statement", "let_declaration", "empty_statement"
+        nil
+      else
+        tail
+      end
+    end
+
+    # True when `node` is a `warp::path!(...)` / `path!(...)` macro.
+    private def path_macro?(node : LibTreeSitter::TSNode, source : String) : Bool
+      macro_node = Noir::TreeSitter.field(node, "macro")
+      return false unless macro_node
+      name = Noir::TreeSitter.node_text(macro_node, source).split("::").last
+      name == "path"
+    end
+
+    # Parse a `path!("a" / u64 / "b")` token tree, appending each string
+    # literal as a path segment and each type token as a `:param`
+    # placeholder. Returns the number of components appended. Param
+    # names follow the warp convention: a lone param is `param`, several
+    # become `param1`, `param2`, … .
+    private def parse_path_macro(node : LibTreeSitter::TSNode,
+                                 source : String,
+                                 path_parts : Array(String),
+                                 params : Array(Param)) : Int32
+      tt = nil.as(LibTreeSitter::TSNode?)
+      Noir::TreeSitter.each_named_child(node) do |child|
+        tt = child if Noir::TreeSitter.node_type(child) == "token_tree"
+      end
+      return 0 unless token_tree = tt
+
+      type_total = 0
+      Noir::TreeSitter.each_named_child(token_tree) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "primitive_type", "type_identifier", "scoped_type_identifier", "generic_type"
+          type_total += 1
+        end
+      end
+
+      count = 0
+      type_idx = 0
+      Noir::TreeSitter.each_named_child(token_tree) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "string_literal"
+          seg = string_content_text(child, source)
+          if seg && !seg.empty?
+            path_parts << seg
+            count += 1
+          end
+        when "primitive_type", "type_identifier", "scoped_type_identifier", "generic_type"
+          type_idx += 1
+          name = type_total > 1 ? "param#{type_idx}" : "param"
+          path_parts << ":#{name}"
+          params << Param.new(name, "", "path") unless params.any? { |p| p.name == name && p.param_type == "path" }
+          count += 1
+        end
+      end
+      count
+    end
+
+    private def string_content_text(string_literal : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(string_literal) do |grand|
+        return Noir::TreeSitter.node_text(grand, source) if Noir::TreeSitter.node_type(grand) == "string_content"
+      end
+      nil
     end
 
     # `.map(handler)` / `.and_then(handler)` / `.then(handler)` — pull


### PR DESCRIPTION
## Summary
warp analyzer FN sweep. The idiomatic `warp::path!(...)` macro and the common "one filter per helper fn" layout were both invisible.

## Changes
- **`warp::path!("a" / u64 / "b")` macro**: string literals → path segments, type tokens → `:param` path params (`param` / `param1`, `param2`, …). tree-sitter leaves the macro args as a flat token_tree, so the call_expression walk saw nothing before.
- **Filter-returning helper fns**: detect routes returned directly from `pub fn list() -> impl Filter { warp::path!(...).and(warp::get())... }`, not just `let`-bound chains. The empty-path guard keeps non-route helper filters (`with_db`, header-only) from emitting bogus endpoints.

## Results
warp repo **18 → 26** endpoints (ground truth ~31). New `warp_path_macro` fixture + spec; all rust functional specs pass.