### PR TITLE
fix(detector): detect embedded JVM servers inside Android source sets

### DIFF
--- a/spec/unit_test/detector/mobile/android_scope_spec.cr
+++ b/spec/unit_test/detector/mobile/android_scope_spec.cr
@@ -43,6 +43,66 @@ describe "Detector Android source scope" do
       cleanup_scope(root)
     end
   end
+
+  it "detects an embedded Ktor server living inside the Android source set" do
+    # An Android app can bundle an on-device HTTP server whose routes
+    # live under app/src/main/java/... — an incidental import would be
+    # scoped out, but a real `routing { }` / `io.ktor.server` construct
+    # must still surface (e.g. plain-app's local web server).
+    root = File.tempname("noir-android-embedded")
+
+    begin
+      src = File.join(root, "app", "src", "main", "java", "com", "example", "web")
+      FileUtils.mkdir_p(src)
+      File.write(File.join(root, "app", "src", "main", "AndroidManifest.xml"), %(<manifest package="com.example.app"/>))
+      File.write(
+        File.join(src, "HttpModule.kt"),
+        <<-KOTLIN
+        package com.example.web
+        import io.ktor.server.routing.routing
+        import io.ktor.server.routing.get
+        fun Application.httpModule() {
+          routing {
+            get("/health") { }
+          }
+        }
+        KOTLIN
+      )
+
+      techs = detect_scope(root)
+      techs.should contain("android")
+      techs.should contain("kotlin_ktor")
+    ensure
+      cleanup_scope(root)
+    end
+  end
+
+  it "does not treat an Android app's incidental Ktor client import as a server" do
+    # `io.ktor.client.*` with no routing construct is just an HTTP
+    # client — it must not flag the Android app as a Ktor server.
+    root = File.tempname("noir-android-ktor-client")
+
+    begin
+      src = File.join(root, "app", "src", "main", "java", "com", "example", "net")
+      FileUtils.mkdir_p(src)
+      File.write(File.join(root, "app", "src", "main", "AndroidManifest.xml"), %(<manifest package="com.example.app"/>))
+      File.write(
+        File.join(src, "ApiClient.kt"),
+        <<-KOTLIN
+        package com.example.net
+        import io.ktor.client.HttpClient
+        import io.ktor.client.request.get
+        suspend fun fetch(client: HttpClient) = client.get("https://example.com")
+        KOTLIN
+      )
+
+      techs = detect_scope(root)
+      techs.should contain("android")
+      techs.should_not contain("kotlin_ktor")
+    ensure
+      cleanup_scope(root)
+    end
+  end
 end
 
 private def detect_scope(root : String) : Array(String)

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -72,6 +72,18 @@ MOBILE_DETECTOR_NAMES = Set{
   "well_known_applinks",
 }
 
