### PR TITLE
fix(rails): cover inline route blocks and speed lookups

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/admin/refunds_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/app/controllers/admin/refunds_controller.rb
@@ -20,6 +20,14 @@ class Admin::RefundsController < ApplicationController
     request.headers['X-Template']
   end
 
+  def inline_summary
+    request.headers['X-Inline-Summary']
+  end
+
+  def inline_preview
+    request.headers['X-Inline-Preview']
+  end
+
   def purge
     request.headers['X-Confirm']
     params["id"]

--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -71,6 +71,8 @@ Rails.application.routes.draw do
   resources :refunds, controller: "admin/refunds", only: [] do
     get :summary, on: :collection
     get :preview
+    collection { get :inline_summary }
+    member { post :inline_preview }
 
     new do
       get :template
@@ -87,6 +89,7 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show"
   get "ping", to: "monitor#ping"
+  match "legacy_ping", to: "monitor#ping", via: "get"
 
   # Optional route segments are Rails DSL, not URL: `(.:format)` and the
   # nested `(/:section)` must be peeled to the required base path, and the

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -106,6 +106,12 @@ expected_endpoints = [
   Endpoint.new("/refunds/new/template", "GET", [
     Param.new("X-Template", "", "header"),
   ]),
+  Endpoint.new("/refunds/inline_summary", "GET", [
+    Param.new("X-Inline-Summary", "", "header"),
+  ]),
+  Endpoint.new("/refunds/1/inline_preview", "POST", [
+    Param.new("X-Inline-Preview", "", "header"),
+  ]),
 
   # Rails concerns: `concern :commentable do resources :comments end`
   # should not emit top-level `/comments` routes, and applying the concern
@@ -128,6 +134,9 @@ expected_endpoints = [
     Param.new("X-Health", "", "header"),
   ]),
   Endpoint.new("/ping", "GET", [
+    Param.new("X-Ping", "", "header"),
+  ]),
+  Endpoint.new("/legacy_ping", "GET", [
     Param.new("X-Ping", "", "header"),
   ]),
 
@@ -192,10 +201,10 @@ total_endpoints = 1 +  # root
                   5 +  # internal/statements except:[destroy]
                   1 +  # /scans only:[index] via controller override
                   2 +  # multiline resources options
-                  3 +  # inline collection/member/new custom routes
+                  5 +  # inline collection/member/new custom routes
                   6 +  # posts
                   4 +  # posts/1/comments + nested likes from concern
-                  2 +  # /up + /ping
+                  3 +  # /up + /ping + legacy string-via match
                   2 +  # optional-segment routes /feed + /report/rss
                   2 +  # %w[browse annotate].each unrolled to /repo/:id/browse + /annotate
                   20 + # devise_for :users

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -92,16 +92,19 @@ module Analyzer::Ruby
     # lives in a different file (a plugin.rb, the host app's routes), so we
     # resolve it cross-file once up front.
     @engine_mount_prefixes = Hash(String, String).new
+    @known_files = Set(String).new
 
     def analyze
-      @engine_mount_prefixes = build_engine_mount_map
+      files = all_files
+      @known_files = Set(String).new(files)
+      @engine_mount_prefixes = build_engine_mount_map(files)
 
-      framework_roots = discover_framework_roots("config/routes.rb")
+      framework_roots = discover_framework_roots(files, "config/routes.rb")
       framework_roots = [@base_path] if framework_roots.empty?
 
       framework_roots.each do |framework_root|
         begin
-          get_public_files(framework_root).each do |file|
+          get_public_files(files, framework_root).each do |file|
             if file =~ /\/public\/(.*)/
               relative_path = $1
               details = Details.new(PathInfo.new(file))
@@ -113,7 +116,7 @@ module Analyzer::Ruby
         end
 
         routes_path = "#{framework_root}/config/routes.rb"
-        next unless File.exists?(routes_path)
+        next unless known_file?(routes_path)
 
         parse_routes_file(routes_path, framework_root)
       end
@@ -125,6 +128,44 @@ module Analyzer::Ruby
       parsed_route_files = Set(String).new
       concern_resources = {} of String => Array(ConcernResource)
       parse_routes_file(routes_path, framework_root, parsed_route_files, [] of Frame, concern_resources)
