### PR TITLE
Fix GraphQL SDL detection for operation documents

### DIFF
--- a/spec/unit_test/detector/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/detector/specification/graphql_sdl_spec.cr
@@ -16,6 +16,24 @@ describe "Detect GraphQL SDL" do
     instance.detect("schema.graphql", content).should be_true
   end
 
+  it "detects SDL with regular-string description on same line as declaration" do
+    content = <<-SDL
+      "Description for the root" type Query {
+        hello: String
+      }
+      SDL
+
+    instance.detect("schema.graphql", content).should be_true
+  end
+
+  it "detects SDL with block-string description immediately followed by declaration on same line" do
+    content = <<-SDL
+      """Block desc""" type Query { hello: String }
+      SDL
+
+    instance.detect("schema.graphql", content).should be_true
+  end
+
   it ".graphqls with schema block" do
     content = <<-SDL
       schema {
@@ -51,6 +69,24 @@ describe "Detect GraphQL SDL" do
   it "rejects operation documents with SDL keyword field names" do
     content = <<-GQL
       query GetStore {
+        store {
+          id
+          type
+          schema {
+            enum
+          }
+        }
+      }
+      GQL
+
+    instance.detect("ops.graphql", content).should be_false
+  end
+
+  it "rejects operation documents even when string literals contain braces, #, or SDL keywords" do
+    # Strings can contain example SDL, # (not comments), or unbalanced braces.
+    # These must not affect depth tracking or cause false SDL detection.
+    content = <<-GQL
+      query GetStore($filter: Filter = "{ schema: 1 } # not a comment", $desc: String = "type Query { x }") {
         store {
           id
           type

--- a/spec/unit_test/detector/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/detector/specification/graphql_sdl_spec.cr
@@ -48,6 +48,22 @@ describe "Detect GraphQL SDL" do
     instance.detect("ops.graphql", content).should be_false
   end
 
+  it "rejects operation documents with SDL keyword field names" do
+    content = <<-GQL
+      query GetStore {
+        store {
+          id
+          type
+          schema {
+            enum
+          }
+        }
+      }
+      GQL
+
+    instance.detect("ops.graphql", content).should be_false
+  end
+
   it "rejects non-graphql files" do
     instance.applicable?("schema.json").should be_false
   end

--- a/src/detector/detectors/specification/graphql_sdl.cr
+++ b/src/detector/detectors/specification/graphql_sdl.cr
@@ -3,17 +3,66 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class GraphqlSdl < Detector
-    # Top-level SDL signals — distinguishes a schema document from an
-    # operation document (which the file_analyzers/graphql_analyzer handles).
-    SDL_SIGNAL = /^[\s]*(?:extend\s+)?(?:type|input|interface|union|enum|scalar|directive|schema)\b/m
+    # SDL declaration signals — distinguished at top-level only by
+    # `sdl_document?`. A broad keyword-only check is too loose: generated
+    # operation documents often select fields named `type`, `schema`, or
+    # `enum`, and those field names can appear at the start of an indented line.
+    SDL_DECLARATION = /^(?:(?:extend\s+)?(?:type|input|interface|enum|scalar)\s+[A-Za-z_][A-Za-z0-9_]*\b|(?:extend\s+)?union\s+[A-Za-z_][A-Za-z0-9_]*\s*=|directive\s+@[A-Za-z_][A-Za-z0-9_]*\b|(?:extend\s+)?schema\b)/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless file_contents.match(SDL_SIGNAL)
+      return false unless sdl_document?(file_contents)
 
       locator = CodeLocator.instance
       locator.push("graphql-sdl", filename)
       true
+    end
+
+    private def sdl_document?(file_contents : String) : Bool
+      depth = 0
+      in_block_string = false
+
+      file_contents.each_line do |line|
+        candidate, in_block_string = detection_line(line, in_block_string)
+        if depth == 0 && candidate.strip.match(SDL_DECLARATION)
+          return true
+        end
+
+        depth = update_depth(candidate, depth)
+      end
+
+      false
+    end
+
+    private def detection_line(line : String, in_block_string : Bool) : Tuple(String, Bool)
+      return {"", true} if in_block_string && !line.includes?("\"\"\"")
+      return {"", false} if in_block_string
+
+      if triple_start = line.index("\"\"\"")
+        before = line[0...triple_start]
+        rest = line[(triple_start + 3)..]
+        if rest && rest.includes?("\"\"\"")
+          return {before, false}
+        end
+        return {before, true}
+      end
+
+      comment_start = line.index('#')
+      return {line[0...comment_start], false} if comment_start
+      {line, false}
+    end
+
+    private def update_depth(line : String, current : Int32) : Int32
+      depth = current
+      line.each_char do |char|
+        case char
+        when '{'
+          depth += 1
+        when '}'
+          depth -= 1 if depth > 0
+        end
+      end
+      depth
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/specification/graphql_sdl.cr
+++ b/src/detector/detectors/specification/graphql_sdl.cr
@@ -7,6 +7,14 @@ module Detector::Specification
     # `sdl_document?`. A broad keyword-only check is too loose: generated
     # operation documents often select fields named `type`, `schema`, or
     # `enum`, and those field names can appear at the start of an indented line.
+    #
+    # `sdl_document?` walks the document with a small state machine:
+    # - tracks brace depth (only outside strings) so keywords inside selections,
+    #   fragments, or default values are ignored
+    # - skips block strings (""") and regular strings ("...") so that string
+    #   literals containing SDL-like keywords, #, or {}/ do not affect detection
+    #   or depth (e.g. default values or descriptions with example SDL)
+    # - strips # comments only when not inside a string
     SDL_DECLARATION = /^(?:(?:extend\s+)?(?:type|input|interface|enum|scalar)\s+[A-Za-z_][A-Za-z0-9_]*\b|(?:extend\s+)?union\s+[A-Za-z_][A-Za-z0-9_]*\s*=|directive\s+@[A-Za-z_][A-Za-z0-9_]*\b|(?:extend\s+)?schema\b)/
 
     def detect(filename : String, file_contents : String) : Bool
@@ -21,9 +29,10 @@ module Detector::Specification
     private def sdl_document?(file_contents : String) : Bool
       depth = 0
       in_block_string = false
+      in_string = false
 
       file_contents.each_line do |line|
-        candidate, in_block_string = detection_line(line, in_block_string)
+        candidate, in_block_string, in_string = detection_line(line, in_block_string, in_string)
         if depth == 0 && candidate.strip.match(SDL_DECLARATION)
           return true
         end
@@ -34,22 +43,66 @@ module Detector::Specification
       false
     end
 
-    private def detection_line(line : String, in_block_string : Bool) : Tuple(String, Bool)
-      return {"", true} if in_block_string && !line.includes?("\"\"\"")
-      return {"", false} if in_block_string
+    # Returns the "visible" code portion of the line (strings and comments excised)
+    # and the updated string states for the *next* line.
+    private def detection_line(line : String, in_block_string : Bool, in_string : Bool) : Tuple(String, Bool, Bool)
+      visible = String::Builder.new
+      i = 0
+      curr_block = in_block_string
+      curr_str = in_string
 
-      if triple_start = line.index("\"\"\"")
-        before = line[0...triple_start]
-        rest = line[(triple_start + 3)..]
-        if rest && rest.includes?("\"\"\"")
-          return {before, false}
+      while i < line.size
+        if curr_block
+          # inside block string: skip until we see closing """
+          if i + 2 < line.size && line[i] == '"' && line[i + 1] == '"' && line[i + 2] == '"'
+            curr_block = false
+            i += 3
+            next
+          end
+          i += 1
+          next
         end
-        return {before, true}
+
+        if curr_str
+          # inside regular "string": skip until unescaped closing "
+          ch = line[i]
+          if ch == '\\' && i + 1 < line.size
+            i += 2
+            next
+          end
+          if ch == '"'
+            curr_str = false
+            i += 1
+            next
+          end
+          i += 1
+          next
+        end
+
+        # not inside any string
+        ch = line[i]
+        if ch == '"'
+          if i + 2 < line.size && line[i + 1] == '"' && line[i + 2] == '"'
+            curr_block = true
+            i += 3
+            next
+          else
+            curr_str = true
+            i += 1
+            next
+          end
+        end
+
+        if ch == '#'
+          # comment: stop here, do not include # or rest of line in visible code
+          break
+        end
+
+        visible << ch
+        i += 1
       end
 
-      comment_start = line.index('#')
-      return {line[0...comment_start], false} if comment_start
-      {line, false}
+      {visible.to_s, curr_block, curr_str}
     end
 
     private def update_depth(line : String, current : Int32) : Int32


### PR DESCRIPTION
### Summary

- tighten GraphQL SDL detection so SDL keywords are only accepted as top-level declarations
- avoid treating GraphQL operation selection fields such as `type`, `schema`, or `enum` as SDL schema signals
- add a regression test for operation documents containing SDL keyword field names

Fixes #1902.

### Verification

- `crystal spec spec/unit_test/detector/specification/graphql_sdl_spec.cr`
- `crystal spec spec/unit_test/detector/specification/graphql_sdl_spec.cr spec/unit_test/analyzer/specification/graphql_sdl_spec.cr spec/functional_test/testers/specification/graphql_sdl_spec.cr`
- `just check`
- `just build`
- `./bin/noir scan /Users/pluto.h/z_app/test/guest-front/packages/bff/src/swg2gql/partner --only-techs graphql_sdl --no-spinner --no-color --no-log` completed in ~0.95s