### PR TITLE
fix(tagger): reduce FP/FN in crypto, debug, file_upload taggers

### DIFF
--- a/spec/unit_test/tagger/taggers/crypto_spec.cr
+++ b/spec/unit_test/tagger/taggers/crypto_spec.cr
@@ -70,6 +70,46 @@ describe "CryptoTagger" do
       endpoint.tags[0].name.should eq("crypto")
     end
 
+    it "tags modern and legacy primitive paths (sha3, chacha20, rc4, 3des, pkcs12)" do
+      tagger = CryptoTagger.new(default_tagger_options)
+
+      endpoints = [
+        Endpoint.new("/api/sha3/digest", "POST"),
+        Endpoint.new("/v1/chacha20/encrypt", "POST"),
+        Endpoint.new("/legacy/rc4", "POST"),
+        Endpoint.new("/cipher/3des", "POST"),
+        Endpoint.new("/keys/export.pkcs12", "GET"),
+      ]
+
+      tagger.perform(endpoints)
+
+      endpoints.each { |ep| ep.tags.map(&.name).should contain("crypto") }
+    end
+
+    it "tags a JOSE jwe/jws path" do
+      tagger = CryptoTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/token/jwe", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("crypto")
+    end
+
+    it "tags an endpoint with a pubkey/privkey parameter" do
+      tagger = CryptoTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/op", "POST", [
+        Param.new("privkey", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("crypto")
+    end
+
     it "tags when two distinct weak signals co-occur" do
       tagger = CryptoTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/debug_spec.cr
+++ b/spec/unit_test/tagger/taggers/debug_spec.cr
@@ -117,6 +117,30 @@ describe "DebugTagger" do
       endpoint.tags[0].name.should eq("debug")
     end
 
+    it "tags an Xdebug remote-debug trigger parameter" do
+      tagger = DebugTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/data", "GET", [
+        Param.new("XDEBUG_SESSION_START", "phpstorm", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("debug")
+    end
+
+    it "tags a Laravel Debugbar path" do
+      tagger = DebugTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/_debugbar/open", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("debug")
+    end
+
     it "tags when two distinct weak diagnostic tokens co-occur" do
       tagger = DebugTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/file_upload_spec.cr
+++ b/spec/unit_test/tagger/taggers/file_upload_spec.cr
@@ -152,6 +152,32 @@ describe "FileUploadTagger" do
       endpoint.tags[0].name.should eq("file_upload")
     end
 
+    it "tags a param whose type is \"file\" regardless of its name" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      # PHP `$_FILES['cv']` / Symfony `$request->files->get('resume')`
+      # surface the raw variable name, which is not in WORDS.
+      endpoint = Endpoint.new("/upload.php", "POST", [
+        Param.new("cv", "", "file"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("file_upload")
+    end
+
+    it "tags POST endpoint with an images path" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/images", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("file_upload")
+    end
+
     it "tags PATCH endpoint with avatar body parameter" do
       tagger = FileUploadTagger.new(default_tagger_options)
 

--- a/src/tagger/taggers/crypto.cr
+++ b/src/tagger/taggers/crypto.cr
@@ -13,21 +13,30 @@ class CryptoTagger < Tagger
   # Unambiguous crypto path segments — one is enough. Matched as whole
   # segments after splitting on `/`, `-`, `_`, `.`. Includes named
   # primitives (aes/rsa/sha256/bcrypt/…) and key-management verbs that
-  # carry no benign meaning as a standalone path segment.
+  # carry no benign meaning as a standalone path segment. Legacy/weak
+  # algorithms (md5/sha1/rc4/3des/blowfish) are kept on purpose — surfacing
+  # an endpoint that still uses one is the point of this tag. Each named
+  # primitive carries a digit or is otherwise distinctive enough to never
+  # collide with a benign word as a whole path segment.
   STRONG_PATH_PARTS = Set{
     "encrypt", "decrypt", "encryption", "decryption", "cipher",
-    "crypto", "cryptography", "hmac", "jwks", "jwk", "jwt", "keystore",
-    "kms", "pgp", "gpg", "unseal", "x509",
-    "aes", "rsa", "dsa", "ecdsa", "ed25519", "sha1", "sha256", "sha512",
-    "md5", "bcrypt", "argon2", "scrypt", "pbkdf2",
+    "crypto", "cryptography", "hmac", "jwks", "jwk", "jwt", "jws", "jwe",
+    "keystore", "kms", "pgp", "gpg", "unseal", "x509",
+    "pkcs7", "pkcs8", "pkcs12", "pfx",
+    "aes", "rsa", "dsa", "ecdsa", "ecdh", "ed25519", "ed448",
+    "x25519", "x448", "curve25519", "secp256k1",
+    "sha1", "sha224", "sha256", "sha384", "sha512", "sha3", "keccak",
+    "ripemd", "ripemd160", "md5", "blake2", "blake3",
+    "rc4", "3des", "blowfish", "twofish", "chacha20", "salsa20",
+    "bcrypt", "argon2", "scrypt", "pbkdf2", "hkdf", "totp", "hotp",
   }
 
   # Parameter names that imply a crypto operation on their own (the
   # plaintext/ciphertext payloads, named key material, passphrases).
   STRONG_PARAM_NAMES = Set{
     "plaintext", "ciphertext", "cleartext", "public_key", "private_key",
-    "secret_key", "signing_key", "encryption_key", "decryption_key",
-    "passphrase", "pem", "hmac",
+    "pubkey", "privkey", "secret_key", "signing_key", "encryption_key",
+    "decryption_key", "passphrase", "pem", "hmac",
   }
 
   # Weaker signals: meaningful for crypto but also seen elsewhere. Tag

--- a/src/tagger/taggers/debug.cr
+++ b/src/tagger/taggers/debug.cr
@@ -18,12 +18,19 @@ class DebugTagger < Tagger
     "debug", "debugger", "xdebug", "actuator", "pprof", "heapdump",
     "heapdumps", "threaddump", "threaddumps", "phpinfo", "profiler",
     "jolokia", "telescope", "loggers", "configprops",
+    "debugbar", "clockwork", "wdt",
   }
 
   # A debug toggle parameter (`?debug=true`, `?xdebug=...`) flips an
   # endpoint into a debug/verbose mode regardless of its path.
   # `__debugger__` is Werkzeug's interactive-console (RCE) marker.
-  STRONG_PARAM_NAMES = Set{"debug", "xdebug", "debug_mode", "debugger", "__debugger__"}
+  # The `xdebug_session*` / `xdebug_profile` triggers (sent as cookie,
+  # GET, or POST param) switch Xdebug into remote-debug or profiling mode
+  # — a well-known production exposure.
+  STRONG_PARAM_NAMES = Set{
+    "debug", "xdebug", "debug_mode", "debugger", "__debugger__",
+    "xdebug_session", "xdebug_session_start", "xdebug_profile", "xdebug_trigger",
+  }
 
   # `internal` / `_internal` is matched only as a standalone slash
   # segment (not the `-`/`_` split used elsewhere), so `/internal/jobs`
@@ -36,7 +43,7 @@ class DebugTagger < Tagger
   # when two *distinct* weak tokens co-occur.
   WEAK_PATH_PARTS = Set{
     "metrics", "monitor", "monitoring", "diagnostics", "diagnostic",
-    "trace", "traces", "console", "dump", "dumps",
+    "trace", "traces", "console", "dump", "dumps", "prometheus",
   }
 
   def initialize(options : Hash(String, YAML::Any))

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -10,7 +10,11 @@ class FileUploadTagger < Tagger
 
   UPLOAD_PARAM_TYPES = Set{"file", "form", "body", "json"}
   UPLOAD_METHODS     = Set{"POST", "PUT", "PATCH"}
-  UPLOAD_PATH_PARTS  = Set{"upload", "uploads", "attach", "attachment", "attachments", "import", "imports", "avatar", "photo", "photos", "media"}
+  UPLOAD_PATH_PARTS  = Set{
+    "upload", "uploads", "attach", "attachment", "attachments",
+    "import", "imports", "avatar", "photo", "photos", "media",
+    "file", "files", "image", "images", "picture", "pictures",
+  }
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -34,9 +38,14 @@ class FileUploadTagger < Tagger
   end
 
   private def upload_param?(param : Param) : Bool
-    name = normalize_param_name(param.name)
     return false unless UPLOAD_PARAM_TYPES.includes?(param.param_type)
 
+    # A param whose type *is* `file` is a file input regardless of its
+    # name — analyzers emit the raw variable name there (`$_FILES['cv']`,
+    # `$request->files->get('resume')`), which won't appear in WORDS.
+    return true if param.param_type == "file"
+
+    name = normalize_param_name(param.name)
     WORDS.includes?(name) || name.ends_with?("_file") || name.ends_with?("_files")
   end
 


### PR DESCRIPTION
## Summary

Reduces false positives / false negatives in the `crypto`, `debug`, and `file_upload` taggers (`src/tagger/taggers/`). These taggers already give the AI/reviewer a solid signal base; this sharpens it by closing concrete recall gaps observed against how analyzers actually emit params and how these surfaces appear in real apps.

## Changes

### `file_upload` — core FN fix
- A `Param` whose `param_type` is **`file`** is now treated as a file input **regardless of its name**. The PHP (`$_FILES['cv']`) and Symfony (`$request->files->get('resume')`) analyzers emit the *raw variable name* with `param_type: "file"`, so uploads named anything outside `WORDS` were silently missed.
- Added `file`, `files`, `image`, `images`, `picture`, `pictures` to the upload path parts (consistent with the existing `photo`/`avatar`/`media` entries; still gated on `POST`/`PUT`/`PATCH`).

### `debug` — FN fix for known exposures
- Tag the **Xdebug trigger params** `XDEBUG_SESSION`, `XDEBUG_SESSION_START`, `XDEBUG_PROFILE`, `XDEBUG_TRIGGER` — the documented production remote-debug / profiler switches.
- Add `debugbar` (Laravel Debugbar), `clockwork` (Clockwork), and `wdt` (Symfony web debug toolbar) as strong paths.
- Add `prometheus` as a weak diagnostic token (still needs two distinct weak tokens to fire).

### `crypto` — primitive coverage
The tag exists to surface weak/obsolete algorithms, so legacy ciphers are deliberately included:
- Hashes: `sha224`, `sha384`, `sha3`, `keccak`, `ripemd`, `ripemd160`, `blake2`, `blake3`
- Ciphers: `rc4`, `3des`, `blowfish`, `twofish`, `chacha20`, `salsa20`
- Curves/KEX: `ecdh`, `ed448`, `x25519`, `x448`, `curve25519`, `secp256k1`
- KDF/OTP: `hkdf`, `totp`, `hotp`
- JOSE: `jws`, `jwe`; cert/key formats: `pkcs7`, `pkcs8`, `pkcs12`, `pfx`
- Params: `pubkey`, `privkey`

Each added token carries a digit or is otherwise distinctive enough not to collide with a benign whole path segment, so the additions are recall-only with negligible FP risk.

## Testing
- New unit cases for each tagger (file-type param, Xdebug trigger, Debugbar path, modern/legacy crypto primitives, JOSE, pubkey/privkey).
- `crystal spec spec/unit_test/tagger/` → **418 examples, 0 failures**.
- `Endpoint#==` ignores tags, so functional fixtures are unaffected.
