### PR TITLE
feat(mobile): combine intent-filter <data> sets, drop content-handler / generic-scheme noise

### DIFF
--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -80,5 +80,35 @@
             </intent-filter>
         </service>
 
+        <!-- App Link declared the common way: scheme and host/path split
+             across separate <data> elements. Android combines them as a
+             cross product, so this yields http/https × the two paths. -->
+        <activity android:name=".SplitLinkActivity" android:exported="true">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="split.example.com" android:pathPrefix="/wiki/" />
+                <data android:host="split.example.com" android:pathPattern="/zh.*" />
+            </intent-filter>
+        </activity>
+
+        <!-- Content-type (mimeType) handler: opens an XML file from a file
+             manager / browser. The scheme-only file/content/https <data>
+             entries are content-source qualifiers, NOT deep links, so this
+             filter must produce no endpoints. -->
+        <activity android:name=".FileImportActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/xml" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:scheme="https" />
+            </intent-filter>
+        </activity>
+
     </application>
 </manifest>

--- a/spec/functional_test/fixtures/mobile/android_gradle_const/app/build.gradle.kts
+++ b/spec/functional_test/fixtures/mobile/android_gradle_const/app/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("com.android.application")
+}
+
+android {
+    // The id below is a constant reference (not a string literal), resolved
+    // from buildSrc (Constants.kt). The manifest has no `package` attribute,
+    // so the package falls back to this resolved value.
+    defaultConfig {
+        applicationId = APP_ID
+        minSdk = 24
+    }
+}

--- a/spec/functional_test/fixtures/mobile/android_gradle_const/app/src/main/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android_gradle_const/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- No `package` attribute: the package comes from the gradle applicationId,
+     which is itself a buildSrc constant reference (applicationId = APP_ID). -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="ConstApp">
+
+        <!-- ${applicationId} as the deep-link host: resolves only if the
+             constant reference was followed to its buildSrc literal. -->
+        <activity android:name=".AuthActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="constapp" android:host="${applicationId}" />
+            </intent-filter>
+        </activity>
+
+        <!-- Data-less exported service: the intent:// URL must carry the
+             resolved package, not an empty `intent:///`. -->
+        <service android:name=".ConstService" android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.ACTION_CONST" />
+            </intent-filter>
+        </service>
+
+    </application>
+</manifest>

--- a/spec/functional_test/fixtures/mobile/android_gradle_const/buildSrc/src/main/kotlin/Constants.kt
+++ b/spec/functional_test/fixtures/mobile/android_gradle_const/buildSrc/src/main/kotlin/Constants.kt
@@ -1,0 +1,6 @@
+// Shared gradle constant, the way multi-module projects (e.g. NewPipe)
+// declare the application id once in buildSrc and reference it from the
+// module build script.
+object Constants {
+    const val APP_ID = "com.example.constapp"
+}

--- a/spec/functional_test/fixtures/mobile/ios/Info.plist
+++ b/spec/functional_test/fixtures/mobile/ios/Info.plist
@@ -13,6 +13,7 @@
 			<array>
 				<string>myapp</string>
 				<string>myapp-alt</string>
