### PR TITLE
perf(analyzer): improve Kotlin Spring extraction

### DIFF
--- a/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_parameter_extractor_ts_spec.cr
@@ -236,6 +236,31 @@ describe Noir::TreeSitterKotlinParameterExtractor do
         {"userIds", "query"},
       ])
     end
+
+    it "indexes methods recovered from split constructor annotations" do
+      source = <<-KT
+        package com.example
+
+        @RestController
+        class C
+        @Autowired constructor(private val service: Service) {
+            @GetMapping("/x")
+            fun get(@RequestParam(value = "q") query: String): String = ""
+        }
+        KT
+
+      params = [] of Param
+      Noir::TreeSitter.parse_kotlin(source) do |root|
+        method = Noir::TreeSitterKotlinParameterExtractor.index_functions_from(root, source)["C#get"]
+        params = Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters_from_method(
+          method, source, "GET", nil, {} of String => Array(Noir::TreeSitterKotlinParameterExtractor::FieldInfo)
+        )
+      end
+
+      params.map { |p| {p.name, p.param_type} }.should eq([
+        {"q", "query"},
+      ])
+    end
   end
 
   describe "#extract_consumes" do

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -299,4 +299,38 @@ describe Noir::TreeSitterKotlinRouteExtractor do
       {"GET", "/real/ping"},
     ])
   end
+
+  it "recovers routes from non-abstract controllers with split constructor annotations" do
+    source = <<-KT
+      package com.example
+
+      @RestController
+      @RequestMapping("/api")
+      class UserController
+      @Autowired constructor(private val service: UserService) {
+          @GetMapping("/{id}")
+          fun show(@PathVariable id: Long): String = ""
+      }
+      KT
+
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path, r.class_name, r.method_name} }.should eq([
+      {"GET", "/api/{id}", "UserController", "show"},
+    ])
+  end
+
+  it "does not recover routes from abstract split-constructor base controllers" do
+    source = <<-KT
+      package com.example
+
+      @RestController
+      abstract class AbstractController<T : Any>
+      @Autowired constructor(private val service: Service<T>) {
+          @GetMapping("/{id}")
+          fun show(@PathVariable id: Long): String = ""
+      }
+      KT
+
+    Noir::TreeSitterKotlinRouteExtractor.extract_routes(source).should be_empty
+  end
 end

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -12,6 +12,7 @@ module Analyzer::Kotlin
     def analyze
       webflux_base_path_map = Hash(String, String).new
       string_constants = Hash(String, String).new
+      local_string_constants = Hash(String, Hash(String, String)).new
       dto_builder = Noir::TreeSitterKotlinDtoIndex.new
 
       file_list = all_files()
@@ -22,7 +23,9 @@ module Analyzer::Kotlin
         next if KotlinEngine.test_path?(path)
 
         content = read_file_content(path)
-        Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(content).each do |name, value|
+        constants = Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(content)
+        local_string_constants[path] = constants
+        constants.each do |name, value|
           string_constants[name] ||= value
         end
       end
@@ -39,7 +42,7 @@ module Analyzer::Kotlin
           process_directory(path, webflux_base_path_map)
         elsif path.ends_with?(".#{KOTLIN_EXTENSION}")
           next if KotlinEngine.test_path?(path)
-          process_kotlin_file(path, dto_builder, webflux_base_path_map, string_constants)
+          process_kotlin_file(path, dto_builder, webflux_base_path_map, string_constants, local_string_constants[path]?)
         end
       end
 
@@ -155,7 +158,8 @@ module Analyzer::Kotlin
     private def process_kotlin_file(path : String,
                                     dto_builder : Noir::TreeSitterKotlinDtoIndex,
                                     webflux_base_path_map : Hash(String, String),
-                                    string_constants : Hash(String, String))
+                                    string_constants : Hash(String, String),
+                                    local_string_constants : Hash(String, String)?)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       content = read_file_content(path)
 
@@ -171,9 +175,14 @@ module Analyzer::Kotlin
         next if package_name.empty?
 
         webflux_base_path = find_base_path(path, webflux_base_path_map)
-        dto_index = dto_builder.build_for_with_root(path, content, root)
 
-        routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes_from(root, content, string_constants)
+        routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes_from(
+          root, content, string_constants, local_string_constants
+        )
+        next if routes.empty?
+
+        dto_index = dto_builder.build_for_with_root(path, content, root)
+        method_nodes = Noir::TreeSitterKotlinParameterExtractor.index_functions_from(root, content)
 
         # Pin the parameter format to the FIRST verb seen for each
         # (class, method) — for multi-verb `@RequestMapping(method =
