### PR TITLE
fix(analyzer/swift/kitura): make route detection receiver-aware to kill phantom endpoints

### DIFF
--- a/spec/functional_test/fixtures/swift/kitura/routes.swift
+++ b/spec/functional_test/fixtures/swift/kitura/routes.swift
@@ -52,9 +52,11 @@ router.get("/profile") { request, response, next in
     next()
 }
 
-// DELETE route
+// DELETE route. The Fluent-style `Grade.delete(id:)` call inside the handler
+// has a non-router receiver and must NOT be reported as an endpoint.
 router.delete("/users/:id") { request, response, next in
     let id = request.parameters["id"]
+    Grade.delete(id: id, completion)
     response.status(.OK)
     next()
 }

--- a/src/analyzer/analyzers/swift/kitura.cr
+++ b/src/analyzer/analyzers/swift/kitura.cr
@@ -14,16 +14,26 @@ module Analyzer::Swift
     ROUTE_BODY_LOOKAHEAD_LIMIT = LOOKAHEAD_LIMIT
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 
+    # `let router = Router()` / `func boot(router: Router)` — the receivers a
+    # Kitura route is registered on. Tracking them makes detection
+    # receiver-aware, so look-alike `.get`/`.delete`/... calls on models or
+    # services (`Grade.delete(id:)`, `cache.get(...)`) stop becoming phantom
+    # endpoints.
+    ROUTER_ASSIGN_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*Router\s*[(<]/
+    ROUTER_PARAM_PATTERN  = /([A-Za-z_]\w*)\s*:\s*Router\b/
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       handler_bodies = named_handler_bodies(lines)
+      router_receivers = collect_router_receivers(lines)
 
       lines.each_with_index do |line, index|
         next unless route_definition_line?(line)
         match = line.match(ROUTE_PATTERN)
         next unless match
+        next unless router_receivers.includes?(match[1])
 
         begin
           # Note: 'all' matches all HTTP methods, defaulting to GET for representation
@@ -121,6 +131,23 @@ module Analyzer::Swift
       route_definition?(line) &&
         !line.includes?("request.parameters") &&
         !line.includes?("request.queryParameters")
+    end
+
+    # The set of router-like receiver names: every `Router()` binding, every
+    # `Router`-typed parameter, plus the conventional `router` whenever a
+    # `.router` property (`app.router`, `self.router`) is accessed — that
+    # access is exactly the receiver `ROUTE_PATTERN` captures for
+    # `app.router.get(...)`.
+    private def collect_router_receivers(lines : Array(String)) : Set(String)
+      receivers = Set(String).new
+      lines.each do |line|
+        if match = line.match(ROUTER_ASSIGN_PATTERN)
+          receivers << match[1]
+        end
+        line.scan(ROUTER_PARAM_PATTERN) { |m| receivers << m[1] }
+        receivers << "router" if line.matches?(/\.router\b/)
+      end
+      receivers
     end
 
     private def attach_route_callees(lines : Array(String),


### PR DESCRIPTION
## Summary

The Kitura analyzer matched **any** `receiver.get/post/put/delete/patch/all(...)` call as a route, so model/service look-alikes became phantom endpoints — e.g. `Grade.delete(id: id, completion)` surfaced as `DELETE /`.

## Fix

Gate route detection on a **router-like receiver** — the same approach the Vapor and Hummingbird analyzers use. A receiver counts as router-like when it is:
- a `Router()` binding (`let router = Router()`),
- a `Router`-typed parameter (`func boot(router: Router)`), or
- the conventional `router`, registered whenever a `.router` property (`app.router`, `self.router`) is accessed — exactly the receiver `ROUTE_PATTERN` captures for `app.router.get(...)`.

## Validation

Real-world `Kitura-Sample`: 54 → **53** — drops the `Grade.delete` phantom `DELETE /`; all 53 real routes retained (61 route calls on `router`, deduped). Added a `Grade.delete(id:)` look-alike to the `kitura` fixture as a regression guard. Kitura specs pass (71 examples).

Co-authored-by: ksg97031 <ksg97031@gmail.com>