### PR TITLE
fix(analyzer/swift/hummingbird): open builder chains on `.add(middleware:)`

### DIFF
--- a/spec/functional_test/fixtures/swift/hummingbird_controllers/Package.resolved
+++ b/spec/functional_test/fixtures/swift/hummingbird_controllers/Package.resolved
@@ -1,0 +1,275 @@
+{
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "7744c2a035c68ec14726c709f031835e3e30bde1",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "async-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/async-kit.git",
+      "state" : {
+        "revision" : "6bbb83cbf9d886623a967a965c8fb1b73e6566f9",
+        "version" : "1.22.0"
+      }
+    },
+    {
+      "identity" : "fluent-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/fluent-kit.git",
+      "state" : {
+        "revision" : "ec094096d715593c4944cb9aeb72a633faa82918",
+        "version" : "1.56.0"
+      }
+    },
+    {
+      "identity" : "fluent-sqlite-driver",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/fluent-sqlite-driver.git",
+      "state" : {
+        "revision" : "e227d94dc3fe7099a096ac2ca28cad1f69bd8d5b",
+        "version" : "4.9.0"
+      }
+    },
+    {
+      "identity" : "hummingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird.git",
+      "state" : {
+        "revision" : "eebb5ecf8a39beea87401f014fdf87f0ce5b159d",
+        "version" : "2.25.0"
+      }
+    },
+    {
+      "identity" : "sql-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/sql-kit.git",
+      "state" : {
+        "revision" : "3779cedb44b1f374f2cca261c6d28f206024a582",
+        "version" : "3.36.0"
+      }
+    },
+    {
+      "identity" : "sqlite-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/sqlite-kit.git",
+      "state" : {
+        "revision" : "f35a863ecc2da5d563b836a9a696b148b0f4169f",
+        "version" : "4.5.2"
+      }
+    },
+    {
+      "identity" : "sqlite-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/sqlite-nio.git",
+      "state" : {
+        "revision" : "95595bbf0e044ee549fbb64aeaeec8d7f7059a16",
+        "version" : "1.12.8"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/spec/functional_test/fixtures/swift/hummingbird_controllers/Sources/App/Controllers.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_controllers/Sources/App/Controllers.swift
@@ -11,6 +11,12 @@ struct TodoController<Context: RequestContext> {
             .post(use: self.create)           // POST   /api/todos
             .patch(":id", use: self.update)   // PATCH  /api/todos/:id
             .delete(":id", use: self.delete)  // DELETE /api/todos/:id
+
+        // A builder chain that *opens* with `.add(middleware:)`: the verb
+        // steps must still attach (regression for chain-start detection).
+        group.add(middleware: AuthMiddleware())
+            .get("me", use: self.current)     // GET    /api/todos/me
+            .post("logout", use: self.logout) // POST   /api/todos/logout
     }
 
     func list(_ request: Request, context: Context) async throws -> [Todo] { [] }
@@ -18,6 +24,8 @@ struct TodoController<Context: RequestContext> {
     func create(_ request: Request, context: Context) async throws -> Todo { Todo() }
     func update(_ request: Request, context: Context) async throws -> Todo { Todo() }
     func delete(_ request: Request, context: Context) async throws -> HTTPResponse.Status { .ok }
+    func current(_ request: Request, context: Context) async throws -> Todo { Todo() }
+    func logout(_ request: Request, context: Context) async throws -> HTTPResponse.Status { .ok }
 }
 
 // `RouteCollection` mounted via `addRoutes(_:atPath:)`; routes inherit the

--- a/spec/functional_test/testers/swift/hummingbird_controllers_spec.cr
+++ b/spec/functional_test/testers/swift/hummingbird_controllers_spec.cr
@@ -4,6 +4,7 @@ require "../../func_spec.cr"
 #   * `addRoutes(to: router.group("api/todos"))` + fluent builder chains
 #   * `RouteCollection` mounted via `addRoutes(_:atPath:)`
 #   * builder chains that resume across trailing closures
+#   * builder chains that *open* with `.add(middleware:)`
 #   * `.on(method:)`, HEAD and `.ws` verbs
 # The fixture also contains non-router `.get(...)`/`.delete(...)` calls
 # (environment.get, storage.get, repository.delete) that must NOT surface
@@ -22,6 +23,8 @@ expected_endpoints = [
   Endpoint.new("/api/todos", "POST"),
   Endpoint.new("/api/todos/:id", "PATCH"),
   Endpoint.new("/api/todos/:id", "DELETE"),
+  Endpoint.new("/api/todos/me", "GET"),
+  Endpoint.new("/api/todos/logout", "POST"),
 ]
 
 FunctionalTester.new("fixtures/swift/hummingbird_controllers/", {

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -202,7 +202,12 @@ module Analyzer::Swift
       offset = from
       while offset < line.size
         slice = line[offset..]
-        match = slice.match(/(?<![.\w])([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|patch|delete|head|on|ws|group)\s*\(/)
+        # `add` (i.e. `.add(middleware:)`) is a `Self`-returning builder step.
+        # A chain that *opens* with it — `group.add(middleware: auth).get(use:)
+        # .post("logout", use:)` — must be recognized so the trailing verb
+        # steps attach; otherwise those routes silently vanish. (`.add` mid-chain
+        # already works once some other step has opened the chain.)
+        match = slice.match(/(?<![.\w])([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|patch|delete|head|on|ws|group|add)\s*\(/)
         break unless match
 
         receiver = match[1]


### PR DESCRIPTION
## Summary

A Hummingbird `RouterGroup` builder chain that **opens** with the `Self`-returning `.add(middleware:)` step was never recognized as a chain, so every verb step chained after it silently vanished:

```swift
group.add(middleware: sessionAuthenticator)
    .get(use: self.current)        // GET  /api/users  ← was dropped
    .post("logout", use: self.logout) // POST /api/users/logout ← was dropped
```

`find_chain_start` only treated verb / `.group` calls as chain openers. `.add` *mid*-chain already worked (some earlier step had opened the chain); the gap was only when `.add` was the first step on the receiver.

## Fix

Add `add` to the chain-start method set in `find_chain_start`. This stays gated on a router-like receiver, and `.add` itself emits no route hit — so it only lets the trailing verb steps attach, with no new false positives.

## Validation

- Real-world: recovers `GET /api/users` and `POST /api/users/logout` in `hummingbird-examples/todos-auth-fluent` (13 → 15 endpoints). No count change in any of the other 28 hummingbird-examples apps.
- Extended the `hummingbird_controllers` functional fixture with a chain that opens with `.add(middleware:)`.
- Full Swift spec suite passes (221 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>