### PR TITLE
fix(analyzer/swift/vapor): make route detection receiver-aware to kill phantom endpoints

### DIFF
--- a/spec/functional_test/fixtures/swift/vapor/AdminRoutes.swift
+++ b/spec/functional_test/fixtures/swift/vapor/AdminRoutes.swift
@@ -1,0 +1,18 @@
+import Vapor
+
+// A `RoutesBuilder` extension: bare `grouped(...)` and `self.<verb>` are
+// router-like even though there is no named router variable. The controller
+// method call inside the handler (`adminController.delete(...)`) shares a verb
+// name with a route but is NOT router-like, so it must not become an endpoint.
+extension RoutesBuilder {
+    func registerAdminRoutes() {
+        let admin = grouped("admin")
+        admin.get("dashboard") { req -> String in   // GET /admin/dashboard
+            return "ok"
+        }
+        self.post("purge") { req -> String in        // POST /purge
+            adminController.delete(req)               // must NOT be DELETE /
+            return "ok"
+        }
+    }
+}

--- a/spec/functional_test/fixtures/swift/vapor/routes.swift
+++ b/spec/functional_test/fixtures/swift/vapor/routes.swift
@@ -1,6 +1,11 @@
 import Vapor
 
 func routes(_ app: Application) throws {
+    // Non-router look-alikes: a static type method and an env lookup whose
+    // receivers are not router-like — must NOT be reported as endpoints.
+    _ = Environment.get("DATABASE_URL")
+    _ = Environment.get("LOG_LEVEL")
+
     // Basic GET route
     app.get("hello") { req -> String in
         return "Hello, world!"
@@ -45,10 +50,15 @@ func routes(_ app: Application) throws {
         return "Session: \(sessionID ?? "none")"
     }
     
-    // DELETE route
+    // DELETE route. The Fluent `.delete(on:)` and HTTP-client `.get(...)`
+    // calls inside the handler use non-router receivers and must NOT be
+    // reported as endpoints.
     app.delete("users", ":id") { req -> EventLoopFuture<HTTPStatus> in
         let id = req.parameters.get("id")
-        return deleteUser(id, on: req.db)
+        _ = req.client.get("http://example.com/health")
+        return User.find(id, on: req.db).flatMap { user in
+            user!.delete(on: req.db)
+        }
     }
     
     // PATCH route

--- a/spec/functional_test/testers/swift/vapor_spec.cr
+++ b/spec/functional_test/testers/swift/vapor_spec.cr
@@ -11,6 +11,9 @@ expected_endpoints = [
   Endpoint.new("/users/:id", "DELETE"),
   Endpoint.new("/articles/:articleID", "PATCH"),
   Endpoint.new("/status", "GET"),
+  # RoutesBuilder extension: bare `grouped(...)` + `self.<verb>` (AdminRoutes).
+  Endpoint.new("/admin/dashboard", "GET"),
+  Endpoint.new("/purge", "POST"),
 ]
 
 FunctionalTester.new("fixtures/swift/vapor/", {

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -12,7 +12,7 @@ module Analyzer::Swift
     # routes.get("path", ":param") { ... }
     ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\(/
     ON_ROUTE_PATTERN           = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.on\s*\(/
-    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\.grouped\s*\(/
+    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*(?:([A-Za-z_]\w*)\.)?grouped\s*\(/
     GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group(?:ed)?\s*\(/
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
@@ -25,6 +25,10 @@ module Analyzer::Swift
     # phantom endpoints.
     ROUTER_PARAM_PATTERN   = /(?:_\s+)?([A-Za-z_]\w*)\s*:\s*(?:some\s+|any\s+|inout\s+)*(?:RoutesBuilder|Router|Application)\b/
     ROUTER_BINDING_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*(?:try\s+|await\s+)*Application\b/
+    # `extension RoutesBuilder { ... self.get(...) ... }` — inside such an
+    # extension `self` (and bare `grouped(...)`, handled by GROUP_ASSIGN_PATTERN)
+    # is router-like.
+    ROUTER_EXTENSION_PATTERN = /\bextension\s+(?:RoutesBuilder|Router)\b/
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
@@ -256,7 +260,11 @@ module Analyzer::Swift
     end
 
     # File-wide pre-pass: register every router-typed parameter/binding so the
-    # main scan can gate route detection on a router-like receiver.
+    # main scan can gate route detection on a router-like receiver. Covers
+    # `Router`/`RoutesBuilder`/`Application` parameters, `Application` bindings,
+    # and `self` inside a `RoutesBuilder`/`Router` extension. (`.grouped(...)`
+    # variables — qualified or implicit-`self` — are tracked separately by
+    # `register_group_assignment`.)
     private def register_router_params(lines : Array(String), prefix_by_receiver : Hash(String, String))
       lines.each do |line|
         stripped = code_line(line)
@@ -266,6 +274,7 @@ module Analyzer::Swift
         if binding = stripped.match(ROUTER_BINDING_PATTERN)
           prefix_by_receiver[binding[1]] ||= ""
         end
+        prefix_by_receiver["self"] ||= "" if stripped.matches?(ROUTER_EXTENSION_PATTERN)
       end
     end
 
@@ -274,12 +283,14 @@ module Analyzer::Swift
       return unless match
 
       variable = match[1]
-      base = match[2]
+      # `base` is absent for an implicit-`self` `grouped(...)` (a RoutesBuilder
+      # extension): the new group then inherits the empty root prefix.
+      base_prefix = (base = match[2]?) ? prefix_for_receiver(base, prefix_by_receiver) : ""
       args = call_arguments(line, match.end(0) || 0)
       return unless args
 
       prefix = parse_route_path(args[0])
-      prefix_by_receiver[variable] = join_paths(prefix_for_receiver(base, prefix_by_receiver), prefix)
+      prefix_by_receiver[variable] = join_paths(base_prefix, prefix)
     end
 
     private def register_group_closure(line : String,

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -16,6 +16,16 @@ module Analyzer::Swift
     GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group(?:ed)?\s*\(/
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
+    # A function parameter (or binding) typed as a Vapor router:
+    # `func routes(_ app: Application)`, `func boot(routes: RoutesBuilder)`,
+    # `func boot(router: Router)` (Vapor 3), `let app = Application(...)`.
+    # Tracking these makes route detection receiver-aware, so that non-router
+    # `.get`/`.delete`/... calls — `Environment.get("DATABASE_URL")`,
+    # `model.delete(on: req.db)`, `req.client.get(url)` — stop surfacing as
+    # phantom endpoints.
+    ROUTER_PARAM_PATTERN   = /(?:_\s+)?([A-Za-z_]\w*)\s*:\s*(?:some\s+|any\s+|inout\s+)*(?:RoutesBuilder|Router|Application)\b/
+    ROUTER_BINDING_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*(?:try\s+|await\s+)*Application\b/
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
@@ -25,12 +35,15 @@ module Analyzer::Swift
       group_prefix_stack = [] of Tuple(String, Int32)
       brace_depth = 0
 
+      # Seed the router-receiver set so route detection is receiver-aware.
+      register_router_params(lines, prefix_by_receiver)
+
       lines.each_with_index do |line, index|
         stripped_line = code_line(line)
         register_group_assignment(stripped_line, prefix_by_receiver)
         register_group_closure(stripped_line, prefix_by_receiver, group_prefix_stack, brace_depth)
 
-        route = route_parts(stripped_line)
+        route = route_parts(stripped_line, prefix_by_receiver)
         unless route
           brace_depth = update_group_depth(stripped_line, brace_depth, group_prefix_stack, prefix_by_receiver)
           next
@@ -207,10 +220,12 @@ module Analyzer::Swift
       {body_lines.join("\n"), route_index + 1}
     end
 
-    private def route_parts(line : String) : Tuple(String, String, String)?
+    private def route_parts(line : String, prefix_by_receiver : Hash(String, String)) : Tuple(String, String, String)?
       return unless route_definition_line?(line)
 
       if match = line.match(ON_ROUTE_PATTERN)
+        return unless router_like?(match[1], prefix_by_receiver)
+
         args = call_arguments(line, match.end(0) || 0)
         return unless args
 
@@ -222,6 +237,8 @@ module Analyzer::Swift
       end
 
       if match = line.match(ROUTE_PATTERN)
+        return unless router_like?(match[1], prefix_by_receiver)
+
         args = call_arguments(line, match.end(0) || 0)
         return unless args
 
@@ -229,6 +246,27 @@ module Analyzer::Swift
       end
 
       nil
+    end
+
+    # A `.get`/`.post`/... call counts as a route only when its receiver is a
+    # known router: a tracked `.grouped(...)` variable, a closure-group var,
+    # or a `RoutesBuilder`/`Router`/`Application`-typed parameter/binding.
+    private def router_like?(receiver : String, prefix_by_receiver : Hash(String, String)) : Bool
+      receiver.split('.').any? { |part| prefix_by_receiver.has_key?(part) }
+    end
+
+    # File-wide pre-pass: register every router-typed parameter/binding so the
+    # main scan can gate route detection on a router-like receiver.
+    private def register_router_params(lines : Array(String), prefix_by_receiver : Hash(String, String))
+      lines.each do |line|
+        stripped = code_line(line)
+        stripped.scan(ROUTER_PARAM_PATTERN) do |match|
+          prefix_by_receiver[match[1]] ||= ""
+        end
+        if binding = stripped.match(ROUTER_BINDING_PATTERN)
+          prefix_by_receiver[binding[1]] ||= ""
+        end
+      end
     end
 
     private def register_group_assignment(line : String, prefix_by_receiver : Hash(String, String))


### PR DESCRIPTION
## Summary

The Vapor analyzer matched **any** `receiver.get(...)`/`.post(...)`/`.delete(...)` call as a route, so non-router calls became phantom endpoints:

| call | phantom endpoint |
|------|------------------|
| `Environment.get("DATABASE_HOST")` | `GET /DATABASE_HOST` |
| `model.delete(on: req.db)` (Fluent) | `DELETE /` |
| `req.application.client.get(url)` (HTTP client) | `GET /<url>` |

## Fix

Gate route detection on a **router-like receiver** — the same approach the Hummingbird analyzer already uses. A receiver counts as router-like when it is:
- a tracked `.grouped(...)` variable (already registered), or
- a closure-group variable, or
- a parameter/binding typed `RoutesBuilder` / `Router` (Vapor 3) / `Application`.

A new file-wide pre-pass (`register_router_params`) seeds that set from the `func routes(_ app: Application)`, `func boot(routes: RoutesBuilder)`, `func boot(router: Router)` and `let app = Application(...)` forms.

## Validation (real OSS — no real route dropped)

| app | before | after | removed |
|-----|--------|-------|---------|
| vapor-til | 54 | **43** | 11 (`Environment.get`, `.delete(on:)`, `client.get`) |
| SteamPress (Vapor 3) | 23 | **20** | 3 |
| vapor (framework repo) | 34 | **27** | 7 (`cache.get`, `req.application.client.get`) |

Every real `app`/`routes`/grouped route is retained. Extended the `vapor` fixture with `Environment.get`, `.delete(on:)` and `req.client.get` look-alikes that must stay out of the report. Full Swift spec suite passes (214 functional examples).

Co-authored-by: ksg97031 <ksg97031@gmail.com>