### PR TITLE
feat(java): param/callee accuracy sweep across 27 OSS apps (FP/FN, DTO, overloads)

### DIFF
--- a/spec/unit_test/miniparser/java_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/java_callee_extractor_spec.cr
@@ -146,6 +146,36 @@ describe Noir::JavaCalleeExtractor do
       # overload to point at.
       handle.not_nil![2].should eq(3)
     end
+
+    it "uses target_line to pick the right overloaded handler body" do
+      source = <<-JAVA
+        package app;
+        class VisitResource {
+          public List<Visit> read(int petId) {
+            return repo.findByPetId(petId);
+          }
+          public Visits read(List<Integer> petIds) {
+            return repo.findByPetIdIn(petIds);
+          }
+        }
+        JAVA
+
+      # The second `read` spans rows 5-7 (0-based); pointing at row 5
+      # must resolve callees from that overload, not the first `read`.
+      with_target = [] of Tuple(String, String, Int32)
+      without_target = [] of Tuple(String, String, Int32)
+      with_java_root(source) do |root|
+        with_target = Noir::JavaCalleeExtractor.callees_in_method(
+          root, source, "VisitResource.java", "VisitResource", "read", 5
+        )
+        without_target = Noir::JavaCalleeExtractor.callees_in_method(
+          root, source, "VisitResource.java", "VisitResource", "read"
+        )
+      end
+      with_target.map(&.[0]).should eq(["repo.findByPetIdIn"])
+      # No hint → first overload.
+      without_target.map(&.[0]).should eq(["repo.findByPetId"])
+    end
   end
 
   describe ".callees_in_body" do

--- a/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
@@ -324,6 +324,187 @@ describe Noir::TreeSitterJavaParameterExtractor do
     end
   end
 
