### PR TITLE
fix(analyzer/zig/zap): support modern zap.Endpoint.init verb-field API

### DIFF
--- a/spec/functional_test/fixtures/zig/zap/src/main.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/main.zig
@@ -3,6 +3,7 @@ const zap = @import("zap");
 const UsersEndpoint = @import("users.zig");
 const HealthEndpoint = @import("health.zig");
 const Endpoints = @import("endpoints.zig");
+const ProjectsEndpoint = @import("projects.zig");
 
 const Handlers = struct {
     pub fn stats(_: *Handlers, r: zap.Request) !void {
@@ -25,6 +26,11 @@ pub fn main() !void {
     // `Endpoints` re-export and bound to `/comments` here.
     var comments = Endpoints.Comments{ .path = "/comments" };
     _ = &comments;
+
+    // Modern `zap.Endpoint.init(.{ .get = …, .post = … })` API — verbs from the
+    // init option fields, path from this `init("/projects")` binding.
+    var projects = ProjectsEndpoint.init("/projects");
+    _ = &projects;
 
     var router = zap.Router.init(std.heap.page_allocator, .{});
     defer router.deinit();

--- a/spec/functional_test/fixtures/zig/zap/src/projects.zig
+++ b/spec/functional_test/fixtures/zig/zap/src/projects.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const zap = @import("zap");
+
+// Modern `zap.Endpoint` API: the whole file is the endpoint struct, but the
+// supported verbs are declared as `zap.Endpoint.init(.{ .get = …, .post = … })`
+// option fields rather than `pub fn get`/… methods. The path is injected at
+// the `ProjectsEndpoint.init("/projects")` call site in main.zig.
+pub const Self = @This();
+
+ep: zap.Endpoint = undefined,
+
+pub fn init(path: []const u8) Self {
+    return .{
+        .ep = zap.Endpoint.init(.{
+            .path = path,
+            .get = getProject,
+            .post = postProject,
+        }),
+    };
+}
+
+fn getProject(_: *zap.Endpoint, r: zap.Request) !void {
+    try listProjects(r);
+}
+
+fn postProject(_: *zap.Endpoint, r: zap.Request) !void {
+    try saveProject(r);
+}
+
+fn listProjects(r: zap.Request) !void {
+    try r.sendJson("[]");
+}
+
+fn saveProject(r: zap.Request) !void {
+    try projectStore.insert(r.body);
+}

--- a/spec/functional_test/testers/zig/zap_spec.cr
+++ b/spec/functional_test/testers/zig/zap_spec.cr
@@ -20,6 +20,12 @@ expected_endpoints << zap_endpoint("/users", "POST", [Callee.new("createUser")])
 expected_endpoints << zap_endpoint("/comments", "GET", [Callee.new("listComments")])
 expected_endpoints << zap_endpoint("/comments", "POST", [Callee.new("createComment")])
 
+# Modern `zap.Endpoint.init(.{ .get = …, .post = … })` API — verbs from the
+# init option fields, path from the `ProjectsEndpoint.init("/projects")`
+# binding, callees from each bound handler's body.
+expected_endpoints << zap_endpoint("/projects", "GET", [Callee.new("listProjects")])
+expected_endpoints << zap_endpoint("/projects", "POST", [Callee.new("saveProject")])
+
 # Router handle_func / handle_func_unbound routes.
 expected_endpoints << zap_endpoint("/stats", "GET", [Callee.new("r.sendJson")])
 expected_endpoints << zap_endpoint("/ping", "GET", [Callee.new("r.sendBody")])

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -31,6 +31,13 @@ module Analyzer::Zig
     LITERAL_PATH_RE = /\.path\s*=\s*"([^"]*)"/
     HANDLE_FUNC_RE  = /\.\s*handle_func(_unbound)?\s*\(/
     IMPORT_RE       = /(?:pub\s+)?(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*@import\(\s*"([^"]+\.zig)"\s*\)/
+    # Modern `zap.Endpoint.init(.{ .path = …, .get = handler, … })` API: the
+    # supported HTTP methods are declared as option *fields* bound to handler
+    # functions, instead of as `pub fn get`/… verb methods on the struct. The
+    # path field is usually a parameter resolved at the `T.init("/p", …)` call
+    # site, so it is reused through the same `bindings` machinery.
+    ENDPOINT_INIT_RE = /(?:zap\s*\.\s*)?Endpoint\s*\.\s*init\s*\(\s*\.\s*\{/
+    INIT_VERB_RE     = /\.\s*(get|post|put|delete|patch|options|head)\s*=\s*&?\s*([A-Za-z_][\w.]*)/
 
     private record StructRegion, name : String, start : Int32, stop : Int32
 
@@ -145,26 +152,77 @@ module Analyzer::Zig
     end
 
     private def emit_endpoint_structs(path, content, stripped, comment_stripped, bindings, explicit, all_fns, include_callee)
+      code_chars = stripped.chars
+
       # Explicit `const X = struct { … }` endpoints.
       explicit.each do |region|
         verbs = verb_methods_in(all_fns, region.start, region.stop) do |off|
           innermost_region(explicit, off) == region
         end
-        next if verbs.empty?
+        api_verbs = endpoint_api_verbs(comment_stripped, code_chars) do |off|
+          off > region.start && off < region.stop && innermost_region(explicit, off) == region
+        end
+        next if verbs.empty? && api_verbs.empty?
         paths = resolve_paths(region.name, path, comment_stripped, region.start, region.stop, bindings)
-        emit_struct_endpoints(path, region.name, paths, verbs, include_callee)
+        emit_struct_endpoints(path, region.name, paths, verbs, include_callee) unless verbs.empty?
+        emit_endpoint_api(path, paths, api_verbs, all_fns, code_chars, include_callee) unless api_verbs.empty?
       end
 
       # File-as-struct (`pub const X = @This();`) endpoints: every verb method
-      # not already claimed by an explicit nested struct belongs to it.
+      # (or `Endpoint.init` verb field) not already claimed by an explicit
+      # nested struct belongs to it.
       if m = stripped.match(THIS_DECL_RE)
         name = m[1]
         verbs = all_fns.select do |f|
           VERBS.includes?(f[:name]) && innermost_region(explicit, f[:open]).nil?
         end
-        unless verbs.empty?
+        api_verbs = endpoint_api_verbs(comment_stripped, code_chars) do |off|
+          innermost_region(explicit, off).nil?
+        end
+        unless verbs.empty? && api_verbs.empty?
           paths = resolve_paths(name, path, comment_stripped, 0, content.size, bindings)
-          emit_struct_endpoints(path, name, paths, verbs, include_callee)
+          emit_struct_endpoints(path, name, paths, verbs, include_callee) unless verbs.empty?
+          emit_endpoint_api(path, paths, api_verbs, all_fns, code_chars, include_callee) unless api_verbs.empty?
+        end
+      end
+    end
+
+    private record ApiVerb, verb : String, handler : String, off : Int32
+
+    # Verb fields of `zap.Endpoint.init(.{ .get = h, .post = h, … })` blocks
+    # whose opening offset satisfies the given scope predicate. Each yields the
+    # HTTP verb plus the handler function it is bound to.
+    private def endpoint_api_verbs(comment_stripped : String, code_chars : Array(Char), & : Int32 -> Bool) : Array(ApiVerb)
+      result = [] of ApiVerb
+      comment_stripped.scan(ENDPOINT_INIT_RE) do |m|
+        off = m.begin(0) || 0
+        next unless yield off
+        brace = (m.end(0) || 0) - 1
+        close = Noir::ZigCalleeExtractor.find_matching(code_chars, brace, '{', '}')
+        next if close.nil?
+        block = comment_stripped[(brace + 1)...close]? || ""
+        block.scan(INIT_VERB_RE) do |vm|
+          entry = ApiVerb.new(vm[1], vm[2], off)
+          result << entry unless result.includes?(entry)
+        end
+      end
+      result
+    end
+
+    private def emit_endpoint_api(path, paths, api_verbs : Array(ApiVerb), all_fns, code_chars : Array(Char), include_callee)
+      return if paths.empty?
+      paths.each do |url|
+        api_verbs.each do |entry|
+          method = VERB_METHOD[entry.verb]
+          name = entry.handler.includes?('.') ? entry.handler.split('.').last : entry.handler
+          fn = all_fns.find { |f| f[:name] == name }
+          line = fn ? fn[:start_line] : Noir::ZigCalleeExtractor.line_at(code_chars, entry.off)
+          endpoint = Endpoint.new(url, method, [] of Param, Details.new(PathInfo.new(path, line)))
+          if include_callee && fn
+            callees = Noir::ZigCalleeExtractor.callees_for_body(fn[:body], path, fn[:start_line])
+            Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+          end
+          @result << endpoint
         end
       end
     end


### PR DESCRIPTION
## Summary

Newer zap (v0.9+) declares an endpoint's supported HTTP methods as **option fields** of `zap.Endpoint.init(.{ … })` instead of as `pub fn get`/… verb methods:

```zig
pub const Self = @This();
ep: zap.Endpoint = undefined,

pub fn init(path: []const u8) Self {
    return .{ .ep = zap.Endpoint.init(.{
        .path = path,
        .get = getUser,
        .post = createUser,
    }) };
}
```

Such a struct defines no verb methods, so the file-as-struct (`pub const Self = @This()`) was emitted with **zero routes**.

This scans `Endpoint.init(.{ … })` blocks — brace-matched on the string-blanked char array, scoped to the enclosing explicit struct or to file level — for `.verb = handler` fields and emits one endpoint per verb. The path still resolves through the existing instantiation-site bindings (`T.init("/projects")`), and callees come from each bound handler function's body.

## Real-world impact (cloned OSS)
| app | before | after |
|---|---|---|
| ElrohirGT/JUWURA (backend) | 0 | 3 (`POST`/`PUT /projects`, `GET /users`, with callees) |

No change to apps using the verb-method or `handle_func` styles (zigzap/zap examples 21, technologylab-ai/fj 15, RestTest 2).

## Test
`spec/functional_test/fixtures/zig/zap` gains a `projects.zig` using the `Endpoint.init(.{.get=,.post=})` API, instantiated with an `init("/projects")` path binding. The spec asserts both routes resolve with handler-body callees. Full zig suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)