### PR TITLE
perf: eliminate PCRE2 recompilation introduced by recent analyzer sweeps

### DIFF
--- a/spec/unit_test/mobile/linker_spec.cr
+++ b/spec/unit_test/mobile/linker_spec.cr
@@ -3,7 +3,6 @@ require "../../spec_helper"
 require "../../../src/models/logger"
 require "../../../src/models/code_locator"
 require "../../../src/mobile/linker.cr"
-require "file_utils"
 
 # The linker resolves an Android mobile endpoint's handler component to its
 # source file, attaches the handler as a code_path, and pulls 1-hop callees

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -85,6 +85,11 @@ module Analyzer::Python
       dict : Array(Tuple(::String, ::String, Regex, Regex))
 
     @request_param_regex_cache = Hash(::String, RequestParamRegexes).new
+    @alias_route_origin_regex_cache = Hash(::String, Regex).new
+
+    private def alias_route_origin_regex(alias_name : ::String) : Regex
+      @alias_route_origin_regex_cache[alias_name] ||= /^\s*#{Regex.escape(alias_name)}\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/
+    end
 
     def analyze
       handler_routes = Hash(::String, Array(Tuple(::String, ::String, Int32, ::String))).new
@@ -236,7 +241,7 @@ module Analyzer::Python
                 method = alias_route_match[2].upcase
                 route_path = alias_route_match[3]
                 handler_name = alias_route_match[4]
-                if orig_match = line.match(/^\s*#{Regex.escape(alias_route_match[1])}\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
+                if orig_match = line.match(alias_route_origin_regex(alias_route_match[1]))
                   route_path = orig_match[1]
                 end
                 prefixes_for_receiver(receiver, app_prefixes).each do |prefix|

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -373,22 +373,30 @@ module Analyzer::Python
                                           list_names : Array(::String)) : Array(::String)
       contents = [] of ::String
       lines = content.split("\n")
+      # Compile once per call; interpolated regex literals inside the
+      # per-line loop would be recompiled on every line.
       list_name_re = list_names.map { |name| Regex.escape(name) }.join("|")
+      assign_check_re = /^\s*(?:#{list_name_re})\s*=/
+      assign_capture_re = /^\s*(?:#{list_name_re})\s*=\s*(.+)$/m
+      append_check_re = /^\s*(?:#{list_name_re})\s*\+=/
+      append_capture_re = /^\s*(?:#{list_name_re})\s*\+=\s*(.+)$/m
+      extend_check_re = /^\s*(?:#{list_name_re})\s*\.\s*extend\s*\(/
+      extend_capture_re = /^\s*(?:#{list_name_re})\s*\.\s*extend\s*\((.*)\)\s*$/m
 
       lines.each_with_index do |line, index|
-        if line.matches?(/^\s*(?:#{list_name_re})\s*=/)
+        if line.matches?(assign_check_re)
           logical_line = collect_python_expression(lines, index, line)
-          if assignment_match = logical_line.match(/^\s*(?:#{list_name_re})\s*=\s*(.+)$/m)
+          if assignment_match = logical_line.match(assign_capture_re)
             add_urlpattern_expression_contents(contents, assignment_match[1], urlpattern_lists)
           end
-        elsif line.matches?(/^\s*(?:#{list_name_re})\s*\+=/)
+        elsif line.matches?(append_check_re)
           logical_line = collect_python_expression(lines, index, line)
-          if append_match = logical_line.match(/^\s*(?:#{list_name_re})\s*\+=\s*(.+)$/m)
+          if append_match = logical_line.match(append_capture_re)
             add_urlpattern_expression_contents(contents, append_match[1], urlpattern_lists)
           end
-        elsif line.matches?(/^\s*(?:#{list_name_re})\s*\.\s*extend\s*\(/)
+        elsif line.matches?(extend_check_re)
           logical_line = collect_python_expression(lines, index, line)
-          if extend_match = logical_line.match(/^\s*(?:#{list_name_re})\s*\.\s*extend\s*\((.*)\)\s*$/m)
+          if extend_match = logical_line.match(extend_capture_re)
             add_urlpattern_expression_contents(contents, extend_match[1], urlpattern_lists)
           end
         end

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -665,10 +665,19 @@ module Analyzer::Rust
       endpoint.push_param(Param.new("form", "", "form")) if extractor_param?(text, "Form")
     end
 
+    # Precompiled per extractor type; interpolated regex literals here would
+    # be recompiled on every function parameter.
+    EXTRACTOR_PARAM_RES = {
+      "Query" => {/Query\s*\(\s*[^)]+\s*\)/, /:\s*(?:[A-Za-z_]\w*::)*Query\b/},
+      "Json"  => {/Json\s*\(\s*[^)]+\s*\)/, /:\s*(?:[A-Za-z_]\w*::)*Json\b/},
+      "Form"  => {/Form\s*\(\s*[^)]+\s*\)/, /:\s*(?:[A-Za-z_]\w*::)*Form\b/},
+    }
+
     private def extractor_param?(text : String, type_name : String) : Bool
+      call_re, type_re = EXTRACTOR_PARAM_RES[type_name]
       text.includes?("#{type_name}<") ||
-        !!text.match(/#{type_name}\s*\(\s*[^)]+\s*\)/) ||
-        !!text.match(/:\s*(?:[A-Za-z_]\w*::)*#{type_name}\b/)
+        !!text.match(call_re) ||
+        !!text.match(type_re)
     end
 
     private def param_binding_name(text : String) : String?

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -765,10 +765,10 @@ module NoirMobileLinker
       return 0 if remaining <= 0
 
       found = 0
+      case_re = Regex.new("^\\s*case\\s+\\.#{Regex.escape(action.action)}\\b")
 
       swift_method_bodies(content, action.method, action.action_type).each do |method|
         lines = method[:body].lines
-        case_re = Regex.new("^\\s*case\\s+\\.#{Regex.escape(action.action)}\\b")
         depth = 0
         in_string = false
 


### PR DESCRIPTION
## Summary

A regression check across the recent analyzer accuracy sweeps (post #1993) found no slowdown on the standard `benchmark-full` mock codebase — HEAD measured equal-to-slightly-faster than the #1993 baseline in a direct release-build A/B. However, a static sweep of the new code found interpolated regex literals (recompiled by Crystal on every evaluation) reintroduced on paths the mock benchmark does not exercise:

- **django** — `extract_url_list_contents` evaluated up to 6 interpolated regex literals per source line of every scanned urls module. Hoisted compilation before the line loop. On a mock Django project (30 apps × 3,000-line `urls.py`): **1.14s → 0.17s (~6.7×)**, identical 330 endpoints.
- **axum** — `extractor_param?` recompiled 2 regexes per function parameter for the fixed `Query`/`Json`/`Form` set. Replaced with a precompiled constant table.
- **aiohttp** — alias-route origin regex (dynamic alias name) memoized per name, matching the existing `@request_param_regex_cache` pattern.
- **mobile/linker** — Swift `case` regex hoisted out of the per-method-body loop (its input is fixed for the call).

Also audited (no change needed): mobile linker file reads are already cache-first via `CodeLocator`; the go_callee_extractor array dedup is bounded by per-route callee counts.

## Verification

- `benchmark-full` A/B vs #1993 baseline release build: no regression (≈0–2% faster).
- Django micro-benchmark above: ~6.7× on regex-heavy urls modules, identical endpoint output.
- Full `crystal spec`: 3,354 unit + 18,209 functional examples, 0 failures.
- `crystal tool format` + ameba clean.