### PR TITLE
fix(tagger): reduce FP/FN in oauth, payment, and mcp taggers

### DIFF
--- a/spec/unit_test/tagger/taggers/mcp_spec.cr
+++ b/spec/unit_test/tagger/taggers/mcp_spec.cr
@@ -58,6 +58,17 @@ describe "McpTagger" do
       endpoint.tags[0].name.should eq("mcp")
     end
 
+    it "tags model-context-protocol paths written with underscores" do
+      tagger = McpTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/model_context_protocol", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("mcp")
+    end
+
     it "tags legacy SSE transport pairs" do
       tagger = McpTagger.new(default_tagger_options)
 

--- a/spec/unit_test/tagger/taggers/oauth_spec.cr
+++ b/spec/unit_test/tagger/taggers/oauth_spec.cr
@@ -173,5 +173,81 @@ describe "OAuthTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "tags the authorization-code redirect handler on a callback path" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/users/auth/google/callback", "GET", [
+        Param.new("code", "abc123", "query"),
+        Param.new("state", "xyz", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "tags an /oauth path carrying a single OAuth parameter" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/oauth/authorize", "GET", [
+        Param.new("client_id", "my-app", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "tags the OAuth device-flow token endpoint" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/oauth/token", "POST", [
+        Param.new("grant_type", "urn:ietf:params:oauth:grant-type:device_code", "form"),
+        Param.new("device_code", "GmRh...", "form"),
+        Param.new("client_id", "my-app", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "does not tag a generic callback receiving only a code" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/payment/callback", "GET", [
+        Param.new("code", "settled", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag a bearer-protected resource served from an oauth host" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("https://oauth.example.com/api/users", "GET", [
+        Param.new("access_token", "ya29...", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag an OIDC discovery document with no OAuth parameters" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/.well-known/openid-configuration", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/payment_spec.cr
+++ b/spec/unit_test/tagger/taggers/payment_spec.cr
@@ -112,5 +112,78 @@ describe "PaymentTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "tags a /pay path" do
+      tagger = PaymentTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/pay", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("payment")
+    end
+
+    it "tags a /purchase path" do
+      tagger = PaymentTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/purchase", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("payment")
+    end
+
+    it "tags an endpoint carrying bank-transfer details (IBAN)" do
+      tagger = PaymentTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/beneficiaries", "POST", [
+        Param.new("iban", "DE89...", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("payment")
+    end
+
+    it "tags an ambiguous /orders path when a money parameter corroborates" do
+      tagger = PaymentTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/orders", "POST", [
+        Param.new("total", "42", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("payment")
+    end
+
+    it "tags a wallet withdrawal carrying an amount" do
+      tagger = PaymentTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/wallet/withdraw", "POST", [
+        Param.new("amount", "100", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("payment")
+    end
+
+    it "does not tag a non-financial withdraw without a money parameter" do
+      tagger = PaymentTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/applications/123/withdraw", "POST", [
+        Param.new("reason", "changed my mind", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/src/tagger/taggers/mcp.cr
+++ b/src/tagger/taggers/mcp.cr
@@ -26,7 +26,10 @@ class McpTagger < Tagger
     segments = path_segments(path)
 
     return true if segments.includes?("mcp")
-    return true if path.includes?("model-context-protocol")
+    # Match the spelled-out name regardless of the separator used
+    # (`model-context-protocol`, `model_context_protocol`, or the squashed
+    # `modelcontextprotocol`).
+    return true if path.gsub(/[-_]/, "").includes?("modelcontextprotocol")
 
     legacy_mcp_endpoint?(endpoint, segments, legacy_prefixes)
   end

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -6,9 +6,17 @@ class OAuthTagger < Tagger
     "grant_type", "code", "redirect_uri", "redirect_url", "client_id", "client_secret",
     "response_type", "scope", "state", "code_challenge", "code_challenge_method",
     "code_verifier", "refresh_token", "access_token", "id_token", "nonce", "audience",
+    "device_code",
   }
 
-  OAUTH_PATH_PARTS = Set{"oauth", "oauth2", "authorize", "authorization", "token", "callback"}
+  # URL path segments that, on their own, strongly imply an OAuth/OIDC
+  # surface. Any OAuth parameter alongside one of these is enough.
+  STRONG_URL_PARTS = Set{"oauth", "oauth2", "oauth20", "openid", "oidc"}
+
+  # URL path segments shared with non-OAuth routes — a CSRF/email "token",
+  # a payment "callback", a generic "authorize". These need corroborating
+  # parameters before flagging.
+  WEAK_URL_PARTS = Set{"authorize", "authorization", "token", "callback"}
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -20,13 +28,28 @@ class OAuthTagger < Tagger
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set
       intersection = WORDS & param_names
 
+      # Match against the URL path only — a host like `oauth.example.com`
+      # or `token.example.com` must not make every API route look like an
+      # OAuth endpoint.
+      parts = path_parts(endpoint.url)
+      strong_url = parts.any? { |part| STRONG_URL_PARTS.includes?(part) }
+      # A strong URL part implies a weak match too (e.g. `/oauth/token`).
+      weak_url = strong_url || parts.any? { |part| WEAK_URL_PARTS.includes?(part) }
+
       # OAuth authorization endpoints commonly use response_type +
       # client_id + redirect_uri, while token endpoints can rely on
       # HTTP Basic auth and expose only grant_type + code/verifier.
       check = strong_oauth_params?(param_names) ||
-              (oauth_url?(endpoint.url) && intersection.size >= 3) ||
-              (oauth_url?(endpoint.url) && oauth_authorization_params?(param_names)) ||
-              (oauth_url?(endpoint.url) && oauth_token_params?(param_names))
+              # Under an unambiguous /oauth|/openid path, a single OAuth
+              # parameter is enough (device-flow `device_code`, an
+              # authorize page's `client_id`, a callback's `code`).
+              (strong_url && !intersection.empty?) ||
+              (weak_url && intersection.size >= 3) ||
+              (weak_url && oauth_authorization_params?(param_names)) ||
+              (weak_url && oauth_token_params?(param_names)) ||
+              # The authorization-code redirect handler — `/callback` (or
+              # `/auth/<provider>/callback`) receiving `code` + `state`.
+              oauth_callback?(parts, param_names)
 
       if check
         tag = Tag.new("oauth", "Suspected OAuth endpoint for granting 3rd party access.", "Oauth")
@@ -39,9 +62,28 @@ class OAuthTagger < Tagger
     name.downcase.tr("-", "_")
   end
 
-  private def oauth_url?(url : String) : Bool
-    parts = url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
-    parts.any? { |part| OAUTH_PATH_PARTS.includes?(part) }
+  # Split the URL's path (scheme/host/query/fragment stripped) into the
+  # tokens used for whole-segment matching.
+  private def path_parts(url : String) : Array(String)
+    path = url.strip
+
+    if scheme_index = path.index("://")
+      remainder = path[(scheme_index + 3)..]
+      if slash_index = remainder.index("/")
+        path = remainder[slash_index..]
+      else
+        path = ""
+      end
+    end
+
+    path = path.split("?", 2)[0]
+    path = path.split("#", 2)[0]
+    path.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+  end
+
+  private def oauth_callback?(parts : Array(String), param_names : Set(String)) : Bool
+    return false unless parts.includes?("callback")
+    param_names.includes?("code") && param_names.includes?("state")
   end
 
   private def oauth_authorization_params?(param_names : Set(String)) : Bool
@@ -60,6 +102,7 @@ class OAuthTagger < Tagger
     param_names.includes?("client_secret") ||
       param_names.includes?("code_verifier") ||
       param_names.includes?("refresh_token") ||
+      param_names.includes?("device_code") ||
       (param_names.includes?("client_id") && param_names.includes?("code"))
   end
 
@@ -69,6 +112,7 @@ class OAuthTagger < Tagger
     param_names.includes?("client_id") ||
       param_names.includes?("code") ||
       param_names.includes?("code_verifier") ||
+      param_names.includes?("device_code") ||
       param_names.includes?("refresh_token")
   end
 end

--- a/src/tagger/taggers/payment.cr
+++ b/src/tagger/taggers/payment.cr
@@ -9,34 +9,41 @@ require "../../models/endpoint"
 class PaymentTagger < Tagger
   # Path segments that strongly imply a payment/financial surface.
   # Matched as whole path segments after splitting on `/`, `-`, `_`, `.`.
+  # `withdrawal(s)` (the noun) stays here; the bare verb `withdraw` is
+  # ambiguous (withdraw an application/registration/bid) and lives below.
   STRONG_PATH_PARTS = Set{
     "payment", "payments", "checkout", "billing", "invoice", "invoices",
-    "refund", "refunds", "payout", "payouts", "withdraw", "withdrawal",
-    "withdrawals", "paypal", "stripe", "braintree",
+    "refund", "refunds", "payout", "payouts", "withdrawal", "withdrawals",
+    "paypal", "stripe", "braintree", "pay", "purchase", "purchases",
   }
 
   # Path segments that often — but not always — mean money: a DB
   # "transaction", a newsletter/web-push "subscription", a battery
-  # "charge". Require a corroborating money parameter before flagging.
+  # "charge", a non-financial "withdraw"/"transfer", an unpaid "order".
+  # Require a corroborating money parameter before flagging.
   AMBIGUOUS_PATH_PARTS = Set{
     "charge", "charges", "transaction", "transactions",
-    "subscription", "subscriptions",
+    "subscription", "subscriptions", "withdraw", "transfer", "transfers",
+    "deposit", "deposits", "wallet", "wallets", "order", "orders",
   }
 
   # Parameter names that strongly imply payment handling on their own
-  # (card data, gateway tokens, payment-method references).
+  # (card data, gateway tokens, payment-method references, bank details).
   STRONG_PARAM_NAMES = Set{
     "card_number", "cardnumber", "cc_number", "ccnumber",
     "cvv", "cvc", "cvv2", "cvn", "csc", "security_code",
-    "card_security_code", "payment_method", "payment_method_id",
-    "payment_intent", "stripe_token", "paypal_token", "card_token",
+    "card_security_code", "card_cvc", "card_expiry", "card_holder",
+    "cardholder_name", "payment_method", "payment_method_id",
+    "payment_method_nonce", "payment_intent", "setup_intent",
+    "stripe_token", "paypal_token", "card_token",
+    "iban", "routing_number", "sort_code",
   }
 
   # Generic money parameters. Weak on their own (and so never trip the
   # tagger by themselves), but enough to corroborate an ambiguous path.
   MONEY_PARAM_NAMES = Set{
     "amount", "currency", "currency_code", "price", "total",
-    "subtotal", "balance",
+    "subtotal", "balance", "total_amount", "amount_due", "grand_total",
   }
 
   def initialize(options : Hash(String, YAML::Any))


### PR DESCRIPTION
## Description

Reduces false positives and false negatives in three security taggers (`src/tagger/taggers`). These taggers enrich Noir's already-strong endpoint context by flagging high-stakes surfaces; this sharpens their precision/recall on real-world route conventions.

### OAuth (`oauth.cr`)
- **Tiered URL matching.** Split URL parts into **strong** (`oauth`, `oauth2`, `openid`, `oidc`) vs **weak** (`authorize`, `authorization`, `token`, `callback`). A single OAuth parameter under a strong `/oauth|/openid` path is now enough — recovers the device-flow token endpoint, the authorize page, and the redirect callback (**FN fix**).
- **Path-only matching (FP fix).** Match the URL *path*, not the host. A bearer-protected resource served from `oauth.example.com/api/users?access_token=…` is no longer mis-tagged as an OAuth endpoint.
- **Authorization-code redirect (FN fix).** Tag the `/callback` (e.g. `/users/auth/google/callback`) handler that receives `code` + `state`.
- Recognize device-flow `device_code` in token-param checks.

### Payment (`payment.cr`)
- **FN:** add strong paths `pay`, `purchase(s)`; add card/bank strong params (`card_holder`, `cardholder_name`, `card_expiry`, `card_cvc`, `payment_method_nonce`, `setup_intent`, `iban`, `routing_number`, `sort_code`); extend money params (`total_amount`, `amount_due`, `grand_total`).
- **FP:** move the ambiguous **verb** `withdraw` behind a money-parameter gate (e.g. "withdraw an application/registration") while keeping the **noun** `withdrawal(s)` strong. Add `transfer(s)`, `deposit(s)`, `wallet(s)`, `order(s)` as money-gated ambiguous paths.

### MCP (`mcp.cr`)
- **FN:** match the spelled-out name regardless of separator — `model_context_protocol` and `modelcontextprotocol` now match alongside `model-context-protocol`.

## Testing
- Added positive and negative spec cases for every new behavior across the three taggers.
- `crystal spec spec/unit_test/tagger/` → **424 examples, 0 failures**.
- Tagger model/integration specs → **37 examples, 0 failures**.

(The full `spec/unit_test/` run fails to compile locally due to a missing `acp` shard — unrelated to this change.)
