### PR TITLE
fix(javascript/nextjs): follow `export * from` route re-exports + destructured verb exports

### DIFF
--- a/spec/functional_test/fixtures/javascript/nextjs_reexport/app/api/(old)/projects/route.ts
+++ b/spec/functional_test/fixtures/javascript/nextjs_reexport/app/api/(old)/projects/route.ts
@@ -1,0 +1,3 @@
+// Wholesale re-export — the verb handlers live in ../../analytics/route.
+// The (old) route group is stripped, so this is served at /api/projects.
+export * from "../../analytics/route";

--- a/spec/functional_test/fixtures/javascript/nextjs_reexport/app/api/analytics/route.ts
+++ b/spec/functional_test/fixtures/javascript/nextjs_reexport/app/api/analytics/route.ts
@@ -1,0 +1,3 @@
+export async function GET(request: Request) {
+  return Response.json({ ok: true });
+}

--- a/spec/functional_test/fixtures/javascript/nextjs_reexport/app/api/workflows/route.ts
+++ b/spec/functional_test/fixtures/javascript/nextjs_reexport/app/api/workflows/route.ts
@@ -1,0 +1,6 @@
+import { serve } from "@upstash/workflow/nextjs";
+
+// Handler destructured from a factory call.
+export const { POST } = serve(async (context) => {
+  await context.run("step", () => ({}));
+});

--- a/spec/functional_test/fixtures/javascript/nextjs_reexport/package.json
+++ b/spec/functional_test/fixtures/javascript/nextjs_reexport/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nextjs-reexport-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "next": "15.5.15"
+  }
+}

