### PR TITLE
fix(ruby): nested params-block prefix leak (grape/hanami), CSRF-tag substring match

### DIFF
--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -41,7 +41,7 @@ module Analyzer::Ruby
       class_prefix = ""
       version_prefix = ""
       pending_params = [] of String
-      in_params_block = false
+      params_block_depth = 0
       last_endpoint : Endpoint? = nil
       lines = content.lines
 
@@ -50,19 +50,26 @@ module Analyzer::Ruby
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?('#')
 
-        if in_params_block
-          if stripped == "end" || stripped.starts_with?("end ")
-            in_params_block = false
-            next
-          end
-          stripped.scan(/(?:requires|optional)\s+[:\'"]([\w]+)[\'"]?/) do |m|
-            pending_params << m[1] if m.size > 1
+        if params_block_depth > 0
+          # Grape allows nested validation blocks (`requires :x, type: Hash do
+          # ... end`), so the params block closes only when depth returns to 0.
+          # A plain boolean let the first inner `end` close it early, leaking the
+          # remaining `end`(s) to the main parser, which then popped the
+          # enclosing namespace/resource prefix frame.
+          if stripped == "end" || stripped.starts_with?("end ") || stripped.starts_with?("end#")
+            params_block_depth -= 1
+            next if params_block_depth <= 0
+          else
+            params_block_depth += ruby_do_block_open_delta(stripped)
+            stripped.scan(/(?:requires|optional)\s+[:\'"]([\w]+)[\'"]?/) do |m|
+              pending_params << m[1] if m.size > 1
+            end
           end
           next
         end
 
         if stripped == "params do" || stripped.starts_with?("params do")
-          in_params_block = true
+          params_block_depth = 1
           next
         end
 

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -418,17 +418,29 @@ module Analyzer::Ruby
     end
 
     private def scan_action_params(endpoint : Endpoint, lines : Array(String))
-      in_params_block = false
+      params_depth = 0
 
       lines.each do |line|
-        # Detect params block
-        if line.strip == "params do"
-          in_params_block = true
-          next
-        elsif line.strip == "end" && in_params_block
-          in_params_block = false
+        stripped = line.strip
+        # dry-validation params blocks nest (`required(:address).hash do ...
+        # end`), so track depth and exit only on the OUTERMOST `end`. A plain
+        # boolean exited on the first inner `end`, dropping later params and
+        # fabricating query params from DSL lines still inside the block.
+        if params_depth == 0 && stripped == "params do"
+          params_depth = 1
           next
         end
+
+        if params_depth > 0
+          if closes_ruby_block?(stripped)
+            params_depth -= 1
+            next if params_depth == 0
+          else
+            params_depth += ruby_do_block_open_delta(stripped)
+          end
+        end
+
+        in_params_block = params_depth > 0
 
         # Extract params from params block
         # Matches required(:name) or optional(:name) - validation methods like

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -192,9 +192,9 @@ class RailsSecurityTagger < FrameworkTagger
   #   except: "create" | except: ["create"]
   private def action_in_filter?(line : String, action_name : String?) : Bool
     return false if action_name.nil?
-    return true if line.includes?(":#{action_name}")
-    return true if line.includes?("\"#{action_name}\"")
-    return true if line.includes?("'#{action_name}'")
+    # Whole-token match (symbol/quote prefix + delimiter) so action `create`
+    # is NOT matched by `:create_comment` / `except: [:show_all]`.
+    return true if line.matches?(/(?::|"|')#{Regex.escape(action_name)}(?:"|'|,|\s|\]|\)|$)/)
     if m = line.match(/%[iIwW]\[([^\]]*)\]/)
       return m[1].split.includes?(action_name)
     end


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **grape** — `in_params_block` was a plain boolean toggled off by the **first** `end`, so a nested `requires :x, type: Hash do ... end` closed it early; the remaining `end` leaked to the main parser and popped the enclosing namespace/resource prefix → the prefix was dropped from every later route in that scope. Now a depth counter (`ruby_do_block_open_delta`) closes only at depth 0.
- **hanami** — identical nested `params do` boolean bug → depth counter; also stops fabricating query params from DSL lines while still inside the block.
- **rails_security tagger** — `only:`/`except:` action filter used a raw substring match, so action `create` matched `only: [:create_comment]` (and `show` was suppressed by `except: [:show_all]`) → wrong CSRF/rate-limit tagging. Now a whole-token word-boundary match.

Full suite green locally.