### PR TITLE
fix(javascript/nestjs): resolve cross-file enum/const @Controller prefixes

### DIFF
--- a/spec/functional_test/fixtures/typescript/nestjs_cross_file_enum/src/assets.controller.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_cross_file_enum/src/assets.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get } from '@nestjs/common';
+import { RouteKey } from './enum';
+
+@Controller(RouteKey.Asset)
+export class AssetsController {
+  @Get('statistics')
+  statistics() {
+    return {};
+  }
+}

--- a/spec/functional_test/fixtures/typescript/nestjs_cross_file_enum/src/enum.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_cross_file_enum/src/enum.ts
@@ -1,0 +1,4 @@
+export enum RouteKey {
+  User = 'users',
+  Asset = 'assets',
+}

--- a/spec/functional_test/fixtures/typescript/nestjs_cross_file_enum/src/users.controller.ts
+++ b/spec/functional_test/fixtures/typescript/nestjs_cross_file_enum/src/users.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { RouteKey } from './enum';
+
+// The controller prefix is an enum member imported from another file.
+@Controller(RouteKey.User)
+export class UsersController {
+  @Get('me')
+  me() {
+    return {};
+  }
+
+  @Get(':id')
+  show(@Param('id') id: string) {
+    return { id };
+  }
+}

--- a/spec/functional_test/testers/typescript/nestjs_cross_file_enum_spec.cr
+++ b/spec/functional_test/testers/typescript/nestjs_cross_file_enum_spec.cr
@@ -1,0 +1,17 @@
+require "../../func_spec.cr"
+
+# `@Controller(RouteKey.User)` where `RouteKey` is an enum defined in a
+# different file (`./enum`) and imported. The controller prefix must
+# resolve cross-file (`users`/`assets`), not collapse to "" — which would
+# leave bare `/me`, `/:id`, `/statistics` and even merge `/:id` from two
+# controllers into one.
+expected_endpoints = [
+  Endpoint.new("/users/me", "GET"),
+  Endpoint.new("/users/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/assets/statistics", "GET"),
+]
+
+FunctionalTester.new("fixtures/typescript/nestjs_cross_file_enum/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -24,8 +24,39 @@ module Analyzer::Javascript
       end
     end
 
+    # Project-wide `EnumName.Member` / `Object.prop` -> value map, used to
+    # resolve `@Controller(...)` prefix constants imported from another
+    # file. nil until `analyze_with_extensions` seeds it.
+    @nest_global_literals : Hash(String, Array(String))? = nil
+
+    # Extensions worth scanning for cross-file enum/object constants —
+    # the enum may live in a `.ts` file even when the route-scan pass only
+    # walks `.js`, so cast a wide net here.
+    GLOBAL_LITERAL_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
+
     def analyze
       analyze_with_extensions([".js", ".jsx"])
+    end
+
+    # Scan every JS/TS source for `enum Foo { Bar = 'x' }` / `const Obj =
+    # { k: 'v' } as const` definitions and keep only the DOTTED keys
+    # (`Foo.Bar`, `Obj.k`) — those are the shape used cross-file as a
+    # `@Controller`/`@Get` prefix. Bare-identifier consts are file-local
+    # and collision-prone, so they stay per-file. Gated on the cheap
+    # `enum `/`as const` substrings so most files are skipped outright.
+    private def collect_global_literal_values : Hash(String, Array(String))
+      acc = Hash(String, Array(String)).new
+      all_files.each do |path|
+        next unless GLOBAL_LITERAL_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
+        content = read_file_content(path)
+        next unless content.includes?("enum ") || content.includes?("as const")
+        extract_literal_values(content).each do |key, value|
+          acc[key] = value if key.includes?(".") && !acc.has_key?(key)
+        end
+      rescue
+        next
+      end
+      acc
     end
 
     protected def analyze_with_extensions(extensions : Array(String)) : Array(Endpoint)
@@ -34,6 +65,13 @@ module Analyzer::Javascript
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       global_prefix_holder = [] of GlobalPrefixConfig
       global_prefix_mutex = Mutex.new
+
+      # Resolve enum/object constants used cross-file as `@Controller(...)`
+      # prefixes before the parallel scan so each file's per-file literal
+      # table can fall back to them (immich mounts every asset/user/...
+      # controller via `@Controller(RouteKey.User)` where `RouteKey` lives
+      # in `src/enum.ts`). Built once, single-fiber, then read-only.
+      @nest_global_literals = collect_global_literal_values
 
       parallel_file_scan(extensions) do |path|
         next if ignored_nest_path?(path)
@@ -248,6 +286,11 @@ module Analyzer::Javascript
     private def analyze_nestjs_controllers(content : String, path : String, result : Array(Endpoint), include_callee : Bool)
       # Split content by controllers and process each separately
       literal_values = extract_literal_values(content)
+      # Back-fill cross-file enum/object constants (per-file definitions
+      # already in `literal_values` win — they are the more specific source).
+      if global = @nest_global_literals
+        global.each { |key, value| literal_values[key] = value unless literal_values.has_key?(key) }
+      end
       controllers = extract_controllers(content, literal_values)
 
       controllers.each do |controller_info|


### PR DESCRIPTION
## Summary

NestJS controllers commonly set their prefix from an enum member defined in another file:

```ts
// src/enum.ts
export enum RouteKey { User = 'users', Asset = 'assets' }

// src/users.controller.ts
import { RouteKey } from './enum';
@Controller(RouteKey.User)   // serves /users
export class UsersController {
  @Get('me')  me()  {}       // /users/me
  @Get(':id') show() {}      // /users/:id
}
```

The analyzer resolved `EnumName.Member` / `Object.prop` constants only within the **same file** (`extract_literal_values` scans the current file's `enum`/`const` bodies). A cross-file prefix expression therefore missed the literal table and fell back to `""` — **every route in the controller lost its prefix**.

On immich this mis-pathed **~46 routes** — `/api/me` instead of `/api/users/me`, `/api/statistics` instead of `/api/assets/statistics` — and several distinct endpoints even **collapsed under the global `(method, url)` dedup** (`GET /api/:id` pointed at *both* `asset.controller.ts` and `user.controller.ts`). String-literal `@Controller('albums')` controllers were unaffected, isolating the bug to enum-constant prefixes.

## Fix

Build a project-wide map of **dotted** enum/object-const literals (`RouteKey.User → 'users'`) once, before the parallel scan, and back-fill it into each file's per-file literal table (per-file definitions still win — they're more specific). Implementation notes:
- Gated on the cheap `enum `/`as const` substrings, so files without an enum are skipped outright.
- Only dotted keys (`Enum.Member`, `Obj.prop`) are kept — bare-identifier consts are file-local and collision-prone.
- Built eagerly (single fiber) so the parallel route scan only reads it.

immich `ts_nestjs` now emits the correctly-prefixed `/api/users/me`, `/api/users/:id`, `/api/assets/statistics`, `/api/assets/:id`, … and the bare `/api/me`, `/api/:id`, `/api/statistics`, `/api/` phantoms are gone.

## Validation
- New `nestjs_cross_file_enum` fixture.
- immich re-scan: 0 mangled routes remain; all `/api/users/*` & `/api/assets/*` present.
- Scan time flat (immich ~2.0s — the pre-scan skips every file without an `enum`).
- Full functional suite **18359 examples, 0 failures**; `crystal tool format --check` + `ameba` clean.