### PR TITLE
fix(loco): gate #[cfg(test)] route builders out of results

### DIFF
--- a/spec/functional_test/fixtures/rust/loco_test_gate/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/loco_test_gate/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "loco_test_gate_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+loco-rs = "0.10"

--- a/spec/functional_test/fixtures/rust/loco_test_gate/src/controllers/notes.rs
+++ b/spec/functional_test/fixtures/rust/loco_test_gate/src/controllers/notes.rs
@@ -1,0 +1,29 @@
+// Loco controller with explicit routes plus a `#[cfg(test)]` route
+// builder that must NOT be reported.
+use loco_rs::prelude::*;
+
+async fn list() -> Result<Response> {
+    format::empty()
+}
+
+async fn create() -> Result<Response> {
+    format::empty()
+}
+
+pub fn routes() -> Routes {
+    Routes::new()
+        .prefix("/api/notes")
+        .add("/", get(list))
+        .add("/", post(create))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub fn test_routes() -> Routes {
+        Routes::new()
+            .prefix("/should-not-appear")
+            .add("/x", get(list))
+    }
+}

--- a/spec/functional_test/testers/rust/loco_test_gate_spec.cr
+++ b/spec/functional_test/testers/rust/loco_test_gate_spec.cr
@@ -1,0 +1,15 @@
+require "../../func_spec.cr"
+
+# Loco: explicit `Routes::new().prefix().add(...)` routes are reported,
+# but a `#[cfg(test)]` route builder in the same controller is excluded.
+expected_endpoints = [
+  Endpoint.new("/api/notes", "GET"),
+  Endpoint.new("/api/notes", "POST"),
+]
+
+FunctionalTester.new("fixtures/rust/loco_test_gate/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_loco"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/loco.cr
+++ b/src/analyzer/analyzers/rust/loco.cr
@@ -28,6 +28,10 @@ module Analyzer::Rust
       # so the content check alone is sufficient.
       return endpoints unless source.includes?("use loco_rs")
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      # `#[cfg(test)] mod tests { Routes::new().add("/x", get(h)); }` and
+      # path-normalization test fixtures live right in the framework's
+      # `src/app_routes.rs` etc.; gate them like the other Rust analyzers.
+      test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = build_function_index(root, source)
@@ -41,7 +45,7 @@ module Analyzer::Rust
         # file uses this builder, the explicit routes are authoritative —
         # we return them and skip the convention pass so the two can't
         # double-count the same controller.
-        explicit = extract_explicit_routes(root, source, path, function_index, include_callee)
+        explicit = extract_explicit_routes(root, source, path, function_index, include_callee, test_regions)
         if !explicit.empty?
           endpoints.concat(explicit)
           next
@@ -59,6 +63,7 @@ module Analyzer::Rust
 
         walk(root) do |node|
           next unless Noir::TreeSitter.node_type(node) == "function_item"
+          next if RustEngine.inside_test_region?(node, test_regions)
           next unless public_async?(node, source)
           name_node = Noir::TreeSitter.field(node, "name")
           next unless name_node
@@ -91,10 +96,12 @@ module Analyzer::Rust
                                         source : String,
                                         path : String,
                                         function_index : Hash(String, LibTreeSitter::TSNode),
-                                        include_callee : Bool) : Array(Endpoint)
+                                        include_callee : Bool,
+                                        test_regions : Array(Tuple(Int32, Int32))) : Array(Endpoint)
       endpoints = [] of Endpoint
       walk(root) do |node|
         next unless Noir::TreeSitter.node_type(node) == "call_expression"
+        next if RustEngine.inside_test_region?(node, test_regions)
         fn_node = Noir::TreeSitter.field(node, "function")
         next unless fn_node && Noir::TreeSitter.node_type(fn_node) == "field_expression"
         field = Noir::TreeSitter.field(fn_node, "field")


### PR DESCRIPTION
## Summary
The loco analyzer was the only Rust analyzer without `#[cfg(test)]` filtering. loco keeps path-normalization test fixtures and test-only `Routes::new().add(...)` builders right in `src/` (app_routes.rs, tests_cfg, …), so both the explicit-routes pass and the Rails-convention fallback emitted them as phantom endpoints.

## Change
Gate both passes via the shared `RustEngine.collect_cfg_test_regions` / `inside_test_region?`, matching axum/salvo/actix/poem/tide.

## Results
loco repo **33 → 20** endpoints — 13 `#[cfg(test)]` FPs removed; the remaining 20 are real framework routes (monitoring `/_health`…, the auth controller, static-asset fallback). New `loco_test_gate` fixture + spec; all rust functional specs pass.