### PR TITLE
feat(zig): add Zig framework support (Jetzig, Zap, httpz, Tokamak)

### DIFF
--- a/docs/content/usage/supported/callee_coverage/index.ko.md
+++ b/docs/content/usage/supported/callee_coverage/index.ko.md
@@ -46,6 +46,7 @@ JSON, JSONL, YAML, TOML 같은 모델 기반 포맷과 plain 모델 직렬화는
 | Scala | Akka HTTP, http4s, Scalatra, ZIO HTTP |
 | Swift | Hummingbird, Kitura, Vapor |
 | TypeScript | NestJS |
+| Zig | Jetzig, Zap, httpz, Tokamak |
 
 ## 완성도 참고사항
 

--- a/docs/content/usage/supported/callee_coverage/index.md
+++ b/docs/content/usage/supported/callee_coverage/index.md
@@ -46,6 +46,7 @@ This matrix lists frameworks with functional test coverage for callee extraction
 | Scala | Akka HTTP, http4s, Scalatra, ZIO HTTP |
 | Swift | Hummingbird, Kitura, Vapor |
 | TypeScript | NestJS |
+| Zig | Jetzig, Zap, httpz, Tokamak |
 
 ## Completeness Notes
 

--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -3689,3 +3689,116 @@ sort_by = "weight"
   </article>
 </div>
 
+## Zig
+
+<div class="tech-grid">
+  <article class="tech-card">
+    <h3 class="tech-card-title">Jetzig</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Tokamak</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Zap</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">httpz</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+</div>
+

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -3689,3 +3689,116 @@ Each card below lists a framework's supported features. **Route** covers endpoin
   </article>
 </div>
 
+## Zig
+
+<div class="tech-grid">
+  <article class="tech-card">
+    <h3 class="tech-card-title">Jetzig</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Tokamak</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">Zap</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip off">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">httpz</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip off">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip off">body</span>
+        <span class="tech-chip off">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
+</div>
+

--- a/spec/functional_test/fixtures/zig/httpz/src/api.zig
+++ b/spec/functional_test/fixtures/zig/httpz/src/api.zig
@@ -1,0 +1,9 @@
+const httpz = @import("httpz");
+
+const Handler = struct {};
+const Action = *const fn (*Handler, *httpz.Request, *httpz.Response) anyerror!void;
+
+// App-local router alias re-exported to route modules. Those modules register
+// routes against `AppRouter` without importing `httpz` themselves.
+pub const AppRouter = httpz.Router(*Handler, Action);
+pub const items = @import("api/items.zig");

--- a/spec/functional_test/fixtures/zig/httpz/src/api/items.zig
+++ b/spec/functional_test/fixtures/zig/httpz/src/api/items.zig
@@ -1,0 +1,24 @@
+// Route module registered from main via `api.items.registerItems(router)`.
+// It deliberately does NOT reference `httpz` — it only sees the re-exported
+// `AppRouter` alias — so it exercises the routing-signal file gate (a file
+// that bears routes but not the framework name).
+const Router = @import("../api.zig").AppRouter;
+
+pub fn registerItems(router: *Router) void {
+    var items = router.group("/items", .{});
+    items.get("/", listItems, .{});
+    items.get("/:id", getItem, .{});
+    items.post("/", createItem, .{});
+}
+
+fn listItems(_: anytype, res: anytype) !void {
+    try res.write("[]");
+}
+
+fn getItem(req: anytype, _: anytype) !void {
+    try lookupItem(req);
+}
+
+fn createItem(req: anytype, _: anytype) !void {
+    try saveItem(req);
+}

--- a/spec/functional_test/fixtures/zig/httpz/src/main.zig
+++ b/spec/functional_test/fixtures/zig/httpz/src/main.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const httpz = @import("httpz");
+
+pub fn main() !void {
+    var server = try httpz.Server().init(std.heap.page_allocator, .{ .port = 5882 }, .{});
+    defer server.deinit();
+
+    var router = try server.router(.{});
+
+    router.get("/", index, .{});
+    router.get("/users/:id", getUser, .{});
+    router.post("/users", createUser, .{});
+    router.delete("/users/:id", deleteUser, .{});
+    router.all("/health", health, .{});
+    router.method("QUERY", "/cache/:key", purgeCache, .{});
+
+    // Prefixed route group.
+    var admin = router.group("/admin", .{});
+    admin.get("/stats", adminStats, .{});
+
+    // Nested group inherits the parent prefix.
+    var v1 = admin.group("/v1", .{});
+    v1.get("/ping", v1Ping, .{});
+
+    try server.listen();
+}
+
+fn index(_: *httpz.Request, res: *httpz.Response) !void {
+    try res.write("home");
+}
+
+fn getUser(req: *httpz.Request, res: *httpz.Response) !void {
+    const id = req.param("id").?;
+    try res.json(.{ .id = id }, .{});
+}
+
+fn createUser(req: *httpz.Request, res: *httpz.Response) !void {
+    try userStore.insert(req.body);
+}
+
+fn deleteUser(req: *httpz.Request, res: *httpz.Response) !void {
+    try userStore.remove(req.param("id").?);
+}
+
+fn health(_: *httpz.Request, res: *httpz.Response) !void {
+    try res.write("ok");
+}
+
+fn purgeCache(_: *httpz.Request, res: *httpz.Response) !void {
+    try cache.purge();
+}
+
+fn adminStats(_: *httpz.Request, res: *httpz.Response) !void {
+    try res.json(stats, .{});
+}
+
+fn v1Ping(_: *httpz.Request, res: *httpz.Response) !void {
+    try res.write("pong");
+}

--- a/spec/functional_test/fixtures/zig/httpz/src/main.zig
+++ b/spec/functional_test/fixtures/zig/httpz/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const httpz = @import("httpz");
+const api = @import("api.zig");
 
 pub fn main() !void {
     var server = try httpz.Server().init(std.heap.page_allocator, .{ .port = 5882 }, .{});
@@ -21,6 +22,9 @@ pub fn main() !void {
     // Nested group inherits the parent prefix.
     var v1 = admin.group("/v1", .{});
     v1.get("/ping", v1Ping, .{});
+
+    // Routes registered from a helper module that doesn't import httpz.
+    api.items.registerItems(router);
 
     try server.listen();
 }

--- a/spec/functional_test/fixtures/zig/jetzig/build.zig.zon
+++ b/spec/functional_test/fixtures/zig/jetzig/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = .jetzig_fixture,
+    .version = "0.0.0",
+    .dependencies = .{
+        .jetzig = .{
+            .url = "https://github.com/jetzig-framework/jetzig",
+        },
+    },
+    .paths = .{""},
+}

--- a/spec/functional_test/fixtures/zig/jetzig/src/app/views/admin/users.zig
+++ b/spec/functional_test/fixtures/zig/jetzig/src/app/views/admin/users.zig
@@ -1,0 +1,10 @@
+const jetzig = @import("jetzig");
+
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    return request.render(.ok);
+}
+
+pub fn get(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = id;
+    return request.render(.ok);
+}

--- a/spec/functional_test/fixtures/zig/jetzig/src/app/views/posts.zig
+++ b/spec/functional_test/fixtures/zig/jetzig/src/app/views/posts.zig
@@ -1,0 +1,46 @@
+const jetzig = @import("jetzig");
+const Post = @import("../models/Post.zig");
+
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    const posts = try Post.findAll(request.allocator);
+    try data.put("posts", posts);
+    return request.render(.ok);
+}
+
+pub fn get(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    const post = try Post.find(id);
+    _ = post;
+    return request.render(.ok);
+}
+
+pub fn new(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    return request.render(.ok);
+}
+
+pub fn edit(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = id;
+    return request.render(.ok);
+}
+
+pub fn post(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    const params = try request.params();
+    const title = params.get("title");
+    _ = title;
+    try Post.create(params);
+    return request.render(.created);
+}
+
+pub fn put(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = id;
+    return request.render(.ok);
+}
+
+pub fn patch(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = id;
+    return request.render(.ok);
+}
+
+pub fn delete(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    try Post.destroy(id);
+    return request.render(.ok);
+}

--- a/spec/functional_test/fixtures/zig/jetzig/src/app/views/root.zig
+++ b/spec/functional_test/fixtures/zig/jetzig/src/app/views/root.zig
@@ -1,0 +1,15 @@
+const jetzig = @import("jetzig");
+
+pub fn index(request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    return request.render(.ok);
+}
+
+pub fn get(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = id;
+    return request.render(.ok);
+}
+
+pub fn edit(id: []const u8, request: *jetzig.Request, data: *jetzig.Data) !jetzig.View {
+    _ = id;
+    return request.render(.ok);
+}

--- a/spec/functional_test/fixtures/zig/tokamak/src/api/widgets.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/api/widgets.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+// Controller mounted with `.router(widgets)` under the `/api` group in
+// main.zig. Each handler encodes its method + path in the function name; the
+// mount composes the `/api` prefix onto them.
+
+pub fn @"GET /widgets"(db: *Db) ![]Widget {
+    return listWidgets(db);
+}
+
+pub fn @"POST /widgets"(db: *Db, data: Widget) !Widget {
+    return createWidget(db, data);
+}
+
+pub fn @"GET /widgets/:id"(db: *Db, id: u32) !Widget {
+    return findWidget(db, id);
+}

--- a/spec/functional_test/fixtures/zig/tokamak/src/main.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/main.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const tk = @import("tokamak");
+
+const routes: []const tk.Route = &.{
+    .get("/", hello),
+    .post("/users", createUser),
+    .group("/api", &.{
+        .get("/health", health),
+        .group("/v1", &.{
+            .get("/items/:id", getItem),
+            .delete("/items/:id", deleteItem),
+        }),
+    }),
+};
+
+fn hello() ![]const u8 {
+    return greet("world");
+}
+
+fn createUser(req: *tk.Request) !void {
+    try db.insert(req.body);
+    audit.log("create");
+}
+
+fn health() ![]const u8 {
+    return "ok";
+}
+
+fn getItem() !void {
+    try store.fetch();
+}
+
+fn deleteItem() !void {
+    try store.remove();
+}
+
+pub fn main() !void {
+    var server = try tk.Server.init(std.heap.page_allocator, routes, .{ .listen = .{ .port = 8080 } });
+    defer server.deinit();
+    try server.start();
+}

--- a/spec/functional_test/fixtures/zig/tokamak/src/main.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/main.zig
@@ -1,11 +1,14 @@
 const std = @import("std");
 const tk = @import("tokamak");
