### PR TITLE
fix(analyzer): eliminate a crash and four O(n²) DoS hangs in source scanning

### DIFF
--- a/src/analyzer/analyzers/csharp/carter.cr
+++ b/src/analyzer/analyzers/csharp/carter.cr
@@ -166,12 +166,19 @@ module Analyzer::CSharp
       prefixes = Hash(String, String).new
       group_assignment_regex = /(?:var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\.MapGroup\s*\(\s*"([^"]+)"\s*\)/
 
-      block_lines.join("\n").scan(group_assignment_regex) do |match|
-        variable = match[1]
-        parent = match[2]
-        prefix = match[3]
-        parent_prefix = prefixes[parent]? || ""
-        prefixes[variable] = join_route_parts(parent_prefix, prefix)
+      block_lines.each do |line|
+        # The assignment can only match a line that mentions `MapGroup`. Skipping
+        # the rest keeps the unbounded identifier captures from backtracking across
+        # a long token run (e.g. a multi-kilobyte route literal), which is O(n²).
+        next unless line.includes?("MapGroup")
+
+        line.scan(group_assignment_regex) do |match|
+          variable = match[1]
+          parent = match[2]
+          prefix = match[3]
+          parent_prefix = prefixes[parent]? || ""
+          prefixes[variable] = join_route_parts(parent_prefix, prefix)
+        end
       end
 
       prefixes

--- a/src/analyzer/analyzers/csharp/carter.cr
+++ b/src/analyzer/analyzers/csharp/carter.cr
@@ -166,13 +166,19 @@ module Analyzer::CSharp
       prefixes = Hash(String, String).new
       group_assignment_regex = /(?:var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\.MapGroup\s*\(\s*"([^"]+)"\s*\)/
 
-      block_lines.each do |line|
+      block_lines.each_with_index do |line, idx|
         # The assignment can only match a line that mentions `MapGroup`. Skipping
         # the rest keeps the unbounded identifier captures from backtracking across
         # a long token run (e.g. a multi-kilobyte route literal), which is O(n²).
         next unless line.includes?("MapGroup")
 
-        line.scan(group_assignment_regex) do |match|
+        # The `var x =` head may sit on the previous line
+        # (`var g =\n  app.MapGroup("/x")`), so match over a two-line window. The
+        # window is bounded, so it can't reintroduce the cross-block backtracking
+        # the per-line guard removed. A single-line assignment matched again from
+        # the next line's window just rewrites the same key with the same value.
+        window = idx > 0 ? "#{block_lines[idx - 1]}\n#{line}" : line
+        window.scan(group_assignment_regex) do |match|
           variable = match[1]
           parent = match[2]
           prefix = match[3]

--- a/src/analyzer/analyzers/csharp/common.cr
+++ b/src/analyzer/analyzers/csharp/common.cr
@@ -76,13 +76,21 @@ module Analyzer::CSharp::Common
   # counter open and run the signature away, while the returned text is built
   # from the real `lines`.
   protected def build_signature(lines : Array(String), masked : Array(String), start_index : Int32) : Tuple(String, Int32)
+    # A caller can hand us a `start_index` that ran past the end of the file
+    # (e.g. after folding an unbalanced multi-line attribute that consumed
+    # every remaining line). Bail out instead of indexing out of bounds.
+    return {"", start_index} if start_index < 0 || start_index >= lines.size
+
     signature = lines[start_index]
-    paren_count = masked[start_index].count('(') - masked[start_index].count(')')
+    start_mask = masked[start_index]?
+    paren_count = start_mask ? start_mask.count('(') - start_mask.count(')') : 0
     index = start_index + 1
 
     while paren_count > 0 && index < lines.size
       signature += " " + lines[index]
-      paren_count += masked[index].count('(') - masked[index].count(')')
+      if m = masked[index]?
+        paren_count += m.count('(') - m.count(')')
+      end
       index += 1
     end
 

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -73,6 +73,10 @@ module Analyzer::Fsharp
 
     private def process_file(path : String, content : String, include_callee : Bool)
       cleaned = strip_fsharp_comments(content)
+      # Address `cleaned` through an `Array(Char)`: integer `String#[](Int)` is
+      # O(n) on non-ASCII source (one em-dash defeats single-byte optimization),
+      # so the per-character work below — and the literal skip — would be O(n²).
+      cleaned_chars = cleaned.chars
       scope_stack = [] of SubRouteScope
       string_constants = collect_string_constants(cleaned)
 
@@ -87,8 +91,8 @@ module Analyzer::Fsharp
         # here is not part of one. Jump past it in a single step — walking it
         # character by character (each re-slicing `cleaned[i..]`) is O(n²) and
         # hangs the scan on a multi-kilobyte literal.
-        if cleaned[i] == '"'
-          i = skip_string_literal(cleaned, i)
+        if cleaned_chars[i] == '"'
+          i = skip_string_literal(cleaned_chars, i)
           next
         end
 
@@ -562,12 +566,14 @@ module Analyzer::Fsharp
     # Returns the index just past the string literal that opens at `open_idx`
     # (which must be a `"`). Handles triple-quoted (`"""…"""`) and ordinary
     # backslash-escaped strings; an unterminated literal returns the end of text.
-    private def skip_string_literal(text : String, open_idx : Int32) : Int32
-      size = text.size
-      if open_idx + 2 < size && text[open_idx + 1] == '"' && text[open_idx + 2] == '"'
+    # Scans over an `Array(Char)` so each access is O(1) — integer `String#[]`
+    # would be O(n) on non-ASCII source, making the skip itself O(n²).
+    private def skip_string_literal(chars : Array(Char), open_idx : Int32) : Int32
+      size = chars.size
+      if open_idx + 2 < size && chars[open_idx + 1] == '"' && chars[open_idx + 2] == '"'
         j = open_idx + 3
         while j + 2 < size
-          break if text[j] == '"' && text[j + 1] == '"' && text[j + 2] == '"'
+          break if chars[j] == '"' && chars[j + 1] == '"' && chars[j + 2] == '"'
           j += 1
         end
         return j + 2 < size ? j + 3 : size
@@ -575,7 +581,7 @@ module Analyzer::Fsharp
 
       j = open_idx + 1
       while j < size
-        c = text[j]
+        c = chars[j]
         if c == '\\'
           j += 2
           next

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -83,6 +83,15 @@ module Analyzer::Fsharp
           scope_stack.pop
         end
 
+        # No route combinator begins with a quote, so a string literal reached
+        # here is not part of one. Jump past it in a single step — walking it
+        # character by character (each re-slicing `cleaned[i..]`) is O(n²) and
+        # hangs the scan on a multi-kilobyte literal.
+        if cleaned[i] == '"'
+          i = skip_string_literal(cleaned, i)
+          next
+        end
+
         rest = cleaned[i..]
 
         # subRoute / subRouteCi / subRoutef "/prefix" (handler)
@@ -548,6 +557,34 @@ module Analyzer::Fsharp
       window = collected.to_s
       methods = METHOD_WORD_PATTERNS.select { |_, pattern| window.match(pattern) }.map { |m, _| m }
       methods.first?
+    end
+
+    # Returns the index just past the string literal that opens at `open_idx`
+    # (which must be a `"`). Handles triple-quoted (`"""…"""`) and ordinary
+    # backslash-escaped strings; an unterminated literal returns the end of text.
+    private def skip_string_literal(text : String, open_idx : Int32) : Int32
+      size = text.size
+      if open_idx + 2 < size && text[open_idx + 1] == '"' && text[open_idx + 2] == '"'
+        j = open_idx + 3
+        while j + 2 < size
+          break if text[j] == '"' && text[j + 1] == '"' && text[j + 2] == '"'
+          j += 1
+        end
+        return j + 2 < size ? j + 3 : size
+      end
+
+      j = open_idx + 1
+      while j < size
+        c = text[j]
+        if c == '\\'
+          j += 2
+          next
+        elsif c == '"'
+          return j + 1
+        end
+        j += 1
+      end
+      size
     end
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?

