### PR TITLE
feat(salvo): cross-file handler params + callees, request-side body/header params

### DIFF
--- a/spec/functional_test/fixtures/rust/salvo_xfile_callee/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/salvo_xfile_callee/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "salvo_xfile_callee_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+salvo = "0.68"

--- a/spec/functional_test/fixtures/rust/salvo_xfile_callee/src/handler.rs
+++ b/spec/functional_test/fixtures/rust/salvo_xfile_callee/src/handler.rs
@@ -1,0 +1,9 @@
+use salvo::prelude::*;
+
+#[handler]
+pub async fn create_user(req: &mut Request, res: &mut Response) {
+    let body = req.parse_json::<UserReq>().await.unwrap();
+    let token = req.header::<&str>("Authorization").unwrap_or_default();
+    UserService::insert(&body, token);
+    res.render(Json(body));
+}

--- a/spec/functional_test/fixtures/rust/salvo_xfile_callee/src/main.rs
+++ b/spec/functional_test/fixtures/rust/salvo_xfile_callee/src/main.rs
@@ -1,0 +1,12 @@
+// The route chain references handlers by name, but the `#[handler]` fns live
+// in a sibling module (`handler.rs`). The per-file index can't see them, so a
+// project-wide handler index supplies their params + callees.
+use salvo::prelude::*;
+
+mod handler;
+
+fn route() -> Router {
+    Router::new()
+        .path("/api")
+        .push(Router::new().path("/users").post(handler::create_user))
+}

