### PR TITLE
fix(output/optimizer): invalid TOML, broken diff-TOML, unlinked postman vars, dedup data loss

### DIFF
--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -58,20 +58,6 @@ class LLMEndpointOptimizer < EndpointOptimizer
     final_endpoints
   end
 
-  # Find endpoints that would benefit from LLM optimization
-  private def find_optimization_candidates(endpoints : Array(Endpoint)) : Array(Endpoint)
-    candidates = [] of Endpoint
-
-    endpoints.each do |endpoint|
-      # Check for non-standard URL patterns that might need refinement
-      if has_non_standard_patterns(endpoint)
-        candidates << endpoint
-      end
-    end
-
-    candidates
-  end
-
   # Check if an endpoint has non-standard patterns that could benefit from LLM optimization
   private def has_non_standard_patterns(endpoint : Endpoint) : Bool
     url = endpoint.url
@@ -185,19 +171,6 @@ class LLMEndpointOptimizer < EndpointOptimizer
   rescue ex : Exception
     @logger.debug "Failed to parse LLM optimization response: #{ex.message}"
     endpoint
-  end
-
-  # Check if two endpoints represent the same logical endpoint for replacement
-  private def matches_endpoint_identity(original : Endpoint, optimized : Endpoint) : Bool
-    # Match by method and similar URL structure (before optimization)
-    return false unless original.method == optimized.method
-
-    # For identity matching, use a flexible comparison that accounts for
-    # parameter names and basic URL structure
-    original_base = original.url.gsub(/\{[^}]+\}/, "{param}").gsub(/:[\w]+/, ":param").gsub(/<[^>]+>/, "<param>")
-    optimized_base = optimized.url.gsub(/\{[^}]+\}/, "{param}").gsub(/:[\w]+/, ":param").gsub(/<[^>]+>/, "<param>")
-
-    original_base == optimized_base
   end
 
   # Setup LLM adapter based on configuration

--- a/src/optimizer/llm_optimizer.cr
+++ b/src/optimizer/llm_optimizer.cr
@@ -33,27 +33,26 @@ class LLMEndpointOptimizer < EndpointOptimizer
 
     @logger.info "Applying LLM-based optimization for non-standard paths and parameters."
 
-    # Filter endpoints that might benefit from LLM optimization
-    candidates = find_optimization_candidates(endpoints)
+    # Filter endpoints that might benefit from LLM optimization, recording their
+    # positions. Writing each optimized result back by index avoids the previous
+    # identity-normalized find(), which collapsed distinct param names
+    # (/api/{userID} and /api/{orderID} both -> /api/{param}) and clobbered
+    # sibling endpoints with the first match.
+    candidate_indexes = [] of Int32
+    endpoints.each_with_index do |endpoint, i|
+      candidate_indexes << i if has_non_standard_patterns(endpoint)
+    end
 
-    if candidates.empty?
+    if candidate_indexes.empty?
       @logger.debug_sub "No endpoints found that would benefit from LLM optimization."
       return endpoints
     end
 
-    @logger.debug_sub "Found #{candidates.size} endpoints that may benefit from LLM optimization."
+    @logger.debug_sub "Found #{candidate_indexes.size} endpoints that may benefit from LLM optimization."
 
-    optimized_endpoints = [] of Endpoint
-
-    candidates.each do |endpoint|
-      optimized_endpoint = llm_optimize_single_endpoint(endpoint)
-      optimized_endpoints << optimized_endpoint
-    end
-
-    # Replace optimized endpoints in the original array
-    final_endpoints = endpoints.map do |endpoint|
-      optimized = optimized_endpoints.find { |opt| matches_endpoint_identity(endpoint, opt) }
-      optimized || endpoint
+    final_endpoints = endpoints.dup
+    candidate_indexes.each do |idx|
+      final_endpoints[idx] = llm_optimize_single_endpoint(final_endpoints[idx])
     end
 
     final_endpoints

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -237,7 +237,7 @@ class EndpointOptimizer
           @logger.debug_sub "  - Found duplicated endpoint: #{tiny_tmp.method} #{tiny_tmp.url}"
           duplicate_count += 1
           tiny_tmp.params.each do |param|
-            existing_param = dup.params.find { |dup_param| dup_param.name == param.name }
+            existing_param = dup.params.find { |dup_param| dup_param.name == param.name && dup_param.param_type == param.param_type }
             unless existing_param
               dup.params << param
             end

--- a/src/output_builder/diff.cr
+++ b/src/output_builder/diff.cr
@@ -86,17 +86,7 @@ class OutputBuilderDiff < OutputBuilder
           io << "[#{section}]\n"
           endpoints.as_a.each do |endpoint|
             io << "\n[[#{section}.endpoint]]\n"
