### PR TITLE
fix(python/tornado): stop extracting routes from docstring code examples

### DIFF
--- a/spec/functional_test/fixtures/python/tornado/app.py
+++ b/spec/functional_test/fixtures/python/tornado/app.py
@@ -54,3 +54,22 @@ routes = [
 ]
 
 application = tornado.web.Application(routes)
+
+
+def routing_examples():
+    """Documentation for Tornado routing (these are NOT real routes).
+
+    Tornado's own source documents routing with ``code-block`` examples
+    embedded in docstrings, which must not be mistaken for endpoints:
+
+    .. code-block:: python
+
+        app = tornado.web.Application([
+            (r"/docstring-phantom", MainHandler),
+        ])
+
+        other = tornado.web.Application(handlers=[
+            (r"/docstring-phantom-2", MainHandler),
+        ])
+    """
+    return None

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -56,7 +56,17 @@ module Analyzer::Python
             api_instances = Hash(::String, ::String).new
             path_api_instances[path] = api_instances
 
+            # Tornado's own source documents routing with
+            # `.. code-block:: python` examples inside module/class
+            # docstrings — routing.py literally shows
+            # `Application([(r"/app1/handler", Handler)])`. Those are not
+            # real routes. Flag every line that begins inside a
+            # triple-quoted string so the route-detection entry points
+            # below skip them.
+            docstring_line = compute_docstring_line_flags(lines)
+
             lines.each_with_index do |line, line_index|
+              next if docstring_line[line_index]
               line = line.gsub(" ", "") # remove spaces for easier regex matching
 
               # Identify Tornado Application instance assignments
@@ -116,6 +126,52 @@ module Analyzer::Python
       end
 
       result
+    end
+
+    # For each line, whether its first character sits inside a
+    # triple-quoted string (i.e. a docstring opened on an earlier line).
+    # A single linear scan tracks the open/close `"""`/`'''` delimiters at
+    # file scope; single-line strings and `#` comments are skipped so a
+    # stray `"""` inside them doesn't flip the state.
+    private def compute_docstring_line_flags(lines : Array(::String)) : Array(Bool)
+      flags = Array(Bool).new(lines.size, false)
+      in_triple = false
+      triple_char = '\0'
+      lines.each_with_index do |line, idx|
+        flags[idx] = in_triple
+        i = 0
+        size = line.size
+        while i < size
+          c = line[i]
+          if in_triple
+            if c == triple_char && i + 2 < size && line[i + 1] == triple_char && line[i + 2] == triple_char
+              in_triple = false
+              i += 3
+              next
+            end
+            i += 1
+          elsif c == '#'
+            break # comment runs to end of line
+          elsif c == '"' || c == '\''
+            if i + 2 < size && line[i + 1] == c && line[i + 2] == c
+              in_triple = true
+              triple_char = c
+              i += 3
+              next
+            end
+            # Single-line string: skip to its (unescaped) closing quote.
+            i += 1
+            while i < size
+              break if line[i] == c && line[i - 1] != '\\'
+              i += 1
+            end
+            i += 1
+          else
+            i += 1
+          end
+        end
+      end
+      flags
     end
 
     private def join_multiline_call(lines : Array(::String), start_index : Int32) : ::String


### PR DESCRIPTION
## Summary

Tornado's own source documents routing with `.. code-block:: python` examples embedded in module/class docstrings — `tornado/routing.py` literally contains:

```python
Rule(PathMatches("/app1/.*"), Application([(r"/app1/handler", Handler)])),
```

…inside a docstring. The analyzer's route-detection entry points (`Application(...)`, `.add_handlers(...)`, module-level handler lists) fired on those lines and even produced a **malformed greedy capture**:

```
GET /app1/.*"), Application([(r"/app1/handler
```

## Root cause

The downstream tuple scanners already track triple-quoted strings, but each one starts fresh in the middle of a block, so they never knew the *enclosing* docstring was already open. The entry points had no file-scope view of docstring state.

## Fix

Track triple-quoted-string spans once at file scope (`compute_docstring_line_flags`) and skip any line that **begins inside** a docstring before route detection runs. Real `Application(...)` calls are never inside docstrings, so there's no recall cost.

## Impact

- Tornado repo: **29 → 18** endpoints (11 phantom docstring routes removed, including the malformed one).
- The fixture gains a function whose docstring holds two example `Application([...])` blocks; the exact-count assertion guards against the regression.

Full suite green: `18445 examples, 0 failures`.