### PR TITLE
fix(analyzer/go/chi): compose path-scoped Group closures (gitea web wrapper)

### DIFF
--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -666,4 +666,36 @@ describe Noir::TreeSitterGoRouteExtractor do
     calls = Noir::TreeSitterGoRouteExtractor.collect_router_builder_callsites(source, builders.keys.to_set)
     calls.should eq([{"addUserRoutes", "/v1"}])
   end
+
+  it "composes path-scoped Group closures that reuse the outer router (gitea web wrapper)" do
+    # Chi's own `Group` takes no path, but gitea's `code.gitea.io/gitea/
+    # modules/web` wrapper exposes `m.Group("/path", func(){...})` where the
+    # closure has NO router parameter and reuses the captured `m`. The
+    # prefix must still compose, recursively, onto the nested verb routes.
+    source = <<-GO
+      package routes
+      func RegisterRoutes(m *web.Router) {
+          m.Get("/", home)
+          m.Group("/{username}/{reponame}", func() {
+              m.Get("/issues", issues)
+              m.Group("/settings", func() {
+                  m.Get("/hooks", hooks)
+                  m.Post("/hooks/gitea/new", newHook)
+              })
+          })
+          m.Group(func() {
+              m.Get("/healthz", healthz)
+          })
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_chi_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"GET", "/"},
+      {"GET", "/healthz"},
+      {"GET", "/{username}/{reponame}/issues"},
+      {"GET", "/{username}/{reponame}/settings/hooks"},
+      {"POST", "/{username}/{reponame}/settings/hooks/gitea/new"},
+    ].sort)
+  end
 end

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -1303,11 +1303,21 @@ module Noir
       end
 
       if (mw = config.middleware_method) && name == mw
-        # (closure only) -> middleware group that doesn't change prefix.
-        # Excludes Gin-style `.Group("/x")` which is handled by
-        # `extract_routes`, not this walker.
-        if chi_closure_arg(call) && !chi_first_string_arg(call, source, string_values)
-          return ChiCall::Group
+        if chi_closure_arg(call)
+          if chi_first_string_arg(call, source, string_values)
+            # (string, closure) -> push prefix. Chi's own `Group` takes no
+            # path, but wrappers like gitea's `code.gitea.io/gitea/modules/web`
+            # expose `m.Group("/path", func(){...})` — a path-scoped group.
+            # Treat that form like `Route` so the prefix composes onto the
+            # routes nested inside (gitea/gogs/forgejo register the bulk of
+            # their tree this way).
+            return ChiCall::Route
+          else
+            # (closure only) -> middleware group that doesn't change prefix.
+            # Excludes Gin-style `.Group("/x")` (no closure) which is handled
+            # by `extract_routes`, not this walker.
+            return ChiCall::Group
+          end
         end
       end
 


### PR DESCRIPTION
## Summary

Chi's own `Group` takes no path — `Group(fn func(r chi.Router))` is a **middleware-only** scope — so `walk_chi` classified every `.Group(...)` as prefix-less. But chi-based wrappers expose a **path-taking** form: gitea's `code.gitea.io/gitea/modules/web` registers the bulk of its route tree as `m.Group("/path", func(){...})`, where the closure has **no router parameter** and reuses the captured `m`.

The string path was silently dropped, so every route nested inside surfaced **bare**:

> `m.Post("/gitea/new", …)` came out as `/gitea/new` instead of `/{username}/{reponame}/settings/hooks/gitea/new` — collapsing whole subtrees onto colliding single-segment paths.

## Fix

`classify_chi_call` now treats `Group(string, closure)` like `Route` (push the prefix), while `Group(closure)` with no path stays a middleware group. The form is unambiguous: **pure chi never accepts a path argument on `Group`**, so `Group("/x", func(){...})` only ever comes from such a wrapper. Composition flows through the existing `prefix_stack`, so nesting works to any depth even though the paramless closure binds no local group alias.

## Validation

| Metric | Before | After |
|--------|--------|-------|
| gitea endpoints | 332 | **467** |
| depth-1 (stripped) routes | 196 | 12 |
| routes with `/{username}/{reponame}` prefix | 18 | 217 |

No malformed URLs (chi regex path constraints like `{sha:[a-f0-9]+}` are preserved). The rest of the Go corpus is **unchanged** — chi-examples / go-admin / gotify / gin / echo / fiber / gozero / pocketbase / hertz / memos all `+0`.

Remaining gitea limitation (documented, not fixed here): routes registered in a reusable helper closure (`addWebhookAddRoutes := func(){...}` invoked under several groups) still emit un-prefixed.

New unit test covers nested path-Groups plus a pathless chi `Group`. Full suite **18547 functional + unit examples, 0 failures**; `ameba` + `crystal tool format --check` clean.