### PR TITLE
fix(python/flask): honor flask_restful/flask-restx `Api(prefix=...)` for resources

### DIFF
--- a/spec/functional_test/fixtures/python/flask_restful/app.py
+++ b/spec/functional_test/fixtures/python/flask_restful/app.py
@@ -36,3 +36,14 @@ api.add_scoped_resource(
     "/items/all",
     endpoint="items",
 )
+
+# `Api(prefix=...)` prepends the prefix to every resource registered on it.
+prefixed_api = Api(app, prefix="/api/v2")
+
+
+class Health(Resource):
+    def get(self):
+        return {"ok": True}
+
+
+prefixed_api.add_resource(Health, "/health")

--- a/spec/functional_test/testers/python/flask_restful_spec.cr
+++ b/spec/functional_test/testers/python/flask_restful_spec.cr
@@ -16,6 +16,7 @@ expected_endpoints = [
   Endpoint.new("/items", "POST"),
   Endpoint.new("/items/all", "GET"),
   Endpoint.new("/items/all", "POST"),
+  Endpoint.new("/api/v2/health", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/flask_restful/", {

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -206,6 +206,12 @@ module Analyzer::Python
               # regex builds entirely unless the call is present (the
               # match itself requires the literal `Api(`).
               if api_line.includes?("Api(")
+                # flask_restful / flask-restx `Api(app, prefix="/api/v1")`
+                # prepends the prefix to every resource. The kwarg sits on
+                # the same (coalesced) Api(...) call; anchor on `(`/`,` so
+                # Blueprint's `url_prefix=` can't be mistaken for it.
+                api_kwarg_prefix = api_line.match(/[,(]prefix=[rf]?['"]([^'"]*)['"]/).try(&.[1]) || ""
+
                 # Api from flask instance
                 flask_instances.each do |key, _prefix|
                   next unless key[0] == current_base_path
@@ -213,7 +219,7 @@ module Analyzer::Python
                   api_match = api_line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_flask_instance_name}[,)]/
                   if api_match
                     api_instance_name = api_match[1]
-                    api_instances[api_instance_name] ||= _prefix
+                    api_instances[api_instance_name] ||= join_flask_paths(_prefix, api_kwarg_prefix)
                   end
                 end
 
@@ -224,7 +230,7 @@ module Analyzer::Python
                   api_match = api_line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_blueprint_instance_name}[,)]/
                   if api_match
                     api_instance_name = api_match[1]
-                    api_instances[api_instance_name] ||= _prefix
+                    api_instances[api_instance_name] ||= join_flask_paths(_prefix, api_kwarg_prefix)
                   end
                 end
               end


### PR DESCRIPTION
## Summary

`Api(app, prefix="/api/v1")` prepends the prefix to **every** resource registered on that `Api` — a standard flask_restful (and flask-restx) feature. The `Api(...)` detection captured the instance name but ignored the `prefix=` kwarg, so:

```python
api = Api(app, prefix="/api/v1")
api.add_resource(Users, "/users")   # surfaced as /users, not /api/v1/users
```

This is a direct follow-up to #2016 (which added `add_resource` support).

## Fix

Capture the `prefix=` kwarg from the (coalesced) `Api(...)` call and join it onto the api instance's prefix. The matcher anchors on `(`/`,` so Blueprint's `url_prefix=` can't be misread as `prefix=`, and an absent kwarg leaves existing behaviour unchanged.

Verified untouched: redash (uses an `Api` subclass without the kwarg → stays 138), the flask-restx namespace fixture, and the flask-restx multi-base suite.

## Tests

Extends the `flask_restful` fixture with a prefixed `Api` asserting `GET /api/v2/health`.

> Note: `just test` shows a **pre-existing** unrelated failure on `fixtures/typescript/tanstack_router/` (a count-check ordering flake from #2022 — reproduces on clean `main`, passes in isolation). It is independent of this Python-only change.