### PR TITLE
perf(js): improve analyzer callee attribution

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_parse_server_callees/app.js
+++ b/spec/functional_test/fixtures/javascript/express_parse_server_callees/app.js
@@ -1,0 +1,12 @@
+const express = require('express')
+void express
+
+class PushAudiencesRouter extends PromiseRouter {
+  mountRoutes() {
+    this.route('GET', '/push_audiences', req => listAudiences(req))
+    this.route('POST', '/push_audiences', req => {
+      const payload = parseAudience(req)
+      return AudienceService.create(payload)
+    })
+  }
+}

--- a/spec/functional_test/fixtures/javascript/fastify_route_config/app.js
+++ b/spec/functional_test/fixtures/javascript/fastify_route_config/app.js
@@ -5,7 +5,7 @@ fastify.route({
   method: 'GET',
   url: '/single',
   handler: async (request, reply) => {
-    return { ok: true }
+    return reply.send(statusService.single())
   }
 })
 
@@ -14,7 +14,7 @@ fastify.route({
   method: ['GET', 'POST'],
   url: '/items/:id',
   handler: async (request, reply) => {
-    return { id: request.params.id }
+    return reply.send(buildItem(request.params.id))
   }
 })
 
@@ -25,7 +25,7 @@ fastify.route({
   url: '/users/:userId',
   handler: async (request, reply) => {
     const email = request.body.email
-    return { ok: true }
+    return reply.send(UserService.update(email))
   }
 })
 

--- a/spec/functional_test/fixtures/javascript/hono_chained_middleware/app.ts
+++ b/spec/functional_test/fixtures/javascript/hono_chained_middleware/app.ts
@@ -1,0 +1,35 @@
+import { Hono } from 'hono'
+
+const auth = {
+  local() {
+    return async (c, next) => next()
+  },
+  remote() {
+    return async (c, next) => next()
+  },
+  session(c) {
+    return { user_id: c.req.header('x-user') }
+  },
+}
+
+const todoService = (env, userId) => ({
+  get() {
+    return []
+  },
+  add(text) {
+    return [{ text, userId }]
+  },
+})
+
+export const TodoAPI = new Hono<{ Bindings: Env }>()
+  .get('/todos', auth.local(), async (c) => {
+    const { user_id } = auth.session(c)
+    const todos = await todoService(c.env, user_id).get()
+    return c.json({ todos })
+  })
+  .post('/todos', auth.remote(), async (c) => {
+    const body = await c.req.json()
+    const { user_id } = auth.session(c)
+    const todos = await todoService(c.env, user_id).add(body.todoText)
+    return c.json({ todos })
+  })

--- a/spec/functional_test/fixtures/javascript/hono_on_array/app.ts
+++ b/spec/functional_test/fixtures/javascript/hono_on_array/app.ts
@@ -8,13 +8,13 @@ app.on('GET', '/single', (c) => c.text('ok'))
 // Array-method app.on (new coverage)
 app.on(['GET', 'POST'], '/items/:id', (c) => {
   const id = c.req.param('id')
-  return c.json({ id })
+  return c.json(itemService.lookup(id))
 })
 
 // Lower-case methods inside array should normalize
 app.on(['put', 'patch'], '/users/:userId', (c) => {
   const userId = c.req.param('userId')
-  return c.json({ userId })
+  return c.json(UserService.update(userId))
 })
 
 export default app

--- a/spec/functional_test/fixtures/javascript/koa/routes/request_catalog.js
+++ b/spec/functional_test/fixtures/javascript/koa/routes/request_catalog.js
@@ -1,0 +1,12 @@
+module.exports = [
+  {
+    method: 'GET',
+    path: '/not-a-route',
+    timeout: 1000,
+  },
+  {
+    method: 'POST',
+    path: '/webhook-template',
+    description: 'outbound request metadata',
+  },
+];

--- a/spec/functional_test/fixtures/javascript/koa/routes/strapi_style.js
+++ b/spec/functional_test/fixtures/javascript/koa/routes/strapi_style.js
@@ -22,5 +22,15 @@ module.exports = (strapi) => {
             path: '/strapi/items/:id',
             handler: 'item.update',
         },
+        {
+            method: 'DELETE',
+            path: '/strapi/items/:id',
+            config: {
+                auth: {
+                    scope: ['admin::items.delete'],
+                },
+            },
+            handler: 'item.delete',
+        },
     ];
 };

--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/docs-string.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/docs-string.tsx
@@ -1,0 +1,5 @@
+const docs = `
+  Use createFileRoute('/docs-only')({ component: DocsOnly }) in app route files.
+`
+
+export const message = docs.trim()

--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/sample.test.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/sample.test.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/test-only')({
+  component: TestOnlyComponent,
+})
+
+function TestOnlyComponent() {
+  return null
+}

--- a/spec/functional_test/fixtures/typescript/tanstack_router/tests/snapshot.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/tests/snapshot.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/snapshot-only')({
+  component: SnapshotOnlyComponent,
+})
+
+function SnapshotOnlyComponent() {
+  return null
+}

--- a/spec/functional_test/fixtures/typescript/trpc/pages/api/trpc/[trpc].ts
+++ b/spec/functional_test/fixtures/typescript/trpc/pages/api/trpc/[trpc].ts
@@ -3,5 +3,6 @@ import { appRouter } from '../../../server/root'
 
 export default createNextApiHandler({
   router: appRouter,
+  endpoint : '/custom-trpc',
   createContext: () => ({}),
 })

--- a/spec/functional_test/fixtures/typescript/trpc/server/docs-string.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/docs-string.ts
@@ -1,0 +1,5 @@
+export const docs = `
+  export const docsOnlyRouter = router({
+    hidden: publicProcedure.query(() => HiddenService.run()),
+  })
+`

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/sample.test.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/sample.test.ts
@@ -1,0 +1,5 @@
+import { router, publicProcedure } from '../trpc'
+
+export const testOnlyRouter = router({
+  debug: publicProcedure.query(() => DebugService.status()),
+})

--- a/spec/functional_test/testers/javascript/astro_spec.cr
+++ b/spec/functional_test/testers/javascript/astro_spec.cr
@@ -33,3 +33,31 @@ FunctionalTester.new("fixtures/javascript/astro/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+describe "Astro route source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "uses exported API handler lines" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/astro/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    users_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users" }
+    users_get.details.code_paths.first.line.should eq(3)
+
+    users_post = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/users" }
+    users_post.details.code_paths.first.line.should eq(9)
+
+    user_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users/{id}" }
+    user_get.details.code_paths.first.line.should eq(3)
+
+    user_put = app.endpoints.find! { |ep| ep.method == "PUT" && ep.url == "/api/users/{id}" }
+    user_put.details.code_paths.first.line.should eq(7)
+  end
+end

--- a/spec/functional_test/testers/javascript/express_parse_server_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/express_parse_server_callees_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/push_audiences", "GET").tap do |ep|
+    ep.push_callee(Callee.new("listAudiences", line: 6))
+  end,
+  Endpoint.new("/push_audiences", "POST").tap do |ep|
+    ep.push_callee(Callee.new("parseAudience", line: 8))
+    ep.push_callee(Callee.new("AudienceService.create", line: 9))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/express_parse_server_callees/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/fastify_route_config_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_route_config_callees_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/single", "GET").tap do |ep|
+    ep.push_callee(Callee.new("reply.send", line: 8))
+    ep.push_callee(Callee.new("statusService.single", line: 8))
+  end,
+  Endpoint.new("/items/:id", "GET").tap do |ep|
+    ep.push_callee(Callee.new("reply.send", line: 17))
+    ep.push_callee(Callee.new("buildItem", line: 17))
+  end,
+  Endpoint.new("/items/:id", "POST").tap do |ep|
+    ep.push_callee(Callee.new("reply.send", line: 17))
+    ep.push_callee(Callee.new("buildItem", line: 17))
+  end,
+  Endpoint.new("/users/:userId", "PUT").tap do |ep|
+    ep.push_callee(Callee.new("reply.send", line: 28))
+    ep.push_callee(Callee.new("UserService.update", line: 28))
+  end,
+  Endpoint.new("/users/:userId", "PATCH").tap do |ep|
+    ep.push_callee(Callee.new("reply.send", line: 28))
+    ep.push_callee(Callee.new("UserService.update", line: 28))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/fastify_route_config/", {
+  :techs => 1,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/hono_chained_middleware_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_chained_middleware_callees_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/todos", "GET").tap do |ep|
+    ep.push_callee(Callee.new("auth.session", line: 26))
+    ep.push_callee(Callee.new("todoService().get", line: 27))
+    ep.push_callee(Callee.new("c.json", line: 28))
+  end,
+  Endpoint.new("/todos", "POST").tap do |ep|
+    ep.push_callee(Callee.new("c.req.json", line: 31))
+    ep.push_callee(Callee.new("auth.session", line: 32))
+    ep.push_callee(Callee.new("todoService().add", line: 33))
+    ep.push_callee(Callee.new("c.json", line: 34))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/hono_chained_middleware/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/hono_on_array_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_on_array_callees_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/items/:id", "GET").tap do |ep|
+    ep.push_callee(Callee.new("c.req.param", line: 10))
+    ep.push_callee(Callee.new("c.json", line: 11))
+    ep.push_callee(Callee.new("itemService.lookup", line: 11))
+  end,
+  Endpoint.new("/items/:id", "POST").tap do |ep|
+    ep.push_callee(Callee.new("c.req.param", line: 10))
+    ep.push_callee(Callee.new("c.json", line: 11))
+    ep.push_callee(Callee.new("itemService.lookup", line: 11))
+  end,
+  Endpoint.new("/users/:userId", "PUT").tap do |ep|
+    ep.push_callee(Callee.new("c.req.param", line: 16))
+    ep.push_callee(Callee.new("c.json", line: 17))
+    ep.push_callee(Callee.new("UserService.update", line: 17))
+  end,
+  Endpoint.new("/users/:userId", "PATCH").tap do |ep|
+    ep.push_callee(Callee.new("c.req.param", line: 16))
+    ep.push_callee(Callee.new("c.json", line: 17))
+    ep.push_callee(Callee.new("UserService.update", line: 17))
+  end,
+]
+
+FunctionalTester.new("fixtures/javascript/hono_on_array/", {
+  :techs => 1,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/javascript/js_ai_context_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/js_ai_context_callees_spec.cr
@@ -1,0 +1,82 @@
+require "../../func_spec.cr"
+
+describe "--ai-context JS framework callee coverage" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "populates Fastify callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/fastify_callees/")
+
+    context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/:id" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("parseUser")
+    context.callees.map(&.name).should contain("serviceFactory().save")
+  end
+
+  it "populates Express Parse Server callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/express_parse_server_callees/")
+
+    context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/push_audiences" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("parseAudience")
+    context.callees.map(&.name).should contain("AudienceService.create")
+  end
+
+  it "populates Fastify route-config callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/fastify_route_config/")
+
+    context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/single" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("reply.send")
+    context.callees.map(&.name).should contain("statusService.single")
+  end
+
+  it "populates Hono callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/hono_callees/")
+
+    context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/:id" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("parseUser")
+    context.callees.map(&.name).should contain("serviceFactory().save")
+  end
+
+  it "populates Hono app.on array callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/hono_on_array/")
+
+    context = endpoints.find! { |ep| ep.method == "GET" && ep.url == "/items/:id" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("c.json")
+    context.callees.map(&.name).should contain("itemService.lookup")
+  end
+
+  it "populates Hono chained middleware callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/hono_chained_middleware/")
+
+    context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/todos" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("c.req.json")
+    context.callees.map(&.name).should contain("todoService().add")
+  end
+
+  it "populates Koa callees without --include-callee" do
+    endpoints = analyze_js_fixture_with_ai_context("fixtures/javascript/koa_callees/")
+
+    context = endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/:id" }.ai_context
+    context = context.should_not be_nil
+    context.callees.map(&.name).should contain("parseBody")
+    context.callees.map(&.name).should contain("serviceFactory().save")
+  end
+end
+
+private def analyze_js_fixture_with_ai_context(fixture_path : String) : Array(Endpoint)
+  options = ConfigInitializer.new.default_options
+  options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/#{fixture_path}")])
+  options["ai_context"] = YAML::Any.new(true)
+  options["nolog"] = YAML::Any.new(true)
+
+  app = NoirRunner.new(options)
+  app.detect
+  app.analyze
+  app.endpoints
+end

--- a/spec/functional_test/testers/javascript/koa_source_lines_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_source_lines_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+describe "Koa route source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps the JSRouteExtractor line number for parser endpoints" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/koa_callees/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/:id" }
+    route_path = endpoint.details.code_paths.first?
+    route_path = route_path.should_not be_nil
+    route_path.line.should eq(7)
+  end
+end