@@ -194,13 +203,26 @@ module Analyzer::Kotlin
           # verb default (POST → form, others → query) is applied
           # per-parameter inside the extractor so an explicit @RequestBody
           # on a POST resolves to json instead of being dragged to form.
-          parameter_format = Noir::TreeSitterKotlinParameterExtractor.extract_consumes_from(
-            root, content, route.class_name, route.method_name
-          )
+          method = method_nodes[key]?
+          parameter_format =
+            if method
+              Noir::TreeSitterKotlinParameterExtractor.extract_consumes_from_method(method, content)
+            else
+              Noir::TreeSitterKotlinParameterExtractor.extract_consumes_from(
+                root, content, route.class_name, route.method_name
+              )
+            end
 
-          parameters = Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters_from(
-            root, content, route.class_name, route.method_name, format_verb, parameter_format, dto_index
-          )
+          parameters =
+            if method
+              Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters_from_method(
+                method, content, format_verb, parameter_format, dto_index
+              )
+            else
+              Noir::TreeSitterKotlinParameterExtractor.extract_method_parameters_from(
+                root, content, route.class_name, route.method_name, format_verb, parameter_format, dto_index
+              )
+            end
 
           # Drop the trailing `/` on webflux_base_path when the route
           # path already starts with one, so the join doesn't produce

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -210,6 +210,14 @@ module Noir
                                        class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
       method = find_function(root, source, class_name, method_name)
       return [] of Param unless method
+      extract_method_parameters_from_method(method, source, verb, parameter_format, class_fields)
+    end
+
+    def extract_method_parameters_from_method(method : LibTreeSitter::TSNode,
+                                              source : String,
+                                              verb : String,
+                                              parameter_format : String?,
+                                              class_fields : Hash(String, Array(FieldInfo))) : Array(Param)
       params = collect_method_params(method, source, verb, parameter_format, class_fields)
       append_constraint_params(method, source, verb, params)
       params
@@ -228,6 +236,10 @@ module Noir
     def extract_consumes_from(root : LibTreeSitter::TSNode, source : String, class_name : String, method_name : String) : String?
       method = find_function(root, source, class_name, method_name)
       return unless method
+      extract_consumes_from_method(method, source)
+    end
+
+    def extract_consumes_from_method(method : LibTreeSitter::TSNode, source : String) : String?
       ann = mapping_annotation_on(method, source)
       return unless ann
       args = annotation_args(ann)
@@ -303,7 +315,96 @@ module Noir
       results
     end
 
