### PR TITLE
fix(tagger/api_docs): recognize OAuth/OIDC/SMART discovery documents

### DIFF
--- a/spec/unit_test/tagger/taggers/api_docs_spec.cr
+++ b/spec/unit_test/tagger/taggers/api_docs_spec.cr
@@ -140,5 +140,20 @@ describe "ApiDocsTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "tags OAuth/OIDC/SMART discovery documents" do
+      ["/.well-known/openid-configuration", "/openid-configuration",
+       "/.well-known/oauth-authorization-server", "/oauth-authorization-server",
+       "/.well-known/oauth-protected-resource",
+       "/.well-known/smart-configuration", "/smart-configuration"].each do |path|
+        tagger = ApiDocsTagger.new(default_tagger_options)
+        endpoint = Endpoint.new(path, "GET")
+
+        tagger.perform([endpoint])
+
+        endpoint.tags.size.should eq(1)
+        endpoint.tags[0].name.should eq("api_docs")
+      end
+    end
   end
 end

--- a/src/tagger/taggers/api_docs.cr
+++ b/src/tagger/taggers/api_docs.cr
@@ -17,6 +17,14 @@ class ApiDocsTagger < Tagger
     "openapi", "openapi3", "redoc", "graphiql", "rapidoc",
     "wsdl", "wadl", "api-docs", "api-doc",
     "asyncapi", "api-json", "api-yaml", "apispec", "apispec_1",
+    # OAuth/OIDC/SMART discovery documents — machine-readable service
+    # descriptions in the same class as WSDL/OpenAPI. They enumerate the
+    # auth surface (every endpoint, supported scopes/grants, jwks_uri) and
+    # are almost always unauthenticated, so they are a first-stop recon
+    # target. Served both at `/.well-known/<name>` and bare `/<name>`; the
+    # names are specific enough to carry no benign collision.
+    "openid-configuration", "oauth-authorization-server",
+    "oauth-protected-resource", "smart-configuration",
   }
 
   # Separator-insensitive lookup so `/swagger_ui`, `/swaggerui`,


### PR DESCRIPTION
## Summary

Found while running `noir -T` against real OAuth/OIDC servers and FHIR apps (ory/hydra, medplum). OAuth/OIDC/SMART **discovery documents** went untagged.

The api_docs tagger already covers machine-readable service descriptions (OpenAPI, WSDL, WADL, AsyncAPI). Discovery documents are the same class — `/.well-known/openid-configuration` & friends enumerate the entire auth surface (every endpoint, supported scopes/grant types, `jwks_uri`) and are almost always unauthenticated. They're a first-stop recon target and information-disclosure risk, exactly the api_docs lens.

### Real-world false negatives (were untagged)
| App | Endpoints |
|-----|-----------|
| medplum | `/openid-configuration`, `/oauth-authorization-server`, `/oauth-protected-resource`, `/smart-configuration`, `/.well-known/smart-configuration` |
| ory/hydra | `/.well-known/openid-configuration` |

Note: these are deliberately **not** tagged `oauth` (that tagger's spec keeps `/.well-known/openid-configuration` untagged — a metadata doc is not an OAuth protocol endpoint), so api_docs is the right home.

### Fix
Add `openid-configuration`, `oauth-authorization-server`, `oauth-protected-resource`, `smart-configuration` as doc segments. They match both `/.well-known/<name>` and bare `/<name>`; the names are specific enough to carry no benign collision.

### Validation
- medplum: api_docs **2 → 7**, ory/hydra **0 → 1**
- No other endpoints changed across the corpus (discourse/ctfd/immich/bitwarden api_docs unchanged) — zero FP.
- New TP spec case; full tagger unit suite green (494 examples, 0 failures).

Co-authored-by: ksg97031 <ksg97031@gmail.com>