### PR TITLE
Improve Python analyzer coverage and context accuracy

### DIFF
--- a/spec/functional_test/fixtures/python/aiohttp/app.py
+++ b/spec/functional_test/fixtures/python/aiohttp/app.py
@@ -34,6 +34,11 @@ async def delete_user(request):
     return web.Response(text=f"deleted {user_id}")
 
 
+async def alias_user(request):
+    alias_id = request.match_info['alias_id']
+    return web.Response(text=f"alias {alias_id}")
+
+
 async def websocket_feed(request):
     channel = request.match_info['channel']
     token = request.query.get('token')
@@ -145,6 +150,9 @@ def setup_routes(app):
     app.router.add_put('/users/{id}', update_user)
     app.router.add_delete('/users/{id}', delete_user)
     app.router.add_route('PATCH', '/users/{id}', update_user)
+    add_route = app.router.add_route
+    add_route('GET', '/alias/{alias_id}', alias_user, name='alias-user')
+    add_route('*', '/wildcard', index, name='wildcard')
     app.router.add_get('/feed/{channel}', websocket_feed)
     app.router.add_routes([web.view('/reports/{id}', ReportView)])
     app.router.add_static('/assets/', path='static')

--- a/spec/functional_test/fixtures/python/django/blog/urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/urls.py
@@ -136,6 +136,10 @@ urlpatterns = [
         r'^legacy/(?P<legacy_id>[0-9]+)/$',
         views.legacy_detail,
         name='legacy_detail'),
+    re_path(
+        r'^nested/(?P<nested_slug>[\w-]+(/[\w-]+)*)_(?P<pk>\d+)/$',
+        views.nested_regex_detail,
+        name='nested_regex_detail'),
 ]
 urlpatterns = base_patterns + urlpatterns
 urlpatterns.extend(extended_patterns)

--- a/spec/functional_test/fixtures/python/django/blog/views.py
+++ b/spec/functional_test/fixtures/python/django/blog/views.py
@@ -460,6 +460,19 @@ def legacy_detail(request, legacy_id):
     preview = request.GET.get('preview')
     return HttpResponse(f"{legacy_id}:{preview}")
 
+def nested_regex_detail(request, nested_slug, pk):
+    preview = request.GET.get('preview')
+    return HttpResponse(f"{nested_slug}:{pk}:{preview}")
+
+@require_POST
+def shop_orders(request):
+    token = request.POST.get('token')
+    return HttpResponse(token)
+
+def shop_daily_report(request):
+    period = request.GET.get('period')
+    return HttpResponse(period)
+
 def local_report_list(request):
     owner = request.GET.get('owner')
     return HttpResponse(owner)

--- a/spec/functional_test/fixtures/python/django/djangoblog/urls.py
+++ b/spec/functional_test/fixtures/python/django/djangoblog/urls.py
@@ -13,10 +13,12 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.apps import apps
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.sitemaps.views import sitemap
 from django.urls import include
+from django.urls import path
 from django.urls import re_path
 from haystack.views import search_view_factory
 
