### PR TITLE
fix(k8s): improve ingress spec detection

### DIFF
--- a/spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
+++ b/spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
@@ -86,4 +86,104 @@ describe "Kubernetes Ingress Analyzer" do
     endpoints[0].url.should eq "/probe"
     tag_descriptions(endpoints[0], "ingress-path-type").should eq ["exact"]
   end
+
+  it "extracts legacy extensions v1beta1 ingress paths" do
+    endpoints = analyze_ingress <<-YAML
+      apiVersion: extensions/v1beta1
+      kind: Ingress
+      metadata: {name: legacy}
+      spec:
+        rules:
+          - host: legacy.example.com
+            http:
+              paths:
+                - path: /legacy
+                  backend:
+                    serviceName: legacy
+                    servicePort: http
+      YAML
+
+    endpoints.size.should eq 1
+    endpoints[0].url.should eq "/legacy"
+    tag_descriptions(endpoints[0], "ingress-host").should eq ["legacy.example.com"]
+  end
+
+  it "uses root path for defaultBackend and backend paths without explicit path" do
+    endpoints = analyze_ingress <<-YAML
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata: {name: defaults}
+      spec:
+        defaultBackend:
+          service:
+            name: default-service
+            port:
+              number: 80
+        rules:
+          - http:
+              paths:
+                - backend:
+                    service:
+                      name: api
+                      port:
+                        number: 80
+      YAML
+
+    endpoints.map(&.url).sort!.should eq ["/", "/"]
+    tag_descriptions(endpoints[0], "ingress-source").should eq ["default-backend"]
+    tag_descriptions(endpoints[1], "ingress-source").should eq ["rule"]
+  end
+
+  it "extracts templated Helm ingress paths with safe defaults" do
+    endpoints = analyze_ingress <<-YAML
+      {{- if .Values.server.ingress.enabled }}
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: {{ include "argo-cd.server.fullname" . }}
+      spec:
+        rules:
+          - host: {{ tpl (.Values.server.ingress.hostname) $ }}
+            http:
+              paths:
+                - path: {{ .Values.server.ingress.path }}
+                  pathType: {{ default "Prefix" .Values.server.ingress.pathType }}
+                  backend:
+                    service:
+                      name: {{ include "argo-cd.server.fullname" . }}
+                - path: /grpc
+                  pathType: Exact
+                  backend:
+                    service:
+                      name: grpc
+      {{- end }}
+      YAML
+
+    endpoints.map(&.url).sort!.should eq ["/", "/grpc"]
+    sources = endpoints.map { |e| tag_descriptions(e, "ingress-source").first }
+    sources.uniq!
+    sources.should eq ["template"]
+    tag_descriptions(endpoints.find! { |e| e.url == "/" }, "ingress-path-type").should eq ["prefix"]
+    tag_descriptions(endpoints.find! { |e| e.url == "/grpc" }, "ingress-path-type").should eq ["exact"]
+  end
+
+  it "extracts ingress paths from Kubernetes List items" do
+    endpoints = analyze_ingress <<-YAML
+      apiVersion: v1
+      kind: List
+      items:
+        - apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata: {name: listed}
+          spec:
+            rules:
+              - http:
+                  paths:
+                    - path: /listed
+                      pathType: Prefix
+      YAML
+
+    endpoints.size.should eq 1
+    endpoints[0].url.should eq "/listed"
+  end
 end

--- a/spec/unit_test/detector/specification/k8s_ingress_spec.cr
+++ b/spec/unit_test/detector/specification/k8s_ingress_spec.cr
@@ -39,4 +39,76 @@ describe "Detect Kubernetes Ingress manifests" do
   it "ignores unrelated extensions" do
     instance.detect("ingress.json", ingress).should be_false
   end
+
+  it "rejects IngressClass manifests" do
+    src = <<-YAML
+      apiVersion: networking.k8s.io/v1
+      kind: IngressClass
+      metadata:
+        name: nginx
+      YAML
+
+    instance.detect("ingressclass.yaml", src).should be_false
+  end
+
+  it "rejects values files that mention ingress examples" do
+    src = <<-YAML
+      ingress:
+        enabled: true
+        example:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+      YAML
+
+    instance.detect("values.yaml", src).should be_false
+  end
+
+  it "detects templated Helm Ingress manifests" do
+    locator = CodeLocator.instance
+    locator.clear "k8s-ingress-spec"
+
+    src = <<-YAML
+      {{- if .Values.ingress.enabled }}
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: {{ include "app.fullname" . }}
+      spec:
+        rules:
+          - host: {{ .Values.ingress.host }}
+            http:
+              paths:
+                - path: {{ .Values.ingress.path }}
+                  pathType: {{ default "Prefix" .Values.ingress.pathType }}
+      {{- end }}
+      YAML
+
+    instance.detect("templates/ingress.yaml", src).should be_true
+    locator.all("k8s-ingress-spec").should eq ["templates/ingress.yaml"]
+  end
+
+  it "detects legacy extensions v1beta1 Ingress manifests" do
+    src = <<-YAML
+      apiVersion: extensions/v1beta1
+      kind: Ingress
+      metadata:
+        name: legacy
+      YAML
+
+    instance.detect("legacy-ingress.yaml", src).should be_true
+  end
+
+  it "detects Ingress manifests inside Kubernetes List items" do
+    src = <<-YAML
+      apiVersion: v1
+      kind: List
+      items:
+        - apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: listed
+      YAML
+
+    instance.detect("list.yaml", src).should be_true
+  end
 end

