### PR TITLE
feat(mobile): report exported ContentProviders as content:// IPC surfaces

### DIFF
--- a/docs/content/usage/supported/mobile/index.ko.md
+++ b/docs/content/usage/supported/mobile/index.ko.md
@@ -12,7 +12,7 @@ Noir는 모바일 앱이 외부에 노출하는 진입점 — 딥링크와 expor
 
 | 플랫폼 | 소스 파일 | 추출 내용 |
 |---|---|---|
-| Android | `AndroidManifest.xml` | 커스텀 URL 스킴 딥링크, exported 인텐트 컴포넌트, 검증된 App Link |
+| Android | `AndroidManifest.xml` | 커스텀 URL 스킴 딥링크, exported 인텐트 컴포넌트, exported ContentProvider, 검증된 App Link |
 | Android | `res/values/strings.xml` | 스킴·호스트·경로에 쓰인 `@string/` 참조 해석 |
 | Android | `build.gradle` / `build.gradle.kts` | 패키지·컴포넌트 이름·스킴·호스트에 쓰인 `${applicationId}`와 커스텀 `manifestPlaceholders` 해석. 매니페스트에 `package` 속성이 없으면 패키지도 여기서 가져옵니다 |
 | Android | `res/navigation/*.xml` | Jetpack Navigation `<deepLink app:uri="...">` 딥링크 — 소속 destination이 처리 컴포넌트가 됩니다 |
@@ -31,9 +31,10 @@ Noir는 모바일 앱이 외부에 노출하는 진입점 — 딥링크와 expor
 |---|---|---|
 | `mobile-scheme` | 커스텀 URL 스킴 딥링크 | `myapp://complex/:id` |
 | `android-intent` | 인텐트로 도달 가능한 exported 컴포넌트 — data URI 없는 action 필터, 또는 intent-filter가 전혀 없는 경우(명시적 인텐트 전용) | `intent://com.example.app/.SyncService` |
+| `android-provider` | 다른 앱이 `content://authority` URI로 도달할 수 있는 exported ContentProvider | `content://com.example.app.provider` |
 | `universal-link` | 검증된 Android App Link / iOS 유니버설 링크, 또는 서버 측 `assetlinks.json` / `apple-app-site-association` 패턴 | `https://app.example.com/complex/:id`, `/buy/*` |
 
-plain 출력에서는 `SCHEME` / `INTENT` / `UNIVERSAL` 프리픽스로 표시됩니다. 처리 컴포넌트, 인텐트 action·category, 호스트, 패키지는 엔드포인트별 metadata 맵에 저장됩니다(JSON / YAML에 직렬화되며, 일반 HTTP 엔드포인트에서는 완전히 생략됩니다).
+plain 출력에서는 `SCHEME` / `INTENT` / `PROVIDER` / `UNIVERSAL` 프리픽스로 표시됩니다. 처리 컴포넌트, 인텐트 action·category, 호스트, 패키지는 엔드포인트별 metadata 맵에 저장됩니다(JSON / YAML에 직렬화되며, 일반 HTTP 엔드포인트에서는 완전히 생략됩니다).
 
 ```
 SCHEME myapp://complex/:id
@@ -63,5 +64,6 @@ SCHEME myapp://complex/:id
 * gradle 플레이스홀더는 매니페스트 위쪽에서 가장 가까운 `build.gradle(.kts)`를 읽어 해석합니다. 같은 플레이스홀더가 여러 번 선언되면(예: `buildTypes` 오버라이드) 먼저 선언된 쪽 — 관례상 `defaultConfig` — 이 우선하며, 빌드 variant별 값은 모델링하지 않습니다. gradle에 값이 없는 플레이스홀더는 URL에 그대로 남고 엔드포인트에 `unresolved` 태그가 붙습니다.
 * 스킴 없는 Jetpack Navigation URI(런타임에는 http·https 모두 매칭)는 `https` 하나로 추출합니다. `{arg}` 세그먼트는 `:arg` path 파라미터로, `?key={arg}` 쿼리 플레이스홀더는 `query` 파라미터로 바뀌고, 끝의 `.*` 와일드카드는 리터럴 프리픽스만 남깁니다.
 * intent-filter가 없는 `android:exported="true"` 컴포넌트는 명시적 인텐트 표면(`android-intent`, metadata에 `explicit`/`exported`/`component_type` 포함)으로 보고됩니다. action·category·data URI가 없어도, 컴포넌트 이름을 지정한 명시적 인텐트는 여전히 그 컴포넌트에 도달합니다. exported가 아니거나 `android:enabled="false"`인 필터 없는 컴포넌트는 보고하지 않습니다. 보호용 `android:permission`은 metadata에 기록되지만 표면을 숨기지는 않습니다 — `normal`/`dangerous` 권한은 다른 앱이 여전히 획득할 수 있기 때문입니다.
+* exported `<provider>`(ContentProvider)는 `android-provider` 표면으로 보고됩니다 — `android:authorities` 항목마다 `content://authority` 엔드포인트 하나씩. provider 클래스가 핸들러(`via`)로 연결되므로 `query` / `insert` / `openFile` 메서드의 callee가 수집되어, raw SQL·파일 싱크가 AI 컨텍스트에 드러납니다. `android:readPermission` / `android:writePermission` / `android:permission`, `android:grantUriPermissions`(또는 `<grant-uri-permission>` 자식), 그리고 `<path-permission>` 오버라이드의 존재 여부가 metadata에 실립니다 — 모두 기록만 하고 숨기지 않습니다. 명시적으로 exported된 provider만 보고합니다(최신 SDK에서 provider 기본값은 not-exported). `<path-permission>`의 경로별 실효 권한은 표시만 하고 해석하지는 않습니다.
 * `assetlinks.json`은 패키지 연결만 선언하고 경로는 없으므로 앱당 `/*` 엔드포인트 하나를 만듭니다. `apple-app-site-association`의 경로(`/buy/*`, `NOT /private/*`)와 `components`는 개별적으로 추출되며, AASA 제외 패턴은 `excluded` 태그가 붙습니다.
 * `apple-app-site-association`은 plain-JSON 형식만 파싱합니다. CMS로 서명된 AASA 파일(구형 앱)은 건너뜁니다.

