### PR TITLE
fix(mobile): don't treat market:// / mms:// as opaque schemes

### DIFF
--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -104,6 +104,16 @@
             </intent-filter>
         </activity>
 
+        <!-- `market://details?id=…` (Play Store) DOES use an authority, so it
+             must keep its `//` (not be treated as an opaque scheme). -->
+        <activity android:name=".StoreActivity" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="market" android:host="details" />
+            </intent-filter>
+        </activity>
+
         <!-- Verified App Link over https (universal-link) -->
         <activity android:name=".WebActivity" android:exported="true">
             <intent-filter android:autoVerify="true">

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -35,6 +35,8 @@ expected_endpoints = [
   # Opaque scheme: `mailto:` has no // authority. (The sibling file/content/
   # `http://*` wildcard-host filter on ShareActivity yields nothing.)
   build.call("mailto:", "mobile-scheme", no_params, [] of String),
+  # `market://details` keeps its authority (NOT opaque despite the short list).
+  build.call("market://details", "mobile-scheme", no_params, [] of String),
   # Verified App Link over https (universal-link)
   build.call("https://myapp.example.com/complex/:id", "universal-link", [Param.new("id", "", "path")], [] of String),
   # Exported, data-less component (android-intent), synthetic intent:// scheme

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -79,6 +79,12 @@ describe "Analyzer::Mobile::Android" do
     find.call("mailto://").should be_nil
   end
 
+  it "keeps the // authority on schemes that use one (market://details)" do
+    # `market://details?id=…` and streaming `mms://host` are NOT opaque.
+    find.call("market://details").not_nil!.protocol.should eq("mobile-scheme")
+    find.call("market:").should be_nil
+  end
+
   it "combines scheme and host/path split across separate <data> elements" do
     # SplitLinkActivity declares schemes and host+path in separate <data>
     # children; Android cross-products them, so all four resolve.

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -119,8 +119,10 @@ module Analyzer::Mobile
 
     # Opaque (authority-less) schemes: `mailto:foo@bar`, `tel:123`, `geo:…`.
     # They take no `//host` part, so the URL is rendered as `scheme:` rather
-    # than `scheme://`.
-    OPAQUE_SCHEMES = Set{"mailto", "tel", "sms", "smsto", "mms", "geo", "market"}
+    # than `scheme://`. Deliberately conservative: `market://details?id=…`
+    # (Play Store) and `mms://host` (media streaming, e.g. VLC) DO use an
+    # authority, so they are NOT listed here.
+    OPAQUE_SCHEMES = Set{"mailto", "tel", "sms", "smsto", "geo"}
 
     # Upper bound on endpoints emitted from a single intent-filter. A media
     # router / browser filter can declare dozens of hosts × paths; the full


### PR DESCRIPTION
Round-3 OSS finding (VLC streaming, Play Store links) — a **regression from #1988**.

The opaque-scheme list (rendered as `scheme:` without `//`) wrongly included `market` and `mms`, but both use an authority:
- `market://details?id=com.example` — Play Store deep link
- `mms://host/stream` — Microsoft Media Server streaming (e.g. VLC)

Listing them as opaque rewrote `market://details` → `market:` and `mms://host` → `mms:`, corrupting real URLs. Narrowed `OPAQUE_SCHEMES` to the genuinely authority-less schemes: **mailto / tel / sms / smsto / geo**.

## Tests
A `market://details` filter asserted to keep its `//`, alongside the existing `mailto:` opaque case. Verified on OrganicMaps that `geo:` stays opaque while the distinct custom schemes `geo.offline://` / `geo.action://` correctly keep `//` (the match is exact). Mobile suite green; ameba + `crystal tool format` clean.

## Other round-3 findings (deferred)
- **home-assistant Android** emits 72 `intent:///` (empty package): the components live in the `wear/` module whose gradle has no explicit `applicationId` (it comes from a build-convention plugin) — the hard multi-module case.
- **home-assistant iOS** `${ENV_URL_HANDLER}://`: the value is in `project.pbxproj`, not a `.xcconfig` (same shape as Firefox Focus's `$(BLOCKZILLA_URL_SCHEME)`).
- **VLC-iOS / Swiftfin / Simplenote** schemes get 0 callees — their open-URL handlers are Objective-C (`- (BOOL)application:openURL:`), which the Swift-only handler discovery + callee extractor don't cover.