### PR TITLE
Fix Rails optional scopes and custom action context

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -97,6 +97,12 @@ Rails.application.routes.draw do
   get "feed(.:format)", to: "monitor#ping"
   get "report(/:section)/rss", to: "monitor#ping"
 
+  # Optional segments in scope prefixes should be normalized the same way as
+  # route literals; the emitted URL is `/localized_ping`, not `/(/:locale)/...`.
+  scope "(/:locale)" do
+    get "localized_ping", to: "monitor#ping"
+  end
+
   # A `%w[...].each do |action|` loop over a literal list (like Redmine's
   # repository routes) unrolls to one route per element with `#{action}`
   # substituted — never leaking raw Ruby or a fabricated `{action}` path

--- a/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/app/controllers/posts_controller.rb
@@ -33,6 +33,11 @@ class PostsController < ApplicationController
     render json: serialize_preview(draft)
   end
 
+  def destroy_memory
+    MemoryStore.destroy(params[:id])
+    AuditLog.write("destroy_memory")
+  end
+
   private
 
   def post_params

--- a/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_callees/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   resources :posts, only: [:index, :show, :create] do
+    member do
+      delete :memory, action: :destroy_memory
+      get :external_ready, to: "monitor#ready"
+    end
+
     collection do
       get :preview
     end

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -148,6 +148,9 @@ expected_endpoints = [
   Endpoint.new("/report/rss", "GET", [
     Param.new("X-Ping", "", "header"),
   ]),
+  Endpoint.new("/localized_ping", "GET", [
+    Param.new("X-Ping", "", "header"),
+  ]),
 
   # `%w[browse annotate].each do |action|` unrolls to one route per literal
   # element with `#{action}` substituted — never leaking raw Ruby or a
@@ -205,7 +208,7 @@ total_endpoints = 1 +  # root
                   6 +  # posts
                   4 +  # posts/1/comments + nested likes from concern
                   3 +  # /up + /ping + legacy string-via match
-                  2 +  # optional-segment routes /feed + /report/rss
+                  3 +  # optional-segment routes /feed + /report/rss + optional scope
                   2 +  # %w[browse annotate].each unrolled to /repo/:id/browse + /annotate
                   20 + # devise_for :users
                   1 +  # mount sidekiq

--- a/spec/functional_test/testers/ruby/rails_callees_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_callees_spec.cr
@@ -20,6 +20,18 @@ create_endpoint = Endpoint.new("/posts", "POST").tap do |ep|
   ep.push_callee(Callee.new("serialize_post", line: 16))
 end
 
+destroy_memory_endpoint = Endpoint.new("/posts/1/memory", "DELETE", [
+  Param.new("id", "", "path"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("MemoryStore.destroy", line: 37))
+  ep.push_callee(Callee.new("AuditLog.write", line: 38))
+end
+
+external_ready_endpoint = Endpoint.new("/posts/1/external_ready", "GET").tap do |ep|
+  ep.push_callee(Callee.new("render", line: 10))
+  ep.push_callee(Callee.new("Ready.check", line: 10))
+end
+
 preview_endpoint = Endpoint.new("/posts/preview", "GET").tap do |ep|
   ep.push_callee(Callee.new("PreviewBuilder.build", line: 20))
   ep.push_callee(Callee.new("render", line: 21))
@@ -60,6 +72,8 @@ expected_endpoints = [
   index_endpoint,
   show_endpoint,
   create_endpoint,
+  destroy_memory_endpoint,
+  external_ready_endpoint,
   preview_endpoint,
   implicit_preview_endpoint,
   legacy_implicit_preview_endpoint,

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -292,7 +292,7 @@ module Analyzer::Ruby
           next unless m = call[1].match(/^\s*(?::(\w+)|['"]([^'"]+)['"])/)
           name = m[1]? || m[2]? || ""
           options = parse_options(call[1])
-          namespace_path = options.has_key?("path") ? options["path"] : name
+          namespace_path = normalize_route_prefix(options.has_key?("path") ? options["path"] : name)
           stack << Frame.new(:namespace, path: namespace_path, controller_subdir: name) if opens_block
           next
         end
@@ -305,9 +305,9 @@ module Analyzer::Ruby
           if m = args.match(/^\s*:(\w+)/)
             scope_path = m[1]
           elsif m = args.match(/^\s*['"]([^'"]+)['"]/)
-            scope_path = m[1].lchop('/')
+            scope_path = normalize_route_prefix(m[1])
           elsif path_option = options["path"]?
-            scope_path = path_option.lchop('/')
+            scope_path = normalize_route_prefix(path_option)
           end
           controller_subdir = options["module"]? || ""
           controller_scope = options["controller"]?
@@ -463,13 +463,23 @@ module Analyzer::Ruby
           # `get :action` form inside member/collection/new blocks, inline
           # `on:` declarations, or directly nested in a resources block.
           if (am = rest.match(/^\s*:(\w+)\b/)) && (in_member || in_collection || in_new || parent_resources_frame(stack))
-            action = am[1]
-            url = custom_resource_action_url(stack, action, route_scope)
+            segment = am[1]
+            url = custom_resource_action_url(stack, segment, route_scope)
             if url
               parent = parent_resources_frame(stack)
-              action_params = parent ? params_for_action(parent.controller_path, action, verb) : ([] of Param)
+              ctrl_path = parent.try(&.controller_path)
+              action_name = controller_action_for_symbol_route(rest, segment)
+
+              if ctrl_action = parse_controller_action(rest, current_controller_scope(stack))
+                ctrl_name, parsed_action = ctrl_action
+                ctrl_path = find_controller_file(framework_root, ctrl_name, stack)
+                action_name = parsed_action
+              end
+
+              action_params = params_for_action(ctrl_path, action_name, verb)
+              action_params = promote_identifier_to_path(action_params) unless in_collection || in_new
               endpoint = Endpoint.new(url, verb, action_params, details)
-              attach_callees_for_action(endpoint, parent.try(&.controller_path), action)
+              attach_callees_for_action(endpoint, ctrl_path, action_name)
               @result << endpoint
             end
             next
@@ -1098,6 +1108,12 @@ module Analyzer::Ruby
       result
     end
 
+    private def normalize_route_prefix(path : String) : String
+      normalized = strip_optional_route_segments(path).lchop('/')
+      normalized = normalized.rchop('/') if normalized.size > 1 && normalized.ends_with?('/')
+      normalized
+    end
+
     private def parse_options(line : String) : Hash(String, String)
       result = {} of String => String
       value_pattern = "nil|['\"][^'\"]+['\"]|:[a-zA-Z_]\\w*|\\[[^\\]]*\\]|%i[\\[\\(][^\\]\\)]*[\\]\\)]|%w[\\[\\(][^\\]\\)]*[\\]\\)]"
@@ -1575,6 +1591,10 @@ module Analyzer::Ruby
         end
       end
       nil
+    end
+
+    private def controller_action_for_symbol_route(rest : String, fallback : String) : String
+      parse_options(rest)["action"]? || fallback
     end
 
     # Rails allows compact declarations such as `post "stories/preview"`


### PR DESCRIPTION
## Summary
- normalize optional route segments in Rails scope/namespace prefixes so paths like `scope "(/:locale)"` do not leak literal parentheses into endpoints
- resolve `get/delete :symbol` custom resource routes through `action:`/`to:` destinations before attaching params and callees
- promote member custom-route `id` params to path params, matching REST member endpoints

## Validation
- `just build`
- `just test`
- `just check`

## Sample app checks
- OpenFarm: bad Rails URLs `19 -> 0`
- Sharetribe: Rails bad URLs `477 -> 0`; remaining bad URLs were nginx/apache analyzer output, not Rails
- Huginn: `DELETE /agents/1/memory` now carries controller callees and `id` as a path param
