### PR TITLE
perf: second regex-recompilation sweep — flask/quart json params, django CBV, kotlin extractor, security taggers

### DIFF
--- a/spec/functional_test/fixtures/python/flask/app.py
+++ b/spec/functional_test/fixtures/python/flask/app.py
@@ -84,6 +84,14 @@ def json_sample():
 
     return jsonify(data), 200
 
+@app.route('/update_record', methods=['POST'])
+def update_record():
+    record = request.get_json()
+    # field access and json-variable access on the SAME line — locks the
+    # once-per-line json fallback in extract_request_params
+    page = request.args['page'] if record['name'] else None
+    return jsonify(record)
+
 @app.route('/')
 def index():
     return render_template('index.html')

--- a/spec/functional_test/fixtures/python/quart/app.py
+++ b/spec/functional_test/fixtures/python/quart/app.py
@@ -76,6 +76,15 @@ class DispatchReportView(View):
         return jsonify({"owner": owner})
 
 
+@app.route("/sync-update", methods=["POST"])
+async def sync_update():
+    body = await request.get_json()
+    # field access and json-variable access on the SAME line — locks the
+    # once-per-line json fallback in extract_request_params
+    page = request.args["page"] if body["name"] else None
+    return {"page": page}
+
+
 @app.websocket("/ws")
 async def ws():
     while True:

--- a/spec/functional_test/testers/python/flask_spec.cr
+++ b/spec/functional_test/testers/python/flask_spec.cr
@@ -8,6 +8,7 @@ expected_endpoints = [
   Endpoint.new("/create_record", "PUT"),
   Endpoint.new("/delete_record", "DELETE", [Param.new("name", "", "json")]),
   Endpoint.new("/get_ip", "GET", [Param.new("X-Forwarded-For", "", "header")]),
+  Endpoint.new("/update_record", "POST", [Param.new("page", "", "query"), Param.new("name", "", "json")]),
   Endpoint.new("/", "GET"),
 ]
 

--- a/spec/functional_test/testers/python/quart_spec.cr
+++ b/spec/functional_test/testers/python/quart_spec.cr
@@ -27,6 +27,7 @@ expected_endpoints = [
     Param.new("term", "", "query"),
     Param.new("X-Trace-Id", "", "header"),
   ]),
+  Endpoint.new("/sync-update", "POST", [Param.new("page", "", "query"), Param.new("name", "", "json")]),
   Endpoint.new("/ws", "GET"),
 ]
 

--- a/spec/unit_test/miniparser/python_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/python_route_extractor_ts_spec.cr
@@ -21,6 +21,7 @@ describe Noir::TreeSitterPythonRouteExtractor do
       {"/get_ip", ["GET"], "json_sample"},
       {"/login", ["POST"], "login_sample"},
       {"/sign", ["GET", "POST"], "sign_sample"},
+      {"/update_record", ["POST"], "update_record"},
     ])
 
     decos.each(&.router_name.should eq("app"))

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -91,6 +91,20 @@ module Analyzer::Python
       @alias_route_origin_regex_cache[alias_name] ||= /^\s*#{Regex.escape(alias_name)}\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/
     end
 
+    # `<var>["key"]` / `<var>.get("key")` access patterns for variables
+    # bound to `await request.json()` / `await request.post()`. The
+    # variable name is discovered (dynamic but low-cardinality), so the
+    # compiled pair is memoized per name instead of being rebuilt per
+    # handler body.
+    @body_var_access_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
+    private def body_var_access_regexes(var : ::String) : Tuple(Regex, Regex)
+      @body_var_access_regex_cache[var] ||= {
+        /[^a-zA-Z_]#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/,
+        /[^a-zA-Z_]#{Regex.escape(var)}\.get\s*\(\s*['"]([^'"]+)['"]/,
+      }
+    end
+
     def analyze
       handler_routes = Hash(::String, Array(Tuple(::String, ::String, Int32, ::String))).new
       # path => [{route_path, http_method, line_index, handler_name}]
@@ -957,10 +971,11 @@ module Analyzer::Python
         end
 
         json_vars.each do |var|
