### PR TITLE
fix(docs): keep footer content clear of the fixed sidebar at narrow widths

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1991,11 +1991,14 @@ p:has(> .member-card) {
     max-width: 900px;
     margin: 0 auto;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
 }
 .footer-branding {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 0.75rem;
     color: var(--text-muted);
@@ -2029,6 +2032,13 @@ p:has(> .member-card) {
 }
 .footer-sep {
     opacity: 0.4;
+}
+/* On docs pages the sidebar (and TOC) are position: fixed and overlay the
+   full-width footer. Reserve their space so the footer content never slides
+   behind them at narrow window widths. The landing page has no .docs-layout,
+   so it keeps the full-width footer. */
+.docs-layout ~ .site-footer {
+    padding-left: calc(2rem + var(--sidebar-w));
 }
 
 /* ==========================================================================
@@ -2083,6 +2093,13 @@ p:has(> .member-card) {
     }
     .docs-main {
         margin-right: 0;
+    }
+}
+
+/* The TOC is fixed on the right above 1100px; keep the footer clear of it. */
+@media (min-width: 1101px) {
+    .docs-layout ~ .site-footer {
+        padding-right: calc(2rem + var(--toc-w));
     }
 }
 
@@ -2231,6 +2248,9 @@ p:has(> .member-card) {
     }
 
     /* Footer */
+    .docs-layout ~ .site-footer {
+        padding-left: 2rem;
+    }
     .footer-inner {
         flex-direction: column;
         gap: 1rem;


### PR DESCRIPTION
## Problem

On the docs site, the footer (`.site-footer`) spans the full viewport width, but the sidebar (and TOC) are `position: fixed` and overlay it (`z-index: 150`). The footer's content is centered (`max-width: 900px; margin: 0 auto`) across the full width with no offset for those fixed columns.

At awkwardly small window widths (roughly the range where the sidebar is still visible, ~769–1100px), the centered footer content — the copyright line and "Documentation built with Hwaro" — slides underneath the fixed sidebar and gets cut off.

## Fix

- **Reserve the fixed columns' space on the footer**, scoped to docs pages only via `.docs-layout ~ .site-footer`. The landing page has no `.docs-layout`, so it keeps the original full-width footer.
  - `padding-left` accounts for the sidebar (`--sidebar-w`).
  - `padding-right` accounts for the TOC (`--toc-w`) only above 1100px, where the TOC is actually visible.
  - The offset is reset back to `2rem` at the mobile breakpoint (≤768px) where the sidebar slides off-screen.
- **Let the footer wrap when space is tight**, like the mobile layout: added `flex-wrap: wrap` + `gap` to `.footer-inner` and `flex-wrap: wrap` to `.footer-branding`, so the branding/links rows break onto new lines instead of overflowing.

CSS-only change; no template or content changes.

https://claude.ai/code/session_01YHVax4Hep5PDnXFpaSnfV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHVax4Hep5PDnXFpaSnfV7)_