### PR TITLE
fix(go): greedy param regexes, SetCookie misread, comment-aware proto, auth prefix

### DIFF
--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -105,15 +105,16 @@ module Analyzer::Go
 
                       ["GetString", "GetStrings", "GetInt", "GetInt8", "GetUint8", "GetInt16", "GetUint16", "GetInt32", "GetUint32",
                        "GetInt64", "GetUint64", "GetBool", "GetFloat"].each do |pattern|
-                        match = line.match(/#{pattern}\(\"(.*)\"\)/)
-                        if match
-                          param_name = match[1]
-                          last_endpoint.params << Param.new(param_name, "", "query")
+                        # Quote-bounded + scan so two accessor calls on one line
+                        # each yield their own param (greedy `(.*)` captured across
+                        # both, producing one garbage name).
+                        line.scan(/#{pattern}\("([^"]*)"\)/) do |m|
+                          last_endpoint.params << Param.new(m[1], "", "query")
                         end
                       end
 
                       if line.includes?("GetCookie(")
-                        match = line.match(/GetCookie\(\"(.*)\"\)/)
+                        match = line.match(/GetCookie\(\"([^"]*)\"\)/)
                         if match
                           cookie_name = match[1]
                           last_endpoint.params << Param.new(cookie_name, "", "cookie")
@@ -121,7 +122,7 @@ module Analyzer::Go
                       end
 
                       if line.includes?("GetSecureCookie(")
-                        match = line.match(/GetSecureCookie\(\"(.*)\"\)/)
+                        match = line.match(/GetSecureCookie\(\"([^"]*)\"\)/)
                         if match
                           cookie_name = match[1]
                           last_endpoint.params << Param.new(cookie_name, "", "cookie")

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -201,18 +201,36 @@ module Analyzer::Go
       in_string = false
       while pos < content.size
         ch = content[pos]
-        if ch == '"' && (pos == 0 || content[pos - 1] != '\\')
-          in_string = !in_string
-        elsif !in_string
-          case ch
-          when '{'
-            depth += 1
-          when '}'
-            depth -= 1
-            if depth == 0
-              return content[(open_pos + 1)..(pos - 1)]
+        if in_string
+          # A quote closes the string only when preceded by an EVEN number of
+          # backslashes (so `\\"` = literal backslash + terminator toggles, but
+          # `\"` = escaped quote does not).
+          if ch == '"'
+            bs = 0
+            bp = pos - 1
+            while bp >= 0 && content[bp] == '\\'
+              bs += 1
+              bp -= 1
             end
+            in_string = false if bs.even?
           end
+        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '/'
+          # Line comment: skip to EOL so a stray `}` or `"` can't shift state.
+          nl = content.index('\n', pos)
+          pos = nl.nil? ? content.size : nl
+          next
+        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '*'
+          # Block comment: skip to the closing */.
+          close = content.index("*/", pos + 2)
+          pos = close.nil? ? content.size : close + 2
+          next
+        elsif ch == '"'
+          in_string = true
+        elsif ch == '{'
+          depth += 1
+        elsif ch == '}'
+          depth -= 1
+          return content[(open_pos + 1)..(pos - 1)] if depth == 0
         end
         pos += 1
       end

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -204,9 +204,10 @@ module Analyzer::Go
       if line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
         add_param_to_endpoint(Param.new("body", "", "json"), target)
       end
-      if line.includes?("Cookie(") &&
-         !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
-        match = line.match(/Cookie\(\"(.*)\"\)/)
+      # Read accessor only: `.Cookie("name")`. The `.Cookie(` anchor excludes
+      # Header.Get/Cookie.Get; the SetCookie exclusion avoids the write API.
+      if line.includes?(".Cookie(") && !line.includes?("SetCookie(")
+        match = line.match(/\.Cookie\s*\(\s*"([^"]*)"/)
         if match
           target.params << Param.new(match[1], "", "cookie")
         end
@@ -225,9 +226,9 @@ module Analyzer::Go
         b = Param.new("body", "", "json")
         targets.each { |t| add_param_to_endpoint(b, t) }
       end
-      if line.includes?("Cookie(") &&
-         !line.includes?("Header.Get") && !line.includes?("Cookie.Get")
-        match = line.match(/Cookie\(\"(.*)\"\)/)
+      # Read accessor only (see add_gin_param_patterns).
+      if line.includes?(".Cookie(") && !line.includes?("SetCookie(")
+        match = line.match(/\.Cookie\s*\(\s*"([^"]*)"/)
         if match
           c = Param.new(match[1], "", "cookie")
           targets.each { |t| t.params << c }

--- a/src/analyzer/analyzers/go/goyave.cr
+++ b/src/analyzer/analyzers/go/goyave.cr
@@ -99,10 +99,11 @@ module Analyzer::Go
                             result << new_endpoint
                             last_endpoint = new_endpoint
 
-                            route.path.scan(/\{([a-zA-Z0-9_]+)(?::([^}]+))?\}/) do |match_data|
-                              param_name = match_data[1]
-                              param_pattern = match_data[2]?
-                              last_endpoint.params << Param.new(param_name, param_pattern || "", "path")
+                            route.path.scan(/\{([a-zA-Z0-9_]+)(?::[^}]+)?\}/) do |match_data|
+                              # The `value` field holds an example value, not a
+                              # route regex constraint — leave it empty (matches
+                              # fasthttp/other Go analyzers).
+                              last_endpoint.params << Param.new(match_data[1], "", "path")
                             end
                           end
                         end

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -199,12 +199,19 @@ class GoAuthTagger < FrameworkTagger
     url = endpoint.url
 
     @middleware_scopes.each do |scope|
-      if url.starts_with?(scope[:prefix])
+      if prefix_covers?(scope[:prefix], url)
         return scope[:description]
       end
     end
 
     nil
+  end
+
+  # Segment-aware prefix match so "/api" guards "/api/x" but not "/apiv2".
+  # The root scope "/" guards every endpoint.
+  private def prefix_covers?(prefix : String, url : String) : Bool
+    return true if prefix == "/"
+    url == prefix || url.starts_with?("#{prefix}/")
   end
 
   private def normalize_prefix(segments : Array(String)) : String


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **beego** — `GetString`/`GetInt`/… and cookie regexes used greedy `(.*)` with no quote boundary → two accessor calls on one line captured one garbage param name. Quote-bounded `([^"]*)` + `scan` so each call yields its own param.
- **gin** — the cookie branch fired on `Cookie(`, which also matches the **write** API `c.SetCookie(...)` → phantom cookie param. Now anchors on `.Cookie(` and excludes `SetCookie(`, with a non-greedy quote-bounded capture.
- **goyave** — stored the path-param regex constraint (`[0-9]+`) in the Param **value** field; value should be empty (matches fasthttp/other Go analyzers).
- **connect_rpc** — `extract_brace_block` wasn't comment-aware → an unbalanced `}` or `"` inside a `//` / `/* */` comment truncated or dropped a whole proto service/message. Now skips comments and uses backslash-parity for the string-close check.
- **go_auth tagger** — group middleware scope used a naive `starts_with?` so `/api` tagged `/apiv2` as auth-protected; now uses segment-aware `prefix_covers?` (mirrors `go_security`).

Full suite green locally.