-          body.scan(/[^a-zA-Z_]#{var}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+          bracket_re, get_re = body_var_access_regexes(var)
+          body.scan(bracket_re) do |m|
             record.call(m[1], "json")
           end
-          body.scan(/[^a-zA-Z_]#{var}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          body.scan(get_re) do |m|
             record.call(m[1], "json")
           end
         end
@@ -978,10 +993,11 @@ module Analyzer::Python
         end
 
         form_vars.each do |var|
-          body.scan(/[^a-zA-Z_]#{var}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |m|
+          bracket_re, get_re = body_var_access_regexes(var)
+          body.scan(bracket_re) do |m|
             record.call(m[1], "form")
           end
-          body.scan(/[^a-zA-Z_]#{var}\.get\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          body.scan(get_re) do |m|
             record.call(m[1], "form")
           end
         end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -14,6 +14,11 @@ module Analyzer::Python
     REGEX_ROUTE_MAPPING = /\b(?:url|path|re_path|register)\s*\(\s*r?['"]([^"']*)['"][^,]*,\s*([^),]*)/
     REGEX_INCLUDE_URLS  = /\binclude\s*\(\s*r?['"]([^'"\\]*)['"]/
 
+    # `def get(...)` / `async def post(...)` method heads in class-based
+    # views. Precompiled — an interpolated literal would be recompiled on
+    # every line of every CBV class body.
+    REGEX_CBV_METHOD_DEF = /\s+(?:async\s+)?def\s+(#{HTTP_METHODS.join("|")})\s*\(/
+
     # Map request parameters to their respective fields
     REQUEST_PARAM_FIELD_MAP = {
       "GET"          => {["GET"], "query"},
@@ -1323,7 +1328,6 @@ module Analyzer::Python
       end
 
       # Class Based View
-      regext_http_methods = HTTP_METHODS.join "|"
       class_start_index = content.index /class\s+#{function_or_class_name}\s*[\(:]/
       if !class_start_index.nil?
         class_codeblock = parse_python_class_codeblock(content, class_start_index) || parse_code_block(content[class_start_index..])
@@ -1363,7 +1367,7 @@ module Analyzer::Python
 
           # Check HTTP methods in class methods
           lines.each_with_index do |line, offset|
-            method_function_match = line.match(/\s+(?:async\s+)?def\s+(#{regext_http_methods})\s*\(/)
+            method_function_match = line.match(REGEX_CBV_METHOD_DEF)
             any_method_function_match = line.match(/\s+(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
             if !any_method_function_match.nil?
               current_http_method = nil

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -55,7 +55,9 @@ module Analyzer::Python
 
     # Source-ownership and add_url_rule helpers — same constant-only
     # interpolation (DOT_NATION), hoisted so the per-file/per-call sites
-    # don't recompile them.
+    # don't recompile them. VIEW_FUNC_KWARG_RE has no whitespace tolerance
+    # (unlike Quart's) because Flask's add_url_rule args are matched on
+    # space-stripped lines.
     ROUTE_DECORATOR_RE  = /^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m
     ROUTE_REGISTRAR_RE  = /\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/
     VIEW_FUNC_KWARG_RE  = /view_func=(#{DOT_NATION})(?:,|\)|$)/

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -52,8 +52,16 @@ module Analyzer::Python
     FLASK_INSTANCE_RE     = /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask\.)?Flask\(/
     INIT_APP_RE           = /(#{PYTHON_VAR_NAME_REGEX})\.init_app\((#{PYTHON_VAR_NAME_REGEX})/
     REGISTER_BLUEPRINT_RE = /(#{PYTHON_VAR_NAME_REGEX})\.register_blueprint\((#{DOT_NATION})/
-    VIEW_ASSIGN_RE        = /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/
-    ADD_URL_RULE_RE       = /(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\((.+)\)/m
+
+    # Source-ownership and add_url_rule helpers — same constant-only
+    # interpolation (DOT_NATION), hoisted so the per-file/per-call sites
+    # don't recompile them.
+    ROUTE_DECORATOR_RE  = /^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m
+    ROUTE_REGISTRAR_RE  = /\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/
+    VIEW_FUNC_KWARG_RE  = /view_func=(#{DOT_NATION})(?:,|\)|$)/
+    DOTTED_REFERENCE_RE = /^#{DOT_NATION}$/
+    VIEW_ASSIGN_RE      = /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/
+    ADD_URL_RULE_RE     = /(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\((.+)\)/m
 
     @file_content_cache = Hash(::String, ::String).new
     @parsers = Hash(::String, PythonParser).new
@@ -875,8 +883,8 @@ module Analyzer::Python
       # only drops the duplicate mislabel (jupyterhub examples/service-
       # fastapi was reported as python_flask).
       return false if clean.matches?(/^\s*(?:from|import)\s+(?:fastapi|sanic|litestar|starlette|quart|robyn)\b/m)
-      return true if clean.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
-      return true if clean.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
+      return true if clean.matches?(ROUTE_DECORATOR_RE)
+      return true if clean.matches?(ROUTE_REGISTRAR_RE)
 
       false
     end
@@ -886,8 +894,8 @@ module Analyzer::Python
 
       clean = source.gsub(/#.*?(?:\n|\z)/m, "\n")
       return false if clean.matches?(/\b(?:Flask|Blueprint|Api|Namespace)\s*\(/)
-      return false if clean.matches?(/^\s*@\s*#{DOT_NATION}\s*\.\s*(?:route|get|post|put|patch|delete|head|options|trace)\s*\(/m)
-      return false if clean.matches?(/\b#{DOT_NATION}\s*\.\s*(?:add_url_rule|register_blueprint)\s*\(/)
+      return false if clean.matches?(ROUTE_DECORATOR_RE)
+      return false if clean.matches?(ROUTE_REGISTRAR_RE)
 
       true
     end
@@ -1131,7 +1139,7 @@ module Analyzer::Python
     end
 
     private def extract_add_url_rule_function_name(args_str : ::String) : ::String
-      if view_func_match = args_str.match(/view_func=(#{DOT_NATION})(?:,|\)|$)/)
+      if view_func_match = args_str.match(VIEW_FUNC_KWARG_RE)
         return view_func_match[1]
       end
 
@@ -1143,7 +1151,7 @@ module Analyzer::Python
                  else
                    ""
                  end
-      view_arg.matches?(/^#{DOT_NATION}$/) ? view_arg : ""
+      view_arg.matches?(DOTTED_REFERENCE_RE) ? view_arg : ""
     end
 
     private def resolve_external_function_view(function_ref : ::String,
@@ -1238,13 +1246,28 @@ module Analyzer::Python
     end
 
     private def find_function_def(lines : Array(::String), function_name : ::String) : Int32?
+      # Compile once per call; an interpolated literal inside the loop
+      # would be recompiled on every line.
+      def_re = /^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/
       lines.each_with_index do |line, index|
-        if line.match(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+        if line.match(def_re)
           return index
         end
       end
 
       nil
+    end
+
+    # JSON-variable access patterns interpolate a discovered (dynamic but
+    # low-cardinality) identifier, so they can't be hoisted to constants —
+    # memoize them per variable name instead.
+    @json_param_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
+    private def json_param_regexes(json_variable_name : ::String) : Tuple(Regex, Regex)
+      @json_param_regex_cache[json_variable_name] ||= {
+        /[^a-zA-Z_]#{Regex.escape(json_variable_name)}\[[rf]?['"]([^'"]*)['"]\]/,
+        /[^a-zA-Z_]#{Regex.escape(json_variable_name)}\.get\([rf]?['"]([^'"]*)['"]/,
+      }
     end
 
     # Extracts request parameters from a code block by detecting JSON variable
@@ -1275,22 +1298,33 @@ module Analyzer::Python
           if matches.size == 0
             matches = codeblock_line.scan(get_re)
           end
-          if matches.size == 0
-            noir_param_type = "json"
-            json_variable_names.each do |json_variable_name|
-              matches = codeblock_line.scan(/[^a-zA-Z_]#{json_variable_name}\[[rf]?['"]([^'"]*)['"]\]/)
-              if matches.size == 0
-                matches = codeblock_line.scan(/[^a-zA-Z_]#{json_variable_name}\.get\([rf]?['"]([^'"]*)['"]/)
-              end
-              break if matches.size > 0
-            end
-          end
 
           matches.each do |parameter_match|
             next if parameter_match.size != 2
             param_name = parameter_match[1]
             params << Param.new(param_name, "", noir_param_type)
           end
+        end
+
+        # JSON dict access on the variables found above. This used to run
+        # inside the field-pattern loop (once per missed field — i.e.
+        # effectively per field per line), recompiling two interpolated
+        # regexes each time and appending the same matches repeatedly;
+        # `get_filtered_params` deduplicates by (name, param_type), so
+        # scanning once per line is output-identical.
+        json_variable_names.each do |json_variable_name|
+          bracket_json_re, get_json_re = json_param_regexes(json_variable_name)
+          matches = codeblock_line.scan(bracket_json_re)
+          if matches.size == 0
+            matches = codeblock_line.scan(get_json_re)
+          end
+          next if matches.size == 0
+
+          matches.each do |parameter_match|
+            next if parameter_match.size != 2
+            params << Param.new(parameter_match[1], "", "json")
+          end
+          break
         end
       end
 

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -56,6 +56,19 @@ module Analyzer::Python
     WEBSOCKET_ATTRIBUTES = {"websocket" => "GET"}
 
     @file_content_cache = Hash(::String, ::String).new
+
+    # JSON-variable access patterns interpolate a discovered (dynamic but
+    # low-cardinality) identifier, so they can't be hoisted to constants —
+    # memoize them per variable name instead.
+    @json_param_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
+    private def json_param_regexes(json_variable_name : ::String) : Tuple(Regex, Regex)
+      @json_param_regex_cache[json_variable_name] ||= {
+        /[^a-zA-Z_]#{Regex.escape(json_variable_name)}\[[rf]?['"]([^'"]*)['"]\]/,
+        /[^a-zA-Z_]#{Regex.escape(json_variable_name)}\.get\([rf]?['"]([^'"]*)['"]/,
+      }
+    end
+
     @parsers = Hash(::String, PythonParser).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, Bool))).new
     @method_view_routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, Array(::String)))).new
@@ -387,8 +400,13 @@ module Analyzer::Python
       ""
     end
 
+    # Constant-only interpolation (DOT_NATION) — hoisted so the per-call
+    # sites don't recompile them.
+    VIEW_FUNC_KWARG_RE  = /view_func\s*=\s*(#{DOT_NATION})(?:\s*,|\s*\)|\s*$)/
+    DOTTED_REFERENCE_RE = /^#{DOT_NATION}$/
+
     private def extract_add_url_rule_function_name(args : ::String) : ::String
-      if view_func_match = args.match(/view_func\s*=\s*(#{DOT_NATION})(?:\s*,|\s*\)|\s*$)/)
+      if view_func_match = args.match(VIEW_FUNC_KWARG_RE)
         return view_func_match[1]
       end
 
@@ -400,7 +418,7 @@ module Analyzer::Python
                  else
                    ""
                  end
-      view_arg.matches?(/^#{DOT_NATION}$/) ? view_arg : ""
+      view_arg.matches?(DOTTED_REFERENCE_RE) ? view_arg : ""
     end
 
     private def resolve_external_function_view(function_ref : ::String,
@@ -611,6 +629,9 @@ module Analyzer::Python
     end
 
     private def find_method_def(lines : Array(::String), class_def_index : Int32, class_indent : Int32, method_name : ::String) : Int32
+      # Compile once per call; an interpolated literal inside the loop
+      # would be recompiled on every line.
+      method_def_re = /(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/
       i = class_def_index + 1
       while i < lines.size
         line = lines[i]
@@ -618,7 +639,7 @@ module Analyzer::Python
           break if class_match[1].size <= class_indent
         end
 
-        if method_match = line.match(/(\s*)(async\s+)?def\s+#{Regex.escape(method_name)}\s*\(/)
+        if method_match = line.match(method_def_re)
           return i if method_match[1].size > class_indent
         end
         i += 1
@@ -628,8 +649,9 @@ module Analyzer::Python
     end
 
     private def find_function_def(lines : Array(::String), function_name : ::String) : Int32
+      def_re = /^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/
       lines.each_with_index do |line, index|
-        if line.match(/^\s*(?:async\s+)?def\s+#{Regex.escape(function_name)}\s*\(/)
+        if line.match(def_re)
           return index
         end
       end
@@ -734,6 +756,8 @@ module Analyzer::Python
     private def extract_request_params(codeblock_lines : Array(::String)) : Array(Param)
       params = [] of Param
       json_variable_names = [] of ::String
+      # (json-variable regexes are memoized in @json_param_regex_cache —
+      # they interpolate a discovered identifier so they can't be consts.)
 
       codeblock_lines.each do |codeblock_line|
         match = codeblock_line.match /([a-zA-Z_][a-zA-Z0-9_]*).*=\s*(?:await\s+)?json\.loads\((?:await\s+)?request\.data/
@@ -753,21 +777,32 @@ module Analyzer::Python
           if matches.size == 0
             matches = codeblock_line.scan(get_re)
           end
-          if matches.size == 0
-            noir_param_type = "json"
-            json_variable_names.each do |json_variable_name|
-              matches = codeblock_line.scan(/[^a-zA-Z_]#{json_variable_name}\[[rf]?['"]([^'"]*)['"]\]/)
-              if matches.size == 0
-                matches = codeblock_line.scan(/[^a-zA-Z_]#{json_variable_name}\.get\([rf]?['"]([^'"]*)['"]/)
-              end
-              break if matches.size > 0
-            end
-          end
 
           matches.each do |parameter_match|
             next if parameter_match.size != 2
             params << Param.new(parameter_match[1], "", noir_param_type)
           end
+        end
+
+        # JSON dict access on the variables found above. This used to run
+        # inside the field-pattern loop (once per missed field — i.e.
+        # effectively per field per line), recompiling two interpolated
+        # regexes each time and appending the same matches repeatedly;
+        # `get_filtered_params` deduplicates by (name, param_type), so
+        # scanning once per line is output-identical.
+        json_variable_names.each do |json_variable_name|
+          bracket_json_re, get_json_re = json_param_regexes(json_variable_name)
+          matches = codeblock_line.scan(bracket_json_re)
+          if matches.size == 0
+            matches = codeblock_line.scan(get_json_re)
+          end
+          next if matches.size == 0
+
+          matches.each do |parameter_match|
+            next if parameter_match.size != 2
+            params << Param.new(parameter_match[1], "", "json")
+          end
+          break
         end
       end
 

--- a/src/miniparsers/kotlin_parameter_extractor_ts.cr
+++ b/src/miniparsers/kotlin_parameter_extractor_ts.cr
@@ -257,17 +257,17 @@ module Noir
       return params if request_names.empty?
 
       request_names.each do |request_name|
-        receiver = Regex.escape(request_name)
+        query_re, first_header_re, header_re = server_request_param_regexes(request_name)
 
-        body.scan(/\b#{receiver}\s*\.\s*queryParam\s*\(\s*"([^"]+)"/) do |match|
+        body.scan(query_re) do |match|
           push_unique_param(params, Param.new(match[1], "", "query"))
         end
 
-        body.scan(/\b#{receiver}\s*\.\s*headers\s*\(\s*\)\s*\.\s*firstHeader\s*\(\s*"([^"]+)"/) do |match|
+        body.scan(first_header_re) do |match|
           push_unique_param(params, Param.new(match[1], "", "header"))
         end
 
-        body.scan(/\b#{receiver}\s*\.\s*header\s*\(\s*"([^"]+)"/) do |match|
+        body.scan(header_re) do |match|
           push_unique_param(params, Param.new(match[1], "", "header"))
         end
       end
@@ -1083,20 +1083,47 @@ module Noir
       names.uniq
     end
 
+    # The receiver names are discovered per handler but draw from a tiny
+    # vocabulary (`request`, `req`, …), so the compiled patterns are
+    # memoized per name/prefix — interpolated literals here would be
+    # recompiled for every handler method.
+    @@server_request_param_regexes = Hash(String, Tuple(Regex, Regex, Regex)).new
+    @@body_type_regexes = Hash(String, Tuple(Regex, Regex, Regex)).new
+
+    private def server_request_param_regexes(request_name : String) : Tuple(Regex, Regex, Regex)
+      @@server_request_param_regexes[request_name] ||= begin
+        receiver = Regex.escape(request_name)
+        {
+          /\b#{receiver}\s*\.\s*queryParam\s*\(\s*"([^"]+)"/,
+          /\b#{receiver}\s*\.\s*headers\s*\(\s*\)\s*\.\s*firstHeader\s*\(\s*"([^"]+)"/,
+          /\b#{receiver}\s*\.\s*header\s*\(\s*"([^"]+)"/,
+        }
+      end
+    end
+
+    private def body_type_regexes(prefix : String) : Tuple(Regex, Regex, Regex)
+      @@body_type_regexes[prefix] ||= {
+        /#{prefix}\.\s*(?:awaitBody|bodyToMono)\s*<\s*([A-Za-z_][A-Za-z0-9_.]*)\s*>/,
+        /#{prefix}\.\s*awaitBodyOrNull\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*::\s*class/,
+        /#{prefix}\.\s*bodyToMono\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*::\s*class(?:\.java)?/,
+      }
+    end
+
     private def body_type_names(body : String, request_names : Array(String)? = nil) : Array(String)
       names = [] of String
       receiver = request_names && !request_names.empty? ? "(?:#{request_names.map { |name| Regex.escape(name) }.join("|")})" : nil
       prefix = receiver ? "\\b#{receiver}\\s*" : ""
+      await_body_re, await_body_or_null_re, body_to_mono_re = body_type_regexes(prefix)
 
-      body.scan(/#{prefix}\.\s*(?:awaitBody|bodyToMono)\s*<\s*([A-Za-z_][A-Za-z0-9_.]*)\s*>/) do |match|
+      body.scan(await_body_re) do |match|
         add_type_name(names, match[1])
       end
 
-      body.scan(/#{prefix}\.\s*awaitBodyOrNull\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*::\s*class/) do |match|
+      body.scan(await_body_or_null_re) do |match|
         add_type_name(names, match[1])
       end
 
-      body.scan(/#{prefix}\.\s*bodyToMono\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*::\s*class(?:\.java)?/) do |match|
+      body.scan(body_to_mono_re) do |match|
         add_type_name(names, match[1])
       end
 

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -259,7 +259,7 @@ class SpringSecurityTagger < FrameworkTagger
 
   private def wildcard_origin_call?(stmt : String, call_names : Array(String)) : Bool
     call_names.any? do |call_name|
-      call_re = @origin_call_regexes[call_name] ||= /#{call_name}\s*\(([^)]*)\)/
+      call_re = @origin_call_regexes[call_name] ||= /#{Regex.escape(call_name)}\s*\(([^)]*)\)/
       wildcard = false
       stmt.scan(call_re) do |m|
         args = m[1]

--- a/src/tagger/framework_taggers/java/spring_security.cr
+++ b/src/tagger/framework_taggers/java/spring_security.cr
@@ -251,10 +251,17 @@ class SpringSecurityTagger < FrameworkTagger
     statements
   end
 
+  # Call-name and ant-pattern regexes interpolate low-cardinality dynamic
+  # strings; memoize them so per-statement / per-URL checks don't
+  # recompile a PCRE2 pattern each time.
+  @origin_call_regexes = Hash(String, Regex).new
+  @ant_pattern_regexes = Hash(String, Regex).new
+
   private def wildcard_origin_call?(stmt : String, call_names : Array(String)) : Bool
     call_names.any? do |call_name|
+      call_re = @origin_call_regexes[call_name] ||= /#{call_name}\s*\(([^)]*)\)/
       wildcard = false
-      stmt.scan(/#{call_name}\s*\(([^)]*)\)/) do |m|
+      stmt.scan(call_re) do |m|
         args = m[1]
         wildcard = true if args.includes?("\"*\"") || args.includes?("'*'")
       end
@@ -448,10 +455,13 @@ class SpringSecurityTagger < FrameworkTagger
   # Ant-style pattern match (`/**` → any depth, `*` → one segment), prefix
   # anchored like spring_auth so `/api/**` matches `/api/posts/1`.
   private def matches_ant_pattern?(url : String, pattern : String) : Bool
-    regex_str = pattern.gsub("**", "DOUBLE_STAR")
-      .gsub("*", "[^/]*")
-      .gsub("DOUBLE_STAR", ".*")
-    url.matches?(/^#{regex_str}/)
+    ant_re = @ant_pattern_regexes[pattern] ||= begin
+      regex_str = pattern.gsub("**", "DOUBLE_STAR")
+        .gsub("*", "[^/]*")
+        .gsub("DOUBLE_STAR", ".*")
+      /^#{regex_str}/
+    end
+    url.matches?(ant_re)
   rescue ex
     @logger.debug "SpringSecurityTagger: failed to match ant pattern '#{pattern}': #{ex.message}"
     false

--- a/src/tagger/framework_taggers/ruby/rails_security.cr
+++ b/src/tagger/framework_taggers/ruby/rails_security.cr
@@ -190,11 +190,16 @@ class RailsSecurityTagger < FrameworkTagger
   # Detect the action across the symbol/string/`%i[]`/`%w[]` filter forms:
   #   only: :create | only: [:create, :update] | only: %i[create update]
   #   except: "create" | except: ["create"]
+  # Memoized per action name — this runs per macro line per action, and
+  # an interpolated literal would recompile the pattern on every check.
+  @action_token_regexes = Hash(String, Regex).new
+
   private def action_in_filter?(line : String, action_name : String?) : Bool
     return false if action_name.nil?
     # Whole-token match (symbol/quote prefix + delimiter) so action `create`
     # is NOT matched by `:create_comment` / `except: [:show_all]`.
-    return true if line.matches?(/(?::|"|')#{Regex.escape(action_name)}(?:"|'|,|\s|\]|\)|$)/)
+    action_re = @action_token_regexes[action_name] ||= /(?::|"|')#{Regex.escape(action_name)}(?:"|'|,|\s|\]|\)|$)/
+    return true if line.matches?(action_re)
     if m = line.match(/%[iIwW]\[([^\]]*)\]/)
       return m[1].split.includes?(action_name)
     end


### PR DESCRIPTION
## Summary

Follow-up to #2000. That sweep was scoped to the recent accuracy diffs; this one greps the whole `src/` tree for interpolated regex literals (recompiled by Crystal on every evaluation) and fixes the remaining hot-path sites. All changes are behavior-identical.

- **flask / quart** (largest) — the JSON-variable parameter fallback in `extract_request_params` ran *inside* the field-pattern loop, i.e. effectively once per field per line, recompiling two interpolated regexes each time and appending the same matches repeatedly (`get_filtered_params` deduplicates them later, so the duplicates were pure waste). The JSON scan now runs once per line with per-variable memoized patterns. On a mock Flask project (30 files × 10 json-heavy 100-line handlers): **2.62s → 0.56s (~4.7×)**, output byte-identical (300 endpoints).
- **flask / quart** — `find_function_def` / `find_method_def` compiled a name-interpolated regex on every line scanned; hoisted before the loop (the same bug #1960 fixed in aiohttp's `find_handler_def`).
- **django** — the class-based-view `def get/post/…` matcher recompiled per line of every CBV class body (an old site missed by previous sweeps); hoisted to `REGEX_CBV_METHOD_DEF`.
- **kotlin** (`TreeSitterKotlinParameterExtractor`) — `ServerRequest` queryParam/header and `awaitBody`/`bodyToMono` patterns recompiled per handler method; memoized per receiver name/prefix (tiny vocabulary: `request`, `req`, …).
- **rails_security / spring_security taggers** — action-token, origin-call, and ant-pattern regexes memoized; these run per macro line per action / per URL per rule when `-T` is enabled.
- **aiohttp** — `var["k"]` / `var.get("k")` body-variable patterns (json + form) memoized per name.
- **Hygiene** — constant-only `DOT_NATION` interpolations in flask/quart hoisted to class consts.

Audited but intentionally left alone: `python_route_extractor.scan_decorators` (bench-harness-only caller), `models/detector.cr` gem matchers (Gemfile-shaped files only), `js_callee_extractor` alternation (once per file), and the PHP/Lua/C++/Scala/C# analyzers (already `||=`-memoized).

## Verification

- Flask json-heavy micro-benchmark: **4.7×**, output diff empty.
- `benchmark-full` A/B vs pre-fix main: unchanged within noise (the mock's one-line handlers don't exercise these paths).
- Full `crystal spec`: 3,354 unit + 18,209 functional examples, 0 failures.
- `crystal tool format` + ameba clean on all touched files.