### PR TITLE
fix(typescript): stop the SPA-client filter from dropping TanStack Router / tRPC routes

### DIFF
--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/react-page.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/react-page.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+
+// Regression guard: a route file that imports `react` (as real TanStack
+// Router pages do) must NOT be skipped by the client-side-framework
+// filter — its route is a definition here, not an outbound API call.
+export const Route = createFileRoute('/react-page')({
+  component: ReactPage,
+})
+
+function ReactPage() {
+  const [count] = useState(0)
+  return count
+}

--- a/spec/functional_test/fixtures/typescript/trpc/server/routers/account.ts
+++ b/spec/functional_test/fixtures/typescript/trpc/server/routers/account.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod'
+// Regression guard: a tRPC router module that pulls in `react` (e.g. an
+// RSC/client helper leaks through a shared import) must still be scanned —
+// the client-side-framework filter is for the verb-DSL extractor only.
+import { cache } from 'react'
 import { router, protectedProcedure, publicProcedure } from '../trpc'
 
 const accountProcedures = {

--- a/spec/functional_test/testers/typescript/tanstack_router_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_spec.cr
@@ -41,6 +41,10 @@ expected_endpoints = [
   # Empty file routes should emit the route without borrowing later
   # unrelated object literals as route config.
   Endpoint.new("/empty", "GET", [] of Param),
+  # A route file that imports `react` must still be scanned — the
+  # client-side-framework filter applies to the verb-DSL extractor, not
+  # to TanStack Router's own (React) route definitions.
+  Endpoint.new("/react-page", "GET", [] of Param),
 ]
 
 FunctionalTester.new("fixtures/typescript/tanstack_router/", {

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -30,7 +30,9 @@ module Analyzer::Typescript
 
       raw = read_file_content(path)
       return unless tanstack_route_candidate?(raw)
-      return if Noir::JSRouteExtractor.test_stub_only?(path, raw)
+      # TanStack Router route files are React/Vue components — don't let the
+      # client-side-framework markers skip them (they all import `react`).
+      return if Noir::JSRouteExtractor.test_stub_only?(path, raw, include_client_frameworks: false)
 
       # Comments can hold stale routes; drop them so a commented-out
       # `createFileRoute('/old')` doesn't get reported.

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -31,7 +31,10 @@ module Analyzer::Typescript
 
           raw = read_file_content(path)
           next unless trpc_candidate?(raw)
-          next if Noir::JSRouteExtractor.test_stub_only?(path, raw)
+          # tRPC router modules may import `react` (RSC/client helpers); the
+          # `createTRPCRouter`/procedure shape already gates detection, so
+          # don't let the client-side-framework markers skip them.
+          next if Noir::JSRouteExtractor.test_stub_only?(path, raw, include_client_frameworks: false)
 
           content = Noir::JSRouteExtractor.strip_js_comments(raw)
           next unless trpc_candidate?(content)

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -672,11 +672,21 @@ module Noir
     #     lib (express, fastify, ...), keep it so legit test-server
     #     harnesses (e.g. mattermost's `webhook_serve.js`) keep
     #     their routes.
-    def self.test_stub_only?(file_path : String, content : String) : Bool
+    # `include_client_frameworks` controls whether a client-side UI
+    # framework import (Vue/React/...) counts as a skip signal. It must be
+    # ON for the verb-DSL extractor (a React/Vue file calling `api.get(...)`
+    # is an outbound client call, not a route), but OFF for analyzers whose
+    # OWN route definitions live in client-side files — TanStack Router
+    # (`createFileRoute`) and tRPC route modules routinely `import { ... }
+    # from 'react'`, and skipping them on that basis dropped every such
+    # route. The test-stub *library* markers (msw/supertest/...) and path/
+    # filename markers still apply in both modes.
+    def self.test_stub_only?(file_path : String, content : String,
+                             include_client_frameworks : Bool = true) : Bool
       return true if TEST_STUB_FILENAME_MARKERS.any? { |m| file_path.includes?(m) }
       return true if STRICT_TEST_PATH_MARKERS.any? { |m| file_path.includes?(m) }
       has_library = TEST_STUB_LIBRARY_MARKERS.any? { |m| content.includes?(m) } ||
-                    CLIENT_SIDE_FRAMEWORK_MARKERS.any? { |m| content.includes?(m) }
+                    (include_client_frameworks && CLIENT_SIDE_FRAMEWORK_MARKERS.any? { |m| content.includes?(m) })
       has_path_marker = TEST_STUB_PATH_MARKERS.any? { |m| file_path.includes?(m) }
       return false unless has_library || has_path_marker
       HTTP_SERVER_LIBRARY_MARKERS.none? { |m| content.includes?(m) }


### PR DESCRIPTION
## Summary

A **regression** introduced by the SPA-client filter in #2007, surfaced while auditing the TypeScript-specific analyzers.

The client-side-framework markers (`from 'react'`, `from 'vue'`, …) were added to `test_stub_only?` so a Vue/React file's `api.get(...)` **outbound** calls wouldn't become phantom Express routes. But `test_stub_only?` is also called by the **TanStack Router** and **tRPC** analyzers — and *their* route definitions live in client-side files:

```tsx
// a TanStack Router page — a React component
import { createFileRoute } from '@tanstack/react-router'
import { useState } from 'react'          // <- this made the whole route disappear
export const Route = createFileRoute('/anchor')({ component: Anchor })
```

So every TanStack route file that imported `react` was skipped. On the official `basic-file-based` example noir dropped from **6 routes to 2** — only `route-a`/`route-b` (the two files that happen not to import `react`) survived. This silently broke **every real TanStack Router app** since #2007 (it's a React router — virtually every route file imports react).

## Fix

Gate the client-side-framework markers behind a new `include_client_frameworks` parameter on `test_stub_only?` (default **ON**, so the verb-DSL extractor and Hono's `extract_on_routes` are unchanged), and pass it **OFF** from the TanStack Router and tRPC analyzers — they already gate detection on their own framework shapes (`createFileRoute` / `createTRPCRouter`), so a client-side import is not a skip signal for them. The test-stub *library* markers (msw/supertest/…) and path/filename markers still apply in both modes. directus's SPA frontend filter (verb-DSL) is unaffected.

## Validation
- `basic-file-based` example: **2 → 6** routes (`/`, `/anchor`, `/posts`, `/posts/:postId`, `/route-a`, `/route-b`).
- documenso tRPC: 65 (unchanged); directus SPA filter: unchanged (only the 2 known long-tail helper files remain).
- Adds **react-importing** route/router files to the `tanstack_router` and `trpc` fixtures — the exact gap that let this regression ship (no existing TS fixture imported react).
- Full functional suite **18445 examples, 0 failures**; `crystal tool format --check` + `ameba` clean.