### PR TITLE
style(spec/dart): fix ameba Style/VerboseBlock in angel3 tester

### DIFF
--- a/spec/functional_test/testers/dart/angel3_spec.cr
+++ b/spec/functional_test/testers/dart/angel3_spec.cr
@@ -44,5 +44,5 @@ it "composes nested Angel3 group() prefixes" do
 end
 
 it "does not treat a package:http client get() as a route" do
-  tester.app.endpoints.any? { |found| found.url.includes?("example.com") }.should be_false
+  tester.app.endpoints.any?(&.url.includes?("example.com")).should be_false
 end


### PR DESCRIPTION
The `lint` CI job currently fails on `main`:

```
spec/functional_test/testers/dart/angel3_spec.cr:47:24 [Correctable]
[C] Style/VerboseBlock: Use short block notation instead: `any?(&.url.includes?("example.com"))`
```

This applies the ameba autocorrect (`any? { |found| found.url.includes?(...) }` → `any?(&.url.includes?(...))`), unblocking lint for all open PRs. Functionally identical; angel3 functional spec still passes (64 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>