### PR TITLE
docs: fix broken landing hero images on Korean page

### DIFF
--- a/docs/content/_index.ko.md
+++ b/docs/content/_index.ko.md
@@ -30,11 +30,11 @@ template = "landing"
     <div class="hero-showcase">
       <div class="split-stage">
         <div class="split-pane split-a">
-          <img src="./images/landing/1.webp" alt="소스 코드를 사람이 읽기 좋은 엔드포인트 목록으로 변환" width="1904" height="1162" loading="eager" decoding="async" fetchpriority="high">
+          <img src="../images/landing/1.webp" alt="소스 코드를 사람이 읽기 좋은 엔드포인트 목록으로 변환" width="1904" height="1162" loading="eager" decoding="async" fetchpriority="high">
           <span class="split-tag">source &rarr; endpoints</span>
         </div>
         <div class="split-pane split-b">
-          <img src="./images/landing/2.webp" alt="엔드포인트별 AI 컨텍스트: callee, guard, 보안 시그널" width="1904" height="1162" loading="lazy" decoding="async">
+          <img src="../images/landing/2.webp" alt="엔드포인트별 AI 컨텍스트: callee, guard, 보안 시그널" width="1904" height="1162" loading="lazy" decoding="async">
           <span class="split-tag">ai context</span>
         </div>
         <span class="split-hint">hover to reveal</span>


### PR DESCRIPTION
## Summary

The Korean landing page (https://owasp-noir.github.io/noir/ko/) shows broken hero images. The two showcase images used `./images/landing/*.webp`, which on the `/noir/ko/` page resolves to `/noir/ko/images/landing/...` and 404s.

The rest of the images on the same page (trust logos, mascot) already use `../images/...`, which correctly resolves to `/noir/images/...`. These hero paths were left over from the English `_index.md` (which is served at the site root `/noir/`, so `./images/...` works there).

## Change

- `docs/content/_index.ko.md`: change the two hero `<img>` sources from `./images/landing/{1,2}.webp` to `../images/landing/{1,2}.webp`, making all image paths on the Korean page consistent and resolvable.

## Notes

- Images live in `docs/static/images/` (served at `/noir/images/...`); no asset changes needed.
- English landing page is unaffected.

https://claude.ai/code/session_01XdYzPdaq1insLgATYiXryA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdYzPdaq1insLgATYiXryA)_