### PR TITLE
feat(rocket): cross-file .mount() prefix composition

### DIFF
--- a/spec/functional_test/fixtures/rust/rocket_mount/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rocket_mount/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rocket_mount_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rocket = "0.5"

--- a/spec/functional_test/fixtures/rust/rocket_mount/src/admin.rs
+++ b/spec/functional_test/fixtures/rust/rocket_mount/src/admin.rs
@@ -1,0 +1,11 @@
+use rocket::{get, routes, Route};
+
+// mounted at /admin (via the concat prefix) -> GET /admin/dashboard
+#[get("/dashboard")]
+fn dashboard() -> &'static str {
+    "dashboard"
+}
+
+pub fn routes() -> Vec<Route> {
+    routes![dashboard]
+}

--- a/spec/functional_test/fixtures/rust/rocket_mount/src/api/mod.rs
+++ b/spec/functional_test/fixtures/rust/rocket_mount/src/api/mod.rs
@@ -1,0 +1,21 @@
+use rocket::{get, routes, Route};
+
+// alias re-export: `v1_routes` resolves to `v1::routes`
+use crate::api::v1::routes as v1_routes;
+
+mod v1;
+
+// mounted at /api -> GET /api/ping
+#[get("/ping")]
+fn ping() -> &'static str {
+    "pong"
+}
+
+// `all_routes()` is what main.rs mounts at /api. It aggregates its own
+// `routes![ping]` plus the v1 sub-collector via the aliased append, so
+// every leaf (ping + v1::status) inherits /api.
+pub fn all_routes() -> Vec<Route> {
+    let mut r = routes![ping];
+    r.append(&mut v1_routes());
+    r
+}

--- a/spec/functional_test/fixtures/rust/rocket_mount/src/api/v1.rs
+++ b/spec/functional_test/fixtures/rust/rocket_mount/src/api/v1.rs
@@ -1,0 +1,12 @@
+use rocket::{get, routes, Route};
+
+// reached via api::all_routes() -> append v1::routes(); mounted at /api
+// -> GET /api/status
+#[get("/status")]
+fn status() -> &'static str {
+    "ok"
+}
+
+pub fn routes() -> Vec<Route> {
+    routes![status]
+}

--- a/spec/functional_test/fixtures/rust/rocket_mount/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rocket_mount/src/main.rs
@@ -1,0 +1,20 @@
+// Router setup. The `.mount()` calls live here; the handlers live in
+// sibling modules. Exercises every cross-file mount shape:
+//   * direct routes![] with module-qualified leaves   (/users)
+//   * array-concat prefix [base, "/admin"].concat()    (/admin)
+//   * mount(prefix, collector_fn()) + recursive append (/api)
+#[macro_use]
+extern crate rocket;
+
+mod admin;
+mod api;
+mod users;
+
+#[launch]
+fn rocket() -> _ {
+    let base = "";
+    rocket::build()
+        .mount("/users", routes![users::list, users::get_one])
+        .mount([base, "/admin"].concat(), admin::routes())
+        .mount("/api", api::all_routes())
+}

--- a/spec/functional_test/fixtures/rust/rocket_mount/src/users.rs
+++ b/spec/functional_test/fixtures/rust/rocket_mount/src/users.rs
@@ -1,0 +1,13 @@
+use rocket::get;
+
+// mounted at /users -> GET /users
+#[get("/")]
+fn list() -> &'static str {
+    "list"
+}
+
+// mounted at /users -> GET /users/{id}
+#[get("/<id>")]
+fn get_one(id: u32) -> String {
+    format!("user {id}")
+}

