### PR TITLE
fix(analyzer/crystal): skip heredoc bodies so doc-example routes aren't emitted

### DIFF
--- a/spec/functional_test/fixtures/crystal/kemal/src/testapp.cr
+++ b/spec/functional_test/fixtures/crystal/kemal/src/testapp.cr
@@ -43,4 +43,23 @@ mount "/api/v1", api
 
 public_folder "custom_public"
 
+# A documentation string that embeds example routing inside a heredoc.
+# Heredoc bodies are string DATA, not executable routing DSL, so none of
+# the verbs below may surface as endpoints. The terminator must also stop
+# the masking so the real route declared afterwards is still detected.
+USAGE = <<-MD
+  ## Routing example
+
+      get "/ghost-in-heredoc" do
+        env.params.query["leak"]
+      end
+
+      post "/ghost-in-heredoc/submit" do
+      end
+  MD
+
+get "/after-heredoc" do
+  "still routed"
+end
+
 Kemal.run

--- a/spec/functional_test/testers/crystal/kemal_spec.cr
+++ b/spec/functional_test/testers/crystal/kemal_spec.cr
@@ -15,6 +15,10 @@ expected_endpoints = [
   ]),
   Endpoint.new("/api/v1/users/", "GET", [Param.new("page", "", "query")]),
   Endpoint.new("/api/v1/users/:id", "GET"),
+  # Real route declared after a `<<-MD … MD` doc heredoc — proves the
+  # terminator stops the masking instead of blanking the rest of the file.
+  # The example `get`/`post` calls inside the heredoc must NOT appear.
+  Endpoint.new("/after-heredoc", "GET"),
   Endpoint.new("/1.html", "GET"),
   Endpoint.new("/2.html", "GET"),
 ]

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -44,6 +44,7 @@ module Analyzer::Crystal
           lines << line
         end
       end
+      lines = mask_crystal_heredocs(lines)
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -18,6 +18,7 @@ module Analyzer::Crystal
           lines << line
         end
       end