+  describe "implicit (un-annotated) parameter binding" do
+    empty_fields = Hash(String, Array(Noir::TreeSitterJavaParameterExtractor::FieldInfo)).new
+
+    it "binds an un-annotated scalar on GET as a query param" do
+      source = <<-JAVA
+        class C {
+            @GetMapping("/hr")
+            public List<Hr> getAllHrs(String keywords) { return null; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "getAllHrs", "GET", nil, empty_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.should eq([{"keywords", "query"}])
+    end
+
+    it "binds an un-annotated wrapper-array on DELETE as a query param" do
+      source = <<-JAVA
+        class C {
+            @DeleteMapping("/")
+            public RespBean deleteByIds(Integer[] ids) { return null; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "deleteByIds", "DELETE", nil, empty_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.should eq([{"ids", "query"}])
+    end
+
+    it "binds an un-annotated scalar on POST as a form param" do
+      source = <<-JAVA
+        class C {
+            @PostMapping("/login")
+            public String login(String username, String password) { return ""; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "login", "POST", nil, empty_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.should eq([{"username", "form"}, {"password", "form"}])
+    end
+
+    it "emits an annotated wrapper-array param (@RequestParam Integer[])" do
+      source = <<-JAVA
+        class C {
+            @GetMapping("/x")
+            public String x(@RequestParam Integer[] ids) { return ""; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "x", "GET", nil, empty_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.should eq([{"ids", "query"}])
+    end
+
+    it "drops an @AuthenticationPrincipal command object instead of expanding its fields" do
+      source = <<-JAVA
+        class C {
+            @PostMapping("/articles")
+            public Object create(@RequestBody NewArticle a, @AuthenticationPrincipal User user) { return null; }
+        }
+        JAVA
+      class_fields = {
+        "NewArticle" => [Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("title", "private", true, "")],
+        "User"       => [Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("password", "private", true, "")],
+      }
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "create", "POST", nil, class_fields
+      )
+      params.map(&.name).should eq(["title"])
+    end
+
+    it "skips framework argument-resolver types not present in the DTO index" do
+      source = <<-JAVA
+        class C {
+            @GetMapping("/")
+            public String list(Pageable pageable, Model model, String q) { return ""; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "list", "GET", nil, empty_fields
+      )
+      params.map(&.name).should eq(["q"])
+    end
+  end
+
+  describe "@RequestBody field-visibility binding" do
+    # A Lombok `@Getter`-only DTO has private fields and no setters.
+    getter_dto = <<-JAVA
+      class Body {
+          private String email;
+          private String password;
+      }
+      JAVA
+
+    it "expands every field for a JSON @RequestBody even without setters" do
+      class_fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(getter_dto)
+      source = <<-JAVA
+        class C {
+            @PostMapping("/login")
+            public String login(@RequestBody Body body) { return ""; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "login", "POST", nil, class_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.sort!.should eq([{"email", "json"}, {"password", "json"}])
+    end
+
+    it "keeps the setter/public gate for un-annotated form binding" do
+      class_fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(getter_dto)
+      source = <<-JAVA
+        class C {
+            @PostMapping("/login")
+            public String login(Body body) { return ""; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "login", "POST", nil, class_fields
+      )
+      params.should be_empty
+    end
+  end
+
+  describe "record DTO components" do
+    it "indexes record components as bindable fields" do
+      source = <<-JAVA
+        public record CreateArticle(String title, String description, int rank) {}
+        JAVA
+      fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(source)["CreateArticle"]
+      fields.map(&.name).should eq(["title", "description", "rank"])
+    end
+
+    it "expands a record @RequestBody into its components" do
+      record_src = <<-JAVA
+        public record Body(String email, String password) {}
+        JAVA
+      class_fields = Noir::TreeSitterJavaParameterExtractor.extract_class_fields(record_src)
+      source = <<-JAVA
+        class C {
+            @PostMapping("/login")
+            public String login(@RequestBody Body body) { return ""; }
+        }
+        JAVA
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "C", "login", "POST", nil, class_fields
+      )
+      params.map(&.name).sort!.should eq(["email", "password"])
+    end
+  end
+
+  describe "overloaded handler disambiguation" do
+    overloaded = <<-JAVA
+      class VisitResource {
+          @GetMapping("owners/*/pets/{petId}/visits")
+          public List<Visit> read(@PathVariable int petId) { return null; }
+
+          @GetMapping("pets/visits")
+          public Visits read(@RequestParam List<Integer> petIds) { return null; }
+      }
+      JAVA
+
+    empty_fields = Hash(String, Array(Noir::TreeSitterJavaParameterExtractor::FieldInfo)).new
+
+    it "selects the overload whose body contains the route annotation line" do
+      # The second `read` overload's @GetMapping is on line 5 (0-based 4).
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        overloaded, "VisitResource", "read", "GET", nil, empty_fields, 4
+      )
+      params.map(&.name).should eq(["petIds"])
+    end
+
+    it "falls back to the first overload without a line hint" do
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        overloaded, "VisitResource", "read", "GET", nil, empty_fields
+      )
+      # First `read` takes a @PathVariable, which is not emitted as a param.
+      params.should be_empty
+    end
+  end
+
   describe ".extract_class_supertypes" do
     it "maps each class to its superclass simple name" do
       source = <<-JAVA

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -306,32 +306,36 @@ module Analyzer::Java
             # Reactive routes declared via `router().route(...).andRoute(...)`
             # — regex-scoped because the builder-pattern shape isn't
             # worth a dedicated tree-sitter walk yet.
-            #
-            # `extract_string_constants` and the per-block route/nest scans
-            # are amortised across the two passes below (constants once,
-            # not once-per-block as before).
-            constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content)
             route_blocks = [] of Tuple(Array(Tuple(Int32, String, String, String)), Array(Tuple(Int32, Int32, String)))
-            content.scan(REGEX_ROUTER_CODE_BLOCK) do |route_code|
-              method_code = route_code[0]
-              # Pick up `nest(RequestPredicates.path("/prefix"), ...)`
-              # / `nest(path("/prefix"), ...)` byte ranges so verb
-              # calls inside the nested lambda get the prefix added.
-              # Servlet-fn and WebFlux both use this idiom heavily;
-              # without prefix awareness routes like
-              # `route().nest(path("/product"), builder ->
-              # builder.GET("/name/{name}", ...))` surfaced as
-              # `GET /name/{name}` instead of `GET /product/name/{name}`.
-              route_blocks << {collect_router_route_calls(method_code, constants), collect_nest_prefixes(method_code, constants)}
-            end
-
-            # Resolve same-file `this::handler` method bodies to 1-hop
-            # callees so reactive endpoints carry handler context too.
             reactive_callees = {} of String => Array(Callee)
-            if include_callee
-              wanted = Set(String).new
-              route_blocks.each { |calls, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
-              reactive_callees = build_reactive_method_callees(content, path, wanted)
+
+            # Single tree-sitter parse for the whole reactive file: the
+            # constant table and the `this::handler` callee resolution both
+            # read from this one `root`, so the file isn't parsed twice
+            # when callees are requested (and constants are resolved once,
+            # not once-per-block).
+            Noir::TreeSitter.parse_java(content) do |root|
+              constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+              content.scan(REGEX_ROUTER_CODE_BLOCK) do |route_code|
+                method_code = route_code[0]
+                # Pick up `nest(RequestPredicates.path("/prefix"), ...)`
+                # / `nest(path("/prefix"), ...)` byte ranges so verb
+                # calls inside the nested lambda get the prefix added.
+                # Servlet-fn and WebFlux both use this idiom heavily;
+                # without prefix awareness routes like
+                # `route().nest(path("/product"), builder ->
+                # builder.GET("/name/{name}", ...))` surfaced as
+                # `GET /name/{name}` instead of `GET /product/name/{name}`.
+                route_blocks << {collect_router_route_calls(method_code, constants), collect_nest_prefixes(method_code, constants)}
+              end
+
+              # Resolve same-file `this::handler` method bodies to 1-hop
+              # callees so reactive endpoints carry handler context too.
+              if include_callee
+                wanted = Set(String).new
+                route_blocks.each { |calls, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
+                reactive_callees = build_reactive_method_callees(root, content, path, wanted)
+              end
             end
 
             route_blocks.each do |calls, nest_prefixes|
@@ -818,30 +822,30 @@ module Analyzer::Java
       ""
     end
 
-    # Parse the file once and return `{handler_method_name => [Callee]}`
-    # for every wanted handler, mirroring the Vert.x analyzer's
-    # method-reference callee resolution. Name collisions keep the first
+    # Walk the already-parsed `root` and return `{handler_method_name =>
+    # [Callee]}` for every wanted handler, mirroring the Vert.x analyzer's
+    # method-reference callee resolution. Shares the caller's parse so a
+    # reactive file is read once. Name collisions keep the first
     # declaration (reactive router configs rarely repeat handler names in
     # one file).
-    private def build_reactive_method_callees(content : String,
+    private def build_reactive_method_callees(root : LibTreeSitter::TSNode,
+                                              content : String,
                                               path : String,
                                               wanted : Set(String)) : Hash(String, Array(Callee))
       result = {} of String => Array(Callee)
       return result if wanted.empty?
 
-      Noir::TreeSitter.parse_java(content) do |root|
-        walk_reactive_method_declarations(root) do |method|
-          name_node = Noir::TreeSitter.field(method, "name")
-          next unless name_node
-          method_name = Noir::TreeSitter.node_text(name_node, content)
-          next unless wanted.includes?(method_name)
-          next if result.has_key?(method_name)
+      walk_reactive_method_declarations(root) do |method|
+        name_node = Noir::TreeSitter.field(method, "name")
+        next unless name_node
+        method_name = Noir::TreeSitter.node_text(name_node, content)
+        next unless wanted.includes?(method_name)
+        next if result.has_key?(method_name)
 
-          body = Noir::TreeSitter.field(method, "body")
-          next unless body
-          result[method_name] = Noir::JavaCalleeExtractor.callees_in_body(body, content, path).map do |(name, callee_path, callee_line)|
-            Callee.new(name, path: callee_path, line: callee_line)
-          end
+        body = Noir::TreeSitter.field(method, "body")
+        next unless body
+        result[method_name] = Noir::JavaCalleeExtractor.callees_in_body(body, content, path).map do |(name, callee_path, callee_line)|
+          Callee.new(name, path: callee_path, line: callee_line)
         end
       end
 

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -188,7 +188,7 @@ module Analyzer::Java
                 # "json" rather than inheriting "form".
 
                 parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
-                  root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index
+                  root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index, route.line
                 )
                 merge_route_condition_params(parameters, route.params)
 
@@ -213,7 +213,7 @@ module Analyzer::Java
                 # other analyzer's first-cut honest scope.
                 if include_callee && !(route.class_name.empty? || route.method_name.empty?)
                   Noir::JavaCalleeExtractor.callees_in_method(
-                    root, content, path, route.class_name, route.method_name
+                    root, content, path, route.class_name, route.method_name, route.line
                   ).each do |entry|
                     name, callee_path, callee_line = entry
                     endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
@@ -242,7 +242,7 @@ module Analyzer::Java
 
                         parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
                           interface_root, entry.source, entry_route.class_name, entry_route.method_name,
-                          entry_route.verb, parameter_format, interface_dto_index
+                          entry_route.verb, parameter_format, interface_dto_index, entry_route.line
                         )
                         merge_route_condition_params(parameters, implementation.params + entry_route.params)
                       end
@@ -306,9 +306,14 @@ module Analyzer::Java
             # Reactive routes declared via `router().route(...).andRoute(...)`
             # — regex-scoped because the builder-pattern shape isn't
             # worth a dedicated tree-sitter walk yet.
+            #
+            # `extract_string_constants` and the per-block route/nest scans
+            # are amortised across the two passes below (constants once,
+            # not once-per-block as before).
+            constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content)
+            route_blocks = [] of Tuple(Array(Tuple(Int32, String, String, String)), Array(Tuple(Int32, Int32, String)))
             content.scan(REGEX_ROUTER_CODE_BLOCK) do |route_code|
               method_code = route_code[0]
-              constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content)
               # Pick up `nest(RequestPredicates.path("/prefix"), ...)`
               # / `nest(path("/prefix"), ...)` byte ranges so verb
               # calls inside the nested lambda get the prefix added.
@@ -317,10 +322,21 @@ module Analyzer::Java
               # `route().nest(path("/product"), builder ->
               # builder.GET("/name/{name}", ...))` surfaced as
               # `GET /name/{name}` instead of `GET /product/name/{name}`.
-              nest_prefixes = collect_nest_prefixes(method_code, constants)
+              route_blocks << {collect_router_route_calls(method_code, constants), collect_nest_prefixes(method_code, constants)}
+            end
 
-              collect_router_route_calls(method_code, constants).each do |call|
-                pos, method, endpoint = call
+            # Resolve same-file `this::handler` method bodies to 1-hop
+            # callees so reactive endpoints carry handler context too.
+            reactive_callees = {} of String => Array(Callee)
+            if include_callee
+              wanted = Set(String).new
+              route_blocks.each { |calls, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
+              reactive_callees = build_reactive_method_callees(content, path, wanted)
+            end
+
+            route_blocks.each do |calls, nest_prefixes|
+              calls.each do |call|
+                pos, method, endpoint, handler_ref = call
                 nest_prefix = ""
                 nest_prefixes.each do |start_b, end_b, prefix|
                   if pos >= start_b && pos < end_b
@@ -329,7 +345,15 @@ module Analyzer::Java
                 end
                 composed = nest_prefix.empty? ? endpoint : join_paths(nest_prefix, endpoint)
                 details = Details.new(PathInfo.new(path))
-                @result << Endpoint.new(join_paths(configured_base_path, composed), method, details)
+                reactive_endpoint = Endpoint.new(join_paths(configured_base_path, composed), method, details)
+
+                if include_callee && !handler_ref.empty?
+                  if handler_callees = reactive_callees[handler_ref]?
+                    handler_callees.each { |callee| reactive_endpoint.push_callee(callee) }
+                  end
+                end
+
+                @result << reactive_endpoint
               end
             end
           end
@@ -754,8 +778,8 @@ module Analyzer::Java
     # whose match position falls inside `[start, end)` should have
     # `prefix` prepended.
     private def collect_router_route_calls(code : String,
-                                           constants : Hash(String, String)) : Array(Tuple(Int32, String, String))
-      calls = [] of Tuple(Int32, String, String)
+                                           constants : Hash(String, String)) : Array(Tuple(Int32, String, String, String))
+      calls = [] of Tuple(Int32, String, String, String)
 
       code.scan(REGEX_ROUTE_CALL) do |match|
         open_idx = (match.end || 0) - 1
@@ -764,14 +788,75 @@ module Analyzer::Java
         next unless close_idx
 
         args = code[(open_idx + 1)...close_idx]
-        first_arg = first_argument(args)
-        path = resolve_router_path(first_arg, constants)
+        arg_list = top_level_arguments(args)
+        path = resolve_router_path(arg_list.first? || "", constants)
         next unless path
 
-        calls << {match.begin || 0, match[2], path.gsub(/\n/, "")}
+        # The handler is the second argument of `.GET("/x", this::handle)`
+        # / `route(RequestPredicates.GET("/x"), this::handle)`. Capture a
+        # same-file method-reference name so the reactive branch can pull
+        # 1-hop callees out of that handler body (WebFlux/servlet-fn
+        # RouterFunction handlers carry the real behaviour worth surfacing
+        # for ai-context).
+        handler_ref = arg_list.size >= 2 ? handler_method_reference(arg_list[1]) : ""
+        calls << {match.begin || 0, match[2], path.gsub(/\n/, ""), handler_ref}
       end
 
       calls
+    end
+
+    # Extract the method name from a functional-handler argument when it
+    # is a same-file method reference (`this::handle`, `Type::handle`,
+    # `handler::handle`). Returns "" for lambdas and anything else — those
+    # carry no resolvable same-file declaration to walk.
+    private def handler_method_reference(arg : String) : String
+      expr = arg.strip
+      if idx = expr.rindex("::")
+        name = expr[(idx + 2)..].strip
+        return name if name.matches?(/\A[A-Za-z_][A-Za-z0-9_]*\z/)
+      end
+      ""
+    end
+
+    # Parse the file once and return `{handler_method_name => [Callee]}`
+    # for every wanted handler, mirroring the Vert.x analyzer's
+    # method-reference callee resolution. Name collisions keep the first
+    # declaration (reactive router configs rarely repeat handler names in
+    # one file).
+    private def build_reactive_method_callees(content : String,
+                                              path : String,
+                                              wanted : Set(String)) : Hash(String, Array(Callee))
+      result = {} of String => Array(Callee)
+      return result if wanted.empty?
+
+      Noir::TreeSitter.parse_java(content) do |root|
+        walk_reactive_method_declarations(root) do |method|
+          name_node = Noir::TreeSitter.field(method, "name")
+          next unless name_node
+          method_name = Noir::TreeSitter.node_text(name_node, content)
+          next unless wanted.includes?(method_name)
+          next if result.has_key?(method_name)
+
+          body = Noir::TreeSitter.field(method, "body")
+          next unless body
+          result[method_name] = Noir::JavaCalleeExtractor.callees_in_body(body, content, path).map do |(name, callee_path, callee_line)|
+            Callee.new(name, path: callee_path, line: callee_line)
+          end
+        end
+      end
+
+      result
+    end
+
+    private def walk_reactive_method_declarations(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      if Noir::TreeSitter.node_type(node) == "method_declaration"
+        block.call(node)
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_reactive_method_declarations(child, &block)
+      end
     end
 
     private def collect_nest_prefixes(code : String,

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -158,6 +158,12 @@ module Analyzer::Java
       file_list.select do |path|
         next false unless File.exists?(path)
         next false unless path.ends_with?(".xml")
+        # Test-source Struts config (`src/test/resources/struts.xml`,
+        # `src/it/...`) exercises the framework itself and never backs a
+        # deployed action — gate it the same way the `.java` selection at
+        # the top of `analyze` does via the shared `JavaEngine.test_path?`
+        # convention.
+        next false if JavaEngine.test_path?(path)
         basename = File.basename(path)
         STRUTS_CONFIG_BASENAMES.includes?(basename) || basename.ends_with?("-struts.xml")
       end

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -198,7 +198,22 @@ module Analyzer::Java
         candidates << RouteCandidate.new(router_name, "GET", endpoint)
       end
 
-      candidates.uniq
+      # A Vert.x Web route path is always anchored at the router root, so
+      # the path string passed to `router.get(...)`, `route(...)`,
+      # `mountSubRouter(...)`, etc. must start with `/`. Generic
+      # `<ident>.get/put/...` calls on collections (`map.put("ez", ...)`,
+      # `cache.get("key")`, `headers.get("X")`) share the verb-method
+      # spelling but never carry a slash-prefixed first argument, so the
+      # leading-slash gate filters them out without a type-tracking pass.
+      candidates.select { |candidate| vertx_route_path?(candidate.endpoint) }.uniq!
+    end
+
+    # Vert.x Web requires path-string routes to begin with `/` (regex
+    # routes go through `routeWithRegex`, which this analyzer doesn't
+    # model). Anything else is a collection/`Map` method that merely
+    # shares the `get`/`put`/`delete`/... spelling.
+    private def vertx_route_path?(endpoint : String) : Bool
+      endpoint.starts_with?('/')
     end
 
     private def extract_mounts(content : String, constants : Hash(String, String)) : Array(MountCandidate)
@@ -214,6 +229,7 @@ module Analyzer::Java
         child_router = args[1].strip[/\A\w+\z/]?
 
         next if endpoint.nil? || endpoint.empty? || child_router.nil? || child_router.empty?
+        next unless vertx_route_path?(endpoint)
 
         mounts << MountCandidate.new(parent_router, endpoint, child_router)
       end

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -40,11 +40,12 @@ module Noir::JavaCalleeExtractor
                         source : String,
                         file_path : String,
                         class_name : String,
-                        method_name : String) : Array(Tuple(String, String, Int32))
+                        method_name : String,
+                        target_line : Int32? = nil) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
     return sink if class_name.empty? || method_name.empty?
 
-    method_node = find_method(root, source, class_name, method_name)
+    method_node = find_method(root, source, class_name, method_name, target_line)
     return sink unless method_node
     body = Noir::TreeSitter.field(method_node, "body")
     return sink unless body
@@ -128,27 +129,40 @@ module Noir::JavaCalleeExtractor
     end
   end
 
+  # `target_line` (0-based row of the route's mapping annotation, when
+  # available) disambiguates overloaded handlers: the annotation lives
+  # inside the correct overload's node span, so the method whose
+  # `[start_row, end_row]` range contains that line wins. Falls back to
+  # the first same-named method otherwise, matching prior behaviour.
   private def find_method(root : LibTreeSitter::TSNode,
                           source : String,
                           class_name : String,
-                          method_name : String) : LibTreeSitter::TSNode?
-    result : LibTreeSitter::TSNode? = nil
+                          method_name : String,
+                          target_line : Int32? = nil) : LibTreeSitter::TSNode?
+    first : LibTreeSitter::TSNode? = nil
+    matched : LibTreeSitter::TSNode? = nil
     walk_class_decls(root) do |decl|
-      next if result
+      next if matched
       name_node = Noir::TreeSitter.field(decl, "name")
       next unless name_node
       next unless Noir::TreeSitter.node_text(name_node, source) == class_name
       body = Noir::TreeSitter.field(decl, "body")
       next unless body
       Noir::TreeSitter.each_named_child(body) do |member|
-        next if result
+        next if matched
         next unless Noir::TreeSitter.node_type(member) == "method_declaration"
         mn = Noir::TreeSitter.field(member, "name")
         next unless mn
-        result = member if Noir::TreeSitter.node_text(mn, source) == method_name
+        next unless Noir::TreeSitter.node_text(mn, source) == method_name
+        first ||= member
+        if line = target_line
+          start_row = Noir::TreeSitter.node_start_row(member)
+          end_row = Noir::TreeSitter.node_end_row(member)
+          matched = member if line >= start_row && line <= end_row
+        end
       end
     end
-    result
+    matched || first
   end
 
   private def walk_class_decls(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -26,6 +26,37 @@ module Noir
     # DTO expansion.
     PRIMITIVE_TYPES = Set{"long", "int", "integer", "char", "boolean", "string", "multipartfile"}
 
+    # Scalar types Spring binds directly from a single request value
+    # (query string, form field, or — when annotated — path segment).
+    # Superset of `PRIMITIVE_TYPES`: covers the remaining numeric/date
+    # wrappers and `MultipartFile` so an un-annotated `Integer[] ids` or
+    # `BigDecimal amount` handler argument surfaces as a parameter
+    # instead of being silently dropped. Array (`Integer[]`), varargs,
+    # and single-type-argument collection forms (`List<Long>`,
+    # `Optional<String>`) all reduce to their element type before lookup
+    # via `simple_param_base`. Framework argument-resolver types (Model,
+    # HttpServletRequest, Pageable, Authentication, Principal,
+    # BindingResult, …) are deliberately absent — they are resolved by
+    # Spring, not bound from the request, so they must not surface.
+    SIMPLE_PARAM_TYPES = Set{
+      "long", "int", "integer", "short", "byte", "double", "float",
+      "boolean", "char", "character", "string", "bigdecimal", "biginteger",
+      "number", "uuid", "date", "localdate", "localdatetime", "localtime",
+      "instant", "multipartfile",
+    }
+
+    # Parameter annotations whose value is supplied by a Spring argument
+    # resolver, not bound from the HTTP request the client controls. A
+    # parameter carrying one of these is NOT an attack-surface input even
+    # when its type is a bindable DTO (the classic `@AuthenticationPrincipal
+    # User user`), so it must be excluded from the un-annotated
+    # implicit-binding path. Validation annotations (`@Valid`, `@Min`, …)
+    # are intentionally absent — they leave binding semantics untouched.
+    INJECTED_PARAM_ANNOTATIONS = Set{
+      "AuthenticationPrincipal", "CurrentUser", "CurrentSecurityContext",
+      "SessionAttribute", "RequestAttribute",
+    }
+
     # Subset of servlet types whose method body is scanned for
     # `request.getParameter("x")` / `request.getHeader("x")` calls.
     SERVLET_REQUEST_TYPES = Set{"HttpServletRequest"}
@@ -100,7 +131,48 @@ module Noir
         fields = collect_class_fields(body, source, lombok_setters)
         results[class_name] = fields unless fields.empty?
       end
+      # Java records: the header components ARE the bindable fields (a
+      # record can't declare extra instance state), bound through the
+      # canonical constructor for both JSON and form requests. Records are
+      # an increasingly common request-DTO shape, so index their
+      # components too. Walked separately from `walk_class_containers` so
+      # the shared class/interface walker's callers stay record-free.
+      if source.includes?("record ")
+        walk_record_declarations(root) do |decl|
+          name_node = Noir::TreeSitter.field(decl, "name")
+          next unless name_node
+          class_name = Noir::TreeSitter.node_text(name_node, source)
+          fields = collect_record_fields(decl, source)
+          results[class_name] = fields unless fields.empty? || results.has_key?(class_name)
+        end
+      end
       results
+    end
+
+    private def walk_record_declarations(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      block.call(node) if Noir::TreeSitter.node_type(node) == "record_declaration"
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_record_declarations(child, &block)
+      end
+    end
+
+    # Collect a record's component list as bindable fields. Each component
+    # is a `formal_parameter` (`record Foo(String a, int b)`); the
+    # canonical constructor makes every one settable from a request, so
+    # they bind regardless of HTTP method or content type.
+    private def collect_record_fields(decl : LibTreeSitter::TSNode, source : String) : Array(FieldInfo)
+      fields = [] of FieldInfo
+      params = Noir::TreeSitter.field(decl, "parameters")
+      return fields unless params
+      Noir::TreeSitter.each_named_child(params) do |component|
+        next unless Noir::TreeSitter.node_type(component) == "formal_parameter"
+        name_node = Noir::TreeSitter.field(component, "name")
+        next unless name_node
+        name = Noir::TreeSitter.node_text(name_node, source)
+        next if name.empty?
+        fields << FieldInfo.new(name, "public", true, "")
+      end
+      fields
     end
 
     def extract_class_supertypes(source : String) : Hash(String, String)
@@ -158,10 +230,11 @@ module Noir
                                   method_name : String,
                                   verb : String,
                                   parameter_format : String?,
-                                  class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
+                                  class_fields : Hash(String, Array(FieldInfo)),
+                                  target_line : Int32? = nil) : Array(Param)
       params = [] of Param
       Noir::TreeSitter.parse_java(source) do |root|
-        params = extract_method_parameters_from(root, source, class_name, method_name, verb, parameter_format, class_fields)
+        params = extract_method_parameters_from(root, source, class_name, method_name, verb, parameter_format, class_fields, target_line)
       end
       params
     end
@@ -172,8 +245,9 @@ module Noir
                                        method_name : String,
                                        verb : String,
                                        parameter_format : String?,
-                                       class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
-      method = find_method(root, source, class_name, method_name)
+                                       class_fields : Hash(String, Array(FieldInfo)),
+                                       target_line : Int32? = nil) : Array(Param)
+      method = find_method(root, source, class_name, method_name, target_line)
       return [] of Param unless method
       constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
       collect_method_params(method, source, verb, parameter_format, class_fields, constants, class_name)
@@ -347,29 +421,42 @@ module Noir
 
     # Find the (class_name, method_name) method_declaration in the
     # tree. Returns nil when absent.
+    # Locate the `method_declaration` named `method_name` inside class
+    # `class_name`. When `target_line` is given (the route's mapping
+    # annotation row, 0-based) it disambiguates overloaded handlers: the
+    # annotation sits inside the *correct* overload's node span, so the
+    # method whose `[start_row, end_row]` range contains `target_line`
+    # wins. Without a line hint — or when no overload contains it — the
+    # first same-named method is returned, preserving prior behaviour.
     private def find_method(root : LibTreeSitter::TSNode,
                             source : String,
                             class_name : String,
-                            method_name : String) : LibTreeSitter::TSNode?
-      result : LibTreeSitter::TSNode? = nil
+                            method_name : String,
+                            target_line : Int32? = nil) : LibTreeSitter::TSNode?
+      first : LibTreeSitter::TSNode? = nil
+      matched : LibTreeSitter::TSNode? = nil
       walk_class_containers(root) do |decl|
-        next if result
+        next if matched
         name_node = Noir::TreeSitter.field(decl, "name")
         next unless name_node
         next unless Noir::TreeSitter.node_text(name_node, source) == class_name
         body = Noir::TreeSitter.field(decl, "body")
         next unless body
         Noir::TreeSitter.each_named_child(body) do |member|
-          next if result
+          next if matched
           next unless Noir::TreeSitter.node_type(member) == "method_declaration"
           mn = Noir::TreeSitter.field(member, "name")
           next unless mn
-          if Noir::TreeSitter.node_text(mn, source) == method_name
-            result = member
+          next unless Noir::TreeSitter.node_text(mn, source) == method_name
+          first ||= member
+          if line = target_line
+            start_row = Noir::TreeSitter.node_start_row(member)
+            end_row = Noir::TreeSitter.node_end_row(member)
+            matched = member if line >= start_row && line <= end_row
           end
         end
       end
-      result
+      matched || first
     end
 
     # Iterate annotation names (marker or full) attached to a
@@ -563,6 +650,7 @@ module Noir
       # `@RequestHeader` / `@CookieValue`; the first we see wins.
       ann_kind = nil
       ann_node : LibTreeSitter::TSNode? = nil
+      injected_param = false
       if mods = find_modifiers(fp)
         Noir::TreeSitter.each_named_child(mods) do |ann|
           ty = Noir::TreeSitter.node_type(ann)
@@ -570,6 +658,7 @@ module Noir
           n = Noir::TreeSitter.field(ann, "name")
           next unless n
           sn = simple_name(Noir::TreeSitter.node_text(n, source))
+          injected_param = true if INJECTED_PARAM_ANNOTATIONS.includes?(sn)
           case sn
           when "PathVariable"
             ann_kind = :path
@@ -597,6 +686,12 @@ module Noir
 
       return parameter_format if ann_kind == :path # legacy: @PathVariable is not emitted
 
+      # An argument-resolver parameter (`@AuthenticationPrincipal`, …) with
+      # no request-binding annotation is server-supplied, not a request
+      # input — drop it before the implicit-binding path can expand its
+      # (often DTO-typed) fields into phantom params.
+      return parameter_format if ann_kind.nil? && injected_param
+
       effective_format = parameter_format
       case ann_kind
       when :body
@@ -609,15 +704,23 @@ module Noir
         effective_format = "cookie"
       end
       if effective_format.nil?
-        # No parameter annotation and no `consumes` hint. A POST binds an
-        # un-annotated command object / scalar as form data (Spring
-        # `@ModelAttribute` semantics); other verbs carry no implicit
-        # request body, so the parameter isn't a request input. Applying
-        # this per-parameter — rather than pre-seeding the whole method
-        # with "form" — lets an explicit `@RequestBody` on the same POST
-        # resolve to "json" instead of being dragged to "form".
-        return parameter_format unless verb == "POST"
-        effective_format = "form"
+        # No parameter annotation and no `consumes` hint. Spring still
+        # binds the argument implicitly:
+        #   * a scalar (or array/collection of scalars) and a command
+        #     object both bind from request values for every verb — query
+        #     string on GET/DELETE/…, form body on POST;
+        #   * a framework argument-resolver type (Model,
+        #     HttpServletRequest, Pageable, Authentication, BindingResult,
+        #     …) binds from neither and must not surface.
+        # Emit only the first two kinds; recognise a command object by its
+        # presence in the resolved DTO field map. POST keeps the legacy
+        # "form" classification; other verbs use "query" (no implicit
+        # request body). Applying this per-parameter — rather than
+        # pre-seeding the whole method — lets an explicit `@RequestBody` on
+        # the same POST resolve to "json" instead of being dragged along.
+        bindable = simple_bindable_param?(type_name) || class_fields.has_key?(type_name)
+        return parameter_format unless bindable
+        effective_format = verb == "POST" ? "form" : "query"
       end
 
       default_value : String? = nil
@@ -650,20 +753,53 @@ module Noir
         end
       end
 
-      type_key = type_name.downcase
-      if PRIMITIVE_TYPES.includes?(type_key)
+      if simple_bindable_param?(type_name)
         sink << Param.new(parameter_name, default_value || "", effective_format)
       elsif SERVLET_REQUEST_TYPES.includes?(type_name)
         scan_servlet_body(method, source, arg_name, effective_format, sink)
       elsif fields = class_fields[type_name]?
+        # `@RequestBody` is deserialised by Jackson, which populates every
+        # non-static instance field by reflection (and via
+        # all-args/`@Builder` constructors) regardless of setter
+        # visibility — so a Lombok `@Getter`-only or constructor-bound DTO
+        # still binds all its fields. Form/model-attribute binding goes
+        # through Spring's `WebDataBinder`, which needs a public field or a
+        # setter, so keep that stricter gate for non-JSON formats.
+        json_body = effective_format == "json"
         fields.each do |field|
-          next unless field.access_modifier == "public" || field.has_setter?
+          next unless json_body || field.access_modifier == "public" || field.has_setter?
           expanded_default = default_value || field.init_value
           sink << Param.new(field.name, expanded_default, effective_format)
         end
       end
 
       effective_format
+    end
+
+    # True when `type_name` is a scalar Spring binds from one request
+    # value, including its array (`Integer[]`), varargs, and
+    # single-argument collection (`List<Long>`, `Optional<String>`)
+    # forms. Drives both the un-annotated implicit-binding gate and the
+    # final emit dispatch, so an annotated `@RequestParam Integer[] ids`
+    # surfaces too (the bare `PRIMITIVE_TYPES` lookup missed array forms).
+    private def simple_bindable_param?(type_name : String) : Bool
+      SIMPLE_PARAM_TYPES.includes?(simple_param_base(type_name))
+    end
+
+    # Reduce a parameter type to its lower-cased element-type simple name:
+    # strip a single-argument collection/`Optional` wrapper, array
+    # brackets and varargs, then drop any package/outer-class qualifier.
+    private def simple_param_base(type_name : String) : String
+      base = type_name.strip
+      if match = base.match(/\A(?:java\.util\.)?(?:List|Set|Collection|Iterable|Optional)\s*<\s*(.+?)\s*>\z/)
+        base = match[1].strip
+      end
+      base = base.gsub(/\[\s*\]/, "")
+      base = base.rstrip(". ")
+      if idx = base.rindex('.')
+        base = base[(idx + 1)..]
+      end
+      base.downcase
     end
 
     # Resolve either a string literal, a local Java constant, or a


### PR DESCRIPTION
## Summary

A Java-analyzer accuracy sweep validated by scanning **27 cloned Java OSS apps** with `noir` and cross-referencing every endpoint/param/callee against the source. Covers Spring (MVC + WebFlux), JAX-RS, Quarkus, Micronaut, Vert.x, Struts2, Dropwizard, Armeria, Play, Javalin. Builds on the prior Java sweeps in the analyzer-accuracy series.

Apps include: spring-petclinic / -rest / -microservices, eladmin, vhr, ruoyi, mall / mall-swarm, litemall, newbee-mall, halo, piggymetrics, jhipster-sample, spring-boot-realworld, quarkus-quickstarts, play-samples, vertx-examples / vert.x, micronaut-core / -security, dropwizard, jersey, armeria, struts, javalin, spark.

## False positives removed

- **Vert.x** route paths must start with `/` (Vert.x Web semantics). The regex route detector was matching any `<ident>.get/put/...` call, so `map.put("ez", …)`, `new JsonObject().put("id", …)`, `cache.get("k")` surfaced as `PUT /ez`, `PUT /id`, etc. A leading-slash gate removes them. *vertx-core 1253 → 0 (it's the library, so 0 is correct), vertx-examples 72 → 46 (all `JsonObject.put` FPs).*
- **Struts2** now gates `src/test/**/struts.xml` config via the shared `JavaEngine.test_path?` (the `.java` selection already did). *struts 285 → 271.*

## Spring parameter recall (shared `java_parameter_extractor_ts`)

The largest cluster of findings — many endpoints reported **zero** request params.

- **Un-annotated implicit binding.** A scalar / array / `List<X>` argument with no annotation now binds as Spring does (query on GET/DELETE/PUT, form on POST), via a new `SIMPLE_PARAM_TYPES` allow-set + `simple_bindable_param?`/`simple_param_base` (strips `[]`, varargs, `List/Set/Collection/Optional<…>`). This also fixes the annotated `@RequestParam Integer[] ids` case the bare `PRIMITIVE_TYPES` lookup silently dropped.
- **JSON `@RequestBody` field visibility.** Jackson populates every non-static field by reflection, so a Lombok `@Getter`-only / `@AllArgsConstructor` / `@Builder` DTO now expands all its fields. Form/model-attribute binding keeps the stricter public-or-setter gate.
- **Java records.** Record components are indexed as bindable fields.
- **`@AuthenticationPrincipal` FP guard.** `@AuthenticationPrincipal` / `@CurrentUser` / `@CurrentSecurityContext` / `@SessionAttribute` / `@RequestAttribute` parameters are dropped before implicit binding can expand their (often DTO-typed) fields into phantom params. Validation annotations (`@Valid`, `@Min`) stay transparent.

Param-coverage gains (endpoints with ≥1 param, counts otherwise stable — no FP endpoint growth): eladmin +56, litemall +40, mall +22, ruoyi +9, vhr +6, newbee-mall +7, plus richer `@RequestBody` bodies.

## Callee / correctness

- **Spring reactive `RouterFunction`.** Builder-style `router().GET("/x", this::handler)` now resolves the same-file handler method body to 1-hop callees. *halo reactive endpoints: callees 0 → 63.*
- **Overloaded handlers.** `find_method` (both the param and callee extractors) takes an optional `target_line`; the route's mapping-annotation row falls inside the correct overload's node span, so two same-named handlers no longer cross-wire params and callees (e.g. petclinic-micro `VisitResource.read`).

## Validation

- `crystal spec`: unit **2924** + functional **16512**, 0 failures.
- 19 new unit tests (param implicit binding, JSON field visibility, records, `@AuthenticationPrincipal`, overload disambiguation).
- `ameba` clean, `crystal tool format --check` clean.