### PR TITLE
fix(analyzer/dart/frog): require an onRequest handler for route files

### DIFF
--- a/spec/functional_test/fixtures/dart/dart_frog/routes/dashboard_route.dart
+++ b/spec/functional_test/fixtures/dart/dart_frog/routes/dashboard_route.dart
@@ -1,0 +1,14 @@
+// A Flutter client's UI navigation file that happens to live under a
+// `routes/` directory in a full-stack monorepo. It exports a widget, not
+// a Dart Frog `onRequest` handler, so it must NOT be reported as an HTTP
+// endpoint.
+import 'package:flutter/material.dart';
+
+class DashboardRoute extends StatelessWidget {
+  const DashboardRoute({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('Dashboard')));
+  }
+}

--- a/spec/functional_test/testers/dart/dart_frog_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_spec.cr
@@ -35,7 +35,15 @@ expected_endpoints = [
   Endpoint.new("/articles/{id}", "PUT", [Param.new("id", "", "path")]),
 ]
 
-FunctionalTester.new("fixtures/dart/dart_frog/", {
+tester = FunctionalTester.new("fixtures/dart/dart_frog/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,
-}, expected_endpoints).perform_tests
+}, expected_endpoints)
+tester.perform_tests
+
+# `routes/dashboard_route.dart` is a Flutter UI widget (no `onRequest`
+# handler) that happens to live under `routes/`. It must not be reported
+# as an HTTP endpoint.
+it "ignores routes/ files without an onRequest handler" do
+  tester.app.endpoints.any? { |e| e.url == "/dashboard_route" }.should be_false
+end

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -34,6 +34,15 @@ module Analyzer::Dart
 
     FALLBACK_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"]
 
+    # Every Dart Frog route file exports an `onRequest` handler — either a
+    # function (`Response onRequest(...)`, `Future<Response> onRequest(...)`)
+    # or the assignment form (`Handler onRequest = ...`). A `.dart` file
+    # under a `routes/` directory that lacks it is not a server route. This
+    # matters for full-stack monorepos, where a Flutter client commonly
+    # keeps its UI navigation under `lib/.../routes/` — those widget files
+    # must not be reported as HTTP endpoints.
+    ON_REQUEST_HANDLER_REGEX = /\bonRequest\s*[(=]/
+
     # Crystal recompiles an interpolated regex literal on every evaluation
     # (a full PCRE2 JIT compile) — precompile the fixed verb probes once
     # at load time instead of per handler file.
@@ -71,6 +80,11 @@ module Analyzer::Dart
             logger.debug "Error reading #{path}: #{e.message}"
             next
           end
+
+          # Only files exporting an `onRequest` handler are Dart Frog
+          # routes; skip a Flutter client's `routes/` UI files and any
+          # other non-route `.dart` that happens to live under `routes/`.
+          next unless content.matches?(ON_REQUEST_HANDLER_REGEX)
 
           methods = detect_methods(content)
           callees = include_callee ? callees_for_on_request(content, path) : [] of Noir::DartCalleeExtractor::Entry


### PR DESCRIPTION
## Problem

The Dart Frog analyzer treated **every** `.dart` file under a `routes/` directory as a route, emitting fall-back endpoints for any file with no explicit `HttpMethod.*` references.

In a full-stack monorepo — the dominant Dart Frog usage pattern — a Flutter client commonly keeps its **UI navigation** under `lib/.../routes/`:

```dart
// lib/feature_room/ui/routes/create_room.dart
import 'package:flutter/material.dart';
class CreateRoomRoute extends ConsumerStatefulWidget { ... }   // NOT a server route
```

These widget files were surfaced as phantom HTTP endpoints (each as 5 fall-back verbs), and a UI file sharing a name with a real route (`create_room`) polluted the real endpoint's method set.

## Fix

Every Dart Frog route file exports an `onRequest` handler — the function form (`Response onRequest(...)` / `Future<Response> onRequest(...)`) or the assignment form (`Handler onRequest = ...`). Gate route emission on that handler being present, so non-route `.dart` files under `routes/` are skipped.

## Real-app impact

`df_realtimechat` (Dart Frog server + Flutter client in one repo): **26 → 12** endpoints — drops `/room_routes`, `/join_room`, and a phantom 5-verb `/create_room` from the Flutter UI tree, while leaving the four real `server/routes/` endpoints (`/`, `/check_room`, `/create_room` POST, `/ws/{room}`) intact.

No change to any pure-server Dart Frog app in the test corpus (df framework examples, talkstream, sample, ecommerce, mahasiswa, mysql, cutietodo, teamship, fullstack — all unchanged).

## Tests

- New Flutter-widget fixture under the dart_frog fixture's `routes/` + a regression assertion that it is not reported.
- `crystal spec` full suite green (22377 examples, 0 failures); format + ameba clean.

Co-authored-by: ksg97031 <ksg97031@gmail.com>