### PR TITLE
Improve Java framework params and callees

### DIFF
--- a/spec/functional_test/fixtures/java/micronaut/src/main/java/com/example/api/BookController.java
+++ b/spec/functional_test/fixtures/java/micronaut/src/main/java/com/example/api/BookController.java
@@ -1,6 +1,7 @@
 package com.example.api;
 
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
@@ -15,6 +16,10 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Put;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.annotation.RequestBean;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.security.authentication.Authentication;
+import java.security.Principal;
+import java.time.Month;
 
 @Controller("/books")
 public class BookController implements BookApi {
@@ -73,6 +78,21 @@ public class BookController implements BookApi {
         return HttpResponse.ok();
     }
 
+    @Get("/template{?q}")
+    public HttpResponse<?> template(@QueryValue String q) {
+        return HttpResponse.ok();
+    }
+
+    @Get("/paged{?filter*}")
+    public HttpResponse<?> paged(BookFilter filter) {
+        return HttpResponse.ok();
+    }
+
+    @Get("/calendar/{month}")
+    public HttpResponse<?> calendar(Month month, Principal principal, Authentication authentication, HttpRequest<?> request) {
+        return HttpResponse.ok();
+    }
+
     @Post
     @Consumes(MediaType.APPLICATION_JSON)
     public HttpResponse<?> create(@Body Book book) {
@@ -81,6 +101,18 @@ public class BookController implements BookApi {
 
     @Post(value = "/forms", consumes = MediaType.APPLICATION_FORM_URLENCODED)
     public HttpResponse<?> formBody(@Body Book book) {
+        return HttpResponse.ok();
+    }
+
+    @Post("/attachment")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public HttpResponse<?> attachment(CompletedFileUpload file) {
+        return HttpResponse.ok();
+    }
+
+    @Post("/scalar")
+    public HttpResponse<?> scalarBody(@Body("isbn") String isbn,
+                                      @Body("name") String name) {
         return HttpResponse.ok();
     }
 

--- a/spec/functional_test/fixtures/java/quarkus/src/main/java/com/example/api/GreetingResource.java
+++ b/spec/functional_test/fixtures/java/quarkus/src/main/java/com/example/api/GreetingResource.java
@@ -7,8 +7,11 @@ import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 import org.jboss.resteasy.reactive.RestHeader;
@@ -42,7 +45,17 @@ public class GreetingResource {
     @Path("/login")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public Response login(@RestForm String username,
-                          @RestForm("pwd") String password) {
+                          @RestForm("pwd") String password,
+                          RoutingContext ctx,
+                          @Suspended AsyncResponse ar) {
+        return Response.ok().build();
+    }
+
+    @POST
+    @Path("/upload")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response upload(MultipartFormDataInput data) {
+        data.getFormDataMap().get("image");
         return Response.ok().build();
     }
 
@@ -59,4 +72,7 @@ public class GreetingResource {
                            @RestCookie("session") String session) {
         return Response.noContent().build();
     }
+}
+
+class RoutingContext {
 }

--- a/spec/functional_test/fixtures/java/quarkus/src/main/java/com/example/api/ReactiveRoutes.java
+++ b/spec/functional_test/fixtures/java/quarkus/src/main/java/com/example/api/ReactiveRoutes.java
@@ -1,5 +1,7 @@
 package com.example.api;
 
+import static io.quarkus.vertx.web.Route.HandlerType.FAILURE;
+
 import io.quarkus.vertx.web.Body;
 import io.quarkus.vertx.web.Header;
 import io.quarkus.vertx.web.Param;
@@ -23,5 +25,13 @@ public class ReactiveRoutes {
     @Route(path = "/status")
     public String status() {
         return "ok";
+    }
+
+    @Route(path = "/*", type = FAILURE)
+    public void failure() {
+    }
+
+    @Route(path = "/qualified-failure", type = io.quarkus.vertx.web.Route.HandlerType.FAILURE)
+    public void qualifiedFailure() {
     }
 }

--- a/spec/functional_test/fixtures/java/quarkus_callees/src/main/java/com/example/api/ReactiveRoutes.java
+++ b/spec/functional_test/fixtures/java/quarkus_callees/src/main/java/com/example/api/ReactiveRoutes.java
@@ -1,0 +1,60 @@
+package com.example.api;
+
+import static io.quarkus.vertx.web.Route.HttpMethod.POST;
+
+import io.quarkus.vertx.web.Body;
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+
+@RouteBase(path = "/reactive")
+public class ReactiveRoutes {
+    private final ReactiveService service = new ReactiveService();
+
+    @Route(path = "/jobs/:jobId", methods = POST)
+    public String submit(@Param String jobId, @Body String payload) {
+        validate(jobId);
+        java.util.function.Function<String, String> sanitizer = this::sanitize;
+        String sanitized = sanitizer.apply(payload);
+        service.submit(jobId, sanitized);
+        AuditLog.write("reactive-submit");
+        return sanitized;
+    }
+
+    @Route(path = "/profile")
+    public String profile() {
+        String profile = this.buildProfile();
+        AuditLog.write(profile);
+        return profile;
+    }
+
+    private void validate(String jobId) {}
+
+    private String sanitize(String payload) {
+        return payload.trim();
+    }
+
+    private String buildProfile() {
+        return "profile";
+    }
+
+    private String overloaded(String raw) {
+        wrongOverload(raw);
+        return raw;
+    }
+
+    @Route(path = "/overloaded", methods = POST)
+    public String overloaded() {
+        return routeOverload();
+    }
+
+    private String routeOverload() {
+        return "route";
+    }
+
+    private void wrongOverload(String raw) {}
+}
+
+class ReactiveService {
+    void submit(String jobId, String payload) {}
+}

--- a/spec/functional_test/testers/java/micronaut_spec.cr
+++ b/spec/functional_test/testers/java/micronaut_spec.cr
@@ -31,6 +31,16 @@ expected_endpoints = [
     Param.new("author", "", "query"),
     Param.new("year", "", "query"),
   ]),
+  Endpoint.new("/books/template", "GET", [
+    Param.new("q", "", "query"),
+  ]),
+  Endpoint.new("/books/paged", "GET", [
+    Param.new("author", "", "query"),
+    Param.new("year", "", "query"),
+  ]),
+  Endpoint.new("/books/calendar/{month}", "GET", [
+    Param.new("month", "", "path"),
+  ]),
   Endpoint.new("/books/interface/{isbn}", "GET", [
     Param.new("isbn", "", "path"),
     Param.new("edition", "", "query"),
@@ -48,6 +58,13 @@ expected_endpoints = [
     Param.new("title", "", "form"),
     Param.new("author", "", "form"),
     Param.new("year", "", "form"),
+  ]),
+  Endpoint.new("/books/attachment", "POST", [
+    Param.new("file", "", "form"),
+  ]),
+  Endpoint.new("/books/scalar", "POST", [
+    Param.new("isbn", "", "json"),
+    Param.new("name", "", "json"),
   ]),
   Endpoint.new("/books/login", "POST", [
     Param.new("username", "", "query"),

--- a/spec/functional_test/testers/java/quarkus_callees_spec.cr
+++ b/spec/functional_test/testers/java/quarkus_callees_spec.cr
@@ -19,6 +19,26 @@ expected_endpoints = [
     ep.push_callee(Callee.new("AuditLog.write", line: 30))
     ep.push_callee(Callee.new("Response.ok", line: 31))
   end,
+
+  Endpoint.new("/reactive/jobs/:jobId", "POST", [
+    Param.new("jobId", "", "path"),
+    Param.new("payload", "", "json"),
+  ]).tap do |ep|
+    ep.push_callee(Callee.new("validate", line: 16))
+    ep.push_callee(Callee.new("this.sanitize", line: 17))
+    ep.push_callee(Callee.new("sanitizer.apply", line: 18))
+    ep.push_callee(Callee.new("service.submit", line: 19))
+    ep.push_callee(Callee.new("AuditLog.write", line: 20))
+  end,
+
+  Endpoint.new("/reactive/profile", "GET").tap do |ep|
+    ep.push_callee(Callee.new("this.buildProfile", line: 26))
+    ep.push_callee(Callee.new("AuditLog.write", line: 27))
+  end,
+
+  Endpoint.new("/reactive/overloaded", "POST").tap do |ep|
+    ep.push_callee(Callee.new("routeOverload", line: 48))
+  end,
 ]
 
 FunctionalTester.new("fixtures/java/quarkus_callees/", {

--- a/spec/functional_test/testers/java/quarkus_spec.cr
+++ b/spec/functional_test/testers/java/quarkus_spec.cr
@@ -17,6 +17,9 @@ expected_endpoints = [
     Param.new("username", "", "form"),
     Param.new("pwd", "", "form"),
   ]),
+  Endpoint.new("/platform/q/greetings/upload", "POST", [
+    Param.new("image", "", "form"),
+  ]),
   Endpoint.new("/platform/q/greetings/{id}", "PUT", [
     Param.new("id", "", "path"),
     Param.new("message", "", "json"),

--- a/spec/unit_test/miniparser/java_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/java_callee_extractor_spec.cr
@@ -40,6 +40,43 @@ describe Noir::JavaCalleeExtractor do
       callees.each(&.[1].should(eq("UserController.java")))
     end
 
+    it "captures Java method references as dotted callees" do
+      source = <<-JAVA
+        package app;
+        class QueueResource {
+          public List<Quark> receive() {
+            return messages.stream()
+              .map(Message::body)
+              .map(this::toQuark)
+              .map(FileObject::from)
+              .collect(Collectors.toList());
+          }
+          private Quark toQuark(String message) {
+            return parse(message);
+          }
+          private Quark parse(String message) { return null; }
+        }
+        JAVA
+
+      to_quark_line = source.lines.index!(&.includes?("private Quark toQuark")) + 1
+      callees = [] of Tuple(String, String, Int32)
+      with_java_root(source) do |root|
+        callees = Noir::JavaCalleeExtractor.callees_in_method(
+          root, source, "QueueResource.java", "QueueResource", "receive"
+        )
+      end
+
+      names = callees.map(&.[0])
+      names.should contain("Message.body")
+      names.should contain("this.toQuark")
+      names.should contain("FileObject.from")
+      names.should contain("Collectors.toList")
+
+      local_ref = callees.find { |entry| entry[0] == "this.toQuark" }
+      local_ref.should_not be_nil
+      local_ref.not_nil![2].should eq(to_quark_line)
+    end
+
     it "returns an empty list when the class or method can't be found" do
       source = <<-JAVA
         package app;
@@ -185,6 +222,7 @@ describe Noir::JavaCalleeExtractor do
           public void m() {
             a();
             b.c();
+            xs.stream().map(Type::from);
           }
         }
         JAVA
@@ -208,6 +246,7 @@ describe Noir::JavaCalleeExtractor do
       names = callees.not_nil!.map(&.[0])
       names.should contain("a")
       names.should contain("b.c")
+      names.should contain("Type.from")
     end
   end
 end

--- a/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/java_parameter_extractor_ts_spec.cr
@@ -396,6 +396,103 @@ describe Noir::TreeSitterJavaParameterExtractor do
       params.map(&.name).should eq(["title"])
     end
 
+    it "skips support objects supplied by path-only @ModelAttribute methods" do
+      source = <<-JAVA
+        @RequestMapping("/owners/{ownerId}")
+        class PetController {
+            @ModelAttribute("owner")
+            public Owner findOwner(@PathVariable("ownerId") int ownerId) { return null; }
+
+            @GetMapping("/pets/new")
+            public String init(Owner owner, Model model) { return ""; }
+
+            @PostMapping("/pets/new")
+            public String create(Owner owner, @Valid Pet pet, BindingResult result) { return ""; }
+        }
+        JAVA
+      class_fields = {
+        "Owner" => [
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("firstName", "private", true, ""),
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("lastName", "private", true, ""),
+        ],
+        "Pet" => [
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("name", "private", true, ""),
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("birthDate", "private", true, ""),
+        ],
+      }
+
+      get_params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "PetController", "init", "GET", nil, class_fields
+      )
+      get_params.should be_empty
+
+      post_params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "PetController", "create", "POST", nil, class_fields
+      )
+      post_params.map { |p| {p.name, p.param_type} }.should eq([
+        {"name", "form"},
+        {"birthDate", "form"},
+      ])
+    end
+
+    it "keeps optional @ModelAttribute form objects bindable" do
+      source = <<-JAVA
+        class OwnerController {
+            @ModelAttribute("owner")
+            public Owner findOwner(@PathVariable(name = "ownerId", required = false) Integer ownerId) { return null; }
+
+            @GetMapping("/owners")
+            public String search(@RequestParam(defaultValue = "1") int page, Owner owner, BindingResult result) { return ""; }
+        }
+        JAVA
+      class_fields = {
+        "Owner" => [
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("firstName", "private", true, ""),
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("lastName", "private", true, ""),
+        ],
+      }
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "OwnerController", "search", "GET", nil, class_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.should eq([
+        {"page", "query"},
+        {"firstName", "query"},
+        {"lastName", "query"},
+      ])
+    end
+
+    it "skips model.put support objects from @ModelAttribute supplier bodies" do
+      source = <<-JAVA
+        class VisitController {
+            @ModelAttribute("visit")
+            public Visit load(@PathVariable int ownerId, Map<String, Object> model) {
+                Owner owner = owners.findById(ownerId).get();
+                model.put("owner", owner);
+                return new Visit();
+            }
+
+            @PostMapping("/visits")
+            public String create(@ModelAttribute Owner owner, @Valid Visit visit, BindingResult result) { return ""; }
+        }
+        JAVA
+      class_fields = {
+        "Owner" => [
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("firstName", "private", true, ""),
+        ],
+        "Visit" => [
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("date", "private", true, ""),
+          Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("description", "private", true, ""),
+        ],
+      }
+      params = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters(
+        source, "VisitController", "create", "POST", nil, class_fields
+      )
+      params.map { |p| {p.name, p.param_type} }.should eq([
+        {"date", "form"},
+        {"description", "form"},
+      ])
+    end
+
     it "skips framework argument-resolver types not present in the DTO index" do
       source = <<-JAVA
         class C {

--- a/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/jaxrs_extractor_ts_spec.cr
@@ -255,6 +255,98 @@ describe Noir::TreeSitterJaxRsExtractor do
     ])
   end
 
+  it "skips injected context types without dropping explicit request params" do
+    source = <<-JAVA
+      package com.example.api;
+
+      import io.quarkus.security.identity.SecurityIdentity;
+      import io.smallrye.jwt.auth.principal.JsonWebToken;
+      import io.vertx.ext.web.RoutingContext;
+      import jakarta.ws.rs.POST;
+      import jakarta.ws.rs.Path;
+      import jakarta.ws.rs.container.AsyncResponse;
+      import jakarta.ws.rs.container.Suspended;
+      import jakarta.ws.rs.core.SecurityContext;
+      import jakarta.ws.rs.core.Response;
+      import org.jboss.resteasy.reactive.RestForm;
+
+      @Path("/auth")
+      public class LoginResource {
+          @POST
+          @Path("/login")
+          public Response login(@RestForm String username,
+                                RoutingContext ctx,
+                                SecurityContext securityContext,
+                                SecurityIdentity identity,
+                                JsonWebToken token,
+                                @Suspended AsyncResponse ar,
+                                LoginPayload payload) {
+              return Response.ok().build();
+          }
+      }
+
+      class LoginPayload {
+          public String otp;
+      }
+      JAVA
+
+    dto_index = {
+      "LoginPayload" => [
+        Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("otp", "public", false, ""),
+      ],
+    }
+    routes = Noir::TreeSitterJaxRsExtractor.extract_routes(source, dto_index: dto_index)
+    routes.map { |r| {r.verb, r.path, r.params} }.should eq([
+      {"POST", "/auth/login", [
+        Param.new("username", "", "form"),
+        Param.new("otp", "", "json"),
+      ]},
+    ])
+  end
+
+  it "extracts multipart form fields from MultipartFormDataInput usage" do
+    source = <<-JAVA
+      package com.example.api;
+
+      import jakarta.ws.rs.Consumes;
+      import jakarta.ws.rs.POST;
+      import jakarta.ws.rs.Path;
+      import jakarta.ws.rs.core.MediaType;
+      import jakarta.ws.rs.core.Response;
+      import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataInput;
+
+      @Path("/images")
+      public class ImageResource {
+          @POST
+          @Path("/watermark")
+          @Consumes(MediaType.MULTIPART_FORM_DATA)
+          public Response watermark(MultipartFormDataInput data) {
+              data.getFormDataMap().get("image").get(0);
+              data.getFormDataMap().get("metadata");
+              return Response.accepted().build();
+          }
+
+          @POST
+          @Path("/raw")
+          @Consumes("multipart/form-data")
+          public Response raw(MultipartFormDataInput data) {
+              return Response.accepted().build();
+          }
+      }
+      JAVA
+
+    routes = Noir::TreeSitterJaxRsExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path, r.params} }.should eq([
+      {"POST", "/images/watermark", [
+        Param.new("image", "", "form"),
+        Param.new("metadata", "", "form"),
+      ]},
+      {"POST", "/images/raw", [
+        Param.new("data", "", "form"),
+      ]},
+    ])
+  end
+
   it "extracts Jakarta ServerEndpoint routes with ws protocol" do
     source = <<-JAVA
       package com.example.api;

--- a/spec/unit_test/miniparser/micronaut_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/micronaut_extractor_ts_spec.cr
@@ -45,12 +45,16 @@ describe Noir::TreeSitterMicronautExtractor do
 
       import io.micronaut.http.MediaType;
       import io.micronaut.http.annotation.Body;
+      import io.micronaut.http.annotation.Consumes;
       import io.micronaut.http.annotation.Controller;
       import io.micronaut.http.annotation.Get;
       import io.micronaut.http.annotation.Header;
       import io.micronaut.http.annotation.Post;
       import io.micronaut.http.annotation.QueryValue;
       import io.micronaut.http.annotation.RequestBean;
+      import io.micronaut.http.multipart.CompletedFileUpload;
+
+      import static io.micronaut.http.MediaType.MULTIPART_FORM_DATA;
 
       @Controller("/books")
       public class BookController {
@@ -65,8 +69,24 @@ describe Noir::TreeSitterMicronautExtractor do
               return "";
           }
 
+          @Post("/scalar")
+          public String scalar(@Body("isbn") String isbn, @Body("name") String name) {
+              return "";
+          }
+
+          @Post(value = "/scalar-form", consumes = MediaType.APPLICATION_FORM_URLENCODED)
+          public String scalarForm(@Body("name") String name) {
+              return "";
+          }
+
           @Post(value = "/process", processes = MediaType.MULTIPART_FORM_DATA)
           public String process(@Body Book book) {
+              return "";
+          }
+
+          @Consumes(MULTIPART_FORM_DATA)
+          @Post("/attachment")
+          public String attachment(CompletedFileUpload file) {
               return "";
           }
 
@@ -108,13 +128,77 @@ describe Noir::TreeSitterMicronautExtractor do
       {"POST", "/books/forms", [
         Param.new("title", "", "form"),
       ]},
+      {"POST", "/books/scalar", [
+        Param.new("isbn", "", "json"),
+        Param.new("name", "", "json"),
+      ]},
+      {"POST", "/books/scalar-form", [
+        Param.new("name", "", "form"),
+      ]},
       {"POST", "/books/process", [
         Param.new("title", "", "form"),
+      ]},
+      {"POST", "/books/attachment", [
+        Param.new("file", "", "form"),
       ]},
       {"GET", "/books/filter", [
         Param.new("author", "", "query"),
         Param.new("year", "", "query"),
       ]},
+    ])
+  end
+
+  it "normalizes URI query templates and expands matching complex parameters as query params" do
+    source = <<-JAVA
+      package com.example.api;
+
+      import io.micronaut.http.annotation.Controller;
+      import io.micronaut.http.annotation.Get;
+      import io.micronaut.http.annotation.QueryValue;
+
+      @Controller("/genres")
+      public class GenreController {
+          @Get("/list{?args*}")
+          public String list(SortingAndOrderArguments args) {
+              return "";
+          }
+
+          @Get("/search{?q}")
+          public String search(@QueryValue String q) {
+              return "";
+          }
+
+          @Get("/{month}")
+          public String byMonth(Month month, Principal principal, HttpRequest<?> request, Pageable pageable) {
+              return "";
+          }
+      }
+
+      class SortingAndOrderArguments {
+          private Integer offset;
+          private Integer max;
+          public void setOffset(Integer offset) { this.offset = offset; }
+          public void setMax(Integer max) { this.max = max; }
+      }
+      JAVA
+
+    dto_index = {
+      "SortingAndOrderArguments" => [
+        Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("offset", "private", true, ""),
+        Noir::TreeSitterJavaParameterExtractor::FieldInfo.new("max", "private", true, ""),
+      ],
+    } of String => Array(Noir::TreeSitterJavaParameterExtractor::FieldInfo)
+
+    routes = Noir::TreeSitterMicronautExtractor.extract_routes(source, dto_index)
+    routes.map { |r| {r.verb, r.path, r.params} }.should eq([
+      {"GET", "/genres/list", [
+        Param.new("offset", "", "query"),
+        Param.new("max", "", "query"),
+      ]},
+      {"GET", "/genres/search", [
+        Param.new("q", "", "query"),
+      ]},
+      {"GET", "/genres/{month}", [] of Param},
     ])
   end
 

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../engines/java_engine"
+require "../../../miniparsers/java_callee_extractor"
 require "../../../miniparsers/jaxrs_extractor_ts"
 require "../../../miniparsers/import_graph"
 require "yaml"
