### PR TITLE
feat(kotlin): FP/FN/param/callee accuracy sweep across ktor/http4k/spring (27 OSS apps)

### DIFF
--- a/spec/functional_test/fixtures/kotlin/http4k/src/main/kotlin/com/example/Application.kt
+++ b/spec/functional_test/fixtures/kotlin/http4k/src/main/kotlin/com/example/Application.kt
@@ -52,5 +52,11 @@ val app = routes(
         val email = req.form("email")
         val phone = req.form("phone")
         Response(OK)
-    }
+    },
+
+    // verbs-under-path idiom: the path is bound once, verbs grouped inside
+    "/widgets/{id}" bind routes(
+        GET to { _: Request -> Response(OK) },
+        DELETE to { _: Request -> Response(OK) }
+    )
 )

--- a/spec/functional_test/testers/kotlin/http4k_spec.cr
+++ b/spec/functional_test/testers/kotlin/http4k_spec.cr
@@ -29,6 +29,12 @@ expected_endpoints = [
     Param.new("email", "", "form"),
     Param.new("phone", "", "form"),
   ]),
+  Endpoint.new("/widgets/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/widgets/{id}", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/kotlin/http4k/", {

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -325,4 +325,116 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
     routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
     (routes[1].line - routes[0].line).should eq(1)
   end
+
+  it "emits WebSocket and SSE handlers as GET routes" do
+    source = <<-KT
+      routing {
+          webSocket("/echo") { }
+          sse("/events") { }
+          route("/v1") {
+              webSocket("/feed") { }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/echo"},
+      {"GET", "/events"},
+      {"GET", "/v1/feed"},
+    ])
+  end
+
+  it "does not mistake a plugin config DSL lambda for an HTTP verb route" do
+    source = <<-KT
+      routing {
+          install(CachingHeaders) {
+              options { call, content -> null }
+          }
+          route("/index") {
+              get { call.respondText("Index") }
+          }
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+    # The `options { }` inside install(CachingHeaders) is config, not an
+    # OPTIONS route; only the real GET /index should surface.
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/index"},
+    ])
+  end
+
+  describe "type-safe resource routing" do
+    it "resolves @Resource routes, composing nested + parent paths" do
+      source = <<-KT
+        @Resource("/articles")
+        class Articles {
+            @Resource("new")
+            class New(val parent: Articles)
+            @Resource("{id}")
+            class Id(val parent: Articles, val id: Long) {
+                @Resource("edit")
+                class Edit(val parent: Id)
+            }
+        }
+
+        fun Application.module() {
+            routing {
+                get<Articles> { }
+                get<Articles.New> { }
+                post<Articles> { }
+                get<Articles.Id> { }
+                get<Articles.Id.Edit> { }
+            }
+        }
+        KT
+
+      resources = Noir::TreeSitterKotlinKtorRouteExtractor.extract_resource_classes(source)
+      paths = Noir::TreeSitterKotlinKtorRouteExtractor.compose_resource_paths(resources)
+      routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source, resource_paths: paths)
+      routes.map { |r| {r.verb, r.path} }.should eq([
+        {"GET", "/articles"},
+        {"GET", "/articles/new"},
+        {"POST", "/articles"},
+        {"GET", "/articles/{id}"},
+        {"GET", "/articles/{id}/edit"},
+      ])
+    end
+
+    it "composes a constructor-property parent resource declared elsewhere" do
+      api_module = <<-KT
+        @Resource("/api")
+        data object Root
+        KT
+      routes_module = <<-KT
+        @Resource("/tags")
+        class TagsResource(val root: Root = Root)
+
+        fun Route.tagRoutes() {
+            get<TagsResource> { }
+        }
+        KT
+
+      resources = Noir::TreeSitterKotlinKtorRouteExtractor.extract_resource_classes(api_module) +
+                  Noir::TreeSitterKotlinKtorRouteExtractor.extract_resource_classes(routes_module)
+      paths = Noir::TreeSitterKotlinKtorRouteExtractor.compose_resource_paths(resources)
+      routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(routes_module, resource_paths: paths)
+      routes.map { |r| {r.verb, r.path} }.should eq([
+        {"GET", "/api/tags"},
+      ])
+    end
+
+    it "skips an unresolved type-safe route instead of emitting the bare prefix" do
+      source = <<-KT
+        fun Application.module() {
+            routing {
+                get<UnknownResource> { }
+            }
+        }
+        KT
+
+      Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source).should be_empty
+    end
+  end
 end

--- a/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
@@ -184,6 +184,58 @@ describe Noir::TreeSitterKotlinParameterExtractor do
         {"X-Trace", "", "header"},
       ])
     end
+
+    it "keeps @RequestBody json while an un-annotated command object on the same POST stays form" do
+      fields = {
+        "Dto"     => [Noir::TreeSitterKotlinParameterExtractor::FieldInfo.new("a", "public", true, "")],
+        "Command" => [Noir::TreeSitterKotlinParameterExtractor::FieldInfo.new("b", "public", true, "")],
+      }
+      source = <<-KT
+        @RestController
+        class C {
+            @PostMapping("/x")
+            fun create(@RequestBody dto: Dto, command: Command): String = ""
+        }
+        KT
+      # The analyzer passes consumes-only (nil here); the POST verb default
+      # is applied per-parameter, so @RequestBody is json and the
+      # un-annotated command object is form.
+      params = extract(source, "C", "create", "POST", parameter_format: nil, fields: fields)
+      params.map { |p| {p.name, p.param_type} }.should eq([
+        {"a", "json"},
+        {"b", "form"},
+      ])
+    end
+
+    it "drops an @AuthenticationPrincipal / @CurrentUser injected parameter instead of expanding its DTO" do
+      fields = {
+        "SecurityUserItem" => [
+          Noir::TreeSitterKotlinParameterExtractor::FieldInfo.new("userId", "public", true, ""),
+          Noir::TreeSitterKotlinParameterExtractor::FieldInfo.new("role", "public", true, ""),
+        ],
+      }
+      source = <<-KT
+        @RestController
+        class C {
+            @PostMapping("/x")
+            fun act(@CurrentUser user: SecurityUserItem): String = ""
+        }
+        KT
+      extract(source, "C", "act", "POST", fields: fields).should be_empty
+    end
+
+    it "emits an @RequestParam collection parameter by name" do
+      source = <<-KT
+        @RestController
+        class C {
+            @GetMapping("/x")
+            fun get(@RequestParam(name = "userIds") userIds: List<Long>): String = ""
+        }
+        KT
+      extract(source, "C", "get", "GET").map { |p| {p.name, p.param_type} }.should eq([
+        {"userIds", "query"},
+      ])
+    end
   end
 
   describe "#extract_consumes" do
