### PR TITLE
style(lint): use find! instead of find {...}.not_nil! in http4k spec

### DIFF
--- a/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
@@ -102,12 +102,12 @@ describe Noir::TreeSitterHttp4kExtractor do
       )
       KT
     routes = Noir::TreeSitterHttp4kExtractor.extract_routes(source)
-    redirect = routes.find { |r| r.path == "/redirect" }.not_nil!
+    redirect = routes.find! { |r| r.path == "/redirect" }
     redirect.query_params.should eq(["target"])
     redirect.header_params.should be_empty
     redirect.has_body?.should be_false
 
-    ping = routes.find { |r| r.path == "/ping" }.not_nil!
+    ping = routes.find! { |r| r.path == "/ping" }
     ping.has_body?.should be_false
   end
 end


### PR DESCRIPTION
Fixes the `lint` CI job failure on main. ameba `Lint/NotNilAfterNoBang` flagged two `routes.find {...}.not_nil!` calls in `spec/unit_test/miniparser/http4k_extractor_ts_spec.cr` (introduced in #1891). Replaced with the equivalent `find! {...}`.

Full ameba run after the fix: **1323 inspected, 0 failures**. http4k spec still passes (5 examples).