@@ -64,7 +65,7 @@ module Analyzer::Java
         application_base_path = application_base_path_for(path, package_name, application_base_paths)
         configured_base_path = configured_base_path_for(path, path_configs, application_base_path)
 
-        extract_reactive_route_endpoints(content, path, path_configs).each do |endpoint|
+        extract_reactive_route_endpoints(content, path, path_configs, include_callee).each do |endpoint|
           @result << endpoint
         end
 
@@ -295,19 +296,30 @@ module Analyzer::Java
       end
     end
 
+    private struct ReactiveMethodCallees
+      getter start_byte : Int32
+      getter end_byte : Int32
+      getter callees : Array(Callee)
+
+      def initialize(@start_byte, @end_byte, @callees)
+      end
+    end
+
     private def extract_reactive_route_endpoints(content : String,
                                                  path : String,
-                                                 configs : Hash(String, QuarkusPathConfig)) : Array(Endpoint)
+                                                 configs : Hash(String, QuarkusPathConfig),
+                                                 include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
       return endpoints unless content.includes?("io.quarkus.vertx.web.Route")
 
       http_root_path = (configs[project_root_for(path)]? || QuarkusPathConfig.new).http_root_path
       route_bases = reactive_route_bases(content)
+      method_callees = include_callee ? reactive_route_method_callees(content, path) : [] of ReactiveMethodCallees
 
       content.scan(/@Route\b\s*(?:\((.*?)\))?/m) do |match|
         offset = match.begin(0) || 0
         body = match[1]? || ""
