### PR TITLE
Fix nested iOS scheme build setting resolution

### DIFF
--- a/spec/functional_test/fixtures/mobile/ios/Config.xcconfig
+++ b/spec/functional_test/fixtures/mobile/ios/Config.xcconfig
@@ -1,4 +1,5 @@
 // Build settings substituted into Info.plist at build time. The
 // CFBundleURLSchemes entry `$(BUNDLE_URL_SCHEME)` resolves from here.
 BUNDLE_URL_SCHEME = resolvedscheme
+NESTED_BUNDLE_URL_SCHEME = $(BUNDLE_URL_SCHEME)-nested
 APP_BUNDLE_ID = com.example.myapp

--- a/spec/functional_test/fixtures/mobile/ios/Info.plist
+++ b/spec/functional_test/fixtures/mobile/ios/Info.plist
@@ -15,6 +15,7 @@
 				<string>myapp-alt</string>
 				<string>https</string>
 				<string>$(BUNDLE_URL_SCHEME)</string>
+				<string>$(NESTED_BUNDLE_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>

--- a/spec/functional_test/testers/mobile/ios_spec.cr
+++ b/spec/functional_test/testers/mobile/ios_spec.cr
@@ -24,6 +24,9 @@ expected_endpoints = [
   build.call("myapp-alt://", "mobile-scheme", [Param.new("redirect", "", "query"), Param.new("token", "", "query")], ["handleDeepLink", "webView?.load", "routeOpenURL", "handleObjcDeepLink"]),
   # CFBundleURLSchemes entry `$(BUNDLE_URL_SCHEME)` resolved from Config.xcconfig.
   build.call("resolvedscheme://", "mobile-scheme", no_params, [] of String),
+  # CFBundleURLSchemes entry `$(NESTED_BUNDLE_URL_SCHEME)` resolves through
+  # another build-setting reference in Config.xcconfig.
+  build.call("resolvedscheme-nested://", "mobile-scheme", no_params, [] of String),
   # Universal links (universal-link), linked to the userActivity handlers:
   # the Swift `routeUniversalLink` and the Objective-C `routeObjcUniversalLink`
   # from LegacyAppDelegate.m `application:continueUserActivity:`.

--- a/spec/unit_test/analyzer/mobile_ios_spec.cr
+++ b/spec/unit_test/analyzer/mobile_ios_spec.cr
@@ -32,6 +32,13 @@ describe "Analyzer::Mobile::Ios" do
     find.call("$(BUNDLE_URL_SCHEME)://").should be_nil
   end
 
+  it "resolves nested Xcode build-setting scheme placeholders from .xcconfig" do
+    # CFBundleURLSchemes has `$(NESTED_BUNDLE_URL_SCHEME)`; Config.xcconfig
+    # resolves it through `$(BUNDLE_URL_SCHEME)`.
+    find.call("resolvedscheme-nested://").not_nil!.protocol.should eq("mobile-scheme")
+    find.call("$(NESTED_BUNDLE_URL_SCHEME)://").should be_nil
+  end
+
   it "maps applinks: associated domains to universal links" do
     find.call("https://myapp.example.com/").not_nil!.protocol.should eq("universal-link")
   end

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -81,8 +81,9 @@ module Analyzer::Mobile
 
     # How far up from the Info.plist to look for the project's .xcconfig
     # files, and how many to read.
-    XCCONFIG_SEARCH_DEPTH =  6
-    MAX_XCCONFIG_FILES    = 40
+    XCCONFIG_SEARCH_DEPTH            =  6
+    MAX_XCCONFIG_FILES               = 40
+    MAX_BUILD_VAR_SUBSTITUTION_DEPTH =  8
     # `KEY = value` (xcconfig assignment); the value runs to a trailing
     # comment / end of line.
     XCCONFIG_ASSIGN_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^\n]*)$/
@@ -129,11 +130,22 @@ module Analyzer::Mobile
       @logger.debug "Failed to parse xcconfig #{path}: #{e.message}"
     end
 
