### PR TITLE
feat(mobile): Android phase-2 deep links — gradle ${applicationId} placeholders, Jetpack Navigation graphs

### DIFF
--- a/docs/content/usage/supported/mobile/index.ko.md
+++ b/docs/content/usage/supported/mobile/index.ko.md
@@ -14,12 +14,14 @@ Noir는 모바일 앱이 외부에 노출하는 진입점 — 딥링크와 expor
 |---|---|---|
 | Android | `AndroidManifest.xml` | 커스텀 URL 스킴 딥링크, exported 인텐트 컴포넌트, 검증된 App Link |
 | Android | `res/values/strings.xml` | 스킴·호스트·경로에 쓰인 `@string/` 참조 해석 |
+| Android | `build.gradle` / `build.gradle.kts` | 패키지·컴포넌트 이름·스킴·호스트에 쓰인 `${applicationId}`와 커스텀 `manifestPlaceholders` 해석. 매니페스트에 `package` 속성이 없으면 패키지도 여기서 가져옵니다 |
+| Android | `res/navigation/*.xml` | Jetpack Navigation `<deepLink app:uri="...">` 딥링크 — 소속 destination이 처리 컴포넌트가 됩니다 |
 | iOS | `Info.plist` | `CFBundleURLTypes` 커스텀 URL 스킴 |
 | iOS | `*.entitlements` | `associated-domains`의 `applinks:` 유니버설 링크 |
 | Android | `/.well-known/assetlinks.json` | 서버 측 App Links 연결 선언(Digital Asset Links) |
 | iOS | `apple-app-site-association` | 서버 측 유니버설 링크 `paths` / `components` 패턴 |
 
-앞의 네 행은 앱 번들에 선언되는 **클라이언트** 측 연결이고, 마지막 두 행은 **서버** 측 — OS가 해당 호스트의 URL에 대해 앱을 열도록 호스트가 게시하는 well-known 파일 — 입니다. 둘 다 동일한 `universal-link` protocol과 출력 모델을 통해 처리됩니다.
+앞의 여섯 행은 앱 번들에 선언되는 **클라이언트** 측 연결이고, 마지막 두 행은 **서버** 측 — OS가 해당 호스트의 URL에 대해 앱을 열도록 호스트가 게시하는 well-known 파일 — 입니다. 둘 다 동일한 `universal-link` protocol과 출력 모델을 통해 처리됩니다.
 
 ## 엔드포인트 모델
 
@@ -58,6 +60,7 @@ SCHEME myapp://complex/:id
 
 * 핸들러 연결에는 소스 코드가 필요합니다. 매니페스트·plist만 있는 스캔도 엔드포인트는 추출하지만 callee·파라미터·AI 컨텍스트는 붙지 않습니다.
 * 바이너리(컴파일된) `Info.plist`는 건너뜁니다. 소스 저장소의 XML plist는 파싱합니다.
-* gradle `${applicationId}` 플레이스홀더와 Jetpack Navigation 딥링크는 아직 해석하지 않습니다.
+* gradle 플레이스홀더는 매니페스트 위쪽에서 가장 가까운 `build.gradle(.kts)`를 읽어 해석합니다. 같은 플레이스홀더가 여러 번 선언되면(예: `buildTypes` 오버라이드) 먼저 선언된 쪽 — 관례상 `defaultConfig` — 이 우선하며, 빌드 variant별 값은 모델링하지 않습니다. gradle에 값이 없는 플레이스홀더는 URL에 그대로 남고 엔드포인트에 `unresolved` 태그가 붙습니다.
+* 스킴 없는 Jetpack Navigation URI(런타임에는 http·https 모두 매칭)는 `https` 하나로 추출합니다. `{arg}` 세그먼트는 `:arg` path 파라미터로, `?key={arg}` 쿼리 플레이스홀더는 `query` 파라미터로 바뀌고, 끝의 `.*` 와일드카드는 리터럴 프리픽스만 남깁니다.
 * `assetlinks.json`은 패키지 연결만 선언하고 경로는 없으므로 앱당 `/*` 엔드포인트 하나를 만듭니다. `apple-app-site-association`의 경로(`/buy/*`, `NOT /private/*`)와 `components`는 개별적으로 추출되며, AASA 제외 패턴은 `excluded` 태그가 붙습니다.
 * `apple-app-site-association`은 plain-JSON 형식만 파싱합니다. CMS로 서명된 AASA 파일(구형 앱)은 건너뜁니다.

--- a/docs/content/usage/supported/mobile/index.md
+++ b/docs/content/usage/supported/mobile/index.md
@@ -14,12 +14,14 @@ Noir extracts mobile app entry points — the deep links and exported components
 |---|---|---|
 | Android | `AndroidManifest.xml` | custom URL-scheme deep links, exported intent components, verified App Links |
 | Android | `res/values/strings.xml` | resolves `@string/` references used in schemes / hosts / paths |
+| Android | `build.gradle` / `build.gradle.kts` | resolves `${applicationId}` and custom `manifestPlaceholders` used in package / component names / schemes / hosts; supplies the package when the manifest has no `package` attribute |
+| Android | `res/navigation/*.xml` | Jetpack Navigation `<deepLink app:uri="...">` deep links — the owning destination becomes the handling component |
 | iOS | `Info.plist` | `CFBundleURLTypes` custom URL schemes |
 | iOS | `*.entitlements` | `associated-domains` `applinks:` universal links |
 | Android | `/.well-known/assetlinks.json` | server-side App Links association (Digital Asset Links) |
 | iOS | `apple-app-site-association` | server-side universal-link `paths` / `components` patterns |
 
