### PR TITLE
fix(javascript/koa): resolve cross-file `.routes()` nested-mount prefixes

### DIFF
--- a/spec/functional_test/fixtures/javascript/koa_nested_mount/app.js
+++ b/spec/functional_test/fixtures/javascript/koa_nested_mount/app.js
@@ -1,0 +1,7 @@
+const Koa = require('koa');
+const router = require('./routes');
+
+const app = new Koa();
+app.use(router.routes());
+
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/koa_nested_mount/routes/articles-router.js
+++ b/spec/functional_test/fixtures/javascript/koa_nested_mount/routes/articles-router.js
@@ -1,0 +1,7 @@
+const Router = require('koa-router');
+const router = new Router();
+
+router.get('/articles', (ctx) => {});
+router.get('/articles/:slug', (ctx) => {});
+
+module.exports = router.routes();

--- a/spec/functional_test/fixtures/javascript/koa_nested_mount/routes/index.js
+++ b/spec/functional_test/fixtures/javascript/koa_nested_mount/routes/index.js
@@ -1,0 +1,15 @@
+const Router = require('koa-router');
+const router = new Router();
+const api = new Router();
+
+const users = require('./users-router');
+const articles = require('./articles-router');
+
+// Aggregate sub-routers into `api` (no prefix), then mount `api` under
+// /api via the koa-router `.routes()` middleware chain.
+api.use(users);
+api.use(articles);
+
+router.use('/api', api.routes());
+
+module.exports = router;

--- a/spec/functional_test/fixtures/javascript/koa_nested_mount/routes/users-router.js
+++ b/spec/functional_test/fixtures/javascript/koa_nested_mount/routes/users-router.js
@@ -1,0 +1,8 @@
+const Router = require('koa-router');
+const router = new Router();
+
+router.post('/users', (ctx) => {});
+router.post('/users/login', (ctx) => {});
+router.get('/user', (ctx) => {});
+
+module.exports = router.routes();

