### PR TITLE
feat(actix): cross-file scope prefix composition for #[get] handlers

### DIFF
--- a/spec/functional_test/fixtures/rust/actix_crossfile_scope/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/actix_crossfile_scope/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "actix_crossfile_scope_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4"

--- a/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/admin.rs
+++ b/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/admin.rs
@@ -1,0 +1,14 @@
+use actix_web::{get, HttpResponse};
+
+// Mounted at `/admin` -> GET /admin/dashboard
+#[get("/dashboard")]
+async fn dashboard() -> HttpResponse {
+    HttpResponse::Ok().body("dashboard")
+}
+
+// Mounted at `/admin` -> GET /admin/list
+// Collides on leaf name with `posts::list`.
+#[get("/list")]
+async fn list() -> HttpResponse {
+    HttpResponse::Ok().body("admin list")
+}

--- a/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/main.rs
+++ b/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/main.rs
@@ -1,0 +1,48 @@
+// Router setup file. The scope tree lives here, but the `#[get]` /
+// `#[post]` handlers it mounts are defined in *other* modules
+// (`users.rs`, `posts.rs`, `admin.rs`). This is the rauthy-style
+// cross-file scope composition the analyzer must resolve: a handler's
+// real URL is its attribute path prefixed by the scope it is
+// registered under in this file, not in its own file.
+use actix_web::{web, App, HttpServer};
+
+mod admin;
+mod posts;
+mod users;
+
+// `api_services()` returns the composed scope; it is mounted via
+// `.service(api_services())`, so the prefix is only discoverable by
+// walking this function body (a different file from the handlers).
+fn api_services() -> actix_web::Scope {
+    web::scope("/auth")
+        // registered directly under /auth
+        .service(users::get_me)
+        .service(
+            web::scope("/v1")
+                // registered under /auth/v1
+                .service(users::list_users)
+                .service(posts::create_post)
+                // collision: `list` also exists in `admin` — module-aware
+                // matching must keep them apart.
+                .service(posts::list),
+        )
+}
+
+// A second, independent top-level scope in the same router file.
+fn admin_services() -> actix_web::Scope {
+    web::scope("/admin")
+        .service(admin::dashboard)
+        .service(admin::list)
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            .service(api_services())
+            .service(admin_services())
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}

--- a/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/posts.rs
+++ b/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/posts.rs
@@ -1,0 +1,15 @@
+use actix_web::{get, post, HttpResponse};
+
+// Mounted at `/auth/v1` -> POST /auth/v1/posts
+#[post("/posts")]
+async fn create_post() -> HttpResponse {
+    HttpResponse::Ok().body("created")
+}
+
+// Mounted at `/auth/v1` -> GET /auth/v1/posts
+// `list` collides with `admin::list`; module-aware lookup must give
+// this one `/auth/v1` and the admin one `/admin`.
+#[get("/posts")]
+async fn list() -> HttpResponse {
+    HttpResponse::Ok().body("posts")
+}

--- a/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/users.rs
+++ b/spec/functional_test/fixtures/rust/actix_crossfile_scope/src/users.rs
@@ -1,0 +1,13 @@
+use actix_web::{get, HttpResponse};
+
+// Mounted at `/auth` in main.rs -> GET /auth/me
+#[get("/me")]
+async fn get_me() -> HttpResponse {
+    HttpResponse::Ok().body("me")
+}
+
+// Mounted at `/auth/v1` in main.rs -> GET /auth/v1/users
+#[get("/users")]
+async fn list_users() -> HttpResponse {
+    HttpResponse::Ok().body("users")
+}

