### PR TITLE
feat(mobile): scope webview_load / intent_redirect sinks to mobile endpoints

### DIFF
--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -1256,6 +1256,36 @@ describe "NoirAIContext" do
     context.sinks.map(&.kind).should_not contain("data_store_query")
   end
 
+  it "scopes the mobile webview_load sink to mobile endpoints" do
+    # The two mobile-only sinks live in the global catalog but must only
+    # apply to deep-link endpoints. An HTTP route handler with a
+    # `.loadUrl` callee must NOT get a webview_load sink.
+    http_ep = Endpoint.new("/page", "GET")
+    http_ep.push_callee(Callee.new("webView.loadUrl", "PageController.kt", 12))
+    http_ctx = NoirAIContext.apply([http_ep])[0].ai_context.should_not be_nil
+    http_ctx.sinks.map(&.kind).should_not contain("webview_load")
+
+    # The same callee on a deep-link endpoint DOES surface the sink.
+    mobile_ep = Endpoint.new("myapp://open", "GET")
+    mobile_ep.protocol = "mobile-scheme"
+    mobile_ep.push_callee(Callee.new("webView.loadUrl", "DeepLinkActivity.kt", 12))
+    mobile_ctx = NoirAIContext.apply([mobile_ep])[0].ai_context.should_not be_nil
+    mobile_ctx.sinks.map(&.kind).should contain("webview_load")
+  end
+
+  it "scopes the mobile intent_redirect sink to mobile endpoints" do
+    http_ep = Endpoint.new("/dispatch", "POST")
+    http_ep.push_callee(Callee.new("startActivity", "DispatchController.java", 20))
+    http_ctx = NoirAIContext.apply([http_ep])[0].ai_context.should_not be_nil
+    http_ctx.sinks.map(&.kind).should_not contain("intent_redirect")
+
+    mobile_ep = Endpoint.new("intent://com.example/.Dispatch", "GET")
+    mobile_ep.protocol = "android-intent"
+    mobile_ep.push_callee(Callee.new("startActivity", "DispatchActivity.java", 20))
+    mobile_ctx = NoirAIContext.apply([mobile_ep])[0].ai_context.should_not be_nil
+    mobile_ctx.sinks.map(&.kind).should contain("intent_redirect")
+  end
+
   it "surfaces database query parameter binding as validator evidence" do
     source = <<-CODE
       suspend fun findOne(id: String): Post? =

--- a/src/ai_context/builder.cr
+++ b/src/ai_context/builder.cr
@@ -1000,7 +1000,15 @@ module NoirAIContext
       graphql_tag.try(&.description) || endpoint.url
     end
 
+    # The mobile-only sinks (webview_load / intent_redirect) are matched
+    # only for deep-link endpoints; HTTP route handlers get the catalog
+    # without them. See `MOBILE_SINK_KINDS` in patterns.cr.
+    private def sink_patterns_for(endpoint : Endpoint) : Array(PatternDefinition)
+      endpoint.mobile? ? SINK_PATTERNS : NON_MOBILE_SINK_PATTERNS
+    end
+
     private def add_callee_entries(context : AIContext, endpoint : Endpoint)
+      sink_patterns = sink_patterns_for(endpoint)
       endpoint.callees.each do |callee|
         callee_snippet = @reader.snippet_for(callee.path, callee.line, CALLEE_SNIPPET_RADIUS)
 
@@ -1015,7 +1023,7 @@ module NoirAIContext
           snippet: callee_snippet
         ))
 
-        if sink = PatternMatcher.detect_from_patterns(callee.name, callee_snippet, SINK_PATTERNS, callee.path, callee.line, "callee")
+        if sink = PatternMatcher.detect_from_patterns(callee.name, callee_snippet, sink_patterns, callee.path, callee.line, "callee")
           context.push_sink(enrich_callee_sink(sink, callee, callee_snippet))
         end
 
@@ -1126,7 +1134,7 @@ module NoirAIContext
         # double-emit but a route that's both `xss` and `sql` will
         # surface both. Previously we capped the whole route at one
         # sink, which silently dropped the second / third class.
-        SINK_PATTERNS.each do |pattern|
+        sink_patterns_for(endpoint).each do |pattern|
           next if context.sinks.any? { |s| s.kind == pattern.kind }
           if sink = PatternMatcher.detect_single_pattern(pattern, "", snippet, path_info.path, path_info.line, "route_source")
             context.push_sink(sink)

--- a/src/ai_context/patterns.cr
+++ b/src/ai_context/patterns.cr
@@ -207,6 +207,20 @@ module NoirAIContext
     ),
   ] of PatternDefinition
 
+  # Sink kinds that only make sense on a mobile deep-link endpoint — a
+  # WebView load or an intent launch fed by inbound deep-link data. They
+  # live in the global SINK_PATTERNS so the catalog stays in one place,
+  # but the Builder evaluates them only for `endpoint.mobile?` endpoints:
+  # an HTTP route handler never opens a WebView or launches an Android
+  # intent, so firing these against every route is conceptually wrong
+  # (and a latent FP source as the name/source patterns broaden).
+  MOBILE_SINK_KINDS = Set{"webview_load", "intent_redirect"}
+
+  # The non-mobile view of the sink catalog, computed once. Used for
+  # HTTP endpoints so the two mobile-only sinks above are never matched
+  # against server-side route/callee snippets.
+  NON_MOBILE_SINK_PATTERNS = SINK_PATTERNS.reject { |pattern| MOBILE_SINK_KINDS.includes?(pattern.kind) }
+
   VALIDATOR_PATTERNS = [
     PatternDefinition.new(
       "validation",


### PR DESCRIPTION
Follow-up to the mobile deep-link work (#1943), noted during the #1974 review.

The two mobile-specific AI-context sink patterns — `webview_load` (WebView `loadUrl` / `loadData` / `evaluateJavascript`) and `intent_redirect` (`startActivity` / `sendBroadcast` / `startService`) — live in the global `SINK_PATTERNS` and were matched against **every** endpoint with a `code_path`, HTTP routes included. They are conceptually mobile-only: an HTTP route handler never opens a WebView or launches an Android intent.

## Change
- `patterns.cr`: add `MOBILE_SINK_KINDS = {webview_load, intent_redirect}` and a precomputed `NON_MOBILE_SINK_PATTERNS` view of the catalog.
- `builder.cr`: a `sink_patterns_for(endpoint)` helper returns the full catalog for `endpoint.mobile?` and the non-mobile view otherwise; used at both sink-scan sites (callee scan + route-source scan).

Net effect: deep-link endpoints keep deriving `webview_load` / `intent_redirect`; HTTP endpoints never match them. Low risk (those tokens essentially never appear in server-side route handlers), but removes the conceptual mismatch and a latent FP source as the patterns broaden.

## Tests
Two regression specs in `augmentor_spec.cr`: the same `webView.loadUrl` / `startActivity` callee surfaces the sink on a mobile endpoint but not an HTTP one. Full ai_context spec green (160 examples).