### PR TITLE
fix(analyzer/scala/tapir): prefix composition, val constants, and multi-line .in() accuracy

### DIFF
--- a/spec/functional_test/fixtures/scala/tapir_compose/ComposeApi.scala
+++ b/spec/functional_test/fixtures/scala/tapir_compose/ComposeApi.scala
@@ -1,0 +1,47 @@
+package com.example.tapir.compose
+
+import sttp.tapir._
+import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
+import sttp.tapir.server.ServerEndpoint
+
+case class Book(title: String, year: Int)
+case class Register_IN(login: String, email: String, password: String)
+
+object ComposeApi {
+  // Path constant reused as a prefix.
+  private val UserPath = "user"
+
+  // Reusable query-param combinator bound to a val.
+  private val limitParameter = query[Option[Int]]("limit").description("max results")
+
+  // Base endpoint carrying a shared '/books' prefix.
+  private val baseEndpoint = endpoint.errorOut(stringBody).in("books")
+
+  // Derived endpoint: inherits '/books', multi-line .in whose
+  // .description(...) / .example(...) literals must NOT leak into the path.
+  val addBook: PublicEndpoint[Book, String, Unit, Any] = baseEndpoint.post
+    .in("add")
+    .in(
+      jsonBody[Book]
+        .description("The book to add")
+        .example(Book("Pride and Prejudice", 1813))
+    )
+    .in(header[String]("X-Auth-Token"))
+
+  // Derived endpoint: inherits '/books', resolves the param-const reference.
+  val listing = baseEndpoint.get
+    .in("list" / "all")
+    .in(limitParameter)
+
+  // Const-prefixed routes.
+  val register = endpoint.post.in(UserPath / "register").in(jsonBody[Register_IN])
+  val getUser  = endpoint.get.in(UserPath)
+
+  // Endpoints inside a List with an Endpoint-typed generic — the type name must
+  // not start a chain that swallows the entries.
+  val all = List[ServerEndpoint[Any, Any]](
+    endpoint.get.in("p1").serverLogic(_ => ???),
+    endpoint.get.in("p1" / "p2").serverLogic(_ => ???)
+  )
+}

