### PR TITLE
feat(kotlin): typed-body routes, Spring const-val paths, http4k Response-builder FP

### DIFF
--- a/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
@@ -71,4 +71,43 @@ describe Noir::TreeSitterHttp4kExtractor do
     })
     routes.should be_empty
   end
+
+  it "extracts request reads (query/header/body) from the request object" do
+    source = <<-KT
+      val app = routes(
+          "/x" bind POST to { req: Request ->
+              val q = req.query("q")
+              val h = req.header("X-Key")
+              val b = req.bodyString()
+          }
+      )
+      KT
+    route = Noir::TreeSitterHttp4kExtractor.extract_routes(source).first
+    route.query_params.should eq(["q"])
+    route.header_params.should eq(["X-Key"])
+    route.has_body?.should be_true
+  end
+
+  it "does not mint request params from Response builder calls" do
+    # `Response(...).header(...)` / `.body(...)` WRITE the response, so
+    # they must not be read as request inputs — otherwise a bodyless GET
+    # gains a phantom body:json and a redirect gains a 'location' header.
+    source = <<-KT
+      val app = routes(
+          "/redirect" bind POST to { req: Request ->
+              val target = req.query("target")
+              Response(SEE_OTHER).header("location", "/done").body("ignored")
+          },
+          "/ping" bind GET to { Response(OK).body("pong") }
+      )
+      KT
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source)
+    redirect = routes.find { |r| r.path == "/redirect" }.not_nil!
+    redirect.query_params.should eq(["target"])
+    redirect.header_params.should be_empty
+    redirect.has_body?.should be_false
+
+    ping = routes.find { |r| r.path == "/ping" }.not_nil!
+    ping.has_body?.should be_false
+  end
 end

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -455,5 +455,23 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
 
       Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source).should be_empty
     end
+
+    it "treats a typed verb WITH a string path as a normal body route, not a resource" do
+      # `post<EmailRequest>("/push/email") { }` (kopapi typed-body DSL):
+      # the `<Type>` names the request body, the string is the real path.
+      # Must NOT be mistaken for resource routing and dropped.
+      source = <<-KT
+        fun Route.notificationRoutes() {
+            post<EmailRequest>("/push/email") { request -> }
+            put<UpdateUser>("/users/{id}") { }
+        }
+        KT
+
+      routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source)
+      routes.map { |r| {r.verb, r.path, r.receive_type} }.should eq([
+        {"POST", "/push/email", "EmailRequest"},
+        {"PUT", "/users/{id}", "UpdateUser"},
+      ])
+    end
   end
 end

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -236,6 +236,48 @@ describe Noir::TreeSitterKotlinRouteExtractor do
     Noir::TreeSitterKotlinRouteExtractor.extract_routes(source).should be_empty
   end
 
+  it "expands $VAR interpolations inside constant values (transitively)" do
+    consts = {
+      "PUBLIC_URL"  => "/public",
+      "STATIC_URL"  => "$PUBLIC_URL/static",
+      "ACCOUNT_URL" => "${PUBLIC_URL}/account",
+      "PROP"        => "${spring.config}", # Spring property placeholder stays untouched
+    }
+    expanded = Noir::TreeSitterKotlinRouteExtractor.expand_constant_interpolations(consts)
+    expanded["STATIC_URL"].should eq("/public/static")
+    expanded["ACCOUNT_URL"].should eq("/public/account")
+    expanded["PROP"].should eq("${spring.config}")
+  end
+
+  it "composes a class-level @RequestMapping prefix from a cross-file bare const" do
+    source = <<-KT
+      @RestController
+      @RequestMapping(path = [PUBLIC_URL])
+      class AuthController {
+          @PostMapping("/register")
+          fun register(): String = ""
+      }
+      KT
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, {"PUBLIC_URL" => "/public"})
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"POST", "/public/register"},
+    ])
+  end
+
+  it "resolves a $CONST interpolation inside an inline mapping path literal" do
+    source = <<-KT
+      @RestController
+      class VersionController {
+          @GetMapping(path = ["$PUBLIC_URL/version"])
+          fun version(): String = ""
+      }
+      KT
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, {"PUBLIC_URL" => "/public"})
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/public/version"},
+    ])
+  end
+
   it "skips @FeignClient interfaces (outbound clients, not server routes)" do
     source = <<-KT
       @FeignClient(value = "example-api")

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -27,6 +27,11 @@ module Analyzer::Kotlin
         end
       end
 
