### PR TITLE
fix(rust): FP/FN + string-slicing in axum/warp/rwf/rocket/salvo/actix

### DIFF
--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -583,10 +583,14 @@ module Analyzer::Rust
 
     # Build a map of each `scope(...)`/`resource(...)` call's start byte
     # to its fully composed path prefix, threading the prefix top-down
-    # through `.service(...)` arguments. Only chains rooted on a
-    # non-scope base (`cfg`, `App::new()`, a variable) are entered;
-    # nested scopes are reached purely through `.service`, so each one's
-    # prefix is unambiguous and long scope chains aren't re-walked.
+    # through `.service(...)` arguments. Chains rooted on a non-scope
+    # base (`cfg`, `App::new()`, a variable) carry no inherited prefix;
+    # chains rooted *directly* at a `scope(...)`/`resource(...)` (a
+    # helper that returns a configured `Scope`) are entered too so their
+    # own segment seeds the prefix. A nested scope is reached both as a
+    # `.service` argument of its parent (composed prefix) and as its own
+    # standalone chain root (bare segment); `register_scope_chain` keeps
+    # whichever produced the longer prefix, so the composed one wins.
     private def collect_scope_prefixes(root : LibTreeSitter::TSNode,
                                        source : String,
                                        test_regions : Array(Tuple(Int32, Int32))) : Hash(Int32, String)
@@ -594,8 +598,6 @@ module Analyzer::Rust
       walk_calls(root) do |call|
         next if RustEngine.inside_test_region?(call, test_regions)
         next unless router_chain_root?(call, source)
-        kind, _, _ = resolve_chain_base(call, source)
-        next unless kind == :other
         register_scope_chain(call, "", map, source)
       end
       map
@@ -628,7 +630,13 @@ module Analyzer::Rust
           inherited
         end
       if (kind == :scope || kind == :resource) && base_node
-        map[node_byte(base_node)] = prefix
+        key = node_byte(base_node)
+        # Longest-prefix-wins: the same scope is registered both as its
+        # parent's `.service` argument (fully composed) and as its own
+        # standalone chain root (bare segment). Keep the composed one so
+        # the standalone walk can't overwrite it with a shorter prefix.
+        existing = map[key]?
+        map[key] = prefix if existing.nil? || prefix.size > existing.size
       end
 
       cursor = expr

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -170,8 +170,33 @@ module Analyzer::Rust
     private def router_emit?(call : LibTreeSitter::TSNode, source : String) : Bool
       name = field_call_name(call, source)
       return false unless name
+      # `fallback`/`fallback_service` are common method names on non-router
+      # types and emit a path-less `/*`; require a plausibly-router receiver to
+      # avoid phantom endpoints from e.g. `Config{..}.fallback(handler)`.
+      if name == "fallback" || name == "fallback_service"
+        return router_chain_receiver?(call, source)
+      end
       return true if ROUTER_EMIT_NAMES.includes?(name)
       BUILDER_ROUTE_EMIT_NAMES.includes?(name) && route_builder_receiver?(call, source)
+    end
+
+    # Conservative receiver check: reject only clearly-non-router receivers
+    # (struct literals, arrays, scalar literals); accept router variables,
+    # fields, self, and any call chain (real routers are `Router::new()...` or a
+    # router variable, so this keeps zero false negatives on those forms).
+    private def router_chain_receiver?(call : LibTreeSitter::TSNode, source : String) : Bool
+      fn = Noir::TreeSitter.field(call, "function")
+      return false unless fn && Noir::TreeSitter.node_type(fn) == "field_expression"
+      recv = Noir::TreeSitter.field(fn, "value")
+      return false unless recv
+      case Noir::TreeSitter.node_type(recv)
+      when "struct_expression", "array_expression",
+           "integer_literal", "float_literal", "string_literal",
+           "boolean_literal", "char_literal", "unit_expression"
+        false
+      else
+        true
+      end
     end
 
     # Walks Axum router builder chains with an active path prefix.
@@ -582,11 +607,17 @@ module Analyzer::Rust
 
     private def string_literal_text(node : LibTreeSitter::TSNode, source : String) : String?
       return unless Noir::TreeSitter.node_type(node) == "string_literal"
