### PR TITLE
chore(lint): fix ameba violations breaking main CI

### DIFF
--- a/spec/unit_test/detector/mobile/android_scope_spec.cr
+++ b/spec/unit_test/detector/mobile/android_scope_spec.cr
@@ -58,15 +58,15 @@ describe "Detector Android source scope" do
       File.write(
         File.join(src, "HttpModule.kt"),
         <<-KOTLIN
-        package com.example.web
-        import io.ktor.server.routing.routing
-        import io.ktor.server.routing.get
-        fun Application.httpModule() {
-          routing {
-            get("/health") { }
+          package com.example.web
+          import io.ktor.server.routing.routing
+          import io.ktor.server.routing.get
+          fun Application.httpModule() {
+            routing {
+              get("/health") { }
+            }
           }
-        }
-        KOTLIN
+          KOTLIN
       )
 
       techs = detect_scope(root)
@@ -89,11 +89,11 @@ describe "Detector Android source scope" do
       File.write(
         File.join(src, "ApiClient.kt"),
         <<-KOTLIN
-        package com.example.net
-        import io.ktor.client.HttpClient
-        import io.ktor.client.request.get
-        suspend fun fetch(client: HttpClient) = client.get("https://example.com")
-        KOTLIN
+          package com.example.net
+          import io.ktor.client.HttpClient
+          import io.ktor.client.request.get
+          suspend fun fetch(client: HttpClient) = client.get("https://example.com")
+          KOTLIN
       )
 
       techs = detect_scope(root)

--- a/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr
@@ -499,7 +499,7 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
         KT
 
       resources = Noir::TreeSitterKotlinKtorRouteExtractor.extract_resource_classes(source)
-      resources.map(&.simple_name).sort.should eq(["VideoPage", "VideoStream"])
+      resources.map(&.simple_name).sort!.should eq(["VideoPage", "VideoStream"])
     end
 
     it "resolves resource<T> { } as a prefix wrapper for nested verbs and method/handle" do
@@ -525,7 +525,7 @@ describe Noir::TreeSitterKotlinKtorRouteExtractor do
       resources = Noir::TreeSitterKotlinKtorRouteExtractor.extract_resource_classes(source)
       paths = Noir::TreeSitterKotlinKtorRouteExtractor.compose_resource_paths(resources)
       routes = Noir::TreeSitterKotlinKtorRouteExtractor.extract_routes(source, resource_paths: paths)
-      routes.map { |r| {r.verb, r.path} }.sort.should eq([
+      routes.map { |r| {r.verb, r.path} }.sort!.should eq([
         {"GET", "/login"},
         {"POST", "/login"},
       ])

--- a/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_ktor_route_extractor_ts.cr
@@ -292,7 +292,7 @@ module Noir
     # annotation detached from the class that follows. Returns the path,
     # or nil for any other node.
     private def detached_resource_path(node : LibTreeSitter::TSNode, source : String) : String?
-      return nil unless Noir::TreeSitter.node_type(node) == "prefix_expression"
+      return unless Noir::TreeSitter.node_type(node) == "prefix_expression"
       ann : LibTreeSitter::TSNode? = nil
       paren : LibTreeSitter::TSNode? = nil
       Noir::TreeSitter.each_named_child(node) do |c|
@@ -303,7 +303,7 @@ module Noir
       end
       a = ann
       p = paren
-      return nil unless a && p
+      return unless a && p
 
       is_resource = false
       Noir::TreeSitter.each_named_child(a) do |c|
@@ -311,7 +311,7 @@ module Noir
           is_resource = simple_type_name(Noir::TreeSitter.node_text(c, source)) == "Resource"
         end
       end
-      return nil unless is_resource
+      return unless is_resource
 
       result : String? = nil
       Noir::TreeSitter.each_named_child(p) do |c|


### PR DESCRIPTION
## Problem

The `lint` job in main's CI is **red** — `crystal tool format --check` passes but `ameba` reports **7 violations** introduced by recent merges (#2008 mobile, #2009 Ktor). The per-PR workflow only lints changed files, so these full-repo findings slipped through.

```
1448 inspected, 7 failures
```

## Fix

All 7 are `[Correctable]` and behaviour-preserving:

| File | Count | Rule | Change |
|------|-------|------|--------|
| `src/miniparsers/kotlin_ktor_route_extractor_ts.cr` | 3 | `Style/RedundantNilInControlExpression` | `return nil unless …` → `return unless …` (method returns `String?`; bare `return` already yields `nil`) |
| `spec/.../kotlin_ktor_route_extractor_ts_spec.cr` | 2 | `Performance/ChainedCallWithNoBang` | `.map(...).sort` → `.sort!` on the freshly-mapped temporary array |
| `spec/.../mobile/android_scope_spec.cr` | 2 | `Style/HeredocIndent` | heredoc body re-indented +2; `<<-` strips the closing-delimiter indent so the embedded Kotlin source is byte-identical |

## Validation

- `ameba` now: **1448 inspected, 0 failures**.
- `crystal tool format --check`: clean.
- Affected specs (`android_scope_spec`, `kotlin_ktor_route_extractor_ts_spec`): 32 examples, 0 failures — behaviour unchanged.