--- a/spec/functional_test/testers/javascript/koa_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_spec.cr
@@ -29,6 +29,9 @@ expected_endpoints = [
   Endpoint.new("/strapi/items/:id", "PUT", [
     Param.new("id", "", "path"),
   ]),
+  Endpoint.new("/strapi/items/:id", "DELETE", [
+    Param.new("id", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/javascript/koa/", {

--- a/spec/functional_test/testers/javascript/nextjs_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/nextjs_callees_spec.cr
@@ -74,3 +74,28 @@ FunctionalTester.new("fixtures/javascript/nextjs_callees/", {
 ], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
+
+describe "Next.js callee source attribution" do
+  it "uses aliased route handlers and server-action export lines" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs_callees/")])
+    options["include_callee"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    report = app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/api/reports" }
+    report.details.code_paths.first.line.should eq(3)
+
+    post = app.endpoints.find! { |endpoint| endpoint.method == "POST" && endpoint.url == "/api/orders/{id}" }
+    post.details.code_paths.first.line.should eq(13)
+
+    create_action = app.endpoints.find! { |endpoint| endpoint.method == "POST" && endpoint.url == "/createUser" }
+    create_action.details.code_paths.first.line.should eq(3)
+
+    delete_action = app.endpoints.find! { |endpoint| endpoint.method == "POST" && endpoint.url == "/deleteUser" }
+    delete_action.details.code_paths.first.line.should eq(12)
+  end
+end

--- a/spec/functional_test/testers/javascript/nextjs_spec.cr
+++ b/spec/functional_test/testers/javascript/nextjs_spec.cr
@@ -194,3 +194,30 @@ describe "Next.js App Router method-local params" do
     post.params.any? { |param| param.name == "username" && param.param_type == "json" }.should be_true
   end
 end
+
+describe "Next.js source attribution" do
+  it "uses handler and server-action lines instead of the file start" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/nextjs/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    pages = app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/api/users" }
+    pages.details.code_paths.first.line.should eq(3)
+
+    app_get = app.endpoints.find! { |endpoint| endpoint.method == "GET" && endpoint.url == "/api/products/{id}" }
+    app_get.details.code_paths.first.line.should eq(8)
+
+    app_delete = app.endpoints.find! { |endpoint| endpoint.method == "DELETE" && endpoint.url == "/api/products/{id}" }
+    app_delete.details.code_paths.first.line.should eq(20)
+
+    create_action = app.endpoints.find! { |endpoint| endpoint.method == "POST" && endpoint.url == "/createUser" }
+    create_action.details.code_paths.first.line.should eq(3)
+
+    delete_action = app.endpoints.find! { |endpoint| endpoint.method == "POST" && endpoint.url == "/deleteUser" }
+    delete_action.details.code_paths.first.line.should eq(9)
+  end
+end

--- a/spec/functional_test/testers/javascript/remix_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/remix_callees_spec.cr
@@ -53,3 +53,32 @@ FunctionalTester.new("fixtures/javascript/remix_callees/", {
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
+
+describe "Remix callee source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "uses direct and aliased loader/action handler lines" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/remix_callees/")])
+    options["include_callee"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    api_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users" }
+    api_get.details.code_paths.first.line.should eq(3)
+
+    api_post = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/users" }
+    api_post.details.code_paths.first.line.should eq(12)
+
+    user_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/users/{id}" }
+    user_get.details.code_paths.first.line.should eq(3)
+
+    user_post = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/{id}" }
+    user_post.details.code_paths.first.line.should eq(8)
+  end
+end

--- a/spec/functional_test/testers/javascript/remix_spec.cr
+++ b/spec/functional_test/testers/javascript/remix_spec.cr
@@ -27,3 +27,31 @@ FunctionalTester.new("fixtures/javascript/remix/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+describe "Remix route source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "uses loader and action handler lines" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/remix/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    api_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users" }
+    api_get.details.code_paths.first.line.should eq(3)
+
+    api_post = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/users" }
+    api_post.details.code_paths.first.line.should eq(7)
+
+    user_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/users/{id}" }
+    user_get.details.code_paths.first.line.should eq(3)
+
+    user_delete = app.endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/users/{id}" }
+    user_delete.details.code_paths.first.line.should eq(7)
+  end
+end

--- a/spec/functional_test/testers/javascript/restify_source_lines_spec.cr
+++ b/spec/functional_test/testers/javascript/restify_source_lines_spec.cr
@@ -1,0 +1,22 @@
+require "../../func_spec.cr"
+
+describe "Restify route source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "keeps the JSRouteExtractor line number for parser endpoints" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/restify_callees/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/users/:id" }
+    route_path = endpoint.details.code_paths.first?
+    route_path = route_path.should_not be_nil
+    route_path.line.should eq(7)
+  end
+end

--- a/spec/functional_test/testers/javascript/sveltekit_callees_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_callees_spec.cr
@@ -38,3 +38,32 @@ FunctionalTester.new("fixtures/javascript/sveltekit_callees/", {
 ], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests
+
+describe "SvelteKit callee source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "uses direct and aliased exported API handler lines" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/sveltekit_callees/")])
+    options["include_callee"] = YAML::Any.new(true)
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    list = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users" }
+    list.details.code_paths.first.line.should eq(3)
+
+    create = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/users" }
+    create.details.code_paths.first.line.should eq(11)
+
+    update = app.endpoints.find! { |ep| ep.method == "PUT" && ep.url == "/api/users/{id}" }
+    update.details.code_paths.first.line.should eq(3)
+
+    delete = app.endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/api/users/{id}" }
+    delete.details.code_paths.first.line.should eq(11)
+  end
+end

--- a/spec/functional_test/testers/javascript/sveltekit_spec.cr
+++ b/spec/functional_test/testers/javascript/sveltekit_spec.cr
@@ -35,3 +35,31 @@ FunctionalTester.new("fixtures/javascript/sveltekit/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+describe "SvelteKit route source attribution" do
+  before_each do
+    CodeLocator.instance.clear_all
+  end
+
+  it "uses exported API handler lines" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/javascript/sveltekit/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    users_get = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/api/users" }
+    users_get.details.code_paths.first.line.should eq(3)
+
+    users_post = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/api/users" }
+    users_post.details.code_paths.first.line.should eq(9)
+
+    user_put = app.endpoints.find! { |ep| ep.method == "PUT" && ep.url == "/api/users/{id}" }
+    user_put.details.code_paths.first.line.should eq(5)
+
+    user_delete = app.endpoints.find! { |ep| ep.method == "DELETE" && ep.url == "/api/users/{id}" }
+    user_delete.details.code_paths.first.line.should eq(10)
+  end
+end

--- a/spec/functional_test/testers/typescript/tanstack_router_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_spec.cr
@@ -47,3 +47,23 @@ FunctionalTester.new("fixtures/typescript/tanstack_router/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+describe "TanStack Router source attribution" do
+  it "keeps createFileRoute line numbers and skips test/string fixtures" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/tanstack_router/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    posts = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/posts" }
+    posts.details.code_paths.first.line.should eq(4)
+
+    urls = app.endpoints.map(&.url)
+    urls.should_not contain("/test-only")
+    urls.should_not contain("/snapshot-only")
+    urls.should_not contain("/docs-only")
+  end
+end

--- a/spec/functional_test/testers/typescript/trpc_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_callees_spec.cr
@@ -1,13 +1,13 @@
 require "../../func_spec.cr"
 
-list = Endpoint.new("/api/trpc/user.list", "GET")
+list = Endpoint.new("/custom-trpc/user.list", "GET")
 list.push_callee(Callee.new("UserService.list", line: 5))
 
-create = Endpoint.new("/api/trpc/user.create", "POST")
+create = Endpoint.new("/custom-trpc/user.create", "POST")
 create.push_callee(Callee.new("AuditLog.write", line: 12))
 create.push_callee(Callee.new("UserService.create", line: 13))
 
-feed = Endpoint.new("/api/trpc/post.liveFeed", "SUBSCRIBE")
+feed = Endpoint.new("/custom-trpc/post.liveFeed", "SUBSCRIBE")
 feed.push_callee(Callee.new("FeedService.live", line: 10))
 
 FunctionalTester.new("fixtures/typescript/trpc/", {

--- a/spec/functional_test/testers/typescript/trpc_spec.cr
+++ b/spec/functional_test/testers/typescript/trpc_spec.cr
@@ -1,27 +1,59 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
-  Endpoint.new("/api/trpc/user.list", "GET", [] of Param),
-  Endpoint.new("/api/trpc/user.byId", "GET", [
+  Endpoint.new("/custom-trpc/user.list", "GET", [] of Param),
+  Endpoint.new("/custom-trpc/user.byId", "GET", [
     Param.new("id", "", "query"),
   ]),
-  Endpoint.new("/api/trpc/user.create", "POST", [
+  Endpoint.new("/custom-trpc/user.create", "POST", [
     Param.new("name", "", "body"),
     Param.new("email", "", "body"),
   ]),
-  Endpoint.new("/api/trpc/post.list", "GET", [] of Param),
-  Endpoint.new("/api/trpc/post.byId", "GET", [
+  Endpoint.new("/custom-trpc/post.list", "GET", [] of Param),
+  Endpoint.new("/custom-trpc/post.byId", "GET", [
     Param.new("postId", "", "query"),
   ]),
-  Endpoint.new("/api/trpc/post.liveFeed", "SUBSCRIBE", [] of Param),
-  Endpoint.new("/api/trpc/account.me", "GET", [] of Param),
-  Endpoint.new("/api/trpc/account.update", "POST", [
+  Endpoint.new("/custom-trpc/post.liveFeed", "SUBSCRIBE", [] of Param),
+  Endpoint.new("/custom-trpc/account.me", "GET", [] of Param),
+  Endpoint.new("/custom-trpc/account.update", "POST", [
     Param.new("displayName", "", "body"),
   ]),
-  Endpoint.new("/api/trpc/health", "GET", [] of Param),
+  Endpoint.new("/custom-trpc/health", "GET", [] of Param),
 ]
 
 FunctionalTester.new("fixtures/typescript/trpc/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
 }, expected_endpoints).perform_tests
+
+describe "tRPC source filtering" do
+  it "skips test route fixtures and route-like docs strings" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/trpc/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    urls = app.endpoints.map(&.url)
+    urls.should_not contain("/custom-trpc/debug")
+    urls.should_not contain("/custom-trpc/hidden")
+  end
+
+  it "attributes nested procedures to their procedure key line" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/typescript/trpc/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    by_id = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/custom-trpc/post.byId" }
+    by_id.details.code_paths.first.line.should eq(6)
+
+    live_feed = app.endpoints.find! { |ep| ep.method == "SUBSCRIBE" && ep.url == "/custom-trpc/post.liveFeed" }
+    live_feed.details.code_paths.first.line.should eq(9)
+  end
+end

--- a/spec/unit_test/miniparser/js_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_callee_extractor_spec.cr
@@ -19,6 +19,24 @@ describe Noir::JSCalleeExtractor do
     ])
   end
 
+  it "keys multiline chained route callees by the call start line" do
+    source = <<-JS
+      app
+        .get('/split', async (req, res) => {
+          return res.json(await loadSplit())
+        })
+      JS
+
+    callees = Noir::JSCalleeExtractor.callees_for_routes(source, "app.js")
+    route_callees = callees[Noir::JSCalleeExtractor.route_key("GET", "/split", 1)]
+    route_callees.map(&.[0]).should eq([
+      "res.json",
+      "loadSplit",
+    ])
+    method_line_callees = callees[Noir::JSCalleeExtractor.route_key("GET", "/split", 2)]
+    method_line_callees.map(&.[0]).should eq(route_callees.map(&.[0]))
+  end
+
   it "extracts callees from a standalone function body with adjusted lines" do
     body = <<-JS
 
@@ -71,6 +89,9 @@ describe Noir::JSCalleeExtractor do
       {"json", 7},
       {"deleteUser", 7},
     ])
+
+    Noir::JSCalleeExtractor.exported_function_line(source, "GET").should eq(1)
+    Noir::JSCalleeExtractor.exported_function_line(source, "DELETE").should eq(7)
   end
 
   it "extracts callees from typed exported arrow handlers" do

--- a/src/analyzer/analyzers/javascript/astro.cr
+++ b/src/analyzer/analyzers/javascript/astro.cr
@@ -87,16 +87,16 @@ module Analyzer::Javascript
       methods = detect_api_methods(content)
       mutex.synchronize do
         methods.each do |verb|
-          endpoint = build_endpoint(url, verb, path)
+          endpoint = build_endpoint(url, verb, path, api_method_line(content, verb) || 1)
           attach_exported_callees(endpoint, content, path, verb) if callees_needed?
           result << endpoint
         end
       end
     end
 
-    private def build_endpoint(url : String, verb : String, path : String) : Endpoint
+    private def build_endpoint(url : String, verb : String, path : String, line : Int32 = 1) : Endpoint
       endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, 1))
+      endpoint.details = Details.new(PathInfo.new(path, line))
       url.scan(/\{(\w+)\}/) do |match|
         endpoint.push_param(Param.new(match[1], "", "path"))
       end
@@ -163,6 +163,25 @@ module Analyzer::Javascript
         end
       end
       explicit.empty? ? FALLBACK_API_METHODS : explicit
+    end
+
+    private def api_method_line(content : String, verb : String) : Int32?
+      if match = content.match(EXPORT_FUNCTION_RES[verb])
+        return line_for_match(content, match)
+      end
+
+      if match = content.match(EXPORT_CONST_RES[verb])
+        return line_for_match(content, match)
+      end
+
+      if content.includes?("export {") && content.includes?(verb)
+        Noir::JSCalleeExtractor.exported_function_line(content, verb)
+      end
+    end
+
+    private def line_for_match(content : String, match : Regex::MatchData) : Int32
+      start = match.begin(0) || 0
+      content.to_slice[0, start].count('\n'.ord.to_u8) + 1
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -16,7 +16,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # Phase 1: Pre-scan to build router mount map
       scan_for_router_mounts
@@ -54,7 +54,7 @@ module Analyzer::Javascript
           # parse-community/parse-server alone parks ~51 routes in
           # `src/Routers/*.js` (AudiencesRouter, GlobalConfigRouter,
           # UsersRouter, ...) via this pattern.
-          extract_parse_server_routes(path, content, result)
+          extract_parse_server_routes(path, content, result, include_callee)
         rescue e
           logger.debug "Parser failed for #{path}: #{e.message}, falling back to regex"
 
@@ -77,7 +77,7 @@ module Analyzer::Javascript
     # literal so non-PromiseRouter `this.route(...)` shapes (e.g.
     # routing-controllers' `this.route` builder) don't accidentally
     # fire — the latter takes no quoted-method first argument.
-    private def extract_parse_server_routes(path : String, content : String, result : Array(Endpoint))
+    private def extract_parse_server_routes(path : String, content : String, result : Array(Endpoint), include_callee : Bool)
       # Cheap guard: the Parse Server idiom is literally `this.route(`.
       # Skip the full-content regex scan on every other file so a large
       # frontend tree doesn't pay it once per JS/TS file (issue #1903).
@@ -97,15 +97,133 @@ module Analyzer::Javascript
         next if seen.includes?(key)
         seen << key
 
-        line = m.begin ? content[0...m.begin].count('\n') + 1 : 1
+        match_start = m.begin(0) || m.begin || 0
+        call_start = content.index("this.route", match_start) || match_start
+        line = content[0...call_start].count('\n') + 1
         details = Details.new(PathInfo.new(path, line))
         endpoint = Endpoint.new(url, method, details)
         url.scan(/:(\w+)/) do |pm|
           next unless pm.size > 0
           endpoint.push_param(Param.new(pm[1], "", "path"))
         end
+        attach_js_callees(endpoint, parse_server_route_callees(content, path, call_start)) if include_callee
         result << endpoint
       end
+    end
+
+    private def parse_server_route_callees(content : String, path : String, call_start : Int32) : Array(Noir::JSCalleeExtractor::Entry)
+      paren_open = content.index("(", call_start)
+      return [] of Noir::JSCalleeExtractor::Entry unless paren_open
+
+      paren_close = Noir::JSRouteExtractor.find_matching_paren(content, paren_open)
+      return [] of Noir::JSCalleeExtractor::Entry unless paren_close
+
+      args = split_top_level_args(content, paren_open + 1, paren_close)
+      return [] of Noir::JSCalleeExtractor::Entry if args.size < 3
+
+      callees = [] of Noir::JSCalleeExtractor::Entry
+      args[2..].each do |handler_source, handler_start|
+        callees.concat(handler_callees(handler_source, handler_start, content, path))
+      end
+      callees
+    end
+
+    private def handler_callees(handler_source : String, handler_start : Int32, content : String, path : String) : Array(Noir::JSCalleeExtractor::Entry)
+      if arrow_idx = handler_source.index("=>")
+        body_start = skip_whitespace(content, handler_start + arrow_idx + 2)
+        return [] of Noir::JSCalleeExtractor::Entry if body_start >= content.size
+
+        if content[body_start]? == '{'
+          return block_handler_callees(content, path, body_start)
+        end
+
+        body = content[body_start...(handler_start + handler_source.size)].strip
+        return [] of Noir::JSCalleeExtractor::Entry if body.empty?
+
+        return Noir::JSCalleeExtractor.callees_for_function_body(body, path, line_for_pos(content, body_start), language: javascript_source_language(path))
+      end
+
+      function_idx = handler_source.index(/\bfunction\b/)
+      return [] of Noir::JSCalleeExtractor::Entry unless function_idx
+
+      open_brace = content.index("{", handler_start + function_idx)
+      return [] of Noir::JSCalleeExtractor::Entry unless open_brace
+
+      block_handler_callees(content, path, open_brace)
+    end
+
+    private def block_handler_callees(content : String, path : String, open_brace : Int32) : Array(Noir::JSCalleeExtractor::Entry)
+      close_brace = Noir::JSRouteExtractor.find_matching_brace(content, open_brace)
+      return [] of Noir::JSCalleeExtractor::Entry unless close_brace
+
+      body = content[(open_brace + 1)...close_brace]
+      Noir::JSCalleeExtractor.callees_for_function_body(body, path, line_for_pos(content, open_brace), language: javascript_source_language(path))
+    end
+
+    private def split_top_level_args(content : String, start_pos : Int32, end_pos : Int32) : Array(Tuple(String, Int32))
+      args = [] of Tuple(String, Int32)
+      arg_start = start_pos
+      depth = 0
+      quote : Char? = nil
+      escaped = false
+      i = start_pos
+
+      while i < end_pos
+        char = content[i]
+
+        if quote
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
+          end
+          i += 1
+          next
+        end
+
+        case char
+        when '\'', '"', '`'
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+        when ','
+          if depth == 0
+            args << normalized_arg(content, arg_start, i)
+            arg_start = i + 1
+          end
+        end
+
+        i += 1
+      end
+
+      args << normalized_arg(content, arg_start, end_pos)
+      args
+    end
+
+    private def normalized_arg(content : String, start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
+      start_idx = skip_whitespace(content, start_pos)
+      stop_idx = end_pos
+      while stop_idx > start_idx && content[stop_idx - 1].whitespace?
+        stop_idx -= 1
+      end
+
+      {content[start_idx...stop_idx], start_idx}
+    end
+
+    private def skip_whitespace(content : String, pos : Int32) : Int32
+      i = pos
+      while i < content.size && content[i].whitespace?
+        i += 1
+      end
+      i
+    end
+
+    private def line_for_pos(content : String, pos : Int32) : Int32
+      content[0...pos].count('\n') + 1
     end
 
     # Process static directories and add endpoints for each file

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -1,4 +1,5 @@
 require "../../engines/javascript_engine"
+require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
@@ -6,7 +7,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
-      include_callee = any_to_bool(@options["include_callee"])
+      include_callee = callees_needed?
 
       parallel_file_scan do |path|
         begin
@@ -42,7 +43,7 @@ module Analyzer::Javascript
           # never a real config — issue #1903).
           unless Noir::JSRouteExtractor.test_stub_only?(path, content) ||
                  Noir::JSRouteExtractor.minified_content?(content)
-            extract_route_configs(path, content, result)
+            extract_route_configs(path, content, result, include_callee)
           end
 
           collect_static_paths(path, content, static_dirs, :fastify)
@@ -69,7 +70,7 @@ module Analyzer::Javascript
     # shared parser misses: the config object may span multiple lines,
     # and `methods` may be an array. For each block, decode the method
     # (or methods) and the url/path and emit one endpoint per method.
-    private def extract_route_configs(path : String, content : String, result : Array(Endpoint))
+    private def extract_route_configs(path : String, content : String, result : Array(Endpoint), include_callee : Bool)
       http_methods = %w[get post put delete patch options head]
 
       # Match the call site `instance.route(` and walk the balanced
@@ -127,6 +128,7 @@ module Analyzer::Javascript
           p = line_to_param(handler_line)
           body_params << p if !p.name.empty? && !body_params.any? { |bp| bp.name == p.name && bp.param_type == p.param_type }
         end
+        route_callees = include_callee ? route_config_callees(config, path, line_no) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |http_method|
           method_up = http_method.upcase
@@ -144,10 +146,113 @@ module Analyzer::Javascript
           body_params.each do |bp|
             endpoint.push_param(bp) unless endpoint.params.any? { |p| p.name == bp.name && p.param_type == bp.param_type }
           end
+          attach_js_callees(endpoint, route_callees)
 
           result << endpoint
         end
       end
+    end
+
+    private def route_config_callees(config : String, path : String, start_line : Int32) : Array(Noir::JSCalleeExtractor::Entry)
+      if handler = route_config_handler_body(config, start_line)
+        body, body_line = handler
+        Noir::JSCalleeExtractor.callees_for_function_body(body, path, body_line, language: javascript_source_language(path))
+      else
+        [] of Noir::JSCalleeExtractor::Entry
+      end
+    end
+
+    private def route_config_handler_body(config : String, start_line : Int32) : Tuple(String, Int32)?
+      if match = config.match(/(?:^|[,{]\s*)handler\s*:/m)
+        value_start = skip_whitespace(config, match.end(0) || 0)
+        arrow_idx = config.index("=>", value_start)
+        function_idx = config.index(/\bfunction\b/, value_start)
+
+        if function_idx && (!arrow_idx || function_idx < arrow_idx)
+          if open_brace = config.index("{", function_idx)
+            return block_body(config, open_brace, start_line)
+          end
+        elsif arrow_idx
+          body_start = skip_whitespace(config, arrow_idx + 2)
+          if config[body_start]? == '{'
+            return block_body(config, body_start, start_line)
+          end
+
+          body_end = route_config_value_end(config, body_start)
+          body = config[body_start...body_end].strip
+          return {body, start_line + config[0...body_start].count('\n')} unless body.empty?
+        end
+      end
+
+      if match = config.match(/(?:^|[,{]\s*)handler\s*\(/m)
+        open_paren = config.index("(", match.begin(0) || 0)
+        return unless open_paren
+
+        close_paren = Noir::JSRouteExtractor.find_matching_paren(config, open_paren)
+        return unless close_paren
+
+        open_brace = skip_whitespace(config, close_paren + 1)
+        return unless config[open_brace]? == '{'
+
+        block_body(config, open_brace, start_line)
+      end
+    end
+
+    private def block_body(config : String, open_brace : Int32, start_line : Int32) : Tuple(String, Int32)?
+      close_brace = Noir::JSRouteExtractor.find_matching_brace(config, open_brace)
+      return unless close_brace
+
+      body = config[(open_brace + 1)...close_brace]
+      {body, start_line + config[0...open_brace].count('\n')}
+    end
+
+    private def skip_whitespace(content : String, pos : Int32) : Int32
+      i = pos
+      while i < content.size && content[i].whitespace?
+        i += 1
+      end
+      i
+    end
+
+    private def route_config_value_end(config : String, start : Int32) : Int32
+      depth = 0
+      quote : Char? = nil
+      escaped = false
+      i = start
+
+      while i < config.size
+        char = config[i]
+
+        if quote
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
+          end
+          i += 1
+          next
+        end
+
+        case char
+        when '\'', '"', '`'
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']'
+          depth -= 1 if depth > 0
+        when '}'
+          return i if depth == 0
+          depth -= 1
+        when ','
+          return i if depth == 0
+        end
+
+        i += 1
+      end
+
+      i
     end
 
     # Helper method to create an endpoint with details
@@ -162,100 +267,98 @@ module Analyzer::Javascript
 
     private def analyze_with_regex(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)) = [] of Hash(String, String))
       # Original regex-based analysis as a fallback
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        # current_router_base = ""
-        fastify_instances = [] of String
-        route_plugin_prefixes = {} of String => String
-        plugin_functions = {} of String => Bool
-        file_content = file.gets_to_end
+      last_endpoint = Endpoint.new("", "")
+      # current_router_base = ""
+      fastify_instances = [] of String
+      route_plugin_prefixes = {} of String => String
+      plugin_functions = {} of String => Bool
+      file_content = read_file_content(path)
 
-        collect_static_paths(path, file_content, static_dirs, :fastify)
+      collect_static_paths(path, file_content, static_dirs, :fastify)
 
-        # First scan for fastify instances and plugin registrations
-        file_content.each_line do |line|
-          # Detect Fastify initialization
-          if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:require\s*\(\s*['"]fastify['"]\s*\)|\s*fastify\()/
-            fastify_instances << $1
+      # First scan for fastify instances and plugin registrations
+      file_content.each_line do |line|
+        # Detect Fastify initialization
+        if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:require\s*\(\s*['"]fastify['"]\s*\)|\s*fastify\()/
+          fastify_instances << $1
+        end
+
+        # Detect plugin function declarations
+        if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(\s*(?:fastify|app|server)\s*,\s*options\s*\)\s*=>/
+          plugin_functions[$1] = true
+        end
+
+        # Also detect traditional function syntax for plugins
+        if line =~ /(?:function\s+(\w+)\s*\(\s*(?:fastify|app|server)(?:\s*,\s*options)?\s*\)|(?:const|let|var)\s+(\w+)\s*=\s*function\s*\(\s*(?:fastify|app|server)(?:\s*,\s*options)?\s*\))/
+          plugin_name = $1 || $2
+          plugin_functions[plugin_name] = true unless plugin_name.empty?
+        end
+
+        # Detect plugin registration with prefix - more flexible pattern matching
+        if line =~ /(\w+)\.register\s*\(\s*(\w+)(?:[^{]*|\s*,\s*)\{[^}]*prefix\s*:\s*['"]([^'"]+)['"]/
+          # fastify_var = $1
+          plugin_var = $2
+          prefix = $3
+          if plugin_functions.has_key?(plugin_var) || plugin_var.includes?("Routes")
+            route_plugin_prefixes[plugin_var] = prefix
           end
+        end
+      end
 
-          # Detect plugin function declarations
-          if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(\s*(?:fastify|app|server)\s*,\s*options\s*\)\s*=>/
-            plugin_functions[$1] = true
-          end
+      # Now process the file line by line for endpoints
+      current_plugin_var = ""
+      inside_plugin_function = false
+      plugin_indent_level = 0
+      plugin_prefix = ""
 
-          # Also detect traditional function syntax for plugins
-          if line =~ /(?:function\s+(\w+)\s*\(\s*(?:fastify|app|server)(?:\s*,\s*options)?\s*\)|(?:const|let|var)\s+(\w+)\s*=\s*function\s*\(\s*(?:fastify|app|server)(?:\s*,\s*options)?\s*\))/
-            plugin_name = $1 || $2
-            plugin_functions[plugin_name] = true unless plugin_name.empty?
-          end
+      file_content.each_line.with_index do |line, index|
+        # Detect plugin function definitions
+        if !inside_plugin_function && line =~ /(?:const|let|var)\s+(\w+Routes|\w+)\s*=\s*(?:async\s*)?\(\s*(?:fastify|app|server)\s*,\s*options\s*\)\s*=>/
+          function_name = $1
+          current_plugin_var = function_name
+          inside_plugin_function = true
+          plugin_indent_level = line.index("{") || 0
+          plugin_prefix = route_plugin_prefixes.fetch(current_plugin_var, "")
+        end
 
-          # Detect plugin registration with prefix - more flexible pattern matching
-          if line =~ /(\w+)\.register\s*\(\s*(\w+)(?:[^{]*|\s*,\s*)\{[^}]*prefix\s*:\s*['"]([^'"]+)['"]/
-            # fastify_var = $1
-            plugin_var = $2
-            prefix = $3
-            if plugin_functions.has_key?(plugin_var) || plugin_var.includes?("Routes")
-              route_plugin_prefixes[plugin_var] = prefix
+        # Check if we're exiting a plugin function
+        if inside_plugin_function && line =~ /^\s*\}\s*;?\s*$/
+          # Check if the indentation level matches with the function start
+          if line.strip == "}" || line.strip == "};"
+            current_indent = line.index("}") || 0
+            if current_indent <= plugin_indent_level
+              inside_plugin_function = false
+              current_plugin_var = ""
+              plugin_prefix = ""
             end
           end
         end
 
-        # Now process the file line by line for endpoints
-        current_plugin_var = ""
-        inside_plugin_function = false
-        plugin_indent_level = 0
-        plugin_prefix = ""
-
-        file_content.each_line.with_index do |line, index|
-          # Detect plugin function definitions
-          if !inside_plugin_function && line =~ /(?:const|let|var)\s+(\w+Routes|\w+)\s*=\s*(?:async\s*)?\(\s*(?:fastify|app|server)\s*,\s*options\s*\)\s*=>/
-            function_name = $1
-            current_plugin_var = function_name
-            inside_plugin_function = true
-            plugin_indent_level = line.index("{") || 0
-            plugin_prefix = route_plugin_prefixes.fetch(current_plugin_var, "")
-          end
-
-          # Check if we're exiting a plugin function
-          if inside_plugin_function && line =~ /^\s*\}\s*;?\s*$/
-            # Check if the indentation level matches with the function start
-            if line.strip == "}" || line.strip == "};"
-              current_indent = line.index("}") || 0
-              if current_indent <= plugin_indent_level
-                inside_plugin_function = false
-                current_plugin_var = ""
-                plugin_prefix = ""
-              end
+        # Detect regular routes or routes within plugins
+        endpoint = line_to_endpoint(line)
+        unless endpoint.method.empty?
+          # Apply plugin prefix if inside a plugin function
+          if inside_plugin_function && !plugin_prefix.empty?
+            # Handle path joining properly
+            if endpoint.url.starts_with?("/") && plugin_prefix.ends_with?("/")
+              endpoint.url = "#{plugin_prefix[0..-2]}#{endpoint.url}"
+            elsif !endpoint.url.starts_with?("/") && !plugin_prefix.ends_with?("/")
+              endpoint.url = "#{plugin_prefix}/#{endpoint.url}"
+            else
+              endpoint.url = "#{plugin_prefix}#{endpoint.url}"
             end
           end
 
-          # Detect regular routes or routes within plugins
-          endpoint = line_to_endpoint(line)
-          unless endpoint.method.empty?
-            # Apply plugin prefix if inside a plugin function
-            if inside_plugin_function && !plugin_prefix.empty?
-              # Handle path joining properly
-              if endpoint.url.starts_with?("/") && plugin_prefix.ends_with?("/")
-                endpoint.url = "#{plugin_prefix[0..-2]}#{endpoint.url}"
-              elsif !endpoint.url.starts_with?("/") && !plugin_prefix.ends_with?("/")
-                endpoint.url = "#{plugin_prefix}/#{endpoint.url}"
-              else
-                endpoint.url = "#{plugin_prefix}#{endpoint.url}"
-              end
-            end
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          result << endpoint
+          last_endpoint = endpoint
+        end
 
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint.details = details
-            result << endpoint
-            last_endpoint = endpoint
-          end
-
-          # Get parameters from line
-          param = line_to_param(line)
-          if !param.name.empty? && !last_endpoint.method.empty?
-            last_endpoint.push_param(param)
-          end
+        # Get parameters from line
+        param = line_to_param(line)
+        if !param.name.empty? && !last_endpoint.method.empty?
+          last_endpoint.push_param(param)
         end
       end
     end

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -5,6 +5,9 @@ require "./express/router_mount_scanner"
 
 module Analyzer::Javascript
   class Hono < JavascriptEngine
+    ON_ROUTE_CALL_HINTS   = [".on(", ".on ("]
+    ON_ROUTE_CALL_PATTERN = /\.(?:\s|\n|\r)*on(?:\s|\n|\r)*\(/
+
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
@@ -14,7 +17,7 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
-          include_callee = any_to_bool(@options["include_callee"])
+          include_callee = callees_needed?
           callees_by_route = include_callee ? Noir::JSCalleeExtractor.callees_for_routes(content, path) : {} of String => Array(Noir::JSCalleeExtractor::Entry)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee, route_callees: callees_by_route)
@@ -30,9 +33,10 @@ module Analyzer::Javascript
           # gate, `app.on('GET', '/x10', ...)` from hono's own
           # `*.test.ts` suites slips through, and without the minified
           # gate a multi-MB bundle pays the full scan (issue #1903).
-          unless Noir::JSRouteExtractor.test_stub_only?(path, content) ||
-                 Noir::JSRouteExtractor.minified_content?(content)
-            extract_on_routes(path, content, result, callees_by_route)
+          if on_route_candidate?(content) &&
+             !Noir::JSRouteExtractor.test_stub_only?(path, content) &&
+             !Noir::JSRouteExtractor.minified_content?(content)
+            extract_on_routes(path, content, result, callees_by_route, include_callee)
           end
 
           collect_static_paths(path, content, static_dirs, :hono)
@@ -51,34 +55,47 @@ module Analyzer::Javascript
       process_js_static_dirs(static_dirs, result)
     end
 
+    private def on_route_candidate?(content : String) : Bool
+      ON_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) } ||
+        content.matches?(ON_ROUTE_CALL_PATTERN)
+    end
+
     private def extract_on_routes(path : String,
                                   content : String,
                                   result : Array(Endpoint),
-                                  callees_by_route : Hash(String, Array(Noir::JSCalleeExtractor::Entry)))
+                                  callees_by_route : Hash(String, Array(Noir::JSCalleeExtractor::Entry)),
+                                  include_callee : Bool)
       http_methods = %w[get post put delete patch options head]
       lines = content.lines
+      line_offset = 0
       lines.each_with_index do |line, index|
         methods = [] of String
         url = ""
+        call_start = nil.as(Int32?)
 
         # app.on('GET', '/path', ...) - single method string
-        if line =~ /\b(?:app|router|hono)\s*\.\s*on\s*\(\s*['"](\w+)['"]\s*,\s*['"]([^'"]+)['"]/
-          method = $1.downcase
+        if match = line.match(/\b(?:app|router|hono)\s*\.\s*on\s*\(\s*['"](\w+)['"]\s*,\s*['"]([^'"]+)['"]/)
+          method = match[1].downcase
           if http_methods.includes?(method)
             methods << method
-            url = $2
+            url = match[2]
+            call_start = line_offset + (match.begin(0) || 0)
           end
           # app.on(['GET', 'POST'], '/path', ...) - array of methods
-        elsif line =~ /\b(?:app|router|hono)\s*\.\s*on\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"]/
-          methods_str = $1
-          url = $2
+        elsif match = line.match(/\b(?:app|router|hono)\s*\.\s*on\s*\(\s*\[([^\]]+)\]\s*,\s*['"]([^'"]+)['"]/)
+          methods_str = match[1]
+          url = match[2]
+          call_start = line_offset + (match.begin(0) || 0)
           methods_str.scan(/['"](\w+)['"]/) do |m|
             method = m[1].downcase
             methods << method if http_methods.includes?(method) && !methods.includes?(method)
           end
         end
 
-        next if methods.empty? || url.empty?
+        if methods.empty? || url.empty?
+          line_offset += line.bytesize + 1
+          next
+        end
 
         # Pre-extract handler-body params once so each method-variant
         # endpoint gets the same params without re-walking lines.
@@ -90,6 +107,7 @@ module Analyzer::Javascript
             body_params << param
           end
         end
+        direct_callees = include_callee && call_start ? on_route_callees(content, path, call_start) : [] of Noir::JSCalleeExtractor::Entry
 
         methods.each do |http_method|
           next if result.any? { |e| e.url == url && e.method == http_method.upcase }
@@ -98,33 +116,145 @@ module Analyzer::Javascript
           details = Details.new(PathInfo.new(path, index + 1))
           endpoint.details = details
           Noir::JSRouteExtractor.attach_callees(endpoint, callees_by_route, http_method.upcase, url, index + 1)
+          attach_js_callees(endpoint, direct_callees)
 
           body_params.each { |param| endpoint.push_param(param) }
           extract_path_params(endpoint)
 
           result << endpoint
         end
+        line_offset += line.bytesize + 1
       end
     end
 
-    private def analyze_with_regex(path : String, result : Array(Endpoint))
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        file_content = file.gets_to_end
+    private def on_route_callees(content : String, path : String, call_start : Int32) : Array(Noir::JSCalleeExtractor::Entry)
+      paren_open = content.index("(", call_start)
+      return [] of Noir::JSCalleeExtractor::Entry unless paren_open
 
-        file_content.each_line.with_index do |line, index|
-          endpoints = line_to_endpoints(line)
-          endpoints.each do |endpoint|
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint.details = details
-            result << endpoint
-            last_endpoint = endpoint
+      paren_close = Noir::JSRouteExtractor.find_matching_paren(content, paren_open)
+      return [] of Noir::JSCalleeExtractor::Entry unless paren_close
+
+      args = split_top_level_args(content, paren_open + 1, paren_close)
+      return [] of Noir::JSCalleeExtractor::Entry if args.size < 3
+
+      handler_source, handler_start = args[2]
+      handler_callees(handler_source, handler_start, content, path)
+    end
+
+    private def handler_callees(handler_source : String, handler_start : Int32, content : String, path : String) : Array(Noir::JSCalleeExtractor::Entry)
+      if arrow_idx = handler_source.index("=>")
+        body_start = skip_whitespace(content, handler_start + arrow_idx + 2)
+        return [] of Noir::JSCalleeExtractor::Entry if body_start >= content.size
+
+        if content[body_start]? == '{'
+          return block_handler_callees(content, path, body_start)
+        end
+
+        body = content[body_start...(handler_start + handler_source.size)].strip
+        return [] of Noir::JSCalleeExtractor::Entry if body.empty?
+
+        return Noir::JSCalleeExtractor.callees_for_function_body(body, path, line_for_pos(content, body_start), language: javascript_source_language(path))
+      end
+
+      function_idx = handler_source.index(/\bfunction\b/)
+      return [] of Noir::JSCalleeExtractor::Entry unless function_idx
+
+      open_brace = content.index("{", handler_start + function_idx)
+      return [] of Noir::JSCalleeExtractor::Entry unless open_brace
+
+      block_handler_callees(content, path, open_brace)
+    end
+
+    private def block_handler_callees(content : String, path : String, open_brace : Int32) : Array(Noir::JSCalleeExtractor::Entry)
+      close_brace = Noir::JSRouteExtractor.find_matching_brace(content, open_brace)
+      return [] of Noir::JSCalleeExtractor::Entry unless close_brace
+
+      body = content[(open_brace + 1)...close_brace]
+      Noir::JSCalleeExtractor.callees_for_function_body(body, path, line_for_pos(content, open_brace), language: javascript_source_language(path))
+    end
+
+    private def split_top_level_args(content : String, start_pos : Int32, end_pos : Int32) : Array(Tuple(String, Int32))
+      args = [] of Tuple(String, Int32)
+      arg_start = start_pos
+      depth = 0
+      quote : Char? = nil
+      escaped = false
+      i = start_pos
+
+      while i < end_pos
+        char = content[i]
+
+        if quote
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == quote
+            quote = nil
           end
+          i += 1
+          next
+        end
 
-          line_to_params(line).each do |param|
-            unless last_endpoint.method.empty?
-              last_endpoint.push_param(param)
-            end
+        case char
+        when '\'', '"', '`'
+          quote = char
+        when '(', '[', '{'
+          depth += 1
+        when ')', ']', '}'
+          depth -= 1 if depth > 0
+        when ','
+          if depth == 0
+            args << normalized_arg(content, arg_start, i)
+            arg_start = i + 1
+          end
+        end
+
+        i += 1
+      end
+
+      args << normalized_arg(content, arg_start, end_pos)
+      args
+    end
+
+    private def normalized_arg(content : String, start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
+      start_idx = skip_whitespace(content, start_pos)
+      stop_idx = end_pos
+      while stop_idx > start_idx && content[stop_idx - 1].whitespace?
+        stop_idx -= 1
+      end
+
+      {content[start_idx...stop_idx], start_idx}
+    end
+
+    private def skip_whitespace(content : String, pos : Int32) : Int32
+      i = pos
+      while i < content.size && content[i].whitespace?
+        i += 1
+      end
+      i
+    end
+
+    private def line_for_pos(content : String, pos : Int32) : Int32
+      content[0...pos].count('\n') + 1
+    end
+
+    private def analyze_with_regex(path : String, result : Array(Endpoint))
+      last_endpoint = Endpoint.new("", "")
+      file_content = read_file_content(path)
+
+      file_content.each_line.with_index do |line, index|
+        endpoints = line_to_endpoints(line)
+        endpoints.each do |endpoint|
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          result << endpoint
+          last_endpoint = endpoint
+        end
+
+        line_to_params(line).each do |param|
+          unless last_endpoint.method.empty?
+            last_endpoint.push_param(param)
           end
         end
       end

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -6,7 +6,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
-      include_callee = any_to_bool(@options["include_callee"])
+      include_callee = callees_needed?
 
       parallel_file_scan([".js", ".ts", ".mjs"]) do |path|
         begin
@@ -14,8 +14,9 @@ module Analyzer::Javascript
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|
-            details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-            endpoint.details = details
+            if endpoint.details.code_paths.empty?
+              endpoint.details = Details.new(PathInfo.new(path))
+            end
 
             if endpoint.url.includes?(":")
               endpoint.url.scan(/:(\w+)/) do |m|
@@ -56,26 +57,36 @@ module Analyzer::Javascript
     # values are single-quoted strings (the convention across every
     # `@strapi/plugin-*` route file).
     private def extract_strapi_routes(path : String, content : String, result : Array(Endpoint))
+      return unless strapi_route_candidate?(content)
+
       seen = Set(Tuple(String, String, Int32)).new
       lines = content.lines
       lines.each_with_index do |line, index|
         next unless m = line.match(/^\s*method:\s*['"]([A-Z]+)['"]\s*,?/)
         method = m[1].upcase
         next unless ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes?(method)
-        # Strapi parks `path:` either on the same line (rare) or
-        # the very next line; lookahead at most four lines so
-        # interleaved comments / type declarations don't desync.
+        # Strapi route objects carry `method`, `path`, and `handler`.
+        # Requiring the handler keeps generic HTTP client/config objects
+        # like `{ method: 'GET', path: '/health' }` from becoming Koa
+        # endpoints just because the project imports Koa elsewhere.
         path_str = nil.as(String?)
-        (1..4).each do |off|
+        handler_seen = false
+        object_depth = 1
+        (0..16).each do |off|
           next unless idx = index + off
           next unless idx < lines.size
-          break if path_str
-          if pm = lines[idx].match(/^\s*path:\s*['"]([^'"]+)['"]/)
+          candidate = lines[idx]
+          if pm = candidate.match(/(?:^\s*|[,{]\s*)path:\s*['"]([^'"]+)['"]/)
             path_str = pm[1]
-            break
+          end
+          handler_seen = true if candidate.match(/(?:^\s*|[,{]\s*)handler:\s*['"][^'"]+['"]/)
+          if off > 0
+            object_depth += candidate.count('{') - candidate.count('}')
+            break if object_depth <= 0
           end
         end
         next unless route_path = path_str
+        next unless handler_seen
         # Skip duplicate (same triple already emitted for this file).
         key = {method, route_path, index + 1}
         next if seen.includes?(key)
@@ -93,76 +104,80 @@ module Analyzer::Javascript
       end
     end
 
+    private def strapi_route_candidate?(content : String) : Bool
+      content.includes?("method:") &&
+        content.includes?("path:") &&
+        content.includes?("handler:")
+    end
+
     # Process static directories and add endpoints for each file
     private def process_static_dirs(static_dirs : Array(Hash(String, String)), result : Array(Endpoint))
       process_js_static_dirs(static_dirs, result)
     end
 
     private def analyze_with_regex(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)) = [] of Hash(String, String))
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file_content = file.gets_to_end
-        # Regex for Koa router: router.get('/path', ...) or app.get('/path', ...)
-        # Covers .get, .post, .put, .del, .patch, .all
-        # Also captures router prefixes like router.use('/prefix', subRouter.routes())
+      file_content = read_file_content(path)
+      # Regex for Koa router: router.get('/path', ...) or app.get('/path', ...)
+      # Covers .get, .post, .put, .del, .patch, .all
+      # Also captures router prefixes like router.use('/prefix', subRouter.routes())
 
-        router_prefixes = {} of String => String # To store router variable name and its prefix
+      router_prefixes = {} of String => String # To store router variable name and its prefix
 
-        collect_static_paths(path, file_content, static_dirs, :koa)
+      collect_static_paths(path, file_content, static_dirs, :koa)
 
-        # Detect router prefixes
-        # Example: const adminRouter = new Router({ prefix: '/admin' });
-        # Example: router.use('/api/v1', apiV1Router.routes());
-        file_content.scan(/const\s+(\w+)\s*=\s*new\s+Router\(\s*{\s*prefix:\s*['"]([^'"]+)['"]\s*}\s*\)/) do |match|
-          router_name = match[1]
-          prefix = match[2]
-          router_prefixes[router_name] = prefix
+      # Detect router prefixes
+      # Example: const adminRouter = new Router({ prefix: '/admin' });
+      # Example: router.use('/api/v1', apiV1Router.routes());
+      file_content.scan(/const\s+(\w+)\s*=\s*new\s+Router\(\s*{\s*prefix:\s*['"]([^'"]+)['"]\s*}\s*\)/) do |match|
+        router_name = match[1]
+        prefix = match[2]
+        router_prefixes[router_name] = prefix
+      end
+
+      file_content.scan(/(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)\.routes\(\s*\)/) do |match|
+        parent_router = match[1] # This could be app or another router
+        prefix = match[2]
+        child_router_name = match[3]
+
+        base_prefix = router_prefixes.fetch(parent_router, "")
+        full_prefix = File.join(base_prefix, prefix)
+        router_prefixes[child_router_name] = full_prefix
+      end
+
+      # Detect routes
+      # Example: router.get('/users', ctx => { ... });
+      # Example: app.get('/status', async (ctx) => { ... });
+      file_content.scan(/(?:(\w+)\.|app\.)(get|post|put|delete|del|patch|all)\s*\(\s*['"]([^'"]+)['"]/) do |match|
+        router_var = match[1] # Can be nil if it's app.get directly
+        http_method = Noir::JSRouteExtractor.normalize_http_method(match[2])
+        route_path = match[3]
+
+        current_prefix = ""
+        if router_var && router_prefixes.has_key?(router_var)
+          current_prefix = router_prefixes[router_var]
         end
 
-        file_content.scan(/(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)\.routes\(\s*\)/) do |match|
-          parent_router = match[1] # This could be app or another router
-          prefix = match[2]
-          child_router_name = match[3]
+        full_path = File.join(current_prefix, route_path)
+        full_path = "/" if full_path.empty? # Handle empty path case
+        full_path = "/#{full_path}" unless full_path.starts_with?('/')
 
-          base_prefix = router_prefixes.fetch(parent_router, "")
-          full_prefix = File.join(base_prefix, prefix)
-          router_prefixes[child_router_name] = full_prefix
+        endpoint = Endpoint.new(full_path, http_method)
+        details = Details.new(PathInfo.new(path, 1)) # Approximate line number
+        endpoint.details = details
+
+        # Extract path parameters from the route_path itself
+        route_path.scan(/:(\w+)/) do |m|
+          if m.size > 0 && !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
+            param = Param.new(m[1], "", "path")
+            endpoint.push_param(param)
+          end
         end
 
-        # Detect routes
-        # Example: router.get('/users', ctx => { ... });
-        # Example: app.get('/status', async (ctx) => { ... });
-        file_content.scan(/(?:(\w+)\.|app\.)(get|post|put|delete|del|patch|all)\s*\(\s*['"]([^'"]+)['"]/) do |match|
-          router_var = match[1] # Can be nil if it's app.get directly
-          http_method = Noir::JSRouteExtractor.normalize_http_method(match[2])
-          route_path = match[3]
+        # Extract parameters from handler body
+        extract_koa_params_from_content(file_content, router_var || "app", match[2], route_path, endpoint)
 
-          current_prefix = ""
-          if router_var && router_prefixes.has_key?(router_var)
-            current_prefix = router_prefixes[router_var]
-          end
-
-          full_path = File.join(current_prefix, route_path)
-          full_path = "/" if full_path.empty? # Handle empty path case
-          full_path = "/#{full_path}" unless full_path.starts_with?('/')
-
-          endpoint = Endpoint.new(full_path, http_method)
-          details = Details.new(PathInfo.new(path, 1)) # Approximate line number
-          endpoint.details = details
-
-          # Extract path parameters from the route_path itself
-          route_path.scan(/:(\w+)/) do |m|
-            if m.size > 0 && !endpoint.params.any? { |p| p.name == m[1] && p.param_type == "path" }
-              param = Param.new(m[1], "", "path")
-              endpoint.push_param(param)
-            end
-          end
-
-          # Extract parameters from handler body
-          extract_koa_params_from_content(file_content, router_var || "app", match[2], route_path, endpoint)
-
-          unless result.any? { |e| e.url == full_path && e.method == http_method }
-            result << endpoint
-          end
+        unless result.any? { |e| e.url == full_path && e.method == http_method }
+          result << endpoint
         end
       end
     end

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -113,27 +113,25 @@ module Analyzer::Javascript
     end
 
     private def analyze_nestjs_file(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)), include_callee : Bool, global_prefix_holder : Array(GlobalPrefixConfig), global_prefix_mutex : Mutex)
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
+      content = read_file_content(path)
 
-        collect_static_paths(path, content, static_dirs, :nestjs)
-        collect_static_paths(path, content, static_dirs, :express) if nestjs_bootstrap_source?(content)
+      collect_static_paths(path, content, static_dirs, :nestjs)
+      collect_static_paths(path, content, static_dirs, :express) if nestjs_bootstrap_source?(content)
 
-        # Strip JS/TS comments so commented-out decorators
-        # (e.g. `// @Get('/old')`) don't generate phantom routes.
-        sanitized = Noir::JSRouteExtractor.strip_js_comments(content)
+      # Strip JS/TS comments so commented-out decorators
+      # (e.g. `// @Get('/old')`) don't generate phantom routes.
+      sanitized = Noir::JSRouteExtractor.strip_js_comments(content)
 
-        # `app.setGlobalPrefix('api')` in a bootstrap file scopes
-        # every controller below it. Record it now; apply once after
-        # all files have been parsed.
-        if prefix = extract_global_prefix_config(sanitized)
-          global_prefix_mutex.synchronize do
-            global_prefix_holder << prefix if global_prefix_holder.empty?
-          end
+      # `app.setGlobalPrefix('api')` in a bootstrap file scopes
+      # every controller below it. Record it now; apply once after
+      # all files have been parsed.
+      if prefix = extract_global_prefix_config(sanitized)
+        global_prefix_mutex.synchronize do
+          global_prefix_holder << prefix if global_prefix_holder.empty?
         end
-
-        analyze_nestjs_controllers(sanitized, path, result, include_callee)
       end
+
+      analyze_nestjs_controllers(sanitized, path, result, include_callee)
     rescue e : Exception
       logger.debug "Error analyzing NestJS file #{path}: #{e.message}"
     end

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -77,16 +77,17 @@ module Analyzer::Javascript
       sanitized = Noir::JSRouteExtractor.strip_js_comments(content)
 
       methods = detect_pages_router_methods(sanitized)
-      default_body_info = include_callee ? extract_default_export_body(content) : nil
+      default_body_info = extract_default_export_body(content)
+      default_source_line = default_body_info.try(&.[1]) || 1
 
       methods.each do |method|
         endpoint = Endpoint.new(url, method)
-        endpoint.details = Details.new(PathInfo.new(path, 1))
+        body_info = extract_exported_method_body(content, method) || default_body_info
+        endpoint.details = Details.new(PathInfo.new(path, body_info.try(&.[1]) || default_source_line))
 
         extract_path_params(url, endpoint)
         extract_pages_router_params(sanitized, endpoint)
         if include_callee
-          body_info = extract_exported_method_body(content, method) || default_body_info
           attach_callees(endpoint, path, body_info) if body_info
         end
 
@@ -133,15 +134,15 @@ module Analyzer::Javascript
 
       methods.each do |method|
         endpoint = Endpoint.new(url, method)
-        endpoint.details = Details.new(PathInfo.new(path, 1))
-        body_info = include_callee ? extract_exported_method_body(content, method) : nil
+        method_body_info = extract_exported_method_body(content, method)
+        endpoint.details = Details.new(PathInfo.new(path, method_body_info.try(&.[1]) || 1))
         param_body_info = extract_exported_method_body(sanitized, method)
         param_source = param_body_info.try(&.[0]) || sanitized
 
         extract_path_params(url, endpoint)
         extract_app_router_params(param_source, endpoint)
         if include_callee
-          attach_callees(endpoint, path, body_info) if body_info
+          attach_callees(endpoint, path, method_body_info) if method_body_info
         end
 
         mutex.synchronize { result << endpoint }
@@ -195,7 +196,7 @@ module Analyzer::Javascript
       url = "/" + action_name
       endpoint = Endpoint.new(url, "POST")
       endpoint.kind = "server-action"
-      endpoint.details = Details.new(PathInfo.new(path, 1))
+      endpoint.details = Details.new(PathInfo.new(path, param_body_info.try(&.[1]) || line_for_index(sanitized, match.begin(0) || 0)))
 
       extract_server_action_params(args, body, endpoint)
       attach_callees(endpoint, path, callee_body_info) if include_callee && callee_body_info

--- a/src/analyzer/analyzers/javascript/remix.cr
+++ b/src/analyzer/analyzers/javascript/remix.cr
@@ -79,15 +79,18 @@ module Analyzer::Javascript
         verbs = detect_verbs(is_page, has_loader, has_action)
         next if verbs.empty?
 
+        loader_line = has_loader ? exported_handler_line(content, "loader") : nil
+        action_line = has_action ? exported_handler_line(content, "action") : nil
         loader_callees = include_callee && has_loader ? Noir::JSCalleeExtractor.callees_for_exported_function(content, path, "loader") : nil
         action_callees = include_callee && has_action ? Noir::JSCalleeExtractor.callees_for_exported_function(content, path, "action") : nil
 
         endpoints = verbs.map do |verb|
-          endpoint = build_endpoint(url, verb, path)
+          endpoint_line = verb == "GET" ? (loader_line || 1) : (action_line || 1)
+          endpoint = build_endpoint(url, verb, path, endpoint_line)
           if include_callee
             callees = verb == "GET" ? loader_callees : action_callees
-            callees.try &.each do |name, callee_path, line|
-              endpoint.push_callee(Callee.new(name, path: callee_path, line: line))
+            callees.try &.each do |name, callee_path, callee_line|
+              endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
             end
           end
           endpoint
@@ -101,9 +104,9 @@ module Analyzer::Javascript
       result
     end
 
-    private def build_endpoint(url : String, verb : String, path : String) : Endpoint
+    private def build_endpoint(url : String, verb : String, path : String, line : Int32 = 1) : Endpoint
       endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, 1))
+      endpoint.details = Details.new(PathInfo.new(path, line))
       url.scan(/\{(\w+)\}/) do |match|
         endpoint.push_param(Param.new(match[1], "", "path"))
       end
@@ -171,6 +174,53 @@ module Analyzer::Javascript
       content.matches?(cached_regex("remix:export_fn:#{name}") { /export\s+(?:async\s+)?function\s+#{name}\b/ }) ||
         content.matches?(cached_regex("remix:export_const:#{name}") { /export\s+(?:const|let|var)\s+#{name}\b\s*(?::[^=]+)?=/ }) ||
         content.matches?(cached_regex("remix:export_brace:#{name}") { /export\s+\{\s*[^}]*\b#{name}\b[^}]*\}/ })
+    end
+
+    private def exported_handler_line(content : String, name : String) : Int32?
+      if match = content.match(cached_regex("remix:line_export_fn:#{name}") { /export\s+(?:async\s+)?function\s+#{Regex.escape(name)}\b/ })
+        return line_for_match(content, match)
+      end
+
+      if match = content.match(cached_regex("remix:line_export_const:#{name}") { /export\s+(?:const|let|var)\s+#{Regex.escape(name)}\b\s*(?::[^=]+)?=/ })
+        return line_for_match(content, match)
+      end
+
+      if local_name = exported_alias_for(content, name)
+        named_handler_line(content, local_name)
+      end
+    end
+
+    private def exported_alias_for(content : String, exported_name : String) : String?
+      content.scan(/export\s+\{\s*([^}]+)\}/) do |match|
+        match[1].split(",").each do |part|
+          pieces = part.strip.split(/\s+as\s+/)
+          next if pieces.empty?
+
+          if pieces.size == 1
+            local_name = pieces[0].strip
+            return local_name if local_name == exported_name
+          elsif pieces.size == 2
+            local_name = pieces[0].strip
+            alias_name = pieces[1].strip
+            return local_name if alias_name == exported_name
+          end
+        end
+      end
+    end
+
+    private def named_handler_line(content : String, name : String) : Int32?
+      if match = content.match(cached_regex("remix:line_named_fn:#{name}") { /\b(?:async\s+)?function\s+#{Regex.escape(name)}\b/ })
+        return line_for_match(content, match)
+      end
+
+      if match = content.match(cached_regex("remix:line_named_const:#{name}") { /\b(?:const|let|var)\s+#{Regex.escape(name)}\b\s*(?::[^=]+)?=/ })
+        line_for_match(content, match)
+      end
+    end
+
+    private def line_for_match(content : String, match : Regex::MatchData) : Int32
+      start = match.begin(0) || 0
+      content.to_slice[0, start].count('\n'.ord.to_u8) + 1
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -6,7 +6,7 @@ module Analyzer::Javascript
     def analyze
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       parallel_file_scan do |path|
         begin
@@ -15,9 +15,9 @@ module Analyzer::Javascript
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|
-            # Add file location details
-            details = Details.new(PathInfo.new(path, 1)) # Line number is approximate
-            endpoint.details = details
+            if endpoint.details.code_paths.empty?
+              endpoint.details = Details.new(PathInfo.new(path))
+            end
 
             # Parse path parameters from the URL path itself
             if endpoint.url.includes?(":")
@@ -61,130 +61,128 @@ module Analyzer::Javascript
 
     private def analyze_with_regex(path : String, result : Array(Endpoint), static_dirs : Array(Hash(String, String)) = [] of Hash(String, String))
       # Original regex-based analysis as a fallback
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        last_endpoint = Endpoint.new("", "")
-        server_var_names = [] of String
-        router_var_names = [] of String
-        router_base_paths = {} of String => String
-        current_router_base = ""
-        current_router_var = ""
-        file_content = file.gets_to_end
+      last_endpoint = Endpoint.new("", "")
+      server_var_names = [] of String
+      router_var_names = [] of String
+      router_base_paths = {} of String => String
+      current_router_base = ""
+      current_router_var = ""
+      file_content = read_file_content(path)
 
-        collect_static_paths(path, file_content, static_dirs, :restify)
+      collect_static_paths(path, file_content, static_dirs, :restify)
 
-        # First scan for server and router variable declarations
-        file_content.each_line do |line|
-          # Detect Restify server creation
-          if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*restify\.createServer/
-            server_var_names << $1
-          end
+      # First scan for server and router variable declarations
+      file_content.each_line do |line|
+        # Detect Restify server creation
+        if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*restify\.createServer/
+          server_var_names << $1
+        end
 
-          # Detect router initialization - improved to catch more router variable patterns
-          if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:new\s+)?(?:restify\.)?Router/
+        # Detect router initialization - improved to catch more router variable patterns
+        if line =~ /(?:const|let|var)\s+(\w+)\s*=\s*(?:new\s+)?(?:restify\.)?Router/
+          router_var_names << $1
+          current_router_var = $1
+        end
+
+        # Also detect variables with Router in the name
+        if line =~ /(?:const|let|var)\s+(\w+Router)\s*=/
+          unless router_var_names.includes?($1)
             router_var_names << $1
-            current_router_var = $1
-          end
-
-          # Also detect variables with Router in the name
-          if line =~ /(?:const|let|var)\s+(\w+Router)\s*=/
-            unless router_var_names.includes?($1)
-              router_var_names << $1
-            end
-          end
-
-          # Detect router mounting with use
-          if line =~ /\.use\s*\(\s*['"]([^'"]+)['"]/
-            current_router_base = $1
-          end
-
-          # Detect applyRoutes with base path - improved pattern matching
-          if line =~ /(\w+)\.applyRoutes\s*\(\s*(\w+)(?:\s*,\s*['"]([^'"]+)['"])?/
-            router_var = $1
-            # server_var = $2
-            base_path = $3 || ""
-
-            if router_var_names.includes?(router_var)
-              router_base_paths[router_var] = base_path
-            end
           end
         end
 
-        # Special handling for function-based route definitions
-        function_routes = extract_function_routes(file_content, server_var_names)
-        function_routes.each do |endpoint|
-          details = Details.new(PathInfo.new(path, 1))
-          endpoint.details = details
-
-          # Extract path parameters from the URL
-          if endpoint.url.includes?(":")
-            endpoint.url.scan(/:(\w+)/) do |m|
-              if m.size > 0
-                param = Param.new(m[1], "", "path")
-                endpoint.push_param(param)
-              end
-            end
-          end
-
-          result << endpoint
+        # Detect router mounting with use
+        if line =~ /\.use\s*\(\s*['"]([^'"]+)['"]/
+          current_router_base = $1
         end
 
-        # Now process the file line by line for endpoints
-        file_content.each_line.with_index do |line, index|
-          endpoint = line_to_endpoint(line, server_var_names, router_var_names)
+        # Detect applyRoutes with base path - improved pattern matching
+        if line =~ /(\w+)\.applyRoutes\s*\(\s*(\w+)(?:\s*,\s*['"]([^'"]+)['"])?/
+          router_var = $1
+          # server_var = $2
+          base_path = $3 || ""
 
-          unless endpoint.method.empty?
-            # Store the variable this endpoint is associated with
-            endpoint_var = extract_endpoint_var(line)
-
-            # Apply base paths from applyRoutes if applicable
-            if !endpoint_var.empty? && router_base_paths.has_key?(endpoint_var)
-              base_path = router_base_paths[endpoint_var]
-              # Ensure proper path joining
-              unless base_path.empty?
-                if endpoint.url.starts_with?("/") && base_path.ends_with?("/")
-                  endpoint.url = "#{base_path[0..-2]}#{endpoint.url}"
-                elsif !endpoint.url.starts_with?("/") && !base_path.ends_with?("/")
-                  endpoint.url = "#{base_path}/#{endpoint.url}"
-                else
-                  endpoint.url = "#{base_path}#{endpoint.url}"
-                end
-              end
-              # Apply current router base if this is a generic router endpoint
-            elsif !current_router_base.empty? && !endpoint.url.starts_with?("/")
-              endpoint.url = "#{current_router_base}/#{endpoint.url}"
-            elsif !current_router_base.empty? && endpoint.url != "/" && !endpoint.url.starts_with?(current_router_base)
-              endpoint.url = "#{current_router_base}#{endpoint.url}"
-            end
-
-            details = Details.new(PathInfo.new(path, index + 1))
-            endpoint.details = details
-            result << endpoint
-            last_endpoint = endpoint
-          end
-
-          # Extract parameters from the URL path itself
-          if !last_endpoint.method.empty? && !last_endpoint.url.empty? && last_endpoint.url.includes?(":")
-            last_endpoint.url.scan(/:(\w+)/) do |m|
-              if m.size > 0
-                param = Param.new(m[1], "", "path")
-                last_endpoint.push_param(param)
-              end
-            end
-          end
-
-          # Get parameters from line
-          param = line_to_param(line)
-          unless param.name.empty? || last_endpoint.method.empty?
-            last_endpoint.push_param(param)
+          if router_var_names.includes?(router_var)
+            router_base_paths[router_var] = base_path
           end
         end
-
-        # After processing all lines, look for router patterns we might have missed
-        scan_for_router_endpoints(file_content, result, path, router_var_names, router_base_paths)
-
-        # Directly detect test fixture router patterns
-        detect_test_fixture_routers(file_content, result, path)
       end
+
+      # Special handling for function-based route definitions
+      function_routes = extract_function_routes(file_content, server_var_names)
+      function_routes.each do |endpoint|
+        details = Details.new(PathInfo.new(path, 1))
+        endpoint.details = details
+
+        # Extract path parameters from the URL
+        if endpoint.url.includes?(":")
+          endpoint.url.scan(/:(\w+)/) do |m|
+            if m.size > 0
+              param = Param.new(m[1], "", "path")
+              endpoint.push_param(param)
+            end
+          end
+        end
+
+        result << endpoint
+      end
+
+      # Now process the file line by line for endpoints
+      file_content.each_line.with_index do |line, index|
+        endpoint = line_to_endpoint(line, server_var_names, router_var_names)
+
+        unless endpoint.method.empty?
+          # Store the variable this endpoint is associated with
+          endpoint_var = extract_endpoint_var(line)
+
+          # Apply base paths from applyRoutes if applicable
+          if !endpoint_var.empty? && router_base_paths.has_key?(endpoint_var)
+            base_path = router_base_paths[endpoint_var]
+            # Ensure proper path joining
+            unless base_path.empty?
+              if endpoint.url.starts_with?("/") && base_path.ends_with?("/")
+                endpoint.url = "#{base_path[0..-2]}#{endpoint.url}"
+              elsif !endpoint.url.starts_with?("/") && !base_path.ends_with?("/")
+                endpoint.url = "#{base_path}/#{endpoint.url}"
+              else
+                endpoint.url = "#{base_path}#{endpoint.url}"
+              end
+            end
+            # Apply current router base if this is a generic router endpoint
+          elsif !current_router_base.empty? && !endpoint.url.starts_with?("/")
+            endpoint.url = "#{current_router_base}/#{endpoint.url}"
+          elsif !current_router_base.empty? && endpoint.url != "/" && !endpoint.url.starts_with?(current_router_base)
+            endpoint.url = "#{current_router_base}#{endpoint.url}"
+          end
+
+          details = Details.new(PathInfo.new(path, index + 1))
+          endpoint.details = details
+          result << endpoint
+          last_endpoint = endpoint
+        end
+
+        # Extract parameters from the URL path itself
+        if !last_endpoint.method.empty? && !last_endpoint.url.empty? && last_endpoint.url.includes?(":")
+          last_endpoint.url.scan(/:(\w+)/) do |m|
+            if m.size > 0
+              param = Param.new(m[1], "", "path")
+              last_endpoint.push_param(param)
+            end
+          end
+        end
+
+        # Get parameters from line
+        param = line_to_param(line)
+        unless param.name.empty? || last_endpoint.method.empty?
+          last_endpoint.push_param(param)
+        end
+      end
+
+      # After processing all lines, look for router patterns we might have missed
+      scan_for_router_endpoints(file_content, result, path, router_var_names, router_base_paths)
+
+      # Directly detect test fixture router patterns
+      detect_test_fixture_routers(file_content, result, path)
     end
 
     # Method to extract routes defined within functions

--- a/src/analyzer/analyzers/javascript/sveltekit.cr
+++ b/src/analyzer/analyzers/javascript/sveltekit.cr
@@ -100,7 +100,7 @@ module Analyzer::Javascript
 
       methods = detect_api_methods(content)
       endpoints = methods.map do |verb|
-        endpoint = build_endpoint(url, verb, path)
+        endpoint = build_endpoint(url, verb, path, api_method_line(content, verb) || 1)
         attach_callees(endpoint, path, content, verb) if include_callee
         endpoint
       end
@@ -110,9 +110,9 @@ module Analyzer::Javascript
       end
     end
 
-    private def build_endpoint(url : String, verb : String, path : String) : Endpoint
+    private def build_endpoint(url : String, verb : String, path : String, line : Int32 = 1) : Endpoint
       endpoint = Endpoint.new(url, verb)
-      endpoint.details = Details.new(PathInfo.new(path, 1))
+      endpoint.details = Details.new(PathInfo.new(path, line))
       url.scan(/\{(\w+)\}/) do |match|
         endpoint.push_param(Param.new(match[1], "", "path"))
       end
@@ -164,6 +164,25 @@ module Analyzer::Javascript
         end
       end
       explicit.empty? ? FALLBACK_API_METHODS : explicit
+    end
+
+    private def api_method_line(content : String, verb : String) : Int32?
+      if match = content.match(EXPORT_FUNCTION_RES[verb])
+        return line_for_match(content, match)
+      end
+
+      if match = content.match(EXPORT_CONST_RES[verb])
+        return line_for_match(content, match)
+      end
+
+      if content.includes?("export {") && content.includes?(verb)
+        Noir::JSCalleeExtractor.exported_function_line(content, verb)
+      end
+    end
+
+    private def line_for_match(content : String, match : Regex::MatchData) : Int32
+      start = match.begin(0) || 0
+      content.to_slice[0, start].count('\n'.ord.to_u8) + 1
     end
 
     private def attach_callees(endpoint : Endpoint, path : String, content : String, verb : String)

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -26,31 +26,66 @@ module Analyzer::Typescript
     end
 
     private def analyze_tanstack_file(path : String, result : Array(Endpoint))
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        raw = file.gets_to_end
-        # Comments can hold stale routes; drop them so a commented-out
-        # `createFileRoute('/old')` doesn't get reported.
-        content = Noir::JSRouteExtractor.strip_js_comments(raw)
+      return if tanstack_test_fixture_path?(path)
 
-        # Extract routes from createFileRoute
-        analyze_file_routes(content, path, result)
+      raw = read_file_content(path)
+      return unless tanstack_route_candidate?(raw)
+      return if Noir::JSRouteExtractor.test_stub_only?(path, raw)
 
-        # Extract code-based route trees from createRoute
-        analyze_create_routes(content, path, result)
+      # Comments can hold stale routes; drop them so a commented-out
+      # `createFileRoute('/old')` doesn't get reported.
+      content = Noir::JSRouteExtractor.strip_js_comments(raw)
+      return unless tanstack_route_candidate?(content)
 
-        # Extract routes from createLazyFileRoute
-        analyze_lazy_file_routes(content, path, result)
-      end
+      literal_mask = string_literal_mask(content)
+
+      # Extract routes from createFileRoute
+      analyze_file_routes(content, path, result, literal_mask)
+
+      # Extract code-based route trees from createRoute
+      analyze_create_routes(content, path, result, literal_mask)
+
+      # Extract routes from createLazyFileRoute
+      analyze_lazy_file_routes(content, path, result, literal_mask)
     rescue e : Exception
       logger.debug "Error analyzing TanStack Router file #{path}: #{e.message}"
     end
 
-    private def analyze_file_routes(content : String, path : String, result : Array(Endpoint))
+    ROUTE_CONSTRUCTOR_HINTS = [
+      "createFileRoute",
+      "createLazyFileRoute",
+      "createRoute",
+      "createRootRoute",
+      "createRootRouteWithContext",
+    ]
+
+    private def tanstack_route_candidate?(content : String) : Bool
+      ROUTE_CONSTRUCTOR_HINTS.any? { |hint| content.includes?(hint) }
+    end
+
+    TEST_FIXTURE_PATH_MARKERS = [
+      "/test/",
+      "/tests/",
+      "/__tests__/",
+      "/e2e/",
+      "/snapshots/",
+      "/test-files/",
+    ]
+
+    private def tanstack_test_fixture_path?(path : String) : Bool
+      TEST_FIXTURE_PATH_MARKERS.any? { |marker| path.includes?(marker) } ||
+        path.includes?(".test.") ||
+        path.includes?(".spec.")
+    end
+
+    private def analyze_file_routes(content : String, path : String, result : Array(Endpoint), literal_mask : Array(Bool))
       # Pattern for createFileRoute('/path')
       # Example: export const Route = createFileRoute('/posts/$postId')()
       file_route_pattern = /createFileRoute\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/
 
       content.scan(file_route_pattern) do |match|
+        next if literal_position?(literal_mask, match.begin(0))
+
         if match.size > 0
           route_path = match[1]
           next if pathless_only_route?(route_path)
@@ -58,7 +93,7 @@ module Analyzer::Typescript
           # Convert TanStack Router path params ($param) to standard format (:param)
           normalized_path = normalize_path(route_path)
 
-          endpoint = create_endpoint(normalized_path, "GET", path)
+          endpoint = create_endpoint(normalized_path, "GET", path, match.begin(0) || 0, content)
           extract_path_parameters(normalized_path, endpoint)
           extract_search_params(content, endpoint)
           attach_file_route_callees(content, path, match.begin(0) || 0, endpoint) if callees_needed?
@@ -67,19 +102,21 @@ module Analyzer::Typescript
       end
     end
 
-    private def analyze_lazy_file_routes(content : String, path : String, result : Array(Endpoint))
+    private def analyze_lazy_file_routes(content : String, path : String, result : Array(Endpoint), literal_mask : Array(Bool))
       # Pattern for createLazyFileRoute('/path')
       # Example: export const Route = createLazyFileRoute('/posts/$postId')()
       lazy_file_route_pattern = /createLazyFileRoute\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/
 
       content.scan(lazy_file_route_pattern) do |match|
+        next if literal_position?(literal_mask, match.begin(0))
+
         if match.size > 0
           route_path = match[1]
           next if pathless_only_route?(route_path)
 
           normalized_path = normalize_path(route_path)
 
-          endpoint = create_endpoint(normalized_path, "GET", path)
+          endpoint = create_endpoint(normalized_path, "GET", path, match.begin(0) || 0, content)
           extract_path_parameters(normalized_path, endpoint)
           extract_search_params(content, endpoint)
           attach_file_route_callees(content, path, match.begin(0) || 0, endpoint) if callees_needed?
@@ -88,8 +125,8 @@ module Analyzer::Typescript
       end
     end
 
-    private def analyze_create_routes(content : String, path : String, result : Array(Endpoint))
-      routes = extract_code_routes(content)
+    private def analyze_create_routes(content : String, path : String, result : Array(Endpoint), literal_mask : Array(Bool))
+      routes = extract_code_routes(content, literal_mask)
       unless routes.empty?
         route_map = Hash(String, CodeRoute).new
         routes.each { |route| route_map[route.name] = route }
@@ -112,6 +149,8 @@ module Analyzer::Typescript
       root_route_pattern = /createRootRoute(?:WithContext(?:\s*<[^>]+>)?\s*\(\s*\))?\s*\(\s*\{[^}]*path\s*:\s*['"`]([^'"`]+)['"`][^}]*\}/
 
       content.scan(root_route_pattern) do |match|
+        next if literal_position?(literal_mask, match.begin(0))
+
         if match.size > 0
           route_path = match[1]
           normalized_path = normalize_path(route_path)
@@ -124,12 +163,14 @@ module Analyzer::Typescript
       end
     end
 
-    private def extract_code_routes(content : String) : Array(CodeRoute)
+    private def extract_code_routes(content : String, literal_mask : Array(Bool)) : Array(CodeRoute)
       routes = [] of CodeRoute
       assignment_pattern = /\b(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*createRoute\s*\(/
 
       content.scan(assignment_pattern) do |match|
         start_pos = match.begin(0)
+        next if literal_position?(literal_mask, start_pos)
+
         open_paren = match.end(0).try { |idx| content.rindex('(', idx - 1) }
         next unless start_pos && open_paren
 
@@ -145,6 +186,44 @@ module Analyzer::Typescript
       end
 
       routes
+    end
+
+    private def string_literal_mask(content : String) : Array(Bool)
+      mask = Array(Bool).new(content.bytesize, false)
+      i = 0
+
+      while i < content.bytesize
+        byte = content.byte_at(i)
+        if byte == '\''.ord || byte == '"'.ord || byte == '`'.ord
+          quote = byte
+          mask[i] = true
+          i += 1
+
+          while i < content.bytesize
+            current = content.byte_at(i)
+            mask[i] = true
+
+            if current == '\\'.ord && i + 1 < content.bytesize
+              i += 1
+              mask[i] = true
+            elsif current == quote
+              i += 1
+              break
+            end
+
+            i += 1
+          end
+        else
+          i += 1
+        end
+      end
+
+      mask
+    end
+
+    private def literal_position?(literal_mask : Array(Bool), pos : Int32?) : Bool
+      return false unless pos
+      pos < literal_mask.size && literal_mask[pos]
     end
 
     private def extract_string_property(block : String, property : String) : String?

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -27,20 +27,26 @@ module Analyzer::Typescript
 
       parallel_file_scan([".js", ".ts", ".jsx", ".tsx", ".cts", ".mts", ".cjs", ".mjs"]) do |path|
         begin
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            raw = file.gets_to_end
-            content = Noir::JSRouteExtractor.strip_js_comments(raw)
-            base_path = configured_base_for(path)
-            collected = collect_routers(content, path, base_path)
-            unless collected.empty?
-              routers_mu.synchronize do
-                collected.each { |r| routers[router_key(r)] = r }
-              end
+          next if trpc_test_fixture_path?(path)
+
+          raw = read_file_content(path)
+          next unless trpc_candidate?(raw)
+          next if Noir::JSRouteExtractor.test_stub_only?(path, raw)
+
+          content = Noir::JSRouteExtractor.strip_js_comments(raw)
+          next unless trpc_candidate?(content)
+
+          literal_mask = string_literal_mask(content)
+          base_path = configured_base_for(path)
+          collected = collect_routers(content, path, base_path, literal_mask)
+          unless collected.empty?
+            routers_mu.synchronize do
+              collected.each { |r| routers[router_key(r)] = r }
             end
-            if found = extract_prefix(content)
-              prefix_mu.synchronize do
-                url_prefixes[base_path] = found
-              end
+          end
+          if found = extract_prefix(content, literal_mask)
+            prefix_mu.synchronize do
+              url_prefixes[base_path] = found
             end
           end
         rescue e
@@ -72,6 +78,89 @@ module Analyzer::Typescript
       result
     end
 
+    ROUTER_HINTS = [
+      "router(",
+      "router (",
+      "createTRPCRouter",
+    ]
+
+    PROCEDURE_HINTS = [
+      ".query(",
+      ".query (",
+      ".mutation(",
+      ".mutation (",
+      ".subscription(",
+      ".subscription (",
+    ]
+
+    PREFIX_HINTS = [
+      "endpoint:",
+      "createExpressMiddleware",
+      "createKoaMiddleware",
+      "fastifyTRPCPlugin",
+      "fastifyTRPC",
+    ]
+
+    private def trpc_candidate?(content : String) : Bool
+      content.matches?(/endpoint\s*:/) ||
+        PREFIX_HINTS.any? { |hint| content.includes?(hint) } ||
+        (ROUTER_HINTS.any? { |hint| content.includes?(hint) } &&
+          PROCEDURE_HINTS.any? { |hint| content.includes?(hint) })
+    end
+
+    TEST_FIXTURE_PATH_MARKERS = [
+      "/test/",
+      "/tests/",
+      "/__tests__/",
+      "/e2e/",
+      "/snapshots/",
+      "/test-files/",
+    ]
+
+    private def trpc_test_fixture_path?(path : String) : Bool
+      TEST_FIXTURE_PATH_MARKERS.any? { |marker| path.includes?(marker) } ||
+        path.includes?(".test.") ||
+        path.includes?(".spec.")
+    end
+
+    private def string_literal_mask(content : String) : Array(Bool)
+      mask = Array(Bool).new(content.bytesize, false)
+      i = 0
+
+      while i < content.bytesize
+        byte = content.byte_at(i)
+        if byte == '\''.ord || byte == '"'.ord || byte == '`'.ord
+          quote = byte
+          mask[i] = true
+          i += 1
+
+          while i < content.bytesize
+            current = content.byte_at(i)
+            mask[i] = true
+
+            if current == '\\'.ord && i + 1 < content.bytesize
+              i += 1
+              mask[i] = true
+            elsif current == quote
+              i += 1
+              break
+            end
+
+            i += 1
+          end
+        else
+          i += 1
+        end
+      end
+
+      mask
+    end
+
+    private def literal_position?(literal_mask : Array(Bool), pos : Int32?) : Bool
+      return false unless pos
+      pos < literal_mask.size && literal_mask[pos]
+    end
+
     private def router_key(router : Router) : RouterKey
       router_key(router.base_path, router.name)
     end
@@ -80,7 +169,7 @@ module Analyzer::Typescript
       {base_path, name}
     end
 
-    private def collect_routers(content : String, path : String, base_path : String) : Array(Router)
+    private def collect_routers(content : String, path : String, base_path : String, literal_mask : Array(Bool)) : Array(Router)
       collected = [] of Router
       # Capture `(export )? (const|let|var) NAME = <prefix>?(router|createTRPCRouter)({...})`.
       # Prefix tolerates `t.router(`, `initTRPC.create().router(`, `_.router(` etc.
@@ -88,6 +177,8 @@ module Analyzer::Typescript
 
       content.scan(pattern) do |match|
         match_start = match.begin(0) || 0
+        next if literal_position?(literal_mask, match_start)
+
         match_end = match.end(0) || 0
         next if match_end == 0
 
@@ -106,7 +197,9 @@ module Analyzer::Typescript
 
       content.scan(identifier_arg_pattern) do |match|
         match_start = match.begin(0) || 0
-        body_info = extract_object_assignment_body(content, match[2])
+        next if literal_position?(literal_mask, match_start)
+
+        body_info = extract_object_assignment_body(content, match[2], literal_mask)
         next unless body_info
 
         body, object_line = body_info
@@ -117,13 +210,15 @@ module Analyzer::Typescript
       collected
     end
 
-    private def extract_object_assignment_body(content : String, identifier : String) : Tuple(String, Int32)?
+    private def extract_object_assignment_body(content : String, identifier : String, literal_mask : Array(Bool)) : Tuple(String, Int32)?
       pattern = cached_regex("trpc:object_assign:#{identifier}") do
         /\b(?:export\s+)?(?:const|let|var)\s+#{Regex.escape(identifier)}(?:\s*:[^=]+)?\s*=\s*\{/
       end
 
       content.scan(pattern) do |match|
         match_start = match.begin(0) || 0
+        next if literal_position?(literal_mask, match_start)
+
         match_end = match.end(0) || 0
         next if match_end == 0
 
@@ -141,19 +236,22 @@ module Analyzer::Typescript
       nil
     end
 
-    private def extract_prefix(content : String) : String?
+    private def extract_prefix(content : String, literal_mask : Array(Bool)) : String?
       # Explicit endpoint option in fetch/openapi handlers.
-      if m = content.match(/endpoint\s*:\s*['"`]([^'"`]+)['"`]/)
+      content.scan(/endpoint\s*:\s*['"`]([^'"`]+)['"`]/) do |m|
+        next if literal_position?(literal_mask, m.begin(0))
         return m[1]
       end
 
       # Express/Koa-style mounting: `app.use('/api/trpc', trpcExpress.createExpressMiddleware(...))`.
-      if m = content.match(/\.\s*use\s*\(\s*['"`]([^'"`]+)['"`]\s*,\s*[^)]*?(?:trpcExpress\.createExpressMiddleware|createExpressMiddleware|createKoaMiddleware)/m)
+      content.scan(/\.\s*use\s*\(\s*['"`]([^'"`]+)['"`]\s*,\s*[^)]*?(?:trpcExpress\.createExpressMiddleware|createExpressMiddleware|createKoaMiddleware)/m) do |m|
+        next if literal_position?(literal_mask, m.begin(0))
         return m[1]
       end
 
       # Fastify plugin: `fastify.register(fastifyTRPCPlugin, { prefix: '/api/trpc' })`.
-      if m = content.match(/(?:fastifyTRPCPlugin|fastifyTRPC)\b[^)]*?prefix\s*:\s*['"`]([^'"`]+)['"`]/m)
+      content.scan(/(?:fastifyTRPCPlugin|fastifyTRPC)\b[^)]*?prefix\s*:\s*['"`]([^'"`]+)['"`]/m) do |m|
+        next if literal_position?(literal_mask, m.begin(0))
         return m[1]
       end
 
@@ -315,11 +413,11 @@ module Analyzer::Typescript
         dotted = prefix_dotted.empty? ? key : "#{prefix_dotted}.#{key}"
         base = url_prefix.empty? ? "/" : url_prefix.chomp('/')
         url = "#{base}/#{dotted}"
+        procedure_line = router.line + value_line - 1
         endpoint = Endpoint.new(url, method)
-        endpoint.details = Details.new(PathInfo.new(router.file, router.line))
+        endpoint.details = Details.new(PathInfo.new(router.file, procedure_line))
 
         attach_input_params(value, method, endpoint)
-        procedure_line = router.line + value_line - 1
         attach_procedure_callees(value, router.file, procedure_line, endpoint) if callees_needed?
 
         result << endpoint

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -96,6 +96,21 @@ module Noir::JSCalleeExtractor
     [] of Entry
   end
 
+  def exported_function_line(source : String,
+                             export_name : String) : Int32?
+    source_for_ast = normalize_handler_source(source)
+    line : Int32? = nil
+    Noir::TreeSitter.parse_javascript(source_for_ast) do |root|
+      if handler = exported_handler(root, root, source_for_ast, export_name, 0)
+        line = Noir::TreeSitter.node_start_row(handler) + 1
+      end
+    end
+
+    line
+  rescue
+    nil
+  end
+
   def callees_for_default_event_handler(source : String,
                                         file_path : String,
                                         *,
@@ -185,8 +200,10 @@ module Noir::JSCalleeExtractor
       route_info = route_info_for_call(node, source)
       if route_info
         method, path, handler = route_info
-        line = Noir::TreeSitter.node_start_row(node) + 1
-        by_route[route_key(method, path, line)] = callees_in_handler(handler, source, file_path, definitions)
+        callees = callees_in_handler(handler, source, file_path, definitions)
+        route_call_lines(node).each do |line|
+          by_route[route_key(method, path, line)] = callees
+        end
       end
     end
 
@@ -691,6 +708,20 @@ module Noir::JSCalleeExtractor
 
     property = Noir::TreeSitter.field(function, "property")
     property ? Noir::TreeSitter.node_text(property, source).downcase : ""
+  end
+
+  private def route_call_lines(call : LibTreeSitter::TSNode) : Array(Int32)
+    lines = [Noir::TreeSitter.node_start_row(call) + 1]
+    function = Noir::TreeSitter.field(call, "function") || first_named_child(call)
+    if function && Noir::TreeSitter.node_type(function) == "member_expression"
+      property = Noir::TreeSitter.field(function, "property")
+      if property
+        property_line = Noir::TreeSitter.node_start_row(property) + 1
+        lines << property_line unless lines.includes?(property_line)
+      end
+    end
+
+    lines
   end
 
   private def arguments_node(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?


### PR DESCRIPTION
## Summary
- improve JS/TS analyzer scan performance with cheaper candidate filters and cached file reads
- expand callee and `--ai-context=callee` coverage across Express, Fastify, Hono, Koa, Restify, Next.js, Remix, SvelteKit, Astro, TanStack Router, and tRPC
- improve endpoint source attribution for file-routed APIs and server actions
- add regression coverage for review findings: multiline JS route callee keys, Strapi config-before-handler route objects, and whitespace-tolerant tRPC endpoint prefixes

## Validation
- `crystal spec spec/unit_test/miniparser/js_callee_extractor_spec.cr spec/functional_test/testers/javascript/koa_spec.cr spec/functional_test/testers/javascript/hono_chained_middleware_callees_spec.cr spec/functional_test/testers/javascript/js_ai_context_callees_spec.cr spec/functional_test/testers/typescript/trpc_spec.cr spec/functional_test/testers/typescript/trpc_callees_spec.cr`
- `crystal spec spec/functional_test/testers/javascript spec/functional_test/testers/typescript`
- `just build`
- `just test`
- `just check`
- `git diff --check`