-        next if body.includes?("HandlerType.FAILURE")
+        next if reactive_failure_route?(body)
 
         method_name = route_method_name_after(content, match.end(0) || offset)
         next if method_name.empty?
@@ -322,11 +334,60 @@ module Analyzer::Java
         reactive_route_methods(body).each do |method|
           next if endpoints.any? { |endpoint| endpoint.url == endpoint_path && endpoint.method == method }
 
-          endpoints << Endpoint.new(endpoint_path, method, params, details)
+          endpoint = Endpoint.new(endpoint_path, method, params, details)
+          if callees = reactive_method_callees_for(method_callees, content, offset)
+            callees.each { |callee| endpoint.push_callee(callee) }
+          end
+          endpoints << endpoint
         end
       end
 
       endpoints
+    end
+
+    private def reactive_route_method_callees(content : String, path : String) : Array(ReactiveMethodCallees)
+      result = [] of ReactiveMethodCallees
+      Noir::TreeSitter.parse_java(content) do |root|
+        walk_method_declarations(root) do |method|
+          body = Noir::TreeSitter.field(method, "body")
+          next unless body
+
+          callees = Noir::JavaCalleeExtractor.callees_in_body(body, content, path).map do |(name, callee_path, callee_line)|
+            Callee.new(name, path: callee_path, line: callee_line)
+          end
+          result << ReactiveMethodCallees.new(
+            LibTreeSitter.ts_node_start_byte(method).to_i,
+            LibTreeSitter.ts_node_end_byte(method).to_i,
+            callees
+          )
+        end
+      end
+      result
+    end
+
+    private def reactive_method_callees_for(method_callees : Array(ReactiveMethodCallees),
+                                            content : String,
+                                            annotation_offset : Int32) : Array(Callee)?
+      annotation_byte = content.char_index_to_byte_index(annotation_offset) || annotation_offset
+      method_callees.find do |entry|
+        annotation_byte >= entry.start_byte && annotation_byte < entry.end_byte
+      end.try(&.callees)
+    end
+
+    private def walk_method_declarations(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+      if Noir::TreeSitter.node_type(node) == "method_declaration"
+        block.call(node)
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_method_declarations(child, &block)
+      end
+    end
+
+    private def reactive_failure_route?(annotation_body : String) : Bool
+      annotation_body.includes?("HandlerType.FAILURE") ||
+        !!annotation_body.match(/\btype\s*=\s*(?:Route\.)?FAILURE\b/)
     end
 
     private def reactive_route_bases(content : String) : Array(ReactiveRouteBase)
@@ -367,6 +428,13 @@ module Analyzer::Java
       annotation_body.scan(/(?:Route\.)?HttpMethod\.([A-Z]+)/) do |match|
         method = match[1].upcase
         methods << method if HTTP_METHOD_NAMES.includes?(method)
+      end
+
+      annotation_body.scan(/\bmethods?\s*=\s*(\{[^}]*\}|[A-Z_][A-Z0-9_]*)/m) do |match|
+        match[1].scan(/\b([A-Z]+)\b/) do |method_match|
+          method = method_match[1].upcase
+          methods << method if HTTP_METHOD_NAMES.includes?(method)
+        end
       end
 
       methods.empty? ? ["GET"] : methods.uniq

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -9,12 +9,14 @@ require "../ext/tree_sitter/tree_sitter"
 #
 #   1. Find the (class_name, method_name) `method_declaration` in the
 #      already-parsed root.
