### PR TITLE
fix(tagger): cut FP/FN in pii, soap, webhook, websocket taggers

### DIFF
--- a/spec/unit_test/tagger/taggers/crypto_spec.cr
+++ b/spec/unit_test/tagger/taggers/crypto_spec.cr
@@ -83,7 +83,7 @@ describe "CryptoTagger" do
 
       tagger.perform(endpoints)
 
-      endpoints.each { |ep| ep.tags.map(&.name).should contain("crypto") }
+      endpoints.each(&.tags.map(&.name).should(contain("crypto")))
     end
 
     it "tags a JOSE jwe/jws path" do

--- a/spec/unit_test/tagger/taggers/pii_spec.cr
+++ b/spec/unit_test/tagger/taggers/pii_spec.cr
@@ -100,5 +100,60 @@ describe "PiiTagger" do
       endpoint.tags.size.should eq(1)
       endpoint.tags[0].name.should eq("pii")
     end
+
+    it "normalizes camelCase strong names (dateOfBirth)" do
+      tagger = PiiTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/kyc", "POST", [
+        Param.new("dateOfBirth", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("pii")
+    end
+
+    it "tags two camelCase medium names (firstName + lastName)" do
+      tagger = PiiTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/profile", "POST", [
+        Param.new("firstName", "", "json"),
+        Param.new("lastName", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("pii")
+    end
+
+    it "matches a strong token inside a compound name (customerSsn)" do
+      tagger = PiiTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/customer", "POST", [
+        Param.new("customerSsn", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("pii")
+    end
+
+    it "does not tag a benign token that merely contains a PII substring" do
+      tagger = PiiTagger.new(default_tagger_options)
+
+      # `lesson` contains the substring "ssn" but is a single token, so
+      # token matching must not fire on it.
+      endpoint = Endpoint.new("/api/courses", "POST", [
+        Param.new("lessonId", "", "json"),
+        Param.new("lessonName", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/soap_spec.cr
+++ b/spec/unit_test/tagger/taggers/soap_spec.cr
@@ -78,5 +78,52 @@ describe "SoapTagger" do
       endpoint1.tags.size.should eq(1)
       endpoint2.tags.size.should eq(0)
     end
+
+    it "tags WSDL / ASMX URLs" do
+      ["/service?wsdl", "/Service.wsdl", "/Account.asmx"].each do |url|
+        tagger = SoapTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(url, "GET")
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("soap")
+      end
+    end
+
+    it "tags a SOAP 1.2 Content-Type header" do
+      tagger = SoapTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/webservice", "POST", [
+        Param.new("Content-Type", "application/soap+xml; charset=utf-8", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("soap")
+    end
+
+    it "does not tag a bare 'soap' path segment (store listing FP)" do
+      tagger = SoapTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/products/soap", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "ignores a soapaction-like name on a non-header param" do
+      tagger = SoapTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/data", "POST", [
+        Param.new("soapaction", "x", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/webhook_spec.cr
+++ b/spec/unit_test/tagger/taggers/webhook_spec.cr
@@ -91,5 +91,42 @@ describe "WebhookTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "tags on newer provider signature headers" do
+      ["X-Shopify-Hmac-Sha256", "Svix-Signature", "X-Razorpay-Signature",
+       "X-Line-Signature", "X-Amz-Sns-Message-Type"].each do |header|
+        tagger = WebhookTagger.new(default_tagger_options)
+        endpoint = Endpoint.new("/integrations/x", "POST", [
+          Param.new(header, "", "header"),
+        ])
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("webhook")
+      end
+    end
+
+    it "does not tag an in-app notifications resource (FP guard)" do
+      ["POST", "DELETE", "PUT"].each do |method|
+        tagger = WebhookTagger.new(default_tagger_options)
+        endpoint = Endpoint.new("/api/notifications", method)
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(0)
+      end
+    end
+
+    it "still tags a POST /notify (payment IPN callback)" do
+      tagger = WebhookTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/payment/notify", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("webhook")
+    end
   end
 end

--- a/spec/unit_test/tagger/taggers/websocket_spec.cr
+++ b/spec/unit_test/tagger/taggers/websocket_spec.cr
@@ -75,7 +75,7 @@ describe "WebsocketTagger" do
       endpoint.tags[0].name.should eq("websocket")
     end
 
-    it "requires at least 2 matching headers" do
+    it "tags on a single conclusive handshake header (Sec-WebSocket-Key)" do
       tagger = WebsocketTagger.new(default_tagger_options)
 
       endpoint = Endpoint.new("/chat", "GET", [
@@ -84,7 +84,70 @@ describe "WebsocketTagger" do
 
       tagger.perform([endpoint])
 
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("websocket")
+    end
+
+    it "tags on Sec-WebSocket-Accept alone" do
+      tagger = WebsocketTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/chat", "GET", [
+        Param.new("Sec-WebSocket-Accept", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+    end
+
+    it "requires at least 2 weak handshake headers" do
+      tagger = WebsocketTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/chat", "GET", [
+        Param.new("sec-websocket-version", "13", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
       endpoint.tags.size.should eq(0)
+    end
+
+    it "tags on two weak handshake headers" do
+      tagger = WebsocketTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/chat", "GET", [
+        Param.new("sec-websocket-version", "13", "header"),
+        Param.new("sec-websocket-protocol", "chat", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+    end
+
+    it "tags on an explicit Upgrade: websocket header" do
+      tagger = WebsocketTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/chat", "GET", [
+        Param.new("Upgrade", "websocket", "header"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+    end
+
+    it "tags Socket.IO / SockJS URLs even when protocol stays http" do
+      ["/socket.io/", "/sockjs/info"].each do |path|
+        tagger = WebsocketTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(path, "GET")
+        endpoint.protocol = "http"
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("websocket")
+      end
     end
 
     it "does not tag endpoint without WebSocket indicators" do

--- a/src/tagger/taggers/pii.cr
+++ b/src/tagger/taggers/pii.cr
@@ -11,23 +11,43 @@ class PiiTagger < Tagger
   # the endpoint because these names rarely appear outside a PII context.
   STRONG_NAMES = Set{
     "ssn", "social_security", "social_security_number",
-    "credit_card", "creditcard", "card_number", "cardnumber",
+    "credit_card", "creditcard", "credit_card_number", "creditcardnumber",
+    "card_number", "cardnumber", "card_no", "cardno",
     "cc_number", "ccnumber", "cvv", "cvc", "cvv2", "card_cvv",
-    "card_security_code",
-    "passport", "passport_number", "national_id", "nationalid",
-    "national_identity", "tax_id", "taxid",
+    "card_security_code", "cardholder_name", "card_holder",
+    "card_expiry", "card_expiration",
+    "passport", "passport_number", "passport_no", "passportno",
+    "national_id", "nationalid", "national_identity",
+    "national_insurance_number", "tax_id", "taxid",
+    "tax_number", "taxnumber", "aadhaar", "aadhar",
+    "aadhaar_number", "aadhar_number",
     "drivers_license", "driver_license", "license_number",
-    "iban", "bank_account", "routing_number",
+    "iban", "bank_account", "bank_account_number", "routing_number",
+    "sort_code",
     "date_of_birth", "dob", "birthdate", "birth_date",
+  }
+
+  # Single, unambiguous tokens. Matched anywhere in a (normalized) param
+  # name so compound names like `userSsn`, `customer_cvv`, or
+  # `applicantPassport` are caught without enumerating every prefix.
+  STRONG_TOKENS = Set{
+    "ssn", "cvv", "cvc", "cvv2", "iban", "passport", "dob",
+    "aadhaar", "aadhar",
   }
 
   # Weaker individually (a single one shows up in countless benign
   # forms), so require at least two before tagging.
   MEDIUM_NAMES = Set{
-    "email", "e_mail", "phone", "phone_number", "mobile", "telephone",
+    "email", "e_mail", "email_address", "phone", "phone_number",
+    "phone_no", "mobile", "mobile_number", "mobile_phone", "cell_phone",
+    "telephone",
     "first_name", "last_name", "full_name", "fullname", "given_name",
-    "family_name", "address", "street_address", "postal_code", "zip",
-    "zipcode", "zip_code", "gender", "nationality",
+    "family_name", "middle_name", "maiden_name",
+    "address", "street_address", "mailing_address", "billing_address",
+    "shipping_address", "home_address",
+    "postal_code", "zip", "zipcode", "zip_code",
+    "gender", "nationality", "birthday", "place_of_birth",
+    "marital_status",
   }
 
   def initialize(options : Hash(String, YAML::Any))
@@ -39,7 +59,8 @@ class PiiTagger < Tagger
     endpoints.each do |endpoint|
       param_names = endpoint.params.map { |param| normalize_param_name(param.name) }.to_set
 
-      has_strong = !(STRONG_NAMES & param_names).empty?
+      has_strong = !(STRONG_NAMES & param_names).empty? ||
+                   param_names.any? { |name| name.split('_').any? { |token| STRONG_TOKENS.includes?(token) } }
       medium_hits = (MEDIUM_NAMES & param_names).size
 
       check = has_strong || medium_hits >= 2
@@ -55,7 +76,17 @@ class PiiTagger < Tagger
     end
   end
 
+  # Fold camelCase, separators, and casing into one snake_case form so a
+  # param written as `firstName`, `First-Name`, or `first_name` all match
+  # the lists, which are kept in snake_case. camelCase boundaries get an
+  # underscore *before* separators are unified; digit runs are left
+  # intact so `cvv2` survives.
   private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
+    name
+      .gsub(/([a-z0-9])([A-Z])/) { "#{$1}_#{$2}" }
+      .gsub(/([A-Z]+)([A-Z][a-z])/) { "#{$1}_#{$2}" }
+      .downcase
+      .gsub(/[^a-z0-9]+/, "_")
+      .strip('_')
   end
 end

--- a/src/tagger/taggers/soap.cr
+++ b/src/tagger/taggers/soap.cr
@@ -1,8 +1,20 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+# Flags SOAP / XML web-service endpoints. SOAP surfaces warrant XML-
+# specific review (XXE, SOAP-action spoofing, WS-Security handling) that
+# differs from a typical REST/JSON route, so calling them out helps a
+# reviewer pick the right lens.
 class SoapTagger < Tagger
-  WORDS = ["soapaction"]
+  # Request headers that mark a SOAP call. `SOAPAction` is mandatory in
+  # SOAP 1.1; `Content-Type: application/soap+xml` is the SOAP 1.2 marker.
+  HEADER_NAMES = Set{"soapaction"}
+
+  # Unambiguous SOAP / XML-web-service URL markers: WSDL documents and the
+  # classic ASP.NET (`.asmx`) handler. A bare `soap` path segment is
+  # deliberately *not* matched — it collides with non-SOAP routes
+  # (e.g. a `/products/soap` store listing).
+  URL_MARKERS = ["?wsdl", ".wsdl", ".asmx"]
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -11,23 +23,26 @@ class SoapTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
-
-      endpoint.params.each do |param|
-        tmp_params.push param.name.to_s.downcase
-      end
-
-      words_set = Set.new(WORDS)
-      tmp_params_set = Set.new(tmp_params)
-      intersection = words_set & tmp_params_set
-
-      # A `SOAPAction` header is enough to flag the endpoint as SOAP.
-      check = intersection.size >= 1
+      check = soap_header?(endpoint) || soap_url?(endpoint.url)
 
       if check
         tag = Tag.new("soap", "SOAP endpoint for XML-based web service communication, supporting structured information exchanges across network applications.", "SOAP")
         endpoint.add_tag(tag)
       end
     end
+  end
+
+  private def soap_header?(endpoint : Endpoint) : Bool
+    endpoint.params.any? do |param|
+      next false unless param.param_type == "header"
+      name = param.name.downcase.tr("-", "_")
+      next true if HEADER_NAMES.includes?(name)
+      name == "content_type" && param.value.downcase.includes?("soap+xml")
+    end
+  end
+
+  private def soap_url?(url : String) : Bool
+    lowered = url.downcase
+    URL_MARKERS.any? { |marker| lowered.includes?(marker) }
   end
 end

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -12,9 +12,14 @@ class WebhookTagger < Tagger
 
   # Weaker path segments shared with non-webhook routes. Require a POST
   # (or other write) method before flagging on these alone.
+  #
+  # `notification(s)` are intentionally excluded: an in-app notifications
+  # resource (`POST /api/notifications`, `DELETE /notifications/{id}`) is
+  # far more common than a notification *webhook*, and it is a write, so
+  # the method gate doesn't help. The verb form `notify` is kept — it is
+  # the canonical callback term for payment IPNs (`notify_url`).
   MEDIUM_PATH_PARTS = Set{
-    "hook", "hooks", "callback", "callbacks", "notify", "notification",
-    "notifications",
+    "hook", "hooks", "callback", "callbacks", "notify",
   }
 
   # Webhooks are delivered as non-GET requests. Gate the weaker path
@@ -26,10 +31,23 @@ class WebhookTagger < Tagger
   # Provider-specific signature/event headers. Any one is a strong
   # webhook indicator on its own.
   SIGNATURE_HEADERS = Set{
+    # GitHub / GitLab / Bitbucket / generic
     "x_hub_signature", "x_hub_signature_256", "x_signature",
-    "x_webhook_signature", "stripe_signature", "x_slack_signature",
-    "x_github_event", "x_gitlab_event", "x_gitlab_token",
-    "x_event_key", "paypal_transmission_sig",
+    "x_webhook_signature", "webhook_signature", "x_hook_signature",
+    "x_event_key", "x_github_event", "x_gitlab_event", "x_gitlab_token",
+    # Payments
+    "stripe_signature", "paypal_transmission_sig",
+    "x_razorpay_signature", "x_paystack_signature",
+    "x_square_hmacsha256_signature",
+    # Chat / comms
+    "x_slack_signature", "x_line_signature", "x_zm_signature",
+    "x_signature_ed25519", "x_telegram_bot_api_secret_token",
+    # E-commerce / SaaS / infra
+    "x_shopify_hmac_sha256", "x_shopify_topic",
+    "x_wc_webhook_signature", "x_wc_webhook_topic",
+    "x_twilio_signature", "x_twilio_email_event_webhook_signature",
+    "x_amz_sns_message_type", "x_mandrill_signature",
+    "svix_id", "svix_signature", "svix_timestamp",
   }
 
   def initialize(options : Hash(String, YAML::Any))

--- a/src/tagger/taggers/websocket.cr
+++ b/src/tagger/taggers/websocket.cr
@@ -1,9 +1,32 @@
 require "../../models/tagger"
 require "../../models/endpoint"
 
+# Flags WebSocket endpoints — long-lived, bidirectional channels whose
+# threat model (origin checks on the handshake, per-message authz, no
+# CSRF token on the upgrade) differs from a request/response route.
 class WebsocketTagger < Tagger
-  WORDS        = ["sec-websocket-key", "sec-websocket-accept", "sec-websocket-version"]
+  # AsyncAPI specs carry the raw server protocol (`ws`, `wss`,
+  # `websocket`); HTTP analyzers set `ws`. Accept every spelling so
+  # `wss`/`websocket` endpoints aren't missed.
   WS_PROTOCOLS = Set{"ws", "wss", "websocket"}
+
+  # Handshake headers that appear essentially *only* in a WebSocket
+  # upgrade, so a single one is conclusive. `Sec-WebSocket-Key` (client)
+  # and `Sec-WebSocket-Accept` (server) are reserved for the handshake.
+  STRONG_HEADERS = Set{"sec_websocket_key", "sec_websocket_accept"}
+
+  # Also part of the handshake but individually a touch less conclusive;
+  # two together flag the endpoint.
+  WEAK_HEADERS = Set{
+    "sec_websocket_version", "sec_websocket_protocol",
+    "sec_websocket_extensions",
+  }
+
+  # Transport-library markers that survive in the URL even when the
+  # analyzer leaves the protocol as plain HTTP — Socket.IO and SockJS run
+  # an HTTP handshake before upgrading, so their routes are emitted as
+  # ordinary HTTP endpoints.
+  URL_MARKERS = ["socket.io", "sockjs"]
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -12,34 +35,44 @@ class WebsocketTagger < Tagger
 
   def perform(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
-      tmp_params = [] of String
-
-      # AsyncAPI specs carry the raw server protocol (`ws`, `wss`,
-      # `websocket`), while HTTP analyzers set `ws`. Normalize case and
-      # accept all WebSocket protocol spellings so `wss`/`websocket`
-      # endpoints aren't missed.
-      if WS_PROTOCOLS.includes?(endpoint.protocol.downcase)
+      if websocket?(endpoint)
         tag = Tag.new("websocket", "WebSocket endpoint for real-time, bidirectional communication between clients and servers, enabling efficient data exchanges.", "WebSocket")
         endpoint.add_tag(tag)
-      else
-        endpoint.params.each do |param|
-          tmp_params.push param.name.to_s.downcase
-        end
-
-        words_set = Set.new(WORDS)
-        tmp_params_set = Set.new(tmp_params)
-        intersection = words_set & tmp_params_set
-
-        # Require at least two WebSocket-related headers to flag the
-        # endpoint when the protocol metadata is missing (e.g. for
-        # plain HTTP endpoints that happen to mention Sec-WebSocket-*).
-        check = intersection.size >= 2
-
-        if check
-          tag = Tag.new("websocket", "WebSocket endpoint for real-time, bidirectional communication between clients and servers, enabling efficient data exchanges.", "WebSocket")
-          endpoint.add_tag(tag)
-        end
       end
     end
+  end
+
+  private def websocket?(endpoint : Endpoint) : Bool
+    return true if WS_PROTOCOLS.includes?(endpoint.protocol.downcase)
+    return true if url_marker?(endpoint.url)
+    header_websocket?(endpoint)
+  end
+
+  private def url_marker?(url : String) : Bool
+    lowered = url.downcase
+    URL_MARKERS.any? { |marker| lowered.includes?(marker) }
+  end
+
+  # A single conclusive handshake header (`Sec-WebSocket-Key`/`-Accept`),
+  # an explicit `Upgrade: websocket`, or any two weaker handshake headers
+  # mark the endpoint when the protocol metadata is missing.
+  private def header_websocket?(endpoint : Endpoint) : Bool
+    strong = 0
+    weak = 0
+    upgrade = false
+
+    endpoint.params.each do |param|
+      next unless param.param_type == "header"
+      name = param.name.downcase.tr("-", "_")
+      if STRONG_HEADERS.includes?(name)
+        strong += 1
+      elsif WEAK_HEADERS.includes?(name)
+        weak += 1
+      elsif name == "upgrade" && param.value.downcase.includes?("websocket")
+        upgrade = true
+      end
+    end
+
+    strong >= 1 || upgrade || weak >= 2
   end
 end


### PR DESCRIPTION
## Summary

Tightens four metadata taggers in `src/tagger/taggers` to enrich Noir's AI/review context with fewer misses and fewer false flags. These taggers feed downstream consumers that prioritize sensitive routes, so both recall (FN) and precision (FP) matter. Each change is grounded in how the analyzers actually emit endpoints (param casing, header `param_type`, protocol metadata).

### PII (`pii.cr`)
- **FN — camelCase normalization.** `normalize_param_name` only did `downcase` + `-`→`_`, so analyzers that emit `firstName`, `dateOfBirth`, `emailAddress`, `postalCode`, … (JS/Java/etc.) were **silently missed** because the lists are snake_case. Now camelCase boundaries fold to snake_case first (`firstName` → `first_name`), with digit runs left intact so `cvv2` survives.
- **FN — strong tokens in compound names.** A new `STRONG_TOKENS` set matches unambiguous single tokens (`ssn`, `cvv`, `iban`, `passport`, `dob`, …) anywhere in a normalized name, catching `customerSsn`, `applicantPassport`, etc. Token-level (not substring) matching keeps `lessonId` from tripping on the `ssn` substring.
- **FN — list coverage.** Added card/passport/tax/national-id/address/phone/name variants.

### SOAP (`soap.cr`)
- **FN — URL + content-type.** Only the `SOAPAction` header was detected. Now also flags `?wsdl` / `.wsdl` / `.asmx` URLs and the SOAP 1.2 `application/soap+xml` `Content-Type`.
- **FP guard.** `SOAPAction` is matched only as a `header` param; a bare `soap` path segment stays excluded (e.g. `/products/soap` store listing).

### Webhook (`webhook.cr`)
- **FP — drop `notification(s)` path parts.** An in-app notifications resource (`POST /api/notifications`, `DELETE /notifications/{id}`) is a write, so the existing not-a-read gate couldn't save it from being mistagged as a webhook. The verb `notify` is kept (canonical payment-IPN `notify_url`).
- **FN — broader signature headers.** Added Shopify, Svix (Clerk/Resend), Razorpay, Paystack, Square, Twilio, Line, Zoom, Discord (`X-Signature-Ed25519`), Telegram, WooCommerce, SNS, Mandrill, and generic `webhook_signature`/`x_hook_signature`.

### WebSocket (`websocket.cr`)
- **FN — conclusive single header.** `Sec-WebSocket-Key`/`-Accept` are reserved for the handshake, so one is now enough (previously **2** of any sec-websocket-* were required). An explicit `Upgrade: websocket` also flags. Weaker handshake headers (version/protocol/extensions) still need two.
- **FN — transport markers.** Socket.IO / SockJS run an HTTP handshake before upgrading, so their routes arrive as plain-HTTP endpoints; `socket.io` / `sockjs` URLs are now detected.

## Test plan
- Added/updated specs for every change above (camelCase, compound-token + substring-FP guard, WSDL/asmx/soap+xml, soap-segment FP, notifications FP, new signature headers, single-strong-header, Upgrade, Socket.IO/SockJS).
- `crystal spec spec/unit_test/tagger/` → 427 examples, 0 failures.
- `crystal spec spec/unit_test/` → 3035 examples, 0 failures.
- Full `crystal build src/noir.cr` compiles; ameba clean on all changed files.