### PR TITLE
fix(tagger/debug): ignore URI scheme so deep-link bundle-id flavors don't match

### DIFF
--- a/spec/unit_test/tagger/taggers/debug_spec.cr
+++ b/spec/unit_test/tagger/taggers/debug_spec.cr
@@ -183,5 +183,29 @@ describe "DebugTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "does not tag a deep-link whose scheme bundle id has a `debug` build flavor (FP guard)" do
+      ["ShareMedia-app.futo.immich.debug.Widget://",
+       "ShareMedia-app.futo.immich.debug.ShareExtension://",
+       "com.example.app.debug://"].each do |url|
+        tagger = DebugTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(url, "GET")
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(0)
+      end
+    end
+
+    it "still tags a real debug deep-link target after the scheme" do
+      tagger = DebugTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("myapp://debug/console", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("debug")
+    end
   end
 end

--- a/src/tagger/taggers/debug.cr
+++ b/src/tagger/taggers/debug.cr
@@ -81,14 +81,29 @@ class DebugTagger < Tagger
   end
 
   private def url_parts(url : String) : Array(String)
-    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+    strip_scheme(url).downcase.split(/[\/\-_\.]+/).reject(&.empty?)
   end
 
   # Slash/dot-delimited segments only (hyphens and underscores kept
   # inside a segment), so `internal` matches as its own path component
   # but not as part of a compound word.
   private def internal_segment?(url : String) : Bool
-    url.downcase.split(/[\/.]+/).reject(&.empty?).any? { |seg| INTERNAL_SEGMENTS.includes?(seg) }
+    strip_scheme(url).downcase.split(/[\/.]+/).reject(&.empty?).any? { |seg| INTERNAL_SEGMENTS.includes?(seg) }
+  end
+
+  # Drop a leading URI scheme (`scheme://`) before tokenizing. Mobile
+  # deep-link entry points arrive as custom-scheme URLs whose scheme is the
+  # app's reverse-domain bundle id — e.g.
+  # `ShareMedia-app.futo.immich.debug.Widget://`, where `debug` is the build
+  # *flavor*, not a debug endpoint. Tokenizing the scheme produced a false
+  # `debug` match; the authority/path after `://` (the real deep-link
+  # target, e.g. `myapp://debug-console`) is kept and still matched.
+  private def strip_scheme(url : String) : String
+    if idx = url.index("://")
+      url[(idx + 3)..]
+    else
+      url
+    end
   end
 
   private def normalize_param_name(name : String) : String


### PR DESCRIPTION
## Summary

Found while running `noir -T` against real OSS apps (immich). The **debug** tagger flagged mobile deep-link entry points as debug endpoints.

The tagger tokenizes the whole endpoint URL (split on `/ - _ .`). Mobile deep links emitted by the Android/iOS analyzers arrive as custom-scheme URLs whose scheme is the app's reverse-domain **bundle id**. When the bundle id carries a `debug` build flavor, the `debug` token tripped the tagger — even though there is no debug endpoint.

### Real-world false positives (immich)
| Endpoint | Was |
|----------|-----|
| `GET ShareMedia-app.futo.immich.debug.Widget://` | `debug` |
| `GET ShareMedia-app.futo.immich.debug.ShareExtension://` | `debug` |

Here `futo.immich.debug` is the debug-build bundle prefix, not a route.

### Fix
Strip a leading `scheme://` before tokenizing. The authority/path **after** `://` (the real deep-link target, e.g. `myapp://debug-console`) is kept and still matched, and plain `/debug/...` web paths are unaffected (no scheme present).

### Validation
- immich `debug` false positives: **2 → 0**
- No other tags changed across the corpus (immich/discourse/ctfd/oscar/redash/gophish/bitwarden/medusa).
- New FP-guard + true-positive spec cases; full tagger unit suite green (240 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>