### PR TITLE
feat(analyzer/cpp): add cpp-httplib (yhirose) framework support

### DIFF
--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -212,6 +212,33 @@ sort_by = "weight"
       </div>
     </div>
   </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">cpp-httplib</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
 </div>
 
 ## Clojure

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -212,6 +212,33 @@ Each card below lists a framework's supported features. **Route** covers endpoin
       </div>
     </div>
   </article>
+  <article class="tech-card">
+    <h3 class="tech-card-title">cpp-httplib</h3>
+    <div class="tech-card-row">
+      <span class="tech-card-label">Route</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip on">endpoint</span>
+        <span class="tech-chip on">method</span>
+        <span class="tech-chip on">query</span>
+        <span class="tech-chip on">path</span>
+        <span class="tech-chip on">body</span>
+        <span class="tech-chip on">header</span>
+        <span class="tech-chip off">cookie</span>
+        <span class="tech-chip off">static</span>
+        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">callee</span>
+      </div>
+    </div>
+    <div class="tech-card-row">
+      <span class="tech-card-label">AI Context</span>
+      <div class="tech-card-chips">
+        <span class="tech-chip off">guards</span>
+        <span class="tech-chip on">sinks</span>
+        <span class="tech-chip on">validators</span>
+        <span class="tech-chip on">signals</span>
+      </div>
+    </div>
+  </article>
 </div>
 
 ## Clojure

--- a/spec/functional_test/fixtures/cpp/httplib/main.cpp
+++ b/spec/functional_test/fixtures/cpp/httplib/main.cpp
@@ -1,0 +1,55 @@
+#include <httplib.h>
+
+// Named-function handler resolved from the same file: its header read and
+// repository call attach to the Delete endpoint.
+void delete_user(const httplib::Request& req, httplib::Response& res)
+{
+    auto token = req.get_header_value("X-Token");
+    repository_delete(req.path_params.at("id"));
+    res.status = 204;
+}
+
+int main()
+{
+    httplib::Server svr;
+
+    // Inline lambda handler with query + header + body params.
+    svr.Get("/", [](const httplib::Request& req, httplib::Response& res) {
+        auto q = req.get_param_value("q");
+        auto auth = req.get_header_value("Authorization");
+        res.set_content("ok", "text/plain");
+    });
+
+    // Named path parameter `:id` → {id}.
+    svr.Get("/users/:id", [](const httplib::Request& req, httplib::Response& res) {
+        auto id = req.path_params.at("id");
+        res.set_content(id, "text/plain");
+    });
+
+    // POST with a JSON body read in the lambda.
+    svr.Post("/users", [](const httplib::Request& req, httplib::Response& res) {
+        auto data = req.body;
+        res.status = 201;
+    });
+
+    // Named-function handler defined above.
+    svr.Delete("/users/:id", delete_user);
+
+    // Raw-string regex route — kept verbatim, no named params.
+    svr.Get(R"(/files/(.*))", [](const httplib::Request& req, httplib::Response& res) {
+        auto name = req.matches[1];
+        res.set_content(name, "text/plain");
+    });
+
+    // PATCH route.
+    svr.Patch("/settings", [](const httplib::Request& req, httplib::Response& res) {
+        res.status = 200;
+    });
+
+    // A cpp-httplib CLIENT call must NOT be treated as a route.
+    httplib::Client cli("http://example.com");
+    auto external = cli.Get("/external");
+
+    svr.listen("0.0.0.0", 8080);
+    return 0;
+}

