### PR TITLE
fix(core): .http rewrite, fiber leak, config probe coercion, openrouter limit, O(n^2) import scan, ollama ctx

### DIFF
--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -365,7 +365,7 @@ describe LLM do
       end
 
       it "contains all expected providers" do
-        expected = %w[openai xai anthropic azure github ollama google cohere vllm lmstudio default]
+        expected = %w[openai xai anthropic azure github ollama google cohere vllm lmstudio openrouter default]
         (limits.keys - expected).should be_empty
       end
     end

--- a/src/analyzer/analyzers/file_analyzers/http.cr
+++ b/src/analyzer/analyzers/file_analyzers/http.cr
@@ -6,8 +6,9 @@ require "json"
 def parse_params(query : String?, params : Array(Param), type : String)
   return unless query
   query.to_s.split("&").each do |param|
-    key, value = param.split("=")
-    params << Param.new(key, value, type)
+    next if param.empty?
+    pair = param.split("=", 2)
+    params << Param.new(pair[0], pair[1]? || "", type)
   end
 end
 
@@ -19,66 +20,89 @@ def parse_body(body : String, params : Array(Param))
       params << Param.new(key, value.to_s, "json")
     end
   rescue
+    # Not valid JSON: treat as a urlencoded form body. Skip fragments that
+    # have no `=` (e.g. an incomplete JSON accumulation) instead of crashing
+    # on the multiple-assignment.
     body.split("&").each do |param|
-      key, value = param.split("=")
-      params << Param.new(key, value, "form")
+      pair = param.split("=", 2)
+      next if pair.size < 2
+      params << Param.new(pair[0], pair[1], "form")
     end
   end
-end
-
-def process_line(line : String, index : Int32, path : String, url : String, method : String, endpoint_url : String, headers : Bool, body : String, params : Array(Param), parsed_url : URI, results : Array(Endpoint))
-  if line.strip == "###"
-    if !endpoint_url.empty? && parsed_url.to_s.includes? url
-      details = Details.new(PathInfo.new(path, index + 1))
-      results << Endpoint.new(parsed_url.path, method, params, details)
-    end
-    return "", "", false, "", [] of Param, URI.parse("")
-  end
-
-  if line.match(/^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD) (https?:\/\/[^\s]+)/)
-    method, endpoint_url = line.split
-    headers = true
-    parsed_url = URI.parse(endpoint_url)
-    parse_params(parsed_url.query, params, "query")
-  elsif headers && line.strip.empty?
-    headers = false
-  elsif headers
-    header_name, header_value = line.split(": ", 2)
-    params << Param.new(header_name, header_value, "header")
-  elsif !headers && !line.strip.empty?
-    body += line
-  end
-
-  parse_body(body, params)
-
-  if parsed_url.to_s.includes? url
-    details = Details.new(PathInfo.new(path, index + 1))
-    results << Endpoint.new(parsed_url.path, method, params, details)
-  end
-
-  return method, endpoint_url, headers, body, params, parsed_url
 end
 
 FileAnalyzer.add_hook(->(path : String, url : String) : Array(Endpoint) {
   results = [] of Endpoint
 
-  if File.extname(path) == ".http"
-    begin
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+  return results unless File.extname(path) == ".http"
+
+  begin
+    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
+      method = ""
+      endpoint_url = ""
+      headers = false
+      body = ""
+      params = [] of Param
+      parsed_url = URI.parse("")
+      start_line = 0
+
+      # Commit the request accumulated so far (if any) as one endpoint. The
+      # body is parsed once here on the fully-accumulated text, and params is
+      # dup'd so the emitted endpoint can never be mutated by a later request.
+      commit = -> {
+        if !endpoint_url.empty? && parsed_url.to_s.includes?(url)
+          parse_body(body, params)
+          details = Details.new(PathInfo.new(path, start_line))
+          results << Endpoint.new(parsed_url.path, method, params.dup, details)
+        end
+      }
+
+      reset = -> {
         method = ""
         endpoint_url = ""
         headers = false
         body = ""
         params = [] of Param
         parsed_url = URI.parse("")
+      }
 
-        file.each_line.with_index do |line, index|
-          next if line.starts_with?("#") || line.starts_with?("//")
-          method, endpoint_url, headers, body, params, parsed_url = process_line(line, index, path, url, method, endpoint_url, headers, body, params, parsed_url, results)
+      file.each_line.with_index do |line, index|
+        stripped = line.strip
+
+        # `###` (optionally followed by a label) separates requests.
+        if stripped.starts_with?("###")
+          commit.call
+          reset.call
+          next
+        end
+
+        # Skip true comments (the `###` separator is handled above).
+        next if line.starts_with?("#") || line.starts_with?("//")
+
+        if line.match(/^(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD) (https?:\/\/[^\s]+)/)
+          # A new request line ends the previous one even without a `###`.
+          commit.call
+          reset.call
+
+          method, endpoint_url = line.split
+          headers = true
+          parsed_url = URI.parse(endpoint_url)
+          start_line = index + 1
+          parse_params(parsed_url.query, params, "query")
+        elsif headers && stripped.empty?
+          headers = false
+        elsif headers
+          header_parts = line.split(": ", 2)
+          params << Param.new(header_parts[0], header_parts[1], "header") if header_parts.size == 2
+        elsif !headers && !stripped.empty?
+          body += line
         end
       end
-    rescue
+
+      # Flush the final request (files usually have no trailing `###`).
+      commit.call
     end
+  rescue
   end
 
   results

--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -829,7 +829,12 @@ module Analyzer::AI
       end
 
       response = if adapter.supports_context?
-                   ctx_key = "#{@provider}:#{@model}:#{kind}"
+                   # BUNDLE_ANALYZE runs one fiber per bundle concurrently and they
+                   # would all share this one key — reusing a single KV-context
+                   # across independent bundles contaminates results (and races the
+                   # adapter's @contexts Hash). Disable context reuse for that kind;
+                   # each request already carries the full system + bundle prompt.
+                   ctx_key = kind == "BUNDLE_ANALYZE" ? nil : "#{@provider}:#{@model}:#{kind}"
                    adapter.request_with_context(system_prompt, payload, format, ctx_key)
                  else
                    messages = [{"role" => "system", "content" => system_prompt}, {"role" => "user", "content" => payload}]

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -20,7 +20,7 @@ class ConfigInitializer
     ai_context
     nolog
     no_spinner
-    send_req
+    probe # legacy `send_req` is migrated to `probe` before this coercion runs
     all_taggers
     status_codes
     passive_scan

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -517,6 +517,12 @@ module LLM
       "gpt-oss-20b"  => 128000,
       "default"      => 4000,
     },
+    # OpenRouter proxies many large-context frontier models whose exact ids we
+    # don't control, so use a generous model-agnostic default rather than the
+    # 4000-token global default (which over-shards bundles).
+    "openrouter" => {
+      "default" => 128000,
+    },
     "default" => 4000,
   }
 

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -279,9 +279,9 @@ module Noir::ImportGraph::Python
           # Parse `import (\n a,\n b,\n c)` pattern — track
           # bytes from the opening `(` to the matching `)`.
           index = offset + round_bracket_index + 1
