### PR TITLE
Improve Apache httpd specification analyzer

### DIFF
--- a/spec/functional_test/fixtures/specification/apache_httpd/site.conf
+++ b/spec/functional_test/fixtures/specification/apache_httpd/site.conf
@@ -8,5 +8,9 @@
         AuthType Basic
     </LocationMatch>
     Alias /static /var/www/static
+    ScriptAlias /cgi-bin/ /var/www/cgi-bin/
+    ProxyPass /backend http://backend:8080/
+    RedirectMatch 301 ^/legacy/(.*)$ /v2/$1
     RewriteRule ^/api/(.*)$ /v1/$1 [L,QSA]
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 </VirtualHost>

--- a/spec/functional_test/testers/specification/apache_httpd_spec.cr
+++ b/spec/functional_test/testers/specification/apache_httpd_spec.cr
@@ -7,6 +7,9 @@ expected_endpoints = [
   Endpoint.new("/v1/users", "ANY"),
   Endpoint.new("/admin/.*", "ANY"),
   Endpoint.new("/static", "ANY"),
+  Endpoint.new("/cgi-bin/", "ANY"),
+  Endpoint.new("/backend", "ANY"),
+  Endpoint.new("/legacy/(.*)", "ANY"),
   Endpoint.new("/api/(.*)", "ANY"),
 ]
 

--- a/spec/unit_test/analyzer/specification/apache_httpd_spec.cr
+++ b/spec/unit_test/analyzer/specification/apache_httpd_spec.cr
@@ -56,6 +56,55 @@ describe "Apache httpd Analyzer" do
     tag_descriptions(endpoints[0], "apache-rewrite-target").should eq ["/new/$1"]
   end
 
+  it "extracts proxy, script alias, and redirect directives" do
+    endpoints = analyze_apache <<-CONF
+      <VirtualHost *:443>
+          ServerName proxy.example.com
+          ProxyPass /api http://backend:8080/
+          ProxyPassMatch ^/ws/(.*)$ ws://backend/$1
+          ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+          Redirect permanent /old https://example.com/new
+          RedirectMatch 301 ^/legacy/(.*)$ /new/$1
+      </VirtualHost>
+      CONF
+
+    pairs = endpoints.map { |e| {e.url, tag_descriptions(e, "apache-path-type").first} }.sort!
+    pairs.should eq([
+      {"/api", "proxy"},
+      {"/cgi-bin/", "script-alias"},
+      {"/old", "redirect"},
+      {"^/legacy/(.*)$", "redirect-regex"},
+      {"^/ws/(.*)$", "proxy-regex"},
+    ])
+    endpoints.each do |e|
+      tag_descriptions(e, "apache-host").should eq ["proxy.example.com"]
+    end
+  end
+
+  it "skips location-scoped proxy targets and non-url alias arguments" do
+    endpoints = analyze_apache <<-CONF
+      <Location /backend>
+          ProxyPass http://backend:8080/
+      </Location>
+      <LocationMatch "^/files/(.*)$">
+          Alias /var/www/files/$1
+      </LocationMatch>
+      CONF
+
+    endpoints.map(&.url).sort!.should eq ["/backend", "^/files/(.*)$"]
+  end
+
+  it "skips no-substitution and static asset rewrites" do
+    endpoints = analyze_apache <<-CONF, ".htaccess"
+      RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+      RewriteRule ^(?:build|tests)/.* - [R=404,L]
+      RewriteRule ^(.*css_[a-zA-Z0-9-_]+)\\.css$ $1\\.css\\.br [QSA]
+      RewriteRule ^remote/(.*) remote.php [L]
+      CONF
+
+    endpoints.map(&.url).should eq ["^remote/(.*)"]
+  end
+
   it "supports multiple ServerAlias hosts" do
     endpoints = analyze_apache <<-CONF
       <VirtualHost *:80>

--- a/spec/unit_test/detector/specification/apache_httpd_spec.cr
+++ b/spec/unit_test/detector/specification/apache_httpd_spec.cr
@@ -28,6 +28,18 @@ describe "Detect Apache httpd config" do
     instance.detect(".htaccess", htaccess).should be_true
   end
 
