### PR TITLE
fix(javascript/hono): resolve `.route('/prefix', child)` sub-app mounts

### DIFF
--- a/spec/functional_test/fixtures/javascript/hono_route_mount/src/index.ts
+++ b/spec/functional_test/fixtures/javascript/hono_route_mount/src/index.ts
@@ -1,0 +1,11 @@
+import { Hono } from 'hono'
+
+const book = new Hono()
+book.get('/list', (c) => c.text('List'))
+book.get('/:id', (c) => c.text('Detail'))
+book.post('/', (c) => c.text('Create'))
+
+const app = new Hono()
+app.route('/book', book)
+
+export default app

--- a/spec/functional_test/fixtures/javascript/hono_route_mount_crossfile/src/index.ts
+++ b/spec/functional_test/fixtures/javascript/hono_route_mount_crossfile/src/index.ts
@@ -1,0 +1,4 @@
+import { Hono } from 'hono'
+import TodoAPI from './todo'
+
+export default new Hono().route('/api', TodoAPI)

--- a/spec/functional_test/fixtures/javascript/hono_route_mount_crossfile/src/todo.ts
+++ b/spec/functional_test/fixtures/javascript/hono_route_mount_crossfile/src/todo.ts
@@ -1,0 +1,8 @@
+import { Hono } from 'hono'
+
+const api = new Hono()
+api.get('/todos', (c) => c.json([]))
+api.post('/todos', (c) => c.json({}))
+api.delete('/todos/:id', (c) => c.json({}))
+
+export default api

