### PR TITLE
Improve Go Gin and Echo route scan filtering

### DIFF
--- a/spec/functional_test/fixtures/go/echo_importless_routes/go.mod
+++ b/spec/functional_test/fixtures/go/echo_importless_routes/go.mod
@@ -1,0 +1,5 @@
+module echo_importless_routes
+
+go 1.21
+
+require github.com/labstack/echo/v4 v4.11.1

--- a/spec/functional_test/fixtures/go/echo_importless_routes/main.go
+++ b/spec/functional_test/fixtures/go/echo_importless_routes/main.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/labstack/echo/v4"
+
+type RouteRegistrar interface {
+	GET(string, echo.HandlerFunc, ...echo.MiddlewareFunc) *echo.Route
+	POST(string, echo.HandlerFunc, ...echo.MiddlewareFunc) *echo.Route
+}
+
+func main() {
+	e := echo.New()
+	registerRoutes(e)
+}
+
+func getFeature(c echo.Context) error {
+	return nil
+}
+
+func createFeature(c echo.Context) error {
+	return nil
+}

--- a/spec/functional_test/fixtures/go/echo_importless_routes/routes.go
+++ b/spec/functional_test/fixtures/go/echo_importless_routes/routes.go
@@ -1,0 +1,6 @@
+package main
+
+func registerRoutes(e RouteRegistrar) {
+	e.GET("/features", getFeature)
+	e.POST("/features", createFeature)
+}

--- a/spec/functional_test/fixtures/go/gin_importless_routes/go.mod
+++ b/spec/functional_test/fixtures/go/gin_importless_routes/go.mod
@@ -1,0 +1,5 @@
+module gin_importless_routes
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.10.0

--- a/spec/functional_test/fixtures/go/gin_importless_routes/main.go
+++ b/spec/functional_test/fixtures/go/gin_importless_routes/main.go
@@ -1,0 +1,17 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+type RouteRegistrar interface {
+	GET(string, ...gin.HandlerFunc) gin.IRoutes
+	POST(string, ...gin.HandlerFunc) gin.IRoutes
+}
+
+func main() {
+	r := gin.Default()
+	registerRoutes(r)
+}
+
+func getFeature(c *gin.Context) {}
+
+func createFeature(c *gin.Context) {}

--- a/spec/functional_test/fixtures/go/gin_importless_routes/routes.go
+++ b/spec/functional_test/fixtures/go/gin_importless_routes/routes.go
@@ -1,0 +1,6 @@
+package main
+
+func registerRoutes(r RouteRegistrar) {
+	r.GET("/features", getFeature)
+	r.POST("/features", createFeature)
+}

--- a/spec/functional_test/testers/go/echo_importless_routes_spec.cr
+++ b/spec/functional_test/testers/go/echo_importless_routes_spec.cr
@@ -1,0 +1,11 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/features", "GET"),
+  Endpoint.new("/features", "POST"),
+]
+
+FunctionalTester.new("fixtures/go/echo_importless_routes/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/gin_importless_routes_spec.cr
+++ b/spec/functional_test/testers/go/gin_importless_routes_spec.cr
@@ -1,0 +1,11 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/features", "GET"),
+  Endpoint.new("/features", "POST"),
+]
+
+FunctionalTester.new("fixtures/go/gin_importless_routes/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -13,6 +13,7 @@ module Analyzer::Go
       # O(1) lookup into `package_function_bodies` rather than re-
       # walking every sibling source file.
       package_function_bodies = collect_package_function_bodies(file_contents)
+      framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
       begin
@@ -33,13 +34,14 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    dir = File.dirname(path)
+                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static"])
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 
                     # Tree-sitter pre-pass: every Echo verb route
                     # (`e.GET`, `g.POST`, …) with its group prefix applied.
-                    cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
+                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
                     ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups, handle_method: "Add")
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
@@ -53,7 +55,7 @@ module Analyzer::Go
                     # function bodies via the per-directory map.
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
                     callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # `e.Static("/url", "./dir")` — same shape as Gin/Fiber/etc.

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -24,6 +24,7 @@ module Analyzer::Go
       # router.Group("/v1"))`). The prefix lives at the call site, so it
       # must be grafted onto the helper's routes.
       builder_prefixes_by_dir = resolve_router_builder_prefixes(file_contents, package_groups)