-    # Resolves `$(VAR)` / `${VAR}` against the xcconfig map; unknown
-    # references are kept verbatim (same behavior as before this resolver).
+    # Resolves `$(VAR)` / `${VAR}` against the xcconfig map. Values in
+    # xcconfig files may themselves point at another build setting
+    # (`APP_SCHEME = ${BRANDED_SCHEME}`), so resolve repeatedly with a
+    # bounded depth. Unknown or cyclic references are kept verbatim.
     private def substitute_build_vars(value : String, vars : Hash(String, String)) : String
       return value unless value.includes?("$(") || value.includes?("${")
-      value.gsub(BUILD_VAR_RE) { vars[$~[1]]? || $~[0] }
+
+      resolved = value
+      MAX_BUILD_VAR_SUBSTITUTION_DEPTH.times do
+        next_value = resolved.gsub(BUILD_VAR_RE) { vars[$~[1]]? || $~[0] }
+        break if next_value == resolved
+
+        resolved = next_value
+        break unless resolved.includes?("$(") || resolved.includes?("${")
+      end
+      resolved
     end
 
     private def parse_entitlements(doc : XML::Node, path : String)


### PR DESCRIPTION
## Summary

Fix iOS deep-link scheme resolution when an `Info.plist` `CFBundleURLSchemes` entry points to a build setting whose `.xcconfig` value points to another build setting.

Before this change, Noir only substituted one level, so real apps could emit unresolved/malformed mobile-scheme URLs such as `${WP_JETPACK_APP_URL_SCHEME}://`.

## Real OSS research

Built the scanner with:

```sh
shards build --release --no-debug --production
```

Shallow-cloned and scanned these Android apps:

| App | Mobile endpoints |
| --- | ---: |
| signalapp/Signal-Android | 24 |
| bitwarden/android | 24 |
| mihonapp/mihon | 7 |
| ProtonMail/android-mail | 1 |
| owncloud/android | 4 |
| briar/briar | 2 |

Shallow-cloned and scanned these iOS apps:

| App | Mobile endpoints |
| --- | ---: |
| wordpress-mobile/WordPress-iOS | 12 |
| TelegramMessenger/Telegram-iOS | 4 |
| bitwarden/ios | 6 |
| brave/brave-ios | 4 |
| owncloud/ios-app | 2 |
| mozilla-mobile/focus-ios | 1 |

Nextcloud iOS and ProtonMail iOS were also checked, including forced `-t ios`, but did not expose mobile entry points in the scanned source state.

## Defect

WordPress-iOS has this chain:

| Source | Value |
| --- | --- |
| `Sources/Jetpack/Info.plist:554` | `${WP_APP_URL_SCHEME}` |
| `config/Jetpack.alpha.xcconfig:6` | `WP_APP_URL_SCHEME = ${WP_JETPACK_APP_URL_SCHEME}` |
| `config/Common.alpha.xcconfig:7` | `WP_JETPACK_APP_URL_SCHEME = jpalpha` |

Noir resolved only the first hop, leaving the second build setting in the output.

## Before / After

Command:

```sh
./bin/noir --no-color --no-spinner -b /tmp/noir-mobile-research-20260611/wordpress-ios -f json --ai-context
```

| App | Before | After |
| --- | --- | --- |
| WordPress-iOS | `${WP_JETPACK_APP_URL_SCHEME}://` (`mobile-scheme`, 10 callees) | `jpalpha://` (`mobile-scheme`, 10 callees) |

Total WordPress-iOS mobile endpoint count remains 12; this is a URL correctness fix, not a count expansion.

## Tests

```sh
crystal spec spec/unit_test/analyzer/mobile_ios_spec.cr
crystal spec spec/functional_test/testers/mobile/ios_spec.cr
crystal tool format --check
crystal run lib/ameba/bin/ameba.cr -- src/analyzer/analyzers/mobile/ios.cr spec/functional_test/testers/mobile/ios_spec.cr spec/unit_test/analyzer/mobile_ios_spec.cr
shards build --release --no-debug --production
crystal spec
```

Full suite result: `21160 examples, 0 failures, 0 errors, 0 pending`.

## Notes

Known-hard backlog items not attempted in this PR: pbxproj-only build settings, SwiftUI `onOpenURL(perform:)` closure discovery, and Objective-C handlers where query/callee logic is more than one hop from `application:openURL:`.