+      # Resolve `$OTHER_CONST` interpolations now that every file's
+      # constants are collected, so a shared `Paths.kt` chain like
+      # `const val STATIC_URL = "$PUBLIC_URL/static"` yields `/public/static`.
+      string_constants = Noir::TreeSitterKotlinRouteExtractor.expand_constant_interpolations(string_constants)
+
       file_list.each do |path|
         next unless File.exists?(path)
 

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -408,6 +408,15 @@ module Noir
     private def navigation_method_name(callee : LibTreeSitter::TSNode?, source : String) : String
       return "" unless callee
       return "" unless Noir::TreeSitter.node_type(callee) == "navigation_expression"
+      # Only treat `<receiver>.query/header/form/body(...)` as a REQUEST
+      # read when the receiver is a plain identifier (the handler's
+      # `req`/`it`/`request`). A receiver that is itself a call — most
+      # commonly `Response(OK).body(...)` / `Response(SEE_OTHER).header(
+      # "location", ...)` — is a RESPONSE builder, and matching it would
+      # mint a phantom request body/header param (notably a spurious
+      # `body:json` on bodyless GET routes).
+      receiver = first_named_child(callee)
+      return "" unless receiver && Noir::TreeSitter.node_type(receiver) == "simple_identifier"
       last_navigation_segment(callee, source)
     end
 

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -438,17 +438,23 @@ module Noir
         name = call_name(node, source)
         case
         when active && HTTP_VERB_NAMES.has_key?(name)
-          # Type-safe resource routing: `get<Articles.New> { ... }` carries
-          # a `<Type>` argument instead of a string path. Resolve the type
-          # to its @Resource-composed path; if it can't be resolved, skip
-          # rather than emit the bare routing prefix (a misleading "/").
-          if type_name = call_type_argument_name(node, source)
+          type_name = call_type_argument_name(node, source)
+          path_arg = call_string_argument(node, source, string_constants, local_string_constants)
+          if type_name && path_arg.nil?
+            # Type-safe RESOURCE routing: `get<Articles.New> { ... }` —
+            # a `<Type>` argument and NO string path. Resolve the type to
+            # its @Resource-composed path; if it can't be resolved, skip
+            # rather than emit the bare routing prefix (a misleading "/").
             if rp = resolve_resource_path(type_name, resource_paths)
               emit_resource_route(node, source, HTTP_VERB_NAMES[name], join_paths(prefix, rp), routes, include_callees)
             end
             return
           end
-          emit_route(node, source, name, prefix, routes, string_constants, local_string_constants, include_callees)
+          # `post<Body>("/path") { req -> }` (kopapi/typed-body DSL) and the
+          # plain `post("/path") { }` form both land here — the `<Type>`,
+          # when present alongside a path, names the request body, not a
+          # resource. Pass it through as the body type so the param surfaces.
+          emit_route(node, source, name, prefix, routes, string_constants, local_string_constants, include_callees, type_name)
           return
         when active && name == "route"
           path_arg = call_string_argument(node, source, string_constants, local_string_constants)
@@ -501,17 +507,21 @@ module Noir
                            routes : Array(Route),
                            string_constants : Hash(String, String),
                            local_string_constants : Hash(String, String),
-                           include_callees : Bool)
+                           include_callees : Bool,
+                           body_type : String? = nil)
       path_arg = call_string_argument(node, source, string_constants, local_string_constants)
-      return if path_arg.nil? && call_has_value_arguments?(node)
+      return if path_arg.nil? && call_has_value_arguments?(node) && body_type.nil?
       return unless path_arg || call_has_lambda?(node)
 
       verb = HTTP_VERB_NAMES[name]
       full_path = join_paths(prefix, path_arg || "")
       line = Noir::TreeSitter.node_start_row(node)
 
