### PR TITLE
fix(tagger): cut FP/FN in admin, api_docs, cors taggers

### DIFF
--- a/spec/unit_test/tagger/taggers/admin_spec.cr
+++ b/spec/unit_test/tagger/taggers/admin_spec.cr
@@ -59,6 +59,30 @@ describe "AdminTagger" do
       endpoint.tags[0].name.should eq("admin")
     end
 
+    it "tags a camelCase privilege-mutation parameter" do
+      tagger = AdminTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/users/42", "PATCH", [
+        Param.new("isSuperuser", "true", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("admin")
+    end
+
+    it "tags a superadmin path segment" do
+      tagger = AdminTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/superadmin/settings", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("admin")
+    end
+
     it "tags a weak privilege parameter only on a state-changing method" do
       tagger = AdminTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/api_docs_spec.cr
+++ b/spec/unit_test/tagger/taggers/api_docs_spec.cr
@@ -79,6 +79,38 @@ describe "ApiDocsTagger" do
       endpoint.tags[0].name.should eq("api_docs")
     end
 
+    it "tags an underscore-separated swagger_ui endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/swagger_ui.html", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "tags a versioned drf /api/v1/schema endpoint" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/v1/schema/", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("api_docs")
+    end
+
+    it "does not tag a data-schema sub-resource under /api" do
+      tagger = ApiDocsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/forms/42/schema", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
     it "does not tag a bare schema segment without api/openapi context" do
       tagger = ApiDocsTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/cors_spec.cr
+++ b/spec/unit_test/tagger/taggers/cors_spec.cr
@@ -50,6 +50,45 @@ describe "CorsTagger" do
       endpoint.tags[0].name.should eq("cors")
     end
 
+    it "tags endpoint with access-control-allow-credentials" do
+      tagger = CorsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/data", "OPTIONS", [
+        Param.new("access-control-allow-credentials", "true", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("cors")
+    end
+
+    it "tags endpoint with access-control-request-headers" do
+      tagger = CorsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/data", "OPTIONS", [
+        Param.new("Access-Control-Request-Headers", "X-Custom", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("cors")
+    end
+
+    it "tags a CGI-style HTTP_ORIGIN header" do
+      tagger = CorsTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/data", "GET", [
+        Param.new("HTTP_ORIGIN", "https://example.com", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("cors")
+    end
+
     it "does not tag endpoint without CORS parameters" do
       tagger = CorsTagger.new(default_tagger_options)
 

--- a/src/tagger/taggers/admin.cr
+++ b/src/tagger/taggers/admin.cr
@@ -8,20 +8,28 @@ require "../../models/endpoint"
 class AdminTagger < Tagger
   # Path segments that strongly imply an administrative surface. Matched
   # as whole path segments (after splitting on `/`, `-`, `_`, `.`) so
-  # `/admin/users` matches but `/badminton` does not. `/wp-admin` is
-  # covered too: the split yields an `admin` token.
+  # `/admin/users` matches but `/badminton` does not. `/wp-admin` and
+  # `/super-admin` are covered too: the split yields an `admin` token.
+  # `superadmin` (no separator) is listed explicitly since the split
+  # can't recover it.
   STRONG_PATH_PARTS = Set{
-    "admin", "admins", "administrator", "administration",
-    "superuser", "sysadmin", "backoffice", "impersonate", "godmode",
+    "admin", "admins", "administrator", "administration", "administrative",
+    "superuser", "superadmin", "sysadmin", "backoffice", "impersonate",
+    "godmode",
   }
 
   # Parameter names that imply a privilege/role grant regardless of the
   # route or method, e.g. a generic `/users/{id}` PATCH that accepts
-  # `is_admin`. These are specific enough to flag on their own.
+  # `is_admin`. These are specific enough to flag on their own. Matched
+  # separator-insensitively via `normalize_param_name`, so `is_admin`,
+  # `isAdmin`, and `is-admin` all collapse to the same key.
   STRONG_PRIVILEGE_PARAM_NAMES = Set{
-    "is_admin", "isadmin", "is_superuser", "is_staff", "is_root",
-    "make_admin", "grant_admin", "admin_only", "sudo", "impersonate",
+    "is_admin", "is_superuser", "is_superadmin", "is_staff", "is_root",
+    "make_admin", "grant_admin", "admin_only", "superadmin", "sudo",
+    "impersonate",
   }
+  STRONG_PRIVILEGE_PARAM_NAMES_NORMALIZED =
+    STRONG_PRIVILEGE_PARAM_NAMES.map(&.gsub(/[-_]/, "")).to_set
 
   # Weaker, more generic privilege hints. These also appear as read-only
   # filters (`GET /roles?privilege=x`, `?as_user=...` view switching), so
@@ -29,6 +37,8 @@ class AdminTagger < Tagger
   WEAK_PRIVILEGE_PARAM_NAMES = Set{
     "run_as", "as_user", "elevate", "privilege", "privileged",
   }
+  WEAK_PRIVILEGE_PARAM_NAMES_NORMALIZED =
+    WEAK_PRIVILEGE_PARAM_NAMES.map(&.gsub(/[-_]/, "")).to_set
 
   READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS"}
 
@@ -42,10 +52,10 @@ class AdminTagger < Tagger
       is_admin_url = admin_url?(endpoint.url)
       is_write = !READ_ONLY_METHODS.includes?(endpoint.method.upcase)
       has_strong_privilege_param = endpoint.params.any? do |param|
-        STRONG_PRIVILEGE_PARAM_NAMES.includes?(normalize_param_name(param.name))
+        STRONG_PRIVILEGE_PARAM_NAMES_NORMALIZED.includes?(normalize_param_name(param.name))
       end
       has_weak_privilege_param = is_write && endpoint.params.any? do |param|
-        WEAK_PRIVILEGE_PARAM_NAMES.includes?(normalize_param_name(param.name))
+        WEAK_PRIVILEGE_PARAM_NAMES_NORMALIZED.includes?(normalize_param_name(param.name))
       end
 
       check = is_admin_url || has_strong_privilege_param || has_weak_privilege_param
@@ -66,7 +76,9 @@ class AdminTagger < Tagger
     parts.any? { |part| STRONG_PATH_PARTS.includes?(part) }
   end
 
+  # Strip case and separators so snake_case (`is_admin`), kebab-case
+  # (`is-admin`), and camelCase (`isAdmin`) all map to a single key.
   private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
+    name.downcase.gsub(/[-_]/, "")
   end
 end

--- a/src/tagger/taggers/api_docs.cr
+++ b/src/tagger/taggers/api_docs.cr
@@ -13,11 +13,16 @@ class ApiDocsTagger < Tagger
   # generic `/docs` documentation site is not (FastAPI apps are still
   # caught via `/openapi.json` / `/redoc`).
   DOC_SEGMENTS = Set{
-    "swagger", "swagger-ui", "swaggerui", "swagger-resources",
+    "swagger", "swagger-ui", "swagger-resources",
     "openapi", "openapi3", "redoc", "graphiql", "rapidoc",
-    "wsdl", "wadl", "api-docs", "api_docs", "apidocs",
+    "wsdl", "wadl", "api-docs", "api-doc",
     "asyncapi", "api-json", "api-yaml", "apispec", "apispec_1",
   }
+
+  # Separator-insensitive lookup so `/swagger_ui`, `/swaggerui`,
+  # `/open-api`, and `/api_docs` all match regardless of whether the
+  # source used `-`, `_`, or no separator at all.
+  DOC_SEGMENTS_NORMALIZED = DOC_SEGMENTS.map(&.gsub(/[-_]/, "")).to_set
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -27,7 +32,7 @@ class ApiDocsTagger < Tagger
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       segments = doc_segments(endpoint.url)
-      check = segments.any? { |seg| DOC_SEGMENTS.includes?(seg) } ||
+      check = segments.any? { |seg| DOC_SEGMENTS_NORMALIZED.includes?(seg.gsub(/[-_]/, "")) } ||
               api_schema?(segments)
 
       if check
@@ -46,10 +51,24 @@ class ApiDocsTagger < Tagger
   end
 
   # `schema` is too generic to match on its own (GraphQL `/schema`,
-  # resource schema routes), so only flag it alongside an `api`/`openapi`
-  # segment — the drf-spectacular `/api/schema/` shape.
+  # resource schema routes), so only flag the drf-spectacular
+  # `/api/schema/` shape: a `schema` segment directly preceded by an
+  # `api`/`openapi` token or a version token (`/api/v1/schema`). This
+  # keeps the documentation endpoint while excluding data-schema
+  # sub-resources like `/api/forms/{id}/schema` that merely return a
+  # JSON Schema for a resource.
   private def api_schema?(segments : Array(String)) : Bool
-    segments.includes?("schema") &&
-      (segments.includes?("api") || segments.includes?("openapi"))
+    idx = segments.index("schema")
+    return false unless idx
+    return false unless segments.includes?("api") || segments.includes?("openapi")
+
+    prev = idx > 0 ? segments[idx - 1] : nil
+    return false unless prev
+    prev == "api" || prev == "openapi" || version_segment?(prev)
+  end
+
+  # A version path token such as `v1`, `v2`, `v10`.
+  private def version_segment?(segment : String) : Bool
+    !!(segment =~ /\Av\d+\z/)
   end
 end

--- a/src/tagger/taggers/cors.cr
+++ b/src/tagger/taggers/cors.cr
@@ -2,8 +2,6 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class CorsTagger < Tagger
-  WORDS = ["origin", "access-control-allow-origin", "access-control-request-method"]
-
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "cors"
@@ -11,29 +9,32 @@ class CorsTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
-
-      # CORS is a header-level concern: `Origin` and `Access-Control-*`
-      # are request/response headers. Matching a bare `origin` query/body
-      # param (e.g. `?origin=JFK` on a flights API) was a false positive,
-      # so only consider header params.
-      endpoint.params.each do |param|
-        next unless param.param_type == "header"
-        tmp_params.push param.name.to_s.downcase
+      # CORS is a header-level concern: `Origin` and the whole
+      # `Access-Control-*` family are request/response headers. Matching
+      # a bare `origin` query/body param (e.g. `?origin=JFK` on a flights
+      # API) was a false positive, so only consider header params. A
+      # single CORS-related header is enough to flag the endpoint.
+      check = endpoint.params.any? do |param|
+        next false unless param.param_type == "header"
+        cors_header?(param.name.to_s)
       end
-
-      words_set = Set.new(WORDS)
-      tmp_params_set = Set.new(tmp_params)
-      intersection = words_set & tmp_params_set
-
-      # A single CORS-related parameter (e.g. an `Origin` header) is
-      # enough to flag the endpoint.
-      check = intersection.size >= 1
 
       if check
         tag = Tag.new("cors", "CORS endpoint enabling cross-origin requests, allowing web applications from different domains to interact.", "CORS")
         endpoint.add_tag(tag)
       end
     end
+  end
+
+  # Matches the `Origin` request header and the full `Access-Control-*`
+  # family (`...-allow-origin`, `...-allow-credentials`, `...-allow-methods`,
+  # `...-allow-headers`, `...-expose-headers`, `...-max-age`,
+  # `...-request-method`, `...-request-headers`). Underscore variants and
+  # the CGI-style `HTTP_ORIGIN` are normalized so they match too.
+  private def cors_header?(name : String) : Bool
+    normalized = name.downcase.tr("_", "-")
+    normalized == "origin" ||
+      normalized == "http-origin" ||
+      normalized.starts_with?("access-control-")
   end
 end


### PR DESCRIPTION
## Summary

Reduces false positives and false negatives across three semantic taggers in `src/tagger/taggers`. These taggers enrich Noir's endpoint context (admin surfaces, API-docs exposure, CORS) — this sharpens their precision/recall so the signals downstream consumers (and AI reviewers) rely on are cleaner.

### `admin`
- **FN:** privilege param matching only did `tr("-","_")`, so `isAdmin` matched (an `isadmin` dup was hard-coded) but `isSuperuser`, `isStaff`, `makeAdmin`, etc. did not. Param names are now normalized separator-insensitively (downcase + strip `-`/`_`), so snake_case, kebab-case, and camelCase all collapse to one key.
- **FN:** added `superadmin` (single word) and `administrative` path segments, plus `superadmin` / `is_superadmin` privilege params.

### `api_docs`
- **FN:** segment comparison was separator-sensitive — `swagger-ui`/`swaggerui` matched but `swagger_ui` did not. Doc segments are now compared separator-insensitively, so `/swagger_ui`, `/open-api`, `/api_docs` all match. Added `api-doc` (singular).
- **FP:** `api_schema?` matched whenever `api` **and** `schema` appeared anywhere, flagging data-schema sub-resources like `/api/forms/{id}/schema`. Tightened to require `schema` be directly preceded by an `api`/`openapi`/version token — keeps drf-spectacular `/api/schema/` and now also `/api/v1/schema`, while dropping the sub-resource FP.

### `cors`
- **FN:** only `access-control-allow-origin` and `access-control-request-method` were matched. Now matches the full `Access-Control-*` family (`allow-credentials`, `allow-methods`, `allow-headers`, `expose-headers`, `max-age`, `request-headers`, …) plus `Origin` and CGI-style `HTTP_ORIGIN`, with underscore variants normalized. Still header-only (the `?origin=JFK` query FP fix is preserved).

## Test
- Added spec cases for each behavior (camelCase admin param, `superadmin` path, `swagger_ui`, versioned `/api/v1/schema`, the data-schema FP, `Access-Control-*` headers, `HTTP_ORIGIN`).
- `crystal spec spec/unit_test` → 3027 examples, 0 failures.
- `ameba` clean on the three taggers.