+  it "detects Apache config templates case-insensitively" do
+    locator = CodeLocator.instance
+    locator.clear "apache-httpd-spec"
+
+    instance.detect("conf/extra.conf.in", "  proxypass /api http://backend\n").should be_true
+    locator.all("apache-httpd-spec").should eq ["conf/extra.conf.in"]
+  end
+
+  it "ignores directives that only appear in comments" do
+    instance.detect("commented.conf", "# ProxyPass /api http://backend\n").should be_false
+  end
+
   it "rejects .conf without Apache directives" do
     instance.detect("config.conf", "key = value\nfoo=bar\n").should be_false
   end

--- a/src/analyzer/analyzers/specification/apache_httpd.cr
+++ b/src/analyzer/analyzers/specification/apache_httpd.cr
@@ -4,15 +4,8 @@ module Analyzer::Specification
   class ApacheHttpd < Analyzer
     METHOD_ANY = "ANY"
 
-    LOCATION_OPEN_RE       = /^<Location\s+([^>]+)>/i
-    LOCATION_MATCH_OPEN_RE = /^<LocationMatch\s+([^>]+)>/i
-    DIRECTORY_OPEN_RE      = /^<Directory\s+([^>]+)>/i
-    VHOST_OPEN_RE          = /^<VirtualHost\s+([^>]*)>/i
-    VHOST_CLOSE_RE         = /^<\/VirtualHost>/i
-    SERVER_NAME_RE         = /^ServerName\s+(\S+)/i
-    SERVER_ALIAS_RE        = /^ServerAlias\s+(.+)/i
-    ALIAS_RE               = /^Alias\s+(\S+)\s+(\S+)/i
-    REWRITE_RE             = /^RewriteRule\s+(\S+)\s+(\S+)/i
+    REDIRECT_STATUSES = Set{"permanent", "temp", "temporary", "seeother", "gone"}
+    STATIC_EXTENSIONS = Set{".css", ".js", ".gz", ".br", ".ico", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".woff", ".woff2", ".ttf", ".eot", ".map"}
 
     def analyze
       spec_files = CodeLocator.instance.all("apache-httpd-spec")
@@ -21,10 +14,9 @@ module Analyzer::Specification
       spec_files.each do |path|
         next unless File.exists?(path)
 
-        details = Details.new(PathInfo.new(path))
         content = read_file_content(path)
         begin
-          process_content(content, path, details)
+          process_content(content, path)
         rescue e
           @logger.debug "Exception processing #{path}"
           @logger.debug_sub e
@@ -34,39 +26,223 @@ module Analyzer::Specification
       @result
     end
 
-    private def process_content(content : String, path : String, details : Details)
+    private def process_content(content : String, path : String)
       hosts = [] of String
-      in_vhost = false
+      line_no = 0
 
-      content.lines.each_with_index do |raw, idx|
+      content.each_line do |raw|
+        line_no += 1
         line = strip_comment(raw).strip
         next if line.empty?
-        line_no = idx + 1
 
-        if VHOST_OPEN_RE.match(line)
-          in_vhost = true
+        if block_open?(line, "VirtualHost")
           hosts = [] of String
-        elsif VHOST_CLOSE_RE.match(line)
-          in_vhost = false
+        elsif block_close?(line, "VirtualHost")
           hosts = [] of String
-        elsif m = SERVER_NAME_RE.match(line)
-          hosts << m[1]
-        elsif m = SERVER_ALIAS_RE.match(line)
-          m[1].split(/\s+/).reject(&.empty?).each { |alias_host| hosts << alias_host }
-        elsif m = LOCATION_OPEN_RE.match(line)
-          location = strip_quotes(m[1].strip)
+        elsif directive?(line, "ServerName")
+          args = directive_args(line, "ServerName")
+          hosts << args[0] if args.size > 0
+        elsif directive?(line, "ServerAlias")
+          directive_args(line, "ServerAlias").each { |alias_host| hosts << alias_host }
+        elsif location = block_arg(line, "Location")
           emit_endpoint(location, "prefix", hosts, "location", path, line_no)
