### PR TITLE
feat(mobile): normalize <data> schemes — drop local-content/wildcard noise, emit opaque schemes correctly

### DIFF
--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -82,6 +82,28 @@
             </intent-filter>
         </activity>
 
+        <!-- Local-content + bare-wildcard-host handler: file/content are
+             always dropped (on-device content, not a deep link), and a bare
+             `*` host makes http host-less and dropped too. Yields nothing. -->
+        <activity android:name=".ShareActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" android:host="*" />
+                <data android:scheme="file" android:host="*" />
+                <data android:scheme="http" android:host="*" />
+            </intent-filter>
+        </activity>
+
+        <!-- Opaque-scheme handler: `mailto:` takes no // authority. -->
+        <activity android:name=".ComposeActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="mailto" />
+            </intent-filter>
+        </activity>
+
         <!-- Verified App Link over https (universal-link) -->
         <activity android:name=".WebActivity" android:exported="true">
             <intent-filter android:autoVerify="true">

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -32,6 +32,9 @@ expected_endpoints = [
   build.call("altscheme://alt", "mobile-scheme", no_params, [] of String),
   # Unresolvable @string scheme: kept verbatim, NOT rooted to /@string/...
   build.call("@string/missing_scheme://ghost", "mobile-scheme", no_params, [] of String),
+  # Opaque scheme: `mailto:` has no // authority. (The sibling file/content/
+  # `http://*` wildcard-host filter on ShareActivity yields nothing.)
+  build.call("mailto:", "mobile-scheme", no_params, [] of String),
   # Verified App Link over https (universal-link)
   build.call("https://myapp.example.com/complex/:id", "universal-link", [Param.new("id", "", "path")], [] of String),
   # Exported, data-less component (android-intent), synthetic intent:// scheme

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -68,6 +68,17 @@ describe "Analyzer::Mobile::Android" do
     find.call("intent://com.example.myapp/.MainActivity").should be_nil
   end
 
+  it "drops local-content (file/content) and bare-* wildcard-host data filters" do
+    find.call("content://*").should be_nil
+    find.call("file://*").should be_nil
+    find.call("http://*").should be_nil
+  end
+
+  it "renders an opaque scheme without a // authority" do
+    find.call("mailto:").not_nil!.protocol.should eq("mobile-scheme")
+    find.call("mailto://").should be_nil
+  end
+
   it "combines scheme and host/path split across separate <data> elements" do
     # SplitLinkActivity declares schemes and host+path in separate <data>
     # children; Android cross-products them, so all four resolve.

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -111,6 +111,17 @@ module Analyzer::Mobile
     # host-less, since that's how a runtime-routed custom scheme is declared.
     GENERIC_SCHEMES = Set{"http", "https", "file", "content"}
 
+    # Local-content schemes. `file://` / `content://` URIs always point at
+    # on-device content (a file picked from a file manager, a ContentProvider
+    # row), never a remotely reachable deep link — so they are suppressed
+    # regardless of host (including a bare `*` wildcard host).
+    LOCAL_SCHEMES = Set{"file", "content"}
+
+    # Opaque (authority-less) schemes: `mailto:foo@bar`, `tel:123`, `geo:…`.
+    # They take no `//host` part, so the URL is rendered as `scheme:` rather
+    # than `scheme://`.
+    OPAQUE_SCHEMES = Set{"mailto", "tel", "sms", "smsto", "mms", "geo", "market"}
+
     # Upper bound on endpoints emitted from a single intent-filter. A media
     # router / browser filter can declare dozens of hosts × paths; the full
     # cross product would flood the inventory with near-duplicates, so past
@@ -143,7 +154,10 @@ module Analyzer::Mobile
           schemes << scheme unless scheme.empty? || schemes.includes?(scheme)
         end
         if host = resolve(attr(data, "host"), strings, placeholders)
-          hosts << host unless host.empty? || hosts.includes?(host)
+          # A bare `*` host matches any authority — it carries no specific
+          # target, so treat it as host-less (`scheme://*` == `scheme://`).
+          # A wildcard *subdomain* (`*.example.com`) is kept as-is.
+          hosts << host unless host.empty? || host == "*" || hosts.includes?(host)
         end
         norm = normalize_path(data, strings, placeholders)
         paths << norm unless norm.empty? || paths.includes?(norm)
@@ -152,7 +166,7 @@ module Analyzer::Mobile
 
       data_filter_combos(schemes, hosts, paths, has_mime_type).each do |scheme, host, norm_path|
         web = scheme == "http" || scheme == "https"
-        url = "#{scheme}://#{host}#{norm_path}"
+        url = build_data_url(scheme, host, norm_path)
         next unless seen_urls.add?(url)
 
         protocol = (web && auto_verify) ? "universal-link" : "mobile-scheme"
@@ -173,6 +187,8 @@ module Analyzer::Mobile
       effective_paths = paths.empty? ? [""] : paths
 
       schemes.each do |scheme|
+        # Local-content schemes never describe a remote deep link.
+        next if LOCAL_SCHEMES.includes?(scheme)
         if hosts.empty?
           # Host-less: keep only custom schemes. A generic scheme with no
           # host — and any scheme in a content-type (mimeType) filter — is a
@@ -213,6 +229,14 @@ module Analyzer::Mobile
       endpoint.metadata = build_metadata("", actions, categories, "", package)
 
       @result << endpoint
+    end
+
+    # Renders a `<data>` URL. Opaque schemes (mailto/tel/geo/…) have no
+    # `//authority`, so they're emitted as `scheme:`; everything else uses
+    # the usual `scheme://host/path`.
+    private def build_data_url(scheme : String, host : String, norm_path : String) : String
+      return "#{scheme}:" if OPAQUE_SCHEMES.includes?(scheme)
+      "#{scheme}://#{host}#{norm_path}"
     end
 
     # --- Jetpack Navigation (res/navigation/*.xml) -------------------------


### PR DESCRIPTION
Two round-2 OSS cleanups in the Android intent-filter `<data>` handling (AnkiDroid, Thunderbird).

## 1. Local-content + bare-wildcard-host noise (AnkiDroid)

`file://` / `content://` URIs always address **on-device** content (a file picked from a file manager, a ContentProvider row), never a remotely reachable deep link — now suppressed regardless of host, not only when host-less. And a bare `*` host (`android:host="*"`) matches any authority and carries no specific target, so it's treated as host-less: `http://*` collapses to a host-less generic scheme and drops out. A wildcard **subdomain** (`*.example.com`) is still kept.

AnkiDroid's IntentHandler stops emitting four `content://*` / `file://*` / `http://*` / `https://*` phantoms.

## 2. Opaque schemes (Thunderbird)

`mailto:`, `tel:`, `sms:`, `geo:` … take no `//authority`. The analyzer always appended `://`, so Thunderbird's mail handler surfaced as the malformed `mailto://`. These now render as `scheme:` (the mobile URL guard from #1984 keeps the optimizer from rooting the `//`-less form).

## Real-OSS effect
| app | before | after |
|---|---|---|
| AnkiDroid | 11 mobile (incl. `content://*`, `file://*`, `http://*`, `https://*`) | 7 (only `anki://x-callback-url/browser` custom scheme + intents) |
| Thunderbird | `mailto://` | `mailto:` |

## Tests
A wildcard-host `file`/`content`/`http://*` filter asserted to yield nothing, and an opaque `mailto` filter asserted to render `mailto:`. Mobile + optimizer suites green; ameba + `crystal tool format` clean.