@@ -226,6 +278,22 @@ describe Noir::TreeSitterKotlinParameterExtractor do
       fields = Noir::TreeSitterKotlinParameterExtractor.extract_class_fields(source)
       fields["Article"].map(&.name).should eq(["title", "body"])
       fields["Article"].map(&.init_value).should eq(["", "todo"])
+    end
+
+    it "does not leak property annotation tokens into a field's init value" do
+      source = <<-KT
+        data class CreateUserRequest(
+            @field:Schema(description = "User Name")
+            @field:NotBlank(message = "field name is blank")
+            val name: String,
+            @field:Email
+            val email: String,
+        )
+        KT
+      fields = Noir::TreeSitterKotlinParameterExtractor.extract_class_fields(source)
+      fields["CreateUserRequest"].map(&.name).should eq(["name", "email"])
+      # The `@field:...` annotation source must not bleed into init_value.
+      fields["CreateUserRequest"].map(&.init_value).should eq(["", ""])
     end
 
     it "collects class-body var/val properties" do

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -235,4 +235,26 @@ describe Noir::TreeSitterKotlinRouteExtractor do
 
     Noir::TreeSitterKotlinRouteExtractor.extract_routes(source).should be_empty
   end
+
+  it "skips @FeignClient interfaces (outbound clients, not server routes)" do
+    source = <<-KT
+      @FeignClient(value = "example-api")
+      interface ExampleApi {
+          @RequestMapping(method = [RequestMethod.POST], value = ["/example/example-api"])
+          fun example(): String
+      }
+
+      @RestController
+      @RequestMapping("/real")
+      class RealController {
+          @GetMapping("/ping")
+          fun ping(): String = "pong"
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/real/ping"},
+    ])
+  end
 end

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -145,6 +145,23 @@ describe "EndpointOptimizer" do
       result[1].params[1].name.should eq("comment_id")
     end
 
+    it "extracts every variable from a comma-packed segment" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      # Spring's matrix-style mapping packs sibling path variables into one
+      # segment separated by commas (e.g.
+      # @GetMapping("/bbox/{xMin},{yMin},{xMax},{yMax}")). Each is a path
+      # param; only the first used to be captured.
+      endpoints = [
+        Endpoint.new("/bbox/{xMin},{yMin},{xMax},{yMax}", "GET"),
+        Endpoint.new("/user/{userName}/location/{x},{y}", "PUT"),
+      ]
+
+      result = optimizer.add_path_parameters(endpoints)
+      result[0].params.map(&.name).should eq(["xMin", "yMin", "xMax", "yMax"])
+      result[0].params.all? { |p| p.param_type == "path" }.should be_true
+      result[1].params.map(&.name).should eq(["userName", "x", "y"])
+    end
+
     it "extracts parameters from colon patterns" do
       optimizer = EndpointOptimizer.new(logger, options)
       endpoints = [

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -10,17 +10,28 @@ module Analyzer::Kotlin
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
       string_constants = Hash(String, String).new
+      raw_resources = [] of Noir::TreeSitterKotlinKtorRouteExtractor::RawResource
       file_list.each do |path|
         next unless File.exists?(path)
         next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
         next if KotlinEngine.test_path?(path)
 
-        Noir::TreeSitterKotlinKtorRouteExtractor.extract_string_constants(read_file_content(path)).each do |name, value|
+        content = read_file_content(path)
+        Noir::TreeSitterKotlinKtorRouteExtractor.extract_string_constants(content).each do |name, value|
           next unless fully_qualified_constant?(name)
 
           string_constants[name] ||= value
         end
+
+        # `@Resource` classes may live in a shared module separate from
+        # the route files (Ktor KMP `commonMain`), so collect them across
+        # the whole project before composing type-safe-route paths.
+        if content.includes?("@Resource")
+          raw_resources.concat(Noir::TreeSitterKotlinKtorRouteExtractor.extract_resource_classes(content))
+        end
       end
+
+      resource_paths = Noir::TreeSitterKotlinKtorRouteExtractor.compose_resource_paths(raw_resources)
 
       file_list.each do |path|
         next unless File.exists?(path)
@@ -30,7 +41,7 @@ module Analyzer::Kotlin
         content = read_file_content(path)
         next unless potential_ktor_route_file?(content)
 
-        Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content, string_constants, include_callees: include_callee).each do |route|
+        Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(content, string_constants, resource_paths, include_callees: include_callee).each do |route|
           @result << build_endpoint(route, path)
         end
       end

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -185,17 +185,13 @@ module Analyzer::Kotlin
           key = "#{route.class_name}##{route.method_name}"
           format_verb = first_verb[key]? || route.verb
 
+          # Pass only the `consumes`-derived format (nil when absent). The
+          # verb default (POST → form, others → query) is applied
+          # per-parameter inside the extractor so an explicit @RequestBody
+          # on a POST resolves to json instead of being dragged to form.
           parameter_format = Noir::TreeSitterKotlinParameterExtractor.extract_consumes_from(
             root, content, route.class_name, route.method_name
           )
-          if parameter_format.nil?
-            parameter_format = case format_verb
-                               when "POST", "PUT", "DELETE", "PATCH"
-                                 "form"
-                               when "GET"
-                                 "query"
-                               end
-          end
 
           parameters = Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters_from(
             root, content, route.class_name, route.method_name, format_verb, parameter_format, dto_index

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -76,7 +76,7 @@ module Noir
       routes = [] of Route
       local_string_constants = extract_string_constants(source)
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees)
+        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees, false)
       end
       routes
     end
