### PR TITLE
feat(mobile): link iOS deep-link handlers written in Objective-C

### DIFF
--- a/spec/functional_test/fixtures/mobile/ios/LegacyAppDelegate.m
+++ b/spec/functional_test/fixtures/mobile/ios/LegacyAppDelegate.m
@@ -1,0 +1,22 @@
+#import "LegacyAppDelegate.h"
+
+// A legacy Objective-C app delegate. Its open-URL / continue-userActivity
+// handlers use the Objective-C message-send syntax (and wrapped signatures),
+// which the Swift-only discovery used to miss entirely.
+@implementation LegacyAppDelegate
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+    return [self handleObjcDeepLink:url];
+}
+
+- (BOOL)application:(UIApplication *)application
+    continueUserActivity:(NSUserActivity *)userActivity
+      restorationHandler:(void (^)(NSArray *))restorationHandler
+{
+    return [self routeObjcUniversalLink:userActivity];
+}
+
+@end

--- a/spec/functional_test/testers/mobile/ios_spec.cr
+++ b/spec/functional_test/testers/mobile/ios_spec.cr
@@ -17,14 +17,17 @@ no_params = [] of Param
 expected_endpoints = [
   # Custom schemes (mobile-scheme), linked to the URL handlers: SceneDelegate
   # `scene(_:openURLContexts:)` callees + the redirect query param, plus
-  # `routeOpenURL` from the AppDelegate `application(_:open:)` whose signature
-  # is folded across multiple lines.
-  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL"]),
-  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL"]),
+  # `routeOpenURL` from the AppDelegate `application(_:open:)` (multi-line
+  # signature) and `handleObjcDeepLink` from the Objective-C
+  # `application:openURL:` in LegacyAppDelegate.m.
+  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
+  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
   # CFBundleURLSchemes entry `$(BUNDLE_URL_SCHEME)` resolved from Config.xcconfig.
   build.call("resolvedscheme://", "mobile-scheme", no_params, [] of String),
-  # Universal links (universal-link), linked to the userActivity handler.
-  build.call("https://myapp.example.com/", "universal-link", no_params, ["routeUniversalLink"]),
+  # Universal links (universal-link), linked to the userActivity handlers:
+  # the Swift `routeUniversalLink` and the Objective-C `routeObjcUniversalLink`
+  # from LegacyAppDelegate.m `application:continueUserActivity:`.
+  build.call("https://myapp.example.com/", "universal-link", no_params, ["routeUniversalLink", "routeObjcUniversalLink"]),
   build.call("https://www.example.com/", "universal-link", no_params, ["routeUniversalLink"]),
 ]
 

--- a/spec/unit_test/miniparser/objc_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/objc_callee_extractor_spec.cr
@@ -1,0 +1,59 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/objc_callee_extractor"
+
+describe Noir::ObjcCalleeExtractor do
+  it "extracts message-send selectors (incl. nested) from an Objective-C body" do
+    body = <<-OBJC
+      [self performMagicLinkAuthenticationWith:url];
+      if ([self handleOpenNoteWithUrl:url]) { return YES; }
+      NSURLComponents *c = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+      if ([[c host] isEqualToString:@"new"]) {
+          Note *n = [[SPObjectManager sharedManager] newNoteWithContent:body tags:tags];
+          [self presentNote:n animated:NO];
+      }
+      OBJC
+
+    names = Noir::ObjcCalleeExtractor.callees_for_body(body, "SPAppDelegate.m", 1).map { |n, _, _| n }
+    names.should contain("performMagicLinkAuthenticationWith")
+    names.should contain("handleOpenNoteWithUrl")
+    names.should contain("componentsWithURL")
+    names.should contain("host")                # `[c host]` no-arg message
+    names.should contain("isEqualToString")
+    names.should contain("sharedManager")       # inner of a nested send
+    names.should contain("newNoteWithContent")  # outer of a nested send
+    names.should contain("presentNote")
+  end
+
+  it "captures the dispatch selectors in a handler-loop body" do
+    body = <<-OBJC
+      for (id<VLCURLHandler> handler in URLHandlers.handlers) {
+          if ([handler canHandleOpenWithUrl:url options:options]) {
+              return [handler performOpenWithUrl:url options:options];
+          }
+      }
+      OBJC
+
+    names = Noir::ObjcCalleeExtractor.callees_for_body(body, "VLCAppDelegate.m", 1).map { |n, _, _| n }
+    names.should contain("canHandleOpenWithUrl")
+    names.should contain("performOpenWithUrl")
+  end
+
+  it "ignores control flow, memory-management selectors, and subscripts" do
+    body = <<-OBJC
+      // open the note
+      id obj = arr[0];
+      NSString *s = dict[@"key"];
+      Foo *f = [[Foo alloc] init];
+      if (obj) { [obj doRealWork:s]; }
+      OBJC
+
+    names = Noir::ObjcCalleeExtractor.callees_for_body(body, "X.m", 1).map { |n, _, _| n }
+    names.should contain("doRealWork")
+    names.should_not contain("if")
+    names.should_not contain("alloc")
+    names.should_not contain("init")
+    # `arr[0]` / `dict[@"key"]` subscripts are not message sends
+    names.should_not contain("arr")
+    names.should_not contain("dict")
+  end
+end

