### PR TITLE
feat(mobile): extract query params from Objective-C deep-link handlers

### DIFF
--- a/spec/functional_test/fixtures/mobile/ios/LegacyAppDelegate.m
+++ b/spec/functional_test/fixtures/mobile/ios/LegacyAppDelegate.m
@@ -9,6 +9,12 @@
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
 {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+    for (NSURLQueryItem *item in components.queryItems) {
+        if ([item.name isEqualToString:@"token"]) {
+            return [self handleObjcDeepLink:item.value];
+        }
+    }
     return [self handleObjcDeepLink:url];
 }
 

--- a/spec/functional_test/testers/mobile/ios_spec.cr
+++ b/spec/functional_test/testers/mobile/ios_spec.cr
@@ -16,12 +16,12 @@ no_params = [] of Param
 
 expected_endpoints = [
   # Custom schemes (mobile-scheme), linked to the URL handlers: SceneDelegate
-  # `scene(_:openURLContexts:)` callees + the redirect query param, plus
+  # `scene(_:openURLContexts:)` callees + the `redirect` query param, plus
   # `routeOpenURL` from the AppDelegate `application(_:open:)` (multi-line
-  # signature) and `handleObjcDeepLink` from the Objective-C
-  # `application:openURL:` in LegacyAppDelegate.m.
-  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
-  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
+  # signature), and `handleObjcDeepLink` + the `token` query param from the
+  # Objective-C `application:openURL:` in LegacyAppDelegate.m.
+  build.call("myapp://", "mobile-scheme", [Param.new("redirect", "", "query"), Param.new("token", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
+  build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query"), Param.new("token", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
   # CFBundleURLSchemes entry `$(BUNDLE_URL_SCHEME)` resolved from Config.xcconfig.
   build.call("resolvedscheme://", "mobile-scheme", no_params, [] of String),
   # Universal links (universal-link), linked to the userActivity handlers:

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -305,6 +305,16 @@ module NoirMobileLinker
     QUERY_NAME_RE = /\$\d+\.name\s*==\s*"([^"]+)"/
     QUERY_ITEM_RE = /URLQueryItem\(\s*name:\s*"([^"]+)"/
 
+    # Objective-C query reads. The dominant idiom is iterating
+    # `components.queryItems` and comparing the item's `name` against a
+    # literal — `[item.name isEqualToString:@"token"]` (e.g. VLC reads
+    # plexToken / payment_intent this way). Anchored to `.name` / `name]`
+    # (not a bare `isEqualToString:`) so a `[host isEqualToString:@"new"]`
+    # check can't become a phantom param. Also the explicit query-item
+    # constructor.
+    OBJC_QUERY_NAME_RE = /(?:\.name|\bname\])\s+isEqualToString:\s*@"([^"]+)"/
+    OBJC_QUERY_ITEM_RE = /\bqueryItemWithName:\s*@"([^"]+)"/
+
     def self.discover : Hash(Symbol, NoirMobileLinker::HandlerInfo)
       url = NoirMobileLinker::HandlerInfo.new
       activity = NoirMobileLinker::HandlerInfo.new
@@ -383,12 +393,10 @@ module NoirMobileLinker
         callees.each do |name, fpath, fline|
           target.callees << Callee.new(name, path: fpath, line: fline)
         end
-        # Query-param extraction is Swift-specific (URLQueryItem idioms);
-        # Objective-C query reads are left to a follow-up.
-        unless objc
-          body.scan(QUERY_NAME_RE) { |m| target.params << Param.new(m[1], "", "query") }
-          body.scan(QUERY_ITEM_RE) { |m| target.params << Param.new(m[1], "", "query") }
-        end
+        # Query params read from the inbound URL, per dialect.
+        name_re, item_re = objc ? {OBJC_QUERY_NAME_RE, OBJC_QUERY_ITEM_RE} : {QUERY_NAME_RE, QUERY_ITEM_RE}
+        body.scan(name_re) { |m| target.params << Param.new(m[1], "", "query") }
+        body.scan(item_re) { |m| target.params << Param.new(m[1], "", "query") }
       end
     end
 


### PR DESCRIPTION
Completes the input-surface symmetry for iOS Objective-C handlers (follow-up to #1990). Android reads `getQueryParameter("x")`, Swift reads `URLQueryItem` / `$0.name == "x"`; the Objective-C analog iterates `components.queryItems`:

```objc
for (NSURLQueryItem *item in components.queryItems) {
    if ([item.name isEqualToString:@"token"]) { … }
}
```

The handler scan now pulls those names (and `queryItemWithName:@"x"` constructors) as `query` params, anchored to `.name` / `name]` (not a bare `isEqualToString:`) so a `[host isEqualToString:@"new"]` host check can't become a phantom param.

## Validation note (transparent)
Fixture-validated. The Objective-C apps in the OSS sweep (**VLC**, **Simplenote**) don't exercise it — VLC dispatches to plugin `VLCURLHandler` classes and Simplenote parses the whole query via a category, so their query reads sit **more than one hop** from the central `application:openURL:` body the linker scans (callees still link via #1990). Inline reading directly in the delegate handler is a common iOS pattern, so this helps apps shaped that way; landing it for symmetry with the Android / Swift extractors.

## Tests
The `LegacyAppDelegate.m` fixture's openURL handler now reads a `token` query item, asserted to surface as a `query` param on the custom-scheme endpoints. Mobile suite green; ameba + `crystal tool format` clean.