### PR TITLE
Improve Rust handler context extraction

### DIFF
--- a/spec/functional_test/fixtures/rust/axum/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum/src/main.rs
@@ -1,4 +1,5 @@
-use axum::{response::Html, routing::{any, get, post}, Router};
+use axum::{extract::{Form, Query}, http::HeaderMap, response::Html, routing::{any, get, post}, Router};
+use axum_extra::extract::CookieJar;
 use tower_http::services::ServeDir;
 
 #[tokio::main]
@@ -7,6 +8,10 @@ async fn main() {
         .route("/", get(handler))
         .route("/foo", get(handler))
         .route("/bar", post(handler))
+        .route("/search", get(search))
+        .route("/submit", post(submit))
+        .route("/headers", get(headers))
+        .route("/session", get(session))
         // Verb-agnostic registration — typically used for WebSocket
         // upgrade endpoints. axum 0.7 exports `routing::any`.
         .route("/ws", any(handler))
@@ -38,6 +43,24 @@ async fn main() {
 
 async fn handler() -> Html<&'static str> {
     Html("<h1>Hello, World!</h1>")
+}
+
+async fn search(Query(params): Query<SearchParams>) -> Html<&'static str> {
+    Html(SearchService::render(params))
+}
+
+async fn submit(Form(form): Form<LoginForm>) -> Html<&'static str> {
+    Html(LoginService::render(form))
+}
+
+async fn headers(headers: HeaderMap) -> Html<&'static str> {
+    let request_id = headers.get("X-Request-Id");
+    Html(HeaderService::render(request_id))
+}
+
+async fn session(jar: CookieJar) -> Html<&'static str> {
+    let session = jar.get("session_id");
+    Html(SessionService::render(session))
 }
 
 fn v1_routes() -> Router {

--- a/spec/functional_test/fixtures/rust/axum_callees/src/external.rs
+++ b/spec/functional_test/fixtures/rust/axum_callees/src/external.rs
@@ -1,0 +1,6 @@
+use axum::Json;
+
+pub async fn create_external(Json(payload): Json<ExternalPayload>) -> Json<ExternalPayload> {
+    ExternalService::create(payload).await;
+    Json(payload)
+}

--- a/spec/functional_test/fixtures/rust/axum_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/axum_callees/src/main.rs
@@ -1,11 +1,14 @@
 use axum::{response::Html, routing::{get, post}, Json, Router};
 
+mod external;
+
 #[tokio::main]
 async fn main() {
     let app = Router::new()
         .route("/", get(home))
         .route("/profile", get(profile))
-        .route("/users", post(create_user));
+        .route("/users", post(create_user))
+        .route("/external", post(external::create_external));
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
         .await

--- a/spec/functional_test/fixtures/rust/warp_callees/src/external.rs
+++ b/spec/functional_test/fixtures/rust/warp_callees/src/external.rs
@@ -1,0 +1,5 @@
+pub async fn create_external(user: crate::CreateUser) -> Result<impl warp::Reply, warp::Rejection> {
+    let created = ExternalService::create(user);
+    AuditLog::write_external();
+    Ok(UserPresenter::render(created))
+}

--- a/spec/functional_test/fixtures/rust/warp_callees/src/main.rs
+++ b/spec/functional_test/fixtures/rust/warp_callees/src/main.rs
@@ -38,6 +38,8 @@ pub unsafe fn generic_handler<T>() -> impl Reply {
     GenericPresenter::render(value)
 }
 
+mod external;
+
 #[tokio::main]
 async fn main() {
     let home = warp::path::end()
@@ -56,6 +58,12 @@ async fn main() {
         .and(warp::post())
         .and_then(create_user);
 
+    let external_route = warp::path("external")
+        .and(warp::path::end())
+        .and(warp::body::json::<CreateUser>())
+        .and(warp::post())
+        .and_then(external::create_external);
+
     let profile_route = warp::path("profile")
         .and(warp::path::end())
         .and(warp::query::<SearchQuery>())
@@ -70,6 +78,7 @@ async fn main() {
     let routes = home
         .or(get_user_route)
         .or(create_user_route)
+        .or(external_route)
         .or(profile_route)
         .or(generic_route);
 

--- a/spec/functional_test/testers/rust/axum_callees_spec.cr
+++ b/spec/functional_test/testers/rust/axum_callees_spec.cr
@@ -1,51 +1,61 @@
 require "../../func_spec.cr"
 
 home = Endpoint.new("/", "GET").tap do |ep|
-  ep.push_callee(Callee.new("HealthCheck::ready", line: 17))
-  ep.push_callee(Callee.new("Html", line: 18))
-  ep.push_callee(Callee.new("render_home", line: 18))
+  ep.push_callee(Callee.new("HealthCheck::ready", line: 20))
+  ep.push_callee(Callee.new("Html", line: 21))
+  ep.push_callee(Callee.new("render_home", line: 21))
 end
 
 profile = Endpoint.new("/profile", "GET").tap do |ep|
-  ep.push_callee(Callee.new("ProfileService::load", line: 22))
-  ep.push_callee(Callee.new("FeatureFlags::enabled", line: 23))
-  ep.push_callee(Callee.new("Metrics::record_profile", line: 24))
-  ep.push_callee(Callee.new("Json", line: 26))
-  ep.push_callee(Callee.new("ProfilePresenter::render", line: 26))
+  ep.push_callee(Callee.new("ProfileService::load", line: 25))
+  ep.push_callee(Callee.new("FeatureFlags::enabled", line: 26))
+  ep.push_callee(Callee.new("Metrics::record_profile", line: 27))
+  ep.push_callee(Callee.new("Json", line: 29))
+  ep.push_callee(Callee.new("ProfilePresenter::render", line: 29))
 end
 
-create_user = Endpoint.new("/users", "POST").tap do |ep|
-  ep.push_callee(Callee.new("UserService::create", line: 30))
-  ep.push_callee(Callee.new("AuditLog::write", line: 31))
-  ep.push_callee(Callee.new("Json", line: 32))
+create_user = Endpoint.new("/users", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("UserService::create", line: 33))
+  ep.push_callee(Callee.new("AuditLog::write", line: 34))
+  ep.push_callee(Callee.new("Json", line: 35))
+end
+
+create_external = Endpoint.new("/external", "POST", [
+  Param.new("body", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ExternalService::create", line: 4))
+  ep.push_callee(Callee.new("Json", line: 5))
 end
 
 read_account = Endpoint.new("/account", "GET").tap do |ep|
-  ep.push_callee(Callee.new("AccountService::read", line: 48))
-  ep.push_callee(Callee.new("Json", line: 49))
+  ep.push_callee(Callee.new("AccountService::read", line: 51))
+  ep.push_callee(Callee.new("Json", line: 52))
 end
 
 update_account = Endpoint.new("/account", "PUT").tap do |ep|
-  ep.push_callee(Callee.new("AccountService::update", line: 54))
-  ep.push_callee(Callee.new("AuditLog::write_update", line: 55))
+  ep.push_callee(Callee.new("AccountService::update", line: 57))
+  ep.push_callee(Callee.new("AuditLog::write_update", line: 58))
 end
 
 builder_get = Endpoint.new("/builder", "GET").tap do |ep|
-  ep.push_callee(Callee.new("BuilderService::read", line: 60))
+  ep.push_callee(Callee.new("BuilderService::read", line: 63))
 end
 
 builder_public = Endpoint.new("/builder-public", "POST").tap do |ep|
-  ep.push_callee(Callee.new("BuilderService::create", line: 64))
+  ep.push_callee(Callee.new("BuilderService::create", line: 67))
 end
 
 scoped = Endpoint.new("/scoped", "GET").tap do |ep|
-  ep.push_callee(Callee.new("RightService::hit", line: 85))
+  ep.push_callee(Callee.new("RightService::hit", line: 88))
 end
 
 expected_endpoints = [
   home,
   profile,
   create_user,
+  create_external,
   read_account,
   update_account,
   builder_get,

--- a/spec/functional_test/testers/rust/axum_spec.cr
+++ b/spec/functional_test/testers/rust/axum_spec.cr
@@ -12,10 +12,24 @@ expected_endpoints = [
   Endpoint.new("/", "GET"),
   Endpoint.new("/foo", "GET"),
   Endpoint.new("/bar", "POST"),
+  Endpoint.new("/search", "GET", [
+    Param.new("query", "", "query"),
+  ]),
+  Endpoint.new("/submit", "POST", [
+    Param.new("form", "", "form"),
+  ]),
+  Endpoint.new("/headers", "GET", [
+    Param.new("X-Request-Id", "", "header"),
+  ]),
+  Endpoint.new("/session", "GET", [
+    Param.new("session_id", "", "cookie"),
+  ]),
   Endpoint.new("/api/users", "GET"),
   Endpoint.new("/api/admin", "POST"),
   Endpoint.new("/v1/projects", "GET"),
-  Endpoint.new("/v1/projects/{id}", "GET"),
+  Endpoint.new("/v1/projects/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
   Endpoint.new("/root/api/audit", "GET"),
 ]
 %w[/ws /favicon.ico /assets/* /*].each do |path|

--- a/spec/functional_test/testers/rust/warp_callees_spec.cr
+++ b/spec/functional_test/testers/rust/warp_callees_spec.cr
@@ -21,6 +21,14 @@ create_user = Endpoint.new("/users", "POST", [
   ep.push_callee(Callee.new("UserPresenter::render", line: 28))
 end
 
+external = Endpoint.new("/external", "POST", [
+  Param.new("CreateUser", "", "json"),
+]).tap do |ep|
+  ep.push_callee(Callee.new("ExternalService::create", line: 2))
+  ep.push_callee(Callee.new("AuditLog::write_external", line: 3))
+  ep.push_callee(Callee.new("UserPresenter::render", line: 4))
+end
+
 profile = Endpoint.new("/profile", "GET", [
   Param.new("SearchQuery", "", "query"),
 ]).tap do |ep|
@@ -37,6 +45,7 @@ expected_endpoints = [
   home,
   get_user,
   create_user,
+  external,
   profile,
   generic,
 ]

--- a/spec/unit_test/ai_context/augmentor_spec.cr
+++ b/spec/unit_test/ai_context/augmentor_spec.cr
@@ -2485,6 +2485,30 @@ describe "NoirAIContext" do
     end
   end
 
+  it "emits ssrf for Rust reqwest direct HTTP callees with URL-like input" do
+    source = <<-RUST
+      async fn proxy(url: String) -> String {
+          reqwest::get(url).await.unwrap().text().await.unwrap()
+      }
+      RUST
+
+    with_temp_ai_context_source(source) do |path|
+      endpoint = Endpoint.new("/fetch/{url}", "GET", [
+        Param.new("url", "", "path"),
+      ])
+      details = endpoint.details
+      details.technology = "rust_axum"
+      details.add_path(PathInfo.new(path, 1))
+      endpoint.details = details
+      endpoint.push_callee(Callee.new("reqwest::get", path, 2))
+
+      context = NoirAIContext.apply([endpoint])[0].ai_context.should_not be_nil
+      context.sinks.map(&.kind).should contain("outbound_http")
+      context.sinks.map(&.name).should contain("reqwest::get")
+      context.signals.map(&.kind).should contain("ssrf")
+    end
+  end
+
   it "includes WebClient target URIs in outbound HTTP sink evidence" do
     source = <<-CODE
       fun withDetails(id: Long) {

--- a/src/ai_context/patterns.cr
+++ b/src/ai_context/patterns.cr
@@ -55,8 +55,25 @@ module NoirAIContext
       "outbound_http",
       "Potential outbound HTTP/client sink inferred from code or callee name",
       64,
-      name_patterns: [/\bhttp\b/i, /\bfetch\b/i, /\bclient\b/i, /\baxios\b/i, /\bgetForObject\b/i, /\bexchange\b/i],
-      source_patterns: [/requests\.(get|post|put|delete)/i, /\bfetch\s*\(/i, /\baxios\./i, /\bhttp\.(Get|Post|NewRequest)/, /\bclient\.(get|post|request)/i, /\b\w+\.(getForObject|postForObject|exchange)\s*\(/i]
+      name_patterns: [
+        /\b(?:reqwest|hyper|hyper_util|ureq|surf|isahc|attohttpc|awc)::[A-Za-z_][A-Za-z0-9_:!]*/i,
+        /\bhttp\b/i,
+        /\bfetch\b/i,
+        /\bclient\b/i,
+        /\baxios\b/i,
+        /\bgetForObject\b/i,
+        /\bexchange\b/i,
+      ],
+      source_patterns: [
+        /requests\.(get|post|put|delete)/i,
+        /\bfetch\s*\(/i,
+        /\baxios\./i,
+        /\bhttp\.(Get|Post|NewRequest)/,
+        /\bclient\.(get|post|request)/i,
+        /\b\w+\.(getForObject|postForObject|exchange)\s*\(/i,
+        /\b(?:reqwest|ureq|surf|isahc|attohttpc)::(?:get|post|put|delete|patch|request)\s*(?:::<[^>]+>)?\s*\(/i,
+        /\b(?:hyper|hyper_util|awc)::[A-Za-z0-9_:]*Client\b/,
+      ]
     ),
     # ----- New in v1.1 (--ai-context coverage expansion) -----
     #

--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -12,6 +12,7 @@ module Analyzer::Rust
   # it, skipping intermediate attribute_items and doc comments.
   class ActixWeb < RustEngine
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
+    alias GlobalFunctionEntry = NamedTuple(name: String, path: String, hints: Array(String), params_text: String?, callees: Array(Noir::RustCalleeExtractor::Entry))
 
     # Cross-file scope registrations: `web::scope("/auth").service(mod::handler)`
     # frequently mounts a `#[get("/x")]` handler that lives in a *different*
@@ -36,7 +37,7 @@ module Analyzer::Rust
     # `/api` prefix. `analyze` records each configured fn's scope prefix(es)
     # up front; the builder pass prepends them to routes emitted inside the fn.
     @configure_fn_prefix : Array(NamedTuple(base: String, ref: String, prefix: String, source_path: String))? = nil
-    @global_function_index : Array(NamedTuple(name: String, path: String, hints: Array(String), params_text: String?, body_text: String?, body_start_line: Int32))? = nil
+    @global_function_index : Array(GlobalFunctionEntry)? = nil
     @project_import_aliases : Hash(String, String)? = nil
 
     def analyze
@@ -905,10 +906,7 @@ module Analyzer::Rust
       entry = lookup_global_function(handler_name)
       return unless entry
       extract_function_params_from_text(entry[:params_text], endpoint)
-      if include_callee && (body = entry[:body_text])
-        callees = Noir::RustCalleeExtractorTS.callees_for_body_text(body, entry[:path], entry[:body_start_line])
-        attach_rust_callees(endpoint, callees)
-      end
+      attach_rust_callees(endpoint, entry[:callees]) if include_callee
     end
 
     private def lookup_global_function(ref : String)
@@ -930,7 +928,7 @@ module Analyzer::Rust
         return cached
       end
 
-      entries = [] of NamedTuple(name: String, path: String, hints: Array(String), params_text: String?, body_text: String?, body_start_line: Int32)
+      entries = [] of GlobalFunctionEntry
       all_files.each do |fpath|
         next if File.directory?(fpath)
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
@@ -944,13 +942,17 @@ module Analyzer::Rust
               next unless name_node
               body = Noir::TreeSitter.field(node, "body")
               params = Noir::TreeSitter.field(node, "parameters")
+              callees = if callees_needed? && body
+                          Noir::RustCalleeExtractorTS.callees_in_body(body, src, fpath)
+                        else
+                          [] of Noir::RustCalleeExtractor::Entry
+                        end
               entries << {
-                name:            Noir::TreeSitter.node_text(name_node, src),
-                path:            fpath,
-                hints:           module_hints(fpath),
-                params_text:     params ? Noir::TreeSitter.node_text(params, src) : nil,
-                body_text:       body ? Noir::TreeSitter.node_text(body, src) : nil,
-                body_start_line: body ? Noir::TreeSitter.node_start_row(body) + 1 : 1,
+                name:        Noir::TreeSitter.node_text(name_node, src),
+                path:        fpath,
+                hints:       module_hints(fpath),
+                params_text: params ? Noir::TreeSitter.node_text(params, src) : nil,
+                callees:     callees,
               }
             end
           end

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -13,6 +13,7 @@ module Analyzer::Rust
   class Axum < RustEngine
     alias UtoipaScopedKey = Tuple(String, String, String)
     alias UtoipaNestEdge = Tuple(UtoipaScopedKey, String)
+    alias HandlerContext = NamedTuple(params: Array(Param), callees: Array(Noir::RustCalleeExtractor::Entry))
 
     # Verbs accepted as the inner handler call (`get(...)`, `post(...)`,
     # …). Anything outside this set is treated as `GET` to match the
@@ -37,9 +38,16 @@ module Analyzer::Rust
     # collectors); `analyze_file` then emits each `#[utoipa::path]` handler
     # at its composed URL.
     @utoipa_prefix : Hash(UtoipaScopedKey, Array(String))? = nil
+    @external_handler_context_cache = {} of String => HandlerContext
+    @external_handler_miss_cache = Set(String).new
+    @external_handler_context_cache_mutex = Mutex.new
 
     def analyze
       @utoipa_prefix = build_utoipa_prefix_index
+      @external_handler_context_cache_mutex.synchronize do
+        @external_handler_context_cache.clear
+        @external_handler_miss_cache.clear
+      end
       super
     end
 
@@ -63,7 +71,8 @@ module Analyzer::Rust
       test_regions = RustEngine.collect_cfg_test_regions(source)
 
       Noir::TreeSitter.parse_rust(source) do |root|
-        function_index = include_callee ? build_function_index(root, source) : Hash(String, LibTreeSitter::TSNode).new
+        function_index = build_function_index(root, source)
+        handler_context_cache = {} of String => HandlerContext
         router_functions = build_router_function_index(root, source)
         mounted_router_names = collect_mounted_router_names(root, source, test_regions)
         nested_router_prefixes = collect_nested_router_prefixes(root, source, test_regions, "", mounted_router_names)
@@ -82,10 +91,10 @@ module Analyzer::Rust
             RustEngine.fan_out_verbs(raw_verb).each do |verb|
               details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
               endpoint = Endpoint.new(path_str, verb, details)
+              extract_path_params(path_str, endpoint)
 
-              if include_callee && handler_name
-                entries = callee_entries_for_handler(function_index, source, path, handler_name)
-                attach_rust_callees(endpoint, entries)
+              if handler_name
+                attach_handler_context(endpoint, function_index, source, path, handler_name, include_callee, handler_context_cache)
               end
 
               endpoints << endpoint
@@ -121,10 +130,10 @@ module Analyzer::Rust
               RustEngine.fan_out_verbs(raw_verb).each do |verb|
                 details = Details.new(PathInfo.new(path, Noir::TreeSitter.node_start_row(node) + 1))
                 endpoint = Endpoint.new(path_str, verb, details)
+                extract_path_params(path_str, endpoint)
 
-                if include_callee && handler_name
-                  entries = callee_entries_for_handler(function_index, source, path, handler_name)
-                  attach_rust_callees(endpoint, entries)
+                if handler_name
+                  attach_handler_context(endpoint, function_index, source, path, handler_name, include_callee, handler_context_cache)
                 end
 
                 endpoints << endpoint
@@ -144,7 +153,7 @@ module Analyzer::Rust
         # via `routes!()`, not `.route()`), composed with their OpenApiRouter
         # nest prefix.
         if source.includes?("utoipa::path")
-          collect_utoipa_endpoints(root, source, path, test_regions, include_callee, function_index, endpoints)
+          collect_utoipa_endpoints(root, source, path, test_regions, include_callee, function_index, handler_context_cache, endpoints)
         end
       end
 
@@ -608,6 +617,121 @@ module Analyzer::Rust
       "#{prefix.rstrip('/')}/#{path.lstrip('/')}"
     end
 
+    private def extract_path_params(route : String, endpoint : Endpoint)
+      route.scan(/:([A-Za-z_]\w*)/) do |match|
+        push_path_param(endpoint, match[1])
+      end
+
+      route.scan(/\{\**([A-Za-z_]\w*)\}/) do |match|
+        push_path_param(endpoint, match[1])
+      end
+
+      route.scan(%r{/\*([A-Za-z_]\w*)}) do |match|
+        push_path_param(endpoint, match[1])
+      end
+    end
+
+    private def push_path_param(endpoint : Endpoint, name : String)
+      endpoint.push_param(Param.new(name, "", "path"))
+    end
+
+    private def extract_function_params(function : LibTreeSitter::TSNode,
+                                        source : String,
+                                        endpoint : Endpoint)
+      header_vars = Set(String).new
+      cookie_vars = Set(String).new
+
+      params = Noir::TreeSitter.field(function, "parameters")
+      if params
+        Noir::TreeSitter.each_named_child(params) do |param|
+          text = Noir::TreeSitter.node_text(param, source)
+          extract_function_param_text(text, endpoint)
+          if binding = param_binding_name(text)
+            header_vars.add(binding) if text.includes?("HeaderMap")
+            cookie_vars.add(binding) if text.includes?("CookieJar")
+          end
+        end
+      end
+
+      body = Noir::TreeSitter.field(function, "body")
+      return unless body
+
+      collect_header_and_cookie_params(body, source, endpoint, header_vars, cookie_vars)
+    end
+
+    private def extract_function_param_text(text : String, endpoint : Endpoint)
+      endpoint.push_param(Param.new("query", "", "query")) if extractor_param?(text, "Query")
+      endpoint.push_param(Param.new("body", "", "json")) if extractor_param?(text, "Json")
+      endpoint.push_param(Param.new("form", "", "form")) if extractor_param?(text, "Form")
+    end
+
+    private def extractor_param?(text : String, type_name : String) : Bool
+      text.includes?("#{type_name}<") ||
+        !!text.match(/#{type_name}\s*\(\s*[^)]+\s*\)/) ||
+        !!text.match(/:\s*(?:[A-Za-z_]\w*::)*#{type_name}\b/)
+    end
+
+    private def param_binding_name(text : String) : String?
+      match = text.match(/^\s*(?:mut\s+)?([A-Za-z_]\w*)\s*:/)
+      match.try(&.[1])
+    end
+
+    private def collect_header_and_cookie_params(body : LibTreeSitter::TSNode,
+                                                 source : String,
+                                                 endpoint : Endpoint,
+                                                 header_vars : Set(String),
+                                                 cookie_vars : Set(String))
+      walk(body) do |call|
+        next unless Noir::TreeSitter.node_type(call) == "call_expression"
+
+        fn_text = call_function_text(call, source)
+        next unless fn_text
+
+        if header_read_call?(fn_text, header_vars)
+          first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source).try do |name|
+            endpoint.push_param(Param.new(name, "", "header")) if header_name?(name)
+          end
+        elsif cookie_read_call?(fn_text, cookie_vars)
+          first_string_literal_text(Noir::TreeSitter.field(call, "arguments"), source).try do |name|
+            endpoint.push_param(Param.new(name, "", "cookie"))
+          end
+        end
+      end
+    end
+
+    private def header_read_call?(fn_text : String, header_vars : Set(String)) : Bool
+      return true if fn_text.ends_with?(".headers().get")
+
+      header_vars.any? { |name| fn_text == "#{name}.get" }
+    end
+
+    private def cookie_read_call?(fn_text : String, cookie_vars : Set(String)) : Bool
+      return true if fn_text.ends_with?(".cookie")
+
+      cookie_vars.any? { |name| fn_text == "#{name}.get" }
+    end
+
+    private def header_name?(name : String) : Bool
+      name.includes?("-") || name.in?(%w[Authorization Content-Type Accept])
+    end
+
+    private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?
+      function = Noir::TreeSitter.field(call, "function")
+      function ? Noir::TreeSitter.node_text(function, source) : nil
+    end
+
+    private def first_string_literal_text(node : LibTreeSitter::TSNode?, source : String) : String?
+      return unless node
+      return string_literal_text(node, source) if Noir::TreeSitter.node_type(node) == "string_literal"
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        if text = first_string_literal_text(child, source)
+          return text
+        end
+      end
+      nil
+    end
+
     private def string_literal_text(node : LibTreeSitter::TSNode, source : String) : String?
       return unless Noir::TreeSitter.node_type(node) == "string_literal"
       # tree-sitter-rust splits a literal with escapes into multiple children
@@ -658,10 +782,10 @@ module Analyzer::Rust
 
         name = Noir::TreeSitter.node_text(name_node, source)
         if scope.empty?
-          index[name] = body_node unless index.has_key?(name)
+          index[name] = node unless index.has_key?(name)
         else
           qualified_name = "#{scope.join("::")}::#{name}"
-          index[qualified_name] = body_node unless index.has_key?(qualified_name)
+          index[qualified_name] = node unless index.has_key?(qualified_name)
         end
       when "mod_item"
         name_node = Noir::TreeSitter.field(node, "name")
@@ -679,27 +803,69 @@ module Analyzer::Rust
       end
     end
 
-    private def callee_entries_for_handler(index : Hash(String, LibTreeSitter::TSNode),
-                                           source : String,
-                                           path : String,
-                                           handler_name : String) : Array(Noir::RustCalleeExtractor::Entry)
-      if body_node = function_body_for_handler(index, handler_name)
-        return Noir::RustCalleeExtractorTS.callees_in_body(body_node, source, path)
+    private def attach_handler_context(endpoint : Endpoint,
+                                       index : Hash(String, LibTreeSitter::TSNode),
+                                       source : String,
+                                       path : String,
+                                       handler_name : String,
+                                       include_callee : Bool,
+                                       handler_context_cache : Hash(String, HandlerContext))
+      cache_key = "#{path}\0#{handler_name}\0#{include_callee}"
+      if context = handler_context_cache[cache_key]?
+        attach_cached_handler_context(endpoint, context)
+        return
       end
 
-      external_handler_callees(handler_name, path)
+      if function = function_for_handler(index, handler_name)
+        context = handler_context_for_function(function, source, path, include_callee)
+        handler_context_cache[cache_key] = context
+        attach_cached_handler_context(endpoint, context)
+        return
+      end
+
+      attach_external_handler_context(endpoint, handler_name, path, include_callee, handler_context_cache)
     end
 
-    private def function_body_for_handler(index : Hash(String, LibTreeSitter::TSNode), handler_name : String) : LibTreeSitter::TSNode?
+    private def function_for_handler(index : Hash(String, LibTreeSitter::TSNode), handler_name : String) : LibTreeSitter::TSNode?
       return index[handler_name]? if index.has_key?(handler_name)
       return if handler_name.includes?("::")
 
       index[handler_name]?
     end
 
-    private def external_handler_callees(handler_name : String, current_path : String) : Array(Noir::RustCalleeExtractor::Entry)
+    private def callee_entries_for_function(function : LibTreeSitter::TSNode,
+                                            source : String,
+                                            path : String) : Array(Noir::RustCalleeExtractor::Entry)
+      body = Noir::TreeSitter.field(function, "body")
+      return [] of Noir::RustCalleeExtractor::Entry unless body
+
+      Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
+    end
+
+    private def handler_context_for_function(function : LibTreeSitter::TSNode,
+                                             source : String,
+                                             path : String,
+                                             include_callee : Bool) : HandlerContext
+      endpoint = Endpoint.new("", "GET")
+      extract_function_params(function, source, endpoint)
+      callees = include_callee ? callee_entries_for_function(function, source, path) : [] of Noir::RustCalleeExtractor::Entry
+      {params: endpoint.params, callees: callees}
+    end
+
+    private def attach_cached_handler_context(endpoint : Endpoint, context : HandlerContext)
+      context[:params].each do |param|
+        endpoint.push_param(param)
+      end
+      attach_rust_callees(endpoint, context[:callees]) unless context[:callees].empty?
+    end
+
+    private def attach_external_handler_context(endpoint : Endpoint,
+                                                handler_name : String,
+                                                current_path : String,
+                                                include_callee : Bool,
+                                                handler_context_cache : Hash(String, HandlerContext))
       parts = handler_name.split("::").reject(&.empty?)
-      return [] of Noir::RustCalleeExtractor::Entry if parts.size < 2
+      return if parts.size < 2
 
       function_name = parts.last
       module_parts = parts[0...-1]
@@ -707,18 +873,54 @@ module Analyzer::Rust
       candidate_module_paths(current_path, module_parts).each do |candidate|
         next unless File.exists?(candidate)
 
-        source = read_file_content(candidate)
-        entries = [] of Noir::RustCalleeExtractor::Entry
-        Noir::TreeSitter.parse_rust(source) do |root|
-          index = build_function_index(root, source)
-          if body_node = index[function_name]?
-            entries = Noir::RustCalleeExtractorTS.callees_in_body(body_node, source, candidate)
-          end
+        cache_key = "#{candidate}\0#{function_name}\0#{include_callee}"
+        if context = handler_context_cache[cache_key]?
+          attach_cached_handler_context(endpoint, context)
+          return
         end
-        return entries
+
+        if context = cached_external_handler_context(candidate, function_name, include_callee)
+          handler_context_cache[cache_key] = context
+          attach_cached_handler_context(endpoint, context)
+          return
+        end
+      end
+    end
+
+    private def cached_external_handler_context(candidate : String,
+                                                function_name : String,
+                                                include_callee : Bool) : HandlerContext?
+      cache_key = "#{candidate}\0#{function_name}\0#{include_callee}"
+      miss_key = "#{candidate}\0#{function_name}"
+
+      @external_handler_context_cache_mutex.synchronize do
+        return @external_handler_context_cache[cache_key]? if @external_handler_context_cache.has_key?(cache_key)
+        return if @external_handler_miss_cache.includes?(miss_key)
+
+        context = parse_external_handler_context(candidate, function_name, include_callee)
+        if context
+          @external_handler_context_cache[cache_key] = context
+        else
+          @external_handler_miss_cache.add(miss_key)
+        end
+        context
+      end
+    end
+
+    private def parse_external_handler_context(candidate : String,
+                                               function_name : String,
+                                               include_callee : Bool) : HandlerContext?
+      source = read_file_content(candidate)
+      context = nil.as(HandlerContext?)
+
+      Noir::TreeSitter.parse_rust(source) do |root|
+        index = build_function_index(root, source)
+        if function = index[function_name]?
+          context = handler_context_for_function(function, source, candidate, include_callee)
+        end
       end
 
-      [] of Noir::RustCalleeExtractor::Entry
+      context
     end
 
     private def candidate_module_paths(current_path : String, module_parts : Array(String)) : Array(String)
@@ -773,6 +975,7 @@ module Analyzer::Rust
     private def collect_utoipa_endpoints(root : LibTreeSitter::TSNode, source : String, path : String,
                                          test_regions : Array(Tuple(Int32, Int32)), include_callee : Bool,
                                          function_index : Hash(String, LibTreeSitter::TSNode),
+                                         handler_context_cache : Hash(String, HandlerContext),
                                          endpoints : Array(Endpoint))
       file_mod = primary_module(path)
       base = configured_base_for(path)
@@ -804,9 +1007,9 @@ module Analyzer::Rust
           urls.each do |url|
             details = Details.new(PathInfo.new(path, attr_row))
             endpoint = Endpoint.new(url, verb, details)
-            if include_callee && leaf
-              entries = callee_entries_for_handler(function_index, source, path, leaf)
-              attach_rust_callees(endpoint, entries)
+            extract_path_params(url, endpoint)
+            if leaf
+              attach_handler_context(endpoint, function_index, source, path, leaf, include_callee, handler_context_cache)
             end
             endpoints << endpoint
           end

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -27,6 +27,18 @@ module Analyzer::Rust
       "options" => "OPTIONS",
     }
 
+    @external_handler_callee_cache = {} of String => Array(Noir::RustCalleeExtractor::Entry)
+    @external_handler_miss_cache = Set(String).new
+    @external_handler_callee_cache_mutex = Mutex.new
+
+    def analyze
+      @external_handler_callee_cache_mutex.synchronize do
+        @external_handler_callee_cache.clear
+        @external_handler_miss_cache.clear
+      end
+      super
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       source = read_file_content(path)
@@ -59,8 +71,12 @@ module Analyzer::Rust
 
           if include_callee
             handler_name = find_handler_name(value, source)
-            if handler_name && (handler_fn = function_index[handler_name]?)
-              attach_handler_callees(handler_fn, source, path, endpoint)
+            if handler_name
+              if handler_fn = function_for_handler(function_index, handler_name)
+                attach_handler_callees(handler_fn, source, path, endpoint)
+              else
+                attach_external_handler_callees(handler_name, path, endpoint)
+              end
             end
           end
 
@@ -283,19 +299,23 @@ module Analyzer::Rust
           when "identifier"
             found = Noir::TreeSitter.node_text(arg, source)
           when "scoped_identifier"
-            found = Noir::TreeSitter.node_text(arg, source).split("::").last
+            found = Noir::TreeSitter.node_text(arg, source)
           when "generic_function"
             # `handlers::generic_handler::<u32>` — peel the turbofish.
             inner = Noir::TreeSitter.field(arg, "function")
             if inner
-              text = Noir::TreeSitter.node_text(inner, source)
-              found = text.split("::").last
+              found = Noir::TreeSitter.node_text(inner, source)
             end
           end
           break if found
         end
       end
       found
+    end
+
+    private def function_for_handler(index : Hash(String, LibTreeSitter::TSNode), handler_name : String) : LibTreeSitter::TSNode?
+      leaf = handler_name.split("::").last
+      index[handler_name]? || index[leaf]?
     end
 
     private def attach_handler_callees(function : LibTreeSitter::TSNode,
@@ -306,6 +326,101 @@ module Analyzer::Rust
       return unless body
       entries = Noir::RustCalleeExtractorTS.callees_in_body(body, source, path)
       attach_rust_callees(endpoint, entries)
+    end
+
+    private def attach_external_handler_callees(handler_name : String,
+                                                current_path : String,
+                                                endpoint : Endpoint)
+      parts = handler_name.split("::").reject(&.empty?)
+      return if parts.size < 2
+
+      function_name = parts.last
+      module_parts = parts[0...-1]
+
+      candidate_module_paths(current_path, module_parts).each do |candidate|
+        next unless File.exists?(candidate)
+
+        if entries = cached_external_handler_callees(candidate, function_name)
+          attach_rust_callees(endpoint, entries)
+          return
+        end
+      end
+    end
+
+    private def cached_external_handler_callees(candidate : String,
+                                                function_name : String) : Array(Noir::RustCalleeExtractor::Entry)?
+      cache_key = "#{candidate}\0#{function_name}"
+
+      @external_handler_callee_cache_mutex.synchronize do
+        return @external_handler_callee_cache[cache_key]? if @external_handler_callee_cache.has_key?(cache_key)
+        return if @external_handler_miss_cache.includes?(cache_key)
+
+        entries = parse_external_handler_callees(candidate, function_name)
+        if entries
+          @external_handler_callee_cache[cache_key] = entries
+        else
+          @external_handler_miss_cache.add(cache_key)
+        end
+        entries
+      end
+    end
+
+    private def parse_external_handler_callees(candidate : String,
+                                               function_name : String) : Array(Noir::RustCalleeExtractor::Entry)?
+      source = read_file_content(candidate)
+      entries = nil.as(Array(Noir::RustCalleeExtractor::Entry)?)
+
+      Noir::TreeSitter.parse_rust(source) do |root|
+        index = build_function_index(root, source)
+        if function = index[function_name]?
+          body = Noir::TreeSitter.field(function, "body")
+          entries = body ? Noir::RustCalleeExtractorTS.callees_in_body(body, source, candidate) : [] of Noir::RustCalleeExtractor::Entry
+        end
+      end
+
+      entries
+    end
+
+    private def candidate_module_paths(current_path : String, module_parts : Array(String)) : Array(String)
+      return [] of String if module_parts.empty?
+
+      base_dir, parts = module_base_dir(current_path, module_parts)
+      return [] of String if parts.empty?
+
+      module_path = parts.join("/")
+      [
+        File.join(base_dir, "#{module_path}.rs"),
+        File.join(base_dir, module_path, "mod.rs"),
+      ]
+    end
+
+    private def module_base_dir(current_path : String, module_parts : Array(String)) : Tuple(String, Array(String))
+      first = module_parts.first
+      rest = module_parts[1..]? || [] of String
+
+      case first
+      when "crate"
+        {crate_src_dir(current_path), rest}
+      when "self"
+        {current_module_dir(current_path), rest}
+      when "super"
+        {File.dirname(current_module_dir(current_path)), rest}
+      else
+        {current_module_dir(current_path), module_parts}
+      end
+    end
+
+    private def current_module_dir(current_path : String) : String
+      File.dirname(current_path)
+    end
+
+    private def crate_src_dir(current_path : String) : String
+      marker = "/src/"
+      if idx = current_path.rindex(marker)
+        current_path[0, idx + marker.size - 1]
+      else
+        File.dirname(current_path)
+      end
     end
 
     private def call_function_text(call : LibTreeSitter::TSNode, source : String) : String?


### PR DESCRIPTION
## Summary
- extract Axum handler context for path/query/form/json/header/cookie params and external module handlers
- cache Actix builder handler callees to avoid repeated body parsing
- resolve Warp scoped external handlers for callee extraction
- expand Rust outbound HTTP AI-context patterns
- include new external fixture modules for Axum and Warp callee coverage

## Tests
- `crystal spec spec/functional_test/testers/rust/warp_callees_spec.cr`
- `just build`
- `crystal spec spec/functional_test/testers/rust spec/unit_test/miniparser/rust_callee_extractor_ts_spec.cr spec/unit_test/ai_context/augmentor_spec.cr`
- `just test`
- `just check`
