### PR TITLE
fix(php/symfony): parse multi-line #[Route] attrs + Request::METHOD_* verbs

### DIFF
--- a/spec/functional_test/fixtures/php/symfony/src/Controller/StorefrontController.php
+++ b/spec/functional_test/fixtures/php/symfony/src/Controller/StorefrontController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+// Multi-line `#[Route(...)]` attributes whose `path:` sits after a
+// newline+indent (and a nested multi-line `defaults: [...]`), with HTTP verbs
+// given as `Request::METHOD_*` constants instead of string literals — the
+// shape Shopware's storefront uses for hundreds of routes.
+class StorefrontController extends AbstractController
+{
+    #[Route(
+        path: '/account/login',
+        name: 'frontend.account.login.page',
+        defaults: [
+            'XmlHttpRequest' => true,
+        ],
+        methods: [Request::METHOD_GET]
+    )]
+    public function loginPage(Request $request): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/account/login',
+        name: 'frontend.account.login',
+        methods: [Request::METHOD_POST]
+    )]
+    public function login(Request $request): Response
+    {
+        return new Response();
+    }
+
+    #[Route(
+        path: '/account/order/{id}',
+        methods: [Request::METHOD_GET, Request::METHOD_POST]
+    )]
+    public function order(string $id): Response
+    {
+        return new Response();
+    }
+}

--- a/spec/functional_test/testers/php/symfony_callees_spec.cr
+++ b/spec/functional_test/testers/php/symfony_callees_spec.cr
@@ -83,7 +83,7 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,
-  :endpoints => 21,
+  :endpoints => 25, # +4 from StorefrontController multi-line routes (no callees)
 }, expected_endpoints, {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests

--- a/spec/functional_test/testers/php/symfony_spec.cr
+++ b/spec/functional_test/testers/php/symfony_spec.cr
@@ -47,6 +47,16 @@ expected_endpoints = [
   Endpoint.new("/api/admin/reports/{id}", "POST", [
     Param.new("id", "", "path"),
   ]),
+  # From StorefrontController multi-line #[Route] attributes whose verbs are
+  # `Request::METHOD_*` constants and whose `path:` sits after a newline.
+  Endpoint.new("/account/login", "GET"),
+  Endpoint.new("/account/login", "POST"),
+  Endpoint.new("/account/order/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/account/order/{id}", "POST", [
+    Param.new("id", "", "path"),
+  ]),
   # From routes.yaml
   Endpoint.new("/api/health", "GET"),
   Endpoint.new("/api/docs", "GET"),
@@ -70,5 +80,5 @@ expected_endpoints = [
 
 FunctionalTester.new("fixtures/php/symfony/", {
   :techs     => 2,  # Detection still sees php_symfony and php_pure
-  :endpoints => 21, # Analysis suppresses redundant php_pure file endpoints
+  :endpoints => 25, # Analysis suppresses redundant php_pure file endpoints
 }, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -160,7 +160,13 @@ module Analyzer::Php
     end
 
     private def extract_symfony_route_path(context : String) : String?
-      if path_match = context.match(/(?:^|[,(]\s*)path\s*[:=]\s*['"]([^'"]+)['"]/i)
+      # `path:` / `path =` as a standalone key. A multi-line `#[Route(\n  path:
+      # '/x',\n  …)]` puts `path` after a newline+indent, which the old
+      # `(?:^|[,(]\s*)` anchor missed — so every multi-line route attribute
+      # (Shopware's whole storefront) was dropped. A negative-lookbehind on a
+      # word char accepts any non-word boundary (start, comma, paren, newline,
+      # space) while still rejecting `subpath:` / `routePath:`.
+      if path_match = context.match(/(?<!\w)path\s*[:=]\s*['"]([^'"]+)['"]/i)
         return path_match[1]
       end
 
@@ -174,21 +180,28 @@ module Analyzer::Php
     private def extract_methods_from_symfony_context(context : String) : Array(String)
       methods = [] of String
 
-      if match = context.match(/methods\s*[:=]\s*\[([^\]]+)\]/)
-        methods_str = match[1]
-        methods_str.scan(/['"]([^'"]+)['"]/).each do |method_match|
-          methods << method_match[1].upcase
-        end
-      elsif match = context.match(/methods\s*=\s*\{([^}]+)\}/)
-        methods_str = match[1]
-        methods_str.scan(/["']([^"']+)["']/).each do |method_match|
-          methods << method_match[1].upcase
-        end
+      if match = context.match(/methods\s*[:=]\s*\[([^\]]+)\]/m)
+        methods.concat(extract_method_tokens(match[1]))
+      elsif match = context.match(/methods\s*=\s*\{([^}]+)\}/m)
+        methods.concat(extract_method_tokens(match[1]))
       elsif match = context.match(/methods\s*[:=]\s*['"]([^'"]+)['"]/)
+        methods << match[1].upcase
+      elsif match = context.match(/methods\s*[:=]\s*(?:[\w\\]+::)?METHOD_(\w+)/i)
         methods << match[1].upcase
       end
 
-      methods
+      methods.uniq
+    end
+
+    # Methods inside a `methods: [...]` / `={...}` list — either string
+    # literals (`'POST'`) or Symfony's `Request::METHOD_POST` constants (used
+    # heavily by Shopware), which the string scan alone would have missed and
+    # silently defaulted to GET.
+    private def extract_method_tokens(list : String) : Array(String)
+      tokens = [] of String
+      list.scan(/['"]([^'"]+)['"]/) { |m| tokens << m[1].upcase }
+      list.scan(/METHOD_(\w+)/i) { |m| tokens << m[1].upcase }
+      tokens
     end
 
     private def extract_methods_from_annotation_context(context : String) : Array(String)


### PR DESCRIPTION
## Summary

Two gaps dropped the **majority** of routes in attribute-heavy Symfony apps (Shopware's entire storefront, Bolt):

### 1. Multi-line `#[Route]` `path:` missed
`extract_symfony_route_path` anchored the `path:` key with `(?:^|[,(]\s*)`, matching only a single-line `#[Route(path: '/x', ...)]`. A multi-line attribute —
```php
#[Route(
    path: '/account/order',
    defaults: [ ... ],
    methods: [Request::METHOD_GET]
)]
```
puts `path:` after a newline+indent, which the anchor missed, so **every such route was silently skipped**. Replaced with a `(?<!\w)` word-boundary lookbehind that accepts any non-word boundary (start, comma, paren, newline, space) while still rejecting `subpath:` / `routePath:`.

### 2. `Request::METHOD_*` verb constants ignored
`methods:` only read string literals (`'POST'`). Symfony's `Request::METHOD_POST` constants (used throughout Shopware) were ignored, so a POST/PUT/DELETE route silently defaulted to **GET**. `extract_method_tokens` now also reads `METHOD_*` constants, and the list regexes are DOTALL for multi-line `methods: [...]`.

## Impact (real OSS)
| app | before → after |
|---|---|
| **Shopware** | 220 → **540** (519/544 declared method-level routes matched, was ~40%) |
| **Bolt** | 52 → **76** |
| Part-DB / Sylius | unchanged (no regression) |

## Tests
New `StorefrontController` fixture covering the multi-line `#[Route]` shape with `Request::METHOD_*` verb constants (incl. two verbs sharing a path and a two-verb list). Full PHP functional suite green; `format` + `ameba` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)