### PR TITLE
feat(analyzer/swift/hummingbird): support the HummingbirdRouter result-builder DSL

### DIFF
--- a/spec/functional_test/fixtures/swift/hummingbird_router_dsl/Package.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_router_dsl/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "HummingbirdRouterDSL",
+    platforms: [
+       .macOS(.v14)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "HummingbirdRouter", package: "hummingbird"),
+            ]
+        ),
+    ]
+)

--- a/spec/functional_test/fixtures/swift/hummingbird_router_dsl/Sources/App/Application+build.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_router_dsl/Sources/App/Application+build.swift
@@ -1,0 +1,26 @@
+import Hummingbird
+import HummingbirdRouter
+
+// The `HummingbirdRouter` result-builder DSL: routes are declared
+// structurally inside a `RouterBuilder { }` block, not via `router.get(...)`.
+func buildApplication() -> some ApplicationProtocol {
+    let router = RouterBuilder(context: AppRequestContext.self) {
+        // Middleware elements — PascalCase, but not route primitives.
+        LogRequestsMiddleware(.info)
+
+        // Top-level route with an inline trailing-closure handler.
+        Get("/health") { _, _ -> HTTPResponse.Status in
+            .ok                                  // GET /health
+        }
+
+        // A controller whose `body` is spliced in at the root prefix.
+        UserController()
+
+        // An inline group with a `handler:`-style route.
+        RouteGroup("admin") {
+            Get("stats", handler: self.stats)    // GET /admin/stats
+        }
+    }
+
+    return Application(router: router)
+}

--- a/spec/functional_test/fixtures/swift/hummingbird_router_dsl/Sources/App/UserController.swift
+++ b/spec/functional_test/fixtures/swift/hummingbird_router_dsl/Sources/App/UserController.swift
@@ -1,0 +1,52 @@
+import Hummingbird
+import HummingbirdRouter
+
+// A `RouterController` whose `body` declares routes with the result-builder
+// DSL. The enclosing `RouteGroup("user")` prefixes every nested primitive.
+struct UserController: RouterController {
+    typealias Context = AppRequestContext
+
+    var body: some RouterMiddleware<Context> {
+        RouteGroup("user") {
+            // No path → bound to the group root.
+            Put(handler: self.create)               // PUT  /user
+            Post("signup", handler: self.signup)    // POST /user/signup
+
+            // Trailing-closure handler. The PascalCase constructor inside the
+            // closure is a model, NOT a route, and must not be emitted.
+            Get("login") { request, context -> Token in
+                let credentials = try await request.decode(as: Credentials.self, context: context)
+                let token = Token(value: "stub")    // look-alike, must be ignored
+                return token
+            }
+
+            // Nested group — composes the prefix further.
+            RouteGroup("mfa") {
+                Post("enable", handler: self.enable) // POST /user/mfa/enable
+            }
+        }
+    }
+
+    @Sendable func create(_ request: Request, context: Context) async throws -> User {
+        let user = try await request.decode(as: User.self, context: context)
+        return user
+    }
+
+    @Sendable func signup(_ request: Request, context: Context) async throws -> User {
+        try await request.decode(as: User.self, context: context)
+    }
+
+    @Sendable func enable(_ request: Request, context: Context) async throws -> HTTPResponse.Status {
+        .ok
+    }
+}
+
+// A custom middleware conforming via `: RouterMiddleware` (not `some
+// RouterMiddleware`) — the conformance must not open a route-emitting scope,
+// so the `Post(...)`-looking constructor in its `handle` body is never a route.
+struct RedirectMiddleware<Context: RequestContext>: RouterMiddleware {
+    func handle(_ request: Request, context: Context, next: Responder) async throws -> Response {
+        let audit = Post(event: "redirect")   // look-alike, must be ignored
+        return try await next(request, context)
+    }
+}

