### PR TITLE
fix(gotham): gate #[cfg(test)] route registrations out of results

### DIFF
--- a/spec/functional_test/fixtures/rust/gotham_cfgtest/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/gotham_cfgtest/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gotham_cfgtest_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gotham = "0.7"

--- a/spec/functional_test/fixtures/rust/gotham_cfgtest/src/main.rs
+++ b/spec/functional_test/fixtures/rust/gotham_cfgtest/src/main.rs
@@ -1,0 +1,24 @@
+// Only the production route should surface; the cfg(test)-gated tests module
+// below registers routes purely to exercise the router and must be excluded.
+use gotham::router::builder::*;
+use gotham::router::Router;
+
+fn router() -> Router {
+    Router::builder().get("/health").to(health)
+}
+
+fn health() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_router_test() {
+        let _ = Router::builder()
+            .get("/test-only")
+            .to(health)
+            .post("/internal/submit")
+            .to(health);
+    }
+}

--- a/spec/functional_test/testers/rust/gotham_cfgtest_spec.cr
+++ b/spec/functional_test/testers/rust/gotham_cfgtest_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Routes registered inside a `#[cfg(test)] mod tests { ... }` block are
+# unit-test scaffolding, not production endpoints. The gotham analyzer now
+# gates them out via the shared cfg(test) region scan (like axum/loco/tide/
+# salvo), so only the production route surfaces.
+expected_endpoints = [
+  Endpoint.new("/health", "GET"),
+]
+
+FunctionalTester.new("fixtures/rust/gotham_cfgtest/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_gotham"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/gotham.cr
+++ b/src/analyzer/analyzers/rust/gotham.cr
@@ -23,9 +23,15 @@ module Analyzer::Rust
       source = read_file_content(path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
+      # Gotham's framework repo parks route registrations inside
+      # `#[cfg(test)] mod tests { ... build_router(|route| { route.get(...) }) }`
+      # blocks (e.g. `router/builder/mod.rs`). Gate them out like the other
+      # Rust analyzers do, via the shared cfg(test) region scan.
+      test_regions = RustEngine.collect_cfg_test_regions(source)
+
       Noir::TreeSitter.parse_rust(source) do |root|
         function_index = build_function_index(root, source)
-        walk_with_prefix(root, source, "", path, function_index, include_callee, endpoints)
+        walk_with_prefix(root, source, "", path, function_index, include_callee, endpoints, test_regions)
       end
 
       endpoints
@@ -44,15 +50,16 @@ module Analyzer::Rust
                                  path : String,
                                  function_index : Hash(String, LibTreeSitter::TSNode),
                                  include_callee : Bool,
-                                 endpoints : Array(Endpoint))
-      if Noir::TreeSitter.node_type(node) == "call_expression"
+                                 endpoints : Array(Endpoint),
+                                 test_regions : Array(Tuple(Int32, Int32)))
+      if Noir::TreeSitter.node_type(node) == "call_expression" && !RustEngine.inside_test_region?(node, test_regions)
         if scope = decode_scope(node, source)
           seg, block = scope
-          walk_with_prefix(block, source, join_paths(prefix, seg), path, function_index, include_callee, endpoints)
+          walk_with_prefix(block, source, join_paths(prefix, seg), path, function_index, include_callee, endpoints, test_regions)
           return
         end
         if block = decode_pipeline_closure(node, source)
-          walk_with_prefix(block, source, prefix, path, function_index, include_callee, endpoints)
+          walk_with_prefix(block, source, prefix, path, function_index, include_callee, endpoints, test_regions)
           return
         end
         if assoc = decode_associate(node, source)
@@ -81,7 +88,7 @@ module Analyzer::Rust
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_with_prefix(child, source, prefix, path, function_index, include_callee, endpoints)
+        walk_with_prefix(child, source, prefix, path, function_index, include_callee, endpoints, test_regions)
       end
     end
 


### PR DESCRIPTION
## Summary

The gotham analyzer was the **only** Rust analyzer not gating `#[cfg(test)]` blocks. gotham's own framework repo parks a `build_router_test()` under `#[cfg(test)] mod tests` in `router/builder/mod.rs`, so its scaffolding routes leaked into output as production endpoints:

```
GET /resource, GET /hello/:name, GET /add, GET /b, POST /api/submit,
GET /goodbye/:name:[a-zA-Z]+, GET /trailing-slash/, DELETE/HEAD/PATCH/POST /resource, ...
```

## What changed

`analyze_file` now runs the shared `RustEngine.collect_cfg_test_regions` scan, and `walk_with_prefix` skips any `call_expression` inside a test region — matching axum/loco/tide/salvo.

## Impact (real OSS)

- **gotham framework repo**: 41 → **28** (−13 `#[cfg(test)]`-only routes that were false positives).
- Real example apps unaffected (their routes are production).

## Tests

New `gotham_cfgtest` fixture: a production `.get("/health")` plus a `#[cfg(test)] mod tests` block whose routes must be excluded. All 1353 rust functional specs pass.