### PR TITLE
fix(typescript/tanstack-router): route groups, multi-line createFileRoute, concurrency

### DIFF
--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/(marketing).pricing.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/(marketing).pricing.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+// A `(group)` route-group segment is organizational only — it must be
+// stripped from the URL, so this serves `/pricing`, not
+// `/(marketing)/pricing`.
+export const Route = createFileRoute('/(marketing)/pricing')({
+  component: Pricing,
+})
+
+function Pricing() {
+  return null
+}

--- a/spec/functional_test/fixtures/typescript/tanstack_router/routes/wrapped.tsx
+++ b/spec/functional_test/fixtures/typescript/tanstack_router/routes/wrapped.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+// A formatter-wrapped multi-line createFileRoute call with a trailing
+// comma must still be matched.
+export const Route = createFileRoute(
+  '/wrapped',
+)({
+  component: Wrapped,
+})
+
+function Wrapped() {
+  return null
+}

--- a/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_callees_spec.cr
@@ -11,7 +11,7 @@ docs.push_callee(Callee.new("DocsRootComponent"))
 
 FunctionalTester.new("fixtures/typescript/tanstack_router/", {
   :techs     => 1,
-  :endpoints => 11,
+  :endpoints => 14,
 }, [posts, shop, docs], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/typescript/tanstack_router_spec.cr
+++ b/spec/functional_test/testers/typescript/tanstack_router_spec.cr
@@ -45,6 +45,10 @@ expected_endpoints = [
   # client-side-framework filter applies to the verb-DSL extractor, not
   # to TanStack Router's own (React) route definitions.
   Endpoint.new("/react-page", "GET", [] of Param),
+  # `(group)` route-group segments are stripped from the URL.
+  Endpoint.new("/pricing", "GET", [] of Param),
+  # A formatter-wrapped multi-line createFileRoute (trailing comma) is matched.
+  Endpoint.new("/wrapped", "GET", [] of Param),
 ]
 
 FunctionalTester.new("fixtures/typescript/tanstack_router/", {

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -17,9 +17,17 @@ module Analyzer::Typescript
 
     def analyze
       result = [] of Endpoint
+      mutex = Mutex.new
 
       parallel_file_scan([".ts", ".tsx"]) do |path|
-        analyze_tanstack_file(path, result)
+        # Collect into a per-file buffer, then merge under the mutex —
+        # `parallel_file_scan` can run concurrently, so appending straight
+        # to the shared `result` risks a lost/duplicated endpoint.
+        file_endpoints = [] of Endpoint
+        analyze_tanstack_file(path, file_endpoints)
+        unless file_endpoints.empty?
+          mutex.synchronize { result.concat(file_endpoints) }
+        end
       end
 
       result
@@ -83,7 +91,9 @@ module Analyzer::Typescript
     private def analyze_file_routes(content : String, path : String, result : Array(Endpoint), literal_mask : Array(Bool))
       # Pattern for createFileRoute('/path')
       # Example: export const Route = createFileRoute('/posts/$postId')()
-      file_route_pattern = /createFileRoute\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/
+      # A trailing comma is tolerated so a formatter-wrapped multi-line call
+      # (`createFileRoute(\n  '/path',\n)`) is still matched.
+      file_route_pattern = /createFileRoute\s*\(\s*['"`]([^'"`]+)['"`]\s*,?\s*\)/
 
       content.scan(file_route_pattern) do |match|
         next if literal_position?(literal_mask, match.begin(0))
@@ -107,7 +117,7 @@ module Analyzer::Typescript
     private def analyze_lazy_file_routes(content : String, path : String, result : Array(Endpoint), literal_mask : Array(Bool))
       # Pattern for createLazyFileRoute('/path')
       # Example: export const Route = createLazyFileRoute('/posts/$postId')()
-      lazy_file_route_pattern = /createLazyFileRoute\s*\(\s*['"`]([^'"`]+)['"`]\s*\)/
+      lazy_file_route_pattern = /createLazyFileRoute\s*\(\s*['"`]([^'"`]+)['"`]\s*,?\s*\)/
 
       content.scan(lazy_file_route_pattern) do |match|
         next if literal_position?(literal_mask, match.begin(0))
@@ -284,7 +294,12 @@ module Analyzer::Typescript
 
     private def pathless_segment?(path : String) : Bool
       stripped = path.strip.lstrip('/').rstrip('/')
-      stripped.starts_with?("_") && !stripped.empty?
+      return false if stripped.empty?
+      # Organizational-only segments that never contribute to the URL:
+      # `_layout` pathless layouts (leading underscore) and `(group)`
+      # route groups (`app/routes/(marketing)/about` serves `/about`).
+      stripped.starts_with?("_") ||
+        (stripped.starts_with?("(") && stripped.ends_with?(")"))
     end
 
     private def pathless_only_route?(path : String) : Bool


### PR DESCRIPTION
## Summary

Found auditing the official TanStack Router examples (after #2022 un-broke the analyzer for React route files):

1. **`(group)` route groups stayed in the URL.** `pathless_segment?` only stripped `_layout` segments, so `app/routes/(marketing)/about` was emitted as `/(marketing)/about` instead of `/about`. Now `(...)` route groups are stripped too.
2. **Multi-line `createFileRoute` was missed.** A formatter-wrapped call —
   ```tsx
   export const Route = createFileRoute(
     '/route-group',
   )({ ... })
   ```
   didn't match because the regex required the path string immediately followed by `)`. A trailing comma is now tolerated. (kitchen-sink's `route-group` route was dropped for exactly this reason.)
3. **Missing mutex.** `analyze` appended to the shared `result` from inside `parallel_file_scan` without a lock (unlike the SvelteKit/Koa analyzers). Now each file's endpoints are collected locally and merged under a mutex.

`kitchen-sink-file-based`: **11 → 12** routes (recovers `/route-group`).

## Also: repairs a stale test count

`tanstack_router_callees_spec.cr` hardcodes `:endpoints`, and #2022 left it at `11` when it added `react-page.tsx` to the shared `tanstack_router` fixture (the main tester was bumped to 12, the callees one wasn't). Combined with the two new guard fixtures here it's now **14** (react-page + `(group).pricing` + `wrapped`). This also turns the `tanstack_router_callees` test — currently red on `main` — back green.

## Validation
- New fixtures: `(marketing).pricing.tsx` (route group → `/pricing`) and `wrapped.tsx` (multi-line trailing comma → `/wrapped`).
- Full functional suite **18451 examples, 0 failures**; `crystal tool format --check` + `ameba` clean.