### PR TITLE
feat(llm): add claude-fable-5 and claude-mythos-5 token limits

### DIFF
--- a/spec/unit_test/llm/prompt_spec.cr
+++ b/spec/unit_test/llm/prompt_spec.cr
@@ -188,6 +188,14 @@ describe LLM do
         anthropic["claude-opus-4-8"].should eq(1000000)
       end
 
+      it "includes claude-fable-5 with 1000000 tokens" do
+        anthropic["claude-fable-5"].should eq(1000000)
+      end
+
+      it "includes claude-mythos-5 with 1000000 tokens" do
+        anthropic["claude-mythos-5"].should eq(1000000)
+      end
+
       it "has default of 100000" do
         anthropic["default"].should eq(100000)
       end

--- a/src/llm/prompt.cr
+++ b/src/llm/prompt.cr
@@ -404,6 +404,8 @@ module LLM
       "claude-opus-4-6"    => 200000,
       "claude-opus-4-7"    => 200000,
       "claude-opus-4-8"    => 1000000,
+      "claude-fable-5"     => 1000000,
+      "claude-mythos-5"    => 1000000,
       "default"            => 100000,
     },
     "azure" => {


### PR DESCRIPTION
Adds support for the newly released Claude models in the Anthropic provider token limit map used for AI-powered endpoint analysis bundling.

### Changes
- `src/llm/prompt.cr`: Add `claude-fable-5` and `claude-mythos-5` (both 1,000,000 token context) under the `anthropic` provider in `MODEL_TOKEN_LIMITS`.
- `spec/unit_test/llm/prompt_spec.cr`: Add unit tests asserting the new entries.

### Context
- Per Anthropic's model overview (https://platform.claude.com/docs/en/about-claude/models/overview) and the launch post, both models ship with a 1M token context window (and 128k max output).
- `claude-fable-5` is the most capable widely released model.
- `claude-mythos-5` is the high-capability configuration available via Project Glasswing.

### Verification
- `just build` ✓
- `just test` (all 20k+ examples) ✓
- `crystal tool format` ✓
- Basic functional smoke test on Crystal fixtures ✓

Users can now use `--ai-provider anthropic --ai-model claude-fable-5` (or `claude-mythos-5`) without hitting the unknown-model warning and the conservative default token budget.