### PR TITLE
fix(tagger/webhook): stop tagging OAuth/SSO authorization-code callbacks

### DIFF
--- a/spec/unit_test/tagger/taggers/webhook_spec.cr
+++ b/spec/unit_test/tagger/taggers/webhook_spec.cr
@@ -80,6 +80,33 @@ describe "WebhookTagger" do
       endpoint.tags.size.should eq(0)
     end
 
+    it "does not tag an OAuth/OIDC authorization-code callback (FP guard)" do
+      ["/api/oauth/callback", "/oauth2/callback", "/openid/callback",
+       "/auth/google/callback", "/auth/:provider/callback",
+       "/users/auth/github/callback"].each do |path|
+        tagger = WebhookTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(path, "POST", [
+          Param.new("code", "", "query"),
+          Param.new("state", "", "query"),
+        ])
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(0)
+      end
+    end
+
+    it "still tags a webhook under an auth path via a strong signal" do
+      tagger = WebhookTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/auth/webhooks/provider", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("webhook")
+    end
+
     it "does not tag an unrelated endpoint" do
       tagger = WebhookTagger.new(default_tagger_options)
 

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -28,6 +28,19 @@ class WebhookTagger < Tagger
   # several analyzers emit for catch-all routes.
   READ_ONLY_METHODS = Set{"GET", "HEAD", "OPTIONS"}
 
+  # OAuth / OIDC / SSO authorization-code callbacks (`/oauth/callback`,
+  # `/auth/<provider>/callback`) are browser-redirect handlers, not
+  # inbound webhooks — but they share the generic `callback` path word and
+  # can arrive as a POST, so they were being mis-tagged. When `callback`
+  # is the *only* webhook signal and one of these auth segments is present
+  # in the path, suppress it. A genuine payment IPN at `/payments/callback`
+  # carries no auth segment and still tags.
+  AUTH_CALLBACK_SEGMENTS = Set{
+    "oauth", "oauth2", "openid", "oidc", "auth", "authentication",
+    "sso", "saml", "login", "signin",
+  }
+  CALLBACK_PARTS = Set{"callback", "callbacks"}
+
   # Provider-specific signature/event headers. Any one is a strong
   # webhook indicator on its own.
   SIGNATURE_HEADERS = Set{
@@ -84,7 +97,15 @@ class WebhookTagger < Tagger
   end
 
   private def medium_webhook_url?(url : String) : Bool
-    url_parts(url).any? { |part| MEDIUM_PATH_PARTS.includes?(part) }
+    parts = url_parts(url)
+    matched = parts.select { |part| MEDIUM_PATH_PARTS.includes?(part) }
+    return false if matched.empty?
+
+    # A non-callback medium word (hook/hooks/notify) is a webhook signal on
+    # its own. Bare callback(s) under an OAuth/SSO segment is an auth
+    # redirect handler, not a webhook — drop that lone signal.
+    return true if matched.any? { |part| !CALLBACK_PARTS.includes?(part) }
+    parts.none? { |part| AUTH_CALLBACK_SEGMENTS.includes?(part) }
   end
 
   private def url_parts(url : String) : Array(String)


### PR DESCRIPTION
## Summary

Found while running `noir -T` (all taggers) against real OSS apps. The **webhook** tagger was tagging OAuth/OIDC/SSO authorization-code callbacks as inbound webhooks.

The tagger flags any write-method route whose path contains the generic `callback` word (alongside `hook`/`hooks`/`notify`). But OAuth/OIDC/SSO callbacks (`/api/oauth/callback`, `/auth/<provider>/callback`) are **browser-redirect handlers**, not server-to-server webhooks — and several arrive as `POST`, so they tripped the write-method gate.

### Real-world false positives
| App | Endpoint | Was |
|-----|----------|-----|
| immich | `POST /api/oauth/callback` | `webhook` |
| discourse | `POST /auth/:provider/callback` (OmniAuth SSO) | `webhook` |

### Fix
Suppress the **lone** `callback`/`callbacks` signal when an auth-provider segment (`oauth`/`oauth2`/`openid`/`oidc`/`auth`/`authentication`/`sso`/`saml`/`login`/`signin`) is present in the path.

Preserved:
- A genuine payment IPN at `/payments/callback` (no auth segment) — still tagged.
- Any `/auth/.../webhooks/...` route — still tagged via the strong `webhook` signal.
- Real webhooks in the corpus (mailgun, mandrill, patreon, `/chat/hooks/:key`) — unchanged.

### Validation
- immich: webhook FP `1 → 0`
- discourse: webhook `26 → 25` (only the OmniAuth callback dropped; all real webhooks kept)
- New FP-guard spec cases; full tagger unit suite green (238 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>