### PR TITLE
fix(rocket): resolve route collectors aliased in a nested use group

### DIFF
--- a/spec/functional_test/fixtures/rust/rocket_nested_alias/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/rocket_nested_alias/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "rocket_nested_alias_fixture"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rocket = "0.5"

--- a/spec/functional_test/fixtures/rust/rocket_nested_alias/src/events.rs
+++ b/spec/functional_test/fixtures/rust/rocket_nested_alias/src/events.rs
@@ -1,0 +1,11 @@
+use rocket::{post, routes, Route};
+
+// mounted at /events via the aliased collector -> POST /events/collect
+#[post("/collect")]
+fn post_events_collect() -> &'static str {
+    "ok"
+}
+
+pub fn build_routes() -> Vec<Route> {
+    routes![post_events_collect]
+}

--- a/spec/functional_test/fixtures/rust/rocket_nested_alias/src/main.rs
+++ b/spec/functional_test/fixtures/rust/rocket_nested_alias/src/main.rs
@@ -1,0 +1,16 @@
+// A collector re-exported through a *nested* `use` group: the alias path is
+// relative to the inner group (`build_routes`, not `events::build_routes`),
+// so the mount must resolve it as a module-qualified suffix to apply /events.
+#[macro_use]
+extern crate rocket;
+
+mod events;
+
+use crate::{
+    events::{build_routes as events_routes},
+};
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build().mount("/events", events_routes())
+}

--- a/spec/functional_test/testers/rust/rocket_nested_alias_spec.cr
+++ b/spec/functional_test/testers/rust/rocket_nested_alias_spec.cr
@@ -1,0 +1,17 @@
+require "../../func_spec.cr"
+
+# A route collector re-exported through a nested `use crate::{ events::{
+# build_routes as events_routes } }` group. The alias target is recorded
+# relative to the inner group (`build_routes`), so the `.mount("/events",
+# events_routes())` resolution must match it as a unique module-qualified
+# suffix to apply the /events prefix (vaultwarden's core_events_routes shape).
+expected_endpoints = [
+  Endpoint.new("/events/collect", "POST"),
+]
+
+FunctionalTester.new("fixtures/rust/rocket_nested_alias/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "only_techs" => YAML::Any.new("rust_rocket"),
+}).perform_tests

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -280,6 +280,13 @@ module Analyzer::Rust
       leaf = ref.split("::").last
       if target = alias_map[leaf]?
         return target if fn_leaves.has_key?(target)
+        # A re-export written inside a nested `use a::{ b as c }` group records
+        # the alias target relative to that group (`events_routes`, not
+        # `core::events_routes`), so it won't be a registry key directly —
+        # match it as a unique module-qualified suffix instead.
+        tleaf = target.split("::").last
+        tmatches = fn_leaves.keys.select(&.ends_with?("::#{tleaf}"))
+        return tmatches.first if tmatches.size == 1
       end
       segs = ref.split("::")
       cand = segs.size >= 2 ? "#{segs[-2]}::#{segs[-1]}" : segs[-1]


### PR DESCRIPTION
## Summary

vaultwarden re-exports its events collector through a **doubly-nested** `use` group:

```rust
pub use crate::api::{
    core::{ events_routes as core_events_routes },  // <- relative to core::
};
.mount([basepath, "/events"].concat(), api::core_events_routes())
```

tree-sitter records the `use_as_clause` path **relative to the inner `core::` group** (`events_routes`, not `core::events_routes`), so the alias target wasn't a registry key and the mount chain went unresolved — `post_events_collect` (`#[post("/collect")]`) surfaced as `POST /collect` instead of `POST /events/collect`.

(Found by an adversarial audit of the round-3 mount-composition work — the one real miss out of vaultwarden's 298 routes.)

## What changed

`resolve_fn_key` now falls back to a **unique module-qualified suffix match** when the alias target isn't a direct registry key, so the relative `events_routes` resolves to `core::events_routes` → `events::main_routes` → `post_events_collect`.

## Impact

- **vaultwarden**: `POST /collect` → `POST /events/collect` (total flat at 298).

## Tests

New `rocket_nested_alias` fixture covers a collector re-exported through a nested `use` group. All 1361 rust functional specs pass.