### PR TITLE
fix(clojure): cross-file dedup data loss + byte/char callee corruption/line numbers

### DIFF
--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -35,13 +35,16 @@ module Analyzer::Clojure
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      seen = Set(String).new
       all_files.each do |path|
         next unless clojure_file?(path)
 
         content = read_file_content(path)
         next unless pedestal_source?(content)
 
+        # Per-file dedup (the key has no path component); a shared set across
+        # files drops legitimate same-method+route endpoints (and their params)
+        # from every file after the first.
+        seen = Set(String).new
         function_callees = include_callee ? Noir::ClojureCalleeExtractor.function_callees(content, path) : Hash(String, Array(Noir::ClojureCalleeExtractor::Entry)).new
         walk_forms(content, 0, content.bytesize, "", path, seen, include_callee, function_callees)
       end

--- a/src/analyzer/analyzers/clojure/ring.cr
+++ b/src/analyzer/analyzers/clojure/ring.cr
@@ -52,7 +52,8 @@ module Analyzer::Clojure
         method = METHOD_KEYWORDS[match[1].downcase]
         route = decode_string(match[2])
         next unless route.starts_with?('/')
-        offset = match.begin(0) || 0
+        # byte offset (line_number_for uses byte_slice; begin(0) is a char index)
+        offset = match.byte_begin(0)
         emit_endpoint(content, path, offset, method, route, seen)
       end
     end

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -300,7 +300,9 @@ module Noir::ClojureCalleeExtractor
       i += 1
     end
 
-    {source[index...i], i}
+    # `index`/`i` are byte offsets (advanced via byte_at), so slice by bytes —
+    # char-indexing here corrupts every name after a multi-byte UTF-8 char.
+    {source.byte_slice(index, i - index), i}
   end
 
   private def skip_ws_and_comments(source : String, index : Int32, limit : Int32) : Int32


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **clojure_callee_extractor** — `read_symbol` returned `source[index...i]` (**char** slice) built from **byte** offsets (`byte_at`), corrupting every callee name after a multi-byte UTF-8 char in a handler body. Now `byte_slice` (consistent with the rest of the module + the analyzer `read_symbol` implementations).
- **pedestal** — the `seen` dedup set (keyed only by `method::route`, no file path) was created **once** outside the per-file loop, so two files legitimately exposing the same method+route had every file-after-the-first dropped (losing its distinct params/callees). Moved `seen` inside the per-file loop (matches `ring`).
- **ring** — `extract_vector_dispatches` passed a char-based `match.begin(0)` to `line_number_for`, which treats it as a **byte** offset → too-small line numbers when multi-byte text precedes the route. Now `match.byte_begin(0)`.

Full suite green locally.