-The first four rows are the **client** side of the association, declared in the app bundle. The last two are the **server** side — the well-known files a host publishes so the OS opens the app for its URLs. Both flow through the same `universal-link` protocol and output model.
+The first six rows are the **client** side of the association, declared in the app bundle. The last two are the **server** side — the well-known files a host publishes so the OS opens the app for its URLs. Both flow through the same `universal-link` protocol and output model.
 
 ## Endpoint model
 
@@ -58,6 +60,7 @@ Mobile endpoints stay in the structured inventory — JSON, JSONL, YAML, SARIF, 
 
 * Source code must be present for handler linkage. A manifest- or plist-only scan still yields the endpoints, just without callees, params, or AI context.
 * Binary (compiled) `Info.plist` files are skipped; source-repo XML plists are parsed.
-* gradle `${applicationId}` placeholders and Jetpack Navigation deep links are not yet resolved.
+* gradle placeholder resolution reads the nearest `build.gradle(.kts)` above the manifest; when the same placeholder is declared more than once (e.g. a `buildTypes` override), the first declaration — by convention `defaultConfig` — wins. Variant-specific values are not modeled. A placeholder with no gradle value stays verbatim in the URL and the endpoint is tagged `unresolved`.
+* Scheme-less Jetpack Navigation URIs (which match both http and https at runtime) are emitted once under `https`. `{arg}` segments become `:arg` path params, `?key={arg}` query placeholders become `query` params, and a trailing `.*` wildcard keeps the literal prefix.
 * `assetlinks.json` only declares the package association (no paths), so it yields a single `/*` endpoint per app. `apple-app-site-association` paths (`/buy/*`, `NOT /private/*`) and `components` are emitted individually; AASA exclusions are tagged `excluded`.
 * Only the plain-JSON form of `apple-app-site-association` is parsed; CMS-signed AASA files (older apps) are skipped.

--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -4,11 +4,34 @@
 
     <application android:label="MyApp">
 
