### PR TITLE
fix(javascript): treat `.vue`/`.svelte` SFC imports as a frontend marker

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_sfc_import_skip/server.js
+++ b/spec/functional_test/fixtures/javascript/express_sfc_import_skip/server.js
@@ -1,0 +1,4 @@
+const express = require('express');
+const app = express();
+app.get('/api/health', (req, res) => res.json({ ok: true }));
+app.listen(3000);

--- a/spec/functional_test/fixtures/javascript/express_sfc_import_skip/web/module.ts
+++ b/spec/functional_test/fixtures/javascript/express_sfc_import_skip/web/module.ts
@@ -1,0 +1,13 @@
+// A Vue module-definition file: it wires up Single-File Components and
+// also fires a wrapped API client. Importing a `.vue` component marks it
+// as frontend, so the `api.patch(...)` outbound call must NOT be emitted
+// as an Express endpoint.
+import Overview from './Overview.vue';
+import api from './api';
+
+export default {
+  routes: [Overview],
+  async save(collection) {
+    await api.patch(`/collections/${collection}`, { meta: {} });
+  },
+};

--- a/spec/functional_test/testers/javascript/express_sfc_import_skip_spec.cr
+++ b/spec/functional_test/testers/javascript/express_sfc_import_skip_spec.cr
@@ -1,0 +1,14 @@
+require "../../func_spec.cr"
+
+# A file that imports a `.vue` (or `.svelte`) Single-File Component is
+# frontend by construction — its wrapped-API-client calls
+# (`api.patch('/collections/x', {...})`) are outbound requests, not route
+# registrations. Only the real Express route survives.
+expected_endpoints = [
+  Endpoint.new("/api/health", "GET"),
+]
+
+FunctionalTester.new("fixtures/javascript/express_sfc_import_skip/", {
+  :techs     => 1,
+  :endpoints => 1,
+}, expected_endpoints).perform_tests

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -526,6 +526,14 @@ module Noir
       "from \"solid-js", "from 'solid-js",
       "from \"preact\"", "from 'preact'",
       "from \"preact/", "from 'preact/",
+      # Single-File-Component imports (`import Foo from './Foo.vue'`). A
+      # file that pulls in a `.vue`/`.svelte` component is frontend by
+      # construction — a route/module definition file that wires up
+      # components and happens to call a wrapped API client. directus's
+      # `app/src/modules/**/index.ts` is the canonical case: it imports
+      # dozens of `.vue` routes and also fires `api.patch(...)`.
+      ".vue\"", ".vue'",
+      ".svelte\"", ".svelte'",
     ]
 
     # Real HTTP-server library imports. When any of these is present


### PR DESCRIPTION
## Summary

A file that imports a **Single-File Component** — `import Foo from './Foo.vue'` / `'./Foo.svelte'` — is frontend by construction. These are typically route/module-definition files that wire up components *and* fire a wrapped API client. Those `api.patch('/collections/x', {...})` calls are outbound requests, not route registrations, but they slipped past the existing client-side-framework filter (added in #2007) because such files don't import the `vue`/`svelte` **package** directly — only a `.vue`/`.svelte` file.

Add the SFC import suffixes (`.vue"`, `.vue'`, `.svelte"`, `.svelte'`) to `CLIENT_SIDE_FRAMEWORK_MARKERS`, gated as before by the HTTP-server-import exemption (so an SSR entrypoint importing both a component and express keeps its routes). No real backend route file imports an SFC.

directus `app/src/modules/**/index.ts` is the canonical case — it imports dozens of `.vue` route components and also calls `api.patch(...)`.

## Validation
- New `express_sfc_import_skip` fixture.
- Full functional suite **18421 examples, 0 failures**; corpus endpoint counts unchanged (express-rwa 20, koa-realworld 38, hono-examples 43, nestjs-realworld 21, fastify-realapp 14); `crystal tool format --check` + `ameba` clean.

## Remaining (genuine long tail)
Two directus helper files (`app/src/utils/delete-folder.ts`, `app/src/ai/composables/use-prompts.ts`) import neither a UI-framework package nor an SFC — only a wrapped `@/api`/`useApi` axios client. The only remaining signal is the outbound-call argument shape (`api.get('/x', { config })` — an options object where a route registration would have a handler function), which can't be filtered without risking Fastify's `app.get('/x', { schema }, handler)`. Left as-is.