### PR TITLE
Improve Nginx spec detection

### DIFF
--- a/spec/unit_test/analyzer/specification/nginx_spec.cr
+++ b/spec/unit_test/analyzer/specification/nginx_spec.cr
@@ -65,6 +65,30 @@ describe "Nginx Analyzer" do
     ])
   end
 
+  it "preserves hash characters in regex locations" do
+    endpoints = analyze_nginx <<-CONF
+      server {
+          location ~* (?:#.*#|\\.(?:bak|conf|log)|~)$ {
+              deny all;
+          }
+      }
+      CONF
+
+    endpoints.map(&.url).should eq(["(?:#.*#|\\.(?:bak|conf|log)|~)$"])
+  end
+
+  it "skips internal named and templated locations" do
+    endpoints = analyze_nginx <<-CONF
+      server {
+          location @fallback { proxy_pass http://fallback; }
+          location {{ .Path }} { proxy_pass http://backend; }
+          location /public { proxy_pass http://public; }
+      }
+      CONF
+
+    endpoints.map(&.url).should eq(["/public"])
+  end
+
   it "tracks multiple server blocks independently" do
     endpoints = analyze_nginx <<-CONF
       server {

--- a/spec/unit_test/detector/specification/nginx_spec.cr
+++ b/spec/unit_test/detector/specification/nginx_spec.cr
@@ -26,7 +26,36 @@ describe "Detect Nginx config" do
     instance.detect("sites-enabled/api.conf", src).should be_true
   end
 
+  it "detects nginx include fragments without server blocks" do
+    instance.detect("h5bp/location/security_file_access.conf", <<-CONF).should be_true
+      location ~* /\\.(?!well-known\\/) {
+          deny all;
+      }
+      CONF
+  end
+
+  it "detects nginx templates" do
+    instance.detect("nginx.tmpl", <<-CONF).should be_true
+      {{ if .Enabled }}
+      server {
+          location /debug {
+              return 200;
+          }
+      }
+      {{ end }}
+      CONF
+  end
+
   it "rejects .conf without nginx-shape directives" do
     instance.detect("config.conf", "key = value\nfoo = bar\n").should be_false
+  end
+
+  it "rejects nginx-looking words inside comments" do
+    instance.detect("comment.conf", <<-CONF).should be_false
+      # server {
+      #   location /commented-out {
+      #   }
+      # }
+      CONF
   end
 end

--- a/src/analyzer/analyzers/specification/nginx.cr
+++ b/src/analyzer/analyzers/specification/nginx.cr
@@ -34,14 +34,13 @@ module Analyzer::Specification
     private record Frame, kind : String, value : String, line : Int32
 
     private def process_content(content : String, details : Details)
-      lines = content.lines
       stack = [] of Frame
       server_names = [] of String
       server_tls = false
       server_depth = 0
 
-      lines.each_with_index do |raw, idx|
-        line = strip_comment(raw).strip
+      content.each_line.with_index do |raw, idx|
+        line = strip_template_actions(strip_comment(raw)).strip
         next if line.empty?
 
         # Pre-handle a trailing `}` so we pop the closing frame
@@ -70,9 +69,12 @@ module Analyzer::Specification
           server_tls = true if balanced.matches?(LISTEN_TLS_RE)
         elsif m = LOCATION_RE.match(balanced)
           modifier = m[1]? || ""
-          location = m[2].gsub(/[{};]\z/, "")
-          stack << Frame.new("location", location, idx + 1)
-          emit_location(details, location, modifier, METHOD_ANY, server_names, server_tls, idx + 1)
+          raw_location = m[2]
+          location = normalize_location_path(raw_location)
+          unless location.empty? || internal_location?(raw_location) || internal_location?(location)
+            stack << Frame.new("location", location, idx + 1)
+            emit_location(details, location, modifier, METHOD_ANY, server_names, server_tls, idx + 1)
+          end
         elsif m = METHOD_BLOCK_RE.match(balanced)
           method = m[1].upcase
           if loc = current_location(stack)
@@ -97,8 +99,26 @@ module Analyzer::Specification
     end
 
     private def strip_comment(line : String) : String
-      idx = line.index('#')
-      idx.nil? ? line : line[0...idx]
+      previous = '\0'
+      line.each_char_with_index do |ch, idx|
+        if ch == '#' && (idx == 0 || previous.whitespace? || previous.in?(';', '{', '}'))
+          return line[0...idx]
+        end
+        previous = ch
+      end
+      line
+    end
+
+    private def strip_template_actions(line : String) : String
+      line.gsub(/\{\{.*?\}\}/, "")
+    end
+
+    private def normalize_location_path(path : String) : String
+      path.gsub(/[{};]\z/, "")
+    end
+
+    private def internal_location?(path : String) : Bool
+      path.starts_with?("@") || path.includes?("{{") || path.includes?("}}")
     end
 
     private def emit_location(details : Details, path : String, modifier : String, method : String, hosts : Array(String), tls : Bool, line : Int32)

--- a/src/detector/detectors/specification/nginx.cr
+++ b/src/detector/detectors/specification/nginx.cr
@@ -4,9 +4,10 @@ require "../../../models/code_locator"
 module Detector::Specification
   class Nginx < Detector
     # `.conf` is by far the most common extension for Nginx fragments;
-    # a tilde-prefixed `nginx.conf` (no extension) is the canonical
-    # main file in many distributions. Accept both.
-    EXTENSIONS = {".conf"}
+    # `.tmpl`/`.template` files are common in docker-gen and deployment
+    # repositories that render Nginx configs from templates.
+    EXTENSIONS  = {".conf", ".tmpl", ".template"}
+    LOCATION_RE = /^\s*location\s+(?:(?:=|~\*|~|\^~)\s+)?\S+/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
@@ -31,12 +32,28 @@ module Detector::Specification
     end
 
     private def nginx_shape?(content : String) : Bool
-      # Distinguish from Apache `.conf` files (which use directive
-      # blocks like `<Directory>`) and unrelated configs by requiring
-      # at least one nginx-specific directive.
-      content.includes?("location ") &&
-        (content.includes?("server ") || content.includes?("server{") ||
-          content.includes?("http {") || content.includes?("http{"))
+      # Include fragments often contain only `location` blocks, so scan
+      # executable directives instead of requiring a top-level server/http block.
+      content.each_line do |raw|
+        line = strip_template_actions(strip_comment(raw))
+        return true if line.matches?(LOCATION_RE)
+      end
+      false
+    end
+
+    private def strip_comment(line : String) : String
+      previous = '\0'
+      line.each_char_with_index do |ch, idx|
+        if ch == '#' && (idx == 0 || previous.whitespace? || previous.in?(';', '{', '}'))
+          return line[0...idx]
+        end
+        previous = ch
+      end
+      line
+    end
+
+    private def strip_template_actions(line : String) : String
+      line.gsub(/\{\{.*?\}\}/, "")
     end
   end
 end


### PR DESCRIPTION
## Summary
- detect Nginx include fragments and nginx template files with line-based directive scanning
- preserve `#` characters inside regex locations instead of truncating them as comments
- skip internal named locations and templated location paths while parsing templates
- reduce analyzer allocations by iterating lines directly instead of materializing `content.lines`

## OSS validation
Checked against shallow clones under `/tmp/noir-nginx-oss`:
- `h5bp/server-configs-nginx`: endpoints increased 3 -> 5; fixed malformed `/(?:` regex output and detected two location include fragments
- `nginx-proxy/nginx-proxy`: endpoints increased 1 -> 4 by detecting static locations in `nginx.tmpl`; templated `{{ .Path }}` location is skipped
- `linuxserver/docker-baseimage-alpine-nginx`: unchanged at 0 endpoints

Repeated `--only-techs nginx --no-spinner` scans stayed around 0.02-0.04s on these samples.

## Tests
- `just build`
- `CRYSTAL_CACHE_DIR=$(mktemp -d /tmp/noir-crystal-cache.XXXXXX) just test`
- `CRYSTAL_CACHE_DIR=$(mktemp -d /tmp/noir-crystal-cache.XXXXXX) just check`
- targeted nginx analyzer/detector/functional specs
