### PR TITLE
fix(analyzer/clojure/ring): detect bare-string case/condp URI dispatch

### DIFF
--- a/spec/functional_test/fixtures/clojure/ring/src/demo/core.clj
+++ b/spec/functional_test/fixtures/clojure/ring/src/demo/core.clj
@@ -28,5 +28,25 @@
     :else
     {:status 404}))
 
+;; Bare-string `case`/`condp` dispatch directly on the URI (no method): each
+;; key-position `/`-string is a GET route. A `case` on any non-`(:uri …)`
+;; value (here `(:server-name req)`) must NOT emit phantom routes.
+(defn uri-handler [req]
+  (case (:uri req)
+    "/about"       (about-page)
+    "/contact/:id" (contact-page req)
+    (not-found)))
+
+(defn uri-condp-handler [req]
+  (condp = (:uri req)
+    "/status"            {:status 200}
+    ("/up" "/readiness") {:status 200}
+    (default)))
+
+(defn host-router [req]
+  (case (:server-name req)
+    "/admin-host" (admin-app req)
+    (main-app req)))
+
 (defn -main [& _args]
   (jetty/run-jetty handler {:port 3000}))

--- a/spec/functional_test/testers/clojure/ring_spec.cr
+++ b/spec/functional_test/testers/clojure/ring_spec.cr
@@ -8,6 +8,13 @@ expected_endpoints = [
   Endpoint.new("/metrics", "GET"),
   Endpoint.new("/sessions", "DELETE"),
   Endpoint.new("/version", "GET"),
+  Endpoint.new("/about", "GET"),
+  Endpoint.new("/contact/:id", "GET", [
+    Param.new("id", "", "path"),
+  ]),
+  Endpoint.new("/status", "GET"),
+  Endpoint.new("/up", "GET"),
+  Endpoint.new("/readiness", "GET"),
 ]
 
 FunctionalTester.new("fixtures/clojure/ring/", {

--- a/src/analyzer/analyzers/clojure/ring.cr
+++ b/src/analyzer/analyzers/clojure/ring.cr
@@ -91,6 +91,9 @@ module Analyzer::Clojure
             else
               walk_forms(source, after_symbol, form_end, path, seen, and_method)
             end
+          when "case", "condp"
+            extract_uri_case_dispatch(source, base, after_symbol, form_end, path, seen)
+            walk_forms(source, after_symbol, form_end, path, seen, and_method)
           else
             walk_forms(source, after_symbol, form_end, path, seen, and_method)
           end
@@ -99,6 +102,68 @@ module Analyzer::Clojure
         else
           i += 1
         end
+      end
+    end
+
+    # `(case (:uri request) "/a" h1 "/b" h2 default)` and
+    # `(condp = (:uri request) "/a" h1 "/b" h2 default)` dispatch directly on
+    # the request URI with bare string keys. Only fires when the dispatch value
+    # is a `(:uri ...)` accessor (and, for condp, the predicate is `=`), so a
+    # `case` on any other value never produces phantom routes. Each clause key
+    # in *key position* that is a `/`-rooted string literal — or a list of them
+    # `("/a" "/b")` for fall-through — becomes a GET endpoint.
+    private def extract_uri_case_dispatch(source : String, base : String, start : Int32, limit : Int32,
+                                          path : String, seen : Set(String))
+      i = skip_ws_and_comments(source, start, limit)
+
+      if base == "condp"
+        pred, after_pred = read_form_token(source, i, limit)
+        return unless pred == "="
+        i = after_pred
+      end
+
+      dispatch, after_dispatch = read_form_token(source, i, limit)
+      return unless uri_accessor?(dispatch)
+
+      emit_string_clause_keys(source, after_dispatch, limit, path, seen)
+    end
+
+    # Walk `key value key value … [default]` clauses, emitting an endpoint for
+    # every key-position `/`-rooted string. Values (handler forms) are skipped
+    # so a handler that happens to return a `/`-string is never a route.
+    private def emit_string_clause_keys(source : String, start : Int32, limit : Int32,
+                                        path : String, seen : Set(String))
+      i = skip_ws_and_comments(source, start, limit)
+      is_key = true
+      while i < limit
+        token, after = read_form_token(source, i, limit)
+        break if token.empty?
+
+        if is_key
+          if token.starts_with?('"')
+            route = decode_literal(token)
+            emit_endpoint(source, path, i, "GET", route, seen) if route.starts_with?('/')
+          elsif token.starts_with?('(')
+            # Fall-through list of keys: `("/a" "/b")` — each string is a route.
+            emit_list_string_keys(source, i + 1, find_matching_delimiter(source, i, '(', ')', limit), path, seen)
+          end
+        end
+
+        is_key = !is_key
+        i = after
+      end
+    end
+
+    private def emit_list_string_keys(source : String, start : Int32, limit : Int32, path : String, seen : Set(String))
+      i = skip_ws_and_comments(source, start, limit)
+      while i < limit
+        token, after = read_form_token(source, i, limit)
+        break if token.empty?
+        if token.starts_with?('"')
+          route = decode_literal(token)
+          emit_endpoint(source, path, i, "GET", route, seen) if route.starts_with?('/')
+        end
+        i = after
       end
     end
 


### PR DESCRIPTION
## Description
The raw-Ring analyzer's own docstring says it extracts endpoints from `case`, `condp`, or `cond` dispatch — but in practice it only matched `[:method "/path"]` vector keys and `(= "/path" (:uri …))` comparisons. The idiomatic **URI-only** form, with bare string keys, produced **zero** endpoints:
```clojure
(case (:uri request)
  "/"      (home-page request)
  "/about" (about-page request)
  (not-found))

(condp = (:uri request)
  "/login"  (login request)
  "/logout" (logout request)
  (default))
```

## Fix
`extract_uri_case_dispatch`: when a `case` (or `condp =`) dispatches on a `(:uri …)` accessor, each **key-position** `/`-rooted string literal becomes a GET endpoint. A fall-through list of keys `("/a" "/b")` emits both. Path params (`/contact/:id`) are extracted as usual.

The match is **strictly gated** on the dispatch value being `(:uri …)`, so a `case`/`condp` on any other value (`(:server-name req)`, `(:status resp)`, a let-bound symbol) emits nothing — no phantom routes. Handler values are skipped, so a clause whose handler returns a `/`-string is never mistaken for a route.

## Validation
- Synthetic probes: `case`/`condp` URI dispatch → correct routes incl. fall-through lists + path params; FP guards (`case` on `:server-name`/`:status`/let-bound var) → 0 endpoints.
- Full functional suite: **19027 examples, 0 failures**. fmt + ameba clean. Fixture regression + FP guard added.

Co-authored-by: ksg97031 <ksg97031@gmail.com>