### PR TITLE
fix(miniparsers): byte/char gateway scan, jaxrs @DefaultValue, kotlin const-brace counting

### DIFF
--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -589,7 +589,8 @@ module Noir
         close_idx = find_matching_delimiter(visible_source, open_idx, '(', ')')
         if close_idx
           expr = source[open_idx..close_idx]
-          line = source.byte_slice(0, open_idx).count('\n')
+          # open_idx is a CHAR index; char-slice for the line count too.
+          line = source[0, open_idx].count('\n')
           yield expr, line
           offset = close_idx + 1
         else
@@ -674,39 +675,37 @@ module Noir
     end
 
     private def split_gateway_args(args : String) : Array(String)
+      # Char-indexed: `args` may contain multi-byte path literals, so a byte loop
+      # with char slices (`args[start...i]`) mis-slices and can raise IndexError.
       parts = [] of String
       start = 0
       depth = 0
       in_string = false
       escape = false
-      bytes = args.to_slice
-      i = 0
-      while i < bytes.size
-        byte = bytes[i]
+      args.each_char_with_index do |char, i|
         if in_string
           if escape
             escape = false
-          elsif byte == '\\'.ord
+          elsif char == '\\'
             escape = true
-          elsif byte == '"'.ord
+          elsif char == '"'
             in_string = false
           end
         else
-          case byte
-          when '"'.ord
+          case char
+          when '"'
             in_string = true
-          when '('.ord, '['.ord, '{'.ord
+          when '(', '[', '{'
             depth += 1
-          when ')'.ord, ']'.ord, '}'.ord
+          when ')', ']', '}'
             depth -= 1 if depth > 0
-          when ','.ord
+          when ','
             if depth == 0
               parts << args[start...i].strip
               start = i + 1
             end
           end
         end
-        i += 1
       end
       parts << args[start..].strip
       parts.reject(&.empty?)
@@ -733,79 +732,75 @@ module Noir
     end
 
     private def visible_java_code(source : String) : String
-      slash = '/'.ord.to_u8
-      star = '*'.ord.to_u8
-      double_quote = '"'.ord.to_u8
-      single_quote = '\''.ord.to_u8
-      backslash = '\\'.ord.to_u8
-      newline = '\n'.ord.to_u8
-      space = ' '.ord.to_u8
-
-      bytes = source.to_slice
+      # Blank out comments and string/char literals (so their contents can't be
+      # mistaken for code), emitting exactly ONE output char per input char so
+      # char positions stay aligned with `source` — the gateway scan derives
+      # char indices here and char-slices `source` with them.
+      chars = source.chars
       mode = :code
-      quote = 0_u8
+      quote = '\0'
       escaped = false
       i = 0
 
       String.build(source.bytesize) do |io|
-        while i < bytes.size
-          byte = bytes[i]
+        while i < chars.size
+          char = chars[i]
 
           case mode
           when :line_comment
-            if byte == newline
-              io.write_byte(byte)
+            if char == '\n'
+              io << char
               mode = :code
             else
-              io.write_byte(space)
+              io << ' '
             end
             i += 1
           when :block_comment
-            if byte == newline
-              io.write_byte(byte)
+            if char == '\n'
+              io << char
               i += 1
-            elsif i + 1 < bytes.size && byte == star && bytes[i + 1] == slash
-              io.write_byte(space)
-              io.write_byte(space)
+            elsif char == '*' && chars[i + 1]? == '/'
+              io << ' '
+              io << ' '
               i += 2
               mode = :code
             else
-              io.write_byte(space)
+              io << ' '
               i += 1
             end
           when :string
-            if byte == quote && !escaped
-              io.write_byte(space)
+            if char == quote && !escaped
+              io << ' '
               i += 1
               mode = :code
             else
-              io.write_byte(byte == newline ? byte : space)
+              io << (char == '\n' ? '\n' : ' ')
               if escaped
                 escaped = false
               else
-                escaped = byte == backslash
+                escaped = char == '\\'
               end
               i += 1
             end
           else
-            if i + 1 < bytes.size && byte == slash && bytes[i + 1] == slash
-              io.write_byte(space)
-              io.write_byte(space)
+            if char == '/' && chars[i + 1]? == '/'
+              io << ' '
+              io << ' '
               i += 2
               mode = :line_comment
-            elsif i + 1 < bytes.size && byte == slash && bytes[i + 1] == star
-              io.write_byte(space)
-              io.write_byte(space)
+            elsif char == '/' && chars[i + 1]? == '*'
+              io << ' '
+              io << ' '
               i += 2
               mode = :block_comment
