### PR TITLE
fix(analyzer/lua/lor): exclude lor's *.test.lua + test/ dirs from route scan

### DIFF
--- a/spec/functional_test/fixtures/lua/lor/test/sample.test.lua
+++ b/spec/functional_test/fixtures/lua/lor/test/sample.test.lua
@@ -1,0 +1,14 @@
+-- lor's own test convention (`*.test.lua` under a `test/` dir). The routes
+-- below are phantom test-app routes and MUST NOT be emitted as endpoints.
+local lor = require("lor.index")
+local app = lor()
+
+app:get("/phantom/test/route", function(req, res, next)
+    res:send("should not be detected")
+end)
+
+app:post("/user/123/create", function(req, res, next)
+    res:send("should not be detected")
+end)
+
+app:run()

--- a/src/analyzer/analyzers/lua/lor.cr
+++ b/src/analyzer/analyzers/lua/lor.cr
@@ -85,12 +85,18 @@ module Analyzer::Lua
       result
     end
 
-    # Skip Busted spec files (`*_spec.lua`) and `spec*/` directories — the lor
-    # framework (vendored under `lib/lor` in several apps) ships ~dozens of
-    # phantom routes in `spec/cases/*_spec.lua` against inline test apps.
+    # Skip the lor framework's own test suite, which apps vendor under
+    # `lib/lor`, `resty/thirdparty/lor`, etc. and which defines dozens of
+    # phantom routes against inline test apps. lor uses the Busted `*_spec.lua`
+    # convention AND a `*.test.lua` convention (e.g. `test/stack.test.lua`,
+    # `test/path_pattern_2.test.lua`), both under `spec*/` or `test*/`
+    # directories. Without this, Mio surfaced 20 phantom routes
+    # (`/user/123/create`, `/test/foo/bar`, …) from its vendored
+    # `resty/thirdparty/lor/test/*.test.lua` and only 1 real route.
     private def lor_test_path?(path : String) : Bool
       base = File.basename(path)
       return true if base.ends_with?("_spec.lua") || base.ends_with?("_spec.moon")
+      return true if base.ends_with?(".test.lua") || base.ends_with?(".test.moon")
       expanded_path = File.expand_path(path)
 
       base_paths.any? do |root|
@@ -99,7 +105,9 @@ module Analyzer::Lua
         expanded_root = File.expand_path(root)
         expanded_root = expanded_root.rstrip('/') unless expanded_root == File::SEPARATOR
         tail = expanded_path[expanded_root.size..]?.try(&.lchop(File::SEPARATOR)) || ""
-        tail.split(File::SEPARATOR).any? { |seg| seg == "spec" || seg.starts_with?("spec_") }
+        tail.split(File::SEPARATOR).any? do |seg|
+          seg == "spec" || seg.starts_with?("spec_") || seg == "test" || seg == "tests"
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Follow-up to #2055. Real-world lor apps vendor the lor framework itself (under `lib/lor`, `resty/thirdparty/lor`, …), and lor's own test suite defines phantom routes against inline test apps. The analyzer already skipped Busted `*_spec.lua` + `spec*/` dirs, but lor also uses a **`*.test.lua`** convention (`test/stack.test.lua`, `test/path_pattern_2.test.lua`) under `test*/` directories.

## Fix

Extend `lor_test_path?` to also skip:
- `*.test.lua` / `*.test.moon` files (lor's test-file naming)
- `test` / `tests` directory segments (alongside the existing `spec` / `spec_*`)

The directory check stays anchored below `base_paths`, so a project's own routes are never affected.

## Impact

`iresty/Mio` previously surfaced **21 endpoints — 20 of them phantom** (`/user/123/create`, `/test/foo/bar`, `/test/all`, …) from its vendored `resty/thirdparty/lor/test/*.test.lua`, leaving only 1 real route buried in noise. Now Mio yields its 1 statically-resolvable route (`GET /`); its other real routes use the dynamic `gateway.api` table-registration pattern, which is deferred (paths registered via `router[m](router, uri, …)` indirection).

All other validated apps are **unchanged**: lor-example 11, openresty-china 48, glualor 11, vue-admin-back 79, lua-redis-admin 29, openresty-im 8, orange 38, xorange 44.

## Tests

- New regression fixture `fixtures/lua/lor/test/sample.test.lua` with phantom routes that must be excluded (endpoint count stays 15).
- Full Lua suite green (491 examples), ameba + format clean.