+const widgets = @import("api/widgets.zig");
 
 const routes: []const tk.Route = &.{
     .get("/", hello),
     .post("/users", createUser),
     .group("/api", &.{
         .get("/health", health),
+        // Controller mount — widgets routes compose the `/api` prefix.
+        .router(widgets),
         .group("/v1", &.{
             .get("/items/:id", getItem),
             .delete("/items/:id", deleteItem),
@@ -20,6 +23,9 @@ fn hello() ![]const u8 {
 fn createUser(req: *tk.Request) !void {
     try db.insert(req.body);
     audit.log("create");
+    // Data-object `.put` with a non-rooted key — must NOT become a `PUT /name`
+    // route (the leading-slash guard rejects it).
+    try root.put("name", req.body);
 }
 
 fn health() ![]const u8 {

--- a/spec/functional_test/fixtures/zig/zap/build.zig.zon
+++ b/spec/functional_test/fixtures/zig/zap/build.zig.zon
@@ -1,0 +1,10 @@
+.{
+    .name = .zap_fixture,
+    .version = "0.0.0",
+    .dependencies = .{
+        .zap = .{
+            .url = "https://github.com/zigzap/zap",
+        },
+    },
+    .paths = .{""},
+}

--- a/spec/functional_test/fixtures/zig/zap/src/endpoints.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/endpoints.zig
@@ -1,0 +1,4 @@
+// Namespace module that re-exports endpoint structs. Instantiation sites
+// reach the structs through this alias (`Endpoints.Comments`), exercising the
+// namespaced-type path binding.
+pub const Comments = @import("endpoints/comments.zig");

--- a/spec/functional_test/fixtures/zig/zap/src/endpoints/comments.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/endpoints/comments.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const zap = @import("zap");
+
+// Idiomatic `const Self = @This();` endpoint struct. The path is bound at the
+// namespaced instantiation site in main.zig (`Endpoints.Comments{ .path =
+// "/comments" }`), NOT here, so the `path` field default is a dead value that
+// the binding must override.
+const Self = @This();
+
+path: []const u8 = "/unused",
+
+pub fn get(_: *Self, r: zap.Request) !void {
+    try listComments(r);
+}
+
+pub fn post(_: *Self, r: zap.Request) !void {
+    try createComment(r);
+}
+
+fn listComments(r: zap.Request) !void {
+    try r.sendJson("[]");
+}
+
+fn createComment(r: zap.Request) !void {
+    try commentStore.insert(r.body);
+}

--- a/spec/functional_test/fixtures/zig/zap/src/health.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/health.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const zap = @import("zap");
+
+pub const HealthEndpoint = @This();
+
+// Path declared as a struct field default.
+path: []const u8 = "/health",
+error_strategy: zap.Endpoint.ErrorStrategy = .log_to_response,
+
+pub fn get(_: *HealthEndpoint, _: std.mem.Allocator, r: zap.Request) !void {
+    try r.sendBody("ok");
+}

--- a/spec/functional_test/fixtures/zig/zap/src/main.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const zap = @import("zap");
 const UsersEndpoint = @import("users.zig");
 const HealthEndpoint = @import("health.zig");
+const Endpoints = @import("endpoints.zig");
 
 const Handlers = struct {
     pub fn stats(_: *Handlers, r: zap.Request) !void {
@@ -19,6 +20,11 @@ pub fn main() !void {
 
     var health: HealthEndpoint = .{};
     _ = &health;
+
+    // Namespaced struct literal — the `Comments` type is reached via the
+    // `Endpoints` re-export and bound to `/comments` here.
+    var comments = Endpoints.Comments{ .path = "/comments" };
+    _ = &comments;
 
     var router = zap.Router.init(std.heap.page_allocator, .{});
     defer router.deinit();

--- a/spec/functional_test/fixtures/zig/zap/src/main.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/main.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const zap = @import("zap");
+const UsersEndpoint = @import("users.zig");
+const HealthEndpoint = @import("health.zig");
+
+const Handlers = struct {
+    pub fn stats(_: *Handlers, r: zap.Request) !void {
+        try r.sendJson("{}");
+    }
+};
+
+fn ping(r: zap.Request) !void {
+    try r.sendBody("pong");
+}
+
+pub fn main() !void {
+    var users = UsersEndpoint.init("/users");
+    _ = &users;
+
+    var health: HealthEndpoint = .{};
+    _ = &health;
+
+    var router = zap.Router.init(std.heap.page_allocator, .{});
+    defer router.deinit();
+
+    var handlers = Handlers{};
+    try router.handle_func("/stats", &handlers, &Handlers.stats);
+    try router.handle_func_unbound("/ping", ping);
+
+    var listener = zap.HttpListener.init(.{
+        .port = 3000,
+        .on_request = router.on_request_handler(),
+    });
+    try listener.listen();
+}

--- a/spec/functional_test/fixtures/zig/zap/src/users.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/users.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const zap = @import("zap");
+
+pub const UsersEndpoint = @This();
+
+// Path injected at construction time (see main.zig's `init("/users")`).
+path: []const u8,
+
+pub fn init(p: []const u8) UsersEndpoint {
+    return .{ .path = p };
+}
+
+pub fn get(_: *UsersEndpoint, r: zap.Request) !void {
+    try listUsers(r);
+}
+
+pub fn post(_: *UsersEndpoint, r: zap.Request) !void {
+    try createUser(r);
+}
+
+fn listUsers(r: zap.Request) !void {
+    try r.sendJson("[]");
+}
+
+fn createUser(r: zap.Request) !void {
+    try userStore.insert(r.body);
+}

--- a/spec/functional_test/testers/zig/httpz_spec.cr
+++ b/spec/functional_test/testers/zig/httpz_spec.cr
@@ -26,6 +26,12 @@ expected_endpoints << httpz_endpoint("/admin/stats", "GET", [] of Param, [Callee
 # Nested group prefix composition.
 expected_endpoints << httpz_endpoint("/admin/v1/ping", "GET", [] of Param, [Callee.new("res.write")])
 
+# Routes registered from a helper module that never names `httpz` — caught by
+# the routing-signal file gate, with the local group prefix composed.
+expected_endpoints << httpz_endpoint("/items/", "GET", [] of Param, [Callee.new("res.write")])
+expected_endpoints << httpz_endpoint("/items/:id", "GET", [Param.new("id", "", "path")], [Callee.new("lookupItem")])
+expected_endpoints << httpz_endpoint("/items/", "POST", [] of Param, [Callee.new("saveItem")])
+
 FunctionalTester.new("fixtures/zig/httpz/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/spec/functional_test/testers/zig/httpz_spec.cr
+++ b/spec/functional_test/testers/zig/httpz_spec.cr
@@ -1,0 +1,34 @@
+require "../../func_spec.cr"
+
+def httpz_endpoint(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+id_param = [Param.new("id", "", "path")]
+
+expected_endpoints = [] of Endpoint
+
+expected_endpoints << httpz_endpoint("/", "GET", [] of Param, [Callee.new("res.write")])
+expected_endpoints << httpz_endpoint("/users/:id", "GET", id_param, [
+  Callee.new("req.param"),
+  Callee.new("res.json"),
+])
+expected_endpoints << httpz_endpoint("/users", "POST", [] of Param, [Callee.new("userStore.insert")])
+expected_endpoints << httpz_endpoint("/users/:id", "DELETE", id_param, [Callee.new("userStore.remove")])
+# `router.all(...)` resolves to GET.
+expected_endpoints << httpz_endpoint("/health", "GET", [] of Param, [Callee.new("res.write")])
+# `router.method("QUERY", ...)` keeps the custom verb.
+expected_endpoints << httpz_endpoint("/cache/:key", "QUERY", [Param.new("key", "", "path")], [Callee.new("cache.purge")])
+# Group prefix composition.
+expected_endpoints << httpz_endpoint("/admin/stats", "GET", [] of Param, [Callee.new("res.json")])
+# Nested group prefix composition.
+expected_endpoints << httpz_endpoint("/admin/v1/ping", "GET", [] of Param, [Callee.new("res.write")])
+
+FunctionalTester.new("fixtures/zig/httpz/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/zig/jetzig_spec.cr
+++ b/spec/functional_test/testers/zig/jetzig_spec.cr
@@ -1,0 +1,48 @@
+require "../../func_spec.cr"
+
+def jetzig_endpoint(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+id_param = [Param.new("id", "", "path")]
+
+expected_endpoints = [] of Endpoint
+
+# root.zig -> mounted at `/`.
+expected_endpoints << jetzig_endpoint("/", "GET")
+expected_endpoints << jetzig_endpoint("/:id", "GET", id_param)
+expected_endpoints << jetzig_endpoint("/:id/edit", "GET", id_param)
+
+# posts.zig -> full resourceful set under `/posts`.
+expected_endpoints << jetzig_endpoint("/posts", "GET", [] of Param, [
+  Callee.new("Post.findAll"),
+  Callee.new("data.put"),
+  Callee.new("request.render"),
+])
+expected_endpoints << jetzig_endpoint("/posts/:id", "GET", id_param)
+expected_endpoints << jetzig_endpoint("/posts/new", "GET")
+expected_endpoints << jetzig_endpoint("/posts/:id/edit", "GET", id_param)
+expected_endpoints << jetzig_endpoint("/posts", "POST", [Param.new("title", "", "query")], [
+  Callee.new("request.params"),
+  Callee.new("params.get"),
+  Callee.new("Post.create"),
+])
+expected_endpoints << jetzig_endpoint("/posts/:id", "PUT", id_param)
+expected_endpoints << jetzig_endpoint("/posts/:id", "PATCH", id_param)
+expected_endpoints << jetzig_endpoint("/posts/:id", "DELETE", id_param, [
+  Callee.new("Post.destroy"),
+  Callee.new("request.render"),
+])
+
+# admin/users.zig -> nested view mounted at `/admin/users`.
+expected_endpoints << jetzig_endpoint("/admin/users", "GET")
+expected_endpoints << jetzig_endpoint("/admin/users/:id", "GET", id_param)
+
+FunctionalTester.new("fixtures/zig/jetzig/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/zig/tokamak_spec.cr
+++ b/spec/functional_test/testers/zig/tokamak_spec.cr
@@ -1,0 +1,29 @@
+require "../../func_spec.cr"
+
+def tokamak_endpoint(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+id_param = [Param.new("id", "", "path")]
+
+expected_endpoints = [] of Endpoint
+
+expected_endpoints << tokamak_endpoint("/", "GET", [] of Param, [Callee.new("greet")])
+expected_endpoints << tokamak_endpoint("/users", "POST", [] of Param, [
+  Callee.new("db.insert"),
+  Callee.new("audit.log"),
+])
+# `.group("/api", …)` prefix.
+expected_endpoints << tokamak_endpoint("/api/health", "GET")
+# Nested `.group("/v1", …)` inherits `/api`.
+expected_endpoints << tokamak_endpoint("/api/v1/items/:id", "GET", id_param, [Callee.new("store.fetch")])
+expected_endpoints << tokamak_endpoint("/api/v1/items/:id", "DELETE", id_param, [Callee.new("store.remove")])
+
+FunctionalTester.new("fixtures/zig/tokamak/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/functional_test/testers/zig/tokamak_spec.cr
+++ b/spec/functional_test/testers/zig/tokamak_spec.cr
@@ -21,6 +21,12 @@ expected_endpoints << tokamak_endpoint("/api/health", "GET")
 expected_endpoints << tokamak_endpoint("/api/v1/items/:id", "GET", id_param, [Callee.new("store.fetch")])
 expected_endpoints << tokamak_endpoint("/api/v1/items/:id", "DELETE", id_param, [Callee.new("store.remove")])
 
+# `.router(widgets)` controller mount — the `@"METHOD /path"` handlers compose
+# the enclosing `/api` group prefix.
+expected_endpoints << tokamak_endpoint("/api/widgets", "GET", [] of Param, [Callee.new("listWidgets")])
+expected_endpoints << tokamak_endpoint("/api/widgets", "POST", [] of Param, [Callee.new("createWidget")])
+expected_endpoints << tokamak_endpoint("/api/widgets/:id", "GET", id_param, [Callee.new("findWidget")])
+
 FunctionalTester.new("fixtures/zig/tokamak/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/spec/functional_test/testers/zig/zap_spec.cr
+++ b/spec/functional_test/testers/zig/zap_spec.cr
@@ -14,6 +14,12 @@ expected_endpoints << zap_endpoint("/health", "GET", [Callee.new("r.sendBody")])
 expected_endpoints << zap_endpoint("/users", "GET", [Callee.new("listUsers")])
 expected_endpoints << zap_endpoint("/users", "POST", [Callee.new("createUser")])
 
+# `const Self = @This()` endpoint reached via the `Endpoints.Comments`
+# namespace re-export and bound to `/comments` at the instantiation site —
+# the binding overrides the dead `path = "/unused"` field default.
+expected_endpoints << zap_endpoint("/comments", "GET", [Callee.new("listComments")])
+expected_endpoints << zap_endpoint("/comments", "POST", [Callee.new("createComment")])
+
 # Router handle_func / handle_func_unbound routes.
 expected_endpoints << zap_endpoint("/stats", "GET", [Callee.new("r.sendJson")])
 expected_endpoints << zap_endpoint("/ping", "GET", [Callee.new("r.sendBody")])

--- a/spec/functional_test/testers/zig/zap_spec.cr
+++ b/spec/functional_test/testers/zig/zap_spec.cr
@@ -1,0 +1,26 @@
+require "../../func_spec.cr"
+
+def zap_endpoint(url, method, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [] of Endpoint
+
+# Endpoint structs — verbs come from the struct methods, the path from a
+# field default (`/health`) or a project-wide `init("/users")` binding.
+expected_endpoints << zap_endpoint("/health", "GET", [Callee.new("r.sendBody")])
+expected_endpoints << zap_endpoint("/users", "GET", [Callee.new("listUsers")])
+expected_endpoints << zap_endpoint("/users", "POST", [Callee.new("createUser")])
+
+# Router handle_func / handle_func_unbound routes.
+expected_endpoints << zap_endpoint("/stats", "GET", [Callee.new("r.sendJson")])
+expected_endpoints << zap_endpoint("/ping", "GET", [Callee.new("r.sendBody")])
+
+FunctionalTester.new("fixtures/zig/zap/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/detector/zig/zig_spec.cr
+++ b/spec/unit_test/detector/zig/zig_spec.cr
@@ -1,0 +1,74 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/zig/*"
+
+describe "Detect Zig frameworks" do
+  options = create_test_options
+
+  describe Detector::Zig::Jetzig do
+    instance = Detector::Zig::Jetzig.new options
+
+    it "detects @import(\"jetzig\") in a source file" do
+      instance.detect("src/app/views/root.zig", "const jetzig = @import(\"jetzig\");").should be_true
+    end
+
+    it "detects a .jetzig dependency in build.zig.zon" do
+      instance.detect("build.zig.zon", ".{ .dependencies = .{ .jetzig = .{ .url = \"x\" } } }").should be_true
+    end
+
+    it "ignores an unrelated zig file" do
+      instance.detect("src/main.zig", "const std = @import(\"std\");").should be_false
+    end
+
+    it "ignores a non-zig file" do
+      instance.detect("main.rb", "@import(\"jetzig\")").should be_false
+    end
+  end
+
+  describe Detector::Zig::Zap do
+    instance = Detector::Zig::Zap.new options
+
+    it "detects @import(\"zap\")" do
+      instance.detect("src/main.zig", "const zap = @import(\"zap\");").should be_true
+    end
+
+    it "detects zigzap/zap url in build.zig.zon" do
+      instance.detect("build.zig.zon", ".zap = .{ .url = \"https://github.com/zigzap/zap\" }").should be_true
+    end
+
+    it "ignores an unrelated zig file" do
+      instance.detect("src/main.zig", "const httpz = @import(\"httpz\");").should be_false
+    end
+  end
+
+  describe Detector::Zig::Httpz do
+    instance = Detector::Zig::Httpz.new options
+
+    it "detects @import(\"httpz\")" do
+      instance.detect("src/main.zig", "const httpz = @import(\"httpz\");").should be_true
+    end
+
+    it "detects a .httpz dependency in build.zig.zon" do
+      instance.detect("build.zig.zon", ".httpz = .{ .url = \"x\" }").should be_true
+    end
+
+    it "ignores an unrelated zig file" do
+      instance.detect("src/main.zig", "const std = @import(\"std\");").should be_false
+    end
+  end
+
+  describe Detector::Zig::Tokamak do
+    instance = Detector::Zig::Tokamak.new options
+
+    it "detects @import(\"tokamak\")" do
+      instance.detect("src/main.zig", "const tk = @import(\"tokamak\");").should be_true
+    end
+
+    it "detects cztomsik/tokamak url in build.zig.zon" do
+      instance.detect("build.zig.zon", ".tokamak = .{ .url = \"https://github.com/cztomsik/tokamak\" }").should be_true
+    end
+
+    it "ignores an unrelated zig file" do
+      instance.detect("src/main.zig", "const zap = @import(\"zap\");").should be_false
+    end
+  end
+end

--- a/spec/unit_test/miniparser/zig_callee_extractor_spec.cr
+++ b/spec/unit_test/miniparser/zig_callee_extractor_spec.cr
@@ -1,0 +1,91 @@
+require "spec"
+require "../../../src/miniparsers/zig_callee_extractor"
+
+describe Noir::ZigCalleeExtractor do
+  it "extracts receiver-chain and bare callees, skipping keywords and builtins" do
+    body = <<-ZIG
+        const user = try userStore.find(id);
+        if (user == null) return error.NotFound;
+        try res.json(user, .{});
+        log("done");
+        const t = @import("std");
+      ZIG
+
+    callees = Noir::ZigCalleeExtractor.callees_for_body(body, "main.zig", 10)
+    names = callees.map { |name, _, _| name }
+    names.should contain("userStore.find")
+    names.should contain("res.json")
+    names.should contain("log")
+    # `if`, `return`, `try`, the `@import` builtin and `error.NotFound` (no call
+    # paren) must not surface as callees.
+    names.should_not contain("if")
+    names.should_not contain("return")
+    names.should_not contain("@import")
+  end
+
+  it "drops calls inside comments and string literals" do
+    body = <<-ZIG
+        realCall();
+        // commentedCall();
+        const s = "stringCall()";
+        const doc =
+            \\\\ multilineCall()
+        ;
+      ZIG
+
+    names = Noir::ZigCalleeExtractor.callees_for_body(body, "main.zig", 1).map { |n, _, _| n }
+    names.should contain("realCall")
+    names.should_not contain("commentedCall")
+    names.should_not contain("stringCall")
+    names.should_not contain("multilineCall")
+  end
+
+  it "filters std.* noise roots" do
+    body = <<-ZIG
+        std.debug.print("x", .{});
+        businessLogic();
+      ZIG
+
+    names = Noir::ZigCalleeExtractor.callees_for_body(body, "main.zig", 1).map { |n, _, _| n }
+    names.should contain("businessLogic")
+    names.should_not contain("std.debug.print")
+  end
+
+  it "indexes function bodies by name with correct start lines" do
+    source = <<-ZIG
+      const std = @import("std");
+
+      pub fn handler(req: *Request) !void {
+          try doWork();
+      }
+
+      fn helper() void {}
+      ZIG
+
+    bodies = Noir::ZigCalleeExtractor.function_bodies(source, "main.zig")
+    bodies.has_key?("handler").should be_true
+    bodies.has_key?("helper").should be_true
+    bodies["handler"][:body].should contain("doWork")
+    bodies["handler"][:start_line].should eq(3)
+  end
+
+  it "preserves string contents in strip_comments but blanks comments" do
+    source = "const p = \"/api/users\"; // route\n"
+    stripped = Noir::ZigCalleeExtractor.strip_comments(source)
+    stripped.should contain("/api/users")
+    stripped.should_not contain("route")
+  end
+
+  it "skips anonymous struct return types when locating the body brace" do
+    source = <<-ZIG
+      fn make() struct { x: u32 } {
+          return build();
+      }
+      ZIG
+
+    bodies = Noir::ZigCalleeExtractor.function_bodies(source, "main.zig")
+    bodies.has_key?("make").should be_true
+    bodies["make"][:body].should contain("build")
+    bodies["make"][:body].should_not contain("x: u32")
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -187,6 +187,10 @@ def initialize_analyzers(logger : NoirLogger)
     {"ts_nestjs", Typescript::Nestjs},
     {"ts_tanstack_router", Typescript::TanstackRouter},
     {"ts_trpc", Typescript::TRPC},
+    {"zig_jetzig", Zig::Jetzig},
+    {"zig_zap", Zig::Zap},
+    {"zig_httpz", Zig::Httpz},
+    {"zig_tokamak", Zig::Tokamak},
     {"ai", AI::Unified},
   ])
 
@@ -233,6 +237,16 @@ def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
   # analyzer is unaffected — it owns the Phoenix.Router DSL.
   if filtered.includes?("elixir_bandit") && filtered.includes?("elixir_plug")
     filtered.reject!("elixir_plug")
+  end
+
+  # Jetzig and Tokamak are both built on top of http.zig (httpz), so a
+  # project that vendors either framework's source also carries the
+  # `@import("httpz")` / `.httpz` dependency markers the httpz detector
+  # keys on. When the more specific framework is present it owns the
+  # routing DSL; keep it and drop the redundant httpz entry so the httpz
+  # analyzer doesn't also scan the framework's internals.
+  if filtered.includes?("zig_httpz") && (filtered.includes?("zig_jetzig") || filtered.includes?("zig_tokamak"))
+    filtered.reject!("zig_httpz")
   end
 
   filtered

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -31,7 +31,14 @@ module Analyzer::Zig
       all_files.each do |path|
         next unless path.ends_with?(".zig")
         content = read_file_content(path)
-        next unless content.includes?("httpz")
+        # Route-bearing files don't always reference `httpz` literally — a
+        # common layout registers routes in a helper `fn group(router: *Foo)`
+        # whose file only imports an app-local `Router` alias (book-store's
+        # `api/category.zig`). Gate on a cheap routing signal (a `/…` string
+        # argument, or a `.group(` call) instead of the framework name so
+        # those files are still scanned. The analyzer only runs at all when
+        # the project is already detected as httpz.
+        next unless content.includes?("(\"/") || content.includes?(".group(")
         process_file(path, content, include_callee)
       end
 

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -1,0 +1,117 @@
+require "../../../models/analyzer"
+require "../../../miniparsers/zig_callee_extractor"
+require "../../../utils/url_path"
+
+module Analyzer::Zig
+  # http.zig (httpz) registers routes on a router object:
+  #
+  #   router.get("/api/user/:id", getUser, .{});
+  #   router.post("/api/users", createUser, .{});
+  #   router.all("/*", notFound, .{});
+  #   router.method("TEA", "/", teaList, .{});
+  #
+  # Prefixed groups compose: `var admin = router.group("/admin", .{});`
+  # followed by `admin.get("/users", …)` yields `/admin/users`. The handler
+  # is the second argument; its function body supplies the callees.
+  class Httpz < Analyzer
+    VERBS       = %w[get post put delete head patch trace options connect all]
+    VERB_METHOD = {
+      "get" => "GET", "post" => "POST", "put" => "PUT", "delete" => "DELETE",
+      "head" => "HEAD", "patch" => "PATCH", "trace" => "TRACE",
+      "options" => "OPTIONS", "connect" => "CONNECT", "all" => "GET",
+    }
+
+    GROUP_RE  = /(?:var|const)\s+(\w+)\s*=\s*(\w+)\s*\.\s*group\s*\(\s*"([^"]*)"/
+    ROUTE_RE  = /(\w+)\s*\.\s*(get|post|put|delete|head|patch|trace|options|connect|all)\s*\(\s*"(\/[^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
+    METHOD_RE = /(\w+)\s*\.\s*method\s*\(\s*"([^"]*)"\s*,\s*"(\/[^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
+
+    def analyze
+      include_callee = callees_needed?
+
+      all_files.each do |path|
+        next unless path.ends_with?(".zig")
+        content = read_file_content(path)
+        next unless content.includes?("httpz")
+        process_file(path, content, include_callee)
+      end
+
+      @result
+    end
+
+    private def process_file(path : String, content : String, include_callee : Bool)
+      text = Noir::ZigCalleeExtractor.strip_comments(content)
+      bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
+
+      group_prefixes = resolve_group_prefixes(text)
+
+      text.scan(ROUTE_RE) do |m|
+        receiver = m[1]
+        verb = m[2]
+        route = m[3]
+        handler = m[4]
+        prefix = group_prefixes[receiver]? || ""
+        url = Noir::URLPath.join(prefix, route)
+        emit(path, text, m.begin(0) || 0, url, VERB_METHOD[verb], handler, bodies, include_callee)
+      end
+
+      text.scan(METHOD_RE) do |m|
+        receiver = m[1]
+        method = m[2].upcase
+        route = m[3]
+        handler = m[4]
+        prefix = group_prefixes[receiver]? || ""
+        url = Noir::URLPath.join(prefix, route)
+        emit(path, text, m.begin(0) || 0, url, method, handler, bodies, include_callee)
+      end
+    end
+
+    # Build groupVar => composed-prefix, resolving nested groups
+    # (`v1 = admin.group("/v1", …)` inherits `/admin`).
+    private def resolve_group_prefixes(text : String) : Hash(String, String)
+      raw = {} of String => Tuple(String, String) # var => {parent, prefix}
+      text.scan(GROUP_RE) do |m|
+        raw[m[1]] = {m[2], m[3]}
+      end
+
+      resolved = {} of String => String
+      raw.each_key do |var|
+        resolved[var] = compose_prefix(var, raw, [] of String)
+      end
+      resolved
+    end
+
+    private def compose_prefix(var : String, raw : Hash(String, Tuple(String, String)), seen : Array(String)) : String
+      entry = raw[var]?
+      return "" if entry.nil?
+      return entry[1] if seen.includes?(var) # cycle guard
+      parent, prefix = entry
+      parent_prefix = raw.has_key?(parent) ? compose_prefix(parent, raw, seen + [var]) : ""
+      Noir::URLPath.join(parent_prefix, prefix)
+    end
+
+    private def emit(path, text, offset, url, method, handler, bodies, include_callee)
+      params = extract_path_params(url)
+      line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
+      details = Details.new(PathInfo.new(path, line))
+      endpoint = Endpoint.new(url, method, params, details)
+
+      if include_callee
+        name = handler.includes?('.') ? handler.split('.').last : handler
+        if body = bodies[name]?
+          callees = Noir::ZigCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
+          Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+        end
+      end
+
+      @result << endpoint
+    end
+
+    private def extract_path_params(url : String) : Array(Param)
+      params = [] of Param
+      url.scan(/:([A-Za-z_]\w*)/) do |m|
+        params << Param.new(m[1], "", "path")
+      end
+      params
+    end
+  end
+end

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -1,0 +1,135 @@
+require "../../../models/analyzer"
+require "../../../miniparsers/zig_callee_extractor"
+
+module Analyzer::Zig
+  # Jetzig uses filesystem-based "resourceful" routing (Rails-style). A view
+  # file under `src/app/views/<name>.zig` is mounted at `/<name>`, and the
+  # public function names inside it map to a fixed (HTTP method, URL-suffix)
+  # table:
+  #
+  #   index  -> GET    /<name>
+  #   get    -> GET    /<name>/:id
+  #   new    -> GET    /<name>/new
+  #   edit   -> GET    /<name>/:id/edit
+  #   post   -> POST   /<name>
+  #   put    -> PUT    /<name>/:id
+  #   patch  -> PATCH  /<name>/:id
+  #   delete -> DELETE /<name>/:id
+  #
+  # `root.zig` is special-cased to `/`. The view function body is the request
+  # handler, so its 1-hop calls are surfaced as callees and `params.get("…")`
+  # reads become query parameters.
+  class Jetzig < Analyzer
+    VIEWS_MARKER = "app#{File::SEPARATOR}views#{File::SEPARATOR}"
+
+    # action => {http method, url suffix, has resource id}
+    ACTIONS = {
+      "index"  => {"GET", "", false},
+      "get"    => {"GET", "/:id", true},
+      "new"    => {"GET", "/new", false},
+      "edit"   => {"GET", "/:id/edit", true},
+      "post"   => {"POST", "", false},
+      "put"    => {"PUT", "/:id", true},
+      "patch"  => {"PATCH", "/:id", true},
+      "delete" => {"DELETE", "/:id", true},
+    }
+
+    ACTION_FN_RE = /(?:^|[^A-Za-z0-9_.])pub\s+fn\s+(index|get|new|edit|post|put|patch|delete)\s*\(/
+    PARAM_GET_RE = /\b(?:params|query)\s*\.\s*get\s*\(\s*"([^"]+)"/
+
+    def analyze
+      include_callee = callees_needed?
+
+      all_files.each do |path|
+        next unless path.ends_with?(".zig")
+        next unless jetzig_view?(path)
+
+        content = read_file_content(path)
+        # A view file always references the framework (`*jetzig.Request`,
+        # `!jetzig.View`); gate on it so an unrelated `.zig` file that
+        # happens to live under an `app/views/` tree isn't mined for routes.
+        next unless content.includes?("jetzig")
+
+        process_view(path, content, include_callee)
+      end
+
+      @result
+    end
+
+    private def jetzig_view?(path : String) : Bool
+      path.includes?(VIEWS_MARKER)
+    end
+
+    private def process_view(path : String, content : String, include_callee : Bool)
+      resource = resource_for(path)
+      return if resource.nil?
+
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+      # Strings preserved — `params.get("foo")` reads need the literal name.
+      comment_stripped = Noir::ZigCalleeExtractor.strip_comments(content)
+      table = Noir::ZigCalleeExtractor.function_table(content, path)
+      by_name = {} of String => Noir::ZigCalleeExtractor::FunctionInfo
+      table.each { |info| by_name[info[:name]] ||= info }
+
+      stripped.scan(ACTION_FN_RE) do |match|
+        action = match[1]
+        spec = ACTIONS[action]?
+        next if spec.nil?
+        method, suffix, has_id = spec
+
+        url = build_url(resource, suffix)
+        line = Noir::ZigCalleeExtractor.line_at(stripped.chars, match.begin(0) || 0)
+        details = Details.new(PathInfo.new(path, line))
+
+        params = [] of Param
+        params << Param.new("id", "", "path") if has_id
+
+        info = by_name[action]?
+        if info
+          body_with_strings = comment_stripped[(info[:open] + 1)...info[:close]]? || ""
+          params.concat(extract_params(body_with_strings))
+        end
+
+        endpoint = Endpoint.new(url, method, params, details)
+
+        if include_callee && info
+          callees = Noir::ZigCalleeExtractor.callees_for_body(info[:body], path, info[:start_line])
+          Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+        end
+
+        @result << endpoint
+      end
+    end
+
+    # Resource path = the view file path below `app/views/`, extension
+    # stripped, OS separators normalised to `/`. `root` collapses to the
+    # site root.
+    private def resource_for(path : String) : String?
+      idx = path.rindex(VIEWS_MARKER)
+      return if idx.nil?
+      rel = path[(idx + VIEWS_MARKER.size)..]
+      rel = rel[0...-4] if rel.ends_with?(".zig")
+      rel = rel.gsub(File::SEPARATOR, "/")
+      rel
+    end
+
+    # `base` is either empty (root) or `/<resource>` (never trailing-slash),
+    # and every suffix is empty or leading-slash, so the concatenation is
+    # already free of double slashes.
+    private def build_url(resource : String, suffix : String) : String
+      base = resource == "root" ? "" : "/#{resource}"
+      url = "#{base}#{suffix}"
+      url.empty? ? "/" : url
+    end
+
+    private def extract_params(body : String) : Array(Param)
+      params = [] of Param
+      body.scan(PARAM_GET_RE) do |match|
+        name = match[1]
+        next if name.empty?
+        params << Param.new(name, "", "query")
+      end
+      params
+    end
+  end
+end

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -1,0 +1,114 @@
+require "../../../models/analyzer"
+require "../../../miniparsers/zig_callee_extractor"
+require "../../../utils/url_path"
+
+module Analyzer::Zig
+  # Tokamak declares routes as a flat data structure of `tk.Route` values:
+  #
+  #   const routes: []const tk.Route = &.{
+  #     .get("/", hello),
+  #     .post("/users", createUser),
+  #     .group("/api", &.{
+  #       .get("/health", health),
+  #     }),
+  #   };
+  #
+  # `.group(prefix, &.{ … })` composes its prefix onto every nested route, so
+  # the analyzer tracks brace nesting to accumulate prefixes. `.post0`/`.put0`/
+  # `.patch0` are the body-less variants of the same verbs. The handler (second
+  # argument) supplies the callees.
+  class Tokamak < Analyzer
+    VERB_METHOD = {
+      "get" => "GET", "post" => "POST", "post0" => "POST", "put" => "PUT",
+      "put0" => "PUT", "patch" => "PATCH", "patch0" => "PATCH",
+      "delete" => "DELETE", "head" => "HEAD", "options" => "OPTIONS",
+    }
+
+    GROUP_RE = /\.\s*group\s*\(\s*"([^"]*)"\s*,\s*&?\s*\.\s*\{/
+    ROUTE_RE = /\.\s*(get|post0|post|put0|put|patch0|patch|delete|head|options)\s*\(\s*"([^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
+
+    private record GroupFrame, prefix : String, close : Int32
+
+    def analyze
+      include_callee = callees_needed?
+
+      all_files.each do |path|
+        next unless path.ends_with?(".zig")
+        content = read_file_content(path)
+        next unless content.includes?("tokamak") || content.includes?("tk.Route") || content.includes?("Route")
+        process_file(path, content, include_callee)
+      end
+
+      @result
+    end
+
+    private def process_file(path : String, content : String, include_callee : Bool)
+      text = Noir::ZigCalleeExtractor.strip_comments(content)
+      chars = text.chars
+      bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
+
+      events = collect_events(text, chars)
+      stack = [] of GroupFrame
+
+      events.each do |ev|
+        stack.reject! { |frame| frame.close < ev[:off] }
+
+        if ev[:kind] == :group
+          close = ev[:close]
+          stack << GroupFrame.new(ev[:prefix], close) if close
+          next
+        end
+
+        prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
+        url = Noir::URLPath.join(prefix, ev[:path])
+        emit(path, text, ev[:off], url, ev[:method], ev[:handler], bodies, include_callee)
+      end
+    end
+
+    # Group-open and route events, ordered by source offset, so a single pass
+    # with a brace-keyed stack reconstructs the prefix in scope for each route.
+    private def collect_events(text : String, chars : Array(Char))
+      events = [] of NamedTuple(kind: Symbol, off: Int32, prefix: String, close: Int32?, path: String, method: String, handler: String)
+
+      text.scan(GROUP_RE) do |m|
+        brace_open = (m.end(0) || 0) - 1
+        close = Noir::ZigCalleeExtractor.find_matching(chars, brace_open, '{', '}')
+        events << {kind: :group, off: m.begin(0) || 0, prefix: m[1], close: close, path: "", method: "", handler: ""}
+      end
+
+      text.scan(ROUTE_RE) do |m|
+        verb = m[1]
+        method = VERB_METHOD[verb]?
+        next if method.nil?
+        events << {kind: :route, off: m.begin(0) || 0, prefix: "", close: nil, path: m[2], method: method, handler: m[3]}
+      end
+
+      events.sort_by { |ev| ev[:off] }
+    end
+
+    private def emit(path, text, offset, url, method, handler, bodies, include_callee)
+      params = extract_path_params(url)
+      line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
+      details = Details.new(PathInfo.new(path, line))
+      endpoint = Endpoint.new(url, method, params, details)
+
+      if include_callee
+        name = handler.includes?('.') ? handler.split('.').last : handler
+        if body = bodies[name]?
+          callees = Noir::ZigCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
+          Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+        end
+      end
+
+      @result << endpoint
+    end
+
+    private def extract_path_params(url : String) : Array(Param)
+      params = [] of Param
+      url.scan(/:([A-Za-z_]\w*)/) do |m|
+        params << Param.new(m[1], "", "path")
+      end
+      params
+    end
+  end
+end

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -3,20 +3,27 @@ require "../../../miniparsers/zig_callee_extractor"
 require "../../../utils/url_path"
 
 module Analyzer::Zig
-  # Tokamak declares routes as a flat data structure of `tk.Route` values:
+  # Tokamak declares routes two ways:
   #
-  #   const routes: []const tk.Route = &.{
-  #     .get("/", hello),
-  #     .post("/users", createUser),
-  #     .group("/api", &.{
-  #       .get("/health", health),
-  #     }),
-  #   };
+  #   1. Inline `tk.Route` arrays:
+  #        const routes: []const tk.Route = &.{
+  #          .get("/", hello),
+  #          .group("/api", &.{ .get("/health", health) }),
+  #        };
+  #      `.group(prefix, &.{ … })` composes its prefix onto every nested route;
+  #      `.post0`/`.put0`/`.patch0` are body-less verb variants.
   #
-  # `.group(prefix, &.{ … })` composes its prefix onto every nested route, so
-  # the analyzer tracks brace nesting to accumulate prefixes. `.post0`/`.put0`/
-  # `.patch0` are the body-less variants of the same verbs. The handler (second
-  # argument) supplies the callees.
+  #   2. Controller modules mounted with `.router(T)`. The controller declares
+  #      one handler per route, naming the function with the method + path:
+  #        pub fn @"GET /chat/:id"(db: *Session, id: u32) !Chat { … }
+  #      `.router(chat)` (where `chat = @import("api/chat.zig")`) mounts every
+  #      such function, composing any enclosing `.group(...)` prefix. The
+  #      mount and the controller usually live in different files, so the
+  #      mount prefixes are resolved project-wide and keyed by controller file.
+  #
+  # Not yet resolved: a `.group(prefix, RouteConst)` whose body is a reference
+  # to a `tk.Route` const (rather than an inline `&.{ … }` array) — those
+  # controllers' routes are emitted without the referenced-group prefix.
   class Tokamak < Analyzer
     VERB_METHOD = {
       "get" => "GET", "post" => "POST", "post0" => "POST", "put" => "PUT",
@@ -25,28 +32,101 @@ module Analyzer::Zig
     }
 
     GROUP_RE = /\.\s*group\s*\(\s*"([^"]*)"\s*,\s*&?\s*\.\s*\{/
-    ROUTE_RE = /\.\s*(get|post0|post|put0|put|patch0|patch|delete|head|options)\s*\(\s*"([^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
+    # The path must be a rooted URL (`"/..."`). Tokamak handlers commonly build
+    # a JSON response with `root.put("name", value)` / `data.get("key")`; those
+    # data-object calls share the verb names but never take a `/`-rooted key,
+    # so the leading-slash guard keeps them out of the route set.
+    ROUTE_RE        = /\.\s*(get|post0|post|put0|put|patch0|patch|delete|head|options)\s*\(\s*"(\/[^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
+    ROUTER_MOUNT_RE = /\.\s*router\s*\(\s*([A-Za-z_][\w.]*)\s*\)/
+    ROUTE_FN_RE     = /pub\s+fn\s+@"(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+(\/[^"]*)"/
+    IMPORT_RE       = /(?:pub\s+)?(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*@import\(\s*"([^"]+\.zig)"\s*\)/
 
     private record GroupFrame, prefix : String, close : Int32
 
     def analyze
       include_callee = callees_needed?
+      zig_files = all_files.select(&.ends_with?(".zig"))
 
-      all_files.each do |path|
-        next unless path.ends_with?(".zig")
+      alias_to_file = build_alias_map(zig_files)
+      mounts = build_router_mounts(zig_files, alias_to_file)
+
+      zig_files.each do |path|
         content = read_file_content(path)
-        next unless content.includes?("tokamak") || content.includes?("tk.Route") || content.includes?("Route")
-        process_file(path, content, include_callee)
+        next unless route_file?(content)
+        process_file(path, content, mounts, include_callee)
       end
 
       @result
     end
 
-    private def process_file(path : String, content : String, include_callee : Bool)
+    private def route_file?(content : String) : Bool
+      content.includes?("tk.Route") || content.includes?(".group(") ||
+        content.includes?(".router(") || content.includes?("pub fn @\"")
+    end
+
+    # alias identifier => absolute file it `@import`s.
+    private def build_alias_map(files : Array(String)) : Hash(String, String)
+      map = {} of String => String
+      files.each do |path|
+        content = read_file_content(path)
+        next unless content.includes?("@import")
+        dir = File.dirname(path)
+        Noir::ZigCalleeExtractor.strip_comments(content).scan(IMPORT_RE) do |m|
+          map[m[1]] = File.expand_path(File.join(dir, m[2]))
+        end
+      end
+      map
+    end
+
+    # controller file => the URL prefixes it is `.router(...)`-mounted at.
+    private def build_router_mounts(files : Array(String), alias_to_file : Hash(String, String)) : Hash(String, Array(String))
+      mounts = Hash(String, Array(String)).new
+      files.each do |path|
+        content = read_file_content(path)
+        next unless content.includes?(".router(")
+        text = Noir::ZigCalleeExtractor.strip_comments(content)
+        chars = text.chars
+
+        events = [] of NamedTuple(kind: Symbol, off: Int32, prefix: String, close: Int32?, target: String)
+        text.scan(GROUP_RE) do |m|
+          brace = (m.end(0) || 0) - 1
+          close = Noir::ZigCalleeExtractor.find_matching(chars, brace, '{', '}')
+          events << {kind: :group, off: m.begin(0) || 0, prefix: m[1], close: close, target: ""}
+        end
+        text.scan(ROUTER_MOUNT_RE) do |m|
+          events << {kind: :router, off: m.begin(0) || 0, prefix: "", close: nil, target: m[1]}
+        end
+        events.sort_by! { |ev| ev[:off] }
+
+        stack = [] of GroupFrame
+        events.each do |ev|
+          stack.reject! { |frame| frame.close < ev[:off] }
+          if ev[:kind] == :group
+            close = ev[:close]
+            stack << GroupFrame.new(ev[:prefix], close) if close
+            next
+          end
+          target_file = alias_to_file[ev[:target].split('.').last]?
+          next if target_file.nil?
+          prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
+          list = mounts[target_file] ||= [] of String
+          list << prefix unless list.includes?(prefix)
+        end
+      end
+      mounts
+    end
+
+    private def process_file(path : String, content : String, mounts : Hash(String, Array(String)), include_callee : Bool)
       text = Noir::ZigCalleeExtractor.strip_comments(content)
       chars = text.chars
       bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
 
+      emit_route_array(path, text, chars, bodies, include_callee)
+      emit_controller_routes(path, content, text, mounts, include_callee)
+    end
+
+    # Inline `tk.Route` array routes (.get/.post/.group/…).
+    private def emit_route_array(path, text, chars, bodies, include_callee)
       events = collect_events(text, chars)
       stack = [] of GroupFrame
 
@@ -61,7 +141,31 @@ module Analyzer::Zig
 
         prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
         url = Noir::URLPath.join(prefix, ev[:path])
-        emit(path, text, ev[:off], url, ev[:method], ev[:handler], bodies, include_callee)
+        name = ev[:handler].includes?('.') ? ev[:handler].split('.').last : ev[:handler]
+        callees = include_callee ? body_callees(bodies, name, path) : [] of Noir::ZigCalleeExtractor::Entry
+        emit(path, text, ev[:off], url, ev[:method], callees)
+      end
+    end
+
+    # `pub fn @"METHOD /path"` controller handlers, prefixed by every
+    # `.router(...)` mount point that targets this file (or bare when the file
+    # isn't mounted, or its mount chain crosses a route-value reference we
+    # don't expand).
+    private def emit_controller_routes(path, content, text, mounts, include_callee)
+      return unless content.includes?("pub fn @\"")
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+      stripped_chars = stripped.chars
+      prefixes = mounts[File.expand_path(path)]?
+      prefixes = [""] if prefixes.nil? || prefixes.empty?
+
+      text.scan(ROUTE_FN_RE) do |m|
+        method = m[1]
+        rel = m[2]
+        offset = m.begin(0) || 0
+        callees = include_callee ? route_fn_callees(stripped_chars, m.end(0) || 0, path) : [] of Noir::ZigCalleeExtractor::Entry
+        prefixes.each do |pre|
+          emit(path, text, offset, Noir::URLPath.join(pre, rel), method, callees)
+        end
       end
     end
 
@@ -86,20 +190,51 @@ module Analyzer::Zig
       events.sort_by { |ev| ev[:off] }
     end
 
-    private def emit(path, text, offset, url, method, handler, bodies, include_callee)
+    private def body_callees(bodies, name, path) : Array(Noir::ZigCalleeExtractor::Entry)
+      if body = bodies[name]?
+        return Noir::ZigCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
+      end
+      [] of Noir::ZigCalleeExtractor::Entry
+    end
+
+    # The 1-hop callees inside a `@"METHOD /path"` function body. `function_table`
+    # keys on plain `fn name(`, so the `@"…"`-named handlers are resolved here
+    # directly by brace-matching from the function header.
+    private def route_fn_callees(chars : Array(Char), after_name : Int32, path : String) : Array(Noir::ZigCalleeExtractor::Entry)
+      paren = index_of(chars, after_name, '(')
+      return [] of Noir::ZigCalleeExtractor::Entry if paren.nil?
+      close_paren = Noir::ZigCalleeExtractor.find_matching(chars, paren, '(', ')')
+      return [] of Noir::ZigCalleeExtractor::Entry if close_paren.nil?
+      brace = index_of(chars, close_paren + 1, '{')
+      return [] of Noir::ZigCalleeExtractor::Entry if brace.nil?
+      close_brace = Noir::ZigCalleeExtractor.find_matching(chars, brace, '{', '}')
+      return [] of Noir::ZigCalleeExtractor::Entry if close_brace.nil?
+
+      body = String.build do |io|
+        i = brace + 1
+        while i < close_brace && i < chars.size
+          io << chars[i]
+          i += 1
+        end
+      end
+      Noir::ZigCalleeExtractor.callees_for_body(body, path, Noir::ZigCalleeExtractor.line_at(chars, brace))
+    end
+
+    private def index_of(chars : Array(Char), from : Int32, char : Char) : Int32?
+      i = from
+      while i < chars.size
+        return i if chars[i] == char
+        i += 1
+      end
+      nil
+    end
+
+    private def emit(path, text, offset, url, method, callees : Array(Noir::ZigCalleeExtractor::Entry))
       params = extract_path_params(url)
       line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
       details = Details.new(PathInfo.new(path, line))
       endpoint = Endpoint.new(url, method, params, details)
-
-      if include_callee
-        name = handler.includes?('.') ? handler.split('.').last : handler
-        if body = bodies[name]?
-          callees = Noir::ZigCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
-          Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
-        end
-      end
-
+      Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
       @result << endpoint
     end
 

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -85,12 +85,15 @@ module Analyzer::Zig
         content = read_file_content(path)
         next unless content.includes?(".router(")
         text = Noir::ZigCalleeExtractor.strip_comments(content)
-        chars = text.chars
+        # `strip_comments` keeps string contents, so `{`/`}` inside a literal
+        # would corrupt brace matching. `strip_non_code` blanks strings at the
+        # same offsets, so it is the right char array for `find_matching`.
+        code_chars = Noir::ZigCalleeExtractor.strip_non_code(content).chars
 
         events = [] of NamedTuple(kind: Symbol, off: Int32, prefix: String, close: Int32?, target: String)
         text.scan(GROUP_RE) do |m|
           brace = (m.end(0) || 0) - 1
-          close = Noir::ZigCalleeExtractor.find_matching(chars, brace, '{', '}')
+          close = Noir::ZigCalleeExtractor.find_matching(code_chars, brace, '{', '}')
           events << {kind: :group, off: m.begin(0) || 0, prefix: m[1], close: close, target: ""}
         end
         text.scan(ROUTER_MOUNT_RE) do |m|
@@ -118,16 +121,19 @@ module Analyzer::Zig
 
     private def process_file(path : String, content : String, mounts : Hash(String, Array(String)), include_callee : Bool)
       text = Noir::ZigCalleeExtractor.strip_comments(content)
-      chars = text.chars
+      # Strings preserved in `text` for reading paths/handlers; brace matching
+      # runs on the string-blanked (but offset-identical) char array so a `{`/`}`
+      # inside a literal can't throw off group-scope tracking.
+      code_chars = Noir::ZigCalleeExtractor.strip_non_code(content).chars
       bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
 
-      emit_route_array(path, text, chars, bodies, include_callee)
+      emit_route_array(path, text, code_chars, bodies, include_callee)
       emit_controller_routes(path, content, text, mounts, include_callee)
     end
 
     # Inline `tk.Route` array routes (.get/.post/.group/…).
-    private def emit_route_array(path, text, chars, bodies, include_callee)
-      events = collect_events(text, chars)
+    private def emit_route_array(path, text, code_chars, bodies, include_callee)
+      events = collect_events(text, code_chars)
       stack = [] of GroupFrame
 
       events.each do |ev|
@@ -171,12 +177,12 @@ module Analyzer::Zig
 
     # Group-open and route events, ordered by source offset, so a single pass
     # with a brace-keyed stack reconstructs the prefix in scope for each route.
-    private def collect_events(text : String, chars : Array(Char))
+    private def collect_events(text : String, code_chars : Array(Char))
       events = [] of NamedTuple(kind: Symbol, off: Int32, prefix: String, close: Int32?, path: String, method: String, handler: String)
 
       text.scan(GROUP_RE) do |m|
         brace_open = (m.end(0) || 0) - 1
-        close = Noir::ZigCalleeExtractor.find_matching(chars, brace_open, '{', '}')
+        close = Noir::ZigCalleeExtractor.find_matching(code_chars, brace_open, '{', '}')
         events << {kind: :group, off: m.begin(0) || 0, prefix: m[1], close: close, path: "", method: "", handler: ""}
       end
 

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -1,0 +1,234 @@
+require "../../../models/analyzer"
+require "../../../miniparsers/zig_callee_extractor"
+
+module Analyzer::Zig
+  # zap exposes routes two ways:
+  #
+  #   * Endpoint structs — a struct (often the whole file via
+  #     `pub const X = @This();`) carrying a `path` slug and one verb method
+  #     per supported HTTP method (`pub fn get/post/put/delete/patch/options/
+  #     head`). The slug is usually bound where the endpoint is instantiated
+  #     (`X.init("/users", …)`, `.{ .path = "/stop" }`), not inside the
+  #     struct, so paths are resolved project-wide and keyed by struct type.
+  #   * `zap.Router` — `router.handle_func("/p", &inst, &T.method)` and
+  #     `router.handle_func_unbound("/p", handler)` map a path to a handler
+  #     for any method.
+  class Zap < Analyzer
+    VERBS       = %w[get post put delete patch options head]
+    VERB_METHOD = {
+      "get" => "GET", "post" => "POST", "put" => "PUT", "delete" => "DELETE",
+      "patch" => "PATCH", "options" => "OPTIONS", "head" => "HEAD",
+    }
+
+    STRUCT_DECL_RE  = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*struct\s*\{/
+    THIS_DECL_RE    = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*@This\(\)/
+    VERB_FN_RE      = /(?:^|[^A-Za-z0-9_.])pub\s+fn\s+(get|post|put|delete|patch|options|head)\s*\(/
+    FIELD_PATH_RE   = /\bpath\s*:\s*\[\]const u8\s*=\s*"([^"]*)"/
+    INIT_RE         = /(?<![A-Za-z0-9_.])([A-Za-z_]\w*)\.init\s*\(([^()]*)\)/
+    LITERAL_PATH_RE = /\.path\s*=\s*"([^"]*)"/
+    HANDLE_FUNC_RE  = /\.\s*handle_func(_unbound)?\s*\(/
+
+    private record StructRegion, name : String, start : Int32, stop : Int32
+
+    def analyze
+      include_callee = callees_needed?
+      zig_files = all_files.select(&.ends_with?(".zig"))
+
+      bindings = build_path_bindings(zig_files)
+
+      zig_files.each do |path|
+        content = read_file_content(path)
+        next unless content.includes?("zap")
+        process_file(path, content, bindings, include_callee)
+      end
+
+      @result
+    end
+
+    # typeName => candidate paths, collected across the whole project from
+    # `init()` call sites and `.path = "…"` struct literals. Over-collection is
+    # harmless: a binding is only consumed for a type later confirmed to be an
+    # endpoint struct (one that defines verb methods).
+    private def build_path_bindings(files : Array(String)) : Hash(String, Array(String))
+      bindings = Hash(String, Array(String)).new
+      files.each do |path|
+        content = read_file_content(path)
+        next unless content.includes?(".path") || content.includes?(".init(")
+        text = Noir::ZigCalleeExtractor.strip_comments(content)
+
+        text.scan(INIT_RE) do |m|
+          type = m[1]
+          if pm = m[2].match(/"(\/[^"]*)"/)
+            add_binding(bindings, type, pm[1])
+          end
+        end
+
+        text.scan(LITERAL_PATH_RE) do |m|
+          lit = m[1]
+          next if lit.empty? || lit == "(undefined)"
+          if type = nearest_type_before(text, m.begin(0) || 0)
+            add_binding(bindings, type, lit)
+          end
+        end
+      end
+      bindings
+    end
+
+    private def add_binding(bindings, type, path)
+      list = bindings[type] ||= [] of String
+      list << path unless list.includes?(path)
+    end
+
+    # The last Uppercase-initial identifier in the window preceding a
+    # `.path = "…"` literal — almost always the struct type being
+    # instantiated. Liberal by design (see build_path_bindings).
+    private def nearest_type_before(text : String, offset : Int32) : String?
+      start = offset > 160 ? offset - 160 : 0
+      window = text[start...offset]
+      type = nil
+      window.scan(/(?<![A-Za-z0-9_.])([A-Z][A-Za-z0-9_]*)/) { |m| type = m[1] }
+      type
+    end
+
+    private def process_file(path : String, content : String, bindings : Hash(String, Array(String)), include_callee : Bool)
+      comment_stripped = Noir::ZigCalleeExtractor.strip_comments(content)
+      all_fns = Noir::ZigCalleeExtractor.function_table(content, path)
+
+      explicit = explicit_struct_regions(content)
+      emit_endpoint_structs(path, content, comment_stripped, bindings, explicit, all_fns, include_callee)
+      emit_router_routes(path, content, comment_stripped, all_fns, include_callee)
+    end
+
+    private def explicit_struct_regions(content : String) : Array(StructRegion)
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+      chars = stripped.chars
+      regions = [] of StructRegion
+      stripped.scan(STRUCT_DECL_RE) do |m|
+        name = m[1]
+        brace = (m.end(0) || 0) - 1
+        close = Noir::ZigCalleeExtractor.find_matching(chars, brace, '{', '}')
+        next if close.nil?
+        regions << StructRegion.new(name, brace, close)
+      end
+      regions
+    end
+
+    private def emit_endpoint_structs(path, content, comment_stripped, bindings, explicit, all_fns, include_callee)
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+
+      # Explicit `const X = struct { … }` endpoints.
+      explicit.each do |region|
+        verbs = verb_methods_in(all_fns, region.start, region.stop) do |off|
+          innermost_region(explicit, off) == region
+        end
+        next if verbs.empty?
+        paths = resolve_paths(region.name, comment_stripped, region.start, region.stop, bindings)
+        emit_struct_endpoints(path, region.name, paths, verbs, include_callee)
+      end
+
+      # File-as-struct (`pub const X = @This();`) endpoints: every verb method
+      # not already claimed by an explicit nested struct belongs to it.
+      if m = stripped.match(THIS_DECL_RE)
+        name = m[1]
+        verbs = all_fns.select do |f|
+          VERBS.includes?(f[:name]) && innermost_region(explicit, f[:open]).nil?
+        end
+        unless verbs.empty?
+          paths = resolve_paths(name, comment_stripped, 0, content.size, bindings)
+          emit_struct_endpoints(path, name, paths, verbs, include_callee)
+        end
+      end
+    end
+
+    private def verb_methods_in(all_fns, start, stop, &)
+      all_fns.select do |f|
+        next false unless VERBS.includes?(f[:name])
+        next false unless f[:open] > start && f[:open] < stop
+        yield f[:open]
+      end
+    end
+
+    # The smallest explicit struct region containing `offset`, or nil.
+    private def innermost_region(explicit : Array(StructRegion), offset : Int32) : StructRegion?
+      best : StructRegion? = nil
+      explicit.each do |r|
+        next unless offset > r.start && offset < r.stop
+        if best.nil? || (r.stop - r.start) < (best.stop - best.start)
+          best = r
+        end
+      end
+      best
+    end
+
+    private def resolve_paths(type : String, comment_stripped : String, start : Int32, stop : Int32, bindings) : Array(String)
+      paths = [] of String
+      region = comment_stripped[start...stop]? || ""
+      region.scan(FIELD_PATH_RE) do |m|
+        lit = m[1]
+        next if lit.empty? || lit == "(undefined)"
+        paths << lit unless paths.includes?(lit)
+      end
+      bindings[type]?.try(&.each { |p| paths << p unless paths.includes?(p) })
+      paths
+    end
+
+    private def emit_struct_endpoints(path, type, paths, verbs, include_callee)
+      return if paths.empty?
+      paths.each do |url|
+        verbs.each do |fn|
+          method = VERB_METHOD[fn[:name]]
+          details = Details.new(PathInfo.new(path, fn[:start_line]))
+          endpoint = Endpoint.new(url, method, [] of Param, details)
+          if include_callee
+            callees = Noir::ZigCalleeExtractor.callees_for_body(fn[:body], path, fn[:start_line])
+            Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+          end
+          @result << endpoint
+        end
+      end
+    end
+
+    # `router.handle_func("/p", …)` / `handle_func_unbound("/p", handler)`.
+    private def emit_router_routes(path, content, comment_stripped, all_fns, include_callee)
+      chars = comment_stripped.chars
+      comment_stripped.scan(HANDLE_FUNC_RE) do |m|
+        open_paren = (m.end(0) || 0) - 1
+        close = Noir::ZigCalleeExtractor.find_matching(chars, open_paren, '(', ')')
+        next if close.nil?
+        args = comment_stripped[(open_paren + 1)...close]
+        url_match = args.match(/\s*"([^"]*)"/)
+        next if url_match.nil?
+        url = url_match[1]
+        next if url.empty?
+
+        line = Noir::ZigCalleeExtractor.line_at(chars, m.begin(0) || 0)
+        details = Details.new(PathInfo.new(path, line))
+        endpoint = Endpoint.new(url, "GET", [] of Param, details)
+
+        if include_callee
+          if handler = router_handler_name(args)
+            if body = all_fns.find { |f| f[:name] == handler }
+              callees = Noir::ZigCalleeExtractor.callees_for_body(body[:body], path, body[:start_line])
+              Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+            end
+          end
+        end
+
+        @result << endpoint
+      end
+    end
+
+    # The handler argument's simple function name: the last `.`-segment of the
+    # final `&Type.method` / bare identifier token in the call's argument list.
+    private def router_handler_name(args : String) : String?
+      candidates = [] of String
+      args.scan(/&?\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)/) do |m|
+        token = m[1].gsub(/\s+/, "")
+        candidates << token unless token.empty?
+      end
+      return if candidates.empty?
+      last = candidates.last
+      last.includes?('.') ? last.split('.').last : last
+    end
+  end
+end

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -20,14 +20,30 @@ module Analyzer::Zig
       "patch" => "PATCH", "options" => "OPTIONS", "head" => "HEAD",
     }
 
-    STRUCT_DECL_RE  = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*struct\s*\{/
-    THIS_DECL_RE    = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*@This\(\)/
-    FIELD_PATH_RE   = /\bpath\s*:\s*\[\]const u8\s*=\s*"([^"]*)"/
-    INIT_RE         = /(?<![A-Za-z0-9_.])([A-Za-z_]\w*)\.init\s*\(([^()]*)\)/
+    STRUCT_DECL_RE = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*struct\s*\{/
+    THIS_DECL_RE   = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*@This\(\)/
+    FIELD_PATH_RE  = /\bpath\s*:\s*\[\]const u8\s*=\s*"([^"]*)"/
+    # `.` is intentionally NOT in the lookbehind: endpoint types are commonly
+    # reached through a namespace re-export (`Endpoints.UserWeb.init("/u")`),
+    # and the meaningful key is the final segment (`UserWeb`), which is itself
+    # preceded by a `.`.
+    INIT_RE         = /(?<![A-Za-z0-9_])([A-Za-z_]\w*)\.init\s*\(([^()]*)\)/
     LITERAL_PATH_RE = /\.path\s*=\s*"([^"]*)"/
     HANDLE_FUNC_RE  = /\.\s*handle_func(_unbound)?\s*\(/
+    IMPORT_RE       = /(?:pub\s+)?(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*@import\(\s*"([^"]+\.zig)"\s*\)/
 
     private record StructRegion, name : String, start : Int32, stop : Int32
+
+    # by_type:        instantiation type name => candidate URL paths.
+    # aliases_by_file: absolute struct file => the identifiers other files
+    #   import it as. Endpoint structs are idiomatically written as
+    #   `const Self = @This();`, so a path bound at the instantiation site
+    #   (`Foo.init("/x")`, `.{ .path = "/x" }`) is keyed by the *import alias*
+    #   `Foo`, never the internal `Self`. Mapping file => aliases lets the
+    #   struct recover its own bindings.
+    private record PathBindings,
+      by_type : Hash(String, Array(String)),
+      aliases_by_file : Hash(String, Array(String))
 
     def analyze
       include_callee = callees_needed?
@@ -44,21 +60,33 @@ module Analyzer::Zig
       @result
     end
 
-    # typeName => candidate paths, collected across the whole project from
-    # `init()` call sites and `.path = "…"` struct literals. Over-collection is
-    # harmless: a binding is only consumed for a type later confirmed to be an
-    # endpoint struct (one that defines verb methods).
-    private def build_path_bindings(files : Array(String)) : Hash(String, Array(String))
-      bindings = Hash(String, Array(String)).new
+    # Collected across the whole project: type => candidate paths from
+    # `init()` call sites and `.path = "…"` struct literals, plus the
+    # file => import-alias map. Over-collection of `by_type` is harmless: a
+    # binding is only consumed for a type later confirmed to be an endpoint
+    # struct (one that defines verb methods).
+    private def build_path_bindings(files : Array(String)) : PathBindings
+      by_type = Hash(String, Array(String)).new
+      aliases_by_file = Hash(String, Array(String)).new
       files.each do |path|
         content = read_file_content(path)
-        next unless content.includes?(".path") || content.includes?(".init(")
         text = Noir::ZigCalleeExtractor.strip_comments(content)
+
+        if content.includes?("@import")
+          dir = File.dirname(path)
+          text.scan(IMPORT_RE) do |m|
+            resolved = File.expand_path(File.join(dir, m[2]))
+            list = aliases_by_file[resolved] ||= [] of String
+            list << m[1] unless list.includes?(m[1])
+          end
+        end
+
+        next unless content.includes?(".path") || content.includes?(".init(")
 
         text.scan(INIT_RE) do |m|
           type = m[1]
           if pm = m[2].match(/"(\/[^"]*)"/)
-            add_binding(bindings, type, pm[1])
+            add_binding(by_type, type, pm[1])
           end
         end
 
@@ -66,11 +94,11 @@ module Analyzer::Zig
           lit = m[1]
           next if lit.empty? || lit == "(undefined)"
           if type = nearest_type_before(text, m.begin(0) || 0)
-            add_binding(bindings, type, lit)
+            add_binding(by_type, type, lit)
           end
         end
       end
-      bindings
+      PathBindings.new(by_type, aliases_by_file)
     end
 
     private def add_binding(bindings, type, path)
@@ -80,16 +108,18 @@ module Analyzer::Zig
 
     # The last Uppercase-initial identifier in the window preceding a
     # `.path = "…"` literal — almost always the struct type being
-    # instantiated. Liberal by design (see build_path_bindings).
+    # instantiated. Liberal by design (see build_path_bindings). `.` is
+    # allowed in the lookbehind so a namespaced type (`Endpoints.UserWeb`)
+    # resolves to its final segment (`UserWeb`).
     private def nearest_type_before(text : String, offset : Int32) : String?
       start = offset > 160 ? offset - 160 : 0
       window = text[start...offset]
       type = nil
-      window.scan(/(?<![A-Za-z0-9_.])([A-Z][A-Za-z0-9_]*)/) { |m| type = m[1] }
+      window.scan(/(?<![A-Za-z0-9_])([A-Z][A-Za-z0-9_]*)/) { |m| type = m[1] }
       type
     end
 
-    private def process_file(path : String, content : String, bindings : Hash(String, Array(String)), include_callee : Bool)
+    private def process_file(path : String, content : String, bindings : PathBindings, include_callee : Bool)
       comment_stripped = Noir::ZigCalleeExtractor.strip_comments(content)
       # Comments + all literals blanked once; reused for struct-region brace
       # matching and the `@This()` file-struct scan.
@@ -121,7 +151,7 @@ module Analyzer::Zig
           innermost_region(explicit, off) == region
         end
         next if verbs.empty?
-        paths = resolve_paths(region.name, comment_stripped, region.start, region.stop, bindings)
+        paths = resolve_paths(region.name, path, comment_stripped, region.start, region.stop, bindings)
         emit_struct_endpoints(path, region.name, paths, verbs, include_callee)
       end
 
@@ -133,7 +163,7 @@ module Analyzer::Zig
           VERBS.includes?(f[:name]) && innermost_region(explicit, f[:open]).nil?
         end
         unless verbs.empty?
-          paths = resolve_paths(name, comment_stripped, 0, content.size, bindings)
+          paths = resolve_paths(name, path, comment_stripped, 0, content.size, bindings)
           emit_struct_endpoints(path, name, paths, verbs, include_callee)
         end
       end
@@ -159,16 +189,32 @@ module Analyzer::Zig
       best
     end
 
-    private def resolve_paths(type : String, comment_stripped : String, start : Int32, stop : Int32, bindings) : Array(String)
-      paths = [] of String
+    # Resolve an endpoint struct's URL paths. Instantiation-site bindings
+    # (keyed by the struct's own name and by every alias the file is imported
+    # as) take precedence; a `path` field default is only the fallback for a
+    # struct that is constructed bare (`.{}`). Preferring the binding drops a
+    # dead/overridden field default (e.g. a copy-pasted `path = "/post"` that
+    # the call site replaces with `.path = "/comment"`).
+    private def resolve_paths(type : String, file_path : String, comment_stripped : String, start : Int32, stop : Int32, bindings : PathBindings) : Array(String)
+      keys = [type]
+      if aliases = bindings.aliases_by_file[File.expand_path(file_path)]?
+        aliases.each { |a| keys << a unless keys.includes?(a) }
+      end
+
+      binding_paths = [] of String
+      keys.each do |key|
+        bindings.by_type[key]?.try(&.each { |p| binding_paths << p unless binding_paths.includes?(p) })
+      end
+      return binding_paths unless binding_paths.empty?
+
+      field_paths = [] of String
       region = comment_stripped[start...stop]? || ""
       region.scan(FIELD_PATH_RE) do |m|
         lit = m[1]
         next if lit.empty? || lit == "(undefined)"
-        paths << lit unless paths.includes?(lit)
+        field_paths << lit unless field_paths.includes?(lit)
       end
-      bindings[type]?.try(&.each { |p| paths << p unless paths.includes?(p) })
-      paths
+      field_paths
     end
 
     private def emit_struct_endpoints(path, type, paths, verbs, include_callee)

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -235,10 +235,14 @@ module Analyzer::Zig
 
     # `router.handle_func("/p", …)` / `handle_func_unbound("/p", handler)`.
     private def emit_router_routes(path, content, comment_stripped, all_fns, include_callee)
-      chars = comment_stripped.chars
+      # Paths are read from `comment_stripped` (string contents kept), but the
+      # `(`/`)` matching must run on the string-blanked char array — a paren
+      # inside a string argument would otherwise corrupt the argument span.
+      # Both strips share offsets, so `close` indexes `comment_stripped` too.
+      code_chars = Noir::ZigCalleeExtractor.strip_non_code(content).chars
       comment_stripped.scan(HANDLE_FUNC_RE) do |m|
         open_paren = (m.end(0) || 0) - 1
-        close = Noir::ZigCalleeExtractor.find_matching(chars, open_paren, '(', ')')
+        close = Noir::ZigCalleeExtractor.find_matching(code_chars, open_paren, '(', ')')
         next if close.nil?
         args = comment_stripped[(open_paren + 1)...close]
         url_match = args.match(/\s*"([^"]*)"/)
@@ -246,7 +250,7 @@ module Analyzer::Zig
         url = url_match[1]
         next if url.empty?
 
-        line = Noir::ZigCalleeExtractor.line_at(chars, m.begin(0) || 0)
+        line = Noir::ZigCalleeExtractor.line_at(code_chars, m.begin(0) || 0)
         details = Details.new(PathInfo.new(path, line))
         endpoint = Endpoint.new(url, "GET", [] of Param, details)
 

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -22,7 +22,6 @@ module Analyzer::Zig
 
     STRUCT_DECL_RE  = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*struct\s*\{/
     THIS_DECL_RE    = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*@This\(\)/
-    VERB_FN_RE      = /(?:^|[^A-Za-z0-9_.])pub\s+fn\s+(get|post|put|delete|patch|options|head)\s*\(/
     FIELD_PATH_RE   = /\bpath\s*:\s*\[\]const u8\s*=\s*"([^"]*)"/
     INIT_RE         = /(?<![A-Za-z0-9_.])([A-Za-z_]\w*)\.init\s*\(([^()]*)\)/
     LITERAL_PATH_RE = /\.path\s*=\s*"([^"]*)"/
@@ -92,15 +91,17 @@ module Analyzer::Zig
 
     private def process_file(path : String, content : String, bindings : Hash(String, Array(String)), include_callee : Bool)
       comment_stripped = Noir::ZigCalleeExtractor.strip_comments(content)
+      # Comments + all literals blanked once; reused for struct-region brace
+      # matching and the `@This()` file-struct scan.
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
       all_fns = Noir::ZigCalleeExtractor.function_table(content, path)
 
-      explicit = explicit_struct_regions(content)
-      emit_endpoint_structs(path, content, comment_stripped, bindings, explicit, all_fns, include_callee)
+      explicit = explicit_struct_regions(stripped)
+      emit_endpoint_structs(path, content, stripped, comment_stripped, bindings, explicit, all_fns, include_callee)
       emit_router_routes(path, content, comment_stripped, all_fns, include_callee)
     end
 
-    private def explicit_struct_regions(content : String) : Array(StructRegion)
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+    private def explicit_struct_regions(stripped : String) : Array(StructRegion)
       chars = stripped.chars
       regions = [] of StructRegion
       stripped.scan(STRUCT_DECL_RE) do |m|
@@ -113,9 +114,7 @@ module Analyzer::Zig
       regions
     end
 
-    private def emit_endpoint_structs(path, content, comment_stripped, bindings, explicit, all_fns, include_callee)
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
-
+    private def emit_endpoint_structs(path, content, stripped, comment_stripped, bindings, explicit, all_fns, include_callee)
       # Explicit `const X = struct { … }` endpoints.
       explicit.each do |region|
         verbs = verb_methods_in(all_fns, region.start, region.stop) do |off|

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -39,6 +39,10 @@ DETECTOR_IGNORED_DIR_NAMES = Set{
   "node_modules", "vendor", "__pycache__", ".venv", "venv",
   ".pytest_cache", ".tox", ".gradle", ".bundle", ".dart_tool",
   ".cargo", ".terraform",
+  # Zig build outputs / fetched-dependency cache. Vendored deps under
+  # `.zig-cache` carry their own `@import("httpz")` etc. and would
+  # otherwise make every Zig project look like it uses every framework.
+  ".zig-cache", "zig-cache", ".zig-out", "zig-out",
   # Common build / dist / cache outputs
   "dist", "build", "target", "out", "tmp", ".cache",
   ".next", ".nuxt", ".svelte-kit", ".turbo", ".parcel-cache",
@@ -312,6 +316,10 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     Typescript::Nestjs,
     Typescript::TanstackRouter,
     Typescript::TRPC,
+    Zig::Jetzig,
+    Zig::Zap,
+    Zig::Httpz,
+    Zig::Tokamak,
   ])
 
   # Handle --only-techs: filter detector_list to only specified techs

--- a/src/detector/detectors/zig/httpz.cr
+++ b/src/detector/detectors/zig/httpz.cr
@@ -1,0 +1,24 @@
+require "../../../models/detector"
+
+module Detector::Zig
+  class Httpz < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"httpz\")")
+
+      if File.basename(filename) == "build.zig.zon"
+        return true if file_contents.matches?(/\.httpz\s*=\s*\.\{/)
+        return true if file_contents.includes?("karlseguin/http.zig")
+      end
+
+      false
+    end
+
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
+    end
+
+    def set_name
+      @name = "zig_httpz"
+    end
+  end
+end

--- a/src/detector/detectors/zig/jetzig.cr
+++ b/src/detector/detectors/zig/jetzig.cr
@@ -1,0 +1,27 @@
+require "../../../models/detector"
+
+module Detector::Zig
+  class Jetzig < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      # Source files import the framework directly.
+      return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"jetzig\")")
+
+      # The Zig package manifest declares a `.jetzig` dependency. `.zon`
+      # uses dot-prefixed field names, so match the dependency key.
+      if File.basename(filename) == "build.zig.zon"
+        return true if file_contents.matches?(/\.jetzig\s*=\s*\.\{/)
+        return true if file_contents.includes?("jetzig-framework/jetzig")
+      end
+
+      false
+    end
+
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
+    end
+
+    def set_name
+      @name = "zig_jetzig"
+    end
+  end
+end

--- a/src/detector/detectors/zig/tokamak.cr
+++ b/src/detector/detectors/zig/tokamak.cr
@@ -1,0 +1,24 @@
+require "../../../models/detector"
+
+module Detector::Zig
+  class Tokamak < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"tokamak\")")
+
+      if File.basename(filename) == "build.zig.zon"
+        return true if file_contents.matches?(/\.tokamak\s*=\s*\.\{/)
+        return true if file_contents.includes?("cztomsik/tokamak")
+      end
+
+      false
+    end
+
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
+    end
+
+    def set_name
+      @name = "zig_tokamak"
+    end
+  end
+end

--- a/src/detector/detectors/zig/zap.cr
+++ b/src/detector/detectors/zig/zap.cr
@@ -1,0 +1,24 @@
+require "../../../models/detector"
+
+module Detector::Zig
+  class Zap < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      return true if filename.ends_with?(".zig") && file_contents.includes?("@import(\"zap\")")
+
+      if File.basename(filename) == "build.zig.zon"
+        return true if file_contents.matches?(/\.zap\s*=\s*\.\{/)
+        return true if file_contents.includes?("zigzap/zap")
+      end
+
+      false
+    end
+
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
+    end
+
+    def set_name
+      @name = "zig_zap"
+    end
+  end
+end

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -1,0 +1,408 @@
+require "../models/endpoint"
+
+# Shared structural helper for the Zig framework analyzers (jetzig, zap,
+# httpz, tokamak). Zig has no vendored tree-sitter grammar in noir, so the
+# analyzers lean on this hand-rolled miniparser for two jobs:
+#
+#   * `function_table` / `function_bodies` — index every `fn name(...) { … }`
+#     in a source file so a route whose handler lives in a named function
+#     (httpz `router.get("/x", getUser, .{})`, tokamak `.get("/", hello)`)
+#     can resolve that handler's body for callee extraction.
+#   * `callees_for_body` — pull the 1-hop function calls out of a handler
+#     body, used by `--include-callee` and `--ai-context`.
+#
+# The scanners blank out comments and string/char literals first
+# (`strip_non_code`) so a call-shaped token inside a doc-string or a `//`
+# comment is never surfaced as a phantom callee, and they address the
+# source through an `Array(Char)` (O(1) indexing) so a single non-ASCII byte
+# anywhere in the file can't turn the per-character loops into O(n²).
+module Noir::ZigCalleeExtractor
+  extend self
+
+  # (name, path, line) — mirrors the other callee extractors' tuple so the
+  # `attach_to` helper can feed `Endpoint#push_callee` directly.
+  alias Entry = Tuple(String, String, Int32)
+  alias FunctionBody = NamedTuple(body: String, path: String, start_line: Int32)
+  alias FunctionInfo = NamedTuple(name: String, body: String, start_line: Int32, open: Int32, close: Int32)
+
+  # Zig keywords that are followed by `(` in normal code (`if (…)`,
+  # `while (…)`, `switch (…)`, `catch (…)`) and would otherwise be reported
+  # as callees. `fn`/`return`/`try` etc. never precede a call paren directly
+  # but are kept here for clarity.
+  KEYWORDS = Set{
+    "addrspace", "align", "allowzero", "and", "anyframe", "anytype", "asm",
+    "async", "await", "break", "callconv", "catch", "comptime", "const",
+    "continue", "defer", "else", "enum", "errdefer", "error", "export",
+    "extern", "fn", "for", "if", "inline", "noalias", "noinline", "nosuspend",
+    "opaque", "or", "orelse", "packed", "pub", "resume", "return",
+    "linksection", "struct", "suspend", "switch", "test", "threadlocal",
+    "try", "union", "unreachable", "usingnamespace", "var", "volatile",
+    "while",
+  }
+
+  # Receiver roots whose calls are pure noise for endpoint review context.
+  # `std.*` (std.debug.print, std.mem.eql, std.fmt.*) appears in nearly
+  # every handler and drowns the meaningful callees.
+  NOISE_ROOTS = Set{"std"}
+
+  # A call expression: an optional `@` (builtin) + identifier, then any number
+  # of `.identifier` accessors, immediately followed by `(`. The lookbehind
+  # stops the match from starting in the middle of an identifier or chain, so
+  # `foo.bar(` yields `foo.bar` once, not also `bar`.
+  CALL_REGEX = /(?<![A-Za-z0-9_.@])(@?[A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)*)\s*\(/
+
+  # `(?:pub )? (modifiers)* fn name (` — captures the function name. The
+  # `extern "C"` calling-convention string is already blanked by
+  # `strip_non_code`, so only the keyword spacing has to be tolerated.
+  FUNCTION_REGEX = /(?:^|[^A-Za-z0-9_.])fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/
+
+  # ---- public entry points (String overloads) -----------------------------
+
+  def strip_non_code(source : String) : String
+    String.build { |io| strip_non_code(source.chars).each { |c| io << c } }
+  end
+
+  # Like `strip_non_code` but keeps the contents of double-quoted string
+  # literals — route paths live inside `"…"`, so the framework analyzers scan
+  # this form to read the URL while still ignoring routes that sit in a
+  # comment, a `\\` multiline doc-string, or a char literal.
+  def strip_comments(source : String) : String
+    String.build { |io| strip_comments(source.chars).each { |c| io << c } }
+  end
+
+  def function_table(source : String, file_path : String) : Array(FunctionInfo)
+    chars = source.chars
+    stripped = strip_non_code(chars)
+    stripped_str = String.build { |io| stripped.each { |c| io << c } }
+    table = [] of FunctionInfo
+
+    stripped_str.scan(FUNCTION_REGEX) do |match|
+      name = match[1]
+      paren = match.end(0)
+      next if paren.nil?
+      open_paren = paren - 1
+      close_paren = find_matching(stripped, open_paren, '(', ')')
+      next if close_paren.nil?
+
+      brace = next_body_brace(stripped, close_paren + 1)
+      next if brace.nil?
+      close_brace = find_matching(stripped, brace, '{', '}')
+      next if close_brace.nil?
+
+      body = slice(stripped, brace + 1, close_brace)
+      table << {
+        name:       name,
+        body:       body,
+        start_line: line_at(stripped, brace),
+        open:       brace,
+        close:      close_brace,
+      }
+    end
+
+    table
+  end
+
+  # Convenience map keyed by simple function name. When two functions share a
+  # name (e.g. several zap endpoint structs each defining `get`) the first
+  # wins; callers that need struct scoping should filter `function_table`
+  # by offset instead.
+  def function_bodies(source : String, file_path : String) : Hash(String, FunctionBody)
+    bodies = {} of String => FunctionBody
+    function_table(source, file_path).each do |info|
+      next if bodies.has_key?(info[:name])
+      bodies[info[:name]] = {body: info[:body], path: file_path, start_line: info[:start_line]}
+    end
+    bodies
+  end
+
+  def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
+    entries = [] of Entry
+    seen = Set(String).new
+
+    # Blank comments/strings so a call-shaped token inside them is never
+    # surfaced. Idempotent on the already-stripped bodies the analyzers pass
+    # in (spaces stay spaces, newlines and length are preserved so line
+    # math is unaffected).
+    body = strip_non_code(body)
+
+    body.scan(CALL_REGEX) do |match|
+      raw = match[1]
+      name = raw.gsub(/\s+/, "")
+      offset = match.begin(0) || 0
+      next unless callable?(name)
+      next if seen.includes?(name)
+
+      seen << name
+      entries << {name, file_path, start_line + newlines_before(body, offset)}
+    end
+
+    entries
+  end
+
+  def attach_to(endpoint : Endpoint, callees : Array(Entry))
+    callees.each do |name, path, line|
+      endpoint.push_callee(Callee.new(name, path: path, line: line))
+    end
+  end
+
+  # ---- filtering -----------------------------------------------------------
+
+  private def callable?(name : String) : Bool
+    return false if name.empty?
+    return false if name.starts_with?('@') # builtins (@import, @field, …)
+    root = name.includes?('.') ? name.split('.', 2).first : name
+    return false if KEYWORDS.includes?(root)
+    return false if NOISE_ROOTS.includes?(root)
+    # A bare keyword call like `if(` (no chain) is filtered above via root;
+    # a chained access whose first segment is a keyword is unusual but the
+    # root check already covers it.
+    true
+  end
+
+  # ---- structural primitives (Array(Char), O(1) indexing) ------------------
+
+  def strip_non_code(chars : Array(Char)) : Array(Char)
+    out = Array(Char).new(chars.size)
+    i = 0
+    n = chars.size
+
+    while i < n
+      c = chars[i]
+
+      # Line comment: `// …` and Zig doc comments `///` / `//!`.
+      if c == '/' && i + 1 < n && chars[i + 1] == '/'
+        while i < n && chars[i] != '\n'
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      # Multiline string literal: a `\\` token runs to end of line. Checked
+      # before the char/string branches so a `//` or quote inside it can't
+      # re-open a comment or literal.
+      if c == '\\' && i + 1 < n && chars[i + 1] == '\\'
+        while i < n && chars[i] != '\n'
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      # Character literal: `'a'`, `'\n'`, `'\''`.
+      if c == '\''
+        out << ' '
+        i += 1
+        while i < n && chars[i] != '\''
+          if chars[i] == '\\' && i + 1 < n
+            out << ' '
+            out << ' '
+            i += 2
+            next
+          end
+          out << ' '
+          i += 1
+        end
+        if i < n
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      # Double-quoted string literal: `"…"` with `\"` escapes.
+      if c == '"'
+        out << ' '
+        i += 1
+        while i < n && chars[i] != '"'
+          if chars[i] == '\\' && i + 1 < n
+            out << ' '
+            out << ' '
+            i += 2
+            next
+          end
+          out << ' '
+          i += 1
+        end
+        if i < n
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      out << c
+      i += 1
+    end
+
+    out
+  end
+
+  def strip_comments(chars : Array(Char)) : Array(Char)
+    out = Array(Char).new(chars.size)
+    i = 0
+    n = chars.size
+
+    while i < n
+      c = chars[i]
+
+      # Line / doc comments.
+      if c == '/' && i + 1 < n && chars[i + 1] == '/'
+        while i < n && chars[i] != '\n'
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      # Multiline string literal (`\\ …` to EOL) — blanked so a route-shaped
+      # token inside a doc-string isn't surfaced.
+      if c == '\\' && i + 1 < n && chars[i + 1] == '\\'
+        while i < n && chars[i] != '\n'
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      # Char literal — blanked.
+      if c == '\''
+        out << ' '
+        i += 1
+        while i < n && chars[i] != '\''
+          if chars[i] == '\\' && i + 1 < n
+            out << ' '
+            out << ' '
+            i += 2
+            next
+          end
+          out << ' '
+          i += 1
+        end
+        if i < n
+          out << ' '
+          i += 1
+        end
+        next
+      end
+
+      # Double-quoted string literal — contents PRESERVED.
+      if c == '"'
+        out << c
+        i += 1
+        while i < n && chars[i] != '"'
+          if chars[i] == '\\' && i + 1 < n
+            out << chars[i]
+            out << chars[i + 1]
+            i += 2
+            next
+          end
+          out << chars[i]
+          i += 1
+        end
+        if i < n
+          out << chars[i]
+          i += 1
+        end
+        next
+      end
+
+      out << c
+      i += 1
+    end
+
+    out
+  end
+
+  # Find the index of the delimiter matching the opener at `open_index`.
+  # Returns nil on imbalance. Operates on the already-stripped char array so
+  # braces inside strings/comments are gone.
+  def find_matching(chars : Array(Char), open_index : Int32, open : Char, close : Char) : Int32?
+    depth = 0
+    i = open_index
+    n = chars.size
+    while i < n
+      ch = chars[i]
+      if ch == open
+        depth += 1
+      elsif ch == close
+        depth -= 1
+        return i if depth == 0
+      end
+      i += 1
+    end
+    nil
+  end
+
+  # The first `{` at or after `from` that opens a function body. An anonymous
+  # struct/enum/union/error return type can carry its own `{` before the body
+  # brace; skip past it so we land on the real body opener.
+  private def next_body_brace(chars : Array(Char), from : Int32) : Int32?
+    i = from
+    n = chars.size
+    while i < n
+      ch = chars[i]
+      if ch == '{'
+        if container_keyword_before?(chars, i)
+          inner = find_matching(chars, i, '{', '}')
+          return if inner.nil?
+          i = inner + 1
+          next
+        end
+        return i
+      end
+      # A `;` before any `{` means this was a declaration/prototype, not a
+      # definition with a body.
+      return if ch == ';'
+      i += 1
+    end
+    nil
+  end
+
+  private def container_keyword_before?(chars : Array(Char), brace_index : Int32) : Bool
+    j = brace_index - 1
+    while j >= 0 && chars[j].whitespace?
+      j -= 1
+    end
+    return false if j < 0
+    word_end = j + 1
+    while j >= 0 && (chars[j].ascii_alphanumeric? || chars[j] == '_')
+      j -= 1
+    end
+    word = slice(chars, j + 1, word_end)
+    word == "struct" || word == "enum" || word == "union" || word == "opaque" || word == "error"
+  end
+
+  private def slice(chars : Array(Char), start : Int32, stop : Int32) : String
+    return "" if start >= stop
+    String.build do |io|
+      idx = start
+      while idx < stop && idx < chars.size
+        io << chars[idx]
+        idx += 1
+      end
+    end
+  end
+
+  def line_at(chars : Array(Char), offset : Int32) : Int32
+    count = 1
+    i = 0
+    limit = offset > chars.size ? chars.size : offset
+    while i < limit
+      count += 1 if chars[i] == '\n'
+      i += 1
+    end
+    count
+  end
+
+  private def newlines_before(text : String, offset : Int32) : Int32
+    count = 0
+    i = 0
+    text.each_char do |ch|
+      break if i >= offset
+      count += 1 if ch == '\n'
+      i += 1
+    end
+    count
+  end
+end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -31,6 +31,7 @@ module NoirTechs
     "scala_akka", "scala_http4s", "scala_play", "scala_scalatra", "scala_tapir", "scala_zio_http",
     "swift_hummingbird", "swift_kitura", "swift_vapor",
     "ts_nestjs", "ts_tanstack_router", "ts_trpc",
+    "zig_jetzig", "zig_zap", "zig_httpz", "zig_tokamak",
   ]
 
   AI_CONTEXT_GUARD_SUPPORTED_TECHS = [
@@ -1605,6 +1606,78 @@ module NoirTechs
         },
         :static_path => true,
         :websocket   => true,
+      },
+    },
+    :zig_jetzig => {
+      :framework => "Jetzig",
+      :language  => "Zig",
+      :similar   => ["jetzig", "zig-jetzig", "zig_jetzig"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => false,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+    },
+    :zig_zap => {
+      :framework => "Zap",
+      :language  => "Zig",
+      :similar   => ["zap", "zigzap", "zig-zap", "zig_zap"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => false,
+          :path   => false,
+          :body   => false,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+    },
+    :zig_httpz => {
+      :framework => "httpz",
+      :language  => "Zig",
+      :similar   => ["httpz", "http.zig", "http_zig", "zig-httpz", "zig_httpz"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => false,
+          :path   => true,
+          :body   => false,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+    },
+    :zig_tokamak => {
+      :framework => "Tokamak",
+      :language  => "Zig",
+      :similar   => ["tokamak", "zig-tokamak", "zig_tokamak"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => false,
+          :path   => true,
+          :body   => false,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => false,
       },
     },
     :kotlin_http4k => {


### PR DESCRIPTION
## Summary

Adds first-class **Zig** language support to noir with detectors + analyzers for the four mainstream Zig web frameworks. Each surfaces endpoints, path parameters, and best-effort **1-hop callees** (feeding `--include-callee` and `--ai-context`).

| Framework | Routing model handled |
|-----------|------------------------|
| **Jetzig** | Filesystem "resourceful" routing — `src/app/views/<name>.zig` → Rails-style `(method, /name[/:id][/new\|/edit])`; `root.zig` → `/`; nested views; `params.get("…")` query params |
| **Zap** | Endpoint structs (path slug + verb methods) with project-wide path resolution from `init("/p")` / `.path = "/p"`; `Router.handle_func` / `handle_func_unbound` |
| **httpz** | `router.<verb>("/p", h, .{})`, `.method(...)`, `.all`, `:param` vars, nested `group(prefix)` composition |
| **Tokamak** | Declarative `tk.Route` arrays with nested `.group(prefix, …)` brace-tracked prefix composition, `.post0`/`.put0`/`.patch0` |

This enriches noir's already-broad AI-context coverage with the Zig ecosystem — the same endpoint/param/callee model the other 100+ frameworks emit, now for Zig.

## How it works

Zig has no vendored tree-sitter grammar in noir, so a hand-rolled shared miniparser (`src/miniparsers/zig_callee_extractor.cr`) does the structural work:
- indexes `fn name(...) { … }` bodies so named handlers resolve their callees,
- extracts 1-hop calls (receiver chains + bare calls), filtering Zig keywords, `@builtins` and the `std.*` prelude,
- blanks comments / string + char / `\\` multiline literals first (no phantom callees), and addresses source via `Array(Char)` to stay O(n) on non-ASCII input.

The detector walk now also prunes Zig build caches (`.zig-cache`, `zig-out`, …). Jetzig and Tokamak both wrap httpz, so co-detection of `zig_httpz` on their own source is filtered as redundant during analysis (same pattern as `elixir_plug`/`php_pure`).

## Validation

- New unit specs (extractor + detectors) and functional specs with per-framework fixtures, all asserting endpoints + params + callees.
- Full suite green: **21,893 examples, 0 failures**; `ameba` + `crystal tool format --check` clean.
- Smoke-tested against the upstream repos (jetzig demo, zap/http.zig examples, tokamak) — correct routes incl. nested groups (`/api/v1/items/:id`), no crashes, sub-second scans.

## Notes / deferred

- Cross-file handler resolution for callees is same-file only for now (jetzig views and zap endpoint structs are self-contained; httpz/tokamak handlers are typically file-local).
- Zap's catch-all `Router` routes are reported as `GET` (the router dispatches any method); jetzig custom routes and tokamak `.router(T)` reflection-mounts are out of scope for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)