### PR TITLE
fix(specification): malformed-input crashes, char/byte split, wrong-scope logic

### DIFF
--- a/src/analyzer/analyzers/specification/apisix.cr
+++ b/src/analyzer/analyzers/specification/apisix.cr
@@ -49,6 +49,8 @@ module Analyzer::Specification
     end
 
     private def process_route_json(route : JSON::Any, details : Details)
+      # Skip non-object array entries; subscripting a scalar raises "Expected Hash".
+      return unless route.as_h?
       paths = route_paths_json(route)
       return if paths.empty?
       methods = route_methods_json(route)
@@ -63,6 +65,8 @@ module Analyzer::Specification
     end
 
     private def process_route_yaml(route : YAML::Any, details : Details)
+      # Skip non-object array entries; subscripting a scalar raises "Expected Hash".
+      return unless route.as_h?
       paths = route_paths_yaml(route)
       return if paths.empty?
       methods = route_methods_yaml(route)

--- a/src/analyzer/analyzers/specification/asyncapi.cr
+++ b/src/analyzer/analyzers/specification/asyncapi.cr
@@ -119,7 +119,7 @@ module Analyzer::Specification
     end
 
     private def resolve_channel_path_json(root : JSON::Any, channel_ref : JSON::Any?, channels : Hash(String, JSON::Any)) : String
-      return "" unless channel_ref
+      return "" unless channel_ref && channel_ref.as_h?
       if ref = channel_ref["$ref"]?.try(&.as_s?)
         # Try to read `address` from the referenced channel, else
         # use the last path segment as the channel key.
@@ -138,7 +138,9 @@ module Analyzer::Specification
 
     private def collect_message_payload_json(root : JSON::Any, message : JSON::Any, params : Array(Param), seen : Set(String) = Set(String).new)
       msg = message
-      while ref = msg["$ref"]?.try(&.as_s?)
+      # `msg` may be reassigned to a $ref target that resolves to a scalar;
+      # gate every subscript on as_h? so a non-object never raises "Expected Hash".
+      while msg.as_h? && (ref = msg["$ref"]?.try(&.as_s?))
         return if seen.includes?(ref)
         seen << ref
         if resolved = resolve_ref_json(root, ref)
@@ -147,12 +149,15 @@ module Analyzer::Specification
           return
         end
       end
-      if payload = msg["payload"]?
+      if msg.as_h? && (payload = msg["payload"]?)
         collect_schema_props_json(root, payload, "json", params)
       end
     end
 
     private def collect_schema_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+      # A scalar schema (e.g. JSON-Schema boolean, or an allOf element `true`)
+      # makes the `["..."]?` subscripts below raise "Expected Hash".
+      return unless schema.as_h?
       if ref = schema["$ref"]?.try(&.as_s?)
         return if seen.includes?(ref)
         seen << ref
@@ -263,7 +268,7 @@ module Analyzer::Specification
     end
 
     private def resolve_channel_path_yaml(root : YAML::Any, channel_ref : YAML::Any?) : String
