### PR TITLE
fix(docs): resolve highlight.js/css 404 under /noir/ subpath

### DIFF
--- a/docs/templates/404.html
+++ b/docs/templates/404.html
@@ -6,7 +6,7 @@
       <a href="{{ base_url }}/" class="error-link">Return to Home</a>
     </div>
   </div>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   {{ auto_includes_js }}
 </body>
 </html>

--- a/docs/templates/_highlight_js.html
+++ b/docs/templates/_highlight_js.html
@@ -1,0 +1,2 @@
+<script src="{{ base_url }}/assets/js/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>

--- a/docs/templates/blog_post.html
+++ b/docs/templates/blog_post.html
@@ -87,7 +87,7 @@
     </div>
   </footer>
   <script src="{{ base_url }}/js/search.js" defer></script>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   <script src="{{ base_url }}/js/codeblock.js"></script>
   {{ auto_includes_js }}
 </body>

--- a/docs/templates/blog_section.html
+++ b/docs/templates/blog_section.html
@@ -86,7 +86,7 @@
     </div>
   </footer>
   <script src="{{ base_url }}/js/search.js" defer></script>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   {{ auto_includes_js }}
 </body>
 </html>

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -29,7 +29,7 @@
   <script src="{{ base_url }}/js/sidebar.js"></script>
   <script src="{{ base_url }}/js/toc.js"></script>
   <script src="{{ base_url }}/js/search.js" defer></script>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   <script src="{{ base_url }}/js/codeblock.js"></script>
   {{ auto_includes_js }}
 </body>

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -74,7 +74,10 @@
   <link rel="preload" href="{{ base_url }}/fonts/inter-600-latin.woff2" as="font" type="font/woff2" crossorigin>
   <link rel="stylesheet" href="{{ base_url }}/css/fonts.css">
   <link rel="stylesheet" href="{{ base_url }}/css/style.css">
-  {{ highlight_css }}
+  {# hwaro's `highlight_css`/`highlight_js` emit root-absolute /assets/ paths that
+     ignore the base_url subpath, 404ing under /noir/. Reference the vendored
+     assets via base_url ourselves instead. #}
+  <link rel="stylesheet" href="{{ base_url }}/assets/css/highlight/atom-one-dark.min.css">
   {{ auto_includes_css }}
 </head>
 <body>

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -28,7 +28,7 @@
     </div>
   </footer>
   <script src="{{ base_url }}/js/search.js" defer></script>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   {{ auto_includes_js }}
 </body>
 </html>

--- a/docs/templates/taxonomy.html
+++ b/docs/templates/taxonomy.html
@@ -77,7 +77,7 @@
     </div>
   </footer>
   <script src="{{ base_url }}/js/search.js" defer></script>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   {{ auto_includes_js }}
 </body>
 </html>

--- a/docs/templates/taxonomy_term.html
+++ b/docs/templates/taxonomy_term.html
@@ -103,7 +103,7 @@
     </div>
   </footer>
   <script src="{{ base_url }}/js/search.js" defer></script>
-  {{ highlight_js }}
+  {% include "_highlight_js.html" %}
   {{ auto_includes_js }}
 </body>
 </html>


### PR DESCRIPTION
## Problem

Accessing docs pages throws console errors:

```
404  atom-one-dark.min.css
404  highlight.min.js
ReferenceError: Can't find variable: hljs
```

## Root cause

#1928 self-hosted highlight.js (`use_cdn = false`). hwaro's built-in `{{ highlight_css }}` / `{{ highlight_js }}` variables emit **root-absolute** `/assets/...` paths that ignore the `base_url` subpath. The site is served at `owasp-noir.github.io/noir/`, so those paths resolve to `owasp-noir.github.io/assets/...` → 404. Failing to load `highlight.min.js` then breaks `hljs.highlightAll()` with a `ReferenceError`.

Every other asset in the templates already uses the `{{ base_url }}/...` convention; only these two hwaro-emitted tags were missing the prefix.

> This is ultimately a hwaro bug (missing base_url prefix when `use_cdn=false` + non-root base_url). This PR works around it in noir's templates; the workaround can be removed once hwaro is fixed upstream.

## Fix

- Add `docs/templates/_highlight_js.html` partial emitting the script tags via `{{ base_url }}` (7 call sites).
- `header.html`: replace `{{ highlight_css }}` with an explicit `{{ base_url }}/assets/css/highlight/atom-one-dark.min.css` link.
- Replace `{{ highlight_js }}` with the partial in footer/landing/blog_post/blog_section/taxonomy/taxonomy_term/404.

## Verification

`hwaro build` re-render:
- CSS/JS now emit `https://owasp-noir.github.io/noir/assets/...` (EN + KO).
- 0 remaining root-absolute `/assets/` refs across all generated HTML.
- Vendored assets confirmed present under `docs/public/assets/...`.
- CSP (`script-src 'self'`) still satisfied (same-origin).