--- a/spec/functional_test/testers/rust/actix_crossfile_scope_spec.cr
+++ b/spec/functional_test/testers/rust/actix_crossfile_scope_spec.cr
@@ -1,0 +1,24 @@
+require "../../func_spec.cr"
+
+# Cross-file scope composition: the `web::scope("/auth").service(
+# mod::handler)` tree lives in `main.rs`, but the `#[get]/#[post]`
+# handlers it mounts are defined in sibling modules (`users.rs`,
+# `posts.rs`, `admin.rs`). The analyzer must prefix each handler with
+# the scope it is registered under in the *other* file, resolving the
+# right scope module-aware so the `list` leaf shared by `posts` and
+# `admin` keeps `/auth/v1/posts` distinct from `/admin/list`.
+expected_endpoints = [
+  Endpoint.new("/auth/me", "GET"),
+  Endpoint.new("/auth/v1/users", "GET"),
+  Endpoint.new("/auth/v1/posts", "POST"),
+  Endpoint.new("/auth/v1/posts", "GET"),
+  Endpoint.new("/admin/dashboard", "GET"),
+  Endpoint.new("/admin/list", "GET"),
+]
+
+FunctionalTester.new("fixtures/rust/actix_crossfile_scope/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_actix_web"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -13,6 +13,25 @@ module Analyzer::Rust
   class ActixWeb < RustEngine
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
+    # Cross-file scope registrations: `web::scope("/auth").service(mod::handler)`
+    # frequently mounts a `#[get("/x")]` handler that lives in a *different*
+    # file (the scope tree sits in `main.rs` / a router-setup module, the
+    # `#[get]` handler in `api/<mod>.rs`). The per-file scope pass below only
+    # sees same-file registrations, so those handlers lose their prefix
+    # (`/x` instead of `/auth/v1/x`). `analyze` walks every file once up
+    # front to record each **module-qualified** `.service(mod::handler)`
+    # registration's fully composed prefix; `analyze_file` then falls back to
+    # this index when a handler isn't registered in its own file. Only
+    # qualified (`mod::handler`) refs are globalised — bare `.service(handler)`
+    # refs stay file-local so identically named handlers across the standalone
+    # sub-apps of an example monorepo don't cross-contaminate.
+    @cross_file_scope_regs : Array(NamedTuple(ref: String, prefix: String))? = nil
+
+    def analyze
+      @cross_file_scope_regs = build_cross_file_scope_registrations
+      super
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
@@ -31,6 +50,12 @@ module Analyzer::Rust
 
           handler_name = function_name(function, source)
           prefixes = handler_name ? scoped_services[handler_name]? : nil
+          # Same-file scope pass found nothing — the handler is mounted
+          # cross-file via `.service(mod::handler)`. Resolve its prefix from
+          # the global index (module-qualified, so name clashes stay apart).
+          if (prefixes.nil? || prefixes.empty?) && handler_name
+            prefixes = lookup_cross_file_prefixes(handler_name, path)
+          end
 
           methods.each do |method|
             if prefixes && !prefixes.empty?
@@ -170,6 +195,107 @@ module Analyzer::Rust
         Noir::TreeSitter.node_text(node, source)
       when "scoped_identifier"
         Noir::TreeSitter.node_text(node, source).split("::").last
+      end
+    end
+
+    # First pass over the whole project: collect every module-qualified
+    # `.service(mod::handler)` registration's fully composed scope prefix.
+    # Gated to files that actually carry both a `scope(` and a `.service(`
+    # (router-setup files) so handler-only files cost nothing here.
+    private def build_cross_file_scope_registrations : Array(NamedTuple(ref: String, prefix: String))
+      regs = [] of NamedTuple(ref: String, prefix: String)
+      all_files.each do |path|
+        next if File.directory?(path)
+        next unless File.exists?(path) && File.extname(path) == ".rs"
+        next if RustEngine.test_path?(path)
+        src = read_file_content(path)
+        next unless src.includes?("scope(") && src.includes?(".service(")
+        begin
+          test_regions = RustEngine.collect_cfg_test_regions(src)
+          Noir::TreeSitter.parse_rust(src) do |root|
+            collect_qualified_registrations(root, src, test_regions, "", regs)
+          end
+        rescue e
+          logger.debug "actix cross-file scope scan error #{path}: #{e}"
+        end
+      end
+      regs
+    end
+
+    # Mirror of `collect_service_registrations`' prefix threading, but records
+    # only **scoped** (`mod::handler`) `.service(...)` args — the cross-file
+    # case. Bare-identifier args are left to the per-file pass.
+    private def collect_qualified_registrations(node : LibTreeSitter::TSNode,
+                                                source : String,
+                                                test_regions : Array(Tuple(Int32, Int32)),
+                                                active_prefix : String,
+                                                regs : Array(NamedTuple(ref: String, prefix: String)))
+      if Noir::TreeSitter.node_type(node) == "call_expression"
+        return if RustEngine.inside_test_region?(node, test_regions)
+
+        if field_call_name(node, source) == "service"
+          args = Noir::TreeSitter.field(node, "arguments")
+          return unless args
+          named = named_children(args)
+          return unless named.size == 1
+
+          function = Noir::TreeSitter.field(node, "function")
+          return unless function
+          receiver = Noir::TreeSitter.field(function, "value")
+          receiver_prefix = receiver ? (extract_scope_prefix(receiver, source) || "") : ""
+          service_prefix = scoped_route_path(active_prefix, receiver_prefix)
+
+          arg = named[0]
+          case Noir::TreeSitter.node_type(arg)
+          when "scoped_identifier"
+            regs << {ref: Noir::TreeSitter.node_text(arg, source), prefix: service_prefix}
+          when "identifier"
+            # bare same-file handler — handled by per-file scoped_services
+          else
+            collect_qualified_registrations(arg, source, test_regions, service_prefix, regs)
+          end
+
+          collect_qualified_registrations(receiver, source, test_regions, active_prefix, regs) if receiver
+          return
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_qualified_registrations(child, source, test_regions, active_prefix, regs)
+      end
+    end
+
+    # Resolve a handler function's cross-file scope prefix(es). Matches the
+    # global index module-aware: the segment before the leaf in the
+    # registration ref (`api_keys::get_api_keys` → `api_keys`) must equal the
+    # handler file's module (its filename stem, or the parent dir for
+    # `mod.rs`/`lib.rs`/`main.rs`). When no module matches we return nil
+    # rather than guess, so a leaf shared by two modules never borrows the
+    # wrong prefix.
+    private def lookup_cross_file_prefixes(name : String, file_path : String) : Array(String)?
+      regs = @cross_file_scope_regs
+      return unless regs
+      hints = module_hints(file_path)
+      matched = [] of String
+      regs.each do |r|
+        segs = r[:ref].split("::")
+        next unless segs[-1]? == name
+        mod = segs.size >= 2 ? segs[-2] : nil
+        matched << r[:prefix] if mod && hints.includes?(mod)
+      end
+      matched.empty? ? nil : matched.uniq
+    end
+
+    # Candidate module names a Rust source file can be referred to by. A
+    # plain `foo.rs` is module `foo`; the `mod.rs` / `lib.rs` / `main.rs`
+    # convention names the module after the parent directory.
+    private def module_hints(path : String) : Array(String)
+      base = File.basename(path, ".rs")
+      if base == "mod" || base == "lib" || base == "main"
+        parent = File.basename(File.dirname(path))
+        parent.empty? ? [] of String : [parent]
+      else
+        [base]
       end
     end
 


### PR DESCRIPTION
## Summary

Actix apps routinely mount attribute-macro handlers from a router-setup file while the handlers themselves live elsewhere:

```rust
// main.rs / server.rs — the scope tree
web::scope("/auth").service(web::scope("/v1").service(api_keys::get_api_keys))

// api/api_keys.rs — the handler
#[get("/api_keys")]
async fn get_api_keys() -> HttpResponse { ... }
```

The per-file scope pass only saw same-file `.service()` registrations, so every cross-file handler lost its prefix — emitting `GET /api_keys` when the real route is `GET /auth/v1/api_keys`.

## What changed

`analyze()` now does a cheap first pass over the project (gated to files carrying both `scope(` and `.service(`, i.e. router-setup files) recording each **module-qualified** `.service(mod::handler)` registration's fully composed scope prefix. `analyze_file` falls back to this index when a handler isn't registered in its own file.

Matching is **module-aware**: the segment before the leaf in the registration ref (`api_keys::get_api_keys` → `api_keys`) must equal the handler file's module (filename stem, or parent dir for `mod.rs`/`lib.rs`/`main.rs`). When no module matches we return nil rather than guess, so a leaf shared by two modules never borrows the wrong prefix. Bare `.service(handler)` refs stay file-local so identically named handlers across the standalone sub-apps of an example monorepo don't cross-contaminate.

## Impact (real OSS)

- **rauthy**: 261 routes corrected to their real `/auth/v1` / `/auth` URLs (were all emitted prefix-less).
- **0 regressions** on lemmy (217), lldap (15), realworld_actix (19), actix_examples (85), zero2prod (13).
- Scan time flat (rauthy ~0.65s).

This is enrichment of an already-accurate base: the routes were detected, but their URLs were wrong for AI context. Now they're correct.

## Tests

New fixture `actix_crossfile_scope` exercises nested scopes (`/auth` + `/auth/v1`), an independent top-level scope (`/admin`), and a leaf-name collision across modules (`posts::list` → `/auth/v1/posts` vs `admin::list` → `/admin/list`). All 1257 rust functional specs pass.