--- a/spec/unit_test/miniparser/objc_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/objc_callee_extractor_spec.cr
@@ -17,10 +17,10 @@ describe Noir::ObjcCalleeExtractor do
     names.should contain("performMagicLinkAuthenticationWith")
     names.should contain("handleOpenNoteWithUrl")
     names.should contain("componentsWithURL")
-    names.should contain("host")                # `[c host]` no-arg message
+    names.should contain("host") # `[c host]` no-arg message
     names.should contain("isEqualToString")
-    names.should contain("sharedManager")       # inner of a nested send
-    names.should contain("newNoteWithContent")  # outer of a nested send
+    names.should contain("sharedManager")      # inner of a nested send
+    names.should contain("newNoteWithContent") # outer of a nested send
     names.should contain("presentNote")
   end
 

--- a/src/miniparsers/objc_callee_extractor.cr
+++ b/src/miniparsers/objc_callee_extractor.cr
@@ -1,0 +1,75 @@
+require "../models/endpoint"
+require "./swift_callee_extractor"
+
+# Best-effort 1-hop callee extraction for Objective-C method bodies. Mirrors
+# `SwiftCalleeExtractor` but understands the message-send syntax
+# (`[receiver selector:arg]`) that dominates Objective-C — the selector is the
+# callee. C-style function calls (`CGRectMake(...)`) are picked up too.
+#
+# Comment / string stripping is shared with the Swift extractor (Objective-C
+# uses the same `//`, `/* */`, and `"..."` lexical forms).
+module Noir::ObjcCalleeExtractor
+  extend self
+
+  alias Entry = Tuple(String, String, Int32)
+
+  # Keywords and primitive type names that can sit where a selector / call
+  # name would, but are never a 1-hop callee.
+  RESERVED = Set{
+    "if", "else", "for", "while", "do", "switch", "case", "default",
+    "return", "break", "continue", "goto", "sizeof", "self", "super",
+    "nil", "Nil", "NULL", "YES", "NO", "id", "void", "BOOL", "in",
+    "typeof", "__typeof", "__bridge", "__weak", "__strong", "instancetype",
+    "const", "static", "extern", "inline", "_cmd", "block", "weakSelf",
+  }
+
+  # Pure memory-management selectors — real calls, but noise as callees.
+  MEMORY_SELECTORS = Set{
+    "alloc", "init", "new", "retain", "release", "autorelease",
+    "dealloc", "copy", "mutableCopy",
+  }
+
+  # `[receiver selector...]` where the receiver is an identifier / dotted
+  # property chain / `self` — captures the first selector keyword.
+  MSG_IDENT_RECEIVER_RE = /\[\s*(?:[A-Za-z_]\w*)(?:\s*\.\s*[A-Za-z_]\w*)*\s+([A-Za-z_]\w*)\s*[:\]]/
+  # The selector of an outer message whose receiver is itself a bracketed
+  # subexpression: `[[Foo bar] selector:...]` -> the `] selector` boundary.
+  MSG_BRACKET_RECEIVER_RE = /\]\s+([A-Za-z_]\w*)\s*[:\]]/
+  # A C-style function call (`CGRectMake(...)`), not a `.method(`/`](` form.
+  C_CALL_RE = /(?<![.\w\]])([A-Za-z_]\w*)\s*\(/
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    block_comment_depth = 0
+    in_string = false
+
+    body.lines.each_with_index do |line, index|
+      stripped, block_comment_depth, in_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(
+        line, block_comment_depth, in_string
+      )
+      scan_line(stripped, file_path, start_line + index, entries)
+    end
+
+    dedup_entries(entries)
+  end
+
+  private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    {MSG_IDENT_RECEIVER_RE, MSG_BRACKET_RECEIVER_RE}.each do |re|
+      line.scan(re) { |m| add_entry(entries, m[1], file_path, line_number) }
+    end
+    line.scan(C_CALL_RE) { |m| add_entry(entries, m[1], file_path, line_number) }
+  end
+
+  private def add_entry(entries : Array(Entry), name : String, file_path : String, line_number : Int32)
+    return if name.empty? || RESERVED.includes?(name) || MEMORY_SELECTORS.includes?(name)
+    entries << {name, file_path, line_number}
+  end
+
+  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    seen = Set(String).new
+    entries.select do |name, path, line|
+      key = "#{name}\0#{path}\0#{line}"
+      seen.add?(key)
+    end
+  end
+end

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -4,6 +4,7 @@ require "../ext/tree_sitter/tree_sitter"
 require "../miniparsers/kotlin_callee_extractor"
 require "../miniparsers/java_callee_extractor"
 require "../miniparsers/swift_callee_extractor"
+require "../miniparsers/objc_callee_extractor"
 
 # Post-analysis pass that links mobile deep-link endpoints (produced by the
 # config-file analyzers from AndroidManifest.xml) to the source code that
@@ -283,6 +284,20 @@ module NoirMobileLinker
     # before classifying it against the handler patterns above.
     SIGNATURE_START_RE = /\bfunc\s+(?:application|scene)\s*\(/
 
+    # Objective-C counterparts. The same delegate methods are written as
+    # message-style declarations: `- (BOOL)application:(UIApplication *)app
+    # openURL:(NSURL *)url options:…`. Matched on the folded signature, so a
+    # wrapped parameter list still classifies.
+    OBJC_URL_HANDLER_RES = [
+      /\bapplication:.*\bopenURL:/,
+      /\bscene:.*\bopenURLContexts:/,
+    ]
+    OBJC_ACTIVITY_HANDLER_RES = [
+      /\bapplication:.*\bcontinueUserActivity:/,
+      /\bscene:.*\bcontinueUserActivity:/,
+    ]
+    OBJC_SIGNATURE_START_RE = /^\s*[+-]\s*\([^)]*\)\s*(?:application|scene):/
+
     # URLQueryItem name comparisons inside a handler — the iOS analog of
     # Android's getQueryParameter. Anchored to the closure-shorthand form
     # (`$0.name == "x"`) and an explicit `URLQueryItem(name: "x")` so a plain
@@ -295,18 +310,40 @@ module NoirMobileLinker
       activity = NoirMobileLinker::HandlerInfo.new
 
       CodeLocator.instance.files_by_extension(".swift").each do |path|
-        next if path.includes?("/.build/") || path.includes?("/.swiftpm/")
+        next if skip_ios_source?(path)
         content = NoirMobileLinker.read_content(path)
         next unless content
-        scan_file(path, content, url, activity)
+        scan_file(path, content, url, activity,
+          URL_HANDLER_RES, ACTIVITY_HANDLER_RES, SIGNATURE_START_RE, objc: false)
+      end
+
+      {".m", ".mm"}.each do |ext|
+        CodeLocator.instance.files_by_extension(ext).each do |path|
+          next if skip_ios_source?(path)
+          content = NoirMobileLinker.read_content(path)
+          next unless content
+          scan_file(path, content, url, activity,
+            OBJC_URL_HANDLER_RES, OBJC_ACTIVITY_HANDLER_RES, OBJC_SIGNATURE_START_RE, objc: true)
+        end
       end
 
       {:url => url, :activity => activity}
     end
 
+    private def self.skip_ios_source?(path : String) : Bool
+      path.includes?("/.build/") || path.includes?("/.swiftpm/") ||
+        path.includes?("/Pods/") || path.includes?("/Carthage/")
+    end
+
+    # Scans one source file for the central deep-link dispatch handlers,
+    # accumulating callees (and Swift query params) into the shared
+    # `url` / `activity` handler info. `objc` selects the Objective-C handler
+    # patterns + callee extractor; otherwise the Swift ones are used.
     private def self.scan_file(path : String, content : String,
                                url : NoirMobileLinker::HandlerInfo,
-                               activity : NoirMobileLinker::HandlerInfo)
+                               activity : NoirMobileLinker::HandlerInfo,
+                               url_res : Array(Regex), activity_res : Array(Regex),
+                               sig_re : Regex, objc : Bool)
       lines = content.lines
       depth = 0
       in_string = false
