### PR TITLE
feat(analyzer/dart/get_server): resolve inter-constant path interpolation

### DIFF
--- a/spec/functional_test/fixtures/dart/get_server/lib/main.dart
+++ b/spec/functional_test/fixtures/dart/get_server/lib/main.dart
@@ -17,6 +17,8 @@ void main() {
         GetPage(name: Routes.SOCKET, page: () => SocketPage(), method: Method.ws),
         // `name:` as a plain string literal.
         GetPage(name: '/health', page: () => HealthPage(), method: Method.get),
+        // Resolves the inter-constant interpolation `'$API/items'` → `/api/items`.
+        GetPage(name: Routes.ITEMS, page: () => ItemsPage(), method: Method.get),
       ],
       port: 8080,
     ),

--- a/spec/functional_test/fixtures/dart/get_server/lib/pages.dart
+++ b/spec/functional_test/fixtures/dart/get_server/lib/pages.dart
@@ -9,3 +9,5 @@ class UploadPage extends Widget {}
 class SocketPage extends Widget {}
 
 class HealthPage extends Widget {}
+
+class ItemsPage extends Widget {}

--- a/spec/functional_test/fixtures/dart/get_server/lib/routes.dart
+++ b/spec/functional_test/fixtures/dart/get_server/lib/routes.dart
@@ -6,4 +6,8 @@ class Routes {
   static const USER = '/user/:id';
   static const UPLOAD = '/upload';
   static const SOCKET = '/socket';
+
+  // One path constant interpolated into another resolves transitively.
+  static const API = '/api';
+  static const ITEMS = '$API/items';
 }

--- a/spec/functional_test/testers/dart/get_server_spec.cr
+++ b/spec/functional_test/testers/dart/get_server_spec.cr
@@ -18,6 +18,9 @@ expected_endpoints = [
   get_server_endpoint("/socket", "GET", [] of Param, [Callee.new("SocketPage", line: 17)]),
   # Plain string-literal name.
   get_server_endpoint("/health", "GET", [] of Param, [Callee.new("HealthPage", line: 19)]),
+  # `Routes.ITEMS = '$API/items'` resolves the inter-constant
+  # interpolation to `/api/items`.
+  get_server_endpoint("/api/items", "GET", [] of Param, [Callee.new("ItemsPage", line: 21)]),
 ]
 
 # `name: Routes.USER` → `/user/:id` → `{id}`; no `method:` defaults to

--- a/src/analyzer/analyzers/dart/get_server.cr
+++ b/src/analyzer/analyzers/dart/get_server.cr
@@ -82,7 +82,46 @@ module Analyzer::Dart
         logger.debug e
       end
 
+      # A path constant can interpolate another (`const TURN_OFF =
+      # '$TUYA/turn_off'`); resolve those references now that every
+      # constant has been collected project-wide.
+      resolve_const_interpolations(const_map)
+
       assemble(raw_pages, const_map, include_callee)
+    end
+
+    INTERP_BRACE = /\$\{([^}]+)\}/
+    INTERP_BARE  = /\$([A-Za-z_]\w*)/
+
+    # Substitute `$IDENT` / `${expr}` interpolations with the referenced
+    # path constant's value (by bare constant name). Unknown references are
+    # left untouched.
+    private def resolve_interpolation(value : String, const_map : Hash(String, String)) : String
+      result = value.gsub(INTERP_BRACE) do
+        key = $~[1].strip.split('.').last
+        const_map[key]? || $~[0]
+      end
+      result.gsub(INTERP_BARE) do
+        const_map[$~[1]]? || $~[0]
+      end
+    end
+
+    # Resolve constant-to-constant interpolation to a fixpoint (a few
+    # passes settle chains like `B = '$A/x'`, `C = '$B/y'`). Capped so an
+    # unresolved/cyclic reference can't loop forever.
+    private def resolve_const_interpolations(const_map : Hash(String, String))
+      5.times do
+        changed = false
+        const_map.each do |key, value|
+          next unless value.includes?('$')
+          resolved = resolve_interpolation(value, const_map)
+          if resolved != value
+            const_map[key] = resolved
+            changed = true
+          end
+        end
+        break unless changed
+      end
     end
 
     # `static const NAME = '/path'` (and plain `const NAME = '/path'`)
@@ -155,7 +194,9 @@ module Analyzer::Dart
     private def resolve_name(arg : String, const_map : Hash(String, String)) : String?
       stripped = arg.strip
       if literal = Helper.extract_string_literal(stripped)
-        return normalize_path(literal)
+        # `name: '$TUYA/turn_off'` — an interpolated literal resolves
+        # against the collected path constants.
+        return normalize_path(resolve_interpolation(literal, const_map))
       end
       # Reference to a path constant (`Routes.HOME` / `HOME`): resolve by
       # the bare constant name.


### PR DESCRIPTION
## Summary

Follow-up to #2065 (GetServer support). GetServer route paths are frequently declared as `static const` values that **interpolate another path constant**:

```dart
static const TUYA = '/tuya';
static const TURN_OFF = '$TUYA/turn_off';      // → /tuya/turn_off
static const CHANGE_COLOR = '$TUYA/change_color';
```

The analyzer stored the raw constant value, so `GetPage(name: Routes.TURN_OFF, ...)` surfaced as **`/$TUYA/turn_off`** (an unresolved interpolation).

## Fix

Resolve `$IDENT` / `${expr}` interpolations against the project-wide path constants — to a fixpoint so chained references (`B = '$A/x'`, `C = '$B/y'`) settle — both when finalizing the constant map and when a `GetPage(name: '$TUYA/...')` uses an interpolated string literal directly. Unknown references are left intact.

## Real-app impact

`makayasa/donation_webhook`: `/$TUYA/turn_off`, `/$TUYA/turn_on`, `/$TUYA/change_color` → `/tuya/turn_off`, `/tuya/turn_on`, `/tuya/change_color`. Other GetServer apps unchanged (fw_getserver 45, gs_ormmysql 4, gs_example 21).

## Tests

- Extended the get_server fixture with an interpolated constant (`ITEMS = '$API/items'` → `/api/items`) + spec assertion.
- `crystal spec` full suite green (22667 examples, 0 failures); format + ameba clean.

Co-authored-by: ksg97031 <ksg97031@gmail.com>