### PR TITLE
feat(mobile): report exported Android components without intent-filters as explicit-intent surfaces

### DIFF
--- a/docs/content/usage/supported/mobile/index.ko.md
+++ b/docs/content/usage/supported/mobile/index.ko.md
@@ -30,7 +30,7 @@ Noir는 모바일 앱이 외부에 노출하는 진입점 — 딥링크와 expor
 | protocol | 의미 | 예시 URL |
 |---|---|---|
 | `mobile-scheme` | 커스텀 URL 스킴 딥링크 | `myapp://complex/:id` |
-| `android-intent` | data URI 없는 exported 인텐트 컴포넌트 | `intent://com.example.app/.SyncService` |
+| `android-intent` | 인텐트로 도달 가능한 exported 컴포넌트 — data URI 없는 action 필터, 또는 intent-filter가 전혀 없는 경우(명시적 인텐트 전용) | `intent://com.example.app/.SyncService` |
 | `universal-link` | 검증된 Android App Link / iOS 유니버설 링크, 또는 서버 측 `assetlinks.json` / `apple-app-site-association` 패턴 | `https://app.example.com/complex/:id`, `/buy/*` |
 
 plain 출력에서는 `SCHEME` / `INTENT` / `UNIVERSAL` 프리픽스로 표시됩니다. 처리 컴포넌트, 인텐트 action·category, 호스트, 패키지는 엔드포인트별 metadata 맵에 저장됩니다(JSON / YAML에 직렬화되며, 일반 HTTP 엔드포인트에서는 완전히 생략됩니다).
@@ -62,5 +62,6 @@ SCHEME myapp://complex/:id
 * 바이너리(컴파일된) `Info.plist`는 건너뜁니다. 소스 저장소의 XML plist는 파싱합니다.
 * gradle 플레이스홀더는 매니페스트 위쪽에서 가장 가까운 `build.gradle(.kts)`를 읽어 해석합니다. 같은 플레이스홀더가 여러 번 선언되면(예: `buildTypes` 오버라이드) 먼저 선언된 쪽 — 관례상 `defaultConfig` — 이 우선하며, 빌드 variant별 값은 모델링하지 않습니다. gradle에 값이 없는 플레이스홀더는 URL에 그대로 남고 엔드포인트에 `unresolved` 태그가 붙습니다.
 * 스킴 없는 Jetpack Navigation URI(런타임에는 http·https 모두 매칭)는 `https` 하나로 추출합니다. `{arg}` 세그먼트는 `:arg` path 파라미터로, `?key={arg}` 쿼리 플레이스홀더는 `query` 파라미터로 바뀌고, 끝의 `.*` 와일드카드는 리터럴 프리픽스만 남깁니다.
+* intent-filter가 없는 `android:exported="true"` 컴포넌트는 명시적 인텐트 표면(`android-intent`, metadata에 `explicit`/`exported`/`component_type` 포함)으로 보고됩니다. action·category·data URI가 없어도, 컴포넌트 이름을 지정한 명시적 인텐트는 여전히 그 컴포넌트에 도달합니다. exported가 아니거나 `android:enabled="false"`인 필터 없는 컴포넌트는 보고하지 않습니다. 보호용 `android:permission`은 metadata에 기록되지만 표면을 숨기지는 않습니다 — `normal`/`dangerous` 권한은 다른 앱이 여전히 획득할 수 있기 때문입니다.
 * `assetlinks.json`은 패키지 연결만 선언하고 경로는 없으므로 앱당 `/*` 엔드포인트 하나를 만듭니다. `apple-app-site-association`의 경로(`/buy/*`, `NOT /private/*`)와 `components`는 개별적으로 추출되며, AASA 제외 패턴은 `excluded` 태그가 붙습니다.
 * `apple-app-site-association`은 plain-JSON 형식만 파싱합니다. CMS로 서명된 AASA 파일(구형 앱)은 건너뜁니다.

