### PR TITLE
fix(ruby/sinatra): reject non-rooted string args as routes (SQL/HTTP-client FP)

### DIFF
--- a/spec/functional_test/fixtures/ruby/sinatra/app.rb
+++ b/spec/functional_test/fixtures/ruby/sinatra/app.rb
@@ -22,6 +22,20 @@ class HeaderShim
   end
 end
 
+# Regression guard: the verb words double as ordinary Ruby methods. A
+# Rails+Sinatra app runs these in migrations / service objects that the
+# Sinatra analyzer also scans. The string argument is not a rooted route
+# path, so none may surface as an endpoint (the old matcher turned the
+# raw SQL into a phantom `DELETE /DELETE FROM ...`, and a non-rooted
+# Rails route `get "release-notes"` leaked without its real scope).
+class Maintenance
+  def run
+    delete "DELETE FROM articles WHERE archived = true"
+    post "https://hooks.example.com/notify"
+    get "release-notes"
+  end
+end
+
 get '/' do
   puts param['query']
   puts cookies[:cookie1]

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -56,6 +56,15 @@ module Analyzer::Ruby
 
         if m = leading.match(verb_pattern)
           path = normalize_ruby_interpolation(m[1])
+          # Sinatra/Hanami route patterns are always rooted at `/` (or an
+          # interpolated `{prefix}` segment). The verb words double as
+          # ordinary Ruby methods — ActiveRecord migrations run
+          # `delete "DELETE FROM articles WHERE ..."`, HTTP clients call
+          # `post "https://..."`, etc. — so a string argument that isn't a
+          # rooted path is not a route. Without this guard the Sinatra
+          # analyzer (which scans every `.rb` file) turned raw SQL into
+          # phantom `DELETE /DELETE FROM ...` endpoints.
+          next unless path.starts_with?('/') || path.starts_with?('{')
           if details
             return Endpoint.new(path, verb.upcase, details)
           else


### PR DESCRIPTION
## Summary

The Sinatra analyzer scans **every** `.rb` file, and the HTTP-verb words (`get`/`post`/`delete`/…) double as ordinary Ruby methods. In a Rails+Sinatra app (e.g. [Upcase](https://github.com/thoughtbot/upcase)) this produces phantom endpoints:

```ruby
# db/migrate/*.rb — ActiveRecord SQL helper, not a route
delete "DELETE FROM articles WHERE archived = true"   # → DELETE /DELETE FROM articles ...

# service object — HTTP client call
post "https://hooks.example.com/notify"               # → POST /https:

# config/routes.rb — a Rails route inside `scope "upcase"`
get "forum", to: redirect("...")                      # → GET /forum  (missing /upcase scope)
get "", to: "marketing#show"                          # → GET /", to:  (malformed)
```

## Fix

Sinatra and Hanami route patterns are always rooted at `/` (or an interpolated `{prefix}` segment), so the shared `line_to_endpoint` now rejects any captured path that isn't. The Rails analyzer already emits the correctly-scoped versions (`/upcase/forum`, …), so this only drops false positives — no recall cost.

## Impact

- **Upcase: 126 → 114** (12 FPs removed: 5 SQL migrations, 1 malformed empty-path, 6 wrong-`/upcase`-prefix Rails routes the Sinatra pass mis-scoped).
- No other OSS app in the sweep changed. Gollum and the Sinatra repo's real routes (all `/`-rooted) are untouched.

## Tests

The sinatra fixture gains a `Maintenance` class exercising the SQL-`delete`, scheme-URL-`post`, and non-rooted-`get` shapes; the exact-count assertion (still 11) guards the regression.

> Note: `just test` shows a **pre-existing, unrelated** failure on `fixtures/typescript/tanstack_router/` (reproduces on clean `main`, passes in isolation) — independent of this Ruby-only change.