### PR TITLE
fix(dart): byte/char crash + corruption in callee extraction (dart_frog/serverpod/shelf)

### DIFF
--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -95,7 +95,8 @@ module Analyzer::Dart
 
     private def callees_for_on_request(content : String, path : String) : Array(Noir::DartCalleeExtractor::Entry)
       content.scan(/\bonRequest\s*\(/) do |match|
-        match_start = match.begin(0) || 0
+        # match.begin is a CHAR index; the extractor scans by BYTE offset.
+        match_start = (match.begin(0).try { |i| content.char_index_to_byte_index(i) }) || 0
         open_paren = Noir::DartCalleeExtractor.find_next_code_char(content, '(', match_start)
         next unless open_paren
 
@@ -115,7 +116,7 @@ module Analyzer::Dart
       # the most useful callee — without this it would be lost entirely.
       if m = content.match(/\bonRequest\s*=\s*([^;]+);/)
         rhs = m[1].strip
-        line = Noir::DartCalleeExtractor.line_number_for(content, m.begin(0) || 0)
+        line = Noir::DartCalleeExtractor.line_number_for(content, (m.begin(0).try { |i| content.char_index_to_byte_index(i) }) || 0)
         return assignment_callees(rhs, path, line)
       end
 

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -136,10 +136,16 @@ module Analyzer::Dart
       close_paren = find_matching_paren(class_body, open_paren)
       return [] of Noir::DartCalleeExtractor::Entry unless close_paren
 
-      body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, close_paren + 1)
+      # close_paren is a CHAR index (find_matching_paren is char-based); the
+      # extractor scans/returns BYTE offsets. Convert at the boundary so the
+      # body slice is correct and line_for_offset (char-based) gets char offsets.
+      start_byte = class_body.char_index_to_byte_index(close_paren + 1)
+      return [] of Noir::DartCalleeExtractor::Entry unless start_byte
+      body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, start_byte)
       return [] of Noir::DartCalleeExtractor::Entry unless body_info
       body, body_start, _ = body_info
-      start_line = line_for_offset(file_content, class_body_start + body_start)
+      body_start_char = class_body.byte_index_to_char_index(body_start) || 0
+      start_line = line_for_offset(file_content, class_body_start + body_start_char)
       Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
@@ -350,11 +356,14 @@ module Analyzer::Dart
                                         class_body_start : Int32,
                                         close_paren : Int32,
                                         file_content : String) : Array(Noir::DartCalleeExtractor::Entry)
-      body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, close_paren + 1)
+      start_byte = class_body.char_index_to_byte_index(close_paren + 1)
+      return [] of Noir::DartCalleeExtractor::Entry unless start_byte
+      body_info = Noir::DartCalleeExtractor.extract_body_after(class_body, start_byte)
       return [] of Noir::DartCalleeExtractor::Entry unless body_info
 
       body, body_start, _ = body_info
-      start_line = line_for_offset(file_content, class_body_start + body_start)
+      body_start_char = class_body.byte_index_to_char_index(body_start) || 0
+      start_line = line_for_offset(file_content, class_body_start + body_start_char)
       Noir::DartCalleeExtractor.callees_for_body(body, path, start_line)
     end
 
@@ -489,7 +498,9 @@ module Analyzer::Dart
           result << ' '
           result << ' '
           i += 2
-          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
+          # Scan to EOF; the old `i + 1 < chars.size` bound left the final char
+          # of an UNTERMINATED block comment un-blanked (leaked as live code).
+          while i < chars.size && !(chars[i] == '*' && i + 1 < chars.size && chars[i + 1] == '/')
             result << (chars[i] == '\n' ? '\n' : ' ')
             i += 1
           end

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -272,7 +272,10 @@ module Analyzer::Dart
     private def annotation_callees(content : String,
                                    annotation_close : Int32,
                                    path : String) : Array(Noir::DartCalleeExtractor::Entry)
-      body_info = Noir::DartCalleeExtractor.extract_body_after(content, annotation_close + 1)
+      # annotation_close is a CHAR index; extract_body_after scans by BYTE offset.
+      close_b = content.char_index_to_byte_index(annotation_close + 1)
+      return [] of Noir::DartCalleeExtractor::Entry unless close_b
+      body_info = Noir::DartCalleeExtractor.extract_body_after(content, close_b)
       return [] of Noir::DartCalleeExtractor::Entry unless body_info
 
       body, body_start, _ = body_info
