### PR TITLE
feat(python): litestar websocket_listener/stream + Django method-restrictor FP fixes

### DIFF
--- a/spec/functional_test/fixtures/python/django/blog/urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/urls.py
@@ -120,6 +120,18 @@ urlpatterns = [
         r'delete_test',
         views.delete_test,
         name='delete_test'),
+    path(
+        r'require_post',
+        views.require_post_view,
+        name='require_post_view'),
+    path(
+        r'require_methods',
+        views.require_methods_view,
+        name='require_methods_view'),
+    path(
+        r'widget/delete',
+        views.WidgetDeleteView.as_view(),
+        name='widget_delete'),
     re_path(
         r'^legacy/(?P<legacy_id>[0-9]+)/$',
         views.legacy_detail,

--- a/spec/functional_test/fixtures/python/django/blog/views.py
+++ b/spec/functional_test/fixtures/python/django/blog/views.py
@@ -11,7 +11,9 @@ from django.templatetags.static import static
 from django.utils import timezone
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST, require_http_methods
 from django.views.generic.detail import DetailView
+from django.views.generic.edit import DeleteView
 from django.views.generic.list import ListView
 from haystack.views import SearchView
 from rest_framework import mixins, viewsets
@@ -436,6 +438,23 @@ def delete_test(request):
         return 'delete'
 
     return "test"
+
+@require_POST
+def require_post_view(request):
+    # @require_POST pins this to POST only — GET must NOT be emitted.
+    return "ok"
+
+@csrf_exempt
+@require_http_methods(["GET", "POST"])
+def require_methods_view(request):
+    # Restricted to exactly GET + POST by the decorator; the non-route
+    # @csrf_exempt above it must not defeat the decorator-stack walk.
+    return "ok"
+
+class WidgetDeleteView(DeleteView):
+    # Django's generic DeleteView serves GET (confirm) + POST (delete),
+    # never the HTTP DELETE verb.
+    model = Article
 
 def legacy_detail(request, legacy_id):
     preview = request.GET.get('preview')

--- a/spec/functional_test/fixtures/python/litestar/app.py
+++ b/spec/functional_test/fixtures/python/litestar/app.py
@@ -1,5 +1,5 @@
 import external_handlers
-from litestar import Controller, Litestar, get, post, put, delete, route, Router, websocket
+from litestar import Controller, Litestar, get, post, put, delete, route, Router, websocket, websocket_listener
 from litestar.connection import Request
 from litestar.handlers import WebsocketListener
 from litestar.params import Dependency
@@ -76,6 +76,11 @@ async def multi(request: Request) -> dict:
 @websocket("/ws/{room_id:str}")
 async def room_socket(socket: WebsocketListener, room_id: str, token: str) -> None:
     await socket.accept()
+
+
+@websocket_listener("/ws-listener")
+async def listener_socket() -> str:
+    return "ok"
 
 
 @get("/headers")

--- a/spec/functional_test/testers/python/django_spec.cr
+++ b/spec/functional_test/testers/python/django_spec.cr
@@ -139,6 +139,14 @@ expected_endpoints = [
   Endpoint.new("/test", "PATCH", [Param.new("test_param", "", "form")]),
   Endpoint.new("/delete_test", "GET"),
   Endpoint.new("/delete_test", "DELETE"),
+  # @require_POST → POST only (no implicit GET).
+  Endpoint.new("/require_post", "POST"),
+  # @require_http_methods(["GET", "POST"]) under a non-route decorator.
+  Endpoint.new("/require_methods", "GET"),
+  Endpoint.new("/require_methods", "POST"),
+  # DeleteView → GET (confirm) + POST (delete), never HTTP DELETE.
+  Endpoint.new("/widget/delete", "GET"),
+  Endpoint.new("/widget/delete", "POST"),
   Endpoint.new("/legacy/{legacy_id}/", "GET", [
     Param.new("preview", "", "query"),
     Param.new("legacy_id", "", "path"),

--- a/spec/functional_test/testers/python/litestar_spec.cr
+++ b/spec/functional_test/testers/python/litestar_spec.cr
@@ -18,6 +18,7 @@ expected_endpoints = [
     Param.new("room_id", "", "path"),
     Param.new("token", "", "query"),
   ]),
+  Endpoint.new("/ws-listener", "GET"),
   Endpoint.new("/headers", "GET", [Param.new("X-Token", "", "header")]),
   Endpoint.new("/cookies", "GET", [Param.new("session", "", "cookie")]),
   Endpoint.new("/inline/summary", "GET", [Param.new("mode", "", "query")]),
@@ -45,4 +46,10 @@ it "marks Litestar websocket endpoints with ws protocol" do
   websocket_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws/{room_id}" }
   websocket_route.should_not be_nil
   websocket_route.try(&.protocol).should eq("ws")
+end
+
+it "detects @websocket_listener handlers as ws endpoints" do
+  listener_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/ws-listener" }
+  listener_route.should_not be_nil
+  listener_route.try(&.protocol).should eq("ws")
 end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -964,14 +964,31 @@ module Analyzer::Python
           function_define_line = lines[0]
           lines = lines[1..]
 
-          # Check if the decorator line contains an HTTP method
+          # Check the decorator stack above the def for HTTP methods.
+          # Walk every contiguous decorator line (not just the one
+          # directly above the def) so a method-restricting decorator
+          # under, say, `@login_required` is still seen.
           index = content_lines.index(function_define_line)
           if !index.nil?
-            while index > 0
-              index -= 1
-
+            restricted_methods = nil
+            index -= 1
+            while index >= 0
               preceding_definition = content_lines[index]
-              if preceding_definition.size > 0 && preceding_definition[0] == '@'
+              stripped = preceding_definition.lstrip
+              index -= 1
+              next if stripped.empty?                 # tolerate blank lines between stacked decorators
+              break unless stripped.starts_with?("@") # only the contiguous decorator stack
+
+              # `django.views.decorators.http` restrictors pin the exact
+              # verb set and, crucially, drop the implicit GET default —
+              # a `@require_POST` view answers 405 to GET, so emitting GET
+              # was a false positive (and POST was missed entirely because
+              # the bare `require_POST` token has no trailing delimiter for
+              # the generic scan below).
+              if methods = extract_django_require_methods(stripped)
+                restricted_methods ||= [] of ::String
+                methods.each { |m| restricted_methods << m unless restricted_methods.includes?(m) }
+              else
                 HTTP_METHODS.each do |http_method_name|
                   method_name_match = preceding_definition.downcase.match /[^a-zA-Z0-9](#{http_method_name})[^a-zA-Z0-9]/
                   if !method_name_match.nil?
@@ -979,8 +996,11 @@ module Analyzer::Python
                   end
                 end
               end
+            end
 
-              break
+            # A method-restricting decorator replaces the implicit GET.
+            if rm = restricted_methods
+              suspicious_http_methods = rm unless rm.empty?
             end
           end
 
@@ -1042,7 +1062,13 @@ module Analyzer::Python
             suspicious_http_methods << "GET"
             suspicious_http_methods << "POST"
           elsif class_define_line.includes? "Delete"
-            suspicious_http_methods << "DELETE"
+            # Django's generic `DeleteView` serves the confirmation page
+            # on GET and performs the delete on POST — it does NOT expose
+            # the HTTP DELETE verb. Emitting DELETE here was a false
+            # positive on every `class X(DeleteView)` (wagtail: 5). A view
+            # that genuinely handles HTTP DELETE defines `def delete(self,
+            # request, ...)`, which the explicit method-def scan below
+            # already picks up, so real DELETE endpoints are unaffected.
             suspicious_http_methods << "POST"
           elsif class_define_line.includes? "Create"
             suspicious_http_methods << "POST"
@@ -1391,6 +1417,34 @@ module Analyzer::Python
     private def append_code_path(details : Details, path_info : PathInfo)
       return if details.code_paths.any? { |existing| existing == path_info }
       details.add_path(path_info)
+    end
+
+    # Map a `django.views.decorators.http` restrictor decorator line to
+    # the exact HTTP verbs it allows, or nil when the decorator isn't a
+    # method restrictor. These decorators define the allowed-method set
+    # authoritatively (everything else 405s), so the caller uses the
+    # result to REPLACE the implicit GET default rather than add to it.
+    private def extract_django_require_methods(decorator : ::String) : Array(::String)?
+      if match = decorator.match(/@\s*(?:\w+\.)*require_http_methods\s*\(\s*(?:request_method_list\s*=\s*)?[\[(]([^\])]*)[\])]/)
+        methods = [] of ::String
+        match[1].scan(/[rf]?['"]([A-Za-z]+)['"]/) do |m|
+          verb = m[1].upcase
+          methods << verb if HTTP_METHODS.any? { |hm| hm.upcase == verb }
+        end
+        return methods.empty? ? nil : methods
+      end
+
+      # `@require_POST` / `@require_GET` — verb embedded in the name.
+      if match = decorator.match(/@\s*(?:\w+\.)*require_(GET|POST|HEAD)\b/i)
+        return [match[1].upcase]
+      end
+
+      # `@require_safe` allows GET + HEAD.
+      if decorator.matches?(/@\s*(?:\w+\.)*require_safe\b/)
+        return ["GET", "HEAD"]
+      end
+
+      nil
     end
 
     # Extract parameters from a line of code

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -5,7 +5,12 @@ module Analyzer::Python
     # Decorator matching: @get("/path"), @post("/path"), etc. The tail
     # after the path literal is captured so extra kwargs (like methods=)
     # can be inspected for multi-method @route decorators.
-    DECORATOR_REGEX = /@(get|post|put|patch|delete|head|options|route|websocket)\s*\(([^)]*)/
+    # `websocket(?:_listener|_stream)?` also matches Litestar's
+    # `@websocket_listener("/ws")` and `@websocket_stream("/ws")`
+    # decorators (the listener/stream class-based WS handlers), which
+    # take a positional path just like `@websocket` — without the
+    # variants every listener/stream endpoint was silently dropped.
+    DECORATOR_REGEX = /@(get|post|put|patch|delete|head|options|route|websocket(?:_listener|_stream)?)\s*\(([^)]*)/
     # Path literal inside a decorator. Litestar accepts both a positional
     # path and an explicit `path=` keyword argument.
     DECORATOR_PATH_REGEX    = /^\s*[rf]?['"]([^'"]*)['"]/
@@ -88,7 +93,7 @@ module Analyzer::Python
           route_path = path_match[1]
 
           methods = [] of ::String
-          websocket_route = decorator == "websocket"
+          websocket_route = decorator.starts_with?("websocket")
           if decorator == "route"
             http_match = body.match(HTTP_METHOD_KW_REGEX)
             if http_match
@@ -465,7 +470,7 @@ module Analyzer::Python
     private def coalesce_litestar_decorator(lines : Array(::String),
                                             index : Int32,
                                             line : ::String) : ::String
-      return line unless line.matches?(/@(?:get|post|put|patch|delete|head|options|route|websocket)\s*\(/)
+      return line unless line.matches?(/@(?:get|post|put|patch|delete|head|options|route|websocket(?:_listener|_stream)?)\s*\(/)
       delta = python_decorator_paren_delta(line)
       return line if delta <= 0
 


### PR DESCRIPTION
Part of a 26-OSS-app Python analyzer accuracy sweep.

## Litestar
- `DECORATOR_REGEX` (and the multi-line coalesce guard) now match `@websocket_listener` / `@websocket_stream` — the class-based WebSocket handler decorators — not just `@websocket`. Those endpoints were silently dropped; they are now emitted with `protocol=ws` like `@websocket`.

## Django
- **`class X(DeleteView)` no longer emits a phantom HTTP `DELETE` endpoint.** Django's generic `DeleteView` serves the confirmation page on GET and performs the delete on POST — it does not expose the HTTP DELETE verb. A view that genuinely handles DELETE defines `def delete(self, request, …)`, which the explicit method-def scan already picks up, so real DELETE endpoints are unaffected. (wagtail: 5 false-positive DELETE removed.)
- **`@require_POST` / `@require_GET` / `@require_safe` / `@require_http_methods([...])` now pin the exact verb set and DROP the implicit GET default.** A `@require_POST` view answers 405 to GET, yet noir emitted GET and missed POST (the bare `require_POST` token had no trailing delimiter for the generic method-name scan). The decorator-stack walk now also looks past non-route decorators (e.g. `@csrf_exempt`) instead of only the line directly above the `def`. (wagtail: 7 GET→POST corrections.)

## Validation
- **wagtail: 171 → 160 endpoints, all corrections** (−5 phantom DELETE, −7 wrong-GET now POST). Litestar `@websocket_listener` detection confirmed in isolation.
- New fixture cases (`@require_POST`, `@require_http_methods`, `DeleteView`, `@websocket_listener`) added; 340 litestar + django functional examples pass, no regressions across the other 24 OSS apps.