@@ -131,22 +131,26 @@ module Noir
                      string_constants : Hash(String, String),
                      local_string_constants : Hash(String, String),
                      depth : Int32,
-                     include_callees : Bool)
+                     include_callees : Bool,
+                     in_routes : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
 
-      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees)
+      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees, in_routes)
         return
       end
 
       if ty == "call_expression" && call_function_name(node, source) == "routes"
-        walk_routes_args(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees)
+        # Arguments of a `routes(...)` call are inside the routing
+        # block — a bare `VERB to handler` arg there is a real route
+        # bound to the current prefix (the verbs-under-path idiom).
+        walk_routes_args(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees, true)
         return
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees)
+        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, in_routes)
       end
     end
 
@@ -164,52 +168,52 @@ module Noir
                             string_constants : Hash(String, String),
                             local_string_constants : Hash(String, String),
                             depth : Int32,
-                            include_callees : Bool) : Bool
+                            include_callees : Bool,
+                            in_routes : Bool) : Bool
       lhs, op, rhs = infix_parts(node, source)
       return false unless lhs && rhs
 
       case op
       when "to"
-        # Outer node — inner must be `path bind VERB`.
-        return false unless Noir::TreeSitter.node_type(lhs) == "infix_expression"
-        inner_lhs, inner_op, inner_rhs = infix_parts(lhs, source)
-        return false unless inner_op == "bind"
-        return false unless inner_lhs && inner_rhs
+        if Noir::TreeSitter.node_type(lhs) == "infix_expression"
+          # `path bind VERB to handler` — the canonical form — or
+          # `path[ meta {...}] bindContract VERB to handler` for the
+          # contract DSL. Both glue a literal path to a verb on the
+          # inner infix, then attach the handler via the outer `to`.
+          inner_lhs, inner_op, inner_rhs = infix_parts(lhs, source)
+          return false unless inner_op == "bind" || inner_op == "bindContract"
+          return false unless inner_lhs && inner_rhs
 
-        verb = resolve_verb(inner_rhs, source)
-        return false unless verb
+          # `bindContract` routes are almost always defined in a helper
+          # function returning `ContractRoute` and assembled into a
+          # `contract { routes += foo() }` block mounted under a prefix
+          # elsewhere — so emitting them standalone yields a path that's
+          # missing its mount prefix (a wrong URL). Only emit them when
+          # we're inside a `routes(...)` whose prefix we already know.
+          # The canonical `bind` form carries its own absolute-ish path,
+          # so it stays unconditional (preserves existing behaviour).
+          return false if inner_op == "bindContract" && !in_routes
 
-        path_text = resolve_string_value(inner_lhs, source, string_constants, local_string_constants)
-        return false unless path_text
-        full = join_paths(prefix, path_text)
-        line = Noir::TreeSitter.node_start_row(node)
+          verb = resolve_verb(inner_rhs, source)
+          return false unless verb
 
-        query, header, form = [] of String, [] of String, [] of String
-        has_body = false
-        scan_handler(rhs, source, 0) do |kind, value|
-          case kind
-          when :query  then query << value
-          when :header then header << value
-          when :form   then form << value
-          when :body   then has_body = true
-          end
+          path_text = route_path_from(inner_lhs, source, string_constants, local_string_constants)
+          return false unless path_text
+          emit_route(verb, join_paths(prefix, path_text), node, rhs, source, routes, include_callees)
+          true
+        else
+          # Bare `VERB to handler` directly inside a `routes(...)` call
+          # — the verbs-under-path idiom, e.g.
+          #   "/{id}" bind routes(GET to Get(fs), DELETE to Delete(fs))
+          # The path is supplied by the enclosing prefix; only treat it
+          # as a route when we actually reached it via `routes(...)` so
+          # a stray `a to b` pair elsewhere isn't misread.
+          return false unless in_routes
+          verb = resolve_verb(lhs, source)
+          return false unless verb
+          emit_route(verb, prefix.empty? ? "/" : prefix, node, rhs, source, routes, include_callees)
+          true
         end
-
-        # http4k's routing idiom is `"/x" bind GET to handler`, not
-        # `get { ... }` — there's no Ktor-style nested routing DSL
-        # inside a handler body, so the routing-skip filter is off
-        # to avoid silently dropping real handler calls named `get`,
-        # `post`, etc.
-        callees = [] of Tuple(String, Int32)
-        if include_callees
-          Noir::KotlinCalleeExtractor.callees_in_lambda(rhs, source, "", skip_routing: false).each do |entry|
-            name, _path, line_no = entry
-            callees << {name, line_no}
-          end
-        end
-
-        routes << Route.new(verb, full, line, has_body, query, header, form, callees)
-        true
       when "bind"
         return false unless Noir::TreeSitter.node_type(rhs) == "call_expression"
         return false unless call_function_name(rhs, source) == "routes"
@@ -217,11 +221,67 @@ module Noir
         path_text = resolve_string_value(lhs, source, string_constants, local_string_constants)
         return false unless path_text
         new_prefix = join_paths(prefix, path_text)
