### PR TITLE
fix(php/cakephp): ignore Bake `.twig` route templates + honour prefix() path option

### DIFF
--- a/spec/functional_test/fixtures/php/cakephp/config/routes.php
+++ b/spec/functional_test/fixtures/php/cakephp/config/routes.php
@@ -37,6 +37,12 @@ return static function (RouteBuilder $routes) {
             ->setMethods(['GET']);
     });
 
+    // prefix() with an explicit ['path' => ...] option mounts under that path,
+    // not the dasherized prefix name (so this is /v1.0/status, not /v10/status).
+    $routes->prefix('v10', ['path' => '/v1.0'], function (RouteBuilder $builder) {
+        $builder->get('/status', ['controller' => 'Api', 'action' => 'status']);
+    });
+
     // Static Router facade form used by older apps and plugin route files.
     Router::scope('/legacy', function (RouteBuilder $routes) {
         $routes->get('/ping', ['controller' => 'Legacy', 'action' => 'ping']);

--- a/spec/functional_test/fixtures/php/cakephp/config/routes.php.twig
+++ b/spec/functional_test/fixtures/php/cakephp/config/routes.php.twig
@@ -1,0 +1,14 @@
+<?php
+// CakePHP "Bake" code-generation template — NOT a real routes file. Its
+// `{{ plugin }}` placeholders are unrendered Twig, so it must never be parsed
+// (the `config/routes.php` substring used to match `config/routes.php.twig`).
+use Cake\Routing\RouteBuilder;
+use Cake\Routing\Router;
+
+Router::plugin('{{ plugin }}', ['path' => '/'], function (RouteBuilder $route) {
+    $route->prefix('api', function (RouteBuilder $route) {
+        $route->prefix('v10', ['path' => '/v1.0'], function (RouteBuilder $route) {
+            $route->resources('{{ plugin }}');
+        });
+    });
+});

--- a/spec/functional_test/testers/php/cakephp_spec.cr
+++ b/spec/functional_test/testers/php/cakephp_spec.cr
@@ -19,11 +19,15 @@ expected_endpoints = [
   Endpoint.new("/sessions/{id}", "DELETE", [Param.new("id", "", "path")]),
   # prefix() opens a prefixed scope like scope()
   Endpoint.new("/groups/{id}", "GET", [Param.new("id", "", "path")]),
+  # prefix() with ['path' => '/v1.0'] mounts under the path option, not /v10.
+  # (The sibling `config/routes.php.twig` Bake template's `{{ plugin }}` routes
+  # are ignored entirely — a `.twig` file is not a routes file.)
+  Endpoint.new("/v1.0/status", "GET"),
   # Static Router facade form
   Endpoint.new("/legacy/ping", "GET"),
 ]
 
 FunctionalTester.new("fixtures/php/cakephp/", {
   :techs     => 2,  # Detection still sees php_cakephp and php_pure
-  :endpoints => 17, # Analysis suppresses redundant php_pure file endpoints
+  :endpoints => 18, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -7,8 +7,11 @@ module Analyzer::Php
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
-      # Analyze CakePHP routes file
-      if path.includes?("config/routes.php")
+      # Analyze CakePHP routes file. Require a real `.php` extension so a Bake
+      # code-generation template (`.../config/routes.php.twig`) — whose body is
+      # full of unrendered `{{ plugin }}` placeholders — isn't mistaken for a
+      # routes file by the `config/routes.php` substring match.
+      if path.includes?("config/routes.php") && path.ends_with?(".php")
         endpoints.concat(analyze_routes_file(path))
       end
 
@@ -187,6 +190,16 @@ module Analyzer::Php
         end
         name = prelude.match(/['"]([^'"]+)['"]/)
         return name ? "/#{name[1].downcase}" : ""
+      end
+
+      # `prefix('v10', ['path' => '/v1.0'], ...)` mounts under the explicit
+      # `path` option, NOT the dasherized prefix name — honour it like `plugin`
+      # does (`scope('/api', ...)` has no such option, so it falls through to
+      # its first string arg, the path itself).
+      if method == "prefix"
+        if path = prelude.match(/['"]path['"]\s*=>\s*['"]([^'"]*)['"]/i)
+          return path[1]
+        end
       end
 
       first = prelude.match(/['"]([^'"]*)['"]/)


### PR DESCRIPTION
## Summary

Two CakePHP analyzer accuracy bugs surfaced by **croogo** (a real CakePHP app).

### 1. Bake `.twig` template parsed as a routes file
The routes-file gate `path.includes?("config/routes.php")` also matched the Bake **code-generation template** `.../config/routes.php.twig`, whose body is full of unrendered `{{ plugin }}` Twig placeholders. noir emitted phantom routes like `GET /api/v10/{{ plugin }}`. Now it requires a real `.php` extension.

### 2. `prefix()` `['path' => ...]` option ignored
`prefix('v10', ['path' => '/v1.0'], ...)` mounts the sub-routes under the explicit `path` option, not the dasherized prefix name. `scope_prefix_from_prelude` only honoured `path =>` for `plugin()`, so the prefix surfaced as `/v10` instead of `/v1.0`. Now `prefix()` checks the option too (`scope()` still uses its first string arg, which already *is* the path).

### Impact (croogo)
- Phantom `{{ plugin }}` routes removed (78 → 72 cakephp endpoints).
- The crate-registry-style API routes corrected: `/api/v10/{{ plugin }}` → `/api/v1.0/Blocks`, `/api/v1.0/Links`, … (66 routes now carry the correct `/v1.0` prefix).

### Tests
Existing `cakephp` fixture extended with a `['path' => '/v1.0']` prefix and a sibling `config/routes.php.twig` Bake template (must be ignored). Full PHP functional suite green; `format` + `ameba` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)