### PR TITLE
perf(elixir): precompile per-verb route regexes (blockscout 32s → 1.7s)

### DIFF
--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -12,6 +12,24 @@ module Analyzer::Elixir
     @route_map : Hash(RouteMapKey, ControllerAction) = Hash(RouteMapKey, ControllerAction).new
     @route_macros : Hash(String, RouteMacro) = Hash(String, RouteMacro).new
 
+    # `get`/`post`/… → its precompiled route regex. `add_standard_route` runs
+    # once per verb per line of every `.ex` file; `Regex.new` there recompiled
+    # the same 7 PCRE2 patterns on every call (~3.4M recompiles on a 2400-file
+    # repo, the dominant scan cost). The pattern depends only on the fixed verb
+    # set, so build it once. See `add_standard_route` for the shape rationale.
+    STANDARD_ROUTE_METHODS = {
+      "get"     => "GET",
+      "post"    => "POST",
+      "patch"   => "PATCH",
+      "put"     => "PUT",
+      "delete"  => "DELETE",
+      "options" => "OPTIONS",
+      "head"    => "HEAD",
+    }
+    STANDARD_ROUTE_PATTERNS = STANDARD_ROUTE_METHODS.keys.to_h do |verb|
+      {verb, Regex.new("(?:^|[^.\\w])#{verb}\\s*(?:\\(\\s*)?['\"]([^'\"]+)['\"]\\s*,\\s*([A-Z]\\w*(?:\\.[A-Za-z_]\\w*)*|unquote\\(\\s*\\w+\\s*\\))(?=\\s*[,)]|\\s*$)(?:\\s*,\\s*:(\\w+[!?]?))?")}
+    end
+
     struct ControllerAction
       property controller : String
       property action : String
@@ -1046,7 +1064,12 @@ module Analyzer::Elixir
       # `(?=\\s*[,)]|\\s*$)` lookahead requires the module reference to be
       # followed by an arg separator / call close — a `(` or `!` (a call)
       # rejects it.
-      pattern = Regex.new("(?:^|[^.\\w])#{route_macro}\\s*(?:\\(\\s*)?['\"]([^'\"]+)['\"]\\s*,\\s*([A-Z]\\w*(?:\\.[A-Za-z_]\\w*)*|unquote\\(\\s*\\w+\\s*\\))(?=\\s*[,)]|\\s*$)(?:\\s*,\\s*:(\\w+[!?]?))?")
+      #
+      # Cheap substring gate first: the precompiled regex still has to scan
+      # the line, so skip it entirely for the (vast) majority of lines that
+      # don't even contain the verb keyword.
+      return unless line.includes?(route_macro)
+      pattern = STANDARD_ROUTE_PATTERNS[route_macro]
       line.scan(pattern) do |match|
         full_path = scoped_route_path(scope_prefix, match[1])
         endpoint = Endpoint.new(full_path, http_method)

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -212,13 +212,21 @@ module Analyzer::Elixir
       "forward" => "FORWARD",
     }
 
+    # Precompiled per-verb route regexes. `line_to_endpoint` runs once per
+    # line of every `.ex` file, and `Regex.new` rebuilt these 8 PCRE2
+    # patterns on every call — the same recompilation cost the Phoenix
+    # analyzer carried. Build them once.
+    PLUG_ROUTE_PATTERNS = PLUG_ROUTE_MACROS.keys.to_h do |verb|
+      {verb, Regex.new("(?:^|[^.\\w])#{verb}\\s+[\"']([^\"']+)[\"']")}
+    end
+
     def line_to_endpoint(line : String) : Array(Endpoint)
       endpoints = Array(Endpoint).new
 
       # Match Plug.Router style route definitions, e.g. `get "/path", do: …`
       PLUG_ROUTE_MACROS.each do |verb, method|
-        pattern = Regex.new("(?:^|[^.\\w])#{verb}\\s+[\"']([^\"']+)[\"']")
-        line.scan(pattern) do |match|
+        next unless line.includes?(verb)
+        line.scan(PLUG_ROUTE_PATTERNS[verb]) do |match|
           path = match[1]
           endpoints << Endpoint.new(path, method) if plug_route_path?(path)
         end


### PR DESCRIPTION
## Summary

Both Elixir analyzers rebuilt their route regexes with `Regex.new` on **every call**:
- `add_standard_route` (Phoenix) runs once per verb (7) per line of every `.ex` file.
- `line_to_endpoint` (Plug) once per verb (8) per line.

Crystal recompiles an interpolated `Regex.new` from scratch each time (a full PCRE2 compile), so a large repo paid **millions** of identical recompiles — the dominant Elixir scan cost.

## Fix

The patterns depend only on the fixed verb set, so build them once into `STANDARD_ROUTE_PATTERNS` / `PLUG_ROUTE_PATTERNS` constants, plus a cheap `line.includes?(verb)` substring gate before each scan.

## Impact (release scans, endpoint output byte-identical)

| App | Before | After | |
|-----|--------|-------|--|
| blockscout | 31.9s | **1.7s** | 18× |
| firezone | 11.7s | 0.7s | 16× |
| analytics | 11.1s | 0.9s | 12× |
| livebook | 8.1s | 0.2s | 40× |

Pure perf — no endpoint changes. Full suite green: `18507 examples, 0 failures`.