--- a/docs/content/usage/supported/mobile/index.md
+++ b/docs/content/usage/supported/mobile/index.md
@@ -30,7 +30,7 @@ Mobile entry points are endpoints with `method = "GET"`; their nature is carried
 | protocol | meaning | example URL |
 |---|---|---|
 | `mobile-scheme` | custom URL-scheme deep link | `myapp://complex/:id` |
-| `android-intent` | exported intent component with no data URI | `intent://com.example.app/.SyncService` |
+| `android-intent` | exported intent component reachable by intent — a data-less action filter, or no intent-filter at all (explicit-intent only) | `intent://com.example.app/.SyncService` |
 | `universal-link` | verified Android App Link / iOS universal link, or a server-side `assetlinks.json` / `apple-app-site-association` pattern | `https://app.example.com/complex/:id`, `/buy/*` |
 
 In plain output they render under a `SCHEME` / `INTENT` / `UNIVERSAL` prefix. The handling component, intent action and category, host, and package are stored in a per-endpoint metadata map (serialized in JSON / YAML; omitted entirely for ordinary HTTP endpoints):
@@ -62,5 +62,6 @@ Mobile endpoints stay in the structured inventory — JSON, JSONL, YAML, SARIF, 
 * Binary (compiled) `Info.plist` files are skipped; source-repo XML plists are parsed.
 * gradle placeholder resolution reads the nearest `build.gradle(.kts)` above the manifest; when the same placeholder is declared more than once (e.g. a `buildTypes` override), the first declaration — by convention `defaultConfig` — wins. Variant-specific values are not modeled. A placeholder with no gradle value stays verbatim in the URL and the endpoint is tagged `unresolved`.
 * Scheme-less Jetpack Navigation URIs (which match both http and https at runtime) are emitted once under `https`. `{arg}` segments become `:arg` path params, `?key={arg}` query placeholders become `query` params, and a trailing `.*` wildcard keeps the literal prefix.
+* An `android:exported="true"` component with no intent-filter is reported as an explicit-intent surface (`android-intent`, with `explicit`/`exported`/`component_type` in metadata): an explicit intent naming the component still reaches it even with no action, category, or data URI. A filter-less component that is not exported, or is `android:enabled="false"`, is not reported. A guarding `android:permission` is recorded in metadata but does not suppress the surface — `normal`/`dangerous` permissions remain obtainable by another app.
 * `assetlinks.json` only declares the package association (no paths), so it yields a single `/*` endpoint per app. `apple-app-site-association` paths (`/buy/*`, `NOT /private/*`) and `components` are emitted individually; AASA exclusions are tagged `excluded`.
 * Only the plain-JSON form of `apple-app-site-association` is parsed; CMS-signed AASA files (older apps) are skipped.

--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -187,5 +187,39 @@
             </intent-filter>
         </activity>
 
+        <!-- Exported component with NO intent-filter: cannot be matched by an
+             implicit intent, but an explicit intent naming the component still
+             reaches it, so it is an IPC surface (android-intent, explicit). The
+             handler source links callees/extras like any other component. -->
+        <activity android:name=".ExportedActivity" android:exported="true" />
+
+        <!-- Exported, filter-less activity-alias: addressed by its own name
+             (kept in the URL), but the handler code is the target activity, so
+             `via` resolves to targetActivity for the code linker. -->
+        <activity-alias
+            android:name=".ExportedAlias"
+            android:targetActivity=".AliasTargetActivity"
+            android:exported="true" />
+
+        <!-- Exported, filter-less service: another explicit-intent surface. -->
+        <service android:name=".ExportedService" android:exported="true" />
+
+        <!-- Exported, filter-less receiver guarded by a custom permission: the
+             permission rides along in metadata but does not suppress it (a
+             normal/dangerous permission is still obtainable by another app). -->
+        <receiver android:name=".ExportedReceiver" android:exported="true"
+            android:permission="com.example.permission.CUSTOM" />
+
+        <!-- NOT exported, no filter: internal only, must NOT be reported. -->
+        <activity android:name=".InternalActivity" android:exported="false" />
+
+        <!-- Implicitly not exported (filter-less default): must NOT be reported. -->
+        <activity android:name=".DefaultActivity" />
+
+        <!-- Exported but explicitly disabled: not a live entry point, so it
+             must NOT be reported even though exported="true". -->
+        <activity android:name=".DisabledActivity" android:exported="true"
+            android:enabled="false" />
+
     </application>
 </manifest>