-#   2. Walk its body for `method_invocation` nodes.
+#   2. Walk its body for `method_invocation` / `method_reference` nodes.
 #   3. For each, reconstruct a textual callee:
 #        * `foo()`              → `foo`
 #        * `service.save(x)`    → `service.save`
 #        * `this.foo()`         → `this.foo`
 #        * `Foo.bar()` (static) → `Foo.bar`
+#        * `Message::body`      → `Message.body`
+#        * `this::toDto`        → `this.toDto`
 #        * `getFoo().bar()`     → "" (chained on a call — dropped as
 #                                 noise, mirroring the Python/Go
 #                                 chained-call filter)
@@ -53,7 +55,8 @@ module Noir::JavaCalleeExtractor
     decl_index = build_method_decl_index(root, source)
 
     walk(body) do |n|
-      next unless Noir::TreeSitter.node_type(n) == "method_invocation"
+      node_type = Noir::TreeSitter.node_type(n)
+      next unless node_type == "method_invocation" || node_type == "method_reference"
       name = callee_text(n, source)
       next if name.empty?
       row = Noir::TreeSitter.node_start_row(n)
@@ -84,7 +87,8 @@ module Noir::JavaCalleeExtractor
                       file_path : String) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
     walk(body) do |n|
-      next unless Noir::TreeSitter.node_type(n) == "method_invocation"
+      node_type = Noir::TreeSitter.node_type(n)
+      next unless node_type == "method_invocation" || node_type == "method_reference"
       name = callee_text(n, source)
       next if name.empty?
       row = Noir::TreeSitter.node_start_row(n)
@@ -96,6 +100,10 @@ module Noir::JavaCalleeExtractor
   # ---- private helpers -----------------------------------------------
 
   private def callee_text(call : LibTreeSitter::TSNode, source : String) : String
+    if Noir::TreeSitter.node_type(call) == "method_reference"
+      return method_reference_text(call, source)
+    end
+
     name_node = Noir::TreeSitter.field(call, "name")
     return "" unless name_node
     name = Noir::TreeSitter.node_text(name_node, source)
@@ -107,6 +115,29 @@ module Noir::JavaCalleeExtractor
     receiver = receiver_text(object, source)
     return "" if receiver.empty? # chained-on-call or unsupported receiver
     "#{receiver}.#{name}"
