### PR TITLE
fix(javascript): real-world FP/FN accuracy sweep — TS ESM mounts, SPA-client filter, Fastify autoload, param-regex

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_frontend_client_skip/server.js
+++ b/spec/functional_test/fixtures/javascript/express_frontend_client_skip/server.js
@@ -1,0 +1,6 @@
+const express = require('express');
+const app = express();
+
+app.get('/api/health', (req, res) => res.json({ ok: true }));
+
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/express_frontend_client_skip/web/store.js
+++ b/spec/functional_test/fixtures/javascript/express_frontend_client_skip/web/store.js
@@ -1,0 +1,20 @@
+// SPA store: a wrapped axios client (`api`) makes OUTBOUND calls. These
+// are NOT route registrations — the pinia import marks this as browser
+// code, so its `api.get(...)` / `api.post(...)` calls must be skipped
+// rather than emitted as phantom Express endpoints.
+import { defineStore } from 'pinia';
+import api from './api';
+
+export const useUsers = defineStore('users', {
+  actions: {
+    load(id) {
+      return api.get(`/users/${id}`);
+    },
+    create(payload) {
+      return api.post('/users', payload);
+    },
+    remove(id) {
+      return api.delete(`/users/${id}`);
+    },
+  },
+});

--- a/spec/functional_test/fixtures/javascript/express_param_constraint/app.js
+++ b/spec/functional_test/fixtures/javascript/express_param_constraint/app.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const app = express();
+
+// path-to-regexp param constraints: the `(...)` group after a `:param`
+// narrows the match but is noise for the endpoint surface. Each route
+// should normalize to the bare param (`:id`, `:name`, `:pk`) with no
+// phantom param leaking from the constraint body.
+app.get('/users/:id([0-9]+)', (req, res) => res.json({}));
+app.get('/files/:name([a-z]+)', (req, res) => res.json({}));
+app.delete('/items/:pk([0-9a-f-]+)', (req, res) => res.json({}));
+
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/express_ts_esm_mount/app.ts
+++ b/spec/functional_test/fixtures/javascript/express_ts_esm_mount/app.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+// TypeScript ESM (moduleResolution: NodeNext) imports its OWN sibling
+// `.ts` sources through a `.js` specifier. The files on disk are
+// `controllers/users.ts` and `controllers/posts.ts`.
+import usersRouter from './controllers/users.js';
+import postsRouter from './controllers/posts.js';
+
+const app = express();
+
+app.use('/users', usersRouter);
+app.use('/posts', postsRouter);
+
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/express_ts_esm_mount/controllers/posts.ts
+++ b/spec/functional_test/fixtures/javascript/express_ts_esm_mount/controllers/posts.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/', (req, res) => res.json({}));
+router.post('/', (req, res) => res.json({}));
+
+export default router;

--- a/spec/functional_test/fixtures/javascript/express_ts_esm_mount/controllers/users.ts
+++ b/spec/functional_test/fixtures/javascript/express_ts_esm_mount/controllers/users.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/me', (req, res) => res.json({}));
+router.get('/:id', (req, res) => res.json({}));
+
+export default router;

--- a/spec/functional_test/fixtures/javascript/fastify_autoload/app.ts
+++ b/spec/functional_test/fixtures/javascript/fastify_autoload/app.ts
@@ -1,0 +1,14 @@
+import Fastify from 'fastify';
+import fastifyAutoload from '@fastify/autoload';
+import path from 'node:path';
+
+const app = Fastify();
+
+// @fastify/autoload derives each route file's prefix from its directory
+// path relative to `dir`. `routes/api/tasks/index.ts` therefore mounts
+// under `/api/tasks`, even though the file registers `app.get('/:id')`.
+app.register(fastifyAutoload, {
+  dir: path.join(import.meta.dirname, 'routes'),
+});
+
+app.listen({ port: 3000 });

--- a/spec/functional_test/fixtures/javascript/fastify_autoload/routes/api/tasks/index.ts
+++ b/spec/functional_test/fixtures/javascript/fastify_autoload/routes/api/tasks/index.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance } from 'fastify';
+
+export default async function (app: FastifyInstance) {
+  app.get('/:id', async (request) => ({ id: (request.params as any).id }));
+  app.post('/', async (request) => {
+    const { title } = request.body as any;
+    return { title };
+  });
+}