--- a/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/ExportedActivity.kt
+++ b/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/ExportedActivity.kt
@@ -1,0 +1,20 @@
+package com.example.myapp
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+// Exported activity with no intent-filter. It is reachable only by an explicit
+// intent naming the component, but it still reads attacker-controllable extras
+// and forwards them, so the IPC surface is real and worth linking to code.
+class ExportedActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val token = intent.getStringExtra("token")
+        handleExplicitIntent(token)
+    }
+
+    private fun handleExplicitIntent(token: String?) {
+        startActivity(Intent(this, NextActivity::class.java))
+    }
+}

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -52,6 +52,19 @@ expected_endpoints = [
   build.call("https://myapp.example.com/complex/:id", "universal-link", [Param.new("id", "", "path")], [] of String),
   # Exported, data-less component (android-intent), synthetic intent:// scheme
   build.call("intent://com.example.myapp/.SyncService", "android-intent", no_params, [] of String),
+  # Exported components with NO intent-filter: explicit-intent IPC surfaces.
+  # The activity ships handler source, so the linker grafts the intent read +
+  # forward and the `token` extra; the service / receiver are config-only here.
+  build.call("intent://com.example.myapp/.ExportedActivity", "android-intent", [
+    Param.new("token", "", "extra"),
+  ], ["intent.getStringExtra", "handleExplicitIntent", "startActivity"]),
+  build.call("intent://com.example.myapp/.ExportedService", "android-intent", no_params, [] of String),
+  build.call("intent://com.example.myapp/.ExportedReceiver", "android-intent", no_params, [] of String),
+  # Filter-less exported activity-alias: addressed by its own name, but `via`
+  # resolves to targetActivity, so it links AliasTargetActivity's callees.
+  build.call("intent://com.example.myapp/.ExportedAlias", "android-intent", [
+    Param.new("aliasToken", "", "extra"),
+  ], ["intent.getStringExtra", "dispatchAlias"]),
   # gradle manifestPlaceholders: ${deepLinkScheme} / ${deepLinkHost} resolved
   # from build.gradle defaultConfig (the buildTypes override must not win)
   build.call("myapp://links.example.com", "mobile-scheme", no_params, [] of String),

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -71,6 +71,47 @@ describe "Analyzer::Mobile::Android" do
     ep.metadata.not_nil!["action"].should eq("com.example.ACTION_SYNC")
   end
 
+  it "emits an explicit android-intent surface for an exported, filter-less component" do
+    ep = find.call("intent://com.example.myapp/.ExportedActivity").not_nil!
+    ep.protocol.should eq("android-intent")
+    md = ep.metadata.not_nil!
+    md["component_type"].should eq("activity")
+    md["explicit"].should eq("true")
+    md["exported"].should eq("true")
+    md["package"].should eq("com.example.myapp")
+    # No intent-filter, so no action/category metadata.
+    md.has_key?("action").should be_false
+  end
+
+  it "records the component kind for filter-less service / receiver surfaces" do
+    find.call("intent://com.example.myapp/.ExportedService").not_nil!.metadata.not_nil!["component_type"].should eq("service")
+    find.call("intent://com.example.myapp/.ExportedReceiver").not_nil!.metadata.not_nil!["component_type"].should eq("receiver")
+  end
+
+  it "carries a guarding android:permission in metadata without suppressing the surface" do
+    md = find.call("intent://com.example.myapp/.ExportedReceiver").not_nil!.metadata.not_nil!
+    md["permission"].should eq("com.example.permission.CUSTOM")
+  end
+
+  it "uses targetActivity as via for a filter-less exported activity-alias" do
+    # The alias is addressed by its own name in the URL, but its handler code
+    # lives in targetActivity, so `via` points there for the linker.
+    ep = find.call("intent://com.example.myapp/.ExportedAlias").not_nil!
+    md = ep.metadata.not_nil!
+    md["component_type"].should eq("activity-alias")
+    md["via"].should eq(".AliasTargetActivity")
+    md["explicit"].should eq("true")
+  end
+
+  it "does not report a filter-less component that is not exported" do
+    find.call("intent://com.example.myapp/.InternalActivity").should be_nil
+    find.call("intent://com.example.myapp/.DefaultActivity").should be_nil
+  end
+
+  it "does not report an exported component that is explicitly disabled" do
+    find.call("intent://com.example.myapp/.DisabledActivity").should be_nil
+  end
+
   it "does not emit anything for a MAIN/LAUNCHER component" do
     find.call("intent://com.example.myapp/.MainActivity").should be_nil
   end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -6,12 +6,16 @@ module Analyzer::Mobile
   #   * custom URL scheme deep links (intent-filter > data android:scheme)
   #   * verified App Links (autoVerify intent-filter on http/https)
   #   * exported components with a data-less action filter (IPC surface)
+  #   * exported components with no intent-filter (explicit-intent surface)
   #   * Jetpack Navigation deep links (res/navigation/*.xml <deepLink>)
   #
   # One endpoint is emitted per deep-link URI; the handling component lives
   # in `metadata["via"]`, not a separate entry. A bare `intent://component`
-  # endpoint is emitted only for exported components whose filter declares
-  # an action but no <data> URI (and isn't the launcher).
+  # endpoint models the Android IPC surface: it is emitted for an exported
+  # component whose filter declares an action but no <data> URI (and isn't
+  # the launcher), and for an exported component with no intent-filter at all
+  # — the latter is still reachable by an explicit intent naming the component
+  # (tagged `explicit` in metadata).
   #
   # All endpoints keep method = "GET"; the mobile semantics live in
   # `protocol` (mobile-scheme / universal-link / android-intent). `@string/`
@@ -71,13 +75,31 @@ module Analyzer::Mobile
                                   package : String, strings : Hash(String, String),
                                   placeholders : Hash(String, String),
                                   path : String, seen_urls : Set(String))