+  end
+
+  private def method_reference_text(ref : LibTreeSitter::TSNode, source : String) : String
+    receiver, name = method_reference_parts(ref, source)
+    return "" if receiver.empty? || name.empty?
+
+    "#{receiver}.#{name}"
+  end
+
+  private def method_reference_parts(ref : LibTreeSitter::TSNode, source : String) : Tuple(String, String)
+    text = Noir::TreeSitter.node_text(ref, source).strip
+    pieces = text.split("::", 2)
+    return {"", ""} unless pieces.size == 2
+
+    receiver = pieces[0].strip.gsub(/\s+/, "")
+    name = pieces[1].strip.gsub(/\A<[^>]+>\s*/, "")
+    # Match the chained-call filter used for method invocations:
+    # `factory()::build` is a call-chain continuation, not a clean 1-hop
+    # callee target.
+    return {"", ""} if receiver.empty? || receiver.includes?("(")
+    return {"", ""} if name.empty?
+
+    {receiver, name}
   end
 
   # Reconstruct a dotted receiver text from `identifier` / `field_access`
@@ -208,6 +239,7 @@ module Noir::JavaCalleeExtractor
   # line (1-based) only when the call is unambiguous:
   #   - unqualified `foo(...)` (no `object` field), or
   #   - `this.foo(...)` (object is the literal `this`),
+  #   - `this::foo` method reference,
   # AND the same-file declaration map contains exactly one match.
   # Returns `nil` for qualified non-`this` calls, ambiguous names, and
   # names with no matching same-file declaration — callers fall back to
@@ -215,6 +247,12 @@ module Noir::JavaCalleeExtractor
   private def resolve_same_file_line(call : LibTreeSitter::TSNode,
                                      source : String,
                                      decl_index : Hash(String, Int32?)) : Int32?
+    if Noir::TreeSitter.node_type(call) == "method_reference"
+      receiver, name = method_reference_parts(call, source)
+      return unless receiver == "this"
+      return resolve_decl_line(name, decl_index)
+    end
+
     name_node = Noir::TreeSitter.field(call, "name")
     return unless name_node
     name = Noir::TreeSitter.node_text(name_node, source)
@@ -225,6 +263,10 @@ module Noir::JavaCalleeExtractor
       return unless Noir::TreeSitter.node_type(object) == "this"
     end
 
+    resolve_decl_line(name, decl_index)
+  end
+
+  private def resolve_decl_line(name : String, decl_index : Hash(String, Int32?)) : Int32?
     return unless decl_index.has_key?(name)
     row = decl_index[name]
     return if row.nil?

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -99,6 +99,14 @@ module Noir
       end
     end
 
+    private struct ModelAttributeSupplier
+      getter name : String
+      getter type_name : String
+
+      def initialize(@name, @type_name)
+      end
+    end
+
     # Scan every `class_declaration` / `interface_declaration` in
     # `source` and return `{class_name => [FieldInfo]}`. Only classes
     # with at least one field appear; setter detection walks sibling
@@ -250,7 +258,8 @@ module Noir
       method = find_method(root, source, class_name, method_name, target_line)
       return [] of Param unless method
       constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
-      collect_method_params(method, source, verb, parameter_format, class_fields, constants, class_name)
+      model_attributes = model_attribute_suppliers(root, source, class_name)
+      collect_method_params(method, source, verb, parameter_format, class_fields, constants, class_name, model_attributes)
     end
 
     # Find `@*Mapping` annotation on (class_name, method_name) and
@@ -459,6 +468,162 @@ module Noir
       matched || first
     end
 
+    private def find_class(root : LibTreeSitter::TSNode,
+                           source : String,
+                           class_name : String) : LibTreeSitter::TSNode?
+      result : LibTreeSitter::TSNode? = nil
+      walk_class_containers(root) do |decl|
+        next if result
+        name_node = Noir::TreeSitter.field(decl, "name")
+        next unless name_node
+        result = decl if Noir::TreeSitter.node_text(name_node, source) == class_name
+      end
+      result
+    end
+
+    private def model_attribute_suppliers(root : LibTreeSitter::TSNode,
+                                          source : String,
+                                          class_name : String) : Array(ModelAttributeSupplier)
+      suppliers = [] of ModelAttributeSupplier
+      class_decl = find_class(root, source, class_name)
+      return suppliers unless class_decl
+      body = Noir::TreeSitter.field(class_decl, "body")
+      return suppliers unless body
+
+      Noir::TreeSitter.each_named_child(body) do |member|
+        next unless Noir::TreeSitter.node_type(member) == "method_declaration"
+        ann = annotation_node_on(member, source, "ModelAttribute")
+        next unless ann
+
+        return_type = method_return_type(member, source)
+        unless return_type.empty? || return_type == "void"
+          attr_name = annotation_string_arg(ann, source) || default_model_attribute_name(return_type)
+          if path_only_model_attribute_supplier?(member, source)
+            suppliers << ModelAttributeSupplier.new(attr_name, simple_type_name(return_type))
+          end
+        end
+
+        suppliers.concat(model_put_suppliers(member, source))
+      end
+
+      suppliers.uniq { |supplier| {supplier.name, supplier.type_name} }
+    end
+
+    private def model_put_suppliers(method : LibTreeSitter::TSNode,
+                                    source : String) : Array(ModelAttributeSupplier)
+      suppliers = [] of ModelAttributeSupplier
+      text = Noir::TreeSitter.node_text(method, source)
+      declarations = Hash(String, String).new
+
+      text.scan(/\b([A-Z][A-Za-z0-9_.$]*(?:\s*<[^;=()]*>)?)\s+([a-z][A-Za-z0-9_]*)\s*=/m) do |match|
+        declarations[match[2]] = simple_type_name(match[1])
+      end
+
+      text.scan(/\b[A-Za-z_][A-Za-z0-9_]*\.put\(\s*"([^"]+)"\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/m) do |match|
+        attr_name = match[1]
+        var_name = match[2]
+        if type_name = declarations[var_name]?
+          suppliers << ModelAttributeSupplier.new(attr_name, type_name)
+        end
+      end
+
+      suppliers
+    end
+
+    private def path_only_model_attribute_supplier?(method : LibTreeSitter::TSNode, source : String) : Bool
+      params = Noir::TreeSitter.field(method, "parameters")
+      return false unless params
+
+      saw_path_variable = false
+      Noir::TreeSitter.each_named_child(params) do |param|
+        next unless Noir::TreeSitter.node_type(param) == "formal_parameter"
+        next if framework_model_output_param?(param, source)
+
+        ann = annotation_node_on(param, source, "PathVariable")
+        return false unless ann
+        return false if annotation_text(ann, source).includes?("required = false") ||
+                        annotation_text(ann, source).includes?("required=false")
+        saw_path_variable = true
+      end
+
+      saw_path_variable
+    end
+
+    private def framework_model_output_param?(param : LibTreeSitter::TSNode, source : String) : Bool
+      type_node = Noir::TreeSitter.field(param, "type")
+      return false unless type_node
+
+      type_name = simple_type_name(Noir::TreeSitter.node_text(type_node, source)).downcase
+      type_name == "map" || type_name == "model" || type_name == "modelmap"
+    end
+
+    private def method_return_type(method : LibTreeSitter::TSNode, source : String) : String
+      if type_node = Noir::TreeSitter.field(method, "type")
+        return simple_type_name(Noir::TreeSitter.node_text(type_node, source))
+      end
+
+      ""
+    end
+
+    private def annotation_node_on(decl : LibTreeSitter::TSNode,
+                                   source : String,
+                                   annotation_name : String) : LibTreeSitter::TSNode?
+      mods = find_modifiers(decl)
+      return unless mods
+      Noir::TreeSitter.each_named_child(mods) do |ann|
+        ty = Noir::TreeSitter.node_type(ann)
+        next unless ty == "annotation" || ty == "marker_annotation"
+        n = Noir::TreeSitter.field(ann, "name")
+        next unless n
+        return ann if simple_name(Noir::TreeSitter.node_text(n, source)) == annotation_name
+      end
+      nil
+    end
+
+    private def annotation_string_arg(ann : LibTreeSitter::TSNode, source : String) : String?
+      args = Noir::TreeSitter.field(ann, "arguments")
+      return unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        case Noir::TreeSitter.node_type(arg)
+        when "string_literal"
+          return decode_string_literal(arg, source)
+        when "element_value_pair"
+          key = Noir::TreeSitter.field(arg, "key")
+          val = Noir::TreeSitter.field(arg, "value")
+          next unless key && val
+          next unless Noir::TreeSitter.node_text(key, source) == "value" ||
+                      Noir::TreeSitter.node_text(key, source) == "name"
+          return decode_string_literal(val, source) if Noir::TreeSitter.node_type(val) == "string_literal"
+        end
+      end
+      nil
+    end
+
+    private def annotation_text(ann : LibTreeSitter::TSNode, source : String) : String
+      Noir::TreeSitter.node_text(ann, source)
+    end
+
+    private def default_model_attribute_name(type_name : String) : String
+      simple = simple_type_name(type_name)
+      return "" if simple.empty?
+
+      simple[0].downcase.to_s + simple[1..]
+    end
+
+    private def simple_type_name(type_name : String) : String
+      name = type_name.strip
+      name = name.sub(/\A(?:public|protected|private|static|final|abstract)\s+/, "")
+      if idx = name.index('<')
+        name = name[...idx]
+      end
+      name = name.gsub(/\[\s*\]/, "")
+      if idx = name.rindex('.')
+        name = name[(idx + 1)..]
+      end
+      name.strip
+    end
+
     # Iterate annotation names (marker or full) attached to a
     # declaration's `modifiers` child. Yields just the simple name
     # (e.g. `"RequestParam"` even for `@org.springframework.web.bind.
