### PR TITLE
fix(analyzer/perl/catalyst): drop phantom routes from unresolvable Moose-role chain fragments

### DIFF
--- a/spec/functional_test/fixtures/perl/catalyst/lib/MyApp/Role/Crud.pm
+++ b/spec/functional_test/fixtures/perl/catalyst/lib/MyApp/Role/Crud.pm
@@ -1,0 +1,15 @@
+package MyApp::Role::Crud;
+use Moose::Role;
+
+# A CRUD action carried by a Moose role. Its `Chained('object')` parent is
+# supplied by whichever controller composes the role at runtime, so within
+# this package the chain has no resolvable root. The analyzer must treat it
+# as an incomplete chain fragment and NOT invent a phantom top-level
+# `/purge` route (the real path is `/<controller>/<id>/purge`, which needs
+# runtime role composition static analysis cannot perform).
+sub purge : Chained('object') PathPart('purge') Args(0) {
+    my ( $self, $c ) = @_;
+    $c->stash( purged => 1 );
+}
+
+1;

--- a/spec/functional_test/testers/perl/catalyst_spec.cr
+++ b/spec/functional_test/testers/perl/catalyst_spec.cr
@@ -47,6 +47,10 @@ expected_endpoints = [
     Param.new("arg", "", "path"),
   ]),
   Endpoint.new("/preflight", "OPTIONS"),
+  # NB: lib/MyApp/Role/Crud.pm carries a `purge : Chained('object')` action
+  # whose parent is composed in at runtime. It must NOT surface as a phantom
+  # `/purge` route — the absence of any such endpoint here asserts that
+  # unresolvable chain fragments are dropped, not emitted at the root.
 ]
 
 FunctionalTester.new("fixtures/perl/catalyst/", {

--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -265,10 +265,18 @@ module Analyzer::Perl
       base = ""
       chained_to = first_attr(action, "chained")
       unless chained_to.empty? || chained_to == "/"
-        if parent = resolve_chained_parent(action, chained_to, actions_by_name, actions_by_private)
-          parent_path = chained_path(parent, actions_by_name, actions_by_private, seen)
-          base = parent_path || ""
-        end
+        # A named `Chained('parent')` that resolves to nothing is an
+        # incomplete chain fragment, not a standalone route. This happens
+        # when CRUD actions live in a Moose role/base controller and chain
+        # to a `base`/`object` link defined in a *different* package (the
+        # role is composed into many controllers at runtime, so the link
+        # only exists after composition). Emitting it would invent a phantom
+        # top-level path (`/create`, `/delete`), so skip it instead.
+        parent = resolve_chained_parent(action, chained_to, actions_by_name, actions_by_private)
+        return unless parent
+        parent_path = chained_path(parent, actions_by_name, actions_by_private, seen)
+        return if parent_path.nil?
+        base = parent_path
       end
 
       part = if attr_present?(action, "pathpart")


### PR DESCRIPTION
## Summary

Accuracy sweep of the **Catalyst** analyzer against 10 real-world OSS apps (metacpan-web, Gitalist, libki, manoc, WriteOff, ifcomp, HiveWeb, ox4li, openehr-web, CPAN-Magic-Mirror).

Standard Catalyst dispatch — `Chained`/`PathPart`/`CaptureArgs`/`Args`, cross-controller absolute chains, `Local`/`Path`/`Global`, REST `ActionClass('REST')` method handlers — verified **accurate** across all 10 apps. This PR fixes the one false-positive class found.

## Problem

Apps that build CRUD/URIStructure chains with **Moose roles** define the terminal action in one package and the `base`/`object`/`find` chain link in a *sibling* role composed into the controller at runtime:

```perl
# App::Manoc::ControllerRole::CommonCRUD / Gitalist::URIStructure::*
sub create : Chained('base')   PathPart('create') Args(0) { ... }
sub view   : Chained('object') PathPart('')       Args(0) { ... }
```

Statically the relative parent isn't in the action's own package, so the chain never resolves. The analyzer fell back to an empty base and emitted the action **at the document root** — phantom paths like `/create`, `/delete`, `/tree`, `/search` whose real location is `/<controller>/<id>/...` only after composition.

## Fix

`chained_path` now returns `nil` when a named (non-root) `Chained('parent')` can't be resolved, so the incomplete fragment is skipped rather than surfacing a misleading top-level route. Absolute chains (`Chained('/dist/root')`) and same-package relative chains are untouched.

## Impact

| app | before | after | note |
|-----|-------:|------:|------|
| metacpan-web / libki / WriteOff / HiveWeb / ifcomp / ox4li / openehr-web / cpan-magic-mirror | — | **unchanged** | standard in-controller dispatch, byte-for-byte identical |
| manoc | 64 | 20 | sheds phantom `/create`, `/delete`, `/list`, `/js`, … ; keeps every resolved route (`/ip/:cap/edit`, `/query/*`, …) |
| gitalist | 28 | 8 | sheds phantom `/tree`, `/search`, `/atom`, … ; keeps resolved routes (`/`, `/opml`, `/legacy/:arg`, …) |

Only the two role-composition apps change, and they shed **only** phantom paths. Scan time unchanged.

## Follow-up

Fully *resolving* these chains — composing role/base actions into each consuming controller and honoring `__PACKAGE__->config(action => { setup => { PathPart => ... }})` — would recover the real paths (`/building/create`, `/<repo>/tree`). That's a larger feature tracked separately; this PR removes the misleading output in the meantime.

## Tests

- New fixture `lib/MyApp/Role/Crud.pm` asserts a role-composed `Chained('object')` fragment is not emitted as `/purge`.
- Full suite green (`crystal spec spec/functional_test/` — 19174 examples, 0 failures); `crystal tool format` + ameba clean.

Co-authored-by: ksg97031 <ksg97031@gmail.com>