--- a/spec/functional_test/testers/javascript/hono_route_mount_crossfile_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_route_mount_crossfile_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Hono mounts an imported sub-app on an anonymous fluent chain
+# (`export default new Hono().route('/api', TodoAPI)`). The child file's
+# routes inherit the `/api` prefix even though there is no named caller
+# for the mount call to bind to.
+expected_endpoints = [
+  Endpoint.new("/api/todos", "GET"),
+  Endpoint.new("/api/todos", "POST"),
+  Endpoint.new("/api/todos/:id", "DELETE", [Param.new("id", "", "path")]),
+]
+
+FunctionalTester.new("fixtures/javascript/hono_route_mount_crossfile/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/javascript/hono_route_mount_spec.cr
+++ b/spec/functional_test/testers/javascript/hono_route_mount_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Hono mounts a same-file local sub-app via `app.route('/book', book)`. The
+# sub-app's routes inherit the `/book` prefix, and the mount call itself
+# must NOT leak phantom `/book` routes (the chain scanner used to walk past
+# the two-arg `.route(...)` and mis-attribute later verb calls to it).
+expected_endpoints = [
+  Endpoint.new("/book/list", "GET"),
+  Endpoint.new("/book/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/book/", "POST"),
+]
+
+FunctionalTester.new("fixtures/javascript/hono_route_mount/", {
+  :techs     => 1,
+  :endpoints => 3,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
+++ b/src/analyzer/analyzers/javascript/express/router_mount_scanner.cr
@@ -129,6 +129,18 @@ module Analyzer::Javascript
       scan_config_array_mounts(content, main_file, locator,
         require_map, function_map, var_to_function, var_prefix, global_deferred_mounts)
 
+      # Hono sub-app mount `.route('/prefix', ChildApp)`. Unlike the
+      # `.use('/p', r)` scans above this needs no named caller — Hono
+      # commonly mounts on an anonymous fluent chain
+      # (`export default new Hono().use(...).route('/api', TodoAPI)`), so
+      # bind on the call itself. A two-argument `.route('/prefix', Ident)`
+      # is unambiguously a mount (Express's `.route('/path')` takes a
+      # single arg), and an imported `Ident` resolves to the child file
+      # whose routes inherit the prefix. Same-file local children
+      # (`const book = new Hono()`) aren't in require/function maps and are
+      # handled by the parser's first-pass `.route(...)` scan instead.
+      scan_hono_route_mounts(content, main_file, locator, require_map, function_map)
+
       # Store file context for second pass
       file_contexts[main_file] = {
         require_map:     require_map,
@@ -380,6 +392,33 @@ module Analyzer::Javascript
             end
           end
         end
+      end
+    end
+
+    # Hono `<chain>.route('/prefix', ChildApp)` mounts. Registers the
+    # prefix on the child's file when `ChildApp` is an imported router,
+    # regardless of (or in the absence of) a named caller.
+    HONO_ROUTE_MOUNT_RE = /\.route\s*\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)\s*\)/
+
+    private def scan_hono_route_mounts(
+      content : String,
+      main_file : String,
+      locator : CodeLocator,
+      require_map : Hash(String, String),
+      function_map : Hash(String, String),
+    )
+      content.scan(HONO_ROUTE_MOUNT_RE) do |m|
+        next unless m.size >= 3
+        prefix = m[1]
+        child = m[2]
+        next unless mount_prefix?(prefix)
+
+        child_file = require_map[child]? || function_map[child]?
+        next unless child_file
+
+        key = ExpressConstants.file_key(child_file)
+        push_prefix_to_locator(locator, key, prefix,
+          "Mapped Hono .route mount: #{child_file} => #{prefix}")
       end
     end
 

--- a/src/miniparsers/js_parser.cr
+++ b/src/miniparsers/js_parser.cr
@@ -115,7 +115,7 @@ module Noir
         # Pattern: identifier.use('/prefix', ...)
         if (@tokens[idx].type == :identifier) &&
            (idx + 1 < @tokens.size) && (@tokens[idx + 1].type == :dot) &&
-           (idx + 2 < @tokens.size) && (@tokens[idx + 2].value == "use" || @tokens[idx + 2].value == "register") &&
+           (idx + 2 < @tokens.size) && (@tokens[idx + 2].value == "use" || @tokens[idx + 2].value == "register" || @tokens[idx + 2].value == "route") &&
            (idx + 3 < @tokens.size) && (@tokens[idx + 3].type == :lparen) &&
            (idx + 4 < @tokens.size) &&
            (@tokens[idx + 4].type == :string ||
@@ -723,6 +723,19 @@ module Noir
            @tokens[idx + 1].type == :dot &&
            @tokens[idx + 2].value == "route" &&
            @tokens[idx + 3].type == :lparen
+          # Skip Hono sub-app mounts `app.route('/prefix', child)`: a
+          # string/template path immediately followed by a comma carries a
+          # second (router) argument, so this is a mount, not a chainable
+          # route-builder. Without this guard the chain scanner below walks
+          # past the call — across ASI statement boundaries — and
+          # mis-attributes later verb calls to `/prefix`. The mount's prefix
+          # is applied to the child via the first-pass `.route(...)` scan.
+          if idx + 5 < @tokens.size &&
+             (@tokens[idx + 4].type == :string || @tokens[idx + 4].type == :template_literal) &&
+             @tokens[idx + 5].type == :comma
+            idx += 1
+            next
+          end
           router_var = @tokens[idx].value
           # resolve path at idx+4
           paths = [] of PathEntry
@@ -1064,7 +1077,14 @@ module Noir
          idx + 3 < @tokens.size &&
          @tokens[idx + 3].type == :lparen &&
          idx + 4 < @tokens.size &&
-         @tokens[idx + 4].type == :string
+         @tokens[idx + 4].type == :string &&
+         # Only an Express route-builder `app.route('/path').get()...` — the
+         # string must be the SOLE argument (immediately followed by `)`).
+         # `app.route('/prefix', child)` is a Hono sub-app mount (two args),
+         # not a chainable route; treating it as one made the chain scanner
+         # walk forward and mis-attribute later verb calls to `/prefix`.
+         idx + 5 < @tokens.size &&
+         @tokens[idx + 5].type == :rparen
         base_path = @tokens[idx + 4].value
         router_var = @tokens[idx].value
         raw_path = base_path


### PR DESCRIPTION
## Summary

Completes the two Hono items deferred from the round-2 audit (follow-up to #2015). Hono composes sub-apps with `parent.route('/prefix', child)`, which noir left unprefixed — and worse, leaked phantom routes.

### 1. Phantom removal + same-file mounts (`js_parser.cr`)
The `app.route('/path').get()…` chain parser assumed a **single-argument** route-builder. On a two-arg mount `app.route('/book', book)` it walked forward — across ASI statement boundaries — and mis-attributed *later* verb calls to `/book` (`GET /book`, `POST /book` phantoms). Both `.route` chain scanners now bail when the path string is immediately followed by a comma (a second, router argument). With the phantom gone, `.route` is added to the first-pass mount scan, so a same-file `const book = new Hono(); app.route('/book', book)` propagates `/book` to `book`'s routes — `GET /book/:id` instead of a bare `/:id`.

### 2. Cross-file / anonymous-chain mounts (`router_mount_scanner.cr`)
Hono often mounts on an **anonymous fluent chain**:
```ts
export default new Hono().use(cors()).route('/api', TodoAPI)
```
There's no named caller for the `.use(...)` mount regexes to bind to. A new scan matches `.route('/prefix', Ident)` directly and, when `Ident` is an imported router, registers the prefix on the child's file. A two-arg `.route` with a string path is unambiguously a Hono mount (Express's `.route('/path')` is single-arg), so this never touches Express route-builders.

## Validation
- Same-file: `app.route('/book', book)` → `/book/list`, `/book/:id`, `/book/` (no phantom `/book`).
- Cross-file: `new Hono().route('/api', TodoAPI)` → `/api/todos`, `/api/todos/:id`.
- New `hono_route_mount` + `hono_route_mount_crossfile` fixtures.
- Full functional suite **18377 examples, 0 failures**; the shared `RouterMountScanner` change leaves the Express corpus unchanged (directus 277, express-rwa 20); `crystal tool format --check` + `ameba` clean.