### PR TITLE
feat(mobile): link iOS deep links to dispatch handlers — callees, params, ai_context (#1943)

### DIFF
--- a/spec/functional_test/fixtures/mobile/ios/SceneDelegate.swift
+++ b/spec/functional_test/fixtures/mobile/ios/SceneDelegate.swift
@@ -1,0 +1,31 @@
+import UIKit
+import WebKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var webView: WKWebView?
+
+    // Custom URL scheme dispatch (myapp:// , myapp-alt://)
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let redirect = components?.queryItems?.first(where: { $0.name == "redirect" })?.value
+        handleDeepLink(url)
+        if let redirect = redirect, let target = URL(string: redirect) {
+            webView?.load(URLRequest(url: target))
+        }
+    }
+
+    // Universal link dispatch (https://...)
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard let url = userActivity.webpageURL else { return }
+        routeUniversalLink(url)
+    }
+
+    private func handleDeepLink(_ url: URL) {
+        logEvent(url.absoluteString)
+    }
+
+    private func routeUniversalLink(_ url: URL) {
+        openProfile(url.lastPathComponent)
+    }
+}

--- a/spec/functional_test/testers/mobile/ios_spec.cr
+++ b/spec/functional_test/testers/mobile/ios_spec.cr
@@ -4,20 +4,24 @@ require "../../func_spec.cr"
 # Mobile endpoints keep method = "GET"; the protocol carries the semantics.
 # Endpoint is a struct, so `.tap(&.protocol=)` would NOT persist (the block
 # mutates a copy) — build via a Proc that returns the mutated local so
-# FunctionalTester actually asserts the protocol.
-build = ->(url : String, protocol : String) do
-  ep = Endpoint.new(url, "GET")
+# FunctionalTester actually asserts the protocol, callees, and params.
+build = ->(url : String, protocol : String, params : Array(Param), callees : Array(String)) do
+  ep = Endpoint.new(url, "GET", params)
   ep.protocol = protocol
+  callees.each { |name| ep.push_callee(Callee.new(name)) }
   ep
 end
 
