### PR TITLE
fix(analyzer/scala/scalatra): compose servlet mount prefixes and skip test sources

### DIFF
--- a/spec/functional_test/fixtures/scala/scalatra_mount/src/main/scala/ScalatraBootstrap.scala
+++ b/spec/functional_test/fixtures/scala/scalatra_mount/src/main/scala/ScalatraBootstrap.scala
@@ -1,0 +1,9 @@
+import com.example.ApiController
+import org.scalatra._
+import javax.servlet.ServletContext
+
+class ScalatraBootstrap extends LifeCycle {
+  override def init(context: ServletContext): Unit = {
+    context.mount(new ApiController, "/api/users")
+  }
+}

--- a/spec/functional_test/fixtures/scala/scalatra_mount/src/main/scala/com/example/ApiController.scala
+++ b/spec/functional_test/fixtures/scala/scalatra_mount/src/main/scala/com/example/ApiController.scala
@@ -1,0 +1,21 @@
+package com.example
+
+import org.scalatra._
+
+// Mounted at "/api/users" in ScalatraBootstrap, so every route below is served
+// under that prefix.
+class ApiController extends ScalatraServlet {
+  get("/") {
+    "list of users"
+  }
+
+  get("/:id") {
+    val id = params("id")
+    s"user $id"
+  }
+
+  post("/") {
+    val name = params("name")
+    s"created $name"
+  }
+}

--- a/spec/functional_test/fixtures/scala/scalatra_mount/src/test/scala/com/example/ApiControllerSpec.scala
+++ b/spec/functional_test/fixtures/scala/scalatra_mount/src/test/scala/com/example/ApiControllerSpec.scala
@@ -1,0 +1,21 @@
+package com.example
+
+import org.scalatra.test.scalatest._
+
+// Test client calls — `get(...)`/`post(...)` here are HTTP requests, not route
+// definitions, and must not be reported as endpoints.
+class ApiControllerSpec extends ScalatraFunSuite {
+  addServlet(classOf[ApiController], "/api/users/*")
+
+  test("lists users") {
+    get("/api/users/42") {
+      status should equal(200)
+    }
+  }
+
+  test("creates a user") {
+    post("/api/users/", "name" -> "dave") {
+      status should equal(200)
+    }
+  }
+}