+      # A component explicitly disabled in the manifest can't be launched
+      # (until something re-enables it at runtime), so it isn't a live entry
+      # point — skip it regardless of how it would otherwise be reached.
+      return if attr(component, "enabled") == "false"
+
       exported = bool_attr(component, "exported")
       component_name = substitute(attr(component, "name") || "", placeholders)
       handler_name = component_tag == "activity-alias" ? substitute(attr(component, "targetActivity") || component_name, placeholders) : component_name
 
       filters = [] of XML::Node
       each_child(component, "intent-filter") { |f| filters << f }
-      return if filters.empty?
+
+      if filters.empty?
+        # No intent-filter: a filter-less component defaults to NOT exported,
+        # so it is reachable from another app only when `exported="true"` is
+        # set explicitly — and then an explicit intent naming `package/component`
+        # still reaches it without any action/category/data. The launcher is the
+        # only filter-less component that is implicitly an app surface, and it
+        # always declares a MAIN filter, so it never lands here.
+        if exported
+          emit_explicit_component_endpoint(component_name, handler_name, component_tag,
+            package, attr(component, "permission"), path, seen_urls)
+        end
+        return
+      end
 
       filters.each do |filter|
         actions = collect_names(filter, "action")
@@ -230,6 +252,41 @@ module Analyzer::Mobile
       endpoint = Endpoint.new(url, "GET", Details.new(PathInfo.new(path)))
       endpoint.protocol = "android-intent"
       endpoint.metadata = build_metadata("", actions, categories, "", package)