+no_params = [] of Param
+
 expected_endpoints = [
-  # CFBundleURLTypes > CFBundleURLSchemes (mobile-scheme); scheme-only, no path
-  build.call("myapp://", "mobile-scheme"),
-  build.call("myapp-alt://", "mobile-scheme"),
-  # associated-domains applinks: (universal-link); ?mode= stripped, webcredentials ignored
-  build.call("https://myapp.example.com/", "universal-link"),
-  build.call("https://www.example.com/", "universal-link"),
+  # Custom schemes (mobile-scheme), linked to the SceneDelegate URL handler:
+  # callees + the redirect query param read from URLQueryItem.
+  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load"]),
+  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load"]),
+  # Universal links (universal-link), linked to the userActivity handler.
+  build.call("https://myapp.example.com/", "universal-link", no_params, ["routeUniversalLink"]),
+  build.call("https://www.example.com/", "universal-link", no_params, ["routeUniversalLink"]),
 ]
 
 FunctionalTester.new("fixtures/mobile/ios/", {

--- a/src/ai_context/patterns.cr
+++ b/src/ai_context/patterns.cr
@@ -195,8 +195,8 @@ module NoirAIContext
       "webview_load",
       "WebView load of a potentially attacker-controlled URL/HTML — a deep-link XSS/SSRF surface on mobile",
       80,
-      name_patterns: [/\.loadUrl\b/i, /\.loadData(WithBaseURL)?\b/i, /\.evaluateJavascript\b/i],
-      source_patterns: [/\.loadUrl\s*\(/i, /\.loadData(WithBaseURL)?\s*\(/i, /\.evaluateJavascript\s*\(/i]
+      name_patterns: [/\.loadUrl\b/i, /\.loadData(WithBaseURL)?\b/i, /\.evaluateJavascript\b/i, /\b(?:wk)?web_?view\w*\??\.load\b/i],
+      source_patterns: [/\.loadUrl\s*\(/i, /\.loadData(WithBaseURL)?\s*\(/i, /\.evaluateJavascript\s*\(/i, /\b(?:wk)?web_?view\w*\??\.load\s*\(/i, /\.load\s*\(\s*URLRequest/]
     ),
     PatternDefinition.new(
       "intent_redirect",

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -3,6 +3,7 @@ require "../models/code_locator"
 require "../ext/tree_sitter/tree_sitter"
 require "../miniparsers/kotlin_callee_extractor"
 require "../miniparsers/java_callee_extractor"
+require "../miniparsers/swift_callee_extractor"
 
 # Post-analysis pass that links mobile deep-link endpoints (produced by the
 # config-file analyzers from AndroidManifest.xml) to the source code that
@@ -35,7 +36,15 @@ module NoirMobileLinker
   EXTRA_PARAM_RE = /\.get(?:String|Int|Integer|Boolean|Long|Float|Double|Char|Byte|Short|Parcelable|Serializable|StringArray|CharSequence|Bundle)Extra\s*\(\s*"([^"]+)"/
 
   def self.apply(endpoints : Array(Endpoint), logger : NoirLogger) : Array(Endpoint)
-    return endpoints unless endpoints.any? { |ep| android_handler_target?(ep) }
+    link_android(endpoints, logger)
+    link_ios(endpoints, logger)
+    endpoints
+  end
+
+  # Android: each component maps to its own handler class (metadata["via"] /
+  # the intent:// component), resolved per endpoint.
+  private def self.link_android(endpoints : Array(Endpoint), logger : NoirLogger)
+    return unless endpoints.any? { |ep| android_handler_target?(ep) }
 
     index = ClassIndex.new
     endpoints.each_with_index do |endpoint, i|
@@ -52,8 +61,39 @@ module NoirMobileLinker
         logger.debug "Mobile linker failed for #{endpoint.url} (#{resolved[:path]}): #{e.message}"
       end
     end
+  end
 
-    endpoints
+  # iOS: deep links are dispatched centrally (App/SceneDelegate), so there is
+  # no per-endpoint `via`. Discover the handlers once and attach by kind —
+  # URL handlers (onOpenURL / application(open:) / scene(openURLContexts:))
+  # to custom schemes, userActivity handlers to universal links.
+  private def self.link_ios(endpoints : Array(Endpoint), logger : NoirLogger)
+    return unless endpoints.any? { |ep| ios_handler_target?(ep) }
+
+    begin
+      handlers = IosHandlers.discover
+    rescue e
+      logger.debug "Mobile linker (iOS) handler discovery failed: #{e.message}"
+      return
+    end
+
+    endpoints.each_with_index do |endpoint, i|
+      next unless ios_handler_target?(endpoint)
+      info = endpoint.protocol == "universal-link" ? handlers[:activity] : handlers[:url]
+      next if info.empty?
+      endpoints[i] = apply_handler_info(endpoint, info)
+    end
+  end
+
+  private def self.ios_handler_target?(endpoint : Endpoint) : Bool
+    MOBILE_PROTOCOLS.includes?(endpoint.protocol) && endpoint.details.technology == "ios"
+  end
+
+  private def self.apply_handler_info(endpoint : Endpoint, info : HandlerInfo) : Endpoint
+    info.code_paths.each { |pi| endpoint.details.add_path(pi) }
+    info.callees.each { |callee| endpoint.push_callee(callee) }
+    info.params.each { |param| endpoint.push_param(param) }
+    endpoint
   end
 
   # An endpoint we can resolve to an Android component: a mobile protocol
@@ -203,6 +243,135 @@ module NoirMobileLinker
           end
         end
       end
+    end
+  end
+
+  # Aggregated handler evidence to graft onto an endpoint.
+  struct HandlerInfo
+    getter code_paths : Array(PathInfo)
+    getter callees : Array(Callee)
+    getter params : Array(Param)
+
+    def initialize
+      @code_paths = [] of PathInfo
+      @callees = [] of Callee
+      @params = [] of Param
+    end
+
+    def empty? : Bool
+      @code_paths.empty? && @callees.empty? && @params.empty?
+    end
+  end
+
+  # Scans .swift files once for the central deep-link dispatch handlers and
+  # groups their callees/params by kind. URL handlers process custom schemes;
+  # userActivity handlers process universal links.
+  module IosHandlers
+    # Same-line markers for the brace that opens a handler body.
+    URL_HANDLER_RES = [
+      /\.onOpenURL\s*\{/,
+      /\bfunc\s+application\s*\(.*\bopen\s+url\s*:/,
+      /\bfunc\s+scene\s*\(.*\bopenURLContexts\b/,
+    ]
+    ACTIVITY_HANDLER_RES = [
+      /\bfunc\s+application\s*\(.*\bcontinue\s+userActivity\s*:/,
+      /\bfunc\s+scene\s*\(.*\bcontinue\s+userActivity\s*:/,
+      /\.onContinueUserActivity\s*\(/,
+    ]
+
+    # URLQueryItem name comparisons inside a handler — the iOS analog of
+    # Android's getQueryParameter. Anchored to the closure-shorthand form
+    # (`$0.name == "x"`) and an explicit `URLQueryItem(name: "x")` so a plain
+    # `user.name == "admin"` comparison can't become a phantom query param.
+    QUERY_NAME_RE = /\$\d+\.name\s*==\s*"([^"]+)"/
+    QUERY_ITEM_RE = /URLQueryItem\(\s*name:\s*"([^"]+)"/
+
+    def self.discover : Hash(Symbol, NoirMobileLinker::HandlerInfo)
+      url = NoirMobileLinker::HandlerInfo.new
+      activity = NoirMobileLinker::HandlerInfo.new
+
+      CodeLocator.instance.files_by_extension(".swift").each do |path|
+        next if path.includes?("/.build/") || path.includes?("/.swiftpm/")
+        content = NoirMobileLinker.read_content(path)
+        next unless content
+        scan_file(path, content, url, activity)
+      end
+
+      {:url => url, :activity => activity}
+    end
+
+    private def self.scan_file(path : String, content : String,
+                               url : NoirMobileLinker::HandlerInfo,
+                               activity : NoirMobileLinker::HandlerInfo)
+      lines = content.lines
+      depth = 0
+      in_string = false
+
+      lines.each_with_index do |line, index|
+        stripped, depth, in_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, depth, in_string)
+        target = if URL_HANDLER_RES.any? { |re| stripped.matches?(re) }
+                   url
+                 elsif ACTIVITY_HANDLER_RES.any? { |re| stripped.matches?(re) }
+                   activity
+                 end
+        next unless target
+
+        brace = find_opening_brace(lines, index)
+        next unless brace
+        body, body_line = body_after_opening_brace(lines, brace[:index], brace[:col])
+
+        target.code_paths << PathInfo.new(path, index + 1)
+        Noir::SwiftCalleeExtractor.callees_for_body(body, path, body_line).each do |name, fpath, fline|
+          target.callees << Callee.new(name, path: fpath, line: fline)
+        end
+        body.scan(QUERY_NAME_RE) { |m| target.params << Param.new(m[1], "", "query") }
+        body.scan(QUERY_ITEM_RE) { |m| target.params << Param.new(m[1], "", "query") }
+      end
+    end
+
+    # Finds the first `{` at/after the matched line (same line, else the next
+    # few lines for a func whose brace is on its own line).
+    private def self.find_opening_brace(lines : Array(String), start : Int32) : NamedTuple(index: Int32, col: Int32)?
+      idx = start
+      while idx < lines.size && idx <= start + 3
+        col = lines[idx].index('{')
+        return {index: idx, col: col} if col
+        idx += 1
+      end
+      nil
+    end
+
+    # Brace-matched body text starting just after lines[opening_index][col],
+    # ignoring braces inside comments/strings. Ported from the Swift analyzers'
+    # shared body_after_opening_brace.
+    private def self.body_after_opening_brace(lines : Array(String), opening_index : Int32, col : Int32) : Tuple(String, Int32)
+      first = lines[opening_index][(col + 1)..]? || ""
+      clean, depth, in_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(first, 0, false)
+      brace = 1 + clean.count('{') - clean.count('}')
+      if brace <= 0
+        # Single-line body: trim the closing `}` and anything after it so a
+        # trailing `.padding()` etc. doesn't leak into the handler body.
+        closing = clean.rindex('}')
+        return {closing ? first[0...closing] : first, opening_index + 1}
+      end
+
+      body = [first]
+      idx = opening_index + 1
+      while idx < lines.size && brace > 0
+        line = lines[idx]
+        stripped, depth, in_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, depth, in_string)
+        nxt = brace + stripped.count('{') - stripped.count('}')
+        if nxt <= 0
+          closing = stripped.rindex('}')
+          body << (closing ? line[0...closing] : line) unless line.strip == "}"
+          break
+        end
+        body << line
+        brace = nxt
+        idx += 1
+      end
+
+      {body.join("\n"), opening_index + 1}
     end
   end
 end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2,7 +2,7 @@ require "json"
 
 module NoirTechs
   CALLEE_SUPPORTED_TECHS = [
-    "android",
+    "android", "ios",
     "cpp_crow", "cpp_drogon",
     "clojure_compojure", "clojure_reitit", "clojure_ring",
     "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
@@ -34,7 +34,7 @@ module NoirTechs
   ]
 
   AI_CONTEXT_GUARD_SUPPORTED_TECHS = [
-    "android",
+    "android", "ios",
     "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
     "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_aspnet_mvc", "cs_carter", "cs_fastendpoints",
     "elixir_bandit", "elixir_phoenix", "elixir_plug",


### PR DESCRIPTION
Part of #1943, the final piece of the mobile deep-link series. Re-created on `main` after the original stack base was deleted. Builds on the Android code-linkage (#1971, merged) and iOS analyzer (#1972, merged).

## Summary

Extends the deep-link → handler-code linkage to **iOS**, so iOS deep links carry their handler's callees, input params, and ai_context taint — the same end-to-end picture as Android.

iOS config files name no handler (deep links are dispatched centrally by the App/SceneDelegate), so the linker discovers the handlers **once** and attaches them **by kind**:

| Handler | matches | attached to |
|---|---|---|
| URL | `.onOpenURL` / `application(_:open:)` / `scene(_:openURLContexts:)` | custom-scheme endpoints |
| userActivity | `application(_:continue:)` / `scene(_:continue:)` / `.onContinueUserActivity` | universal-link endpoints |

Reuses `Noir::SwiftCalleeExtractor` (porting the Swift analyzers' brace-matched body extraction) for callees, captures `URLQueryItem` `$0.name == "x"` reads as query params, and adds the handler file as a `code_path`. The `webview_load` sink name pattern is broadened to match webview-receiver `.load` callees (`webView?.load`) since the AI-context route-scope snippet truncates on verbose Swift signatures.

Result on `myapp://`: SceneDelegate handler callees, the `redirect` query param, and `ai_context sinks=[webview_load]`.

## Review-driven fixes included
- iOS query-param regex anchored to the URLQueryItem idioms (`$0.name` / `URLQueryItem(name:)`) so a plain `user.name == "x"` can't become a phantom param.
- Single-line handler bodies trim the trailing `}` (ported behavior).

## Tests
Fixture gains `SceneDelegate.swift`; iOS tester asserts per-kind callees + the query param. Full suite green; ameba + format clean.