### PR TITLE
fix(analyzer/dart/frog): narrow WebSocket routes to GET with ws protocol

### DIFF
--- a/docs/content/usage/supported/language_and_frameworks/index.ko.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.ko.md
@@ -564,7 +564,7 @@ sort_by = "weight"
         <span class="tech-chip off">header</span>
         <span class="tech-chip off">cookie</span>
         <span class="tech-chip off">static</span>
-        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">websocket</span>
         <span class="tech-chip on">callee</span>
       </div>
     </div>

--- a/docs/content/usage/supported/language_and_frameworks/index.md
+++ b/docs/content/usage/supported/language_and_frameworks/index.md
@@ -564,7 +564,7 @@ Each card below lists a framework's supported features. **Route** covers endpoin
         <span class="tech-chip off">header</span>
         <span class="tech-chip off">cookie</span>
         <span class="tech-chip off">static</span>
-        <span class="tech-chip off">websocket</span>
+        <span class="tech-chip on">websocket</span>
         <span class="tech-chip on">callee</span>
       </div>
     </div>

--- a/spec/functional_test/fixtures/dart/dart_frog/routes/ws.dart
+++ b/spec/functional_test/fixtures/dart/dart_frog/routes/ws.dart
@@ -1,0 +1,14 @@
+import 'package:dart_frog/dart_frog.dart';
+import 'package:dart_frog_web_socket/dart_frog_web_socket.dart';
+
+// A WebSocket route: the handler upgrades the request, so it serves only a
+// GET (the upgrade handshake) and must not fan out to the fall-back verb
+// set. The endpoint's protocol is reported as `ws`.
+Future<Response> onRequest(RequestContext context) async {
+  final handler = webSocketHandler((channel, protocol) {
+    channel.stream.listen((event) {
+      channel.sink.add(event);
+    });
+  });
+  return handler(context);
+}

--- a/spec/functional_test/testers/dart/dart_frog_spec.cr
+++ b/spec/functional_test/testers/dart/dart_frog_spec.cr
@@ -33,6 +33,9 @@ expected_endpoints = [
   # mirror and contributes nothing.)
   Endpoint.new("/articles/{id}", "GET", [Param.new("id", "", "path")]),
   Endpoint.new("/articles/{id}", "PUT", [Param.new("id", "", "path")]),
+  # `ws.dart` upgrades to a WebSocket (`webSocketHandler`), so it serves a
+  # single GET (the upgrade handshake) — not the fall-back verb set.
+  Endpoint.new("/ws", "GET"),
 ]
 
 tester = FunctionalTester.new("fixtures/dart/dart_frog/", {
@@ -46,4 +49,12 @@ tester.perform_tests
 # as an HTTP endpoint.
 it "ignores routes/ files without an onRequest handler" do
   tester.app.endpoints.any? { |e| e.url == "/dashboard_route" }.should be_false
+end
+
+# A `webSocketHandler` route is a single GET with the `ws` protocol, not a
+# 5-verb fall-back.
+it "narrows a WebSocket route to GET and marks the ws protocol" do
+  ws = tester.app.endpoints.select { |e| e.url == "/ws" }
+  ws.map(&.method).should eq(["GET"])
+  ws.first.protocol.should eq("ws")
 end

--- a/src/analyzer/analyzers/dart/dart_frog.cr
+++ b/src/analyzer/analyzers/dart/dart_frog.cr
@@ -86,11 +86,15 @@ module Analyzer::Dart
           # other non-route `.dart` that happens to live under `routes/`.
           next unless content.matches?(ON_REQUEST_HANDLER_REGEX)
 
-          methods = detect_methods(content)
+          # A `dart_frog_web_socket` route upgrades an HTTP GET; it does
+          # not serve the other verbs, so narrow it to GET (rather than the
+          # fall-back verb set) and mark the protocol as WebSocket.
+          websocket = websocket_route?(content)
+          methods = websocket ? ["GET"] : detect_methods(content)
           callees = include_callee ? callees_for_on_request(content, path) : [] of Noir::DartCalleeExtractor::Entry
           mutex.synchronize do
             methods.each do |verb|
-              result << build_endpoint(url, verb, path, callees)
+              result << build_endpoint(url, verb, path, callees, websocket)
             end
           end
         end
@@ -101,11 +105,19 @@ module Analyzer::Dart
       result
     end
 
+    # A route file whose handler upgrades to a WebSocket. `webSocketHandler`
+    # is the `package:dart_frog_web_socket` entry point.
+    private def websocket_route?(content : String) : Bool
+      content.includes?("webSocketHandler")
+    end
+
     private def build_endpoint(url : String,
                                verb : String,
                                path : String,
-                               callees : Array(Noir::DartCalleeExtractor::Entry) = [] of Noir::DartCalleeExtractor::Entry) : Endpoint
+                               callees : Array(Noir::DartCalleeExtractor::Entry) = [] of Noir::DartCalleeExtractor::Entry,
+                               websocket : Bool = false) : Endpoint
       endpoint = Endpoint.new(url, verb)
+      endpoint.protocol = "ws" if websocket
       endpoint.details = Details.new(PathInfo.new(path, 1))
       url.scan(/\{(\w+)\}/) do |match|
         endpoint.push_param(Param.new(match[1], "", "path"))

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -492,7 +492,7 @@ module NoirTechs
           :cookie => false,
         },
         :static_path => false,
-        :websocket   => false,
+        :websocket   => true,
       },
     },
     :dart_serverpod => {


### PR DESCRIPTION
## Problem

A `dart_frog_web_socket` route handler upgrades an HTTP **GET** request — it does not serve POST/PUT/DELETE/PATCH. But such a handler has no `HttpMethod.*` references, so the analyzer fell back to the standard 5-verb set, reporting **four phantom verbs** for every WebSocket endpoint:

```dart
import 'package:dart_frog_web_socket/dart_frog_web_socket.dart';

Future<Response> onRequest(RequestContext context) async {
  final handler = webSocketHandler((channel, protocol) { ... });
  return handler(context);
}
```

→ previously emitted `GET POST PUT DELETE PATCH /ws` (4 phantom).

## Fix

Detect the `webSocketHandler` entry point and, for those routes, emit a single `GET` and set the endpoint protocol to `ws` — matching how the `go/fiber` and `python/fastapi` analyzers report WebSocket endpoints. The `dart_frog` tech's `websocket` capability flag flips to `true`.

## Real-app impact

| App | Route | Before → After |
|-----|-------|----------------|
| df_realtimechat | `/ws/{room}` | 5 verbs → `GET` (`protocol: ws`) |
| df_talkstream | `/chat/ws` | 5 verbs → `GET` (`protocol: ws`) |
| dart_frog example | `web_socket_counter/routes/ws.dart` | 5 verbs → `GET` (`protocol: ws`) |

No change to non-WebSocket routes.

## Tests

- New `webSocketHandler` fixture route + assertions (GET-only method set, `ws` protocol).
- `crystal spec` full suite green (22559 examples, 0 failures); format + ameba clean; supported docs regenerated.

Co-authored-by: ksg97031 <ksg97031@gmail.com>