### PR TITLE
fix(tagger/account_recovery): recognize spelled-out MFA, WebAuthn, and passkey routes

### DIFF
--- a/spec/unit_test/tagger/taggers/account_recovery_spec.cr
+++ b/spec/unit_test/tagger/taggers/account_recovery_spec.cr
@@ -149,5 +149,42 @@ describe "AccountRecoveryTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "tags spelled-out multi-factor paths the bare 2fa/mfa words miss" do
+      ["/two-factor/authenticator", "/two_factor/yubikey",
+       "/twofactor", "/u/preferences/second-factor",
+       "/account/multi-factor/enroll"].each do |path|
+        tagger = AccountRecoveryTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(path, "POST")
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("account_recovery")
+      end
+    end
+
+    it "tags WebAuthn / passkey credential ceremonies" do
+      ["/accounts/webauthn/assertion-options", "/session/passkey/challenge",
+       "/u/create_passkey", "/passkeys"].each do |path|
+        tagger = AccountRecoveryTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(path, "POST")
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("account_recovery")
+      end
+    end
+
+    it "does not tag a path that merely contains the squished form as a substring" do
+      tagger = AccountRecoveryTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/twofactorial/results", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/src/tagger/taggers/account_recovery.cr
+++ b/src/tagger/taggers/account_recovery.cr
@@ -16,7 +16,18 @@ class AccountRecoveryTagger < Tagger
   # does not).
   STRONG_PATH_PARTS = Set{
     "password", "passwd", "forgot", "mfa", "2fa", "totp", "otp",
+    # WebAuthn / FIDO2 passkey ceremonies are credential registration and
+    # step-up authentication — squarely credential-management. These
+    # survive the separator split as whole segments.
+    "webauthn", "passkey", "passkeys",
   }
+
+  # Spelled-out multi-factor path words. The generic separator split turns
+  # `two-factor` into the harmless tokens `[two, factor]`, so the `mfa`/`2fa`
+  # forms above never match these. Checked against separator-stripped slash
+  # segments instead, so `two-factor`, `two_factor`, and `twofactor` (and
+  # the `second-`/`multi-` spellings) all match.
+  STRONG_SQUISHED_SEGMENTS = Set{"twofactor", "multifactor", "secondfactor"}
 
   # Parameter names that mark a credential change or a recovery/step-up
   # code regardless of the route.
@@ -49,7 +60,8 @@ class AccountRecoveryTagger < Tagger
       url_segments = url_parts(endpoint.url)
 
       has_strong = !(STRONG_PARAM_NAMES & param_names).empty? ||
-                   url_segments.any? { |part| STRONG_PATH_PARTS.includes?(part) }
+                   url_segments.any? { |part| STRONG_PATH_PARTS.includes?(part) } ||
+                   mfa_squished_segment?(endpoint.url)
 
       weak_tokens = Set(String).new
       url_segments.each do |part|
@@ -71,6 +83,18 @@ class AccountRecoveryTagger < Tagger
 
   private def url_parts(url : String) : Array(String)
     url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+  end
+
+  # Match `two-factor` / `second-factor` / `multi-factor` (and their `_` or
+  # no-separator spellings) as whole slash segments, without the generic
+  # separator split fragmenting them into benign tokens. Exact membership
+  # after stripping in-segment punctuation, so `/twofactorsomething` does
+  # not match.
+  private def mfa_squished_segment?(url : String) : Bool
+    path = url.split("?", 2)[0].split("#", 2)[0]
+    path.downcase.split("/").any? do |segment|
+      STRONG_SQUISHED_SEGMENTS.includes?(segment.gsub(/[^a-z0-9]/, ""))
+    end
   end
 
   private def normalize_param_name(name : String) : String


### PR DESCRIPTION
## Summary

Found while running `noir -T` against real OSS apps (bitwarden, discourse). The **account_recovery** tagger missed a large class of MFA / credential endpoints — quintessential account-takeover surface.

The strong path words only covered the bare `mfa`/`2fa`/`totp`/`otp` forms. The generic separator split fragments the spelled-out `two-factor`/`second-factor`/`multi-factor` into the benign tokens `[two, factor]`, so those routes — and WebAuthn/passkey credential ceremonies — went **completely untagged**.

### Real-world false negatives
| App | Examples (were untagged) |
|-----|--------------------------|
| bitwarden | `/two-factor/authenticator`, `/two-factor/webauthn`, `/two-factor/duo`, `/accounts/webauthn/assertion-options`, `/two-factor/disable` |
| discourse | `/session/passkey/auth`, `/u/create_passkey`, `/u/register_passkey`, `/u/preferences/second-factor`, `/u/second_factor` |

### Fix
- Add `webauthn`/`passkey`/`passkeys` as whole-segment strong path words (FIDO2 credential registration + step-up auth).
- Match `two-factor`/`second-factor`/`multi-factor` (and their `_`/squashed spellings) against **separator-stripped slash segments**, with exact membership so `/twofactorial/...` does not match.

### Validation
- bitwarden: account_recovery **29 → 68** (+39, all `/two-factor/*` and `/accounts/webauthn/*` enrollment & step-up routes)
- discourse: **34 → 48** (+14, `/session/passkey/*`, `/u/*_passkey`, `/preferences/second-factor`)
- Every newly tagged endpoint is a genuine MFA/credential route; no other tags changed.
- New TP + FP-guard spec cases; full tagger unit suite green (491 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>