### PR TITLE
feat(mobile): guard HTTP-shaped output/delivery against deep-link endpoints (#1943)

### DIFF
--- a/spec/unit_test/output_builder/mobile_guard_spec.cr
+++ b/spec/unit_test/output_builder/mobile_guard_spec.cr
@@ -1,0 +1,56 @@
+require "../../spec_helper"
+require "../../../src/output_builder/curl"
+require "../../../src/output_builder/oas3"
+require "../../../src/models/endpoint"
+require "../../../src/utils/utils"
+
+# Mobile deep-link endpoints are app URLs, not HTTP requests — they must be
+# excluded from HTTP-shaped output (curl/httpie/powershell, OpenAPI) and from
+# active probing/proxy delivery, while remaining in the JSON/YAML inventory.
+describe "mobile endpoint guards" do
+  options = {
+    "debug"   => YAML::Any.new(false),
+    "verbose" => YAML::Any.new(false),
+    "color"   => YAML::Any.new(false),
+    "nolog"   => YAML::Any.new(false),
+    "output"  => YAML::Any.new(""),
+    "url"     => YAML::Any.new(""),
+  }
+
+  http = Endpoint.new("/api/users", "GET")
+  scheme = Endpoint.new("myapp://complex/:id", "GET")
+  scheme.protocol = "mobile-scheme"
+  intent = Endpoint.new("intent://com.example.app/.Foo", "GET")
+  intent.protocol = "android-intent"
+  applink = Endpoint.new("https://app.example.com/", "GET")
+  applink.protocol = "universal-link"
+  endpoints = [http, scheme, intent, applink]
+
+  it "Endpoint#mobile? identifies the three mobile protocols" do
+    http.mobile?.should be_false
+    scheme.mobile?.should be_true
+    intent.mobile?.should be_true
+    applink.mobile?.should be_true
+  end
+
+  it "curl output excludes mobile endpoints but keeps HTTP" do
+    builder = OutputBuilderCurl.new(options)
+    builder.io = IO::Memory.new
+    builder.print(endpoints)
+    out = builder.io.to_s
+    out.should contain("/api/users")
+    out.should_not contain("myapp://")
+    out.should_not contain("intent://")
+    out.should_not contain("app.example.com")
+  end
+
+  it "OAS3 output excludes mobile endpoints from paths" do
+    builder = OutputBuilderOas3.new(options)
+    builder.io = IO::Memory.new
+    builder.print(endpoints)
+    spec = JSON.parse(builder.io.to_s)
+    paths = spec["paths"].as_h.keys
+    paths.should contain("/api/users")
+    paths.any? { |p| p.includes?("myapp") || p.includes?("intent") }.should be_false
+  end
+end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -223,13 +223,20 @@ module Analyzer::Mobile
       attr(node, local_name) == "true"
     end
 
-    # Reads an attribute by local name, ignoring the `android:` namespace
-    # prefix (libxml2 exposes the prefixed name on the node).
+    ANDROID_NS = "http://schemas.android.com/apk/res/android"
+
+    # Reads an attribute by local name (libxml2 exposes the prefixed name).
+    # Prefers the `android:`-namespaced attribute so a `tools:`/other-prefix
+    # `scheme`/`host`/`exported` in the same tag can't shadow the real value;
+    # falls back to a non-namespaced match (e.g. `package` on <manifest>).
     private def attr(node : XML::Node, local_name : String) : String?
+      fallback : String? = nil
       node.attributes.each do |a|
-        return a.content if a.name == local_name
+        next unless a.name == local_name
+        return a.content if a.namespace.try(&.href) == ANDROID_NS
+        fallback ||= a.content
       end
-      nil
+      fallback
     end
 
     private def find_child(node : XML::Node, local_name : String) : XML::Node?

--- a/src/deliver/send_proxy.cr
+++ b/src/deliver/send_proxy.cr
@@ -10,6 +10,7 @@ class SendWithProxy < Deliver
     wg = WaitGroup.new
 
     applied_endpoints.each do |endpoint|
+      next if endpoint.mobile? # can't replay an app deep link through an HTTP proxy
       wg.add(1)
       spawn do
         begin

--- a/src/deliver/send_req.cr
+++ b/src/deliver/send_req.cr
@@ -9,6 +9,7 @@ class SendReq < Deliver
     wg = WaitGroup.new
 
     applied_endpoints.each do |endpoint|
+      next if endpoint.mobile? # can't HTTP-probe an app deep link
       wg.add(1)
       spawn do
         begin

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -20,8 +20,6 @@ require "../miniparsers/swift_callee_extractor"
 # endpoints (no `via`, dispatched by the App/SceneDelegate) are left for a
 # follow-up.
 module NoirMobileLinker
-  MOBILE_PROTOCOLS = Set{"mobile-scheme", "android-intent", "universal-link"}
-
   # Methods where an Android component reads its inbound intent / deep link.
   HANDLER_METHODS = %w[
     onCreate onNewIntent onStart onResume onStartCommand onHandleIntent
@@ -86,7 +84,7 @@ module NoirMobileLinker
   end
 
   private def self.ios_handler_target?(endpoint : Endpoint) : Bool
-    MOBILE_PROTOCOLS.includes?(endpoint.protocol) && endpoint.details.technology == "ios"
+    endpoint.mobile? && endpoint.details.technology == "ios"
   end
 
   private def self.apply_handler_info(endpoint : Endpoint, info : HandlerInfo) : Endpoint
@@ -100,7 +98,7 @@ module NoirMobileLinker
   # with either a `via` class (scheme / universal-link) or an intent://
   # component URL (android-intent). iOS schemes carry neither.
   private def self.android_handler_target?(endpoint : Endpoint) : Bool
-    return false unless MOBILE_PROTOCOLS.includes?(endpoint.protocol)
+    return false unless endpoint.mobile?
     return true if endpoint.url.starts_with?("intent://")
     !!(endpoint.metadata.try &.has_key?("via"))
   end

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -7,6 +7,16 @@ struct Endpoint
   property url, method, params, protocol, kind, details, tags, callees, internal
   property ai_context : AIContext?
 
+  # Non-HTTP mobile deep-link protocols. These endpoints are app URLs you
+  # open (myapp://, intent://, verified https app links), not HTTP requests
+  # you send — so they are excluded from HTTP-shaped output (curl/httpie/
+  # powershell, OpenAPI) and from active probing / proxy delivery.
+  MOBILE_PROTOCOLS = Set{"mobile-scheme", "android-intent", "universal-link"}
+
+  def mobile? : Bool
+    MOBILE_PROTOCOLS.includes?(@protocol)
+  end
+
   # Free-form metadata for non-HTTP entry points (mobile deep-link
   # schemes, Android intents, universal links: action/category/host/
   # package/...). nil for ordinary endpoints and suppressed from

--- a/src/output_builder/curl.cr
+++ b/src/output_builder/curl.cr
@@ -4,6 +4,7 @@ require "../models/endpoint"
 class OutputBuilderCurl < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
+      next if endpoint.mobile? # mobile deep links aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
       parts = ["curl", "-i", "-X", shell_quote(endpoint.method), shell_quote(baked[:url])]

--- a/src/output_builder/httpie.cr
+++ b/src/output_builder/httpie.cr
@@ -5,6 +5,7 @@ require "json"
 class OutputBuilderHttpie < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
+      next if endpoint.mobile? # mobile deep links aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
       parts = ["http"]

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -10,6 +10,7 @@ class OutputBuilderOas2 < OutputBuilder
     paths = {} of String => Hash(String, JSON::Any)
 
     endpoints.each do |endpoint|
+      next if endpoint.mobile? # deep links aren't HTTP paths; keep them out of the spec
       parameters = [] of Hash(String, JSON::Any)
       consumes = [] of String
       cookie_names = [] of String

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -10,6 +10,7 @@ class OutputBuilderOas3 < OutputBuilder
     paths = {} of String => Hash(String, JSON::Any)
 
     endpoints.each do |endpoint|
+      next if endpoint.mobile? # deep links aren't HTTP paths; keep them out of the spec
       parameters = [] of Hash(String, JSON::Any)
       json_properties = {} of String => JSON::Any
       form_properties = {} of String => JSON::Any

--- a/src/output_builder/powershell.cr
+++ b/src/output_builder/powershell.cr
@@ -4,6 +4,7 @@ require "../models/endpoint"
 class OutputBuilderPowershell < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
+      next if endpoint.mobile? # mobile deep links aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
       cmd = "Invoke-WebRequest -Method \"#{escape_powershell(endpoint.method)}\" -Uri \"#{escape_powershell(baked[:url])}\""


### PR DESCRIPTION
Follow-up hardening for the mobile deep-link analyzers (#1967/#1971/#1972/#1973, merged).

## Why

Mobile deep-link endpoints (`myapp://`, `intent://com.example.app/.Foo`, verified `https://` app links) are app URLs you *open*, not HTTP requests you *send*. Today they'd leak into HTTP-shaped formats as nonsense — `curl -X GET myapp://...`, a `myapp://` key in an OpenAPI `paths` object (invalid OAS), or a failed `Crest` probe.

## What

Adds a shared `Endpoint#mobile?` (backed by `Endpoint::MOBILE_PROTOCOLS`) and excludes mobile endpoints where an HTTP shape is assumed:

| Surface | Behavior |
|---|---|
| curl / httpie / powershell builders | skip mobile endpoints |
| OpenAPI 2 / 3 builders | skip mobile endpoints (not valid OAS paths) |
| send_req (active probe) / send_proxy (replay) | skip mobile endpoints |
| json / yaml / jsonl / sarif / markdown / mermaid / html | kept — inventory of the surface |
| elasticsearch / webhook export | kept — part of the exported surface |

The linker reuses `Endpoint#mobile?` (dropping its duplicate protocol set).

## Also (review follow-up)

The Android manifest `attr()` reader now prefers the `android:`-namespaced attribute, so a `tools:scheme` / other-prefixed `scheme`/`host`/`exported` in the same tag can't shadow the real `android:` value (verified: `tools:scheme="ignored"` previously won by document order).

## Tests

`spec/unit_test/output_builder/mobile_guard_spec.cr`: asserts `Endpoint#mobile?` and that curl/OAS3 exclude mobile endpoints while keeping HTTP ones. Full suite 21027 examples, 0 failures; ameba + format clean.

Part of #1943.