--- a/docs/content/usage/supported/mobile/index.md
+++ b/docs/content/usage/supported/mobile/index.md
@@ -12,7 +12,7 @@ Noir extracts mobile app entry points — the deep links and exported components
 
 | Platform | Source file | What it yields |
 |---|---|---|
-| Android | `AndroidManifest.xml` | custom URL-scheme deep links, exported intent components, verified App Links |
+| Android | `AndroidManifest.xml` | custom URL-scheme deep links, exported intent components, exported ContentProviders, verified App Links |
 | Android | `res/values/strings.xml` | resolves `@string/` references used in schemes / hosts / paths |
 | Android | `build.gradle` / `build.gradle.kts` | resolves `${applicationId}` and custom `manifestPlaceholders` used in package / component names / schemes / hosts; supplies the package when the manifest has no `package` attribute |
 | Android | `res/navigation/*.xml` | Jetpack Navigation `<deepLink app:uri="...">` deep links — the owning destination becomes the handling component |
@@ -31,9 +31,10 @@ Mobile entry points are endpoints with `method = "GET"`; their nature is carried
 |---|---|---|
 | `mobile-scheme` | custom URL-scheme deep link | `myapp://complex/:id` |
 | `android-intent` | exported intent component reachable by intent — a data-less action filter, or no intent-filter at all (explicit-intent only) | `intent://com.example.app/.SyncService` |
+| `android-provider` | exported ContentProvider reachable by another app through a `content://authority` URI | `content://com.example.app.provider` |
 | `universal-link` | verified Android App Link / iOS universal link, or a server-side `assetlinks.json` / `apple-app-site-association` pattern | `https://app.example.com/complex/:id`, `/buy/*` |
 
