### PR TITLE
fix(analyzer/zig/tokamak): resolve struct/value-form controller mounts + const route decls

### DIFF
--- a/spec/functional_test/fixtures/zig/tokamak/src/api/resources.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/api/resources.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+
+// Controllers declared as `pub const @"METHOD /path" = handler;` bindings
+// rather than functions. The handler is defined elsewhere, so these routes
+// carry no inline callees. Each struct is mounted by qualified name
+// (`.router(resources.Public)`); its routes inherit only the prefix of the
+// mount that selects that struct.
+
+pub const Public = struct {
+    pub const @"GET /ping" = ping;
+    pub const @"POST /login" = login;
+};
+
+pub const Private = struct {
+    pub const @"DELETE /sessions/:id" = dropSession;
+};
+
+fn ping() ![]const u8 {
+    return "pong";
+}
+
+fn login() !void {}
+
+fn dropSession() !void {}

--- a/spec/functional_test/fixtures/zig/tokamak/src/main.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/main.zig
@@ -21,6 +21,22 @@ const routes: []const tk.Route = &.{
         .router(resources.Public),
         .router(resources.Private),
     }),
+    // Value-form group: the body is a single route value (`.router(local)`),
+    // not a `&.{ … }` array, so the `/svc` prefix is scoped to the group call's
+    // own parentheses. `local` is a struct declared in this file.
+    .group("/svc", .router(local)),
+};
+
+// Local controller struct mounted by the value-form group above. Its root
+// handler (`@"GET /"`) collapses to `/svc` without a trailing slash.
+const local = struct {
+    pub fn @"GET /"() ![]const u8 {
+        return ping();
+    }
+
+    pub fn @"POST /sync"() !void {
+        try worker.run();
+    }
 };
 
 fn hello() ![]const u8 {

--- a/spec/functional_test/fixtures/zig/tokamak/src/main.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const tk = @import("tokamak");
 const widgets = @import("api/widgets.zig");
+const resources = @import("api/resources.zig");
 
 const routes: []const tk.Route = &.{
     .get("/", hello),
@@ -13,6 +14,12 @@ const routes: []const tk.Route = &.{
             .get("/items/:id", getItem),
             .delete("/items/:id", deleteItem),
         }),
+    }),
+    // Qualified struct mounts — each struct's `pub const @"…"` routes compose
+    // the `/admin` prefix, partitioned by struct.
+    .group("/admin", &.{
+        .router(resources.Public),
+        .router(resources.Private),
     }),
 };
 

--- a/spec/functional_test/testers/zig/tokamak_spec.cr
+++ b/spec/functional_test/testers/zig/tokamak_spec.cr
@@ -35,6 +35,11 @@ expected_endpoints << tokamak_endpoint("/admin/ping", "GET")
 expected_endpoints << tokamak_endpoint("/admin/login", "POST")
 expected_endpoints << tokamak_endpoint("/admin/sessions/:id", "DELETE", id_param)
 