@@ -603,7 +768,8 @@ module Noir
                                       parameter_format : String?,
                                       class_fields : Hash(String, Array(FieldInfo)),
                                       constants : Hash(String, String),
-                                      current_class : String) : Array(Param)
+                                      current_class : String,
+                                      model_attributes = [] of ModelAttributeSupplier) : Array(Param)
       params = [] of Param
       fparams = Noir::TreeSitter.field(method, "parameters")
       return params unless fparams
@@ -616,7 +782,7 @@ module Noir
 
       Noir::TreeSitter.each_named_child(fparams) do |fp|
         next unless Noir::TreeSitter.node_type(fp) == "formal_parameter"
-        current_format = emit_param_for(fp, method, source, verb, current_format, class_fields, constants, current_class, params)
+        current_format = emit_param_for(fp, method, source, verb, current_format, class_fields, constants, current_class, params, model_attributes)
       end
 
       # Collapse duplicate `(name, type)` params. A handler binding two
@@ -637,7 +803,8 @@ module Noir
                                class_fields : Hash(String, Array(FieldInfo)),
                                constants : Hash(String, String),
                                current_class : String,
-                               sink : Array(Param)) : String?
+                               sink : Array(Param),
+                               model_attributes = [] of ModelAttributeSupplier) : String?
       type_node = Noir::TreeSitter.field(fp, "type")
       name_node = Noir::TreeSitter.field(fp, "name")
       return parameter_format unless type_node && name_node
@@ -651,6 +818,8 @@ module Noir
       ann_kind = nil
       ann_node : LibTreeSitter::TSNode? = nil
       injected_param = false
+      validated_param = false
+      model_attribute_name : String? = nil
       if mods = find_modifiers(fp)
         Noir::TreeSitter.each_named_child(mods) do |ann|
           ty = Noir::TreeSitter.node_type(ann)
@@ -659,6 +828,8 @@ module Noir
           next unless n
           sn = simple_name(Noir::TreeSitter.node_text(n, source))
           injected_param = true if INJECTED_PARAM_ANNOTATIONS.includes?(sn)
+          validated_param = true if sn == "Valid" || sn == "Validated"
+          model_attribute_name = annotation_string_arg(ann, source) if sn == "ModelAttribute"
           case sn
           when "PathVariable"
             ann_kind = :path
@@ -691,6 +862,10 @@ module Noir
       # input — drop it before the implicit-binding path can expand its
       # (often DTO-typed) fields into phantom params.
       return parameter_format if ann_kind.nil? && injected_param
+      if ann_kind.nil? && !validated_param &&
+         supplied_model_attribute_param?(arg_name, type_name, model_attribute_name, model_attributes)
+        return parameter_format
+      end
 
       effective_format = parameter_format
       case ann_kind
@@ -774,6 +949,19 @@ module Noir
       end
 
       effective_format
+    end
+
+    private def supplied_model_attribute_param?(arg_name : String,
+                                                type_name : String,
+                                                model_attribute_name : String?,
+                                                model_attributes : Array(ModelAttributeSupplier)) : Bool
+      return false if model_attributes.empty?
+
+      param_type = simple_type_name(type_name)
+      model_attributes.any? do |supplier|
+        supplier.type_name == param_type &&
+          (supplier.name == arg_name || (!model_attribute_name.nil? && supplier.name == model_attribute_name))
+      end
     end
 
     # True when `type_name` is a scalar Spring binds from one request

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -33,8 +33,7 @@ module Noir
   #     index (same pipeline as Spring's `@RequestBody`).
   #
   # Out of scope for this first cut: meta-annotations,
-  # `@MatrixParam`, `@Context` (always skipped — framework
-  # injection, not user input).
+  # `@MatrixParam`.
   module TreeSitterJaxRsExtractor
     extend self
 
@@ -76,6 +75,24 @@ module Noir
       "boolean", "byte", "char", "short", "int", "long",
       "float", "double", "void", "string", "object",
       "integer", "character",
+    }
+
+    # Framework-provided method parameters that can be injected by
+    # type in RESTEasy Reactive / Quarkus or are commonly carried by
+    # JAX-RS/Servlet `@Context` / `@Suspended`. These are never
+    # request bodies.
+    INJECTED_PARAM_TYPES = Set{
+      "routingcontext", "httpserverrequest", "httpserverresponse",
+      "containerrequestcontext", "containerresponsecontext",
+      "securitycontext", "uriinfo", "httpheaders", "resourcecontext",
+      "providers", "sse", "sseeventsink", "asyncresponse",
+      "httpservletrequest", "httpservletresponse",
+      "servletrequest", "servletresponse",
+      "securityidentity", "jsonwebtoken",
+    }
+
+    MULTIPART_FORM_PARAM_TYPES = Set{
+      "multipartformdatainput", "multipartinput", "formdatamultipart",
     }
 
     alias SourceEntry = Tuple(String, String) # file_path, source
@@ -642,6 +659,8 @@ module Noir
           result = "form"
         elsif text.includes?("APPLICATION_JSON") || text.includes?("application/json")
           result = "json"
+        elsif text.includes?("MULTIPART_FORM_DATA") || text.includes?("multipart/form-data")
+          result = "form"
         end
       end
       result
@@ -684,9 +703,10 @@ module Noir
       formal = formal_parameters_node(method)
       return params unless formal
 
