### PR TITLE
feat(analyzer/zig/jetzig): extract explicit app.route(...) custom routes

### DIFF
--- a/spec/functional_test/fixtures/zig/jetzig/src/app/api/products.zig
+++ b/spec/functional_test/fixtures/zig/jetzig/src/app/api/products.zig
@@ -1,0 +1,25 @@
+const jetzig = @import("jetzig");
+
+// A view module reached only through explicit `app.route(...)` registrations
+// (it lives under `app/api/`, not `app/views/`, so resourceful routing never
+// mounts it). Its action functions still supply the route callees.
+
+pub fn index(request: *jetzig.Request) !jetzig.View {
+    _ = try Product.findAll();
+    return request.render(.ok);
+}
+
+pub fn get(id: []const u8, request: *jetzig.Request) !jetzig.View {
+    _ = try Product.find(id);
+    return request.render(.ok);
+}
+
+pub fn post(request: *jetzig.Request) !jetzig.View {
+    try Product.create(.{});
+    return request.render(.created);
+}
+
+pub fn delete(id: []const u8, request: *jetzig.Request) !jetzig.View {
+    try Product.destroy(id);
+    return request.render(.ok);
+}

--- a/spec/functional_test/fixtures/zig/jetzig/src/main.zig
+++ b/spec/functional_test/fixtures/zig/jetzig/src/main.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+const jetzig = @import("jetzig");
+
+pub fn init(app: *jetzig.App) !void {
+    // Explicit custom routes pointing at a view module outside `app/views/`.
+    app.route(.GET, "/api/products", @import("app/api/products.zig"), .index);
+    app.route(.GET, "/api/products/:id", @import("app/api/products.zig"), .get);
+    app.route(.POST, "/api/products", @import("app/api/products.zig"), .post);
+    // A commented-out registration must NOT be picked up.
+    // app.route(.DELETE, "/api/products/:id", @import("app/api/products.zig"), .delete);
+}

