### PR TITLE
fix(analyzer/clojure/pedestal): ignore namespaced-verb client/log calls as routes

### DIFF
--- a/spec/functional_test/fixtures/clojure/pedestal/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/pedestal/src/demo/core.clj
@@ -2,7 +2,17 @@
   (:require [io.pedestal.http :as http]
             [io.pedestal.http.route :as route]
             [io.pedestal.http.route.definition :refer [defroutes]]
-            [io.pedestal.http.route.definition.table :as table]))
+            [io.pedestal.http.route.definition.table :as table]
+            [clj-http.client :as client]
+            [clojure.tools.logging :as log]))
+
+;; Regression guard: a namespaced verb whose first string is a full URL or a
+;; log message is an HTTP-client / logging call, NOT a route helper — it must
+;; not emit a phantom endpoint.
+(defn call-upstream [_request]
+  (log/trace "writing event to stream")
+  (client/post "http://localhost:8888/api" {:body "x"})
+  (client/get "https://example.com/health" {}))
 
 (defn home-page [_request] {:status 200 :body "home"})
 (defn list-users [_request] {:status 200 :body "users"})

--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -117,11 +117,19 @@ module Analyzer::Clojure
       base = base_symbol(symbol)
       if method = helper_method(symbol, base)
         route_path, route_literal_end = first_string_literal(source, after_symbol, list_end)
-        if route_path
+        # Pedestal route helpers take a literal path beginning with `/`
+        # (`(route/get "/health" [] handler)`). A namespaced verb whose first
+        # string is a full URL — `(client/post "http://host/api" ...)` from
+        # clj-http/http-kit — or a log message — `(log/trace "writing event")`
+        # — is not a route; let the walker descend over it instead of emitting
+        # a phantom endpoint (`join_path` would otherwise force a leading `/`).
+        if route_path && route_path.starts_with?("/")
           handler_range = helper_handler_range(source, route_literal_end + 1, list_end)
           emit_endpoint(source, list_start, join_path(prefix, route_path), method, path, seen, include_callee, function_callees, handler_range)
+          true
+        else
+          false
         end
-        true
       elsif base == "table-routes"
         process_table_routes_call(source, after_symbol, list_end, prefix, path, seen, include_callee, function_callees)
         true


### PR DESCRIPTION
## Description

The Pedestal helper-route branch matched **any** namespaced symbol whose last segment is an HTTP verb and captured its first string literal as a route path. Because `join_path` force-prepends a leading slash, HTTP-client URLs and log messages leaked as phantom endpoints:

- `(client/post "http://localhost:8888/api" …)` → `POST /http:/localhost:8888/api`
- `(log/trace "writing event to stream")` → `TRACE /writing event to stream`

## Fix

Pedestal route helpers always take a literal path beginning with `/` (`(route/get "/health" [] handler)`). Require the captured literal to start with `/` before emitting; otherwise fall through and let the walker descend over the form normally.

## Validation

Against real OSS (`metosin/reitit`, `walmartlabs/lacinia-pedestal`):
- `metosin/reitit` (perf-test/test): 169 → 159 pedestal endpoints (−10 phantom `client/get` URLs + `log/trace` messages)
- `lacinia-pedestal`: dropped `POST /http:/localhost:8888/api`, kept real `GET /ws` + `POST /api`
- No real routes lost; `route/get "/health"` style helpers still extracted.

Added a regression guard to the pedestal fixture (`client/post`/`log/trace` lines emit no endpoints). Full Clojure suite green (342 examples, 0 failures), fmt + ameba clean.

Co-authored-by: ksg97031 <ksg97031@gmail.com>