+# Value-form group `.group("/svc", .router(local))` mounting a same-file struct.
+# The root handler collapses to `/svc` (no trailing slash).
+expected_endpoints << tokamak_endpoint("/svc", "GET", [] of Param, [Callee.new("ping")])
+expected_endpoints << tokamak_endpoint("/svc/sync", "POST", [] of Param, [Callee.new("worker.run")])
+
 FunctionalTester.new("fixtures/zig/tokamak/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/spec/functional_test/testers/zig/tokamak_spec.cr
+++ b/spec/functional_test/testers/zig/tokamak_spec.cr
@@ -27,6 +27,14 @@ expected_endpoints << tokamak_endpoint("/api/widgets", "GET", [] of Param, [Call
 expected_endpoints << tokamak_endpoint("/api/widgets", "POST", [] of Param, [Callee.new("createWidget")])
 expected_endpoints << tokamak_endpoint("/api/widgets/:id", "GET", id_param, [Callee.new("findWidget")])
 
+# Qualified struct mounts (`.router(resources.Public/.Private)`): the
+# `pub const @"METHOD /path"` route bindings inherit only the `/admin` prefix
+# of the mount selecting their enclosing struct. Handlers are defined
+# elsewhere, so these carry no callees.
+expected_endpoints << tokamak_endpoint("/admin/ping", "GET")
+expected_endpoints << tokamak_endpoint("/admin/login", "POST")
+expected_endpoints << tokamak_endpoint("/admin/sessions/:id", "DELETE", id_param)
+
 FunctionalTester.new("fixtures/zig/tokamak/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -46,6 +46,11 @@ module Analyzer::Zig
     }
 
     GROUP_RE = /\.\s*group\s*\(\s*"([^"]*)"\s*,\s*&?\s*\.\s*\{/
+    # Value-form group whose body is a single route value rather than an
+    # `&.{ … }` array (`tk.group("/api", tk.router(api))`). The negative
+    # lookahead — which must absorb its own leading whitespace, so a
+    # backtracking `\s*` can't slip past it — keeps the array form to GROUP_RE.
+    GROUP_VALUE_RE = /\.\s*group\s*\(\s*"([^"]*)"\s*,(?!\s*&?\s*\.\s*\{)/
     # The path must be a rooted URL (`"/..."`). Tokamak handlers commonly build
     # a JSON response with `root.put("name", value)` / `data.get("key")`; those
     # data-object calls share the verb names but never take a `/`-rooted key,
@@ -111,13 +116,26 @@ module Analyzer::Zig
         # `strip_comments` keeps string contents, so `{`/`}` inside a literal
         # would corrupt brace matching. `strip_non_code` blanks strings at the
         # same offsets, so it is the right char array for `find_matching`.
-        code_chars = Noir::ZigCalleeExtractor.strip_non_code(content).chars
+        stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+        code_chars = stripped.chars
+        local_structs = struct_regions(stripped).map(&.name)
 
         events = [] of NamedTuple(kind: Symbol, off: Int32, prefix: String, close: Int32?, target: String)
+        # Array-form group: `.group("/p", &.{ … })` — scoped by its body braces.
         text.scan(GROUP_RE) do |m|
           brace = (m.end(0) || 0) - 1
           close = Noir::ZigCalleeExtractor.find_matching(code_chars, brace, '{', '}')
           events << {kind: :group, off: m.begin(0) || 0, prefix: m[1], close: close, target: ""}
+        end
+        # Value-form group: `.group("/p", tk.router(x))` — the body is a single
+        # route value, not a `&.{ … }` array, so the scope is the group call's
+        # own parentheses.
+        text.scan(GROUP_VALUE_RE) do |m|
+          start = m.begin(0) || 0
+          paren = index_of(code_chars, start, '(')
+          next if paren.nil?
+          close = Noir::ZigCalleeExtractor.find_matching(code_chars, paren, '(', ')')
+          events << {kind: :group, off: start, prefix: m[1], close: close, target: ""}
         end
         text.scan(ROUTER_MOUNT_RE) do |m|
           events << {kind: :router, off: m.begin(0) || 0, prefix: "", close: nil, target: m[1]}
@@ -132,7 +150,7 @@ module Analyzer::Zig
             stack << GroupFrame.new(ev[:prefix], close) if close
             next
           end
-          resolved = resolve_router_target(ev[:target], alias_to_file)
+          resolved = resolve_router_target(ev[:target], alias_to_file, File.expand_path(path), local_structs)
           next if resolved.nil?
           target_file, scope = resolved
           prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
@@ -150,7 +168,9 @@ module Analyzer::Zig
     #     itself a `@import` alias → whole-file mount (scope nil).
     #   * `.router(api.Protected)` — `api` is the file alias, `Protected` a
     #     struct declared inside it → file-scoped to that struct.
-    private def resolve_router_target(target : String, alias_to_file : Hash(String, String)) : Tuple(String, String?)?
+    #   * `.router(api)` — `api` is a `const api = struct { … }` declared in the
+    #     current file → same-file mount scoped to that struct.
+    private def resolve_router_target(target : String, alias_to_file : Hash(String, String), current_file : String, local_structs : Array(String)) : Tuple(String, String?)?
       segments = target.split('.')
       if file = alias_to_file[segments.last]?
         return {file, nil}
@@ -159,6 +179,9 @@ module Analyzer::Zig
         if file = alias_to_file[segments.first]?
           return {file, segments[1]}
         end
+      end
+      if segments.size == 1 && local_structs.includes?(segments.first)
+        return {current_file, segments.first}
       end
       nil
     end
@@ -190,7 +213,7 @@ module Analyzer::Zig
         end
 
         prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
-        url = Noir::URLPath.join(prefix, ev[:path])
+        url = join_route(prefix, ev[:path])
         name = ev[:handler].includes?('.') ? ev[:handler].split('.').last : ev[:handler]
         callees = include_callee ? body_callees(bodies, name, path) : [] of Noir::ZigCalleeExtractor::Entry
         emit(path, text, ev[:off], url, ev[:method], callees)
@@ -221,7 +244,7 @@ module Analyzer::Zig
           offset = m.begin(0) || 0
           callees = include_callee ? route_fn_callees(stripped_chars, m.end(0) || 0, path) : [] of Noir::ZigCalleeExtractor::Entry
           prefixes_for(file_mounts, enclosing_struct(regions, offset)).each do |pre|
-            emit(path, text, offset, Noir::URLPath.join(pre, rel), method, callees)
+            emit(path, text, offset, join_route(pre, rel), method, callees)
           end
         end
       end
@@ -232,7 +255,7 @@ module Analyzer::Zig
           rel = m[2]
           offset = m.begin(0) || 0
           prefixes_for(file_mounts, enclosing_struct(regions, offset)).each do |pre|
-            emit(path, text, offset, Noir::URLPath.join(pre, rel), method, [] of Noir::ZigCalleeExtractor::Entry)
+            emit(path, text, offset, join_route(pre, rel), method, [] of Noir::ZigCalleeExtractor::Entry)
           end
         end
       end
@@ -351,6 +374,14 @@ module Analyzer::Zig
         params << Param.new(m[1], "", "path")
       end
       params
+    end
+
+    # Join a mount/group prefix with a route path. A bare-root route ("/")
+    # mounted under a non-empty prefix collapses to the prefix itself rather
+    # than picking up a trailing slash (`/api` + `/` => `/api`, not `/api/`).
+    private def join_route(prefix : String, route : String) : String
+      return prefix if route == "/" && !prefix.empty?
+      Noir::URLPath.join(prefix, route)
     end
   end
 end

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -21,6 +21,20 @@ module Analyzer::Zig
   #      mount and the controller usually live in different files, so the
   #      mount prefixes are resolved project-wide and keyed by controller file.
   #
+  # A controller's routes can also be declared as `const` bindings rather than
+  # functions — the handler lives in another file and the route is just a name:
+  #
+  #   pub const Protected = struct {
+  #       pub const @"GET /projects" = getAllProjects;
+  #       pub const @"PUT /projects/:id" = updateProject;
+  #   };
+  #
+  # Such structs are mounted by *qualified* name (`.router(api.Protected)`,
+  # where `api = @import("api.zig")` and `Protected` is a struct inside it), so
+  # the route set of one file is partitioned across several mounts. Each route
+  # therefore carries the prefix of every mount that targets its enclosing
+  # struct (or any whole-file mount).
+  #
   # Not yet resolved: a `.group(prefix, RouteConst)` whose body is a reference
   # to a `tk.Route` const (rather than an inline `&.{ … }` array) — those
   # controllers' routes are emitted without the referenced-group prefix.
@@ -39,9 +53,16 @@ module Analyzer::Zig
     ROUTE_RE        = /\.\s*(get|post0|post|put0|put|patch0|patch|delete|head|options)\s*\(\s*"(\/[^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
     ROUTER_MOUNT_RE = /\.\s*router\s*\(\s*([A-Za-z_][\w.]*)\s*\)/
     ROUTE_FN_RE     = /pub\s+fn\s+@"(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+(\/[^"]*)"/