--- a/spec/functional_test/testers/zig/jetzig_spec.cr
+++ b/spec/functional_test/testers/zig/jetzig_spec.cr
@@ -40,6 +40,20 @@ expected_endpoints << jetzig_endpoint("/posts/:id", "DELETE", id_param, [
 expected_endpoints << jetzig_endpoint("/admin/users", "GET")
 expected_endpoints << jetzig_endpoint("/admin/users/:id", "GET", id_param)
 
+# Explicit `app.route(...)` custom routes in main.zig. The view module under
+# `app/api/` is resolved cross-file for callees; the commented `.DELETE`
+# registration is excluded.
+expected_endpoints << jetzig_endpoint("/api/products", "GET", [] of Param, [
+  Callee.new("Product.findAll"),
+  Callee.new("request.render"),
+])
+expected_endpoints << jetzig_endpoint("/api/products/:id", "GET", id_param, [
+  Callee.new("Product.find"),
+])
+expected_endpoints << jetzig_endpoint("/api/products", "POST", [] of Param, [
+  Callee.new("Product.create"),
+])
+
 FunctionalTester.new("fixtures/zig/jetzig/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -37,20 +37,30 @@ module Analyzer::Zig
     ACTION_FN_RE = /(?:^|[^A-Za-z0-9_.])pub\s+fn\s+(index|get|new|edit|post|put|patch|delete)\s*\(/
     PARAM_GET_RE = /\b(?:params|query)\s*\.\s*get\s*\(\s*"([^"]+)"/
 
+    # Explicit custom route registered in the app's startup hook, e.g.
+    #   app.route(.GET, "/api/products/:id", @import("app/api/products.zig"), .get);
+    # The view module lives outside `app/views/` (so resourceful routing never
+    # sees it) and the action is named by the trailing `.<action>` enum literal.
+    CUSTOM_ROUTE_RE = /\.\s*route\s*\(\s*\.\s*(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|CONNECT|TRACE)\s*,\s*"(\/[^"]*)"\s*,\s*@import\s*\(\s*"([^"]+\.zig)"\s*\)\s*,\s*\.\s*(\w+)\s*\)/
+
     def analyze
       include_callee = callees_needed?
 
       all_files.each do |path|
         next unless path.ends_with?(".zig")
-        next unless jetzig_view?(path)
 
         content = read_file_content(path)
+
         # A view file always references the framework (`*jetzig.Request`,
         # `!jetzig.View`); gate on it so an unrelated `.zig` file that
         # happens to live under an `app/views/` tree isn't mined for routes.
-        next unless content.includes?("jetzig")
+        if jetzig_view?(path) && content.includes?("jetzig")
+          process_view(path, content, include_callee)
+        end
 
-        process_view(path, content, include_callee)
+        # Explicit `app.route(...)` registrations live in the startup file
+        # (`main.zig`), not under `app/views/`.
+        process_custom_routes(path, content, include_callee) if content.includes?(".route(")
       end
 
       @result
@@ -99,6 +109,55 @@ module Analyzer::Zig
 
         @result << endpoint
       end
+    end
+
+    # Explicit `app.route(.VERB, "/path", @import("view.zig"), .action)`
+    # registrations. The path is taken verbatim (with `:param` placeholders),
+    # the verb from the enum literal, and 1-hop callees from the named action
+    # function in the imported view module (which lives outside `app/views/`,
+    # so it is resolved cross-file here).
+    private def process_custom_routes(path : String, content : String, include_callee : Bool)
+      text = Noir::ZigCalleeExtractor.strip_comments(content)
+      dir = File.dirname(path)
+
+      text.scan(CUSTOM_ROUTE_RE) do |m|
+        method = m[1]
+        url = m[2]
+        import_rel = m[3]
+        action = m[4]
+
+        line = Noir::ZigCalleeExtractor.line_at(text.chars, m.begin(0) || 0)
+        endpoint = Endpoint.new(url, method, path_params(url), Details.new(PathInfo.new(path, line)))
+
+        if include_callee
+          view_path = File.expand_path(File.join(dir, import_rel))
+          action_callees(view_path, action).tap do |callees|
+            Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+          end
+        end
+
+        @result << endpoint
+      end
+    end
+
+    # 1-hop callees of the named action function inside an `@import`-ed view
+    # module. Returns empty when the file or function can't be resolved.
+    private def action_callees(view_path : String, action : String) : Array(Noir::ZigCalleeExtractor::Entry)
+      return [] of Noir::ZigCalleeExtractor::Entry unless view_path.ends_with?(".zig") && File.file?(view_path)
+      content = read_file_content(view_path)
+      bodies = Noir::ZigCalleeExtractor.function_bodies(content, view_path)
+      if body = bodies[action]?
+        return Noir::ZigCalleeExtractor.callees_for_body(body[:body], body[:path], body[:start_line])
+      end
+      [] of Noir::ZigCalleeExtractor::Entry
+    end
+
+    private def path_params(url : String) : Array(Param)
+      params = [] of Param
+      url.scan(/:([A-Za-z_]\w*)/) do |m|
+        params << Param.new(m[1], "", "path")
+      end
+      params
     end
 
     # Resource path = the view file path below `app/views/`, extension


### PR DESCRIPTION
## Summary

Jetzig supports two routing styles. Filesystem **resourceful** routing (`app/views/<name>.zig`) was already covered; **explicit custom routes** registered in the startup hook were not:

```zig
pub fn init(app: *jetzig.App) !void {
    app.route(.GET,    "/api/products",     @import("app/api/products.zig"), .index);
    app.route(.GET,    "/api/products/:id", @import("app/api/products.zig"), .get);
    app.route(.POST,   "/api/products",     @import("app/api/products.zig"), .post);
}
```

The view module lives **outside** `app/views/`, so filesystem routing never mounts it and every such endpoint was dropped.

This scans files containing `.route(` for `app.route(.VERB, "/path", @import("view.zig"), .action)` and:
- emits the route verbatim, with `:param` path parameters;
- resolves 1-hop callees from the named action function in the imported module (cross-file, since the view isn't a resourceful view).

Comments are stripped first, so a commented-out `// app.route(...)` (common in the jetzig demo scaffold) is correctly ignored.

## Real-world impact (cloned OSS)
| app | before | after |
|---|---|---|
| muthuishere/jetzig-web-app-demo | 1 | 7 (6 `/api/*` routes recovered, with cross-file callees) |

No change to resourceful-only apps (jetzig demo 32, thienpow/zui 27, zecrets 4, cheffy 1) — the commented demo registration stays excluded.

## Test
`spec/functional_test/fixtures/zig/jetzig` gains a `main.zig` with three live `app.route(...)` registrations + one commented, and an `app/api/products.zig` view module. The spec asserts the routes, `:id` params, cross-file callees, and exclusion of the commented `.DELETE`. Full zig suite green (200 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)