@@ -314,25 +351,25 @@ module NoirMobileLinker
       lines.each_with_index do |line, index|
         stripped, depth, in_string = Noir::SwiftCalleeExtractor.strip_non_code_with_state(line, depth, in_string)
 
-        # A handler's func signature may span several lines (SwiftLint folds
-        # long parameter lists), e.g.
+        # A handler's signature may span several lines (SwiftLint / Objective-C
+        # both wrap long parameter lists), e.g.
         #   func application(
         #     _ app: UIApplication,
         #     open url: URL
         #   ) -> Bool {
         # so when a line opens such a signature, fold it through to the body
-        # brace before matching — otherwise no single line carries both
-        # `func application(` and `open url:` and the handler is missed.
+        # brace before matching — otherwise no single line carries both the
+        # method name and the `openURL` / `continueUserActivity` discriminator.
         signature = stripped
-        if stripped.matches?(SIGNATURE_START_RE) && !stripped.includes?('{')
+        if stripped.matches?(sig_re) && !stripped.includes?('{')
           if sig_brace = find_opening_brace(lines, index)
             signature = lines[index..sig_brace[:index]].join(" ")
           end
         end
 
-        target = if URL_HANDLER_RES.any? { |re| signature.matches?(re) }
+        target = if url_res.any? { |re| signature.matches?(re) }
                    url
