### PR TITLE
fix(analyzer/scala/http4s): detect AuthedRoutes.of and resolve their mount prefix

### DIFF
--- a/spec/functional_test/fixtures/scala/http4s/Routes.scala
+++ b/spec/functional_test/fixtures/scala/http4s/Routes.scala
@@ -48,8 +48,18 @@ object Routes {
       Ok("ok")
   }
 
+  // AuthedRoutes wrapped in a middleware; the user is bound with `as`.
+  val secureRoutes: HttpRoutes[IO] = authMiddleware(AuthedRoutes.of[String, IO] {
+    case GET -> Root / "profile" as user =>
+      Ok(s"profile for $user")
+
+    case req @ POST -> Root / "account" as user =>
+      req.as[UpdateItem].flatMap(_ => Ok(s"updated by $user"))
+  })
+
   val httpApp = Router(
     "/api" -> userRoutes,
-    "/v1" -> healthRoutes
+    "/v1" -> healthRoutes,
+    "/auth" -> secureRoutes
   ).orNotFound
 }

--- a/spec/functional_test/testers/scala/http4s_spec.cr
+++ b/spec/functional_test/testers/scala/http4s_spec.cr
@@ -17,6 +17,9 @@ expected_endpoints = [
   Endpoint.new("/api/ping", "HEAD"),
   Endpoint.new("/api/bulk", "POST", [Param.new("body", "CreateUser", "json")]),
   Endpoint.new("/v1/health", "GET"),
+  # AuthedRoutes mounted at /auth; the trailing `as user` must not become a path.
+  Endpoint.new("/auth/profile", "GET"),
+  Endpoint.new("/auth/account", "POST", [Param.new("body", "UpdateItem", "json")]),
 ]
 
 FunctionalTester.new("fixtures/scala/http4s/", {

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -19,18 +19,26 @@ module Analyzer::Scala
       lines = content.split('\n')
       code_lines = scala_code_lines(content)
 
-      routes_names = collect_routes_bindings(content)
+      routes_names = collect_routes_bindings(code_lines)
       mount_prefixes = collect_mount_prefixes(code_lines, routes_names)
 
       current_routes_name : String? = nil
+      pending_def_name : String? = nil
 
       i = 0
       while i < lines.size
         stripped = code_lines[i]? || ""
         trimmed = stripped.strip
 
-        if m = stripped.match(/\b(?:val|def|lazy\s+val)\s+(\w+)\s*(?::[^=]*?)?=\s*HttpRoutes\.of\b/)
-          current_routes_name = m[1]
+        # The routes value/def header and the `HttpRoutes.of`/`AuthedRoutes.of`
+        # builder may sit on different lines (and the builder may be wrapped, as
+        # in `def authRoutes = basicAuth(AuthedRoutes.of { … })`), so remember
+        # the most recent binding name and attach it when the builder appears.
+        if dm = stripped.match(/(?<![.\w])(?:val|def|lazy\s+val)\s+(\w+)\b/)
+          pending_def_name = dm[1]
+        end
+        if pending_def_name && stripped.matches?(/(?:HttpRoutes|AuthedRoutes)\.of\b/)
+          current_routes_name = pending_def_name
         end
 
         if case_line?(trimmed)
@@ -134,6 +142,9 @@ module Analyzer::Scala
       return if methods.empty?
 
       remainder = body[method_match[0].size..].strip
+      # AuthedRoutes patterns end with `as <user>` — drop it so the trailing
+      # binding isn't mistaken for a path segment.
+      remainder = remainder.sub(/\s+as\s+\w+\s*$/, "")
 
       path_part = remainder
       query_part = ""
@@ -199,10 +210,16 @@ module Analyzer::Scala
       route_path
     end
 
-    private def collect_routes_bindings(content : String) : Set(String)
+    private def collect_routes_bindings(code_lines : Array(String)) : Set(String)
       names = Set(String).new
-      content.scan(/\b(?:val|def|lazy\s+val)\s+(\w+)\s*(?::[^=]*?)?=\s*HttpRoutes\.of\b/) do |m|
-        names << m[1]
+      pending : String? = nil
+      code_lines.each do |line|
+        if dm = line.match(/(?<![.\w])(?:val|def|lazy\s+val)\s+(\w+)\b/)
+          pending = dm[1]
+        end
+        if pending && line.matches?(/(?:HttpRoutes|AuthedRoutes)\.of\b/)
+          names << pending
+        end
       end
       names
     end


### PR DESCRIPTION
## Summary

http4s accuracy sweep (http4s example services, gvolpe/trading). http4s auth routes use `AuthedRoutes.of { case GET -> Root / "x" as user => }`, usually wrapped in a middleware and mounted via `Router("/auth" -> authRoutes)`. The analyzer only recognized `HttpRoutes.of`, required the builder to sit directly after `=`, and treated the trailing `as user` as a path segment — so every `AuthedRoutes` endpoint was dropped (or collapsed to `/`).

### Fixes

- Recognize `AuthedRoutes.of` alongside `HttpRoutes.of`.
- Bind the routes value name across lines and through a wrapping call (`def authRoutes = basicAuth(AuthedRoutes.of { … })`), so the `Router` mount prefix resolves.
- Strip the `as <user>` suffix before parsing path segments.

### Impact

http4s `ExampleService` now reports **`GET /auth/protected`** (AuthedRoutes mounted at `/auth`), previously missing entirely. `HttpRoutes.of` apps (gvolpe/trading) unchanged.

### Tests

- Extended `fixtures/scala/http4s/Routes.scala` with a middleware-wrapped `AuthedRoutes.of` mounted at `/auth` (`GET /auth/profile`, `POST /auth/account`), asserting detection, mount-prefix composition, and that `as user` is not a path segment.
- Full suite green.

Co-authored-by: ksg97031 <ksg97031@gmail.com>