### PR TITLE
fix(analyzer/zig/httpz): accept @"…" quoted-identifier route handlers

### DIFF
--- a/spec/functional_test/fixtures/zig/httpz/src/main.zig
+++ b/spec/functional_test/fixtures/zig/httpz/src/main.zig
@@ -14,6 +14,9 @@ pub fn main() !void {
     router.delete("/users/:id", deleteUser, .{});
     router.all("/health", health, .{});
     router.method("QUERY", "/cache/:key", purgeCache, .{});
+    // Handler named with a `@"…"` quoted identifier (a Zig reserved word). The
+    // route must still be captured even though the name isn't a plain ident.
+    router.get("/error", @"error", .{});
 
     // Prefixed route group.
     var admin = router.group("/admin", .{});
@@ -52,6 +55,10 @@ fn health(_: *httpz.Request, res: *httpz.Response) !void {
 
 fn purgeCache(_: *httpz.Request, res: *httpz.Response) !void {
     try cache.purge();
+}
+
+fn @"error"(_: *httpz.Request, res: *httpz.Response) !void {
+    try res.status(500);
 }
 
 fn adminStats(_: *httpz.Request, res: *httpz.Response) !void {

--- a/spec/functional_test/testers/zig/httpz_spec.cr
+++ b/spec/functional_test/testers/zig/httpz_spec.cr
@@ -21,6 +21,9 @@ expected_endpoints << httpz_endpoint("/users/:id", "DELETE", id_param, [Callee.n
 expected_endpoints << httpz_endpoint("/health", "GET", [] of Param, [Callee.new("res.write")])
 # `router.method("QUERY", ...)` keeps the custom verb.
 expected_endpoints << httpz_endpoint("/cache/:key", "QUERY", [Param.new("key", "", "path")], [Callee.new("cache.purge")])
+# `@"…"` quoted-identifier handler (a reserved word) — the route is captured
+# even though the `@"…"` name isn't indexed for body/callee lookup.
+expected_endpoints << httpz_endpoint("/error", "GET")
 # Group prefix composition.
 expected_endpoints << httpz_endpoint("/admin/stats", "GET", [] of Param, [Callee.new("res.json")])
 # Nested group prefix composition.

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -21,9 +21,13 @@ module Analyzer::Zig
       "options" => "OPTIONS", "connect" => "CONNECT", "all" => "GET",
     }
 
-    GROUP_RE  = /(?:var|const)\s+(\w+)\s*=\s*(\w+)\s*\.\s*group\s*\(\s*"([^"]*)"/
-    ROUTE_RE  = /(\w+)\s*\.\s*(get|post|put|delete|head|patch|trace|options|connect|all)\s*\(\s*"(\/[^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
-    METHOD_RE = /(\w+)\s*\.\s*method\s*\(\s*"([^"]*)"\s*,\s*"(\/[^"]*)"\s*,\s*([A-Za-z_][\w.]*)/
+    GROUP_RE = /(?:var|const)\s+(\w+)\s*=\s*(\w+)\s*\.\s*group\s*\(\s*"([^"]*)"/
+    # The handler is the 2nd argument. It can be a plain/qualified identifier
+    # (`getUser`, `Users.list`) or a `@"…"` quoted identifier — Zig spells a
+    # reserved word used as a name that way, so `router.get("/error", @"error")`
+    # is idiomatic. The `@"…"` alternative keeps that form from being dropped.
+    ROUTE_RE  = /(\w+)\s*\.\s*(get|post|put|delete|head|patch|trace|options|connect|all)\s*\(\s*"(\/[^"]*)"\s*,\s*(@"[^"]*"|[A-Za-z_][\w.]*)/
+    METHOD_RE = /(\w+)\s*\.\s*method\s*\(\s*"([^"]*)"\s*,\s*"(\/[^"]*)"\s*,\s*(@"[^"]*"|[A-Za-z_][\w.]*)/
 
     def analyze
       include_callee = callees_needed?


### PR DESCRIPTION
## Summary

httpz routes whose handler is a Zig **reserved word** are spelled with a quoted identifier:

```zig
router.get("/error", @"error", .{});
```

The handler (2nd argument) group in `ROUTE_RE` / `METHOD_RE` only matched a plain or qualified identifier (`[A-Za-z_][\w.]*`), so the leading `@` failed the match and the **entire route was dropped**. Added a `@"…"` alternative to the handler token.

The endpoint is now captured. Callees stay empty for the `@"…"` form because those function names aren't indexed by `function_table` (it scans string-blanked source, where the `@"error"` name is hollowed out) — the route itself is the FN we care about.

## Real-world impact (cloned OSS)
| app | before | after |
|---|---|---|
| zig-bitcoin/btczee | 2 | 3 (`GET /error`) |
| karlseguin/http.zig (examples) | 61 | 62 (`GET /error`) |

No change to any other cloned httpz app (hz_zero, duckdb-proxy, wrumz, …).

## Test
`spec/functional_test/fixtures/zig/httpz` gains a `router.get("/error", @"error", .{})` route + handler; the spec asserts the endpoint is captured. Full zig suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)