--- a/spec/functional_test/testers/scala/tapir_compose_spec.cr
+++ b/spec/functional_test/testers/scala/tapir_compose_spec.cr
@@ -1,0 +1,23 @@
+require "../../func_spec.cr"
+
+# Prefix composition: base endpoints, val path/param constants, multi-line
+# .in() args, modifier-call literals that must not leak, and Endpoint-typed
+# generics that must not merge List entries.
+expected_endpoints = [
+  Endpoint.new("/books/add", "POST", [
+    Param.new("body", "Book", "json"),
+    Param.new("X-Auth-Token", "String", "header"),
+  ]),
+  Endpoint.new("/books/list/all", "GET", [
+    Param.new("limit", "Option[Int]", "query"),
+  ]),
+  Endpoint.new("/user/register", "POST", [Param.new("body", "Register_IN", "json")]),
+  Endpoint.new("/user", "GET"),
+  Endpoint.new("/p1", "GET"),
+  Endpoint.new("/p1/p2", "GET"),
+]
+
+FunctionalTester.new("fixtures/scala/tapir_compose/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -109,8 +109,9 @@ module Analyzer::Scala
           search_offset = vm.end
         end
 
-        next unless match = code.match(BASE_ENDPOINT_RE, search_offset)
-        col = match.begin || 0
+        masked = struct_lines[index]? || ""
+        col = base_match_col(code, masked, search_offset)
+        next unless col
         chain_text, last_line = collect_chain(code_lines, struct_lines, index, col)
         consumed_until = last_line
         chains << Chain.new(name, chain_text, index + 1)
@@ -164,6 +165,23 @@ module Analyzer::Scala
     private def leading_ident(chain : String) : String?
       m = chain.match(/^\s*([A-Za-z_]\w*)/)
       m ? m[1] : nil
+    end
+
+    # Column of the first real base-endpoint token at/after `offset`, skipping
+    # matches that sit inside a `[...]` type-argument list (e.g. the type name in
+    # `List[ServerEndpoint[Any, F]](...)`). Such a match would otherwise start a
+    # chain whose head carries an unbalanced `(` from the enclosing call and
+    # swallow the following endpoint lines. `secureEndpoint[ApiKey].post` is kept
+    # because the identifier itself is at bracket depth 0.
+    private def base_match_col(code : String, masked : String, offset : Int32) : Int32?
+      while m = code.match(BASE_ENDPOINT_RE, offset)
+        col = m.begin || 0
+        prefix = col <= masked.size ? masked[0...col] : masked
+        bracket_depth = prefix.count('[') - prefix.count(']')
+        return col if bracket_depth <= 0
+        offset = col + m[0].size
+      end
+      nil
     end
 
     # Collect a Tapir endpoint chain spanning multiple lines. A line is part of

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -13,6 +13,11 @@ module Analyzer::Scala
 
     BASE_ENDPOINT_RE = /(?<![.\w])(?:[A-Za-z_]\w*[Ee]ndpoint|endpoint|infallibleEndpoint)\b/
 
+    # Leading `val NAME [: TYPE] =` of a definition. Group 1 captures the name;
+    # `match.end` marks where the right-hand side (the actual endpoint chain)
+    # begins. `=(?![=>])` avoids stopping on `==`/`=>`.
+    VAL_DEF_RE = /^\s*(?:(?:private|protected|implicit|lazy|final|override)\s+)*val\s+(\w+)\s*(?::\s*[^=]+?\s*)?=(?![=>])\s*/
+
     # Type token allows one level of nested brackets (e.g. Option[String], List[User]).
     TYPE_PATTERN = "(?:[^\\[\\]]|\\[[^\\[\\]]*\\])+"
 
@@ -34,16 +39,26 @@ module Analyzer::Scala
 
     private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = content.split('\n')
-      code_lines = scala_code_lines(content)
+      lexer = scala_lexer(content)
+      code_lines = lexer.code_lines
+      struct_lines = lexer.masked_lines
       consumed_until = -1
 
-      lines.each_with_index do |_, index|
+      code_lines.each_index do |index|
         next if index <= consumed_until
         code = code_lines[index]? || ""
-        next unless match = code.match(BASE_ENDPOINT_RE)
+
+        # Skip the `val NAME [: TYPE] =` prefix so a val whose name (or type
+        # annotation, e.g. `PublicEndpoint[...]`) ends in "Endpoint" doesn't
+        # get matched in place of the RHS base token.
+        search_offset = 0
+        if vm = code.match(VAL_DEF_RE)
+          search_offset = vm.end
+        end
+
+        next unless match = code.match(BASE_ENDPOINT_RE, search_offset)
         col = match.begin || 0
-        chain_text, last_line = collect_chain(lines, code_lines, index, col)
+        chain_text, last_line = collect_chain(code_lines, struct_lines, index, col)
         consumed_until = last_line
 
         endpoint = parse_chain(chain_text, path, index + 1)
@@ -53,21 +68,87 @@ module Analyzer::Scala
       endpoints
     end
 
-    private def collect_chain(lines : Array(String), code_lines : Array(String), start : Int32, col : Int32) : Tuple(String, Int32)
-      head = code_lines[start]? || ""
-      first = col < head.size ? head[col..] : ""
+    # Collect a Tapir endpoint chain spanning multiple lines. A line is part of
+    # the chain when it continues an open `(` (a multi-line `.in(...)` argument)
+    # OR begins with `.` (a chained combinator). Paren depth is counted on the
+    # structural view so parens inside string literals don't skew the balance.
+    private def collect_chain(code_lines : Array(String), struct_lines : Array(String), start : Int32, col : Int32) : Tuple(String, Int32)
+      head_code = code_lines[start]? || ""
+      head_struct = struct_lines[start]? || ""
+      first = col < head_code.size ? head_code[col..] : ""
+      first_struct = col < head_struct.size ? head_struct[col..] : ""
       parts = [first]
+      depth = paren_balance(first_struct)
       idx = start + 1
-      while idx < lines.size
+      while idx < code_lines.size
         code = code_lines[idx]? || ""
-        if code.lstrip.starts_with?(".")
+        masked = struct_lines[idx]? || ""
+        if depth > 0
           parts << code
+          depth += paren_balance(masked)
+          idx += 1
+        elsif code.lstrip.starts_with?(".")
+          parts << code
+          depth += paren_balance(masked)
           idx += 1
         else
           break
         end
       end
       {parts.join("\n"), idx - 1}
+    end
+
+    private def paren_balance(s : String) : Int32
+      s.count('(') - s.count(')')
+    end
+
+    # Number of open *call* parens just before each character, ignoring parens
+    # inside string literals. A `(` is a call paren when it directly follows an
+    # identifier / `]` (e.g. `example(`, `path[String](`); a `(` after an
+    # operator, whitespace or start is a grouping paren and does not count. This
+    # lets a literal inside `("a" / b)` stay a path segment while one inside
+    # `.example("a")` is rejected.
+    private def call_paren_depths(s : String) : Array(Int32)
+      depths = Array(Int32).new(s.size, 0)
+      call_depth = 0
+      stack = [] of Bool
+      in_str = false
+      prev_sig = '\0'
+      i = 0
+      while i < s.size
+        depths[i] = call_depth
+        c = s[i]
+        if in_str
+          if c == '\\'
+            depths[i + 1] = call_depth if i + 1 < s.size
+            i += 2
+            next
+          elsif c == '"'
+            in_str = false
+            prev_sig = '"'
+          end
+        else
+          case c
+          when '"'
+            in_str = true
+            prev_sig = '"'
+          when '('
+            is_call = prev_sig.ascii_alphanumeric? || prev_sig == '_' || prev_sig == ']'
+            stack << is_call
+            call_depth += 1 if is_call
+            prev_sig = '('
+          when ')'
+            if last = stack.pop?
+              call_depth -= 1 if last
+            end
+            prev_sig = ')'
+          else
+            prev_sig = c unless c.ascii_whitespace?
+          end
+        end
+        i += 1
+      end
+      depths
     end
 
     private def parse_chain(chain : String, path : String, line_no : Int32) : Endpoint?
@@ -134,8 +215,15 @@ module Analyzer::Scala
     end
 
     private def process_in_args(args : String, endpoint : Endpoint, segments : Array(String))
+      depths = call_paren_depths(args)
       args.scan(IN_TOKEN_RE) do |m|
         if literal = m["literal"]?
+          # A string is a path segment only when it is NOT an argument to a
+          # method call. `.example("...")` / `.description("...")` chained onto a
+          # combinator must not leak into the path, but grouping parens used for
+          # input composition — `("a" / path[..]).and(..)` — keep their literals.
+          pos = m.begin || 0
+          next unless (depths[pos]? || 0) == 0
           literal.split('/').reject(&.empty?).each { |seg| segments << seg }
         elsif m["path_type"]?
           name = m["path_name"]? || default_path_name(segments)

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -37,22 +37,55 @@ module Analyzer::Scala
       extract_routes_from_content(path, content)
     end
 
+    # One collected endpoint chain. `name` is the `val` it was assigned to (if
+    # any) so other chains can reuse it as a base for prefix composition.
+    private record Chain, name : String?, text : String, line : Int32
+
     private def extract_routes_from_content(path : String, content : String) : Array(Endpoint)
-      endpoints = [] of Endpoint
       lexer = scala_lexer(content)
       code_lines = lexer.code_lines
       struct_lines = lexer.masked_lines
-      consumed_until = -1
 
+      chains = collect_chains(code_lines, struct_lines)
+
+      # Map every named chain so a later chain that starts from one of them
+      # (e.g. `val addBook = baseEndpoint.post...`) can inherit its path prefix.
+      defs = {} of String => String
+      chains.each { |c| (n = c.name) && (defs[n] = c.text) }
+
+      cache = {} of String => Tuple(Array(String), Array(Param))
+      endpoints = [] of Endpoint
+      chains.each do |chain|
+        method = detect_method(chain.text)
+        next unless method
+
+        endpoint = create_endpoint("/", method.upcase, path, chain.line)
+        seen = Set(String).new
+        (n = chain.name) && (seen << n)
+        segments, params = resolve_chain(chain.text, defs, cache, seen)
+        endpoint.url = segments.empty? ? "/" : "/" + segments.join("/")
+        params.each { |p| add_param(endpoint, p.name, p.value, p.param_type) }
+        endpoints << endpoint
+      end
+
+      endpoints
+    end
+
+    private def collect_chains(code_lines : Array(String), struct_lines : Array(String)) : Array(Chain)
+      chains = [] of Chain
+      consumed_until = -1
       code_lines.each_index do |index|
         next if index <= consumed_until
         code = code_lines[index]? || ""
 
         # Skip the `val NAME [: TYPE] =` prefix so a val whose name (or type
         # annotation, e.g. `PublicEndpoint[...]`) ends in "Endpoint" doesn't
-        # get matched in place of the RHS base token.
+        # get matched in place of the RHS base token. The captured name lets the
+        # chain be reused as a base for prefix composition.
+        name = nil
         search_offset = 0
         if vm = code.match(VAL_DEF_RE)
+          name = vm[1]
           search_offset = vm.end
         end
 
@@ -60,12 +93,40 @@ module Analyzer::Scala
         col = match.begin || 0
         chain_text, last_line = collect_chain(code_lines, struct_lines, index, col)
         consumed_until = last_line
+        chains << Chain.new(name, chain_text, index + 1)
+      end
+      chains
+    end
 
-        endpoint = parse_chain(chain_text, path, index + 1)
-        endpoints << endpoint if endpoint
+    # Resolve a chain's path segments and params, prepending those of the base
+    # endpoint it was derived from. `endpoint`/`infallibleEndpoint` are the
+    # terminal roots; any other leading identifier that names a known chain is a
+    # reusable base (`val base = endpoint.in("books")`). `seen` guards cycles.
+    private def resolve_chain(chain : String, defs : Hash(String, String),
+                              cache : Hash(String, Tuple(Array(String), Array(Param))),
+                              seen : Set(String)) : Tuple(Array(String), Array(Param))
+      own_segments = [] of String
+      own_params = [] of Param
+      extract_in_blocks(chain).each do |args|
+        process_in_args(args, own_params, own_segments)
       end
 
-      endpoints
+      head = leading_ident(chain)
+      if head && head != "endpoint" && head != "infallibleEndpoint" && !seen.includes?(head) && (base_chain = defs[head]?)
+        base_segs, base_params = cache[head]? || begin
+          resolved = resolve_chain(base_chain, defs, cache, seen | Set{head})
+          cache[head] = resolved
+          resolved
+        end
+        return {base_segs + own_segments, base_params + own_params}
+      end
+
+      {own_segments, own_params}
+    end
+
+    private def leading_ident(chain : String) : String?
+      m = chain.match(/^\s*([A-Za-z_]\w*)/)
+      m ? m[1] : nil
     end
 
     # Collect a Tapir endpoint chain spanning multiple lines. A line is part of
@@ -151,21 +212,6 @@ module Analyzer::Scala
       depths
     end
 
-    private def parse_chain(chain : String, path : String, line_no : Int32) : Endpoint?
-      method = detect_method(chain)
-      return unless method
-
-      endpoint = create_endpoint("/", method.upcase, path, line_no)
-      segments = [] of String
-
-      extract_in_blocks(chain).each do |args|
-        process_in_args(args, endpoint, segments)
-      end
-
-      endpoint.url = segments.empty? ? "/" : "/" + segments.join("/")
-      endpoint
-    end
-
     private def detect_method(chain : String) : String?
       METHOD_CALL_PATTERNS.each do |m, pattern|
         return m if chain.matches?(pattern)
@@ -214,7 +260,7 @@ module Analyzer::Scala
       nil
     end
 
-    private def process_in_args(args : String, endpoint : Endpoint, segments : Array(String))
+    private def process_in_args(args : String, params : Array(Param), segments : Array(String))
       depths = call_paren_depths(args)
       args.scan(IN_TOKEN_RE) do |m|
         if literal = m["literal"]?
@@ -228,17 +274,17 @@ module Analyzer::Scala
         elsif m["path_type"]?
           name = m["path_name"]? || default_path_name(segments)
           segments << "{#{name}}"
-          add_param(endpoint, name, "", "path")
+          collect_param(params, name, "", "path")
         elsif q = m["query_name"]?
-          add_param(endpoint, q, m["query_type"]? || "", "query")
+          collect_param(params, q, m["query_type"]? || "", "query")
         elsif q = m["queries_name"]?
-          add_param(endpoint, q, m["queries_type"]? || "", "query")
+          collect_param(params, q, m["queries_type"]? || "", "query")
         elsif h = m["header_name"]?
-          add_param(endpoint, h, m["header_type"]? || "", "header")
+          collect_param(params, h, m["header_type"]? || "", "header")
         elsif h = m["header_name2"]?
-          add_param(endpoint, h, "", "header")
+          collect_param(params, h, "", "header")
         elsif c = m["cookie_name"]?
-          add_param(endpoint, c, m["cookie_type"]? || "", "cookie")
+          collect_param(params, c, m["cookie_type"]? || "", "cookie")
         elsif body = m["body"]?
           inner = m["body_type"]? || ""
           param_type = case body
@@ -249,9 +295,14 @@ module Analyzer::Scala
                        else
                          "body"
                        end
-          add_param(endpoint, "body", inner, param_type)
+          collect_param(params, "body", inner, param_type)
         end
       end
+    end
+
+    private def collect_param(params : Array(Param), name : String, type_value : String, param_type : String)
+      return if params.any? { |p| p.name == name && p.param_type == param_type }
+      params << Param.new(name, type_value, param_type)
     end
 
     private def add_param(endpoint : Endpoint, name : String, type_value : String, param_type : String)

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -18,6 +18,25 @@ module Analyzer::Scala
     # begins. `=(?![=>])` avoids stopping on `==`/`=>`.
     VAL_DEF_RE = /^\s*(?:(?:private|protected|implicit|lazy|final|override)\s+)*val\s+(\w+)\s*(?::\s*[^=]+?\s*)?=(?![=>])\s*/
 
+    MODIFIERS = "(?:(?:private|protected|implicit|lazy|final|override)\\s+)*"
+
+    # `val UserPath = "user"` (optionally `/`-joined literals). The captured
+    # value is already in literal form, so substituting it back into a `.in(...)`
+    # block lets the normal path-literal scan pick up the segments.
+    PATH_CONST_RE = Regex.new(
+      "^\\s*#{MODIFIERS}val\\s+(\\w+)\\s*(?::\\s*String\\s*)?=\\s*" \
+      "(\"(?:[^\"\\\\]|\\\\.)*\"(?:\\s*/\\s*\"(?:[^\"\\\\]|\\\\.)*\")*)\\s*$"
+    )
+
+    # `val limitParameter = query[Option[Int]]("limit")...` — a reusable input
+    # combinator bound to a val. Only the combinator core is captured so any
+    # trailing `.description(...)` is dropped.
+    PARAM_CONST_RE = Regex.new(
+      "^\\s*#{MODIFIERS}val\\s+(\\w+)\\s*=\\s*" \
+      "((?:query|queries|header|cookie|path)\\[#{TYPE_PATTERN}\\]\\s*\\(\\s*\"[^\"]+\"\\s*\\)" \
+      "|header\\s*\\(\\s*\"[^\"]+\"\\s*\\))"
+    )
+
     # Type token allows one level of nested brackets (e.g. Option[String], List[User]).
     TYPE_PATTERN = "(?:[^\\[\\]]|\\[[^\\[\\]]*\\])+"
 
@@ -53,6 +72,7 @@ module Analyzer::Scala
       defs = {} of String => String
       chains.each { |c| (n = c.name) && (defs[n] = c.text) }
 
+      consts = build_consts(code_lines)
       cache = {} of String => Tuple(Array(String), Array(Param))
       endpoints = [] of Endpoint
       chains.each do |chain|
@@ -62,7 +82,7 @@ module Analyzer::Scala
         endpoint = create_endpoint("/", method.upcase, path, chain.line)
         seen = Set(String).new
         (n = chain.name) && (seen << n)
-        segments, params = resolve_chain(chain.text, defs, cache, seen)
+        segments, params = resolve_chain(chain.text, defs, consts, cache, seen)
         endpoint.url = segments.empty? ? "/" : "/" + segments.join("/")
         params.each { |p| add_param(endpoint, p.name, p.value, p.param_type) }
         endpoints << endpoint
@@ -103,18 +123,19 @@ module Analyzer::Scala
     # terminal roots; any other leading identifier that names a known chain is a
     # reusable base (`val base = endpoint.in("books")`). `seen` guards cycles.
     private def resolve_chain(chain : String, defs : Hash(String, String),
+                              consts : Hash(String, String),
                               cache : Hash(String, Tuple(Array(String), Array(Param))),
                               seen : Set(String)) : Tuple(Array(String), Array(Param))
       own_segments = [] of String
       own_params = [] of Param
       extract_in_blocks(chain).each do |args|
-        process_in_args(args, own_params, own_segments)
+        process_in_args(args, own_params, own_segments, consts)
       end
 
       head = leading_ident(chain)
       if head && head != "endpoint" && head != "infallibleEndpoint" && !seen.includes?(head) && (base_chain = defs[head]?)
         base_segs, base_params = cache[head]? || begin
-          resolved = resolve_chain(base_chain, defs, cache, seen | Set{head})
+          resolved = resolve_chain(base_chain, defs, consts, cache, seen | Set{head})
           cache[head] = resolved
           resolved
         end
@@ -122,6 +143,22 @@ module Analyzer::Scala
       end
 
       {own_segments, own_params}
+    end
+
+    # Collect `val NAME = "literal"` path constants and `val NAME = query[..](..)`
+    # input-combinator constants so a `.in(NAME / ...)` reference resolves to the
+    # real path/param instead of being dropped.
+    private def build_consts(code_lines : Array(String)) : Hash(String, String)
+      consts = {} of String => String
+      code_lines.each do |line|
+        next if line.empty?
+        if m = line.match(PATH_CONST_RE)
+          consts[m[1]] = m[2]
+        elsif m = line.match(PARAM_CONST_RE)
+          consts[m[1]] = m[2]
+        end
+      end
+      consts
     end
 
     private def leading_ident(chain : String) : String?
@@ -260,7 +297,8 @@ module Analyzer::Scala
       nil
     end
 
-    private def process_in_args(args : String, params : Array(Param), segments : Array(String))
+    private def process_in_args(args : String, params : Array(Param), segments : Array(String), consts : Hash(String, String))
+      args = substitute_consts(args, consts) unless consts.empty?
       depths = call_paren_depths(args)
       args.scan(IN_TOKEN_RE) do |m|
         if literal = m["literal"]?
@@ -303,6 +341,94 @@ module Analyzer::Scala
     private def collect_param(params : Array(Param), name : String, type_value : String, param_type : String)
       return if params.any? { |p| p.name == name && p.param_type == param_type }
       params << Param.new(name, type_value, param_type)
+    end
+
+    # Replace top-level identifier references to known path/param constants with
+    # their literal/combinator form before tokenizing. Only substitutes outside
+    # any call parens or `[...]` type args, and never a `.member`/`call(` — so a
+    # const name reused as a type or modifier argument is left untouched.
+    private def substitute_consts(args : String, consts : Hash(String, String)) : String
+      io = String::Builder.new
+      i = 0
+      size = args.size
+      call_depth = 0
+      bracket_depth = 0
+      stack = [] of Bool
+      in_str = false
+      prev_sig = '\0'
+      while i < size
+        c = args[i]
+        if in_str
+          io << c
+          if c == '\\' && i + 1 < size
+            io << args[i + 1]
+            i += 2
+            next
+          elsif c == '"'
+            in_str = false
+            prev_sig = '"'
+          end
+          i += 1
+          next
+        end
+
+        case c
+        when '"'
+          in_str = true
+          io << c
+          prev_sig = '"'
+          i += 1
+        when '['
+          bracket_depth += 1
+          io << c
+          prev_sig = '['
+          i += 1
+        when ']'
+          bracket_depth -= 1
+          io << c
+          prev_sig = ']'
+          i += 1
+        when '('
+          is_call = prev_sig.ascii_alphanumeric? || prev_sig == '_' || prev_sig == ']'
+          stack << is_call
+          call_depth += 1 if is_call
+          io << c
+          prev_sig = '('
+          i += 1
+        when ')'
+          if last = stack.pop?
+            call_depth -= 1 if last
+          end
+          io << c
+          prev_sig = ')'
+          i += 1
+        else
+          if c.ascii_letter? || c == '_'
+            start = i
+            while i < size && (args[i].ascii_alphanumeric? || args[i] == '_')
+              i += 1
+            end
+            ident = args[start...i]
+            j = i
+            while j < size && args[j].ascii_whitespace?
+              j += 1
+            end
+            following = j < size ? args[j] : '\0'
+            if call_depth == 0 && bracket_depth == 0 && prev_sig != '.' &&
+               following != '(' && following != '.' && (sub = consts[ident]?)
+              io << sub
+            else
+              io << ident
+            end
+            prev_sig = ident[-1]
+          else
+            io << c
+            prev_sig = c unless c.ascii_whitespace?
+            i += 1
+          end
+        end
+      end
+      io.to_s
     end
 
     private def add_param(endpoint : Endpoint, name : String, type_value : String, param_type : String)


### PR DESCRIPTION
## Summary

Accuracy sweep of the **Tapir** Scala analyzer against real OSS apps (softwaremill/bootzooka, softwaremill/tapir examples). The Tapir endpoint-builder DSL leans heavily on factoring shared route fragments into base endpoints and `val` constants, and on multi-line `.in(...)` blocks — none of which the analyzer previously composed, so prefixes and params were dropped while `.example(...)`/`.description(...)` literals leaked into URLs.

### Fixes (each its own commit)

1. **Multi-line `.in()` collection + modifier-literal filter** — the chain collector only followed lines beginning with `.`, truncating multi-line `.in(\n jsonBody[T]\n .example(...)\n)` blocks (losing body/header params). Now follows open parens across lines, and classifies path literals by *call-paren* depth so `.example("x")`/`.description("x")` no longer leak into the path while grouping parens `("a" / path[..]).and(..)` keep theirs.

2. **Base-endpoint prefix composition** — `val base = endpoint.in("books")` reused as `val addBook = base.post.in("add")` now yields `POST /books/add` (was `POST /add`). Named chains are collected first, then each endpoint resolves its segments/params back through its base (cycle-guarded, memoized).

3. **`val` path/param constant resolution** — `private val UserPath = "user"` + `.in(UserPath / "register")` now yields `/user/register` (bootzooka emitted `/register`); reusable `val limitParameter = query[..]("limit")` referenced via `.in(limitParameter)` resolves to the query param.

4. **Endpoint-typed generics guard** — a type arg like `ServerEndpoint` in `List[ServerEndpoint[Any, F]](...)` matched the base-endpoint regex and, with the new paren-aware collector, swallowed following `List` entries (merged into bogus `/p1/p1/p2` paths). Matches inside `[...]` type args are now ignored; `secureEndpoint[ApiKey].post` is unaffected.

### Impact (real apps)

- **bootzooka**: every endpoint now carries its correct prefix — `POST /user/register`, `POST /user/login`, `POST /passwordreset/reset`, `GET /admin/version`, … (was `/register`, `/login`, `/reset`, `/version`); the `.example(...)` FP `POST /register/john/john@bootzooka.com/1234_abcd_ABCD` is gone.
- **tapir examples** (booksExample): `POST /books/add` + body/header params, `GET /books/list/all` + `limit` query, `GET /books/list/{genre}` (were `/add`, `/list/all`, `/{genre}` with missing params).
- tapir repo overall: 178 → 158 scala_tapir endpoints, the drop being genuine example-value FP removal (`/alan/tom`, `/{country}/Poland/UK/...`, `/x-path/x-query/...`, etc.).

### Tests

- New fixture `fixtures/scala/tapir_compose/` + tester covering base prefix, path/param constants, multi-line `.in()`, modifier-literal filtering, and the `List[ServerEndpoint[...]]` merge guard.
- Full suite green (`crystal spec`: 22194 examples, 0 failures). Scan time unchanged (~0.85s for the tapir repo).

Co-authored-by: ksg97031 <ksg97031@gmail.com>