### PR TITLE
fix(analyzer/scala/zio_http): declarative Endpoint DSL params + drop response-header FPs

### DIFF
--- a/spec/functional_test/fixtures/scala/zio_http/EndpointDsl.scala
+++ b/spec/functional_test/fixtures/scala/zio_http/EndpointDsl.scala
@@ -1,0 +1,33 @@
+package com.example.ziohttp
+
+import zio._
+import zio.http._
+import zio.http.codec._
+import zio.http.endpoint._
+
+object EndpointDsl {
+  // Declarative endpoint DSL. Path params come from the path; the trailing
+  // `.out[Int]` must NOT register a phantom `{id2}` path param.
+  val getUser =
+    Endpoint(Method.GET / "v2" / "users" / int("userId")).out[Int]
+
+  // Query params live on the codec chain, not in a handler block.
+  val listPosts =
+    Endpoint(Method.GET / "v2" / "users" / int("userId") / "posts")
+      .query(HttpCodec.query[String]("name"))
+      .out[List[String]]
+
+  // Response headers built with `Headers(Header.X(...))` must not be read as
+  // request header params.
+  val routes: Routes[Any, Response] = Routes(
+    Method.GET / "v2" / "download" -> handler { (req: Request) =>
+      Response(
+        body = Body.empty,
+        headers = Headers(
+          Header.ContentType(MediaType.application.`octet-stream`),
+          Header.ContentDisposition.attachment("file.bin")
+        )
+      )
+    },
+  )
+}

--- a/spec/functional_test/testers/scala/zio_http_spec.cr
+++ b/spec/functional_test/testers/scala/zio_http_spec.cr
@@ -21,6 +21,15 @@ expected_endpoints = [
     Param.new("X-API-Key", "", "header"),
   ]),
   Endpoint.new("/search", "POST", [Param.new("q", "", "query")]),
+  # Declarative Endpoint(...) DSL: trailing `.out[Int]` must not add a phantom
+  # path param; query comes from the `.query(...)` codec chain.
+  Endpoint.new("/v2/users/{userId}", "GET", [Param.new("userId", "", "path")]),
+  Endpoint.new("/v2/users/{userId}/posts", "GET", [
+    Param.new("userId", "", "path"),
+    Param.new("name", "", "query"),
+  ]),
+  # Response headers (`Headers(Header.ContentType(...))`) are not request params.
+  Endpoint.new("/v2/download", "GET"),
 ]
 
 FunctionalTester.new("fixtures/scala/zio_http/", {

--- a/src/analyzer/analyzers/scala/zio_http.cr
+++ b/src/analyzer/analyzers/scala/zio_http.cr
@@ -39,14 +39,21 @@ module Analyzer::Scala
             endpoint.push_param(Param.new(name, "", "path"))
           end
 
-          block_info = extract_handler_block(lines, index)
-          if block_info
-            block_content, block_start = block_info
-            extract_params_from_block(endpoint, block_content)
-            if include_callee
-              callees = Noir::ScalaCalleeExtractor.callees_for_body(block_content, path, block_start)
-              attach_scala_callees(endpoint, callees)
+          if arrow_idx
+            block_info = extract_handler_block(lines, index)
+            if block_info
+              block_content, block_start = block_info
+              extract_params_from_block(endpoint, block_content)
+              if include_callee
+                callees = Noir::ScalaCalleeExtractor.callees_for_body(block_content, path, block_start)
+                attach_scala_callees(endpoint, callees)
+              end
             end
+          else
+            # Declarative `Endpoint(Method.X / …)` form: query/header/body come
+            # from the codec chain (`.query(HttpCodec.query[T]("n"))`, `.in[T]`)
+            # that follows on continuation lines, not from a handler block.
+            extract_declarative_params(endpoint, collect_declarative_chain(code_lines, index))
           end
 
           endpoints << endpoint
@@ -110,6 +117,12 @@ module Analyzer::Scala
               params << name
             end
           end
+        elsif ch == ')'
+          # A bare `)` (matchers consume their own parens) closes the enclosing
+          # `Endpoint(Method.GET / …)` — the path ends here. Without this the
+          # trailing builder, e.g. `.out[Int]`, gets mis-parsed (the `Int` in
+          # `[Int]` would register a phantom `{id2}` path param).
+          break
         else
           i += 1
         end
@@ -122,6 +135,37 @@ module Analyzer::Scala
     private def matcher_ident?(ident : String) : Bool
       base = ident.includes?('.') ? ident.split('.').last : ident
       MATCHER_IDENTS.includes?(base.downcase)
+    end
+
+    # The codec chain of a declarative endpoint: the route line plus the
+    # following `.`-prefixed continuation lines (`.query(...)`, `.header(...)`,
+    # `.out[...]`).
+    private def collect_declarative_chain(code_lines : Array(String), index : Int32) : String
+      parts = [code_lines[index]? || ""]
+      idx = index + 1
+      while idx < code_lines.size
+        line = code_lines[idx]? || ""
+        break unless line.lstrip.starts_with?(".")
+        parts << line
+        idx += 1
+      end
+      parts.join("\n")
+    end
+
+    private def extract_declarative_params(endpoint : Endpoint, chain : String)
+      chain.scan(/\bquery\s*\[[^\]]*\]\s*\(\s*"([^"]+)"\s*\)/) do |m|
+        name = m[1]
+        unless endpoint.params.any? { |p| p.name == name && p.param_type == "query" }
+          endpoint.push_param(Param.new(name, "", "query"))
+        end
+      end
+
+      chain.scan(/\bheader\s*\[[^\]]*\]\s*\(\s*"([^"]+)"\s*\)/) do |m|
+        name = m[1]
+        unless endpoint.params.any? { |p| p.name == name && p.param_type == "header" }
+          endpoint.push_param(Param.new(name, "", "header"))
+        end
+      end
     end
 
     private def default_param_name(index : Int32) : String
