### PR TITLE
test: add miniparser specs for AdonisJS, Elysia, Hapi, and Python route extractors

### DIFF
--- a/spec/unit_test/miniparser/adonisjs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/adonisjs_extractor_ts_spec.cr
@@ -1,0 +1,104 @@
+require "spec"
+require "../../../src/miniparsers/adonisjs_extractor_ts"
+
+describe Noir::TreeSitterAdonisJsExtractor do
+  it "extracts top-level verb routes" do
+    source = <<-TS
+      Route.get('/', 'HomeController.index')
+      Route.post('/login', 'AuthController.login')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/"},
+      {"POST", "/login"},
+    ])
+  end
+
+  it "fans out .any into the standard verb set" do
+    source = <<-TS
+      Route.any('/wildcard', 'WildcardController.handle')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map(&.verb).sort.should eq(["DELETE", "GET", "PATCH", "POST", "PUT"])
+    routes.map(&.path).uniq.should eq(["/wildcard"])
+  end
+
+  it "applies group prefixes, including nested groups with .prefix" do
+    source = <<-TS
+      Route.group(() => {
+          Route.get('/users', 'UsersController.index')
+
+          Route.group(() => {
+              Route.post('/posts', 'PostsController.store')
+          }).prefix('/blog').middleware('auth')
+      }).prefix('/api/v1')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      {"GET", "/api/v1/users"},
+      {"POST", "/api/v1/blog/posts"},
+    ].sort)
+  end
+
+  it "expands .resource into the five REST API routes" do
+    source = <<-TS
+      Route.resource('articles', 'ArticlesController').apiOnly()
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      {"GET", "/articles"},
+      {"POST", "/articles"},
+      {"GET", "/articles/:id"},
+      {"PUT", "/articles/:id"},
+      {"DELETE", "/articles/:id"},
+    ].sort)
+  end
+
+  it "restricts resource routes with .only" do
+    source = <<-TS
+      Route.resource('tags', 'TagsController').only(['index', 'show'])
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      {"GET", "/tags"},
+      {"GET", "/tags/:id"},
+    ].sort)
+  end
+
+  it "drops actions listed in .except" do
+    source = <<-TS
+      Route.resource('tags', 'TagsController').except(['destroy', 'update'])
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    # index (GET /tags), store (POST /tags), show (GET /tags/:id) remain.
+    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      {"GET", "/tags"},
+      {"GET", "/tags/:id"},
+      {"POST", "/tags"},
+    ].sort)
+  end
+
+  it "handles inline arrow-function handlers" do
+    source = <<-TS
+      Route.get('/health', () => ({ ok: true }))
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/health"}])
+  end
+
+  it "captures the controller action as a callee when requested" do
+    source = <<-TS
+      Route.get('/users', 'UsersController.index')
+      TS
+
+    routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source, include_callees: true)
+    routes.first.callees.map(&.[0]).should contain("UsersController.index")
+  end
+end

--- a/spec/unit_test/miniparser/adonisjs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/adonisjs_extractor_ts_spec.cr
@@ -21,8 +21,8 @@ describe Noir::TreeSitterAdonisJsExtractor do
       TS
 
     routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
-    routes.map(&.verb).sort.should eq(["DELETE", "GET", "PATCH", "POST", "PUT"])
-    routes.map(&.path).uniq.should eq(["/wildcard"])
+    routes.map(&.verb).sort!.should eq(["DELETE", "GET", "PATCH", "POST", "PUT"])
+    routes.map(&.path).uniq!.should eq(["/wildcard"])
   end
 
   it "applies group prefixes, including nested groups with .prefix" do
@@ -37,7 +37,7 @@ describe Noir::TreeSitterAdonisJsExtractor do
       TS
 
     routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
-    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
       {"GET", "/api/v1/users"},
       {"POST", "/api/v1/blog/posts"},
     ].sort)
@@ -49,7 +49,7 @@ describe Noir::TreeSitterAdonisJsExtractor do
       TS
 
     routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
-    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
       {"GET", "/articles"},
       {"POST", "/articles"},
       {"GET", "/articles/:id"},
@@ -64,7 +64,7 @@ describe Noir::TreeSitterAdonisJsExtractor do
       TS
 
     routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
-    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
       {"GET", "/tags"},
       {"GET", "/tags/:id"},
     ].sort)
@@ -77,7 +77,7 @@ describe Noir::TreeSitterAdonisJsExtractor do
 
     routes = Noir::TreeSitterAdonisJsExtractor.extract_routes(source)
     # index (GET /tags), store (POST /tags), show (GET /tags/:id) remain.