--- a/spec/functional_test/testers/scala/scalatra_mount_spec.cr
+++ b/spec/functional_test/testers/scala/scalatra_mount_spec.cr
@@ -1,0 +1,15 @@
+require "../../func_spec.cr"
+
+# ApiController is mounted at "/api/users" in ScalatraBootstrap, so each route is
+# served under that prefix. The `get(...)`/`post(...)` calls in the test spec are
+# HTTP client requests, not route definitions, and must be excluded.
+expected_endpoints = [
+  Endpoint.new("/api/users", "GET"),
+  Endpoint.new("/api/users/:id", "GET", [Param.new("id", "", "path")]),
+  Endpoint.new("/api/users", "POST", [Param.new("name", "", "query")]),
+]
+
+FunctionalTester.new("fixtures/scala/scalatra_mount/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -11,9 +11,57 @@ module Analyzer::Scala
       {method, /(?<![.\w])#{method}\s*\(\s*"([^"]+)"/}
     end
 
+    # Servlet/filter class name -> mount prefix, harvested from
+    # `context.mount(new XController, "/prefix")` in ScalatraBootstrap.
+    @mount_prefixes = {} of String => String
+
+    def analyze
+      @mount_prefixes = build_mount_prefixes
+      parallel_file_scan do |path|
+        result.concat(analyze_file(path))
+      end
+      result
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
+      return [] of Endpoint if scalatra_test_path?(path)
       content = File.read(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
+    end
+
+    # Scalatra (like a servlet container) mounts each servlet/filter at a base
+    # path in ScalatraBootstrap; without it every route is reported relative to
+    # its servlet (`/:id`) instead of the served path (`/hackers-api/:id`).
+    private def build_mount_prefixes : Hash(String, String)
+      map = {} of String => String
+      all_files.each do |path|
+        next if File.directory?(path)
+        next unless File.exists?(path) && File.extname(path) == ".scala"
+        next if scalatra_test_path?(path)
+        begin
+          content = File.read(path)
+        rescue
+          next
+        end
+        next unless content.includes?("mount")
+
+        scala_code_lines(content).each do |line|
+          next unless line.includes?("mount")
+          line.scan(/\bmount\s*\(\s*(?:new\s+)?([A-Za-z_][\w.]*).*?"(\/[^"]*)"/) do |m|
+            cls = m[1].split('.').last
+            map[cls] ||= normalize_mount_prefix(m[2])
+          end
+        end
+      end
+      map
+    end
+
+    private def normalize_mount_prefix(prefix : String) : String
+      prefix.rstrip("/*")
+    end
+
+    private def scalatra_test_path?(path : String) : Bool
+      path.includes?("/src/test/") || path.includes?("/src/sbt-test/")
     end
 
     # Extract routes from Scalatra DSL
@@ -21,6 +69,7 @@ module Analyzer::Scala
       endpoints = [] of Endpoint
       lines = content.split('\n')
       code_lines = scala_code_lines(content)
+      mount_prefix = single_mount_prefix(code_lines)
 
       lines.each_with_index do |_line, index|
         stripped_line = (code_lines[index]? || "").strip
@@ -35,7 +84,8 @@ module Analyzer::Scala
             # Only process if it looks like a URL path (starts with /)
             next unless route_path.starts_with?("/")
 
-            endpoint = create_endpoint(route_path, method.upcase, path, index + 1)
+            full_path = apply_mount_prefix(mount_prefix, route_path)
+            endpoint = create_endpoint(full_path, method.upcase, path, index + 1)
 
             # Extract path parameters from the route
             extract_path_params(endpoint, route_path)
@@ -130,6 +180,32 @@ module Analyzer::Scala
           endpoint.push_param(Param.new(param_name, "", "cookie"))
         end
       end
+    end
+
+    # A controller file usually declares one servlet; if exactly one class/object
+    # in it has a mount prefix, every route in the file is served under it. When
+    # the file holds several mounted classes the mapping is ambiguous, so fall
+    # back to no prefix rather than risk a wrong one.
+    private def single_mount_prefix(code_lines : Array(String)) : String
+      return "" if @mount_prefixes.empty?
+
+      prefixes = Set(String).new
+      code_lines.each do |line|
+        next unless line.includes?("class") || line.includes?("object") || line.includes?("trait")
+        line.scan(/(?<![.\w])(?:class|object|trait)\s+(\w+)/) do |m|
+          if pfx = @mount_prefixes[m[1]]?
+            prefixes << pfx
+          end
+        end
+      end
+
+      prefixes.size == 1 ? prefixes.first : ""
+    end
+
+    private def apply_mount_prefix(prefix : String, route : String) : String
+      return route if prefix.empty?
+      return prefix if route == "/" || route.empty?
+      "#{prefix}/#{route.lstrip('/')}"
     end
 
     # Create an endpoint with the given path and method


### PR DESCRIPTION
## Summary

Scalatra accuracy sweep against scalatra/scalatra-in-action.

### Fixes

1. **FN — servlet mount prefixes.** Scalatra (servlet-style) mounts each servlet at a base path in `ScalatraBootstrap` (`context.mount(new ApiController, "/hackers-api")`), but routes were reported relative to the servlet (`/:id` instead of `/hackers-api/:id`). Harvest the `class → prefix` map from `mount(...)` calls across the project and prepend it to the routes of the mounted class declared in each file (single-class-per-file; ambiguous multi-class files fall back to no prefix).

2. **FP — test sources.** `get("/x/42")` / `post("/x", ...)` inside `src/test` specs are HTTP client calls, not route definitions, yet were reported as endpoints. Skip `/src/test/` and `/src/sbt-test/`, consistent with the Play/Tapir analyzers.

### Impact (scalatra-in-action)

Routes now carry their mount prefix — `GET /hackers-api/:id`, `GET /hackers/new`, `GET /database/create`, `GET /sessions/new`, … (were `/:id`, `/new`, `/create`). ~10 test-request FPs (`GET /greet/dave`, `PUT /routes/100?routeName=foo&description=bar`, …) removed.

### Tests

- New `fixtures/scala/scalatra_mount/` with a `ScalatraBootstrap` mounting `ApiController` at `/api/users`, plus a `src/test` spec whose client calls must be excluded.
- Existing Scalatra fixtures (no mounts) unchanged. Full suite green.

Co-authored-by: ksg97031 <ksg97031@gmail.com>