### PR TITLE
feat(mobile): link Android deep links to handler code — callees, input params, ai_context (#1943)

### DIFF
--- a/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/DeepLinkActivity.kt
+++ b/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/DeepLinkActivity.kt
@@ -1,0 +1,24 @@
+package com.example.myapp
+
+import android.app.Activity
+import android.os.Bundle
+import android.webkit.WebView
+
+class DeepLinkActivity : Activity() {
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val data = intent.data
+        val target = data?.getQueryParameter("redirect")
+        val id = data?.lastPathSegment
+        renderProfile(id)
+        if (target != null) {
+            webView.loadUrl(target)
+        }
+    }
+
+    private fun renderProfile(id: String?) {
+        webView.loadData("<h1>" + id + "</h1>", "text/html", "utf-8")
+    }
+}

--- a/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/DeepLinkActivity.kt
+++ b/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/DeepLinkActivity.kt
@@ -11,14 +11,17 @@ class DeepLinkActivity : Activity() {
         super.onCreate(savedInstanceState)
         val data = intent.data
         val target = data?.getQueryParameter("redirect")
+        val campaign = data?.getQueryParameter("utm_source")
+        val userId = intent.getStringExtra("userId")
+        val verified = intent.getBooleanExtra("verified", false)
         val id = data?.lastPathSegment
-        renderProfile(id)
+        renderProfile(id, userId)
         if (target != null) {
             webView.loadUrl(target)
         }
     }
 