-      return "" unless channel_ref
+      return "" unless channel_ref && channel_ref.as_h?
       if ref_node = channel_ref[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
           if resolved = resolve_ref_yaml(root, ref)
@@ -286,7 +291,9 @@ module Analyzer::Specification
 
     private def collect_message_payload_yaml(root : YAML::Any, message : YAML::Any, params : Array(Param), seen : Set(String) = Set(String).new)
       msg = message
-      while ref_node = msg[YAML::Any.new("$ref")]?
+      # `msg` may be reassigned to a $ref target that resolves to a scalar;
+      # gate every subscript on as_h? so a non-object never raises "Expected Hash".
+      while msg.as_h? && (ref_node = msg[YAML::Any.new("$ref")]?)
         ref = ref_node.as_s?
         break unless ref
         return if seen.includes?(ref)
@@ -297,12 +304,15 @@ module Analyzer::Specification
           return
         end
       end
-      if payload_node = msg[YAML::Any.new("payload")]?
+      if msg.as_h? && (payload_node = msg[YAML::Any.new("payload")]?)
         collect_schema_props_yaml(root, payload_node, "json", params)
       end
     end
 
     private def collect_schema_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+      # A scalar schema (e.g. JSON-Schema boolean, or an allOf element `true`)
+      # makes the `[...]?` subscripts below raise "Expected Hash".
+      return unless schema.as_h?
       if ref_node = schema[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
           return if seen.includes?(ref)

--- a/src/analyzer/analyzers/specification/envoy.cr
+++ b/src/analyzer/analyzers/specification/envoy.cr
@@ -53,6 +53,7 @@ module Analyzer::Specification
 
     private def process_yaml(data : YAML::Any, details : Details)
       extract_virtual_hosts_yaml(data).each do |vh|
+        next unless vh.as_h?
         if routes_node = vh["routes"]?
           if routes = routes_node.as_a?
             routes.each { |route| process_route_yaml(route, details) }
@@ -76,6 +77,7 @@ module Analyzer::Specification
       if resources = data["resources"]?
         if arr = resources.as_a?
           arr.each do |resource|
+            next unless resource.as_h?
             if vh = resource["virtual_hosts"]?
               if vharr = vh.as_a?
                 result.concat(vharr)
@@ -88,6 +90,7 @@ module Analyzer::Specification
     end
 
     private def process_route_yaml(route : YAML::Any, details : Details)
+      return unless route.as_h?
       return unless match = route["match"]?
 
       path = extract_path_yaml(match)
@@ -97,7 +100,7 @@ module Analyzer::Specification
       url = build_url(path)
       @result << Endpoint.new(url, method, details)
 
-      if route_action = route["route"]?
+      if (route_action = route["route"]?) && route_action.as_h?
         if rewrite = route_action["prefix_rewrite"]?.try(&.as_s?)
           rewritten_url = build_url(rewrite)
           @result << Endpoint.new(rewritten_url, method, details) unless rewritten_url == url
@@ -106,13 +109,14 @@ module Analyzer::Specification
     end
 
     private def extract_path_yaml(match : YAML::Any) : String?
+      return unless match.as_h?
       if prefix = match["prefix"]?.try(&.as_s?)
         return prefix
       end
       if path = match["path"]?.try(&.as_s?)
         return path
       end
-      if safe_regex = match["safe_regex"]?
+      if (safe_regex = match["safe_regex"]?) && safe_regex.as_h?
         return safe_regex["regex"]?.try(&.as_s?)
       end
       # Envoy v2 legacy field
@@ -120,14 +124,16 @@ module Analyzer::Specification
     end
 
     private def extract_method_yaml(match : YAML::Any) : String?
+      return unless match.as_h?
       return unless headers_node = match["headers"]?
       return unless headers = headers_node.as_a?
       headers.each do |header|
+        next unless header.as_h?
         next unless header["name"]?.try(&.as_s?) == ":method"
         if exact = header["exact_match"]?.try(&.as_s?)
           return exact.upcase
         end
-        if sm = header["string_match"]?
+        if (sm = header["string_match"]?) && sm.as_h?
           if exact2 = sm["exact"]?.try(&.as_s?)
             return exact2.upcase
           end
@@ -140,6 +146,7 @@ module Analyzer::Specification
 
     private def process_json(data : JSON::Any, details : Details)
       extract_virtual_hosts_json(data).each do |vh|
+        next unless vh.as_h?
         if routes_node = vh["routes"]?
           if routes = routes_node.as_a?
             routes.each { |route| process_route_json(route, details) }
@@ -163,6 +170,7 @@ module Analyzer::Specification
       if resources = data["resources"]?
         if arr = resources.as_a?
           arr.each do |resource|
+            next unless resource.as_h?
             if vh = resource["virtual_hosts"]?
               if vharr = vh.as_a?
                 result.concat(vharr)
@@ -175,6 +183,7 @@ module Analyzer::Specification
     end
 
     private def process_route_json(route : JSON::Any, details : Details)
+      return unless route.as_h?
       return unless match = route["match"]?
 
       path = extract_path_json(match)
@@ -184,7 +193,7 @@ module Analyzer::Specification
       url = build_url(path)
       @result << Endpoint.new(url, method, details)
 
-      if route_action = route["route"]?
+      if (route_action = route["route"]?) && route_action.as_h?
         if rewrite = route_action["prefix_rewrite"]?.try(&.as_s?)
           rewritten_url = build_url(rewrite)
           @result << Endpoint.new(rewritten_url, method, details) unless rewritten_url == url
@@ -193,27 +202,30 @@ module Analyzer::Specification
     end
 
     private def extract_path_json(match : JSON::Any) : String?
+      return unless match.as_h?
       if prefix = match["prefix"]?.try(&.as_s?)
         return prefix
       end
       if path = match["path"]?.try(&.as_s?)
         return path
       end
-      if safe_regex = match["safe_regex"]?
+      if (safe_regex = match["safe_regex"]?) && safe_regex.as_h?
         return safe_regex["regex"]?.try(&.as_s?)
       end
       match["regex"]?.try(&.as_s?)
     end
 
     private def extract_method_json(match : JSON::Any) : String?
+      return unless match.as_h?
       return unless headers_node = match["headers"]?
       return unless headers = headers_node.as_a?
       headers.each do |header|
+        next unless header.as_h?
         next unless header["name"]?.try(&.as_s?) == ":method"
         if exact = header["exact_match"]?.try(&.as_s?)
           return exact.upcase
         end
-        if sm = header["string_match"]?
+        if (sm = header["string_match"]?) && sm.as_h?
           if exact2 = sm["exact"]?.try(&.as_s?)
             return exact2.upcase
           end

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -88,18 +88,35 @@ module Analyzer::Specification
       in_string = false
       while pos < content.size
         ch = content[pos]
-        if ch == '"' && (pos == 0 || content[pos - 1] != '\\')
-          in_string = !in_string
-        elsif !in_string
-          case ch
-          when '{'
-            depth += 1
-          when '}'
-            depth -= 1
-            if depth == 0
-              return content[(open_pos + 1)..(pos - 1)]
+        if in_string
+          # A quote closes the string only when preceded by an EVEN number of
+          # backslashes (`\\"` toggles, `\"` does not).
+          if ch == '"'
+            bs = 0
+            bp = pos - 1
+            while bp >= 0 && content[bp] == '\\'
+              bs += 1
+              bp -= 1
             end
+            in_string = false if bs.even?
           end
+        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '/'
+          # Line comment: skip to EOL so a stray `}` or `"` can't shift state.
+          nl = content.index('\n', pos)
+          pos = nl.nil? ? content.size : nl
+          next
+        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '*'
+          # Block comment: skip to the closing */.
+          close = content.index("*/", pos + 2)
+          pos = close.nil? ? content.size : close + 2
+          next
+        elsif ch == '"'
+          in_string = true
+        elsif ch == '{'
+          depth += 1
+        elsif ch == '}'
+          depth -= 1
+          return content[(open_pos + 1)..(pos - 1)] if depth == 0
         end
         pos += 1
       end
@@ -208,8 +225,18 @@ module Analyzer::Specification
       # Match google.api.http option
       return mappings unless options_block.includes?("google.api.http")
 
+      # Restrict the primary rule's `body:` to the portion before any
+      # additional_bindings, so a body declared only inside a binding does not
+      # leak into the parent mapping (mis-classifying its fields as JSON body).
+      primary_scope =
+        if ab_idx = options_block.index("additional_bindings")
+          options_block[0...ab_idx]
+        else
+          options_block
+        end
+
       body_value : String? = nil
-      if body_match = options_block.match(/body\s*:\s*"([^"]*)"/)
+      if body_match = primary_scope.match(/body\s*:\s*"([^"]*)"/)
         body_value = body_match[1]
       end
 