-            elsif byte == double_quote || byte == single_quote
-              io.write_byte(space)
-              quote = byte
+            elsif char == '"' || char == '\''
+              io << ' '
+              quote = char
               escaped = false
               i += 1
               mode = :string
             else
-              io.write_byte(byte)
+              io << char
               i += 1
             end
           end
@@ -817,42 +812,42 @@ module Noir
                                         open_idx : Int32,
                                         open_char : Char,
                                         close_char : Char) : Int32?
+      # Char-indexed (open_idx comes from char-based String#index and the result
+      # is char-sliced by callers). visible_java_code preserves char positions,
+      # so char index N in visible_source == char index N in source. ASCII-identical.
       depth = 1
-      i = open_idx + 1
-      bytes = code.to_slice
-      open_byte = open_char.ord
-      close_byte = close_char.ord
-      double_quote = '"'.ord
-      single_quote = '\''.ord
-      backslash = '\\'.ord
       in_string = false
-      quote = 0
+      quote = '\0'
       escape = false
+      result = nil
 
-      while i < bytes.size && depth > 0
-        byte = bytes[i]
+      code.each_char_with_index do |char, i|
+        next if i <= open_idx
         if in_string
           if escape
             escape = false
-          elsif byte == backslash
+          elsif char == '\\'
             escape = true
-          elsif byte == quote
+          elsif char == quote
             in_string = false
           end
         else
-          if byte == double_quote || byte == single_quote
+          if char == '"' || char == '\''
             in_string = true
-            quote = byte
-          elsif byte == open_byte
+            quote = char
+          elsif char == open_char
             depth += 1
-          elsif byte == close_byte
+          elsif char == close_char
             depth -= 1
           end
         end
-        i += 1
+        if depth == 0
+          result = i
+          break
+        end
       end
 
-      depth == 0 ? i - 1 : nil
+      result
     end
 
     # Iterate annotations attached to a declaration. Yields

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -586,17 +586,9 @@ module Noir
           when "string_literal", "identifier", "field_access", "scoped_identifier", "binary_expression", "parenthesized_expression"
             result = resolve_path_value(child, source, constants, current_class)
           when "element_value_pair"
-            key = ""
-            value : LibTreeSitter::TSNode? = nil
-            Noir::TreeSitter.each_named_child(child) do |sub|
-              case Noir::TreeSitter.node_type(sub)
-              when "identifier"
-                key = Noir::TreeSitter.node_text(sub, source) if key.empty?
-              else
-                value = sub if value.nil?
-              end
-            end
-            if key == "value" && value
+            key = Noir::TreeSitter.field(child, "key")
+            value = Noir::TreeSitter.field(child, "value")
+            if key && value && Noir::TreeSitter.node_text(key, source) == "value"
               result = resolve_path_value(value, source, constants, current_class)
             end
           end
@@ -720,6 +712,7 @@ module Noir
 
       ann_kind : Symbol? = nil
       ann_arg : String? = nil
+      ann_format : String? = nil
       default_value : String? = nil
 
       each_annotation(param, source) do |name, args, _|
@@ -732,11 +725,11 @@ module Noir
           ann_kind = :context
         elsif name == "DefaultValue"
           default_value = first_string_arg(args, source, constants, current_class)
-        elsif format = PARAM_ANNOTATION_FORMAT[name]?
+        elsif fmt = PARAM_ANNOTATION_FORMAT[name]?
           ann_kind = :param
+          ann_format = fmt
           ann_arg = first_string_arg(args, source, constants, current_class)
           ann_arg ||= ""
-          sink << Param.new(ann_arg.presence || param_name, default_value || "", format)
         end
       end
 
@@ -753,7 +746,9 @@ module Noir
         end
         return
       when :param
-        # already emitted above
+        # Emit here (not inside the loop) so @DefaultValue is captured
+        # regardless of annotation order on the parameter.
+        sink << Param.new((ann_arg || "").presence || param_name, default_value || "", ann_format || "query")
         return
       end
 

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -120,6 +120,12 @@ module Noir
       routes
     end
 
+    # Blank out string/char literal contents (keeping the quotes) so structural
+    # brace counting ignores braces that live inside a string value.
+    private def structural_only(line : String) : String
+      line.gsub(/"(?:[^"\\]|\\.)*"/, %("")).gsub(/'(?:[^'\\]|\\.)*'/, "''")
+    end
+
     def extract_string_constants(source : String) : Hash(String, String)
       constants = Hash(String, String).new
       package_name = ""
@@ -149,9 +155,12 @@ module Noir
         end
 
         unless current_type.empty?
