### PR TITLE
fix(analyzer/zig): skip routes registered inside test blocks (FP)

### DIFF
--- a/spec/functional_test/fixtures/zig/httpz/src/main.zig
+++ b/spec/functional_test/fixtures/zig/httpz/src/main.zig
@@ -32,6 +32,16 @@ pub fn main() !void {
     try server.listen();
 }
 
+test "router registers routes" {
+    // A route registered inside a `test { … }` block is a unit-test fixture,
+    // not a runtime endpoint — it must NOT be emitted.
+    var server = try httpz.Server().init(std.testing.allocator, .{}, .{});
+    defer server.deinit();
+    var router = try server.router(.{});
+    router.get("/test-only", index, .{});
+    router.post("/test-only", createUser, .{});
+}
+
 fn index(_: *httpz.Request, res: *httpz.Response) !void {
     try res.write("home");
 }

--- a/spec/functional_test/fixtures/zig/tokamak/src/main.zig
+++ b/spec/functional_test/fixtures/zig/tokamak/src/main.zig
@@ -68,3 +68,19 @@ pub fn main() !void {
     defer server.deinit();
     try server.start();
 }
+
+test "routes" {
+    // Inline routes and a controller handler declared inside a `test { … }`
+    // block are unit-test fixtures — neither may be emitted as an endpoint.
+    const test_routes: []const tk.Route = &.{
+        .get("/test-only", hello),
+    };
+    _ = test_routes;
+}
+
+test "controller route fixture" {
+    const Fixture = struct {
+        pub fn @"GET /test-only/fn"() !void {}
+    };
+    _ = Fixture;
+}

