### PR TITLE
fix(analyzer/swift/vapor): register .grouped(...) bindings with a dotted base

### DIFF
--- a/spec/functional_test/fixtures/swift/vapor/routes.swift
+++ b/spec/functional_test/fixtures/swift/vapor/routes.swift
@@ -10,7 +10,14 @@ func routes(_ app: Application) throws {
     app.get("hello") { req -> String in
         return "Hello, world!"
     }
-    
+
+    // Multi-segment grouped base (`app.routes.grouped(...)`): the new group
+    // must register as router-like with the composed prefix.
+    let v2 = app.routes.grouped("v2")
+    v2.get("ping") { req -> String in
+        return "pong"                            // GET /v2/ping
+    }
+
     // POST route with body
     app.post("users") { req -> EventLoopFuture<User> in
         let user = try req.content.decode(User.self)

--- a/spec/functional_test/testers/swift/vapor_spec.cr
+++ b/spec/functional_test/testers/swift/vapor_spec.cr
@@ -2,6 +2,7 @@ require "../../func_spec.cr"
 
 expected_endpoints = [
   Endpoint.new("/hello", "GET"),
+  Endpoint.new("/v2/ping", "GET"),
   Endpoint.new("/users", "POST"),
   Endpoint.new("/users/:userID", "GET"),
   Endpoint.new("/users/:userID/posts/:postID", "PUT"),

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -10,9 +10,11 @@ module Analyzer::Swift
     # app.get("path") { ... }
     # app.post("path", "segment") { ... }
     # routes.get("path", ":param") { ... }
-    ROUTE_PATTERN              = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\(/
-    ON_ROUTE_PATTERN           = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.on\s*\(/
-    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*(?:([A-Za-z_]\w*)\.)?grouped\s*\(/
+    ROUTE_PATTERN    = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.(get|post|put|delete|patch)\s*\(/
+    ON_ROUTE_PATTERN = /([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.on\s*\(/
+    # The base may be a dotted receiver (`app.routes.grouped(...)`), an implicit
+    # `self` (bare `grouped(...)`), or a single identifier (`router.grouped(...)`).
+    GROUP_ASSIGN_PATTERN       = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*(?:([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\.)?grouped\s*\(/
     GROUP_CLOSURE_PATTERN      = /([A-Za-z_]\w*)\.group(?:ed)?\s*\(/
     FUNCTION_SIGNATURE_PATTERN = /\bfunc\s+([A-Za-z_]\w*)\s*\(/
 


### PR DESCRIPTION
## Summary

Follow-up to #2064. `GROUP_ASSIGN_PATTERN` only captured a **single-identifier** base, so a route group bound through a multi-segment receiver was never registered as router-like:

```swift
let resourceServerProtected = app.routes.grouped(authMiddleware)
resourceServerProtected.post("oauth", "token_info", use: ...)   // was dropped
```

After the receiver-aware gating in #2064, an unregistered receiver means its routes are filtered out — so `POST /oauth/token_info` in `brokenhandsio/vapor-oauth` regressed to missing.

## Fix

Allow a dotted base (`app.routes.grouped(...)`) in the pattern. The prefix still resolves correctly through the existing per-segment `prefix_for_receiver` (`app` → root).

## Validation

`brokenhandsio/vapor-oauth` now reports `POST /oauth/token_info` again. (The pre-existing `GET /` it used to report was a `request.query.get(...)` false positive that stays correctly filtered.) No change to vapor-til (43), SteamPress (20), vapor repo (27), admin-panel (2). Extended the `vapor` fixture with an `app.routes.grouped("v2")` group; full Swift suite passes (234 examples).

Co-authored-by: ksg97031 <ksg97031@gmail.com>