+      framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         WaitGroup.wait do |wg|
@@ -43,7 +44,8 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    dir = File.dirname(path)
+                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Handle", "Static"])
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 
@@ -52,7 +54,7 @@ module Analyzer::Go
                     # line loop below can attribute body params (Query/PostForm
                     # /GetHeader/Cookie) to the most recently declared route —
                     # matching the legacy `last_endpoint` semantics.
-                    cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
+                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
 
                     # Router-builder expansion: graft call-site prefixes onto
                     # the routes of `func addXRoutes(rg *gin.RouterGroup)`
@@ -65,7 +67,6 @@ module Analyzer::Go
                     # keep their params/callees.) Expanded helpers' bodies are
                     # suppressed in the whole-file pass to avoid emitting the
                     # prefix-less variant alongside the corrected one.
-                    dir = File.dirname(path)
                     dir_builder_prefixes = builder_prefixes_by_dir[dir]? || EMPTY_BUILDER_PREFIXES
                     expand_builders = [] of Tuple(String, Noir::TreeSitterGoRouteExtractor::RouterBuilder, Set(String))
                     suppress_ranges = [] of Range(Int32, Int32)
@@ -96,7 +97,7 @@ module Analyzer::Go
                     # function bodies via the per-directory map.
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
                     callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     # Gin uses `r.Static("/url", "./dir")`. Pick these up

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -156,6 +156,38 @@ module Analyzer::Go
       package_groups[dir]? || Hash(String, String).new
     end
 
+    GO_HTTP_ROUTE_CALL_RE = /\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|Get|Post|Put|Delete|Patch|Head|Options|ANY|Any|All)\s*\(/
+
+    # Per-package directories that import a target framework. Some real
+    # projects hide the concrete framework type behind a local interface, so
+    # the file that calls `router.GET(...)` may not import Gin/Echo itself.
+    def framework_package_dirs(file_contents : Hash(String, String), import_marker : String) : Set(String)
+      dirs = Set(String).new
+      file_contents.each do |path, content|
+        dirs << File.dirname(path) if content.includes?(import_marker)
+      end
+      dirs
+    end
+
+    # Cheap gate before the tree-sitter route pass. Handler-only files often
+    # import Gin/Echo for `*gin.Context` / `echo.Context`, but they cannot emit
+    # endpoints unless they contain a route/static registration call.
+    def go_route_source_candidate?(content : String, extra_methods : Array(String)) : Bool
+      return true if content.matches?(GO_HTTP_ROUTE_CALL_RE)
+      extra_methods.any? do |method|
+        content.matches?(/\.#{Regex.escape(method)}\s*\(/)
+      end
+    end
+
+    def framework_route_source_candidate?(content : String,
+                                          dir : String,
+                                          framework_dirs : Set(String),
+                                          import_marker : String,
+                                          extra_methods : Array(String)) : Bool
+      return false unless content.includes?(import_marker) || framework_dirs.includes?(dir)
+      go_route_source_candidate?(content, extra_methods)
+    end
+
     # --- Cross-file function body pre-pass --------------------------------
     #
     # Walks every cached `.go` source in `file_contents` and collects


### PR DESCRIPTION
## Summary
- add a cheap Go route-call candidate gate before Gin/Echo tree-sitter route parsing
- allow route files without direct Gin/Echo imports when another file in the same Go package imports the framework
- add Gin and Echo functional fixtures for local-interface route registrars

## Validation
- just build
- just test
- just check
- sampled gin-vue-admin, sonic, gin-examples, and echo before/after JSON endpoint tuples; no existing endpoint tuple changes

## Sample scan timings
- gin-vue-admin: before 6.7681s, after 1.3828s Noir scan time
- gin-examples: before 0.6795s, after 0.1107s Noir scan time
- echo framework repo: before 1.6671s, after 0.3426s Noir scan time
- sonic: after 1.7898s Noir scan time with endpoint count unchanged