### PR TITLE
fix(java): byte/char index bugs, header truncation, dead routes detection

### DIFF
--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -464,8 +464,13 @@ module Analyzer::Java
 
     private def service_with_routes_class?(cls : LibTreeSitter::TSNode, content : String) : Bool
       header = Noir::TreeSitter.node_text(cls, content)
-      if body_start = header.index('{')
-        header = header[...body_start]
+      # Bound the header at the class body via the AST, not the first '{' — an
+      # annotation arg like `@SomeAnno({"a","b"})` would otherwise truncate the
+      # `implements HttpServiceWithRoutes` clause and drop the class's routes.
+      if body = Noir::TreeSitter.field(cls, "body")
+        class_start = LibTreeSitter.ts_node_start_byte(cls).to_i
+        body_start = LibTreeSitter.ts_node_start_byte(body).to_i
+        header = content.byte_slice(class_start, body_start - class_start)
       end
 
       header.includes?("HttpServiceWithRoutes") || header.includes?("ServiceWithRoutes")
@@ -666,42 +671,38 @@ module Analyzer::Java
                                         open_idx : Int32,
                                         open_char : Char,
                                         close_char : Char) : Int32?
+      # Scan by CHARACTER (not byte): open_idx is a char index from String#index
+      # and callers char-slice with the returned index. A byte scan corrupts both
+      # on multi-byte UTF-8. ASCII-identical to the previous byte loop.
       depth = 1
-      i = open_idx + 1
-      bytes = code.to_slice
-      open_byte = open_char.ord
-      close_byte = close_char.ord
-      double_quote = '"'.ord
-      single_quote = '\''.ord
-      backslash = '\\'.ord
       in_string = false
-      quote = 0
+      quote = '\0'
       escape = false
 
-      while i < bytes.size && depth > 0
-        byte = bytes[i]
+      code.each_char_with_index do |ch, i|
+        next if i <= open_idx
         if in_string
           if escape
             escape = false
-          elsif byte == backslash
+          elsif ch == '\\'
             escape = true
-          elsif byte == quote
+          elsif ch == quote
             in_string = false
           end
         else
-          if byte == double_quote || byte == single_quote
+          if ch == '"' || ch == '\''
             in_string = true
-            quote = byte
-          elsif byte == open_byte
+            quote = ch
+          elsif ch == open_char
             depth += 1
-          elsif byte == close_byte
+          elsif ch == close_char
             depth -= 1
           end
         end
-        i += 1
+        return i if depth == 0
       end
 
-      depth == 0 ? i - 1 : nil
+      nil
     end
 
     # ---- annotation-based service routes ------------------------------

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -254,38 +254,42 @@ module Analyzer::Java
     end
 
     private def find_matching_paren(code : String, open_idx : Int32) : Int32?
+      # Scan by CHARACTER (not byte): open_idx is a char index and the caller
+      # char-slices with the returned index. ASCII-identical to the byte loop.
       depth = 1
-      i = open_idx + 1
-      bytes = code.to_slice
       in_string = false
       escape = false
-      while i < bytes.size && depth > 0
-        c = bytes[i]
+      code.each_char_with_index do |char, idx|
+        next if idx <= open_idx
         if in_string
           if escape
             escape = false
-          elsif c == '\\'.ord
+          elsif char == '\\'
             escape = true
-          elsif c == '"'.ord
+          elsif char == '"'
             in_string = false
           end
         else
-          case c
-          when '"'.ord then in_string = true
-          when '('.ord then depth += 1
-          when ')'.ord then depth -= 1
+          case char
+          when '"' then in_string = true
+          when '(' then depth += 1
+          when ')'
+            depth -= 1
+            return idx if depth.zero?
           end
         end
-        i += 1
       end
-      depth == 0 ? i - 1 : nil
+      nil
     end
 
     private def enable_webjars_call?(content : String, marker : Int32) : Bool
+      # marker is a CHAR index; use char-based slicing (byte_slice would misread
+      # the prefix when a multi-byte char precedes the call). `content[start, n]`
+      # clamps at end-of-string instead of raising.
       match =
-        if content.byte_slice(marker).starts_with?("enableWebjars")
+        if content[marker, 13] == "enableWebjars"
           "enableWebjars"
-        elsif content.byte_slice(marker).starts_with?("enableWebJars")
+        elsif content[marker, 13] == "enableWebJars"
           "enableWebJars"
         else
           return false

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -498,7 +498,9 @@ module Analyzer::Java
         when ')', ']', '}'
           depth -= 1 if depth > 0
         else
-          return i if depth == 0 && text.byte_slice(i, operator.size) == operator
+          # `i` is a CHAR index; char-slice (byte_slice would treat i as a byte
+          # offset and desync the match when a multi-byte char precedes it).
+          return i if depth == 0 && text[i, operator.size] == operator
         end
         i += 1
       end

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -486,42 +486,38 @@ module Analyzer::Java
                                         open_idx : Int32,
                                         open_char : Char,
                                         close_char : Char) : Int32?
