### PR TITLE
fix(php/laminas): stop detecting non-routing Zend/Laminas transitive deps

### DIFF
--- a/spec/unit_test/detector/php/laminas_detector_spec.cr
+++ b/spec/unit_test/detector/php/laminas_detector_spec.cr
@@ -41,4 +41,12 @@ describe "Detect Laminas" do
     instance.detect("index.php", "<?php echo 'Hello World';").should_not be_true
     instance.detect("composer.json", %({"require": {"slim/slim": "^4.12"}})).should_not be_true
   end
+
+  it "does not detect non-routing Laminas/Zend transitive deps" do
+    # PSR-7 / Swoole-adapter packages are pulled in transitively by countless
+    # Laravel/Symfony/Yii apps; they must NOT trip the Laminas routing analyzer.
+    instance.detect("composer.lock", %({"packages": [{"name": "zendframework/zend-diactoros"}]})).should_not be_true
+    instance.detect("composer.lock", %({"packages": [{"name": "laminas/laminas-diactoros"}]})).should_not be_true
+    instance.detect("composer.lock", %({"packages": [{"name": "mezzio/mezzio-swoole"}]})).should_not be_true
+  end
 end

--- a/src/detector/detectors/php/laminas.cr
+++ b/src/detector/detectors/php/laminas.cr
@@ -14,8 +14,14 @@ module Detector::Php
 
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "composer.json" || File.basename(filename) == "composer.lock"
-        return true if LAMINAS_PACKAGES.any? { |package| file_contents.includes?(package) }
-        return true if file_contents.includes?("\"zendframework/")
+        # Match the package as a complete quoted name (`"mezzio/mezzio"`), not a
+        # bare substring. A loose `includes?("mezzio/mezzio")` matched the Swoole
+        # server adapter `mezzio/mezzio-swoole` (a transitive dep of many
+        # Laravel/Symfony/Yii apps), and the blanket `"zendframework/"` matched
+        # non-routing PSR-7 deps like `zendframework/zend-diactoros` — both fired
+        # the Laminas analyzer on apps that never use Laminas routing, surfacing
+        # HTTP-client `$x->get('https://…')` calls as phantom endpoints.
+        return true if LAMINAS_PACKAGES.any? { |package| file_contents.includes?(%("#{package}")) }
       end
 
       if filename.ends_with?(".php")


### PR DESCRIPTION
## Summary

The Laminas detector matched composer package names as **bare substrings**, so it fired on apps that merely pull a Zend/Laminas utility in *transitively* and never use Laminas routing:
- `includes?("mezzio/mezzio")` matched the Swoole server adapter **`mezzio/mezzio-swoole`** (monica, koel, humhub, Part-DB all ship it);
- the blanket `includes?("\"zendframework/")` matched PSR-7 deps like **`zendframework/zend-diactoros`**.

Once tripped, the Laminas analyzer's programmatic-route scan (`$x->get('…')`) surfaced ordinary HTTP-client calls as phantom endpoints — e.g. firefly-iii's `$client->get('https://api.github.com/.../releases')` became `GET /https:/api.github.com/...`.

## Fix
Match each package as a **complete quoted name** (`"mezzio/mezzio"`) and drop the blanket `"zendframework/"` check — the real legacy routing packages (`zendframework/zend-mvc`/`-router`/`-expressive`) are already listed exactly. The PHP-namespace signals (`use Mezzio\…`, `Mezzio\Application`, `RouteStackInterface`) are unchanged.

## Impact (real OSS)
Removes **~95 phantom endpoints** across 7 apps and skips the whole Laminas analysis pass on them:

| app | before → after |
|---|---|
| humhub | 415 → 374 (−41) |
| invoiceninja | 515 → 489 (−26) |
| Part-DB | 248 → 242 (−11 laminas, +5 real Symfony routes un-shadowed) |
| firefly-iii | 585 → 579 (−6) |
| monica | 310 → 304 (−6) |
| pixelfed | 920 → 917 (−3) |
| koel | 286 → 284 (−2) |

Bonus perf: Part-DB scan **3.5s → 0.5s** (no longer runs the Laminas pass over 995 files). `laminas-mvc-skeleton` still detected correctly.

## Tests
New negative detector cases (`zend-diactoros`, `laminas-diactoros`, `mezzio-swoole` must not detect); all PHP detector specs green; `format` + `ameba` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)