### PR TITLE
fix(python/flask): resolve flask-restx blueprint url_prefix + Resource verbs cross-file

### DIFF
--- a/spec/functional_test/fixtures/python/flask_restx/app.py
+++ b/spec/functional_test/fixtures/python/flask_restx/app.py
@@ -1,0 +1,25 @@
+from flask import Flask, Blueprint
+from flask_restx import Api
+
+from resources import users_ns
+
+app = Flask(__name__)
+
+# Blueprint carries the API version prefix; the Api is mounted onto it.
+api_bp = Blueprint("api", __name__, url_prefix="/api/v1")
+
+# Multi-line Api(...) constructor — the blueprint argument sits on a
+# continuation line, which the route-detection regex must coalesce to
+# link the `/api/v1` prefix to this Api instance.
+api = Api(
+    api_bp,
+    version="1.0",
+    title="Demo API",
+    doc="/docs",
+)
+
+# Explicit mount path; combined with the blueprint url_prefix this makes
+# every users_ns route resolve under `/api/v1/users`.
+api.add_namespace(users_ns, "/users")
+
+app.register_blueprint(api_bp)

--- a/spec/functional_test/fixtures/python/flask_restx/resources.py
+++ b/spec/functional_test/fixtures/python/flask_restx/resources.py
@@ -1,0 +1,23 @@
+from flask_restx import Namespace, Resource
+
+# The namespace and its routes live in a DIFFERENT file from the
+# Blueprint + Api wiring (app.py). The blueprint's url_prefix
+# (`/api/v1`) and the add_namespace mount (`/users`) are only visible
+# in app.py, so resolving these routes requires cross-file propagation
+# of the namespace prefix.
+users_ns = Namespace("users", description="user operations")
+
+
+@users_ns.route("/<int:user_id>")
+class UserDetail(Resource):
+    def get(self, user_id):
+        return {}
+
+    def delete(self, user_id):
+        return {}
+
+
+@users_ns.route("/me")
+class CurrentUser(Resource):
+    def get(self):
+        return {}

--- a/spec/functional_test/testers/python/flask_restx_spec.cr
+++ b/spec/functional_test/testers/python/flask_restx_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+# flask-restx: a Blueprint carries the url_prefix, an Api is mounted on
+# the blueprint, and `add_namespace(ns, "/users")` sets the mount path —
+# all in app.py — while the namespace's Resource routes live in
+# resources.py. The fully-resolved prefix is `/api/v1` (blueprint) +
+# `/users` (add_namespace), and each Resource verb-method is its own
+# endpoint.
+expected_endpoints = [
+  Endpoint.new("/api/v1/users/<int:user_id>", "GET", [Param.new("user_id", "", "path")]),
+  Endpoint.new("/api/v1/users/<int:user_id>", "DELETE", [Param.new("user_id", "", "path")]),
+  Endpoint.new("/api/v1/users/me", "GET"),
+]
+
+FunctionalTester.new("fixtures/python/flask_restx/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -38,6 +38,14 @@ module Analyzer::Python
       path_api_instances = Hash(::String, Hash(::String, ::String)).new
       register_blueprint = Hash(::String, Hash(::String, ::String)).new
       blueprint_mounts = Hash(::String, Array(Tuple(::String, ::String, ::String))).new
+      # flask-restx namespaces are module-level singletons: the Api host
+      # file (`api/__init__.py`) wires `api.add_namespace(ns, "/x")` with
+      # the blueprint's `url_prefix` (`/api/v1`), but each namespace's
+      # ROUTES live in a different file (`api/v1/x.py`). `path_api_instances`
+      # is per-file, so the route file never saw the host-computed prefix
+      # and every `@ns.route` surfaced without `/api/v1`. This GLOBAL map
+      # (namespace var name -> fully-resolved prefix) bridges the two files.
+      namespace_prefixes = Hash(::String, ::String).new
 
       # Iterate through all Python files in all base paths. Pulls from
       # the detector-built file_map so subtree pruning and --exclude-path
@@ -112,9 +120,21 @@ module Analyzer::Python
                 end
               end
 
+              # `Api(...)` and `add_namespace(...)` calls routinely wrap
+              # across lines (`X = Api(\n  blueprint,\n  ...\n)`), which
+              # hid the blueprint/app argument from the single-line regex
+              # and broke the whole `blueprint url_prefix -> Api -> namespace`
+              # chain. Coalesce continuation lines when the call is
+              # unbalanced so the argument is visible.
+              api_line = if line.includes?("Api(") && python_paren_delta(original_line) > 0
+                           join_until_python_call_closes(lines, line_index, original_line).gsub(" ", "")
+                         else
+                           line
+                         end
+
               # Api from flask instance
               flask_instances.each do |_flask_instance_name, _prefix|
-                api_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_flask_instance_name}/
+                api_match = api_line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_flask_instance_name}[,)]/
                 if api_match
                   api_instance_name = api_match[1]
                   api_instances[api_instance_name] ||= _prefix