-        walk_routes_args(rhs, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees)
+        walk_routes_args(rhs, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
         true
       else
         false
       end
+    end
+
+    # Build and append a Route from a verb, full path, and handler
+    # node. Shared by the canonical `path bind VERB to handler`, the
+    # contract `bindContract` form, and the bare verbs-under-path form.
+    private def emit_route(verb : String,
+                           full : String,
+                           node : LibTreeSitter::TSNode,
+                           handler : LibTreeSitter::TSNode,
+                           source : String,
+                           routes : Array(Route),
+                           include_callees : Bool)
+      line = Noir::TreeSitter.node_start_row(node)
+
+      query, header, form = [] of String, [] of String, [] of String
+      has_body = false
+      scan_handler(handler, source, 0) do |kind, value|
+        case kind
+        when :query  then query << value
+        when :header then header << value
+        when :form   then form << value
+        when :body   then has_body = true
+        end
+      end
+
+      # http4k's routing idiom is `"/x" bind GET to handler`, not
+      # `get { ... }` — there's no Ktor-style nested routing DSL
+      # inside a handler body, so the routing-skip filter is off
+      # to avoid silently dropping real handler calls named `get`,
+      # `post`, etc.
+      callees = [] of Tuple(String, Int32)
+      if include_callees
+        Noir::KotlinCalleeExtractor.callees_in_lambda(handler, source, "", skip_routing: false).each do |entry|
+          name, _path, line_no = entry
+          callees << {name, line_no}
+        end
+      end
+
+      routes << Route.new(verb, full, line, has_body, query, header, form, callees)
+    end
+
+    # Resolve the path for a contract/bind LHS. Plain string literals
+    # and constants resolve directly; the contract DSL wraps the path
+    # in a `"/x" meta { ... }` infix, so peel the `meta` operator and
+    # resolve its left operand.
+    private def route_path_from(node : LibTreeSitter::TSNode,
+                                source : String,
+                                string_constants : Hash(String, String),
+                                local_string_constants : Hash(String, String)) : String?
+      if Noir::TreeSitter.node_type(node) == "infix_expression"
+        l, op, _r = infix_parts(node, source)
+        return unless l
+        return unless op == "meta"
+        return resolve_string_value(l, source, string_constants, local_string_constants)
+      end
+      resolve_string_value(node, source, string_constants, local_string_constants)
     end
 
     # Walk every argument inside a `routes(...)` call and recurse.
@@ -235,14 +295,15 @@ module Noir
                                  string_constants : Hash(String, String),
                                  local_string_constants : Hash(String, String),
                                  depth : Int32,
-                                 include_callees : Bool)
+                                 include_callees : Bool,
+                                 in_routes : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       args = call_value_arguments(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "value_argument"
         Noir::TreeSitter.each_named_child(arg) do |child|
-          walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees)
+          walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, in_routes)
         end
       end
     end

--- a/src/miniparsers/kotlin_callee_extractor.cr
+++ b/src/miniparsers/kotlin_callee_extractor.cr
@@ -36,6 +36,7 @@ module Noir::KotlinCalleeExtractor
   # callees don't leak into the parent route's list.
   ROUTING_DSL_NAMES = Set{
     "get", "post", "put", "delete", "patch", "head", "options",
+    "webSocket", "webSocketRaw", "sse",
     "route", "routing", "authenticate", "rateLimit", "install",
     "intercept", "host", "port",
   }

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -49,17 +49,26 @@ module Noir
       "patch"   => "PATCH",
       "head"    => "HEAD",
       "options" => "OPTIONS",
+      # WebSocket / SSE handlers are registered with the same path +
+      # trailing-lambda DSL as the HTTP verbs. The connection opens with
+      # a GET (the WebSocket upgrade / SSE stream are both GET requests),
+      # so surface them as GET routes rather than dropping them.
+      "webSocket"    => "GET",
+      "webSocketRaw" => "GET",
+      "sse"          => "GET",
     }
 
     # Pass-through DSL calls — descend into their lambda body without
     # changing the path prefix. `routing` is the entry point;
     # `authenticate` wraps a sub-tree behind an auth realm; the
-    # remaining names cover the common Ktor scoping helpers.
+    # remaining names cover the common Ktor scoping helpers. `install`
+    # is handled separately (see `walk`) because only `install(Routing)`
+    # contributes routes — every other plugin config block must NOT be
+    # walked as routing.
     PASSTHROUGH_NAMES = Set{
       "routing",
       "authenticate",
       "rateLimit",
-      "install",
       "intercept",
       "host",
       "port",
@@ -83,11 +92,30 @@ module Noir
       end
     end
 
-    def extract_routes(source : String, string_constants = Hash(String, String).new, *, include_callees : Bool = false) : Array(Route)
+    # A `@Resource`-annotated class collected from a single file, before
+    # cross-class path composition. `lexical_name` is the dotted name as
+    # it would be referenced (`Articles.New`); `ctor_param_types` are the
+    # simple type names of its primary-constructor properties, one of
+    # which (when it names another resource, e.g. `root: Root` /
+    # `parent: ArticlesResource`) is the path-composition parent.
+    struct RawResource
+      getter simple_name : String
+      getter lexical_name : String
+      getter own_path : String
+      getter ctor_param_types : Array(String)
+
+      def initialize(@simple_name, @lexical_name, @own_path, @ctor_param_types)
+      end
+    end
+
+    def extract_routes(source : String,
+                       string_constants = Hash(String, String).new,
+                       resource_paths = Hash(String, String).new,
+                       *, include_callees : Bool = false) : Array(Route)
       routes = [] of Route
       local_string_constants = extract_string_constants(source)
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees, false)
+        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees, false, resource_paths)
       end
       routes
     end
@@ -133,6 +161,256 @@ module Noir
       constants
     end
 
