### PR TITLE
feat(mobile): resolve groovy GString interpolation in gradle applicationId

### DIFF
--- a/spec/functional_test/fixtures/mobile/android_gradle_gstring/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android_gradle_gstring/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- No `package` attribute: the package comes from the gradle applicationId,
+     which is a groovy GString ("${appPkg}") resolved from a `def`. -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application android:label="GStringApp">
+
+        <!-- ${applicationId} host resolves only if the GString applicationId
+             was followed to its `def` literal. -->
+        <activity android:name=".AuthActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="gstringscheme" android:host="${applicationId}" />
+            </intent-filter>
+        </activity>
+
+        <!-- Data-less exported service: the intent:// URL must carry the
+             resolved package, not an empty intent:/// . -->
+        <service android:name=".GStringService" android:exported="true">
+            <intent-filter>
+                <action android:name="com.example.ACTION_GSTRING" />
+            </intent-filter>
+        </service>
+
+    </application>
+</manifest>

--- a/spec/functional_test/fixtures/mobile/android_gradle_gstring/build.gradle
+++ b/spec/functional_test/fixtures/mobile/android_gradle_gstring/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'com.android.application'
+}
+
+// The id is built from a groovy `def` via GString interpolation, the Aegis
+// shape: the applicationId literal is "${appPkg}", not a plain string.
+def appPkg = "com.example.gstringapp"
+
+android {
+    namespace appPkg
+
+    defaultConfig {
+        applicationId "${appPkg}"
+    }
+}

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -200,3 +200,29 @@ describe "Analyzer::Mobile::Android (gradle constant reference)" do
     find.call("intent://com.example.constapp/.ConstService").not_nil!.protocol.should eq("android-intent")
   end
 end
+
+# applicationId built from a groovy GString (`applicationId "${appPkg}"`)
+# whose `def appPkg = "..."` lives in the same script (the Aegis shape).
+describe "Analyzer::Mobile::Android (gradle GString applicationId)" do
+  options = create_test_options
+  manifest = File.expand_path(
+    File.join(__DIR__, "..", "..", "functional_test", "fixtures", "mobile", "android_gradle_gstring",
+      "AndroidManifest.xml"))
+
+  CodeLocator.instance.clear("android-manifest")
+  CodeLocator.instance.push("android-manifest", manifest)
+  endpoints = Analyzer::Mobile::Android.new(options).analyze
+
+  find = ->(url : String) { endpoints.find { |e| e.url == url } }
+
+  it "resolves a GString applicationId into ${applicationId}" do
+    ep = find.call("gstringscheme://com.example.gstringapp").not_nil!
+    ep.protocol.should eq("mobile-scheme")
+    ep.tags.any? { |t| t.name == "unresolved" }.should be_false
+  end
+
+  it "uses the GString-resolved applicationId as the intent:// package" do
+    find.call("intent:///.GStringService").should be_nil
+    find.call("intent://com.example.gstringapp/.GStringService").not_nil!.protocol.should eq("android-intent")
+  end
+end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -401,10 +401,14 @@ module Analyzer::Mobile
     private def parse_gradle(content : String, gradle_path : String) : GradleConfig
       # Prefer a quoted literal; fall back to a constant reference
       # (`applicationId APP_ID`) resolved against this script or buildSrc.
+      # A quoted literal may itself be a groovy GString (`"${packageName}"`),
+      # so resolve any interpolation it carries.
       application_id = content.match(APPLICATION_ID_RE).try(&.[1]) ||
                        resolve_const_ref(content, APPLICATION_ID_CONST_RE, gradle_path)
+      application_id = resolve_gstring(application_id, content, gradle_path)
       namespace = content.match(NAMESPACE_RE).try(&.[1]) ||
                   resolve_const_ref(content, NAMESPACE_CONST_RE, gradle_path)
+      namespace = resolve_gstring(namespace, content, gradle_path)
       placeholders = {} of String => String
 
       content.scan(PLACEHOLDER_MAP_RE) do |m|
@@ -430,6 +434,16 @@ module Analyzer::Mobile
     # How far up from the module script to look for a `buildSrc/` source tree
     # holding shared gradle constants.
     BUILDSRC_SEARCH_DEPTH = 4
+
+    # Resolves groovy GString interpolations (`applicationId "${packageName}"`)
+    # in a captured applicationId / namespace value by looking each `${name}`
+    # up as a gradle constant (same script, then buildSrc). The name comes
+    # straight from `${...}`, so there is no loose prose-matching risk;
+    # unknown names stay verbatim and nil passes through.
+    private def resolve_gstring(value : String?, content : String, gradle_path : String) : String?
+      return value if value.nil? || !value.includes?("${")
+      value.gsub(/\$\{(\w+)\}/) { resolve_constant($~[1], content, gradle_path) || $~[0] }
+    end
 
     # Matches a constant reference (`applicationId APP_ID`) and resolves the
     # named constant to its string literal. Returns nil when the value is not


### PR DESCRIPTION
Round-2 OSS finding (**Aegis**). The `applicationId` is a groovy GString built from a `def`, not a plain literal:

```groovy
def packageName = "com.beemdevelopment.aegis"
android {
    defaultConfig { applicationId "${packageName}" }
}
```

The quoted-literal regex captured `${packageName}` verbatim, so with no `package` attribute in the manifest the package fell back to the unresolved GString — every intent:// URL came out as `intent://${packageName}/...`.

## Fix
Resolve `${name}` interpolations in the captured applicationId / namespace by looking each name up as a gradle constant (same script, then `buildSrc`, reusing the resolver added in #1981). The name comes straight from `${...}`, so there's no loose prose-matching risk; an unknown name stays verbatim.

## Real-OSS effect (Aegis)
| before | after |
|---|---|
| `intent://${packageName}/.ui.PanicResponderActivity` | `intent://com.beemdevelopment.aegis/.ui.PanicResponderActivity` |

(all three exported components corrected.)

## Tests
Fixture `android_gradle_gstring/` with `def appPkg = "…"` + `applicationId "${appPkg}"` and no manifest `package`, exercising both `${applicationId}` substitution and the package fallback. Mobile suite green; ameba + `crystal tool format` clean.