### PR TITLE
Optimize regex compilation in Python framework analyzers

### DIFF
--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -28,6 +28,26 @@ module Analyzer::Python
 
     BARE_DECORATORS = %w[route get post put delete patch head options]
 
+    # Per-line matchers, hoisted so they compile once: an interpolated
+    # regex literal recompiles (PCRE2 JIT) on every evaluation, and the
+    # bare-decorator patterns ran per decorator name on every source
+    # line. The `.to_s` expansion is byte-identical to the previous
+    # inline form, so matching behaviour is unchanged.
+    # Tuple shape: {deco_name, "@deco" guard, bare_re, original_line_re, keyword_path_re}
+    BARE_DECORATOR_PATTERNS = BARE_DECORATORS.map do |deco_name|
+      {deco_name,
+       "@#{deco_name}",
+       /^@#{deco_name}\([rf]?['"]([^'"]*)['"](.*)/,
+       /@#{deco_name}\s*\(\s*[rf]?['"]([^'"]*)['"]/,
+       /^\s*@#{deco_name}\s*\([^)]*\b(?:path|rule|uri)\s*=\s*[rf]?['"]([^'"]*)['"]/m}
+    end
+    PROGRAMMATIC_ROUTE_RE = /\b(#{PYTHON_VAR_NAME_REGEX})\.route\s*\((.*)\)\s*$/m
+    BOTTLE_INSTANCE_RE    = /^(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:bottle\.)?Bottle\(/
+    MOUNT_RE              = /\b(#{PYTHON_VAR_NAME_REGEX})\.mount\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})/
+
+    @keyword_regex_cache = Hash(::String, Regex).new
+    @json_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
     def analyze
       # Pulls from the detector-built file_map so subtree pruning and
       # --exclude-path apply to this pass too.
@@ -71,35 +91,41 @@ module Analyzer::Python
             lines.each_with_index do |line, line_index|
               effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
               stripped = effective_line.gsub(" ", "")
-              BARE_DECORATORS.each do |deco_name|
-                # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
-                if bare_match = stripped.match(/^@#{deco_name}\([rf]?['"]([^'"]*)['"](.*)/)
-                  # Recover spaces in path via the original line.
-                  path_value = bare_match[1]
-                  if orig_match = effective_line.match(/@#{deco_name}\s*\(\s*[rf]?['"]([^'"]*)['"]/)
-                    path_value = orig_match[1]
+              # `@deco` (contiguous in the source by both regex shapes) is a
+              # necessary condition for either match, so non-decorator lines
+              # skip the regex work entirely.
+              if stripped.includes?('@')
+                BARE_DECORATOR_PATTERNS.each do |deco_name, deco_guard, bare_re, orig_re, kw_re|
+                  next unless stripped.includes?(deco_guard)
+                  # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
+                  if bare_match = stripped.match(bare_re)
+                    # Recover spaces in path via the original line.
+                    path_value = bare_match[1]
+                    if orig_match = effective_line.match(orig_re)
+                      path_value = orig_match[1]
+                    end
+                    extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
+                    process_route(
+                      path,
+                      lines,
+                      line_index,
+                      path_value,
+                      extra,
+                      definition_base_path: current_base_path,
+                      source: file_content
+                    )
+                  elsif kw_path_match = effective_line.match(kw_re)
+                    extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
+                    process_route(
+                      path,
+                      lines,
+                      line_index,
+                      kw_path_match[1],
+                      extra,
+                      definition_base_path: current_base_path,
+                      source: file_content
+                    )
                   end
-                  extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
-                  process_route(
-                    path,
-                    lines,
-                    line_index,
-                    path_value,
-                    extra,
-                    definition_base_path: current_base_path,
-                    source: file_content
-                  )
-                elsif kw_path_match = effective_line.match(/^\s*@#{deco_name}\s*\([^)]*\b(?:path|rule|uri)\s*=\s*[rf]?['"]([^'"]*)['"]/m)
-                  extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
-                  process_route(
-                    path,
-                    lines,
-                    line_index,
-                    kw_path_match[1],
-                    extra,
-                    definition_base_path: current_base_path,
-                    source: file_content
-                  )
                 end
               end
 
@@ -130,7 +156,7 @@ module Analyzer::Python
                                            *,
                                            definition_base_path : String,
                                            source : String)
-      route_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.route\s*\((.*)\)\s*$/m)
+      route_match = line.match(PROGRAMMATIC_ROUTE_RE)
       return unless route_match
 
       receiver = route_match[1]
@@ -166,14 +192,14 @@ module Analyzer::Python
 
       lines.each_with_index do |line, index|
         stripped = line.gsub(" ", "")
-        if instance_match = stripped.match(/^(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:bottle\.)?Bottle\(/)
+        if stripped.includes?("Bottle(") && (instance_match = stripped.match(BOTTLE_INSTANCE_RE))
           prefixes[instance_match[1]] ||= [""]
         end
 
         next unless line.includes?(".mount(")
 
         effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
-        effective_line.scan(/\b(#{PYTHON_VAR_NAME_REGEX})\.mount\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})/) do |mount_match|
+        effective_line.scan(MOUNT_RE) do |mount_match|
           next if mount_match.size < 4
           parent_router = mount_match[1]
           prefix = mount_match[2]
@@ -381,9 +407,16 @@ module Analyzer::Python
       parts
     end
 
+    # Memoized per keyword — the keyword set is tiny (`path`, `rule`,
+    # `uri`) but this runs per argument of every programmatic route.
+    private def keyword_string_regex(keyword : String) : Regex
+      @keyword_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
+    end
+
     private def extract_keyword_string(args : Array(String), keyword : String) : String?
+      keyword_re = keyword_string_regex(keyword)
       args.each do |arg|
-        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        keyword_match = arg.match(keyword_re)
         next unless keyword_match
 
         return extract_python_string(keyword_match[1])
@@ -456,6 +489,25 @@ module Analyzer::Python
     # Attribute names on accessor objects that are not user parameters.
     DICT_METHOD_NAMES = Set{"get", "getall", "getone", "items", "keys", "values", "pop"}
 
+    # `extract_request_params` runs once per route and used to rebuild
+    # three PCRE2 patterns per accessor on every call. The accessor set
+    # is fixed, so precompile the access patterns once here.
+    # Tuple shape: {noir_param_type, get_re, bracket_re, attribute_re}
+    DICT_ACCESSOR_PATTERNS = DICT_ACCESSORS.map do |accessor, param_type|
+      {param_type,
+       /request\.#{accessor}\.get\s*\(\s*['"]([^'"]+)['"]/,
+       /request\.#{accessor}\s*\[\s*['"]([^'"]+)['"]\s*\]/,
+       /request\.#{accessor}\.([A-Za-z_][A-Za-z0-9_]*)\b/}
+    end
+
+    private def json_var_regexes(var : String) : Tuple(Regex, Regex)
+      @json_var_regex_cache[var] ||= begin
+        v = Regex.escape(var)
+        {/#{v}\.get\s*\(\s*['"]([^'"]+)['"]/,
+         /#{v}\s*\[\s*['"]([^'"]+)['"]\s*\]/}
+      end
+    end
+
     # Scan a function body for Bottle's request accessors.
     # Bottle uses explicit accessor names (`request.forms` for form,
     # `request.json` for json, …) so method-based disambiguation isn't needed.
@@ -476,17 +528,17 @@ module Analyzer::Python
         json_variables << m[1] unless json_variables.includes?(m[1])
       end
 
-      DICT_ACCESSORS.each do |accessor, param_type|
+      DICT_ACCESSOR_PATTERNS.each do |param_type, get_re, bracket_re, attribute_re|
         # request.<accessor>.get("name")
-        body.scan(/request\.#{accessor}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+        body.scan(get_re) do |m|
           record.call(m[1], param_type)
         end
         # request.<accessor>["name"]
-        body.scan(/request\.#{accessor}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+        body.scan(bracket_re) do |m|
           record.call(m[1], param_type)
         end
         # request.<accessor>.<attribute>  — skip dict-API method names.
-        body.scan(/request\.#{accessor}\.([A-Za-z_][A-Za-z0-9_]*)\b/) do |m|
+        body.scan(attribute_re) do |m|
           next if DICT_METHOD_NAMES.includes?(m[1])
           record.call(m[1], param_type)
         end
@@ -498,10 +550,11 @@ module Analyzer::Python
       end
 
       json_variables.each do |var|
-        body.scan(/#{Regex.escape(var)}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+        get_re, bracket_re = json_var_regexes(var)
+        body.scan(get_re) do |m|
           record.call(m[1], "json")
         end
-        body.scan(/#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+        body.scan(bracket_re) do |m|
           record.call(m[1], "json")
         end
       end

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -27,6 +27,9 @@ module Analyzer::Python
       "on_options" => "OPTIONS",
     }
 
+    @keyword_regex_cache = Hash(::String, Regex).new
+    @media_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
     def analyze
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
@@ -338,9 +341,17 @@ module Analyzer::Python
       parts
     end
 
+    # Memoized per keyword — the keyword set is tiny (`prefix`) but this
+    # runs per argument of every static-route declaration (an interpolated
+    # regex literal recompiles PCRE2 on every evaluation).
+    private def keyword_string_regex(keyword : ::String) : Regex
+      @keyword_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
+    end
+
     private def extract_keyword_string(args : Array(::String), keyword : ::String) : ::String?
+      keyword_re = keyword_string_regex(keyword)
       args.each do |arg|
-        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        keyword_match = arg.match(keyword_re)
         next unless keyword_match
 
         return extract_python_string(keyword_match[1])
@@ -368,6 +379,17 @@ module Analyzer::Python
     private def normalize_path(route_path : ::String) : ::String
       route_path.gsub(/\{([a-zA-Z_][a-zA-Z0-9_]*):[^}]+\}/) do |_match|
         "{#{$~[1]}}"
+      end
+    end
+
+    # Memoized per media-variable name (`data`, `body`, ...): the patterns
+    # interpolate a discovered name so they can't be class constants, but
+    # responder bodies reuse the same few names across a whole project.
+    private def media_var_regexes(var : ::String) : Tuple(Regex, Regex)
+      @media_var_regex_cache[var] ||= begin
+        v = Regex.escape(var)
+        {/(?:^|[^a-zA-Z0-9_])#{v}\s*\[\s*['"]([^'"]+)['"]\s*\]/,
+         /(?:^|[^a-zA-Z0-9_])#{v}\.get\s*\(\s*['"]([^'"]+)['"]/}
       end
     end
 
@@ -440,11 +462,14 @@ module Analyzer::Python
             record.call(m[1], "json")
           end
           media_vars.each do |var|
-            line.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+            # The var name is a necessary substring for either pattern.
+            next unless line.includes?(var)
+            bracket_re, get_re = media_var_regexes(var)
+            line.scan(bracket_re) do |m|
               media_field_seen = true
               record.call(m[1], "json")
             end
-            line.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+            line.scan(get_re) do |m|
               media_field_seen = true
               record.call(m[1], "json")
             end

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -24,6 +24,30 @@ module Analyzer::Python
     PATH_PARAM_REGEX       = /\{([a-zA-Z_][a-zA-Z0-9_]*)(?::[a-zA-Z_][a-zA-Z0-9_]*)?\}/
     TYPED_PATH_PARAM_REGEX = /\{([a-zA-Z_][a-zA-Z0-9_]*):[a-zA-Z_][a-zA-Z0-9_]*\}/
 
+    # Hoisted out of the per-line/per-param loops: an interpolated regex
+    # literal recompiles (PCRE2 JIT) on every evaluation, and these
+    # interpolate only constants or fixed sets. The `.to_s` expansion is
+    # byte-identical to the previous inline form, so matching behaviour
+    # is unchanged.
+    DOTTED_HANDLER_RE   = /(#{PYTHON_VAR_NAME_REGEX})\.(#{PYTHON_VAR_NAME_REGEX})/
+    CONTROLLER_CLASS_RE = /^\s*class\s+(#{PYTHON_VAR_NAME_REGEX})\s*\(([^)]*)\)/
+    CLASS_HEAD_RE       = /^\s*class\s+(#{PYTHON_VAR_NAME_REGEX})\s*\(/
+
+    # `classify_param` runs once per typed handler parameter and rebuilt
+    # one PCRE2 pattern per primitive type on every call.
+    PRIMITIVE_TYPE_PATTERNS = ["str", "int", "float", "bool", "bytes", "UUID", "date", "datetime"].map do |t|
+      /\b#{t}\b/
+    end
+
+    # `collect_request_attr_params` runs twice per handler-body line per
+    # attribute; the attribute set is fixed, so precompile the patterns.
+    REQUEST_ATTR_PATTERNS = %w[query_params path_params headers cookies].to_h do |attr|
+      {attr, {
+        /request\.#{attr}\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
+        /request\.#{attr}\.get\(\s*[rf]?['"]([^'"]+)['"]/,
+      }}
+    end
+
     def analyze
       python_files = get_files_by_extension(".py")
       external_handler_prefixes = Hash(::String, Hash(::String, ::String)).new do |hash, key|
@@ -274,7 +298,7 @@ module Analyzer::Python
       handlers_match = body.match(/route_handlers\s*=\s*\[([^\]]*)\]/m)
       return unless handlers_match
 
-      handlers_match[1].scan(/(#{PYTHON_VAR_NAME_REGEX})\.(#{PYTHON_VAR_NAME_REGEX})/) do |handler_match|
+      handlers_match[1].scan(DOTTED_HANDLER_RE) do |handler_match|
         next if handler_match.size < 3
         module_name = handler_match[1]
         handler_name = handler_match[2]
@@ -292,7 +316,8 @@ module Analyzer::Python
       prefixes = Hash(::String, ::String).new
 
       lines.each_with_index do |line, idx|
-        class_match = line.match(/^\s*class\s+(#{PYTHON_VAR_NAME_REGEX})\s*\(([^)]*)\)/)
+        next unless line.includes?("class")
+        class_match = line.match(CONTROLLER_CLASS_RE)
         next unless class_match
 
         class_name = class_match[1]
@@ -337,7 +362,7 @@ module Analyzer::Python
         unless line.strip.empty?
           indent = line.size - line.lstrip.size
           if indent < handler_indent
-            if class_match = line.match(/^\s*class\s+(#{PYTHON_VAR_NAME_REGEX})\s*\(/)
+            if line.includes?("class") && (class_match = line.match(CLASS_HEAD_RE))
               class_name = class_match[1]
               if controller_prefixes.has_key?(class_name)
                 return {class_name, controller_prefixes[class_name]}
@@ -425,9 +450,8 @@ module Analyzer::Python
       return "json" if stripped.includes?("Body")
       return "query" if stripped.includes?("Parameter") || stripped.includes?("Query")
 
-      primitive_types = ["str", "int", "float", "bool", "bytes", "UUID", "date", "datetime"]
-      primitive_types.each do |t|
-        return "query" if stripped.matches?(/\b#{t}\b/)
+      PRIMITIVE_TYPE_PATTERNS.each do |t_re|
+        return "query" if stripped.matches?(t_re)
       end
 
       # Pydantic/msgspec/dataclass models are treated as request body
@@ -446,10 +470,14 @@ module Analyzer::Python
     end
 
     private def collect_request_attr_params(line : ::String, attr : ::String, noir_type : ::String, params : Array(Param))
-      line.scan(/request\.#{attr}\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
+      # The attr substring is a necessary condition for either pattern,
+      # so most lines skip the regex matches entirely.
+      return unless line.includes?(attr)
+      bracket_re, get_re = REQUEST_ATTR_PATTERNS[attr]
+      line.scan(bracket_re) do |m|
         add_unique(params, Param.new(m[1], "", noir_type))
       end
-      line.scan(/request\.#{attr}\.get\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
+      line.scan(get_re) do |m|
         add_unique(params, Param.new(m[1], "", noir_type))
       end
     end

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -35,6 +35,23 @@ module Analyzer::Python
       "header" => ["headers"],
       "cookie" => ["cookies"],
     }
+
+    # `extract_request_params` runs once per endpoint and used to rebuild
+    # two PCRE2 patterns per accessor on every call (an interpolated regex
+    # literal recompiles on every evaluation). The accessor set is fixed,
+    # so precompile the access patterns once here; the `.to_s` expansion
+    # is byte-identical to the previous inline form.
+    # Tuple shape: {noir_param_type, bracket_re, get_re}
+    ACCESSOR_PATTERNS = ACCESSOR_MAP.flat_map do |param_type, accessors|
+      accessors.map do |accessor|
+        {param_type,
+         /(?:self\.)?request\.#{accessor}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
+         /(?:self\.)?request\.#{accessor}\.get(?:all|one)?\s*\(\s*[rf]?['"]([^'"]+)['"]/}
+      end
+    end
+
+    @keyword_regex_cache = Hash(String, Regex).new
+
     alias RouteNameKey = Tuple(String, String)
     alias RouteMap = Hash(RouteNameKey, Tuple(String, String))
 
@@ -352,9 +369,16 @@ module Analyzer::Python
       parts
     end
 
+    # Memoized per keyword — the keyword set is tiny (`name`) but this
+    # runs per argument of every static-view declaration.
+    private def keyword_string_regex(keyword : String) : Regex
+      @keyword_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
+    end
+
     private def extract_python_keyword_string(args : Array(String), keyword : String) : String?
+      keyword_re = keyword_string_regex(keyword)
       args.each do |arg|
-        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        keyword_match = arg.match(keyword_re)
         next unless keyword_match
 
         return extract_python_string(keyword_match[1])
@@ -491,14 +515,12 @@ module Analyzer::Python
         end
       end
 
-      ACCESSOR_MAP.each do |param_type, accessors|
-        accessors.each do |accessor|
-          body.scan(/(?:self\.)?request\.#{accessor}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
-            record.call(m[1], param_type)
-          end
-          body.scan(/(?:self\.)?request\.#{accessor}\.get(?:all|one)?\s*\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
-            record.call(m[1], param_type)
-          end
+      ACCESSOR_PATTERNS.each do |param_type, bracket_re, get_re|
+        body.scan(bracket_re) do |m|
+          record.call(m[1], param_type)
+        end
+        body.scan(get_re) do |m|
+          record.call(m[1], param_type)
         end
       end
 

--- a/src/analyzer/analyzers/python/robyn.cr
+++ b/src/analyzer/analyzers/python/robyn.cr
@@ -23,6 +23,16 @@ module Analyzer::Python
     HTTP_METHOD_DECORATORS = %w[get post put patch delete head options trace]
     WEBSOCKET_ATTRIBUTES   = {"websocket" => "GET"}
 
+    # Hoisted out of the per-line loops: an interpolated regex literal
+    # recompiles (PCRE2 JIT) on every evaluation, and these interpolate
+    # only constants. The `.to_s` expansion is byte-identical to the
+    # previous inline form, so matching behaviour is unchanged.
+    ROBYN_INSTANCE_RE = /^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?Robyn\s*\(/
+    SUBROUTER_RE      = /^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?SubRouter\s*\((.*)/m
+    INCLUDE_ROUTER_RE = /\b(#{PYTHON_VAR_NAME_REGEX})\.include_router\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})/
+
+    @json_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
     def analyze
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
@@ -92,7 +102,7 @@ module Analyzer::Python
     #   SubRouter(__file__, "/api")
     private def collect_router_assignments(lines : Array(::String), router_prefixes : Hash(::String, ::String))
       lines.each_with_index do |line, index|
-        if m = line.match(/^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?Robyn\s*\(/)
+        if line.includes?("Robyn") && (m = line.match(ROBYN_INSTANCE_RE))
           router_prefixes[m[1]] = ""
         end
 
@@ -101,7 +111,7 @@ module Analyzer::Python
                          else
                            line
                          end
-        if m = effective_line.match(/^\s*(#{PYTHON_VAR_NAME_REGEX})\s*=\s*(?:robyn\.)?SubRouter\s*\((.*)/m)
+        if effective_line.includes?("SubRouter") && (m = effective_line.match(SUBROUTER_RE))
           name = m[1]
           tail = m[2]
           prefix = extract_subrouter_prefix(tail)
@@ -140,7 +150,7 @@ module Analyzer::Python
         next unless line.includes?(".include_router(")
 
         effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, index, line) : line
-        effective_line.scan(/\b(#{PYTHON_VAR_NAME_REGEX})\.include_router\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})/) do |m|
+        effective_line.scan(INCLUDE_ROUTER_RE) do |m|
           next if m.size < 3
           includes << {m[1], m[2]}
         end
@@ -212,6 +222,17 @@ module Analyzer::Python
       body.join("\n")
     end
 
+    # Memoized per JSON-variable name (`data`, `body`, ...): the patterns
+    # interpolate a discovered name so they can't be class constants, but
+    # handler bodies reuse the same few names across a whole project.
+    private def json_var_regexes(var : ::String) : Tuple(Regex, Regex)
+      @json_var_regex_cache[var] ||= begin
+        v = Regex.escape(var)
+        {/#{v}\[['"]([^'"]+)['"]\]/,
+         /#{v}\.get\(['"]([^'"]+)['"]/}
+      end
+    end
+
     # Robyn exposes `request.json()`, `request.query_params`, and
     # `request.headers` for parameter access. The fixture-level idioms
     # are bracket / `.get()` access, which is enough to recover the
@@ -245,8 +266,9 @@ module Analyzer::Python
       end
 
       json_vars.each do |var|
-        body.scan(/#{Regex.escape(var)}\[['"]([^'"]+)['"]\]/) { |m| record.call(m[1], "json") }
-        body.scan(/#{Regex.escape(var)}\.get\(['"]([^'"]+)['"]/) { |m| record.call(m[1], "json") }
+        bracket_re, get_re = json_var_regexes(var)
+        body.scan(bracket_re) { |m| record.call(m[1], "json") }
+        body.scan(get_re) { |m| record.call(m[1], "json") }
       end
 
       # `request.query_params.get("name")` / `request.query_params["name"]`

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -24,6 +24,31 @@ module Analyzer::Python
       "header" => nil,
     }
 
+    # Hoisted out of the analyze loops: an interpolated regex literal
+    # recompiles (PCRE2 JIT) on every evaluation, and these interpolate
+    # only constants. The `.to_s` expansion is byte-identical to the
+    # previous inline form, so matching behaviour is unchanged.
+    SANIC_INSTANCE_RE   = /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:sanic\.)?Sanic\(/
+    STATIC_CALL_RE      = /\b(#{PYTHON_VAR_NAME_REGEX})\.static\s*\((.*)\)\s*$/m
+    ADD_ROUTE_CALL_RE   = /\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m
+    AS_VIEW_RE          = /^(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/
+    DOTTED_REFERENCE_RE = /^#{PYTHON_VAR_NAME_REGEX}(?:\.#{PYTHON_VAR_NAME_REGEX})*$/
+    BLUEPRINT_CALL_RE   = /\.blueprint\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})(.*?)\)/m
+
+    # `get_endpoints` rebuilt two PCRE2 patterns per request field on
+    # every handler-body line. The field set is fixed, so precompile the
+    # access patterns (and the `request.<field>` guard substring) once.
+    # Tuple shape: {guard_substring, noir_param_type, paren_re, bracket_re}
+    REQUEST_PARAM_FIELD_PATTERNS = REQUEST_PARAM_FIELDS.map do |field, tuple|
+      {"request.#{field}",
+       tuple[1],
+       /request\.#{field}(?:\.get)?\(['"']([^'"']+)['"']\)/,
+       /request\.#{field}\[['"']([^'"']+)['"']\]/}
+    end
+
+    @keyword_regex_cache = Hash(::String, Regex).new
+    @json_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
     @file_content_cache = Hash(::String, ::String).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
     @programmatic_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
@@ -78,7 +103,7 @@ module Analyzer::Python
 
               # Identify Sanic instance assignments (tree-sitter extractor
               # doesn't cover this shape yet).
-              sanic_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:sanic\.)?Sanic\(/
+              sanic_match = line.includes?("Sanic(") ? line.match(SANIC_INSTANCE_RE) : nil
               if sanic_match
                 sanic_instance_name = sanic_match[1]
                 api_instances[sanic_instance_name] ||= ""
@@ -323,7 +348,7 @@ module Analyzer::Python
     end
 
     private def parse_static_route(line : ::String) : Tuple(::String, ::String)?
-      call_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.static\s*\((.*)\)\s*$/m)
+      call_match = line.match(STATIC_CALL_RE)
       return unless call_match
 
       router_name = call_match[1]
@@ -337,7 +362,7 @@ module Analyzer::Python
     end
 
     private def parse_programmatic_class_route(line : ::String) : Tuple(::String, ::String, ::String, ::String)?
-      call_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m)
+      call_match = line.match(ADD_ROUTE_CALL_RE)
       return unless call_match
 
       router_name = call_match[1]
@@ -352,7 +377,7 @@ module Analyzer::Python
     end
 
     private def parse_programmatic_route(line : ::String) : Tuple(::String, ::String, ::String, ::String)?
-      call_match = line.match(/\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m)
+      call_match = line.match(ADD_ROUTE_CALL_RE)
       return unless call_match
 
       router_name = call_match[1]
@@ -371,7 +396,7 @@ module Analyzer::Python
       handler = extract_keyword_expression(args, "handler") || args[0]?
       return "" unless handler
 
-      if class_match = handler.strip.match(/^(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/)
+      if class_match = handler.strip.match(AS_VIEW_RE)
         return class_match[1]
       end
 
@@ -413,9 +438,17 @@ module Analyzer::Python
       methods
     end
 
+    # Memoized per keyword — the keyword set is tiny (`handler`, `uri`,
+    # `path`, `methods`, ...) but this runs per argument of every
+    # programmatic route.
+    private def keyword_expression_regex(keyword : ::String) : Regex
+      @keyword_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
+    end
+
     private def extract_keyword_expression(args : Array(::String), keyword : ::String) : ::String?
+      keyword_re = keyword_expression_regex(keyword)
       args.each do |arg|
-        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        keyword_match = arg.match(keyword_re)
         return keyword_match[1].strip if keyword_match
       end
 
@@ -437,7 +470,7 @@ module Analyzer::Python
 
     private def clean_reference(expression : ::String) : ::String
       reference = expression.strip
-      return reference if reference.matches?(/^#{PYTHON_VAR_NAME_REGEX}(?:\.#{PYTHON_VAR_NAME_REGEX})*$/)
+      return reference if reference.matches?(DOTTED_REFERENCE_RE)
 
       ""
     end
@@ -530,8 +563,12 @@ module Analyzer::Python
     end
 
     private def find_function_def(lines : Array(::String), function_name : ::String) : Int32?
+      # Compile the name-specific matcher once per call instead of on
+      # every line, and gate it behind cheap substring necessary checks.
+      function_def_re = /^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/
       lines.each_with_index do |line, index|
-        if line.match(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+        next unless line.includes?("def") && line.includes?(function_name)
+        if line.match(function_def_re)
           return index
         end
       end
@@ -575,6 +612,9 @@ module Analyzer::Python
     end
 
     private def find_class_method_def(lines : Array(::String), class_def_index : Int32, class_indent : Int32, method_name : ::String) : Int32?
+      # Compile the name-specific matcher once per call instead of on
+      # every line, and gate it behind a cheap substring necessary check.
+      method_def_re = /(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/
       i = class_def_index + 1
       while i < lines.size
         line = lines[i]
@@ -582,7 +622,7 @@ module Analyzer::Python
           break if class_match[1].size <= class_indent
         end
 
-        if method_match = line.match(/(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/)
+        if line.includes?(method_name) && (method_match = line.match(method_def_re))
           return i if method_match[1].size > class_indent
         end
 
@@ -607,7 +647,7 @@ module Analyzer::Python
     private def collect_blueprint_registrations(source : ::String,
                                                 registrations : Hash(ScopedNameKey, Array(::String)),
                                                 base_path : ::String)
-      source.scan(/\.blueprint\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})(.*?)\)/m) do |match|
+      source.scan(BLUEPRINT_CALL_RE) do |match|
         next if match.size < 3
         blueprint_name = match[1]
         tail = match[2]
@@ -663,10 +703,9 @@ module Analyzer::Python
 
       # Second pass: extract parameters
       codeblock_lines.each do |code_line|
-        REQUEST_PARAM_FIELDS.each do |field, (http_methods, param_type)|
-          if code_line.includes?("request.#{field}")
+        REQUEST_PARAM_FIELD_PATTERNS.each do |guard, param_type, param_regex, bracket_regex|
+          if code_line.includes?(guard)
             # Extract parameter access patterns
-            param_regex = /request\.#{field}(?:\.get)?\(['"']([^'"']+)['"']\)/
             code_line.scan(param_regex) do |match|
               param_name = match[1]
               param = Param.new(param_name, "", param_type)
@@ -674,7 +713,6 @@ module Analyzer::Python
             end
 
             # Handle bracket notation: request.args['param']
-            bracket_regex = /request\.#{field}\[['"']([^'"']+)['"']\]/
             code_line.scan(bracket_regex) do |match|
               param_name = match[1]
               param = Param.new(param_name, "", param_type)
@@ -685,8 +723,11 @@ module Analyzer::Python
 
         # Extract JSON parameters from variable usage
         json_variable_names.each do |json_var|
+          # The var name is a necessary substring for either pattern.
+          next unless code_line.includes?(json_var)
+          bracket_regex, get_regex = json_var_regexes(json_var)
+
           # Look for patterns like: json_var['param_name']
-          bracket_regex = /#{json_var}\[['"']([^'"']+)['"']\]/
           code_line.scan(bracket_regex) do |match|
             param_name = match[1]
             param = Param.new(param_name, "", "json")
@@ -694,7 +735,6 @@ module Analyzer::Python
           end
 
           # Look for patterns like: json_var.get('param_name')
-          get_regex = /#{json_var}\.get\(['"']([^'"']+)['"']\)/
           code_line.scan(get_regex) do |match|
             param_name = match[1]
             param = Param.new(param_name, "", "json")
@@ -714,6 +754,16 @@ module Analyzer::Python
       end
 
       endpoints
+    end
+
+    # Memoized per JSON-variable name (`data`, `body`, ...): the patterns
+    # interpolate a discovered name so they can't be class constants, but
+    # handler bodies reuse the same few names across a whole project.
+    private def json_var_regexes(json_var : ::String) : Tuple(Regex, Regex)
+      @json_var_regex_cache[json_var] ||= {
+        /#{json_var}\[['"']([^'"']+)['"']\]/,
+        /#{json_var}\.get\(['"']([^'"']+)['"']\)/,
+      }
     end
 
     private def join_paths(prefix : ::String, path : ::String) : ::String

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -18,6 +18,41 @@ module Analyzer::Python
     PATH_PARAM_REGEX       = /\{([a-zA-Z_][a-zA-Z0-9_]*)(?::[a-zA-Z_][a-zA-Z0-9_]*)?\}/
     TYPED_PATH_PARAM_REGEX = /\{([a-zA-Z_][a-zA-Z0-9_]*):[a-zA-Z_][a-zA-Z0-9_]*\}/
 
+    # Hoisted out of the analyze loops: an interpolated regex literal
+    # recompiles (PCRE2 JIT) on every evaluation, and these interpolate
+    # only constants. The `.to_s` expansion is byte-identical to the
+    # previous inline form, so matching behaviour is unchanged.
+    ADD_ROUTE_RE        = /(#{DOT_NATION})\.add_(websocket_)?route\s*\((.*)\)/m
+    CLASS_METHOD_DEF_RE = /^\s*(?:async\s+)?def\s+(get|post|put|patch|delete|head|options)\s*\(([^)]*)\)/
+
+    # Request-access matchers interpolate a discovered request-var name
+    # (`request`, `self.request`, ...) so they can't be class constants,
+    # but a handler set only uses a handful of distinct names — memoize
+    # the compiled set per name instead of rebuilding it on every line
+    # of every handler body.
+    private record AwaitBodyRegexes,
+      json_await : Regex,
+      form_await : Regex,
+      json_assign : Regex,
+      form_assign : Regex
+
+    @await_body_regex_cache = Hash(::String, AwaitBodyRegexes).new
+    @attr_regex_cache = Hash(Tuple(::String, ::String), Tuple(Regex, Regex)).new
+    @body_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+    @keyword_expr_regex_cache = Hash(::String, Regex).new
+
+    private def await_body_regexes(request_name : ::String) : AwaitBodyRegexes
+      @await_body_regex_cache[request_name] ||= begin
+        rp = Regex.escape(request_name)
+        AwaitBodyRegexes.new(
+          json_await: /await\s+#{rp}\.json\s*\(/,
+          form_await: /await\s+#{rp}\.form\s*\(/,
+          json_assign: /([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{rp}\.json\s*\(/,
+          form_assign: /([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{rp}\.form\s*\(/,
+        )
+      end
+    end
+
     def analyze
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
@@ -74,7 +109,7 @@ module Analyzer::Python
         effective_line = effective_line.gsub(/((?:WebSocketRoute|Route)\s*\()\s*path\s*=\s*([rf]?['"][^'"]*['"])/, "\\1\\2,")
 
         if effective_line.includes?(".add_route(") || effective_line.includes?(".add_websocket_route(")
-          effective_line.scan(/(#{DOT_NATION})\.add_(websocket_)?route\s*\((.*)\)/m) do |programmatic_match|
+          effective_line.scan(ADD_ROUTE_RE) do |programmatic_match|
             next if programmatic_match.size < 4
             receiver = normalize_receiver(programmatic_match[1])
             websocket_route = !(programmatic_match[2]?).to_s.empty?
@@ -554,9 +589,16 @@ module Analyzer::Python
       methods.uniq
     end
 
+    # Memoized per keyword — the keyword set is tiny (`path`, `endpoint`,
+    # `methods`) but this runs per argument of every programmatic route.
+    private def keyword_expression_regex(keyword : ::String) : Regex
+      @keyword_expr_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
+    end
+
     private def extract_python_keyword_expression(args : Array(::String), keyword : ::String) : ::String?
+      keyword_re = keyword_expression_regex(keyword)
       args.each do |arg|
-        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        keyword_match = arg.match(keyword_re)
         return keyword_match[1].strip if keyword_match
       end
 
@@ -688,7 +730,6 @@ module Analyzer::Python
       end
 
       class_indent = lines[class_line].size - lines[class_line].lstrip.size
-      methods_re = "get|post|put|patch|delete|head|options"
       i = class_line + 1
       while i < lines.size
         line = lines[i]
@@ -696,23 +737,24 @@ module Analyzer::Python
           indent = line.size - line.lstrip.size
           break if indent <= class_indent
 
-          if method_match = line.match(/^\s*(?:async\s+)?def\s+(#{methods_re})\s*\(([^)]*)\)/)
+          if method_match = line.match(CLASS_METHOD_DEF_RE)
             method = method_match[1].upcase
             request_name = extract_request_arg_name(method_match[2])
+            request_body_res = request_name ? await_body_regexes(request_name) : nil
             codeblock = parse_code_block(lines[i..])
             if codeblock
               params = [] of Param
               codeblock.split("\n").each do |cl|
-                if request_name
+                if request_name && request_body_res
                   collect_request_attr_params(cl, request_name, "path_params", "path", params)
                   collect_request_attr_params(cl, request_name, "query_params", "query", params)
                   collect_request_attr_params(cl, request_name, "headers", "header", params)
                   collect_request_attr_params(cl, request_name, "cookies", "cookie", params)
 
-                  if cl.matches?(/await\s+#{Regex.escape(request_name)}\.json\s*\(/)
+                  if cl.matches?(request_body_res.json_await)
                     add_unique(params, Param.new("body", "", "json"))
                   end
-                  if cl.matches?(/await\s+#{Regex.escape(request_name)}\.form\s*\(/)
+                  if cl.matches?(request_body_res.form_await)
                     add_unique(params, Param.new("body", "", "form"))
                   end
                 end
@@ -818,13 +860,14 @@ module Analyzer::Python
         return cache[handler_name]
       end
 
+      request_body_res = await_body_regexes(request_name)
       codeblock.split("\n").each do |cl|
         collect_websocket_params(cl, request_name, params)
 
-        if cl.matches?(/await\s+#{Regex.escape(request_name)}\.json\s*\(/)
+        if cl.matches?(request_body_res.json_await)
           add_unique(params, Param.new("body", "", "json"))
         end
-        if cl.matches?(/await\s+#{Regex.escape(request_name)}\.form\s*\(/)
+        if cl.matches?(request_body_res.form_await)
           add_unique(params, Param.new("body", "", "form"))
         end
       end
@@ -884,31 +927,49 @@ module Analyzer::Python
       end
     end
 
+    private def request_attr_regexes(request_name : ::String, attr : ::String) : Tuple(Regex, Regex)
+      @attr_regex_cache[{request_name, attr}] ||= begin
+        rp = Regex.escape(request_name)
+        {/#{rp}\.#{attr}\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
+         /#{rp}\.#{attr}\.get\(\s*[rf]?['"]([^'"]+)['"]/}
+      end
+    end
+
     private def collect_request_attr_params(line : ::String, request_name : ::String, attr : ::String, noir_type : ::String, params : Array(Param))
-      line.scan(/#{Regex.escape(request_name)}\.#{attr}\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
+      # The attr substring is a necessary condition for either pattern,
+      # so most lines skip the regex matches entirely.
+      return unless line.includes?(attr)
+      bracket_re, get_re = request_attr_regexes(request_name, attr)
+      line.scan(bracket_re) do |m|
         add_unique(params, Param.new(m[1], "", noir_type))
       end
-      line.scan(/#{Regex.escape(request_name)}\.#{attr}\.get\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
+      line.scan(get_re) do |m|
         add_unique(params, Param.new(m[1], "", noir_type))
       end
     end
 
+    private def body_var_regexes(var : ::String) : Tuple(Regex, Regex)
+      @body_var_regex_cache[var] ||= begin
+        v = Regex.escape(var)
+        {/(?:^|[^a-zA-Z0-9_])#{v}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
+         /(?:^|[^a-zA-Z0-9_])#{v}\.get\(\s*[rf]?['"]([^'"]+)['"]/}
+      end
+    end
+
     private def collect_request_body_params(codeblock : ::String, request_name : ::String, params : Array(Param))
-      request_pattern = Regex.escape(request_name)
-      {
-        "json" => "json",
-        "form" => "form",
-      }.each do |method_name, noir_type|
+      request_body_res = await_body_regexes(request_name)
+      { {"json", request_body_res.json_assign}, {"form", request_body_res.form_assign} }.each do |noir_type, assign_re|
         body_vars = [] of ::String
-        codeblock.scan(/([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{request_pattern}\.#{method_name}\s*\(/) do |m|
+        codeblock.scan(assign_re) do |m|
           body_vars << m[1]
         end
 
         body_vars.each do |var|
-          codeblock.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |m|
+          bracket_re, get_re = body_var_regexes(var)
+          codeblock.scan(bracket_re) do |m|
             add_unique(params, Param.new(m[1], "", noir_type))
           end
-          codeblock.scan(/(?:^|[^a-zA-Z0-9_])#{Regex.escape(var)}\.get\(\s*[rf]?['"]([^'"]+)['"]/) do |m|
+          codeblock.scan(get_re) do |m|
             add_unique(params, Param.new(m[1], "", noir_type))
           end
         end


### PR DESCRIPTION
Follow-up to #1957 / #1960 / #1963 — applies the same hoist / precompute / guard / memoize recipe to the remaining regex-based Python analyzers. Closes #1961.

## Background

Crystal recompiles an interpolated regex literal (`/...#{x}.../`) on every evaluation — a full PCRE2 JIT compile. The starlette/bottle/sanic/litestar/robyn/pyramid/falcon analyzers rebuilt the same patterns on every source line, every route, or every handler-body line. (`engines/python_engine.cr`'s two sites from the issue were already fixed in #1964.)

## Changes (behavior-preserving — `.to_s` expansion is byte-identical)

1. **Constant-only interpolations → class constants** compiled once at load: starlette `ADD_ROUTE_RE`/`CLASS_METHOD_DEF_RE`; bottle programmatic-route/`Bottle(`/mount; sanic `Sanic(`/static/add_route/as_view/blueprint; litestar class & dotted-handler matchers; robyn `Robyn(`/`SubRouter(`/include_router.
2. **Fixed-set interpolations → precompiled pattern tables**: sanic `REQUEST_PARAM_FIELD_PATTERNS` (incl. the per-line guard substring), bottle `BARE_DECORATOR_PATTERNS` + `DICT_ACCESSOR_PATTERNS`, pyramid `ACCESSOR_PATTERNS`, litestar `REQUEST_ATTR_PATTERNS` + `PRIMITIVE_TYPE_PATTERNS`.
3. **find-def loops** (sanic `find_function_def` / `find_class_method_def`) compiled a name-specific matcher on every line, once per route → compile once per call + cheap substring guard (same as aiohttp `find_handler_def` in #1960).
4. **Discovered-name matchers memoized per name**: starlette request-var `AwaitBodyRegexes` / attr / body-var caches, bottle/sanic/robyn json-var caches, falcon media-var cache, and keyword-extraction caches across all five keyword extractors.

## Results (release builds, synthetic 25–30k-endpoint apps, 100 files each, best-of-3; PCRE2 calls counted exactly via an `LD_PRELOAD` shim on `pcre2_compile_8`)

| framework | wall-clock | speedup | PCRE2 compile calls | output |
|---|---|---|---|---|
| starlette | 35.11 s → 2.92 s | **12.0×** | 1,353,828 → 1,451 | identical |
| bottle | 82.30 s → 2.51 s | **32.8×** | 3,373,019 → 1,419 | identical |
| sanic | 122.24 s → 7.12 s | **17.2×** | 4,900,020 → 9,427 | identical |
| litestar | 22.53 s → 2.86 s | **7.9×** | 902,024 → 1,422 | identical |
| robyn | 10.96 s → 2.38 s | **4.6×** | 342,623 → 1,423 | identical |
| pyramid | 14.92 s → 4.07 s | **3.7×** | 421,323 → 1,421 | identical |
| falcon | 6.45 s → 3.21 s | **2.0×** | 141,334 → 1,434 | identical |

Scaling proof (starlette, 10 vs 100 files): baseline compiles grow 136,578 → 1,353,828 (linear in input); patched stays at exactly **1,451** in both — a startup constant. The ~1.4k residual is other analyzers'/detectors' load-time patterns; sanic's ~9.4k residual is the intended once-per-call find-def compiles (scales with route count, no longer with lines × routes).

## Verification

- Output **byte-identical** — full endpoint JSON (urls, methods, params, details, callees) canonically sorted and byte-compared: empty diff on all 7 synthetic apps, all 16 spec fixtures of the touched frameworks, and the fixtures of the untouched Python analyzers (flask/quart/django/aiohttp/tornado/fastapi) that share `PythonEngine`.
- Param extraction intact at scale (e.g. starlette 179,500 params, bottle 75,000 — identical on both binaries).
- Full spec suite: **20,948 examples, 0 failures, 0 errors** (3,243 unit + 17,705 functional).
- `crystal tool format --check` and ameba clean.

https://claude.ai/code/session_01DzEgHXAgMJDcbUsFq2CdJt