+# Strong server-routing constructs. A `.kt` / `.java` file that sits
+# inside an Android app's source set is normally scoped to mobile
+# detectors only (an incidental `import ...SpringApplication` must not
+# flag the project as a server). But an Android app can legitimately
+# *embed* an on-device HTTP server — e.g. plain-app runs a local Ktor
+# web server whose routes live under `app/src/main/java/...`. When a
+# file carries one of these markers it is a real server, so the
+# Ktor / http4k / Spring detectors are allowed to run on it. Kept as a
+# single precompiled constant — recompiling it per file would recreate
+# the PCRE2 program on every read.
+ANDROID_EMBEDDED_SERVER_MARKER = /io\.ktor\.server\.|embeddedServer|\brouting\s*\{|\bfun\s+Route\.|org\.http4k\.routing|@RestController|@RequestMapping|@(?:Get|Post|Put|Delete|Patch)Mapping|\bRouterFunction\b/
+
 def detector_android_source_prefixes_for_manifest(manifest_path : String) : Array(String)
   prefixes = [] of String
   manifest_dir = File.dirname(manifest_path)
@@ -475,13 +487,22 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               detector_list.each_with_index do |detector, idx|
                 candidate_detector_indices << idx if detector.applicable?(full_path)
               end
-              if detector_android_source_file?(full_path, android_source_prefixes)
-                candidate_detector_indices.reject! do |idx|
-                  !detector_mobile_detector?(detector_list[idx].name)
-                end
+
+              # An Android source-set file is normally narrowed to the
+              # mobile detectors only (see ANDROID_EMBEDDED_SERVER_MARKER /
+              # the Android-source scope spec). The exception — a genuine
+              # embedded on-device server — can only be told apart from an
+              # incidental framework import by reading the file, so defer
+              # the narrowing until after the content read below.
+              android_source_file = detector_android_source_file?(full_path, android_source_prefixes)
+              if android_source_file && candidate_detector_indices.all? { |idx| detector_mobile_detector?(detector_list[idx].name) }
+                # No server detector is even applicable here, so the
+                # marker check cannot change the outcome — keep the
+                # content-free fast path.
+                android_source_file = false
               end
 
-              if candidate_detector_indices.empty? && active_passive_scans.empty?
+              if candidate_detector_indices.empty? && active_passive_scans.empty? && !android_source_file
                 # Keep the path visible to analyzers without paying to
                 # read/cache content that neither detection nor passive
                 # scan will inspect. Analyzer reads still fall back to
@@ -496,6 +517,23 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 logger.debug "Skipping #{full_path}: binary content (file is text-extension but bytes look binary)"
                 skipped_files += 1
                 next
+              end
+
+              # Apply the Android-source narrowing now that content is
+              # available: drop the server-framework detectors unless the
+              # file carries a real server-routing construct (an embedded
+              # on-device server).
+              if android_source_file && !content.matches?(ANDROID_EMBEDDED_SERVER_MARKER)
+                candidate_detector_indices.reject! do |idx|
+                  !detector_mobile_detector?(detector_list[idx].name)
+                end
+                if candidate_detector_indices.empty? && active_passive_scans.empty?
+                  # Nothing left to detect and no passive scan to run.
+                  # register_file already records the path in file_map and
+                  # caches the (already-read) content for the analyzers.
+                  locator.register_file(full_path, content)
+                  next
+                end
               end
 
               if full_path.ends_with?(".json") && !content.matches?(generic_json_spec_marker)


### PR DESCRIPTION
## Summary

A `.kt` / `.java` file under an Android app's source set (`app/src/main/java|kotlin/...`) is currently scoped to the **mobile detectors only**, so an incidental `import org.springframework...SpringApplication` in an Activity does not falsely flag the project as a server framework (the [Android-source scope spec](spec/unit_test/detector/mobile/android_scope_spec.cr)).

That blanket rule also hid **genuinely embedded on-device servers**. [`plain-app`](https://github.com/ismartcoding/plain-app) runs a local **Ktor** web server whose routes live entirely under `app/src/main/java/...`, so `kotlin_ktor` was never detected and **all 14 of its REST endpoints were missed** — only the 5 Android deep-link intents surfaced.

## Fix

Defer the mobile-only narrowing until the file content is available, and keep the Ktor / http4k / Spring detectors when the file carries a **real server-routing construct**:

```
io.ktor.server.  |  embeddedServer  |  routing {  |  fun Route.
org.http4k.routing
@RestController  |  @RequestMapping  |  @Get/Post/Put/Delete/PatchMapping  |  RouterFunction
```

Incidental **client** imports (`io.ktor.client.*`) carry no routing construct, so the existing "don't treat app imports as server signals" guarantee is preserved. Files with no server detector applicable keep the content-free fast path; the marker check only reads content for Android-source files that already have a JVM web-framework detector applicable.

## Impact

| App | before | after |
|-----|-------:|------:|
| plain-app (embedded Ktor server in an Android app) | 0 Ktor | **14 Ktor** |

The rest of the Kotlin OSS corpus (ktor-samples, http4k, kcrud, ktask, notykt, petclinic-kotlin, …) is unchanged. Scan time on non-Android projects is unchanged; on a large pure-Android app the only added cost is reading source files that have a JVM web-framework import but no routing construct (well under the run-to-run noise).

## Tests

- New scope specs: an embedded Ktor server inside the Android source set **is** detected; an incidental Ktor **client** import is **not**.
- Existing `android_scope_spec` (incidental `SpringApplication` import not flagged; sibling server module still detected) still passes.
- Full suite green (`crystal spec`: 21,604 examples, 0 failures).