-        <!-- Launcher activity: no <data>, must NOT produce any endpoint -->
+        <!-- Launcher activity: no <data>, must NOT produce any endpoint.
+             The <nav-graph> reference is resolved by globbing
+             res/navigation/*.xml, not by following this element. -->
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <nav-graph android:resource="@navigation/nav_graph" />
+        </activity>
+
+        <!-- gradle manifest placeholders: component name from
+             ${applicationId}, scheme/host from manifestPlaceholders -->
+        <activity android:name="${applicationId}.PlaceholderActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="${deepLinkScheme}" android:host="${deepLinkHost}" />
+            </intent-filter>
+        </activity>
+
+        <!-- Placeholder missing from build.gradle: kept verbatim and
+             tagged "unresolved" -->
+        <activity android:name=".UnresolvedActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="myapp" android:host="${missingHost}" />
             </intent-filter>
         </activity>
 

--- a/spec/functional_test/fixtures/mobile/android/build.gradle
+++ b/spec/functional_test/fixtures/mobile/android/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example.myapp'
+
+    defaultConfig {
+        applicationId "com.example.myapp"
+        manifestPlaceholders = [
+            deepLinkScheme: "myapp",
+            deepLinkHost  : "links.example.com"
+        ]
+    }
+
+    buildTypes {
+        debug {
+            // Override that must NOT win over defaultConfig (first wins).
+            manifestPlaceholders = [deepLinkHost: "debug.example.com"]
+        }
+    }
+}

--- a/spec/functional_test/fixtures/mobile/android/res/navigation/nav_graph.xml
+++ b/spec/functional_test/fixtures/mobile/android/res/navigation/nav_graph.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/profileFragment">
+
+    <!-- Deep link with a templated path segment and a query placeholder -->
+    <fragment
+        android:id="@+id/profileFragment"
+        android:name="com.example.myapp.ProfileFragment">
+        <deepLink app:uri="myapp://users/{userId}?ref={ref}" />
+    </fragment>
+
+    <!-- Scheme-less URI: Navigation implies http/https; a trailing .* is a
+         wildcard match -->
+    <fragment
+        android:id="@+id/searchFragment"
+        android:name="com.example.myapp.SearchFragment">
+        <deepLink app:uri="nav.example.com/search/.*" />
+    </fragment>
+
+    <!-- Nested graph; the fragment name uses a gradle placeholder -->
+    <navigation
+        android:id="@+id/settings_nested"
+        app:startDestination="@id/notificationsFragment">
+        <fragment
+            android:id="@+id/notificationsFragment"
+            android:name="${applicationId}.NotificationsFragment">
+            <deepLink app:uri="myapp://settings/notifications" />
+        </fragment>
+    </navigation>
+
+</navigation>

--- a/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/ProfileFragment.kt
+++ b/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/ProfileFragment.kt
@@ -1,0 +1,19 @@
+package com.example.myapp
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+
+class ProfileFragment : Fragment() {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val userId = arguments?.getString("userId")
+        val ref = activity?.intent?.data?.getQueryParameter("ref")
+        loadProfile(userId, ref)
+    }
+
+    private fun loadProfile(userId: String?, ref: String?) {
+        // render the profile for the deep-linked user
+    }
+}

--- a/spec/functional_test/fixtures/mobile/android_kts/app/build.gradle.kts
+++ b/spec/functional_test/fixtures/mobile/android_kts/app/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.android.application")
+}
+
+android {
+    namespace = "com.example.ktsapp"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.ktsapp"
+        minSdk = 24
+        targetSdk = 34
+
+        manifestPlaceholders["authHost"] = "auth.example.com"
+        manifestPlaceholders += mapOf("authScheme" to "ktsauth")
+        manifestPlaceholders.put("legacyScheme", "ktslegacy")
+    }
+}

--- a/spec/functional_test/fixtures/mobile/android_kts/app/src/main/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android_kts/app/src/main/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Modern AGP manifest: no `package` attribute — the package comes from
+     build.gradle.kts (applicationId / namespace), two directories up. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="KtsApp">
+
+        <!-- Component name from ${applicationId}; scheme/host from kts
+             manifestPlaceholders (indexed assignment + mapOf forms) -->
+        <activity android:name="${applicationId}.AuthActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="${authScheme}" android:host="${authHost}" android:path="/callback" />
+            </intent-filter>
+        </activity>
+
+        <!-- Placeholder declared via manifestPlaceholders.put(...) -->
+        <activity android:name=".LegacyActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="${legacyScheme}" android:host="legacy" />
+            </intent-filter>
+        </activity>
+
+        <!-- Exported, data-less service: intent:// URL must use the gradle
+             applicationId since the manifest has no package attribute -->
+        <service android:name=".KtsService" android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.ACTION_KTS" />
+            </intent-filter>
+        </service>
+
+    </application>
+</manifest>

--- a/spec/functional_test/fixtures/mobile/android_kts/app/src/main/res/navigation/auth_graph.xml
+++ b/spec/functional_test/fixtures/mobile/android_kts/app/src/main/res/navigation/auth_graph.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/auth_graph"
+    app:startDestination="@id/loginFragment">
+
+    <!-- ${applicationId} used as the scheme of a navigation deep link
+         (the AppAuth redirect-scheme pattern) -->
+    <fragment
+        android:id="@+id/loginFragment"
+        android:name="com.example.ktsapp.LoginFragment">
+        <deepLink app:uri="${applicationId}://oauth/callback" />
+    </fragment>
+
+</navigation>

--- a/spec/functional_test/testers/mobile/android_kts_spec.cr
+++ b/spec/functional_test/testers/mobile/android_kts_spec.cr
@@ -1,0 +1,27 @@
+require "../../func_spec.cr"
+
+# Kotlin-DSL gradle module (build.gradle.kts two directories above the
+# manifest). The manifest has no `package` attribute, so the package and
+# all `${...}` placeholders resolve from gradle: applicationId, indexed
+# manifestPlaceholders["k"] = "v", mapOf("k" to "v") and put("k", "v").
+build = ->(url : String, protocol : String) do
+  ep = Endpoint.new(url, "GET", [] of Param)
+  ep.protocol = protocol
+  ep
+end
+
+expected_endpoints = [
+  # ${authScheme} / ${authHost} from manifestPlaceholders (indexed + mapOf)
+  build.call("ktsauth://auth.example.com/callback", "mobile-scheme"),
+  # ${legacyScheme} from manifestPlaceholders.put(...)
+  build.call("ktslegacy://legacy", "mobile-scheme"),
+  # Data-less exported service: package comes from the gradle applicationId
+  build.call("intent://com.example.ktsapp/.KtsService", "android-intent"),
+  # Navigation deep link whose scheme is ${applicationId}
+  build.call("com.example.ktsapp://oauth/callback", "mobile-scheme"),
+]
+
+FunctionalTester.new("fixtures/mobile/android_kts/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -32,6 +32,22 @@ expected_endpoints = [
   build.call("https://myapp.example.com/complex/:id", "universal-link", [Param.new("id", "", "path")], [] of String),
   # Exported, data-less component (android-intent), synthetic intent:// scheme
   build.call("intent://com.example.myapp/.SyncService", "android-intent", no_params, [] of String),
+  # gradle manifestPlaceholders: ${deepLinkScheme} / ${deepLinkHost} resolved
+  # from build.gradle defaultConfig (the buildTypes override must not win)
+  build.call("myapp://links.example.com", "mobile-scheme", no_params, [] of String),
+  # Placeholder missing from build.gradle: kept verbatim (tagged unresolved)
+  build.call("myapp://${missingHost}", "mobile-scheme", no_params, [] of String),
+  # Jetpack Navigation deep link: {userId} -> :userId path param, ?ref={ref}
+  # -> query param; linked to ProfileFragment.onViewCreated for callees.
+  build.call("myapp://users/:userId", "mobile-scheme", [
+    Param.new("userId", "", "path"),
+    Param.new("ref", "", "query"),
+  ], ["loadProfile"]),
+  # Scheme-less Navigation URI: http/https implied, emitted under https;
+  # the trailing `.*` wildcard keeps the literal prefix only.
+  build.call("https://nav.example.com/search/", "mobile-scheme", no_params, [] of String),
+  # Deep link inside a nested <navigation> graph
+  build.call("myapp://settings/notifications", "mobile-scheme", no_params, [] of String),
 ]
 
 FunctionalTester.new("fixtures/mobile/android/", {

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -3,7 +3,7 @@ require "../../../src/models/code_locator"
 require "../../../src/analyzer/analyzers/mobile/android.cr"
 
 # FunctionalTester only checks url / method / protocol / params, so the
-# `metadata` hash and path-normalization edge cases are asserted here.
+# `metadata` hash, tags, and path-normalization edge cases are asserted here.
 describe "Analyzer::Mobile::Android" do
   options = create_test_options
   manifest = File.expand_path(
@@ -56,5 +56,82 @@ describe "Analyzer::Mobile::Android" do
 
   it "does not emit anything for a MAIN/LAUNCHER component" do
     find.call("intent://com.example.myapp/.MainActivity").should be_nil
+  end
+
+  it "resolves gradle manifestPlaceholders in scheme / host / component name" do
+    ep = find.call("myapp://links.example.com").not_nil!
+    ep.protocol.should eq("mobile-scheme")
+    md = ep.metadata.not_nil!
+    md["via"].should eq("com.example.myapp.PlaceholderActivity")
+    md["host"].should eq("links.example.com")
+    ep.tags.any? { |t| t.name == "unresolved" }.should be_false
+  end
+
+  it "prefers the defaultConfig placeholder value over a buildTypes override" do
+    find.call("myapp://debug.example.com").should be_nil
+  end
+
+  it "keeps an unknown placeholder verbatim and tags it unresolved" do
+    ep = find.call("myapp://${missingHost}").not_nil!
+    ep.tags.any? { |t| t.name == "unresolved" }.should be_true
+  end
+
+  it "emits a Jetpack Navigation deep link with templated args and query params" do
+    ep = find.call("myapp://users/:userId").not_nil!
+    ep.protocol.should eq("mobile-scheme")
+    ep.metadata.not_nil!["via"].should eq("com.example.myapp.ProfileFragment")
+    ep.metadata.not_nil!["action"].should eq("android.intent.action.VIEW")
+    ep.params.any? { |p| p.name == "ref" && p.param_type == "query" }.should be_true
+    # The endpoint's file evidence points at the navigation graph itself.
+    ep.details.code_paths.any?(&.path.ends_with?("nav_graph.xml")).should be_true
+  end
+
+  it "implies https for a scheme-less Navigation URI and strips the .* wildcard" do
+    ep = find.call("https://nav.example.com/search/").not_nil!
+    ep.protocol.should eq("mobile-scheme")
+    ep.metadata.not_nil!["via"].should eq("com.example.myapp.SearchFragment")
+    ep.metadata.not_nil!["host"].should eq("nav.example.com")
+  end
+
+  it "walks nested <navigation> graphs and resolves ${applicationId} in fragment names" do
+    ep = find.call("myapp://settings/notifications").not_nil!
+    ep.metadata.not_nil!["via"].should eq("com.example.myapp.NotificationsFragment")
+  end
+end
+
+# Kotlin-DSL gradle (build.gradle.kts found by walking up from the manifest)
+# and a manifest without a `package` attribute.
+describe "Analyzer::Mobile::Android (gradle kts / package fallback)" do
+  options = create_test_options
+  manifest = File.expand_path(
+    File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android_kts",
+      "app", "src", "main", "AndroidManifest.xml"))
+
+  CodeLocator.instance.clear("android-manifest")
+  CodeLocator.instance.push("android-manifest", manifest)
+  endpoints = Analyzer::Mobile::Android.new(options).analyze
+
+  find = ->(url : String) { endpoints.find { |e| e.url == url } }
+
+  it "resolves kts indexed / mapOf manifestPlaceholders and ${applicationId} names" do
+    ep = find.call("ktsauth://auth.example.com/callback").not_nil!
+    md = ep.metadata.not_nil!
+    md["via"].should eq("com.example.ktsapp.AuthActivity")
+    md["package"].should eq("com.example.ktsapp")
+  end
+
+  it "resolves placeholders declared via manifestPlaceholders.put(...)" do
+    find.call("ktslegacy://legacy").should_not be_nil
+  end
+
+  it "falls back to the gradle applicationId when the manifest has no package" do
+    ep = find.call("intent://com.example.ktsapp/.KtsService").not_nil!
+    ep.protocol.should eq("android-intent")
+  end
+
+  it "resolves ${applicationId} used as a Navigation deep-link scheme" do
+    ep = find.call("com.example.ktsapp://oauth/callback").not_nil!
+    ep.protocol.should eq("mobile-scheme")
+    ep.metadata.not_nil!["via"].should eq("com.example.ktsapp.LoginFragment")
   end
 end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -6,6 +6,7 @@ module Analyzer::Mobile
   #   * custom URL scheme deep links (intent-filter > data android:scheme)
   #   * verified App Links (autoVerify intent-filter on http/https)
   #   * exported components with a data-less action filter (IPC surface)
+  #   * Jetpack Navigation deep links (res/navigation/*.xml <deepLink>)
   #
   # One endpoint is emitted per deep-link URI; the handling component lives
   # in `metadata["via"]`, not a separate entry. A bare `intent://component`
@@ -14,7 +15,9 @@ module Analyzer::Mobile
   #
   # All endpoints keep method = "GET"; the mobile semantics live in
   # `protocol` (mobile-scheme / universal-link / android-intent). `@string/`
-  # values are resolved against res/values/strings.xml when present.
+  # values are resolved against res/values/strings.xml when present, and
+  # gradle manifest placeholders (`${applicationId}`, custom
+  # `manifestPlaceholders`) against the nearest build.gradle(.kts).
   class Android < Analyzer
     LAUNCHER_ACTION = "android.intent.action.MAIN"
 
@@ -42,26 +45,34 @@ module Analyzer::Mobile
       manifest = find_child(doc, "manifest")
       return unless manifest
 
-      package = attr(manifest, "package") || ""
       strings = load_strings(path)
+      gradle = load_gradle(path)
+      placeholders = gradle.placeholders
 
-      application = find_child(manifest, "application")
-      return unless application
+      # Modern AGP projects omit the `package` attribute (the namespace /
+      # applicationId live in build.gradle), and older ones may template it.
+      package = substitute(attr(manifest, "package") || "", placeholders)
+      package = gradle.package_fallback if package.empty?
 
       seen_urls = Set(String).new
 
-      {"activity", "activity-alias", "service", "receiver"}.each do |component_tag|
-        each_child(application, component_tag) do |component|
-          process_component(component, package, strings, path, seen_urls)
+      if application = find_child(manifest, "application")
+        {"activity", "activity-alias", "service", "receiver"}.each do |component_tag|
+          each_child(application, component_tag) do |component|
+            process_component(component, package, strings, placeholders, path, seen_urls)
+          end
         end
       end
+
+      parse_navigation_graphs(path, package, strings, placeholders, seen_urls)
     end
 
     private def process_component(component : XML::Node,
                                   package : String, strings : Hash(String, String),
+                                  placeholders : Hash(String, String),
                                   path : String, seen_urls : Set(String))
       exported = bool_attr(component, "exported")
-      component_name = attr(component, "name") || ""
+      component_name = substitute(attr(component, "name") || "", placeholders)
 
       filters = [] of XML::Node
       each_child(component, "intent-filter") { |f| filters << f }
@@ -79,7 +90,7 @@ module Analyzer::Mobile
           # handling component rides along as metadata["via"].
           data_nodes.each do |data|
             emit_data_endpoint(data, actions, categories, package, strings,
-              path, auto_verify, component_name, seen_urls)
+              placeholders, path, auto_verify, component_name, seen_urls)
           end
         elsif exported
           # Exported component with an action but no <data>: an IPC surface
@@ -98,13 +109,14 @@ module Analyzer::Mobile
     # http/https) endpoint for one <data> node.
     private def emit_data_endpoint(data : XML::Node, actions : Array(String),
                                    categories : Array(String), package : String,
-                                   strings : Hash(String, String), path : String,
+                                   strings : Hash(String, String),
+                                   placeholders : Hash(String, String), path : String,
                                    auto_verify : Bool, via : String, seen_urls : Set(String))
-      scheme = resolve(attr(data, "scheme"), strings)
+      scheme = resolve(attr(data, "scheme"), strings, placeholders)
       return if scheme.nil? || scheme.empty?
 
-      host = resolve(attr(data, "host"), strings) || ""
-      norm_path = normalize_path(data, strings)
+      host = resolve(attr(data, "host"), strings, placeholders) || ""
+      norm_path = normalize_path(data, strings, placeholders)
       web = scheme == "http" || scheme == "https"
 
       url = "#{scheme}://#{host}#{norm_path}"
@@ -136,6 +148,215 @@ module Analyzer::Mobile
       @result << endpoint
     end
 
+    # --- Jetpack Navigation (res/navigation/*.xml) -------------------------
+
+    # Scheme emitted for scheme-less Navigation URIs. Navigation matches
+    # both http and https for them; one canonical https endpoint keeps the
+    # inventory free of http/https twins.
+    NAV_DEFAULT_SCHEME = "https"
+    NAV_VIEW_ACTION    = "android.intent.action.VIEW"
+
+    # Jetpack Navigation graphs declare deep links outside the manifest:
+    # res/navigation/*.xml <deepLink app:uri="..."> under a destination
+    # (fragment / activity / dialog / nested <navigation>). They reuse the
+    # mobile-scheme / universal-link model; the destination's android:name
+    # becomes metadata["via"] so the code linker resolves the handler the
+    # same way as a manifest component.
+    private def parse_navigation_graphs(manifest_path : String, package : String,
+                                        strings : Hash(String, String),
+                                        placeholders : Hash(String, String),
+                                        seen_urls : Set(String))
+      nav_dir = File.join(File.dirname(manifest_path), "res", "navigation")
+      return unless Dir.exists?(nav_dir)
+
+      Dir.glob(File.join(nav_dir, "*.xml")).sort.each do |nav_path|
+        begin
+          doc = XML.parse(read_file_content(nav_path))
+          root = find_child(doc, "navigation")
+          next unless root
+          walk_navigation(root, "", package, strings, placeholders, nav_path, seen_urls)
+        rescue e
+          @logger.debug "Failed to parse navigation graph #{nav_path}: #{e.message}"
+          @logger.debug_sub e
+        end
+      end
+    end
+
+    # Recursively visits destinations, carrying the nearest android:name
+    # down as the handling component for any <deepLink> beneath it (nested
+    # <navigation> elements have no name of their own).
+    private def walk_navigation(node : XML::Node, via : String, package : String,
+                                strings : Hash(String, String),
+                                placeholders : Hash(String, String),
+                                nav_path : String, seen_urls : Set(String))
+      node.children.each do |child|
+        next unless child.element?
+        if child.name == "deepLink"
+          emit_nav_deep_link(child, via, package, strings, placeholders, nav_path, seen_urls)
+        else
+          child_via = resolve(attr(child, "name"), strings, placeholders) || via
+          walk_navigation(child, child_via, package, strings, placeholders, nav_path, seen_urls)
+        end
+      end
+    end
+
+    # Emits one endpoint per <deepLink app:uri="...">. Navigation URIs may
+    # omit the scheme (http/https implied), template path/query values with
+    # `{arg}`, and end a path in a `.*` wildcard. Query placeholders become
+    # `query` params and the query string is dropped from the URL, matching
+    # how the HTTP analyzers model queries. mimeType/action-only deepLinks
+    # (no uri) are not addressable from outside and are skipped.
+    private def emit_nav_deep_link(node : XML::Node, via : String, package : String,
+                                   strings : Hash(String, String),
+                                   placeholders : Hash(String, String),
+                                   nav_path : String, seen_urls : Set(String))
+      uri = resolve(attr(node, "uri"), strings, placeholders)
+      return if uri.nil? || uri.empty?
+
+      if m = uri.match(%r{\A([A-Za-z][A-Za-z0-9+.\-]*)://})
+        scheme = m[1]
+        rest = uri[m[0].size..]
+      else
+        scheme = NAV_DEFAULT_SCHEME
+        rest = uri.lchop("//")
+      end
+
+      rest, _, query = rest.partition('?')
+      if slash = rest.index('/')
+        host = rest[0...slash]
+        raw_path = rest[slash..]
+      else
+        host = rest
+        raw_path = ""
+      end
+      # A trailing `.*` is a wildcard match; keep the literal prefix.
+      raw_path = raw_path.sub(/\.\*\z/, "")
+
+      url = "#{scheme}://#{host}#{templatize(raw_path)}"
+      return unless seen_urls.add?(url)
+
+      web = scheme == "http" || scheme == "https"
+      auto_verify = bool_attr(node, "autoVerify")
+      protocol = (web && auto_verify) ? "universal-link" : "mobile-scheme"
+
+      endpoint = Endpoint.new(url, "GET", Details.new(PathInfo.new(nav_path)))
+      endpoint.protocol = protocol
+      action = attr(node, "action") || NAV_VIEW_ACTION
+      endpoint.metadata = build_metadata(via, [action], [] of String, host, package)
+
+      query.split('&').each do |pair|
+        name = pair.partition('=')[0]
+        endpoint.push_param(Param.new(name, "", "query")) unless name.empty?
+      end
+
+      mark_unresolved(endpoint, url)
+      @result << endpoint
+    end
+
+    # --- gradle (${applicationId} / manifestPlaceholders) ------------------
+
+    # Gradle-derived manifest context: the `${applicationId}` / custom
+    # manifestPlaceholders substitution map, plus the module namespace /
+    # applicationId used as a package fallback for manifests without a
+    # `package` attribute.
+    private struct GradleConfig
+      getter application_id : String?
+      getter namespace : String?
+      getter placeholders : Hash(String, String)
+
+      def initialize(@application_id, @namespace, @placeholders)
+      end
+
+      def self.empty
+        new(nil, nil, {} of String => String)
+      end
+
+      def package_fallback : String
+        application_id || namespace || ""
+      end
+    end
+
+    # `applicationId "com.x"` (groovy) / `applicationId = "com.x"` (kts);
+    # the quote requirement keeps `applicationIdSuffix` from matching.
+    APPLICATION_ID_RE = /\bapplicationId\s*(?:=\s*)?["']([^"']+)["']/
+    NAMESPACE_RE      = /\bnamespace\s*(?:=\s*)?["']([^"']+)["']/
+    # The bracketed segment after `manifestPlaceholders` — a groovy map
+    # literal (`= [k: "v"]`), a kts `+= mapOf("k" to "v")`, or a
+    # `putAll(mapOf(...))` — captured up to the first closing bracket.
+    PLACEHOLDER_MAP_RE = /manifestPlaceholders[^\[(\n]*[\[(]([^\])]*)/
+    # `key: "value"`, `"key": "value"` (groovy) and `"key" to "value"` (kts).
+    PLACEHOLDER_PAIR_RE = /["']?([A-Za-z_]\w*)["']?\s*(?::|\bto\b)\s*["']([^"']*)["']/
+    # `manifestPlaceholders["key"] = "value"` / `manifestPlaceholders.put("key", "value")` (kts).
+    PLACEHOLDER_INDEX_RE = /manifestPlaceholders\s*\[\s*["'](\w+)["']\s*\]\s*=\s*["']([^"']*)["']/
+    PLACEHOLDER_PUT_RE   = /manifestPlaceholders\s*\.\s*put\s*\(\s*["'](\w+)["']\s*,\s*["']([^"']*)["']\s*\)/
+
+    private def load_gradle(manifest_path : String) : GradleConfig
+      gradle_path = find_gradle_file(manifest_path)
+      return GradleConfig.empty unless gradle_path
+
+      begin
+        parse_gradle(read_file_content(gradle_path))
+      rescue e
+        @logger.debug "Failed to parse gradle file #{gradle_path}: #{e.message}"
+        GradleConfig.empty
+      end
+    end
+
+    # The module build script lives above the manifest (`app/build.gradle`
+    # vs `app/src/main/AndroidManifest.xml`); the nearest one wins so a
+    # root-project script can't shadow the module's applicationId.
+    private def find_gradle_file(manifest_path : String) : String?
+      dir = File.dirname(File.expand_path(manifest_path))
+      4.times do
+        {"build.gradle", "build.gradle.kts"}.each do |name|
+          candidate = File.join(dir, name)
+          return candidate if File.exists?(candidate)
+        end
+        parent = File.dirname(dir)
+        break if parent == dir
+        dir = parent
+      end
+      nil
+    end
+
+    # Regex-based extraction over both gradle DSLs. First occurrence wins,
+    # so defaultConfig values (declared first by convention) take precedence
+    # over buildType / flavor overrides; variant-specific placeholder values
+    # are intentionally not modeled.
+    private def parse_gradle(content : String) : GradleConfig
+      application_id = content.match(APPLICATION_ID_RE).try(&.[1])
+      namespace = content.match(NAMESPACE_RE).try(&.[1])
+      placeholders = {} of String => String
+
+      content.scan(PLACEHOLDER_MAP_RE) do |m|
+        m[1].scan(PLACEHOLDER_PAIR_RE) do |pair|
+          placeholders[pair[1]] = pair[2] unless placeholders.has_key?(pair[1])
+        end
+      end
+      {PLACEHOLDER_INDEX_RE, PLACEHOLDER_PUT_RE}.each do |re|
+        content.scan(re) do |m|
+          placeholders[m[1]] = m[2] unless placeholders.has_key?(m[1])
+        end
+      end
+
+      # AGP always provides ${applicationId} even without an explicit
+      # manifestPlaceholders entry.
+      if app_id = application_id
+        placeholders["applicationId"] = app_id unless placeholders.has_key?("applicationId")
+      end
+
+      GradleConfig.new(application_id, namespace, placeholders)
+    end
+
+    # Replaces `${placeholder}` references with their gradle values; unknown
+    # placeholders are kept verbatim so `mark_unresolved` can tag them.
+    private def substitute(value : String, placeholders : Hash(String, String)) : String
+      return value unless value.includes?("${")
+      value.gsub(/\$\{(\w+)\}/) { |s| placeholders[$~[1]]? || s }
+    end
+
+    # -----------------------------------------------------------------------
+
     private def build_metadata(via : String, actions : Array(String),
                                categories : Array(String), host : String,
                                package : String) : Hash(String, String)
@@ -151,14 +372,15 @@ module Analyzer::Mobile
     # Normalizes android:path / pathPrefix / pathPattern to a Noir-style
     # path. Templated `{id}` segments are rewritten to `:id` so the
     # optimizer's path-param pass picks them up.
-    private def normalize_path(data : XML::Node, strings : Hash(String, String)) : String
-      if path = resolve(attr(data, "path"), strings)
+    private def normalize_path(data : XML::Node, strings : Hash(String, String),
+                               placeholders : Hash(String, String)) : String
+      if path = resolve(attr(data, "path"), strings, placeholders)
         return templatize(path)
       end
-      if prefix = resolve(attr(data, "pathPrefix"), strings)
+      if prefix = resolve(attr(data, "pathPrefix"), strings, placeholders)
         return templatize(prefix)
       end
-      if pattern = resolve(attr(data, "pathPattern"), strings)
+      if pattern = resolve(attr(data, "pathPattern"), strings, placeholders)
         # Patterns are regex-ish (.* / .*foo); keep the literal prefix only.
         literal = pattern.split(/[.*\\]/).first
         return templatize(literal)
@@ -166,24 +388,28 @@ module Analyzer::Mobile
       ""
     end
 
+    # The `$` lookbehind keeps an unresolved gradle `${placeholder}` intact
+    # (for the unresolved tag) while `{id}` still becomes `:id`.
     private def templatize(path : String) : String
-      path.gsub(/\{([^}]+)\}/, ":\\1")
+      path.gsub(/(?<!\$)\{([^}]+)\}/, ":\\1")
     end
 
     private def mark_unresolved(endpoint : Endpoint, url : String)
-      return unless url.includes?("@string/") || url.includes?("@{")
+      return unless url.includes?("@string/") || url.includes?("@{") || url.includes?("${")
       endpoint.add_tag(Tag.new("unresolved", "Contains an unresolved manifest reference", "android"))
     end
 
-    # Resolves @string/foo against res/values/strings.xml; leaves any other
-    # value as-is and passes nil through.
-    private def resolve(value : String?, strings : Hash(String, String)) : String?
+    # Resolves @string/foo against res/values/strings.xml and gradle
+    # `${placeholder}` references; leaves any other value as-is and passes
+    # nil through.
+    private def resolve(value : String?, strings : Hash(String, String),
+                        placeholders : Hash(String, String)) : String?
       return value if value.nil?
       if value.starts_with?("@string/")
         key = value.lchop("@string/")
-        return strings[key]? || value
+        value = strings[key]? || value
       end
-      value
+      substitute(value, placeholders)
     end
 
     # Loads <manifest_dir>/res/values/strings.xml into a name→value hash.
@@ -228,7 +454,8 @@ module Analyzer::Mobile
     # Reads an attribute by local name (libxml2 exposes the prefixed name).
     # Prefers the `android:`-namespaced attribute so a `tools:`/other-prefix
     # `scheme`/`host`/`exported` in the same tag can't shadow the real value;
-    # falls back to a non-namespaced match (e.g. `package` on <manifest>).
+    # falls back to a non-namespaced match (e.g. `package` on <manifest>,
+    # `app:uri` on a navigation <deepLink>).
     private def attr(node : XML::Node, local_name : String) : String?
       fallback : String? = nil
       node.attributes.each do |a|

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -21,9 +21,11 @@ require "../miniparsers/swift_callee_extractor"
 # follow-up.
 module NoirMobileLinker
   # Methods where an Android component reads its inbound intent / deep link.
+  # onCreateView / onViewCreated cover Jetpack Navigation fragment
+  # destinations, which receive deep-link path/query values as arguments.
   HANDLER_METHODS = %w[
     onCreate onNewIntent onStart onResume onStartCommand onHandleIntent
-    handleIntent handleDeepLink onReceive onBind
+    handleIntent handleDeepLink onReceive onBind onCreateView onViewCreated
   ]
 
   # Inputs the handler reads from the inbound deep link. `getQueryParameter`

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -86,6 +86,10 @@ class EndpointOptimizer
     # through the block-local binding only edits a copy. Rewrite
     # via array index so the in-place change actually persists.
     endpoints.each_with_index do |endpoint, idx|
+      # Mobile deep-link URLs are not HTTP route templates: a `${...}`
+      # there is an unresolved gradle manifest placeholder (kept verbatim
+      # and tagged by the Android analyzer), not a JS template literal.
+      next if endpoint.mobile?
       endpoint.url = normalize_url_shape(endpoint.url)
       endpoints[idx] = endpoint
     end
@@ -247,8 +251,11 @@ class EndpointOptimizer
           tiny_tmp.url = "/#{tiny_tmp.url}"
         end
 
-        tiny_tmp.url = normalize_url_shape(tiny_tmp.url)
-        dedup_url = normalize_url_shape(tiny_tmp.url, collection_endpoint?(tiny_tmp))
+        # Mobile deep-link URLs are kept verbatim: a `${...}` there is an
+        # unresolved gradle manifest placeholder, not a JS template literal
+        # for the shape-normalizer to rewrite.
+        tiny_tmp.url = normalize_url_shape(tiny_tmp.url) unless tiny_tmp.mobile?
+        dedup_url = tiny_tmp.mobile? ? tiny_tmp.url : normalize_url_shape(tiny_tmp.url, collection_endpoint?(tiny_tmp))
 
         key = {tiny_tmp.method, dedup_url, endpoint_source_scope(tiny_tmp, cross_tech_keys)}
 


### PR DESCRIPTION
Closes #1977. Implements both Android phase-2 deep-link sources documented as limitations in the Supported → Mobile Apps page, extending the existing Android analyzer and the mobile linker — no model changes.

## gradle `${applicationId}` / manifestPlaceholders

* The analyzer finds the nearest `build.gradle` / `build.gradle.kts` above the manifest (covers both the fixture-flat and `app/src/main/` layouts) and extracts `applicationId`, `namespace`, and `manifestPlaceholders` from either DSL — groovy map literal, kts indexed assignment (`manifestPlaceholders["k"] = "v"`), `+= mapOf("k" to "v")`, and `.put("k", "v")` forms.
* `${...}` placeholders are substituted in the manifest `package`, component names, and `<data>` scheme / host / path (and in Navigation URIs). The first declaration of a placeholder wins, so `defaultConfig` takes precedence over `buildTypes` overrides; variant-specific values are intentionally not modeled.
* When the manifest has no `package` attribute (modern AGP), the package falls back to the gradle `applicationId` / `namespace` — fixing `intent://` component URLs and `via` class resolution for those projects.
* A placeholder with no gradle value stays verbatim in the URL and the endpoint is tagged `unresolved` (same convention as unresolved `@string/` refs). `templatize` now uses a `$` lookbehind so an unresolved `${ph}` in a path isn't mangled into `$:ph`.

## Jetpack Navigation deep links

* `res/navigation/*.xml` graphs are parsed as a third Android source: every `<deepLink app:uri="...">` under any destination (fragment / activity / dialog / nested `<navigation>`) becomes an endpoint, reusing the `mobile-scheme` / `universal-link` model.
* The owning destination's `android:name` becomes `metadata["via"]`, so the existing linker resolves the handler class; `onCreateView` / `onViewCreated` were added to the linker's handler methods for fragment destinations (callees + input params + AI context work as for activities).
* URI handling: `{arg}` segments → `:arg` (picked up as path params by the optimizer), `?key={arg}` query placeholders → `query` params with the query string dropped from the URL, scheme-less URIs (http+https implied at runtime) emitted once under `https`, trailing `.*` wildcard keeps the literal prefix, `app:action` honored (defaults to `VIEW`).

## Optimizer guard

`normalize_url_shapes` rewrote `${missingHost}` → `{missingHost}` (JS template-literal heuristic). Mobile deep-link URLs are now skipped by the shape normalizer — a `${...}` there is an unresolved gradle placeholder the analyzer deliberately kept verbatim.

## Tests

* Extended the `fixtures/mobile/android` fixture: `build.gradle` (with a `buildTypes` override that must lose), placeholder + unresolved-placeholder activities, `res/navigation/nav_graph.xml` (templated args + query placeholder, scheme-less URI with `.*` wildcard, nested graph with `${applicationId}` fragment name), and `ProfileFragment.kt` for linker coverage.
* New `fixtures/mobile/android_kts` fixture: kts DSL two directories above the manifest, no manifest `package` attribute, all three kts placeholder forms, and `${applicationId}` as a Navigation deep-link scheme.
* Unit specs assert metadata (`via` / `host` / `package` / `action`), the `unresolved` tag, defaultConfig-wins, and nav-graph file evidence; functional specs assert URLs, protocols, path/query params, and linker callees end-to-end.
* Full suite: 21,071 examples, 0 failures; `crystal tool format --check` and ameba clean.

Docs: Supported → Mobile Apps (EN + KO) — parse-source table extended, the phase-2 limitation bullet replaced with the actual resolution semantics.

https://claude.ai/code/session_01Kw7KQ7kNCgnrKrM3VmTv6Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kw7KQ7kNCgnrKrM3VmTv6Y)_