-            endpoint.as_h.each do |key, value|
-              case value.raw
-              when String, Int64, Float64, Bool
-                io << "#{key} = #{toml_value(value)}\n"
-              when Array
-                io << "#{key} = ["
-                items = value.as_a.map { |item| toml_value(item) }
-                io << items.join(", ")
-                io << "]\n"
-              end
-            end
+            io << generate_table_content(endpoint.as_h)
           end
           io << "\n"
         end
@@ -105,16 +95,40 @@ class OutputBuilderDiff < OutputBuilder
     result
   end
 
+  private def generate_table_content(data : Hash(String, JSON::Any)) : String
+    String.build do |io|
+      data.each do |key, value|
+        case value.raw
+        when String, Int64, Float64, Bool
+          io << "#{key} = #{toml_value(value)}\n"
+        when Array
+          io << "#{key} = ["
+          io << value.as_a.map { |item| toml_value(item) }.join(", ")
+          io << "]\n"
+        when Hash
+          io << "#{key} = { "
+          io << value.as_h.map { |k, v| "#{k} = #{toml_value(v)}" }.join(", ")
+          io << " }\n"
+        end
+      end
+    end
+  end
+
   private def toml_value(value : JSON::Any) : String
     case raw = value.raw
     when String
-      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"")}")
+      # Escape control chars so a multi-line value can't break the TOML document.
+      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\b", "\\b").gsub("\t", "\\t").gsub("\n", "\\n").gsub("\f", "\\f").gsub("\r", "\\r")}")
     when Int64, Float64
       raw.to_s
     when Bool
       raw.to_s
     when Nil
       %("")
+    when Array
+      "[#{raw.map { |item| toml_value(item) }.join(", ")}]"
+    when Hash
+      "{ #{raw.map { |k, v| "#{k} = #{toml_value(v)}" }.join(", ")} }"
     else
       %("#{raw}")
     end

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -17,6 +17,11 @@ class OutputBuilderPostman < OutputBuilder
           # Handle <type:param> format - convert to :param
           match = part.match(/<[^:>]+:(\w+)>/)
           match ? ":#{match[1]}" : part
+        elsif part.starts_with?("{") && part.ends_with?("}")
+          # Handle {name} / {name:constraint} - convert to Postman's :name so the
+          # `variable` entry actually links to the URL placeholder.
+          match = part.match(/\A\{(\w+)(?::[^}]+)?\}\z/)
+          match ? ":#{match[1]}" : part
         else
           part
         end

--- a/src/output_builder/toml.cr
+++ b/src/output_builder/toml.cr
@@ -78,7 +78,9 @@ class OutputBuilderToml < OutputBuilder
   private def toml_value(value : JSON::Any) : String
     case raw = value.raw
     when String
-      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"")}")
+      # TOML basic strings can't contain raw newlines/control chars — escape
+      # them so a multi-line snippet/description doesn't break the document.
+      %("#{raw.gsub("\\", "\\\\").gsub("\"", "\\\"").gsub("\b", "\\b").gsub("\t", "\\t").gsub("\n", "\\n").gsub("\f", "\\f").gsub("\r", "\\r")}")
     when Int64, Float64
       raw.to_s
     when Bool


### PR DESCRIPTION
Per-subsystem split of a larger bug-hunt.

### Bugs fixed
- **output_builder/toml** — `toml_value` escaped only backslash/quote for strings; a value with a raw newline/control char (multi-line snippet/description) produced **invalid TOML**. Now escapes `\b \t \n \f \r`.
- **output_builder/diff** (`--diff -f toml`) — `generate_toml_from_diff` rendered param/tag/callee arrays through a `toml_value` with no Array/Hash branch → leaked `JSON::Any(...)` debug text with unescaped quotes (invalid TOML) and dropped Hash fields (`details`/`ai_context`). Now mirrors `toml.cr` (`generate_table_content` + Array/Hash branches).
- **output_builder/postman** — only `<type:param>` segments were rewritten to `:param`; `{id}`-style segments were left literal, so the path-variable entry was never linked to the URL placeholder. Added a brace-template branch.
- **optimizer** — duplicate-endpoint param merge deduped by **name only**, dropping a same-named param of a different type. Now dedups by `(name, param_type)`.
- **llm_optimizer** — identity-normalized `find()` replaced every param-name-equivalent endpoint with the **first** optimized result, clobbering distinct siblings (`/api/{userID}` and `/api/{orderID}`). Now writes back by stable index.

Full suite green locally.