@@ -40,6 +42,7 @@ handler500 = 'blog.views.server_error_view'
 handle403 = 'blog.views.permission_denied_view'
 urlpatterns = [
                   re_path(r'', include('blog.urls', namespace='blog')),
+                  path('shop/', include(apps.get_app_config('fixture_shop').urls[0])),
                   # [REDACTED]
               ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 if settings.DEBUG:

--- a/spec/functional_test/fixtures/python/django/fixture_reports/apps.py
+++ b/spec/functional_test/fixtures/python/django/fixture_reports/apps.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from blog import views
+
+
+class FixtureReportsConfig:
+    label = "fixture_reports"
+    name = "fixture_reports"
+
+    def get_urls(self):
+        urlpatterns = [
+            path("daily/", views.shop_daily_report, name="shop-daily-report"),
+        ]
+        return self.post_process_urls(urlpatterns)

--- a/spec/functional_test/fixtures/python/django/fixture_shop/apps.py
+++ b/spec/functional_test/fixtures/python/django/fixture_shop/apps.py
@@ -1,0 +1,19 @@
+from django.apps import apps
+from django.urls import include, path
+
+from blog import views
+
+
+class FixtureShopConfig:
+    label = "fixture_shop"
+    name = "fixture_shop"
+
+    def ready(self):
+        self.reports_app = apps.get_app_config("fixture_reports")
+
+    def get_urls(self):
+        urls = [
+            path("orders/", views.shop_orders, name="shop-orders"),
+            path("reports/", include(self.reports_app.urls[0])),
+        ]
+        return urls

--- a/spec/functional_test/fixtures/python/fastapi_callees/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_callees/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from api import api
 from db import save_user, audit_log
 
@@ -15,6 +15,10 @@ def rate_limit(_n):
 
 def build_status():
     return {"ok": True}
+
+
+def require_admin():
+    return True
 
 
 def export_file(file_path: str):
@@ -71,3 +75,12 @@ def list_reports(
     user = save_user("report")
     audit_log(user)
     return {"ok": True}
+
+
+@app.get(
+    "/decorated",
+    dependencies=[Depends(require_admin)],
+)
+def decorated(limit: int = 10):
+    audit_log(limit)
+    return {"limit": limit}

--- a/spec/functional_test/fixtures/python/litestar/app.py
+++ b/spec/functional_test/fixtures/python/litestar/app.py
@@ -123,6 +123,17 @@ class ReportsController(Controller):
         return {"org_id": org_id, "title": data.title}
 
 
+class AbsoluteController(Controller):
+    @get(
+        path="/absolute/status",
+    )
+    async def absolute_status(self) -> dict:
+        make_cookie(
+            path="/not-a-controller-prefix",
+        )
+        return {}
+
+
 router = Router(path="/api", route_handlers=[list_items, get_item])
 admin_router = Router(path="/admin", route_handlers=[ReportsController])
 external_router = Router(path="/external", route_handlers=[external_handlers.external_summary])
@@ -145,4 +156,5 @@ app = Litestar(route_handlers=[
     router,
     admin_router,
     external_router,
+    AbsoluteController,
 ])

--- a/spec/functional_test/fixtures/python/sanic/app.py
+++ b/spec/functional_test/fixtures/python/sanic/app.py
@@ -99,6 +99,20 @@ class ReportMethodView(HTTPMethodView):
         return response.json({'id': report_id, 'title': title})
 
 
+class ProgrammaticWebsocketApp:
+    def __init__(self):
+        self.app = Sanic("programmatic_ws")
+        self.app.add_websocket_route(
+            self.feed,
+            "/programmatic-feed/<channel>",
+            name="programmatic-feed",
+        )
+
+    async def feed(self, request: Request, ws, channel: str):
+        token = request.args.get("token")
+        await ws.send(json.dumps({"channel": channel, "token": token}))
+
+
 app.add_route(
     update_report,
     '/reports/<report_id:int>/status',

--- a/spec/functional_test/testers/python/aiohttp_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_spec.cr
@@ -19,6 +19,16 @@ expected_endpoints = [
   Endpoint.new("/users/{id}", "PATCH", [
     Param.new("id", "", "path"),
   ]),
+  Endpoint.new("/alias/{alias_id}", "GET", [
+    Param.new("alias_id", "", "path"),
+  ]),
+  Endpoint.new("/wildcard", "GET"),
+  Endpoint.new("/wildcard", "POST"),
+  Endpoint.new("/wildcard", "PUT"),
+  Endpoint.new("/wildcard", "DELETE"),
+  Endpoint.new("/wildcard", "PATCH"),
+  Endpoint.new("/wildcard", "HEAD"),
+  Endpoint.new("/wildcard", "OPTIONS"),
   Endpoint.new("/feed/{channel}", "GET", [
     Param.new("channel", "", "path"),
     Param.new("token", "", "query"),

--- a/spec/functional_test/testers/python/django_spec.cr
+++ b/spec/functional_test/testers/python/django_spec.cr
@@ -151,6 +151,13 @@ expected_endpoints = [
     Param.new("preview", "", "query"),
     Param.new("legacy_id", "", "path"),
   ]),
+  Endpoint.new("/nested/{nested_slug}_{pk}/", "GET", [
+    Param.new("preview", "", "query"),
+    Param.new("nested_slug", "", "path"),
+    Param.new("pk", "", "path"),
+  ]),
+  Endpoint.new("/shop/orders/", "POST", [Param.new("token", "", "form")]),
+  Endpoint.new("/shop/reports/daily/", "GET", [Param.new("period", "", "query")]),
 ]
 
 FunctionalTester.new("fixtures/python/django/", {

--- a/spec/functional_test/testers/python/fastapi_callees_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_callees_spec.cr
@@ -54,7 +54,7 @@ expected_endpoints = [
   #    body callees are resolved.
   Endpoint.new("/exports/{file_path}", "GET").tap do |ep|
     ep.push_param(Param.new("file_path", "", "path"))
-    ep.push_callee(Callee.new("export_file", main_path, 27))
+    ep.push_callee(Callee.new("export_file", main_path, 31))
     ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 
@@ -64,6 +64,15 @@ expected_endpoints = [
   #    as the end of the block.
   Endpoint.new("/reports", "GET").tap do |ep|
     ep.push_callee(Callee.new("save_user", db_path, 1))
+    ep.push_callee(Callee.new("audit_log", db_path, 5))
+  end,
+
+  # 8. GET /decorated — multi-line route decorator with a Depends()
+  #    call before the handler. The decorator continuation must not be
+  #    treated as the handler def; otherwise `limit` is missed and
+  #    Depends is emitted as a handler callee.
+  Endpoint.new("/decorated", "GET").tap do |ep|
+    ep.push_param(Param.new("limit", "10", "query"))
     ep.push_callee(Callee.new("audit_log", db_path, 5))
   end,
 ]
@@ -88,5 +97,22 @@ describe "FastAPI programmatic route callees" do
     endpoint = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/exports/{file_path}" }
     endpoint.callees.should be_empty
     endpoint.params.select { |param| param.name == "file_path" }.map(&.param_type).should eq(["path"])
+  end
+end
+
+describe "FastAPI multi-line decorator callee scope" do
+  it "does not treat decorator dependency calls as handler callees" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/fastapi_callees/")])
+    options["nolog"] = YAML::Any.new(true)
+    options["include_callee"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/decorated" }
+    endpoint.params.any? { |param| param.name == "limit" && param.param_type == "query" }.should be_true
+    endpoint.callees.map(&.name).should_not contain("Depends")
   end
 end

--- a/spec/functional_test/testers/python/litestar_spec.cr
+++ b/spec/functional_test/testers/python/litestar_spec.cr
@@ -34,6 +34,7 @@ expected_endpoints = [
     Param.new("data", "", "json"),
   ]),
   Endpoint.new("/external/summary", "GET", [Param.new("mode", "", "query")]),
+  Endpoint.new("/absolute/status", "GET"),
 ]
 
 tester = FunctionalTester.new("fixtures/python/litestar/", {

--- a/spec/functional_test/testers/python/sanic_spec.cr
+++ b/spec/functional_test/testers/python/sanic_spec.cr
@@ -40,6 +40,12 @@ expected_endpoints = [
   ]),
   Endpoint.new("/assets/*", "GET"),
   Endpoint.new("/api/v1/reports/files/*", "GET"),
+  Endpoint.new("/programmatic-feed/{channel}", "GET", [
+    Param.new("channel", "", "path"),
+    Param.new("token", "", "query"),
+  ]).tap do |endpoint|
+    endpoint.protocol = "ws"
+  end,
 ]
 
 tester = FunctionalTester.new("fixtures/python/sanic/", {

--- a/spec/unit_test/analyzer/python_engine_spec.cr
+++ b/spec/unit_test/analyzer/python_engine_spec.cr
@@ -3,6 +3,10 @@ require "../../../src/models/code_locator"
 require "../../../src/analyzer/engines/python_engine"
 
 class PythonEngineSpecHarness < Analyzer::Python::PythonEngine
+  def def_line_after(lines : Array(String), decorator_line : Int32) : Int32?
+    find_def_line(lines, decorator_line)
+  end
+
   def callees_from(body : String,
                    body_start_line : Int32,
                    path : String,
@@ -52,5 +56,20 @@ describe Analyzer::Python::PythonEngine do
     callees[0].name.should eq("unknown_call")
     callees[0].path.should eq(caller_path)
     callees[0].line.should eq(2)
+  end
+
+  it "skips multi-line route decorators when locating the decorated function" do
+    harness = PythonEngineSpecHarness.new(create_test_options)
+    lines = [
+      "@router.get(",
+      "  \"/users\",",
+      "  dependencies=[Depends(require_admin)],",
+      ")",
+      "@audit_required",
+      "def list_users(limit: int = 100):",
+      "    return []",
+    ]
+
+    harness.def_line_after(lines, 0).should eq(5)
   end
 end

--- a/spec/unit_test/models/endpoint_spec.cr
+++ b/spec/unit_test/models/endpoint_spec.cr
@@ -66,6 +66,31 @@ describe "Initialize 4 arguments" do
   end
 end
 
+describe "Endpoint detail ownership" do
+  it "does not share mutable code paths from reused Details" do
+    shared_details = Details.new(PathInfo.new("openapi.json", 1))
+
+    first = Endpoint.new("/first", "GET", shared_details)
+    second = Endpoint.new("/second", "GET", shared_details)
+
+    first.details.add_path(PathInfo.new("first_controller.py", 10))
+
+    first.details.code_paths.map(&.path).should eq(["openapi.json", "first_controller.py"])
+    second.details.code_paths.map(&.path).should eq(["openapi.json"])
+  end
+
+  it "does not share mutable tags from reused Params" do
+    param = Param.new("token", "", "header")
+    first = Endpoint.new("/first", "GET", [param])
+    second = Endpoint.new("/second", "GET", [param])
+
+    first.params[0].add_tag(Tag.new("auth", "", "test"))
+
+    first.params[0].tags.size.should eq(1)
+    second.params[0].tags.should be_empty
+  end
+end
+
 describe "Endpoint equality" do
   it "same endpoints" do
     endpoint1 = Endpoint.new("/abcd", "GET")

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -224,6 +224,32 @@ describe "EndpointOptimizer" do
       end
     end
 
+    it "does not leak code paths across OAS endpoints that reused Details" do
+      optimizer = EndpointOptimizer.new(logger, options)
+
+      oas_details = Details.new(PathInfo.new("openapi.json", 1))
+      oas_details.technology = "oas3"
+      oas_tags = Endpoint.new("/api/tags", "GET", oas_details)
+      oas_users = Endpoint.new("/api/users", "POST", oas_details)
+
+      tags_details = Details.new(PathInfo.new("tags.py", 12))
+      tags_details.technology = "python_litestar"
+      tags_endpoint = Endpoint.new("/api/tags", "GET", tags_details)
+
+      users_details = Details.new(PathInfo.new("users.py", 24))
+      users_details.technology = "python_litestar"
+      users_endpoint = Endpoint.new("/api/users", "POST", users_details)
+
+      result = optimizer.optimize_endpoints([oas_tags, oas_users, tags_endpoint, users_endpoint])
+
+      result.size.should eq(2)
+      tags = result.find! { |endpoint| endpoint.url == "/api/tags" }
+      users = result.find! { |endpoint| endpoint.url == "/api/users" }
+
+      tags.details.code_paths.map(&.path).should eq(["openapi.json", "tags.py"])
+      users.details.code_paths.map(&.path).should eq(["openapi.json", "users.py"])
+    end
+
     it "merges Postman colon path templates with Kotlin Spring brace templates" do
       optimizer = EndpointOptimizer.new(logger, options)
       temp_dir = File.join(Dir.tempdir, "noir-optimizer-postman-colon-#{Process.pid}-#{Time.utc.to_unix_ms}")
@@ -711,6 +737,19 @@ describe "EndpointOptimizer" do
       result[0].params.map(&.name).should eq(["xMin", "yMin", "xMax", "yMax"])
       result[0].params.all? { |p| p.param_type == "path" }.should be_true
       result[1].params.map(&.name).should eq(["userName", "x", "y"])
+    end
+
+    it "does not treat regex quantifiers as curly brace path params" do
+      optimizer = EndpointOptimizer.new(logger, options)
+      endpoints = [
+        Endpoint.new("/archive/\\d{4}/", "GET"),
+        Endpoint.new("/archive/{year}/", "GET"),
+      ]
+
+      result = optimizer.add_path_parameters(endpoints)
+
+      result[0].params.should be_empty
+      result[1].params.map(&.name).should eq(["year"])
     end
 
     it "extracts parameters from colon patterns" do

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -42,6 +42,8 @@ module Analyzer::Python
     ADD_METHOD_RE       = /(#{DOT_NATION})\.add_(#{METHODS_ALT})\([rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
     ADD_STATIC_RE       = /(#{DOT_NATION})\.add_static\([rf]?['"]([^'"]*)['"]/
     ADD_ROUTE_RE        = /(#{DOT_NATION})\.add_route\([rf]?['"]([A-Za-z*]+)['"]\s*,\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
+    ADD_ROUTE_ALIAS_RE  = /^(#{PYTHON_VAR_NAME_REGEX})\([rf]?['"]([A-Za-z*]+)['"]\s*,\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
+    ROUTE_ALIAS_RE      = /^(#{PYTHON_VAR_NAME_REGEX})=(#{DOT_NATION})\.add_route/
     ADD_VIEW_RE         = /(#{DOT_NATION})\.add_view\([rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
     WEB_METHOD_GUARD_RE = /\bweb\.(?:#{METHODS_ALT})\s*\(/
     WEB_METHOD_RE       = /\bweb\.(#{METHODS_ALT})\s*\(\s*[rf]?['"]([^'"]*)['"]\s*,\s*(?:handler\s*=\s*)?(#{DOT_NATION})/
@@ -101,12 +103,13 @@ module Analyzer::Python
           File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
             file_content = file.gets_to_end
             lines = file_content.lines
-            next unless lines.any?(&.includes?("aiohttp"))
+            next unless aiohttp_relevant_source?(file_content)
 
             import_modules = find_imported_modules(current_base_path, path, file_content)
             app_prefixes = collect_app_prefixes(lines)
             route_table_prefixes = collect_route_table_prefixes(lines, app_prefixes)
             route_list_prefixes = collect_route_list_prefixes(lines, app_prefixes)
+            route_aliases = Hash(::String, ::String).new
 
             handler_routes[path] ||= [] of Tuple(::String, ::String, Int32, ::String)
             class_view_routes[path] ||= [] of Tuple(::String, Int32, ::String)
@@ -158,15 +161,17 @@ module Analyzer::Python
                 if orig_match = line.match(/@#{aiohttp_route_deco[1]}\s*\.\s*route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
                   route_path = orig_match[1]
                 end
-                process_decorator_route(
-                  path,
-                  lines,
-                  line_index,
-                  route_path,
-                  method,
-                  definition_base_path: current_base_path,
-                  source: file_content
-                )
+                expand_aiohttp_methods(method).each do |expanded_method|
+                  process_decorator_route(
+                    path,
+                    lines,
+                    line_index,
+                    route_path,
+                    expanded_method,
+                    definition_base_path: current_base_path,
+                    source: file_content
+                  )
+                end
               end
 
               # Style A: app.router.add_<method>("/path", handler)
@@ -203,6 +208,10 @@ module Analyzer::Python
               end
 
               # Style A: app.router.add_route("METHOD", "/path", handler)
+              if stripped.includes?(".add_route") && (alias_match = stripped.match(ROUTE_ALIAS_RE))
+                route_aliases[alias_match[1]] = alias_match[2]
+              end
+
               add_route_match = stripped.includes?(".add_route(") ? stripped.match(ADD_ROUTE_RE) : nil
               if add_route_match
                 receiver = add_route_match[1]
@@ -213,7 +222,27 @@ module Analyzer::Python
                   route_path = orig_match[1]
                 end
                 prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                  handler_routes[path] << {join_paths(prefix, route_path), method, line_index, handler_name}
+                  expand_aiohttp_methods(method).each do |expanded_method|
+                    handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
+                  end
+                end
+              end
+
+              # Style A alias:
+              #   add_route = app.router.add_route
+              #   add_route("GET", "/path", handler)
+              alias_route_match = stripped.includes?("(") ? stripped.match(ADD_ROUTE_ALIAS_RE) : nil
+              if alias_route_match && (receiver = route_aliases[alias_route_match[1]]?)
+                method = alias_route_match[2].upcase
+                route_path = alias_route_match[3]
+                handler_name = alias_route_match[4]
+                if orig_match = line.match(/^\s*#{Regex.escape(alias_route_match[1])}\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
+                  route_path = orig_match[1]
+                end
+                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                  expand_aiohttp_methods(method).each do |expanded_method|
+                    handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
+                  end
                 end
               end
 
@@ -328,6 +357,24 @@ module Analyzer::Python
       end
 
       result
+    end
+
+    private def aiohttp_relevant_source?(source : ::String) : Bool
+      source.includes?("aiohttp") ||
+        source.includes?("RouteTableDef") ||
+        source.includes?("web.") ||
+        HTTP_METHOD_NAMES.any? { |method| source.includes?(".add_#{method}(") } ||
+        source.includes?(".add_route") ||
+        source.includes?(".add_routes(") ||
+        source.includes?(".add_static(") ||
+        source.includes?(".add_view(")
+    end
+
+    private def expand_aiohttp_methods(method : ::String) : Array(::String)
+      normalized = method.upcase
+      return HTTP_METHOD_NAMES.map(&.upcase) if normalized == "*"
+
+      [normalized]
     end
 
     private def emit_class_view_endpoints(path : ::String,

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -6,6 +6,8 @@ module Analyzer::Python
     # Base path for the Django project
     @django_base_path : ::String = ""
     @visited_url_paths = Hash(String, Bool).new
+    @django_app_config_path_cache = Hash(::String, ::String).new
+    @visited_app_config_paths = Set(::String).new
 
     # Regular expressions for extracting Django URL configurations
     REGEX_ROOT_URLCONF  = /\s*ROOT_URLCONF\s*=\s*r?['"]([^'"\\]*)['"]/
@@ -246,6 +248,7 @@ module Analyzer::Python
       original_content = content
       package_map = find_imported_modules(@django_base_path, url_base_path, content)
       import_aliases = extract_python_import_aliases(original_content)
+      app_config_refs = extract_django_app_config_refs(original_content)
       drf_router_registrations = extract_drf_router_registrations(content)
       urlpattern_lists = extract_urlpattern_lists(content)
       route_path = PathInfo.new(django_urls.filepath)
@@ -284,6 +287,13 @@ module Analyzer::Python
             end
           end
           next if new_django_urls
+
+          if app_config_path = resolve_django_app_config_include_path(view, app_config_refs)
+            extract_endpoints_from_django_app_config(join_url_parts(django_urls.prefix, route).lchop("/"), app_config_path, route_path).each do |endpoint|
+              endpoints << endpoint
+            end
+            next
+          end
 
           if imported_urlconf_path = extract_imported_include_target(view, package_map)
             new_django_urls = DjangoUrls.new("#{django_urls.prefix}#{route}", imported_urlconf_path, django_urls.basepath)
@@ -332,23 +342,8 @@ module Analyzer::Python
             endpoints << Endpoint.new(url, "GET", Details.new(route_path))
           else
             view = extract_wrapped_view_reference(view)
-            dotted_as_names_split = view.split(".")
-
-            filepath = ""
-            function_or_class_name = ""
-            dotted_as_names_split.each_with_index do |name, index|
-              if (package_map.has_key? name) && (index < dotted_as_names_split.size)
-                filepath, package_type = package_map[name]
-                function_or_class_name = name
-                if package_type == PackageType::FILE && index + 1 < dotted_as_names_split.size
-                  function_or_class_name = dotted_as_names_split[index + 1]
-                end
-
-                break
-              end
-            end
-
-            if !filepath.empty? && /^[a-zA-Z_][a-zA-Z0-9_]*$/.match(function_or_class_name)
+            if view_target = resolve_django_view_target(view, package_map)
+              filepath, function_or_class_name = view_target
               extract_endpoints_from_file(url, filepath, function_or_class_name).each do |endpoint|
                 append_code_path(endpoint.details, route_path)
                 endpoints << endpoint
@@ -366,23 +361,34 @@ module Analyzer::Python
     end
 
     private def extract_urlpatterns_contents(content : ::String, urlpattern_lists : Hash(::String, ::String)) : Array(::String)
+      extract_url_list_contents(content, urlpattern_lists, ["urlpatterns"])
+    end
+
+    private def extract_app_config_url_contents(content : ::String, urlpattern_lists : Hash(::String, ::String)) : Array(::String)
+      extract_url_list_contents(content, urlpattern_lists, ["urls", "urlpatterns"])
+    end
+
+    private def extract_url_list_contents(content : ::String,
+                                          urlpattern_lists : Hash(::String, ::String),
+                                          list_names : Array(::String)) : Array(::String)
       contents = [] of ::String
       lines = content.split("\n")
+      list_name_re = list_names.map { |name| Regex.escape(name) }.join("|")
 
       lines.each_with_index do |line, index|
-        if line.matches?(/^\s*urlpatterns\s*=/)
+        if line.matches?(/^\s*(?:#{list_name_re})\s*=/)
           logical_line = collect_python_expression(lines, index, line)
-          if assignment_match = logical_line.match(/^\s*urlpatterns\s*=\s*(.+)$/m)
+          if assignment_match = logical_line.match(/^\s*(?:#{list_name_re})\s*=\s*(.+)$/m)
             add_urlpattern_expression_contents(contents, assignment_match[1], urlpattern_lists)
           end
-        elsif line.matches?(/^\s*urlpatterns\s*\+=/)
+        elsif line.matches?(/^\s*(?:#{list_name_re})\s*\+=/)
           logical_line = collect_python_expression(lines, index, line)
-          if append_match = logical_line.match(/^\s*urlpatterns\s*\+=\s*(.+)$/m)
+          if append_match = logical_line.match(/^\s*(?:#{list_name_re})\s*\+=\s*(.+)$/m)
             add_urlpattern_expression_contents(contents, append_match[1], urlpattern_lists)
           end
-        elsif line.matches?(/^\s*urlpatterns\s*\.\s*extend\s*\(/)
+        elsif line.matches?(/^\s*(?:#{list_name_re})\s*\.\s*extend\s*\(/)
           logical_line = collect_python_expression(lines, index, line)
-          if extend_match = logical_line.match(/^\s*urlpatterns\s*\.\s*extend\s*\((.*)\)\s*$/m)
+          if extend_match = logical_line.match(/^\s*(?:#{list_name_re})\s*\.\s*extend\s*\((.*)\)\s*$/m)
             add_urlpattern_expression_contents(contents, extend_match[1], urlpattern_lists)
           end
         end
@@ -508,6 +514,190 @@ module Analyzer::Python
       pattern_lists
     end
 
+    private def extract_django_app_config_refs(content : ::String) : Hash(::String, ::String)
+      refs = Hash(::String, ::String).new
+      content.each_line do |line|
+        next if line.lstrip.starts_with?("#")
+        line.scan(/\bself\.([A-Za-z_][A-Za-z0-9_]*)\s*=\s*apps\.get_app_config\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+          next unless match.size == 3
+          refs[match[1]] = match[2]
+        end
+      end
+      refs
+    end
+
+    private def resolve_django_app_config_include_path(view : ::String,
+                                                       app_config_refs : Hash(::String, ::String)) : ::String?
+      if direct_match = view.match(/\bapps\.get_app_config\s*\(\s*['"]([^'"]+)['"]\s*\)\.urls\b/)
+        return resolve_django_app_config_path(direct_match[1])
+      end
+
+      if self_match = view.match(/\bself\.([A-Za-z_][A-Za-z0-9_]*)\.urls\b/)
+        ref_name = self_match[1]
+        if label = app_config_refs[ref_name]?
+          resolve_django_app_config_path(label)
+        end
+      end
+    end
+
+    private def resolve_django_app_config_path(label : ::String) : ::String?
+      cache_key = "#{@django_base_path}:#{label}"
+      if cached = @django_app_config_path_cache[cache_key]?
+        return cached.empty? ? nil : cached
+      end
+
+      escaped_label = Regex.escape(label)
+      label_re = Regex.new("^\\s*label\\s*=\\s*[r]?['\"]#{escaped_label}['\"]")
+      exact_name_re = Regex.new("^\\s*name\\s*=\\s*[r]?['\"]#{escaped_label}['\"]")
+      tail_name_re = Regex.new("^\\s*name\\s*=\\s*[r]?['\"][^'\"]*\\.#{escaped_label}['\"]")
+
+      candidates = all_files.select do |file|
+        next false unless file.ends_with?(".py")
+        next false if file.includes?("/site-packages/")
+        next false if PythonEngine.python_test_path?(file, base_path_for(file))
+        base = File.basename(file)
+        base == "apps.py" || base == "config.py"
+      end
+      candidates.sort_by! { |file| {file.ends_with?("/config.py") ? 0 : 1, file.count('/'), file} }
+
+      candidates.each do |file|
+        begin
+          content = read_file_content(file)
+        rescue
+          next
+        end
+
+        if content.each_line.any? { |line| line.matches?(label_re) || line.matches?(exact_name_re) || line.matches?(tail_name_re) }
+          @django_app_config_path_cache[cache_key] = file
+          return file
+        end
+      end
+
+      @django_app_config_path_cache[cache_key] = ""
+      nil
+    end
+
+    private def extract_endpoints_from_django_app_config(prefix : ::String,
+                                                         app_config_path : ::String,
+                                                         parent_route_path : PathInfo) : Array(Endpoint)
+      endpoints = [] of Endpoint
+      expanded_key = "#{File.expand_path(app_config_path)}:#{prefix}"
+      return endpoints if @visited_app_config_paths.includes?(expanded_key)
+      @visited_app_config_paths << expanded_key
+
+      begin
+        content = read_file_content(app_config_path)
+        package_map = find_imported_modules(@django_base_path, File.dirname(app_config_path), content)
+        urlpattern_lists = extract_urlpattern_lists(content)
+        app_config_refs = extract_django_app_config_refs(content)
+        route_path = PathInfo.new(app_config_path)
+
+        extract_app_config_url_contents(content, urlpattern_lists).each do |pattern_content|
+          extract_app_config_pattern_endpoints(prefix, pattern_content, app_config_path, package_map, urlpattern_lists, app_config_refs, route_path, parent_route_path).each do |endpoint|
+            endpoints << endpoint
+          end
+        end
+      rescue e
+        logger.debug e.message
+      end
+
+      endpoints
+    end
+
+    private def extract_app_config_pattern_endpoints(prefix : ::String,
+                                                     pattern_content : ::String,
+                                                     current_app_config_path : ::String,
+                                                     package_map,
+                                                     urlpattern_lists : Hash(::String, ::String),
+                                                     app_config_refs : Hash(::String, ::String),
+                                                     route_path : PathInfo,
+                                                     parent_route_path : PathInfo) : Array(Endpoint)
+      endpoints = [] of Endpoint
+
+      extract_route_mappings(pattern_content).each do |route_mapping|
+        route, view = route_mapping
+        route = normalize_django_route(route)
+        nested_prefix = join_url_parts(prefix, route).lchop("/")
+
+        if nested_app_config_path = resolve_django_app_config_include_path(view, app_config_refs)
+          extract_endpoints_from_django_app_config(nested_prefix, nested_app_config_path, route_path).each do |endpoint|
+            append_code_path(endpoint.details, parent_route_path)
+            endpoints << endpoint
+          end
+          next
+        end
+
+        if local_patterns = extract_local_include_target(view)
+          if nested_pattern_content = urlpattern_lists[local_patterns]?
+            extract_app_config_pattern_endpoints(nested_prefix, nested_pattern_content, current_app_config_path, package_map, urlpattern_lists, app_config_refs, route_path, parent_route_path).each do |endpoint|
+              endpoints << endpoint
+            end
+            next
+          end
+        end
+
+        if inline_patterns = extract_inline_include_patterns(view)
+          extract_app_config_pattern_endpoints(nested_prefix, inline_patterns, current_app_config_path, package_map, urlpattern_lists, app_config_refs, route_path, parent_route_path).each do |endpoint|
+            endpoints << endpoint
+          end
+          next
+        end
+
+        if imported_urlconf_path = extract_imported_include_target(view, package_map)
+          new_django_urls = DjangoUrls.new(nested_prefix, imported_urlconf_path, @django_base_path)
+          unless @visited_url_paths.has_key? new_django_urls.filepath
+            extract_endpoints(new_django_urls).each do |endpoint|
+              append_code_path(endpoint.details, route_path)
+              append_code_path(endpoint.details, parent_route_path)
+              endpoints << endpoint
+            end
+          end
+          next
+        end
+
+        url = join_url_parts(prefix, route)
+        if view.empty?
+          endpoint = Endpoint.new(url, "GET", Details.new(route_path))
+          append_code_path(endpoint.details, parent_route_path)
+          endpoints << endpoint
+        else
+          view = extract_wrapped_view_reference(view)
+          if view_target = resolve_django_view_target(view, package_map)
+            filepath, function_or_class_name = view_target
+            extract_endpoints_from_file(url, filepath, function_or_class_name).each do |endpoint|
+              append_code_path(endpoint.details, route_path)
+              append_code_path(endpoint.details, parent_route_path)
+              endpoints << endpoint
+            end
+          else
+            endpoint = Endpoint.new(url, "GET", Details.new(route_path))
+            append_code_path(endpoint.details, parent_route_path)
+            endpoints << endpoint
+          end
+        end
+      end
+
+      endpoints
+    end
+
+    private def resolve_django_view_target(view : ::String, package_map) : Tuple(::String, ::String)?
+      dotted_as_names_split = view.split(".")
+
+      dotted_as_names_split.each_with_index do |name, index|
+        if (package_map.has_key? name) && (index < dotted_as_names_split.size)
+          filepath, package_type = package_map[name]
+          function_or_class_name = name
+          if package_type == PackageType::FILE && index + 1 < dotted_as_names_split.size
+            function_or_class_name = dotted_as_names_split[index + 1]
+          end
+
+          return {filepath, function_or_class_name} if !filepath.empty? && /^[a-zA-Z_][a-zA-Z0-9_]*$/.match(function_or_class_name)
+        end
+      end
+
+      nil
+    end
+
     private def python_bracket_delta(line : ::String) : Int32
       depth = 0
       in_quote : Char? = nil
@@ -587,9 +777,66 @@ module Analyzer::Python
 
     private def normalize_django_route(route : ::String) : ::String
       normalized = route.gsub(/^\^/, "").gsub(/\$$/, "")
-      normalized.gsub(/\(\?P<([A-Za-z_][A-Za-z0-9_]*)>[^)]*\)/) do
-        "{#{$~[1]}}"
+      normalize_django_named_regex_groups(normalized)
+    end
+
+    private def normalize_django_named_regex_groups(route : ::String) : ::String
+      normalized = String.build do |io|
+        index = 0
+        while index < route.size
+          if route.byte_slice(index, 4) == "(?P<"
+            name_start = index + 4
+            name_end = route.index('>', name_start)
+            unless name_end
+              io << route[index]
+              index += 1
+              next
+            end
+
+            name = route[name_start...name_end]
+            if name.matches?(/^[A-Za-z_][A-Za-z0-9_]*$/)
+              group_end = django_named_group_end(route, name_end + 1)
+              if group_end
+                io << "{#{name}}"
+                index = group_end + 1
+                next
+              end
+            end
+          end
+
+          io << route[index]
+          index += 1
+        end
       end
+      normalized
+    end
+
+    private def django_named_group_end(route : ::String, start_index : Int32) : Int32?
+      depth = 1
+      index = start_index
+      in_char_class = false
+      escaped = false
+
+      while index < route.size
+        ch = route[index]
+        if escaped
+          escaped = false
+        elsif ch == '\\'
+          escaped = true
+        elsif in_char_class
+          in_char_class = false if ch == ']'
+        elsif ch == '['
+          in_char_class = true
+        elsif ch == '('
+          depth += 1
+        elsif ch == ')'
+          depth -= 1
+          return index if depth == 0
+        end
+        index += 1
+      end
+
+      nil
     end
 
     private def extract_python_import_aliases(content : ::String) : Hash(::String, ::String)

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -330,16 +330,21 @@ module Analyzer::Python
         end
 
         class_indent = line.size - line.lstrip.size
+        class_attr_indent = class_indent + INDENTATION_SIZE
         body_idx = idx + 1
         while body_idx < lines.size
           body_line = lines[body_idx]
           unless body_line.strip.empty?
             indent = body_line.size - body_line.lstrip.size
             break if indent <= class_indent
+            stripped = body_line.lstrip
+            break if indent == class_attr_indent && (stripped.starts_with?("@") || stripped.starts_with?("def ") || stripped.starts_with?("async def "))
 
-            if path_attr = body_line.match(/^\s*path\s*=\s*[rf]?['"]([^'"]*)['"]/)
-              prefix = path_attr[1]
-              break
+            if indent == class_attr_indent
+              if path_attr = body_line.match(/^\s*path\s*=\s*[rf]?['"]([^'"]*)['"]/)
+                prefix = path_attr[1]
+                break
+              end
             end
           end
           body_idx += 1

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -28,12 +28,13 @@ module Analyzer::Python
     # recompiles (PCRE2 JIT) on every evaluation, and these interpolate
     # only constants. The `.to_s` expansion is byte-identical to the
     # previous inline form, so matching behaviour is unchanged.
-    SANIC_INSTANCE_RE   = /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:sanic\.)?Sanic\(/
-    STATIC_CALL_RE      = /\b(#{PYTHON_VAR_NAME_REGEX})\.static\s*\((.*)\)\s*$/m
-    ADD_ROUTE_CALL_RE   = /\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m
-    AS_VIEW_RE          = /^(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/
-    DOTTED_REFERENCE_RE = /^#{PYTHON_VAR_NAME_REGEX}(?:\.#{PYTHON_VAR_NAME_REGEX})*$/
-    BLUEPRINT_CALL_RE   = /\.blueprint\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})(.*?)\)/m
+    SANIC_INSTANCE_RE           = /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:sanic\.)?Sanic\(/
+    STATIC_CALL_RE              = /\b(#{PYTHON_VAR_NAME_REGEX})\.static\s*\((.*)\)\s*$/m
+    ADD_ROUTE_CALL_RE           = /\b(#{PYTHON_VAR_NAME_REGEX})\.add_route\s*\((.*)\)\s*$/m
+    ADD_WEBSOCKET_ROUTE_CALL_RE = /\b(#{PYTHON_VAR_NAME_REGEX})\.add_websocket_route\s*\((.*)\)\s*$/m
+    AS_VIEW_RE                  = /^(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/
+    DOTTED_REFERENCE_RE         = /^#{PYTHON_VAR_NAME_REGEX}(?:\.#{PYTHON_VAR_NAME_REGEX})*$/
+    BLUEPRINT_CALL_RE           = /\.blueprint\s*\(\s*(#{PYTHON_VAR_NAME_REGEX})(.*?)\)/m
 
     # `get_endpoints` rebuilt two PCRE2 patterns per request field on
     # every handler-body line. The field set is fixed, so precompile the
@@ -52,6 +53,7 @@ module Analyzer::Python
     @file_content_cache = Hash(::String, ::String).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
     @programmatic_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
+    @programmatic_websocket_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
     @programmatic_class_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String))).new
     @static_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String))).new
 
@@ -120,6 +122,15 @@ module Analyzer::Python
                   router_name, route_path, handler_name, extra_params = route_info
                   @programmatic_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
                   @programmatic_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
+                end
+              end
+
+              if line.includes?(".add_websocket_route(")
+                effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+                if route_info = parse_programmatic_websocket_route(effective_line)
+                  router_name, route_path, handler_name, extra_params = route_info
+                  @programmatic_websocket_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+                  @programmatic_websocket_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
                 end
               end
 
@@ -247,6 +258,7 @@ module Analyzer::Python
           handler_path = path
           handler_source = source
           handler_lines = lines
+          function_def_index ||= find_self_method_def(lines, line_index, handler_name)
           if function_def_index.nil?
             import_modules = find_imported_modules(definition_base_path, path, source)
             resolved = resolve_external_handler(handler_name, path, import_modules)
@@ -275,6 +287,57 @@ module Analyzer::Python
           registration_prefixes.each do |registration_prefix|
             full_prefix = join_paths(registration_prefix, prefix)
             get_endpoints("GET", route_path, extra_params, codeblock_lines, full_prefix).each do |endpoint|
+              endpoint.details = Details.new(PathInfo.new(path, line_index + 1))
+              handler_callees.each { |c| endpoint.push_callee(c) }
+              result << endpoint
+            end
+          end
+        end
+      end
+
+      @programmatic_websocket_routes.each do |router_name, router_info_list|
+        router_info_list.each do |route_info|
+          line_index, path, route_path, extra_params, handler_name = route_info
+          source = fetch_file_content(path)
+          lines = source.lines
+          definition_base_path = python_base_path_for(path)
+          api_instances = path_api_instances[path]
+          prefix = api_instances[router_name]? || ""
+          registration_prefixes = blueprint_registration_prefixes[{definition_base_path, router_name}]? || [""]
+
+          function_def_index = find_function_def(lines, handler_name)
+          handler_path = path
+          handler_source = source
+          handler_lines = lines
+          function_def_index ||= find_self_method_def(lines, line_index, handler_name)
+          if function_def_index.nil?
+            import_modules = find_imported_modules(definition_base_path, path, source)
+            resolved = resolve_external_handler(handler_name, path, import_modules)
+            next unless resolved
+
+            handler_path, function_name = resolved
+            next unless File.exists?(handler_path)
+
+            handler_source = fetch_file_content(handler_path)
+            handler_lines = handler_source.lines
+            function_def_index = find_function_def(handler_lines, function_name)
+            next if function_def_index.nil?
+          end
+
+          codeblock = parse_code_block(handler_lines[function_def_index..])
+          next if codeblock.nil?
+          codeblock_lines = codeblock.split("\n")
+          handler_callees = build_callees_from(
+            codeblock,
+            function_def_index,
+            handler_path,
+            definition_base_path: definition_base_path,
+            source: handler_source
+          )
+
+          registration_prefixes.each do |registration_prefix|
+            full_prefix = join_paths(registration_prefix, prefix)
+            get_endpoints("GET", route_path, extra_params, codeblock_lines, full_prefix, "websocket").each do |endpoint|
               endpoint.details = Details.new(PathInfo.new(path, line_index + 1))
               handler_callees.each { |c| endpoint.push_callee(c) }
               result << endpoint
@@ -392,6 +455,19 @@ module Analyzer::Python
       {router_name, route_path, handler_name, extra_params}
     end
 
+    private def parse_programmatic_websocket_route(line : ::String) : Tuple(::String, ::String, ::String, ::String)?
+      call_match = line.match(ADD_WEBSOCKET_ROUTE_CALL_RE)
+      return unless call_match
+
+      router_name = call_match[1]
+      args = split_python_arguments(call_match[2])
+      handler_name = extract_programmatic_handler(args)
+      route_path = extract_programmatic_route_path(args)
+      return if handler_name.empty? || route_path.empty?
+
+      {router_name, route_path, handler_name, "methods=['GET']"}
+    end
+
     private def extract_programmatic_handler_class(args : Array(::String)) : ::String
       handler = extract_keyword_expression(args, "handler") || args[0]?
       return "" unless handler
@@ -497,6 +573,36 @@ module Analyzer::Python
       if import_info = import_modules[reference]?
         import_path = import_info.first
         return {import_path, reference} unless import_path.empty?
+      end
+
+      nil
+    end
+
+    private def find_self_method_def(lines : Array(::String), route_line_index : Int32, handler_name : ::String) : Int32?
+      return unless handler_name.starts_with?("self.")
+
+      method_name = handler_name.split(".", 2)[1]?
+      return if method_name.nil? || method_name.empty?
+
+      class_scope = find_enclosing_class_scope(lines, route_line_index)
+      return unless class_scope
+
+      class_def_index, class_indent = class_scope
+      find_class_method_def(lines, class_def_index, class_indent, method_name)
+    end
+
+    private def find_enclosing_class_scope(lines : Array(::String), line_index : Int32) : Tuple(Int32, Int32)?
+      current_line = lines[line_index]?
+      return unless current_line
+
+      current_indent = current_line.index(/\S/) || 0
+      i = line_index
+      while i >= 0
+        if class_match = lines[i].match(/^(\s*)class\s+/)
+          class_indent = class_match[1].size
+          return {i, class_indent} if class_indent < current_indent
+        end
+        i -= 1
       end
 
       nil

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -351,27 +351,43 @@ module Analyzer::Python
     alias PackageType = Noir::ImportGraph::Python::PackageType
 
     # Walk forward from `decorator_line` past any stacked decorators,
-    # blank lines, and comments to the actual `def` / `async def` that
-    # they apply to. Returns the 0-based line of the def, or nil if
-    # none is found before a non-decorator/non-blank statement.
+    # decorator continuation lines, blank lines, and comments to the
+    # actual `def` / `async def` that they apply to. Returns the 0-based
+    # line of the def, or nil if none is found before a non-decorator/
+    # non-blank statement.
     #
     # This exists because real-world Python decorator stacks
-    # (`@app.post(...)` + `@auth_required`, blank-line spacers, or a
-    # `# comment` between the route decorator and the def) make the
-    # "def is at decorator_line + 1" assumption silently wrong — both
-    # for parameter extraction and for handler-body parsing.
+    # (`@app.post(...)` + `@auth_required`, multi-line route decorators,
+    # blank-line spacers, or a `# comment` between the route decorator
+    # and the def) make the "def is at decorator_line + 1" assumption
+    # silently wrong — both for parameter extraction and for handler-body
+    # parsing.
     def find_def_line(lines : Array(::String), decorator_line : Int32) : Int32?
-      i = decorator_line + 1
+      i = decorator_line
       while i < lines.size
         stripped = lines[i].lstrip
         if stripped.starts_with?("def ") || stripped.starts_with?("async def ")
           return i
         end
-        # Skip over stacked decorators, blank lines, and comment lines.
-        if stripped.empty? || stripped.starts_with?('@') || stripped.starts_with?('#')
+
+        if stripped.starts_with?('@')
+          paren_delta = python_paren_delta(lines[i])
+          i += 1
+          while i < lines.size && paren_delta > 0
+            paren_delta += python_paren_delta(lines[i])
+            i += 1
+          end
+          next
+        end
+
+        # Skip over blank lines and comment lines between decorators and
+        # the handler. Django/FastAPI examples commonly use these as
+        # visual separators in larger route modules.
+        if stripped.empty? || stripped.starts_with?('#')
           i += 1
           next
         end
+
         # Anything else means we walked past the handler — give up.
         return
       end

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -31,8 +31,10 @@ struct Endpoint
   # opt in; empty for the rest.
   @callees : Array(Callee) = [] of Callee
 
-  def initialize(@url : String, @method : String, @params : Array(Param) = [] of Param,
-                 @details : Details = Details.new, @internal : Bool = false)
+  def initialize(@url : String, @method : String, params : Array(Param) = [] of Param,
+                 details : Details = Details.new, @internal : Bool = false)
+    @params = params.map(&.detached_copy)
+    @details = details.detached_copy
     @protocol = "http"
     @kind = ""
     @tags = [] of Tag
@@ -41,8 +43,9 @@ struct Endpoint
     @metadata = nil
   end
 
-  def initialize(@url : String, @method : String, @details : Details)
+  def initialize(@url : String, @method : String, details : Details)
     @params = [] of Param
+    @details = details.detached_copy
     @protocol = "http"
     @kind = ""
     @tags = [] of Tag
@@ -53,7 +56,7 @@ struct Endpoint
   end
 
   def details=(details : Details)
-    @details = details
+    @details = details.detached_copy
   end
 
   def protocol=(protocol : String)
@@ -157,6 +160,12 @@ struct Param
     return if @tags.any? { |existing| existing.name == tag.name && existing.tagger == tag.tagger }
     @tags << tag
   end
+
+  def detached_copy : Param
+    copy = Param.new(@name, @value, @param_type)
+    @tags.each { |tag| copy.add_tag(tag) }
+    copy
+  end
 end
 
 struct Details
@@ -174,6 +183,18 @@ struct Details
 
   def add_path(code_path : PathInfo)
     @code_paths << code_path
+  end
+
+  def detached_copy : Details
+    copy = Details.new
+    @code_paths.each { |code_path| copy.add_path(code_path) }
+    if status_code = @status_code
+      copy.status_code = status_code
+    end
+    if technology = @technology
+      copy.technology = technology
+    end
+    copy
   end
 
   def status_code=(status_code : Int32)

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -754,13 +754,12 @@ class EndpointOptimizer
     endpoints.each do |endpoint|
       new_endpoint = endpoint
 
-      # `{param}` patterns. The placeholder may sit at a segment
-      # boundary (`/{id}`) or share a segment with sibling variables
-      # separated by a comma — Spring's matrix-style `@GetMapping(
-      # "/bbox/{xMin},{yMin},{xMax},{yMax}")` packs four into one
-      # segment, so allow a leading `,` as well as `/` (otherwise only
-      # the first variable in the segment is captured).
-      endpoint.url.scan(/[\/,]\{([^}]+)\}/).each do |match|
+      # `{param}` patterns. A placeholder may sit at a segment boundary
+      # (`/{id}`) or share a segment with literal separators
+      # (`/{slug}_{pk}`, `/{name}.json`, `/{x},{y}`). Scan all brace
+      # placeholders in the URL instead of assuming the preceding
+      # character is `/` or `,`.
+      endpoint.url.scan(/\{([^}]+)\}/).each do |match|
         raw = match[1]
         # Strip a leading `*` from catch-all path variables (Spring,
         # Armeria and ASP.NET all spell the rest-of-path capture as
@@ -768,7 +767,7 @@ class EndpointOptimizer
         # constraint after `:`. The parameter is named `name`, not
         # `*name` or `name:regex`.
         param = raw.split(":")[0].lstrip('*')
-        next if param.empty?
+        next unless valid_path_param_name?(param)
         new_endpoint.url = register_path_param(new_endpoint.url, new_endpoint.params, "{#{raw}}", param)
       end
 


### PR DESCRIPTION
## Summary
- Expand Python analyzer coverage for Django AppConfig URL lists, aiohttp aliases/wildcards, Sanic programmatic routes/websockets, and Litestar controller prefix handling.
- Improve callee/context accuracy by handling multiline Python decorators and detaching shared endpoint details/params before merging.
- Avoid false path params from regex quantifiers such as `\d{4}` while preserving compound brace path templates.

## Validation
- `just build`
- `just test`
- `just check`