### PR TITLE
fix(analyzer/scala/play): stop sub-routes prefix doubling and Scala/Java Play misdetection

### DIFF
--- a/spec/functional_test/fixtures/scala/play/conf/appeal.routes
+++ b/spec/functional_test/fixtures/scala/play/conf/appeal.routes
@@ -1,0 +1,5 @@
+# Sub-routes file written with absolute paths that already include the mount
+# prefix (lila convention). The `-> /appeal` include must not prepend again.
+GET  /appeal           controllers.Appeal.home
+GET  /appeal/landing   controllers.Appeal.landing(q: Option[String] ?= None)
+POST /appeal/:username controllers.Appeal.reply(username: String)

--- a/spec/functional_test/fixtures/scala/play/conf/routes
+++ b/spec/functional_test/fixtures/scala/play/conf/routes
@@ -23,3 +23,7 @@ POST /xml controllers.MissingController.xml
 POST /whitespace controllers.MissingController.whitespace
 
 -> /admin admin.Routes
+
+# lila-style include: the sub-routes file already carries the mount prefix,
+# so it must NOT be doubled into /appeal/appeal/...
+-> /appeal appeal.Routes

--- a/spec/functional_test/testers/scala/play_spec.cr
+++ b/spec/functional_test/testers/scala/play_spec.cr
@@ -49,6 +49,11 @@ expected_endpoints = [
     Param.new("id", "", "path"),
     Param.new("body", "", "json"),
   ]),
+  # Included sub-routes file written with absolute paths (lila convention):
+  # the `-> /appeal` prefix must not be doubled into /appeal/appeal/...
+  Endpoint.new("/appeal", "GET"),
+  Endpoint.new("/appeal/landing", "GET", [Param.new("q", "", "query")]),
+  Endpoint.new("/appeal/:username", "POST", [Param.new("username", "", "path")]),
 ]
 
 FunctionalTester.new("fixtures/scala/play/", {

--- a/spec/unit_test/detector/java/play_spec.cr
+++ b/spec/unit_test/detector/java/play_spec.cr
@@ -9,8 +9,12 @@ describe "Detect Java Play" do
     instance.detect("routes", "GET /users controllers.Users.list(page: Integer)").should be_true
   end
 
-  it "routes.conf file with Java-style route definitions (Boolean type)" do
-    instance.detect("routes.conf", "POST /users/:id controllers.Users.update(id: Long, active: Boolean)").should be_true
+  it "routes.conf file with Java-style Integer type alongside other params" do
+    instance.detect("routes.conf", "GET /users controllers.Users.list(page: Integer, active: Boolean)").should be_true
+  end
+
+  it "does not treat a Boolean-only routes file as Java (Boolean is also a Scala type)" do
+    instance.detect("routes.conf", "POST /users/:id controllers.Users.update(id: Long, active: Boolean)").should be_false
   end
 
   it "java file with play.mvc.Controller import" do

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -424,7 +424,7 @@ module Analyzer::Scala
         # Example: GET /users/:id controllers.Users.show(id: Long)
         if route_match = stripped_line.match(/^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+([^\s]+)\s+(.+)/)
           method = route_match[1]
-          route_path = join_paths(prefix, route_match[2])
+          route_path = join_included_route(prefix, route_match[2])
           action = route_match[3]
 
           endpoint = create_endpoint(route_path, method, path, index + 1)
@@ -520,6 +520,25 @@ module Analyzer::Scala
       return suffix if prefix.empty?
       return prefix.rstrip('/') if suffix.empty?
       "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
+    end
+
+    # Join a mount prefix onto a route defined in an included routes file, but
+    # don't double the prefix when the included file already carries it.
+    # Standard Play sub-routes are relative (`-> /appeal appeal.Routes` over
+    # `GET /landing` → `/appeal/landing`), but large apps such as lila write the
+    # full path in the sub-file (`GET /appeal/landing`), where prepending again
+    # would yield `/appeal/appeal/landing`. The boundary check (exact match or
+    # `prefix/…`) keeps a coincidental relative path like `/appeals` prefixed.
+    private def join_included_route(prefix : String, suffix : String) : String
+      return join_paths(prefix, suffix) if prefix.empty?
+
+      normalized_prefix = prefix.rstrip('/')
+      normalized_suffix = suffix.starts_with?('/') ? suffix : "/#{suffix}"
+      if normalized_suffix == normalized_prefix || normalized_suffix.starts_with?("#{normalized_prefix}/")
+        return normalized_suffix
+      end
+
+      join_paths(prefix, suffix)
     end
 
     # Extract path parameters from route pattern

--- a/src/detector/detectors/java/play.cr
+++ b/src/detector/detectors/java/play.cr
@@ -12,12 +12,14 @@ module Detector::Java
                        file_contents.includes?("play.routing")
       end
 
-      # Check routes file only if there are Java indicators nearby
+      # Check routes file only with a Java-specific type marker. `Integer` is
+      # Java-only (Scala routes use `Int`); `Boolean`/`Long` are shared with
+      # Scala, so keying on them misclassifies a Scala Play app as Java and runs
+      # a second analyzer over the same routes — lila's `Boolean` action params
+      # produced a full set of duplicate, prefix-doubled `java_play` endpoints.
       if filename.ends_with?("routes") || filename.ends_with?("routes.conf")
-        # Check for Play-style route definitions with Java-style types
         if file_contents =~ /^\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+/m
-          # Look for Java-specific patterns in routes file (e.g., Integer instead of Int)
-          return true if file_contents.includes?("Integer") || file_contents.includes?("Boolean")
+          return true if file_contents.includes?("Integer")
         end
       end
 


### PR DESCRIPTION
## Summary

Play accuracy sweep against real OSS, primarily **lichess (lila)** — the largest open-source Scala Play app — plus playframework/play-samples and play-scala-rest-api-example.

### Fixes

1. **`scala/play`: don't double a mount prefix the sub-routes file already carries.** Standard Play sub-routes are relative (`-> /admin admin.Routes` over `GET /stats` → `/admin/stats`), but lila writes the full path in the included file (`GET /appeal/landing` under `-> /appeal`), which the analyzer prepended again → `/appeal/appeal/landing`. Included routes now join with a boundary-aware check (exact match or `prefix/…`), so an already-prefixed sub-route is kept as-is while a coincidental relative path like `/appeals` is still prefixed.

2. **`detector/java/play`: drop the `Boolean` marker.** `Boolean` is a Scala type too, so a Scala Play routes file with an `active: Boolean` action param matched the *Java* Play detector and ran the Java analyzer over the same routes — producing a full set of duplicate, prefix-doubled `java_play` endpoints. `Integer` is the Java-only marker (Scala uses `Int`); genuine Java Play apps still detect via their `.java` `play.mvc` controllers.

### Impact (lila)

Before: `/appeal/appeal`, `/class/class/$id<…>`, `/report/report/…` doublings emitted as `java_play`, on top of the correct `scala_play` set. After: a single, correct `scala_play` set — `/appeal`, `/appeal/landing`, `/class/$id<…>`, etc. — matching lila's actual routes (lichess.org/appeal, not /appeal/appeal). ~40 prefix-doubled FPs removed; `java_play` no longer misfires on the Scala app. play-samples / rest-api unchanged.

### Tests

- Extended `fixtures/scala/play` with an absolute-path sub-routes include (`appeal.routes`) asserting no doubling.
- Updated the Java Play detector spec: a `Boolean`-only routes file must not be classified as Java.
- Full suite green.

Co-authored-by: ksg97031 <ksg97031@gmail.com>