### PR TITLE
fix(cpp): byte/char index mismatch in crow/drogon callee + lambda extraction

### DIFF
--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -73,7 +73,10 @@ module Analyzer::Cpp
         route_path = route_match[1]
         normalized_path, path_params = normalize_path(route_path)
         details = Details.new(PathInfo.new(path, index + 1))
-        route_offset = line_offsets[index] + (route_match.begin(0) || 0)
+        # line_offsets is byte-based; begin(0) is a char index within the line —
+        # convert the line prefix to its byte length so route_offset is a true
+        # byte offset consistent with the byte-based extractor/search below.
+        route_offset = line_offsets[index] + line[0, (route_match.begin(0) || 0)].bytesize
         search_start = route_offset + route_match[0].bytesize
 
         # The websocket handler is a chain of `.onopen/.onmessage/...` lambdas
@@ -136,11 +139,13 @@ module Analyzer::Cpp
     end
 
     private def next_route_offset(source : String, search_start : Int32) : Int32
+      # search_start is a byte offset; use byte_index so the returned limit stays
+      # in byte space (consistent with the byte-based lambda extractor).
       offsets = [
-        source.index("CROW_ROUTE", search_start),
-        source.index("CROW_BP_ROUTE", search_start),
-        source.index("CROW_WEBSOCKET_ROUTE", search_start),
-        source.index("route_dynamic", search_start),
+        source.byte_index("CROW_ROUTE", search_start),
+        source.byte_index("CROW_BP_ROUTE", search_start),
+        source.byte_index("CROW_WEBSOCKET_ROUTE", search_start),
+        source.byte_index("route_dynamic", search_start),
       ].compact
       offsets.min? || source.bytesize
     end

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -226,7 +226,7 @@ module Analyzer::Cpp
         close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
         next unless close_paren
 
-        args = split_top_level_args(content[(open_paren + 1)...close_paren])
+        args = split_top_level_args(content.byte_slice(open_paren + 1, close_paren - open_paren - 1))
         block.call(args, call_start)
       end
     end
@@ -342,7 +342,9 @@ module Analyzer::Cpp
     end
 
     private def handler_target_for_register_handler(content : String, search_start : Int32) : HandlerTarget?
-      handler_index = content.index("registerHandler", search_start)
+      # search_start is a BYTE offset; byte_index keeps it in byte space so the
+      # result feeds the byte-based find_next_code_char below consistently.
+      handler_index = content.byte_index("registerHandler", search_start)
       return unless handler_index
 
       open_paren = Noir::CppCalleeExtractor.find_next_code_char(content, '(', handler_index)
@@ -351,7 +353,7 @@ module Analyzer::Cpp
       close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(content, open_paren, '(', ')')
       return unless close_paren
 
-      args = split_top_level_args(content[(open_paren + 1)...close_paren])
+      args = split_top_level_args(content.byte_slice(open_paren + 1, close_paren - open_paren - 1))
       return if args.size < 2
 
       raw_handler = args[1].strip
@@ -455,7 +457,7 @@ module Analyzer::Cpp
         body_open = Noir::CppCalleeExtractor.find_next_code_char(content, '{', close_paren + 1)
         next unless body_open
         next if body_open > range_end
-        next unless method_suffix?(content[(close_paren + 1)...body_open])
+        next unless method_suffix?(content.byte_slice(close_paren + 1, body_open - close_paren - 1))
 
         semicolon = Noir::CppCalleeExtractor.find_next_code_char(content, ';', close_paren + 1)
         next if semicolon && semicolon < body_open
@@ -463,7 +465,7 @@ module Analyzer::Cpp
         body_close = Noir::CppCalleeExtractor.find_matching_delimiter(content, body_open, '{', '}')
         next unless body_close
 
-        return {content[(body_open + 1)...body_close], Noir::CppCalleeExtractor.line_number_for(content, body_open)}
+        return {content.byte_slice(body_open + 1, body_close - body_open - 1), Noir::CppCalleeExtractor.line_number_for(content, body_open)}
       end
 
       nil

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -93,7 +93,7 @@ module Analyzer::Cpp
                     ["GET"]
                   end
 
-        match_start = match.begin(0) || 0
+        match_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         line_number = Noir::CppCalleeExtractor.line_number_for(content, match_start)
         callees = include_callee ? callees_for_block_after(content, path, match_start) : [] of Noir::CppCalleeExtractor::Entry
         route_params = params_for_register_handler(content, match_start)