--- a/spec/functional_test/testers/rust/rocket_mount_spec.cr
+++ b/spec/functional_test/testers/rust/rocket_mount_spec.cr
@@ -1,0 +1,24 @@
+require "../../func_spec.cr"
+
+# Cross-file `.mount()` prefix composition. main.rs mounts handlers that
+# live in sibling modules; the analyzer must prefix each `#[get]` route
+# with the base it is mounted under. Covers the three real-world shapes:
+#   * direct `routes![users::list, users::get_one]`           -> /users/*
+#   * array-concat prefix `[base, "/admin"].concat()`         -> /admin/*
+#   * `mount("/api", api::all_routes())` where the collector
+#     aggregates `routes![ping]` + an aliased recursive append
+#     `r.append(&mut v1_routes())` (v1_routes => v1::routes)   -> /api/*
+expected_endpoints = [
+  Endpoint.new("/users", "GET"),
+  Endpoint.new("/users/{id}", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/admin/dashboard", "GET"),
+  Endpoint.new("/api/ping", "GET"),
+  Endpoint.new("/api/status", "GET"),
+]
+
+FunctionalTester.new("fixtures/rust/rocket_mount/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_rocket"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -13,6 +13,28 @@ module Analyzer::Rust
   class Rocket < RustEngine
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
 
+    # Cross-file `.mount()` prefix composition. A Rocket handler's real URL
+    # is its `#[get("/x")]` attribute path prefixed by the base it is mounted
+    # under — but the `.mount("/api", routes![...])` call lives in `main.rs`
+    # while the handler lives in another module, so the per-file pass emits
+    # `/x` instead of `/api/x`. `analyze` walks the project once up front to
+    # build a `{module, handler_leaf} => [prefix]` index, resolving:
+    #   * direct `.mount("/p", routes![a, mod::b])`,
+    #   * `.mount(prefix, route_fn())` where `route_fn` returns `routes![...]`
+    #     (and recursively `routes.append(&mut submod::routes())`),
+    #   * `use path::routes as alias;` re-export aliases,
+    #   * array-concat prefixes (`[basepath, "/api"].concat()`).
+    # Each leaf is tagged with the module of the `routes!` it appears in
+    # (or the ref's own module when qualified) so a handler only inherits a
+    # prefix when it lives in the registering module — names shared across
+    # modules never cross-contaminate.
+    @mount_index : Hash(Tuple(String, String), Array(String))? = nil
+
+    def analyze
+      @mount_index = build_mount_index
+      super
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
@@ -24,27 +46,319 @@ module Analyzer::Rust
           next unless route
           route_path, method, data_param, attr_row = route
 
-          details = Details.new(PathInfo.new(path, attr_row))
-          params = extract_params(route_path, data_param)
           # Rocket route attributes carry their query params inline
           # (`/path?<q>&<limit>`) and bracket their path params
           # (`/with-param/<id>`). The query spec gets parsed into
-          # actual params in `extract_params` above, but the URL we
+          # actual params in `extract_params` below, but the URL we
           # ship out should be the canonical bare path with `{name}`
           # placeholders — strip the `?...` suffix and convert
           # `<name>` → `{name}` so output matches every other
           # framework's path shape.
           canonical_path = canonicalize_rocket_path(route_path)
-          endpoint = Endpoint.new(canonical_path, method, params, details)
 
-          extract_function_extras(function, source, endpoint)
-          attach_handler_callees(function, source, path, endpoint) if include_callee
+          # Resolve the `.mount("/base", ...)` prefix(es) this handler is
+          # registered under (cross-file). A handler mounted at several
+          # bases (or at none) emits one endpoint per resolved URL.
+          handler_leaf = rocket_function_name(function, source)
+          prefixes = handler_leaf ? lookup_mount_prefixes(handler_leaf, path) : nil
+          urls = if prefixes && !prefixes.empty?
+                   prefixes.map { |pfx| join_mount_path(pfx, canonical_path) }
+                 else
+                   [canonical_path]
+                 end
 
-          endpoints << endpoint
+          urls.each do |url|
+            details = Details.new(PathInfo.new(path, attr_row))
+            params = extract_params(route_path, data_param)
+            endpoint = Endpoint.new(url, method, params, details)
+
+            extract_function_extras(function, source, endpoint)
+            attach_handler_callees(function, source, path, endpoint) if include_callee
+
+            endpoints << endpoint
+          end
         end
       end
 
       endpoints
+    end
+
+    # ── cross-file `.mount()` prefix index ───────────────────────────
+
+    # Walk the whole project once, gathering `use ... as alias;` re-exports,
+    # every `fn routes()`-style route collector's leaves + sub-collector
+    # calls, and every `.mount(prefix, ...)`. Resolve them into a
+    # `{module, handler_leaf} => [prefix]` index.
+    private def build_mount_index : Hash(Tuple(String, String), Array(String))
+      alias_map = {} of String => String
+      fn_leaves = {} of String => Array(Tuple(String, String?))
+      fn_appends = {} of String => Array(String)
+      mounts = [] of Tuple(String, Symbol, Array(Tuple(String, String?)), String?, String)
+
+      all_files.each do |path|
+        next if File.directory?(path)
+        next unless File.exists?(path) && File.extname(path) == ".rs"
+        next if RustEngine.test_path?(path)
+        src = read_file_content(path)
+        next unless src.includes?("routes!") || src.includes?(".mount(") || src.includes?("routes as")
+        file_mod = primary_module(path)
+        begin
+          test_regions = RustEngine.collect_cfg_test_regions(src)
+          Noir::TreeSitter.parse_rust(src) do |root|
+            collect_use_aliases(root, src, alias_map)
+            collect_route_fns(root, src, file_mod, test_regions, fn_leaves, fn_appends)
+            collect_mounts(root, src, file_mod, test_regions, mounts)
+          end
+        rescue e
+          logger.debug "rocket mount-index scan error #{path}: #{e}"
+        end
+      end
+
+      index = {} of Tuple(String, String) => Array(String)
+      mounts.each do |prefix, kind, list_leaves, call_ref, file_mod|
+        leaves =
+          if kind == :list
+            list_leaves
+          else
+            resolved = [] of Tuple(String, String?)
+            if cr = call_ref
+              resolve_route_fn(cr, alias_map, fn_leaves, fn_appends, Set(String).new, resolved)
+            end
+            resolved
+          end
+        leaves.each do |leaf, mod_opt|
+          key = {mod_opt || file_mod, leaf}
+          bucket = (index[key] ||= [] of String)
+          bucket << prefix unless bucket.includes?(prefix)
+        end
+      end
+      index
+    end
+
+    # `core::routes as core_routes` -> alias_map["core_routes"] = "core::routes"
+    # (last two segments of the re-export path).
+    private def collect_use_aliases(node : LibTreeSitter::TSNode, source : String, alias_map : Hash(String, String))
+      walk(node) do |n|
+        next unless Noir::TreeSitter.node_type(n) == "use_as_clause"
+        path = Noir::TreeSitter.field(n, "path")
+        ali = Noir::TreeSitter.field(n, "alias")
+        next unless path && ali
+        segs = Noir::TreeSitter.node_text(path, source).split("::")
+        target = segs.size >= 2 ? "#{segs[-2]}::#{segs[-1]}" : segs[-1]
+        alias_map[Noir::TreeSitter.node_text(ali, source)] = target
+      end
+    end
+
+    # Record every fn whose body builds a route list: its `routes![...]`
+    # leaves (keyed `module::fnname`) and any `submod::routes()` sub-collector
+    # calls (for the `routes.append(&mut submod::routes())` aggregation form).
+    private def collect_route_fns(node : LibTreeSitter::TSNode, source : String,
+                                  file_mod : String, test_regions : Array(Tuple(Int32, Int32)),
+                                  fn_leaves : Hash(String, Array(Tuple(String, String?))),
+                                  fn_appends : Hash(String, Array(String)))
+      walk(node) do |n|
+        next unless Noir::TreeSitter.node_type(n) == "function_item"
+        next if RustEngine.inside_test_region?(n, test_regions)
+        name_node = Noir::TreeSitter.field(n, "name")
+        body = Noir::TreeSitter.field(n, "body")
+        next unless name_node && body
+
+        leaves = [] of Tuple(String, String?)
+        appends = [] of String
+        walk(body) do |b|
+          case Noir::TreeSitter.node_type(b)
+          when "macro_invocation"
+            collect_routes_macro_leaves(b, source, leaves)
+          when "call_expression"
+            # `routes.append(&mut submod::routes())` (scoped) and the
+            # `r.append(&mut aliased_routes())` (bare, resolved via a
+            # `use ... as` alias) sub-collector forms. Non-route calls are
+            # filtered out at resolution time (resolve_fn_key returns nil).
+            cfn = Noir::TreeSitter.field(b, "function")
+            appends << Noir::TreeSitter.node_text(cfn, source) if cfn && {"scoped_identifier", "identifier"}.includes?(Noir::TreeSitter.node_type(cfn))
+          end
+        end
+        next if leaves.empty? && appends.empty?
+        key = "#{file_mod}::#{Noir::TreeSitter.node_text(name_node, source)}"
+        fn_leaves[key] = leaves
+        fn_appends[key] = appends
+      end
+    end
+
+    # Find every `.mount(prefix, arg)` call and record it as either a direct
+    # `routes![...]` leaf list or a deferred route-collector call to resolve.
+    private def collect_mounts(node : LibTreeSitter::TSNode, source : String,
+                               file_mod : String, test_regions : Array(Tuple(Int32, Int32)),
+                               mounts : Array(Tuple(String, Symbol, Array(Tuple(String, String?)), String?, String)))
+      walk(node) do |n|
+        next unless Noir::TreeSitter.node_type(n) == "call_expression"
+        next if RustEngine.inside_test_region?(n, test_regions)
+        fnf = Noir::TreeSitter.field(n, "function")
+        next unless fnf && Noir::TreeSitter.node_type(fnf) == "field_expression"
+        fld = Noir::TreeSitter.field(fnf, "field")
+        next unless fld && Noir::TreeSitter.node_text(fld, source) == "mount"
+        args = Noir::TreeSitter.field(n, "arguments")
+        next unless args
+        named = [] of LibTreeSitter::TSNode
+        Noir::TreeSitter.each_named_child(args) { |c| named << c }
+        next if named.size < 2
+
+        prefix = extract_mount_prefix(named[0], source)
+        next unless prefix
+        arg = named[1]
+        case Noir::TreeSitter.node_type(arg)
+        when "macro_invocation"
+          leaves = [] of Tuple(String, String?)
+          collect_routes_macro_leaves(arg, source, leaves)
+          mounts << {prefix, :list, leaves, nil, file_mod} unless leaves.empty?
+        when "call_expression"
+          cfn = Noir::TreeSitter.field(arg, "function")
+          if cfn && {"scoped_identifier", "identifier"}.includes?(Noir::TreeSitter.node_type(cfn))
+            mounts << {prefix, :call, [] of Tuple(String, String?), Noir::TreeSitter.node_text(cfn, source), file_mod}
+          end
+        when "identifier"
+          mounts << {prefix, :call, [] of Tuple(String, String?), Noir::TreeSitter.node_text(arg, source), file_mod}
+        end
+      end
+    end
+
+    # Pull handler leaves out of a `routes![a, mod::b, x::y::z]` macro. The
+    # macro body is a flat `token_tree` (scoped paths are NOT single nodes),
+    # so we parse the token-tree text: split on commas, take each item's
+    # path, and tag the leaf with the segment before it (its module) when
+    # the ref is qualified.
+    private def collect_routes_macro_leaves(macro_node : LibTreeSitter::TSNode, source : String,
+                                            leaves : Array(Tuple(String, String?)))
+      mname = Noir::TreeSitter.field(macro_node, "macro")
+      return unless mname && Noir::TreeSitter.node_text(mname, source).split("::").last == "routes"
+      token_tree = nil.as(LibTreeSitter::TSNode?)
+      Noir::TreeSitter.each_named_child(macro_node) do |child|
+        token_tree = child if Noir::TreeSitter.node_type(child) == "token_tree"
+      end
+      return unless tt = token_tree
+      parse_routes_list(Noir::TreeSitter.node_text(tt, source), leaves)
+    end
+
+    private def parse_routes_list(text : String, leaves : Array(Tuple(String, String?)))
+      inner = text.strip
+      inner = inner[1..] if inner.starts_with?('[') || inner.starts_with?('(')
+      inner = inner[0...-1] if inner.ends_with?(']') || inner.ends_with?(')')
+      inner = inner.gsub(/\/\/[^\n]*/, " ").gsub(%r{/\*.*?\*/}m, " ")
+      inner.split(',').each do |raw|
+        m = raw.match(/([A-Za-z_]\w*(?:\s*::\s*[A-Za-z_]\w*)*)/)
+        next unless m
+        segs = m[1].split("::").map(&.strip)
+        next if segs.empty?
+        leaves << {segs[-1], segs.size >= 2 ? segs[-2] : nil}
+      end
+    end
+
+    # Resolve a route-collector ref (`api::core_routes`, `accounts::routes`,
+    # a `routes_var`) to its handler leaves, following `use ... as` aliases
+    # and recursing through `routes.append(&mut submod::routes())`. Each leaf
+    # is tagged with the collector fn's module (or the ref's own module when
+    # the `routes![...]` entry was qualified).
+    private def resolve_route_fn(ref : String, alias_map : Hash(String, String),
+                                 fn_leaves : Hash(String, Array(Tuple(String, String?))),
+                                 fn_appends : Hash(String, Array(String)),
+                                 visited : Set(String), acc : Array(Tuple(String, String?)))
+      key = resolve_fn_key(ref, alias_map, fn_leaves)
+      return unless key
+      return if visited.includes?(key)
+      visited.add(key)
+      fn_mod = key.split("::").first
+      if leaves = fn_leaves[key]?
+        leaves.each { |leaf, mod_opt| acc << {leaf, mod_opt || fn_mod} }
+      end
+      if appends = fn_appends[key]?
+        appends.each { |aref| resolve_route_fn(aref, alias_map, fn_leaves, fn_appends, visited, acc) }
+      end
+    end
+
+    private def resolve_fn_key(ref : String, alias_map : Hash(String, String),
+                               fn_leaves : Hash(String, Array(Tuple(String, String?)))) : String?
+      leaf = ref.split("::").last
+      if target = alias_map[leaf]?
+        return target if fn_leaves.has_key?(target)
+      end
+      segs = ref.split("::")
+      cand = segs.size >= 2 ? "#{segs[-2]}::#{segs[-1]}" : segs[-1]
+      return cand if fn_leaves.has_key?(cand)
+      matches = fn_leaves.keys.select(&.ends_with?("::#{leaf}"))
+      matches.size == 1 ? matches.first : nil
+    end
+
+    # `.mount("/api", ...)` / `.mount([basepath, "/api"].concat(), ...)` /
+    # `.mount(format-free array forms, ...)` → the literal prefix. Non-literal
+    # segments (a `basepath` config var) contribute nothing; the literal parts
+    # are joined, matching Rocket's runtime concatenation for the common
+    # empty-base default.
+    private def extract_mount_prefix(node : LibTreeSitter::TSNode, source : String) : String?
+      case Noir::TreeSitter.node_type(node)
+      when "string_literal", "raw_string_literal"
+        string_content(node, source)
+      when "array_expression"
+        parts = [] of String
+        Noir::TreeSitter.each_named_child(node) do |el|
+          if {"string_literal", "raw_string_literal"}.includes?(Noir::TreeSitter.node_type(el))
+            if s = string_content(el, source)
+              parts << s
+            end
+          end
+        end
+        parts.empty? ? nil : parts.join
+      when "call_expression"
+        fnf = Noir::TreeSitter.field(node, "function")
+        return unless fnf && Noir::TreeSitter.node_type(fnf) == "field_expression"
+        fld = Noir::TreeSitter.field(fnf, "field")
+        return unless fld && {"concat", "join", "to_string", "to_owned", "into"}.includes?(Noir::TreeSitter.node_text(fld, source))
+        recv = Noir::TreeSitter.field(fnf, "value")
+        recv ? extract_mount_prefix(recv, source) : nil
+      end
+    end
+
+    private def rocket_function_name(function : LibTreeSitter::TSNode, source : String) : String?
+      name = Noir::TreeSitter.field(function, "name")
+      name ? Noir::TreeSitter.node_text(name, source) : nil
+    end
+
+    # Canonical single module a `.rs` file is referred to by. A plain
+    # `foo.rs` is module `foo`; `foo/mod.rs` is module `foo`. A crate root
+    # (`src/main.rs` / `src/lib.rs`) has no module name of its own, so we key
+    # it by the crate directory — this keeps the identically named
+    # `examples/<x>/src/main.rs` roots of a framework example monorepo apart
+    # instead of collapsing them all to a shared `src` pseudo-module.
+    private def primary_module(path : String) : String
+      base = File.basename(path, ".rs")
+      dir = File.dirname(path)
+      case base
+      when "mod"
+        File.basename(dir)
+      when "lib", "main"
+        parent = File.basename(dir)
+        parent == "src" ? File.basename(File.dirname(dir)) : parent
+      else
+        base
+      end
+    end
+
+    # Mount prefix(es) for a handler, matched module-aware so a leaf shared
+    # across modules only inherits the prefix of the module that registers
+    # it. nil when the handler isn't mounted anywhere visible.
+    private def lookup_mount_prefixes(leaf : String, file_path : String) : Array(String)?
+      index = @mount_index
+      return unless index
+      if prefixes = index[{primary_module(file_path), leaf}]?
+        return prefixes
+      end
+      nil
+    end
+
+    private def join_mount_path(prefix : String, path : String) : String
+      pfx = (prefix.starts_with?("/") ? prefix : "/#{prefix}").rstrip("/")
+      return path.starts_with?("/") ? path : "/#{path}" if pfx.empty?
+      suffix = path.lstrip("/")
+      suffix.empty? ? pfx : "#{pfx}/#{suffix}"
     end
 
     # `#[get("/x")]` / `#[post("/x", data = "<body>")]` →


### PR DESCRIPTION
## Summary

A Rocket handler's real URL is its `#[get("/x")]` attribute path prefixed by the base it is mounted under. But the `.mount("/api", routes![...])` call lives in `main.rs` while the handlers live in other modules, so the per-file analyzer emitted `/x` instead of `/api/x` for nearly every route.

```rust
// main.rs
.mount([basepath, "/api"].concat(), api::core_routes())

// api/core/accounts.rs
#[post("/accounts/register")]   // real route: POST /api/accounts/register
async fn register(...) { ... }
```

## What changed

`analyze()` builds a `{module, handler_leaf} => [prefix]` index up front, resolving the real-world mount shapes:

- direct `.mount("/p", routes![a, mod::b])`
- `.mount(prefix, collector_fn())` where the collector returns `routes![...]` **and** recursively `routes.append(&mut submod::routes())`
- `use path::routes as alias` re-exports (vaultwarden mounts `api::core_routes`, an alias for `core::routes`)
- array-concat prefixes `[basepath, "/api"].concat()`

Each leaf is tagged with the module of the `routes!` it appears in (or the ref's own module when qualified) and matched against the handler file's module, so a name shared across modules never borrows the wrong prefix. Crate-root files (`src/main.rs`/`src/lib.rs`) key by their crate directory so identically named example roots stay apart.

## Impact (real OSS)

| app | before | after | note |
|---|---|---|---|
| vaultwarden | 294 | 298 | 266 routes corrected to `/api`, `/admin`, `/identity`, … (verified against mount table) |
| realworld | 11 | 19 | all `/api`; also recovers 8 routes previously lost to cross-analyzer `(method,url)` dedup vs the bundled postman collection |
| plume | 93 | 97 | `/api/v1` |
| rocket repo | 47 | 83 | example-app mount composition |

This is enrichment of an already-accurate base: the handlers were detected, but their URLs were wrong for AI context. No double-prefixes, no empty segments; scan time flat.

## Tests

New `rocket_mount` fixture covers direct `routes![]`, concat-prefix, collector-fn indirection, and an aliased recursive `append`. All 1285 rust functional specs pass.