### PR TITLE
feat(mobile): resolve iOS Info.plist $(VAR) URL schemes from .xcconfig

### DIFF
--- a/spec/functional_test/fixtures/mobile/ios/Config.xcconfig
+++ b/spec/functional_test/fixtures/mobile/ios/Config.xcconfig
@@ -1,0 +1,4 @@
+// Build settings substituted into Info.plist at build time. The
+// CFBundleURLSchemes entry `$(BUNDLE_URL_SCHEME)` resolves from here.
+BUNDLE_URL_SCHEME = resolvedscheme
+APP_BUNDLE_ID = com.example.myapp

--- a/spec/functional_test/fixtures/mobile/ios/Info.plist
+++ b/spec/functional_test/fixtures/mobile/ios/Info.plist
@@ -14,6 +14,7 @@
 				<string>myapp</string>
 				<string>myapp-alt</string>
 				<string>https</string>
+				<string>$(BUNDLE_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>

--- a/spec/functional_test/testers/mobile/ios_spec.cr
+++ b/spec/functional_test/testers/mobile/ios_spec.cr
@@ -21,6 +21,8 @@ expected_endpoints = [
   # is folded across multiple lines.
   build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL"]),
   build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL"]),
+  # CFBundleURLSchemes entry `$(BUNDLE_URL_SCHEME)` resolved from Config.xcconfig.
+  build.call("resolvedscheme://", "mobile-scheme", no_params, [] of String),
   # Universal links (universal-link), linked to the userActivity handler.
   build.call("https://myapp.example.com/", "universal-link", no_params, ["routeUniversalLink"]),
   build.call("https://www.example.com/", "universal-link", no_params, ["routeUniversalLink"]),

--- a/spec/unit_test/analyzer/mobile_ios_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_spec.cr
@@ -25,6 +25,13 @@ describe "Analyzer::Mobile::Ios" do
     find.call("https://").should be_nil
   end
 
+  it "resolves an Xcode build-setting scheme placeholder from .xcconfig" do
+    # CFBundleURLSchemes has `$(BUNDLE_URL_SCHEME)`; Config.xcconfig defines
+    # `BUNDLE_URL_SCHEME = resolvedscheme`.
+    find.call("resolvedscheme://").not_nil!.protocol.should eq("mobile-scheme")
+    find.call("$(BUNDLE_URL_SCHEME)://").should be_nil
+  end
+
   it "maps applinks: associated domains to universal links" do
     find.call("https://myapp.example.com/").not_nil!.protocol.should eq("universal-link")
   end

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -50,13 +50,20 @@ module Analyzer::Mobile
       url_types = dict_value(root, "CFBundleURLTypes")
       return unless url_types
 
+      build_vars = load_xcconfig_vars(path)
+
       seen = Set(String).new
       each_array_dict(url_types) do |entry|
         schemes = dict_value(entry, "CFBundleURLSchemes")
         next unless schemes
 
-        each_array_string(schemes) do |scheme|
-          next if scheme.empty?
+        each_array_string(schemes) do |raw_scheme|
+          next if raw_scheme.empty?
+          # Xcode build-setting placeholders (`$(MOZ_PUBLIC_URL_SCHEME)`,
+          # `${APPLICATION_SCHEME}`) are substituted at build time from
+          # .xcconfig — resolve them here so Firefox/Element surface
+          # `firefox://` / `element://` instead of the literal variable.
+          scheme = substitute_build_vars(raw_scheme, build_vars)
           # Generic web/file schemes (registered e.g. so the app is
           # selectable as a browser) carry no app-specific deep-link
           # surface — a bare `http://` / `https://` is not an addressable
@@ -70,6 +77,63 @@ module Analyzer::Mobile
           @result << endpoint
         end
       end
+    end
+
+    # How far up from the Info.plist to look for the project's .xcconfig
+    # files, and how many to read.
+    XCCONFIG_SEARCH_DEPTH =  6
+    MAX_XCCONFIG_FILES    = 40
+    # `KEY = value` (xcconfig assignment); the value runs to a trailing
+    # comment / end of line.
+    XCCONFIG_ASSIGN_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^\n]*)$/
+    # `$(VAR)` / `${VAR}` build-setting reference.
+    BUILD_VAR_RE = /\$[({]([A-Za-z_][A-Za-z0-9_]*)[)}]/
+
+    # Loads `KEY = value` definitions from the project's .xcconfig files, so
+    # build-setting placeholders in CFBundleURLSchemes can be resolved. The
+    # files are gathered from the enclosing Xcode project root (so variant
+    # configs in Config/ or Variants/ are seen, not just the ones nearest the
+    # Info.plist); first definition wins.
+    private def load_xcconfig_vars(plist_path : String) : Hash(String, String)
+      vars = {} of String => String
+      root = xcode_project_root(plist_path) || File.dirname(File.expand_path(plist_path))
+      Dir.glob(File.join(root, "**", "*.xcconfig")).sort.first(MAX_XCCONFIG_FILES).each do |xc|
+        parse_xcconfig(xc, vars)
+      end
+      vars
+    end
+
+    # The nearest ancestor of the Info.plist that holds a `.xcodeproj` /
+    # `.xcworkspace`; nil if none within the search depth.
+    private def xcode_project_root(plist_path : String) : String?
+      dir = File.dirname(File.expand_path(plist_path))
+      XCCONFIG_SEARCH_DEPTH.times do
+        has_project = !Dir.glob(File.join(dir, "*.xcodeproj")).empty? ||
+                      !Dir.glob(File.join(dir, "*.xcworkspace")).empty?
+        return dir if has_project
+        parent = File.dirname(dir)
+        break if parent == dir
+        dir = parent
+      end
+      nil
+    end
+
+    private def parse_xcconfig(path : String, vars : Hash(String, String))
+      read_file_content(path).each_line do |line|
+        next if line.lstrip.starts_with?("//") || line.lstrip.starts_with?('#')
+        next unless m = line.match(XCCONFIG_ASSIGN_RE)
+        value = m[2].sub(%r{//.*$}, "").gsub("$(inherited)", "").strip
+        vars[m[1]] = value unless value.empty? || vars.has_key?(m[1])
+      end
+    rescue e
+      @logger.debug "Failed to parse xcconfig #{path}: #{e.message}"
+    end
+
+    # Resolves `$(VAR)` / `${VAR}` against the xcconfig map; unknown
+    # references are kept verbatim (same behavior as before this resolver).
+    private def substitute_build_vars(value : String, vars : Hash(String, String)) : String
+      return value unless value.includes?("$(") || value.includes?("${")
+      value.gsub(BUILD_VAR_RE) { vars[$~[1]]? || $~[0] }
     end
 
     private def parse_entitlements(doc : XML::Node, path : String)


### PR DESCRIPTION
From a second real-OSS mobile sweep (round 2: Element-iOS, Firefox-iOS, Signal-iOS, Wire, Pocket Casts). iOS apps frequently declare their custom URL scheme as an **Xcode build-setting placeholder** in Info.plist and let the build substitute it:

```xml
<key>CFBundleURLSchemes</key>
<array><string>$(MOZ_PUBLIC_URL_SCHEME)</string></array>
```

The analyzer kept the literal `$(MOZ_PUBLIC_URL_SCHEME)://`, so the real scheme never surfaced — **Firefox's entire scheme set** and **Element-iOS's `element://`** came out as unresolved placeholders.

## Fix
Resolve `$(VAR)` / `${VAR}` schemes against the project's `.xcconfig` files. Configs are gathered from the enclosing **Xcode project root** (nearest ancestor with a `.xcodeproj` / `.xcworkspace`) so variant configs under `Config/` or `Variants/` are seen — not just the one next to the Info.plist (Element keeps `APPLICATION_SCHEME` in `Config/AppIdentifiers.xcconfig`, several levels up). First definition wins. An unresolvable reference (e.g. defined only in `project.pbxproj`) is kept verbatim, exactly as before — this only ever improves resolution.

## Real-OSS effect
| app | before | after |
|---|---|---|
| Element-iOS | `$(APPLICATION_SCHEME)://` | `element://` |
| Firefox-iOS | `$(MOZ_PUBLIC_URL_SCHEME)://` | `firefox://`, `fennec://` |

(Firefox Focus's `$(BLOCKZILLA_URL_SCHEME)` is defined only in project.pbxproj, not a .xcconfig, so it stays verbatim — a known limitation, not a regression.)

## Tests
A `Config.xcconfig` fixture defining `BUNDLE_URL_SCHEME` and a `$(BUNDLE_URL_SCHEME)` Info.plist scheme asserted to resolve to `resolvedscheme://` (and to not surface the literal). Mobile suite green; ameba + `crystal tool format` clean.

## Other round-2 findings (deferred / noted)
- Android gradle GString applicationId (`applicationId "${packageName}"` with `def packageName`) — Aegis; extends the constant resolver.
- Android multi-module `${applicationId}` in feature-module manifests (Thunderbird appauth receivers) — the id lives in the app module, not the feature module.
- Intent-filter cross-product can produce spec-correct but developer-unintended combos (Element `http://user`) when one filter mixes lone schemes/hosts with paired `<data>` — left as-is (matches Android semantics).