--- a/spec/functional_test/testers/cpp/httplib_spec.cr
+++ b/spec/functional_test/testers/cpp/httplib_spec.cr
@@ -1,0 +1,58 @@
+require "../../func_spec.cr"
+
+def httplib_endpoint(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+expected_endpoints = [
+  # Inline lambda: query + header params, callees from the body.
+  httplib_endpoint("/", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("Authorization", "", "header"),
+  ], [
+    Callee.new("req.get_param_value"),
+    Callee.new("req.get_header_value"),
+  ]),
+  # `:id` named path parameter → {id}.
+  httplib_endpoint("/users/{id}", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  # POST body read in the lambda.
+  httplib_endpoint("/users", "POST", [
+    Param.new("body", "", "json"),
+  ]),
+  # Named-function handler resolved from the same file: path id + its own
+  # header read, plus the repository callee.
+  httplib_endpoint("/users/{id}", "DELETE", [
+    Param.new("id", "", "path"),
+    Param.new("X-Token", "", "header"),
+  ], [
+    Callee.new("repository_delete"),
+  ]),
+  # Raw-string regex route, kept verbatim.
+  httplib_endpoint("/files/(.*)", "GET"),
+  # Plain route, no params.
+  httplib_endpoint("/settings", "PATCH"),
+]
+
+tester = FunctionalTester.new("fixtures/cpp/httplib/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+})
+
+tester.perform_tests
+
+describe "cpp-httplib route discovery edge cases" do
+  it "does not treat a Client verb call as a route" do
+    tester.app.endpoints.any? { |e| e.url == "/external" }.should be_false
+  end
+
+  it "normalizes `:id` named params but keeps regex routes verbatim" do
+    tester.app.endpoints.any? { |e| e.url == "/users/:id" }.should be_false
+    tester.app.endpoints.any? { |e| e.url == "/files/(.*)" }.should be_true
+  end
+end

--- a/spec/unit_test/detector/cpp/httplib_detector_spec.cr
+++ b/spec/unit_test/detector/cpp/httplib_detector_spec.cr
@@ -1,0 +1,35 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/cpp/*"
+
+describe "Detect C++ cpp-httplib" do
+  options = create_test_options
+  instance = Detector::Cpp::Httplib.new options
+
+  it "include <httplib.h>" do
+    instance.detect("app.cpp", "#include <httplib.h>").should be_true
+  end
+
+  it "include path-prefixed httplib.h" do
+    instance.detect("main.cc", "#include <utility/httplib.h>").should be_true
+  end
+
+  it "include quoted httplib.hpp" do
+    instance.detect("server.hpp", %(#include "httplib/httplib.hpp")).should be_true
+  end
+
+  it "httplib::Server reference" do
+    instance.detect("main.cxx", "httplib::Server svr;").should be_true
+  end
+
+  it "using namespace httplib shorthand" do
+    instance.detect("main.cpp", "using namespace httplib;\nServer svr;").should be_true
+  end
+
+  it "unrelated cpp file" do
+    instance.detect("main.cpp", "#include <iostream>\nint main(){return 0;}").should be_false
+  end
+
+  it "non-cpp extension" do
+    instance.detect("app.py", "#include <httplib.h>").should be_false
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -18,6 +18,7 @@ def initialize_analyzers(logger : NoirLogger)
   define_analyzers([
     {"cpp_drogon", Cpp::Drogon},
     {"cpp_crow", Cpp::Crow},
+    {"cpp_httplib", Cpp::Httplib},
     {"clojure_compojure", Clojure::Compojure},
     {"clojure_pedestal", Clojure::Pedestal},
     {"clojure_reitit", Clojure::Reitit},

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -1,0 +1,267 @@
+require "../../../models/analyzer"
+require "../../../miniparsers/cpp_callee_extractor"
+
+module Analyzer::Cpp
+  # cpp-httplib (yhirose/cpp-httplib) — a header-only HTTP/HTTPS server & client
+  # library. Routes are registered on a `httplib::Server` (or `SSLServer`)
+  # instance: `svr.Get("/path", handler)`, `svr.Post`, `Put`, `Delete`,
+  # `Patch`, `Options`. The handler is either an inline lambda or a named
+  # function. The library's `Client` type shares the same verb method names, so
+  # we only treat calls on a *server* variable as routes.
+  class Httplib < Analyzer
+    CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
+
+    VERBS = {
+      "Get"     => "GET",
+      "Post"    => "POST",
+      "Put"     => "PUT",
+      "Delete"  => "DELETE",
+      "Patch"   => "PATCH",
+      "Options" => "OPTIONS",
+    }
+
+    # receiver.Verb( — group 1 = receiver variable, group 2 = HTTP verb.
+    ROUTE_CALL_REGEX = /\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*(Get|Post|Put|Delete|Patch|Options)\s*\(/
+    # httplib::Server / Server / SSLServer declarations and reference params.
+    SERVER_DECL_QUALIFIED = /\bhttplib::(?:SSL)?Server\s*&?\s*([A-Za-z_][A-Za-z0-9_]*)/
+    SERVER_DECL_BARE      = /\b(?:SSL)?Server\s*&?\s*([A-Za-z_][A-Za-z0-9_]*)/
+    CLIENT_DECL_QUALIFIED = /\bhttplib::(?:SSL)?Client\s*&?\s*([A-Za-z_][A-Za-z0-9_]*)/
+    CLIENT_DECL_BARE      = /\b(?:SSL)?Client\s*&?\s*([A-Za-z_][A-Za-z0-9_]*)/
+
+    # Request accessors mined from a handler body.
+    QUERY_ACCESSORS   = /\b(?:get_param_value|has_param|get_file_value)\s*\(\s*"([^"]+)"/
+    HEADER_ACCESSORS  = /\b(?:get_header_value|has_header)\s*\(\s*"([^"]+)"/
+    PATH_PARAM_ACCESS = /\bpath_params\s*(?:\.\s*at\s*\(\s*|\[\s*)"([^"]+)"/
+    BODY_ACCESS       = /\b(?:req|request)\s*\.\s*body\b/
+    # `:name` path placeholder (cpp-httplib named params).
+    NAMED_PARAM_REGEX = /:([A-Za-z_][A-Za-z0-9_]*)/
+    # Regex metacharacters that mark a route pattern as a regex (kept verbatim).
+    REGEX_META = /[()\[\]\\+*?^$|]/
+
+    def analyze
+      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+
+      begin
+        locator = CodeLocator.instance
+        files = CPP_EXTENSIONS.flat_map { |ext| locator.files_by_extension(ext) }
+
+        parallel_analyze(files) do |path|
+          next if File.directory?(path)
+          next unless File.exists?(path)
+          # The vendored single-header library defines the Server/Client classes
+          # themselves; never scan it for routes (avoids FPs + a big perf hit).
+          next if path.ends_with?("httplib.h") || path.ends_with?("httplib.hpp")
+          analyze_file(path, include_callee)
+        end
+      rescue e
+        logger.debug "httplib analyzer failed: #{e.message}"
+      end
+
+      result
+    end
+
+    private def analyze_file(path : String, include_callee : Bool)
+      source = read_file_content(path)
+      return unless source.includes?("httplib")
+      return unless source.includes?(".Get(") || source.includes?(".Post(") ||
+                    source.includes?(".Put(") || source.includes?(".Delete(") ||
+                    source.includes?(".Patch(") || source.includes?(".Options(")
+
+      source = Noir::CppCalleeExtractor.strip_comments(source)
+      using_ns = source.includes?("using namespace httplib")
+      servers = collect_vars(source, SERVER_DECL_QUALIFIED, using_ns ? SERVER_DECL_BARE : nil)
+      return if servers.empty?
+      clients = collect_vars(source, CLIENT_DECL_QUALIFIED, using_ns ? CLIENT_DECL_BARE : nil)
+      servers -= clients
+
+      source.scan(ROUTE_CALL_REGEX) do |match|
+        receiver = match[1]
+        next unless servers.includes?(receiver)
+
+        verb = VERBS[match[2]]? || next
+        call_start = source.char_index_to_byte_index(match.begin(0) || 0) || 0
+        open_paren = Noir::CppCalleeExtractor.find_next_code_char(source, '(', call_start)
+        next unless open_paren
+        close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(source, open_paren, '(', ')')
+        next unless close_paren
+
+        args = split_top_level_args(source.byte_slice(open_paren + 1, close_paren - open_paren - 1))
+        raw_path = parse_path_arg(args[0]?)
+        next unless raw_path
+
+        normalized_path, path_params = normalize_path(raw_path)
+        line_number = Noir::CppCalleeExtractor.line_number_for(source, call_start)
+        details = Details.new(PathInfo.new(path, line_number))
+        endpoint = Endpoint.new(normalized_path, verb, path_params.dup, details)
+
+        handler_block = handler_body(source, args[1]?, open_paren, close_paren)
+        if handler_block
+          body, start_line = handler_block
+          collect_params(body).each { |param| push_unique(endpoint, param) }
+          if include_callee
+            Noir::CppCalleeExtractor.attach_to(endpoint,
+              Noir::CppCalleeExtractor.callees_for_body(body, path, start_line))
+          end
+        end
+
+        result << endpoint
+      end
+    end
+
+    # Resolves the handler's body: the inline lambda block when present,
+    # otherwise the body of the named function passed as the handler argument.
+    private def handler_body(source : String, handler_arg : String?, open_paren : Int32, close_paren : Int32) : Tuple(String, Int32)?
+      if block = Noir::CppCalleeExtractor.extract_lambda_block_after(source, open_paren, close_paren)
+        return block
+      end
+
+      return unless handler_arg
+      name = handler_arg.strip.lchop('&').strip
+      return unless name.matches?(/\A[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*\z/)
+      simple = name.split("::").last
+      extract_function_body(source, simple)
+    end
+
+    private def extract_function_body(source : String, name : String) : Tuple(String, Int32)?
+      regex = /\b#{Regex.escape(name)}\s*\(/
+      source.scan(regex) do |match|
+        match_start = source.char_index_to_byte_index(match.begin(0) || 0) || 0
+        # Skip call sites (`foo.name(`, `obj::name(`); we want the definition.
+        prev = previous_code_char(source, match_start)
+        next if prev == '.' || prev == '>' || prev == ':'
+
+        open_paren = Noir::CppCalleeExtractor.find_next_code_char(source, '(', match_start)
+        next unless open_paren
+        close_paren = Noir::CppCalleeExtractor.find_matching_delimiter(source, open_paren, '(', ')')
+        next unless close_paren
+
+        body_open = Noir::CppCalleeExtractor.find_next_code_char(source, '{', close_paren + 1)
+        next unless body_open
+        # A `;` before the `{` means this is a declaration/call, not a definition.
+        semicolon = Noir::CppCalleeExtractor.find_next_code_char(source, ';', close_paren + 1)
+        next if semicolon && semicolon < body_open
+
+        body_close = Noir::CppCalleeExtractor.find_matching_delimiter(source, body_open, '{', '}')
+        next unless body_close
+        return {source.byte_slice(body_open + 1, body_close - body_open - 1), Noir::CppCalleeExtractor.line_number_for(source, body_open)}
+      end
+
+      nil
+    end
+
+    private def previous_code_char(source : String, index : Int32) : Char?
+      cursor = index - 1
+      while cursor >= 0
+        char = source.byte_at(cursor).unsafe_chr
+        return char unless char.whitespace?
+        cursor -= 1
+      end
+      nil
+    end
+
+    # Collects identifiers declared with the qualified type (always) and the
+    # bare type (only when `using namespace httplib` makes it unambiguous).
+    private def collect_vars(source : String, qualified : Regex, bare : Regex?) : Set(String)
+      vars = Set(String).new
+      source.scan(qualified) { |m| vars << m[1] }
+      if bare
+        source.scan(bare) { |m| vars << m[1] }
+      end
+      vars
+    end
+
+    # First argument of the route call: a normal `"..."` or raw `R"(...)"`
+    # string literal. Returns nil for anything else (e.g. a variable).
+    private def parse_path_arg(raw : String?) : String?
+      return unless raw
+      s = raw.strip
+      if s.starts_with?("R\"") && (open = s.index('(')) && (close = s.rindex(')'))
+        return s[(open + 1)...close] if close > open
+      end
+      return s[1...-1] if s.size >= 2 && s.starts_with?('"') && s.ends_with?('"')
+      nil
+    end
+
+    private def normalize_path(raw : String) : Tuple(String, Array(Param))
+      # Regex routes are kept verbatim — the captures are positional, with no
+      # named placeholders to rewrite.
+      return {raw, [] of Param} if raw.matches?(REGEX_META)
+
+      params = [] of Param
+      normalized = raw.gsub(NAMED_PARAM_REGEX) do
+        name = $1
+        params << Param.new(name, "", "path")
+        "{#{name}}"
+      end
+      {normalized, params}
+    end
+
+    private def collect_params(body : String) : Array(Param)
+      params = [] of Param
+      body.each_line do |line|
+        line.scan(QUERY_ACCESSORS) { |m| add_param(params, Param.new(m[1], "", "query")) }
+        line.scan(HEADER_ACCESSORS) { |m| add_param(params, Param.new(m[1], "", "header")) }
+        line.scan(PATH_PARAM_ACCESS) { |m| add_param(params, Param.new(m[1], "", "path")) }
+        add_param(params, Param.new("body", "", "json")) if line.matches?(BODY_ACCESS)
+      end
+      params
+    end
+
+    private def add_param(params : Array(Param), param : Param)
+      return if param.name.empty?
+      return if params.any? { |p| p.name == param.name && p.param_type == param.param_type }
+      params << param
+    end
+
+    private def push_unique(endpoint : Endpoint, param : Param)
+      return if endpoint.params.any? { |p| p.name == param.name && p.param_type == param.param_type }
+      endpoint.push_param(param)
+    end
+
+    private def split_top_level_args(raw : String) : Array(String)
+      args = [] of String
+      current = String::Builder.new
+      paren = 0
+      brace = 0
+      bracket = 0
+      in_string = false
+      escaped = false
+
+      raw.each_char do |char|
+        if in_string
+          current << char
+          if escaped
+            escaped = false
+          elsif char == '\\'
+            escaped = true
+          elsif char == '"'
+            in_string = false
+          end
+          next
+        end
+
+        case char
+        when '"' then in_string = true
+        when '(' then paren += 1
+        when ')' then paren -= 1 if paren > 0
+        when '{' then brace += 1
+        when '}' then brace -= 1 if brace > 0
+        when '[' then bracket += 1
+        when ']' then bracket -= 1 if bracket > 0
+        when ','
+          if paren == 0 && brace == 0 && bracket == 0
+            args << current.to_s.strip
+            current = String::Builder.new
+            next
+          end
+        end
+
+        current << char
+      end
+
+      tail = current.to_s.strip
+      args << tail unless tail.empty?
+      args
+    end
+  end
+end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -147,6 +147,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   define_detectors([
     Cpp::Drogon,
     Cpp::Crow,
+    Cpp::Httplib,
     Clojure::Compojure,
     Clojure::Pedestal,
     Clojure::Reitit,

--- a/src/detector/detectors/cpp/httplib.cr
+++ b/src/detector/detectors/cpp/httplib.cr
@@ -1,0 +1,29 @@
+require "../../../models/detector"
+
+module Detector::Cpp
+  class Httplib < Detector
+    CPP_EXTENSIONS = [".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx"]
+
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless CPP_EXTENSIONS.any? { |ext| filename.ends_with?(ext) }
+
+      # The single-header library may be included from any path
+      # (`<httplib.h>`, `"httplib.hpp"`, `<vendor/httplib.h>`, …).
+      return true if file_contents.includes?("httplib.h")
+      return true if file_contents.includes?("httplib.hpp")
+      # Qualified usage, or the `using namespace httplib` shorthand many apps use.
+      return true if file_contents.includes?("httplib::")
+      return true if file_contents.includes?("using namespace httplib")
+
+      false
+    end
+
+    def applicable?(filename : String) : Bool
+      CPP_EXTENSIONS.any? { |ext| filename.ends_with?(ext) } || filename.ends_with?(".c")
+    end
+
+    def set_name
+      @name = "cpp_httplib"
+    end
+  end
+end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -3,7 +3,7 @@ require "json"
 module NoirTechs
   CALLEE_SUPPORTED_TECHS = [
     "android", "ios",
-    "cpp_crow", "cpp_drogon",
+    "cpp_crow", "cpp_drogon", "cpp_httplib",
     "clojure_compojure", "clojure_reitit", "clojure_ring",
     "crystal_amber", "crystal_grip", "crystal_kemal", "crystal_lucky", "crystal_marten",
     "cs_aspnet_core_mvc", "cs_aspnet_core_minimal_api", "cs_aspnet_mvc", "cs_carter", "cs_fastendpoints",
@@ -112,6 +112,24 @@ module NoirTechs
           :body   => true,
           :header => true,
           :cookie => true,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+    },
+    :cpp_httplib => {
+      :framework => "cpp-httplib",
+      :language  => "C++",
+      :similar   => ["httplib", "cpp-httplib", "cpp_httplib", "c++-httplib", "c++_httplib", "yhirose-httplib"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => true,
+          :path   => true,
+          :body   => true,
+          :header => true,
+          :cookie => false,
         },
         :static_path => false,
         :websocket   => false,


### PR DESCRIPTION
## Summary

[cpp-httplib](https://github.com/yhirose/cpp-httplib) is one of the most widely used C++ HTTP libraries (16k+ ★), but noir had no support for it — every cpp-httplib service reported **zero endpoints** (100% FN). This adds a detector + analyzer.

Routes are registered on a `httplib::Server` / `SSLServer` instance:

```cpp
httplib::Server svr;
svr.Get("/users/:id", [](const Request& req, Response& res) { ... });
svr.Post("/users", create_user);                 // named handler
svr.Get(R"(/files/(.*))", handler);              // regex route
```

## What it handles

- **Server vs Client disambiguation** — cpp-httplib's `Client` type has the same verb method names and is *also* called with literal paths (`cli.Get("/hi")`). Routes are only taken from variables typed as a server (server-vars minus client-vars), so client requests aren't mistaken for endpoints.
- **Both include styles & namespaces** — `<httplib.h>`, vendor-prefixed `<utility/httplib.h>`, `"httplib/httplib.hpp"`, qualified `httplib::Server`, and the `using namespace httplib; Server svr;` shorthand.
- **Lambda and named-function handlers** — named handlers are resolved (same file) so their params/callees attach to the endpoint.
- **Path params** — `:name` → `{name}`; regex routes (`R"(...)"` or metachar strings) kept verbatim.
- **Param mining** — `get_param_value`/`has_param`/`get_file_value` (query), `get_header_value`/`has_header` (header), `path_params` (path), `req.body` (body).
- **Perf** — gated on `httplib` + a verb-call substring; the vendored single-header lib file (`httplib.h`/`.hpp`) is skipped (a 10k-line repo scans in ~0.08s).

## Validation (real OSS — all were 0 before)

| repo | endpoints |
|---|---|
| alexgb0/restapi-cpp-httplib-example | 5 |
| eatbreads/fly_server | 13 |
| Zhangddy/CloudBackupServer | 3 |
| systelab/cpp-httplib-webserver-adapter | 6 |
| yhirose/cpp-httplib `example/` | 11 |

No false positives on Crow/Drogon apps (the analyzer doesn't fire without httplib markers + a server variable).

## Tests & docs

- New functional fixture/spec (lambda + named handler, `:id`, raw-string regex, query/header/body params, **client-call exclusion**) and a detector spec.
- Registered in `analyzer.cr` / `detector.cr` / `techs.cr`; regenerated supported-frameworks docs.
- Full suite: 22,300 examples, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>