+      # Scan by CHARACTER (not byte): open_idx is a char index from String#index
+      # and callers char-slice with / range-compare the returned index. A byte
+      # scan corrupts both on multi-byte UTF-8. ASCII-identical.
       depth = 1
-      i = open_idx + 1
-      bytes = code.to_slice
-      open_byte = open_char.ord
-      close_byte = close_char.ord
-      double_quote = '"'.ord
-      single_quote = '\''.ord
-      backslash = '\\'.ord
       in_string = false
-      quote = 0
+      quote = '\0'
       escape = false
 
-      while i < bytes.size && depth > 0
-        byte = bytes[i]
+      code.each_char_with_index do |ch, i|
+        next if i <= open_idx
         if in_string
           if escape
             escape = false
-          elsif byte == backslash
+          elsif ch == '\\'
             escape = true
-          elsif byte == quote
+          elsif ch == quote
             in_string = false
           end
         else
-          if byte == double_quote || byte == single_quote
+          if ch == '"' || ch == '\''
             in_string = true
-            quote = byte
-          elsif byte == open_byte
+            quote = ch
+          elsif ch == open_char
             depth += 1
-          elsif byte == close_byte
+          elsif ch == close_char
             depth -= 1
           end
         end
-        i += 1
+        return i if depth == 0
       end
 
-      depth == 0 ? i - 1 : nil
+      nil
     end
 
     private def bean_index_for(path : String,

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -1095,31 +1095,32 @@ module Analyzer::Java
     # Find the matching `)` for the `(` at `open_idx`, skipping
     # string literals so `"(foo)"` doesn't perturb depth.
     private def find_matching_paren(code : String, open_idx : Int32) : Int32?
+      # Scan by CHARACTER (not byte): open_idx comes from char-based String#index
+      # / MatchData and callers char-slice with the returned index. A byte scan
+      # corrupts both on multi-byte UTF-8 (i18n comments/literals). ASCII-identical.
       depth = 1
-      i = open_idx + 1
-      bytes = code.to_slice
       in_string = false
       escape = false
-      while i < bytes.size && depth > 0
-        c = bytes[i]
+      code.each_char_with_index do |c, i|
+        next if i <= open_idx
         if in_string
           if escape
             escape = false
-          elsif c == '\\'.ord
+          elsif c == '\\'
             escape = true
-          elsif c == '"'.ord
+          elsif c == '"'
             in_string = false
           end
         else
           case c
-          when '"'.ord then in_string = true
-          when '('.ord then depth += 1
-          when ')'.ord then depth -= 1
+          when '"' then in_string = true
+          when '(' then depth += 1
+          when ')' then depth -= 1
           end
         end
-        i += 1
+        return i if depth.zero?
       end
-      depth == 0 ? i - 1 : nil
+      nil
     end
 
     private def path_configs_for(file_list : Array(String)) : Hash(String, SpringPathConfig)

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -702,7 +702,9 @@ module Analyzer::Java
     end
 
     private def line_number_for(content : String, offset : Int32) : Int32
-      content.byte_slice(0, offset).count('\n') + 1
+      # Callers pass CHAR offsets (match.begin / String#index); char-slice so
+      # multi-byte chars before `offset` don't under-count newlines.
+      content[0, offset].count('\n') + 1
     end
 
     private def matching_brace(content : String, open_index : Int32) : Int32?

--- a/src/detector/detectors/java/play.cr
+++ b/src/detector/detectors/java/play.cr
@@ -25,7 +25,7 @@ module Detector::Java
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml")
+      filename.ends_with?(".java") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".xml") || filename.ends_with?(".properties") || filename.ends_with?(".yml") || filename.ends_with?(".yaml") || filename.ends_with?("routes") || filename.ends_with?("routes.conf")
     end
 
     def set_name


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **spring / quarkus / armeria / javalin** — `find_matching_paren` / `find_matching_delimiter` scanned by **byte** offset but callers pass **char** indices and char-slice the result → on a multi-byte UTF-8 char before the delimiter the route is dropped or its path corrupted. Rewritten to scan by character (ASCII-identical).
- **javalin** — `enable_webjars_call?` used `byte_slice(marker)` with a char marker → dropped `/webjars/**` on non-ASCII files.
- **armeria** — `service_with_routes_class?` truncated the class header at the first `{`, which can be inside a leading annotation arg (`@Anno({"a","b"})`), dropping the `implements HttpServiceWithRoutes` clause; now bounds the header at the AST body node.
- **play (analyzer)** — `top_level_operator_index` mixed a char index with `byte_slice`, mis-parsing route-action query params on non-ASCII signatures.
- **struts2** — `line_number_for` used `byte_slice(0, offset)` with char offsets → wrong endpoint line numbers on non-ASCII files.
- **detector/java/play** — `applicable?` excluded the Play `routes`/`routes.conf` files that `detect()` already handles (dead code). *(Note: the Scala-Play counterpart was deliberately left out — its `?=` heuristic also matches Java routes files and would cross-detect.)*

All char-rewrites are byte-identical on ASCII; full suite green locally.