+    # ---- type-safe resource routing ----------------------------------
+
+    # Collect every `@Resource("path")`-annotated class/object in a file
+    # (including nested ones, with their dotted lexical name). The
+    # analyzer gathers these across the whole project before composing
+    # full paths, since a resource's parent is often declared in another
+    # module (Ktor's KMP `commonMain` resource definitions).
+    def extract_resource_classes(source : String) : Array(RawResource)
+      result = [] of RawResource
+      Noir::TreeSitter.parse_kotlin(source) do |root|
+        collect_resource_classes(root, source, "", result, 0)
+      end
+      result
+    end
+
+    # Resolve each raw resource to its full URL path. The parent is the
+    # first primary-constructor property whose type is itself a resource
+    # (`root: Root` → `/api`); the child path joins onto it. Returns a
+    # map keyed by BOTH the dotted lexical name (`Articles.New`) and the
+    # bare simple name (`TagsResource`) so `get<...>` references resolve
+    # either way.
+    def compose_resource_paths(raws : Array(RawResource)) : Hash(String, String)
+      by_simple = Hash(String, RawResource).new
+      raws.each { |r| by_simple[r.simple_name] ||= r }
+
+      result = Hash(String, String).new
+      raws.each do |r|
+        full = compose_full_path(r, by_simple, Set(String).new, 0)
+        next if full.empty?
+        result[r.lexical_name] = full
+        result[r.simple_name] ||= full
+      end
+      result
+    end
+
+    private def compose_full_path(r : RawResource,
+                                  by_simple : Hash(String, RawResource),
+                                  visiting : Set(String),
+                                  depth : Int32) : String
+      return r.own_path if depth > Noir::TreeSitter::MAX_AST_DEPTH
+      return r.own_path if visiting.includes?(r.lexical_name)
+      visiting.add(r.lexical_name)
+
+      parent_path = ""
+      r.ctor_param_types.each do |t|
+        next if t == r.simple_name
+        if parent = by_simple[t]?
+          parent_path = compose_full_path(parent, by_simple, visiting, depth + 1)
+          break
+        end
+      end
+
+      visiting.delete(r.lexical_name)
+      parent_path.empty? ? r.own_path : join_paths(parent_path, r.own_path)
+    end
+
+    private def collect_resource_classes(node : LibTreeSitter::TSNode,
+                                         source : String,
+                                         lexical_prefix : String,
+                                         sink : Array(RawResource),
+                                         depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+      ty = Noir::TreeSitter.node_type(node)
+
+      if ty == "class_declaration" || ty == "object_declaration"
+        name = resource_class_name(node, source)
+        unless name.empty?
+          lexical = lexical_prefix.empty? ? name : "#{lexical_prefix}.#{name}"
+          if own = resource_annotation_path(node, source)
+            sink << RawResource.new(name, lexical, own, ctor_param_type_names(node, source))
+          end
+          if body = resource_class_body(node)
+            Noir::TreeSitter.each_named_child(body) do |member|
+              collect_resource_classes(member, source, lexical, sink, depth + 1)
+            end
+          end
+          return
+        end
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_resource_classes(child, source, lexical_prefix, sink, depth + 1)
+      end
+    end
+
+    private def resource_class_name(decl : LibTreeSitter::TSNode, source : String) : String
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        return Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "type_identifier"
+      end
+      ""
+    end
+
+    private def resource_class_body(decl : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        child = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        return child if Noir::TreeSitter.node_type(child) == "class_body"
+      end
+      nil
+    end
+
+    # `@Resource("/x")` → `/x`. The annotation parses as a `modifiers`
+    # child carrying an `annotation` whose `constructor_invocation` pairs
+    # the `Resource` user_type with a `value_arguments` holding the path
+    # string. Returns nil when the class has no `@Resource`.
+    private def resource_annotation_path(decl : LibTreeSitter::TSNode, source : String) : String?
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        mods = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        next unless Noir::TreeSitter.node_type(mods) == "modifiers"
+        Noir::TreeSitter.each_named_child(mods) do |ann|
+          next unless Noir::TreeSitter.node_type(ann) == "annotation"
+          Noir::TreeSitter.each_named_child(ann) do |sub|
+            next unless Noir::TreeSitter.node_type(sub) == "constructor_invocation"
+            ann_name = ""
+            args : LibTreeSitter::TSNode? = nil
+            Noir::TreeSitter.each_named_child(sub) do |c|
+              case Noir::TreeSitter.node_type(c)
+              when "user_type"
+                ann_name = simple_type_name(Noir::TreeSitter.node_text(c, source))
+              when "value_arguments"
+                args = c
+              end
+            end
+            if ann_name == "Resource" && (a = args)
+              if path = first_string_in_arguments(a, source)
+                return path
+              end
+            end
+          end
+        end
+      end
+      nil
+    end
+
+    private def first_string_in_arguments(args : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "value_argument"
+        Noir::TreeSitter.each_named_child(arg) do |child|
+          return decode_string_literal(child, source) if Noir::TreeSitter.node_type(child) == "string_literal"
+        end
+      end
+      nil
+    end
+
+    private def ctor_param_type_names(decl : LibTreeSitter::TSNode, source : String) : Array(String)
+      result = [] of String
+      count = LibTreeSitter.ts_node_named_child_count(decl)
+      count.times do |i|
+        pc = LibTreeSitter.ts_node_named_child(decl, i.to_u32)
+        next unless Noir::TreeSitter.node_type(pc) == "primary_constructor"
+        Noir::TreeSitter.each_named_child(pc) do |param|
+          next unless Noir::TreeSitter.node_type(param) == "class_parameter"
+          Noir::TreeSitter.each_named_child(param) do |c|
+            ty = Noir::TreeSitter.node_type(c)
+            next unless ty == "user_type" || ty == "nullable_type" || ty == "type_identifier"
+            if leaf = type_leaf(c, source)
+              result << leaf
+              break
+            end
+          end
+        end
+      end
+      result
+    end
+
+    private def simple_type_name(full : String) : String
+      if idx = full.rindex('.')
+        full[(idx + 1)..]
+      else
+        full
+      end
+    end
+
+    # Pull the dotted type name out of a verb call's `<Type>` argument,
+    # e.g. `get<Articles.Id.Edit> { }` → "Articles.Id.Edit". Returns nil
+    # when the call carries no type argument (the ordinary string-path
+    # `get("/x")` form).
+    private def call_type_argument_name(call : LibTreeSitter::TSNode, source : String) : String?
+      ta = direct_type_arguments(call)
+      unless ta
+        first = first_named_child(call)
+        ta = direct_type_arguments(first) if first && Noir::TreeSitter.node_type(first) == "call_expression"
+      end
+      return unless ta
+      parts = [] of String
+      Noir::TreeSitter.each_named_child(ta) do |proj|
+        collect_type_identifiers(proj, source, parts, 0)
+      end
+      parts.empty? ? nil : parts.join(".")
+    end
+
+    private def direct_type_arguments(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        ty = Noir::TreeSitter.node_type(child)
+        return child if ty == "type_arguments"
+        if ty == "call_suffix"
+          Noir::TreeSitter.each_named_child(child) do |sub|
+            return sub if Noir::TreeSitter.node_type(sub) == "type_arguments"
+          end
+        end
+      end
+      nil
+    end
+
+    private def collect_type_identifiers(node : LibTreeSitter::TSNode, source : String, parts : Array(String), depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+      parts << Noir::TreeSitter.node_text(node, source) if Noir::TreeSitter.node_type(node) == "type_identifier"
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_type_identifiers(child, source, parts, depth + 1)
+      end
+    end
+
+    private def resolve_resource_path(type_name : String, resource_paths : Hash(String, String)) : String?
+      resource_paths[type_name]? || resource_paths[type_name.split('.').last]?
+    end
+
+    # Emit a route for a `verb<Resource> { ... }` call. The path is the
+    # composed resource path; the lambda body is scanned for body/query/
+    # header params and callees exactly like a string-path verb route.
+    private def emit_resource_route(node : LibTreeSitter::TSNode,
+                                    source : String,
+                                    verb : String,
+                                    full_path : String,
+                                    routes : Array(Route),
+                                    include_callees : Bool)
+      line = Noir::TreeSitter.node_start_row(node)
+      receive_type : String? = nil
+      has_body = false
+      query_params = [] of String
+      header_params = [] of String
+      form_params = [] of String
+      callees = [] of Tuple(String, Int32)
+
+      if body = call_lambda_body(node)
+        receive_type = scan_handler_body(body, source, query_params, header_params, form_params)
+        has_body = !!receive_type || handler_reads_body?(body, source)
+        if include_callees
+          Noir::KotlinCalleeExtractor.callees_in_lambda(body, source, "").each do |entry|
+            name, _path, line_no = entry
+            callees << {name, line_no}
+          end
+        end
+      end
+
+      routes << Route.new(verb, full_path, line, receive_type, has_body, query_params, header_params, form_params, callees)
+    end
+
     # ---- traversal ----------------------------------------------------
 
     private def walk(node : LibTreeSitter::TSNode,
@@ -143,14 +421,15 @@ module Noir
                      local_string_constants : Hash(String, String),
                      depth : Int32,
                      include_callees : Bool,
-                     active : Bool)
+                     active : Bool,
+                     resource_paths : Hash(String, String))
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
 
       if ty == "function_declaration" && route_extension_function?(node, source)
         if body = function_body_statements(node)
-          walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
+          walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true, resource_paths)
         end
         return
       end
@@ -159,6 +438,16 @@ module Noir
         name = call_name(node, source)
         case
         when active && HTTP_VERB_NAMES.has_key?(name)
+          # Type-safe resource routing: `get<Articles.New> { ... }` carries
+          # a `<Type>` argument instead of a string path. Resolve the type
+          # to its @Resource-composed path; if it can't be resolved, skip
+          # rather than emit the bare routing prefix (a misleading "/").
+          if type_name = call_type_argument_name(node, source)
+            if rp = resolve_resource_path(type_name, resource_paths)
+              emit_resource_route(node, source, HTTP_VERB_NAMES[name], join_paths(prefix, rp), routes, include_callees)
+            end
+            return
+          end
           emit_route(node, source, name, prefix, routes, string_constants, local_string_constants, include_callees)
           return
         when active && name == "route"
@@ -169,19 +458,30 @@ module Noir
             if method = call_http_method_argument(node, source)
               emit_method_route(node, body, source, method, new_prefix, routes, include_callees) if has_handle_call?(body, source)
             end
-            walk(body, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
+            walk(body, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true, resource_paths)
+          end
+          return
+        when name == "install"
+          # `install(Routing) { ... }` contributes routes, so descend as
+          # routing. Every other plugin config block (CachingHeaders,
+          # CORS, StatusPages, …) is configuration, not routing — descend
+          # with routing disabled so a config-DSL lambda that happens to
+          # be named like a verb (e.g. CachingHeaders' `options { }`)
+          # isn't mistaken for an OPTIONS route.
+          if body = call_lambda_body(node)
+            walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, routing_install_call?(node, source), resource_paths)
           end
           return
         when name == "routing" || routing_install_call?(node, source) || (active && PASSTHROUGH_NAMES.includes?(name))
           if body = call_lambda_body(node)
-            walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
+            walk(body, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true, resource_paths)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, active)
+        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, active, resource_paths)
       end
     end
 

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -37,11 +37,33 @@ module Noir
   module TreeSitterKotlinParameterExtractor
     extend self
 
+    # Scalar types Spring binds from a single request value. Array
+    # (`IntArray`), and single-type-argument collection forms
+    # (`List<Long>`, `Optional<String>`) reduce to their element type
+    # via `simple_param_base` before lookup. Mirrors the Java
+    # extractor's `SIMPLE_PARAM_TYPES` so `@RequestParam ids:
+    # List<Long>` surfaces instead of being silently dropped.
     PRIMITIVE_TYPES = Set{
       "long", "int", "integer", "short", "byte",
-      "char", "boolean", "string",
+      "char", "character", "boolean", "string",
       "float", "double", "number",
+      "bigdecimal", "biginteger", "uuid",
+      "date", "localdate", "localdatetime", "localtime", "instant",
       "multipartfile",
+    }
+
+    # Parameter annotations whose value is supplied by a Spring argument
+    # resolver, not bound from the HTTP request the client controls. A
+    # parameter carrying one of these is NOT an attack-surface input
+    # even when its type is a bindable DTO (the classic
+    # `@AuthenticationPrincipal user: User`, or a custom meta-annotation
+    # like `@CurrentUser`), so it must be excluded from the un-annotated
+    # implicit-binding path that would otherwise expand its DTO fields
+    # into phantom params. Validation annotations (`@Valid`, …) are
+    # intentionally absent — they leave binding semantics untouched.
+    INJECTED_PARAM_ANNOTATIONS = Set{
+      "AuthenticationPrincipal", "CurrentUser", "CurrentSecurityContext",
+      "SessionAttribute", "RequestAttribute",
     }
 
     # Verbs whose `params = [...]` constraint emits as query
@@ -443,8 +465,12 @@ module Noir
               name = Noir::TreeSitter.node_text(child, source) if name.empty?
             when "string_literal"
               init = decode_string_literal(child, source)
-            when "user_type", "nullable_type", "binding_pattern_kind"
-              # type / val|var marker — not needed here
+            when "user_type", "nullable_type", "binding_pattern_kind",
+                 "modifiers", "parameter_modifiers", "annotation"
+              # type / val|var marker / property annotations — not a
+              # default value. `modifiers` carries `@field:Email`-style
+              # annotations whose source text would otherwise leak into
+              # `init_value` (and surface as a bogus param default).
             else
               # default-value expressions (numbers, identifiers, etc.)
               # — stringify so the legacy "init_value" semantic stays
@@ -504,7 +530,7 @@ module Noir
         when "parameter_modifiers"
           pending_modifiers = child
         when "parameter"
-          current_format = emit_param_for(child, pending_modifiers, source, current_format, class_fields, params)
+          current_format = emit_param_for(child, pending_modifiers, source, verb, current_format, class_fields, params)
           pending_modifiers = nil
         end
       end
@@ -523,6 +549,7 @@ module Noir
     private def emit_param_for(param : LibTreeSitter::TSNode,
                                modifiers : LibTreeSitter::TSNode?,
                                source : String,
+                               verb : String,
                                parameter_format : String?,
                                class_fields : Hash(String, Array(FieldInfo)),
                                sink : Array(Param)) : String?
@@ -543,10 +570,12 @@ module Noir
 
       ann_kind = nil
       ann_node : LibTreeSitter::TSNode? = nil
+      injected_param = false
       if modifiers
         Noir::TreeSitter.each_named_child(modifiers) do |ann|
           next unless Noir::TreeSitter.node_type(ann) == "annotation"
           name = annotation_simple_name(ann, source)
+          injected_param = true if INJECTED_PARAM_ANNOTATIONS.includes?(name)
           case name
           when "PathVariable"
             ann_kind = :path
@@ -572,11 +601,24 @@ module Noir
         end
       end
 
+      # @PathVariable is carried by the URL, not emitted as a param.
       return parameter_format if ann_kind == :path
+
+      # A Spring argument-resolver parameter (@AuthenticationPrincipal, a
+      # custom @CurrentUser meta-annotation, …) with no request-binding
+      # annotation is server-supplied, not client input — drop it before
+      # the implicit-binding path can expand its (often DTO-typed) fields
+      # into phantom params.
+      return parameter_format if ann_kind.nil? && injected_param
 
       effective_format = parameter_format
       case ann_kind
       when :body
+        # @RequestBody is JSON unless an explicit `consumes` already pinned
+        # the format (e.g. form-urlencoded). The POST verb default is
+        # applied per-parameter below, NOT pre-seeded into parameter_format,
+        # so a @RequestBody on a POST still resolves to json rather than
+        # being dragged along as form.
         effective_format = effective_format.nil? ? "json" : effective_format
       when :query
         effective_format = "query"
@@ -585,7 +627,19 @@ module Noir
       when :cookie
         effective_format = "cookie"
       end
-      return effective_format if effective_format.nil?
+
+      if effective_format.nil?
+        # No parameter annotation and no `consumes` hint. Spring still
+        # binds a scalar (or a command object) from request values — query
+        # string on GET/…, form body on POST. Framework resolver types
+        # (Model, Pageable, BindingResult, …) aren't bindable and must not
+        # surface. Applying the verb default here — rather than seeding the
+        # whole method — lets an explicit @RequestBody on the same POST
+        # resolve to json instead of being dragged to form.
+        bindable = simple_bindable_param?(type_name) || class_fields.has_key?(type_name)
+        return parameter_format unless bindable
+        effective_format = verb == "POST" ? "form" : "query"
+      end
 
       default_value : String? = nil
       parameter_name = arg_name
@@ -612,18 +666,45 @@ module Noir
         end
       end
 
-      type_key = type_name.downcase
-      if PRIMITIVE_TYPES.includes?(type_key)
+      case ann_kind
+      when :query, :header, :cookie
+        # An explicit scalar request input (possibly a collection of
+        # scalars like `@RequestParam ids: List<Long>`) — emit by its
+        # declared name; never DTO-expand.
         sink << Param.new(parameter_name, default_value || "", effective_format)
-      elsif fields = class_fields[type_name]?
-        fields.each do |field|
-          next unless field.access_modifier == "public" || field.has_setter?
-          expanded_default = default_value || field.init_value
-          sink << Param.new(field.name, expanded_default, effective_format)
+      else
+        # @RequestBody or an un-annotated command object: a scalar emits
+        # by name, a known DTO fans out to its fields. Body JSON binds
+        # every field (Jackson reflection); form/model binding keeps the
+        # public-or-setter gate.
+        if simple_bindable_param?(type_name)
+          sink << Param.new(parameter_name, default_value || "", effective_format)
+        elsif fields = class_fields[type_name]?
+          json_body = effective_format == "json"
+          fields.each do |field|
+            next unless json_body || field.access_modifier == "public" || field.has_setter?
+            expanded_default = default_value || field.init_value
+            sink << Param.new(field.name, expanded_default, effective_format)
+          end
         end
       end
 
-      effective_format
+      # Carry the format to subsequent un-annotated params (Spring's
+      # implicit binding makes a trailing `page: Int` share the prior
+      # `@RequestParam`'s query format). A `@RequestBody`'s json is NOT a
+      # method-wide default, though — propagating it would drag a sibling
+      # command object into json, so a body param leaves the carry
+      # untouched (returns the incoming consumes-derived format).
+      ann_kind == :body ? parameter_format : effective_format
+    end
+
+    # True when `type_name` is a scalar Spring binds from a single
+    # request value. `type_name` is the leaf type identifier resolved by
+    # `leaf_type_name`, so a `List<Long>` parameter already reduces to
+    # `List` here — collection element types are handled at the call
+    # site (annotated request params emit by name regardless of type).
+    private def simple_bindable_param?(type_name : String) : Bool
+      PRIMITIVE_TYPES.includes?(type_name.downcase)
     end
 
     private def leaf_type_name(node : LibTreeSitter::TSNode, source : String) : String

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -162,6 +162,13 @@ module Noir
                               string_constants : Hash(String, String),
                               local_string_constants : Hash(String, String))
       class_name = type_identifier_text(node, source)
