### PR TITLE
fix(analyzer): FP/FN + parsing bugs in grip/scala/vapor/lapis/grails/csharp/giraffe/catalyst/mojolicious

### DIFF
--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -15,23 +15,30 @@ module Analyzer::Crystal
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
       last_endpoint = Endpoint.new("", "")
-      current_scopes = [] of String
+      scope_stack = [] of NamedTuple(prefix: String, indent: Int32)
 
       lines.each_with_index do |line, index|
         details = Details.new(PathInfo.new(path, index + 1))
 
-        # Handle scope statements
-        if line.includes?("scope ") && line.includes?(" do")
-          scope_match = line.match(/scope\s+['"](.+?)['"]/)
-          if scope_match && scope_match[1]?
-            current_scopes << scope_match[1]
+        # Open a scope block, recording its indentation.
+        if scope_match = line.match(/^(\s*)scope\s+['"](.+?)['"].*\bdo\b/)
+          scope_stack << {prefix: scope_match[2], indent: scope_match[1].size}
+          next
+        end
+
+        # Close the innermost scope only when an `end` lines up with the
+        # indentation of the `scope ... do` that opened it; inner if/case/def/do
+        # `end`s sit at a deeper indent and must not pop the scope.
+        unless scope_stack.empty?
+          if end_match = line.match(/^(\s*)end\b/)
+            if end_match[1].size == scope_stack.last[:indent]
+              scope_stack.pop
+              next
+            end
           end
         end
 
-        # Handle end statements (basic detection)
-        if line.strip == "end" && current_scopes.size > 0
-          current_scopes.pop
-        end
+        current_scopes = scope_stack.map(&.[:prefix])
 
         # Parse HTTP method calls
         endpoint = line_to_endpoint(line, current_scopes)
@@ -222,7 +229,8 @@ module Analyzer::Crystal
       # Match HTTP method calls: get "/path", Controller
       %w[get post put patch delete options head].each do |method|
         if content.includes?("#{method} ") && content.includes?("\"")
-          if match = content.match(/#{method}\s+['"](.+?)['"]/)
+          # Require a token boundary so `input "/x"` isn't read as `put "/x"`.
+          if match = content.match(/(?:^|[^.\w])#{method}\s+['"](.+?)['"]/)
             path = normalize_crystal_interpolation(match[1])
             full_path = scope_prefix + path
             return Endpoint.new(full_path, method.upcase)
@@ -237,7 +245,7 @@ module Analyzer::Crystal
       scope_prefix = scopes.join("")
 
       if content.includes?("ws ") && content.includes?("\"")
-        if match = content.match(/ws\s+['"](.+?)['"]/)
+        if match = content.match(/(?:^|[^.\w])ws\s+['"](.+?)['"]/)
           path = normalize_crystal_interpolation(match[1])
           full_path = scope_prefix + path
           endpoint = Endpoint.new(full_path, "GET")

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -161,11 +161,13 @@ module Analyzer::CSharp
     private def extract_parameters(full_signature : String, http_method : String) : Array(Param)
       parameters = [] of Param
 
-      # Extract parameter list from signature
-      match = full_signature.match(/\((.*?)\)/)
-      return parameters unless match
+      # Extract parameter list (paren-depth aware so a param with an inner ')'
+      # — a method-call default like `id = GetDefault()` or a tuple type
+      # `(int,int) pair` — isn't truncated at the first ')').
+      param_list = extract_balanced_param_list(full_signature)
+      return parameters unless param_list
 
-      param_list = match[1].strip
+      param_list = param_list.strip
       return parameters if param_list.empty?
 
       # Determine default parameter type based on HTTP method

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -101,7 +101,7 @@ module Analyzer::CSharp::MinimalApiSupport
       return {route, methods}
     end
 
-    inline_prefix = extract_inline_group_prefix(block)
+    inline_prefix = extract_inline_group_prefix(block, group_prefixes)
     if match = block.match(/(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?@?"([^"]+)"/m)
       receiver = match[1]?
       route = apply_group_prefix(match[3], receiver, group_prefixes)
@@ -120,7 +120,7 @@ module Analyzer::CSharp::MinimalApiSupport
   end
 
   private def extract_map_methods_route(block : String, group_prefixes : Hash(String, String)) : Tuple(String?, Array(String))
-    inline_prefix = extract_inline_group_prefix(block)
+    inline_prefix = extract_inline_group_prefix(block, group_prefixes)
 
     if match = block.match(/(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\s*:\s*)?@?"([^"]+)"\s*,\s*([\s\S]+?)(?:=>|\);)/m)
       receiver = match[1]?
@@ -144,13 +144,25 @@ module Analyzer::CSharp::MinimalApiSupport
     methods.uniq
   end
 
-  private def extract_inline_group_prefix(block : String) : String
+  private def extract_inline_group_prefix(block : String, group_prefixes : Hash(String, String)) : String
     map_index = block.index(/\.?\s*Map(?:Get|Post|Put|Delete|Patch|Head|Options|Methods)?\s*\(/)
     return "" unless map_index
 
     prefix_source = block[0...map_index]
     parts = prefix_source.scan(/MapGroup\s*\(\s*@?"([^"]+)"/).map(&.[1]?.to_s)
     return "" if parts.empty?
+
+    # A chained `group.MapGroup("/sub").Map*(...)` registration carries the
+    # accumulated prefix of the leading receiver variable (e.g. `admin` ->
+    # `/admin`) which the verb-regex receiver can't see (it resolves to the
+    # `)` of the chained call). Resolve and prepend it so the route keeps the
+    # full `/admin/sub/...` path instead of dropping to `/sub/...`.
+    if head = prefix_source.match(/\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*MapGroup\s*\(/)
+      if head_prefix = group_prefixes[head[1]]?
+        parts.unshift(head_prefix)
+      end
+    end
+
     join_route_parts_array(parts)
   end
 

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -549,30 +549,60 @@ module Analyzer::Fsharp
       find_matching_delimiter(text, open_idx, '[', ']')
     end
 
+    # Returns the index of the closing quote if chars[i] opens a genuine F#
+    # char literal ('c', '\n', '\\', 'A', '\x41', ...); nil if the apostrophe is
+    # a generic type param (`<'T>`) or a tick identifier (`route'`), which must
+    # NOT be treated as a string delimiter.
+    private def fsharp_char_literal_close(chars : Array(Char), i : Int32) : Int32?
+      if i > 0
+        prev = chars[i - 1]
+        return nil if prev.alphanumeric? || prev == '_' || prev == '\'' || prev == '<'
+      end
+      return nil if i + 1 >= chars.size
+
+      if chars[i + 1] == '\\'
+        j = i + 2
+        limit = i + 10
+        while j < chars.size && j <= limit
+          return j if chars[j] == '\''
+          j += 1
+        end
+        nil
+      else
+        (i + 2 < chars.size && chars[i + 2] == '\'') ? i + 2 : nil
+      end
+    end
+
     private def find_matching_delimiter(text : String, open_idx : Int32,
                                         opener : Char, closer : Char) : Int32?
-      return unless open_idx < text.size && text[open_idx] == opener
+      chars = text.chars
+      return unless open_idx < chars.size && chars[open_idx] == opener
       depth = 1
       i = open_idx + 1
       in_string = false
-      string_quote = '\0'
 
-      while i < text.size && depth > 0
-        c = text[i]
+      while i < chars.size && depth > 0
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
-          in_string = false if c == string_quote
+          in_string = false if c == '"'
           i += 1
           next
         end
 
+        # An apostrophe is usually a generic param (<'T>) or a tick identifier
+        # (route'), not a string. Only skip it when it opens a real char literal.
+        if c == '\''
+          i = (close = fsharp_char_literal_close(chars, i)) ? close + 1 : i + 1
+          next
+        end
+
         case c
-        when '"', '\''
+        when '"'
           in_string = true
-          string_quote = c
         when opener
           depth += 1
         when closer
@@ -611,11 +641,25 @@ module Analyzer::Fsharp
           next
         end
 
-        if c == '"' || c == '\''
+        if c == '"'
           in_string = true
           string_quote = c
           result << c
           i += 1
+          next
+        end
+
+        # Apostrophe: a generic param (<'T>) or tick identifier (route') is NOT
+        # a string — passing it through verbatim keeps later comments strippable.
+        # Only a genuine char literal is copied as an opaque unit.
+        if c == '\''
+          if close = fsharp_char_literal_close(chars, i)
+            (i..close).each { |k| result << chars[k] }
+            i = close + 1
+          else
+            result << c
+            i += 1
+          end
           next
         end
 

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -412,8 +412,10 @@ module Analyzer::Groovy
     # for every recognized DSL form. `prefix` accumulates `group` blocks
     # so nested mappings inherit the outer URL prefix.
     private def emit_mapping_endpoints(path : String, content : String,
-                                       text : String, prefix : String)
-      remaining = consume_groups(path, content, text, prefix)
+                                       text : String, prefix : String, base_offset : Int32 = 0)
+      # `text` may be a group-body SUBSTRING; base_offset is its start offset in
+      # `content` so match offsets resolve to real file line numbers.
+      remaining = consume_groups(path, content, text, prefix, base_offset)
 
       # Verb-prefixed mappings: `get '/users'(controller: ..., action: ...)`.
       # An optional `name <id>:` prefix names the mapping for reverse URL
@@ -423,7 +425,7 @@ module Analyzer::Groovy
       remaining.scan(pattern) do |match|
         verb = match[1].upcase
         url_pattern = prefix + match[3]
-        line = line_for_offset(content, match.begin(0) || 0)
+        line = line_for_offset(content, base_offset + (match.begin(0) || 0))
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),
           Details.new(PathInfo.new(path, line)))
@@ -442,7 +444,7 @@ module Analyzer::Groovy
 
         url_pattern = prefix + match[2]
         body_args = match[3]
-        line = line_for_offset(content, match.begin(0) || 0)
+        line = line_for_offset(content, base_offset + (match.begin(0) || 0))
 
         if body_args.match(/\bresources:\s*['"]/)
           RESOURCES_ENDPOINTS.each do |ep|
@@ -494,7 +496,7 @@ module Analyzer::Groovy
         url_pattern = prefix + match[2]
         body_block = match[3]
         next unless body_block.match(/\b(controller|action|method|view)\s*=/)
-        line = line_for_offset(content, match.begin(0) || 0)
+        line = line_for_offset(content, base_offset + (match.begin(0) || 0))
         verb = extract_method_assignment(body_block) || "GET"
         @result << Endpoint.new(translate_pattern(url_pattern), verb,
           extract_path_params(url_pattern),
@@ -507,7 +509,7 @@ module Analyzer::Groovy
     # copy of `text` with those blocks blanked out so the caller's
     # subsequent regex passes do not double-process them.
     private def consume_groups(path : String, content : String,
-                               text : String, prefix : String) : String
+                               text : String, prefix : String, base_offset : Int32 = 0) : String
       mutable = text
       cursor = 0
       while m = mutable.match(/group\s+(['"])([^'"]+)\1\s*,?\s*\{/, cursor)
@@ -521,7 +523,7 @@ module Analyzer::Groovy
 
         if close_brace
           block_body = mutable[(open_brace + 1)...close_brace]
-          emit_mapping_endpoints(path, content, block_body, prefix + group_prefix)
+          emit_mapping_endpoints(path, content, block_body, prefix + group_prefix, base_offset + open_brace + 1)
           replacement = " " * (close_brace + 1 - match_start)
           mutable = mutable[0...match_start] + replacement + mutable[(close_brace + 1)..]
           cursor = match_start + replacement.size

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -675,17 +675,21 @@ module Analyzer::Lua
         # Lua / MoonScript line comment: --
         # MoonScript also supports `--` and Lua block comments use --[[ ... ]]
         if i + 1 < chars.size && c == '-' && chars[i + 1] == '-'
-          # Block form: --[[ ... ]]
-          if i + 3 < chars.size && chars[i + 2] == '[' && chars[i + 3] == '['
-            4.times { result << ' ' }
-            i += 4
-            while i + 1 < chars.size && !(chars[i] == ']' && chars[i + 1] == ']')
+          # Block form: --[[ ... ]], --[=[ ... ]=], --[==[ ... ]==], ...
+          # Use the leveled detector so a `--[=[ ... ]=]` comment isn't misread
+          # as a line comment (which leaks its body as phantom routes).
+          if comment_level = lua_long_bracket_open?(chars, i + 2)
+            opener_size = comment_level + 2
+            (opener_size + 2).times { result << ' ' } # blank `--` + opener
+            i += 2 + opener_size
+            while i < chars.size
+              if chars[i] == ']' && lua_long_bracket_close?(chars, i, comment_level)
+                (comment_level + 2).times { result << ' ' }
+                i += comment_level + 2
+                break
+              end
               result << (chars[i] == '\n' ? '\n' : ' ')
               i += 1
-            end
-            if i + 1 < chars.size
-              2.times { result << ' ' }
-              i += 2
             end
             next
           end
@@ -708,10 +712,11 @@ module Analyzer::Lua
       return 1 if offset <= 0
       limit = offset > content.size ? content.size : offset
       count = 1
-      i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
-        i += 1
+      # each_char advances in O(1); the old content[i] loop was O(n^2) on
+      # multi-byte (UTF-8) content, stalling large CJK files with many routes.
+      content.each_char_with_index do |ch, i|
+        break if i >= limit
+        count += 1 if ch == '\n'
       end
       count
     end

--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -104,6 +104,9 @@ module Analyzer::Perl
     private def collect_actions(content : String, file_path : String) : Array(RouteAction)
       raw_lines = content.lines
       lines = sanitize_perl_lines(raw_lines)
+      # Count braces over a string/comment/regex-stripped (line-aligned) view so
+      # an unbalanced brace inside a literal can't truncate/extend a sub body.
+      code_lines = code_only_lines(lines)
       package_configs = collect_controller_configs(lines)
       actions = [] of RouteAction
       package_name = ""
@@ -137,8 +140,9 @@ module Analyzer::Perl
           while body_index < lines.size
             body_line = lines[body_index]
             body_lines << body_line
-            brace_depth += brace_delta(body_line)
-            opened = true if body_line.includes?("{")
+            code_line = code_lines[body_index]? || ""
+            brace_depth += brace_delta(code_line)
+            opened = true if code_line.includes?("{")
             break if opened && brace_depth <= 0
             body_index += 1
           end
@@ -577,6 +581,12 @@ module Analyzer::Perl
         delta -= 1 if char == '}'
       end
       delta
+    end
+
+    # Line-aligned copy with strings/comments/regexes blanked (newlines kept),
+    # so brace counting ignores braces inside literals. Mirrors dancer2.cr.
+    private def code_only_lines(sanitized : Array(String)) : Array(String)
+      Noir::PerlCalleeExtractor.strip_non_code(sanitized.join('\n')).lines
     end
   end
 end

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -658,7 +658,9 @@ module Analyzer::Scala
         when ')', ']', '}'
           depth -= 1 if depth > 0
         else
-          return i if depth == 0 && text.byte_slice(i, operator.size) == operator
+          # `i` is a CHAR index; char-slice (byte_slice would treat i as a byte
+          # offset and desync the match when a multi-byte char precedes it).
+          return i if depth == 0 && text[i, operator.size]? == operator
         end
         i += 1
       end

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -339,7 +339,32 @@ module Analyzer::Swift
     end
 
     private def code_line(line : String) : String
-      line.split("//", 2).first
+      # String-aware: only truncate at a `//` OUTSIDE a string literal, so a path
+      # like "api//v2" or a "https://..." redirect arg isn't cut (which made
+      # call_arguments fail and silently drop the route / group prefix).
+      in_string = false
+      escaped = false
+      quote = '"'
+      index = 0
+      while index < line.size
+        char = line[index]
+        if in_string
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            in_string = false
+          end
+        elsif char == '"' || char == '\''
+          in_string = true
+          quote = char
+        elsif char == '/' && line[index + 1]? == '/'
+          return line[0...index]
+        end
+        index += 1
+      end
+      line
     end
 
     private def extract_named_handler_params(route_line : String,

--- a/src/detector/detectors/perl/mojolicious.cr
+++ b/src/detector/detectors/perl/mojolicious.cr
@@ -26,7 +26,7 @@ module Detector::Perl
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".pl") || filename.ends_with?(".pm") || filename.ends_with?(".t") || File.basename(filename) == "cpanfile" || File.basename(filename) == "Makefile.PL" || File.basename(filename) == "dist.ini" || File.basename(filename) == "META.json" || File.basename(filename) == "META.yml"
+      filename.ends_with?(".pl") || filename.ends_with?(".pm") || filename.ends_with?(".psgi") || filename.ends_with?(".t") || File.basename(filename) == "cpanfile" || File.basename(filename) == "Makefile.PL" || File.basename(filename) == "dist.ini" || File.basename(filename) == "META.json" || File.basename(filename) == "META.yml"
     end
 
     def set_name


### PR DESCRIPTION
Final per-framework split of a larger bug-hunt — the remaining smaller-footprint analyzers.

### Bugs fixed
- **crystal/grip** — scope `end` was popped on **any** bare `end` (inner `if`/`case`/`def`), so routes after a nested block lost their scope prefix → indent-matched popping. The verb regex also lacked a token boundary (`input "/x"` matched as `put`).
- **scala/play** — `top_level_operator_index` mixed a char index with `byte_slice` → corrupted param parsing on non-ASCII signatures. Char-based slice.
- **swift/vapor** — `code_line` stripped `//` with a non-string-aware split, truncating any route whose path/arg contains `//` (`"api//v2"` or an `https://` redirect) → route/group-prefix lost. String-aware comment strip.
- **lua/lapis** — `strip_lua_comments` only recognized `--[[`, not leveled `--[=[ … ]=]` block comments → route-shaped code inside such comments surfaced as phantom endpoints; `line_for_offset` did O(n) `content[i]` indexing → **O(n²)** on UTF-8.
- **groovy/grails** — endpoints inside `group { … }` blocks got line numbers measured from the group-body substring, not the file. Thread an absolute base offset.
- **csharp/aspnet_mvc** — `extract_parameters` used a non-greedy `\(.*?\)` that truncated a param list containing parens (method-call default / tuple type). Use the balanced extractor.
- **csharp/minimal_api_support** — chained `group.MapGroup("/sub").Map*(…)` dropped the receiver variable's accumulated prefix; now resolved and prepended.
- **fsharp/giraffe** — `find_matching_delimiter` / `strip_fsharp_comments` treated `'` as a string delimiter, but F# uses it in generics (`<'T>`) and tick identifiers (`route'`) → a route nested in such a scope lost its prefix/verb and comments after a `'` stopped being stripped. Now only treats `'` as a genuine char literal.
- **perl/catalyst** — sub-body brace counting ran on un-stripped source → an unbalanced brace inside a string/regex truncated or over-extended the body. Now counts braces over a string/comment-stripped, line-aligned view (mirrors dancer2).
- **detector/perl/mojolicious** — `applicable?` omitted `.psgi`, making the `.psgi` `detect` branch unreachable.

Full suite green locally.