### PR TITLE
style(spec/dart): use short block notation in angel3 spec (ameba)

### DIFF
--- a/spec/functional_test/testers/dart/angel3_spec.cr
+++ b/spec/functional_test/testers/dart/angel3_spec.cr
@@ -44,5 +44,5 @@ it "composes nested Angel3 group() prefixes" do
 end
 
 it "does not treat a package:http client get() as a route" do
-  tester.app.endpoints.any? { |found| found.url.includes?("example.com") }.should be_false
+  tester.app.endpoints.any?(&.url.includes?("example.com")).should be_false
 end


### PR DESCRIPTION
## Summary

Pre-existing `Style/VerboseBlock` ameba failure on `main` (introduced with the Angel3 spec in #2054) that turns the `lint` check red on every PR branched after it:

```
spec/functional_test/testers/dart/angel3_spec.cr:47:24 [Correctable]
[C] Style/VerboseBlock: Use short block notation instead: `any?(&.url.includes?("example.com"))`
```

Applies the autocorrect — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)