+    end
+
+    private def known_file?(path : String) : Bool
+      return @known_files.includes?(path) unless @known_files.empty?
+      File.exists?(path)
+    end
+
+    private def discover_framework_roots(files : Array(String), anchor : String) : Array(String)
+      suffix = anchor.starts_with?("/") ? anchor : "/#{anchor}"
+      roots = [] of String
+
+      files.each do |file|
+        next unless file.ends_with?(suffix)
+        next unless base_paths.any? do |base|
+                      prefix = base.ends_with?("/") ? base : "#{base}/"
+                      file.starts_with?(prefix) || file == "#{base}#{suffix}"
+                    end
+
+        root = file[0, file.size - suffix.size]
+        roots << root unless roots.includes?(root)
+      end
+
+      roots
+    end
+
+    private def get_public_files(files : Array(String), base_path : String) : Array(String)
+      project_public_roots = Set(String).new
+      files.each do |file|
+        next unless File.basename(file) == "Gemfile"
+        next unless file.starts_with?(base_path)
+        project_public_roots << File.join(File.dirname(file), "public")
+      end
+
+      files.select do |file|
+        next false unless file.starts_with?(base_path)
+        next false if FileHelper::PUBLIC_FILE_IGNORE.includes?(File.basename(file))
+        project_public_roots.any? { |root| file.starts_with?(root + "/") }
+      end
     end
 
     private def parse_routes_file(routes_path : String, framework_root : String,
@@ -153,7 +194,7 @@ module Analyzer::Ruby
       # `controllers foo: 'bar'` remaps the implementing controller.
       doorkeeper_skip = Set(String).new
       doorkeeper_controllers = Hash(String, String).new
-      expand_static_loops(logical_route_lines(routes_path)).each do |raw_line|
+      expand_inline_route_blocks(expand_static_loops(logical_route_lines(routes_path))).each do |raw_line|
         line = raw_line.strip
         next if line.empty?
 
@@ -232,7 +273,7 @@ module Analyzer::Ruby
           draw_names = parse_symbol_list(call[1])
           draw_names.each do |draw_name|
             draw_path = File.join(framework_root, "config", "routes", "#{draw_name}.rb")
-            parse_routes_file(draw_path, framework_root, parsed_route_files, stack, concern_resources) if File.exists?(draw_path)
+            parse_routes_file(draw_path, framework_root, parsed_route_files, stack, concern_resources) if known_file?(draw_path)
           end
           next
         end
@@ -649,6 +690,26 @@ module Analyzer::Ruby
       result
     end
 
+    # Rails commonly writes compact inline route scopes:
+    # `collection { get "preview" }` / `member { post :use }`.
+    # The parser is stack-based, so normalize these to the same do/end
+    # structure before route extraction.
+    INLINE_ROUTE_BLOCK = /^(member|collection|new)\s*\{\s*(.+?)\s*\}\s*$/
+
+    private def expand_inline_route_blocks(lines : Array(String)) : Array(String)
+      result = [] of String
+      lines.each do |line|
+        if m = line.match(INLINE_ROUTE_BLOCK)
+          result << "#{m[1]} do"
+          result << m[2].strip
+          result << "end"
+        else
+          result << line
+        end
+      end
+      result
+    end
+
     private def end_line?(line : String) : Bool
       line == "end" || line.starts_with?("end ") || line.starts_with?("end;") || line.starts_with?("end#")
     end
@@ -658,12 +719,11 @@ module Analyzer::Ruby
     # there) and build the engine-constant -> mount-path map. Forms handled:
     #   mount X::Engine, at: "/p"        mount X::Engine => "/p"
     #   Discourse::Application.routes.append { mount X::Engine, at: "/p" }
-    private def build_engine_mount_map : Hash(String, String)
+    private def build_engine_mount_map(files : Array(String)) : Hash(String, String)
       map = Hash(String, String).new
-      all_files.each do |file|
+      files.each do |file|
         base = File.basename(file)
         next unless base == "plugin.rb" || base.ends_with?("routes.rb")
-        next unless File.exists?(file)
         content = read_file_content(file)
         next unless content.includes?("mount")
 
@@ -909,7 +969,7 @@ module Analyzer::Ruby
         candidates << "#{framework_root}/app/controllers/#{file_base.rchop('y')}ies_controller.rb" if file_base.ends_with?('y')
       end
 
-      existing_controller_path = candidates.find { |c| File.exists?(c) }
+      existing_controller_path = candidates.find { |c| known_file?(c) }
       candidates.each do |ctrl_path|
         @result += controller_to_endpoint(
           ctrl_path, @url, url_segment,
@@ -959,7 +1019,7 @@ module Analyzer::Ruby
     end
 
     private def parse_route_verbs(rest : String, default_verbs : Array(String)) : Array(String)
-      via_match = rest.match(/:?via\s*(?:=>|:)\s*(\[[^\]]+\]|%i[\[\(][^\]\)]*[\]\)]|:\w+)/)
+      via_match = rest.match(/:?via\s*(?:=>|:)\s*(\[[^\]]+\]|%i[\[\(][^\]\)]*[\]\)]|:\w+|['"][A-Za-z_]+['"])/)
       return default_verbs unless via_match
       tail = via_match[1]
       verbs = [] of String
@@ -1126,7 +1186,7 @@ module Analyzer::Ruby
     )
       @result = [] of Endpoint
 