+      multipart_fields = multipart_form_fields(method, source)
       Noir::TreeSitter.each_named_child(formal) do |param|
         next unless Noir::TreeSitter.node_type(param) == "formal_parameter"
-        emit_param_for(param, source, verb, method_format, dto_index, bean_index, constants, current_class, params)
+        emit_param_for(param, source, verb, method_format, dto_index, bean_index, constants, current_class, params, multipart_fields)
       end
       params
     end
@@ -706,7 +726,8 @@ module Noir
                                bean_index : Hash(String, Array(Param)),
                                constants : Hash(String, String),
                                current_class : String,
-                               sink : Array(Param))
+                               sink : Array(Param),
+                               multipart_fields = Hash(String, Array(String)).new)
       param_name, type_name = parameter_name_and_type(param, source)
       return if param_name.empty?
 
@@ -721,7 +742,7 @@ module Noir
           ann_arg = first_string_arg(args, source, constants, current_class)
         elsif name == "BeanParam"
           ann_kind = :bean
-        elsif name == "Context"
+        elsif name == "Context" || name == "Suspended"
           ann_kind = :context
         elsif name == "DefaultValue"
           default_value = first_string_arg(args, source, constants, current_class)
@@ -735,8 +756,8 @@ module Noir
 
       case ann_kind
       when :path, :context
-        # @PathParam → URL carries it; @Context → framework
-        # injection. Skip in both cases.
+        # @PathParam carries it in the URL; @Context/@Suspended are
+        # framework injection. Skip in both cases.
         return
       when :bean
         if fields = bean_index[type_name]?
@@ -756,7 +777,17 @@ module Noir
       # we know them, otherwise emit a single `body` param so the
       # caller still sees something.
       return if PRIMITIVE_TYPES.includes?(type_name.downcase)
+      return if INJECTED_PARAM_TYPES.includes?(type_name.downcase)
       format = method_format || "json"
+      if MULTIPART_FORM_PARAM_TYPES.includes?(type_name.downcase)
+        fields = multipart_fields[param_name]? || [] of String
+        if fields.empty?
+          sink << Param.new(param_name, "", "form")
+        else
+          fields.each { |field| sink << Param.new(field, "", "form") }
+        end
+        return
+      end
       if fields = dto_index[type_name]?
         fields.each do |field|
           next unless field.access_modifier == "public" || field.has_setter?
@@ -781,6 +812,86 @@ module Noir
         end
       end
       {name, type_name}
+    end
+
+    private def multipart_form_fields(method : LibTreeSitter::TSNode, source : String) : Hash(String, Array(String))
+      fields = Hash(String, Array(String)).new { |hash, key| hash[key] = [] of String }
+      body = Noir::TreeSitter.field(method, "body")
+      return fields unless body
+
+      collect_multipart_form_fields(body, source, fields, 0)
+      fields
+    end
+
+    private def collect_multipart_form_fields(node : LibTreeSitter::TSNode,
+                                              source : String,
+                                              fields : Hash(String, Array(String)),
+                                              depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+      if Noir::TreeSitter.node_type(node) == "method_invocation"
+        collect_multipart_form_field_from_call(node, source, fields)
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_multipart_form_fields(child, source, fields, depth + 1)
+      end
+    end
+
+    private def collect_multipart_form_field_from_call(call : LibTreeSitter::TSNode,
+                                                       source : String,
+                                                       fields : Hash(String, Array(String)))
+      name = method_invocation_name(call, source)
+      carrier = ""
+      field_name : String? = nil
+
+      if name == "get"
+        object = Noir::TreeSitter.field(call, "object")
+        if object && Noir::TreeSitter.node_type(object) == "method_invocation" &&
+           method_invocation_name(object, source) == "getFormDataMap"
+          carrier = method_invocation_receiver(object, source)
+          field_name = first_string_arg(method_invocation_args(call), source)
+        end
+      elsif name == "getFormDataPart"
+        carrier = method_invocation_receiver(call, source)
+        field_name = first_string_arg(method_invocation_args(call), source)
+      end
+
+      return if carrier.empty?
+      field = field_name
+      return unless field
+      return if field.empty?
+
+      fields[carrier] << field unless fields[carrier].includes?(field)
+    end
+
+    private def method_invocation_name(call : LibTreeSitter::TSNode, source : String) : String
+      if name_node = Noir::TreeSitter.field(call, "name")
+        return Noir::TreeSitter.node_text(name_node, source)
+      end
+
+      ""
+    end
+
+    private def method_invocation_receiver(call : LibTreeSitter::TSNode, source : String) : String
+      object = Noir::TreeSitter.field(call, "object")
+      return "" unless object
+
+      case Noir::TreeSitter.node_type(object)
+      when "identifier"
+        Noir::TreeSitter.node_text(object, source)
+      when "field_access", "scoped_identifier"
+        last_segment(Noir::TreeSitter.node_text(object, source))
+      else
+        ""
+      end
+    end
+
+    private def method_invocation_args(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(call) do |child|
+        return child if Noir::TreeSitter.node_type(child) == "argument_list"
+      end
+      nil
     end
 
     private def leaf_type_name(node : LibTreeSitter::TSNode, source : String) : String

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -63,6 +63,16 @@ module Noir
       "integer", "character",
     }
 
+    INJECTED_PARAM_TYPES = Set{
+      "authentication", "httprequest", "httpheaders", "pageable",
+      "principal", "x509authentication",
+    }
+
+    FORM_FILE_PARAM_TYPES = Set{
+      "completedfileupload", "streamingfileupload", "completedpart",
+      "partdata",
+    }
+
     struct Route
       getter verb : String
       getter path : String
@@ -257,17 +267,21 @@ module Noir
         method_paths = annotation_paths(method_args, source, constants, class_name)
         method_paths = [""] if method_paths.empty?
         method_consumes = consumes_format(member, source) ||
-                          consumes_format(method_args, source, Set{"consumes", "processes"}) ||
+                          consumes_format_args(method_args, source, Set{"consumes", "processes"}) ||
                           class_consumes
 
-        params = collect_method_params(member, source, method_consumes, dto_index, constants, class_name)
         callees = include_callees ? collect_method_callees(member, source) : [] of Tuple(String, Int32)
         line = Noir::TreeSitter.node_start_row(verb_node)
 
         controller_paths.each do |class_path|
           method_paths.each do |method_path|
             full_path = join_paths(class_path, method_path)
-            routes << Route.new(verb, full_path, class_name, method_name, line, params.dup, callees)
+            normalized_path = strip_uri_template_query(full_path)
+            query_vars = uri_template_query_vars(full_path)
+            path_vars = uri_template_path_vars(normalized_path)
+            params = collect_method_params(member, source, method_consumes, dto_index, constants, class_name, query_vars.to_set, path_vars.to_set)
+            merge_query_template_params(params, unbound_query_template_vars(member, source, query_vars))
+            routes << Route.new(verb, normalized_path, class_name, method_name, line, params, callees)
           end
         end
       end
@@ -309,17 +323,21 @@ module Noir
         method_paths = annotation_paths(method_args, source, constants, interface_name)
         method_paths = [""] if method_paths.empty?
         method_consumes = consumes_format(member, source) ||
-                          consumes_format(method_args, source, Set{"consumes", "processes"}) ||
+                          consumes_format_args(method_args, source, Set{"consumes", "processes"}) ||
                           interface_consumes
 
-        params = collect_method_params(member, source, method_consumes, dto_index, constants, interface_name)
         callees = include_callees ? collect_method_callees(member, source) : [] of Tuple(String, Int32)
         line = Noir::TreeSitter.node_start_row(verb_node)
 
         interface_paths.each do |interface_path|
           method_paths.each do |method_path|
             full_path = join_paths(interface_path, method_path)
-            routes[interface_name] << Route.new(verb, full_path, interface_name, method_name, line, params.dup, callees)
+            normalized_path = strip_uri_template_query(full_path)
+            query_vars = uri_template_query_vars(full_path)
+            path_vars = uri_template_path_vars(normalized_path)
+            params = collect_method_params(member, source, method_consumes, dto_index, constants, interface_name, query_vars.to_set, path_vars.to_set)
+            merge_query_template_params(params, unbound_query_template_vars(member, source, query_vars))
+            routes[interface_name] << Route.new(verb, normalized_path, interface_name, method_name, line, params, callees)
           end
         end
       end
@@ -556,14 +574,14 @@ module Noir
       result : String? = nil
       each_annotation(decl, source) do |name, args, _|
         next unless name == "Consumes"
-        result = consumes_format(args, source)
+        result = consumes_format_args(args, source)
       end
       result
     end
 
-    private def consumes_format(args : LibTreeSitter::TSNode?,
-                                source : String,
-                                keys : Set(String)? = nil) : String?
+    private def consumes_format_args(args : LibTreeSitter::TSNode?,
+                                     source : String,
+                                     keys : Set(String)? = nil) : String?
       return unless args
 
       if keys
@@ -621,6 +639,56 @@ module Noir
       "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
 
+    private def strip_uri_template_query(path : String) : String
+      normalized = path.gsub(/\{\?[^}]*\}/, "")
+      normalized.empty? ? "/" : normalized
+    end
+
+    private def uri_template_query_vars(path : String) : Array(String)
+      vars = [] of String
+      path.scan(/\{\?([^}]*)\}/) do |match|
+        match[1].split(',').each do |raw|
+          name = normalize_uri_template_var(raw)
+          vars << name unless name.empty?
+        end
+      end
+      vars.uniq
+    end
+
+    private def uri_template_path_vars(path : String) : Array(String)
+      vars = [] of String
+      path.scan(/\{([^}?][^}]*)\}/) do |match|
+        name = normalize_uri_template_var(match[1])
+        vars << name unless name.empty?
+      end
+      vars.uniq
+    end
+
+    private def normalize_uri_template_var(raw : String) : String
+      name = raw.strip
+      name = name.rstrip('*')
+      if colon = name.index(':')
+        name = name[...colon]
+      end
+      name.strip
+    end
+
+    private def merge_query_template_params(params : Array(Param), query_vars : Array(String))
+      query_vars.each do |name|
+        next if params.any? { |param| param.name == name && param.param_type == "query" }
+        params << Param.new(name, "", "query")
+      end
+    end
+
+    private def unbound_query_template_vars(method : LibTreeSitter::TSNode,
+                                            source : String,
+                                            query_vars : Array(String)) : Array(String)
+      return query_vars if query_vars.empty?
+
+      names = formal_parameter_names(method, source)
+      query_vars.reject { |name| names.includes?(name) }
+    end
+
     # ---- formal parameter walk --------------------------------------
 
     private def collect_method_params(method : LibTreeSitter::TSNode,
@@ -628,14 +696,16 @@ module Noir
                                       method_format : String?,
                                       dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
                                       constants : Hash(String, String),
-                                      current_class : String) : Array(Param)
+                                      current_class : String,
+                                      query_template_vars = Set(String).new,
+                                      path_template_vars = Set(String).new) : Array(Param)
       params = [] of Param
       formal = formal_parameters_node(method)
       return params unless formal
 
       Noir::TreeSitter.each_named_child(formal) do |param|
         next unless Noir::TreeSitter.node_type(param) == "formal_parameter"
