### PR TITLE
feat(rocket): generic #[route(...)] attribute macro

### DIFF
--- a/spec/functional_test/fixtures/rust/rocket_route_macro/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rocket_route_macro/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rocket_route_macro_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rocket = "0.5"

--- a/spec/functional_test/fixtures/rust/rocket_route_macro/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rocket_route_macro/src/main.rs
@@ -1,0 +1,20 @@
+// Rocket's generic `#[route(...)]` attribute (legacy verb-first and
+// modern method-kwarg forms). Custom non-HTTP methods are skipped.
+#[macro_use]
+extern crate rocket;
+
+#[route(GET, uri = "/legacy")]
+fn legacy() -> &'static str { "ok" }
+
+#[route("/modern", method = POST)]
+fn modern() -> &'static str { "ok" }
+
+#[route("/with-data", method = PUT, data = "<body>")]
+fn with_data(body: String) -> String { body }
+
+// Custom WebDAV method: not a standard HTTP verb -> not emitted.
+#[route("/dav", method = PROPFIND)]
+fn dav() -> &'static str { "ok" }
+
+#[get("/plain")]
+fn plain() -> &'static str { "ok" }

--- a/spec/functional_test/testers/rust/rocket_route_macro_spec.cr
+++ b/spec/functional_test/testers/rust/rocket_route_macro_spec.cr
@@ -1,0 +1,19 @@
+require "../../func_spec.cr"
+
+# Rocket's generic `#[route(...)]` attribute: the legacy verb-first form
+# `#[route(GET, uri = "/p")]`, the modern `#[route("/p", method = POST)]`
+# form (with `data = "<body>"`), and `#[get(...)]`. Custom non-HTTP
+# methods (PROPFIND) are not emitted.
+expected_endpoints = [
+  Endpoint.new("/legacy", "GET"),
+  Endpoint.new("/modern", "POST"),
+  Endpoint.new("/with-data", "PUT", [Param.new("body", "", "body")]),
+  Endpoint.new("/plain", "GET"),
+]
+
+FunctionalTester.new("fixtures/rust/rocket_route_macro/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_rocket"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -55,19 +55,30 @@ module Analyzer::Rust
       attr = find_named_child(attr_item, "attribute")
       return unless attr
 
-      verb = nil.as(String?)
+      attr_name = nil.as(String?)
       Noir::TreeSitter.each_named_child(attr) do |child|
         case Noir::TreeSitter.node_type(child)
         when "identifier", "scoped_identifier"
-          verb = Noir::TreeSitter.node_text(child, source).downcase
+          attr_name = Noir::TreeSitter.node_text(child, source).downcase
           break
         end
       end
-      return unless verb
-      return unless HTTP_VERBS.includes?(verb)
+      return unless attr_name
 
       arguments = Noir::TreeSitter.field(attr, "arguments")
       return unless arguments
+
+      verb =
+        if HTTP_VERBS.includes?(attr_name)
+          attr_name
+        elsif attr_name == "route"
+          # Generic `#[route(GET, uri = "/p")]` / `#[route("/p",
+          # method = GET)]`. Only standard HTTP verbs are emitted; custom
+          # WebDAV-style methods (PROPFIND, VERSION-CONTROL) are skipped.
+          http_verb_in_token_tree(arguments, source)
+        end
+      return unless verb
+
       route_path, data_param = parse_token_tree(arguments, source)
       return unless route_path
       {route_path, verb.upcase, data_param, Noir::TreeSitter.node_start_row(attr_item) + 1}
@@ -101,6 +112,27 @@ module Analyzer::Rust
       end
 
       {route_path, data_param}
+    end
+
+    # Find the first HTTP verb in a `#[route(...)]` argument list — the
+    # leading `GET` of the legacy form or the `method = GET` value of the
+    # modern form. Checks identifiers and verb-valued string literals;
+    # returns the lowercased verb or nil (custom non-HTTP methods skipped).
+    private def http_verb_in_token_tree(arguments : LibTreeSitter::TSNode, source : String) : String?
+      result : String? = nil
+      Noir::TreeSitter.each_named_child(arguments) do |child|
+        next if result
+        case Noir::TreeSitter.node_type(child)
+        when "identifier", "scoped_identifier"
+          v = Noir::TreeSitter.node_text(child, source).split("::").last.downcase
+          result = v if HTTP_VERBS.includes?(v)
+        when "string_literal"
+          if (s = string_content(child, source)) && HTTP_VERBS.includes?(s.downcase)
+            result = s.downcase
+          end
+        end
+      end
+      result
     end
 
     private def strip_angle_brackets(value : String?) : String?


### PR DESCRIPTION
## Summary
Rocket's generic route attribute was unsupported — only the per-verb `#[get]`/`#[post]`/… macros were recognized.

## Changes
Support both forms of `#[route(...)]`:
- **legacy** `#[route(GET, uri = "/p")]` (verb is the leading identifier)
- **modern** `#[route("/p", method = POST, data = "<body>")]` (verb is the `method =` value)

Only standard HTTP verbs are emitted; custom WebDAV-style methods (`PROPFIND`, `VERSION-CONTROL`) are skipped to avoid non-HTTP noise. Path and `data = "<...>"` extraction reuse the existing token-tree parser.

## Results
New `rocket_route_macro` fixture + spec. Real apps (vaultwarden, plume) unchanged (they don't use this macro — no FP). All rust functional specs pass.