-      receive_type : String? = nil
-      has_body = false
+      # A `post<Body>("/x")` typed-body verb names the request body in its
+      # type argument; seed it so the json body param surfaces even when
+      # the handler never calls `call.receive<T>()` explicitly.
+      receive_type : String? = body_type
+      has_body = !body_type.nil?
       query_params = [] of String
       header_params = [] of String
       form_params = [] of String
@@ -519,9 +529,9 @@ module Noir
 
       if body = call_lambda_body(node)
         scan_handler_body(body, source, query_params, header_params, form_params).tap do |rt|
-          receive_type = rt
+          receive_type = rt unless rt.nil?
         end
-        has_body = !!receive_type || handler_reads_body?(body, source)
+        has_body = has_body || !!receive_type || handler_reads_body?(body, source)
         # KotlinCalleeExtractor uses `(name, file_path, line)` so it can
         # mirror the Java/Python/Go shape, but Ktor's route extractor
         # doesn't carry the file path — drop the placeholder here and

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -103,6 +103,40 @@ module Noir
       constants
     end
 
+    # Resolve Kotlin string-template interpolations inside collected
+    # constant values, e.g. `const val STATIC_URL = "$PUBLIC_URL/static"`
+    # with `PUBLIC_URL = "/public"` becomes `/public/static`. The regex
+    # capture in `extract_string_constants` stores the raw `$PUBLIC_URL`
+    # text, so without this a path built from such a constant keeps the
+    # literal `$VAR` (or, as an inline annotation literal, mis-parses it
+    # as a `{VAR}` path placeholder). Unresolved references (e.g. Spring
+    # `${config.property}` placeholders) are left untouched. Bounded
+    # iterations resolve transitive chains.
+    def expand_constant_interpolations(constants : Hash(String, String)) : Hash(String, String)
+      return constants unless constants.any? { |_, v| v.includes?('$') }
+      result = constants.dup
+      3.times do
+        changed = false
+        result.each do |name, value|
+          next unless value.includes?('$')
+          expanded = expand_interpolation(value, result)
+          if expanded != value
+            result[name] = expanded
+            changed = true
+          end
+        end
+        break unless changed
+      end
+      result
+    end
+
+    private def expand_interpolation(value : String, constants : Hash(String, String)) : String
+      value.gsub(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/) do
+        ident = $~[1]? || $~[2]?
+        (ident && constants[ident]?) || $~[0]
+      end
+    end
+
     # `_from(root, source)` — accept a pre-parsed root so the Kotlin
     # Spring analyzer can amortise the parse across multiple
     # extractions on the same file. Tree lifetime is the caller's
@@ -723,9 +757,14 @@ module Noir
                                      local_string_constants : Hash(String, String)) : String?
       case Noir::TreeSitter.node_type(node)
       when "string_literal"
-        decode_string_literal(node, source)
+        decode_string_literal(node, source, string_constants, local_string_constants)
       when "simple_identifier"
-        local_string_constants[Noir::TreeSitter.node_text(node, source)]?
+        # A bare const reference. Spring controllers idiomatically keep
+        # their path constants in a shared `Paths.kt` and reference them
+        # unqualified (`@RequestMapping(path = [PUBLIC_URL])`), so fall
+        # back to the cross-file constant map when the name isn't local.
+        name = Noir::TreeSitter.node_text(node, source)
+        local_string_constants[name]? || string_constants[name]?
       when "navigation_expression"
         text = Noir::TreeSitter.node_text(node, source)
         local_string_constants[text]? || fully_qualified_constant(text, string_constants)
@@ -820,17 +859,29 @@ module Noir
     end
 
     # Kotlin `string_literal` wraps content in `string_content`
