### PR TITLE
fix: align `build-release` with production build flags

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,9 +17,11 @@ build:
     shards build
 
 # Build noir binary with --release (slower compile, 2–3x faster runtime; use for benchmarks).
+# Uses the same flags as production release builds (Homebrew, GitHub releases, Docker, Snap)
+# so that local benchmark comparisons against the global binary are fair.
 [group('build')]
 build-release:
-    shards build --release
+    shards build --release --no-debug --production
 
 # Update shards.nix.
 [group('build')]


### PR DESCRIPTION
## Summary
`just build-release` (used by `just benchmark` / `just benchmark-full`) was using only `shards build --release`.

Production release artifacts are built with additional flags:
- Homebrew formula: `shards build --release --no-debug --production`
- GitHub release (macOS): `crystal build ... --no-debug --release`
- Docker / Snap: `--release --no-debug --production --static`

This caused the local `./bin/noir` in benchmarks to be ~2–3% slower than the globally installed `noir` binary (consistent observation on macOS), purely due to debug info and production dependency resolution differences.

## Change
Update `build-release` target (and by extension the `benchmark` targets) to use the same flags as the published binaries.

This makes local benchmark numbers directly comparable to the installed version and removes a source of noise when measuring code-level performance changes.

## Verification
- `just build-release` now produces a binary matching the optimization level of releases.
- `just benchmark` will use the updated target.
- No behavior change for debug `just build`.

See previous benchmark discussion for details.