@@ -168,8 +212,11 @@ module Analyzer::Scala
         end
       end
 
-      # Header objects: Header.Authorization, Header.ContentType — common typed-header lookups
-      block.scan(/Header\.([A-Z][A-Za-z0-9]+)/) do |match|
+      # Header objects read off the request: a bare reference like
+      # `req.header(Header.Authorization)`. Skip construction/builder forms —
+      # `Header.ContentType(MediaType…)` or `Header.ContentDisposition.attachment(…)`
+      # — which set RESPONSE headers, not request params (the `(?![\w(.])` guard).
+      block.scan(/Header\.([A-Z][A-Za-z0-9]+)(?![\w(.])/) do |match|
         typed_name = humanize_header(match[1])
         unless endpoint.params.any? { |p| p.name == typed_name && p.param_type == "header" }
           endpoint.push_param(Param.new(typed_name, "", "header"))


### PR DESCRIPTION
## Summary

ZIO HTTP accuracy sweep — zio/zio-quickstart and the zio-http example suite.

### Fixes

1. **FP — declarative endpoint trailing builder.** `Endpoint(Method.GET / "users" / int("id")).out[Int]` parsed the `Int` in `.out[Int]` as a bare `int` matcher, appending a phantom `{id2}` path param. Path parsing now stops at the `)` that closes the enclosing `Endpoint(...)`.

2. **FN — declarative endpoint query/header params.** Declarative endpoints carry query/header on the codec chain (`.query(HttpCodec.query[String]("name"))`) across continuation lines, which the analyzer never read (it only inspected a handler block). Collect the chain and extract query/header params.

3. **FP — response headers read as request params.** `Headers(Header.ContentType(...), Header.ContentDisposition.attachment(...))` set on a `Response` were extracted as request header params. The typed-header scan now skips construction (`Header.X(...)`) and builder (`Header.X.attachment`) forms, keeping only bare references like `req.header(Header.Authorization)`.

### Impact

- **zio-quickstart**: `GET /download` / `GET /download/stream` lose their bogus `Content-Type` / `Content-Disposition` header params.
- **zio-http EndpointExamples**: `GET /users/{userId}` (was `…/{userId}/{id2}`), `GET /users/{userId}/posts/{postId}` now carries its `name` query param.

### Tests

- New `fixtures/scala/zio_http/EndpointDsl.scala` covering the declarative DSL (`.out[Int]` no phantom param, `.query(...)` extraction) and a `Response` with constructed headers (no header FP).
- Full suite green.

Co-authored-by: ksg97031 <ksg97031@gmail.com>