### PR TITLE
fix(analyzer/cpp/drogon): parse brace-wrapped verb lists in METHOD_ADD/ADD_METHOD_TO

### DIFF
--- a/spec/functional_test/fixtures/cpp/drogon_controllers/ApiCtrl.h
+++ b/spec/functional_test/fixtures/cpp/drogon_controllers/ApiCtrl.h
@@ -25,6 +25,8 @@ class ApiCtrl : public drogon::HttpController<ApiCtrl>
     // Regex with `?` metacharacters must be preserved verbatim (not treated
     // as a query-string separator).
     ADD_METHOD_VIA_REGEX(ApiCtrl::grouped, "/grp/(?:a|b)/(.*)?", Get);
+    // Brace-wrapped verb list `{Post, Options}` — a common real-world form.
+    METHOD_ADD(ApiCtrl::brace, "/brace", {Post, Options});
     METHOD_LIST_END
 
     void root(const HttpRequestPtr &req,
@@ -55,6 +57,12 @@ class ApiCtrl : public drogon::HttpController<ApiCtrl>
 
     void grouped(const HttpRequestPtr &req,
                  std::function<void(const HttpResponsePtr &)> &&callback)
+    {
+        callback(HttpResponse::newHttpResponse());
+    }
+
+    void brace(const HttpRequestPtr &req,
+               std::function<void(const HttpResponsePtr &)> &&callback)
     {
         callback(HttpResponse::newHttpResponse());
     }

--- a/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
+++ b/spec/functional_test/testers/cpp/drogon_controllers_spec.cr
@@ -28,6 +28,9 @@ expected_endpoints = [
   drogon_ctrl_endpoint("/legacy/(.*)", "GET"),
   # Regex `?` metacharacters preserved verbatim (not split as a query string).
   drogon_ctrl_endpoint("/grp/(?:a|b)/(.*)?", "GET"),
+  # Brace-wrapped verb list `{Post, Options}` → both verbs, not a GET fallback.
+  drogon_ctrl_endpoint("/app/v2/ApiCtrl/brace", "POST"),
+  drogon_ctrl_endpoint("/app/v2/ApiCtrl/brace", "OPTIONS"),
   # WS_PATH_ADD → websocket endpoint.
   drogon_ctrl_endpoint("/chat", "GET", "ws"),
   # Multi-line registerHandler whose query-string constraint becomes a param.

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -537,7 +537,9 @@ module Analyzer::Cpp
     private def parse_methods(raw : String) : Array(String)
       methods = [] of String
       raw.split(",").each do |token|
-        name = token.strip
+        # Drogon accepts the verb list either as varargs (`Get, Post`) or wrapped
+        # in a brace init-list (`{Get, Post}`); strip braces so both forms parse.
+        name = token.delete("{}").strip
           .gsub(/^drogon::/, "")
           .gsub(/^HttpMethod::/, "")
           .gsub(/^Http/, "")


### PR DESCRIPTION
## Summary

Drogon lets you declare a route's HTTP verbs either as varargs or wrapped in a brace init-list:

```cpp
METHOD_ADD(Ctrl::fn, "/path", Get, Post);     // varargs — already handled
METHOD_ADD(Ctrl::fn, "/path", {Post, Options}); // brace form — was broken
```

For the brace form, `split_top_level_args` keeps `{Post, Options}` as a single argument, so `parse_methods` split it into the tokens `{Post` and `Options}`. Neither matched the HTTP-method table, the verb list came back empty, and the route silently fell back to **GET**.

Result: real `POST`/`OPTIONS`/etc. endpoints were mis-reported as `GET`.

## Fix

Strip braces per-token in `parse_methods` so both syntaxes resolve to the same verbs.

## Validation (real OSS)

- **marty1885/paroli** — `METHOD_ADD(v1::synthesise, "/synthesise", {Post, Options})` and `METHOD_ADD(audio::speech, "/speech", {Post, Options})` were reported as `GET`; now correctly emit `POST` + `OPTIONS`.
- **marty1885/tlgs** — uses the `{Get}` form throughout; counts and verbs unchanged (21 endpoints), confirming no regression for the single-verb brace case.
- Re-ran the Drogon framework's own `simple_example` and a dozen other Drogon apps (orgChartApi, drogon-realworld, buyer-backend, jsonstore, drogon-auth, …): no FP/FN deltas.

## Tests

Added a `{Post, Options}` case to the `drogon_controllers` fixture/spec. Full C++ suite (254 examples) passes.

Co-authored-by: ksg97031 <ksg97031@gmail.com>