### PR TITLE
fix(lint): escaped heredoc in mautic detector spec

### DIFF
--- a/spec/unit_test/detector/php/mautic_detector_spec.cr
+++ b/spec/unit_test/detector/php/mautic_detector_spec.cr
@@ -18,12 +18,12 @@ describe "Detect Mautic" do
   end
 
   it "detects a Mautic bundle route config" do
-    php_content = <<-PHP
+    php_content = <<-'PHP'
       <?php
       return [
           'routes' => [
               'main' => [
-                  'mautic_x' => ['path' => '/x', 'controller' => 'Mautic\\CoreBundle\\Controller\\XController::indexAction'],
+                  'mautic_x' => ['path' => '/x', 'controller' => 'Mautic\CoreBundle\Controller\XController::indexAction'],
               ],
           ],
       ];


### PR DESCRIPTION
Follow-up to #2036. The `<<-PHP` heredoc in `mautic_detector_spec.cr` embeds `Mautic\CoreBundle\…` backslashes, which ameba's `Style/HeredocEscape` flags — turning the lint job red on main. Switched to a literal `<<-'PHP'` marker with single backslashes (matches real PHP source). Spec still green; `ameba` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)