### PR TITLE
fix(python/flask): don't claim foreign-framework handler files

### DIFF
--- a/spec/functional_test/fixtures/python/flask_foreign/app.py
+++ b/spec/functional_test/fixtures/python/flask_foreign/app.py
@@ -1,0 +1,9 @@
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+@app.route("/flask-home", methods=["GET"])
+def home():
+    q = request.args.get("q")
+    return {"q": q}

--- a/spec/functional_test/fixtures/python/flask_foreign/service.py
+++ b/spec/functional_test/fixtures/python/flask_foreign/service.py
@@ -1,0 +1,16 @@
+# A FastAPI handler file in the same repo. It uses `@app.get`/`@app.post`
+# decorators and never mentions flask. The Flask analyzer must NOT claim
+# it (mislabeling its routes python_flask); the FastAPI analyzer owns it.
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/fastapi-items")
+def list_items():
+    return []
+
+
+@app.post("/fastapi-items")
+def create_item(name: str):
+    return {"name": name}

--- a/spec/functional_test/testers/python/flask_foreign_spec.cr
+++ b/spec/functional_test/testers/python/flask_foreign_spec.cr
@@ -1,0 +1,23 @@
+require "../../func_spec.cr"
+
+# A repo with BOTH a Flask app (app.py) and a FastAPI handler file
+# (service.py) that uses `@app.get`/`@app.post` and never mentions flask.
+# The Flask analyzer must not claim the FastAPI file — its routes belong
+# to the FastAPI analyzer (python_fastapi), not python_flask.
+expected_endpoints = [
+  Endpoint.new("/flask-home", "GET", [Param.new("q", "", "query")]),
+  Endpoint.new("/fastapi-items", "GET"),
+  Endpoint.new("/fastapi-items", "POST", [Param.new("name", "", "query")]),
+]
+
+tester = FunctionalTester.new("fixtures/python/flask_foreign/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+tester.perform_tests
+
+it "tags FastAPI handler-file routes python_fastapi, not python_flask" do
+  fastapi_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/fastapi-items" && endpoint.method == "POST" }
+  fastapi_route.should_not be_nil
+  fastapi_route.try(&.details.technology).should eq("python_fastapi")
+end

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -791,6 +791,17 @@ module Analyzer::Python
 
     private def flask_relevant_source?(source : ::String) : Bool
       return true if source.includes?("flask")
+      # A file that imports a competing decorator-based framework (and
+      # never mentions flask) is NOT Flask — its `@app.get`/`@router.post`
+      # decorators belong to that framework's analyzer. Without this
+      # guard, in any repo where the Flask detector fires (e.g. a sibling
+      # Flask example), the Flask analyzer ALSO claimed FastAPI / Sanic /
+      # Litestar / Starlette / Quart / Robyn handler files and mislabeled
+      # their routes `python_flask` with Flask-style (usually empty)
+      # params. The route's real owner still emits it correctly, so this
+      # only drops the duplicate mislabel (jupyterhub examples/service-
+      # fastapi was reported as python_flask).
+      return false if source.matches?(/^\s*(?:from|import)\s+(?:fastapi|sanic|litestar|starlette|quart|robyn)\b/m)
       return true if source.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
       return true if source.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
 


### PR DESCRIPTION
`flask_relevant_source?` treated **any** file containing an `@x.get(` / `@x.route(` decorator as Flask. In a repo where the Flask detector fires (e.g. a sibling Flask example), the Flask analyzer therefore also processed **FastAPI / Sanic / Litestar / Starlette / Quart / Robyn** handler files and emitted their routes as `python_flask` with Flask-style params. The route's real owner emits the same route too, so cross-analyzer dedup kept whichever ran first — frequently the wrong (Flask) tag.

**Guard:** a source that imports one of those frameworks and never mentions `flask` is not Flask-relevant. Files that genuinely use Flask (mention `flask`, or a blueprint route file with no competing import) are unaffected.

The endpoint set is unchanged — this only fixes the **technology attribution** (and params now come from the correct analyzer, which matters for AI context).

## Validation
- jupyterhub: `examples/service-fastapi/*` + `forced-login/*` routes now `python_fastapi` (were `python_flask`); total unique endpoints identical (146 with/without the guard — verified by stashed A/B build).
- New `flask_foreign` fixture (a Flask app + a FastAPI handler file in one scan) asserts the FastAPI routes are tagged `python_fastapi`.
- CTFd / microblog / flaskbb / apiflask / indico byte-identical. 19799 examples + ameba clean.