-        elsif m = LOCATION_MATCH_OPEN_RE.match(line)
-          location = strip_quotes(m[1].strip)
+        elsif location = block_arg(line, "LocationMatch")
           emit_endpoint(location, "regex", hosts, "locationmatch", path, line_no)
-        elsif m = ALIAS_RE.match(line)
-          path_value = strip_quotes(m[1])
-          emit_endpoint(path_value, "alias", hosts, "alias", path, line_no)
-        elsif m = REWRITE_RE.match(line)
-          pattern = strip_quotes(m[1])
-          target = strip_quotes(m[2])
-          emit_endpoint(pattern, "rewrite-source", hosts, "rewrite", path, line_no, target)
+        elsif directive?(line, "Alias")
+          emit_first_path_arg(line, "Alias", "alias", "alias", hosts, path, line_no)
+        elsif directive?(line, "ScriptAlias")
+          emit_first_path_arg(line, "ScriptAlias", "script-alias", "scriptalias", hosts, path, line_no)
+        elsif directive?(line, "ProxyPass")
+          emit_proxy_pass(line, "ProxyPass", "proxy", "proxypass", hosts, path, line_no)
+        elsif directive?(line, "ProxyPassMatch")
+          emit_proxy_pass(line, "ProxyPassMatch", "proxy-regex", "proxypassmatch", hosts, path, line_no)
+        elsif directive?(line, "Redirect")
+          emit_redirect(line, "Redirect", "redirect", "redirect", hosts, path, line_no)
+        elsif directive?(line, "RedirectMatch")
+          emit_redirect(line, "RedirectMatch", "redirect-regex", "redirectmatch", hosts, path, line_no)
+        elsif directive?(line, "RewriteRule")
+          emit_rewrite(line, hosts, path, line_no)
         end