-    # children, same shape as Java.
-    private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
+    # children, same shape as Java. A `$VAR` / `${VAR}` interpolation
+    # that names a known compile-time constant (e.g.
+    # `@GetMapping("$PUBLIC_URL/version")`) resolves to the constant's
+    # value; anything else (a real runtime template) is preserved as a
+    # `{VAR}` placeholder. Literal `{id}` path params live in
+    # `string_content`, so they're never affected by this resolution.
+    private def decode_string_literal(node : LibTreeSitter::TSNode,
+                                      source : String,
+                                      constants : Hash(String, String)? = nil,
+                                      local_constants : Hash(String, String)? = nil) : String
       buf = String.build do |io|
         Noir::TreeSitter.each_named_child(node) do |child|
           case Noir::TreeSitter.node_type(child)
           when "string_content"
             io << Noir::TreeSitter.node_text(child, source)
           when "interpolated_identifier", "interpolated_expression"
-            io << '{'
-            io << Noir::TreeSitter.node_text(child, source).strip
-            io << '}'
+            ident = Noir::TreeSitter.node_text(child, source).strip
+            resolved = (local_constants.try &.[ident]?) || (constants.try &.[ident]?)
+            if resolved
+              io << resolved
+            else
+              io << '{' << ident << '}'
+            end
           end
         end
       end


### PR DESCRIPTION
## Summary

Round 3 of the Kotlin-analyzer accuracy sweep (follow-up to #1881, #1883). Added **7 new OSS apps** to the corpus (kcrud, kdoc, ktask, kompendium + Spring Boot Kotlin templates), re-ran the per-app analyze → adversarial-verify pass on the merged-main analyzer, and fixed the verified, tractable findings — including a **regression** the new corpus surfaced from #1881.

## Ktor — typed-body route regression (introduced by #1881)
`#1881`'s type-safe `@Resource` routing treated **any** `verb<Type>` as resource routing. But the kopapi/typed-body DSL `post<EmailRequest>("/push/email") { }` carries a `<Type>` *and* a string path — these were mistaken for resource routes and **dropped**. Now:
- a `<Type>` **with** a string path → normal route, with `<Type>` recorded as the request body;
- a `<Type>` **without** a path → resource routing (unchanged).

This recovers real source routes in kdoc/ktask that a bundled Postman collection had been masking via `(method,url)` dedup (so they appeared "present" but with no source callees/params).

## Spring (Kotlin) — shared `Paths.kt` constant resolution
Controllers commonly keep paths in a shared constants file. Three cases now resolve where they previously dropped the prefix or emitted garbage:
- **Cross-file bare const in a keyword/array arg** — `@RequestMapping(path = [PUBLIC_URL])` composes `/public/...`.
- **Interpolated constant value** — `const val STATIC_URL = "$PUBLIC_URL/static"` expands to `/public/static` (transitively, across the project).
- **Inline interpolation in a mapping literal** — `@GetMapping("$PUBLIC_URL/version")` resolves to `/public/version` instead of minting a bogus `{PUBLIC_URL}` path variable.

_(A lone positional bare const — `@GetMapping(FAVICON)` — is intentionally still not resolved cross-file, preserving the existing collision-safety behavior.)_

## http4k — Response-builder misread as request input
A `Response(...).header("location", ...)` / `.body(...)` builder call was scanned as a request read, minting a phantom `body:json` on bodyless GET routes and a phantom `location` header param on redirects. Now only `<requestVar>.query/header/form/body(...)` (a plain-identifier receiver) counts as a request input.

## Out of scope (confirmed cross-cutting, not the Kotlin analyzer)
The most common raw findings this round were again **Postman/OpenAPI collection endpoints shadowing source routes** via global `(method,url)` dedup (kcrud, kdoc, ktask, http4k monorepos). A Kotlin-only run detects those source routes correctly with full callees — the loss is in dedup precedence, a separate concern.

## Validation
- Full spec suite green (**19,685 examples, 0 failures**); `ameba` clean; `crystal tool format` applied.
- New unit specs: typed-body-vs-resource routing, cross-file/interpolated/inline Spring const resolution, and http4k Response-builder exclusion (+ the request-read positive case).