--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -760,10 +760,15 @@ module Analyzer::Fsharp
     private def line_for_offset(content : String, offset : Int32) : Int32
       return 1 if offset <= 0
       limit = offset > content.size ? content.size : offset
+      # Walk with a Char::Reader rather than `content[i]`: integer indexing is
+      # O(n) on a non-ASCII string, so the per-character loop was O(n²) and hung
+      # the scan on a large file with a single multi-byte character in it.
       count = 1
+      reader = Char::Reader.new(content)
       i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
+      while i < limit && reader.has_next?
+        count += 1 if reader.current_char == '\n'
+        reader.next_char
         i += 1
       end
       count

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1279,14 +1279,23 @@ module Analyzer::Python
       json_variable_names = [] of ::String
 
       # Parse JSON variable names (e.g. data = json.loads(request.data), data = request.json)
+      #
+      # The `(ident).*=` shape backtracks catastrophically over a long run of word
+      # characters (the trailing literal's required code unit is a plain letter, so
+      # PCRE2 can't pre-reject). Gate each regex on a cheap substring check so a
+      # multi-kilobyte line that lacks the marker never reaches the matcher.
       codeblock_lines.each do |codeblock_line|
-        match = codeblock_line.match /([a-zA-Z_][a-zA-Z0-9_]*).*=\s*json\.loads\(request\.data/
-        if !match.nil? && match.size == 2 && !json_variable_names.includes?(match[1])
-          json_variable_names << match[1]
+        if codeblock_line.includes?("json.loads")
+          match = codeblock_line.match /([a-zA-Z_][a-zA-Z0-9_]*).*=\s*json\.loads\(request\.data/
+          if !match.nil? && match.size == 2 && !json_variable_names.includes?(match[1])
+            json_variable_names << match[1]
+          end
         end
-        match = codeblock_line.match /([a-zA-Z_][a-zA-Z0-9_]*).*=\s*request\.(?:get_json\([^)]*\)|json)/
-        if !match.nil? && match.size == 2 && !json_variable_names.includes?(match[1])
-          json_variable_names << match[1]
+        if codeblock_line.includes?("request.json") || codeblock_line.includes?("request.get_json")
+          match = codeblock_line.match /([a-zA-Z_][a-zA-Z0-9_]*).*=\s*request\.(?:get_json\([^)]*\)|json)/
+          if !match.nil? && match.size == 2 && !json_variable_names.includes?(match[1])
+            json_variable_names << match[1]
+          end
         end
       end
 

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -67,9 +67,12 @@ module Analyzer::Python
       param_line = def_line.split("(", 2)[1]
 
       index = 0
-      param_name = ""
-      param_type = ""
-      param_default = ""
+      # Accumulate field text in builders rather than `String += Char`: a single
+      # giant parameter default (e.g. a multi-kilobyte literal) otherwise makes the
+      # per-character append O(n²) and can hang the scan.
+      param_name = String::Builder.new
+      param_type = String::Builder.new
+      param_default = String::Builder.new
 
       is_option = false
       is_default = false
@@ -93,11 +96,11 @@ module Analyzer::Python
               index += 1
               next
             elsif parentheses_count == 1 && char == ','
-              parameters << FunctionParameter.new(param_name.strip, param_type.strip, param_default.strip)
+              parameters << FunctionParameter.new(param_name.to_s.strip, param_type.to_s.strip, param_default.to_s.strip)
 
-              param_name = ""
-              param_type = ""
-              param_default = ""
+              param_name = String::Builder.new
+              param_type = String::Builder.new
+              param_default = String::Builder.new
               is_option = false
               is_default = false
               index += 1
@@ -105,8 +108,9 @@ module Analyzer::Python
             elsif char == ')'
               parentheses_count -= 1
               if parentheses_count == 0
-                if param_name.size != 0
-                  parameters << FunctionParameter.new(param_name.strip, param_type.strip, param_default.strip)
+                name_text = param_name.to_s
+                if name_text.bytesize != 0
+                  parameters << FunctionParameter.new(name_text.strip, param_type.to_s.strip, param_default.to_s.strip)
                 end
                 break
               end
@@ -118,11 +122,11 @@ module Analyzer::Python
           end
 
           if is_default
-            param_default += char
+            param_default << char
           elsif is_option
-            param_type += char
+            param_type << char
           else
-            param_name += char
+            param_name << char
           end
 
           index += 1

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -177,42 +177,47 @@ module Noir::HaskellCalleeExtractor
     RESERVED.includes?(name.split('.').last)
   end
 
+  # Scans over an `Array(Char)` rather than `String#[](Int)`: integer indexing
+  # is O(n) on a string that is not single-byte-optimizable (any non-ASCII
+  # character — e.g. an em-dash in a comment), which made this per-character
+  # loop O(n²) and able to hang the scan on a large file.
   private def strip_non_code(source : String) : String
+    chars = source.chars
     index = 0
     stripped = String::Builder.new
 
-    while index < source.size
-      char = source[index]
+    while index < chars.size
+      char = chars[index]
 
-      if index + 1 < source.size && char == '-' && source[index + 1] == '-'
-        index = append_blanks_until_line_end(stripped, source, index)
+      if index + 1 < chars.size && char == '-' && chars[index + 1] == '-'
+        index = append_blanks_until_line_end(stripped, chars, index)
         next
       end
 
-      if index + 1 < source.size && char == '{' && source[index + 1] == '-'
-        finish = skip_block_comment(source, index)
-        append_blanks(stripped, source, index, finish)
+      if index + 1 < chars.size && char == '{' && chars[index + 1] == '-'
+        finish = skip_block_comment(chars, index)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
       end
 
       if char == '"'
-        finish = skip_string(source, index)
-        append_blanks(stripped, source, index, finish)
+        finish = skip_string(chars, index)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
       end
 
-      if char == '\'' && char_literal_start?(source, index)
-        finish = skip_char(source, index)
-        append_blanks(stripped, source, index, finish)
+      if char == '\'' && char_literal_start?(chars, index)
+        finish = skip_char(chars, index)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
       end
 
-      if quasiquote_start?(source, index)
-        finish = skip_quasiquote(source, index)
-        append_blanks(stripped, source, index, finish)
+      if quasiquote_start?(chars, index)
+        finish = skip_quasiquote(chars, index)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
       end
@@ -224,40 +229,40 @@ module Noir::HaskellCalleeExtractor
     stripped.to_s
   end
 
-  private def char_literal_start?(source : String, start : Int32) : Bool
-    return false if start + 2 >= source.size
-    return false if source[start + 1] == '['
+  private def char_literal_start?(chars : Array(Char), start : Int32) : Bool
+    return false if start + 2 >= chars.size
+    return false if chars[start + 1] == '['
 
-    finish = skip_char(source, start)
-    return false if finish >= source.size
+    finish = skip_char(chars, start)
+    return false if finish >= chars.size
     finish - start <= 8
   end
 
-  private def append_blanks_until_line_end(stripped : String::Builder, source : String, start : Int32) : Int32
+  private def append_blanks_until_line_end(stripped : String::Builder, chars : Array(Char), start : Int32) : Int32
     index = start
-    while index < source.size && source[index] != '\n'
+    while index < chars.size && chars[index] != '\n'
       stripped << ' '
       index += 1
     end
     index
   end
 
-  private def append_blanks(stripped : String::Builder, source : String, start : Int32, finish : Int32)
+  private def append_blanks(stripped : String::Builder, chars : Array(Char), start : Int32, finish : Int32)
     index = start