--- a/spec/functional_test/fixtures/javascript/fastify_autoload/routes/home.ts
+++ b/spec/functional_test/fixtures/javascript/fastify_autoload/routes/home.ts
@@ -1,0 +1,5 @@
+import { FastifyInstance } from 'fastify';
+
+export default async function (app: FastifyInstance) {
+  app.get('/', async () => ({ root: true }));
+}

--- a/spec/functional_test/testers/javascript/express_frontend_client_skip_spec.cr
+++ b/spec/functional_test/testers/javascript/express_frontend_client_skip_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# A wrapped HTTP client (`import api from './api'`) hides the raw axios
+# instance behind a local module, so the axios import marker can't see
+# it. The client-side UI framework import (pinia) is the signal that
+# `web/store.js` is browser code: its `api.get(...)`/`api.post(...)`
+# calls are outbound requests, not route registrations, and must be
+# skipped. Only the real Express route survives.
+expected_endpoints = [
+  Endpoint.new("/api/health", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/express_frontend_client_skip/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/express_param_constraint_spec.cr
+++ b/spec/functional_test/testers/javascript/express_param_constraint_spec.cr
@@ -1,0 +1,14 @@
+require "../../func_spec.cr"
+
+# Express param regex constraints (`:id([0-9]+)`) normalize down to the
+# bare param. The constraint body must not leak a phantom path param.
+expected_endpoints = [
+  Endpoint.new("/users/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/files/:name", "GET", [Param.new("name", "", "path")]),
+  Endpoint.new("/items/:pk", "DELETE", [Param.new("pk", "", "path")]),
+]
+
+FunctionalTester.new("fixtures/javascript/express_param_constraint/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/express_ts_esm_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/express_ts_esm_mount_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+# TypeScript ESM (`moduleResolution: NodeNext`) imports a sibling `.ts`
+# source through a `.js` specifier (`import usersRouter from
+# './controllers/users.js'` where the file on disk is `users.ts`).
+# The cross-file router-mount resolver must rewrite the `.js` extension
+# to its `.ts` counterpart, otherwise the mount prefix never attaches
+# and every sub-route loses it (`/me` instead of `/users/me`).
+expected_endpoints = [
+  Endpoint.new("/users/me", "GET"),
+  Endpoint.new("/users/:id", "GET"),
+  Endpoint.new("/posts/", "GET"),
+  Endpoint.new("/posts/", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/express_ts_esm_mount/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/fastify_autoload_spec.cr
+++ b/spec/functional_test/testers/javascript/fastify_autoload_spec.cr
@@ -1,0 +1,15 @@
+require "../../func_spec.cr"
+
+# `@fastify/autoload` mounts each route file under a prefix derived from
+# its directory path relative to the autoload `dir`. A route registered
+# as `app.get('/:id')` inside `routes/api/tasks/index.ts` is served at
+# `/api/tasks/:id`; a route file directly in `routes/` keeps `/`.
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/api/tasks/:id", "GET"),
+  Endpoint.new("/api/tasks/", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/fastify_autoload/", {
+  :techs => 1,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -23,6 +23,12 @@ module Analyzer::Javascript
     MOUNT_IDENT_RES    = MOUNT_CALL_NAMES.map { |c| {c, /(\w+)\.#{c}\s*\(\s*(\w+)\s*,\s*/} }.to_h
     MOUNT_ARRAY_RES    = MOUNT_CALL_NAMES.map { |c| {c, /(\w+)\.#{c}\s*\(\s*\[([^\]]+)\]\s*,\s*/m} }.to_h
 
+    # TypeScript ESM (`moduleResolution: NodeNext`) imports a sibling `.ts`
+    # source through a `.js`-family specifier. Map each JS extension to the
+    # TS source extension(s) it can stand in for, so `resolve_require_path`
+    # can fall back to the real on-disk file when the literal path is absent.
+    JS_TO_TS_EXT = {".js" => [".ts", ".tsx"], ".jsx" => [".tsx"], ".mjs" => [".mts"], ".cjs" => [".cts"]}
+
     # Type alias for file context used in two-pass processing
     alias FileContext = NamedTuple(
       require_map: Hash(String, String),
@@ -1086,6 +1092,25 @@ module Analyzer::Javascript
         [".js", ".ts", ".jsx", ".tsx"].each do |ext|
           with_ext = "#{resolved}#{ext}"
           return with_ext if File.file?(with_ext)
+        end
+      end
+
+      # Case 2b: TypeScript ESM extension rewrite. With tsconfig
+      # `moduleResolution: NodeNext`, TS source imports its OWN sibling
+      # `.ts` modules through a `.js` (or `.mjs`/`.cjs`/`.jsx`) specifier:
+      #   import usersRouter from './controllers/users.js'  // file is users.ts
+      # The literal `.js` path doesn't exist on disk, so Case 1 misses and
+      # Case 2 is skipped (the specifier already ends in a known ext).
+      # Without this, every cross-file router mount in a modern TS project
+      # (directus mounts ~40 controllers this way) fails to resolve and the
+      # sub-routes lose their mount prefix (`/me` instead of `/users/me`).
+      # Swap the JS extension for its TS counterpart before giving up.
+      JS_TO_TS_EXT.each do |js_ext, ts_exts|
+        next unless require_path.ends_with?(js_ext)
+        base = resolved[0...(resolved.size - js_ext.size)]
+        ts_exts.each do |ts_ext|
+          candidate = "#{base}#{ts_ext}"
+          return candidate if File.file?(candidate)
         end
       end
 

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -1,6 +1,7 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "../../../utils/url_path"
 
 module Analyzer::Javascript
   class Fastify < JavascriptEngine
@@ -9,12 +10,25 @@ module Analyzer::Javascript
       static_dirs = [] of Hash(String, String)
       include_callee = callees_needed?
 
+      # `@fastify/autoload` derives each route file's prefix from its
+      # directory path relative to the autoload `dir` — the standard
+      # Fastify project layout (`fastify-cli` scaffolds it, the official
+      # `fastify/demo` uses it). A route registered as `app.get('/:id')`
+      # inside `routes/api/tasks/index.ts` is actually served at
+      # `/api/tasks/:id`. Resolve those directory roots once up front so
+      # the per-file pass can prepend the convention-derived prefix.
+      autoload_roots = collect_autoload_roots
+
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
+          autoload_prefix = autoload_prefix_for(path, autoload_roots)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|
+            unless autoload_prefix.empty?
+              endpoint.url = Noir::URLPath.join(autoload_prefix, endpoint.url)
+            end
             # Preserve the precise route line supplied by the shared extractor.
             # Falling back to path-only keeps older behavior if a parser result
             # somehow lacks location metadata.
@@ -43,7 +57,7 @@ module Analyzer::Javascript
           # never a real config — issue #1903).
           unless Noir::JSRouteExtractor.test_stub_only?(path, content) ||
                  Noir::JSRouteExtractor.minified_content?(content)
-            extract_route_configs(path, content, result, include_callee)
+            extract_route_configs(path, content, result, include_callee, autoload_prefix)
           end
 
           collect_static_paths(path, content, static_dirs, :fastify)
@@ -66,11 +80,66 @@ module Analyzer::Javascript
       process_js_static_dirs(static_dirs, result)
     end
 
+    # Markers that a file configures `@fastify/autoload`. Both the scoped
+    # package and the legacy bare name are matched so older projects work.
+    AUTOLOAD_MARKERS = ["@fastify/autoload", "fastify-autoload"]
+
+    # Discover the absolute directory roots that `@fastify/autoload`
+    # registers. Each `register(autoload, { dir: <expr> })` names a tree
+    # whose subdirectories become route prefixes. `dir` is conventionally
+    # `path.join(import.meta.dirname, 'routes')` / `join(__dirname, 'a',
+    # 'b')`, so the directory is the config file's own directory plus the
+    # string-literal segments of the `dir` expression. Returns the longest
+    # roots first so `autoload_prefix_for` can match the most specific.
+    private def collect_autoload_roots : Array(String)
+      roots = [] of String
+      all_files.each do |path|
+        next unless ExpressConstants::JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
+        content = read_file_content(path)
+        next unless AUTOLOAD_MARKERS.any? { |m| content.includes?(m) }
+        next unless content.includes?("dir")
+
+        base_dir = File.dirname(File.expand_path(path))
+        content.scan(/\bdir\s*:\s*/) do |m|
+          value_start = m.end(0) || 0
+          value_end = route_config_value_end(content, value_start)
+          value = content[value_start...value_end]
+          segments = [] of String
+          value.scan(/['"]([^'"]+)['"]/) { |sm| segments << sm[1] }
+          next if segments.empty?
+
+          root = File.expand_path(File.join([base_dir] + segments))
+          roots << root unless roots.includes?(root)
+        end
+      rescue
+        next
+      end
+      roots.sort_by! { |r| -r.size }
+      roots
+    end
+
+    # Compute the autoload-derived prefix for a file: the path of the
+    # file's directory relative to the most specific autoload root that
+    # contains it. `@fastify/autoload` ignores the filename (an `index.ts`
+    # and a sibling `tasks.ts` in `routes/api/` both mount at `/api`), so
+    # only the directory contributes. A file directly in a root yields ""
+    # (mounted at "/"), which leaves its routes untouched.
+    private def autoload_prefix_for(path : String, roots : Array(String)) : String
+      return "" if roots.empty?
+      file_dir = File.dirname(File.expand_path(path))
+      roots.each do |root|
+        next unless file_dir == root || file_dir.starts_with?("#{root}/")
+        relative = file_dir == root ? "" : file_dir[(root.size + 1)..]
+        return relative.empty? ? "" : "/#{relative}"
+      end
+      ""
+    end
+
     # Walks a file for `fastify.route({ ... })` registrations that the
     # shared parser misses: the config object may span multiple lines,
     # and `methods` may be an array. For each block, decode the method
     # (or methods) and the url/path and emit one endpoint per method.
-    private def extract_route_configs(path : String, content : String, result : Array(Endpoint), include_callee : Bool)
+    private def extract_route_configs(path : String, content : String, result : Array(Endpoint), include_callee : Bool, autoload_prefix : String = "")
       http_methods = %w[get post put delete patch options head]
 
       # Match the call site `instance.route(` and walk the balanced
@@ -115,6 +184,8 @@ module Analyzer::Javascript
         end
 
         next if methods.empty? || url.empty?
+
+        url = Noir::URLPath.join(autoload_prefix, url) unless autoload_prefix.empty?
 
         # Compute line number from the call site offset.
         line_no = content[0...call_start].count('\n') + 1

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -195,6 +195,12 @@ module Noir
 
     JS_RESOLVE_EXTENSIONS = ["ts", "tsx", "js", "jsx", "mjs", "cjs"]
 
+    # TypeScript ESM (`moduleResolution: NodeNext`) imports a sibling `.ts`
+    # source through a `.js`-family specifier — `import x from './a.js'`
+    # where the file on disk is `a.ts`. Map each JS extension to the TS
+    # source extension(s) it can stand in for.
+    JS_TO_TS_EXT = {".js" => [".ts", ".tsx"], ".jsx" => [".tsx"], ".mjs" => [".mts"], ".cjs" => [".cts"]}
+
     def self.resolve_relative_import(from_file : String,
                                      import_specifier : String,
                                      extensions : Array(String) = JS_RESOLVE_EXTENSIONS,
@@ -214,7 +220,22 @@ module Noir
       # nothing. Mirrors Node's behaviour for fully-qualified
       # `./foo.ts` imports.
       if extensions.any? { |ext| import_specifier.ends_with?(".#{ext}") }
-        return File.exists?(combined) ? combined : nil
+        return combined if File.exists?(combined)
+
+        # TS ESM fallback: a `.js`-family specifier resolves to the
+        # sibling `.ts` source when the literal `.js` file is absent.
+        # Without this, cross-file route discovery in every modern TS
+        # project (which compiles to ESM and imports `./x.js`) silently
+        # fails to follow the import.
+        JS_TO_TS_EXT.each do |js_ext, ts_exts|
+          next unless import_specifier.ends_with?(js_ext)
+          base = combined[0...(combined.size - js_ext.size)]
+          ts_exts.each do |ts_ext|
+            candidate = "#{base}#{ts_ext}"
+            return candidate if File.exists?(candidate)
+          end
+        end
+        return
       end
 
       extensions.each do |ext|

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -214,8 +214,24 @@ module Noir
       # "/Object" and sneak past `valid_route_path?`'s "/" check.
       routes.select! { |r| valid_route_path?(r.path) }
 
-      # Ensure all routes have leading slash for consistency
+      # Strip Express param regex constraints (`:id(\d+)`, `:pk(${UUID_REGEX})`)
+      # down to the bare param, then ensure a leading slash. The constraint
+      # group is path-to-regexp syntax that narrows a param's match; it is
+      # noise for the endpoint surface and, when it carries an interpolated
+      # constant like `${UUID_REGEX}`, leaves an ugly literal `({UUID_REGEX})`
+      # plus a phantom `UUID_REGEX` path param. Done once here so every
+      # emission path (fast_scan, express, chained, array) is covered.
       routes.each do |route_item|
+        stripped = strip_param_regex_constraints(route_item.path)
+        if stripped != route_item.path
+          route_item.path = stripped
+          # Drop path params that only existed inside the removed constraint.
+          route_item.params.reject! do |p|
+            p.param_type == "path" &&
+              !stripped.includes?(":#{p.name}") &&
+              !stripped.includes?("{#{p.name}}")
+          end
+        end
         route_item.path = "/#{route_item.path}" unless route_item.path.starts_with?("/")
       end
 
@@ -1309,6 +1325,45 @@ module Noir
       #   - starts with ":" (bare param routes like `app.get(":id", …)`).
       return false unless path.includes?("/") || path == "*" || path.starts_with?(":")
       true
+    end
+
+    # Remove path-to-regexp constraint groups that directly follow an
+    # Express `:param` — `:id(\d+)` → `:id`, `:pk(${UUID_REGEX})` → `:pk`.
+    # Only a `(` immediately after a `:identifier` is treated as a
+    # constraint, so standalone groups like `/(?:a|b)/` are left intact.
+    private def strip_param_regex_constraints(path : String) : String
+      return path unless path.includes?(":") && path.includes?("(")
+
+      result = String::Builder.new(path.bytesize)
+      i = 0
+      len = path.size
+      while i < len
+        ch = path[i]
+        result << ch
+        i += 1
+        next unless ch == ':'
+
+        name_start = i
+        while i < len && (path[i].alphanumeric? || path[i] == '_')
+          result << path[i]
+          i += 1
+        end
+
+        # A `(` right after the param name opens a constraint group —
+        # drop it and its balanced contents without emitting anything.
+        if i > name_start && i < len && path[i] == '('
+          depth = 0
+          while i < len
+            c = path[i]
+            depth += 1 if c == '('
+            depth -= 1 if c == ')'
+            i += 1
+            break if depth == 0
+          end
+        end
+      end
+
+      result.to_s
     end
 
     private def extract_path_params(path : String) : Array(Param)

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -496,6 +496,38 @@ module Noir
       "require(\"@apollo/datasource-rest\")", "require('@apollo/datasource-rest')",
     ]
 
+    # Client-side UI framework imports. A file that imports a browser
+    # UI framework (Vue, React, Angular, Svelte, Solid, Preact) and its
+    # satellite libs (pinia, vue-router, @vueuse, react-router, ...) is
+    # SPA/frontend code, not an HTTP server. Its route-shaped calls are
+    # outbound API-client requests against a configured client — e.g.
+    # directus's admin app does `api.get(`/users/${userId}`)` where `api`
+    # is a wrapped axios instance imported from `@/api`. The existing
+    # axios/got/ky markers miss these because the wrapper hides the raw
+    # client behind a local module, but the UI-framework import is an
+    # unambiguous "this is browser code" signal. directus's admin SPA
+    # alone parks ~61 phantom Express endpoints across
+    # `app/src/{stores,composables,layouts,...}` this way. Like the
+    # test-stub markers, this is gated by the HTTP-server-import
+    # exemption below: an SSR entrypoint that imports BOTH vue and
+    # express keeps its routes.
+    CLIENT_SIDE_FRAMEWORK_MARKERS = [
+      "from \"vue\"", "from 'vue'",
+      "from \"@vue/", "from '@vue/",
+      "from \"vue-router\"", "from 'vue-router'",
+      "from \"@vueuse/", "from '@vueuse/",
+      "from \"pinia\"", "from 'pinia'",
+      "from \"react\"", "from 'react'",
+      "from \"react-dom", "from 'react-dom",
+      "from \"react-router", "from 'react-router",
+      "from \"@angular/", "from '@angular/",
+      "from \"svelte\"", "from 'svelte'",
+      "from \"svelte/", "from 'svelte/",
+      "from \"solid-js", "from 'solid-js",
+      "from \"preact\"", "from 'preact'",
+      "from \"preact/", "from 'preact/",
+    ]
+
     # Real HTTP-server library imports. When any of these is present
     # alongside a test-stub marker, the file is doing legitimate
     # server work (e.g., spinning up a test instance of an Express
@@ -635,7 +667,8 @@ module Noir
     def self.test_stub_only?(file_path : String, content : String) : Bool
       return true if TEST_STUB_FILENAME_MARKERS.any? { |m| file_path.includes?(m) }
       return true if STRICT_TEST_PATH_MARKERS.any? { |m| file_path.includes?(m) }
-      has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) }
+      has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) } ||
+                    CLIENT_SIDE_FRAMEWORK_MARKERS.any? { |m| content.includes?(m) }
       has_path_marker = TEST_STUB_PATH_MARKERS.any? { |m| file_path.includes?(m) }
       return false unless has_library || has_path_marker
       HTTP_SERVER_LIBRARY_MARKERS.none? { |m| content.includes?(m) }


### PR DESCRIPTION
## Summary

Accuracy sweep of the JavaScript/TypeScript analyzers against ~25 real OSS apps (directus, strapi, immich, payloadcms, fastify/demo, koa/express realworld, honohub, …). Four cross-cutting endpoint bugs surfaced — all hurting real apps while passing the existing fixtures. **Net effect on the corpus: 58 phantom endpoints removed and ~154 routes corrected to their true mounted paths, with scan time flat-to-faster** (the SPA filter skips files, so large frontends parse less).

This is an enrichment of an already-solid base — clean apps (e.g. express-realworld) were already 20/20 correct; these fixes close the gaps that only modern real-world layouts expose.

## Fixes

### 1. TypeScript ESM `.js`→`.ts` import resolution
`router_mount_scanner.cr`, `import_graph.cr`

Modern TS projects (`tsconfig` `moduleResolution: NodeNext`/`Bundler`) import a sibling **`.ts`** source through a **`.js`** specifier:

```ts
// app.ts — file on disk is controllers/users.ts
import usersRouter from './controllers/users.js';
app.use('/users', usersRouter);
```

The resolver treated a specifier already ending in `.js` as exact, found no `users.js` on disk, and gave up — so **every cross-file router mount failed** and the controller's routes lost their mount prefix (`/me` instead of `/users/me`). directus mounts 42 controllers this way; all now resolve. Fixed in both the Express mount scanner and the shared `ImportGraph.resolve_relative_import` (used by Hono/Hapi cross-file discovery).

### 2. SPA-client false-positive filter
`js_route_extractor.cr`

Frontend code calling a wrapped axios client renders as phantom routes:

```ts
// directus app/src/... — `api` is a wrapped axios instance from '@/api'
import { defineStore } from 'pinia';
api.get(`/users/${userId}`);   // outbound call, NOT a registration
```

The existing axios/got/ky markers miss these because the wrapper hides the raw client. Files that import a **client-side UI framework** (Vue/React/Angular/Svelte/Solid/Preact + satellites like pinia/vue-router/@vueuse/react-router) and **no** HTTP-server lib are now skipped — gated by the same HTTP-server-import exemption as the existing test-stub markers, so an SSR entrypoint importing both `vue` and `express` keeps its routes. **directus −53, payloadcms −3, honohub −2; zero real endpoints lost** (every drop verified to be a `.ts/.tsx` frontend file).

### 3. Fastify `@fastify/autoload` directory prefix
`fastify.cr`

`@fastify/autoload` (the standard `fastify-cli` / `fastify/demo` layout) derives each route file's prefix from its directory path relative to the autoload `dir`. A route registered as `app.get('/:id')` inside `routes/api/tasks/index.ts` is served at `/api/tasks/:id`. noir now resolves the autoload roots and prepends the convention-derived prefix: `/login`→`/api/auth/login`, `/:id`→`/api/tasks/:id`, etc.

### 4. Express param regex-constraint normalization
`js_parser.cr`

path-to-regexp constraints `:id(\d+)` / `:pk(${UUID_REGEX})` now normalize to the bare `:id` / `:pk`, and no longer leak a phantom path param (`UUID_REGEX`) from the constraint body. Only a `(` directly after a `:param` is stripped, so standalone groups like `/(?:a|b)/` are untouched.

## Validation

- 4 new regression fixtures (`express_ts_esm_mount`, `express_frontend_client_skip`, `fastify_autoload`, `express_param_constraint`).
- **Full functional suite: 18276 examples, 0 failures**; unit: 3360, 0 failures.
- `crystal tool format --check` + `ameba` clean.
- Benchmark (best of 3, large apps): directus 6.1s→5.7s, payload 7.1s→5.3s, immich 2.0s→1.8s — maintained or faster.

## Known follow-ups (not in this PR)
- Koa `router.use('/api', sub.routes())` cross-file nested-mount prefix (koa-realworld serves `/api/*`; noir still emits `/*`).
- Residual SPA false positives from util/composable files that hit `@/api` without importing a UI framework (8 left in directus).