+				<string>https</string>
 			</array>
 		</dict>
 	</array>

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -48,6 +48,14 @@ expected_endpoints = [
   build.call("https://nav.example.com/search/", "mobile-scheme", no_params, [] of String),
   # Deep link inside a nested <navigation> graph
   build.call("myapp://settings/notifications", "mobile-scheme", no_params, [] of String),
+  # App Link whose scheme and host/path are split across separate <data>
+  # elements: Android combines them, so http/https × the two paths all
+  # resolve (autoVerify -> universal-link). The scheme-only file/content/
+  # https content-handler filter on FileImportActivity produces nothing.
+  build.call("http://split.example.com/wiki/", "universal-link", no_params, [] of String),
+  build.call("https://split.example.com/wiki/", "universal-link", no_params, [] of String),
+  build.call("http://split.example.com/zh", "universal-link", no_params, [] of String),
+  build.call("https://split.example.com/zh", "universal-link", no_params, [] of String),
 ]
 
 FunctionalTester.new("fixtures/mobile/android/", {

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -164,3 +164,29 @@ describe "Analyzer::Mobile::Android (gradle kts / package fallback)" do
     ep.metadata.not_nil!["via"].should eq("com.example.ktsapp.LoginFragment")
   end
 end
+
+# applicationId declared as a constant reference (`applicationId = APP_ID`)
+# whose literal lives in a sibling buildSrc/ source tree (the NewPipe shape).
+describe "Analyzer::Mobile::Android (gradle constant reference)" do
+  options = create_test_options
+  manifest = File.expand_path(
+    File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android_gradle_const",
+      "app", "src", "main", "AndroidManifest.xml"))
+
+  CodeLocator.instance.clear("android-manifest")
+  CodeLocator.instance.push("android-manifest", manifest)
+  endpoints = Analyzer::Mobile::Android.new(options).analyze
+
+  find = ->(url : String) { endpoints.find { |e| e.url == url } }
+
+  it "resolves a constant-referenced applicationId from buildSrc into ${applicationId}" do
+    ep = find.call("constapp://com.example.constapp").not_nil!
+    ep.protocol.should eq("mobile-scheme")
+    ep.tags.any? { |t| t.name == "unresolved" }.should be_false
+  end
+
+  it "uses the resolved applicationId as the intent:// package (no empty intent:///)" do
+    find.call("intent:///.ConstService").should be_nil
+    find.call("intent://com.example.constapp/.ConstService").not_nil!.protocol.should eq("android-intent")
+  end
+end

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -58,6 +58,35 @@ describe "Analyzer::Mobile::Android" do
     find.call("intent://com.example.myapp/.MainActivity").should be_nil
   end
 
+  it "combines scheme and host/path split across separate <data> elements" do
+    # SplitLinkActivity declares schemes and host+path in separate <data>
+    # children; Android cross-products them, so all four resolve.
+    %w[
+      http://split.example.com/wiki/ https://split.example.com/wiki/
+      http://split.example.com/zh https://split.example.com/zh
+    ].each do |url|
+      ep = find.call(url).not_nil!
+      ep.protocol.should eq("universal-link") # autoVerify + http/https
+      ep.metadata.not_nil!["host"].should eq("split.example.com")
+      ep.metadata.not_nil!["via"].should eq(".SplitLinkActivity")
+    end
+  end
+
+  it "does not emit a bare scheme-only endpoint from the split-data filter" do
+    # The pre-combining behavior emitted `http://` / `https://` with no host.
+    find.call("http://").should be_nil
+    find.call("https://").should be_nil
+  end
+
+  it "suppresses scheme-only content-handler (mimeType) data entries" do
+    # FileImportActivity is a text/xml content handler; its file/content/
+    # https scheme-only <data> entries are content-source qualifiers, not
+    # deep links, and must not surface as endpoints.
+    find.call("file://").should be_nil
+    find.call("content://").should be_nil
+    endpoints.none? { |e| (e.metadata.try { |m| m["via"]? } || "").includes?("FileImportActivity") }.should be_true
+  end
+
   it "resolves gradle manifestPlaceholders in scheme / host / component name" do
     ep = find.call("myapp://links.example.com").not_nil!
     ep.protocol.should eq("mobile-scheme")

--- a/spec/unit_test/analyzer/mobile_ios_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_spec.cr
@@ -19,6 +19,12 @@ describe "Analyzer::Mobile::Ios" do
     find.call("myapp-alt://").not_nil!.protocol.should eq("mobile-scheme")
   end
 
+  it "suppresses generic web schemes registered as URL types" do
+    # An app may register `https` (e.g. to be selectable as a browser);
+    # a bare `https://` has no host and is not a deep-link entry point.
+    find.call("https://").should be_nil
+  end
+
   it "maps applinks: associated domains to universal links" do
     find.call("https://myapp.example.com/").not_nil!.protocol.should eq("universal-link")
   end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -347,6 +347,14 @@ module Analyzer::Mobile
     # the quote requirement keeps `applicationIdSuffix` from matching.
     APPLICATION_ID_RE = /\bapplicationId\s*(?:=\s*)?["']([^"']+)["']/
     NAMESPACE_RE      = /\bnamespace\s*(?:=\s*)?["']([^"']+)["']/
+    # Unquoted value: a gradle constant reference, e.g. `applicationId APP_ID`
+    # (groovy) or `applicationId = NEWPIPE_APPLICATION_ID_OLD` (kts). The
+    # `(?![A-Za-z0-9_])` after the key keeps `applicationIdSuffix` out, and
+    # the UPPER_SNAKE value requirement keeps prose in a `// applicationId is
+    # ...` comment from matching (gradle constants are upper-case by
+    # convention; a camelCase val is intentionally not followed).
+    APPLICATION_ID_CONST_RE = /\bapplicationId(?![A-Za-z0-9_])\s*(?:=\s*)?([A-Z][A-Z0-9_]+)\b/
+    NAMESPACE_CONST_RE      = /\bnamespace(?![A-Za-z0-9_])\s*(?:=\s*)?([A-Z][A-Z0-9_]+)\b/
     # The bracketed segment after `manifestPlaceholders` — a groovy map
     # literal (`= [k: "v"]`), a kts `+= mapOf("k" to "v")`, or a
     # `putAll(mapOf(...))` — captured up to the first closing bracket.
@@ -362,7 +370,7 @@ module Analyzer::Mobile
       return GradleConfig.empty unless gradle_path
 
       begin
-        parse_gradle(read_file_content(gradle_path))
+        parse_gradle(read_file_content(gradle_path), gradle_path)
       rescue e
         @logger.debug "Failed to parse gradle file #{gradle_path}: #{e.message}"
         GradleConfig.empty
@@ -390,9 +398,13 @@ module Analyzer::Mobile
     # so defaultConfig values (declared first by convention) take precedence
     # over buildType / flavor overrides; variant-specific placeholder values
     # are intentionally not modeled.
-    private def parse_gradle(content : String) : GradleConfig
-      application_id = content.match(APPLICATION_ID_RE).try(&.[1])
-      namespace = content.match(NAMESPACE_RE).try(&.[1])
+    private def parse_gradle(content : String, gradle_path : String) : GradleConfig
+      # Prefer a quoted literal; fall back to a constant reference
+      # (`applicationId APP_ID`) resolved against this script or buildSrc.
+      application_id = content.match(APPLICATION_ID_RE).try(&.[1]) ||
+                       resolve_const_ref(content, APPLICATION_ID_CONST_RE, gradle_path)
+      namespace = content.match(NAMESPACE_RE).try(&.[1]) ||
+                  resolve_const_ref(content, NAMESPACE_CONST_RE, gradle_path)
       placeholders = {} of String => String
 
       content.scan(PLACEHOLDER_MAP_RE) do |m|
@@ -413,6 +425,56 @@ module Analyzer::Mobile
       end
 
       GradleConfig.new(application_id, namespace, placeholders)
+    end
+
+    # How far up from the module script to look for a `buildSrc/` source tree
+    # holding shared gradle constants.
+    BUILDSRC_SEARCH_DEPTH = 4
+
+    # Matches a constant reference (`applicationId APP_ID`) and resolves the
+    # named constant to its string literal. Returns nil when the value is not
+    # a bare identifier (e.g. a method call) or the constant can't be found.
+    private def resolve_const_ref(content : String, ref_re : Regex, gradle_path : String) : String?
+      name = content.match(ref_re).try(&.[1])
+      return nil unless name
+      resolve_constant(name, content, gradle_path)
+    end
+
+    # Resolves a gradle constant to its string literal: the same build script
+    # first (groovy `def APP_ID = "..."`), then a sibling `buildSrc/` source
+    # tree (kotlin `const val APP_ID = "..."`), where multi-module projects
+    # keep shared identifiers.
+    private def resolve_constant(name : String, content : String, gradle_path : String) : String?
+      def_re = /\b#{Regex.escape(name)}\s*=\s*["']([^"']+)["']/
+      if m = content.match(def_re)
+        return m[1]
+      end
+      resolve_buildsrc_constant(def_re, gradle_path)
+    end
+
+    private def resolve_buildsrc_constant(def_re : Regex, gradle_path : String) : String?
+      dir = File.dirname(File.expand_path(gradle_path))
+      BUILDSRC_SEARCH_DEPTH.times do
+        buildsrc = File.join(dir, "buildSrc")
+        if Dir.exists?(buildsrc)
+          {"*.kt", "*.kts", "*.gradle"}.each do |pattern|
+            Dir.glob(File.join(buildsrc, "**", pattern)).sort.each do |src|
+              begin
+                if m = read_file_content(src).match(def_re)
+                  return m[1]
+                end
+              rescue
+                next
+              end
+            end
+          end
+          return nil # buildSrc found but constant absent — stop walking up
+        end
+        parent = File.dirname(dir)
+        break if parent == dir
+        dir = parent
+      end
+      nil
     end
 
     # Replaces `${placeholder}` references with their gradle values; unknown

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -88,10 +88,8 @@ module Analyzer::Mobile
         if !data_nodes.empty?
           # Deep-link / app-link URI(s) — the primary entry points. The
           # handling component rides along as metadata["via"].
-          data_nodes.each do |data|
-            emit_data_endpoint(data, actions, categories, package, strings,
-              placeholders, path, auto_verify, component_name, seen_urls)
-          end
+          emit_filter_endpoints(data_nodes, actions, categories, package, strings,
+            placeholders, path, auto_verify, component_name, seen_urls)
         elsif exported
           # Exported component with an action but no <data>: an IPC surface
           # reachable by explicit/implicit intent. The launcher (MAIN) is
@@ -105,30 +103,99 @@ module Analyzer::Mobile
       end
     end
 
-    # Emits a mobile-scheme (custom scheme) or universal-link (verified
-    # http/https) endpoint for one <data> node.
-    private def emit_data_endpoint(data : XML::Node, actions : Array(String),
-                                   categories : Array(String), package : String,
-                                   strings : Hash(String, String),
-                                   placeholders : Hash(String, String), path : String,
-                                   auto_verify : Bool, via : String, seen_urls : Set(String))
-      scheme = resolve(attr(data, "scheme"), strings, placeholders)
-      return if scheme.nil? || scheme.empty?
+    # Generic/standard schemes carry no app-specific meaning on their own.
+    # A host-less `http://` / `https://` / `file://` / `content://` is a
+    # content-source qualifier — typically paired with a `<data mimeType>`
+    # so the component can open a file type from a browser / file manager —
+    # not a deep-link entry point. Custom schemes (`myapp://`) stay even
+    # host-less, since that's how a runtime-routed custom scheme is declared.
+    GENERIC_SCHEMES = Set{"http", "https", "file", "content"}
 
-      host = resolve(attr(data, "host"), strings, placeholders) || ""
-      norm_path = normalize_path(data, strings, placeholders)
-      web = scheme == "http" || scheme == "https"
+    # Upper bound on endpoints emitted from a single intent-filter. A media
+    # router / browser filter can declare dozens of hosts × paths; the full
+    # cross product would flood the inventory with near-duplicates, so past
+    # the cap the path dimension is dropped (scheme × host) and, if still
+    # over, the result is truncated.
+    MAX_FILTER_COMBOS = 64
 
-      url = "#{scheme}://#{host}#{norm_path}"
-      return unless seen_urls.add?(url)
+    # Emits the deep-link endpoints for one intent-filter. Android matches a
+    # URI against the filter as a whole, treating its `<data>` children as
+    # independent sets: the scheme must be in the scheme set, the host (if
+    # any) in the host set, and the path must satisfy one of the path rules.
+    # A filter routinely splits `<data android:scheme=.../>` and
+    # `<data android:host=... pathPrefix=.../>` across separate elements, so
+    # the real surface is the cross product scheme × host × path — emitting
+    # each `<data>` element on its own produced a bare `scheme://` and missed
+    # the real `scheme://host/path`.
+    private def emit_filter_endpoints(data_nodes : Array(XML::Node),
+                                      actions : Array(String), categories : Array(String),
+                                      package : String, strings : Hash(String, String),
+                                      placeholders : Hash(String, String), path : String,
+                                      auto_verify : Bool, via : String, seen_urls : Set(String))
+      schemes = [] of String
+      hosts = [] of String
+      paths = [] of String
+      has_mime_type = false
 
-      protocol = (web && auto_verify) ? "universal-link" : "mobile-scheme"
-      endpoint = Endpoint.new(url, "GET", Details.new(PathInfo.new(path)))
-      endpoint.protocol = protocol
-      endpoint.metadata = build_metadata(via, actions, categories, host, package)
+      data_nodes.each do |data|
+        has_mime_type = true unless attr(data, "mimeType").nil?
+        if scheme = resolve(attr(data, "scheme"), strings, placeholders)
+          schemes << scheme unless scheme.empty? || schemes.includes?(scheme)
+        end
+        if host = resolve(attr(data, "host"), strings, placeholders)
+          hosts << host unless host.empty? || hosts.includes?(host)
+        end
+        norm = normalize_path(data, strings, placeholders)
+        paths << norm unless norm.empty? || paths.includes?(norm)
+      end
+      return if schemes.empty?
 
-      mark_unresolved(endpoint, url)
-      @result << endpoint
+      data_filter_combos(schemes, hosts, paths, has_mime_type).each do |scheme, host, norm_path|
+        web = scheme == "http" || scheme == "https"
+        url = "#{scheme}://#{host}#{norm_path}"
+        next unless seen_urls.add?(url)
+
+        protocol = (web && auto_verify) ? "universal-link" : "mobile-scheme"
+        endpoint = Endpoint.new(url, "GET", Details.new(PathInfo.new(path)))
+        endpoint.protocol = protocol
+        endpoint.metadata = build_metadata(via, actions, categories, host, package)
+        mark_unresolved(endpoint, url)
+        @result << endpoint
+      end
+    end
+
+    # Cross-products the scheme/host/path sets of one filter into
+    # (scheme, host, path) triples, applying the host-less generic-scheme
+    # suppression and the per-filter cap.
+    private def data_filter_combos(schemes : Array(String), hosts : Array(String),
+                                   paths : Array(String), has_mime_type : Bool) : Array({String, String, String})
+      combos = [] of {String, String, String}
+      effective_paths = paths.empty? ? [""] : paths
+
+      schemes.each do |scheme|
+        if hosts.empty?
+          # Host-less: keep only custom schemes. A generic scheme with no
+          # host — and any scheme in a content-type (mimeType) filter — is a
+          # file/content qualifier, not a remotely reachable deep link.
+          next if has_mime_type || GENERIC_SCHEMES.includes?(scheme)
+          combos << {scheme, "", ""}
+        else
+          hosts.each do |host|
+            effective_paths.each { |norm_path| combos << {scheme, host, norm_path} }
+          end
+        end
+      end
+
+      return combos if combos.size <= MAX_FILTER_COMBOS
+
+      # Over the cap: drop path granularity (scheme × host), then truncate.
+      @logger.debug "Capping intent-filter deep links (#{combos.size} combinations) at #{MAX_FILTER_COMBOS}"
+      collapsed = [] of {String, String, String}
+      seen = Set(String).new
+      combos.each do |scheme, host, _|
+        collapsed << {scheme, host, ""} if seen.add?("#{scheme}://#{host}")
+      end
+      collapsed.first(MAX_FILTER_COMBOS)
     end
 
     # Emits an android-intent endpoint for an exported, data-less component,

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -436,7 +436,7 @@ module Analyzer::Mobile
     # a bare identifier (e.g. a method call) or the constant can't be found.
     private def resolve_const_ref(content : String, ref_re : Regex, gradle_path : String) : String?
       name = content.match(ref_re).try(&.[1])
-      return nil unless name
+      return unless name
       resolve_constant(name, content, gradle_path)
     end
 
@@ -468,7 +468,7 @@ module Analyzer::Mobile
               end
             end
           end
-          return nil # buildSrc found but constant absent — stop walking up
+          return # buildSrc found but constant absent — stop walking up
         end
         parent = File.dirname(dir)
         break if parent == dir

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -12,6 +12,11 @@ module Analyzer::Mobile
   # (deep links are dispatched by the App/SceneDelegate `onOpenURL` /
   # `application(_:open:)`), so `via` is filled later by the code layer.
   class Ios < Analyzer
+    # Generic web/file schemes an app may register without them being a
+    # real deep-link surface (a bare `http://` / `https://` has no host to
+    # address). Compared case-insensitively.
+    GENERIC_SCHEMES = Set{"http", "https", "file", "content"}
+
     def analyze
       locator = CodeLocator.instance
 
@@ -52,6 +57,11 @@ module Analyzer::Mobile
 
         each_array_string(schemes) do |scheme|
           next if scheme.empty?
+          # Generic web/file schemes (registered e.g. so the app is
+          # selectable as a browser) carry no app-specific deep-link
+          # surface — a bare `http://` / `https://` is not an addressable
+          # entry point, just noise in the inventory.
+          next if GENERIC_SCHEMES.includes?(scheme.downcase)
           url = "#{scheme}://"
           next unless seen.add?(url)
 


### PR DESCRIPTION
Mobile deep-link extraction accuracy — three defects found by running the built scanner against real OSS apps (Android: AntennaPod, NewPipe, Tusky, Wikipedia, NextCloud; iOS: DuckDuckGo, NetNewsWire, IceCubes, Wikipedia, Kickstarter — 5 each).

## 1. Android — combine `<data>` elements within a filter (FN + FP)

Android matches a URI against the **whole** intent-filter, treating its `<data>` children as independent sets: scheme ∈ scheme-set, host (if any) ∈ host-set, path satisfies one of the path rules. The common style splits these across separate elements — Wikipedia's PageActivity:

```xml
<data android:scheme="http" />
<data android:scheme="https" />
<data android:host="*.wikipedia.org" android:pathPrefix="/wiki/" />
<data android:host="*.wikipedia.org" android:pathPattern="/zh.*" />
```

The analyzer emitted each `<data>` element on its own, so it produced a bare `http://` / `https://` (FP) and **missed** the real `https://*.wikipedia.org/wiki/` (FN) — the app's whole App-Link surface. Now scheme/host/path sets are cross-producted, capped per filter (drop path → host → truncate) so a media-router filter can't flood the inventory.

## 2. Android — content-handler / generic-scheme noise (FP)

A `<data android:mimeType>` filter is a content-type handler (open an XML/OPML file from a file manager); its scheme-only `file`/`content`/`http`/`https` entries are content-source qualifiers, not deep links. A host-less generic scheme is likewise not addressable. Both suppressed; custom schemes (`antennapod-subscribe://`) still emit host-less.

## 3. iOS — generic URL schemes (FP)

An app may register `http`/`https` as a `CFBundleURLScheme` (e.g. to be selectable as a browser); a bare `https://` has no host. Suppressed.

## 4. Android — gradle constant-reference applicationId / namespace

NewPipe / Tusky declare `applicationId` as a **constant reference**, not a literal (`applicationId = NEWPIPE_APPLICATION_ID_OLD` from buildSrc; `applicationId APP_ID` from a same-script `def`). The quote-anchored regex missed these, so the package resolved empty — NewPipe emitted `intent:///.PlayerService` and Tusky left `${applicationId}` unresolved. Added constant-reference regexes (UPPER_SNAKE value so prose comments don't match) + a resolver that checks the same script then a sibling `buildSrc/` tree.

## Real-OSS before → after

| app | before | after | note |
|---|---|---|---|
| Wikipedia (Android) | 7 | 11 | six `*.wikipedia.org/{wiki,zh,sr}` links recovered; bare `http(s)://` dropped |
| AntennaPod | 25 | 24 | 4 `file/content/http/https` phantoms dropped; 3 split `deeplink/subscribe` links recovered |
| NewPipe | 8 | 142 | youtube/invidious/peertube/bandcamp hosts surfaced; `intent:///` → `intent://org.schabi.newpipe/…` |
| Tusky | 4 | 4 | `${applicationId}` → `com.keylesspalace.tusky` |
| DuckDuckGo (iOS) | 10 | 8 | bare `http://` / `https://` dropped; custom `ddg*://` kept |

## Tests
- Fixtures: split-`<data>` autoVerify app-link + mimeType content handler (asserts it yields nothing); iOS `https` scheme suppression; `android_gradle_const/` exercising the buildSrc constant path end to end.
- Unit + functional mobile specs updated; full mobile suite green; `crystal tool format` clean.

## Deferred follow-ups (separate issues)
- Tusky `@string/oauth_scheme` is defined via a multi-module strings / gradle `resValue` the analyzer doesn't reach, and an unresolved scheme leaves a `/@string/…://` leading-slash artifact (optimizer treats it as relative).
- iOS central-dispatch handler linkage gaps (Kickstarter: schemes extracted, 0 callees).