--- a/spec/functional_test/testers/zig/httpz_spec.cr
+++ b/spec/functional_test/testers/zig/httpz_spec.cr
@@ -35,9 +35,10 @@ expected_endpoints << httpz_endpoint("/items/", "GET", [] of Param, [Callee.new(
 expected_endpoints << httpz_endpoint("/items/:id", "GET", [Param.new("id", "", "path")], [Callee.new("lookupItem")])
 expected_endpoints << httpz_endpoint("/items/", "POST", [] of Param, [Callee.new("saveItem")])
 
-# `deps/httpz/src/tests/test_router.zig` is a vendored copy of the framework
-# checked into the tree; its `/vendored-phantom` route must be skipped, so the
-# endpoint total stays exactly the list above.
+# Two route sources must NOT add endpoints: the `/test-only` routes registered
+# inside main.zig's `test { … }` block (unit-test fixtures), and the vendored
+# `deps/httpz/src/tests/test_router.zig` framework copy's `/vendored-phantom`.
+# The endpoint total therefore stays exactly the list above.
 
 FunctionalTester.new("fixtures/zig/httpz/", {
   :techs     => 1,

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -53,27 +53,35 @@ module Analyzer::Zig
     private def process_file(path : String, content : String, include_callee : Bool)
       text = Noir::ZigCalleeExtractor.strip_comments(content)
       bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
+      # Routes registered inside `test { … }` blocks are test fixtures (and, in
+      # an httpz framework source vendored as a loose file, its own self-tests),
+      # not runtime endpoints.
+      test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(Noir::ZigCalleeExtractor.strip_non_code(content))
 
       group_prefixes = resolve_group_prefixes(text)
 
       text.scan(ROUTE_RE) do |m|
+        offset = m.begin(0) || 0
+        next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
         receiver = m[1]
         verb = m[2]
         route = m[3]
         handler = m[4]
         prefix = group_prefixes[receiver]? || ""
         url = Noir::URLPath.join(prefix, route)
-        emit(path, text, m.begin(0) || 0, url, VERB_METHOD[verb], handler, bodies, include_callee)
+        emit(path, text, offset, url, VERB_METHOD[verb], handler, bodies, include_callee)
       end
 
       text.scan(METHOD_RE) do |m|
+        offset = m.begin(0) || 0
+        next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
         receiver = m[1]
         method = m[2].upcase
         route = m[3]
         handler = m[4]
         prefix = group_prefixes[receiver]? || ""
         url = Noir::URLPath.join(prefix, route)
-        emit(path, text, m.begin(0) || 0, url, method, handler, bodies, include_callee)
+        emit(path, text, offset, url, method, handler, bodies, include_callee)
       end
     end
 

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -193,15 +193,19 @@ module Analyzer::Zig
       # Strings preserved in `text` for reading paths/handlers; brace matching
       # runs on the string-blanked (but offset-identical) char array so a `{`/`}`
       # inside a literal can't throw off group-scope tracking.
-      code_chars = Noir::ZigCalleeExtractor.strip_non_code(content).chars
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+      code_chars = stripped.chars
       bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
+      # Routes declared inside `test { … }` blocks are unit-test fixtures (e.g.
+      # tokamak's own client tests register `.get("/ping", …)`), not endpoints.
+      test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(stripped)
 
-      emit_route_array(path, text, code_chars, bodies, include_callee)
-      emit_controller_routes(path, content, text, mounts, include_callee)
+      emit_route_array(path, text, code_chars, bodies, test_blocks, include_callee)
+      emit_controller_routes(path, content, text, mounts, test_blocks, include_callee)
     end
 
     # Inline `tk.Route` array routes (.get/.post/.group/…).
-    private def emit_route_array(path, text, code_chars, bodies, include_callee)
+    private def emit_route_array(path, text, code_chars, bodies, test_blocks, include_callee)
       events = collect_events(text, code_chars)
       stack = [] of GroupFrame
 
@@ -214,6 +218,7 @@ module Analyzer::Zig
           next
         end
 
+        next if Noir::ZigCalleeExtractor.in_test_block?(ev[:off], test_blocks)
         prefix = stack.reduce("") { |acc, frame| Noir::URLPath.join(acc, frame.prefix) }
         url = join_route(prefix, ev[:path])
         name = ev[:handler].includes?('.') ? ev[:handler].split('.').last : ev[:handler]
@@ -229,7 +234,7 @@ module Analyzer::Zig
     # mounted, or its mount chain crosses a route-value reference we don't
     # expand. `const` routes name a handler defined elsewhere, so they carry no
     # inline body and thus no callees.
-    private def emit_controller_routes(path, content, text, mounts, include_callee)
+    private def emit_controller_routes(path, content, text, mounts, test_blocks, include_callee)
       has_fn = content.includes?("pub fn @\"")
       has_const = content.includes?("pub const @\"")
       return unless has_fn || has_const
@@ -244,6 +249,7 @@ module Analyzer::Zig
           method = m[1]
           rel = m[2]
           offset = m.begin(0) || 0
+          next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
           callees = include_callee ? route_fn_callees(stripped_chars, m.end(0) || 0, path) : [] of Noir::ZigCalleeExtractor::Entry
           prefixes_for(file_mounts, enclosing_struct(regions, offset)).each do |pre|
             emit(path, text, offset, join_route(pre, rel), method, callees)
@@ -256,6 +262,7 @@ module Analyzer::Zig
           method = m[1]
           rel = m[2]
           offset = m.begin(0) || 0
+          next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
           prefixes_for(file_mounts, enclosing_struct(regions, offset)).each do |pre|
             emit(path, text, offset, join_route(pre, rel), method, [] of Noir::ZigCalleeExtractor::Entry)
           end

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -92,7 +92,14 @@ module Analyzer::Zig
 
         next unless content.includes?(".path") || content.includes?(".init(")
 
+        # Path literals/bindings inside `test { … }` blocks are unit-test
+        # fixtures (the zap framework's own `test_auth.zig` binds `.path =
+        # "/test"`); excluding them keeps those phantom paths off real
+        # endpoint structs that happen to share a type name.
+        test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(Noir::ZigCalleeExtractor.strip_non_code(content))
+
         text.scan(INIT_RE) do |m|
+          next if Noir::ZigCalleeExtractor.in_test_block?(m.begin(0) || 0, test_blocks)
           type = m[1]
           if pm = m[2].match(/"(\/[^"]*)"/)
             add_binding(by_type, type, pm[1])
@@ -100,6 +107,7 @@ module Analyzer::Zig
         end
 
         text.scan(LITERAL_PATH_RE) do |m|
+          next if Noir::ZigCalleeExtractor.in_test_block?(m.begin(0) || 0, test_blocks)
           lit = m[1]
           next if lit.empty? || lit == "(undefined)"
           if type = nearest_type_before(text, m.begin(0) || 0)

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -59,6 +59,31 @@ module Noir::ZigCalleeExtractor
     !VENDORED_FRAMEWORK_RE.match(path.gsub('\\', '/')).nil?
   end
 
+  # `test { … }` / `test "name" { … }` block opener. Route registrations inside
+  # a test block are unit-test fixtures — and, in a framework's own source
+  # vendored as a loose file (`modules/httpz.zig`, `modules/router.zig`), its
+  # self-tests — never runtime endpoints.
+  TEST_BLOCK_RE = /(?:^|[^A-Za-z0-9_.])test\s*(?:"(?:[^"\\]|\\.)*"\s*)?\{/
+
+  # Byte ranges of test blocks, brace-matched on the string-blanked source so a
+  # `{`/`}` inside a literal can't throw the matching off. `in_test_block?`
+  # then lets an analyzer drop a route whose registration sits inside one.
+  def test_block_ranges(stripped : String) : Array(Tuple(Int32, Int32))
+    chars = stripped.chars
+    ranges = [] of Tuple(Int32, Int32)
+    stripped.scan(TEST_BLOCK_RE) do |m|
+      brace = (m.end(0) || 0) - 1
+      close = find_matching(chars, brace, '{', '}')
+      next if close.nil?
+      ranges << {m.begin(0) || 0, close}
+    end
+    ranges
+  end
+
+  def in_test_block?(offset : Int32, ranges : Array(Tuple(Int32, Int32))) : Bool
+    ranges.any? { |r| offset > r[0] && offset < r[1] }
+  end
+
   # A call expression: an optional `@` (builtin) + identifier, then any number
   # of `.identifier` accessors, immediately followed by `(`. The lookbehind
   # stops the match from starting in the middle of an identifier or chain, so


### PR DESCRIPTION
## Summary

Route registrations inside Zig `test { … }` / `test "name" { … }` blocks are **unit-test fixtures**, never runtime endpoints. They surfaced as phantom endpoints in two situations:

1. An app's own test fixtures.
2. A framework whose source is vendored as a **loose file** (`modules/httpz.zig`, `modules/router.zig`) — the `<vendor-dir>/<framework>/` path skip (#2086) doesn't catch that layout, but the framework's bundled self-tests still register routes like `/over/9000/`, `/:p1`, `/test/ws`.

Added a shared `Noir::ZigCalleeExtractor.test_block_ranges` / `in_test_block?` (brace-matched on string-blanked source) and applied it across the analyzers:

- **httpz** — drop `router.<verb>(...)` / `.method(...)` matches inside test blocks.
- **tokamak** — drop inline `tk.Route` array routes and `@"METHOD /path"` controller routes inside test blocks.
- **zap** — drop `.path = "…"` / `.init("/p")` path bindings collected from test blocks, so a framework self-test's `.path = "/test"` can't bind onto a real endpoint struct sharing a type name.

## Real-world impact (cloned OSS)
| app | before | after | note |
|---|---|---|---|
| OxT7723/CTFs (httpz) | 29 | 1 | 28 vendored-as-file framework self-test routes dropped; the one real challenge route (`/oracle/:mode/:deviceId`) kept |
| karlseguin/http.zig (examples) | 62 | 16 | framework `src/` self-tests dropped; all `examples/` routes kept |
| cztomsik/tokamak (examples) | 18 | 16 | client-test `/ping`, `/slow` dropped |

No change to any app's real routes (verified across 30+ cloned apps).

## Test
The httpz and tokamak fixtures each gain a `test { … }` block registering routes (inline + controller `@"…"` forms); the functional tests assert the endpoint total is unchanged. Full zig suite green (206 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)