-In plain output they render under a `SCHEME` / `INTENT` / `UNIVERSAL` prefix. The handling component, intent action and category, host, and package are stored in a per-endpoint metadata map (serialized in JSON / YAML; omitted entirely for ordinary HTTP endpoints):
+In plain output they render under a `SCHEME` / `INTENT` / `PROVIDER` / `UNIVERSAL` prefix. The handling component, intent action and category, host, and package are stored in a per-endpoint metadata map (serialized in JSON / YAML; omitted entirely for ordinary HTTP endpoints):
 
 ```
 SCHEME myapp://complex/:id
@@ -63,5 +64,6 @@ Mobile endpoints stay in the structured inventory — JSON, JSONL, YAML, SARIF, 
 * gradle placeholder resolution reads the nearest `build.gradle(.kts)` above the manifest; when the same placeholder is declared more than once (e.g. a `buildTypes` override), the first declaration — by convention `defaultConfig` — wins. Variant-specific values are not modeled. A placeholder with no gradle value stays verbatim in the URL and the endpoint is tagged `unresolved`.
 * Scheme-less Jetpack Navigation URIs (which match both http and https at runtime) are emitted once under `https`. `{arg}` segments become `:arg` path params, `?key={arg}` query placeholders become `query` params, and a trailing `.*` wildcard keeps the literal prefix.
 * An `android:exported="true"` component with no intent-filter is reported as an explicit-intent surface (`android-intent`, with `explicit`/`exported`/`component_type` in metadata): an explicit intent naming the component still reaches it even with no action, category, or data URI. A filter-less component that is not exported, or is `android:enabled="false"`, is not reported. A guarding `android:permission` is recorded in metadata but does not suppress the surface — `normal`/`dangerous` permissions remain obtainable by another app.
+* An exported `<provider>` (ContentProvider) is reported as an `android-provider` surface — one `content://authority` endpoint per `android:authorities` entry. The provider class links as the handler (`via`), so its `query` / `insert` / `openFile` methods contribute callees (a raw SQL / file sink surfaces in AI context). `android:readPermission` / `android:writePermission` / `android:permission`, `android:grantUriPermissions` (or a `<grant-uri-permission>` child), and the presence of `<path-permission>` overrides ride in metadata — all recorded, never suppressed. Only an explicitly exported provider is reported (a provider defaults to not-exported on modern SDKs); the effective per-path permission of a `<path-permission>` is flagged but not resolved.
 * `assetlinks.json` only declares the package association (no paths), so it yields a single `/*` endpoint per app. `apple-app-site-association` paths (`/buy/*`, `NOT /private/*`) and `components` are emitted individually; AASA exclusions are tagged `excluded`.
 * Only the plain-JSON form of `apple-app-site-association` is parsed; CMS-signed AASA files (older apps) are skipped.

--- a/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
+++ b/spec/functional_test/fixtures/mobile/android/AndroidManifest.xml
@@ -221,5 +221,46 @@
         <activity android:name=".DisabledActivity" android:exported="true"
             android:enabled="false" />
 
+        <!-- Exported ContentProvider with no permission: world-reachable via
+             content://authority by any app. The handler source links the
+             query/openFile callees so the SQL sink surfaces in AI context. -->
+        <provider
+            android:name=".ExportedProvider"
+            android:authorities="com.example.myapp.provider"
+            android:exported="true" />
+
+        <!-- Exported provider guarded by read/write permissions and declaring
+             a path-permission override + ad-hoc URI grants (via the child
+             element). All ride in metadata; none suppress the surface. -->
+        <provider
+            android:name=".SecretProvider"
+            android:authorities="com.example.myapp.secret"
+            android:exported="true"
+            android:readPermission="com.example.permission.READ_SECRET"
+            android:writePermission="com.example.permission.WRITE_SECRET">
+            <path-permission android:pathPrefix="/public" />
+            <grant-uri-permission android:pathPattern=".*" />
+        </provider>
+
+        <!-- Multiple authorities: each is an independently addressable surface,
+             so two endpoints are emitted. grantUriPermissions via the attribute. -->
+        <provider
+            android:name=".MultiAuthProvider"
+            android:authorities="com.example.myapp.first;com.example.myapp.second"
+            android:exported="true"
+            android:grantUriPermissions="true" />
+
+        <!-- NOT exported: internal only, must NOT be reported. -->
+        <provider
+            android:name=".InternalProvider"
+            android:authorities="com.example.myapp.internal"
+            android:exported="false" />
+
+        <!-- Default (no exported attribute): API 17+ defaults to not-exported,
+             so it must NOT be reported. -->
+        <provider
+            android:name=".DefaultProvider"
+            android:authorities="com.example.myapp.default" />
+
     </application>
 </manifest>

--- a/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/ExportedProvider.kt
+++ b/spec/functional_test/fixtures/mobile/android/src/main/java/com/example/myapp/ExportedProvider.kt
@@ -1,0 +1,30 @@
+package com.example.myapp
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+// Exported ContentProvider reachable by any other app via content://authority.
+// query() folds caller-supplied `selection` straight into a raw SQL string —
+// the classic provider SQL-injection sink the linker should surface from the
+// provider handler methods (query/insert/...), not just onCreate.
+class ExportedProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? {
+        val db = dbHelper.readableDatabase
+        return db.rawQuery("SELECT * FROM items WHERE name = '$selection'", null)
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? {
+        dbHelper.writableDatabase.execSQL("INSERT INTO items VALUES (?)", arrayOf(values))
+        return uri
+    }
+}