+
+      # `@FeignClient` (Spring Cloud) interfaces declare OUTBOUND remote
+      # client calls with the same `@*Mapping` annotations a controller
+      # uses — they are not server routes, so skip the whole declaration
+      # to avoid emitting phantom inbound endpoints.
+      return if feign_client?(node, source)
+
       class_prefix = class_mapping_prefix(node, source, pending, string_constants, local_string_constants)
       prefix = join_paths(outer_prefix, class_prefix)
 
@@ -175,6 +182,17 @@ module Noir
           end
         end
       end
+    end
+
+    # True when the class/interface declaration carries a `@FeignClient`
+    # annotation (Spring Cloud declarative HTTP client). Such a type's
+    # `@*Mapping` methods describe outbound calls, not server routes.
+    private def feign_client?(decl : LibTreeSitter::TSNode, source : String) : Bool
+      found = false
+      each_annotation(decl, source) do |name, _args, _line|
+        found = true if name == "FeignClient"
+      end
+      found
     end
 
     # Detect whether a `prefix_expression` node carries annotations

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -282,8 +282,13 @@ class EndpointOptimizer
     endpoints.each do |endpoint|
       new_endpoint = endpoint
 
-      # Handle {param} patterns
-      scans = endpoint.url.scan(/\/\{([^}]+)\}/).flatten
+      # Handle {param} patterns. The placeholder may sit at a segment
+      # boundary (`/{id}`) or share a segment with sibling variables
+      # separated by a comma — Spring's matrix-style `@GetMapping(
+      # "/bbox/{xMin},{yMin},{xMax},{yMax}")` packs four into one
+      # segment, so allow a leading `,` as well as `/` (otherwise only
+      # the first variable in the segment is captured).
+      scans = endpoint.url.scan(/[\/,]\{([^}]+)\}/).flatten
       scans.each do |match|
         # Strip a leading `*` from catch-all path variables. Spring,
         # Armeria and ASP.NET all spell the rest-of-path capture as