-    while index < finish && index < source.size
-      stripped << (source[index] == '\n' ? '\n' : ' ')
+    while index < finish && index < chars.size
+      stripped << (chars[index] == '\n' ? '\n' : ' ')
       index += 1
     end
   end
 
-  private def skip_block_comment(source : String, start : Int32) : Int32
+  private def skip_block_comment(chars : Array(Char), start : Int32) : Int32
     index = start + 2
     depth = 1
-    while index < source.size && depth > 0
-      if index + 1 < source.size && source[index] == '{' && source[index + 1] == '-'
+    while index < chars.size && depth > 0
+      if index + 1 < chars.size && chars[index] == '{' && chars[index + 1] == '-'
         depth += 1
         index += 2
-      elsif index + 1 < source.size && source[index] == '-' && source[index + 1] == '}'
+      elsif index + 1 < chars.size && chars[index] == '-' && chars[index + 1] == '}'
         depth -= 1
         index += 2
       else
@@ -267,55 +272,55 @@ module Noir::HaskellCalleeExtractor
     index
   end
 
-  private def skip_string(source : String, start : Int32) : Int32
+  private def skip_string(chars : Array(Char), start : Int32) : Int32
     index = start + 1
-    while index < source.size
-      if source[index] == '\\' && index + 1 < source.size
+    while index < chars.size
+      if chars[index] == '\\' && index + 1 < chars.size
         index += 2
         next
       end
-      return index + 1 if source[index] == '"'
+      return index + 1 if chars[index] == '"'
 
       index += 1
     end
-    source.size
+    chars.size
   end
 
-  private def skip_char(source : String, start : Int32) : Int32
+  private def skip_char(chars : Array(Char), start : Int32) : Int32
     index = start + 1
-    while index < source.size
-      if source[index] == '\\' && index + 1 < source.size
+    while index < chars.size
+      if chars[index] == '\\' && index + 1 < chars.size
         index += 2
         next
       end
-      return index + 1 if source[index] == '\''
+      return index + 1 if chars[index] == '\''
 
       index += 1
     end
-    source.size
+    chars.size
   end
 
-  private def quasiquote_start?(source : String, start : Int32) : Bool
-    return false unless source[start] == '['
+  private def quasiquote_start?(chars : Array(Char), start : Int32) : Bool
+    return false unless chars[start] == '['
 
     index = start + 1
-    return false unless source[index]? && (source[index].ascii_letter? || source[index] == '_')
+    return false unless chars[index]? && (chars[index].ascii_letter? || chars[index] == '_')
 
-    while index < source.size && (source[index].alphanumeric? || source[index] == '_' || source[index] == '\'')
+    while index < chars.size && (chars[index].alphanumeric? || chars[index] == '_' || chars[index] == '\'')
       index += 1
     end
 
-    index < source.size && source[index] == '|'
+    index < chars.size && chars[index] == '|'
   end
 
-  private def skip_quasiquote(source : String, start : Int32) : Int32
+  private def skip_quasiquote(chars : Array(Char), start : Int32) : Int32
     index = start + 1
-    while index + 1 < source.size
-      return index + 2 if source[index] == '|' && source[index + 1] == ']'
+    while index + 1 < chars.size
+      return index + 2 if chars[index] == '|' && chars[index + 1] == ']'
 
       index += 1
     end
-    source.size
+    chars.size
   end
 
   private def dedup_entries(entries : Array(Entry)) : Array(Entry)

