### PR TITLE
fix(python): stop F^D global re-prefix explosion in Flask/Quart import recursion

### DIFF
--- a/spec/unit_test/miniparser/python_parser_spec.cr
+++ b/spec/unit_test/miniparser/python_parser_spec.cr
@@ -124,6 +124,46 @@ describe PythonParser do
       end
     end
 
+    it "re-prefixes a submodule's OWN globals on `from . import sub`" do
+      with_tmpdir do |root|
+        File.write(File.join(root, "sub.py"), "sub_bp = Blueprint(\"sub\")\n")
+        app = File.join(root, "app.py")
+        content = "from . import sub\n"
+        File.write(app, content)
+
+        parsers = Hash(String, PythonParser).new
+        parser = PythonParser.new(app, content, parsers)
+
+        # The submodule's own definition is reachable as `sub.<name>`.
+        parser.@global_variables.has_key?("sub.sub_bp").should be_true
+        parser.@global_variables["sub.sub_bp"].type.should eq("Blueprint")
+      end
+    end
+
+    it "does NOT re-prefix a submodule's transitively re-exported globals" do
+      # Guards the fix for the F^D global-key explosion: when `app`
+      # imports `mid` as a submodule, only `mid`'s OWN definitions
+      # become `mid.<key>` — `mid`'s wildcard re-exports from `deep`
+      # must not be re-prefixed into `mid.<deep-name>`, or each import
+      # level compounds the transitive set and a re-export-heavy package
+      # melts the scanner (redash: 357s → 1.8s after this fix).
+      with_tmpdir do |root|
+        File.write(File.join(root, "deep.py"), "deep_bp = Blueprint(\"deep\")\n")
+        File.write(File.join(root, "mid.py"), "from deep import *\nmid_bp = Blueprint(\"mid\")\n")
+        app = File.join(root, "app.py")
+        content = "from . import mid\n"
+        File.write(app, content)
+
+        parsers = Hash(String, PythonParser).new
+        parser = PythonParser.new(app, content, parsers)
+
+        parser.@global_variables.has_key?("mid.mid_bp").should be_true
+        # `deep_bp` reached `mid` only via wildcard re-export, so it is
+        # NOT one of `mid`'s own globals and must not appear re-prefixed.
+        parser.@global_variables.has_key?("mid.deep_bp").should be_false
+      end
+    end
+
     it "deduplicates revisits via the @visited tracking" do
       with_tmpdir do |root|
         # `app.py` and `b.py` both `from . import a`. Loading via

--- a/src/miniparsers/python.cr
+++ b/src/miniparsers/python.cr
@@ -37,6 +37,22 @@ class PythonParser
                  @visited : Array(String) = Array(String).new,
                  depth : Int32 = 0)
     @global_variables = Hash(String, GlobalVariables).new
+    # `@own_globals` holds ONLY this file's module-level assignments
+    # (`extract_globals`), never the transitively-merged, re-prefixed
+    # entries that flow into `@global_variables` from imports. Import
+    # re-prefixing (`import x.y` → `x.y.<key>`, `from pkg import sub`
+    # → `sub.<key>`) copies from `@own_globals`, NOT `@global_variables`.
+    #
+    # Without this split, each level re-prefixed the *entire*
+    # transitive set of the level below — so a module reachable through
+    # a fan-out of F submodules at depth D contributed F^D keys
+    # (`a.b.c.d.<name>` chains that routing code never references). On
+    # real apps with re-export-heavy packages (redash: 407 `from redash`
+    # imports) this made a scan that yields the same endpoints take
+    # >350s instead of ~1.5s. Copying only own definitions keeps the
+    # merge linear in the number of modules while preserving every
+    # 1-hop `module.instance` lookup Flask/Quart actually performs.
+    @own_globals = Hash(String, GlobalVariables).new
     @basedir = File.dirname(@path)
     while !@basedir.empty? && File.exists?(@basedir + "/__init__.py")
       @basedir = File.dirname(@basedir)
@@ -64,7 +80,9 @@ class PythonParser
         next unless Noir::TreeSitter.node_type(child) == "assignment"
         name, type, value = analyse_assignment(child, source)
         next if name.empty?
-        @global_variables[name] = GlobalVariables.new(name, type, value, @path)
+        gv = GlobalVariables.new(name, type, value, @path)
+        @global_variables[name] = gv
+        @own_globals[name] = gv
       end
     end
   end
@@ -281,7 +299,10 @@ class PythonParser
       sub = get_or_create_parser(pyfile)
       next unless sub
 
-      sub.@global_variables.each do |k, v|
+      # Only the submodule's OWN definitions become `sub.<key>` —
+      # re-prefixing its transitive imports too is what caused the
+      # F^D key explosion (see `@own_globals`).
+      sub.@own_globals.each do |k, v|
         @global_variables["#{local_name}.#{k}"] = v
       end
     end
@@ -334,7 +355,11 @@ class PythonParser
     sub = get_or_create_parser(pyfile)
     return unless sub
 
-    sub.@global_variables.each do |k, v|
+    # `import x.y` exposes `x.y.<name>` for names DEFINED in x/y — copy
+    # only own definitions, not the module's own transitive imports
+    # (those would re-prefix into `x.y.<deep.chain>` keys that routing
+    # never queries, and compound exponentially up the import tree).
+    sub.@own_globals.each do |k, v|
       @global_variables["#{prefix}#{k}"] = v
     end
   end


### PR DESCRIPTION
## Problem

`PythonParser` (used by the Flask + Quart analyzers to resolve routing-relevant globals across files) re-prefixed the **entire transitive** global set of each imported module at every level. `import x.y` and `from pkg import sub` copied the sub-parser's full `@global_variables` — which already held its own transitively-merged, re-prefixed entries — and re-keyed all of them.

A module reachable through a fan-out of `F` submodules at depth `D` therefore contributed `F^D` keys (`a.b.c.d.<name>` chains that routing code never references). On re-export-heavy real apps this is pathological:

- **redash** (407 `from redash …` imports) took **>350s** to produce the **exact same 17 endpoints** it produces in **~1.2–1.8s** once the amplification is removed.

## Fix

Track each file's OWN module-level assignments in a new `@own_globals` map and re-prefix only those on `import x.y` / submodule imports. Wildcard (`from x import *`) and name (`from x import y`) imports are unchanged — they don't re-prefix, so they never amplified. Every 1-hop `module.instance` lookup the Flask/Quart analyzers actually perform is preserved; only never-queried deep transitive chains are dropped.

## Validation

- **redash: 357s+ → ~1.2s (~300×), identical 17 endpoints.**
- CTFd / flaskbb / apiflask / microblog / flask / quart: byte-identical output.
- 17 `python_parser_spec` unit examples (incl. 2 new amplification-guard tests) + 184 Flask functional examples pass.

Part of a 26-OSS-app Python analyzer sweep (separate PRs follow for litestar/Django FP and flask-restx accuracy).