### PR TITLE
fix(python/starlette): compose inline `Mount` prefix inside variable-assigned route lists

### DIFF
--- a/spec/functional_test/fixtures/python/starlette/app.py
+++ b/spec/functional_test/fixtures/python/starlette/app.py
@@ -115,6 +115,17 @@ nested_routes = [
     Mount('/v1', routes=v1_routes),
 ]
 
+# A variable-assigned route list that ALSO holds an *inline* Mount. The
+# list-range lookup used to short-circuit the inline mount stack, so
+# `/billing/invoices` lost its '/billing' prefix. Mounted under '/accounts'
+# below, both prefixes must compose: '/accounts' + '/billing'.
+account_routes = [
+    Route('/overview', internal_status),
+    Mount('/billing', routes=[
+        Route('/invoices', list_items),
+    ]),
+]
+
 internal_app = Starlette(routes=internal_routes)
 programmatic_app = Router()
 programmatic_app.add_route('/audit/{entry_id:int}', audit_entry, methods=['GET'])
@@ -135,6 +146,7 @@ app = Starlette(routes=[
         Route('/items/{id:int}', get_item),
     ]),
     Mount('/admin', routes=admin_routes),
+    Mount('/accounts', routes=account_routes),
     Mount('/internal', app=internal_app),
     Mount('/nested', routes=nested_routes),
     Mount('/programmatic', app=programmatic_app),

--- a/spec/functional_test/testers/python/starlette_spec.cr
+++ b/spec/functional_test/testers/python/starlette_spec.cr
@@ -42,6 +42,10 @@ expected_endpoints = [
   Endpoint.new("/internal/status", "GET", [
     Param.new("region", "", "query"),
   ]),
+  Endpoint.new("/accounts/overview", "GET", [
+    Param.new("region", "", "query"),
+  ]),
+  Endpoint.new("/accounts/billing/invoices", "GET"),
   Endpoint.new("/nested/v1/metrics/{metric_id}", "GET", [
     Param.new("metric_id", "", "path"),
     Param.new("window", "", "query"),

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -193,7 +193,7 @@ module Analyzer::Python
         end
 
         if static_path = parse_staticfiles_mount_path(effective_line)
-          route_prefixes = mounted_route_prefixes_for_line(line_index, mounted_route_list_ranges) || [mount_stack.map(&.[0]).join]
+          route_prefixes = compose_route_prefixes(line_index, mounted_route_list_ranges, mount_stack)
           route_prefixes.each do |prefix|
             result << Endpoint.new(static_route_path(normalize_route_url(prefix, static_path)), "GET", Details.new(PathInfo.new(path, line_index + 1)))
           end
@@ -221,7 +221,7 @@ module Analyzer::Python
           explicit_methods = !methods.empty?
 
           path_params = extract_path_params(route_path)
-          route_prefixes = mounted_route_prefixes_for_line(line_index, mounted_route_list_ranges) || [mount_stack.map(&.[0]).join]
+          route_prefixes = compose_route_prefixes(line_index, mounted_route_list_ranges, mount_stack)
 
           handler_params = [] of Param
           handler_callees = [] of Callee
@@ -566,6 +566,24 @@ module Analyzer::Python
       end
 
       nil
+    end
+
+    # Compose the variable-assigned route-list prefix (outer mount,
+    # resolved by name) with any active inline `Mount('/x', routes=[...])`
+    # on the paren stack (inner mount). A route nested in an inline Mount
+    # that itself lives inside a variable-assigned list (`routes = [...,
+    # Mount('/admin', routes=[Route('/x')])]; app = Starlette(routes=routes)`)
+    # matches the list range, which previously short-circuited and dropped
+    # the inline mount's `/admin` prefix entirely.
+    private def compose_route_prefixes(line_index : Int32,
+                                       mounted_route_list_ranges : Array(Tuple(Int32, Int32, Array(::String))),
+                                       mount_stack : Array(Tuple(::String, Int32))) : Array(::String)
+      mount_prefix = mount_stack.map(&.[0]).join
+      if range_prefixes = mounted_route_prefixes_for_line(line_index, mounted_route_list_ranges)
+        range_prefixes.map { |prefix| "#{prefix}#{mount_prefix}" }
+      else
+        [mount_prefix]
+      end
     end
 
     private def extract_path_params(route_path : ::String) : Array(Param)


### PR DESCRIPTION
## Summary

A route nested in an inline `Mount('/admin', routes=[Route('/x')])` that itself lives inside a **variable-assigned** route list lost the mount prefix:

```python
routes = [
    Mount('/admin', routes=[Route('/dashboard', h)]),
]
app = Starlette(routes=routes)
# emitted  GET /dashboard   (should be  GET /admin/dashboard)
```

The route line matched the variable list's range, and the range lookup short-circuited — returning the list prefix and discarding the active inline-`Mount` stack entirely.

Two related shapes already worked, which is why this slipped through:
- Inline mount directly under `Starlette(routes=[...])` (no intervening variable) ✓
- A mount that references a **named** route list (`Mount('/admin', routes=admin_routes)`) ✓

Only the combination — an inline mount *inside a variable-assigned list* — was broken.

## Fix

Compose the two prefix sources instead of letting the range lookup win outright: the variable-list range prefix (outer mount, resolved by name) joined with any active inline `Mount(...)` on the paren stack (inner mount). The route and StaticFiles-mount sites now share one `compose_route_prefixes` helper.

## Tests

Extends the starlette fixture with a variable-assigned list holding an inline `Mount`, mounted under `/accounts`, asserting both prefixes compose:
- `GET /accounts/overview`
- `GET /accounts/billing/invoices`

Full suite green: `18397 examples, 0 failures`.