### PR TITLE
fix(analyzer/zig): skip vendored framework test/example trees (FP)

### DIFF
--- a/spec/functional_test/fixtures/zig/httpz/deps/httpz/src/tests/test_router.zig
+++ b/spec/functional_test/fixtures/zig/httpz/deps/httpz/src/tests/test_router.zig
@@ -1,0 +1,15 @@
+const httpz = @import("../httpz.zig");
+
+// This file belongs to a *vendored copy of the httpz framework* checked into
+// the source tree (`deps/httpz/…`), not to the application. Its route literal
+// must NOT surface as an app endpoint — the analyzer skips vendored framework
+// trees. If the skip regresses, `/vendored-phantom` would push the endpoint
+// count over the expected total and fail the functional test.
+test "router registers a route" {
+    var router = testRouter();
+    router.get("/vendored-phantom", phantomHandler, .{});
+}
+
+fn phantomHandler(_: *httpz.Request, res: *httpz.Response) !void {
+    try res.write("phantom");
+}

--- a/spec/functional_test/testers/zig/httpz_spec.cr
+++ b/spec/functional_test/testers/zig/httpz_spec.cr
@@ -35,6 +35,10 @@ expected_endpoints << httpz_endpoint("/items/", "GET", [] of Param, [Callee.new(
 expected_endpoints << httpz_endpoint("/items/:id", "GET", [Param.new("id", "", "path")], [Callee.new("lookupItem")])
 expected_endpoints << httpz_endpoint("/items/", "POST", [] of Param, [Callee.new("saveItem")])
 
+# `deps/httpz/src/tests/test_router.zig` is a vendored copy of the framework
+# checked into the tree; its `/vendored-phantom` route must be skipped, so the
+# endpoint total stays exactly the list above.
+
 FunctionalTester.new("fixtures/zig/httpz/", {
   :techs     => 1,
   :endpoints => expected_endpoints.size,

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -34,6 +34,7 @@ module Analyzer::Zig
 
       all_files.each do |path|
         next unless path.ends_with?(".zig")
+        next if Noir::ZigCalleeExtractor.vendored_framework_path?(path)
         content = read_file_content(path)
         # Route-bearing files don't always reference `httpz` literally — a
         # common layout registers routes in a helper `fn group(router: *Foo)`

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -48,6 +48,7 @@ module Analyzer::Zig
 
       all_files.each do |path|
         next unless path.ends_with?(".zig")
+        next if Noir::ZigCalleeExtractor.vendored_framework_path?(path)
 
         content = read_file_content(path)
 

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -71,7 +71,9 @@ module Analyzer::Zig
 
     def analyze
       include_callee = callees_needed?
-      zig_files = all_files.select(&.ends_with?(".zig"))
+      zig_files = all_files.select do |f|
+        f.ends_with?(".zig") && !Noir::ZigCalleeExtractor.vendored_framework_path?(f)
+      end
 
       alias_to_file = build_alias_map(zig_files)
       mounts = build_router_mounts(zig_files, alias_to_file)

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -54,7 +54,9 @@ module Analyzer::Zig
 
     def analyze
       include_callee = callees_needed?
-      zig_files = all_files.select(&.ends_with?(".zig"))
+      zig_files = all_files.select do |f|
+        f.ends_with?(".zig") && !Noir::ZigCalleeExtractor.vendored_framework_path?(f)
+      end
 
       bindings = build_path_bindings(zig_files)
 

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -45,6 +45,20 @@ module Noir::ZigCalleeExtractor
   # every handler and drowns the meaningful callees.
   NOISE_ROOTS = Set{"std"}
 
+  # A `.zig` file that belongs to a *vendored copy of a framework* checked into
+  # the source tree (`zig-pkg/zap/…`, `src/deps/tokamak/…`) rather than to the
+  # application. Such trees ship the framework's own tests and examples
+  # (`zap/src/tests/test_auth.zig`'s `.path = "/test"`, `tokamak/example/`'s
+  # `@"GET /:name"`), whose route literals would otherwise surface as phantom
+  # app endpoints. The standard fetched-dependency cache (`.zig-cache`) is
+  # already pruned upstream; this matches the manual-vendoring layouts —
+  # a vendor directory immediately followed by a framework package directory.
+  VENDORED_FRAMEWORK_RE = %r{/(?:deps|dep|lib|libs|vendor|vendored|pkg|pkgs|zig-pkg|packages|third_party|third-party|modules|subprojects|external|\.deps)/(?:zap|httpz|http\.zig|tokamak|jetzig|zmpl|zmd)/}
+
+  def vendored_framework_path?(path : String) : Bool
+    !VENDORED_FRAMEWORK_RE.match(path.gsub('\\', '/')).nil?
+  end
+
   # A call expression: an optional `@` (builtin) + identifier, then any number
   # of `.identifier` accessors, immediately followed by `(`. The lookbehind
   # stops the match from starting in the middle of an identifier or chain, so


### PR DESCRIPTION
## Summary

When a project checks a **framework's own source into its tree** (`zig-pkg/zap/…`, `src/deps/tokamak/…`) instead of fetching it into `.zig-cache`, the analyzers scanned the framework's bundled tests and examples and emitted their route literals as phantom **app** endpoints:

- zap's `src/tests/test_auth.zig` → `.path = "/test"` (× all verbs)
- tokamak's `example/src/example.zig` → `@"GET /:name"`

Added a shared `Noir::ZigCalleeExtractor.vendored_framework_path?` that matches a **vendor directory immediately followed by a framework package directory** (`/deps/tokamak/`, `/zig-pkg/zap/`, etc.), and skip such files in all four Zig analyzers. The standard fetched-dependency cache (`.zig-cache`) is already pruned upstream; this covers the manual-vendoring layouts that land inside the source tree.

## Real-world impact (cloned OSS)
| app | before | after | dropped |
|---|---|---|---|
| ElrohirGT/JUWURA (`zig-pkg/zap/src/tests`) | 10 | 3 | 7 phantom `/test` |
| MartinAbilev/bugs (`deps/tokamak/example`) | 6 | 5 | `/api/:name` |

No change to any app that doesn't vendor a framework into its source tree (verified across 25 cloned apps).

## Test
`spec/functional_test/fixtures/zig/httpz/deps/httpz/src/tests/test_router.zig` is a vendored framework file with a `/vendored-phantom` route; the httpz functional test asserts the endpoint total is unchanged (the phantom is skipped). Full zig suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)