-          current_depth += line.count("{")
-          current_depth -= line.count("}")
-          if current_depth <= 0 && line.includes?("}")
+          # Count braces on a string-blanked copy so a `}` inside a const string
+          # value (regex/JSON/template) can't close the enclosing type early.
+          structural = structural_only(line)
+          current_depth += structural.count("{")
+          current_depth -= structural.count("}")
+          if current_depth <= 0 && structural.includes?("}")
             current_type = ""
             current_depth = 0
           end
@@ -458,7 +467,12 @@ module Noir
           return
         when active && name == "route"
           path_arg = call_string_argument(node, source, string_constants, local_string_constants)
-          return if path_arg.nil? && call_has_value_arguments?(node)
+          # Skip `route(unknownArg) { … }` overloads whose sole value
+          # argument is neither a string path nor an HTTP method — but let
+          # the path-less method form `route(HttpMethod.Get) { handle { } }`
+          # (which inherits the enclosing prefix) flow through to the
+          # method-route handling below.
+          return if path_arg.nil? && call_has_value_arguments?(node) && call_http_method_argument(node, source).nil?
           new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
           if body = call_lambda_body(node)
             if method = call_http_method_argument(node, source)

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -67,8 +67,11 @@ module Noir
       package_name = ""
       current_type = ""
       current_depth = 0
+      # Scrubbed copy (strings/comments blanked, newlines preserved) for brace
+      # counting, so a `}` inside a const string value can't close the type early.
+      scrubbed_lines = visible_kotlin_code(source).lines
 
-      source.each_line do |line|
+      source.each_line.with_index do |line, idx|
         if package_name.empty?
           if match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_.]*)/)
             package_name = match[1]
@@ -91,9 +94,10 @@ module Noir
         end
 
         unless current_type.empty?
-          current_depth += line.count("{")
-          current_depth -= line.count("}")
-          if current_depth <= 0 && line.includes?("}")
+          structural = scrubbed_lines[idx]? || line
+          current_depth += structural.count("{")
+          current_depth -= structural.count("}")
+          if current_depth <= 0 && structural.includes?("}")
             current_type = ""
             current_depth = 0
           end
@@ -438,12 +442,16 @@ module Noir
         name = match[1]
         expr = lines[i][(match.end(0) || line.size)..]? || ""
         j = i
+        broke_on_decl = false
         unless expr.includes?(".path(")
           j = i + 1
           while j < lines.size
             visible_next_line = visible_lines[j]
-            break if visible_next_line.match(/^\s*(?:[A-Za-z_][A-Za-z0-9_<>.]*\s+)*fun\b/)
-            break if visible_next_line.match(/^\s*(?:class|object|interface|companion\s+object)\b/)
+            if visible_next_line.match(/^\s*(?:[A-Za-z_][A-Za-z0-9_<>.]*\s+)*fun\b/) ||
+               visible_next_line.match(/^\s*(?:class|object|interface|companion\s+object)\b/)
+              broke_on_decl = true
+              break
+            end
             break if visible_next_line.strip == "}"
             expr += "\n#{lines[j]}"
             break if visible_next_line.includes?(".path(")
@@ -455,7 +463,9 @@ module Noir
           helpers[name] = route
         end
 
-        i = j + 1
+        # If the scan stopped ON a new declaration line, re-examine it rather than
+        # skipping it — otherwise a back-to-back PredicateSpec helper is missed.
+        i = broke_on_decl ? j : j + 1
       end
 
       helpers


### PR DESCRIPTION
Per-framework split of a larger bug-hunt (JVM route/param tree-sitter extractors).

### Bugs fixed
- **java_route_extractor_ts** — the Spring Cloud Gateway codepath mixed **byte** and **char** indices (byte-based `find_matching_delimiter` fed char offsets, char-slicing the byte result; `split_gateway_args` iterated bytes but char-sliced → `IndexError` on multi-byte). Made the whole gateway path char-consistent: `find_matching_delimiter` and `split_gateway_args` scan by character, `visible_java_code` preserves char positions (1 char in → 1 char out), and the line count uses a char slice.
- **jaxrs_extractor_ts** — `@DefaultValue` was read into the Param at the moment the `@QueryParam`/`@FormParam` annotation was visited, but Java annotation order is not significant → `@QueryParam("q") @DefaultValue("guest")` lost the default. Param emission is now deferred until all annotations are collected.
- **kotlin_route_extractor_ts / kotlin_ktor_route_extractor_ts** — `extract_string_constants` counted braces on raw lines, so a `}` inside a const string value (`const val P = "regex}"`) closed the enclosing type early and dropped later qualified constant keys. Now counts braces on a string-blanked view. Also fixes a gateway predicate-helper loop that skipped a back-to-back `PredicateSpec` helper.

All char-rewrites are byte-identical on ASCII; full suite green locally.