-      content = nil.as(String?)
+      # tree-sitter-rust splits a literal with escapes into multiple children
+      # ("/a\tb" -> string_content "/a", escape_sequence "\t", string_content "b").
+      # Concatenate every segment instead of keeping only the last one.
+      parts = [] of String
       Noir::TreeSitter.each_named_child(node) do |child|
-        content = Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "string_content"
+        case Noir::TreeSitter.node_type(child)
+        when "string_content", "escape_sequence"
+          parts << Noir::TreeSitter.node_text(child, source)
+        end
       end
-      content
+      parts.empty? ? nil : parts.join
     end
 
     private def build_router_function_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -489,7 +489,9 @@ module Analyzer::Rust
       path_part = parts[0]
       query_part = parts[1]?
 
-      path_part.scan(/<(\w+)>/) do |match|
+      # Tolerate the trailing-segments form `<name..>` so the captured name
+      # matches the `{name}` placeholder canonicalize_rocket_path emits.
+      path_part.scan(/<(\w+)(?:\.\.)?>/) do |match|
         name = match[1]
         params << Param.new(name, "", "path") unless params.any? { |p| p.name == name && p.param_type == "path" }
       end

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -83,6 +83,9 @@ module Analyzer::Rust
           when :crud, :rest
             REST_ROUTES.each do |suffix, http_method|
               route_path = "#{reg.path.rstrip('/')}#{suffix}"
+              # Root-mounted collection routes: "/".rstrip('/') + "" == "" — emit
+              # "/" rather than an invalid empty URL.
+              route_path = "/" if route_path.empty?
               details = Details.new(PathInfo.new(path, reg.row))
               endpoint = Endpoint.new(route_path, http_method, details)
               extract_path_params(route_path, endpoint)

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -459,6 +459,12 @@ module Analyzer::Rust
               depth -= 1 if route[j] == '}'
               j += 1
             end
+            if depth > 0
+              # Unbalanced '{' (no matching '}'): emit the rest verbatim rather
+              # than dropping the final char / producing an empty `{}`.
+              io << route[i..]
+              break
+            end
             inner = route[(i + 1)...(j - 1)]
             stars = inner.starts_with?("**") ? "**" : inner.starts_with?("*") ? "*" : ""
             name = inner.lstrip('*').split(/[:|]/, 2).first

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -131,9 +131,12 @@ module Analyzer::Rust
           if fn_text == "warp::query"
             type_name = first_type_argument(node, source) || "query"
             params << Param.new(type_name, "", "query") unless params.any? { |p| p.name == type_name && p.param_type == "query" }
-          elsif fn_text == "warp::body::json" || fn_text == "warp::body::form"
+          elsif fn_text == "warp::body::json"
             type_name = first_type_argument(node, source) || "body"
             params << Param.new(type_name, "", "json") unless params.any? { |p| p.name == type_name && p.param_type == "json" }
+          elsif fn_text == "warp::body::form"
+            type_name = first_type_argument(node, source) || "body"
+            params << Param.new(type_name, "", "form") unless params.any? { |p| p.name == type_name && p.param_type == "form" }
           end
         when "scoped_identifier"
           text = Noir::TreeSitter.node_text(node, source)


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **axum** — `string_literal_text` kept only the **last** `string_content` child → any path/nest prefix containing a backslash escape was truncated to its tail; now concatenates all `string_content`/`escape_sequence` parts. Also `fallback`/`fallback_service` emitted a phantom path-less `/*` for **any** receiver (e.g. a struct literal) — now requires a plausibly-router receiver (conservative: rejects only struct/array/literal receivers, zero FN on `Router::new()...`/router vars).
- **warp** — `warp::body::form` was labeled `json` instead of `form`.
- **rwf** — root-mounted `crud!`/`rest!` (`"/"`) emitted **empty-string URLs** for the collection routes; normalized to `/`.
- **rocket** — trailing-segments param `<name..>` appeared in the URL but was never extracted as a path Param (URL/param desync); path scan now tolerates `..`.
- **salvo** — `canonicalize_salvo_path` dropped the last char / emitted `{}` on an unbalanced `{`; now emits the remainder verbatim.
- **actix** — scope chains rooted directly at `web::scope(...)` (a helper returning a configured `Scope`) lost their prefix; entered too, keeping the longest (composed) prefix.

Full suite green locally.