### PR TITLE
perf: eliminate PCRE2 recompilation in regex-based JVM/Scala/C++/Ruby/Go/etc. analyzers

### DIFF
--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -26,6 +26,21 @@ module Analyzer::Cpp
 
     REGEX_REGISTER_HANDLER = /app\(\)\s*\.?\s*registerHandler(?:ViaRegex)?\s*\(\s*"([^"]+)"/
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The macro set is fixed, so precompile its
+    # matchers once; the method/class matchers interpolate discovered names
+    # and are memoized per name instead.
+    MACRO_CALL_PATTERNS = {
+      "METHOD_ADD"            => /\bMETHOD_ADD\s*\(/,
+      "ADD_METHOD_TO"         => /\bADD_METHOD_TO\s*\(/,
+      "ADD_METHOD_VIA_REGEX"  => /\bADD_METHOD_VIA_REGEX\s*\(/,
+      "PATH_ADD"              => /\bPATH_ADD\s*\(/,
+      "WS_PATH_ADD"           => /\bWS_PATH_ADD\s*\(/,
+      "WS_ADD_PATH_VIA_REGEX" => /\bWS_ADD_PATH_VIA_REGEX\s*\(/,
+    }
+    @method_def_regexes = Hash(String, Regex).new
+    @class_decl_regexes = Hash(String, Regex).new
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -218,7 +233,8 @@ module Analyzer::Cpp
     end
 
     private def each_macro_call(content : String, macro_name : String, &block : Array(String), Int32 ->)
-      content.scan(/\b#{macro_name}\s*\(/) do |match|
+      macro_regex = MACRO_CALL_PATTERNS[macro_name]? || /\b#{macro_name}\s*\(/
+      content.scan(macro_regex) do |match|
         call_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         open_paren = Noir::CppCalleeExtractor.find_next_code_char(content, '(', call_start)
         next unless open_paren
@@ -443,7 +459,8 @@ module Analyzer::Cpp
 
     private def extract_method_body_in_range(content : String, method_pattern : String, range : SourceRange) : Tuple(String, Int32)?
       range_start, range_end = range
-      content.scan(/\b#{method_pattern}\s*\(/) do |match|
+      method_regex = @method_def_regexes[method_pattern] ||= /\b#{method_pattern}\s*\(/
+      content.scan(method_regex) do |match|
         match_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         next if match_start < range_start || match_start >= range_end
         next if call_context?(content, match_start)
@@ -472,7 +489,8 @@ module Analyzer::Cpp
     end
 
     private def class_body_range(content : String, class_name : String) : SourceRange?
-      content.scan(/\b(?:class|struct)\s+#{Regex.escape(class_name)}\b/) do |match|
+      class_regex = @class_decl_regexes[class_name] ||= /\b(?:class|struct)\s+#{Regex.escape(class_name)}\b/
+      content.scan(class_regex) do |match|
         class_start = (content.char_index_to_byte_index(match.begin(0) || 0)) || 0
         open_brace = Noir::CppCalleeExtractor.find_next_code_char(content, '{', class_start)
         next unless open_brace

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -2,6 +2,13 @@ require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
   class Grip < CrystalEngine
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The verb set is fixed, so precompile the
+    # per-verb route matchers once at load time.
+    VERB_ROUTE_PATTERNS = %w[get post put patch delete options head].map do |method|
+      {method, /(?:^|[^.\w])#{method}\s+['"](.+?)['"]/}
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = [] of String
@@ -227,10 +234,10 @@ module Analyzer::Crystal
       scope_prefix = scopes.join("")
 
       # Match HTTP method calls: get "/path", Controller
-      %w[get post put patch delete options head].each do |method|
+      VERB_ROUTE_PATTERNS.each do |method, route_pattern|
         if content.includes?("#{method} ") && content.includes?("\"")
           # Require a token boundary so `input "/x"` isn't read as `put "/x"`.
-          if match = content.match(/(?:^|[^.\w])#{method}\s+['"](.+?)['"]/)
+          if match = content.match(route_pattern)
             path = normalize_crystal_interpolation(match[1])
             full_path = scope_prefix + path
             return Endpoint.new(full_path, method.upcase)

--- a/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_core_mvc.cr
@@ -7,6 +7,24 @@ module Analyzer::CSharp
 
     DEFAULT_ROUTE = "{controller=Home}/{action=Index}/{id?}"
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The `[FromX]` attribute set is fixed, so
+    # precompile its markers and strippers once at load time; the
+    # param-name regex interpolates a discovered name and is memoized.
+    FROM_ATTRIBUTE_PATTERNS = {
+      "FromQuery"         => "query",
+      "FromRoute"         => "path",
+      "FromBody"          => "json",
+      "FromHeader"        => "header",
+      "FromForm"          => "form",
+      "FromCookie"        => "cookie",
+      "FromServices"      => "service",
+      "FromKeyedServices" => "service",
+    }.map do |attr, type|
+      {"[#{attr}", /\[#{attr}[^\]]*\]/, type}
+    end
+    @param_name_strip_regexes = Hash(String, Regex).new
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       route_patterns_by_base = load_route_patterns_by_base
@@ -370,7 +388,8 @@ module Analyzer::CSharp
           # DbContext, a MediatR sender, …) is not request input — model
           # binding never produces one. Dropping it removes a recurring FP.
           if param_type.nil?
-            type_token = cleaned_def.sub(/\b#{Regex.escape(param_name)}\b\s*(?:=\s*[^,]+)?\s*$/, "").strip.split(/\s+/).last?
+            strip_regex = @param_name_strip_regexes[param_name] ||= /\b#{Regex.escape(param_name)}\b\s*(?:=\s*[^,]+)?\s*$/
+            type_token = cleaned_def.sub(strip_regex, "").strip.split(/\s+/).last?
             next if type_token && Common.csharp_service_type?(type_token)
           end
 
@@ -394,19 +413,10 @@ module Analyzer::CSharp
       param_type = nil
       cleaned = param_def.strip
 
-      {
-        "FromQuery"         => "query",
-        "FromRoute"         => "path",
-        "FromBody"          => "json",
-        "FromHeader"        => "header",
-        "FromForm"          => "form",
-        "FromCookie"        => "cookie",
-        "FromServices"      => "service",
-        "FromKeyedServices" => "service",
-      }.each do |attr, type|
-        if cleaned.includes?("[#{attr}")
+      FROM_ATTRIBUTE_PATTERNS.each do |marker, attr_regex, type|
+        if cleaned.includes?(marker)
           param_type = type
-          cleaned = cleaned.gsub(/\[#{attr}[^\]]*\]/, "")
+          cleaned = cleaned.gsub(attr_regex, "")
         end
       end
 

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -5,6 +5,13 @@ module Analyzer::CSharp
   class AspNetMvc < Analyzer
     include Common
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The attribute set is fixed, so precompile
+    # the route-extraction matchers once at load time.
+    ATTRIBUTE_ROUTE_PATTERNS = ["HttpGet", "HttpPost", "HttpPut", "HttpDelete", "HttpPatch", "Route"].to_h do |attribute|
+      {attribute, /\[#{attribute}[^(]*\(\s*"([^"]+)"/}
+    end
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       # Static Analysis
@@ -233,7 +240,8 @@ module Analyzer::CSharp
 
     private def extract_attribute_route(line : String, attribute : String) : String
       # Extract route from [HttpGet("route")] or [Route("route")]
-      match = line.match(/\[#{attribute}[^(]*\(\s*"([^"]+)"/)
+      attribute_regex = ATTRIBUTE_ROUTE_PATTERNS[attribute]? || /\[#{attribute}[^(]*\(\s*"([^"]+)"/
+      match = line.match(attribute_regex)
       return "" unless match
       match[1]
     end

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -582,8 +582,11 @@ module Analyzer::CSharp::MinimalApiSupport
   # Returns the member definitions (primary-constructor params or public
   # auto-properties) of a record/class/struct used with `[AsParameters]`.
   private def as_parameters_member_defs(type_name : String, lines : Array(String)) : Array(String)
+    # Hoisted out of the loop: an interpolated regex literal recompiles
+    # (PCRE2 JIT) on every evaluation, i.e. once per line.
+    type_decl_regex = /\b(?:record|class|struct)\s+#{Regex.escape(type_name)}\b/
     def_idx = lines.index do |l|
-      l.matches?(/\b(?:record|class|struct)\s+#{Regex.escape(type_name)}\b/)
+      l.includes?(type_name) && l.matches?(type_decl_regex)
     end
     return [] of String unless def_idx
 

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -34,6 +34,13 @@ module Analyzer::Dart
 
     FALLBACK_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile) — precompile the fixed verb probes once
+    # at load time instead of per handler file.
+    HTTP_METHOD_PATTERNS = HTTP_METHOD_MAP.map do |dart_name, verb|
+      {verb, /HttpMethod\.#{dart_name}\b/}
+    end
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       result = [] of Endpoint
@@ -170,10 +177,10 @@ module Analyzer::Dart
       cleaned = Helper.strip_comments(content)
 
       verbs = [] of String
-      HTTP_METHOD_MAP.each do |dart_name, verb|
+      HTTP_METHOD_PATTERNS.each do |verb, method_pattern|
         # Dart Frog exposes verbs as `HttpMethod.<lowercase>` constants.
         # Both `==` comparison and `case`/`switch` patterns reach here.
-        verbs << verb if cleaned.matches?(/HttpMethod\.#{dart_name}\b/)
+        verbs << verb if cleaned.matches?(method_pattern)
       end
       return FALLBACK_METHODS if verbs.empty?
 

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -25,6 +25,12 @@ module Analyzer::Dart
   # the parent router. Each top-level router (not mounted anywhere) is
   # emitted as a separate set of endpoints.
   class Shelf < Analyzer
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile); the router-variable matcher interpolates
+    # a discovered name (`router`, `app`, ...) that repeats across files,
+    # so memoize it per name.
+    @direct_call_regexes = Hash(String, Regex).new
+
     HTTP_METHOD_MAP = {
       "get"     => "GET",
       "post"    => "POST",
@@ -375,7 +381,7 @@ module Analyzer::Dart
                                   include_callee : Bool,
                                   routes : Array(Route),
                                   mounts : Array(Mount))
-      pattern = /(?<![\w$])#{Regex.escape(var_name)}\s*\.\s*([a-zA-Z_]\w*)\s*\(/
+      pattern = @direct_call_regexes[var_name] ||= /(?<![\w$])#{Regex.escape(var_name)}\s*\.\s*([a-zA-Z_]\w*)\s*\(/
       cleaned.scan(pattern) do |m|
         method = m[1]
         next unless relevant_method?(method)

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -20,6 +20,16 @@ module Analyzer::Fsharp
 
     FALLBACK_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). Both the stop-line matcher and the
+    # per-verb window probes interpolate only fixed patterns, so
+    # precompile them once at load time.
+    ROUTE_COMBINATOR      = /(?:route(?:Bind|Ci[fx]?|xp?|f)?|subRoute(?:Ci|f)?)\b/
+    ROUTE_HANDLER_STOP_RE = /\A(?:(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b.*\b#{ROUTE_COMBINATOR}|#{ROUTE_COMBINATOR})/
+    METHOD_WORD_PATTERNS  = HTTP_METHODS.map do |m|
+      {m, /\b#{m}\b/}
+    end
+
     # Mapping of routef format specifiers to noir path-param types.
     ROUTEF_PARAM_TYPES = {
       'i' => "int",
@@ -403,8 +413,7 @@ module Analyzer::Fsharp
       return true if stripped.starts_with?("]") || stripped.starts_with?(")")
       return true if stripped.match(/\A(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b\s*$/)
 
-      route_combinator = /(?:route(?:Bind|Ci[fx]?|xp?|f)?|subRoute(?:Ci|f)?)\b/
-      !!stripped.match(/\A(?:(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b.*\b#{route_combinator}|#{route_combinator})/)
+      !!stripped.match(ROUTE_HANDLER_STOP_RE)
     end
 
     private def line_start_for_offset(text : String, offset : Int32) : Int32
@@ -537,7 +546,7 @@ module Analyzer::Fsharp
       end
 
       window = collected.to_s
-      methods = HTTP_METHODS.select { |m| window.match(/\b#{m}\b/) }
+      methods = METHOD_WORD_PATTERNS.select { |_, pattern| window.match(pattern) }.map { |m, _| m }
       methods.first?
     end
 

--- a/src/analyzer/analyzers/go/beego.cr
+++ b/src/analyzer/analyzers/go/beego.cr
@@ -5,6 +5,14 @@ module Analyzer::Go
   class Beego < GoEngine
     IMPORT_MARKER = "github.com/beego/beego"
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile), and this fixed accessor set used to be
+    # rebuilt for every line — precompile it once at load time.
+    CONTEXT_GETTER_PATTERNS = ["GetString", "GetStrings", "GetInt", "GetInt8", "GetUint8", "GetInt16", "GetUint16", "GetInt32", "GetUint32",
+                               "GetInt64", "GetUint64", "GetBool", "GetFloat"].map do |pattern|
+      {pattern, /#{pattern}\("([^"]*)"\)/}
+    end
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -103,12 +111,12 @@ module Analyzer::Go
                         end
                       end
 
-                      ["GetString", "GetStrings", "GetInt", "GetInt8", "GetUint8", "GetInt16", "GetUint16", "GetInt32", "GetUint32",
-                       "GetInt64", "GetUint64", "GetBool", "GetFloat"].each do |pattern|
+                      CONTEXT_GETTER_PATTERNS.each do |pattern, getter_regex|
                         # Quote-bounded + scan so two accessor calls on one line
                         # each yield their own param (greedy `(.*)` captured across
                         # both, producing one garbage name).
-                        line.scan(/#{pattern}\("([^"]*)"\)/) do |m|
+                        next unless line.includes?(pattern)
+                        line.scan(getter_regex) do |m|
                           last_endpoint.params << Param.new(m[1], "", "query")
                         end
                       end

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -288,8 +288,12 @@ module Analyzer::Go
     end
 
     private def find_line_number(content : String, method_name : String) : Int32?
+      # Hoisted out of the loop: an interpolated regex literal recompiles
+      # (PCRE2 JIT) on every evaluation, i.e. once per line.
+      rpc_regex = /\brpc\s+#{Regex.escape(method_name)}\s*\(/
       content.each_line.with_index do |line, index|
-        if line =~ /\brpc\s+#{Regex.escape(method_name)}\s*\(/
+        next unless line.includes?(method_name)
+        if line =~ rpc_regex
           return index + 1
         end
       end

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -5,6 +5,13 @@ module Analyzer::Go
   class GoZero < GoEngine
     IMPORT_MARKER = "github.com/zeromicro/go-zero"
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The accessor set is fixed, so precompile
+    # the per-accessor matchers once at load time.
+    PARAM_ACCESSOR_PATTERNS = ["Query", "PostForm", "GetHeader", "PathParam", "FormValue"].to_h do |pattern|
+      {pattern, /#{Regex.escape(pattern)}\(\s*"([^"]+)"/}
+    end
+
     def analyze
       # Source Analysis
       public_dirs = [] of (Hash(String, String))
@@ -197,7 +204,8 @@ module Analyzer::Go
                    else                  "query"
                    end
 
-      if match = line.match(/#{Regex.escape(pattern)}\(\s*"([^"]+)"/)
+      accessor_regex = PARAM_ACCESSOR_PATTERNS[pattern]? || /#{Regex.escape(pattern)}\(\s*"([^"]+)"/
+      if match = line.match(accessor_regex)
         return Param.new(match[1], "", param_type)
       end
       Param.new("", "", "")

--- a/src/analyzer/analyzers/go/huma.cr
+++ b/src/analyzer/analyzers/go/huma.cr
@@ -20,6 +20,13 @@ module Analyzer::Go
       "cookie" => "cookie",
     }
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile) — precompile the fixed tag matchers once
+    # at load time instead of per struct field.
+    PARAM_TAG_PATTERNS = PARAM_TAG_KINDS.map do |go_tag, param_type|
+      {param_type, /#{go_tag}:"([^"]+)"/}
+    end
+
     # Huma v2's typed convenience helpers — `huma.Get(api, "/path",
     # handler)` and friends — register an operation without the verbose
     # `huma.Register(api, huma.Operation{...}, handler)` literal. The verb
@@ -383,8 +390,8 @@ module Analyzer::Go
         return
       end
 
-      PARAM_TAG_KINDS.each do |go_tag, param_type|
-        if match = tag.match(/#{go_tag}:"([^"]+)"/)
+      PARAM_TAG_PATTERNS.each do |param_type, tag_regex|
+        if match = tag.match(tag_regex)
           param = Param.new(match[1], "", param_type)
           endpoint.params << param unless endpoint.params.includes?(param)
           return

--- a/src/analyzer/analyzers/haskell/scotty.cr
+++ b/src/analyzer/analyzers/haskell/scotty.cr
@@ -237,8 +237,17 @@ module Analyzer::Haskell
       params
     end
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The probed token set is fixed, so
+    # precompile the matchers once at load time.
+    TOKEN_PATTERNS = {
+      "jsonData" => /(?<![A-Za-z0-9_'])jsonData(?![A-Za-z0-9_'])/,
+      "files"    => /(?<![A-Za-z0-9_'])files(?![A-Za-z0-9_'])/,
+    }
+
     private def mentions_token?(body : String, token : String) : Bool
-      !!body.match(/(?<![A-Za-z0-9_'])#{Regex.escape(token)}(?![A-Za-z0-9_'])/)
+      token_regex = TOKEN_PATTERNS[token]? || /(?<![A-Za-z0-9_'])#{Regex.escape(token)}(?![A-Za-z0-9_'])/
+      !!body.match(token_regex)
     end
 
     private def attach_callees(endpoint : Endpoint,

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -107,6 +107,13 @@ module Analyzer::Java
       "trace"   => "TRACE",
     }
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile) — precompile the fixed per-verb call
+    # matchers once at load time instead of per route expression.
+    ROUTE_VERB_CALL_PATTERNS = ROUTE_VERB_METHODS.map do |method_name, http_method|
+      {method_name, http_method, /\.\s*#{method_name}\s*\(([^)]*)\)/m}
+    end
+
     private def collect_builder_routes(server_codeblock : String,
                                        constants : Hash(String, String),
                                        details : Details)
@@ -134,8 +141,9 @@ module Analyzer::Java
                                               constants : Hash(String, String)) : Array(RouteEntry)
       routes = [] of RouteEntry
       direct_routes = [] of RouteEntry
-      ROUTE_VERB_METHODS.each do |method_name, http_method|
-        expr.scan(/\.\s*#{method_name}\s*\(([^)]*)\)/m) do |match|
+      ROUTE_VERB_CALL_PATTERNS.each do |method_name, http_method, verb_call_regex|
+        next unless expr.includes?(method_name)
+        expr.scan(verb_call_regex) do |match|
           if path = first_builder_path_arg(match[1], constants)
             direct_routes << {http_method, path}
           end

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -6,6 +6,26 @@ module Analyzer::Java
   class Jsp < Analyzer
     alias ServletClassKey = Tuple(String, String)
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The `doGet`/`doPost`/... probe set is
+    # fixed, so precompile it once at load time.
+    SERVLET_DO_METHOD_PATTERNS = {
+      "Get"     => "GET",
+      "Post"    => "POST",
+      "Put"     => "PUT",
+      "Delete"  => "DELETE",
+      "Patch"   => "PATCH",
+      "Head"    => "HEAD",
+      "Options" => "OPTIONS",
+    }.map do |suffix, method|
+      {method, /\bvoid\s+do#{suffix}\s*\(([^)]*)\)\s*(?:throws[^{]+)?\{/m}
+    end
+
+    # The request-access matchers interpolate a discovered receiver name, so
+    # they can't be hoisted — memoize them per receiver instead of rebuilding
+    # four regexes for every handler body.
+    @servlet_param_regexes = Hash(String, Tuple(Regex, Regex, Regex, Regex)).new
+
     def analyze
       servlet_methods = collect_servlet_methods
 
@@ -271,16 +291,8 @@ module Analyzer::Java
     private def extract_servlet_http_methods(content : String) : Hash(String, Array(Param))
       methods = Hash(String, Array(Param)).new
 
-      {
-        "Get"     => "GET",
-        "Post"    => "POST",
-        "Put"     => "PUT",
-        "Delete"  => "DELETE",
-        "Patch"   => "PATCH",
-        "Head"    => "HEAD",
-        "Options" => "OPTIONS",
-      }.each do |suffix, method|
-        if match = content.match(/\bvoid\s+do#{suffix}\s*\(([^)]*)\)\s*(?:throws[^{]+)?\{/m)
+      SERVLET_DO_METHOD_PATTERNS.each do |method, pattern|
+        if match = content.match(pattern)
           request_receivers = servlet_request_receivers(match[1])
           body = extract_balanced_block(content, (match.end(0) || 1) - 1)
           methods[method] = extract_servlet_params(body, method, request_receivers)
@@ -303,22 +315,28 @@ module Analyzer::Java
       request_param_type = method == "GET" ? "query" : "form"
 
       request_receivers.each do |receiver|
-        receiver_pattern = Regex.escape(receiver)
+        parameter_re, attribute_re, header_re, cookie_re = @servlet_param_regexes[receiver] ||= begin
+          receiver_pattern = Regex.escape(receiver)
+          {/#{receiver_pattern}\s*\.\s*get(?:Parameter|ParameterValues)\s*\(\s*["']([^"']+)["']\s*\)/,
+           /#{receiver_pattern}\s*\.\s*getAttribute\s*\(\s*["']([^"']+)["']\s*\)/,
+           /#{receiver_pattern}\s*\.\s*getHeaders?\s*\(\s*["']([^"']+)["']\s*\)/,
+           /#{receiver_pattern}\s*\.\s*getCookies\s*\(/}
+        end
 
-        content.scan(/#{receiver_pattern}\s*\.\s*get(?:Parameter|ParameterValues)\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+        content.scan(parameter_re) do |match|
           add_param(params, match[1], request_param_type)
         end
 
-        content.scan(/#{receiver_pattern}\s*\.\s*getAttribute\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+        content.scan(attribute_re) do |match|
           next if internal_servlet_attribute?(match[1])
           add_param(params, match[1], request_param_type)
         end
 
-        content.scan(/#{receiver_pattern}\s*\.\s*getHeaders?\s*\(\s*["']([^"']+)["']\s*\)/) do |match|
+        content.scan(header_re) do |match|
           add_param(params, match[1], "header")
         end
 
-        add_param(params, "", "cookie") if content.match(/#{receiver_pattern}\s*\.\s*getCookies\s*\(/)
+        add_param(params, "", "cookie") if content.match(cookie_re)
       end
 
       params

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -8,6 +8,14 @@ module Analyzer::Java
     alias ControllerMethod = NamedTuple(headers: Array(String), cookies: Array(String), body_type: String?, callees: Array(Callee))
     alias ScopedKey = Tuple(String, String)
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile), so the name/receiver-specific matchers
+    # below are memoized per interpolated value instead of being rebuilt
+    # for every controller method.
+    @action_name_regexes = Hash(String, Regex).new
+    @request_param_regexes = Hash(Tuple(String, Symbol), Regex).new
+    @body_type_regexes = Hash(String, Tuple(Regex, Regex, Regex, Regex)).new
+
     def analyze
       file_list = all_files()
       routes_files = [] of String
@@ -144,7 +152,8 @@ module Analyzer::Java
       return_type = play_action_return_type(method, content)
       return false unless play_action_return_type?(return_type)
 
-      !!method_source.match(/\b#{Regex.escape(method_name)}\s*\(/)
+      name_regex = @action_name_regexes[method_name] ||= /\b#{Regex.escape(method_name)}\s*\(/
+      !!method_source.match(name_regex)
     end
 
     private def play_action_return_type(method : LibTreeSitter::TSNode, content : String) : String
@@ -200,7 +209,8 @@ module Analyzer::Java
                        end
 
       request_receivers.each do |receiver|
-        method_body.scan(/#{receiver}\s*\.\s*#{method_pattern}\s*\(\s*([^),]+)\s*\)/) do |match|
+        receiver_regex = @request_param_regexes[{receiver, kind}] ||= /#{receiver}\s*\.\s*#{method_pattern}\s*\(\s*([^),]+)\s*\)/
+        method_body.scan(receiver_regex) do |match|
           next unless match.size > 1
           value = resolve_string_arg(match[1], constants)
           params << value if value && !params.includes?(value)
@@ -212,11 +222,17 @@ module Analyzer::Java
 
     private def extract_body_type(method_body : String, request_receivers : Array(String)) : String?
       request_receivers.each do |receiver|
-        body = /#{receiver}\s*\.\s*body\(\)\s*\.\s*/
-        return "json" if method_body.match(/#{body}(?:asJson|as\(\s*JsonNode)/)
-        return "form" if method_body.match(/#{body}(?:asFormUrlEncoded|asMultipartFormData)/)
-        return "xml" if method_body.match(/#{body}asXml/)
-        return "body" if method_body.match(/#{body}as(?:Text|Raw|Bytes)/)
+        json_re, form_re, xml_re, raw_re = @body_type_regexes[receiver] ||= begin
+          body = /#{receiver}\s*\.\s*body\(\)\s*\.\s*/
+          {/#{body}(?:asJson|as\(\s*JsonNode)/,
+           /#{body}(?:asFormUrlEncoded|asMultipartFormData)/,
+           /#{body}asXml/,
+           /#{body}as(?:Text|Raw|Bytes)/}
+        end
+        return "json" if method_body.match(json_re)
+        return "form" if method_body.match(form_re)
+        return "xml" if method_body.match(xml_re)
+        return "body" if method_body.match(raw_re)
       end
 
       nil

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -464,8 +464,17 @@ module Analyzer::Java
       end
     end
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). Only `@Param`/`@Header` are probed, so
+    # precompile their matchers once at load time.
+    ANNOTATION_VALUE_PATTERNS = {
+      "Param"  => /@Param\s*\(\s*(?:(?:value|name)\s*=\s*)?(["'][^"']+["'])\s*\)/m,
+      "Header" => /@Header\s*\(\s*(?:(?:value|name)\s*=\s*)?(["'][^"']+["'])\s*\)/m,
+    }
+
     private def annotation_string_value(arg : String, annotation_name : String) : String?
-      if match = arg.match(/@#{annotation_name}\s*\(\s*(?:(?:value|name)\s*=\s*)?(["'][^"']+["'])\s*\)/m)
+      annotation_regex = ANNOTATION_VALUE_PATTERNS[annotation_name]? || /@#{annotation_name}\s*\(\s*(?:(?:value|name)\s*=\s*)?(["'][^"']+["'])\s*\)/m
+      if match = arg.match(annotation_regex)
         string_literal_value(match[1])
       end
     end

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -539,13 +539,19 @@ module Analyzer::Java
       end
     end
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). Every caller probes the `value` key, so
+    # precompile its matcher once at load time.
+    VALUE_KEY_PATTERN = /(?:^|[,({]\s*)value\s*=\s*"((?:\\.|[^"\\])*)"/m
+
     private def string_annotation_value(args : String, key : String) : String?
       stripped = args.strip
       if stripped.starts_with?("\"")
         return unescape_java_string(stripped)
       end
 
-      if match = stripped.match(/(?:^|[,({]\s*)#{Regex.escape(key)}\s*=\s*"((?:\\.|[^"\\])*)"/m)
+      key_regex = key == "value" ? VALUE_KEY_PATTERN : /(?:^|[,({]\s*)#{Regex.escape(key)}\s*=\s*"((?:\\.|[^"\\])*)"/m
+      if match = stripped.match(key_regex)
         return unescape_java_string("\"#{match[1]}\"")
       end
 

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -25,6 +25,12 @@ module Analyzer::Lua
   # `app.path = "/prefix"` that every route inherits, so the prefix is
   # detected per file and prepended to the routes bound on that app.
   class Lapis < Analyzer
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile); the route matchers interpolate the
+    # discovered app-variable alternation, so memoize them per alternation.
+    @method_call_regexes = Hash(String, Regex).new
+    @match_call_regexes = Hash(String, Regex).new
+
     HTTP_METHODS     = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
     FALLBACK_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
     APP_VAR_RE       = /(?:^|[^A-Za-z0-9_])(?:local\s+)?([A-Za-z_]\w*)\s*=\s*lapis\.Application(?:\b|:extend|\s*\()/
@@ -162,7 +168,7 @@ module Analyzer::Lua
                                   app_vars : Array(String),
                                   app_paths : Hash(String, String))
       alt = app_var_alternation(app_vars)
-      pattern = /\b(#{alt})\s*[:.]\s*(get|post|put|delete|patch|head|options)\s*\(?\s*(['"])([^'"]*)\3(?:\s*,\s*(['"])([^'"]*)\5)?/
+      pattern = @method_call_regexes[alt] ||= /\b(#{alt})\s*[:.]\s*(get|post|put|delete|patch|head|options)\s*\(?\s*(['"])([^'"]*)\3(?:\s*,\s*(['"])([^'"]*)\5)?/
       cleaned.scan(pattern) do |match|
         var = match[1]
         verb = match[2].upcase
@@ -205,7 +211,7 @@ module Analyzer::Lua
                                  app_vars : Array(String),
                                  app_paths : Hash(String, String))
       alt = app_var_alternation(app_vars)
-      pattern = /\b(#{alt})\s*[:.]\s*match\s*\(?\s*(['"])([^'"]*)\2(?:\s*,\s*(['"])([^'"]*)\4)?/
+      pattern = @match_call_regexes[alt] ||= /\b(#{alt})\s*[:.]\s*match\s*\(?\s*(['"])([^'"]*)\2(?:\s*,\s*(['"])([^'"]*)\4)?/
       cleaned.scan(pattern) do |match|
         var = match[1]
         first = match[3]

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -406,8 +406,17 @@ module Analyzer::Perl
       end
     end
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). Only `controller` and `action` are looked
+    # up, so precompile their matchers once at load time.
+    NAMED_TO_ARG_PATTERNS = {
+      "controller" => /(?:^|[,\s])controller\s*=>\s*['"]([A-Za-z_][A-Za-z0-9_:\/-]*)['"]/,
+      "action"     => /(?:^|[,\s])action\s*=>\s*['"]([A-Za-z_][A-Za-z0-9_:\/-]*)['"]/,
+    }
+
     private def named_to_arg(args : String, name : String) : String?
-      if match = args.match(/(?:^|[,\s])#{name}\s*=>\s*['"]([A-Za-z_][A-Za-z0-9_:\/-]*)['"]/)
+      name_regex = NAMED_TO_ARG_PATTERNS[name]? || /(?:^|[,\s])#{name}\s*=>\s*['"]([A-Za-z_][A-Za-z0-9_:\/-]*)['"]/
+      if match = args.match(name_regex)
         match[1]
       end
     end

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -2,6 +2,8 @@ require "../../engines/php_engine"
 
 module Analyzer::Php
   class CakePHP < PhpEngine
+    @method_def_regexes = Hash(String, Regex).new
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
@@ -286,7 +288,10 @@ module Analyzer::Php
       return unless controller_path && File.exists?(controller_path)
 
       content = read_file_content(controller_path)
-      method_match = content.match(/(?:public|protected|private)\s+(?:static\s+)?function\s+#{action_name}\s*\(/)
+      # Memoized: an interpolated regex literal recompiles (PCRE2 JIT) on
+      # every evaluation, and action names repeat across controllers.
+      method_regex = @method_def_regexes[action_name] ||= /(?:public|protected|private)\s+(?:static\s+)?function\s+#{action_name}\s*\(/
+      method_match = content.match(method_regex)
       return unless method_match
 
       method_body = extract_php_method_body_after(content, method_match.begin(0))

--- a/src/analyzer/analyzers/php/codeigniter.cr
+++ b/src/analyzer/analyzers/php/codeigniter.cr
@@ -2,6 +2,8 @@ require "../../engines/php_engine"
 
 module Analyzer::Php
   class CodeIgniter < PhpEngine
+    @method_def_regexes = Hash(String, Regex).new
+
     # CI4 placeholders → param names. CI3 uses the same shapes.
     PLACEHOLDER_MAP = {
       "any"      => "any",
@@ -178,7 +180,10 @@ module Analyzer::Php
       return unless controller_path && File.exists?(controller_path)
 
       content = read_file_content(controller_path)
-      method_match = content.match(/(?:public|protected|private)\s+function\s+#{action_name}\s*\(/)
+      # Memoized: an interpolated regex literal recompiles (PCRE2 JIT) on
+      # every evaluation, and action names repeat across controllers.
+      method_regex = @method_def_regexes[action_name] ||= /(?:public|protected|private)\s+function\s+#{action_name}\s*\(/
+      method_match = content.match(method_regex)
       return unless method_match
 
       method_body = extract_php_method_body_after(content, method_match.begin(0))

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -3,6 +3,8 @@ require "../../../minilexers/php_lexer"
 
 module Analyzer::Php
   class Laravel < PhpEngine
+    @method_def_regexes = Hash(String, Regex).new
+
     private struct RouteGroup
       getter prefix, body, body_start, body_end
 
@@ -385,7 +387,10 @@ module Analyzer::Php
       return unless controller_path && File.exists?(controller_path)
 
       content = read_file_content(controller_path)
-      method_match = content.match(/(?:public|protected|private)\s+(?:static\s+)?function\s+#{Regex.escape(method_name)}\s*\(/)
+      # Memoized: an interpolated regex literal recompiles (PCRE2 JIT) on
+      # every evaluation, and action names repeat across controllers.
+      method_regex = @method_def_regexes[method_name] ||= /(?:public|protected|private)\s+(?:static\s+)?function\s+#{Regex.escape(method_name)}\s*\(/
+      method_match = content.match(method_regex)
       return unless method_match
 
       body_info = extract_php_method_body_after(content, method_match.begin(0))

--- a/src/analyzer/analyzers/php/thinkphp.cr
+++ b/src/analyzer/analyzers/php/thinkphp.cr
@@ -4,6 +4,8 @@ module Analyzer::Php
   class ThinkPHP < PhpEngine
     ALL_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
 
+    @method_def_regexes = Hash(String, Regex).new
+
     private struct RouteGroup
       getter prefix, body, body_start, body_end
 
@@ -321,7 +323,10 @@ module Analyzer::Php
       return unless controller_path && File.exists?(controller_path)
 
       content = read_file_content(controller_path)
-      method_match = content.match(/(?:public|protected|private)\s+(?:static\s+)?function\s+#{Regex.escape(method_name)}\s*\(/)
+      # Memoized: an interpolated regex literal recompiles (PCRE2 JIT) on
+      # every evaluation, and action names repeat across controllers.
+      method_regex = @method_def_regexes[method_name] ||= /(?:public|protected|private)\s+(?:static\s+)?function\s+#{Regex.escape(method_name)}\s*\(/
+      method_match = content.match(method_regex)
       return unless method_match
 
       body_info = extract_php_method_body_after(content, method_match.begin(0))

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -4,6 +4,13 @@ module Analyzer::Ruby
   class Hanami < RubyEngine
     HANAMI_HTTP_VERBS = HTTP_VERBS + ["trace"]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The verb set is fixed, so precompile the
+    # per-verb route matchers once at load time.
+    HANAMI_VERB_PATTERNS = HANAMI_HTTP_VERBS.map do |verb|
+      {verb, /^#{verb}\s*\(?\s*['"]([^'"]*)['"](.*)$/}
+    end
+
     struct RouteFrame
       property path, slice, action_prefix
 
@@ -164,11 +171,11 @@ module Analyzer::Ruby
     end
 
     private def verb_endpoint(line : String, stack : Array(RouteFrame), details : Details) : RouteEndpoint?
-      HANAMI_HTTP_VERBS.each do |verb|
+      HANAMI_VERB_PATTERNS.each do |verb, verb_pattern|
         next unless line.starts_with?(verb)
         next if line.size > verb.size && (line[verb.size].alphanumeric? || line[verb.size] == '_')
 
-        if m = line.match(/^#{verb}\s*\(?\s*['"]([^'"]*)['"](.*)$/)
+        if m = line.match(verb_pattern)
           endpoint = Endpoint.new(join_paths(current_path_prefix(stack), normalize_route_path(m[1])), verb.upcase, details)
           return RouteEndpoint.new(endpoint, extract_action_target(m[2]))
         end
@@ -539,11 +546,14 @@ module Analyzer::Ruby
 
     private def extract_action_body(lines : Array(String), names : Array(String)) : Tuple(String, Int32)?
       index = 0
+      # Hoisted out of the loop: an interpolated regex literal recompiles
+      # (PCRE2 JIT) on every evaluation, i.e. once per line.
+      name_pattern = names.join("|")
+      def_regex = /^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?(?:#{name_pattern})\b/
 
       while index < lines.size
         stripped = Noir::RubyCalleeExtractor.strip_comment(lines[index]).strip
-        name_pattern = names.join("|")
-        if match = stripped.match(/^(?:private\s+|protected\s+|public\s+)?def\s+(?:self\.)?(?:#{name_pattern})\b/)
+        if match = stripped.match(def_regex)
           inline_body, closed_on_def_line = inline_def_body(stripped, match[0])
           body_lines = [] of String
           body_start_line = inline_body ? index + 1 : index + 2

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -4,6 +4,21 @@ module Analyzer::Scala
   class Akka < ScalaEngine
     HTTP_METHODS = %w[get post put delete patch head options]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). `directive_args` runs twice per source
+    # line and the method matchers run once per HTTP verb per route, so
+    # precompile the fixed sets once at load time.
+    DIRECTIVE_ARGS_PATTERNS = {
+      "pathPrefix" => /(?<![.\w])pathPrefix\s*\(([^)]*)\)/,
+      "path"       => /(?<![.\w])path\s*\(([^)]*)\)/,
+    }
+    METHOD_BLOCK_PATTERNS = HTTP_METHODS.to_h do |method|
+      {method, /(?<![.\w])#{Regex.escape(method)}\s*\{/}
+    end
+    METHOD_SCOPE_PATTERNS = HTTP_METHODS.to_h do |method|
+      {method, /(?<![.\w])#{Regex.escape(method)}(?![\w])/}
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
@@ -126,10 +141,11 @@ module Analyzer::Scala
                                       method : String) : Array(Tuple(String, Int32))
       blocks = [] of Tuple(String, Int32)
       index = route_start
+      method_regex = METHOD_BLOCK_PATTERNS[method]? || /(?<![.\w])#{Regex.escape(method)}\s*\{/
 
       while index <= route_end
         stripped = structural_lines[index]? || ""
-        match = stripped.match(/(?<![.\w])#{Regex.escape(method)}\s*\{/)
+        match = stripped.includes?(method) ? stripped.match(method_regex) : nil
         unless match
           index += 1
           next
@@ -214,7 +230,9 @@ module Analyzer::Scala
     end
 
     private def directive_args(line : String, directive : String) : String?
-      match = line.match(/(?<![.\w])#{Regex.escape(directive)}\s*\(([^)]*)\)/)
+      return unless line.includes?(directive)
+      regex = DIRECTIVE_ARGS_PATTERNS[directive]? || /(?<![.\w])#{Regex.escape(directive)}\s*\(([^)]*)\)/
+      match = line.match(regex)
       return unless match
 
       match[1]
@@ -222,7 +240,7 @@ module Analyzer::Scala
 
     private def extract_method_param_scopes(content : String, method : String) : Array(String)
       scopes = [] of String
-      regex = /(?<![.\w])#{Regex.escape(method)}(?![\w])/
+      regex = METHOD_SCOPE_PATTERNS[method]? || /(?<![.\w])#{Regex.escape(method)}(?![\w])/
       search_from = 0
 
       while match = content.match(regex, search_from)

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -4,6 +4,11 @@ module Analyzer::Scala
   class Http4s < ScalaEngine
     HTTP_METHODS = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile); the body-type matcher interpolates a
+    # discovered binding name, so memoize it per name instead.
+    @body_as_regexes = Hash(String, Regex).new
+
     def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
@@ -36,7 +41,8 @@ module Analyzer::Scala
             body_text = extract_case_body(lines, code_lines, end_index)
             body_type : String? = nil
             if binding_name
-              if body_match = body_text.match(/#{Regex.escape(binding_name)}\s*\.\s*as\s*\[\s*([^\]\s]+)\s*\]/)
+              body_as_regex = @body_as_regexes[binding_name] ||= /#{Regex.escape(binding_name)}\s*\.\s*as\s*\[\s*([^\]\s]+)\s*\]/
+              if body_match = body_text.match(body_as_regex)
                 body_type = body_match[1]
               end
             end

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -8,6 +8,12 @@ module Analyzer::Scala
     alias ScopedKey = Tuple(String, String)
     alias MethodRegion = NamedTuple(signature: String, body: String, body_start: Int32)
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile); the `def <name>` matcher interpolates a
+    # discovered method name, so memoize it per name instead of rebuilding
+    # it for every action lookup.
+    @method_def_regexes = Hash(String, Regex).new
+
     def analyze
       file_list = all_files()
       routes_files = [] of String
@@ -200,7 +206,8 @@ module Analyzer::Scala
     # action-builder wrapper (`Action`, `Open`, `Auth`, custom builders) so it
     # is not reported as a callee, matching brace-style behavior.
     private def extract_method_body(structure : String, source : String, method_name : String) : MethodRegion?
-      match = structure.match(/\bdef\s+#{Regex.escape(method_name)}(?![A-Za-z0-9_$])/)
+      method_def_regex = @method_def_regexes[method_name] ||= /\bdef\s+#{Regex.escape(method_name)}(?![A-Za-z0-9_$])/
+      match = structure.match(method_def_regex)
       return unless match
       def_start = match.begin(0) || 0
       cursor = match.end(0)
@@ -745,10 +752,14 @@ module Analyzer::Scala
       candidates = @scala_paths.select { |path| configured_base_for(path) == including_base }
       candidates = @scala_paths if candidates.empty?
 
+      # Hoisted out of the loop: an interpolated regex literal recompiles
+      # (PCRE2 JIT) on every evaluation, i.e. once per candidate file.
+      class_decl_regex = /\b(?:class|object|trait)\s+#{Regex.escape(class_name)}\b/
+
       candidates.each do |path|
         next unless File.basename(path) == filename
         content = read_file_content(path)
-        next unless content.match(/\b(?:class|object|trait)\s+#{Regex.escape(class_name)}\b/)
+        next unless content.match(class_decl_regex)
         next unless content.includes?("SimpleRouter") ||
                     content.includes?("Router.from") ||
                     content.includes?("routing.sird") ||

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -4,6 +4,13 @@ module Analyzer::Scala
   class Scalatra < ScalaEngine
     HTTP_METHODS = %w[get post put delete patch head options]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile), and this matcher used to be rebuilt for
+    # every verb on every line — precompile the fixed set once at load time.
+    ROUTE_PATTERNS = HTTP_METHODS.map do |method|
+      {method, /(?<![.\w])#{method}\s*\(\s*"([^"]+)"/}
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       content = File.read(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
@@ -19,10 +26,11 @@ module Analyzer::Scala
         stripped_line = (code_lines[index]? || "").strip
 
         # Match Scalatra route definitions: get("/path") { ... }
-        HTTP_METHODS.each do |method|
+        ROUTE_PATTERNS.each do |method, route_pattern|
           # Match: get("/users/:id") { ... } and get("/users", operation(...)) { ... }
           # Ensure it's not a method call on an object (e.g., cookies.get)
-          if route_match = stripped_line.match(/(?<![.\w])#{method}\s*\(\s*"([^"]+)"/)
+          next unless stripped_line.includes?(method)
+          if route_match = stripped_line.match(route_pattern)
             route_path = route_match[1]
             # Only process if it looks like a URL path (starts with /)
             next unless route_path.starts_with?("/")

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -4,6 +4,13 @@ module Analyzer::Scala
   class Tapir < ScalaEngine
     HTTP_METHODS = %w[get post put delete patch head options connect trace]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile) — precompile the fixed per-verb matchers
+    # once at load time instead of per chain.
+    METHOD_CALL_PATTERNS = HTTP_METHODS.map do |m|
+      {m, /\.#{m}\b/}
+    end
+
     BASE_ENDPOINT_RE = /(?<![.\w])(?:[A-Za-z_]\w*[Ee]ndpoint|endpoint|infallibleEndpoint)\b/
 
     # Type token allows one level of nested brackets (e.g. Option[String], List[User]).
@@ -79,8 +86,8 @@ module Analyzer::Scala
     end
 
     private def detect_method(chain : String) : String?
-      HTTP_METHODS.each do |m|
-        return m if chain.matches?(/\.#{m}\b/)
+      METHOD_CALL_PATTERNS.each do |m, pattern|
+        return m if chain.matches?(pattern)
       end
 
       if mm = chain.match(/\.method\s*\(\s*Method\.([A-Z]+)\s*\)/)

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -272,8 +272,12 @@ module Analyzer::Specification
     end
 
     private def find_line_number(content : String, method_name : String) : Int32?
+      # Hoisted out of the loop: an interpolated regex literal recompiles
+      # (PCRE2 JIT) on every evaluation, i.e. once per line.
+      rpc_regex = /\brpc\s+#{Regex.escape(method_name)}\s*\(/
       content.each_line.with_index do |line, index|
-        if line =~ /\brpc\s+#{Regex.escape(method_name)}\s*\(/
+        next unless line.includes?(method_name)
+        if line =~ rpc_regex
           return index + 1
         end
       end

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -158,6 +158,12 @@ module Analyzer::Go
 
     GO_HTTP_ROUTE_CALL_RE = /\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|Get|Post|Put|Delete|Patch|Head|Options|ANY|Any|All)\s*\(/
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile); the per-framework extra route methods are
+    # a small fixed set per analyzer, so memoize their matchers per name
+    # instead of rebuilding them for every candidate file.
+    @extra_method_regexes = Hash(String, Regex).new
+
     # Per-package directories that import a target framework. Some real
     # projects hide the concrete framework type behind a local interface, so
     # the file that calls `router.GET(...)` may not import Gin/Echo itself.
@@ -175,7 +181,8 @@ module Analyzer::Go
     def go_route_source_candidate?(content : String, extra_methods : Array(String)) : Bool
       return true if content.matches?(GO_HTTP_ROUTE_CALL_RE)
       extra_methods.any? do |method|
-        content.matches?(/\.#{Regex.escape(method)}\s*\(/)
+        method_regex = @extra_method_regexes[method] ||= /\.#{Regex.escape(method)}\s*\(/
+        content.matches?(method_regex)
       end
     end
 

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -159,11 +159,21 @@ module Analyzer::Python
     def find_json_params(codeblock_lines : Array(::String), json_var_names : Array(::String)) : Array(Param)
       params = [] of Param
 
+      # Hoisted out of the per-line loop: an interpolated regex literal
+      # recompiles (PCRE2 JIT) on every evaluation, i.e. twice per line
+      # per JSON variable.
+      var_patterns = json_var_names.map do |json_var_name|
+        {json_var_name,
+         /[^a-zA-Z_]#{json_var_name}\[[rf]?['"]([^'"]*)['"]\]/,
+         /[^a-zA-Z_]#{json_var_name}\.get\([rf]?['"]([^'"]*)['"]/}
+      end
+
       codeblock_lines.each do |codeblock_line|
-        json_var_names.each do |json_var_name|
-          matches = codeblock_line.scan(/[^a-zA-Z_]#{json_var_name}\[[rf]?['"]([^'"]*)['"]\]/)
+        var_patterns.each do |json_var_name, subscript_regex, get_regex|
+          next unless codeblock_line.includes?(json_var_name)
+          matches = codeblock_line.scan(subscript_regex)
           if matches.size == 0
-            matches = codeblock_line.scan(/[^a-zA-Z_]#{json_var_name}\.get\([rf]?['"]([^'"]*)['"]/)
+            matches = codeblock_line.scan(get_regex)
           end
 
           if !matches.nil?

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -5,6 +5,13 @@ module Analyzer::Ruby
   abstract class RubyEngine < Analyzer
     HTTP_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
+    # Crystal recompiles an interpolated regex literal on every evaluation
+    # (a full PCRE2 JIT compile). The verb set is fixed, so precompile the
+    # `<verb> "<path>"` matchers once at load time.
+    VERB_ROUTE_PATTERNS = HTTP_VERBS.map do |verb|
+      {verb, /^#{verb}\s*\(?\s*['"](.+?)['"]/}
+    end
+
     # Minitest's `*_test.rb` and RSpec's `*_spec.rb` conventions are
     # rigid in Ruby — `rake test` / `mri test` only run files matching
     # the first, and `rspec` discovers the second. Production Ruby
@@ -43,11 +50,11 @@ module Analyzer::Ruby
       # start (possibly after a block opener), so this is a tight
       # constraint without false-negatives in the bundled fixtures.
       leading = content.lstrip
-      HTTP_VERBS.each do |verb|
+      VERB_ROUTE_PATTERNS.each do |verb, verb_pattern|
         next if !leading.starts_with?(verb)
         next if leading.size > verb.size && (leading[verb.size].alphanumeric? || leading[verb.size] == '_')
 
-        if m = leading.match(/^#{verb}\s*\(?\s*['"](.+?)['"]/)
+        if m = leading.match(verb_pattern)
           path = normalize_ruby_interpolation(m[1])
           if details
             return Endpoint.new(path, verb.upcase, details)


### PR DESCRIPTION
Crystal recompiles an interpolated regex literal (`/...#{x}.../`) on every
evaluation — a full PCRE2 JIT compile — and the non-Python, non-JS
regex-based analyzers were rebuilding the same patterns per line, per
route, or per HTTP verb. Apply the recipe from #1957/#1960 across the
remaining analyzers:

1. Fixed-set interpolations (HTTP verbs, servlet `do<Method>` probes,
   accessor/attribute/tag names) hoisted to class constants compiled once
   at load time: scala/{scalatra,akka,tapir}, java/{jsp,armeria,quarkus,
   struts2}, go/{beego,gozero,huma}, csharp/{aspnet_core_mvc,aspnet_mvc},
   fsharp/giraffe, ruby/hanami, engines/ruby_engine, haskell/scotty,
   perl/mojolicious, crystal/grip, dart/dart_frog, cpp/drogon macros.
2. Per-line loops that interpolated a name compiled once per call and
   gated behind a cheap substring guard: go/connect_rpc and
   specification/grpc `find_line_number`, ruby/hanami
   `extract_action_body`, csharp/minimal_api_support
   `as_parameters_member_defs`, scala/play SIRD candidate loop,
   engines/python_engine `find_json_params`.
3. Matchers interpolating discovered receiver/var/method names memoized
   per name: java/play (action names, request receivers, body probes),
   java/jsp servlet receivers, scala/play `def` matcher, scala/http4s
   binding `.as[T]`, cpp/drogon method/class lookups, php/{laravel,
   thinkphp,codeigniter,cakephp} controller actions, dart/shelf router
   vars, lua/lapis app-var alternations, engines/go_engine extra route
   methods.

Verification (release builds, 3-run best):

- Output is byte-identical to the previous binary across all 190
  fixtures of the touched languages (sorted endpoint-set diff empty).
- Full spec suite green: 20,948 examples, 0 failures.
- Synthetic high-volume scans (100 files x 50-100 routes per framework):
  scalatra 4.51s -> 0.20s (23x), akka 1.13s -> 0.18s (6.1x), beego
  2.52s -> 0.42s (6.1x), hanami 1.8x, java/play 1.8x, jsp 1.3x.
- perf profiles: libpcre2 share of samples drops from 71%/69%/72%
  (scalatra/beego/akka) to 16%/5%/19%, and what remains is match work —
  `pcre2_compile_8` itself falls to ~0.35%.

Closes #1962

https://claude.ai/code/session_01HsZiKUwbrrVjped496uHTi