+    ROUTE_CONST_RE  = /pub\s+const\s+@"(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+(\/[^"]*)"/
+    STRUCT_DECL_RE  = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*struct\s*\{/
     IMPORT_RE       = /(?:pub\s+)?(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*@import\(\s*"([^"]+\.zig)"\s*\)/
 
     private record GroupFrame, prefix : String, close : Int32
+    # A `.router(...)` mount targeting a controller file. `scope` is the struct
+    # name within that file the mount selects (`.router(api.Protected)`), or nil
+    # for a whole-file mount (`.router(chat)`).
+    private record RouterMount, scope : String?, prefix : String
+    private record StructRegion, name : String, start : Int32, stop : Int32
 
     def analyze
       include_callee = callees_needed?
@@ -61,7 +82,8 @@ module Analyzer::Zig
 
     private def route_file?(content : String) : Bool
       content.includes?("tk.Route") || content.includes?(".group(") ||
-        content.includes?(".router(") || content.includes?("pub fn @\"")
+        content.includes?(".router(") || content.includes?("pub fn @\"") ||
+        content.includes?("pub const @\"")
     end
 
     # alias identifier => absolute file it `@import`s.
@@ -78,9 +100,10 @@ module Analyzer::Zig
       map
     end
 
-    # controller file => the URL prefixes it is `.router(...)`-mounted at.
-    private def build_router_mounts(files : Array(String), alias_to_file : Hash(String, String)) : Hash(String, Array(String))
-      mounts = Hash(String, Array(String)).new
+    # controller file => the `.router(...)` mounts that target it (prefix +
+    # optional struct scope).
+    private def build_router_mounts(files : Array(String), alias_to_file : Hash(String, String)) : Hash(String, Array(RouterMount))
+      mounts = Hash(String, Array(RouterMount)).new
       files.each do |path|
         content = read_file_content(path)
         next unless content.includes?(".router(")
@@ -109,17 +132,38 @@ module Analyzer::Zig
             stack << GroupFrame.new(ev[:prefix], close) if close
             next
           end
-          target_file = alias_to_file[ev[:target].split('.').last]?
-          next if target_file.nil?
+          resolved = resolve_router_target(ev[:target], alias_to_file)
+          next if resolved.nil?
+          target_file, scope = resolved
           prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
-          list = mounts[target_file] ||= [] of String
-          list << prefix unless list.includes?(prefix)
+          list = mounts[target_file] ||= [] of RouterMount
+          mount = RouterMount.new(scope, prefix)
+          list << mount unless list.includes?(mount)
         end
       end
       mounts
     end
 
-    private def process_file(path : String, content : String, mounts : Hash(String, Array(String)), include_callee : Bool)
+    # A `.router(target)` argument resolves to a controller file (+ optional
+    # struct scope inside it):
+    #   * `.router(chat)` / `.router(api.push)` — the simple/last identifier is
+    #     itself a `@import` alias → whole-file mount (scope nil).
+    #   * `.router(api.Protected)` — `api` is the file alias, `Protected` a
+    #     struct declared inside it → file-scoped to that struct.
+    private def resolve_router_target(target : String, alias_to_file : Hash(String, String)) : Tuple(String, String?)?
+      segments = target.split('.')
+      if file = alias_to_file[segments.last]?
+        return {file, nil}
+      end
+      if segments.size > 1
+        if file = alias_to_file[segments.first]?
+          return {file, segments[1]}
+        end
+      end
+      nil
+    end
+
+    private def process_file(path : String, content : String, mounts : Hash(String, Array(RouterMount)), include_callee : Bool)
       text = Noir::ZigCalleeExtractor.strip_comments(content)
       # Strings preserved in `text` for reading paths/handlers; brace matching
       # runs on the string-blanked (but offset-identical) char array so a `{`/`}`
@@ -153,26 +197,83 @@ module Analyzer::Zig
       end
     end
 
-    # `pub fn @"METHOD /path"` controller handlers, prefixed by every
-    # `.router(...)` mount point that targets this file (or bare when the file
-    # isn't mounted, or its mount chain crosses a route-value reference we
-    # don't expand).
+    # `pub fn @"METHOD /path"` / `pub const @"METHOD /path"` controller routes,
+    # prefixed by every `.router(...)` mount that targets this file (whole-file
+    # mounts apply to top-level routes; struct-scoped mounts apply to routes
+    # inside the matching struct). Falls back to bare when the file isn't
+    # mounted, or its mount chain crosses a route-value reference we don't
+    # expand. `const` routes name a handler defined elsewhere, so they carry no
+    # inline body and thus no callees.
     private def emit_controller_routes(path, content, text, mounts, include_callee)
-      return unless content.includes?("pub fn @\"")
+      has_fn = content.includes?("pub fn @\"")
+      has_const = content.includes?("pub const @\"")
+      return unless has_fn || has_const
+
       stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
       stripped_chars = stripped.chars
-      prefixes = mounts[File.expand_path(path)]?
-      prefixes = [""] if prefixes.nil? || prefixes.empty?
+      file_mounts = mounts[File.expand_path(path)]?
+      regions = struct_regions(stripped)
 
-      text.scan(ROUTE_FN_RE) do |m|
-        method = m[1]
-        rel = m[2]
-        offset = m.begin(0) || 0
-        callees = include_callee ? route_fn_callees(stripped_chars, m.end(0) || 0, path) : [] of Noir::ZigCalleeExtractor::Entry
-        prefixes.each do |pre|
-          emit(path, text, offset, Noir::URLPath.join(pre, rel), method, callees)
+      if has_fn
+        text.scan(ROUTE_FN_RE) do |m|
+          method = m[1]
+          rel = m[2]
+          offset = m.begin(0) || 0
+          callees = include_callee ? route_fn_callees(stripped_chars, m.end(0) || 0, path) : [] of Noir::ZigCalleeExtractor::Entry
+          prefixes_for(file_mounts, enclosing_struct(regions, offset)).each do |pre|
+            emit(path, text, offset, Noir::URLPath.join(pre, rel), method, callees)
+          end
         end
       end
+
+      if has_const
+        text.scan(ROUTE_CONST_RE) do |m|
+          method = m[1]
+          rel = m[2]
+          offset = m.begin(0) || 0
+          prefixes_for(file_mounts, enclosing_struct(regions, offset)).each do |pre|
+            emit(path, text, offset, Noir::URLPath.join(pre, rel), method, [] of Noir::ZigCalleeExtractor::Entry)
+          end
+        end
+      end
+    end
+
+    # Struct declaration regions (`const X = struct { … }`), brace-matched on
+    # the string-blanked char array, so a `@"…"` route name can be attributed
+    # to its enclosing struct.
+    private def struct_regions(stripped : String) : Array(StructRegion)
+      chars = stripped.chars
+      regions = [] of StructRegion
+      stripped.scan(STRUCT_DECL_RE) do |m|
+        name = m[1]
+        brace = (m.end(0) || 0) - 1
+        close = Noir::ZigCalleeExtractor.find_matching(chars, brace, '{', '}')
+        next if close.nil?
+        regions << StructRegion.new(name, brace, close)
+      end
+      regions
+    end
+
+    # The name of the innermost struct region containing `offset`, or nil for a
+    # top-level (file-scope) declaration.
+    private def enclosing_struct(regions : Array(StructRegion), offset : Int32) : String?
+      best : StructRegion? = nil
+      regions.each do |r|
+        next unless offset > r.start && offset < r.stop
+        best = r if best.nil? || (r.stop - r.start) < (best.stop - best.start)
+      end
+      best.try(&.name)
+    end
+
+    # Prefixes a route at `scope` (its enclosing struct name, or nil) inherits:
+    # every whole-file mount plus every mount selecting this struct. Bare when
+    # the file has no resolvable mounts.
+    private def prefixes_for(file_mounts : Array(RouterMount)?, scope : String?) : Array(String)
+      return [""] if file_mounts.nil? || file_mounts.empty?
+      whole = file_mounts.select(&.scope.nil?).map(&.prefix)
+      scoped = scope ? file_mounts.select { |m| m.scope == scope }.map(&.prefix) : [] of String
+      result = (whole + scoped).uniq
+      result.empty? ? [""] : result
     end
 
     # Group-open and route events, ordered by source offset, so a single pass


### PR DESCRIPTION
## Summary

Tokamak FP/FN accuracy sweep against real OSS apps. Three controller-mount shapes were silently dropping their routes or prefixes. All fixes are covered by the extended `tokamak` functional fixture.

### 1. Qualified struct router mounts + `pub const` route declarations
Tokamak controllers can declare routes as `pub const @"METHOD /path" = handler;` bindings inside named structs, mounted by *qualified* name:

```zig
const api = @import("api.zig");
// …
.group("/api", &.{
    .router(api.UnProtected),   // api → api.zig, UnProtected is a struct in it
    .router(api.Protected),
}),
```

Two gaps dropped every such route:
- the `@"…"` route name was only recognised in `pub fn` form, never `pub const`;
- `.router(api.Protected)` resolved the mount by the *last* path segment (`Protected`, never an import alias), so the controller file was never found.

Mounts now carry an optional struct scope. The target resolves by trying the trailing identifier as a whole-file import alias first (unchanged for `.router(chat)` / `.router(api.push)`), then falling back to `alias.Struct`. A file split across several struct mounts is partitioned correctly — each route inherits the prefix of every whole-file mount plus every mount selecting its enclosing struct.

### 2. Value-form group mounts + same-file struct routers
```zig
const api = struct { pub fn @"GET /upload"() … };
const handler = tk.chain(.{
    tk.group("/api", tk.router(api)),   // body is a single route value, not &.{ … }
});
```
- `GROUP_RE` only matched the `&.{ … }` array body, so `tk.group(prefix, tk.router(x))` never tracked its prefix. A value-form group is now scoped to the group call's own parentheses.
- `.router(api)` where `const api = struct { … }` lives in the same file now resolves to that file scoped to the struct.

### 3. Bare-root handler under a prefix
`@"GET /"` mounted under `/api` now collapses to `/api` instead of emitting a trailing-slash `/api/`.

## Real-world impact (cloned OSS)
| app | before | after |
|---|---|---|
| LeviathanST/panama-be | 2 | 22 (all 20 routes under `/api` with path params) |
| MartinAbilev/bugs | mixed | `/api/upload`, `/api/firenuron`, `GET`/`POST /api` correctly prefixed |

No change to ava / pushway / blog (whole-file mounts unaffected).

## Test
- `spec/functional_test/testers/zig/tokamak_spec.cr` extended (qualified struct mounts, `pub const` routes, value-form group, same-file struct router, trailing-slash collapse) — 46 examples, all green.
- Full zig suite (functional + detector + miniparser) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)