--- a/spec/functional_test/testers/rust/salvo_xfile_callee_spec.cr
+++ b/spec/functional_test/testers/rust/salvo_xfile_callee_spec.cr
@@ -1,0 +1,24 @@
+require "../../func_spec.cr"
+
+# Cross-file handler enrichment: the route in main.rs references
+# `handler::create_user`, whose `#[handler]` body lives in handler.rs. A
+# project-wide handler index supplies the params (req.parse_json -> json
+# body, req.header::<&str> -> header) and callees from that other file, so
+# the endpoint is no longer left with zero params/callees.
+create_user = Endpoint.new("/api/users", "POST", [
+  Param.new("body", "", "json"),
+  Param.new("Authorization", "", "header"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("req.parse_json", line: 5))
+  ep.push_callee(Callee.new("req.header", line: 6))
+  ep.push_callee(Callee.new("UserService::insert", line: 7))
+  ep.push_callee(Callee.new("res.render", line: 8))
+end
+
+FunctionalTester.new("fixtures/rust/salvo_xfile_callee/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, [create_user], {
+  "include_callee" => YAML::Any.new(true),
+  "only_techs"     => YAML::Any.new("rust_salvo"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -44,11 +44,57 @@ module Analyzer::Rust
     # PREFIX defined in another module) resolves to its real prefix instead
     # of dropping the constant and emitting just `/user`.
     @str_consts : Hash(String, String)? = nil
+    # Cross-file handler params + callees: salvo apps register routes in
+    # `routes/x.rs` (`.get(add_user)`) while the `#[handler] fn add_user`
+    # lives in `handler/x.rs`. The per-file function index can't see those, so
+    # such endpoints surfaced with zero params/callees. Built only when callee
+    # enrichment is requested (the ai-context path), keyed by handler name.
+    @global_handler_info : Hash(String, HandlerInfo)? = nil
+
+    record HandlerInfo,
+      callees : Array(Noir::RustCalleeExtractor::Entry),
+      params : Array(Param)
 
     def analyze
       @fn_external_prefix = build_fn_external_prefixes
       @str_consts = build_str_consts
+      @global_handler_info = callees_needed? ? build_global_handler_info : nil
       super
+    end
+
+    # Precompute params + callees for every `#[handler]` fn project-wide so a
+    # cross-file `.get(handler)` reference can still be enriched. Gated to
+    # files that actually carry a `#[handler]` so plain modules cost nothing.
+    private def build_global_handler_info : Hash(String, HandlerInfo)
+      info = {} of String => HandlerInfo
+      all_files.each do |fpath|
+        next if File.directory?(fpath)
+        next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
+        next if RustEngine.test_path?(fpath)
+        src = read_file_content(fpath)
+        next unless src.includes?("#[handler]")
+        begin
+          test_regions = RustEngine.collect_cfg_test_regions(src)
+          Noir::TreeSitter.parse_rust(src) do |root|
+            walk(root) do |n|
+              next unless Noir::TreeSitter.node_type(n) == "function_item"
+              next if RustEngine.inside_test_region?(n, test_regions)
+              name_node = Noir::TreeSitter.field(n, "name")
+              next unless name_node
+              name = Noir::TreeSitter.node_text(name_node, src)
+              next if info.has_key?(name)
+              tmp = Endpoint.new("", "")
+              extract_function_params(n, src, tmp)
+              body = Noir::TreeSitter.field(n, "body")
+              callees = body ? Noir::RustCalleeExtractorTS.callees_in_body(body, src, fpath) : [] of Noir::RustCalleeExtractor::Entry
+              info[name] = HandlerInfo.new(callees, tmp.params)
+            end
+          end
+        rescue e
+          logger.debug "salvo global handler scan error #{fpath}: #{e}"
+        end
+      end
+      info
     end
 
     def analyze_file(path : String) : Array(Endpoint)
@@ -145,9 +191,20 @@ module Analyzer::Rust
           endpoint = Endpoint.new("/#{canonicalize_salvo_path(full_path).lstrip('/')}", method, details)
           extract_path_params(full_path, endpoint)
 
-          if handler_name && (handler_function = function_index[handler_name.split("::").last]?)
-            extract_function_params(handler_function, original_source, endpoint)
-            attach_handler_callees(handler_function, original_source, path, endpoint) if include_callee
+          if handler_name
+            leaf = handler_name.split("::").last
+            if handler_function = function_index[leaf]?
+              extract_function_params(handler_function, original_source, endpoint)
+              attach_handler_callees(handler_function, original_source, path, endpoint) if include_callee
+            elsif info = @global_handler_info.try(&.[leaf]?)
+              # The handler lives in another file (`routes/x.rs` references a
+              # `#[handler]` in `handler/x.rs`). Its params + callees were
+              # precomputed in the cross-file index.
+              info.params.each do |p|
+                endpoint.push_param(p) unless endpoint.params.any? { |x| x.name == p.name && x.param_type == p.param_type }
+              end
+              attach_rust_callees(endpoint, info.callees) if include_callee
+            end
           end
 
           endpoints << endpoint
@@ -445,15 +502,26 @@ module Analyzer::Rust
         when "call_expression"
           fn_text = call_function_text(node, source)
           next if fn_text.nil?
-          if fn_text == "req.query" && !endpoint.params.any? { |p| p.name == "query" && p.param_type == "query" }
+          # Strip a turbofish so `req.header::<&str>("x")` /
+          # `req.parse_json::<T>()` match like their bare forms.
+          base = fn_text.gsub(/::<[^>]*>/, "")
+          if (base == "req.query" || base.ends_with?(".parse_queries")) && !endpoint.params.any? { |p| p.name == "query" && p.param_type == "query" }
             endpoint.push_param(Param.new("query", "", "query"))
           end
-          if fn_text == "req.header" || fn_text.ends_with?("req.headers().get")
+          # Salvo's request-side body extractors: `req.parse_json::<T>()` /
+          # `req.extract::<T>()` (JSON) and `req.parse_form::<T>()` (form).
+          if (base.ends_with?(".parse_json") || base.ends_with?(".extract")) && !endpoint.params.any? { |p| p.name == "body" && p.param_type == "json" }
+            endpoint.push_param(Param.new("body", "", "json"))
+          end
+          if base.ends_with?(".parse_form") && !endpoint.params.any? { |p| p.name == "form" && p.param_type == "form" }
+            endpoint.push_param(Param.new("form", "", "form"))
+          end
+          if base == "req.header" || base.ends_with?("req.headers().get")
             if name = first_string_literal_text(Noir::TreeSitter.field(node, "arguments"), source)
               endpoint.push_param(Param.new(name, "", "header")) unless endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
             end
           end
-          if fn_text == "req.cookie"
+          if base == "req.cookie"
             if name = first_string_literal_text(Noir::TreeSitter.field(node, "arguments"), source)
               endpoint.push_param(Param.new(name, "", "cookie")) unless endpoint.params.any? { |p| p.name == name && p.param_type == "cookie" }
             end


### PR DESCRIPTION
## Summary

Salvo apps register routes in `routes/x.rs` (`.get(add_user)`) while the `#[handler]` fn lives in `handler/x.rs`. The per-file function index couldn't see those, so every such endpoint surfaced with **zero params and zero callees** — poor AI context for a common real-app layout (salvo_admin: 0 callees across all 69 endpoints).

## What changed

`analyze()` builds a project-wide `#[handler]` index (params + callees, keyed by handler name, gated to files carrying `#[handler]` and to callee/ai-context mode), and the chain emitter falls back to it when the per-file index misses.

Also extends request-side param detection to salvo's own extractors, stripping a turbofish so:
- `req.parse_json::<T>()` → json body
- `req.parse_form::<T>()` → form
- `req.parse_queries()` → query
- `req.header::<&str>("x")` → header

(`req.query`/`req.header`/`req.cookie` kept as exact matches to avoid `db.query()`-style false positives.)

## Impact (real OSS, ai-context mode)

- **salvo_admin**: 0 → **575 callees**, 0 → **67 params** (e.g. `POST /api/system/user/login` now has `req.parse_json`, `req.header`, `UserAgentUtil::new`, … callees from its cross-file handler body).
- **salvo repo**: 387 → 397 callees, +12 params.
- **myblog**: unchanged (same-file handlers already resolved).

This is the "better callee / ai-context" half of the goal: routes were already correct after the round-3 prefix work; now their handler bodies are analyzed even across files. Scan time stays flat — the index is gated on `#[handler]` presence and only built in callee/ai-context mode.

## Tests

New `salvo_xfile_callee` fixture covers a route whose `#[handler]` lives in another file, asserting the composed URL plus the cross-file params and callees. All 1337 rust functional specs pass.