--- a/src/miniparsers/lua_callee_extractor.cr
+++ b/src/miniparsers/lua_callee_extractor.cr
@@ -43,15 +43,24 @@ module Noir::LuaCalleeExtractor
   BARE_CALL_REGEX     = /(?<![A-Za-z0-9_.:\\@])([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|(?=\s*(?:["'{]|\[\[)))/
   COMMAND_CALL_REGEX  = /(?:^\s*|[=,;]\s*|\breturn\s+)([A-Za-z_][A-Za-z0-9_]*)\s+(?=["'{A-Za-z_@\[])/
 
+  # The structural scanners below address characters by integer index. On a
+  # String that is not single-byte-optimizable (any non-ASCII character —
+  # even one in a comment), `String#[](Int)` is O(n), so the per-character
+  # loops degrade to O(n²) and hang the scan on a large file. They run over an
+  # `Array(Char)` (O(1) indexing) while preserving exact character semantics;
+  # every structural token matched is ASCII and substrings are rebuilt from
+  # the real characters. Public String entry points are kept as thin overloads.
+
   def function_bodies(source : String, file_path : String) : Hash(String, FunctionBody)
     bodies = {} of String => FunctionBody
-    stripped = strip_non_code(source)
+    chars = source.chars
+    stripped = strip_non_code(chars)
 
     stripped.scan(/\bfunction\s+([A-Za-z_][A-Za-z0-9_]*(?:(?:[:.])[A-Za-z_][A-Za-z0-9_]*)*)\s*\(/) do |match|
       function_index = match.begin(0) || 0
-      next unless function_keyword_at?(source, function_index)
+      next unless function_keyword_at?(chars, function_index)
 
-      if body = extract_function_at(source, function_index)
+      if body = extract_function_at(chars, function_index)
         name = match[1]
         add_function_body(bodies, name, body, file_path)
       end
@@ -59,9 +68,9 @@ module Noir::LuaCalleeExtractor
 
     stripped.scan(/(?:^|[\n,{])\s*(?:local\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*function\b/) do |match|
       function_index = (match.begin(0) || 0) + match[0].rindex!("function")
-      next unless function_keyword_at?(source, function_index)
+      next unless function_keyword_at?(chars, function_index)
 
-      if body = extract_function_at(source, function_index)
+      if body = extract_function_at(chars, function_index)
         add_function_body(bodies, match[1], body, file_path)
       end
     end
@@ -71,7 +80,7 @@ module Noir::LuaCalleeExtractor
 
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
-    stripped = strip_nested_function_bodies(strip_non_code(body))
+    stripped = strip_nested_function_bodies(strip_non_code(body).chars)
 
     stripped.each_line.with_index do |line, offset|
       scan_line(line, file_path, start_line + offset, entries)
@@ -90,55 +99,68 @@ module Noir::LuaCalleeExtractor
                              start_index : Int32,
                              search_limit : Int32 = source.size,
                              body_limit : Int32 = source.size) : Tuple(String, Int32)?
-    function_index = find_keyword(source, "function", start_index, search_limit)
+    chars = source.chars
+    function_index = find_keyword(chars, "function", start_index, search_limit)
     return unless function_index
 
-    extract_function_at(source, function_index, body_limit)
+    extract_function_at(chars, function_index, body_limit)
   end
 
+  # Public String overload kept for callers outside this module.
   def extract_function_at(source : String,
                           function_index : Int32,
                           limit : Int32 = source.size) : Tuple(String, Int32)?
-    return unless function_keyword_at?(source, function_index)
+    extract_function_at(source.chars, function_index, limit)
+  end
 
-    body_start = function_body_start(source, function_index, limit)
-    body_end = matching_function_end(source, function_index, limit)
+  def extract_function_at(chars : Array(Char),
+                          function_index : Int32,
+                          limit : Int32 = chars.size) : Tuple(String, Int32)?
+    return unless function_keyword_at?(chars, function_index)
+
+    body_start = function_body_start(chars, function_index, limit)
+    body_end = matching_function_end(chars, function_index, limit)
     return unless body_end
     return if body_end < body_start
 
-    {source[body_start...body_end], line_number_for(source, body_start)}
+    {chars[body_start...body_end].join, line_number_for(chars, body_start)}
   end
 
+  # Public String overload kept for callers outside this module.
   def extract_moonscript_block_after(source : String, arrow_end_index : Int32) : Tuple(String, Int32)?
-    route_line_start = line_start_for(source, arrow_end_index)
-    route_indent = indentation_at(source, route_line_start)
-    route_line_end = line_end_for(source, arrow_end_index)
-    tail = source[arrow_end_index...route_line_end].strip
+    extract_moonscript_block_after(source.chars, arrow_end_index)
+  end
+
+  def extract_moonscript_block_after(chars : Array(Char), arrow_end_index : Int32) : Tuple(String, Int32)?
+    route_line_start = line_start_for(chars, arrow_end_index)
+    route_indent = indentation_at(chars, route_line_start)
+    route_line_end = line_end_for(chars, arrow_end_index)
+    tail = chars[arrow_end_index...route_line_end].join.strip
     unless tail.empty?
-      return {tail, line_number_for(source, arrow_end_index)}
+      return {tail, line_number_for(chars, arrow_end_index)}
     end
 
     body_lines = [] of String
     body_start_line = nil
-    index = route_line_end < source.size ? route_line_end + 1 : source.size
+    index = route_line_end < chars.size ? route_line_end + 1 : chars.size
 
-    while index < source.size
-      current_end = line_end_for(source, index)
-      line = source[index...current_end]
+    while index < chars.size
+      current_end = line_end_for(chars, index)
+      line = chars[index...current_end].join
       stripped = line.strip
 
       if stripped.empty?
         body_lines << line if body_start_line
-        index = current_end < source.size ? current_end + 1 : source.size
+        index = current_end < chars.size ? current_end + 1 : chars.size
         next
       end
 
-      indent = indentation_at(source, index)
+      indent = indentation_at(chars, index)
       break if indent <= route_indent
 
-      body_start_line ||= line_number_for(source, index)
+      body_start_line ||= line_number_for(chars, index)
       body_lines << line
-      index = current_end < source.size ? current_end + 1 : source.size
+      index = current_end < chars.size ? current_end + 1 : chars.size
     end
 
     return unless body_start_line
@@ -155,49 +177,61 @@ module Noir::LuaCalleeExtractor
   # follows, so `respond_to` blocks and wrapped handlers are captured
   # whole. `start_line` is the header line, matching the offsets callers
   # already expect for inline arrows.
+  #
+  # Public String overload kept for callers outside this module.
   def moonscript_value_region(source : String, value_start : Int32) : Tuple(String, Int32)?
-    return if value_start >= source.size
+    moonscript_value_region(source.chars, value_start)
+  end
 
-    header_line_start = line_start_for(source, value_start)
-    header_indent = indentation_at(source, header_line_start)
-    region_end = line_end_for(source, value_start)
-    index = region_end < source.size ? region_end + 1 : source.size
+  def moonscript_value_region(chars : Array(Char), value_start : Int32) : Tuple(String, Int32)?
+    return if value_start >= chars.size
 
-    while index < source.size
-      current_end = line_end_for(source, index)
-      line = source[index...current_end]
+    header_line_start = line_start_for(chars, value_start)
+    header_indent = indentation_at(chars, header_line_start)
+    region_end = line_end_for(chars, value_start)
+    index = region_end < chars.size ? region_end + 1 : chars.size
+
+    while index < chars.size
+      current_end = line_end_for(chars, index)
+      line = chars[index...current_end].join
 
       if line.strip.empty?
         region_end = current_end
-        index = current_end < source.size ? current_end + 1 : source.size
+        index = current_end < chars.size ? current_end + 1 : chars.size
         next
       end
 
-      break if indentation_at(source, index) <= header_indent
+      break if indentation_at(chars, index) <= header_indent
 
       region_end = current_end
-      index = current_end < source.size ? current_end + 1 : source.size
+      index = current_end < chars.size ? current_end + 1 : chars.size
     end
 
     return if region_end <= value_start
-    {source[value_start...region_end], line_number_for(source, value_start)}
+    {chars[value_start...region_end].join, line_number_for(chars, value_start)}
   end
 
+  # Public String overload kept for callers outside this module.
   def find_matching_delimiter(source : String, open_index : Int32, open_char : Char, close_char : Char,
                               limit : Int32 = source.size) : Int32?
+    find_matching_delimiter(source.chars, open_index, open_char, close_char, limit)
+  end
+
+  def find_matching_delimiter(chars : Array(Char), open_index : Int32, open_char : Char, close_char : Char,
+                              limit : Int32 = chars.size) : Int32?
     depth = 0
     index = open_index
 
-    while index < limit && index < source.size
-      char = source[index]
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      char = chars[index]
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif long_bracket_start?(source, index)
-        index = skip_long_bracket(source, index, limit)
+      elsif long_bracket_start?(chars, index)
+        index = skip_long_bracket(chars, index, limit)
         next
       elsif char == '"' || char == '\''
-        index = skip_short_string(source, index, limit)
+        index = skip_short_string(chars, index, limit)
         next
       elsif char == open_char
         depth += 1
@@ -212,6 +246,7 @@ module Noir::LuaCalleeExtractor
     nil
   end
 
+  # Public String overload kept for callers outside this module.
   def line_number_for(source : String, index : Int32) : Int32
     return 1 if index <= 0
 
@@ -219,25 +254,43 @@ module Noir::LuaCalleeExtractor
     source[0...limit].count('\n') + 1
   end
 
+  def line_number_for(chars : Array(Char), index : Int32) : Int32
+    return 1 if index <= 0
+
+    limit = index > chars.size ? chars.size : index
+    count = 1
+    i = 0
+    while i < limit
+      count += 1 if chars[i] == '\n'
+      i += 1
+    end
+    count
+  end
+
+  # Public String overload kept for callers outside this module.
   def strip_non_code(source : String) : String
+    strip_non_code(source.chars)
+  end
+
+  def strip_non_code(chars : Array(Char)) : String
     stripped = String::Builder.new
     index = 0
 
-    while index < source.size
-      char = source[index]
-      if comment_start?(source, index)
-        finish = skip_comment(source, index, source.size)
-        append_blanks(stripped, source, index, finish)
+    while index < chars.size
+      char = chars[index]
+      if comment_start?(chars, index)
+        finish = skip_comment(chars, index, chars.size)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
-      elsif long_bracket_start?(source, index)
-        finish = skip_long_bracket(source, index, source.size)
-        append_string_placeholder(stripped, source, index, finish, "[[]]")
+      elsif long_bracket_start?(chars, index)
+        finish = skip_long_bracket(chars, index, chars.size)
+        append_string_placeholder(stripped, chars, index, finish, "[[]]")
         index = finish
         next
       elsif char == '"' || char == '\''
-        finish = skip_short_string(source, index, source.size)
-        append_string_placeholder(stripped, source, index, finish, "#{char}#{char}")
+        finish = skip_short_string(chars, index, chars.size)
+        append_string_placeholder(stripped, chars, index, finish, "#{char}#{char}")
         index = finish
         next
       end
@@ -305,57 +358,57 @@ module Noir::LuaCalleeExtractor
     !!prefix.match(/\bfunction\s+$/)
   end
 
-  private def strip_nested_function_bodies(source : String) : String
+  private def strip_nested_function_bodies(chars : Array(Char)) : String
     stripped = String::Builder.new
     index = 0
 
-    while index < source.size
-      if function_keyword_at?(source, index)
-        finish = if function_end = matching_function_end(source, index, source.size)
+    while index < chars.size
+      if function_keyword_at?(chars, index)
+        finish = if function_end = matching_function_end(chars, index, chars.size)
                    function_end + "end".size
                  else
                    index + "function".size
                  end
-        append_blanks(stripped, source, index, finish)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
       end
 
-      stripped << source[index]
+      stripped << chars[index]
       index += 1
     end
 
     stripped.to_s
   end
 
-  private def function_body_start(source : String, function_index : Int32, limit : Int32) : Int32
-    paren_index = find_char(source, '(', function_index, limit)
+  private def function_body_start(chars : Array(Char), function_index : Int32, limit : Int32) : Int32
+    paren_index = find_char(chars, '(', function_index, limit)
     return function_index + "function".size unless paren_index
 
-    close_index = find_matching_delimiter(source, paren_index, '(', ')', limit)
+    close_index = find_matching_delimiter(chars, paren_index, '(', ')', limit)
     return close_index + 1 if close_index
 
     function_index + "function".size
   end
 
-  private def matching_function_end(source : String, function_index : Int32, limit : Int32) : Int32?
+  private def matching_function_end(chars : Array(Char), function_index : Int32, limit : Int32) : Int32?
     depth = 0
     pending_do = 0
     index = function_index
 
-    while index < limit && index < source.size
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif long_bracket_start?(source, index)
-        index = skip_long_bracket(source, index, limit)
+      elsif long_bracket_start?(chars, index)
+        index = skip_long_bracket(chars, index, limit)
         next
-      elsif source[index] == '"' || source[index] == '\''
-        index = skip_short_string(source, index, limit)
+      elsif chars[index] == '"' || chars[index] == '\''
+        index = skip_short_string(chars, index, limit)
         next
-      elsif identifier_start?(source[index])
+      elsif identifier_start?(chars[index])
         token_start = index
-        token, index = read_identifier(source, index, limit)
+        token, index = read_identifier(chars, index, limit)
         case token
         when "function", "if", "repeat"
           depth += 1
@@ -383,22 +436,22 @@ module Noir::LuaCalleeExtractor
     nil
   end
 
-  private def find_keyword(source : String, keyword : String, start_index : Int32, limit : Int32) : Int32?
+  private def find_keyword(chars : Array(Char), keyword : String, start_index : Int32, limit : Int32) : Int32?
     index = start_index
 
-    while index < limit && index < source.size
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif long_bracket_start?(source, index)
-        index = skip_long_bracket(source, index, limit)
+      elsif long_bracket_start?(chars, index)
+        index = skip_long_bracket(chars, index, limit)
         next
-      elsif source[index] == '"' || source[index] == '\''
-        index = skip_short_string(source, index, limit)
+      elsif chars[index] == '"' || chars[index] == '\''
+        index = skip_short_string(chars, index, limit)
         next
-      elsif identifier_start?(source[index])
+      elsif identifier_start?(chars[index])
         token_start = index
-        token, index = read_identifier(source, index, limit)
+        token, index = read_identifier(chars, index, limit)
         return token_start if token == keyword
         next
       end
@@ -409,22 +462,22 @@ module Noir::LuaCalleeExtractor
     nil
   end
 
-  private def find_char(source : String, target : Char, start_index : Int32, limit : Int32) : Int32?
+  private def find_char(chars : Array(Char), target : Char, start_index : Int32, limit : Int32) : Int32?
     index = start_index
 
-    while index < limit && index < source.size
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif long_bracket_start?(source, index)
-        index = skip_long_bracket(source, index, limit)
+      elsif long_bracket_start?(chars, index)
+        index = skip_long_bracket(chars, index, limit)
         next
-      elsif source[index] == '"' || source[index] == '\''
-        index = skip_short_string(source, index, limit)
+      elsif chars[index] == '"' || chars[index] == '\''
+        index = skip_short_string(chars, index, limit)
         next
       end
 
-      return index if source[index] == target
+      return index if chars[index] == target
 
       index += 1
     end
@@ -432,21 +485,21 @@ module Noir::LuaCalleeExtractor
     nil
   end
 
-  private def function_keyword_at?(source : String, index : Int32) : Bool
-    return false unless source[index, "function".size]? == "function"
-    before = index > 0 ? source[index - 1] : '\0'
+  private def function_keyword_at?(chars : Array(Char), index : Int32) : Bool
+    return false unless chars[index, "function".size]?.try(&.join) == "function"
+    before = index > 0 ? chars[index - 1] : '\0'
     after_index = index + "function".size
-    after = after_index < source.size ? source[after_index] : '\0'
+    after = after_index < chars.size ? chars[after_index] : '\0'
     !identifier_part?(before) && !identifier_part?(after)
   end
 
-  private def read_identifier(source : String, index : Int32, limit : Int32) : Tuple(String, Int32)
+  private def read_identifier(chars : Array(Char), index : Int32, limit : Int32) : Tuple(String, Int32)
     cursor = index
-    while cursor < limit && cursor < source.size && identifier_part?(source[cursor])
+    while cursor < limit && cursor < chars.size && identifier_part?(chars[cursor])
       cursor += 1
     end
 
-    {source[index...cursor], cursor}
+    {chars[index...cursor].join, cursor}
   end
 
   private def identifier_start?(char : Char) : Bool
@@ -457,54 +510,54 @@ module Noir::LuaCalleeExtractor
     char.ascii_alphanumeric? || char == '_'
   end
 
-  private def comment_start?(source : String, index : Int32) : Bool
-    index + 1 < source.size && source[index] == '-' && source[index + 1] == '-'
+  private def comment_start?(chars : Array(Char), index : Int32) : Bool
+    index + 1 < chars.size && chars[index] == '-' && chars[index + 1] == '-'
   end
 
-  private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
-    if index + 2 < limit && long_bracket_start?(source, index + 2)
-      skip_long_bracket(source, index + 2, limit)
+  private def skip_comment(chars : Array(Char), index : Int32, limit : Int32) : Int32
+    if index + 2 < limit && long_bracket_start?(chars, index + 2)
+      skip_long_bracket(chars, index + 2, limit)
     else
       cursor = index
-      while cursor < limit && cursor < source.size && source[cursor] != '\n'
+      while cursor < limit && cursor < chars.size && chars[cursor] != '\n'
         cursor += 1
       end
       cursor
     end
   end
 
-  private def long_bracket_start?(source : String, index : Int32) : Bool
-    !!long_bracket_equals(source, index)
+  private def long_bracket_start?(chars : Array(Char), index : Int32) : Bool
+    !!long_bracket_equals(chars, index)
   end
 
-  private def long_bracket_equals(source : String, index : Int32) : Int32?
-    return unless index < source.size && source[index] == '['
+  private def long_bracket_equals(chars : Array(Char), index : Int32) : Int32?
+    return unless index < chars.size && chars[index] == '['
 
     cursor = index + 1
     equals = 0
-    while cursor < source.size && source[cursor] == '='
+    while cursor < chars.size && chars[cursor] == '='
       equals += 1
       cursor += 1
     end
 
-    return equals if cursor < source.size && source[cursor] == '['
+    return equals if cursor < chars.size && chars[cursor] == '['
     nil
   end
 
-  private def skip_long_bracket(source : String, index : Int32, limit : Int32) : Int32
-    equals = long_bracket_equals(source, index)
+  private def skip_long_bracket(chars : Array(Char), index : Int32, limit : Int32) : Int32
+    equals = long_bracket_equals(chars, index)
     return index + 1 unless equals
 
     cursor = index + equals + 2
-    while cursor < limit && cursor < source.size
-      if source[cursor] == ']'
+    while cursor < limit && cursor < chars.size
+      if chars[cursor] == ']'
         close_cursor = cursor + 1
         seen_equals = 0
-        while close_cursor < source.size && source[close_cursor] == '='
+        while close_cursor < chars.size && chars[close_cursor] == '='
           seen_equals += 1
           close_cursor += 1
         end
-        return close_cursor + 1 if seen_equals == equals && close_cursor < source.size && source[close_cursor] == ']'
+        return close_cursor + 1 if seen_equals == equals && close_cursor < chars.size && chars[close_cursor] == ']'
       end
       cursor += 1
     end
@@ -512,13 +565,13 @@ module Noir::LuaCalleeExtractor
     limit
   end
 
-  private def skip_short_string(source : String, index : Int32, limit : Int32) : Int32
-    quote = source[index]
+  private def skip_short_string(chars : Array(Char), index : Int32, limit : Int32) : Int32
+    quote = chars[index]
     cursor = index + 1
     escaped = false
 
-    while cursor < limit && cursor < source.size
-      char = source[cursor]
+    while cursor < limit && cursor < chars.size
+      char = chars[cursor]
       if escaped
         escaped = false
       elsif char == '\\'
@@ -532,20 +585,20 @@ module Noir::LuaCalleeExtractor
     limit
   end
 
-  private def append_blanks(builder : String::Builder, source : String, start_index : Int32, finish_index : Int32)
+  private def append_blanks(builder : String::Builder, chars : Array(Char), start_index : Int32, finish_index : Int32)
     index = start_index
-    while index < finish_index && index < source.size
-      builder << (source[index] == '\n' ? '\n' : ' ')
+    while index < finish_index && index < chars.size
+      builder << (chars[index] == '\n' ? '\n' : ' ')
       index += 1
     end
   end
 
-  private def append_string_placeholder(builder : String::Builder, source : String,
+  private def append_string_placeholder(builder : String::Builder, chars : Array(Char),
                                         start_index : Int32, finish_index : Int32, placeholder : String)
     placeholder_index = 0
     index = start_index
-    while index < finish_index && index < source.size
-      if source[index] == '\n'
+    while index < finish_index && index < chars.size
+      if chars[index] == '\n'
         builder << '\n'
       elsif placeholder_index < placeholder.size
         builder << placeholder[placeholder_index]
@@ -557,27 +610,27 @@ module Noir::LuaCalleeExtractor
     end
   end
 
-  private def line_start_for(source : String, index : Int32) : Int32
+  private def line_start_for(chars : Array(Char), index : Int32) : Int32
     cursor = index
-    while cursor > 0 && source[cursor - 1] != '\n'
+    while cursor > 0 && chars[cursor - 1] != '\n'
       cursor -= 1
     end
     cursor
   end
 
-  private def line_end_for(source : String, index : Int32) : Int32
+  private def line_end_for(chars : Array(Char), index : Int32) : Int32
     cursor = index
-    while cursor < source.size && source[cursor] != '\n'
+    while cursor < chars.size && chars[cursor] != '\n'
       cursor += 1
     end
     cursor
   end
 
-  private def indentation_at(source : String, line_start : Int32) : Int32
+  private def indentation_at(chars : Array(Char), line_start : Int32) : Int32
     cursor = line_start
     indent = 0
-    while cursor < source.size
-      case source[cursor]
+    while cursor < chars.size
+      case chars[cursor]
       when ' '
         indent += 1
       when '\t'

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -27,9 +27,17 @@ module Noir::PerlCalleeExtractor
   QUALIFIED_CALL_REGEX = /(?<![A-Za-z0-9_:])([A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+)\s*(?:\(|(?=\s+(?:[A-Za-z_$'"]|\{|\[)))/
   BARE_CALL_REGEX      = /(?<![A-Za-z0-9_:>$])([A-Za-z_][A-Za-z0-9_]*)\s*(?:\(|(?=\s+(?:[A-Za-z_$'"]|\{|\[)))/
 
+  # The structural scanners below address characters by integer index. On a
+  # String that is not single-byte-optimizable (i.e. contains any non-ASCII
+  # character — an em-dash in a comment is enough), `String#[](Int)` is O(n),
+  # so the per-character loops degrade to O(n²) and can hang the scan on a
+  # large file. Working over an `Array(Char)` keeps every index access O(1)
+  # while preserving exact character semantics; the only structural tokens we
+  # ever match are ASCII, and substrings are rebuilt from the real characters.
+
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     entries = [] of Entry
-    stripped = strip_nested_sub_bodies(strip_non_code(body))
+    stripped = strip_nested_sub_bodies(strip_non_code(body).chars)
 
     stripped.each_line.with_index do |line, offset|
       scan_line(line, file_path, start_line + offset, entries)
@@ -66,12 +74,13 @@ module Noir::PerlCalleeExtractor
 
   def named_sub_bodies(source : String, file_path : String) : Hash(String, SubBody)
     bodies = {} of String => SubBody
-    stripped = strip_non_code(source)
+    chars = source.chars
+    stripped = strip_non_code(chars)
 
     stripped.scan(/\bsub\s+([A-Za-z_][A-Za-z0-9_]*)\b/) do |match|
       sub_index = match.begin(0) || 0
-      next unless sub_keyword_at?(source, sub_index)
-      next unless body = extract_sub_at(source, sub_index)
+      next unless sub_keyword_at?(chars, sub_index)
+      next unless body = extract_sub_at(chars, sub_index)
 
       body_text, start_line = body
       bodies[match[1]] ||= {body: body_text, path: file_path, start_line: start_line}
@@ -84,40 +93,54 @@ module Noir::PerlCalleeExtractor
                         start_index : Int32,
                         search_limit : Int32 = source.size,
                         body_limit : Int32 = source.size) : Tuple(String, Int32)?
-    sub_index = find_keyword(source, "sub", start_index, search_limit)
+    chars = source.chars
+    sub_index = find_keyword(chars, "sub", start_index, search_limit)
     return unless sub_index
 
-    extract_sub_at(source, sub_index, body_limit)
+    extract_sub_at(chars, sub_index, body_limit)
   end
 
+  # Public String overload kept for callers outside this module.
   def extract_sub_at(source : String,
                      sub_index : Int32,
                      limit : Int32 = source.size) : Tuple(String, Int32)?
-    return unless sub_keyword_at?(source, sub_index)
-
-    open_brace = find_char(source, '{', sub_index, limit)
-    return unless open_brace
-    close_brace = find_matching_delimiter(source, open_brace, '{', '}', limit)
-    return unless close_brace
-
-    {source[(open_brace + 1)...close_brace], line_number_for(source, open_brace + 1)}
+    extract_sub_at(source.chars, sub_index, limit)
   end
 
+  def extract_sub_at(chars : Array(Char),
+                     sub_index : Int32,
+                     limit : Int32 = chars.size) : Tuple(String, Int32)?
+    return unless sub_keyword_at?(chars, sub_index)
+
+    open_brace = find_char(chars, '{', sub_index, limit)
+    return unless open_brace
+    close_brace = find_matching_delimiter(chars, open_brace, '{', '}', limit)
+    return unless close_brace
+
+    {chars[(open_brace + 1)...close_brace].join, line_number_for(chars, open_brace + 1)}
+  end
+
+  # Public String overload kept for callers outside this module.
   def find_matching_delimiter(source : String, open_index : Int32, open_char : Char, close_char : Char,
                               limit : Int32 = source.size) : Int32?
+    find_matching_delimiter(source.chars, open_index, open_char, close_char, limit)
+  end
+
+  def find_matching_delimiter(chars : Array(Char), open_index : Int32, open_char : Char, close_char : Char,
+                              limit : Int32 = chars.size) : Int32?
     depth = 0
     index = open_index
 
-    while index < limit && index < source.size
-      char = source[index]
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      char = chars[index]
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif quote_like_start?(source, index)
-        index = skip_quote_like(source, index, limit)
+      elsif quote_like_start?(chars, index)
+        index = skip_quote_like(chars, index, limit)
         next
       elsif char == '"' || char == '\''
-        index = skip_short_string(source, index, limit)
+        index = skip_short_string(chars, index, limit)
         next
       elsif char == open_char
         depth += 1
@@ -132,25 +155,30 @@ module Noir::PerlCalleeExtractor
     nil
   end
 
+  # Public String overload kept for callers outside this module.
   def strip_non_code(source : String) : String
+    strip_non_code(source.chars)
+  end
+
+  def strip_non_code(chars : Array(Char)) : String
     stripped = String::Builder.new
     index = 0
 
-    while index < source.size
-      char = source[index]
-      if comment_start?(source, index)
-        finish = skip_comment(source, index, source.size)
-        append_blanks(stripped, source, index, finish)
+    while index < chars.size
+      char = chars[index]
+      if comment_start?(chars, index)
+        finish = skip_comment(chars, index, chars.size)
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
-      elsif quote_like_start?(source, index)
-        finish = skip_quote_like(source, index, source.size)
-        append_string_placeholder(stripped, source, index, finish)
+      elsif quote_like_start?(chars, index)
+        finish = skip_quote_like(chars, index, chars.size)
+        append_string_placeholder(stripped, chars, index, finish)
         index = finish
         next
       elsif char == '"' || char == '\''
-        finish = skip_short_string(source, index, source.size)
-        append_string_placeholder(stripped, source, index, finish)
+        finish = skip_short_string(chars, index, chars.size)
+        append_string_placeholder(stripped, chars, index, finish)
         index = finish
         next
       end
@@ -162,11 +190,25 @@ module Noir::PerlCalleeExtractor
     stripped.to_s
   end
 
+  # Public String overload kept for callers outside this module.
   def line_number_for(source : String, index : Int32) : Int32
     return 1 if index <= 0
 
     limit = index > source.size ? source.size : index
     source[0...limit].count('\n') + 1
+  end
+
+  def line_number_for(chars : Array(Char), index : Int32) : Int32
+    return 1 if index <= 0
+
+    limit = index > chars.size ? chars.size : index
+    count = 1
+    i = 0
+    while i < limit
+      count += 1 if chars[i] == '\n'
+      i += 1
+    end
+    count
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -213,29 +255,29 @@ module Noir::PerlCalleeExtractor
     !!prefix.match(/\bsub\s+$/)
   end
 
-  private def strip_nested_sub_bodies(source : String) : String
+  private def strip_nested_sub_bodies(chars : Array(Char)) : String
     stripped = String::Builder.new
     index = 0
 
-    while index < source.size
-      if sub_keyword_at?(source, index)
-        finish = find_matching_sub_end(source, index) || index + "sub".size
-        append_blanks(stripped, source, index, finish)
+    while index < chars.size
+      if sub_keyword_at?(chars, index)
+        finish = find_matching_sub_end(chars, index) || index + "sub".size
+        append_blanks(stripped, chars, index, finish)
         index = finish
         next
       end
 
-      stripped << source[index]
+      stripped << chars[index]
       index += 1
     end
 
     stripped.to_s
   end
 
-  private def find_matching_sub_end(source : String, sub_index : Int32) : Int32?
-    open_brace = find_char(source, '{', sub_index, source.size)
+  private def find_matching_sub_end(chars : Array(Char), sub_index : Int32) : Int32?
+    open_brace = find_char(chars, '{', sub_index, chars.size)
     return unless open_brace
-    close_brace = find_matching_delimiter(source, open_brace, '{', '}', source.size)
+    close_brace = find_matching_delimiter(chars, open_brace, '{', '}', chars.size)
     return unless close_brace
     close_brace + 1
   end
@@ -259,22 +301,22 @@ module Noir::PerlCalleeExtractor
     name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
   end
 
-  private def find_keyword(source : String, keyword : String, start_index : Int32, limit : Int32) : Int32?
+  private def find_keyword(chars : Array(Char), keyword : String, start_index : Int32, limit : Int32) : Int32?
     index = start_index
 
-    while index < limit && index < source.size
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif quote_like_start?(source, index)
-        index = skip_quote_like(source, index, limit)
+      elsif quote_like_start?(chars, index)
+        index = skip_quote_like(chars, index, limit)
         next
-      elsif source[index] == '"' || source[index] == '\''
-        index = skip_short_string(source, index, limit)
+      elsif chars[index] == '"' || chars[index] == '\''
+        index = skip_short_string(chars, index, limit)
         next
-      elsif identifier_start?(source[index])
+      elsif identifier_start?(chars[index])
         token_start = index
-        token, index = read_identifier(source, index, limit)
+        token, index = read_identifier(chars, index, limit)
         return token_start if token == keyword
         next
       end
@@ -285,22 +327,22 @@ module Noir::PerlCalleeExtractor
     nil
   end
 
-  private def find_char(source : String, target : Char, start_index : Int32, limit : Int32) : Int32?
+  private def find_char(chars : Array(Char), target : Char, start_index : Int32, limit : Int32) : Int32?
     index = start_index
 
-    while index < limit && index < source.size
-      if comment_start?(source, index)
-        index = skip_comment(source, index, limit)
+    while index < limit && index < chars.size
+      if comment_start?(chars, index)
+        index = skip_comment(chars, index, limit)
         next
-      elsif quote_like_start?(source, index)
-        index = skip_quote_like(source, index, limit)
+      elsif quote_like_start?(chars, index)
+        index = skip_quote_like(chars, index, limit)
         next
-      elsif source[index] == '"' || source[index] == '\''
-        index = skip_short_string(source, index, limit)
+      elsif chars[index] == '"' || chars[index] == '\''
+        index = skip_short_string(chars, index, limit)
         next
       end
 
-      return index if source[index] == target
+      return index if chars[index] == target
 
       index += 1
     end
@@ -308,21 +350,21 @@ module Noir::PerlCalleeExtractor
     nil
   end
 
-  private def sub_keyword_at?(source : String, index : Int32) : Bool
-    return false unless source[index, "sub".size]? == "sub"
-    before = index > 0 ? source[index - 1] : '\0'
+  private def sub_keyword_at?(chars : Array(Char), index : Int32) : Bool
+    return false unless chars[index]? == 's' && chars[index + 1]? == 'u' && chars[index + 2]? == 'b'
+    before = index > 0 ? chars[index - 1] : '\0'
     after_index = index + "sub".size
-    after = after_index < source.size ? source[after_index] : '\0'
+    after = after_index < chars.size ? chars[after_index] : '\0'
     !identifier_part?(before) && !identifier_part?(after)
   end
 
-  private def read_identifier(source : String, index : Int32, limit : Int32) : Tuple(String, Int32)
+  private def read_identifier(chars : Array(Char), index : Int32, limit : Int32) : Tuple(String, Int32)
     cursor = index
-    while cursor < limit && cursor < source.size && identifier_part?(source[cursor])
+    while cursor < limit && cursor < chars.size && identifier_part?(chars[cursor])
       cursor += 1
     end
 
-    {source[index...cursor], cursor}
+    {chars[index...cursor].join, cursor}
   end
 
   private def identifier_start?(char : Char) : Bool
@@ -333,54 +375,54 @@ module Noir::PerlCalleeExtractor
     char.ascii_alphanumeric? || char == '_'
   end
 
-  private def comment_start?(source : String, index : Int32) : Bool
-    source[index] == '#'
+  private def comment_start?(chars : Array(Char), index : Int32) : Bool
+    chars[index] == '#'
   end
 
-  private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+  private def skip_comment(chars : Array(Char), index : Int32, limit : Int32) : Int32
     cursor = index
-    while cursor < limit && cursor < source.size && source[cursor] != '\n'
+    while cursor < limit && cursor < chars.size && chars[cursor] != '\n'
       cursor += 1
     end
     cursor
   end
 
-  private def quote_like_start?(source : String, index : Int32) : Bool
-    return false unless index < source.size
-    return false unless source[index] == 'q'
-    return false if index > 0 && identifier_part?(source[index - 1])
+  private def quote_like_start?(chars : Array(Char), index : Int32) : Bool
+    return false unless index < chars.size
+    return false unless chars[index] == 'q'
+    return false if index > 0 && identifier_part?(chars[index - 1])
 
     cursor = index + 1
-    if cursor < source.size && {'q', 'r', 'w', 'x'}.includes?(source[cursor])
+    if cursor < chars.size && {'q', 'r', 'w', 'x'}.includes?(chars[cursor])
       cursor += 1
-    elsif cursor < source.size && identifier_part?(source[cursor])
+    elsif cursor < chars.size && identifier_part?(chars[cursor])
       return false
     end
 
-    while cursor < source.size && source[cursor].whitespace?
+    while cursor < chars.size && chars[cursor].whitespace?
       cursor += 1
     end
-    return false if cursor >= source.size
+    return false if cursor >= chars.size
 
-    !!quote_close_char(source[cursor])
+    !!quote_close_char(chars[cursor])
   end
 
-  private def skip_quote_like(source : String, index : Int32, limit : Int32) : Int32
+  private def skip_quote_like(chars : Array(Char), index : Int32, limit : Int32) : Int32
     cursor = index + 1
-    cursor += 1 if cursor < limit && cursor < source.size && {'q', 'r', 'w', 'x'}.includes?(source[cursor])
-    while cursor < limit && cursor < source.size && source[cursor].whitespace?
+    cursor += 1 if cursor < limit && cursor < chars.size && {'q', 'r', 'w', 'x'}.includes?(chars[cursor])
+    while cursor < limit && cursor < chars.size && chars[cursor].whitespace?
       cursor += 1
     end
-    return index + 1 if cursor >= limit || cursor >= source.size
+    return index + 1 if cursor >= limit || cursor >= chars.size
 
-    open_char = source[cursor]
+    open_char = chars[cursor]
     close_char = quote_close_char(open_char)
     return index + 1 unless close_char
 
     cursor += 1
     escaped = false
-    while cursor < limit && cursor < source.size
-      char = source[cursor]
+    while cursor < limit && cursor < chars.size
+      char = chars[cursor]
       if escaped
         escaped = false
       elsif char == '\\'
@@ -404,13 +446,13 @@ module Noir::PerlCalleeExtractor
     end
   end
 
-  private def skip_short_string(source : String, index : Int32, limit : Int32) : Int32
-    quote = source[index]
+  private def skip_short_string(chars : Array(Char), index : Int32, limit : Int32) : Int32
+    quote = chars[index]
     cursor = index + 1
     escaped = false
 
-    while cursor < limit && cursor < source.size
-      char = source[cursor]
+    while cursor < limit && cursor < chars.size
+      char = chars[cursor]
       if escaped
         escaped = false
       elsif char == '\\'
@@ -424,19 +466,19 @@ module Noir::PerlCalleeExtractor
     limit
   end
 
-  private def append_blanks(builder : String::Builder, source : String, start_index : Int32, finish_index : Int32)
+  private def append_blanks(builder : String::Builder, chars : Array(Char), start_index : Int32, finish_index : Int32)
     index = start_index
-    while index < finish_index && index < source.size
-      builder << (source[index] == '\n' ? '\n' : ' ')
+    while index < finish_index && index < chars.size
+      builder << (chars[index] == '\n' ? '\n' : ' ')
       index += 1
     end
   end
 
-  private def append_string_placeholder(builder : String::Builder, source : String, start_index : Int32, finish_index : Int32)
+  private def append_string_placeholder(builder : String::Builder, chars : Array(Char), start_index : Int32, finish_index : Int32)
     placeholder_written = false
     index = start_index
-    while index < finish_index && index < source.size
-      if source[index] == '\n'
+    while index < finish_index && index < chars.size
+      if chars[index] == '\n'
         builder << '\n'
       elsif !placeholder_written
         builder << ' '


### PR DESCRIPTION
## Summary

A robustness hardening sweep across the source-scanning analyzers: one real crash and a family of O(n²) DoS hangs, found by fuzzing the analyzers with malformed/extreme source files (truncation, multi-kilobyte string literals, deeply nested/unbalanced delimiters, null/invalid-UTF-8 injection) seeded from the real fixtures, then profiling the hot paths.

noir reads arbitrary source trees, so a single pathological-but-legitimate file (minified/generated code, a big embedded literal, an unbalanced attribute near EOF, **or any file containing one non-ASCII character plus a long line**) shouldn't crash or hang the scan.

## Fixes

### 1 — Crash + per-analyzer O(n²) regex/string handling
| Analyzer | Issue | Root cause |
|---|---|---|
| `csharp/common.cr` `build_signature` | **Crash (IndexError)** in `cs_aspnet_core_mvc` | An unbalanced multi-line `[Http*]`/`[Route]` attribute that runs to EOF advances the caller's index to `lines.size`; the shared helper then indexed past the end. Added a bounds guard + tolerate a shorter `masked` array. |
| `csharp/carter.cr` `extract_map_group_prefixes` | O(n²) hang | Unanchored `(var)? IDENT = IDENT.MapGroup` regex over the joined block; a long word-char run backtracks catastrophically (the `=>` lambda arrow defeats PCRE2's required-byte quick-reject). Scan per line, gated on `includes?("MapGroup")`. |
| `python_engine.cr` `parse_function_def` | O(n²) hang | Parameter name/type/default accumulated with `String += Char` — quadratic on a multi-kilobyte parameter default. Switched to `String::Builder`. |
| `python/flask.cr` `extract_request_params` | O(n²) hang | `(ident).*= … json.loads` ran against every line; its required code unit is a plain letter, so a long word-char line can't be pre-rejected. Gated both regexes on a cheap substring check. |

### 2 — Systemic: non-ASCII source made character scanners O(n²)
Integer `String#[](Int)` is **O(n)** on a string that is not single-byte-optimizable (any non-ASCII character — an em-dash in a comment is enough). Several hand-written character scanners addressed source by integer index, so a single multi-byte character turned their per-character loops into O(n²) and hung the scan on a large file. Confirmed hangs: Giraffe `Program.fs` and Dancer2 `MyApp.pm` (both contain `—`).

| Component | Fix |
|---|---|
| `fsharp/giraffe.cr` | scan loop re-sliced `cleaned[i..]` every char and walked string-literal contents → skip string literals in one jump; `line_for_offset` walked raw non-ASCII content with `content[i]` per route → use a `Char::Reader`. |
| `perl_callee_extractor.cr` | scanning core (`strip_non_code`, `find_*`, `skip_*`, `quote_*`, `comment_*`, `append_*`) now runs over an `Array(Char)`; public String entry points preserved as overloads. |
| `lua_callee_extractor.cr` | same `Array(Char)` conversion across the Lua + MoonScript scanning core. |
| `haskell_callee_extractor.cr` | `strip_non_code` + comment/string/char/quasiquote skippers now run over an `Array(Char)`. |

(`cpp` and `dart` callee extractors already scan via `byte_at` and are unaffected.)

## Verification

- Size-scaling micro-repros confirm each was genuinely super-linear and is now linear/bounded, e.g. a 160k-char Carter route: timeout → 140ms; a long Giraffe literal: 8s → 0.3s; Dancer2 non-ASCII + long line: 15s timeout → 0.2s; Lua: 12s timeout → 0.1s.
- Full suite green: **3354 unit + 18221 functional examples, 0 failures**.

## Known follow-ups (not in this PR)

The same `String#[]` O(n²) shape still exists in `groovy_callee_extractor.cr` (via the shared `GroovyLiteralScanner`, also used by the grails analyzer) and in a handful of analyzers that scan by integer index (`typescript/trpc`, `specification/typespec`, `specification/graphql_sdl_parser`, `rust_engine`, `dart/shelf`, …). None reproduced a hang on realistic input here; converting them (the established `Array(Char)`/`byte_at` pattern) is best done as focused follow-ups, especially `GroovyLiteralScanner` which is shared with an analyzer.
