### PR TITLE
fix(ruby/rails): stop truncating route paths at quotes inside `#{...}` interpolation

### DIFF
--- a/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails_advanced/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
   get "#{base_c_route}/:message_id" => "chat#respond"
   post "#{base_c_route}/messages" => "chat#create"
 
+  # Regression guard: a `#{...}` interpolation that embeds its own quotes
+  # (an ENV lookup with a default) must not truncate the path at the inner
+  # quote — the old matcher surfaced a malformed `/#{ENV.fetch('` route.
+  get "/#{ENV.fetch('URL_COMPONENT', 'bb')}/:area" => "billboards#show"
+
   namespace :admin do
     resources :reports
     resources :refunds do

--- a/spec/functional_test/testers/ruby/rails_advanced_spec.cr
+++ b/spec/functional_test/testers/ruby/rails_advanced_spec.cr
@@ -17,6 +17,10 @@ expected_endpoints = [
   Endpoint.new("/c/:channel_title/:channel_id/:message_id", "GET"),
   Endpoint.new("/c/:channel_title/:channel_id/messages", "POST"),
 
+  # `#{ENV.fetch('URL_COMPONENT', 'bb')}` interpolation embeds quotes; the
+  # path must be captured whole (placeholdered), not truncated mid-quote.
+  Endpoint.new("/{ENV.fetch}/:area", "GET"),
+
   # namespace :admin do resources :reports end
   Endpoint.new("/admin/reports", "GET"),
   Endpoint.new("/admin/reports/1", "GET"),
@@ -193,6 +197,7 @@ expected_endpoints = [
 # /scans/1) and devise_for emits its full route set.
 total_endpoints = 1 +  # root
                   2 +  # `#{base_c_route}` interpolation resolved to 2 routes
+                  1 +  # `#{ENV.fetch(...)}` nested-quote interpolation placeholder
                   6 +  # admin/reports
                   4 +  # admin/refunds member (change_status, purge, update_metadata) + collection (new_list)
                   1 +  # admin/monitor/heartbeat (namespaced `to:`)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -513,9 +513,13 @@ module Analyzer::Ruby
 
           # `get "path"` / `get "path" => "..."` / `get "path", to: "..."`.
           # The path literal may be empty (`get "" => "admin#index"` maps a
-          # namespace to its bare prefix), so accept `*` not `+`.
-          if sm = rest.match(/^\s*['"]([^'"]*)['"]/)
-            path = normalize_ruby_interpolation(strip_optional_route_segments(sm[1]))
+          # namespace to its bare prefix), so accept `*` not `+`. A `#{...}`
+          # interpolation can embed its own quotes (`get
+          # "/#{ENV.fetch('X', 'bb')}/:area"`), so consume those blocks
+          # wholesale instead of stopping at the first inner quote — that
+          # truncation surfaced a malformed `/#{ENV.fetch('` route.
+          if sm = rest.match(/^\s*(['"])((?:\#\{[^}]*\}|(?!\1).)*)\1/)
+            path = normalize_ruby_interpolation(strip_optional_route_segments(sm[2]))
             prefix = current_path_prefix_for_route(stack, route_scope)
             path_part = path.starts_with?("/") ? path : "/#{path}"
             url = prefix.empty? ? path_part : "/#{prefix}#{path_part}"


### PR DESCRIPTION
## Summary

A route path interpolation can embed its own string literals:

```ruby
get "/#{ENV.fetch('BILLBOARD_URL_COMPONENT', 'bb')}/:placement_area",
    to: "billboards#show"
```

The path matcher captured `[^'"]*`, which stopped at the first quote **inside** the `#{...}` block, surfacing a malformed `GET /#{ENV.fetch('` endpoint (found on [Forem](https://github.com/forem/forem)).

## Fix

Consume `#{...}` interpolation blocks wholesale so the full path is captured, then placeholdered by the existing interpolation normaliser:

```
/#{ENV.fetch('  →  /{ENV.fetch}/:placement_area
```

Forem's billboard routes are corrected in place (no count change); no other OSS app in the sweep changed.

## Tests

The `rails_advanced` fixture gains a nested-quote ENV-interpolation route. Full suite green: `18475 examples, 0 failures`.