### PR TITLE
perf(javascript): eliminate PCRE2 recompilation in JS/TS analyzers

### DIFF
--- a/src/analyzer/analyzers/javascript/astro.cr
+++ b/src/analyzer/analyzers/javascript/astro.cr
@@ -143,6 +143,12 @@ module Analyzer::Javascript
     # Look for explicit verb exports first
     # (`export const GET = ...` / `export async function POST() {}`),
     # then fall back to the cross-method catch-all set.
+    # Compiled once per verb — interpolated regex literals would otherwise
+    # be rebuilt (full PCRE2 compile) for every method on every file.
+    EXPORT_FUNCTION_RES = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b/} }.to_h
+    EXPORT_CONST_RES    = HTTP_METHODS.map { |m| {m, /export\s+(?:const|let|var)\s+#{m}\b\s*(?::[^=]+)?=/} }.to_h
+    EXPORT_BRACE_RES    = HTTP_METHODS.map { |m| {m, /export\s+\{\s*[^}]*\b#{m}\b[^}]*\}/} }.to_h
+
     private def detect_api_methods(content : String) : Array(String)
       explicit = [] of String
       HTTP_METHODS.each do |m|
@@ -150,9 +156,9 @@ module Analyzer::Javascript
         # `export const GET = ...`, `export const GET: APIRoute = ...`
         # (the trailing TypeScript type annotation is optional), and
         # the `export { GET }` re-export form.
-        if content.match(/export\s+(?:async\s+)?function\s+#{m}\b/) ||
-           content.match(/export\s+(?:const|let|var)\s+#{m}\b\s*(?::[^=]+)?=/) ||
-           content.match(/export\s+\{\s*[^}]*\b#{m}\b[^}]*\}/)
+        if content.match(EXPORT_FUNCTION_RES[m]) ||
+           content.match(EXPORT_CONST_RES[m]) ||
+           content.match(EXPORT_BRACE_RES[m])
           explicit << m
         end
       end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -248,7 +248,9 @@ module Analyzer::Javascript
           http_methods = %w[get post put delete patch options head all]
 
           http_methods.each do |http_method|
-            endpoint_pattern = /#{router_var}\.#{http_method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
+            endpoint_pattern = cached_regex("express:nested_router:#{router_var}:#{http_method}") do
+              /#{router_var}\.#{http_method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
+            end
 
             content.scan(endpoint_pattern) do |em|
               if em.size > 1
@@ -379,7 +381,9 @@ module Analyzer::Javascript
 
         http_methods.each do |method|
           # Enhanced pattern to catch more route handler formats
-          pattern = /#{router_prefix_router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"][^{]*/
+          pattern = cached_regex("express:prefix_router:#{router_prefix_router_name}:#{method}") do
+            /#{router_prefix_router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"][^{]*/
+          end
 
           content.scan(pattern) do |m|
             if m.size > 0
@@ -422,7 +426,9 @@ module Analyzer::Javascript
       http_methods = %w[get post put delete patch options head all]
 
       http_methods.each do |method|
-        pattern = /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"](?:[^{]*)\{([^}]*(?:\{[^}]*\})*[^}]*)\}/m
+        pattern = cached_regex("express:versioned_router:#{router_name}:#{method}") do
+          /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"](?:[^{]*)\{([^}]*(?:\{[^}]*\})*[^}]*)\}/m
+        end
 
         content.scan(pattern) do |m|
           if m.size > 1

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -13,6 +13,16 @@ module Analyzer::Javascript
   class RouterMountScanner
     include ExpressConstants
 
+    # Mount-call verbs scanned for literal prefixes (`.use('/p', r)` /
+    # `.route('/p', app)`). Compiled once per verb — interpolated regex
+    # literals would otherwise be rebuilt (full PCRE2 compile) on every
+    # scan_literal_mount_calls invocation.
+    MOUNT_CALL_NAMES   = %w[use route]
+    MOUNT_STRING_RES   = MOUNT_CALL_NAMES.map { |c| {c, /(\w+)\.#{c}\s*\(\s*['"]([^'"]+)['"]\s*,\s*/} }.to_h
+    MOUNT_BACKTICK_RES = MOUNT_CALL_NAMES.map { |c| {c, /(\w+)\.#{c}\s*\(\s*`([^`$]+)`\s*,\s*/} }.to_h
+    MOUNT_IDENT_RES    = MOUNT_CALL_NAMES.map { |c| {c, /(\w+)\.#{c}\s*\(\s*(\w+)\s*,\s*/} }.to_h
+    MOUNT_ARRAY_RES    = MOUNT_CALL_NAMES.map { |c| {c, /(\w+)\.#{c}\s*\(\s*\[([^\]]+)\]\s*,\s*/m} }.to_h
+
     # Type alias for file context used in two-pass processing
     alias FileContext = NamedTuple(
       require_map: Hash(String, String),
@@ -177,7 +187,7 @@ module Analyzer::Javascript
       global_deferred_mounts : Array(Tuple(String, String, String, String)),
       prefix_constants : Hash(String, String),
     )
-      content.scan(/(\w+)\.#{call_name}\s*\(\s*['"]([^'"]+)['"]\s*,\s*/) do |m|
+      content.scan(MOUNT_STRING_RES[call_name]) do |m|
         next unless m.size >= 3
 
         caller = m[1]
@@ -188,7 +198,7 @@ module Analyzer::Javascript
           require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
       end
 
-      content.scan(/(\w+)\.#{call_name}\s*\(\s*`([^`$]+)`\s*,\s*/) do |m|
+      content.scan(MOUNT_BACKTICK_RES[call_name]) do |m|
         next unless m.size >= 3
 
         caller = m[1]
@@ -199,7 +209,7 @@ module Analyzer::Javascript
           require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
       end
 
-      content.scan(/(\w+)\.#{call_name}\s*\(\s*(\w+)\s*,\s*/) do |m|
+      content.scan(MOUNT_IDENT_RES[call_name]) do |m|
         next unless m.size >= 3
 
         prefix = prefix_constants[m[2]]?
@@ -212,7 +222,7 @@ module Analyzer::Javascript
           require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
       end
 
-      content.scan(/(\w+)\.#{call_name}\s*\(\s*\[([^\]]+)\]\s*,\s*/m) do |m|
+      content.scan(MOUNT_ARRAY_RES[call_name]) do |m|
         next unless m.size >= 3
 
         caller = m[1]

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -312,12 +312,17 @@ module Analyzer::Javascript
       Param.new("", "", "")
     end
 
+    HTTP_METHODS = %w[get post put delete patch options head]
+    # Compiled once — an interpolated regex literal would otherwise be
+    # rebuilt (full PCRE2 compile) for every method on every line.
+    ROUTE_CALL_RES = HTTP_METHODS.map { |m| {m, /\b(?:fastify|app|server)\s*\.\s*#{m}\s*\(\s*['"]([^'"]+)['"]/} }.to_h
+
     def line_to_endpoint(line : String) : Endpoint
-      http_methods = %w[get post put delete patch options head]
+      http_methods = HTTP_METHODS
 
       http_methods.each do |method|
         # Match fastify.method patterns
-        if line =~ /\b(?:fastify|app|server)\s*\.\s*#{method}\s*\(\s*['"]([^'"]+)['"]/
+        if line =~ ROUTE_CALL_RES[method]
           path = $1
           return Endpoint.new(path, method.upcase)
         end

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -52,6 +52,13 @@ module Analyzer::Javascript
 
     FALLBACK_HANDLER_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
+    # Compiled once per verb — interpolated regex literals would otherwise
+    # be rebuilt (full PCRE2 compile) on every evaluation.
+    HANDLER_METHOD_BODY_RES = HTTP_METHODS.map { |v| {v, /(?:^|[\{,\s])(?:async\s+)?#{v}\s*\([^)]*\)\s*\{(.*?)^\s*\}/m} }.to_h
+    HANDLER_PROPERTY_RES    = HTTP_METHODS.map { |v| {v, /(?:^|[\{,\s])#{v}\s*:\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/} }.to_h
+    VERB_KEY_SHORTHAND_RES  = HTTP_METHODS.map { |v| {v, /(^|[\{,\s])(?:async\s+)?#{v}\s*\(/} }.to_h
+    VERB_KEY_PROPERTY_RES   = HTTP_METHODS.map { |v| {v, /(^|[\{,\s])#{v}\s*:/} }.to_h
+
     # Files that are framework plumbing rather than routes.
     SKIPPED_LEAVES = ["_app", "_layout", "_404", "_500", "_middleware"]
 
@@ -115,12 +122,12 @@ module Analyzer::Javascript
       handler_block = extract_handler_object(content)
       return [] of Noir::JSCalleeExtractor::Entry unless handler_block
 
-      if method = handler_block.match(/(?:^|[\{,\s])(?:async\s+)?#{verb}\s*\([^)]*\)\s*\{(.*?)^\s*\}/m)
+      if method = handler_block.match(HANDLER_METHOD_BODY_RES[verb])
         start_line = content[0, content.index(method[0]) || 0].count('\n') + 1
         return Noir::JSCalleeExtractor.callees_for_function_body(method[1], path, start_line, language: javascript_source_language(path))
       end
 
-      if property = handler_block.match(/(?:^|[\{,\s])#{verb}\s*:\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>/)
+      if property = handler_block.match(HANDLER_PROPERTY_RES[verb])
         body_start = property.end(0) || 0
         body = handler_block[body_start..]? || ""
         block_start = content.index(handler_block) || 0
@@ -267,8 +274,8 @@ module Analyzer::Javascript
     private def extract_verb_keys(block : String) : Array(String)
       verbs = [] of String
       HTTP_METHODS.each do |m|
-        if block.match(/(^|[\{,\s])(?:async\s+)?#{m}\s*\(/) ||
-           block.match(/(^|[\{,\s])#{m}\s*:/)
+        if block.match(VERB_KEY_SHORTHAND_RES[m]) ||
+           block.match(VERB_KEY_PROPERTY_RES[m])
           verbs << m
         end
       end

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -180,11 +180,16 @@ module Analyzer::Javascript
       [] of Param
     end
 
+    HTTP_METHODS = %w[get post put delete patch options head]
+    # Compiled once — an interpolated regex literal would otherwise be
+    # rebuilt (full PCRE2 compile) for every method on every line.
+    ROUTE_CALL_RES = HTTP_METHODS.map { |m| {m, /\b(?:app|router|hono)\s*\.\s*#{m}\s*\(\s*['"]([^'"]+)['"]/} }.to_h
+
     def line_to_endpoints(line : String) : Array(Endpoint)
-      http_methods = %w[get post put delete patch options head]
+      http_methods = HTTP_METHODS
 
       http_methods.each do |method|
-        if line =~ /\b(?:app|router|hono)\s*\.\s*#{method}\s*\(\s*['"]([^'"]+)['"]/
+        if line =~ ROUTE_CALL_RES[method]
           path = $1
           return [Endpoint.new(path, method.upcase)]
         end

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -4,6 +4,10 @@ require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
   class Nestjs < JavascriptEngine
+    # Request-object fields read in handler bodies, paired with the param
+    # type they map to. Iterated in this order when extracting params.
+    REQUEST_OBJECT_FIELDS = { {"query", "query"}, {"body", "body"}, {"headers", "header"}, {"params", "path"} }
+
     private struct GlobalPrefixExclude
       getter path : String
       getter method : String?
@@ -857,16 +861,16 @@ module Analyzer::Javascript
       end
       request_names << "req" if request_names.empty?
 
+      # The dot/bracket field regexes are memoized per request-object name
+      # ("req" dominates), so each pattern compiles once per scan instead
+      # of once per handler.
       request_names.each do |name|
-        escaped = Regex.escape(name)
-        body.scan(/\b#{escaped}\.query\.(\w+)/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "query")) }
-        body.scan(/\b#{escaped}\.query\s*\[\s*['"`]([^'"`]+)['"`]\s*\]/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "query")) }
-        body.scan(/\b#{escaped}\.body\.(\w+)/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "body")) }
-        body.scan(/\b#{escaped}\.body\s*\[\s*['"`]([^'"`]+)['"`]\s*\]/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "body")) }
-        body.scan(/\b#{escaped}\.headers\.(\w+)/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "header")) }
-        body.scan(/\b#{escaped}\.headers\s*\[\s*['"`]([^'"`]+)['"`]\s*\]/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "header")) }
-        body.scan(/\b#{escaped}\.params\.(\w+)/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "path")) }
-        body.scan(/\b#{escaped}\.params\s*\[\s*['"`]([^'"`]+)['"`]\s*\]/) { |m| push_unique_param(endpoint, Param.new(m[1], "", "path")) }
+        REQUEST_OBJECT_FIELDS.each do |field, param_type|
+          dot_re = cached_regex("nestjs:req_dot:#{name}:#{field}") { /\b#{Regex.escape(name)}\.#{field}\.(\w+)/ }
+          bracket_re = cached_regex("nestjs:req_bracket:#{name}:#{field}") { /\b#{Regex.escape(name)}\.#{field}\s*\[\s*['"`]([^'"`]+)['"`]\s*\]/ }
+          body.scan(dot_re) { |m| push_unique_param(endpoint, Param.new(m[1], "", param_type)) }
+          body.scan(bracket_re) { |m| push_unique_param(endpoint, Param.new(m[1], "", param_type)) }
+        end
       end
     end
 

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -7,6 +7,14 @@ module Analyzer::Javascript
     HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
     EXTENSIONS   = [".js", ".jsx", ".ts", ".tsx", ".mjs"]
 
+    # Compiled once per verb — interpolated regex literals would otherwise
+    # be rebuilt (full PCRE2 compile) for every method on every file.
+    EXPORT_VERB_FUNCTION_RES     = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b/} }.to_h
+    EXPORT_VERB_CONST_RES        = HTTP_METHODS.map { |m| {m, /export\s+const\s+#{m}\s*=/} }.to_h
+    EXPORT_VERB_BRACE_RES        = HTTP_METHODS.map { |m| {m, /export\s+\{[^}]*\b#{m}\b[^}]*\}/} }.to_h
+    EXPORT_VERB_FUNCTION_SIG_RES = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b\s*\([^)]*\)/} }.to_h
+    EXPORT_VERB_CONST_ARROW_RES  = HTTP_METHODS.map { |m| {m, /export\s+const\s+#{m}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)(?:\s*:\s*[^=]+?)?\s*=>/} }.to_h
+
     def analyze
       result = [] of Endpoint
       mutex = Mutex.new
@@ -159,7 +167,7 @@ module Analyzer::Javascript
         action_name = match[1]
         next if seen.includes?(action_name)
         seen << action_name
-        original_match = content.match(/export\s+async\s+function\s+#{Regex.escape(action_name)}\s*\(([^)]*)\)/)
+        original_match = content.match(cached_regex("nextjs:action_fn:#{action_name}") { /export\s+async\s+function\s+#{Regex.escape(action_name)}\s*\(([^)]*)\)/ })
         register_server_action(path, action_name, match[2], sanitized, match, content, original_match, result, mutex, include_callee)
       end
 
@@ -168,7 +176,7 @@ module Analyzer::Javascript
         action_name = match[1]
         next if seen.includes?(action_name)
         seen << action_name
-        original_match = content.match(/export\s+const\s+#{Regex.escape(action_name)}\s*=\s*async\s*\(([^)]*)\)/)
+        original_match = content.match(cached_regex("nextjs:action_const:#{action_name}") { /export\s+const\s+#{Regex.escape(action_name)}\s*=\s*async\s*\(([^)]*)\)/ })
         register_server_action(path, action_name, match[2], sanitized, match, content, original_match, result, mutex, include_callee)
       end
 
@@ -231,14 +239,15 @@ module Analyzer::Javascript
     end
 
     private def extract_direct_exported_method_body(content : String, method : String) : Tuple(String, Int32)?
-      escaped_method = Regex.escape(method)
-      function_match = content.match(/export\s+(?:async\s+)?function\s+#{escaped_method}\b\s*\([^)]*\)/)
+      # `method` is always one of HTTP_METHODS here, so the per-verb
+      # precompiled tables apply.
+      function_match = content.match(EXPORT_VERB_FUNCTION_SIG_RES[method])
       if function_match
         match_end = function_match.end(0)
         return extract_braced_body(content, match_end) if match_end
       end
 
-      const_match = content.match(/export\s+const\s+#{escaped_method}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)(?:\s*:\s*[^=]+?)?\s*=>/)
+      const_match = content.match(EXPORT_VERB_CONST_ARROW_RES[method])
       if const_match
         match_end = const_match.end(0)
         extract_braced_body(content, match_end) if match_end
@@ -246,14 +255,13 @@ module Analyzer::Javascript
     end
 
     private def extract_named_function_body(content : String, name : String) : Tuple(String, Int32)?
-      escaped_name = Regex.escape(name)
-      function_match = content.match(/(?:^|[^\w$])(?:async\s+)?function\s+#{escaped_name}\b\s*\([^)]*\)/)
+      function_match = content.match(cached_regex("nextjs:named_fn:#{name}") { /(?:^|[^\w$])(?:async\s+)?function\s+#{Regex.escape(name)}\b\s*\([^)]*\)/ })
       if function_match
         match_end = function_match.end(0)
         return extract_braced_body(content, match_end) if match_end
       end
 
-      const_match = content.match(/(?:const|let|var)\s+#{escaped_name}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)(?:\s*:\s*[^=]+?)?\s*=>/)
+      const_match = content.match(cached_regex("nextjs:named_const:#{name}") { /(?:const|let|var)\s+#{Regex.escape(name)}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)(?:\s*:\s*[^=]+?)?\s*=>/ })
       if const_match
         match_end = const_match.end(0)
         extract_braced_body(content, match_end) if match_end
@@ -318,8 +326,8 @@ module Analyzer::Javascript
       # If named HTTP method exports exist, use them; otherwise default handler covers all.
       explicit = [] of String
       HTTP_METHODS.each do |m|
-        if content.match(/export\s+(?:async\s+)?function\s+#{m}\b/) ||
-           content.match(/export\s+const\s+#{m}\s*=/)
+        if content.match(EXPORT_VERB_FUNCTION_RES[m]) ||
+           content.match(EXPORT_VERB_CONST_RES[m])
           explicit << m
         end
       end
@@ -373,9 +381,9 @@ module Analyzer::Javascript
     private def extract_app_router_methods(content : String) : Array(String)
       methods = [] of String
       HTTP_METHODS.each do |m|
-        if content.match(/export\s+(?:async\s+)?function\s+#{m}\b/) ||
-           content.match(/export\s+const\s+#{m}\s*=/) ||
-           content.match(/export\s+\{[^}]*\b#{m}\b[^}]*\}/)
+        if content.match(EXPORT_VERB_FUNCTION_RES[m]) ||
+           content.match(EXPORT_VERB_CONST_RES[m]) ||
+           content.match(EXPORT_VERB_BRACE_RES[m])
           methods << m
         end
       end
@@ -454,11 +462,10 @@ module Analyzer::Javascript
         # Aliased: const body = await request.json(); then body.X or body["X"]
         content.scan(/(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?(?:request|req)\.json\s*\(\s*\)/) do |m|
           varname = m[1]
-          escaped = Regex.escape(varname)
-          content.scan(/\b#{escaped}\.(\w+)/) do |mm|
+          content.scan(cached_regex("nextjs:var_dot:#{varname}") { /\b#{Regex.escape(varname)}\.(\w+)/ }) do |mm|
             add_param(endpoint, mm[1], "json")
           end
-          content.scan(/\b#{escaped}\[['"]([^'"]+)['"]\]/) do |mm|
+          content.scan(cached_regex("nextjs:var_bracket:#{varname}") { /\b#{Regex.escape(varname)}\[['"]([^'"]+)['"]\]/ }) do |mm|
             add_param(endpoint, mm[1], "json")
           end
         end
@@ -471,8 +478,7 @@ module Analyzer::Javascript
           form_vars << m[1] unless form_vars.includes?(m[1])
         end
         form_vars.each do |varname|
-          escaped = Regex.escape(varname)
-          content.scan(/\b#{escaped}\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |m|
+          content.scan(cached_regex("nextjs:var_get:#{varname}") { /\b#{Regex.escape(varname)}\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/ }) do |m|
             add_param(endpoint, m[1], "form")
           end
         end
@@ -502,11 +508,11 @@ module Analyzer::Javascript
         add_unresolved_param(endpoint, m[1], "cookie")
       end
       content.scan(/(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?cookies\s*\(\s*\)/) do |m|
-        escaped = Regex.escape(m[1])
-        content.scan(/\b#{escaped}\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |mm| # store.get("literal")
+        varname = m[1]
+        content.scan(cached_regex("nextjs:var_get:#{varname}") { /\b#{Regex.escape(varname)}\.get\s*\(\s*['"]([^'"]+)['"]\s*\)/ }) do |mm| # store.get("literal")
           add_param(endpoint, mm[1], "cookie")
         end
-        content.scan(/\b#{escaped}\.get\s*\(\s*([A-Za-z_$]\w*)\s*\)/) do |mm| # store.get(CONST) — unresolved
+        content.scan(cached_regex("nextjs:var_get_ident:#{varname}") { /\b#{Regex.escape(varname)}\.get\s*\(\s*([A-Za-z_$]\w*)\s*\)/ }) do |mm| # store.get(CONST) — unresolved
           add_unresolved_param(endpoint, mm[1], "cookie")
         end
       end

--- a/src/analyzer/analyzers/javascript/nitro.cr
+++ b/src/analyzer/analyzers/javascript/nitro.cr
@@ -92,7 +92,7 @@ module Analyzer::Javascript
           # Pattern 2: Variable assignment - const query = getQuery(event); query.param
           if content.match(/(?:const|let|var)\s+(\w+)\s*=\s*(?:getQuery|useQuery)\s*\(\s*event\s*\)/)
             query_var = $1
-            content.scan(/#{Regex.escape(query_var)}\.(\w+)/) do |m|
+            content.scan(cached_regex("nitro:query_dot:#{query_var}") { /#{Regex.escape(query_var)}\.(\w+)/ }) do |m|
               param_name = m[1]
               next if ["toString", "valueOf", "constructor"].includes?(param_name)
               param = Param.new(param_name, "", "query")

--- a/src/analyzer/analyzers/javascript/nuxtjs.cr
+++ b/src/analyzer/analyzers/javascript/nuxtjs.cr
@@ -136,14 +136,14 @@ module Analyzer::Javascript
           # Pattern 2: Variable assignment - const query = getQuery(event); query.param
           sanitized.scan(/(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?(?:getQuery|useQuery|getValidatedQuery)\s*\(\s*event(?:\s*,[\s\S]*?)?\s*\)/) do |var_match|
             query_var = var_match[1]
-            sanitized.scan(/#{Regex.escape(query_var)}\.(\w+)/) do |m|
+            sanitized.scan(cached_regex("nuxtjs:query_dot:#{query_var}") { /#{Regex.escape(query_var)}\.(\w+)/ }) do |m|
               param_name = m[1]
               # Skip common non-parameter properties like 'toString', 'valueOf', etc.
               next if ["toString", "valueOf", "constructor"].includes?(param_name)
               param = Param.new(param_name, "", "query")
               endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
             end
-            sanitized.scan(/#{Regex.escape(query_var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+            sanitized.scan(cached_regex("nuxtjs:query_bracket:#{query_var}") { /#{Regex.escape(query_var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/ }) do |m|
               param_name = m[1]
               param = Param.new(param_name, "", "query")
               endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
@@ -164,13 +164,12 @@ module Analyzer::Javascript
               body_vars << m[1] unless body_vars.includes?(m[1])
             end
             body_vars.each do |body_var|
-              escaped = Regex.escape(body_var)
-              sanitized.scan(/\b#{escaped}\.(\w+)/) do |m|
+              sanitized.scan(cached_regex("nuxtjs:var_dot:#{body_var}") { /\b#{Regex.escape(body_var)}\.(\w+)/ }) do |m|
                 param_name = m[1]
                 param = Param.new(param_name, "", "body")
                 endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "body" }
               end
-              sanitized.scan(/\b#{escaped}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+              sanitized.scan(cached_regex("nuxtjs:var_bracket:#{body_var}") { /\b#{Regex.escape(body_var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/ }) do |m|
                 param_name = m[1]
                 param = Param.new(param_name, "", "body")
                 endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "body" }
@@ -190,13 +189,13 @@ module Analyzer::Javascript
             endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
           end
           sanitized.scan(/(?:const|let|var)\s+(\w+)\s*=\s*getHeaders\s*\(\s*event\s*\)/) do |m|
-            escaped = Regex.escape(m[1])
-            sanitized.scan(/\b#{escaped}\.(\w+)/) do |mm|
+            headers_var = m[1]
+            sanitized.scan(cached_regex("nuxtjs:var_dot:#{headers_var}") { /\b#{Regex.escape(headers_var)}\.(\w+)/ }) do |mm|
               header_name = mm[1]
               param = Param.new(header_name, "", "header")
               endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }
             end
-            sanitized.scan(/\b#{escaped}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |mm|
+            sanitized.scan(cached_regex("nuxtjs:var_bracket:#{headers_var}") { /\b#{Regex.escape(headers_var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/ }) do |mm|
               header_name = mm[1]
               param = Param.new(header_name, "", "header")
               endpoint.push_param(param) unless endpoint.params.any? { |p| p.name == header_name && p.param_type == "header" }

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -166,9 +166,11 @@ module Analyzer::Javascript
     end
 
     private def export_named?(content : String, name : String) : Bool
-      content.matches?(/export\s+(?:async\s+)?function\s+#{name}\b/) ||
-        content.matches?(/export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/) ||
-        content.matches?(/export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/)
+      # `name` is "loader" / "action" — memoized so the three patterns
+      # compile once per scan instead of once per file.
+      content.matches?(cached_regex("remix:export_fn:#{name}") { /export\s+(?:async\s+)?function\s+#{name}\b/ }) ||
+        content.matches?(cached_regex("remix:export_const:#{name}") { /export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/ }) ||
+        content.matches?(cached_regex("remix:export_brace:#{name}") { /export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/ })
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -226,8 +226,12 @@ module Analyzer::Javascript
 
               http_methods.each do |method|
                 # Handle both string paths and object patterns with path property
-                string_pattern = /#{Regex.escape(param_name)}\.#{method}\s*\(\s*['"]([^'"]+)['"]/
-                object_pattern = /#{Regex.escape(param_name)}\.#{method}\s*\(\s*\{\s*path\s*:\s*['"]([^'"]+)['"]/
+                string_pattern = cached_regex("restify:fn_string:#{param_name}:#{method}") do
+                  /#{Regex.escape(param_name)}\.#{method}\s*\(\s*['"]([^'"]+)['"]/
+                end
+                object_pattern = cached_regex("restify:fn_object:#{param_name}:#{method}") do
+                  /#{Regex.escape(param_name)}\.#{method}\s*\(\s*\{\s*path\s*:\s*['"]([^'"]+)['"]/
+                end
 
                 # Extract string paths
                 function_body.scan(string_pattern) do |route_m|
@@ -291,7 +295,9 @@ module Analyzer::Javascript
 
           http_methods.each do |method|
             # Look for route handlers on this router
-            handler_pattern = /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
+            handler_pattern = cached_regex("restify:router_handler:#{router_name}:#{method}") do
+              /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
+            end
 
             content.scan(handler_pattern) do |route_m|
               if route_m.size > 1
@@ -345,7 +351,9 @@ module Analyzer::Javascript
         http_methods = %w[get post put delete patch options head del]
 
         http_methods.each do |method|
-          pattern = /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
+          pattern = cached_regex("restify:router_route:#{router_name}:#{method}") do
+            /#{router_name}\.#{method}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*)\}/m
+          end
 
           content.scan(pattern) do |route_m|
             if route_m.size > 1
@@ -517,8 +525,15 @@ module Analyzer::Javascript
       Param.new("", "", "")
     end
 
+    HTTP_METHOD_KEYS = %w[get post put delete patch options head del]
+    # Compiled once — interpolated regex literals would otherwise be
+    # rebuilt (full PCRE2 compile) for every method on every line.
+    ROUTER_NAME_METHOD_RES = HTTP_METHOD_KEYS.map { |m| {m, /\b(?:\w+Router)\s*\.\s*#{m}\s*\(\s*['"]([^'"]+)['"]/} }.to_h
+    DOT_METHOD_RES         = HTTP_METHOD_KEYS.map { |m| {m, /\.\s*#{m}\s*\(\s*['"]([^'"]+)['"]/} }.to_h
+    VERSIONED_PATH_RES     = HTTP_METHOD_KEYS.map { |m| {m, /\.#{m}\s*\(\s*\{\s*path\s*:\s*['"]([^'"]+)['"]/} }.to_h
+
     def line_to_endpoint(line : String, server_vars = [] of String, router_vars = [] of String) : Endpoint
-      http_methods = %w[get post put delete patch options head del]
+      http_methods = HTTP_METHOD_KEYS
 
       # Build a regex pattern that includes all server and router variable names
       var_pattern = (server_vars + router_vars).join("|")
@@ -526,7 +541,10 @@ module Analyzer::Javascript
 
       http_methods.each do |method|
         # Match server.method, router.method patterns
-        if line =~ /\b(?:#{var_pattern})\s*\.\s*#{method}\s*\(\s*['"]([^'"]+)['"]/
+        var_method_re = cached_regex("restify:var_method:#{var_pattern}:#{method}") do
+          /\b(?:#{var_pattern})\s*\.\s*#{method}\s*\(\s*['"]([^'"]+)['"]/
+        end
+        if line =~ var_method_re
           path = $1
           # Normalizing 'del' to 'delete' for HTTP method naming consistency
           method_normalized = method == "del" ? "DELETE" : method.upcase
@@ -534,14 +552,14 @@ module Analyzer::Javascript
         end
 
         # Generic patterns with dot notation - handle additional router variables
-        if line =~ /\b(?:\w+Router)\s*\.\s*#{method}\s*\(\s*['"]([^'"]+)['"]/
+        if line =~ ROUTER_NAME_METHOD_RES[method]
           path = $1
           method_normalized = method == "del" ? "DELETE" : method.upcase
           return Endpoint.new(path, method_normalized)
         end
 
         # Generic patterns with dot notation
-        if line =~ /\.\s*#{method}\s*\(\s*['"]([^'"]+)['"]/
+        if line =~ DOT_METHOD_RES[method]
           path = $1
           method_normalized = method == "del" ? "DELETE" : method.upcase
           return Endpoint.new(path, method_normalized)
@@ -549,7 +567,10 @@ module Analyzer::Javascript
       end
 
       # Handle route method with HTTP method as parameter
-      if line =~ /\b(?:#{var_pattern})\s*\.\s*route\s*\(\s*['"]([^'"]+)['"].*?\.(?:get|post|put|delete|patch|options|head|del)\s*\(/
+      var_route_re = cached_regex("restify:var_route:#{var_pattern}") do
+        /\b(?:#{var_pattern})\s*\.\s*route\s*\(\s*['"]([^'"]+)['"].*?\.(?:get|post|put|delete|patch|options|head|del)\s*\(/
+      end
+      if line =~ var_route_re
         path = $1
         method = line.scan(/\.(?:get|post|put|delete|patch|options|head|del)\s*\(/)[0][0].gsub(/[\.\s\(]/, "")
         method_normalized = method == "del" ? "DELETE" : method.upcase
@@ -564,7 +585,7 @@ module Analyzer::Javascript
 
       # Handle other HTTP methods with the versioned endpoint format
       http_methods.each do |http_method|
-        if line =~ /\.#{http_method}\s*\(\s*\{\s*path\s*:\s*['"]([^'"]+)['"]/
+        if line =~ VERSIONED_PATH_RES[http_method]
           path = $1
           method_normalized = http_method == "del" ? "DELETE" : http_method.upcase
           return Endpoint.new(path, method_normalized)
@@ -744,9 +765,12 @@ module Analyzer::Javascript
       end
     end
 
+    # Compiled once per method key — these run against every restify file.
+    ANY_VAR_METHOD_RES = HTTP_METHOD_KEYS.map { |m| {m, /(\w+Router|\w+Server|\w+)\s*\.\s*#{m}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*(?:\{[^}]*\})*[^}]*)\}/m} }.to_h
+
     private def extract_routes_for_method(content : String, result : Array(Endpoint), path : String, method_key : String, method_normalized : String)
       # Look for all router/server variables that might define routes
-      var_pattern = /(\w+Router|\w+Server|\w+)\s*\.\s*#{method_key}\s*\(\s*['"]([^'"]+)['"][^{]*\{([^}]*(?:\{[^}]*\})*[^}]*)\}/m
+      var_pattern = ANY_VAR_METHOD_RES[method_key]
 
       content.scan(var_pattern) do |method_match|
         if method_match.size > 2

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -148,12 +148,18 @@ module Analyzer::Javascript
       seg
     end
 
+    # Compiled once per verb — interpolated regex literals would otherwise
+    # be rebuilt (full PCRE2 compile) for every method on every file.
+    EXPORT_FUNCTION_RES = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b/} }.to_h
+    EXPORT_CONST_RES    = HTTP_METHODS.map { |m| {m, /export\s+(?:const|let|var)\s+#{m}\b\s*(?::[^=]+)?=/} }.to_h
+    EXPORT_BRACE_RES    = HTTP_METHODS.map { |m| {m, /export\s+\{\s*[^}]*\b#{m}\b[^}]*\}/} }.to_h
+
     private def detect_api_methods(content : String) : Array(String)
       explicit = [] of String
       HTTP_METHODS.each do |m|
-        if content.match(/export\s+(?:async\s+)?function\s+#{m}\b/) ||
-           content.match(/export\s+(?:const|let|var)\s+#{m}\b\s*(?::[^=]+)?=/) ||
-           content.match(/export\s+\{\s*[^}]*\b#{m}\b[^}]*\}/)
+        if content.match(EXPORT_FUNCTION_RES[m]) ||
+           content.match(EXPORT_CONST_RES[m]) ||
+           content.match(EXPORT_BRACE_RES[m])
           explicit << m
         end
       end

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -148,8 +148,10 @@ module Analyzer::Typescript
     end
 
     private def extract_string_property(block : String, property : String) : String?
-      escaped_property = Regex.escape(property)
-      match = block.match(/(?:^|[,{]\s*)#{escaped_property}\s*:\s*['"`]([^'"`]+)['"`]/m)
+      property_re = cached_regex("tanstack:string_prop:#{property}") do
+        /(?:^|[,{]\s*)#{Regex.escape(property)}\s*:\s*['"`]([^'"`]+)['"`]/m
+      end
+      match = block.match(property_re)
       match.try(&.[1])
     end
 
@@ -389,11 +391,11 @@ module Analyzer::Typescript
         search_name = validate_search_argument_name(value)
         next unless search_name
 
-        value.scan(/\b#{Regex.escape(search_name)}\s*\.\s*([A-Za-z_$][\w$]*)/) do |param_match|
+        value.scan(cached_regex("tanstack:search_dot:#{search_name}") { /\b#{Regex.escape(search_name)}\s*\.\s*([A-Za-z_$][\w$]*)/ }) do |param_match|
           push_unique_query_param(endpoint, param_match[1])
         end
 
-        value.scan(/\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*#{Regex.escape(search_name)}\b/) do |destructure_match|
+        value.scan(cached_regex("tanstack:search_destructure:#{search_name}") { /\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*#{Regex.escape(search_name)}\b/ }) do |destructure_match|
           destructure_match[1].split(",").each do |param|
             param_name = param.strip.split(":").first.strip.split("=").first.strip
             push_unique_query_param(endpoint, param_name)

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -118,8 +118,9 @@ module Analyzer::Typescript
     end
 
     private def extract_object_assignment_body(content : String, identifier : String) : Tuple(String, Int32)?
-      escaped = Regex.escape(identifier)
-      pattern = /\b(?:export\s+)?(?:const|let|var)\s+#{escaped}(?:\s*:[^=]+)?\s*=\s*\{/
+      pattern = cached_regex("trpc:object_assign:#{identifier}") do
+        /\b(?:export\s+)?(?:const|let|var)\s+#{Regex.escape(identifier)}(?:\s*:[^=]+)?\s*=\s*\{/
+      end
 
       content.scan(pattern) do |match|
         match_start = match.begin(0) || 0

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -37,6 +37,20 @@ module Analyzer::Javascript
       end
     end
 
+    # Crystal recompiles an interpolated regex literal (/...#{x}.../) on
+    # every evaluation — a full PCRE2 JIT compile. Patterns keyed by a
+    # discovered name ("req", "query", "body", router vars, ...) are
+    # low-cardinality across a scan, so memoize them per analyzer
+    # instance. Fibers are cooperative (no preview_mt), so the plain
+    # Hash is safe under parallel_file_scan.
+    @dynamic_regex_cache = Hash(String, Regex).new
+
+    protected def cached_regex(key : String, & : -> Regex) : Regex
+      @dynamic_regex_cache.fetch(key) do
+        @dynamic_regex_cache[key] = yield
+      end
+    end
+
     protected def attach_js_callees(endpoint : Endpoint, callees : Array(Noir::JSCalleeExtractor::Entry))
       callees.each do |name, callee_path, line|
         endpoint.push_callee(Callee.new(name, path: callee_path, line: line))

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -674,6 +674,31 @@ module Noir
       method
     end
 
+    # Memoizes the direct-call patterns built in extract_params_from_context;
+    # the alternation is derived from the route's HTTP method, so the key set
+    # is tiny. Fibers are cooperative (no preview_mt), so the plain Hash is
+    # safe under the analyzers' parallel file scans.
+    @@direct_call_res = Hash(String, Regex).new
+
+    # Equivalent to matching /['"`]<literal>['"`]/ — the literal bracketed by
+    # a quote character on each side — without compiling a per-path regex.
+    private def self.quoted_substring?(window : String, literal : String) : Bool
+      search_from = 0
+      while found = window.index(literal, search_from)
+        after_idx = found + literal.size
+        if found > 0 && after_idx < window.size
+          before = window[found - 1]
+          after = window[after_idx]
+          if (before == '\'' || before == '"' || before == '`') &&
+             (after == '\'' || after == '"' || after == '`')
+            return true
+          end
+        end
+        search_from = found + 1
+      end
+      false
+    end
+
     def self.extract_params_from_context(content : String, pattern : JSRoutePattern, endpoint : Endpoint)
       # Extract additional parameters from the route handler content
       # Look for the route declaration and then analyze the handler function
@@ -719,14 +744,18 @@ module Noir
         start_idx = pattern.start_pos
         search_window = content[start_idx, Math.min(content.size - start_idx, 500)]
         method_alternation = method_variations.map { |method| Regex.escape(method) }.join("|")
-        direct_call_pattern = /\.\s*(?:#{method_alternation})\s*\(/i
+        # Memoized — method_alternation has ~8 distinct values, and an
+        # interpolated regex literal would recompile (full PCRE2 compile)
+        # once per endpoint.
+        direct_call_pattern = @@direct_call_res.fetch(method_alternation) do
+          @@direct_call_res[method_alternation] = /\.\s*(?:#{method_alternation})\s*\(/i
+        end
         if direct_match = search_window.match(direct_call_pattern)
           candidate_idx = start_idx + (direct_match.begin(0) || 0)
           open_paren = content.index("(", candidate_idx)
           if open_paren
             arg_window = content[open_paren, Math.min(content.size - open_paren, 300)]
-            escaped_lookup_path = Regex.escape(lookup_path)
-            if arg_window.matches?(/['"`]#{escaped_lookup_path}['"`]/)
+            if quoted_substring?(arg_window, lookup_path)
               idx = candidate_idx
               found_declaration = "direct"
             end


### PR DESCRIPTION
Closes #1959. Follow-up to #1957 / #1960 / #1963 / #1964 / #1966 — the last analyzer family carrying the antipattern.

## Background

Crystal recompiles an interpolated regex literal (`/...#{x}.../`) on every evaluation — a full PCRE2 JIT compile (~3µs vs ~0.05µs for a hoisted constant, ~65× measured in #1957). The JS/TS analyzers rebuilt the same patterns per line, per file, or per handler.

## Changes (behavior-preserving — the `.to_s` expansion is byte-identical)

- **Fixed-set verb patterns → constant tables** (`HTTP_METHODS.map { |m| {m, /.../} }.to_h`):
  - hono / fastify / restify `line_to_endpoint(s)` — these interpolated the method into 1–3 patterns **per method per source line**, the hottest sites.
  - nextjs / sveltekit / astro / fresh / remix per-file export-verb detection loops (7 verbs × 2–3 patterns per file).
  - `RouterMountScanner` `use`/`route` literal-mount matchers (4 patterns per file pass).
- **Dynamic discovered-name patterns → memoized** via a new shared `JavascriptEngine#cached_regex(key, &)` per-instance cache. Names like `req`, `query`, `body`, `formData`, and router vars are low-cardinality across a scan, so each pattern now compiles once per scan instead of once per file/handler: nextjs json/form/cookie var scans + named-function bodies, nestjs request-object field scans (order-preserving `REQUEST_OBJECT_FIELDS` table), nuxtjs/nitro query/body/header vars, restify + express router×method handler patterns, tanstack `validateSearch` vars, trpc object assignments. (Fibers are cooperative — no `preview_mt` — so the plain Hash cache is safe under `parallel_file_scan`.)
- **Shared miniparser** — profiling showed the dominant *remaining* source was not in the analyzers but in `js_route_extractor.cr#extract_params_from_context`, which express/hono/fastify/restify all funnel through: the method-alternation `direct_call_pattern` is now memoized in a class-level cache (~8 distinct keys), and the per-endpoint quoted-path probe `/['"`]#{path}['"`]/` is replaced with an exactly-equivalent quote-bracketed substring check (`quoted_substring?`).

Regexes keyed by a unique path/router name that already compiled once per call (koa handler lookup, express/restify per-path handler extraction) are left as-is — memoization can't reduce their compile count.

## Results

2,700-file synthetic nextjs + hono + fastify + express + restify monorepo (3,300 endpoints), release builds, best-of-5:

| Metric | Before | After |
|---|---|---|
| `pcre2_jit_compile_8` samples (2s window) | 214 | **0** |
| Wall-clock | 3.17 s | **2.42 s** (1.3×) |

## Verification

- Output **byte-identical** across all 70 JS/TS functional-test fixtures (scanned with `--ai-context`) and the synthetic monorepo.
- Full spec suite: **21,160 examples, 0 failures, 0 errors**.
- `crystal tool format --check` clean.

This closes out the cross-language sweep: Python (#1957/#1960/#1963/#1966), JVM/Scala/C++/Ruby/Go (#1964), JS/TS (this PR).