### PR TITLE
fix(analyzer/go/mux): resolve http.MethodX constants in .Methods(), not just string literals

### DIFF
--- a/spec/functional_test/fixtures/go/mux/server.go
+++ b/spec/functional_test/fixtures/go/mux/server.go
@@ -78,5 +78,15 @@ func main() {
 		fmt.Fprintf(w, "builder query")
 	})
 
+	// Idiomatic http.MethodX constant form (portainer-style) — the
+	// constant must resolve to the verb instead of falling back to GET.
+	r.Handle("/profile", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "profile update")
+	})).Methods(http.MethodPut)
+
+	r.HandleFunc("/profile", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "profile view")
+	}).Methods(http.MethodGet, http.MethodHead)
+
 	http.ListenAndServe(":8080", r)
 }

--- a/spec/functional_test/testers/go/mux_spec.cr
+++ b/spec/functional_test/testers/go/mux_spec.cr
@@ -55,6 +55,11 @@ expected_endpoints = [
   ]),
   # handlers.go: nested subrouter
   Endpoint.new("/v2/health", "GET"),
+  # server.go: idiomatic `http.MethodX` constant form must resolve to the
+  # verb instead of defaulting to GET.
+  Endpoint.new("/profile", "PUT"),
+  Endpoint.new("/profile", "GET"),
+  Endpoint.new("/profile", "HEAD"),
 ]
 
 FunctionalTester.new("fixtures/go/mux/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -308,6 +308,31 @@ describe Noir::TreeSitterGoRouteExtractor do
     ].sort)
   end
 
+  it "resolves http.MethodX constants in gorilla mux .Methods(...)" do
+    # The idiomatic constant form (`.Methods(http.MethodPut)`) — used by
+    # portainer and most net/http apps — was unresolved, so every such
+    # route silently fell back to GET.
+    source = <<-GO
+      package main
+      func main() {
+          r := mux.NewRouter()
+          r.Handle("/settings", h.update).Methods(http.MethodPut)
+          r.Handle("/settings", h.inspect).Methods(http.MethodGet)
+          r.HandleFunc("/items", h.list).Methods(http.MethodGet, http.MethodPost)
+          r.HandleFunc("/items/{id}", h.del).Methods(http.MethodDelete)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_routes(source, handlefunc_methods: true)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"DELETE", "/items/{id}"},
+      {"GET", "/items"},
+      {"GET", "/settings"},
+      {"POST", "/items"},
+      {"PUT", "/settings"},
+    ].sort)
+  end
+
   it "extracts gorilla mux route builder chains" do
     source = <<-GO
       package main

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -1121,7 +1121,7 @@ module Noir
         key_node, val_node = gozero_keyed_pair(kv)
         next if key_node.nil? || val_node.nil?
         case Noir::TreeSitter.node_text(key_node, source)
-        when "Method"  then method = gozero_method_value(val_node, source)
+        when "Method"  then method = decode_method_token(val_node, source)
         when "Path"    then rpath = gozero_string_value(val_node, source)
         when "Handler" then handler = Noir::TreeSitter.node_text(val_node, source)
         end
@@ -1222,9 +1222,10 @@ module Noir
       {gozero_unwrap(key), gozero_unwrap(val)}
     end
 
-    # `Method:` is either a string literal ("POST") or an `http.MethodX`
-    # selector; both collapse to the bare upper-cased verb.
-    private def gozero_method_value(node : LibTreeSitter::TSNode, source : String) : String
+    # An HTTP method written as a string literal ("POST") or an
+    # `http.MethodX` selector; both collapse to the bare upper-cased verb.
+    # Shared by go-zero's `Method:` struct field and mux's `.Methods(...)`.
+    private def decode_method_token(node : LibTreeSitter::TSNode, source : String) : String
       case Noir::TreeSitter.node_type(node)
       when "interpreted_string_literal", "raw_string_literal"
         Noir::TreeSitter.node_text(node, source).gsub(/^["`]|["`]$/, "").upcase
@@ -2484,6 +2485,13 @@ module Noir
               case Noir::TreeSitter.node_type(arg)
               when "interpreted_string_literal", "raw_string_literal"
                 verbs << decode_string_literal(arg, source).upcase
+              when "selector_expression"
+                # The idiomatic constant form `.Methods(http.MethodGet,
+                # http.MethodPut)` — `http.MethodPut` → "PUT". Without this
+                # every constant-verb route silently fell back to GET.
+                if verb = decode_method_token(arg, source)
+                  verbs << verb unless verb.empty?
+                end
               end
             end
           end


### PR DESCRIPTION
## Summary

gorilla/mux's `.Methods(...)` decoder only read **string-literal** verbs (`.Methods("PUT")`). The idiomatic Go form passes the `net/http` constants — `.Methods(http.MethodPut)` — which the decoder **ignored**. With `saw_methods` true but no verb collected, every constant-verb route fell back to the default **GET**.

On a real mux app this is catastrophic:

> **portainer** registers its entire API with `http.MethodGet/Post/Put/Delete` constants, so noir reported all **192 routes as GET** — losing every POST/PUT/DELETE and collapsing same-path read/write pairs (`GET /settings` + `PUT /settings`) into one.

## Fix

Handle the `selector_expression` arg the same way go-zero already resolves its `Method:` struct field: take the segment after `Method` (`http.MethodPut` → `PUT`). The shared helper is renamed `gozero_method_value` → `decode_method_token` and now backs both call sites.

## Validation

| | Before | After |
|--|--------|-------|
| portainer endpoints | 192 | **246** |
| method distribution | all GET | GET 120, POST 64, PUT 37, DELETE 25 |

`/settings` correctly splits into GET (inspect) + PUT (update). **gophish** (mux `HandleFunc` with no `.Methods()` → wildcard fan-out) and the rest of the Go corpus are **unchanged**.

mux fixture gains constant-form routes (`http.MethodPut`, `http.MethodGet, http.MethodHead`); new unit test. Full suite **18768 functional + unit examples, 0 failures**; `ameba` + `crystal tool format --check` clean.