+      end
+    end
+
+    private def emit_first_path_arg(line : String, directive : String, path_type : String, origin : String, hosts : Array(String), source_path : String, line_no : Int32)
+      args = directive_args(line, directive)
+      return if args.size < 2
+
+      path_value = args[0]
+      return unless path_like?(path_value)
+
+      emit_endpoint(path_value, path_type, hosts, origin, source_path, line_no)
+    end
+
+    private def emit_proxy_pass(line : String, directive : String, path_type : String, origin : String, hosts : Array(String), source_path : String, line_no : Int32)
+      args = directive_args(line, directive)
+      return if args.size < 2
+
+      path_value = args[0]
+      target = args[1]
+      return unless path_like?(path_value)
+      return if target == "!"
+
+      emit_endpoint(path_value, path_type, hosts, origin, source_path, line_no, target)
+    end
+
+    private def emit_redirect(line : String, directive : String, path_type : String, origin : String, hosts : Array(String), source_path : String, line_no : Int32)
+      args = directive_args(line, directive)
+      return if args.empty?
+
+      path_index = redirect_status?(args[0]) ? 1 : 0
+      return if path_index >= args.size
+
+      path_value = args[path_index]
+      target = args[path_index + 1]?
+      return unless path_like?(path_value)
+
+      emit_endpoint(path_value, path_type, hosts, origin, source_path, line_no, target)
+    end
+
+    private def emit_rewrite(line : String, hosts : Array(String), source_path : String, line_no : Int32)
+      args = directive_args(line, "RewriteRule")
+      return if args.size < 2
+
+      pattern = args[0]
+      target = args[1]
+      return if skip_rewrite?(pattern, target)
+
+      emit_endpoint(pattern, "rewrite-source", hosts, "rewrite", source_path, line_no, target)
+    end
+
+    private def directive_args(line : String, directive : String) : Array(String)
+      offset = directive_offset(line, directive)
+      return [] of String unless offset
+
+      split_args(line[(offset + directive.size)..])
+    end
+
+    private def split_args(value : String) : Array(String)
+      args = [] of String
+      current = String::Builder.new
+      quote = nil.as(Char?)
+      escaped = false
+
+      value.each_char do |char|
+        if escaped
+          current << char
+          escaped = false
+          next
+        end
+
+        if quote
+          case char
+          when '\\'
+            escaped = true
+          when quote
+            quote = nil
+          else
+            current << char
+          end
+          next
+        end
+
+        case char
+        when '"', '\''
+          quote = char
+        when .whitespace?
+          unless current.empty?
+            args << current.to_s
+            current = String::Builder.new
+          end
+        else
+          current << char
+        end
+      end
+
+      args << current.to_s unless current.empty?
+      args
+    end
+
+    private def block_arg(line : String, directive : String) : String?
+      return unless block_open?(line, directive)
+
+      offset = directive_offset(line, directive)
+      return unless offset
+
+      tail = line[(offset + directive.size)..].strip
+      close = tail.rindex('>')
+      return unless close
+
+      strip_quotes(tail[0...close].strip)
+    end
+
+    private def block_open?(line : String, directive : String) : Bool
+      offset = directive_offset(line, directive)
+      return false unless offset
+      return false if offset == 1 && line.size > 1 && line[1] == '/'
+
+      line.starts_with?('<')
+    end
+
+    private def block_close?(line : String, directive : String) : Bool
+      return false unless line.starts_with?("</")
+      ascii_prefix?(line, "</#{directive}")
+    end
+
+    private def directive?(line : String, directive : String) : Bool
+      !!directive_offset(line, directive)
+    end
+
+    private def directive_offset(line : String, directive : String) : Int32?
+      offset = line.starts_with?('<') ? 1 : 0
+      return unless ascii_prefix?(line[offset..], directive)
+
+      end_index = offset + directive.size
+      return offset if end_index >= line.size
+
+      char = line[end_index]
+      return offset if char.whitespace? || char == '>'
+      nil
+    end
+
+    private def ascii_prefix?(value : String, prefix : String) : Bool
+      return false if value.size < prefix.size
+
+      prefix.each_byte.each_with_index do |byte, idx|
+        return false unless ascii_downcase(value.byte_at(idx)) == ascii_downcase(byte)
+      end
+
+      true
+    end
+
+    private def ascii_downcase(byte : UInt8) : UInt8
+      if byte >= 65 && byte <= 90
+        byte + 32
+      else
+        byte
+      end
+    end
+
+    private def redirect_status?(value : String) : Bool
+      lower = value.downcase
+      REDIRECT_STATUSES.includes?(lower) || lower.matches?(/^\d{3}$/)
+    end
+
+    private def path_like?(value : String) : Bool
+      return false if value.empty?
+      return true if value.starts_with?('/') || value.starts_with?("^/") || value.starts_with?("./") || value.starts_with?("../")
+      return true if value.starts_with?("^\\.") || value.starts_with?("\\.")
+      false
+    end
+
+    private def skip_rewrite?(pattern : String, target : String) : Bool
+      return true if target == "-"
+      return true if static_asset_rewrite?(pattern, target)
+      false
+    end
+
+    private def static_asset_rewrite?(pattern : String, target : String) : Bool
+      STATIC_EXTENSIONS.any? do |ext|
+        pattern.includes?(ext) && target.includes?(ext)
       end
     end
 
@@ -80,8 +256,34 @@ module Analyzer::Specification
     end
 
     private def strip_comment(line : String) : String
-      idx = line.index('#')
-      idx.nil? ? line : line[0...idx]
+      quote = nil.as(Char?)
+      escaped = false
+
+      line.each_char_with_index do |char, idx|
+        if escaped
+          escaped = false
+          next
+        end
+
+        if quote
+          case char
+          when '\\'
+            escaped = true
+          when quote
+            quote = nil
+          end
+          next
+        end
+
+        case char
+        when '"', '\''
+          quote = char
+        when '#'
+          return line[0...idx]
+        end
+      end
+
+      line
     end
 
     private def emit_endpoint(path : String, path_type : String, hosts : Array(String), origin : String, source_path : String, line : Int32, target : String? = nil)