-    private fun renderProfile(id: String?) {
+    private fun renderProfile(id: String?, userId: String?) {
         webView.loadData("<h1>" + id + "</h1>", "text/html", "utf-8")
     }
 }

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -16,8 +16,15 @@ no_params = [] of Param
 
 expected_endpoints = [
   # Custom scheme deep link (mobile-scheme), enriched by the code-linkage
-  # pass with callees pulled from DeepLinkActivity.onCreate.
-  build.call("myapp://complex/:id", "mobile-scheme", [Param.new("id", "", "path")], ["renderProfile", "webView.loadUrl"]),
+  # pass with callees + input params read from DeepLinkActivity.onCreate:
+  # getQueryParameter -> query, get*Extra -> extra.
+  build.call("myapp://complex/:id", "mobile-scheme", [
+    Param.new("id", "", "path"),
+    Param.new("redirect", "", "query"),
+    Param.new("utm_source", "", "query"),
+    Param.new("userId", "", "extra"),
+    Param.new("verified", "", "extra"),
+  ], ["renderProfile", "webView.loadUrl"]),
   build.call("myapp://accounts/profile", "mobile-scheme", no_params, [] of String),
   # Scheme resolved from @string/deep_link_scheme
   build.call("myappstr://settings", "mobile-scheme", no_params, [] of String),

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -1,22 +1,30 @@
 require "../../func_spec.cr"
 
 # Mobile entry points keep method = "GET"; the mobile semantics live in
-# `protocol`. FunctionalTester checks url / method / protocol / params, so
-# the protocol is asserted because it differs from the default "http".
-#
-# One endpoint is emitted per deep-link URI (the handling component rides
-# in metadata["via"]); a bare intent:// endpoint appears only for the
-# exported, data-less component.
+# `protocol`. Endpoint is a struct, so `.tap(&.protocol=)` would NOT persist
+# (the block mutates a copy) — build via a Proc that mutates a local and
+# returns it, which does persist. FunctionalTester then asserts protocol
+# (since it differs from "http") and the linker-extracted callees.
+build = ->(url : String, protocol : String, params : Array(Param), callees : Array(String)) do
+  ep = Endpoint.new(url, "GET", params)
+  ep.protocol = protocol
+  callees.each { |name| ep.push_callee(Callee.new(name)) }
+  ep
+end
+
+no_params = [] of Param
+
 expected_endpoints = [
-  # Custom scheme deep links (mobile-scheme)
-  Endpoint.new("myapp://complex/:id", "GET", [Param.new("id", "", "path")]).tap(&.protocol = "mobile-scheme"),
-  Endpoint.new("myapp://accounts/profile", "GET").tap(&.protocol = "mobile-scheme"),
+  # Custom scheme deep link (mobile-scheme), enriched by the code-linkage
+  # pass with callees pulled from DeepLinkActivity.onCreate.
+  build.call("myapp://complex/:id", "mobile-scheme", [Param.new("id", "", "path")], ["renderProfile", "webView.loadUrl"]),
+  build.call("myapp://accounts/profile", "mobile-scheme", no_params, [] of String),
   # Scheme resolved from @string/deep_link_scheme
-  Endpoint.new("myappstr://settings", "GET").tap(&.protocol = "mobile-scheme"),
+  build.call("myappstr://settings", "mobile-scheme", no_params, [] of String),
   # Verified App Link over https (universal-link)
-  Endpoint.new("https://myapp.example.com/complex/:id", "GET", [Param.new("id", "", "path")]).tap(&.protocol = "universal-link"),
+  build.call("https://myapp.example.com/complex/:id", "universal-link", [Param.new("id", "", "path")], [] of String),
   # Exported, data-less component (android-intent), synthetic intent:// scheme
-  Endpoint.new("intent://com.example.myapp/.SyncService", "GET").tap(&.protocol = "android-intent"),
+  build.call("intent://com.example.myapp/.SyncService", "android-intent", no_params, [] of String),
 ]
 
 FunctionalTester.new("fixtures/mobile/android/", {

--- a/spec/unit_test/mobile/linker_spec.cr
+++ b/spec/unit_test/mobile/linker_spec.cr
@@ -1,0 +1,45 @@
+require "../../spec_helper"
+require "../../../src/models/logger"
+require "../../../src/models/code_locator"
+require "../../../src/mobile/linker.cr"
+
+# The linker resolves an Android mobile endpoint's handler component to its
+# source file, attaches the handler as a code_path, and pulls 1-hop callees
+# from the intent-handling methods.
+describe "NoirMobileLinker" do
+  base = File.expand_path(File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android"))
+  kt = File.join(base, "src", "main", "java", "com", "example", "myapp", "DeepLinkActivity.kt")
+
+  logger = NoirLogger.new(false, false, false, true)
+
+  # Seed the file_map so ClassIndex#build can find the .kt via files_by_extension.
+  locator = CodeLocator.instance
+  locator.clear("file_map")
+  locator.register_file(kt, File.read(kt))
+
+  # Endpoint is a struct; mutate locals directly (`.tap` would not persist).
+  scheme = Endpoint.new("myapp://complex/:id", "GET")
+  scheme.protocol = "mobile-scheme"
+  scheme.metadata = {"via" => ".DeepLinkActivity", "package" => "com.example.myapp"}
+
+  bare = Endpoint.new("myapp://accounts/profile", "GET")
+  bare.protocol = "mobile-scheme"
+
+  result = NoirMobileLinker.apply([scheme, bare], logger)
+  linked = result[0]
+
+  it "adds the handler source file as a code_path" do
+    paths = linked.details.code_paths.map { |p| File.basename(p.path) }
+    paths.should contain("DeepLinkActivity.kt")
+  end
+
+  it "extracts 1-hop callees from the intent handler" do
+    names = linked.callees.map(&.name)
+    names.should contain("webView.loadUrl")
+    names.should contain("renderProfile")
+  end
+
+  it "leaves an endpoint whose component has no resolvable source untouched" do
+    result[1].callees.should be_empty
+  end
+end

--- a/spec/unit_test/mobile/linker_spec.cr
+++ b/spec/unit_test/mobile/linker_spec.cr
@@ -39,6 +39,16 @@ describe "NoirMobileLinker" do
     names.should contain("renderProfile")
   end
 
+  it "extracts getQueryParameter reads as query params" do
+    linked.params.any? { |p| p.name == "redirect" && p.param_type == "query" }.should be_true
+    linked.params.any? { |p| p.name == "utm_source" && p.param_type == "query" }.should be_true
+  end
+
+  it "extracts get*Extra reads as extra params" do
+    linked.params.any? { |p| p.name == "userId" && p.param_type == "extra" }.should be_true
+    linked.params.any? { |p| p.name == "verified" && p.param_type == "extra" }.should be_true
+  end
+
   it "leaves an endpoint whose component has no resolvable source untouched" do
     result[1].callees.should be_empty
   end

--- a/src/ai_context/patterns.cr
+++ b/src/ai_context/patterns.cr
@@ -191,6 +191,20 @@ module NoirAIContext
         /\bRandom\s*\(\s*\)\s*\.\s*next(Int|Long|Bytes)?\s*\(/, # JVM/Kotlin non-CSPRNG
       ]
     ),
+    PatternDefinition.new(
+      "webview_load",
+      "WebView load of a potentially attacker-controlled URL/HTML — a deep-link XSS/SSRF surface on mobile",
+      80,
+      name_patterns: [/\.loadUrl\b/i, /\.loadData(WithBaseURL)?\b/i, /\.evaluateJavascript\b/i],
+      source_patterns: [/\.loadUrl\s*\(/i, /\.loadData(WithBaseURL)?\s*\(/i, /\.evaluateJavascript\s*\(/i]
+    ),
+    PatternDefinition.new(
+      "intent_redirect",
+      "Intent launched from inbound deep-link data — intent redirection / component-hijack surface",
+      70,
+      name_patterns: [/\bstartActivity(ForResult)?\b/, /\bsendBroadcast\b/, /\bstartService\b/, /\bbindService\b/],
+      source_patterns: [/\bstartActivity(ForResult)?\s*\(/, /\bsendBroadcast\s*\(/, /\bstartService\s*\(/]
+    ),
   ] of PatternDefinition
 
   VALIDATOR_PATTERNS = [

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -1,0 +1,183 @@
+require "../models/endpoint"
+require "../models/code_locator"
+require "../ext/tree_sitter/tree_sitter"
+require "../miniparsers/kotlin_callee_extractor"
+require "../miniparsers/java_callee_extractor"
+
+# Post-analysis pass that links mobile deep-link endpoints (produced by the
+# config-file analyzers from AndroidManifest.xml) to the source code that
+# handles them. For each Android mobile endpoint it:
+#
+#   1. resolves the handling component (metadata["via"] / the intent://
+#      component) to its .kt/.java source file,
+#   2. adds that file as a `code_path` so the AI-context builder scans the
+#      handler body for sinks/guards, and
+#   3. extracts the handler's 1-hop callees into `endpoint.callees`.
+#
+# The existing AIContext builder then derives sinks/guards/sources from the
+# handler snippet and callees — no mobile-specific wiring needed there. iOS
+# endpoints (no `via`, dispatched by the App/SceneDelegate) are left for a
+# follow-up.
+module NoirMobileLinker
+  MOBILE_PROTOCOLS = Set{"mobile-scheme", "android-intent", "universal-link"}
+
+  # Methods where an Android component reads its inbound intent / deep link.
+  HANDLER_METHODS = %w[
+    onCreate onNewIntent onStart onResume onStartCommand onHandleIntent
+    handleIntent handleDeepLink onReceive onBind
+  ]
+
+  def self.apply(endpoints : Array(Endpoint), logger : NoirLogger) : Array(Endpoint)
+    return endpoints unless endpoints.any? { |ep| android_handler_target?(ep) }
+
+    index = ClassIndex.new
+    endpoints.each_with_index do |endpoint, i|
+      next unless android_handler_target?(endpoint)
+      cls = handler_class(endpoint)
+      next if cls.nil?
+
+      resolved = index.resolve(cls[:simple], cls[:package])
+      next unless resolved
+
+      begin
+        endpoints[i] = link_handler(endpoint, cls[:simple], resolved[:path], resolved[:lang])
+      rescue e
+        logger.debug "Mobile linker failed for #{endpoint.url} (#{resolved[:path]}): #{e.message}"
+      end
+    end
+
+    endpoints
+  end
+
+  # An endpoint we can resolve to an Android component: a mobile protocol
+  # with either a `via` class (scheme / universal-link) or an intent://
+  # component URL (android-intent). iOS schemes carry neither.
+  private def self.android_handler_target?(endpoint : Endpoint) : Bool
+    return false unless MOBILE_PROTOCOLS.includes?(endpoint.protocol)
+    return true if endpoint.url.starts_with?("intent://")
+    !!(endpoint.metadata.try &.has_key?("via"))
+  end
+
+  # Returns the handler class as {simple, package}. `via` is like
+  # ".DeepLinkActivity" (relative to package) or a fully-qualified name; an
+  # intent:// URL encodes "<package>/<component>".
+  private def self.handler_class(endpoint : Endpoint) : NamedTuple(simple: String, package: String)?
+    if via = endpoint.metadata.try &.["via"]?
+      package = endpoint.metadata.try(&.["package"]?) || ""
+      return class_parts(via, package)
+    end
+
+    if endpoint.url.starts_with?("intent://")
+      rest = endpoint.url.lchop("intent://")
+      package, _, component = rest.partition('/')
+      component = rest if component.empty?
+      return class_parts(component, package)
+    end
+
+    nil
+  end
+
+  private def self.class_parts(name : String, package : String) : NamedTuple(simple: String, package: String)
+    name = name.lchop('.')
+    if name.includes?('.')
+      pkg, _, simple = name.rpartition('.')
+      {simple: simple, package: pkg}
+    else
+      {simple: name, package: package}
+    end
+  end
+
+  # Content cache may be cold (budget exhausted, or caching disabled in
+  # tests); fall back to a direct read per the CodeLocator contract.
+  def self.read_content(path : String) : String?
+    cached = CodeLocator.instance.content_for(path)
+    return cached if cached
+    return unless File.exists?(path)
+    File.read(path, encoding: "utf-8", invalid: :skip)
+  end
+
+  private def self.link_handler(endpoint : Endpoint, simple : String,
+                                path : String, lang : Symbol) : Endpoint
+    content = read_content(path) || ""
+
+    callees = [] of Callee
+    if lang == :kotlin
+      Noir::TreeSitter.parse_kotlin(content) do |root|
+        HANDLER_METHODS.each do |method|
+          Noir::KotlinCalleeExtractor.callees_in_method(root, content, path, simple, method).each do |name, fpath, line|
+            callees << Callee.new(name, path: fpath, line: line)
+          end
+        end
+      end
+    else
+      Noir::TreeSitter.parse_java(content) do |root|
+        HANDLER_METHODS.each do |method|
+          Noir::JavaCalleeExtractor.callees_in_method(root, content, path, simple, method).each do |name, fpath, line|
+            callees << Callee.new(name, path: fpath, line: line)
+          end
+        end
+      end
+    end
+
+    anchor_line = handler_anchor_line(content, simple)
+    endpoint.details.add_path(PathInfo.new(path, anchor_line))
+    callees.each { |callee| endpoint.push_callee(callee) }
+    endpoint
+  end
+
+  # Best-effort source line for the handler so the AI-context snippet window
+  # covers the intent-reading code: prefer the first handler-method
+  # declaration, fall back to the class declaration.
+  private def self.handler_anchor_line(content : String, simple : String) : Int32?
+    method_re = /\b(?:fun|void|public|protected|private|override)\b.*\b(?:#{HANDLER_METHODS.join("|")})\s*\(/
+    class_re = /\b(?:class|object)\s+#{Regex.escape(simple)}\b/
+    class_line : Int32? = nil
+
+    content.each_line.with_index do |line, idx|
+      return idx + 1 if line.matches?(method_re)
+      class_line = idx + 1 if class_line.nil? && line.matches?(class_re)
+    end
+
+    class_line
+  end
+
+  # Lazily indexes every project .kt/.java file by the simple names it
+  # declares, so a manifest component name resolves to a file in O(1) after
+  # one content scan. Disambiguates by package when several files share a
+  # class name.
+  class ClassIndex
+    record Entry, path : String, lang : Symbol, package : String
+
+    DECL_RE    = /\b(?:class|object|interface)\s+([A-Z]\w*)/
+    PACKAGE_RE = /^\s*package\s+([\w.]+)/
+
+    def initialize
+      @index = Hash(String, Array(Entry)).new
+      @built = false
+    end
+
+    def resolve(simple : String, package : String) : NamedTuple(path: String, lang: Symbol)?
+      build unless @built
+      entries = @index[simple]?
+      return unless entries
+
+      entry = entries.find { |e| !package.empty? && e.package == package } || entries.first
+      {path: entry.path, lang: entry.lang}
+    end
+
+    private def build
+      @built = true
+      locator = CodeLocator.instance
+      {".kt" => :kotlin, ".java" => :java}.each do |ext, lang|
+        locator.files_by_extension(ext).each do |path|
+          content = NoirMobileLinker.read_content(path)
+          next unless content
+          package = content.match(PACKAGE_RE).try(&.[1]) || ""
+          content.scan(DECL_RE) do |m|
+            (@index[m[1]] ||= [] of Entry) << Entry.new(path, lang.as(Symbol), package)
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -27,6 +27,13 @@ module NoirMobileLinker
     handleIntent handleDeepLink onReceive onBind
   ]
 
+  # Inputs the handler reads from the inbound deep link. `getQueryParameter`
+  # reads a real URI query parameter (surfaced as a "query" param, baked
+  # into the URL like any other); the `get*Extra` family reads Intent extras
+  # (a Bundle, not part of the URI) and is surfaced as the "extra" type.
+  QUERY_PARAM_RE = /\.getQueryParameter\s*\(\s*"([^"]+)"/
+  EXTRA_PARAM_RE = /\.get(?:String|Int|Integer|Boolean|Long|Float|Double|Char|Byte|Short|Parcelable|Serializable|StringArray|CharSequence|Bundle)Extra\s*\(\s*"([^"]+)"/
+
   def self.apply(endpoints : Array(Endpoint), logger : NoirLogger) : Array(Endpoint)
     return endpoints unless endpoints.any? { |ep| android_handler_target?(ep) }
 
@@ -122,7 +129,18 @@ module NoirMobileLinker
     anchor_line = handler_anchor_line(content, simple)
     endpoint.details.add_path(PathInfo.new(path, anchor_line))
     callees.each { |callee| endpoint.push_callee(callee) }
+    extract_input_params(content).each { |param| endpoint.push_param(param) }
     endpoint
+  end
+
+  # Scans the handler source for inbound-deep-link reads. Scoped to the
+  # handler file (the component), which is the deep-link processing unit;
+  # only string-literal keys are captured.
+  private def self.extract_input_params(content : String) : Array(Param)
+    params = [] of Param
+    content.scan(QUERY_PARAM_RE) { |m| params << Param.new(m[1], "", "query") }
+    content.scan(EXTRA_PARAM_RE) { |m| params << Param.new(m[1], "", "extra") }
+    params
   end
 
   # Best-effort source line for the handler so the AI-context snippet window

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -128,18 +128,25 @@ module NoirMobileLinker
 
     anchor_line = handler_anchor_line(content, simple)
     endpoint.details.add_path(PathInfo.new(path, anchor_line))
+    extract_input_params(callees, content).each { |param| endpoint.push_param(param) }
     callees.each { |callee| endpoint.push_callee(callee) }
-    extract_input_params(content).each { |param| endpoint.push_param(param) }
     endpoint
   end
 
-  # Scans the handler source for inbound-deep-link reads. Scoped to the
-  # handler file (the component), which is the deep-link processing unit;
-  # only string-literal keys are captured.
-  private def self.extract_input_params(content : String) : Array(Param)
+  # Extracts inbound-deep-link reads from the *handler-method* call sites
+  # only. `callees` come from `callees_in_method` over HANDLER_METHODS, so
+  # scanning their source lines (rather than the whole file) keeps reads in
+  # unrelated methods of the same component from becoming phantom params.
+  private def self.extract_input_params(callees : Array(Callee), content : String) : Array(Param)
+    lines = content.lines
     params = [] of Param
-    content.scan(QUERY_PARAM_RE) { |m| params << Param.new(m[1], "", "query") }
-    content.scan(EXTRA_PARAM_RE) { |m| params << Param.new(m[1], "", "extra") }
+    callees.each do |callee|
+      line = callee.line
+      next unless line && line >= 1 && line <= lines.size
+      src = lines[line - 1]
+      src.scan(QUERY_PARAM_RE) { |m| params << Param.new(m[1], "", "query") }
+      src.scan(EXTRA_PARAM_RE) { |m| params << Param.new(m[1], "", "extra") }
+    end
     params
   end
 

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -6,6 +6,7 @@ require "../deliver/*"
 require "../output_builder/*"
 require "../optimizer/llm_optimizer.cr"
 require "../ai_context/augmentor.cr"
+require "../mobile/linker.cr"
 require "./endpoint.cr"
 require "./logger.cr"
 require "../utils/*"
@@ -144,6 +145,10 @@ class NoirRunner
     # Use the new optimizer module
     optimizer = LLMEndpointOptimizer.new(@logger, @options)
     @endpoints = optimizer.optimize(@endpoints)
+
+    # Link mobile deep-link endpoints to their handler source (callees +
+    # handler code_path) so taggers and AI context see the real surface.
+    @endpoints = NoirMobileLinker.apply(@endpoints, @logger)
 
     # Set status code
     if any_to_bool(@options["status_codes"]) || !@options["exclude_codes"].to_s.empty?

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -108,6 +108,14 @@ class OutputBuilderCommon < OutputBuilder
         end
       end
 
+      # Intent extras (Bundle inputs, not part of the URI) read by a mobile
+      # handler. Query params bake into the URL, so only "extra" is listed.
+      extra_params = endpoint.params.select { |p| p.param_type == "extra" }
+      if extra_params.size > 0
+        r_extras = extra_params.map(&.name).join(", ").colorize(:cyan).toggle(@is_color)
+        r_buffer << "\n  ○ extras: #{r_extras}"
+      end
+
       if baked[:body_type] == "form"
         form_params = endpoint.params.select { |p| p.param_type == "form" }
         unless form_params.empty?

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2,6 +2,7 @@ require "json"
 
 module NoirTechs
   CALLEE_SUPPORTED_TECHS = [
+    "android",
     "cpp_crow", "cpp_drogon",
     "clojure_compojure", "clojure_reitit", "clojure_ring",
     "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
@@ -33,6 +34,7 @@ module NoirTechs
   ]
 
   AI_CONTEXT_GUARD_SUPPORTED_TECHS = [
+    "android",
     "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
     "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_aspnet_mvc", "cs_carter", "cs_fastendpoints",
     "elixir_bandit", "elixir_phoenix", "elixir_plug",


### PR DESCRIPTION
Part of #1943, follow-up to the Android manifest analyzer (#1967, merged). Re-created on `main` after the original stack base was deleted.

## Summary

Connects each Android deep-link endpoint to the source that handles it, so it carries the handler's callees, the inputs it reads, and the ai_context taint path — not just a config-derived URL.

A post-analysis pass `NoirMobileLinker.apply` (after optimize, before taggers + AI-context) for each Android mobile endpoint:
1. resolves the handler component (`metadata["via"]` / the `intent://` component) to its `.kt`/`.java` file via a lazy class index,
2. adds that file as a `code_path`, and
3. extracts 1-hop callees from the intent-handling methods (`onCreate`, `onNewIntent`, …) via the existing tree-sitter Kotlin/Java callee extractors.

Input params are read from the handler call sites: `uri.getQueryParameter("q")` → query param (bakes into the URL, e.g. `myapp://complex/:id?redirect=`), the `get*Extra` family → `extra` param (rendered as `○ extras: a, b`). The existing AI-context builder (not tech-gated) then derives sinks/sources; two mobile sink patterns are added (`webview_load`, `intent_redirect`).

Result on `myapp://complex/:id`: callees `webView.loadUrl`/`renderProfile`/…, params id(path)+redirect/utm_source(query)+userId/verified(extra), ai_context `sinks=[webview_load]` + all params as `request_input` sources.

## Review-driven fix included
Input-param extraction is scoped to the **handler-method call sites** (not the whole file), so a `getStringExtra` in an unrelated method of the same Activity can't become a phantom param.

## Tests
Fixture gains `DeepLinkActivity.kt`; android tester asserts callees + params; unit spec covers resolution / callee+param extraction / no-op on unresolved. Full suite green; ameba + format clean.