### PR TITLE
fix(python/flask): strip comments before relevance checks in flask_relevant_source?

### DIFF
--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -790,7 +790,15 @@ module Analyzer::Python
     end
 
     private def flask_relevant_source?(source : ::String) : Bool
-      return true if source.includes?("flask")
+      # Strip # comments (to EOL) before relevance heuristics. This prevents
+      # explanatory comments (in fixtures, docs, or real code) that mention
+      # framework names from causing mis-attribution. E.g. a FastAPI file
+      # whose comment says "flask" would otherwise bypass the competing-import
+      # guard and emit duplicate routes under python_flask tech (which then
+      # wins dedup non-deterministically depending on fiber completion order).
+      clean = source.gsub(/#.*?(?:\n|\z)/m, "\n")
+
+      return true if clean.includes?("flask")
       # A file that imports a competing decorator-based framework (and
       # never mentions flask) is NOT Flask — its `@app.get`/`@router.post`
       # decorators belong to that framework's analyzer. Without this
@@ -801,9 +809,9 @@ module Analyzer::Python
       # params. The route's real owner still emits it correctly, so this
       # only drops the duplicate mislabel (jupyterhub examples/service-
       # fastapi was reported as python_flask).
-      return false if source.matches?(/^\s*(?:from|import)\s+(?:fastapi|sanic|litestar|starlette|quart|robyn)\b/m)
-      return true if source.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
-      return true if source.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
+      return false if clean.matches?(/^\s*(?:from|import)\s+(?:fastapi|sanic|litestar|starlette|quart|robyn)\b/m)
+      return true if clean.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
+      return true if clean.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
 
       false
     end


### PR DESCRIPTION
The guard added in 0a16014 ("don't claim foreign-framework handler files") used a loose `source.includes?("flask")` *before* the competing-import check. Any file whose *comment* mentioned "flask" (including the new `flask_foreign` fixture's own explanatory comments, and real-world docs or "similar to flask" notes) would be treated as Flask-relevant.

This caused the Flask analyzer to also emit the FastAPI (etc.) routes. Since all Python analyzers run concurrently and results are concatenated before dedup, the `(method, url)` key in `optimize_endpoints` could be first seen from either analyzer depending on fiber completion order. The `flask_foreign` test's assertion on `.details.technology == "python_fastapi"` therefore flaked (seen as `python_flask` in https://github.com/owasp-noir/noir/actions/runs/26984272313/job/79630377888).

- Comment-strip (`gsub(/#.*?(?:\n|\z)/m, "\n")`) before all relevance heuristics so "flask" in comments/docs no longer triggers false positive.
- The competing import guard now reliably fires for pure FastAPI/Sanic/etc. files even when the Flask detector fired on a sibling file in the tree.
- Decorator and `add_url_rule` fallbacks also now ignore commented-out code.
- 20+ repeated runs of the specific spec + full suite + manual `./bin/noir` run on the fixture all confirm stable `python_fastapi` attribution with no cross-claim duplicates.

This makes the foreign-framework guard (and the per-file relevance filters used by other Python analyzers) robust.

Fixes the test breakage reported in the linked CI run.