-    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
       {"GET", "/tags"},
       {"GET", "/tags/:id"},
       {"POST", "/tags"},

--- a/spec/unit_test/miniparser/elysia_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/elysia_extractor_ts_spec.cr
@@ -11,7 +11,7 @@ describe Noir::TreeSitterElysiaExtractor do
       TS
 
     routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
-    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
       {"GET", "/users"},
       {"POST", "/users"},
     ].sort)
@@ -29,7 +29,7 @@ describe Noir::TreeSitterElysiaExtractor do
       TS
 
     routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
-    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
       {"GET", "/api/v1/health"},
       {"POST", "/api/v1/submit"},
     ].sort)
@@ -42,7 +42,7 @@ describe Noir::TreeSitterElysiaExtractor do
       TS
 
     routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
-    routes.select { |r| r.path == "/any" }.map(&.verb).sort.should eq(
+    routes.select { |r| r.path == "/any" }.map(&.verb).sort!.should eq(
       ["DELETE", "GET", "PATCH", "POST", "PUT"]
     )
   end

--- a/spec/unit_test/miniparser/elysia_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/elysia_extractor_ts_spec.cr
@@ -1,0 +1,114 @@
+require "spec"
+require "../../../src/miniparsers/elysia_extractor_ts"
+
+describe Noir::TreeSitterElysiaExtractor do
+  it "extracts chained verb routes" do
+    source = <<-TS
+      const app = new Elysia()
+          .get('/users', () => [])
+          .post('/users', ({ body }) => body)
+          .listen(3000)
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      {"GET", "/users"},
+      {"POST", "/users"},
+    ].sort)
+  end
+
+  it "joins group prefixes onto inner routes" do
+    source = <<-TS
+      const app = new Elysia()
+          .group('/api/v1', (app) =>
+              app
+                  .get('/health', () => 'ok')
+                  .post('/submit', ({ body }) => body)
+          )
+          .listen(3000)
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      {"GET", "/api/v1/health"},
+      {"POST", "/api/v1/submit"},
+    ].sort)
+  end
+
+  it "fans out the .all verb into the standard verb set" do
+    source = <<-TS
+      const app = new Elysia()
+          .all('/any', () => 'ok')
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.select { |r| r.path == "/any" }.map(&.verb).sort.should eq(
+      ["DELETE", "GET", "PATCH", "POST", "PUT"]
+    )
+  end
+
+  it "marks a body param from the destructured handler signature" do
+    source = <<-TS
+      const app = new Elysia()
+          .post('/submit', ({ body }) => body)
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.first.has_body?.should be_true
+  end
+
+  it "captures query, header and cookie signals from handler bodies" do
+    source = <<-TS
+      const app = new Elysia()
+          .get('/search', ({ query }) => {
+              const filter = query.filter
+              return filter
+          })
+          .get('/trace', ({ headers }) => {
+              const token = headers['x-token']
+              return token
+          })
+          .delete('/sessions/:id', ({ params, cookie }) => {
+              const session = cookie.session
+              return params.id
+          })
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    search = routes.find! { |r| r.path == "/search" }
+    trace = routes.find! { |r| r.path == "/trace" }
+    sessions = routes.find! { |r| r.path == "/sessions/:id" }
+
+    search.query_params.should contain("filter")
+    trace.header_params.should contain("x-token")
+    sessions.cookie_params.should contain("session")
+    # `params.id` maps to the URL placeholder, not a query param.
+    sessions.query_params.should be_empty
+  end
+
+  it "descends through transparent .guard and .use wrappers" do
+    source = <<-TS
+      const app = new Elysia()
+          .guard({ beforeHandle: auth }, (app) =>
+              app.get('/protected', () => 'secret')
+          )
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/protected"}])
+  end
+
+  it "deduplicates repeated param signals" do
+    source = <<-TS
+      const app = new Elysia()
+          .get('/dup', ({ query }) => {
+              const a = query.filter
+              const b = query.filter
+              return a
+          })
+      TS
+
+    routes = Noir::TreeSitterElysiaExtractor.extract_routes(source)
+    routes.first.query_params.should eq(["filter"])
+  end
+end

--- a/spec/unit_test/miniparser/hapi_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/hapi_extractor_ts_spec.cr
@@ -40,8 +40,8 @@ describe Noir::TreeSitterHapiExtractor do
       JS
 
     routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
-    routes.map(&.verb).sort.should eq(["PATCH", "PUT"])
-    routes.map(&.path).uniq.should eq(["/users/{id}"])
+    routes.map(&.verb).sort!.should eq(["PATCH", "PUT"])
+    routes.map(&.path).uniq!.should eq(["/users/{id}"])
   end
 
   it "fans out the wildcard method into the standard verb set" do
