### PR TITLE
fix(haskell): servant alias-expansion DoS + line drift, yesod cross-file handler clobber

### DIFF
--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -319,16 +319,26 @@ module Analyzer::Haskell
         end
 
         if i + 1 < chars.size && c == '{' && chars[i + 1] == '-'
+          # Replace the comment with whitespace, PRESERVING newlines, so a
+          # multi-line `{- -}` doesn't collapse lines and shift every later
+          # endpoint's reported line number (mirrors scotty.cr).
           brace_depth += 1
+          result << ' '
+          result << ' '
           i += 2
           while i < chars.size && brace_depth > 0
             if i + 1 < chars.size && chars[i] == '-' && chars[i + 1] == '}'
               brace_depth -= 1
+              result << ' '
+              result << ' '
               i += 2
             elsif i + 1 < chars.size && chars[i] == '{' && chars[i + 1] == '-'
               brace_depth += 1
+              result << ' '
+              result << ' '
               i += 2
             else
+              result << (chars[i] == '\n' ? '\n' : ' ')
               i += 1
             end
           end
@@ -359,17 +369,27 @@ module Analyzer::Haskell
       found.to_a
     end
 
+    # `visited` only blocks cycles along one path, not repeated sibling
+    # expansions (`type A = B :<|> B` doubles each level -> O(2^N)). Cap the
+    # total expanded size so a crafted alias chain can't hang/OOM the scan;
+    # real Servant bodies expand to far under this, so output is unchanged.
+    MAX_EXPANSION_BYTES = 1_000_000
+
     private def expand_references(body : String, type_aliases : Hash(String, TypeAlias)) : String
-      do_expand(body, type_aliases, Set(String).new)
+      do_expand(body, type_aliases, Set(String).new, [MAX_EXPANSION_BYTES])
     end
 
-    private def do_expand(body : String, type_aliases : Hash(String, TypeAlias), visited : Set(String)) : String
+    private def do_expand(body : String, type_aliases : Hash(String, TypeAlias), visited : Set(String), budget : Array(Int32)) : String
       body.gsub(/\b([A-Z][A-Za-z0-9_']*)\b/) do |raw, m|
         name = m[1]
-        if type_aliases.has_key?(name) && !visited.includes?(name)
+        if budget[0] <= 0
+          raw # budget exhausted: leave the reference unexpanded
+        elsif type_aliases.has_key?(name) && !visited.includes?(name)
           new_visited = visited.dup
           new_visited << name
-          "(#{do_expand(type_aliases[name][:body], type_aliases, new_visited)})"
+          sub = type_aliases[name][:body]
+          budget[0] -= sub.bytesize
+          "(#{do_expand(sub, type_aliases, new_visited, budget)})"
         else
           raw
         end

--- a/src/analyzer/analyzers/haskell/yesod.cr
+++ b/src/analyzer/analyzers/haskell/yesod.cr
@@ -6,11 +6,15 @@ module Analyzer::Haskell
   class Yesod < Analyzer
     HTTP_METHODS = %w[GET POST PUT DELETE PATCH OPTIONS HEAD]
     alias HandlerBody = Noir::HaskellCalleeExtractor::FunctionBody
+    # A handler name can occur in more than one file; keep all bodies and only
+    # attach callees when the name resolves unambiguously (mirrors scotty.cr),
+    # rather than last-write-wins overwriting across files.
+    alias HandlerBodies = Hash(String, Array(HandlerBody))
 
     def analyze
       processed_route_files = Set(String).new
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      handler_bodies = include_callee ? build_handler_bodies : {} of String => HandlerBody
+      handler_bodies = include_callee ? build_handler_bodies : HandlerBodies.new
 
       all_files.each do |path|
         next if File.directory?(path)
@@ -55,15 +59,15 @@ module Analyzer::Haskell
       File.basename(path) == "routes" && File.dirname(path).ends_with?("/config")
     end
 
-    private def build_handler_bodies : Hash(String, HandlerBody)
-      handlers = {} of String => HandlerBody
+    private def build_handler_bodies : HandlerBodies
+      handlers = HandlerBodies.new
 
       all_files.each do |path|
         next if File.directory?(path)
         next unless haskell_source?(path)
 
         Noir::HaskellCalleeExtractor.function_bodies(read_file_content(path), path).each do |body|
-          handlers[body[:name]] = body
+          (handlers[body[:name]] ||= [] of HandlerBody) << body
         end
       end
 
@@ -95,7 +99,7 @@ module Analyzer::Haskell
     private def process_route_content(source_path : String,
                                       content : String,
                                       include_callee : Bool,
-                                      handler_bodies : Hash(String, HandlerBody))
+                                      handler_bodies : HandlerBodies)
       scope_stack = [{indent: -1, raw_segments: [] of String}]
 
       logical_route_lines(content).each do |entry|
@@ -140,10 +144,13 @@ module Analyzer::Haskell
                                        method : String,
                                        route_name : String,
                                        methodless_route : Bool,
-                                       handler_bodies : Hash(String, HandlerBody))
+                                       handler_bodies : HandlerBodies)
       handler_name = handler_name_for(method, route_name, methodless_route)
-      handler_body = handler_bodies[handler_name]?
-      return unless handler_body
+      bodies = handler_bodies[handler_name]?
+      # Only attach when the name is unambiguous; a name defined in multiple
+      # files would otherwise pull callees from the wrong file's body.
+      return unless bodies && bodies.size == 1
+      handler_body = bodies.first
 
       callees = Noir::HaskellCalleeExtractor.callees_for_body(
         handler_body[:body],


### PR DESCRIPTION
Per-framework split of a larger bug-hunt.

### Bugs fixed
- **servant** — `do_expand` recursively substituted aliases with no total-output bound; an alias body referencing another alias more than once (`type A = B :<|> B`) doubled each level → **O(2^N)** growth, hanging/OOMing the scan on a crafted file. Added a 1 MB expansion budget (real Servant bodies are far smaller). Also `strip_haskell_comments` collapsed multi-line block comments **without preserving newlines**, shifting every later endpoint's line number; now preserves newlines (mirrors scotty).
- **yesod** — `build_handler_bodies` stored bodies in a flat `Hash(String, HandlerBody)`, so the same handler name in two files kept only the **last** file's body (wrong/missing callees). Now `Hash(String, Array(HandlerBody))`, attaching callees only when the name resolves unambiguously (mirrors scotty).

Full suite green locally.