### PR TITLE
fix(analyzer/clojure/reitit): bare-handler routes, schema-wrapped & malli param keys

### DIFF
--- a/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
@@ -31,6 +31,17 @@
    ["/status"
     {:handler status-handler}]
 
+   ; Bare handler in the data position — `["/path" handler]` is reitit
+   ; shorthand for `{:handler handler}`; emit a GET endpoint.
+   ["/dashboard" dashboard-handler]
+
+   ; Schema map with a wrapped optional key — `(schema/optional-key :limit)`
+   ; names the `limit` query param just like the bare `:offset` key.
+   ["/orders"
+    {:get {:parameters {:query {(schema/optional-key :limit) int?
+                                :offset int?}}
+           :handler list-orders}}]
+
    ["/admin"
     ["/reports/:id"
      {:patch {:parameters {:path {:id int?}

--- a/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/reitit/src/demo/core.clj
@@ -42,6 +42,12 @@
                                 :offset int?}}
            :handler list-orders}}]
 
+   ; malli map-schema vector params — `[:map [:x …] [:y {…} …]]` names each
+   ; entry key (non-`:map` schemas like `[:maybe …]` carry no named params).
+   ["/items"
+    {:get {:parameters {:query [:map [:tag int?] [:cursor {:optional true} string?]]}
+           :handler list-items}}]
+
    ["/admin"
     ["/reports/:id"
      {:patch {:parameters {:path {:id int?}

--- a/spec/functional_test/testers/clojure/reitit_spec.cr
+++ b/spec/functional_test/testers/clojure/reitit_spec.cr
@@ -23,6 +23,10 @@ expected_endpoints = [
     Param.new("limit", "", "query"),
     Param.new("offset", "", "query"),
   ]),
+  Endpoint.new("/api/items", "GET", [
+    Param.new("tag", "", "query"),
+    Param.new("cursor", "", "query"),
+  ]),
   Endpoint.new("/api/guarded/info", "GET"),
   Endpoint.new("/api/admin/reports/:id", "PATCH", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/clojure/reitit_spec.cr
+++ b/spec/functional_test/testers/clojure/reitit_spec.cr
@@ -18,6 +18,11 @@ expected_endpoints = [
     Param.new("page", "", "query"),
   ]),
   Endpoint.new("/api/status", "GET"),
+  Endpoint.new("/api/dashboard", "GET"),
+  Endpoint.new("/api/orders", "GET", [
+    Param.new("limit", "", "query"),
+    Param.new("offset", "", "query"),
+  ]),
   Endpoint.new("/api/guarded/info", "GET"),
   Endpoint.new("/api/admin/reports/:id", "PATCH", [
     Param.new("id", "", "path"),

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -177,7 +177,29 @@ module Analyzer::Clojure
 
       route_path = decode_string_literal(source.byte_slice(i, str_end - i + 1))
       new_prefix = join_path(prefix, route_path)
+
+      # `["/path" handler]` — a bare handler (symbol / `#'var` / inline
+      # `(fn …)`) in the data position is reitit shorthand for
+      # `{:handler handler}` and responds to any method. Emit a GET endpoint so
+      # the route is not dropped; a map / child-vector in that position is left
+      # to walk_route_body.
+      token, _ = read_form_token(source, str_end + 1, vec_end)
+      if bare_route_handler?(token)
+        handler_start = skip_ws_and_comments(source, str_end + 1, vec_end)
+        handler_end = end_of_value(source, handler_start, vec_end)
+        emit_endpoint(source, handler_start, handler_start, handler_end, new_prefix, "GET", path, include_callee, function_callees, nil)
+      end
+
       walk_route_body(source, str_end + 1, vec_end, new_prefix, path, include_callee, function_callees)
+    end
+
+    # A bare route handler in the data position is an inline `(fn …)`/`(partial
+    # …)` form, a `#'var`/`'sym` reference, or a plain handler symbol. Maps,
+    # child-route vectors, strings and keywords are not handlers.
+    private def bare_route_handler?(token : String) : Bool
+      return false if token.empty?
+      return true if token.starts_with?('(')
+      !normalized_handler_symbol(token).nil?
     end
 
     private def walk_route_body(source : String,
@@ -516,9 +538,14 @@ module Analyzer::Clojure
             keys << name unless name.empty?
             i = after
           else
-            # Non-keyword key — skip it and the value pair.
-            i = end_of_value(source, i, limit)
-            i = skip_ws_and_comments(source, i, limit)
+            # A non-keyword key may still name a param when it's a schema /
+            # malli wrapper — `(s/optional-key :page)`, `[:page {:optional
+            # true}]`. Pull the first keyword inside the key form as the name.
+            key_end = end_of_value(source, i, limit)
+            if name = first_keyword_in(source, i, key_end)
+              keys << name
+            end
+            i = skip_ws_and_comments(source, key_end, limit)
             break if i >= limit
             i = end_of_value(source, i, limit)
             next
@@ -530,6 +557,26 @@ module Analyzer::Clojure
         end
       end
       keys
+    end
+
+    # Return the bind name of the first keyword inside a key form. Schema
+    # wraps optional/required keys (`(s/optional-key :page)`) and malli spells
+    # them as vectors (`[:page {:optional true}]`); in both the parameter name
+    # is the first keyword. Namespace-qualified keywords drop the namespace.
+    private def first_keyword_in(source : String, start : Int32, limit : Int32) : String?
+      i = start
+      while i < limit
+        if source.byte_at(i).unsafe_chr == ':'
+          sym, _ = read_symbol(source, i, limit)
+          name = sym.lstrip(':')
+          if slash_idx = name.rindex('/')
+            name = name[(slash_idx + 1)..]
+          end
+          return name unless name.empty?
+        end
+        i += 1
+      end
+      nil
     end
 
     private def extract_path_param_names(route_path : String) : Array(String)

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -503,17 +503,57 @@ module Analyzer::Clojure
     private def add_group_params(source : String, v_start : Int32, v_end : Int32,
                                  endpoint : Endpoint, ptype : String, path_param_set : Set(String))
       return if v_start >= v_end
-      return unless source.byte_at(v_start).unsafe_chr == '{'
 
-      map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
-      return unless map_end > v_start
+      names = case source.byte_at(v_start).unsafe_chr
+              when '{'
+                # Schema / map literal: `{:x int?, (s/optional-key :y) int?}`.
+                map_end = find_matching_delimiter(source, v_start, '{', '}', v_end)
+                return unless map_end > v_start
+                extract_map_keys(source, v_start + 1, map_end)
+              when '['
+                # malli map schema vector: `[:map [:x int?] [:y {…} int?]]`.
+                vec_end = find_matching_delimiter(source, v_start, '[', ']', v_end)
+                return unless vec_end > v_start
+                extract_malli_map_keys(source, v_start + 1, vec_end)
+              else
+                return
+              end
 
-      extract_map_keys(source, v_start + 1, map_end).each do |name|
+      names.each do |name|
         next if name.empty?
         next if ptype == "path" && path_param_set.includes?(name)
         next if endpoint.params.any? { |p| p.name == name && p.param_type == ptype }
         endpoint.push_param(Param.new(name, "", ptype))
       end
+    end
+
+    # Extract the entry keys of a malli map schema vector
+    # `[:map [:x int?] [:y {:optional true} int?]]`. Only a `:map` head names
+    # request params; other malli schemas (`[:maybe …]`, `[:vector …]`) are
+    # positional and carry none. Each entry is a vector whose first keyword is
+    # the key name; an optional properties map after `:map` is skipped.
+    private def extract_malli_map_keys(source : String, start : Int32, limit : Int32) : Array(String)
+      i = skip_ws_and_comments(source, start, limit)
+      head, after_head = read_symbol(source, i, limit)
+      return [] of String unless head == ":map"
+
+      keys = [] of String
+      j = after_head
+      while j < limit
+        j = skip_ws_and_comments(source, j, limit)
+        break if j >= limit
+        if source.byte_at(j).unsafe_chr == '['
+          entry_end = find_matching_delimiter(source, j, '[', ']', limit)
+          break if entry_end <= j
+          if name = first_keyword_in(source, j + 1, entry_end)
+            keys << name
+          end
+          j = entry_end + 1
+        else
+          j = end_of_value(source, j, limit)
+        end
+      end
+      keys
     end
 
     # Extract first-level keyword keys (`:foo`, `:ns/foo`) from a map


### PR DESCRIPTION
Reitit FP/FN sweep against real OSS (prestancedesign/pingcrm-clojure, luminus reitit template, usermanager-reitit-example, metosin/reitit). Three FN fixes:

### 1. Bare-handler routes (FN)
`["/reports" reports/index]` — a bare handler (symbol / `#'var` / inline `(fn …)`) in the data position is reitit shorthand for `{:handler handler}` and responds to any method. `walk_route_body` skipped the symbol, dropping the route entirely. Now emit a GET endpoint for it; maps / child-route vectors / strings / keywords are still left to the normal walk.

### 2. Schema-wrapped param keys (FN)
`:parameters {:query {(s/optional-key :page) Long}}` — a Plumatic-Schema / malli wrapped key was skipped because it is not a bare keyword. Pull the first keyword inside the key form as the param name.

### 3. malli map-schema vector params (FN)
`reitit.coercion.malli` (the default coercion in modern reitit) declares params as a malli vector — `:parameters {:query [:map [:x int?] [:y {:optional true} int?]]}` — not a Clojure map. `add_group_params` only handled the `{…}` form, dropping every malli-coerced param. Added `extract_malli_map_keys`: a `[:map …]` head names each entry vector's first keyword; non-`:map` schemas (`[:maybe …]`, `[:vector …]`) are positional and yield none.

## Validation
- **pingcrm: 25 → 26 endpoints** (+`GET /reports`); `page` query param now appears on `GET /organizations` + `GET /contacts`.
- malli vector params verified against metosin/reitit openapi/coercion test shapes (`[:map [:x int?] [:y {…} int?]]` → x, y; `[:maybe …]` → none).
- Full functional suite: **18859 examples, 0 failures**. Clojure specs green. fmt + ameba clean. Fixture regression guards added for all three.

Co-authored-by: ksg97031 <ksg97031@gmail.com>