--- a/spec/functional_test/testers/mobile/android_spec.cr
+++ b/spec/functional_test/testers/mobile/android_spec.cr
@@ -65,6 +65,18 @@ expected_endpoints = [
   build.call("intent://com.example.myapp/.ExportedAlias", "android-intent", [
     Param.new("aliasToken", "", "extra"),
   ], ["intent.getStringExtra", "dispatchAlias"]),
+  # Exported ContentProvider (android-provider, content://authority). The
+  # handler source links the provider methods (query/insert), so the raw-SQL
+  # sinks surface as callees for AI context.
+  build.call("content://com.example.myapp.provider", "android-provider", no_params,
+    ["db.rawQuery", "dbHelper.writableDatabase.execSQL"]),
+  # Permission-guarded provider: config-only here (no handler source), but the
+  # read/write permissions + path-permission flag ride in metadata (asserted
+  # in the unit spec).
+  build.call("content://com.example.myapp.secret", "android-provider", no_params, [] of String),
+  # Multiple authorities -> one endpoint each.
+  build.call("content://com.example.myapp.first", "android-provider", no_params, [] of String),
+  build.call("content://com.example.myapp.second", "android-provider", no_params, [] of String),
   # gradle manifestPlaceholders: ${deepLinkScheme} / ${deepLinkHost} resolved
   # from build.gradle defaultConfig (the buildTypes override must not win)
   build.call("myapp://links.example.com", "mobile-scheme", no_params, [] of String),

--- a/spec/unit_test/analyzer/mobile_android_spec.cr
+++ b/spec/unit_test/analyzer/mobile_android_spec.cr
@@ -112,6 +112,45 @@ describe "Analyzer::Mobile::Android" do
     find.call("intent://com.example.myapp/.DisabledActivity").should be_nil
   end
 
+  it "emits a content:// surface for an exported ContentProvider" do
+    ep = find.call("content://com.example.myapp.provider").not_nil!
+    ep.protocol.should eq("android-provider")
+    md = ep.metadata.not_nil!
+    md["component_type"].should eq("provider")
+    md["exported"].should eq("true")
+    md["package"].should eq("com.example.myapp")
+    # The provider class is the handler, surfaced as `via` for the linker.
+    md["via"].should eq(".ExportedProvider")
+    # No permission declared, so no permission keys.
+    md.has_key?("permission").should be_false
+    md.has_key?("read_permission").should be_false
+  end
+
+  it "records read/write permissions, uri grants, and path-permission flags for a provider" do
+    md = find.call("content://com.example.myapp.secret").not_nil!.metadata.not_nil!
+    md["read_permission"].should eq("com.example.permission.READ_SECRET")
+    md["write_permission"].should eq("com.example.permission.WRITE_SECRET")
+    # <grant-uri-permission> child grants ad-hoc URI access.
+    md["grant_uri_permissions"].should eq("true")
+    # <path-permission> child declares granular per-path rules.
+    md["path_permissions"].should eq("true")
+  end
+
+  it "emits one provider endpoint per semicolon-separated authority" do
+    first = find.call("content://com.example.myapp.first").not_nil!
+    second = find.call("content://com.example.myapp.second").not_nil!
+    first.protocol.should eq("android-provider")
+    second.protocol.should eq("android-provider")
+    # grantUriPermissions via the attribute form.
+    first.metadata.not_nil!["grant_uri_permissions"].should eq("true")
+    second.metadata.not_nil!["grant_uri_permissions"].should eq("true")
+  end
+
+  it "does not report a provider that is not exported or default (not-exported)" do
+    find.call("content://com.example.myapp.internal").should be_nil
+    find.call("content://com.example.myapp.default").should be_nil
+  end
+
   it "does not emit anything for a MAIN/LAUNCHER component" do
     find.call("intent://com.example.myapp/.MainActivity").should be_nil
   end

--- a/src/ai_context/builder.cr
+++ b/src/ai_context/builder.cr
@@ -717,11 +717,16 @@ module NoirAIContext
         snippet: snippet
       ))
 
