### PR TITLE
feat(mobile): link iOS deep-link handlers with multi-line func signatures

### DIFF
--- a/spec/functional_test/fixtures/mobile/ios/AppDelegate.swift
+++ b/spec/functional_test/fixtures/mobile/ios/AppDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    // Multi-line (SwiftLint-folded) signature — the Kickstarter shape:
+    // `func application(` and the `open url:` discriminator land on
+    // different lines, and the body brace is several lines below.
+    func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+        routeOpenURL(url)
+        return true
+    }
+
+    private func routeOpenURL(_ url: URL) {
+        logOpen(url.absoluteString)
+    }
+}

--- a/spec/functional_test/testers/mobile/ios_spec.cr
+++ b/spec/functional_test/testers/mobile/ios_spec.cr
@@ -15,10 +15,12 @@ end
 no_params = [] of Param
 
 expected_endpoints = [
-  # Custom schemes (mobile-scheme), linked to the SceneDelegate URL handler:
-  # callees + the redirect query param read from URLQueryItem.
-  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load"]),
-  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load"]),
+  # Custom schemes (mobile-scheme), linked to the URL handlers: SceneDelegate
+  # `scene(_:openURLContexts:)` callees + the redirect query param, plus
+  # `routeOpenURL` from the AppDelegate `application(_:open:)` whose signature
+  # is folded across multiple lines.
+  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL"]),
+  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL"]),
   # Universal links (universal-link), linked to the userActivity handler.
   build.call("https://myapp.example.com/", "universal-link", no_params, ["routeUniversalLink"]),
   build.call("https://www.example.com/", "universal-link", no_params, ["routeUniversalLink"]),

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -278,6 +278,10 @@ module NoirMobileLinker
       /\bfunc\s+scene\s*\(.*\bcontinue\s+userActivity\s*:/,
       /\.onContinueUserActivity\s*\(/,
     ]
+    # Opening of an `application(...)` / `scene(...)` delegate method whose
+    # parameter list may wrap across lines; used to fold the signature
+    # before classifying it against the handler patterns above.
+    SIGNATURE_START_RE = /\bfunc\s+(?:application|scene)\s*\(/
 
     # URLQueryItem name comparisons inside a handler — the iOS analog of
     # Android's getQueryParameter. Anchored to the closure-shorthand form
@@ -309,9 +313,26 @@ module NoirMobileLinker
 
       lines.each_with_index do |line, index|
         stripped, depth, in_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, depth, in_string)
-        target = if URL_HANDLER_RES.any? { |re| stripped.matches?(re) }
+
+        # A handler's func signature may span several lines (SwiftLint folds
+        # long parameter lists), e.g.
+        #   func application(
+        #     _ app: UIApplication,
+        #     open url: URL
+        #   ) -> Bool {
+        # so when a line opens such a signature, fold it through to the body
+        # brace before matching — otherwise no single line carries both
+        # `func application(` and `open url:` and the handler is missed.
+        signature = stripped
+        if stripped.matches?(SIGNATURE_START_RE) && !stripped.includes?('{')
+          if sig_brace = find_opening_brace(lines, index)
+            signature = lines[index..sig_brace[:index]].join(" ")
+          end
+        end
+
+        target = if URL_HANDLER_RES.any? { |re| signature.matches?(re) }
                    url
-                 elsif ACTIVITY_HANDLER_RES.any? { |re| stripped.matches?(re) }
+                 elsif ACTIVITY_HANDLER_RES.any? { |re| signature.matches?(re) }
                    activity
                  end
         next unless target
@@ -329,11 +350,13 @@ module NoirMobileLinker
       end
     end
 
-    # Finds the first `{` at/after the matched line (same line, else the next
-    # few lines for a func whose brace is on its own line).
+    # Finds the first `{` at/after the matched line (same line, else within a
+    # few lines for a func whose parameter list and/or brace wrap onto their
+    # own lines — a folded multi-line signature can run several lines before
+    # the body brace).
     private def self.find_opening_brace(lines : Array(String), start : Int32) : NamedTuple(index: Int32, col: Int32)?
       idx = start
-      while idx < lines.size && idx <= start + 3
+      while idx < lines.size && idx <= start + 6
         col = lines[idx].index('{')
         return {index: idx, col: col} if col
         idx += 1


### PR DESCRIPTION
Closes #1982. From the real-OSS mobile sweep — Kickstarter (ios-oss) extracted its schemes (`ksr://`, `fb…://`) and universal links but got **0 callees**.

## Cause
iOS handler discovery matched the URL / universal-link delegate methods **line-by-line**, so a handler was only seen when one line carried both `func application(` and the `open url:` / `continue userActivity:` discriminator. SwiftLint-style apps fold long signatures across lines:

```swift
func application(
  _ app: UIApplication,
  open url: URL,
  options: [UIApplication.OpenURLOptionsKey: Any] = [:]
) -> Bool {
```

so the discriminator sits on a different line than `func application(`, and the handler (plus its body brace, several lines down) was missed entirely.

## Fix
When a line opens an `application(...)` / `scene(...)` signature, fold it through to the body brace before matching, and widen the brace lookahead to span a wrapped parameter list. Single-line forms (`.onOpenURL { … }`, one-line funcs) are unaffected.

## Real-OSS effect (Kickstarter)
| endpoint | before | after |
|---|---|---|
| `ksr://` / `fb…://` | 0 callees | `facebookSDK.handleOpenURL`, `viewModel.inputs.applicationOpenUrl` |
| `https://*.kickstarter.com/` | 0 callees | `viewModel.inputs.applicationContinueUserActivity` |

0 → all 7 mobile endpoints carry callees.

## Tests
Fixture `AppDelegate.swift` with a folded `application(_:open:)` signature; the iOS functional spec asserts its `routeOpenURL` callee links to the custom-scheme endpoints. Mobile suite green; ameba + `crystal tool format` clean.