### PR TITLE
fix(tagger): reduce FP/FN in graphql, jwt, and hunt taggers

### DIFF
--- a/spec/unit_test/tagger/taggers/graphql_spec.cr
+++ b/spec/unit_test/tagger/taggers/graphql_spec.cr
@@ -117,5 +117,79 @@ describe "GraphqlTagger" do
 
       endpoint.tags.size.should eq(1)
     end
+
+    it "tags a single query parameter whose value is a GraphQL document" do
+      tagger = GraphqlTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api", "POST", [
+        Param.new("query", "{ users { id name } }", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("graphql")
+    end
+
+    it "tags a named-operation mutation body on a generic URL" do
+      tagger = GraphqlTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/data", "POST", [
+        Param.new("query", "mutation CreateUser($n: String!) { createUser(name: $n) { id } }", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.map(&.name).should contain("graphql")
+    end
+
+    it "tags a canonical query + variables body" do
+      tagger = GraphqlTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api", "POST", [
+        Param.new("query", "", "json"),
+        Param.new("variables", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.map(&.name).should contain("graphql")
+    end
+
+    it "tags a standalone __schema introspection parameter" do
+      tagger = GraphqlTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api", "POST", [
+        Param.new("__schema", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.map(&.name).should contain("graphql")
+    end
+
+    it "does not treat a JSON-object query value as a GraphQL document" do
+      tagger = GraphqlTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/search", "POST", [
+        Param.new("query", %({"term": "shoes"}), "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not match gql as a loose substring" do
+      tagger = GraphqlTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/gqlgenerator", "GET", [
+        Param.new("page", "1", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/hunt_param_spec.cr
+++ b/spec/unit_test/tagger/taggers/hunt_param_spec.cr
@@ -334,5 +334,81 @@ describe "HuntParamTagger" do
 
       endpoint.params[0].tags.any? { |t| t.name == "idor" && t.tagger == "Hunt" }.should be_false
     end
+
+    it "tags compound url/uri parameter names as SSRF" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/proxy", "POST", [
+        Param.new("redirectUrl", "http://example.com", "query"),
+        Param.new("callback_uri", "http://example.com", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.any? { |t| t.name == "ssrf" && t.tagger == "Hunt" }.should be_true
+      endpoint.params[1].tags.any? { |t| t.name == "ssrf" && t.tagger == "Hunt" }.should be_true
+    end
+
+    it "does not treat curl-like names ending in url as SSRF" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/run", "POST", [
+        Param.new("curl", "1", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("ssrf")
+    end
+
+    it "tags compound identifier query parameters as IDOR" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/orders", "GET", [
+        Param.new("userId", "42", "query"),
+        Param.new("account_id", "7", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.any? { |t| t.name == "idor" && t.tagger == "Hunt" }.should be_true
+      endpoint.params[1].tags.any? { |t| t.name == "idor" && t.tagger == "Hunt" }.should be_true
+    end
+
+    it "does not promote compound body identifiers to IDOR" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/update", "POST", [
+        Param.new("userId", "42", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("idor")
+    end
+
+    it "tags compound file parameter names as file inclusion" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/download", "GET", [
+        Param.new("file_path", "/etc/passwd", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.any? { |t| t.name == "file-inclusion" && t.tagger == "Hunt" }.should be_true
+    end
+
+    it "does not treat a bare number parameter as IDOR" do
+      tagger = HuntParamTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/page", "GET", [
+        Param.new("number", "5", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.params[0].tags.map(&.name).should_not contain("idor")
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/jwt_spec.cr
+++ b/spec/unit_test/tagger/taggers/jwt_spec.cr
@@ -171,5 +171,62 @@ describe "JwtTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "does not tag Devise-style reset/confirmation tokens on auth routes" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      reset = Endpoint.new("/auth/password/edit", "GET", [
+        Param.new("reset_password_token", "abc123", "query"),
+      ])
+      confirm = Endpoint.new("/auth/confirmation", "GET", [
+        Param.new("confirmation_token", "abc123", "query"),
+      ])
+      unlock = Endpoint.new("/auth/unlock", "GET", [
+        Param.new("unlock_token", "abc123", "query"),
+      ])
+
+      tagger.perform([reset, confirm, unlock])
+
+      reset.tags.size.should eq(0)
+      confirm.tags.size.should eq(0)
+      unlock.tags.size.should eq(0)
+    end
+
+    it "does not tag API pagination tokens" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/items", "GET", [
+        Param.new("page_token", "CAEaBg", "query"),
+        Param.new("next_token", "CAEaBg", "query"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "does not tag a Basic auth Authorization header as JWT" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/login", "POST", [
+        Param.new("Authorization", "Basic dXNlcjpwYXNz", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "still tags an empty Authorization header on an auth route" do
+      tagger = JwtTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/login", "POST", [
+        Param.new("Authorization", "", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.map(&.name).should contain("jwt")
+    end
   end
 end

--- a/src/tagger/taggers/graphql.cr
+++ b/src/tagger/taggers/graphql.cr
@@ -2,7 +2,18 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class GraphqlTagger < Tagger
-  WORDS = ["query", "mutation", "subscription", "operationname", "__schema", "__type", "graphql"]
+  WORDS = ["query", "mutation", "subscription", "operationname", "__schema", "__type", "graphql", "variables"]
+
+  # Strong, near-unique introspection signals: tagging on either alone is
+  # safe because `__schema`/`__type` are GraphQL meta-fields, not names
+  # that show up in REST inputs.
+  INTROSPECTION_NAMES = Set{"__schema", "__type"}
+
+  # Param names that plausibly carry a raw GraphQL document, so a value
+  # that looks like a query/selection set is decisive even on a generic
+  # URL like `/api`. Keeping the set tight avoids scanning unrelated
+  # values (a JSON body, a search string) for GraphQL syntax.
+  BODY_PARAM_NAMES = Set{"query", "mutation", "subscription", "graphql", "gql"}
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -11,27 +22,51 @@ class GraphqlTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
+      names = endpoint.params.map(&.name.to_s.downcase)
+      names_set = Set.new(names)
 
-      endpoint.params.each do |param|
-        tmp_params.push param.name.to_s.downcase
+      intersection = Set.new(WORDS) & names_set
+
+      url_lower = endpoint.url.downcase
+      # `graphql` is distinctive enough as a substring; `gql` is too short
+      # to match loosely (e.g. `/gqlgen`-style strings), so anchor it to a
+      # path segment boundary.
+      is_graphql_url = url_lower.includes?("graphql") || !!url_lower.match(%r{/gql(\b|/|\z)})
+
+      introspection = names_set.any? { |name| INTROSPECTION_NAMES.includes?(name) }
+
+      has_graphql_body = endpoint.params.any? do |param|
+        BODY_PARAM_NAMES.includes?(param.name.to_s.downcase) && graphql_document_value?(param.value)
       end
 
-      # Check URL path for GraphQL indicators
-      url_lower = endpoint.url.downcase
-      is_graphql_url = url_lower.includes?("graphql") || url_lower.includes?("/gql")
-
-      words_set = Set.new(WORDS)
-      tmp_params_set = Set.new(tmp_params)
-      intersection = words_set & tmp_params_set
-
-      # Check that at least two parameters match or URL indicates GraphQL
-      check = intersection.size >= 2 || is_graphql_url
+      # Tag on any decisive signal (URL, introspection field, a body that
+      # parses as a GraphQL document) or on two or more GraphQL-shaped
+      # parameter names together (e.g. `query` + `variables`).
+      check = is_graphql_url || introspection || has_graphql_body || intersection.size >= 2
 
       if check
         tag = Tag.new("graphql", "GraphQL endpoint for flexible API queries, potentially exposing schema introspection and nested data access.", "GraphQL")
         endpoint.add_tag(tag)
       end
     end
+  end
+
+  # Heuristic for "this value is a GraphQL document". Matches a named
+  # operation (`query Foo { ... }`, `mutation { ... }`) or an anonymous
+  # selection set (`{ users { id } }`) while deliberately rejecting JSON
+  # objects (`{"a": 1}`) so a generic JSON body parameter isn't mistaken
+  # for a query.
+  private def graphql_document_value?(value : String) : Bool
+    return false if value.empty?
+    v = value.strip
+    return false if v.empty?
+
+    return true if v.matches?(/\A(query|mutation|subscription)\b[\s\S]*\{/i)
+
+    if v.starts_with?("{") && !v.matches?(/\A\{\s*"/)
+      return true if v.matches?(/\{[^{}]*\{/)
+    end
+
+    false
   end
 end

--- a/src/tagger/taggers/hunt_param.cr
+++ b/src/tagger/taggers/hunt_param.cr
@@ -4,6 +4,11 @@ require "../../models/endpoint"
 class HuntParamTagger < Tagger
   PATH_ALLOWED_TAGS     = Set{"idor", "file-inclusion"}
   BODY_LIKE_PARAM_TYPES = Set{"json", "form", "body"}
+  # IDOR identifier-suffix matching (`userId`, `account_id`) only makes
+  # sense for inputs that address an object directly. Query and path
+  # params qualify; body params stay suppressed to mirror the bare-`id`
+  # heuristic below.
+  IDOR_SUFFIX_PARAM_TYPES = Set{"path", "query"}
 
   TAG_DEFINITIONS = {
     "ssti" => {
@@ -19,7 +24,7 @@ class HuntParamTagger < Tagger
       "description" => "This parameter may be vulnerable to SQL Injection attacks.",
     },
     "idor" => {
-      "words"       => ["id", "user", "account", "number", "order", "false", "doc", "key", "group", "profile", "edit", "report"],
+      "words"       => ["id", "user", "account", "order", "doc", "key", "group", "profile", "edit", "report"],
       "description" => "This parameter may be vulnerable to Insecure Direct Object Reference (IDOR) attacks.",
     },
     "file-inclusion" => {
@@ -69,10 +74,33 @@ class HuntParamTagger < Tagger
     # cased (ID, URL, userId). Normalize so `--use-taggers hunt` doesn't
     # silently miss case variants the way other taggers don't.
     return true if words.includes?(param.name.downcase)
-    return false unless tag_name == "idor"
-    return false unless param.param_type == "path"
 
-    identifier_suffix_like?(param.name)
+    # Compound names are the common shape in real codebases
+    # (`redirectUrl`, `file_path`, `userId`). Match the high-confidence,
+    # low-noise classes on a token basis so these aren't silently dropped
+    # the way an exact-match-only list would.
+    case tag_name
+    when "ssrf"
+      return true if name_tokens(param.name).any? { |token| token == "url" || token == "uri" }
+    when "file-inclusion"
+      return true if name_tokens(param.name).includes?("file")
+    when "idor"
+      if IDOR_SUFFIX_PARAM_TYPES.includes?(param.param_type)
+        return true if identifier_suffix_like?(param.name)
+      end
+    end
+
+    false
+  end
+
+  # Split a parameter name into lowercase word tokens, honoring snake_case,
+  # kebab-case, dotted, and camelCase boundaries (`redirectUrl` ->
+  # ["redirect", "url"], `file_path` -> ["file", "path"]).
+  private def name_tokens(name : String) : Array(String)
+    name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2")
+      .split(/[^A-Za-z0-9]+/)
+      .reject(&.empty?)
+      .map(&.downcase)
   end
 
   private def identifier_suffix_like?(name : String) : Bool

--- a/src/tagger/taggers/jwt.cr
+++ b/src/tagger/taggers/jwt.cr
@@ -12,6 +12,22 @@ class JwtTagger < Tagger
     "captcha_token", "recaptcha_token", "turnstile_token",
   }
 
+  # Substrings that mark a `*_token` param as an opaque, non-JWT token:
+  # CSRF/anti-bot tokens, Rails/Devise lifecycle tokens (password reset,
+  # email confirmation, account unlock/activation, remember-me, invites),
+  # and API pagination cursors. These are random strings, not signed JWTs,
+  # so counting them as JWT signals produces false positives on otherwise
+  # auth-shaped routes.
+  NON_JWT_TOKEN_HINTS = %w[
+    csrf xsrf captcha recaptcha turnstile authenticity nonce
+    reset unlock confirmation verification invitation activation remember unsubscribe
+    page pagination next continuation cursor sync
+  ]
+
+  # HTTP auth schemes that are not bearer/JWT; when an Authorization value
+  # advertises one of these, the header is not a JWT signal.
+  NON_BEARER_SCHEMES = /\A\s*(basic|digest|negotiate|ntlm|hoba|aws4|hmac)\b/i
+
   AUTH_PATH_PARTS = Set{"auth", "authenticate", "authentication", "login", "signin", "sign_in", "token", "refresh", "jwt"}
 
   def initialize(options : Hash(String, YAML::Any))
@@ -39,11 +55,29 @@ class JwtTagger < Tagger
   private def jwt_signal?(param : Param) : Bool
     name = normalize_param_name(param.name)
     return false if EXCLUDED_TOKEN_NAMES.includes?(name)
+
+    if name == "authorization"
+      # A populated Authorization header carrying Basic/Digest/etc. is not
+      # a JWT; only treat it as a signal when the value is absent or
+      # bearer-like.
+      return false if non_bearer_authorization?(param.value)
+      return true
+    end
+
     return true if STRONG_NAMES.includes?(name)
+
+    # Anything below is a generic `token`/`*_token` name. Drop the
+    # well-known opaque tokens before counting it as a JWT signal.
+    return false if NON_JWT_TOKEN_HINTS.any? { |hint| name.includes?(hint) }
     return true if name == "token"
-    return true if name.ends_with?("_token") && !name.includes?("csrf") && !name.includes?("captcha")
+    return true if name.ends_with?("_token")
 
     false
+  end
+
+  private def non_bearer_authorization?(value : String) : Bool
+    return false if value.empty?
+    !!value.match(NON_BEARER_SCHEMES)
   end
 
   private def bearer_or_jwt_value?(value : String) : Bool


### PR DESCRIPTION
## Summary

Reduces false positives and false negatives across three taggers in `src/tagger/taggers`: **graphql**, **jwt**, and **hunt**. These enrich Noir's already-strong AI context by tagging real risk surfaces more precisely while suppressing well-known noise.

## graphql (mostly FN)

- **Value-based detection** — a single `query`/`mutation`/`subscription` param whose value is a GraphQL document (`{ users { id } }`, `mutation Foo { ... }`) is now recognized even on a generic URL like `/api`. JSON object values (`{"term": "..."}`) are deliberately rejected so a plain JSON body isn't mistaken for a query.
- **Introspection** — a standalone `__schema`/`__type` param now tags (these are GraphQL meta-fields, near-unique signals).
- **Canonical body** — added `variables` to the word set so the standard `query` + `variables` POST body is detected.
- **URL precision** — `/gql` is anchored to a path-segment boundary so strings like `/gqlgenerator` no longer match loosely; `graphql` substring matching is unchanged.

## jwt (FP)

- **Opaque tokens excluded** — Devise/Rails lifecycle tokens (`reset_password_token`, `confirmation_token`, `unlock_token`, `remember_token`, `invitation_token`, `activation_token`), CSRF/captcha tokens, and API pagination cursors (`page_token`, `next_token`, `continuation_token`) are no longer counted as JWT signals. These are random strings, not signed JWTs, and previously produced JWT tags on auth-shaped routes.
- **Auth scheme awareness** — an `Authorization` header carrying `Basic`/`Digest`/`Negotiate`/`NTLM` is no longer a JWT signal; an empty/bearer-like `Authorization` still is.

## hunt (FP + FN)

- **Compound names (FN)** — real-world param names are compound. Now matched on a token basis for the high-confidence, low-noise classes:
  - `redirectUrl`, `callback_uri` → `ssrf`
  - `file_path`, `log_file` → `file-inclusion`
  - identifier-suffixed query/path params (`userId`, `account_id`) → `idor` (body params stay suppressed, mirroring the existing bare-`id` heuristic)
  - `curl` and similar non-boundary names do **not** match `url`.
- **Noise removed (FP)** — dropped `number` and `false` from the `idor` word list.

## Testing

- `crystal spec spec/unit_test/tagger/` — 427 examples, 0 failures (16 new cases covering the additions above).
- Hunt-derived AI-context functional specs (gin/echo/spring/fastify/rails/phoenix) — 6 examples, 0 failures (no regressions in `idor`/`ssrf` signal expectations).
- `crystal spec spec/unit_test/ai_context/ spec/unit_test/output_builder/only_tag_spec.cr` — 85 examples, 0 failures.
- `crystal tool format --check` and `ameba` clean on all changed files.