+      lines = mask_crystal_heredocs(lines)
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -30,7 +30,7 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path)
+      lines = mask_crystal_heredocs(File.read_lines(path))
       file_base = configured_base_for(path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -16,6 +16,7 @@ module Analyzer::Crystal
           lines << line
         end
       end
+      lines = mask_crystal_heredocs(lines)
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       last_endpoint = Endpoint.new("", "")

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -61,7 +61,7 @@ module Analyzer::Crystal
     end
 
     private def read_source_lines(path : String) : Array(String)
-      read_file_content(path).lines
+      mask_crystal_heredocs(read_file_content(path).lines)
     end
 
     private def collect_handler_callees : Hash(HandlerActionKey, Array(Noir::CrystalCalleeExtractor::Entry))

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -102,6 +102,59 @@ module Analyzer::Crystal
       first == '/' || first == '*' || first == '{'
     end
 
+    # Opening token of a Crystal heredoc: `<<-DELIM`, optionally quoted
+    # (`<<-'SQL'`). The delimiter must start with an uppercase letter or
+    # underscore — the universal Crystal convention (MD/HTML/SQL/EOF/…) —
+    # which keeps the matcher from firing on `arr << -value`. The negative
+    # lookbehind rejects a `<<-` that sits inside a string literal
+    # (`"<<-MD"`), so a stray quoted token can't open a phantom heredoc and
+    # blank the rest of the file.
+    HEREDOC_OPEN = /(?<!['"])<<-['"]?([A-Z_]\w*)/
+
+    # Crystal heredocs (`<<-DELIM … DELIM`) hold string data, never
+    # executable routing DSL. Real apps embed example code inside them —
+    # Lucky's own guide site documents routing with `get "/me" do … end`
+    # snippets inside `<<-MD … MD` markdown blocks, and noir was emitting
+    # every one of those as a live endpoint (70 of 90 endpoints on the
+    # Lucky website were heredoc examples). Blank out heredoc bodies before
+    # the per-line route/param scan, preserving line count so line numbers
+    # and the indentation-based namespace tracking stay accurate.
+    #
+    # A line that opens several heredocs at once (`foo(<<-A, <<-B)`) is
+    # handled with a FIFO of pending delimiters: A's body comes first, then
+    # B's, each closed by its own terminator.
+    protected def mask_crystal_heredocs(lines : Array(String)) : Array(String)
+      return lines unless lines.any?(&.includes?("<<-"))
+
+      pending = [] of String
+      lines.map do |line|
+        if pending.empty?
+          if line.includes?("<<-")
+            Noir::CrystalCalleeExtractor.strip_comment(line).scan(HEREDOC_OPEN) do |match|
+              pending << match[1]
+            end
+          end
+          line
+        elsif heredoc_terminator?(line.lstrip, pending.first)
+          pending.shift
+          line
+        else
+          ""
+        end
+      end
+    end
+
+    # A heredoc terminator is the delimiter alone on its (optionally
+    # indented) line, allowed a trailing method/operator chain
+    # (`MD.strip`, `SQL)`). Requiring the next char to be a non-identifier
+    # avoids closing on a body line that merely starts with the delimiter
+    # word (`ENDPOINT` does not terminate `<<-END`).
+    private def heredoc_terminator?(stripped : String, delim : String) : Bool
+      return false unless stripped.starts_with?(delim)
+      rest = stripped[delim.size..]
+      rest.empty? || !(rest[0].alphanumeric? || rest[0] == '_')
+    end
+
     protected def each_public_file(&block : String -> Nil) : Nil
       base_paths.each do |base|
         get_public_files(base).each do |file|


### PR DESCRIPTION
## Summary

Crystal heredocs (`<<-DELIM … DELIM`) hold string **data**, never executable routing DSL — but the Kemal/Amber/Grip/Lucky/Marten analyzers scanned files line-by-line and extracted any `get "/x" do` they found, **including inside heredocs**. Apps that document their own routing inside `<<-MD` markdown blocks paid for it heavily:

> On the **Lucky website**, **70 of 90** reported endpoints were example snippets pulled from guide-page markdown (`/me`, `/dashboard`, `/teaparty`, `/fortunes`, …) — not real routes.

## Fix

A shared `mask_crystal_heredocs` pass on the `CrystalEngine` base blanks heredoc bodies before the per-line route/param scan, **preserving line count** so line numbers and the indentation-based namespace tracking stay accurate. Applied in all five Crystal analyzers.

Conservative on the open side to avoid runaway blanking:
- delimiter must start with an **uppercase letter or underscore** (universal Crystal convention — `MD`/`HTML`/`SQL`/`EOF`/… — verified against the real-app corpus), which also rules out `arr << -value`;
- a **negative lookbehind** rejects a `<<-` sitting inside a string literal (`"<<-MD"`), so a stray quoted token can't open a phantom heredoc;
- multiple heredocs opened on one line (`foo(<<-A, <<-B)`) are tracked with a FIFO of pending delimiters.

## Validation (real OSS apps)

| App | Framework | Before | After | Note |
|-----|-----------|--------|-------|------|
| lucky-website | Lucky | 90 | **19** | all 71 removed were heredoc examples; 19 = real action routes + static files |
| invidious | Kemal | 207 | 207 | unchanged — no real routes lost |
| mango (Mango) | Kemal | 65 | 65 | unchanged |
| place-labs staff-api | Amber | 115 | 115 | unchanged |

The Kemal fixture gains a `<<-MD` doc block containing example `get`/`post` calls (must NOT surface) plus a real `/after-heredoc` route declared **after** it (proves the terminator stops the masking instead of blanking the rest of the file).

Full suite: **18493 functional + 3369 unit examples, 0 failures**; `ameba` + `crystal tool format --check` clean.