### PR TITLE
feat(mobile): resolve @string across all res/values files; keep unresolved deep-link schemes verbatim

### DIFF
--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -63,6 +63,25 @@
             </intent-filter>
         </activity>
 
+        <!-- Scheme resolved from a non-strings.xml values file (donottranslate.xml) -->
+        <activity android:name=".AltActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/alt_scheme" android:host="alt" />
+            </intent-filter>
+        </activity>
+
+        <!-- Unresolvable @string scheme: stays verbatim and must NOT be
+             rooted into `/@string/...` by the optimizer. -->
+        <activity android:name=".GhostActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/missing_scheme" android:host="ghost" />
+            </intent-filter>
+        </activity>
+
         <!-- Verified App Link over https (universal-link) -->
         <activity android:name=".WebActivity" android:exported="true">
             <intent-filter android:autoVerify="true">

--- a/spec/functional_test/fixtures/mobile/android/res/values/donottranslate.xml
+++ b/spec/functional_test/fixtures/mobile/android/res/values/donottranslate.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- A second values file: Android merges <string> resources across every
+     res/values/*.xml, not just strings.xml (e.g. Tusky keeps its
+     oauth_scheme here). The scheme below must resolve from this file. -->
+<resources>
+    <string name="alt_scheme" translatable="false">altscheme</string>
+</resources>

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -28,6 +28,10 @@ expected_endpoints = [
   build.call("myapp://accounts/profile", "mobile-scheme", no_params, [] of String),
   # Scheme resolved from @string/deep_link_scheme
   build.call("myappstr://settings", "mobile-scheme", no_params, [] of String),
+  # Scheme resolved from a second values file (donottranslate.xml)
+  build.call("altscheme://alt", "mobile-scheme", no_params, [] of String),
+  # Unresolvable @string scheme: kept verbatim, NOT rooted to /@string/...
+  build.call("@string/missing_scheme://ghost", "mobile-scheme", no_params, [] of String),
   # Verified App Link over https (universal-link)
   build.call("https://myapp.example.com/complex/:id", "universal-link", [Param.new("id", "", "path")], [] of String),
   # Exported, data-less component (android-intent), synthetic intent:// scheme

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -21,6 +21,16 @@ describe "Analyzer::Mobile::Android" do
     ep.not_nil!.protocol.should eq("mobile-scheme")
   end
 
+  it "resolves @string/ references from any res/values/*.xml file" do
+    # alt_scheme lives in donottranslate.xml, not strings.xml.
+    find.call("altscheme://alt").not_nil!.protocol.should eq("mobile-scheme")
+  end
+
+  it "keeps an unresolvable @string scheme verbatim and tags it unresolved" do
+    ep = find.call("@string/missing_scheme://ghost").not_nil!
+    ep.tags.any? { |t| t.name == "unresolved" }.should be_true
+  end
+
   it "normalizes templated {id} segments to :id" do
     find.call("myapp://complex/:id").should_not be_nil
   end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -541,24 +541,27 @@ module Analyzer::Mobile
       substitute(value, placeholders)
     end
 
-    # Loads <manifest_dir>/res/values/strings.xml into a name→value hash.
-    # Returns an empty hash if the file is missing or unparsable.
+    # Loads <string> resources from every res/values/*.xml file. Android
+    # merges string resources across all value files, not just strings.xml —
+    # apps routinely keep deep-link bits elsewhere (e.g. Tusky declares its
+    # oauth_scheme in donottranslate.xml). Returns name→value (first
+    # definition wins); empty if the values directory is absent.
     private def load_strings(manifest_path : String) : Hash(String, String)
       strings = {} of String => String
-      strings_path = File.join(File.dirname(manifest_path), "res", "values", "strings.xml")
-      return strings unless File.exists?(strings_path)
+      values_dir = File.join(File.dirname(manifest_path), "res", "values")
+      return strings unless Dir.exists?(values_dir)
 
-      begin
-        content = read_file_content(strings_path)
-        doc = XML.parse(content)
-        if resources = find_child(doc, "resources")
+      Dir.glob(File.join(values_dir, "*.xml")).sort.each do |path|
+        begin
+          doc = XML.parse(read_file_content(path))
+          next unless resources = find_child(doc, "resources")
           each_child(resources, "string") do |node|
             name = attr(node, "name")
-            strings[name] = node.content if name
+            strings[name] = node.content if name && !strings.has_key?(name)
           end
+        rescue e
+          @logger.debug "Failed to parse values file #{path}: #{e.message}"
         end
-      rescue e
-        @logger.debug "Failed to parse strings.xml #{strings_path}: #{e.message}"
       end
 
       strings

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -246,8 +246,10 @@ class EndpointOptimizer
         # `'/'` char literal — comparing the `Char` returned by `[]` to
         # the `"/"` string is always true, which would prepend a slash
         # even to already-rooted URLs (the double-slash collapse below
-        # papered over it).
-        if !absolute_url && tiny_tmp.url[0] != '/'
+        # papered over it). Mobile deep links are exempt: an unresolved
+        # `@string/...://` or `${...}://` scheme isn't a relative path, so
+        # rooting it (`/@string/...`) would corrupt the URL.
+        if !absolute_url && tiny_tmp.url[0] != '/' && !tiny_tmp.mobile?
           tiny_tmp.url = "/#{tiny_tmp.url}"
         end
 
@@ -534,7 +536,8 @@ class EndpointOptimizer
 
     normalized = url
     absolute_url = normalized.matches?(ABSOLUTE_URL_RE)
-    normalized = "/#{normalized}" if !absolute_url && normalized[0] != '/'
+    normalized = "/#{normalized}" if !absolute_url && normalized[0] != '/' && !endpoint.mobile?
+    return normalized if endpoint.mobile?
     normalized = normalize_url_shape(normalized, collection_endpoint?(endpoint))
     normalized
   end
@@ -709,8 +712,10 @@ class EndpointOptimizer
         # An endpoint that already carries its own scheme + host (HAR /
         # OAS absolute URLs) is self-contained. Prefixing the target or
         # collapsing its scheme `//` would corrupt it, so pass it
-        # through untouched.
-        if tmp_endpoint.url.matches?(ABSOLUTE_URL_RE)
+        # through untouched. Mobile deep links (incl. ones with an
+        # unresolved `@string/...://` scheme) are app URLs, not paths under
+        # the scanned host, so they are never base-joined either.
+        if tmp_endpoint.url.matches?(ABSOLUTE_URL_RE) || tmp_endpoint.mobile?
           tmp << tmp_endpoint
           next
         end


### PR DESCRIPTION
Closes #1983. Two fixes from the real-OSS mobile sweep, both seen on **Tusky** — whose login deep link came out as `/@string/oauth_scheme://com.keylesspalace.tusky`.

## 1. `@string/` resolution across every `res/values/*.xml`

Android merges `<string>` resources from **all** value files in `res/values/`, not just `strings.xml`. `load_strings` only read `strings.xml`, so a scheme declared elsewhere stayed an unresolved `@string/...`. Tusky keeps `oauth_scheme` in `res/values/donottranslate.xml`:

```xml
<string name="oauth_scheme" translatable="false">oauth2redirect</string>
```

Now every `res/values/*.xml` is parsed and merged (first definition wins).

## 2. Don't root an unresolved deep-link scheme

When a scheme can't be resolved the URL keeps its `@string/...://` (or `${...}://`) form, which doesn't match `ABSOLUTE_URL_RE` — so the optimizer treated it as a relative path and prepended `/`, producing `/@string/oauth_scheme://...`. Mobile endpoints are now exempt from the relative-path leading-slash normalization (dedup-prep, dedup-key builder, and the `-u` base-url join), so an unresolved scheme stays verbatim instead of being corrupted.

## Real-OSS effect
`/@string/oauth_scheme://com.keylesspalace.tusky` → **`oauth2redirect://com.keylesspalace.tusky`** (verified on the built scanner).

## Tests
- Fixture: a second values file (`donottranslate.xml`) the scheme resolves from + an unresolvable `@string/missing_scheme://ghost` asserted to stay verbatim (no leading slash) through the full pipeline.
- Optimizer specs unchanged (mobile-only guards); full mobile suite green; ameba + `crystal tool format` clean.