-                 elsif ACTIVITY_HANDLER_RES.any? { |re| signature.matches?(re) }
+                 elsif activity_res.any? { |re| signature.matches?(re) }
                    activity
                  end
         next unless target
@@ -342,11 +379,16 @@ module NoirMobileLinker
         body, body_line = body_after_opening_brace(lines, brace[:index], brace[:col])
 
         target.code_paths << PathInfo.new(path, index + 1)
-        Noir::SwiftCalleeExtractor.callees_for_body(body, path, body_line).each do |name, fpath, fline|
+        callees = objc ? Noir::ObjcCalleeExtractor.callees_for_body(body, path, body_line) : Noir::SwiftCalleeExtractor.callees_for_body(body, path, body_line)
+        callees.each do |name, fpath, fline|
           target.callees << Callee.new(name, path: fpath, line: fline)
         end
-        body.scan(QUERY_NAME_RE) { |m| target.params << Param.new(m[1], "", "query") }
-        body.scan(QUERY_ITEM_RE) { |m| target.params << Param.new(m[1], "", "query") }
+        # Query-param extraction is Swift-specific (URLQueryItem idioms);
+        # Objective-C query reads are left to a follow-up.
+        unless objc
+          body.scan(QUERY_NAME_RE) { |m| target.params << Param.new(m[1], "", "query") }
+          body.scan(QUERY_ITEM_RE) { |m| target.params << Param.new(m[1], "", "query") }
+        end
       end
     end
 


### PR DESCRIPTION
Round-3 OSS finding (**VLC-iOS, Simplenote**, …). iOS handler discovery only scanned `.swift` files and matched `func application(...)`, so apps whose open-URL / continue-userActivity delegates are **Objective-C** linked zero callees — the deep-link → dispatch relationship was lost.

```objc
- (BOOL)application:(UIApplication *)app
            openURL:(NSURL *)url
            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
{
    return [self handleOpenURL:url];   // message-send: selector is the callee
}
```

## What's added
- **`Noir::ObjcCalleeExtractor`** — a best-effort 1-hop callee extractor for Objective-C bodies. Understands the message-send syntax (`[receiver selector:arg]` — the selector is the callee, including the inner *and* outer selectors of nested sends `[[A b] c:…]`) plus C-style calls, reusing the Swift extractor's comment/string stripping. Memory-management selectors (`alloc`/`init`/…) and array subscripts are filtered out.
- The iOS handler scan now also walks **`.m` / `.mm`** files with Objective-C handler patterns (`application:…openURL:`, `scene:…openURLContexts:`, `…continueUserActivity:`), folding wrapped signatures the same way as Swift. (`scan_file` was generalized to take the dialect's regexes + extractor.) Query-param extraction stays Swift-only for now.

## Real-OSS effect
| app | before | after |
|---|---|---|
| VLC-iOS | 13 schemes, **0 callees** | all 13 linked (`canHandleOpenWithUrl` / `performOpenWithUrl` dispatch, nested `passcodeService`/`hasSecret`) |
| Simplenote | universal link, 0 callees | `handleUserActivity` / `performMagicLinkAuthentication…` |

## Tests
`ObjcCalleeExtractor` unit spec (nested sends, control-flow / memory / subscript filtering) + a `LegacyAppDelegate.m` fixture with **multi-line** Objective-C `openURL` / `continueUserActivity` handlers asserted to link their callees. Mobile + miniparser suites green; ameba + `crystal tool format` clean.

## Deferred
- Objective-C query-param extraction (`[url query]` / NSURLComponents idioms).
- Swiftfin's `jellyfin://` still 0 callees — a SwiftUI `onOpenURL` discovery gap (Swift, not Obj-C).