+    def index_functions_from(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
+      result = Hash(String, LibTreeSitter::TSNode).new
+      walk_class_containers(root) do |decl|
+        class_name = type_identifier_text(decl, source)
+        next if class_name.empty?
+        body = class_body_of(decl)
+        next unless body
+        Noir::TreeSitter.each_named_child(body) do |member|
+          next unless Noir::TreeSitter.node_type(member) == "function_declaration"
+          method_name = function_name(member, source)
+          next if method_name.empty?
+          result["#{class_name}##{method_name}"] ||= member
+        end
+      end
+      index_orphan_functions_from(root, source, result)
+      result
+    end
+
     # ---- private helpers ----------------------------------------------
+
+    private def index_orphan_functions_from(root : LibTreeSitter::TSNode,
+                                            source : String,
+                                            result : Hash(String, LibTreeSitter::TSNode))
+      orphan_class : String? = nil
+      Noir::TreeSitter.each_named_child(root) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "class_declaration", "object_declaration", "interface_declaration"
+          if class_body_of(child).nil? && !abstract_type?(child, source)
+            class_name = type_identifier_text(child, source)
+            orphan_class = class_name.empty? ? nil : class_name
+          else
+            orphan_class = nil
+          end
+        when "ERROR"
+          if class_name = orphan_class
+            collect_orphan_function_nodes(child, source, class_name, result)
+          end
+          orphan_class = nil
+        when "prefix_expression"
+          if class_name = split_constructor_class_name(child, source)
+            collect_orphan_function_nodes(child, source, class_name, result)
+          end
+          orphan_class = nil
+        when "annotation"
+          # Constructor annotations may be parsed as a sibling between
+          # the no-body class_declaration and the call_expression that
+          # carries the class body. Keep the orphan class context alive.
+        when "call_expression"
+          if class_name = orphan_class
+            collect_orphan_function_nodes(child, source, class_name, result)
+          end
+          orphan_class = nil
+        else
+          orphan_class = nil
+        end
+      end
+    end
+
+    private def split_constructor_class_name(node : LibTreeSitter::TSNode, source : String) : String?
+      text = Noir::TreeSitter.node_text(node, source)
+      return unless text.includes?(" constructor")
+      return unless text.includes?(" fun ")
+      return if text.match(/\babstract\s+class\b/)
+      match = text.match(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)\b/)
+      match.try &.[1]
+    end
+
+    private def collect_orphan_function_nodes(node : LibTreeSitter::TSNode,
+                                              source : String,
+                                              class_name : String,
+                                              result : Hash(String, LibTreeSitter::TSNode))
+      if Noir::TreeSitter.node_type(node) == "function_declaration"
+        method_name = function_name(node, source)
+        result["#{class_name}##{method_name}"] ||= node unless method_name.empty?
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_orphan_function_nodes(child, source, class_name, result)
+      end
+    end
+
+    private def abstract_type?(decl : LibTreeSitter::TSNode, source : String) : Bool
+      if mods = find_modifiers(decl)
+        Noir::TreeSitter.each_named_child(mods) do |child|
+          return true if Noir::TreeSitter.node_text(child, source) == "abstract"
+        end
+      end
+      false
+    end
 
     private def walk_class_containers(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
       ty = Noir::TreeSitter.node_type(node)

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -145,10 +145,13 @@ module Noir
     # Spring analyzer can amortise the parse across multiple
     # extractions on the same file. Tree lifetime is the caller's
     # responsibility.
-    def extract_routes_from(root : LibTreeSitter::TSNode, source : String, string_constants = Hash(String, String).new) : Array(Route)
+    def extract_routes_from(root : LibTreeSitter::TSNode,
+                            source : String,
+                            string_constants = Hash(String, String).new,
+                            local_string_constants : Hash(String, String)? = nil) : Array(Route)
       routes = [] of Route
-      local_string_constants = extract_string_constants(source)
-      walk_classes(root, source, "", routes, string_constants, local_string_constants)
+      file_constants = local_string_constants || extract_string_constants(source)
+      walk_classes(root, source, "", routes, string_constants, file_constants)
       collect_gateway_routes(source, string_constants, routes)
       routes
     end
@@ -176,20 +179,113 @@ module Noir
       # a class_declaration without `modifiers`. Falling through
       # `each_named_child` would lose the class-level mapping prefix.
       pending = [] of LibTreeSitter::TSNode
+      orphan_class : Tuple(String, String)? = nil
       count = LibTreeSitter.ts_node_named_child_count(node)
       count.times do |i|
         child = LibTreeSitter.ts_node_named_child(node, i.to_u32)
         case Noir::TreeSitter.node_type(child)
         when "class_declaration", "object_declaration", "interface_declaration"
           process_class(child, source, outer_prefix, pending, routes, string_constants, local_string_constants)
+          orphan_class = recoverable_orphan_class(child, source, outer_prefix, pending, string_constants, local_string_constants)
           pending = [] of LibTreeSitter::TSNode
         when "prefix_expression"
-          pending << child if prefix_expression_has_annotation?(child)
+          if recover_split_constructor_prefix(child, source, outer_prefix, routes, string_constants, local_string_constants)
+            pending = [] of LibTreeSitter::TSNode
+          else
+            pending << child if prefix_expression_has_annotation?(child)
+          end
+          orphan_class = nil
+        when "ERROR"
+          if ctx = orphan_class
+            class_name, class_prefix = ctx
+            collect_recovered_function_routes(child, source, class_name, class_prefix, routes, string_constants, local_string_constants)
+          else
+            walk_classes(child, source, outer_prefix, routes, string_constants, local_string_constants)
+          end
+          pending = [] of LibTreeSitter::TSNode
+          orphan_class = nil
+        when "annotation"
+          pending = [] of LibTreeSitter::TSNode unless orphan_class
+        when "call_expression"
+          if ctx = orphan_class
+            class_name, class_prefix = ctx
+            collect_recovered_function_routes(child, source, class_name, class_prefix, routes, string_constants, local_string_constants)
+          else
+            walk_classes(child, source, outer_prefix, routes, string_constants, local_string_constants)
+          end
+          pending = [] of LibTreeSitter::TSNode
+          orphan_class = nil
         else
           pending = [] of LibTreeSitter::TSNode
+          orphan_class = nil
           walk_classes(child, source, outer_prefix, routes, string_constants, local_string_constants)
         end
       end
+    end
+
+    private def recoverable_orphan_class(node : LibTreeSitter::TSNode,
+                                         source : String,
+                                         outer_prefix : String,
+                                         pending : Array(LibTreeSitter::TSNode),
+                                         string_constants : Hash(String, String),
+                                         local_string_constants : Hash(String, String)) : Tuple(String, String)?
+      return if class_body(node)
+      return if feign_client?(node, source)
+      return if abstract_type?(node, source)
+
+      class_name = type_identifier_text(node, source)
+      return if class_name.empty?
+
+      class_prefix = class_mapping_prefix(node, source, pending, string_constants, local_string_constants)
+      {class_name, join_paths(outer_prefix, class_prefix)}
+    end
+
+    private def abstract_type?(decl : LibTreeSitter::TSNode, source : String) : Bool
+      if mods = find_modifiers(decl)
+        Noir::TreeSitter.each_named_child(mods) do |child|
+          return true if Noir::TreeSitter.node_text(child, source) == "abstract"
+        end
+      end
+      false
+    end
+
+    private def recover_split_constructor_prefix(node : LibTreeSitter::TSNode,
+                                                 source : String,
+                                                 outer_prefix : String,
+                                                 routes : Array(Route),
+                                                 string_constants : Hash(String, String),
+                                                 local_string_constants : Hash(String, String)) : Bool
+      text = Noir::TreeSitter.node_text(node, source)
+      return false unless text.includes?(" constructor")
+      return false unless text.includes?(" fun ")
+      return false if text.match(/\babstract\s+class\b/)
+      match = text.match(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)\b/)
+      return false unless match
+
+      class_prefix = split_constructor_prefix(node, source, string_constants, local_string_constants)
+      collect_recovered_function_routes(
+        node, source, match[1], join_paths(outer_prefix, class_prefix), routes, string_constants, local_string_constants
+      )
+      true
+    end
+
+    private def split_constructor_prefix(node : LibTreeSitter::TSNode,
+                                         source : String,
+                                         string_constants : Hash(String, String),
+                                         local_string_constants : Hash(String, String)) : String
+      collect_stray_annotations(node, source).each do |entry|
+        name, args = entry
+        next unless ANNOTATION_VERBS.has_key?(name)
+        next unless args
+        buf = [] of String
+        collect_string_values(args, source, buf, string_constants, local_string_constants)
+        return buf.first unless buf.empty?
+      end
+      text = Noir::TreeSitter.node_text(node, source)
+      if match = text.match(/@(?:[A-Za-z_][A-Za-z0-9_.]*\.)?RequestMapping\s*\(\s*"([^"]*)"/)
+        return match[1]
+      end
+      ""
     end
 
     private def process_class(node : LibTreeSitter::TSNode,
@@ -219,6 +315,23 @@ module Noir
             walk_classes(member, source, prefix, routes, string_constants, local_string_constants)
           end
         end
+      end
+    end
+
+    private def collect_recovered_function_routes(node : LibTreeSitter::TSNode,
+                                                  source : String,
+                                                  class_name : String,
+                                                  class_prefix : String,
+                                                  routes : Array(Route),
+                                                  string_constants : Hash(String, String),
+                                                  local_string_constants : Hash(String, String))
+      if Noir::TreeSitter.node_type(node) == "function_declaration"
+        collect_function_routes(node, source, class_name, class_prefix, routes, string_constants, local_string_constants)
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_recovered_function_routes(child, source, class_name, class_prefix, routes, string_constants, local_string_constants)
       end
     end
 


### PR DESCRIPTION
## Summary
- skip Kotlin DTO index construction for files that do not produce Spring routes
- reuse per-file local string constants and pre-index handler method nodes to avoid repeated AST walks per route
- recover routes/params from Kotlin controllers that use split constructor annotations (`class C` followed by `@Autowired constructor(...)`), while keeping abstract split-constructor base controllers ignored

## Validation
- `just check`
- `just test`
- scanned Kotlin Spring OSS samples: `gs-testing-web`, `kotlin-spring-boot-mvc-starter`, `rest-controller-kotlin`, `spring-04-controller`, `spring-kotlin-web-crud`, `spring-simplicity-kotlin`; normalized endpoint output remained unchanged
- verified a split-constructor controller now emits `GET /api/{id}` with `q` query and `id` path params
