### PR TITLE
fix(java/jsp): drop @WebInitParam value FPs and strip webapp-root from JSP URLs

### DIFF
--- a/spec/functional_test/fixtures/java/jsp/src/main/java/com/example/ReportServlet.java
+++ b/spec/functional_test/fixtures/java/jsp/src/main/java/com/example/ReportServlet.java
@@ -1,11 +1,21 @@
 package com.example;
 
+import jakarta.servlet.annotation.WebInitParam;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@WebServlet(name = "ReportServlet", urlPatterns = {"/reports/*", "/api/reports"})
+// Regression guard: `initParams` nests `@WebInitParam(value="...")`, whose
+// `value=` is an init-param value, NOT a URL pattern. Only `/reports/*` and
+// `/api/reports` are routes — `json` / `Not provided` must not surface.
+@WebServlet(
+    name = "ReportServlet",
+    urlPatterns = {"/reports/*", "/api/reports"},
+    initParams = {
+      @WebInitParam(name = "format", value = "json"),
+      @WebInitParam(name = "fallback", value = "Not provided")
+    })
 public class ReportServlet extends HttpServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response) {
     request.getParameter("reportId");

--- a/spec/functional_test/fixtures/java/jsp/src/main/webapp/reports/summary.jsp
+++ b/spec/functional_test/fixtures/java/jsp/src/main/webapp/reports/summary.jsp
@@ -1,0 +1,6 @@
+<%-- A JSP under the Maven webapp root. It is served relative to that
+     root (`/reports/summary.jsp`), so the `src/main/webapp/` build prefix
+     must be stripped from the URL. --%>
+<%
+    String range = ${param.range}
+%>

--- a/spec/functional_test/testers/java/jsp_spec.cr
+++ b/spec/functional_test/testers/java/jsp_spec.cr
@@ -6,6 +6,9 @@ expected_endpoints = [
     Param.new("password", "", "query"),
   ]),
   Endpoint.new("/el.jsp", "GET", [Param.new("username", "", "query")]),
+  # A JSP under `src/main/webapp/` is served relative to that root — the
+  # build prefix is stripped (`/reports/summary.jsp`, not the repo path).
+  Endpoint.new("/reports/summary.jsp", "GET", [Param.new("range", "", "query")]),
   Endpoint.new("/attribute.jsp", "GET", [Param.new("userId", "", "query")]),
   Endpoint.new("/header.jsp", "GET", [Param.new("X-API-Key", "", "header")]),
   Endpoint.new("/cookie.jsp", "GET", [Param.new("", "", "cookie")]),

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -57,7 +57,7 @@ module Analyzer::Java
                       content = file.gets_to_end
                       params_query = extract_params(content)
                       details = Details.new(PathInfo.new(path))
-                      result << Endpoint.new("/#{relative_path}", "GET", params_query, details)
+                      result << Endpoint.new(jsp_request_path(relative_path), "GET", params_query, details)
                       extract_form_endpoints(content, details).each do |endpoint|
                         result << endpoint
                       end
@@ -346,6 +346,13 @@ module Analyzer::Java
       patterns = [] of String
       body = annotation_body.strip
 
+      # `initParams = {@WebInitParam(name="x", value="y"), ...}` nests its
+      # own `value=` attributes that are init-param values, NOT URL
+      # patterns. Strip the block before scanning so a
+      # `@WebInitParam(value="Not provided")` can't surface as a
+      # `/Not provided` route.
+      body = body.gsub(/\binitParams\s*=\s*\{[^}]*\}/m, "")
+
       if body.starts_with?("\"") || body.starts_with?("'") || body.starts_with?("{")
         body.scan(/["']([^"']+)["']/) do |match|
           add_pattern(patterns, match[1])
@@ -439,6 +446,23 @@ module Analyzer::Java
 
     private def web_inf_jsp?(relative_path : String) : Bool
       relative_path.split(File::SEPARATOR).includes?("WEB-INF")
+    end
+
+    # A JSP is served relative to the WEB application root, not the repo
+    # root. `src/main/webapp/jsp/index.jsp` is reachable at `/jsp/index.jsp`,
+    # so strip the build-layout webapp-root prefix; otherwise the whole
+    # source path (`/libraries-otel/.../src/main/webapp/index.jsp`) leaked
+    # into the URL.
+    WEBAPP_ROOT_MARKERS = ["src/main/webapp/", "src/main/resources/META-INF/resources/", "WebContent/", "WebRoot/"]
+
+    private def jsp_request_path(relative_path : String) : String
+      normalized = relative_path.gsub(File::SEPARATOR, "/")
+      WEBAPP_ROOT_MARKERS.each do |marker|
+        if idx = normalized.index(marker)
+          return "/#{normalized[(idx + marker.size)..]}"
+        end
+      end
+      "/#{normalized}"
     end
 
     private def xml_child_text(node : XML::Node, local_name : String) : String


### PR DESCRIPTION
## Summary

Two false-positive classes surfaced on the Baeldung [tutorials](https://github.com/eugenp/tutorials) corpus.

### 1. `@WebInitParam` value mistaken for a URL pattern

```java
@WebServlet(urlPatterns = "/userServlet", initParams = {
    @WebInitParam(name = "name", value = "Not provided")})
```

The URL-pattern extractor matched the `value=` **inside the nested `@WebInitParam`**, emitting a phantom `GET /Not provided` (and `/savings`) alongside the real route. Fix: strip the `initParams = {...}` block before scanning for `value`/`urlPatterns`.

### 2. JSP URL carried the build path

```
GET /libraries-otel/.../src/main/webapp/index.jsp     ← was
GET /index.jsp                                          ← now
```

A `.jsp` is served relative to the **web-application root**, so strip the `src/main/webapp/` (and `WebContent/`, `WebRoot/`, `META-INF/resources/`) prefix.

## Impact

- tutorials: 30+ JSP URLs corrected in place (`/index.jsp`, `/jsp/ExampleThree.jsp`, …), 4 init-param phantom routes removed.
- Real `/userServlet`, `/account`, `/bankAccount` routes kept.

## Tests

The jsp fixture gains an `initParams` servlet (asserting the value is ignored) and a `src/main/webapp/reports/summary.jsp` (asserting the prefix is stripped). Full suite green: `18531 examples, 0 failures`.