-      return @result unless File.exists?(path)
+      return @result unless known_file?(path)
 
       data = extract_controller_data(path)
       defined_actions = data.defined_actions
@@ -1211,7 +1271,7 @@ module Analyzer::Ruby
       method_bodies = Hash(String, Array(String)).new
       param_type = "form"
 
-      unless File.exists?(path)
+      unless known_file?(path)
         empty = ControllerData.new(param_type, params_method, params_body_by_action, params_query_by_action,
           defined_actions, helper_calls_by_action, callees_by_action, action_lines)
         @controller_data_cache[path] = empty
@@ -1576,7 +1636,7 @@ module Analyzer::Ruby
         candidates << "#{framework_root}/app/controllers/#{subdir}/#{ctrl_name}_controller.rb"
       end
       candidates << "#{framework_root}/app/controllers/#{ctrl_name}_controller.rb"
-      candidates.find { |c| File.exists?(c) }
+      candidates.find { |c| known_file?(c) }
     end
 
     private def action_allowed?(name : String, only : Array(String), except : Array(String)) : Bool


### PR DESCRIPTION
## Summary
- normalize Rails inline `member { ... }`, `collection { ... }`, and `new { ... }` route blocks into the existing block parser to recover custom action routes
- parse string-valued `via: "get"` / `:via => "get"` as concrete HTTP verbs instead of falling back to `ANY`
- cache the analyzer file list in a `Set` and reuse it for Rails root/public/mount/controller existence checks

## OSS validation
Rails-only scans on shallow clones under `/tmp/noir-rails-oss`:
- Redmine: 432 endpoints; `ANY /projects/:id/{hello,bye}` changed to `GET`
- Mastodon: 679 -> 681 endpoints; recovered inline member routes `/media/1/player`, `/backups/1/download`
- Discourse: 1697 -> 1711 endpoints; recovered inline member/collection routes such as `/about/live_post_counts`, `/admin/site_settings/category/:id`, `/discourse_templates/1/use`

Warm Rails-only scan times (`./bin/noir scan ... --only-techs rails -f json --no-log`):
- Redmine: 0.44s -> 0.24s
- Mastodon: 0.75s -> 0.46s
- Discourse: 2.80s -> 1.83s

## Verification
- `crystal spec spec/functional_test/testers/ruby/rails_advanced_spec.cr`
- `crystal spec spec/functional_test/testers/ruby/rails_spec.cr spec/functional_test/testers/ruby/rails_advanced_spec.cr spec/functional_test/testers/ruby/rails_monorepo_spec.cr spec/functional_test/testers/ruby/rails_callees_spec.cr spec/functional_test/testers/ruby/rails_doorkeeper_spec.cr spec/functional_test/testers/ruby/rails_ai_context_spec.cr spec/unit_test/detector/ruby/rails_spec.cr spec/unit_test/tagger/framework_taggers/rails_security_spec.cr`
- `just build`
- `just build-release`
- `just test`
- `just check`