--- a/src/analyzer/analyzers/specification/k8s_ingress.cr
+++ b/src/analyzer/analyzers/specification/k8s_ingress.cr
@@ -4,6 +4,12 @@ module Analyzer::Specification
   class K8sIngress < Analyzer
     METHOD_ANY         = "ANY"
     REWRITE_ANNOTATION = "nginx.ingress.kubernetes.io/rewrite-target"
+    DEFAULT_PATH_TYPE  = "ImplementationSpecific"
+    API_VERSION_LINE   = /(?m)^[ \t-]*apiVersion:\s*["']?(?:networking\.k8s\.io\/[^"'\s#]+|extensions\/v1beta1)["']?\s*(?:#.*)?$/
+    KIND_LINE          = /(?m)^[ \t-]*kind:\s*["']?Ingress["']?\s*(?:#.*)?$/
+    PATH_LINE          = /^[ \t-]*path:\s*(.*)$/
+    PATH_TYPE_LINE     = /^[ \t-]*pathType:\s*(.*)$/
+    HOST_LINE          = /^[ \t-]*host:\s*(.*)$/
 
     def analyze
       spec_files = CodeLocator.instance.all("k8s-ingress-spec")
@@ -17,8 +23,9 @@ module Analyzer::Specification
         begin
           YAML.parse_all(content).each { |doc| process_doc(doc, details) }
         rescue e
-          @logger.debug "Exception processing #{path}"
+          @logger.debug "Exception processing #{path}, falling back to tolerant Ingress template extraction"
           @logger.debug_sub e
+          process_template(content, details)
         end
       end
 
@@ -30,10 +37,16 @@ module Analyzer::Specification
       return unless root
 
       kind = root[YAML::Any.new("kind")]?.try(&.as_s?)
+      if kind == "List"
+        items = root[YAML::Any.new("items")]?.try(&.as_a?) || [] of YAML::Any
+        items.each { |item| process_doc(item, details) }
+        return
+      end
+
       return unless kind == "Ingress"
 
       api_version = root[YAML::Any.new("apiVersion")]?.try(&.as_s?)
-      return unless api_version && api_version.starts_with?("networking.k8s.io/")
+      return unless supported_api_version?(api_version)
 
       metadata = root[YAML::Any.new("metadata")]?.try(&.as_h?) || {} of YAML::Any => YAML::Any
       annotations = metadata[YAML::Any.new("annotations")]?.try(&.as_h?) || {} of YAML::Any => YAML::Any
@@ -43,8 +56,16 @@ module Analyzer::Specification
       return unless spec
 
       tls_hosts = collect_tls_hosts(spec[YAML::Any.new("tls")]?)
+      process_default_backend(spec[YAML::Any.new("defaultBackend")]?, tls_hosts, details)
+
       rules = spec[YAML::Any.new("rules")]?.try(&.as_a?) || [] of YAML::Any
       rules.each { |rule| process_rule(rule, tls_hosts, rewrite_target, details) }
+    end
+
+    private def supported_api_version?(api_version : String?) : Bool
+      return false unless api_version
+
+      api_version.starts_with?("networking.k8s.io/") || api_version == "extensions/v1beta1"
     end
 
     private def collect_tls_hosts(node : YAML::Any?) : Set(String)
@@ -79,9 +100,10 @@ module Analyzer::Specification
         next unless path_h
 
         path = path_h[YAML::Any.new("path")]?.try(&.as_s?) || ""
+        path = "/" if path.empty? && backend_present?(path_h[YAML::Any.new("backend")]?)
         next if path.empty?
 
-        path_type = path_h[YAML::Any.new("pathType")]?.try(&.as_s?) || "ImplementationSpecific"
+        path_type = path_h[YAML::Any.new("pathType")]?.try(&.as_s?) || DEFAULT_PATH_TYPE
         emit_endpoint(path, path_type, host, tls_hosts, details)
 
         if rewrite_target && !rewrite_target.empty?
@@ -91,6 +113,16 @@ module Analyzer::Specification
           end
         end
       end
+    end
+
+    private def process_default_backend(default_backend : YAML::Any?, tls_hosts : Set(String), details : Details)
+      return unless backend_present?(default_backend)
+
+      emit_endpoint("/", DEFAULT_PATH_TYPE, "", tls_hosts, details, "default-backend")
+    end
+
+    private def backend_present?(backend : YAML::Any?) : Bool
+      backend.try(&.as_h?) != nil
     end
 
     private def emit_endpoint(path : String, path_type : String, host : String, tls_hosts : Set(String), details : Details, origin : String = "rule")
@@ -107,6 +139,120 @@ module Analyzer::Specification
     # plain URL strings, not regex back-references.
     private def strip_capture_groups(target : String) : String
       target.gsub(/\$\d+/, "")
+    end
+
+    private def process_template(content : String, details : Details)
+      return unless content.matches?(API_VERSION_LINE) && content.matches?(KIND_LINE)
+
+      tls_hosts = Set(String).new
+      rewrite_target = extract_rewrite_target(content)
+      lines = content.lines
+      host = ""
+      emitted = Set(String).new
+
+      lines.each_with_index do |line, index|
+        if host_match = line.match(HOST_LINE)
+          host = clean_template_host(host_match[1])
+          next
+        end
+
+        path_match = line.match(PATH_LINE)
+        next unless path_match
+
+        path = clean_template_path(path_match[1]) || "/"
+        path_type = find_template_path_type(lines, index) || DEFAULT_PATH_TYPE
+        emit_template_endpoint(path, path_type, host, tls_hosts, details, emitted)
+
+        if rewrite_target && !rewrite_target.empty?
+          rewritten = strip_capture_groups(rewrite_target)
+          emit_template_endpoint(rewritten, path_type, host, tls_hosts, details, emitted, "rewrite") unless rewritten == path
+        end
+      end
+
+      if emitted.empty? && content.matches?(/(?m)^[ \t]*defaultBackend:\s*(?:#.*)?$/)
+        emit_template_endpoint("/", DEFAULT_PATH_TYPE, "", tls_hosts, details, emitted, "default-backend")
+      end
+    end
+
+    private def emit_template_endpoint(path : String, path_type : String, host : String, tls_hosts : Set(String), details : Details, emitted : Set(String), origin : String = "template")
+      key = "#{origin}\0#{host}\0#{path_type}\0#{path}"
+      return if emitted.includes?(key)
+
+      emitted << key
+      emit_endpoint(path, path_type, host, tls_hosts, details, origin)
+    end
+
+    private def extract_rewrite_target(content : String) : String?
+      content.each_line do |line|
+        next unless line.includes?(REWRITE_ANNOTATION)
+
+        if value = line.split(":", 2)[1]?
+          return clean_template_path(value)
+        end
+      end
+    end
+
+    private def find_template_path_type(lines : Array(String), index : Int32) : String?
+      offset = 1
+      while offset <= 6
+        candidate = lines[index + offset]?
+        return unless candidate
+        return if candidate.match(PATH_LINE)
+
+        if match = candidate.match(PATH_TYPE_LINE)
+          return clean_template_path_type(match[1])
+        end
+        offset += 1
+      end
+    end
+
+    private def clean_template_path(value : String) : String?
+      scalar = strip_yaml_comment(value).strip
+      return "/" if scalar.empty?
+
+      scalar = strip_quotes(scalar)
+      return scalar if scalar.starts_with?("/")
+
+      if quoted_path = scalar.match(/["'](\/[^"']*)["']/)
+        return quoted_path[1]
+      end
+
+      "/" if scalar.includes?("{{")
+    end
+
+    private def clean_template_path_type(value : String) : String
+      scalar = strip_yaml_comment(value).strip
+      scalar = strip_quotes(scalar)
+      return scalar if {"Exact", "Prefix", "ImplementationSpecific"}.includes?(scalar)
+
+      if quoted_type = scalar.match(/["'](Exact|Prefix|ImplementationSpecific)["']/)
+        return quoted_type[1]
+      end
+
+      DEFAULT_PATH_TYPE
+    end
+
+    private def clean_template_host(value : String) : String
+      scalar = strip_yaml_comment(value).strip
+      scalar = strip_quotes(scalar)
+      return "" if scalar.includes?("{{")
+
+      scalar
+    end
+
+    private def strip_yaml_comment(value : String) : String
+      value.split("#", 2).first? || value
+    end
+
+    private def strip_quotes(value : String) : String
+      stripped = value.strip
+      if stripped.size >= 2
+        first = stripped[0]
+        last = stripped[stripped.size - 1]
+        return stripped[1, stripped.size - 2] if (first == '"' && last == '"') || (first == '\'' && last == '\'')
+      end
+
+      stripped
     end
   end
 end

--- a/src/detector/detectors/specification/k8s_ingress.cr
+++ b/src/detector/detectors/specification/k8s_ingress.cr
@@ -4,12 +4,12 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class K8sIngress < Detector
-    INGRESS_API_VERSION_PREFIX = "networking.k8s.io/"
+    INGRESS_API_VERSION_PREFIXES = ["networking.k8s.io/", "extensions/v1beta1"]
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless valid_yaml_documents?(file_contents)
-      return false unless ingress_present?(file_contents)
+      return false unless ingress_markers_present?(file_contents)
+      return false unless ingress_document_present?(file_contents)
 
       CodeLocator.instance.push("k8s-ingress-spec", filename)
       true
@@ -28,20 +28,77 @@ module Detector::Specification
       false
     end
 
-    private def valid_yaml_documents?(content : String) : Bool
-      YAML.parse_all(content)
-      true
+    private def ingress_document_present?(content : String) : Bool
+      YAML.parse_all(content).any? do |doc|
+        root = doc.as_h?
+        next false unless root
+
+        ingress_root?(root)
+      end
     rescue
+      # Helm/Kustomize templates often keep recognizable Ingress markers
+      # while breaking strict YAML parsing with `{{ ... }}` expressions.
+      # The analyzer has a tolerant fallback for these files.
+      true
+    end
+
+    private def ingress_markers_present?(content : String) : Bool
+      return false unless INGRESS_API_VERSION_PREFIXES.any? { |prefix| content.includes?(prefix) }
+
+      has_api_version = false
+      has_kind = false
+
+      content.each_line do |line|
+        normalized = normalize_manifest_line(line)
+        if normalized.starts_with?("apiVersion:")
+          has_api_version ||= supported_api_version?(line_value(normalized))
+        elsif normalized.starts_with?("kind:")
+          has_kind ||= line_value(normalized) == "Ingress"
+        end
+
+        return true if has_api_version && has_kind
+      end
+
       false
     end
 
-    private def ingress_present?(content : String) : Bool
-      # Cheap pre-check: the manifest must declare both an Ingress kind
-      # and a networking.k8s.io apiVersion. Tags / Helm templates with
-      # `{{ ... }}` interpolation often leave the spec intact while
-      # breaking strict YAML parsing — the substring guard tolerates
-      # that without us needing to repair the document.
-      content.includes?(INGRESS_API_VERSION_PREFIX) && content.includes?("kind: Ingress")
+    private def supported_api_version?(api_version : String?) : Bool
+      return false unless api_version
+
+      api_version.starts_with?("networking.k8s.io/") || api_version == "extensions/v1beta1"
+    end
+
+    private def ingress_root?(root : Hash(YAML::Any, YAML::Any)) : Bool
+      kind = root[YAML::Any.new("kind")]?.try(&.as_s?)
+      if kind == "List"
+        items = root[YAML::Any.new("items")]?.try(&.as_a?) || [] of YAML::Any
+        return items.any? do |item|
+          item_h = item.as_h?
+          item_h ? ingress_root?(item_h) : false
+        end
+      end
+
+      kind == "Ingress" && supported_api_version?(root[YAML::Any.new("apiVersion")]?.try(&.as_s?))
+    end
+
+    private def normalize_manifest_line(line : String) : String
+      normalized = line.strip
+      normalized = normalized[1..].strip if normalized.starts_with?("-")
+      normalized
+    end
+
+    private def line_value(line : String) : String
+      value = line.split(":", 2)[1]? || ""
+      value = value.split("#", 2).first? || value
+      value = value.strip
+
+      if value.size >= 2
+        first = value[0]
+        last = value[value.size - 1]
+        return value[1, value.size - 2] if (first == '"' && last == '"') || (first == '\'' && last == '\'')
+      end
+
+      value
     end
   end
 end


### PR DESCRIPTION
## Summary
- reduce K8s Ingress detector false positives by checking exact manifest markers and validating parsed root documents instead of substring matches
- add tolerant Helm/Kustomize template fallback extraction for templated Ingress paths/pathTypes
- cover legacy extensions/v1beta1, Kubernetes List.items Ingress manifests, defaultBackend, and backend paths without explicit path

## Open-source sample check
Sampled prometheus-community/helm-charts, grafana/helm-charts, argoproj/argo-helm, and bitnami/charts under /tmp/noir-ingress-samples:
- exact Ingress candidate files: 26
- previous detector-style registration: 2
- updated detector registration: 26
- detector hot-path benchmark over 4,894 YAML files: old avg 5083.52 ms, new avg 4214.11 ms

## Verification
- crystal spec spec/unit_test/detector/specification/k8s_ingress_spec.cr spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
- just build
- just test
- just check