--- a/spec/functional_test/testers/swift/hummingbird_router_dsl_spec.cr
+++ b/spec/functional_test/testers/swift/hummingbird_router_dsl_spec.cr
@@ -1,0 +1,24 @@
+require "../../func_spec.cr"
+
+# Exercises the `HummingbirdRouter` declarative result-builder DSL:
+#   * `RouterBuilder { }` root with a top-level verb + inline group
+#   * a `RouterController` whose `var body: some RouterMiddleware<Context>`
+#     declares routes, with `RouteGroup` prefix composition (incl. nesting)
+#   * verbs with a `handler:` reference, a trailing closure, and no path
+#     (bound to the group root)
+# The fixture also contains look-alike PascalCase constructors inside handler
+# bodies (`Token(...)`, `Post(...)`) and a `: RouterMiddleware` conformance
+# that must NOT surface as endpoints.
+expected_endpoints = [
+  Endpoint.new("/health", "GET"),
+  Endpoint.new("/admin/stats", "GET"),
+  Endpoint.new("/user", "PUT"),
+  Endpoint.new("/user/signup", "POST"),
+  Endpoint.new("/user/login", "GET"),
+  Endpoint.new("/user/mfa/enable", "POST"),
+]
+
+FunctionalTester.new("fixtures/swift/hummingbird_router_dsl/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -58,6 +58,10 @@ module Analyzer::Swift
       base = configured_base_for(path)
 
       hits = collect_route_hits(stripped_lines, lines, base)
+      # `HummingbirdRouter`'s declarative result-builder DSL (`RouterBuilder`,
+      # `RouteGroup`, capitalized `Get`/`Post`/... primitives) is invisible to
+      # the receiver-based chain scanner, so discover it in a second pass.
+      hits.concat(collect_dsl_route_hits(stripped_lines, lines))
 
       hits.each do |hit|
         begin
@@ -403,10 +407,11 @@ module Analyzer::Swift
     end
 
     # The named handler referenced via `use:` (e.g. `use: self.create`
-    # yields "create"). Closures return nil so the caller knows to read
-    # the inline body instead.
+    # yields "create"). The closure API labels it `use:`, the result-builder
+    # DSL labels it `handler:` (`Post("signup", handler: self.signup)`).
+    # Closures return nil so the caller knows to read the inline body instead.
     private def handler_from_args(args_str : String) : String?
-      if match = args_str.match(/\buse:\s*(?:self\.)?([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)/)
+      if match = args_str.match(/\b(?:use|handler):\s*(?:self\.)?([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)/)
         return match[1].split('.').last
       end
       nil
@@ -414,6 +419,194 @@ module Analyzer::Swift
 
     private def router_like?(receiver : String, prefix_by_receiver : Hash(String, String)) : Bool
       receiver.split('.').any? { |part| prefix_by_receiver.has_key?(part) }
+    end
+
+    # ------------------------------------------------------------------
+    # HummingbirdRouter result-builder DSL discovery
+    # ------------------------------------------------------------------
+
+    # The capitalized result-builder primitives exposed by the
+    # `HummingbirdRouter` module. Unlike the receiver-based closure API
+    # (`router.get("x") { ... }`), routes are declared structurally:
+    #
+    #     let router = RouterBuilder(context: Context.self) {
+    #         Get("/health") { _, _ in .ok }   // GET /health
+    #         UserController(...)               // splices its `body` here
+    #         RouteGroup("api") {
+    #             Post("login", handler: self.login) // POST /api/login
+    #         }
+    #     }
+    #
+    #     struct UserController: RouterController {
+    #         var body: some RouterMiddleware<Context> {
+    #             RouteGroup("user") {
+    #                 Put(handler: self.create)          // PUT  /user
+    #                 Post("signup", handler: self.signup) // POST /user/signup
+    #             }
+    #         }
+    #     }
+    #
+    # A route primitive is only honored when it sits *directly* inside a
+    # route-emitting scope — a `RouterBuilder { }` block, a `RouteGroup { }`
+    # block, or a `var/func ... some RouterMiddleware { }` controller body —
+    # never inside a handler closure. That gating keeps look-alike PascalCase
+    # constructors (a `Post(title:)` model, a `Get`-named type) out of the
+    # endpoint list.
+    DSL_VERB_RE    = /(?<![.\w])(Get|Post|Put|Patch|Delete|Head)\s*\(/
+    DSL_GROUP_RE   = /(?<![.\w])RouteGroup\s*\(/
+    DSL_BUILDER_RE = /(?<![.\w])RouterBuilder\s*[(<]/
+    # `var body: some RouterMiddleware<Context>` / `func routes() -> some
+    # RouterMiddleware<Context>` — the controller body that hosts the DSL.
+    DSL_BODY_RE = /\bsome\s+RouterMiddleware\b/
+
+    # One nesting level of the DSL. `:builder`/`:group` scopes emit routes;
+    # `:handler` (a route's trailing closure) and `:other` (struct/func/etc.
+    # bodies) do not.
+    record DslScope, kind : Symbol, prefix : String
+
+    private record DslMarker,
+      col : Int32,
+      kind : Symbol,
+      verb : String,
+      paren_col : Int32,
+      end_col : Int32
+
+    private def collect_dsl_route_hits(stripped_lines : Array(String), original_lines : Array(String)) : Array(RouteHit)
+      hits = [] of RouteHit
+      return hits unless stripped_lines.any? do |l|
+                           l.includes?("RouterBuilder") || l.includes?("RouterMiddleware") || l.includes?("RouteGroup")
+                         end
+
+      stack = [] of DslScope
+      pending : DslScope? = nil
+
+      stripped_lines.each_with_index do |line, index|
+        original = original_lines[index]
+        cursor = 0
+
+        while cursor < line.size
+          brace_open = line.index('{', cursor)
+          brace_close = line.index('}', cursor)
+          marker = next_dsl_marker(line, cursor)
+
+          # Earliest of the three events on this line wins (a marker and a
+          # brace never share a column, so ties cannot occur).
+          candidates = [] of Tuple(Int32, Symbol)
+          candidates << {brace_open, :open} if brace_open
+          candidates << {brace_close, :close} if brace_close
+          candidates << {marker.col, :marker} if marker
+          break if candidates.empty?
+
+          event_col, event = candidates.min_by(&.[0])
+
+          case event
+          when :open
+            stack << (pending || default_dsl_scope(stack))
+            pending = nil
+            cursor = event_col + 1
+          when :close
+            stack.pop?
+            pending = nil
+            cursor = event_col + 1
+          when :marker
+            if m = marker
+              pending, cursor = handle_dsl_marker(m, line, original, index, stack, hits)
+            end
+          end
+        end
+      end
+
+      hits
+    end
+
+    # Process one DSL marker. Returns the scope the *next* `{` should adopt
+    # (or nil) and the column to resume scanning from.
+    private def handle_dsl_marker(m : DslMarker,
+                                  line : String,
+                                  original : String,
+                                  index : Int32,
+                                  stack : Array(DslScope),
+                                  hits : Array(RouteHit)) : Tuple(DslScope?, Int32)
+      case m.kind
+      when :verb
+        args = call_arguments(original, m.paren_col + 1)
+        args_str = args ? args[0] : ""
+        if dsl_emitting?(stack)
+          path = join_paths(current_dsl_prefix(stack), parse_route_path(args_str))
+          hits << RouteHit.new(m.verb.upcase, path, index, handler_from_args(args_str))
+        end
+        # A trailing closure on this verb is its handler body, not a group.
+        {DslScope.new(:handler, current_dsl_prefix(stack)), args ? args[1] + 1 : m.end_col}
+      when :group
+        args = call_arguments(original, m.paren_col + 1)
+        args_str = args ? args[0] : ""
+        prefix = join_paths(current_dsl_prefix(stack), parse_route_path(args_str))
+        {DslScope.new(:group, prefix), args ? args[1] + 1 : m.end_col}
+      else
+        # :builder / :body — a route-emitting root rooted at "".
+        {DslScope.new(:builder, ""), m.end_col}
+      end
+    end
+
+    # The earliest DSL marker at or after `cursor`, or nil.
+    private def next_dsl_marker(line : String, cursor : Int32) : DslMarker?
+      slice = line[cursor..]
+      best : DslMarker? = nil
+
+      if m = slice.match(DSL_VERB_RE)
+        best = pick_marker(best, DslMarker.new(
+          cursor + (m.begin(0) || 0), :verb, m[1],
+          cursor + (m.end(0) || 0) - 1, cursor + (m.end(0) || 0)))
+      end
+      if m = slice.match(DSL_GROUP_RE)
+        best = pick_marker(best, DslMarker.new(
+          cursor + (m.begin(0) || 0), :group, "",
+          cursor + (m.end(0) || 0) - 1, cursor + (m.end(0) || 0)))
+      end
+      if m = slice.match(DSL_BUILDER_RE)
+        best = pick_marker(best, DslMarker.new(
+          cursor + (m.begin(0) || 0), :builder, "",
+          cursor + (m.end(0) || 0) - 1, cursor + (m.end(0) || 0)))
+      end
+      if m = slice.match(DSL_BODY_RE)
+        best = pick_marker(best, DslMarker.new(
+          cursor + (m.begin(0) || 0), :body, "", -1, cursor + (m.end(0) || 0)))
+      end
+
+      best
+    end
+
+    private def pick_marker(current : DslMarker?, candidate : DslMarker) : DslMarker
+      return candidate unless current
+      candidate.col < current.col ? candidate : current
+    end
+
+    # True when the innermost scope emits routes (a builder or group block,
+    # not a handler closure or an unrelated `{ }`).
+    private def dsl_emitting?(stack : Array(DslScope)) : Bool
+      if top = stack.last?
+        top.kind == :builder || top.kind == :group
+      else
+        false
+      end
+    end
+
+    private def current_dsl_prefix(stack : Array(DslScope)) : String
+      stack.reverse_each do |scope|
+        return scope.prefix if scope.kind == :builder || scope.kind == :group
+      end
+      ""
+    end
+
+    # A `{` with no preceding marker. Inside a route-emitting scope it is a
+    # transparent control-flow block (`if`/`for` in the result builder) and
+    # stays emitting at the same prefix; otherwise it is an opaque body.
+    private def default_dsl_scope(stack : Array(DslScope)) : DslScope
+      if dsl_emitting?(stack)
+        DslScope.new(:group, current_dsl_prefix(stack))
+      else
+        DslScope.new(:other, "")
+      end
     end
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`HummingbirdRouter` (Hummingbird 2.x) declares routes **structurally** with a result-builder DSL instead of the receiver-based closure API. The chain scanner can't see any of it (there is no `receiver.verb(...)`), so apps using this DSL reported **zero endpoints**.

```swift
let router = RouterBuilder(context: Context.self) {
    Get("/health") { _, _ in .ok }            // GET /health
    UserController()                           // splices its `body`
    RouteGroup("admin") {
        Get("stats", handler: self.stats)      // GET /admin/stats
    }
}

struct UserController: RouterController {
    var body: some RouterMiddleware<Context> {
        RouteGroup("user") {
            Put(handler: self.create)              // PUT  /user
            Post("signup", handler: self.signup)   // POST /user/signup
            RouteGroup("mfa") {
                Post("enable", handler: self.enable) // POST /user/mfa/enable
            }
        }
    }
}
```

## Approach

A second, structure-driven pass (`collect_dsl_route_hits`) walks brace scopes and emits a route for each capitalized `Get`/`Post`/`Put`/`Patch`/`Delete`/`Head` primitive, composing prefixes through `RouteGroup` (incl. nesting) and `some RouterMiddleware` controller bodies.

**False-positive gating:** a primitive is honored only when it sits *directly* inside a route-emitting scope (a `RouterBuilder`/`RouteGroup` block or a `some RouterMiddleware` body) — never inside a handler closure. So look-alike PascalCase constructors (a `Post(title:)` model, a `Get`-named type) and `: RouterMiddleware` middleware bodies stay out of the report.

`handler_from_args` now also reads the DSL's `handler:` label (not just the closure API's `use:`), so DSL routes pick up their handler's params and callees.

## Validation

Real-world `hummingbird-examples`:

| app | before | after |
|-----|--------|-------|
| auth-cognito | 0 | **17** (all with params + callees) |
| webauthn | 0 | **8** |

No change to any of the other 27 closure-API example apps (zero new false positives). New `hummingbird_router_dsl` functional fixture covers the DSL incl. the FP guards. Full Swift spec suite passes (228 examples).

> Known limitation (follow-up): a `RouterController` mounted inside a cross-file `RouteGroup("api")` is currently emitted at its controller-relative prefix (webauthn's `/user/*` rather than `/api/user/*`). Within-file mounting and root mounts are fully correct.

Co-authored-by: ksg97031 <ksg97031@gmail.com>