@@ -219,7 +219,7 @@ module Analyzer::Cpp
 
     private def each_macro_call(content : String, macro_name : String, &block : Array(String), Int32 ->)
       content.scan(/\b#{macro_name}\s*\(/) do |match|
-        call_start = match.begin(0) || 0
+        call_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         open_paren = Noir::CppCalleeExtractor.find_next_code_char(content, '(', call_start)
         next unless open_paren
 
@@ -269,7 +269,7 @@ module Analyzer::Cpp
     private def controller_scopes(content : String) : Array(ControllerScope)
       scopes = [] of ControllerScope
       content.scan(/\b(?:class|struct)\s+([A-Za-z_][A-Za-z0-9_]*)\b/) do |match|
-        class_start = match.begin(0) || 0
+        class_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', class_start)
         next unless open_brace
 
@@ -290,7 +290,7 @@ module Analyzer::Cpp
     private def enclosing_namespaces(content : String, target : Int32) : Array(String)
       found = [] of Tuple(Int32, String)
       content.scan(/\bnamespace\s+([A-Za-z_][A-Za-z0-9_]*(?:\s*::\s*[A-Za-z_][A-Za-z0-9_]*)*)\s*\{/) do |match|
-        ns_start = match.begin(0) || 0
+        ns_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', ns_start)
         next unless open_brace
         next if open_brace >= target
@@ -442,7 +442,7 @@ module Analyzer::Cpp
     private def extract_method_body_in_range(content : String, method_pattern : String, range : SourceRange) : Tuple(String, Int32)?
       range_start, range_end = range
       content.scan(/\b#{method_pattern}\s*\(/) do |match|
-        match_start = match.begin(0) || 0
+        match_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         next if match_start < range_start || match_start >= range_end
         next if call_context?(content, match_start)
 
@@ -471,7 +471,7 @@ module Analyzer::Cpp
 
     private def class_body_range(content : String, class_name : String) : SourceRange?
       content.scan(/\b(?:class|struct)\s+#{Regex.escape(class_name)}\b/) do |match|
-        class_start = match.begin(0) || 0
+        class_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', class_start)
         next unless open_brace
 

--- a/src/miniparsers/cpp_callee_extractor.cr
+++ b/src/miniparsers/cpp_callee_extractor.cr
@@ -57,19 +57,21 @@ module Noir::CppCalleeExtractor
     close_index = find_matching_delimiter(source, open_index, '{', '}', limit)
     return unless close_index
 
-    {source[(open_index + 1)...close_index], line_number_for(source, open_index)}
+    # open_index/close_index are BYTE offsets (the scanners use byte_at); slice
+    # by bytes — char-indexing here corrupts/crashes on multi-byte UTF-8 source.
+    {source.byte_slice(open_index + 1, close_index - open_index - 1), line_number_for(source, open_index)}
   end
 
   def extract_lambda_block_after(source : String, start_index : Int32, limit : Int32 = source.bytesize) : Tuple(String, Int32)?
     open_index = find_next_code_char(source, '{', start_index, limit)
     return unless open_index
     return if find_next_code_char(source, ';', start_index, open_index)
-    return unless source[start_index...open_index].includes?('[')
+    return unless source.byte_slice(start_index, open_index - start_index).includes?('[')
 
     close_index = find_matching_delimiter(source, open_index, '{', '}', limit)
     return unless close_index
 
-    {source[(open_index + 1)...close_index], line_number_for(source, open_index)}
+    {source.byte_slice(open_index + 1, close_index - open_index - 1), line_number_for(source, open_index)}
   end
 
   def find_next_code_char(source : String, target : Char, start_index : Int32, limit : Int32 = source.bytesize) : Int32?


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **cpp_callee_extractor** — `extract_block_after` / `extract_lambda_block_after` returned **char**-indexed slices built from **byte** offsets (byte_at scanners) → `IndexError` crash or mis-sliced body on multi-byte source. Now slices by bytes (ASCII-identical).
- **crow** — mixed a char-based regex offset (`match.begin` within a line) into a **byte**-based `line_offsets` base, and searched with char-based `source.index` against a byte `search_start`. Now computes `route_offset` as a true byte offset (byte length of the line prefix) and searches via `byte_index`.
- **drogon** — every controller-scope/call seed was a **char** index (`match.begin`) fed to byte-based scanners and compared against byte-based ranges → a route could be attributed to the wrong controller (wrong URL prefix) on multi-byte source. Each seed is now converted char→byte at the boundary.

All conversions are identity on ASCII; full suite green locally.