### PR TITLE
fix(javascript/hono): resolve `.basePath('/prefix')` app prefix

### DIFF
--- a/spec/functional_test/fixtures/javascript/hono_basepath/src/index.ts
+++ b/spec/functional_test/fixtures/javascript/hono_basepath/src/index.ts
@@ -1,0 +1,13 @@
+import { Hono } from 'hono'
+
+// basePath chained on construction.
+const app = new Hono().basePath('/api')
+app.get('/users', (c) => c.json([]))
+app.post('/users/:id', (c) => c.json({}))
+
+// basePath attached after construction.
+const v2 = new Hono()
+v2.basePath('/v2')
+v2.get('/ping', (c) => c.text('pong'))
+
+export default app

--- a/spec/functional_test/testers/javascript/hono_basepath_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_basepath_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Hono attaches its app prefix via `.basePath('/api')`, either chained on
+# construction (`const app = new Hono().basePath('/api')`) or on an
+# existing instance (`v2.basePath('/v2')`). Routes registered on the
+# instance must carry that prefix.
+expected_endpoints = [
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/users/:id", "POST", [Param.new("id", "", "path")]),
+  Endpoint.new("/v2/ping", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/hono_basepath/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints).perform_tests

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -357,13 +357,45 @@ module Noir
         if @tokens[idx].type == :identifier &&
            idx + 4 < @tokens.size &&
            @tokens[idx + 1].type == :dot &&
-           @tokens[idx + 2].value == "prefix" &&
+           # Koa/@koa-router `router.prefix('/api')` and Hono
+           # `app.basePath('/api')` both attach a prefix to an existing
+           # instance.
+           (@tokens[idx + 2].value == "prefix" || @tokens[idx + 2].value == "basePath") &&
            @tokens[idx + 3].type == :lparen
           router_var = @tokens[idx].value
           route_path_entries_from_args(idx + 4).each do |prefix_entry|
             prefix = prefix_entry.path
             router_prefixes[router_var] << prefix unless router_prefixes[router_var].includes?(prefix)
             router_variables.add(router_var)
+          end
+        end
+        idx += 1
+      end
+
+      # Hono attaches its prefix via a `.basePath('/api')` chained directly
+      # onto construction: `const app = new Hono().basePath('/api')`. The
+      # `.basePath` receiver is the `new Hono()` expression (a `)` token),
+      # so the post-construction scan above misses it — walk forward from
+      # an `ident = new ...` assignment to the chained `.basePath(...)`
+      # within the same statement.
+      idx = 0
+      while idx < @tokens.size - 3
+        if @tokens[idx].type == :identifier &&
+           @tokens[idx + 1].value == "=" &&
+           @tokens[idx + 2].value == "new"
+          router_var = @tokens[idx].value
+          j = idx + 3
+          while j + 1 < @tokens.size && @tokens[j].value != ";" && (j - idx) <= 16
+            break if j > idx + 3 && @tokens[j].value == "=" # next statement (no semicolon)
+            if @tokens[j].value == "basePath" && @tokens[j + 1].type == :lparen
+              route_path_entries_from_args(j + 2).each do |prefix_entry|
+                prefix = prefix_entry.path
+                router_prefixes[router_var] << prefix unless router_prefixes[router_var].includes?(prefix)
+                router_variables.add(router_var)
+              end
+              break
+            end
+            j += 1
           end
         end
         idx += 1


### PR DESCRIPTION
## Summary

Hono sets its application prefix with a chained `.basePath('/api')` call, which noir's prefix scanner didn't recognize — so every route registered on the instance lost it (`POST /hello` instead of `POST /api/hello`). Handle both shapes in `scan_router_constructor_prefixes`:

- **construction-chained** — `const app = new Hono().basePath('/api')` — by walking forward from the `ident = new ...` assignment to the chained `.basePath(...)` within the same statement (bounded; stops at the next statement).
- **post-construction** — `app.basePath('/api')` — by extending the existing Koa `.prefix(...)` instance scan to also match `.basePath`.

## Validation
- New `hono_basepath` fixture (both shapes).
- Full functional suite **18367 examples, 0 failures**; `crystal tool format --check` + `ameba` clean.

## Deferred
Hono sub-app `.route('/prefix', child)` mounts — both same-file local (`const book = new Hono(); app.route('/book', book)`) and cross-file anonymous-chain (`new Hono().use(...).route('/api', TodoAPI)`) — interact with the existing RouterMountScanner mount handling (which already half-emits the mount path) and need a holistic reconciliation rather than a piecemeal addition. Left for a focused follow-up.