### PR TITLE
test(python/django): fix DRF callee line numbers after fixture import additions

### DIFF
--- a/spec/functional_test/testers/python/django_drf_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_drf_callees_spec.cr
@@ -4,16 +4,16 @@ expected_endpoints = [
   Endpoint.new("/api/articles/", "GET", [
     Param.new("status", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.query_params.get", line: 32))
-    ep.push_callee(Callee.new("HttpResponse", line: 33))
+    ep.push_callee(Callee.new("request.query_params.get", line: 34))
+    ep.push_callee(Callee.new("HttpResponse", line: 35))
   end,
 
   Endpoint.new("/api/articles/{article_id}/publish/", "POST", [
     Param.new("reason", "", "form"),
     Param.new("article_id", "", "path"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.data.get", line: 41))
-    ep.push_callee(Callee.new("HttpResponse", line: 42))
+    ep.push_callee(Callee.new("request.data.get", line: 43))
+    ep.push_callee(Callee.new("HttpResponse", line: 44))
   end,
 ]
 


### PR DESCRIPTION
Hotfix for the `tests (1.19.0)` CI failure on main.

PR #1885 added `require_POST` / `require_http_methods` / `DeleteView` imports to the shared django blog fixture (`spec/functional_test/fixtures/python/django/blog/views.py`), shifting every subsequent line by **+2**. `django_drf_callees_spec` hardcodes the ArticleViewSet callee line numbers, which therefore drifted:

- `request.query_params.get` 32 → 34
- `HttpResponse` (list) 33 → 35
- `request.data.get` 41 → 43
- `HttpResponse` (publish) 42 → 44

Updated the four asserted lines to match the grown fixture. Full `crystal spec` suite is green (**19752 examples, 0 failures**).