### PR TITLE
fix(python/pyramid): inherit route_name from multi-line @view_defaults

### DIFF
--- a/spec/functional_test/fixtures/python/pyramid/app.py
+++ b/spec/functional_test/fixtures/python/pyramid/app.py
@@ -65,6 +65,27 @@ class OrdersView:
         return {"order_id": order_id}
 
 
+# Multi-line @view_defaults: the closing `)` sits directly above the
+# class, so the route_name must still be inherited by the methods below.
+@view_defaults(
+    route_name="reports",
+    renderer="json",
+    permission="view",
+)
+class ReportsView:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(request_method="GET")
+    def list(self):
+        scope = self.request.params.get("scope")
+        return {"scope": scope}
+
+    @view_config(request_method="DELETE")
+    def delete(self):
+        return {}
+
+
 def main(global_config, **settings):
     config = Configurator(settings=settings)
     config.add_route("home", "/")
@@ -74,6 +95,7 @@ def main(global_config, **settings):
     config.add_route(pattern="/about", name="about")
     config.add_route("ping", "/ping")
     config.add_route("orders", "/orders")
+    config.add_route("reports", "/reports")
     config.add_static_view(
         name="assets",
         path="public",

--- a/spec/functional_test/testers/python/pyramid_spec.cr
+++ b/spec/functional_test/testers/python/pyramid_spec.cr
@@ -34,6 +34,13 @@ expected_endpoints = [
   Endpoint.new("/orders", "POST", [
     Param.new("order_id", "", "json"),
   ]),
+  # Multi-line @view_defaults(route_name="reports") — methods inherit the
+  # class route_name even though the decorator's closing `)` is the line
+  # directly above the class.
+  Endpoint.new("/reports", "GET", [
+    Param.new("scope", "", "query"),
+  ]),
+  Endpoint.new("/reports", "DELETE"),
   Endpoint.new("/assets/*", "GET"),
 ]
 

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -229,13 +229,24 @@ module Analyzer::Python
       while idx >= 0
         line = lines[idx]
         stripped = line.lstrip
+        # A blank line ends the decorator block above the class.
         break if stripped.empty?
-        break unless stripped.starts_with?("@") || decorators.size > 0
 
         decorators.unshift(line)
+        # Stop once we reach the start of the `@view_defaults` decorator.
+        # The previous loop bailed on the FIRST line above the class when
+        # it didn't start with `@` — but a MULTI-LINE
+        # `@view_defaults(\n  route_name="x",\n)` puts the closing `)` (a
+        # continuation line, not an `@…`) directly above the class, so the
+        # whole decorator was skipped and the inherited route_name lost
+        # (warehouse: 18 class-based views via multi-line @view_defaults).
+        # Collect continuation lines until the `@view_defaults` head.
         break if stripped.starts_with?("@view_defaults") ||
                  stripped.starts_with?("@pyramid.view.view_defaults") ||
                  stripped.starts_with?("@pyramid.view_defaults")
+        # Defensive cap so a class with no decorators (no blank-line gap
+        # above it) doesn't walk the whole file.
+        break if decorators.size > 60
         idx -= 1
       end
 


### PR DESCRIPTION
Audited the PyPI **warehouse** codebase (a large real Pyramid app) — **240 → 270 python endpoints (+30)**.

Pyramid class-based views set a shared `route_name` on the class via `@view_defaults` and per-method verbs via `@view_config(request_method=...)`. The analyzer already falls back to the class `@view_defaults` route_name when a method's `@view_config` omits it — but only for a **single-line** decorator. With the common multi-line form:

```python
@view_defaults(
    route_name="manage.organizations",
    renderer="...",
)
class ManageOrganizationsViews:
    @view_config(request_method="GET")
    def list(self): ...
```

the closing `)` is the line directly above the class, and the upward collector bailed on it (it required the first line above the class to start with `@`). The decorator was skipped and every method's route was lost.

Fix: collect continuation lines upward until the `@view_defaults` head.

## Validation
warehouse recovers 18 class-based view groups (`/manage/organizations/`, `/manage/organization/{organization_name}/settings/`, `/security-key-giveaway/`, …). A multi-line `@view_defaults` case was added to the pyramid fixture. 58 pyramid functional + full suite (19758 examples) pass; single-line `@view_defaults` unaffected.