+      signal_description = if endpoint.protocol == "android-provider"
+                             "Exported ContentProvider entry point receives a content:// URI and selection from another app; review downstream SQL, file, and path handling."
+                           else
+                             "Mobile deep-link entry point receives URL/userActivity data from outside the app; review downstream parsing, routing, and WebView/intent usage."
+                           end
       context.push_signal(AIContextEntry.new(
         "deep_link_input",
         source_name,
         source: "mobile_deep_link",
-        description: "Mobile deep-link entry point receives URL/userActivity data from outside the app; review downstream parsing, routing, and WebView/intent usage.",
+        description: signal_description,
         path: source_anchor.try(&.path),
         line: source_anchor.try(&.line),
         confidence: 74,
@@ -741,6 +746,8 @@ module NoirAIContext
         "deep_link.universal_link"
       when "android-intent"
         "deep_link.android_intent"
+      when "android-provider"
+        "ipc.content_provider"
       else
         "deep_link.mobile_scheme"
       end
@@ -752,6 +759,8 @@ module NoirAIContext
         "Universal Link URL supplied by the operating system from an external HTTPS navigation."
       when "android-intent"
         "Android intent deep-link data supplied by another app or browser."
+      when "android-provider"
+        "ContentProvider query/openFile reachable from another app via content:// URI; review the URI, selection, and selectionArgs for SQL injection and path traversal."
       else
         "Custom URL-scheme deep-link supplied by another app or browser."
       end

--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -7,6 +7,7 @@ module Analyzer::Mobile
   #   * verified App Links (autoVerify intent-filter on http/https)
   #   * exported components with a data-less action filter (IPC surface)
   #   * exported components with no intent-filter (explicit-intent surface)
+  #   * exported ContentProviders (content://authority IPC surface)
   #   * Jetpack Navigation deep links (res/navigation/*.xml <deepLink>)
   #
   # One endpoint is emitted per deep-link URI; the handling component lives
@@ -65,6 +66,12 @@ module Analyzer::Mobile
           each_child(application, component_tag) do |component|
             process_component(component, component_tag, package, strings, placeholders, path, seen_urls)
           end
+        end
+
+        # Providers aren't reached by an intent naming the component; they are
+        # addressed by `content://authority`, so they have their own surface.
+        each_child(application, "provider") do |provider|
+          process_provider(provider, package, strings, placeholders, path, seen_urls)
         end
       end
 
@@ -289,6 +296,75 @@ module Analyzer::Mobile
       endpoint.metadata = metadata
 
       @result << endpoint
+    end
+
+    # Processes a `<provider>` (ContentProvider). Unlike the other components,
+    # a provider isn't reached by an intent naming it — it is addressed by a
+    # `content://<authority>` URI through a ContentResolver, so it is modeled
+    # with its own `android-provider` protocol. Only an explicitly exported
+    # provider is reported: pre-API-17 a provider defaulted to exported, but
+    # modern tooling requires the attribute, so requiring `exported="true"`
+    # keeps this conservative — matching how filter-less components are gated.
+    private def process_provider(provider : XML::Node, package : String,
+                                 strings : Hash(String, String),
+                                 placeholders : Hash(String, String),
+                                 path : String, seen_urls : Set(String))
+      return if attr(provider, "enabled") == "false"
+      return unless bool_attr(provider, "exported")
+
+      raw_authorities = attr(provider, "authorities")
+      return if raw_authorities.nil? || raw_authorities.empty?
+
+      component_name = substitute(attr(provider, "name") || "", placeholders)
+
+      metadata = {} of String => String
+      # The provider class handles the surface, so surface it as `via` for the
+      # code linker (an authority is rarely the class name).
+      metadata["via"] = component_name unless component_name.empty?
+      metadata["component_type"] = "provider"
+      metadata["exported"] = "true"
+      metadata["package"] = package unless package.empty?
+      # Read/write may be guarded separately; the umbrella `android:permission`
+      # covers both unless a more specific one overrides it. All are recorded,
+      # not suppressed — the protection level (and so whether another app can
+      # actually hold the permission) is the reviewer's call.
+      add_permission(metadata, "permission", attr(provider, "permission"))
+      add_permission(metadata, "read_permission", attr(provider, "readPermission"))
+      add_permission(metadata, "write_permission", attr(provider, "writePermission"))
+      metadata["grant_uri_permissions"] = "true" if provider_grants_uri?(provider)
+      # `<path-permission>` children apply per-path overrides — frequently an
+      # unprotected sub-path of an otherwise guarded provider. Flag their
+      # presence so a reviewer inspects the granular rules; the effective
+      # per-path permission is intentionally not guessed here.
+      metadata["path_permissions"] = "true" if has_child?(provider, "path-permission")
+
+      # `android:authorities` is a semicolon-separated list; each authority is
+      # an independently addressable surface.
+      raw_authorities.split(';').each do |raw_authority|
+        authority = substitute(raw_authority.strip, placeholders)
+        next if authority.empty?
+
+        url = "content://#{authority}"
+        next unless seen_urls.add?(url)
+
+        endpoint = Endpoint.new(url, "GET", Details.new(PathInfo.new(path)))
+        endpoint.protocol = "android-provider"
+        endpoint.metadata = metadata.dup
+        mark_unresolved(endpoint, url)
+        @result << endpoint
+      end
+    end
+
+    # A provider grants ad-hoc URI access when `android:grantUriPermissions` is
+    # set or it declares `<grant-uri-permission>` children — in either case a
+    # caller can be handed temporary read/write access to specific URIs.
+    private def provider_grants_uri?(provider : XML::Node) : Bool
+      bool_attr(provider, "grantUriPermissions") || has_child?(provider, "grant-uri-permission")
+    end
+
+    private def add_permission(metadata : Hash(String, String), key : String, value : String?)
+      return if value.nil? || value.empty?
+      metadata[key] = value
     end
 
     # Renders a `<data>` URL. Opaque schemes (mailto/tel/geo/…) have no
@@ -701,6 +777,10 @@ module Analyzer::Mobile
         return c if c.element? && c.name == local_name
       end
       nil
+    end
+
+    private def has_child?(node : XML::Node, local_name : String) : Bool
+      !find_child(node, local_name).nil?
     end
 
     private def each_child(node : XML::Node, local_name : String, &)

--- a/src/mobile/linker.cr
+++ b/src/mobile/linker.cr
@@ -29,6 +29,17 @@ module NoirMobileLinker
     handleIntent handleDeepLink onReceive onBind onCreateView onViewCreated
   ]
 
+  # ContentProvider entry points. A provider is reached via ContentResolver,
+  # so its inbound data (the `uri`, `selection`, `selectionArgs`, projection)
+  # arrives through these methods rather than an Intent — `query` / `openFile`
+  # are the classic SQL-injection / path-traversal sinks. Kept separate from
+  # HANDLER_METHODS so these generic verbs are only scanned for provider
+  # components, not grafted onto every activity that happens to have an
+  # `update()`.
+  PROVIDER_HANDLER_METHODS = %w[
+    onCreate query insert update delete bulkInsert openFile openAssetFile call getType applyBatch
+  ]
+
   # Inputs the handler reads from the inbound deep link. `getQueryParameter`
   # reads a real URI query parameter (surfaced as a "query" param, baked
   # into the URL like any other); the `get*Extra` family reads Intent extras
@@ -59,9 +70,11 @@ module NoirMobileLinker
       next unless resolved
 
       begin
-        cache_key = "#{resolved[:lang]}:#{resolved[:path]}:#{cls[:simple]}"
+        is_provider = provider_endpoint?(endpoint)
+        methods = is_provider ? PROVIDER_HANDLER_METHODS : HANDLER_METHODS
+        cache_key = "#{resolved[:lang]}:#{resolved[:path]}:#{cls[:simple]}:#{is_provider}"
         info = handler_cache[cache_key]? || begin
-          fresh = android_handler_info(cls[:simple], resolved[:path], resolved[:lang])
+          fresh = android_handler_info(cls[:simple], resolved[:path], resolved[:lang], methods)
           handler_cache[cache_key] = fresh
           fresh
         end
@@ -126,12 +139,16 @@ module NoirMobileLinker
   end
 
   # An endpoint we can resolve to an Android component: a mobile protocol
-  # with either a `via` class (scheme / universal-link) or an intent://
-  # component URL (android-intent). iOS schemes carry neither.
+  # with either a `via` class (scheme / universal-link / provider) or an
+  # intent:// component URL (android-intent). iOS schemes carry neither.
   private def self.android_handler_target?(endpoint : Endpoint) : Bool
     return false unless endpoint.mobile?
     return true if endpoint.url.starts_with?("intent://")
     !!(endpoint.metadata.try &.has_key?("via"))
+  end
+
+  private def self.provider_endpoint?(endpoint : Endpoint) : Bool
+    endpoint.protocol == "android-provider"
   end
 
   # Returns the handler class as {simple, package}. `via` is like
@@ -172,14 +189,15 @@ module NoirMobileLinker
     File.read(path, encoding: "utf-8", invalid: :skip)
   end
 
-  private def self.android_handler_info(simple : String, path : String, lang : Symbol) : HandlerInfo
+  private def self.android_handler_info(simple : String, path : String, lang : Symbol,
+                                        handler_methods : Array(String) = HANDLER_METHODS) : HandlerInfo
     info = HandlerInfo.new
     content = read_content(path) || ""
 
     callees = [] of Callee
     if lang == :kotlin
       Noir::TreeSitter.parse_kotlin(content) do |root|
-        HANDLER_METHODS.each do |method|
+        handler_methods.each do |method|
           Noir::KotlinCalleeExtractor.callees_in_method(root, content, path, simple, method).each do |name, fpath, line|
             append_android_callee(callees, name, fpath, line)
           end
@@ -193,7 +211,7 @@ module NoirMobileLinker
       end
     else
       Noir::TreeSitter.parse_java(content) do |root|
-        HANDLER_METHODS.each do |method|
+        handler_methods.each do |method|
           Noir::JavaCalleeExtractor.callees_in_method(root, content, path, simple, method).each do |name, fpath, line|
             append_android_callee(callees, name, fpath, line)
           end
@@ -208,7 +226,7 @@ module NoirMobileLinker
     end
 
     callees = prioritize_android_callees(callees)
-    anchor_line = handler_anchor_line(content, simple)
+    anchor_line = handler_anchor_line(content, simple, handler_methods)
     info.code_paths << PathInfo.new(path, anchor_line)
     extract_input_params(callees, content).each { |param| info.params << param }
     callees.first(Callee::MAX_PER_ENDPOINT).each do |callee|
@@ -284,7 +302,10 @@ module NoirMobileLinker
   end
 
   private def self.android_mobile_sink_callee?(name : String) : Bool
-    name.matches?(/(?:^|\.)(?:loadUrl|loadData|loadDataWithBaseURL|evaluateJavascript|startActivity|startActivityForResult|sendBroadcast|startService|bindService)\b/)
+    # WebView / intent-forwarding sinks, plus the ContentProvider data sinks
+    # (raw SQL and file descriptors) reachable from an exported provider's
+    # query/openFile handlers.
+    name.matches?(/(?:^|\.)(?:loadUrl|loadData|loadDataWithBaseURL|evaluateJavascript|startActivity|startActivityForResult|sendBroadcast|startService|bindService|rawQuery|execSQL|compileStatement|openOrCreateDatabase|ParcelFileDescriptor)\b/)
   end
 
   private def self.android_delegate_callee?(callee : Callee) : Bool
@@ -338,8 +359,9 @@ module NoirMobileLinker
   # Best-effort source line for the handler so the AI-context snippet window
   # covers the intent-reading code: prefer the first handler-method
   # declaration, fall back to the class declaration.
-  private def self.handler_anchor_line(content : String, simple : String) : Int32?
-    method_re = /\b(?:fun|void|public|protected|private|override)\b.*\b(?:#{HANDLER_METHODS.join("|")})\s*\(/
+  private def self.handler_anchor_line(content : String, simple : String,
+                                       handler_methods : Array(String) = HANDLER_METHODS) : Int32?
+    method_re = /\b(?:fun|void|public|protected|private|override)\b.*\b(?:#{handler_methods.join("|")})\s*\(/
     class_re = /\b(?:class|object)\s+#{Regex.escape(simple)}\b/
     class_line : Int32? = nil
 

--- a/src/models/endpoint.cr
+++ b/src/models/endpoint.cr
@@ -8,10 +8,11 @@ struct Endpoint
   property ai_context : AIContext?
 
   # Non-HTTP mobile deep-link protocols. These endpoints are app URLs you
-  # open (myapp://, intent://, verified https app links), not HTTP requests
-  # you send — so they are excluded from HTTP-shaped output (curl/httpie/
-  # powershell, OpenAPI) and from active probing / proxy delivery.
-  MOBILE_PROTOCOLS = Set{"mobile-scheme", "android-intent", "universal-link"}
+  # open (myapp://, intent://, verified https app links) or ContentResolver
+  # surfaces you address (content://authority), not HTTP requests you send —
+  # so they are excluded from HTTP-shaped output (curl/httpie/powershell,
+  # OpenAPI) and from active probing / proxy delivery.
+  MOBILE_PROTOCOLS = Set{"mobile-scheme", "android-intent", "universal-link", "android-provider"}
 
   def mobile? : Bool
     MOBILE_PROTOCOLS.includes?(@protocol)

--- a/src/output_builder/common.cr
+++ b/src/output_builder/common.cr
@@ -5,17 +5,22 @@ class OutputBuilderCommon < OutputBuilder
   # Mobile entry points keep method = "GET" internally; the protocol
   # carries the real semantics and drives the display prefix.
   MOBILE_PROTOCOL_LABELS = {
-    "mobile-scheme"  => "SCHEME",
-    "android-intent" => "INTENT",
-    "universal-link" => "UNIVERSAL",
+    "mobile-scheme"    => "SCHEME",
+    "android-intent"   => "INTENT",
+    "universal-link"   => "UNIVERSAL",
+    "android-provider" => "PROVIDER",
   }
 
   # Fixed order so plain output is deterministic. The protocol drives the
   # prefix and "path" comes from path params, so neither is repeated here.
-  # component_type/exported/explicit/permission only appear on explicit-intent
-  # (filter-less exported) components; absent keys are skipped per endpoint.
+  # component_type/exported/explicit appear on explicit-intent (filter-less
+  # exported) and provider surfaces; the *_permission / grant_uri_permissions /
+  # path_permissions keys only on providers. Absent keys are skipped per
+  # endpoint.
   MOBILE_METADATA_KEYS = ["via", "query", "action", "category", "host", "package",
-                          "component_type", "exported", "explicit", "permission", "extras"]
+                          "component_type", "exported", "explicit", "permission",
+                          "read_permission", "write_permission", "grant_uri_permissions",
+                          "path_permissions", "extras"]
 
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|


### PR DESCRIPTION
Follow-up to #2005 (review + extension).

## Context

#2005 inventoried exported **activity / activity-alias / service / receiver** components without intent-filters as explicit-intent surfaces. Reviewing it, the code was solid — but the analyzer only ever walked those four tags. The remaining, and arguably **most dangerous**, Android IPC surface was the **ContentProvider**, which was never inventoried at all.

This continues the same IPC-attack-surface theme: an exported `<provider>` is reachable by any other app through a `content://authority` URI (a ContentResolver `query`/`insert`/`openFile`) — the classic SQL-injection, path-traversal, and arbitrary-file-disclosure surface.

## Behavior

For an explicitly exported `<provider>`, Noir now emits one `android-provider` endpoint per `android:authorities` entry:

```
PROVIDER content://com.example.app.provider
  ○ via: .ExportedProvider
  ○ package: com.example.app
  ○ component_type: provider
  ○ exported: true
  ○ read_permission: com.example.permission.READ_SECRET
  ○ write_permission: com.example.permission.WRITE_SECRET
  ○ grant_uri_permissions: true
  ○ path_permissions: true
```

- The provider **class** rides in `via`, so the code linker resolves the handler (the authority is rarely the class name).
- `android:readPermission` / `android:writePermission` / `android:permission`, `android:grantUriPermissions` (attribute **or** a `<grant-uri-permission>` child), and a `path_permissions` flag when `<path-permission>` overrides exist are all **recorded, not suppressed** — the protection level (whether another app can actually hold a permission) is the reviewer's call.
- Multiple `android:authorities` (`a;b`) → one endpoint each.
- **Only explicitly exported** providers are reported (a provider defaults to not-exported on modern SDKs; lint requires the attribute), matching #2005's conservative gating. **Not** reported: a not-exported / default / `enabled="false"` provider, or one with no authorities.

## Code linkage / AI context

The mobile linker resolves the provider class via `via` and scans the **provider** handler methods (`query`/`insert`/`update`/`delete`/`openFile`/`call`/…) — kept in a separate `PROVIDER_HANDLER_METHODS` set so these generic verbs are *only* scanned for provider endpoints, never grafted onto an activity that happens to have an `update()`. Raw-SQL / file-descriptor sinks (`rawQuery`, `execSQL`, `ParcelFileDescriptor`, …) surface as callees. With `--ai-context`, the provider gets an `ipc.content_provider` source signal describing the URI/selection taint:

```
- sources:
  * request_input: ipc.content_provider — ContentProvider query/openFile reachable from another app via content:// URI; review the URI, selection, and selectionArgs for SQL injection and path traversal.
- callees:
  * db.rawQuery (…ExportedProvider.kt:23)
  * dbHelper.writableDatabase.execSQL (…ExportedProvider.kt:27)
```

## Plumbing

`android-provider` is registered as a mobile protocol (`Endpoint::MOBILE_PROTOCOLS`), so it is excluded from HTTP-shaped output/delivery (cURL/OpenAPI/probe) and the optimizer leaves the `content://` URL intact; it renders under a `PROVIDER` prefix in plain output.

## Tests / docs

- Fixtures: exported provider with handler source (→ linked SQL sinks + `ipc.content_provider`), a permission/grant/path-permission-guarded provider, a multi-authority provider, plus negatives (not-exported, default).
- Unit + functional specs; EN/KO docs updated.
- Full suite green (`crystal spec spec/unit_test` 3364, `spec/functional_test` 18256, 0 failures), `crystal tool format --check` + ameba clean.

## Known follow-ups (deliberately deferred)

- The **effective per-path permission** of a `<path-permission>` is flagged (`path_permissions: true`) but not resolved into separate path-scoped endpoints — the override/fallback semantics are FP-prone and warrant their own pass.
- `grantUriPermissions` on a *non-exported* provider (FileProvider-style temporary grants) is a subtler surface, not covered here.