### PR TITLE
fix(analyzer/go): peel PocketBase .Bind/.Unbind group chains to stop cross-file prefix bleed

### DIFF
--- a/spec/functional_test/fixtures/go/pocketbase/bars.go
+++ b/spec/functional_test/fixtures/go/pocketbase/bars.go
@@ -1,0 +1,23 @@
+// Second handler file in the same package that reuses the `sub` group
+// variable name with a DIFFERENT prefix and attaches middleware via the
+// fluent `.Bind(...)` / `.Unbind(...)` chain. Before the fix the chain
+// blocked local prefix resolution, so `sub` fell back to a cross-file
+// binding and `/foos`/`/bars` contaminated each other.
+package main
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tools/router"
+)
+
+func bindBarApi(app core.App, rg *router.RouterGroup[*core.RequestEvent]) {
+	sub := rg.Group("/bars").Bind(requireAuth()).Unbind("rateLimit")
+	sub.GET("", listBars)
+	sub.POST("", createBar)
+	sub.DELETE("/{id}", deleteBar)
+}
+
+func requireAuth() string                 { return "" }
+func listBars(e *core.RequestEvent) error  { return nil }
+func createBar(e *core.RequestEvent) error { return nil }
+func deleteBar(e *core.RequestEvent) error { return nil }

--- a/spec/functional_test/testers/go/pocketbase_spec.cr
+++ b/spec/functional_test/testers/go/pocketbase_spec.cr
@@ -6,6 +6,13 @@ expected_endpoints = [
   Endpoint.new("/foos/{id}", "GET", [Param.new("id", "", "path")]),
   Endpoint.new("/foos/{id}", "PATCH", [Param.new("id", "", "path")]),
   Endpoint.new("/foos/{id}", "DELETE", [Param.new("id", "", "path")]),
+  # A sibling file reuses the `sub` group var with a different prefix and a
+  # `.Bind(...).Unbind(...)` middleware chain — the chain must be peeled so
+  # `/bars` resolves locally instead of inheriting `/foos` (cross-file
+  # contamination from the shared variable name).
+  Endpoint.new("/bars/", "GET"),
+  Endpoint.new("/bars/", "POST"),
+  Endpoint.new("/bars/{id}", "DELETE", [Param.new("id", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/go/pocketbase/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -235,6 +235,27 @@ describe Noir::TreeSitterGoRouteExtractor do
     ].sort)
   end
 
+  it "peels PocketBase .Bind(...)/.Unbind(...) chains off a group declaration" do
+    # `sub := rg.Group("/bars").Bind(mw).Unbind(id)` — PocketBase's
+    # RouterGroup middleware binders return the group, so the prefix must
+    # still resolve to `/bars` (otherwise the var falls back to a cross-file
+    # binding of the same name and contaminates the routes).
+    source = <<-GO
+      package main
+      func bind(rg *router.RouterGroup) {
+          sub := rg.Group("/bars").Bind(requireAuth()).Unbind("rateLimit")
+          sub.GET("", listBars)
+          sub.DELETE("/{id}", deleteBar)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"DELETE", "/bars/{id}"},
+      {"GET", "/bars/"},
+    ].sort)
+  end
+
   it "collects group assignments from var declarations and later assignments" do
     source = <<-GO
       package main

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -117,6 +117,14 @@ module Noir
       "Use",
       # Goyave fluent-builder configuration methods (all return *Router).
       "SetMeta", "RemoveMeta", "Middleware", "GlobalMiddleware", "CORS",
+      # PocketBase's `*router.RouterGroup` middleware binders return the
+      # group unchanged, so `sub := rg.Group("/x").Bind(mw)` /
+      # `.Unbind(id)` must be peeled to reach the `.Group("/x")` prefix.
+      # Without this the group var goes unresolved and falls back to a
+      # cross-file binding of the same name — pocketbase reuses `subGroup`
+      # across handler files, so one file's `/health` leaked onto every
+      # other file's routes.
+      "Bind", "Unbind", "BindFunc", "UnbindFunc",
     }
 
     # Beego registers controllers with `web.Router("/path", &Ctrl{},


### PR DESCRIPTION
## Summary

A `*router.RouterGroup` group declaration that attaches middleware with the fluent chain — `sub := rg.Group("/x").Bind(mw)` / `.Unbind(id)` — went **unresolved**: `collect_group` only peels `Use`/Goyave-config chain methods, so the `.Bind(...)` tail blocked it from reaching the `.Group("/x")` prefix underneath. The group variable was then left to fall back on a **cross-file binding of the same name**.

PocketBase reuses the same local group var (`subGroup`, `sub`) across its per-resource handler files, each with a different prefix. With the chained files unresolved, the one file whose group had no chain (`/health`) seeded the package-level group map, and that prefix **bled onto every other file's routes**:

> record CRUD, collections, settings, and crons all surfaced under `/health/…` — e.g. `GET /health/{id}` instead of `GET /collections/{collection}/records/{id}`.

The ambiguity guard that exists for exactly this contamination never fired, because the chained files contributed no binding to conflict on.

## Fix

Add `Bind`/`Unbind`/`BindFunc`/`UnbindFunc` (all return the group unchanged) to `PASSTHROUGH_CHAIN_METHODS`. Each file now resolves its own group prefix locally, and — because the conflicting names are now visible — the ambiguity guard correctly drops `subGroup` from the shared map.

## Validation (real PocketBase)

- `/health` routes **18 → 1** (the rest re-homed to their true prefixes — `/collections/{collection}/records/{id}`, `/backups/{key}`, `/crons/{id}`, `/logs/stats`, …);
- **46 → 53** endpoints as previously-collapsed duplicates separate out.

The rest of the Go corpus is **unchanged** (gitea / go-admin / gin / echo / fiber / chi / hertz / gozero / iris / photoprism all `+0`).

Remaining (tracked separately): the `/api` base prefix is the unresolved builder-param case — `rg` is a function parameter, so its `pbRouter.Group("/api")` call-site prefix isn't propagated.

New sibling fixture file (`bars.go`, reuses `sub` with a `.Bind().Unbind()` chain) + contamination spec + unit test. Full suite **18762 functional + unit examples, 0 failures**; `ameba` + `crystal tool format --check` clean.