--- a/spec/functional_test/testers/javascript/nextjs_reexport_spec.cr
+++ b/spec/functional_test/testers/javascript/nextjs_reexport_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+# Next.js app-router edge cases:
+#   * `export * from "<route>"` re-exports the target route's verb
+#     handlers — resolved cross-file and emitted at the re-exporting
+#     file's own URL (`/api/projects` from `(old)/projects/route.ts`).
+#   * `export const { POST } = serve(...)` destructures handlers from a
+#     factory call.
+expected_endpoints = [
+  Endpoint.new("/api/analytics", "GET"),
+  Endpoint.new("/api/projects", "GET"),
+  Endpoint.new("/api/workflows", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/nextjs_reexport/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -1,6 +1,7 @@
 require "../../engines/javascript_engine"
 require "../../../miniparsers/js_callee_extractor"
 require "../../../miniparsers/js_route_extractor"
+require "../../../miniparsers/import_graph"
 
 module Analyzer::Javascript
   class Nextjs < JavascriptEngine
@@ -9,9 +10,13 @@ module Analyzer::Javascript
 
     # Compiled once per verb — interpolated regex literals would otherwise
     # be rebuilt (full PCRE2 compile) for every method on every file.
-    EXPORT_VERB_FUNCTION_RES     = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b/} }.to_h
-    EXPORT_VERB_CONST_RES        = HTTP_METHODS.map { |m| {m, /export\s+const\s+#{m}\s*=/} }.to_h
-    EXPORT_VERB_BRACE_RES        = HTTP_METHODS.map { |m| {m, /export\s+\{[^}]*\b#{m}\b[^}]*\}/} }.to_h
+    EXPORT_VERB_FUNCTION_RES = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b/} }.to_h
+    EXPORT_VERB_CONST_RES    = HTTP_METHODS.map { |m| {m, /export\s+const\s+#{m}\s*=/} }.to_h
+    EXPORT_VERB_BRACE_RES    = HTTP_METHODS.map { |m| {m, /export\s+\{[^}]*\b#{m}\b[^}]*\}/} }.to_h
+    # `export const { POST } = serve<Input>(...)` — handler(s) destructured
+    # from a factory call (e.g. @upstash/workflow/nextjs). The plain brace
+    # regex misses it because `const` sits between `export` and `{`.
+    EXPORT_VERB_CONST_BRACE_RES  = HTTP_METHODS.map { |m| {m, /export\s+const\s+\{[^}]*\b#{m}\b[^}]*\}\s*=/} }.to_h
     EXPORT_VERB_FUNCTION_SIG_RES = HTTP_METHODS.map { |m| {m, /export\s+(?:async\s+)?function\s+#{m}\b\s*\([^)]*\)/} }.to_h
     EXPORT_VERB_CONST_ARROW_RES  = HTTP_METHODS.map { |m| {m, /export\s+const\s+#{m}\s*=\s*(?:async\s*)?(?:\([^)]*\)|\w+)(?:\s*:\s*[^=]+?)?\s*=>/} }.to_h
 
@@ -130,6 +135,7 @@ module Analyzer::Javascript
       sanitized = Noir::JSRouteExtractor.strip_js_comments(content)
 
       methods = extract_app_router_methods(sanitized)
+      methods = methods_from_reexport(path, sanitized) if methods.empty?
       return if methods.empty?
 
       methods.each do |method|
@@ -384,11 +390,40 @@ module Analyzer::Javascript
       HTTP_METHODS.each do |m|
         if content.match(EXPORT_VERB_FUNCTION_RES[m]) ||
            content.match(EXPORT_VERB_CONST_RES[m]) ||
-           content.match(EXPORT_VERB_BRACE_RES[m])
+           content.match(EXPORT_VERB_BRACE_RES[m]) ||
+           content.match(EXPORT_VERB_CONST_BRACE_RES[m])
           methods << m
         end
       end
       methods
+    end
+
+    # An app-router `route.ts` may re-export its verb handlers wholesale
+    # from another route via `export * from "<spec>"` (dub uses this for
+    # ~18 alias routes). The file itself carries no verb token, so resolve
+    # the target relative to this file, read it, and report ITS methods —
+    # emitted at the current file's URL by the caller. Bounded recursion
+    # follows a chain of re-exports.
+    private def methods_from_reexport(path : String, content : String, depth : Int32 = 0) : Array(String)
+      return [] of String if depth > 3
+      specs = [] of String
+      content.scan(/export\s+\*\s+from\s+['"]([^'"]+)['"]/) { |m| specs << m[1] }
+      return [] of String if specs.empty?
+
+      methods = [] of String
+      specs.each do |spec|
+        target = Noir::ImportGraph.resolve_relative_import(path, spec, boundary: @base_path)
+        next unless target
+        begin
+          target_content = Noir::JSRouteExtractor.strip_js_comments(read_file_content(target))
+        rescue
+          next
+        end
+        found = extract_app_router_methods(target_content)
+        found = methods_from_reexport(target, target_content, depth + 1) if found.empty?
+        methods.concat(found)
+      end
+      methods.uniq
     end
 
     private def extract_pages_router_params(content : String, endpoint : Endpoint)


### PR DESCRIPTION
## Summary

Two Next.js **App Router** shapes left real endpoints undetected (found auditing dub):

### 1. `export * from "<route>"` re-exports
An app-router `route.ts` can re-export another route's verb handlers wholesale:
```ts
// app/api/(old)/projects/route.ts
export * from "../../workspaces/route";
```
dub uses this for ~18 alias routes. The file carries no verb token, so `extract_app_router_methods` returned empty and the route was **dropped entirely**. Now, when a route file yields no methods, the `export *` target is resolved relative to the file (via `ImportGraph`, which already handles `.js`→`.ts` and extension resolution), read, and **its** methods are adopted — emitted at the *re-exporting* file's own URL. Bounded recursion follows a chain of re-exports. (`export { GET } from "x"` was already covered by the brace regex.)

### 2. `export const { POST } = serve(...)` destructured handlers
```ts
export const { POST } = serve<Input>(async (context) => { ... });
```
Handlers destructured from a factory call (e.g. `@upstash/workflow/nextjs`). The plain brace regex missed it because `const` sits between `export` and `{`. Added `EXPORT_VERB_CONST_BRACE_RES`.

## Validation
On dub: `/api/projects` (GET/POST), `/api/callback/stripe` (POST), `/api/workspaces/{idOrSlug}/stats/{endpoint}` (GET), `/api/analytics/{eventType}` (GET), `/api/workflows/create-partner-commission` & `/api/workflows/partner-approved` (POST) are now recovered.

- New `nextjs_reexport` fixture.
- Full functional suite **18367 examples, 0 failures**; `crystal tool format --check` + `ameba` clean.