-          while index < content.size && content[index] != ')'
-            index += 1
-          end
+          # Single index() call instead of an O(n^2) per-char walk over the
+          # remaining file (String#[](Int) is O(n) on multi-byte content).
+          index = content.index(')', index) || content.size
           imports = content[(offset + round_bracket_index + 1)..(index - 1)].strip
         end
 

--- a/src/utils/utils.cr
+++ b/src/utils/utils.cr
@@ -9,11 +9,18 @@ def get_relative_path(base_path : String, path : String) : String
                       # This avoids an issue where `.sub(".", "")` would remove the dot from file extensions.
                       path
                     else
-                      # For other base paths, remove the base path prefix.
+                      # Remove the base path prefix, anchored to the START only.
+                      # `String#sub` replaces the first match anywhere, so an
+                      # unanchored double-sub corrupted paths where base_path
+                      # recurred inside a dir/file name.
                       base = base_path.ends_with?("/") ? base_path : "#{base_path}/"
-                      path
-                        .sub(base, "")
-                        .sub(base_path, "") # Fallback if base doesn't end with /
+                      if path.starts_with?(base)
+                        path[base.size..]
+                      elsif path.starts_with?(base_path)
+                        path[base_path.size..]
+                      else
+                        path
+                      end
                     end
 
   # Then, normalize the resulting path.
@@ -55,7 +62,9 @@ end
 # Safely checks if a regex matches a string within a given timeout.
 # This helps mitigate ReDoS (Regular Expression Denial of Service) attacks.
 def regex_matches_with_timeout?(regex : Regex, input : String, timeout : Time::Span = 500.milliseconds) : Bool
-  result_channel = Channel(Bool).new
+  # Buffered (capacity 1): on timeout the caller stops receiving, so an
+  # unbuffered send from the late-finishing fiber would block forever (fiber leak).
+  result_channel = Channel(Bool).new(1)
 
   spawn do
     result_channel.send(regex.matches?(input))


### PR DESCRIPTION
Per-subsystem split of a larger bug-hunt.

### Bugs fixed
- **file_analyzers/http** (`.http`) — the hook reused **one** params array across all requests in a multi-request file (**cross-request param leak**); the per-request reset was dead code (`###` skipped before `process_line`); a multi-line JSON body crashed `parse_body` (IndexError → file aborted, JSON params lost); and a header line without `': '` crashed the hook. Rewrote to commit each request **once** at its boundary with a fresh params array, parse the body once, and guard the splits.
- **utils** — `regex_matches_with_timeout?` sent on an **unbuffered** channel after a timeout with no receiver → the slow-regex fiber blocked forever (**fiber leak**); buffered the channel. Also anchored `get_relative_path`'s prefix strip (unanchored double-`sub` corrupted paths where `base_path` recurred mid-path).
- **config_initializer** — legacy `send_req: yes` migrates to `probe` but `probe` was missing from `BOOLEAN_CONFIG_KEYS`, so it stayed the String `"yes"` (never coerced to Bool), bypassing the `--probe` target-URL guard. Replaced `send_req`→`probe`.
- **llm/prompt** — `get_max_tokens` didn't recognize the documented `openrouter` provider → 4000-token default + over-sharded bundles. Added an `openrouter` entry (128000). Spec updated.
- **miniparsers/import_graph** — parenthesised-import scan walked the file with O(n) `String#[](Int)` char indexing → **O(n²)** on multi-byte content. Now `String#index`.
- **llm_analyzers/unified_ai** — all concurrent `BUNDLE_ANALYZE` bundles shared **one** Ollama KV-context `cache_key`, contaminating results across bundles. Context reuse disabled for that kind.

Full suite green locally.