### PR TITLE
fix(elixir/phoenix): detect plug-style routes with no `:action` atom

### DIFF
--- a/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/api_client.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/api_client.ex
@@ -1,0 +1,11 @@
+defmodule ElixirPhoenixWeb.ApiClient do
+  # HTTP-CLIENT wrapper — these `post`/`get` calls hit a REMOTE API, they
+  # are NOT Phoenix routes. The 2nd arg is either a lowercase variable or a
+  # `Module.fn(...)` call (not a controller module), so none may surface as
+  # endpoints. Regression guard for the optional-action route matcher.
+  def create_session(params, team) do
+    post("/api/v1/org/secrets", params, team)
+    post("com.atproto.repo.createRecord", Jason.encode!(params), team)
+    get("/remote/status", client_opts, team)
+  end
+end

--- a/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
@@ -70,6 +70,13 @@ defmodule ElixirPhoenixWeb.Router do
 
     get "/accounts/:id", Api.UserController, :show
     post("/page", PageController, :home)
+
+    # Plug-style routes: the 2nd arg is a Plug module and the 3rd is plug
+    # opts (`[]` / keyword list), NOT an `:action` atom. Common for API
+    # docs, dashboards and SPA catch-alls; must still be detected.
+    get "/openapi", OpenApiSpex.Plug.RenderSpec, []
+    get "/swaggerui", OpenApiSpex.Plug.SwaggerUI, config: %{path: "/api/openapi"}
+
     match :post, "/hooks", PageController, :home
     match :put, "/hooks", PageController, :home
   end

--- a/spec/functional_test/testers/elixir/phoenix_spec.cr
+++ b/spec/functional_test/testers/elixir/phoenix_spec.cr
@@ -34,6 +34,11 @@ expected_endpoints = [
   Endpoint.new("/comments/:id", "GET", [Param.new("id", "", "path")]),
   Endpoint.new("/api/accounts/:id", "GET", [Param.new("include", "", "query"), Param.new("x-api-version", "", "header"), Param.new("id", "", "path")]),
   Endpoint.new("/api/page", "POST", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
+  # Plug-style routes (the controller is a Plug, the 3rd arg is opts not an
+  # `:action` atom). The HTTP-client calls in api_client.ex must NOT add
+  # phantom endpoints.
+  Endpoint.new("/api/openapi", "GET"),
+  Endpoint.new("/api/swaggerui", "GET"),
   Endpoint.new("/api/hooks", "POST", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
   Endpoint.new("/api/hooks", "PUT", [Param.new("q", "", "query"), Param.new("page", "", "form"), Param.new("limit", "", "form")]),
   Endpoint.new("/dev/dashboard", "GET"),

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -1030,12 +1030,28 @@ module Analyzer::Elixir
                                    scope_module : String,
                                    base : String,
                                    string_bindings : Hash(String, String))
-      pattern = Regex.new("(?:^|[^.\\w])#{route_macro}\\s*(?:\\(\\s*)?['\"]([^'\"]+)['\"]\\s*,\\s*([A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)*|unquote\\(\\s*\\w+\\s*\\))\\s*,\\s*:(\\w+[!?]?)")
+      # The `:action` atom is OPTIONAL: Phoenix's `get(path, plug, plug_opts
+      # \\ [], opts \\ [])` lets a plug-style route omit it
+      # (`get("/metrics", TelemetryUI.Web, [])`,
+      # `get("/", WebAppController, [])`). Requiring `, :action` dropped every
+      # such route (accent: 9 of ~48 missed). Capture the action when present
+      # for the controller/action param map, but emit the endpoint regardless.
+      #
+      # Once the action is optional the 2nd arg MUST be a real controller
+      # module — a capitalized name or `unquote(var)` that is NOT itself a
+      # function call. Otherwise HTTP-CLIENT wrappers (common in Elixir) slip
+      # through: `post("/api/v1/org/secrets", params, team)` (lowercase var,
+      # already excluded by `[A-Z]`) and `post("com.atproto...",
+      # Jason.encode!(params), [...])` (a `Module.fn(...)` call). The
+      # `(?=\\s*[,)]|\\s*$)` lookahead requires the module reference to be
+      # followed by an arg separator / call close — a `(` or `!` (a call)
+      # rejects it.
+      pattern = Regex.new("(?:^|[^.\\w])#{route_macro}\\s*(?:\\(\\s*)?['\"]([^'\"]+)['\"]\\s*,\\s*([A-Z]\\w*(?:\\.[A-Za-z_]\\w*)*|unquote\\(\\s*\\w+\\s*\\))(?=\\s*[,)]|\\s*$)(?:\\s*,\\s*:(\\w+[!?]?))?")
       line.scan(pattern) do |match|
         full_path = scoped_route_path(scope_prefix, match[1])
         endpoint = Endpoint.new(full_path, http_method)
-        if controller = resolve_unquoted_ref(match[2], string_bindings)
-          @route_map[route_map_key(base, http_method, full_path)] = ControllerAction.new(scoped_controller(scope_module, controller), match[3])
+        if (controller = resolve_unquoted_ref(match[2], string_bindings)) && (action = match[3]?)
+          @route_map[route_map_key(base, http_method, full_path)] = ControllerAction.new(scoped_controller(scope_module, controller), action)
         end
         endpoints << endpoint
       end


### PR DESCRIPTION
## Summary

Phoenix's verb macros are `get(path, plug, plug_opts \\ [], opts \\ [])`, so a route whose controller is a plain **Plug** omits the `:action` atom:

```elixir
get "/openapi", OpenApiSpex.Plug.RenderSpec, []
get "/swaggerui", OpenApiSpex.Plug.SwaggerUI, config: %{...}
get "/", WebAppController, []          # SPA catch-all
get "/metrics", TelemetryUI.Web, []     # dashboard
```

The route matcher required a trailing `, :action`, so **every plug-style route was dropped** (accent: 9 of ~48 routes; also analytics/blockscout/changelog/firezone/livebook).

## Fix

Make the `:action` atom optional. The analyzer scans **every** `.ex` file (not just routers), so to stop HTTP-client wrappers from leaking in, the 2nd arg must now be a real controller module:

- **Capitalized** — excludes `post("/api/v1/org/secrets", params, team)` (lowercase var).
- **Not a function call** — a `(?=\s*[,)]|\s*$)` lookahead excludes `post("com.atproto.repo.createRecord", Jason.encode!(params), [])`.

## Impact (all verified real — OpenAPI/Swagger docs, SPA catch-alls, telemetry dashboards, root)

| App | Before | After |
|-----|--------|-------|
| accent | 17 | 26 |
| changelog.com | 265 | 268 |
| firezone | 168 | 170 |
| analytics | 233 | 235 |
| blockscout | 351 | 352 |

**Zero** new false positives, **no** endpoint removed (confirmed the livebook/changelog client-call wrappers stay out).

## Tests

New `api_client.ex` fixture (lowercase-var + `Module.fn(...)` client calls) asserts the guard; the router fixture gains the two plug-style doc routes. Full suite green: `18507 examples, 0 failures`.