### PR DESCRIPTION
## Summary

A Kotlin-analyzer accuracy sweep: ran `noir` (main) over **27 real OSS Kotlin web apps** spanning all three supported Kotlin frameworks (Ktor, http4k, Spring-Kotlin), fanned out a per-app analyze → adversarial-verify pass, and implemented the **verified, tractable** FP/FN/param/callee fixes. The goal was to enrich noir's already-strong Kotlin AI-context with the route shapes and parameter classifications that were slipping through.

Across the corpus, statically-determinable endpoints went **562 → 609** — and many of those replace *wrong-path* emissions (e.g. resource routes previously emitted as bare `/`) rather than just adding new ones.

## Ktor
- **Type-safe resource routing** (biggest gap): resolve `get<Articles.Id.Edit> { }` by building a **project-wide `@Resource` path map**. Composition parent = the first primary-constructor property whose type is another resource (`root: Root` → `/api`, `parent: ArticlesResource`), since resource classes commonly live in a shared `commonMain` module. Unresolved types are skipped rather than emitted at the bare prefix. _ktor-realworld: 4 routes-as-`/` → 19 correct `/api/...`; ktor-samples +15._
- **WebSocket / SSE**: `webSocket` / `webSocketRaw` / `sse` handlers now surface as `GET` routes.
- **install() FP**: only `install(Routing)` descends as routing; other plugin-config blocks no longer have their config DSL misread as verbs (`install(CachingHeaders){ options{} }` was a phantom `OPTIONS` route).