@@ -123,7 +143,7 @@ module Analyzer::Python
 
               # Api from blueprint instance
               blueprint_prefixes.each do |_blueprint_instance_name, _prefix|
-                api_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_blueprint_instance_name}/
+                api_match = api_line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_blueprint_instance_name}[,)]/
                 if api_match
                   api_instance_name = api_match[1]
                   api_instances[api_instance_name] ||= _prefix
@@ -131,14 +151,32 @@ module Analyzer::Python
               end
 
               # Api Namespace
+              ns_line = if line.includes?(".add_namespace(") && python_paren_delta(original_line) > 0
+                          join_until_python_call_closes(lines, line_index, original_line).gsub(" ", "")
+                        else
+                          line
+                        end
               api_instances.each do |_api_instance_name, _prefix|
-                add_namespace_match = line.match /(#{_api_instance_name})\.add_namespace\((#{PYTHON_VAR_NAME_REGEX})/
+                add_namespace_match = ns_line.match /(#{_api_instance_name})\.add_namespace\((#{PYTHON_VAR_NAME_REGEX})/
                 if add_namespace_match
                   parser = get_parser(path)
                   if parser.@global_variables.has_key?(add_namespace_match[2])
                     gv = parser.@global_variables[add_namespace_match[2]]
                     if gv.type == "Namespace"
-                      api_instances[gv.name] = extract_namespace_prefix(parser, add_namespace_match[2], _prefix)
+                      # Prefer the explicit mount path on
+                      # `add_namespace(ns, "/x")` (authoritative); fall
+                      # back to the Namespace(...) definition's own
+                      # path=/name when no positional path is given.
+                      resolved = if mount_path = extract_add_namespace_path(ns_line, _api_instance_name, add_namespace_match[2])
+                                   joined = File.join(_prefix, mount_path)
+                                   joined.starts_with?("/") ? joined : "/#{joined}"
+                                 else
+                                   extract_namespace_prefix(parser, add_namespace_match[2], _prefix)
+                                 end
+                      api_instances[gv.name] = resolved
+                      # Bridge to the namespace's route-definition file,
+                      # which has no view onto this host file's prefixes.
+                      namespace_prefixes[gv.name] = resolved
                     end
                   end
                 end
@@ -443,6 +481,10 @@ module Analyzer::Python
           api_instances = path_api_instances[path]
           if api_instances.has_key?(router_name)
             prefix = api_instances[router_name]
+          elsif namespace_prefixes.has_key?(router_name)
+            # flask-restx namespace whose `add_namespace(...)` (with the
+            # blueprint url_prefix) was resolved in a different file.
+            prefix = namespace_prefixes[router_name]
           else
             parser = get_parser(path)
             prefix = extract_namespace_prefix(parser, router_name, "")
@@ -484,7 +526,19 @@ module Analyzer::Python
           end
 
           function_name_locations.each do |_class_def_index, _function_name|
+            http_verb = HTTP_METHODS.find { |http_method| _function_name.downcase == http_method.downcase }
+
             if is_class_router
+              # A class router is a flask-restx `Resource` / Flask
+              # `MethodView`: each HTTP-verb-named method IS a distinct
+              # endpoint verb (def get -> GET, def delete -> DELETE).
+              # Non-verb methods are helpers — skip them so they don't
+              # emit a phantom GET. Previously the decorator's default
+              # `methods=['GET']` (`.route` has no explicit verb)
+              # overrode the per-method verb in `get_endpoints`, so a
+              # Resource with get+post+delete collapsed to a single GET.
+              next unless http_verb
+
               # Replace the class expect params with the function expect params
               def_expect_params, _ = extract_params_from_decorator(path, lines, _class_def_index, :up)
               if def_expect_params.size > 0
@@ -497,8 +551,12 @@ module Analyzer::Python
             codeblock_lines = codeblock.split("\n")
 
             # Get the HTTP method from the function name when it is not specified in the route decorator
-            method = HTTP_METHODS.find { |http_method| _function_name.downcase == http_method.downcase } || "GET"
-            get_endpoints(method, route_path, extra_params, codeblock_lines, prefix).each do |endpoint|
+            method = http_verb ? http_verb.upcase : "GET"
+            # For class routers the per-method verb is authoritative; the
+            # decorator's synthesized `methods=['GET']` default must not
+            # override it (function routers still honour `methods=`).
+            method_extra_params = is_class_router ? "" : extra_params
+            get_endpoints(method, route_path, method_extra_params, codeblock_lines, prefix).each do |endpoint|
               details = Details.new(PathInfo.new(path, line_index + 1))
               endpoint.details = details
 
@@ -1131,6 +1189,25 @@ module Analyzer::Python
       end
 
       return params, [lines.size - 1, codeline_index].min
+    end
+
+    # Pull the explicit mount path off an `<api>.add_namespace(ns, "/x")`
+    # call (or `path="/x"` kwarg). `ns_line` is the space-stripped,
+    # paren-balanced call text. Returns nil when no positional path /
+    # `path=` is given, so the caller falls back to the Namespace's own
+    # `path=`/name. This is the authoritative mount point in flask-restx
+    # and overrides the namespace definition's default.
+    private def extract_add_namespace_path(ns_line : ::String, api_instance_name : ::String, ns_var : ::String) : ::String?
+      call_match = ns_line.match /#{Regex.escape(api_instance_name)}\.add_namespace\(#{Regex.escape(ns_var)},(.*)\)/
+      return unless call_match
+      args = call_match[1]
+      if kw = args.match /path=[rf]?['"]([^'"]*)['"]/
+        return kw[1]
+      end
+      if pos = args.match /^[rf]?['"]([^'"]*)['"]/
+        return pos[1]
+      end
+      nil
     end
 
     # Function to extract namespace from the parser and update the prefix


### PR DESCRIPTION
Part of a 26-OSS-app Python analyzer accuracy sweep. This is the dominant real-app win: **CTFd 138 → 177 Python endpoints, 0 → 96 carrying the correct `/api/v1` prefix.**

Two linked flask-restx bugs:

### 1. Blueprint `url_prefix` never reached namespace routes
The Api host file (`api/__init__.py`) wires `Api(blueprint)` + `add_namespace(ns, "/x")` where the blueprint declares `url_prefix="/api/v1"`, but each namespace's **routes** live in a different file (`api/v1/x.py`). `path_api_instances` is per-file, so the route file never saw the host-computed prefix and every `@ns.route` surfaced **without** `/api/v1`.

- Fix: a global `namespace var → resolved prefix` map populated at `add_namespace` time and consulted when resolving route prefixes.
- Also: the `X = Api(\n  blueprint,\n …)` constructor is routinely multi-line, which hid the blueprint argument from the single-line regex — now coalesced. The explicit `add_namespace(ns, "/path")` mount is used (authoritative) over the `Namespace()` default.

### 2. Resource classes collapsed to a single GET
`@ns.route` synthesizes a default `methods=['GET']`, which overrode the per-method verb in `get_endpoints` — so a `Resource` with `get`+`post`+`delete` emitted only GET.

- Fix: for class routers the verb-named method **is** the endpoint verb (`def delete` → DELETE); non-verb helper methods no longer emit a phantom GET. (CTFd recovered 20 DELETE + 14 PATCH + 6 POST.)

## Validation
New fixture `spec/functional_test/fixtures/python/flask_restx/` (host file + separate route file + multi-line `Api`) locks both behaviours in. 1813 Python functional + miniparser examples pass; microblog / flaskbb / apiflask / flask / quart byte-identical.

> Note: the audit's biggest *claimed* FN — "dispatch FastAPI ~200 missing routes" — was verified to be a cross-analyzer **dedup artifact** (dispatch ships a checked-in `openapi.yaml`; its oas3 endpoints dedup against `python_fastapi` by (method,url)), **not** a Python-analyzer bug. `--exclude-techs oas3` → python_fastapi 91 → 292. The FastAPI analyzer is accurate.