### PR TITLE
fix(python): detect Flask-AppBuilder exposed routes

### DIFF
--- a/spec/functional_test/fixtures/python/flask_appbuilder/app.py
+++ b/spec/functional_test/fixtures/python/flask_appbuilder/app.py
@@ -1,0 +1,26 @@
+from flask_appbuilder import BaseView
+from flask_appbuilder.api import BaseApi, expose
+
+
+class DatabaseRestApi(BaseApi):
+    resource_name = "database"
+
+    @expose("/<int:pk>/connection", methods=("GET",))
+    def connection(self, pk):
+        return {}
+
+    @expose("/", methods=("POST",))
+    def create(self):
+        return {}
+
+
+class AnnotationLayerView(BaseView):
+    route_base = "/annotationlayer"
+
+    @expose("/list/")
+    def list(self):
+        return ""
+
+    @expose("/<int:pk>/annotation")
+    def get(self, pk):
+        return ""

--- a/spec/functional_test/testers/python/flask_appbuilder_spec.cr
+++ b/spec/functional_test/testers/python/flask_appbuilder_spec.cr
@@ -1,0 +1,13 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/api/v1/database/{pk}/connection", "GET", [Param.new("pk", "", "path")]),
+  Endpoint.new("/api/v1/database", "POST"),
+  Endpoint.new("/annotationlayer/list/", "GET"),
+  Endpoint.new("/annotationlayer/{pk}/annotation", "GET", [Param.new("pk", "", "path")]),
+]
+
+FunctionalTester.new("fixtures/python/flask_appbuilder/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/unit_test/detector/python/flask_spec.cr
+++ b/spec/unit_test/detector/python/flask_spec.cr
@@ -8,4 +8,8 @@ describe "Detect Python Flask" do
   it "detect_flask - app.py" do
     instance.detect("app.py", "from flask import Flask").should be_true
   end
+
+  it "detect_flask_appbuilder - app.py" do
+    instance.detect("app.py", "from flask_appbuilder.api import expose").should be_true
+  end
 end

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -63,6 +63,11 @@ module Analyzer::Python
           file_content = fetch_file_content(path)
           lines = file_content.lines
           if flask_relevant_source?(file_content)
+            extract_flask_appbuilder_exposed_endpoints(path, file_content).each do |endpoint|
+              result << endpoint
+            end
+            next if flask_appbuilder_only_source?(file_content)
+
             api_instances = Hash(::String, ::String).new
             path_api_instances[path] = api_instances
             view_assignments = Hash(::String, ::String).new # Maps view_var -> ClassName (per-file scope)
@@ -800,7 +805,8 @@ module Analyzer::Python
       # wins dedup non-deterministically depending on fiber completion order).
       clean = source.gsub(/#.*?(?:\n|\z)/m, "\n")
 
-      return true if clean.includes?("flask")
+      return true if clean.matches?(/^\s*(?:from|import)\s+flask(?:\b|[._])/m)
+      return true if clean.includes?("@expose(")
       # A file that imports a competing decorator-based framework (and
       # never mentions flask) is NOT Flask — its `@app.get`/`@router.post`
       # decorators belong to that framework's analyzer. Without this
@@ -816,6 +822,17 @@ module Analyzer::Python
       return true if clean.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
 
       false
+    end
+
+    private def flask_appbuilder_only_source?(source : ::String) : Bool
+      return false unless source.includes?("@expose(")
+
+      clean = source.gsub(/#.*?(?:\n|\z)/m, "\n")
+      return false if clean.matches?(/\b(?:Flask|Blueprint|Api|Namespace)\s*\(/)
+      return false if clean.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
+      return false if clean.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
+
+      true
     end
 
     private def extract_flask_static_url_path(constructor_line : ::String) : ::String?
@@ -835,6 +852,131 @@ module Analyzer::Python
       normalized = "/#{normalized}" unless normalized.starts_with?("/")
       normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
       normalized == "/" ? "/*" : "#{normalized}/*"
+    end
+
+    private def extract_flask_appbuilder_exposed_endpoints(path : ::String, source : ::String) : Array(Endpoint)
+      return [] of Endpoint unless source.includes?("@expose(")
+
+      endpoints = [] of Endpoint
+      lines = source.split("\n")
+      class_indent : Int32? = nil
+      route_base = ""
+
+      lines.each_with_index do |line, index|
+        stripped = line.lstrip
+        next if stripped.starts_with?("#")
+        indent = line.size - stripped.size
+
+        if stripped.matches?(/^class\s+([A-Za-z_][A-Za-z0-9_]*)\b/)
+          class_indent = indent
+          route_base = ""
+          next
+        end
+
+        if current_indent = class_indent
+          if !stripped.empty? && indent <= current_indent && !stripped.starts_with?("@")
+            class_indent = nil
+            route_base = ""
+          end
+        end
+
+        next unless class_indent
+
+        if route_base_match = stripped.match(/^route_base\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          route_base = route_base_match[1]
+          next
+        end
+
+        if resource_name_match = stripped.match(/^resource_name\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          route_base = "/api/v1/#{resource_name_match[1]}"
+          next
+        end
+
+        next unless stripped.starts_with?("@expose")
+
+        expose_call = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
+        expose = parse_flask_appbuilder_expose_call(expose_call)
+        next unless expose
+
+        expose_path, methods = expose
+        full_path = join_flask_paths(route_base, expose_path)
+        normalized_path, path_params = normalize_flask_path_params(full_path)
+        methods.each do |method|
+          params = path_params.dup
+          if def_line = find_def_line(lines, index)
+            if codeblock = parse_code_block(lines[def_line..])
+              params.concat(get_filtered_params(method, extract_request_params(codeblock.split("\n"))))
+            end
+          end
+
+          endpoints << Endpoint.new(normalized_path, method, params, Details.new(PathInfo.new(path, index + 1)))
+        end
+      end
+
+      endpoints
+    end
+
+    private def parse_flask_appbuilder_expose_call(line : ::String) : Tuple(::String, Array(::String))?
+      match = line.match(/@expose\s*\((.*)\)\s*$/m)
+      return unless match
+
+      args = split_python_call_args(match[1])
+      route_path = ""
+      args.each do |arg|
+        stripped = arg.strip
+        next if stripped.empty?
+        break if stripped.matches?(/^[A-Za-z_][A-Za-z0-9_]*\s*=/)
+        if string_match = stripped.match(/^[rf]?['"]([^'"]*)['"]/)
+          route_path = string_match[1]
+          break
+        end
+      end
+
+      args.each do |arg|
+        if url_match = arg.match(/^\s*(?:url|rule)\s*=\s*[rf]?['"]([^'"]*)['"]/)
+          route_path = url_match[1]
+          break
+        end
+      end
+
+      route_path = "/" if route_path.empty?
+      methods = [] of ::String
+      args.each do |arg|
+        next unless arg.matches?(/^\s*methods\s*=/)
+        arg.scan(/['"]([A-Za-z]+)['"]/) do |method_match|
+          method = method_match[1].upcase
+          methods << method if HTTP_METHODS.any? { |known| known.upcase == method }
+        end
+      end
+      methods << "GET" if methods.empty?
+
+      {route_path, methods.uniq}
+    end
+
+    private def join_flask_paths(prefix : ::String, path : ::String) : ::String
+      return normalize_joined_flask_path(path) if prefix.empty?
+      return normalize_joined_flask_path(prefix) if path.empty? || path == "/"
+
+      normalized_prefix = prefix.ends_with?("/") ? prefix[0...-1] : prefix
+      normalized_path = path.starts_with?("/") ? path : "/#{path}"
+      normalize_joined_flask_path("#{normalized_prefix}#{normalized_path}")
+    end
+
+    private def normalize_joined_flask_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
+    end
+
+    private def normalize_flask_path_params(path : ::String) : Tuple(::String, Array(Param))
+      params = [] of Param
+      normalized = path.gsub(/<(?:(?:[^:<>]+):)?([A-Za-z_][A-Za-z0-9_]*)>/) do
+        name = $~[1]
+        params << Param.new(name, "", "path") unless params.any? { |param| param.name == name && param.param_type == "path" }
+        "{#{name}}"
+      end
+
+      {normalized, params}
     end
 
     private def clone_path_api_instances(path_api_instances : Hash(::String, Hash(::String, ::String))) : Hash(::String, Hash(::String, ::String))

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -33,6 +33,8 @@ module Analyzer::Python
       return true if relative_path.starts_with?("tests/")
       return true if relative_path.includes?("/test/")
       return true if relative_path.starts_with?("test/")
+      return true if relative_path.includes?("/test_utils/")
+      return true if relative_path.starts_with?("test_utils/")
       base = File.basename(path)
       return true if base == "tests.py"
       return true if base.starts_with?("test_") && base.ends_with?(".py")

--- a/src/detector/detectors/python/flask.cr
+++ b/src/detector/detectors/python/flask.cr
@@ -5,11 +5,14 @@ module Detector::Python
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")
 
-      # Match framework imports while avoiding flask_* packages
+      # Match framework imports while avoiding unrelated flask_* packages.
+      # Flask-AppBuilder is a Flask extension whose projects often expose
+      # routes with `@expose` and never import `flask` directly in view files.
       has_from_import = file_contents.match(/(^|\n)\s*from\s+flask\s+import\s+/)
       has_import = file_contents.match(/(^|\n)\s*import\s+flask(\s|,|$)/)
+      has_appbuilder_import = file_contents.match(/(^|\n)\s*(?:from|import)\s+flask_appbuilder\b/)
 
-      !!(has_from_import || has_import)
+      !!(has_from_import || has_import || has_appbuilder_import)
     end
 
     def applicable?(filename : String) : Bool


### PR DESCRIPTION
## Summary
- detect `flask_appbuilder` imports as Flask-backed apps
- extract Flask-AppBuilder `@expose(...)` endpoints using `route_base` and `resource_name` prefixes
- normalize Flask-style `<int:pk>` / `<path:name>` params into Noir path params
- skip Python `test_utils/` paths to reduce Django URLConf false positives

## OSS checks
- Superset Flask scan: 4 -> 279 endpoints after adding Flask-AppBuilder `@expose` support
- django-cms Django scan: 29 -> 4 endpoints after dropping `test_utils/` URLConf false positives
- full-stack-fastapi-template FastAPI scan: unchanged at 23 endpoints

## Verification
- `just build`
- `crystal spec spec/functional_test/testers/python spec/unit_test/detector/python spec/unit_test/miniparser/python_route_extractor_ts_spec.cr spec/unit_test/miniparser/python_route_extractor_spec.cr spec/unit_test/analyzer/python_engine_spec.cr`
- `just test`
- `just check`