--- a/src/analyzer/analyzers/specification/mitmproxy.cr
+++ b/src/analyzer/analyzers/specification/mitmproxy.cr
@@ -84,7 +84,11 @@ module Analyzer::Specification
       # what slice of the capture the user cares about.
       return if @url.empty? || !full_url.includes?(@url)
 
-      endpoint_path = full_url.gsub(@url, "")
+      # Strip the user URL as a LEADING prefix only — gsub removed every
+      # occurrence, mangling paths where the prefix recurs (e.g. a redirect param).
+      endpoint_path = full_url.starts_with?(@url) ? full_url[@url.size..]? || "" : full_url
+      endpoint_path = "/#{endpoint_path}" unless endpoint_path.starts_with?("/")
+      endpoint_path = "/" if endpoint_path.empty?
       endpoint = Endpoint.new(endpoint_path, method)
 
       headers = request["headers"]?

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -122,6 +122,9 @@ module Analyzer::Specification
     # Follows `$ref` and flattens `allOf` so referenced/composed schemas
     # surface their members.
     private def collect_schema_props_json(root : JSON::Any, schema : JSON::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+      # JSON Schema allows boolean `items` etc.; a scalar node makes the
+      # `["..."]?` subscripts below raise "Expected Hash".
+      return unless schema.as_h?
       if ref = schema["$ref"]?.try(&.as_s?)
         return if seen.includes?(ref)
         seen << ref
@@ -155,6 +158,9 @@ module Analyzer::Specification
     end
 
     private def collect_schema_props_yaml(root : YAML::Any, schema : YAML::Any, param_type : String, params : Array(Param), seen : Set(String) = Set(String).new)
+      # JSON Schema allows boolean `items` etc.; a scalar node makes the
+      # `[...]?` subscripts below raise "Expected Hash".
+      return unless schema.as_h?
       if ref_node = schema[YAML::Any.new("$ref")]?
         if ref = ref_node.as_s?
           return if seen.includes?(ref)

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -18,6 +18,11 @@ module Analyzer::Specification
           yaml_obj = YAML.parse(content)
           source_dir = File.dirname(raml_spec)
 
+          # A non-mapping root (scalar/array/empty) makes the YAML `[...]?`
+          # lookups below raise "Expected Array or Hash" and, with no per-spec
+          # rescue, aborts every other RAML spec. Skip it cleanly instead.
+          next unless yaml_obj.as_h?
+
           base_path = base_path_from(yaml_obj)
           default_media = media_types_from(yaml_obj[YAML::Any.new("mediaType")]?)
           types = yaml_obj[YAML::Any.new("types")]? || YAML::Any.new(nil)

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -217,7 +217,9 @@ module Analyzer::Specification
           next
         end
 
-        if depth == 0 && input.byte_slice(i, delimiter.size) == delimiter
+        # `i` is a CHAR index (input[i]); use char-based slicing, not byte_slice,
+        # so a multi-byte char before a `||` doesn't desync delimiter detection.
+        if depth == 0 && input[i, delimiter.size]? == delimiter
           parts << current.strip unless current.strip.empty?
           current = ""
           i += delimiter.size

--- a/src/analyzer/analyzers/specification/wsdl.cr
+++ b/src/analyzer/analyzers/specification/wsdl.cr
@@ -50,6 +50,11 @@ module Analyzer::Specification
       types_node = find_child(definitions, "types")
       return element_fields unless types_node
 
+      # Track type references explicitly instead of overloading "a 1-element
+      # array means a reference" — a real single-field structure was being
+      # mistaken for a reference and overwritten with an unrelated type's fields.
+      references = {} of String => String
+
       each_child(types_node, "schema") do |schema|
         each_child(schema, "element") do |elem|
           name = elem["name"]?
@@ -59,7 +64,8 @@ module Analyzer::Specification
             collect_sequence_fields(complex_type, fields)
           elsif type_attr = elem["type"]?
             # Reference to a named complexType — resolved in a second pass.
-            element_fields[name] = [type_attr] of String
+            references[name] = strip_prefix(type_attr)
+            element_fields[name] = [] of String
             next
           end
           element_fields[name] = fields
@@ -75,12 +81,10 @@ module Analyzer::Specification
       end
 
       # Second pass: elements that referenced a named type get its fields.
-      element_fields.each do |name, fields|
-        next unless fields.size == 1
-        ref = strip_prefix(fields.first)
+      references.each do |name, ref|
         next if ref == name
         if resolved = element_fields[ref]?
-          element_fields[name] = resolved.dup unless resolved.size == 1 && strip_prefix(resolved.first) == name
+          element_fields[name] = resolved.dup
         end
       end
 

--- a/src/analyzer/analyzers/specification/zap_sites_tree.cr
+++ b/src/analyzer/analyzers/specification/zap_sites_tree.cr
@@ -31,20 +31,24 @@ module Analyzer::Specification
     end
 
     def process_node(node, details)
-      if node.as_h.has_key?("url") && node.as_h.has_key?("method")
-        path = node["url"].as_s
-        method = node["method"].as_s.upcase || "GET"
+      # Use safe accessors: a single malformed node (scalar child, non-array
+      # `children`, non-string `method`) must skip that branch, not raise and
+      # abort the whole sites-tree (the only rescue is at the file level).
+      h = node.as_h?
+      return unless h
+
+      if h.has_key?("url") && h.has_key?("method")
+        path = node["url"].as_s? || ""
+        method = node["method"].as_s?.try(&.upcase) || "GET"
 
         if !path.empty?
           uri = URI.parse(path)
           params = [] of Param
-          if node.as_h.has_key?("data")
-            data = node["data"].as_s
+          if data = node["data"]?.try(&.as_s?)
             begin
               data.split("&").each do |param|
                 param_name = param.split("=")[0]
-                param = Param.new(param_name.to_s, "", "form")
-                params << param
+                params << Param.new(param_name.to_s, "", "form")
               end
             rescue
             end
@@ -54,12 +58,9 @@ module Analyzer::Specification
         end
       end
 
-      if node.as_h.has_key?("children")
-        children = node["children"].as_a
-        if children.size > 0
-          children.each do |child|
-            process_node(child, details)
-          end
+      if children = node["children"]?.try(&.as_a?)
+        children.each do |child|
+          process_node(child, details)
         end
       end
     end

--- a/src/detector/detectors/specification/envoy.cr
+++ b/src/detector/detectors/specification/envoy.cr
@@ -41,8 +41,12 @@ module Detector::Specification
     end
 
     private def find_virtual_hosts_yaml(data : YAML::Any) : Bool
+      # A non-mapping root (array/scalar) makes String-key `[]?` raise; guard it
+      # — the detector runs in a worker fiber with no rescue, so a raise there
+      # kills the worker and loses results for this file.
+      return false unless data.as_h?
       # route_config.virtual_hosts (Envoy bootstrap / static config)
-      if rc = data["route_config"]?
+      if (rc = data["route_config"]?) && rc.as_h?
         if vh = rc["virtual_hosts"]?
           return virtual_hosts_valid_yaml?(vh)
         end
@@ -57,6 +61,7 @@ module Detector::Specification
       if resources = data["resources"]?
         if arr = resources.as_a?
           arr.each do |resource|
+            next unless resource.as_h?
             if vh = resource["virtual_hosts"]?
               return virtual_hosts_valid_yaml?(vh)
             end
@@ -70,6 +75,7 @@ module Detector::Specification
     private def virtual_hosts_valid_yaml?(vh : YAML::Any) : Bool
       if arr = vh.as_a?
         arr.each do |host|
+          next unless host.as_h?
           return true if host["domains"]?
         end
       end
@@ -77,7 +83,8 @@ module Detector::Specification
     end
 
     private def find_virtual_hosts_json(data : JSON::Any) : Bool
-      if rc = data["route_config"]?
+      return false unless data.as_h?
+      if (rc = data["route_config"]?) && rc.as_h?
         if vh = rc["virtual_hosts"]?
           return virtual_hosts_valid_json?(vh)
         end
@@ -90,6 +97,7 @@ module Detector::Specification
       if resources = data["resources"]?
         if arr = resources.as_a?
           arr.each do |resource|
+            next unless resource.as_h?
             if vh = resource["virtual_hosts"]?
               return virtual_hosts_valid_json?(vh)
             end
@@ -103,6 +111,7 @@ module Detector::Specification
     private def virtual_hosts_valid_json?(vh : JSON::Any) : Bool
       if arr = vh.as_a?
         arr.each do |host|
+          next unless host.as_h?
           return true if host["domains"]?
         end
       end


### PR DESCRIPTION
Per-framework split of a larger bug-hunt (spec-format analyzers + envoy detector).

### Crash hardening (a single malformed node aborted the whole file / killed the detector worker fiber)
- **asyncapi / oas3** — boolean/scalar `items`/`$ref`/`channel` made `["..."]?` subscripts raise `"Expected Hash"`; guarded with `as_h?` (was dropping request-body params or all channels).
- **envoy (analyzer + detector)** — unguarded `[]?` on array elements / non-mapping roots; the **detector** crash propagated out of the worker fiber. Receivers now guarded with `as_h?`.
- **apisix** — `route.as_h?` guard so one non-object `routes` entry doesn't drop all routes.
- **raml** — a scalar/array/empty YAML root raised before the mapping guard (no per-spec rescue → aborted every RAML spec); now skipped.
- **zap_sites_tree** — unchecked `as_h`/`as_a`/`as_s` → one bad node aborts the tree; now safe accessors (also fixes the dead `|| "GET"` method fallback).

### Logic fixes
- **traefik** — `split_top_level` used `byte_slice` with a char index → a `||` after a multi-byte char was missed and the OR-alternatives merged. Char-based slice.
- **grpc** — the top-level `body:` value leaked from a nested `additional_bindings`, flipping query params to JSON body. Scoped to before `additional_bindings`.
- **mitmproxy** — `full_url.gsub(@url, "")` stripped **every** occurrence of the user URL, mangling the path. Now strips the leading prefix only (mirrors HAR).
- **wsdl** — a 1-element field array was overloaded to mean "type reference", so a legitimate single-field structure got overwritten by an unrelated type's fields. References tracked explicitly.

Full suite green locally.