@@ -54,7 +54,7 @@ describe Noir::TreeSitterHapiExtractor do
       JS
 
     routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
-    routes.map(&.verb).sort.should eq(["DELETE", "GET", "PATCH", "POST", "PUT"])
+    routes.map(&.verb).sort!.should eq(["DELETE", "GET", "PATCH", "POST", "PUT"])
   end
 
   it "ignores unknown HTTP method strings" do

--- a/spec/unit_test/miniparser/hapi_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/hapi_extractor_ts_spec.cr
@@ -1,0 +1,109 @@
+require "spec"
+require "../../../src/miniparsers/hapi_extractor_ts"
+
+describe Noir::TreeSitterHapiExtractor do
+  it "extracts a single object route with verb and path" do
+    source = <<-JS
+      server.route({
+          method: 'GET',
+          path: '/users',
+          handler: (request, h) => []
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([{"GET", "/users"}])
+  end
+
+  it "extracts every route from an array-of-objects config" do
+    source = <<-JS
+      server.route([
+          { method: 'POST', path: '/users', handler: (request, h) => {} },
+          { method: 'DELETE', path: '/users/{id}', handler: (request, h) => {} }
+      ]);
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"POST", "/users"},
+      {"DELETE", "/users/{id}"},
+    ])
+  end
+
+  it "fans out an array of methods into one route per verb" do
+    source = <<-JS
+      server.route({
+          method: ['PUT', 'PATCH'],
+          path: '/users/{id}',
+          handler: (request, h) => {}
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.map(&.verb).sort.should eq(["PATCH", "PUT"])
+    routes.map(&.path).uniq.should eq(["/users/{id}"])
+  end
+
+  it "fans out the wildcard method into the standard verb set" do
+    source = <<-JS
+      server.route({
+          method: '*',
+          path: '/health',
+          handler: () => 'ok'
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.map(&.verb).sort.should eq(["DELETE", "GET", "PATCH", "POST", "PUT"])
+  end
+
+  it "ignores unknown HTTP method strings" do
+    source = <<-JS
+      server.route({
+          method: 'FOOBAR',
+          path: '/nope',
+          handler: () => {}
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.should be_empty
+  end
+
+  it "captures query, header, cookie and body signals from the handler" do
+    source = <<-JS
+      server.route({
+          method: 'POST',
+          path: '/users/{id}',
+          handler: (request, h) => {
+              const filter = request.query.filter;
+              const trace = request.headers['x-trace'];
+              const session = request.state.session;
+              const data = request.payload;
+              return request.params.id;
+          }
+      });
+      JS
+
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.size.should eq(1)
+    route = routes.first
+    route.query_params.should contain("filter")
+    route.header_params.should contain("x-trace")
+    route.cookie_params.should contain("session")
+    route.has_body?.should be_true
+    # `request.params.id` is the URL placeholder, not an extra param.
+    route.query_params.should_not contain("id")
+  end
+
+  it "does not treat unrelated method calls as routes" do
+    source = <<-JS
+      server.start();
+      logger.route('not a route');
+      JS
+
+    # `.route` with a bare string arg (not an object/array) emits nothing.
+    routes = Noir::TreeSitterHapiExtractor.extract_routes(source)
+    routes.should be_empty
+  end
+end

--- a/spec/unit_test/miniparser/python_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/python_route_extractor_spec.cr
@@ -1,0 +1,134 @@
+require "spec"
+require "../../../src/miniparsers/python_route_extractor"
+
+describe Noir::PythonRouteExtractor do
+  describe "scan_decorators" do
+    it "extracts a @<var>.route decorator with its method tail" do
+      decs = Noir::PythonRouteExtractor.scan_decorators(
+        %(@app.route("/users", methods=["GET", "POST"]))
+      )
+      decs.size.should eq(1)
+      decs[0].router_name.should eq("app")
+      decs[0].path.should eq("/users")
+      decs[0].extra_params.should contain("methods=")
+    end
+
+    it "extracts method-specific decorators and synthesizes the methods tail" do
+      decs = Noir::PythonRouteExtractor.scan_decorators(%(@bp.post("/login")))
+      decs.size.should eq(1)
+      decs[0].router_name.should eq("bp")
+      decs[0].path.should eq("/login")
+      decs[0].extra_params.should eq("methods=['POST']")
+    end
+
+    it "recognizes every supported HTTP method decorator" do
+      %w[get post put patch delete head options trace].each do |method|
+        decs = Noir::PythonRouteExtractor.scan_decorators(%(@r.#{method}("/p")))
+        decs.size.should eq(1)
+        decs[0].extra_params.should eq("methods=['#{method.upcase}']")
+      end
+    end
+
+    it "handles r-string and f-string path prefixes" do
+      Noir::PythonRouteExtractor.scan_decorators(%(@app.route(r"/raw")))[0].path.should eq("/raw")
+      Noir::PythonRouteExtractor.scan_decorators(%(@app.route(f"/fmt")))[0].path.should eq("/fmt")
+    end
+
+    it "recovers space-bearing paths from the original (unstripped) line" do
+      stripped = %(@app.route("/withspace"))
+      original = %(@app.route("/with space"))
+      decs = Noir::PythonRouteExtractor.scan_decorators(stripped, original)
+      decs[0].path.should eq("/with space")
+    end
+
+    it "returns an empty array when no decorator is present" do
+      Noir::PythonRouteExtractor.scan_decorators("x = compute()").should be_empty
+    end
+  end
+
+  describe "scan_blueprint" do
+    it "detects a module-qualified Blueprint assignment with url_prefix" do
+      result = Noir::PythonRouteExtractor.scan_blueprint(
+        %(admin=flask.Blueprint("admin", __name__, url_prefix="/admin")),
+        ["flask"]
+      )
+      result.should_not be_nil
+      name, prefix = result.not_nil!
+      name.should eq("admin")
+      prefix.should eq("/admin")
+    end
+
+    it "detects a bare Blueprint assignment without a prefix" do
+      result = Noir::PythonRouteExtractor.scan_blueprint(
+        %(api=Blueprint("api", __name__)),
+        ["flask"]
+      )
+      result.should_not be_nil
+      name, prefix = result.not_nil!
+      name.should eq("api")
+      prefix.should eq("")
+    end
+
+    it "tolerates a type annotation on the assignment target" do
+      result = Noir::PythonRouteExtractor.scan_blueprint(
+        %(bp:Blueprint=sanic.Blueprint("bp", url_prefix="/v1")),
+        ["sanic"]
+      )
+      result.should_not be_nil
+      result.not_nil![0].should eq("bp")
+      result.not_nil![1].should eq("/v1")
+    end
+
+    it "returns nil when the line is not a Blueprint assignment" do
+      Noir::PythonRouteExtractor.scan_blueprint("x = SomethingElse()", ["flask"]).should be_nil
+    end
+  end
+
+  describe "find_def_line" do
+    it "finds the def immediately below a decorator" do
+      lines = ["@app.route('/x')", "def handler():"]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(1)
+    end
+
+    it "skips chained decorators, comments and blank lines" do
+      lines = [
+        "@app.route('/x')",
+        "@login_required",
+        "# a comment",
+        "",
+        "def handler():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(4)
+    end
+
+    it "walks past a multi-line decorator header" do
+      lines = [
+        "@app.route(",
+        "    '/x',",
+        "    methods=['GET']",
+        ")",
+        "def handler():",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(4)
+    end
+
+    it "matches a class declaration too" do
+      lines = ["@register", "class MyView:"]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(1)
+    end
+
+    it "walks upward to the enclosing def when direction is :up" do
+      lines = [
+        "def existing():",
+        "    pass",
+        "@app.get('/x')",
+      ]
+      Noir::PythonRouteExtractor.find_def_line(lines, 2, :up).should eq(0)
+    end
+
+    it "returns the original index when nothing matches" do
+      lines = ["@app.route('/x')", "x = 1"]
+      Noir::PythonRouteExtractor.find_def_line(lines, 0).should eq(0)
+    end
+  end
+end


### PR DESCRIPTION
These four miniparsers shipped without dedicated unit specs:

- TreeSitterAdonisJsExtractor: verb routes, .any fan-out, nested group
  prefixes, .resource expansion, .only/.except filters, callee capture.
- TreeSitterElysiaExtractor: chained verbs, group prefix joining, .all
  fan-out, destructured body params, query/header/cookie handler signals,
  transparent .guard/.use descent, param dedup.
- TreeSitterHapiExtractor: object and array route configs, method arrays,
  wildcard fan-out, unknown-method rejection, request.query/headers/state/
  payload signal extraction.
- PythonRouteExtractor (non-tree-sitter): scan_decorators, scan_blueprint,
  and find_def_line helpers used by the Flask/Quart/Sanic/Robyn/aiohttp/
  Bottle adapters.

https://claude.ai/code/session_014JkjRM8BQbsC6dje7vjvEa