-        emit_param_for(param, source, method_format, dto_index, constants, current_class, params)
+        emit_param_for(param, source, method_format, dto_index, constants, current_class, params, query_template_vars, path_template_vars)
       end
       params
     end
@@ -647,13 +717,28 @@ module Noir
       nil
     end
 
+    private def formal_parameter_names(method : LibTreeSitter::TSNode, source : String) : Set(String)
+      names = Set(String).new
+      formal = formal_parameters_node(method)
+      return names unless formal
+
+      Noir::TreeSitter.each_named_child(formal) do |param|
+        next unless Noir::TreeSitter.node_type(param) == "formal_parameter"
+        name, _type_name = parameter_name_and_type(param, source)
+        names << name unless name.empty?
+      end
+      names
+    end
+
     private def emit_param_for(param : LibTreeSitter::TSNode,
                                source : String,
                                method_format : String?,
                                dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
                                constants : Hash(String, String),
                                current_class : String,
-                               sink : Array(Param))
+                               sink : Array(Param),
+                               query_template_vars = Set(String).new,
+                               path_template_vars = Set(String).new)
       param_name, type_name = parameter_name_and_type(param, source)
       return if param_name.empty?
 
@@ -690,13 +775,31 @@ module Noir
         # already emitted above
         return
       end
+      return if path_template_vars.includes?(param_name)
+
+      if query_template_vars.includes?(param_name)
+        emit_dto_fields(type_name, dto_index, "query", default_value, sink) do
+          sink << Param.new(param_name, param_value(default_value, ""), "query")
+        end
+        return
+      end
 
       # `@Body` and un-annotated complex parameters share the same
       # body-expansion path. Skip primitives (the `model: Model`
       # equivalent in Spring) so framework-injected helpers don't
       # leak into the param list.
-      return if PRIMITIVE_TYPES.includes?(type_name.downcase)
       format = method_format || "json"
+      if ann_kind == :body && PRIMITIVE_TYPES.includes?(type_name.downcase)
+        sink << Param.new(ann_arg.presence || param_name, param_value(default_value, ""), format)
+        return
+      end
+
+      return if PRIMITIVE_TYPES.includes?(type_name.downcase)
+      return if INJECTED_PARAM_TYPES.includes?(type_name.downcase)
+      if format == "form" && FORM_FILE_PARAM_TYPES.includes?(type_name.downcase)
+        sink << Param.new(ann_arg.presence || param_name, param_value(default_value, ""), "form")
+        return
+      end
       emit_dto_fields(type_name, dto_index, format, default_value, sink) do
         sink << Param.new(ann_arg.presence || param_name, param_value(default_value, type_name), format)
       end


### PR DESCRIPTION
## Summary
- improve Java parameter extraction for Micronaut, JAX-RS, and Quarkus cases including multipart/form fields, injected framework params, and Spring-style model attributes
- extend Java callee extraction for method references and Quarkus reactive routes
- fix Quarkus reactive route regressions for fully qualified failure handlers and overloaded route methods

## Validation
- `crystal spec spec/functional_test/testers/java/quarkus_spec.cr spec/functional_test/testers/java/quarkus_callees_spec.cr`
- `crystal spec spec/functional_test/testers/java spec/unit_test/miniparser spec/unit_test/detector/java`
- `just build`
- `just check`
- `just test`
- Quarkus quickstarts scan comparison after review fixes: endpoints 162, params 142, callees 287 unchanged from prior baseline
