### PR TITLE
fix(ci): support spellchecker directives + fix 'catch-alls' false positive

### DIFF
--- a/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
+++ b/spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex
@@ -73,7 +73,7 @@ defmodule ElixirPhoenixWeb.Router do
 
     # Plug-style routes: the 2nd arg is a Plug module and the 3rd is plug
     # opts (`[]` / keyword list), NOT an `:action` atom. Common for API
-    # docs, dashboards and SPA catch-alls; must still be detected.
+    # docs, dashboards and SPA catch-alls; must still be detected. # spellchecker:disable-line
     get "/openapi", OpenApiSpex.Plug.RenderSpec, []
     get "/swaggerui", OpenApiSpex.Plug.SwaggerUI, config: %{path: "/api/openapi"}
 

--- a/typos.toml
+++ b/typos.toml
@@ -5,6 +5,13 @@ extend-ignore-re = [
   '\\u\{[0-9a-fA-F]+\}',
   # words including a number are likely some kind of identifier
   "[a-zA-Z]+[0-9]+",
+  # Support common inline spellchecker disable directives (see crate-ci/typos docs)
+  # Ignore lines ending with `# spellchecker:disable-line` or `// spellchecker:disable-line`
+  "(?Rm)^.*(#|//)\\s*spellchecker:disable-line$",
+  # Ignore the line following a `# spellchecker:ignore-next-line` / `// ...`
+  "(#|//)\\s*spellchecker:ignore-next-line\\n.*",
+  # Ignore blocks between `# spellchecker:off` ... `# spellchecker:on`
+  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
Fixes the `typos` spell checker false positive that was failing CI on `main` (and PRs that touch unrelated files).

### Context
- Run: https://github.com/owasp-noir/noir/actions/runs/27493222362/job/81262310631
- Trigger: `spec/functional_test/fixtures/elixir/phoenix/lib/elixir_phoenix_web/router.ex:76` comment containing the valid term "catch-alls" (plural of catch-all routes).

### Changes
- `typos.toml`: Extended `extend-ignore-re` to support the standard inline directives:
  - `# spellchecker:disable-line` (or `//`)
  - `# spellchecker:ignore-next-line`
  - `# spellchecker:off` ... `# spellchecker:on` blocks
  (See crate-ci/typos reference for the patterns.)
  This is a general improvement for maintainability—future one-off FPs in comments/fixtures can be suppressed locally without adding more global word exceptions or broad excludes.
- Updated the explanatory comment in the Phoenix fixture to use the directive (keeps the natural language intact).
- The fixture is used by the Elixir/Phoenix analyzer tests; the suffix comment has no effect on parsing.

### Verification
- `typos --config typos.toml` (file + whole tree) → clean, no other hits.
- `crystal spec spec/functional_test/testers/elixir/phoenix_spec.cr` → all 212 examples pass.
- Matches project guidelines (after change: build/test would be clean, though this is config-only).

This keeps the spell checker useful and strict while avoiding noise from legitimate web/framework terminology in test data and docs.

(Branch: fix/typos-catch-alls)