### PR TITLE
fix(tagger/oauth): tag param-less endpoints under a strong /oauth path segment

### DIFF
--- a/spec/unit_test/tagger/taggers/oauth_spec.cr
+++ b/spec/unit_test/tagger/taggers/oauth_spec.cr
@@ -216,6 +216,30 @@ describe "OAuthTagger" do
       endpoint.tags[0].name.should eq("oauth")
     end
 
+    it "tags param-less endpoints under a strong /oauth2 path segment" do
+      ["/oauth2/auth", "/oauth2/device/auth", "/oauth2/device/verify",
+       "/oauth2/sessions/logout", "/oauth/authorize",
+       "/openid/userinfo", "/oidc/token"].each do |path|
+        tagger = OAuthTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(path, "GET")
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("oauth")
+      end
+    end
+
+    it "does not tag a path that merely contains 'openid' as a sub-token" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/.well-known/openid-configuration", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
     it "does not tag a generic callback receiving only a code" do
       tagger = OAuthTagger.new(default_tagger_options)
 

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -39,7 +39,14 @@ class OAuthTagger < Tagger
       # OAuth authorization endpoints commonly use response_type +
       # client_id + redirect_uri, while token endpoints can rely on
       # HTTP Basic auth and expose only grant_type + code/verifier.
-      check = strong_oauth_params?(param_names) ||
+      check = # A whole `/oauth|/oauth2|/openid|/oidc` path segment is an
+              # unambiguous OAuth surface on its own — the host is already
+              # stripped, so this can't fire on `oauth.example.com`. Catches
+              # the param-less endpoints real OAuth servers expose (the
+              # `/oauth2/auth` authorize redirect, `/oauth2/device/verify`,
+              # `/oauth2/sessions/logout`, a GET on `/oauth2/register/{id}`).
+              strong_oauth_segment?(endpoint.url) ||
+              strong_oauth_params?(param_names) ||
               # Under an unambiguous /oauth|/openid path, a single OAuth
               # parameter is enough (device-flow `device_code`, an
               # authorize page's `client_id`, a callback's `code`).
@@ -62,9 +69,8 @@ class OAuthTagger < Tagger
     name.downcase.tr("-", "_")
   end
 
-  # Split the URL's path (scheme/host/query/fragment stripped) into the
-  # tokens used for whole-segment matching.
-  private def path_parts(url : String) : Array(String)
+  # The URL's path with scheme/host/query/fragment stripped and lowercased.
+  private def path_only(url : String) : String
     path = url.strip
 
     if scheme_index = path.index("://")
@@ -78,7 +84,22 @@ class OAuthTagger < Tagger
 
     path = path.split("?", 2)[0]
     path = path.split("#", 2)[0]
-    path.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+    path.downcase
+  end
+
+  # Split the path into `/`-`-`-`_`-`.`-delimited tokens (the loose form used
+  # for the param-corroborated checks).
+  private def path_parts(url : String) : Array(String)
+    path_only(url).split(/[\/\-_\.]+/).reject(&.empty?)
+  end
+
+  # True when a whole `/`-delimited path segment is itself a strong OAuth
+  # marker. Unlike `path_parts`, this does NOT split on `-`/`_`/`.`, so the
+  # OIDC discovery document `/.well-known/openid-configuration` (segment
+  # `openid-configuration`, not `openid`) stays untagged while a param-less
+  # `/oauth2/auth` is caught.
+  private def strong_oauth_segment?(url : String) : Bool
+    path_only(url).split("/").any? { |seg| STRONG_URL_PARTS.includes?(seg) }
   end
 
   private def oauth_callback?(parts : Array(String), param_names : Set(String)) : Bool


### PR DESCRIPTION
## Summary

Found while running `noir -T` against real OAuth/OIDC servers (ory/hydra, zitadel). The **oauth** tagger missed param-less endpoints sitting under an unambiguous `/oauth|/oauth2|/openid|/oidc` path.

The tagger required a corroborating OAuth *parameter* even under a strong `/oauth2/` path. Real OAuth servers expose several param-less endpoints there:

| Endpoint (ory/hydra) | Role | Was |
|----------------------|------|-----|
| `GET /oauth2/auth` | authorization redirect | _untagged_ |
| `POST /oauth2/device/auth`, `GET /oauth2/device/verify` | device flow | _untagged_ |
| `GET /oauth2/sessions/logout` | RP-initiated logout | _untagged_ |
| `GET`/`DELETE /oauth2/register/{id}` | dynamic client reg | _untagged_ (POST/PUT sibling **was** tagged) |

The param requirement was guarding against an `oauth.example.com` *host*, but `path_only` already strips the host — so a path **segment** is safe to act on alone.

### Fix
Tag when a whole `/`-delimited path segment is itself a strong OAuth marker. It matches whole segments (not the `-`/`_`/`.`-split tokens), so the OIDC discovery document `/.well-known/openid-configuration` (segment `openid-configuration`, not `openid`) stays untagged — existing guard preserved.

### Validation
- ory/hydra: oauth **6 → 25**
- zitadel: **6 → 16**
- rocketchat **2 → 10**, discourse **0 → 4**, immich **3 → 8**
- Every recovered endpoint sits under a genuine `/oauth*|/openid|/oidc` segment.
- New TP + sub-token FP-guard spec cases; full tagger unit suite green (493 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>