## http4k
- **Verbs-under-path**: `"/{id}" bind routes(GET to h, DELETE to h2)` now emits both routes at the bound prefix. `bindContract` is handled only inside a known-prefix `routes(...)` context to avoid emitting mount-prefix-less (wrong) URLs.

## Spring (Kotlin)
Ported the mature Java extractor's behaviour to the Kotlin path:
- **`@RequestBody` → json** (was `form`): the POST `form` default is applied **per-parameter**, so a `@RequestBody` DTO resolves to json while an un-annotated command object (e.g. `@Valid owner: Owner`) still binds as form.
- **Injected-param skip**: `@AuthenticationPrincipal` / `@CurrentUser` / `@CurrentSecurityContext` / `@SessionAttribute` / `@RequestAttribute` params are dropped instead of having their DTO fields expanded into phantom params.
- **Collection `@RequestParam`** (`List<Long>`) emitted by name (was dropped).
- DTO field defaults no longer leak `@field:…` annotation source tokens.
- **`@FeignClient`** interfaces skipped (outbound clients, not server routes).

## Optimizer (cross-cutting)
- Capture **every** variable in a comma-packed path segment — `@GetMapping("/bbox/{xMin},{yMin},{xMax},{yMax}")` now yields all four path params, not just the first. (Surfaced by Kotlin Spring matrix-style paths but applies to every language.)

## Validation
- Full spec suite green (**19,635 examples, 0 failures**); `ameba` clean; `crystal tool format` applied.
- New unit specs cover resource routing (nested + cross-file ctor-parent + unresolved-skip), WebSocket/SSE, install-FP, `@RequestBody`/injected/collection params, DTO-token leak, `@FeignClient` skip, and comma-packed path params.
- No analysis-time regression (the resource pass is gated on an `@Resource` content check).

> Note: the most frequent raw finding ("Spring static-path routes dropped") turned out to be a **misdiagnosis** — the Spring analyzer detects those routes correctly; the app ships a Postman collection and global `(method,url)` dedup lets the spec entry shadow the source endpoint for static paths. That's a separate cross-cutting concern and is intentionally **out of scope** here.