@@ -288,12 +291,20 @@ module Analyzer::Dart
       ranges = [] of ClassRange
       cleaned.scan(/\bclass\s+([A-Za-z_]\w*)/) do |m|
         name = m[1]
-        header_end = m.end(0)
+        header_end = m.end(0) # char offset
         next unless header_end
-        open = Noir::DartCalleeExtractor.find_next_code_char(cleaned, '{', header_end)
-        next unless open
-        close = Noir::DartCalleeExtractor.find_matching_delimiter(cleaned, open, '{', '}')
-        next unless close
+        # DartCalleeExtractor scans/returns BYTE offsets; convert char->byte going
+        # in and byte->char coming out so the stored ranges stay in CHAR space and
+        # line up with the char-based match offsets compared in enclosing_class.
+        header_end_b = cleaned.char_index_to_byte_index(header_end)
+        next unless header_end_b
+        open_b = Noir::DartCalleeExtractor.find_next_code_char(cleaned, '{', header_end_b)
+        next unless open_b
+        close_b = Noir::DartCalleeExtractor.find_matching_delimiter(cleaned, open_b, '{', '}')
+        next unless close_b
+        open = cleaned.byte_index_to_char_index(open_b)
+        close = cleaned.byte_index_to_char_index(close_b)
+        next unless open && close
         ranges << {name: name, start: open, finish: close}
       end
       ranges
@@ -432,7 +443,10 @@ module Analyzer::Dart
         return [{stripped, path, line}] of Noir::DartCalleeExtractor::Entry
       end
 
-      body_info = Noir::DartCalleeExtractor.extract_body_after(file_content, close_paren - handler_arg.size)
+      # close_paren is a CHAR index; extract_body_after scans by BYTE offset.
+      start_b = file_content.char_index_to_byte_index(close_paren - handler_arg.size)
+      return [] of Noir::DartCalleeExtractor::Entry unless start_b
+      body_info = Noir::DartCalleeExtractor.extract_body_after(file_content, start_b)
       return [] of Noir::DartCalleeExtractor::Entry unless body_info
 
       body, body_start, _ = body_info

--- a/src/miniparsers/dart_callee_extractor.cr
+++ b/src/miniparsers/dart_callee_extractor.cr
@@ -55,7 +55,9 @@ module Noir::DartCalleeExtractor
     if arrow_index && (!semicolon || arrow_index < semicolon) && (!open_brace || arrow_index < open_brace)
       body_start = arrow_index + 2
       body_end = semicolon || limit
-      return {source[body_start...body_end], body_start, body_end}
+      # body_start/body_end are BYTE offsets (the scanners use byte_at), so slice
+      # by bytes — char-indexing here corrupts/crashes on multi-byte UTF-8 source.
+      return {source.byte_slice(body_start, body_end - body_start), body_start, body_end}
     end
 
     if open_brace && (!semicolon || open_brace < semicolon)
@@ -63,7 +65,8 @@ module Noir::DartCalleeExtractor
       return unless close_brace
 
       body_start = open_brace + 1
-      return {source[body_start...close_brace], body_start, close_brace + 1}
+      # byte offsets -> slice by bytes (see note above).
+      return {source.byte_slice(body_start, close_brace - body_start), body_start, close_brace + 1}
     end
 
     nil


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **dart_callee_extractor** — `extract_body_after` returned **char-indexed** slices (`source[body_start...body_end]`) built from **byte** offsets produced by its byte-based scanners. On multi-byte UTF-8 source the byte offset exceeds the char count → `IndexError` crash (dropping **all** endpoints in serverpod, which has no per-file rescue) or a mis-sliced body. Now slices by bytes (ASCII-identical).
- **dart_frog / serverpod / shelf** — seeded the byte-based extractor with **char** offsets (regex `.begin` / char-based `find_matching_paren`). Converted char↔byte at the extractor boundary (and byte→char for the char-based `line_for_offset`) so class attribution, route prefixes, and line numbers stay correct on multi-byte source.
- **serverpod** — `strip_dart_comments` left the final char of an **unterminated** block comment un-blanked (leaked as live code); now scans to EOF.

All conversions are identity on ASCII; full suite green locally.