--- a/spec/functional_test/testers/javascript/koa_nested_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_nested_mount_spec.cr
@@ -1,0 +1,20 @@
+require "../../func_spec.cr"
+
+# koa-router mounts sub-routers through a `.routes()` middleware chain:
+#   api.use(usersRouter)              // usersRouter = require('./users-router')
+#   router.use('/api', api.routes())  // api aggregated under /api
+# Every sub-router's route must inherit the `/api` prefix even though the
+# sub-routers live in separate files and `api`/`router` are local
+# aggregators with no backing file.
+expected_endpoints = [
+  Endpoint.new("/api/users", "POST"),
+  Endpoint.new("/api/users/login", "POST"),
+  Endpoint.new("/api/user", "GET"),
+  Endpoint.new("/api/articles", "GET"),
+  Endpoint.new("/api/articles/:slug", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/koa_nested_mount/", {
+  :techs     => 1,
+  :endpoints => 5,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/koa_spec.cr
+++ b/spec/functional_test/testers/javascript/koa_spec.cr
@@ -6,9 +6,12 @@ expected_endpoints = [
   Endpoint.new("/users/:id", "GET", [
     Param.new("id", "", "path"),
   ]),
-  Endpoint.new("/info", "GET"),
+  # Cross-file koa-router `.routes()` mounts carry their app.js prefix:
+  #   app.use('/app_prefix', appRouter.routes())  -> /app_prefix/info
+  #   app.use('/api/v1', apiV1Routes.routes())    -> /api/v1/status
+  Endpoint.new("/app_prefix/info", "GET"),
   Endpoint.new("/admin/settings", "GET"),
-  Endpoint.new("/status", "GET"),
+  Endpoint.new("/api/v1/status", "GET"),
   Endpoint.new("/simple", "GET"),
   Endpoint.new("/items/:itemId", "DELETE", [
     Param.new("itemId", "", "path"),

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -1,5 +1,8 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_route_extractor"
+require "../../../miniparsers/import_graph"
+require "../../../models/code_locator"
+require "../../../utils/url_path"
 
 module Analyzer::Javascript
   class Koa < JavascriptEngine
@@ -7,6 +10,16 @@ module Analyzer::Javascript
       result = [] of Endpoint
       static_dirs = [] of Hash(String, String)
       include_callee = callees_needed?
+
+      # koa-router mounts sub-routers through a `.routes()` middleware
+      # chain that the Express-oriented mount scanner can't model:
+      #   const api = new Router()
+      #   api.use(usersRouter)                 // usersRouter = require('./users-router')
+      #   router.use('/api', api.routes())     // api aggregated under /api
+      # Resolve those chains up front and seed each imported child file's
+      # prefix into CodeLocator so the per-file pass emits `/api/users`
+      # instead of a bare `/users`.
+      resolve_koa_mount_prefixes
 
       parallel_file_scan([".js", ".ts", ".mjs"]) do |path|
         begin
@@ -49,6 +62,108 @@ module Analyzer::Javascript
       process_static_dirs(static_dirs, result)
 
       result
+    end
+
+    # Resolve koa-router cross-file mount prefixes and seed them into
+    # CodeLocator under each imported child router's file key. Each file
+    # that does the mounting is resolved independently — the common layout
+    # has one aggregator file (`routes/index.js`) wiring every sub-router.
+    private def resolve_koa_mount_prefixes
+      locator = CodeLocator.instance
+      boundary = @base_path
+
+      all_files.each do |path|
+        next unless [".js", ".ts", ".mjs", ".cjs"].any? { |ext| path.ends_with?(ext) }
+        content = read_file_content(path)
+        # Cheap gate: the mount chain always pairs `.use(` with `.routes(`.
+        next unless content.includes?(".use(") && content.includes?(".routes(")
+        next if Noir::JSRouteExtractor.minified_content?(content)
+
+        # Map local identifiers to the router file they import.
+        imports = Hash(String, String).new
+        record_import = ->(var : String, spec : String) do
+          resolved = Noir::ImportGraph.resolve_relative_import(path, spec, boundary: boundary)
+          imports[var] = resolved if resolved
+        end
+        content.scan(/(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |m|
+          record_import.call(m[1], m[2]) if m.size >= 3
+        end
+        content.scan(/import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/) do |m|
+          record_import.call(m[1], m[2]) if m.size >= 3
+        end
+
+        # Collect mount edges: parent.use('/prefix', child[.routes()]) and
+        # the no-prefix parent.use(child[.routes()]). A bare `child` or a
+        # `child.routes()` wrapper is a router; a `factory()` call (e.g.
+        # `bodyParser()`) is middleware and never matches these shapes.
+        edges = [] of Tuple(String, String, String)
+        content.scan(/(\w+)\.use\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)(?:\.routes\s*\(\s*\))?\s*\)/) do |m|
+          edges << {m[1], m[2], m[3]} if m.size >= 4
+        end
+        content.scan(/(\w+)\.use\s*\(\s*(\w+)(?:\.routes\s*\(\s*\))?\s*\)/) do |m|
+          edges << {m[1], "", m[2]} if m.size >= 3
+        end
+        next if edges.empty?
+
+        prefixes = resolve_mount_edge_prefixes(edges)
+
+        prefixes.each do |router_var, router_prefixes|
+          file = imports[router_var]?
+          next unless file
+          key = Analyzer::Javascript::ExpressConstants.file_key(File.expand_path(file))
+          router_prefixes.each do |prefix|
+            next if prefix.empty?
+            locator.push(key, prefix) unless locator.all(key).includes?(prefix)
+          end
+        end
+      rescue e
+        logger.debug "koa mount prefix resolution failed for #{path}: #{e.message}"
+      end
+    end
+
+    # Resolve every router variable's mount prefix(es) from the edge list.
+    # A variable that is never mounted into another (a root aggregator like
+    # the exported `router`) carries the empty prefix; children inherit the
+    # parent's prefix joined with the edge's own prefix. Iterated to a
+    # fixpoint so a two-level chain (root -> api -> child) fully resolves.
+    private def resolve_mount_edge_prefixes(edges : Array(Tuple(String, String, String))) : Hash(String, Array(String))
+      children = edges.map { |_, _, child| child }.to_set
+      prefixes = Hash(String, Array(String)).new { |h, k| h[k] = [] of String }
+
+      # Seed roots (never a mount target) with the empty prefix.
+      edges.each do |parent, _, _|
+        prefixes[parent] << "" if !children.includes?(parent) && prefixes[parent].empty?
+      end
+
+      max_iterations = 16
+      iterations = 0
+      changed = true
+      while changed && iterations < max_iterations
+        changed = false
+        iterations += 1
+        edges.each do |parent, prefix, child|
+          # Propagate only from a resolved parent (a seeded root or an
+          # already-resolved child). Defaulting an unresolved parent to ""
+          # would leak a wrong prefix (`/sub` instead of `/api/sub`).
+          parent_prefixes = prefixes[parent]?
+          next if parent_prefixes.nil? || parent_prefixes.empty?
+          parent_prefixes.each do |pp|
+            combined = if pp.empty?
+                         prefix
+                       elsif prefix.empty?
+                         pp
+                       else
+                         Noir::URLPath.join(pp, prefix)
+                       end
+            unless prefixes[child].includes?(combined)
+              prefixes[child] << combined
+              changed = true
+            end
+          end
+        end
+      end
+
+      prefixes
     end
 
     # Match Strapi's declarative route entries: object literals

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -266,7 +266,13 @@ module Noir
     # attacker-controlled checkout and pre-existing symlinks on the
     # scanner's disk pointing at sensitive paths.
     private def self.under_boundary?(combined : String, boundary : String) : Bool
-      boundary_abs = File.expand_path(boundary)
+      # `File.expand_path` does NOT strip a trailing separator in Crystal, so
+      # a caller passing `-b project/` would yield `boundary_abs` ending in
+      # `/`, making the `boundary_abs + SEPARATOR` prefix a `//` that no real
+      # path starts with — every import would be (wrongly) rejected as
+      # out-of-boundary. Chomp the trailing separator so the check is robust
+      # to both `project` and `project/` forms.
+      boundary_abs = File.expand_path(boundary).chomp(File::SEPARATOR)
       combined == boundary_abs || combined.starts_with?(boundary_abs + File::SEPARATOR)
     end
   end


### PR DESCRIPTION
## Summary

Follow-up to #2007 (JS accuracy sweep). koa-router aggregates sub-routers through a `.routes()` middleware chain that the Express-oriented mount scanner can't model, so every sub-router lost its mount prefix.

```js
// routes/index.js
const api = new Router();
const users = require('./users-router');     // exports `router.routes()`
api.use(users);                               // aggregate into `api` (no prefix)
router.use('/api', api.routes());             // mount `api` under /api
```

`api` and `router` are **local aggregators with no backing file**, and the `.routes()` wrapper hides the router reference — neither fits the Express `app`-rooted, file-keyed model. Result: koa-realworld served `/users` instead of `/api/users`, and the existing koa fixture literally encoded the bug (`app.use('/app_prefix', appRouter.routes())` was emitted as a bare `/info`, with a code comment noting the prefix *should* apply).

## Fix

A koa-specific pre-pass (`resolve_koa_mount_prefixes`) runs before the per-file scan:
1. For each file that mounts routers, parse its imports and `.use()` edges — `parent.use('/prefix', child.routes())` and the no-prefix `parent.use(child)`. A bare identifier or `child.routes()` is a router; a `factory()` call is middleware and never matches.
2. Resolve every router variable's prefix to a fixpoint: a router never mounted into another (a root aggregator) carries the empty prefix; children inherit `parent + edge` prefix. This handles the two-level `router → api → child` chain.
3. Seed each **imported** child router's resolved prefix into `CodeLocator` under its file key, so the shared extractor emits `/api/users` instead of `/users`.

Contained to the Koa analyzer (only runs when koa is detected); strapi (255 endpoints) and koa-examples (5) are unchanged — they don't use prefixed `.routes()` chains.

### Latent boundary bug (also fixed)
`ImportGraph.resolve_relative_import`'s boundary check used `File.expand_path(boundary)`, but Crystal's `File.expand_path` does **not** strip a trailing separator. A boundary of `project/` therefore produced a `project//` prefix that no real path starts with, so **every** import was rejected as out-of-boundary. This silently broke cross-file resolution whenever the scan base carried a trailing slash (which the spec harness always does). Chomping the separator makes `project` and `project/` behave identically.

## Validation

- koa-realworld: all 19 routes now correctly carry `/api` (`/api/users`, `/api/articles/:slug`, `/api/profiles/:username`, …).
- New `koa_nested_mount` fixture; the existing koa fixture's `/info`/`/status` updated to the now-correct `/app_prefix/info`/`/api/v1/status`.
- Full functional suite **18288 examples, 0 failures**; `crystal tool format --check` + `ameba` clean.
- Regression-checked koa-examples (5→5), strapi (286→286, koa 255→255) — unchanged.