### PR TITLE
fix(analyzer/clojure/compojure): vector path-form routes + coercion-fn & hyphen param accuracy

### DIFF
--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -37,6 +37,12 @@
   (GET "/orders/:id{[0-9]+}" [id :<< as-int]
     {:id id})
 
+  ; An anonymous-fn coercion `#(Integer/parseInt %)` after `:<<` must be
+  ; dropped whole — the Java class/method symbols inside it (`Integer`,
+  ; `parseInt`) must NOT leak as query params. Only `n` is a path param.
+  (GET "/coerce/:n" [n :<< #(Integer/parseInt %)]
+    {:n n})
+
   (context "/api" []
     (POST "/users" request
       request)

--- a/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/compojure/src/demo/core.clj
@@ -43,6 +43,13 @@
   (GET "/coerce/:n" [n :<< #(Integer/parseInt %)]
     {:n n})
 
+  ; Vector path form with an inline regex constraint: the route path is the
+  ; vector's first string. The `:item-id #"[0-9]+"` constraint pair is routing
+  ; metadata, not a param. The kebab-case `item-id` must stay intact (the
+  ; optimizer must not truncate it to a phantom `item` path param).
+  (GET ["/items/:item-id" :item-id #"[0-9]+"] [item-id]
+    {:item-id item-id})
+
   (context "/api" []
     (POST "/users" request
       request)

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -30,6 +30,9 @@ expected_endpoints = [
   Endpoint.new("/orders/:id", "GET", [
     Param.new("id", "", "path"),
   ]),
+  Endpoint.new("/coerce/:n", "GET", [
+    Param.new("n", "", "path"),
+  ]),
   Endpoint.new("/api/users", "POST"),
   Endpoint.new("/api/admin/users/:id", "DELETE", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/clojure/compojure_spec.cr
+++ b/spec/functional_test/testers/clojure/compojure_spec.cr
@@ -33,6 +33,9 @@ expected_endpoints = [
   Endpoint.new("/coerce/:n", "GET", [
     Param.new("n", "", "path"),
   ]),
+  Endpoint.new("/items/:item-id", "GET", [
+    Param.new("item-id", "", "path"),
+  ]),
   Endpoint.new("/api/users", "POST"),
   Endpoint.new("/api/admin/users/:id", "DELETE", [
     Param.new("id", "", "path"),

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -429,8 +429,13 @@ module Analyzer::Clojure
       inner_clean = inner.gsub(/:(?:as|or)\s*\{[^{}]*\}/, " ")
 
       # Compojure's `:<<` applies a coercion fn to the preceding binding,
-      # e.g. `[id :<< as-int]`. The symbol after `:<<` is the coercion fn,
-      # not a request param — drop both the operator and its fn.
+      # e.g. `[id :<< as-int]` or `[x :<< #(Integer/parseInt %)]`. Neither the
+      # operator nor the coercion fn names a request param, so drop both. A fn
+      # written as an anonymous `#(...)` reader or a `(fn …)` form must be
+      # stripped *before* the bare-symbol rule, otherwise the loose word
+      # scanner would harvest the Java class/method names inside it
+      # (`Integer`, `parseInt`). Handles one level of nested parens.
+      inner_clean = inner_clean.gsub(/:<<\s*#?\([^()]*(?:\([^()]*\)[^()]*)*\)/, " ")
       inner_clean = inner_clean.gsub(/:<<\s+[^\s\[\]{}()]+/, " ")
 
       # Vector binding may carry inline destructuring sub-maps like

--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -81,7 +81,7 @@ module Analyzer::Clojure
 
           case base
           when "context"
-            context_path, _ = first_string_literal(source, after_symbol, form_end)
+            context_path, _ = route_path_literal(source, after_symbol, form_end)
             context_path = normalize_route_path(context_path) if context_path
             next_prefix = context_path ? join_path(prefix, context_path) : prefix
             scan_forms(source, after_symbol, form_end, next_prefix, path, include_callee)
@@ -112,7 +112,7 @@ module Analyzer::Clojure
 
     private def add_route(source : String, form_start : Int32, args_start : Int32, form_end : Int32,
                           prefix : String, path : String, method : String, include_callee : Bool)
-      raw_route_path, path_end = first_string_literal(source, args_start, form_end)
+      raw_route_path, path_end = route_path_literal(source, args_start, form_end)
       return unless raw_route_path
       route_path = normalize_route_path(raw_route_path)
 
@@ -528,6 +528,23 @@ module Analyzer::Clojure
         token, _ = read_symbol(source, i, limit)
         token.empty? ? nil : token
       end
+    end
+
+    # The path argument of a route / `context` macro can be a plain string
+    # (`"/foo"`) or a vector carrying inline regex constraints
+    # (`["/foo/:id" :id #"[0-9]+"]`). For the vector form the path is its first
+    # string literal; return the index of the closing `]` so binding/body
+    # parsing resumes after the whole vector rather than inside it.
+    private def route_path_literal(source : String, index : Int32, limit : Int32) : Tuple(String?, Int32)
+      i = skip_ws_and_comments(source, index, limit)
+      if i < limit && source.byte_at(i).unsafe_chr == '['
+        vec_end = find_matching_delimiter(source, i, '[', ']', limit)
+        return {nil, index} if vec_end <= i
+        route_path, _ = first_string_literal(source, i + 1, vec_end)
+        return {route_path, vec_end}
+      end
+
+      first_string_literal(source, index, limit)
     end
 
     private def first_string_literal(source : String, index : Int32, limit : Int32) : Tuple(String?, Int32)

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -894,8 +894,13 @@ class EndpointOptimizer
   # and Express regex constraints `/:id(\\d+)` -> `id`). Path param names are
   # identifiers; anything after the leading identifier describes the segment,
   # not the parameter name.
+  #
+  # Hyphens are part of the identifier — kebab-case path params are idiomatic
+  # in Clojure (`/:artifact-id`, `/:group-id`) and legal in several other
+  # route DSLs. Excluding `-` truncated `artifact-id` to `artifact`, adding a
+  # phantom param that disagreed with the name the analyzer already recorded.
   private def leading_path_param(raw : String) : String?
-    match = raw.match(/\A([A-Za-z_][A-Za-z0-9_]*)/)
+    match = raw.match(/\A([A-Za-z_][A-Za-z0-9_-]*)/)
     match ? match[1] : nil
   end
 


### PR DESCRIPTION
Compojure FP/FN sweep against real OSS (clojars/clojars-web, yogthos/memory-hole, seancorfield/usermanager-example, weavejester/compojure, metosin/compojure-api). Three independent fixes:

### 1. Detect vector path-form routes (FN)
Compojure lets a route / `context` declare its path as a vector carrying inline regex constraints instead of a bare string:
```clojure
(GET ["/:artifact-id" :artifact-id #"[^/]+"] [artifact-id] …)
(GET ["/:group-id/:artifact-id" :group-id #"[^/]+" :artifact-id #"[^/]+"] …)
```
`first_string_literal` broke at the opening `[` and returned nil, so **every vector-form route was dropped**. Added `route_path_literal` (used by both `add_route` and `context`): take the vector's first string as the path and resume binding/body parsing after the closing `]`.

→ **clojars/clojars-web: 31 → 54 endpoints** (+23 real routes across artifact/group/token/repo/api namespaces).

### 2. Drop `:<<` anonymous-fn coercions from query params (FP)
The `:<<` coercion strip only removed a bare symbol (`[id :<< as-int]`). An anonymous-fn coercer — `[x :<< #(Integer/parseInt %)]` — left the fn body behind, so the loose word scanner harvested the Java class/method symbols (`Integer`, `parseInt`, `Boolean`, `valueOf`) as phantom query params. Now strips a `#(...)`/`(...)` form before the bare-symbol rule.

### 3. Keep hyphens in `:param` path-param names (FP, optimizer)
`leading_path_param` matched `[A-Za-z_][A-Za-z0-9_]*`, excluding `-`, so a kebab-case path param `/:artifact-id` was truncated to `artifact` and a phantom param registered alongside the real `artifact-id`. Kebab-case path params are idiomatic in Clojure, so hyphens are now part of the identifier (still splitting `.json`/`?`/`(regex)` suffixes at their real separators). This is a shared optimizer change — full functional suite re-run green.

## Validation
- clojars-web 54 / memory-hole 34 / usermanager 7 / compojure-api 219 — 0 phantom params, 0 suspect URLs.
- Full functional suite: **18766 examples, 0 failures**. Clojure specs + optimizer specs green. fmt + ameba clean.
- Fixture regression guards added for all three.

Co-authored-by: ksg97031 <ksg97031@gmail.com>