+
+      @result << endpoint
+    end
+
+    # Emits an android-intent endpoint for an exported component that declares
+    # no intent-filter. Such a component can't be matched implicitly, but an
+    # explicit intent naming `package/component` still reaches it, so it is part
+    # of the IPC attack surface a security reviewer wants inventoried. Reuses
+    # the synthetic intent:// scheme (so the optimizer/linker treat it like any
+    # other intent component) and records the component kind, the explicit/
+    # exported flags, and any guarding `android:permission` in metadata.
+    private def emit_explicit_component_endpoint(component_name : String, handler_name : String,
+                                                 component_tag : String, package : String,
+                                                 permission : String?, path : String,
+                                                 seen_urls : Set(String))
+      component = component_name.empty? ? package : "#{package}/#{component_name}"
+      url = "intent://#{component}"
+      return unless seen_urls.add?(url)
+
+      endpoint = Endpoint.new(url, "GET", Details.new(PathInfo.new(path)))
+      endpoint.protocol = "android-intent"
+
+      metadata = {} of String => String
+      # An activity-alias is addressed by its own name (kept in the URL), but
+      # its handler code lives in the target activity — surface that as `via`
+      # so the code linker resolves the right class.
+      metadata["via"] = handler_name unless handler_name.empty? || handler_name == component_name
+      metadata["component_type"] = component_tag
+      metadata["exported"] = "true"
+      metadata["explicit"] = "true"
+      metadata["package"] = package unless package.empty?
+      if perm = permission
+        metadata["permission"] = perm unless perm.empty?
+      end
+      endpoint.metadata = metadata
 
       @result << endpoint
     end

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -12,7 +12,10 @@ class OutputBuilderCommon < OutputBuilder
 
   # Fixed order so plain output is deterministic. The protocol drives the
   # prefix and "path" comes from path params, so neither is repeated here.
-  MOBILE_METADATA_KEYS = ["via", "query", "action", "category", "host", "package", "extras"]
+  # component_type/exported/explicit/permission only appear on explicit-intent
+  # (filter-less exported) components; absent keys are skipped per endpoint.
+  MOBILE_METADATA_KEYS = ["via", "query", "action", "category", "host", "package",
+                          "component_type", "exported", "explicit", "permission", "extras"]
 
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|


### PR DESCRIPTION
Closes #2003.

## Summary

An Android component declared `android:exported="true"` but with **no `intent-filter`** cannot be matched by an *implicit* intent, yet an **explicit** intent naming `package/component` still reaches it. That is a real IPC attack surface, and Noir previously dropped it — `process_component` returned early whenever a component had no intent-filter.

This builds on Noir's existing `android-intent` surface (data-less action filters) rather than filling a gap from scratch: the same synthetic `intent://` scheme, optimizer pass-through, and mobile code-linker now also cover filter-less exported components, so handler callees, intent extras, and `--ai-context` taint flow are wired automatically.

## Behavior

For an exported, filter-less `activity` / `activity-alias` / `service` / `receiver`, Noir now emits:

```
INTENT com.example.app/.ExportedActivity
  ○ package: com.example.app
  ○ component_type: activity
  ○ exported: true
  ○ explicit: true
```

- `component_type` / `exported` / `explicit` ride in metadata; a guarding `android:permission` is **recorded, not suppressed** (a `normal`/`dangerous` permission is still obtainable by another app — that judgment belongs to the reviewer).
- An `activity-alias` keeps its own name in the URL but sets `via` = `targetActivity`, so the linker resolves the right handler class.
- **Not** reported: a filter-less component that is not exported, or one that is `android:enabled="false"`.

## Tests / docs

- Fixtures: exported activity (with handler source → linked callees + `token` extra), service, receiver (with permission), activity-alias (→ `via` targetActivity), plus negatives (not-exported, default, disabled).
- Unit + functional specs; EN/KO docs updated.
- Full suite green (`21602 examples, 0 failures`), ameba clean.

The change was adversarially reviewed by a multi-agent workflow (Android security semantics / Crystal correctness / completeness); the one surviving finding — an uncovered alias `via` branch — is closed by the added alias fixture + assertion.