--- a/src/detector/detectors/specification/apache_httpd.cr
+++ b/src/detector/detectors/specification/apache_httpd.cr
@@ -4,7 +4,23 @@ require "../../../models/code_locator"
 module Detector::Specification
   class ApacheHttpd < Detector
     HTACCESS          = ".htaccess"
-    APACHE_DIRECTIVES = ["<VirtualHost", "<Location", "<LocationMatch", "<Directory", "RewriteRule", "Alias ", "ProxyPass"]
+    APACHE_DIRECTIVES = [
+      "<VirtualHost",
+      "<Location",
+      "<LocationMatch",
+      "<Directory",
+      "RewriteRule",
+      "Alias",
+      "ScriptAlias",
+      "ProxyPass",
+      "ProxyPassMatch",
+      "Redirect",
+      "RedirectMatch",
+    ]
+    APACHE_HINTS = APACHE_DIRECTIVES.flat_map do |directive|
+      hint = directive.lchop("<")
+      [hint, hint.downcase]
+    end
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
@@ -17,7 +33,7 @@ module Detector::Specification
     def applicable?(filename : String) : Bool
       base = File.basename(filename)
       return true if base == HTACCESS
-      filename.ends_with?(".conf") && !nginx_only?(filename)
+      apache_conf?(filename) && !nginx_only?(filename)
     end
 
     def set_name
@@ -38,8 +54,49 @@ module Detector::Specification
       lower.includes?("/nginx/") || lower.ends_with?("nginx.conf")
     end
 
+    private def apache_conf?(filename : String) : Bool
+      lower = filename.downcase
+      lower.ends_with?(".conf") || lower.ends_with?(".conf.in") || lower.ends_with?(".conf.template")
+    end
+
     private def apache_shape?(content : String) : Bool
-      APACHE_DIRECTIVES.any? { |d| content.includes?(d) }
+      return false unless APACHE_HINTS.any? { |directive| content.includes?(directive) }
+
+      content.each_line do |raw|
+        line = raw.lstrip
+        next if line.empty? || line.starts_with?('#')
+        return true if APACHE_DIRECTIVES.any? { |directive| apache_directive?(line, directive) }
+      end
+
+      false
+    end
+
+    private def apache_directive?(line : String, directive : String) : Bool
+      return false unless ascii_prefix?(line, directive)
+      return true if directive.starts_with?('<')
+
+      end_index = directive.size
+      return true if end_index >= line.size
+
+      line[end_index].whitespace?
+    end
+
+    private def ascii_prefix?(value : String, prefix : String) : Bool
+      return false if value.size < prefix.size
+
+      prefix.each_byte.each_with_index do |byte, idx|
+        return false unless ascii_downcase(value.byte_at(idx)) == ascii_downcase(byte)
+      end
+
+      true
+    end
+
+    private def ascii_downcase(byte : UInt8) : UInt8
+      if byte >= 65 && byte <= 90
+        byte + 32
+      else
+        byte
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- add Apache httpd extraction for ProxyPass, ProxyPassMatch, ScriptAlias, Redirect, and RedirectMatch directives
- reduce rewrite false positives by skipping no-substitution and static asset rewrite rules
- detect Apache .conf.in/.conf.template files and ignore directives that only appear in comments
- replace regex-per-line analyzer matching with directive token parsing that handles quoted args and inline comments

## OSS samples checked
- apache/httpd
- nextcloud/server
- owncloud/core
- drupal/drupal
- matomo-org/matomo
- roundcube/roundcubemail

## Scan comparison on collected samples
- baseline original scope: 43 endpoints; rewrite-source 31; 3-run real times 2.08s, 1.43s, 1.18s
- after original scope: 26 endpoints; rewrite-source 14; 3-run real times 1.58s, 1.45s, 1.34s
- after expanded scope including .conf.in templates: 231 endpoints with proxy/redirect/script-alias coverage; 3-run real times 1.68s, 1.68s, 1.53s

## Tests
- `just test`
- `just check`
- `crystal spec ./spec/unit_test/analyzer/specification/apache_httpd_spec.cr ./spec/unit_test/detector/specification/apache_httpd_spec.cr ./spec/functional_test/testers/specification/apache_httpd_spec.cr`
- `just build`