### PR TITLE
test(scala/play): sync stale hardcoded endpoint count with shared fixture

### DIFF
--- a/spec/functional_test/testers/scala/play_callees_spec.cr
+++ b/spec/functional_test/testers/scala/play_callees_spec.cr
@@ -14,7 +14,7 @@ post_data.push_callee(Callee.new("Json.toJson"))
 
 FunctionalTester.new("fixtures/scala/play/", {
   :techs     => 1,
-  :endpoints => 19,
+  :endpoints => 22,
 }, [index, protected_endpoint, post_data], {
   "include_callee" => YAML::Any.new(true),
 }).perform_tests


### PR DESCRIPTION
## Summary

Fixes a full-suite-only spec failure introduced as a follow-up gap of #2074:

```
1) test analyze using count check [fixtures/scala/play/]
   Expected: 19
        got: 22
```

## Root cause

Two functional testers analyze the **same** `fixtures/scala/play/` fixture:

- `spec/functional_test/testers/scala/play_spec.cr` derives its count from `expected_endpoints.size`, so #2074 — which added the 3 `/appeal` sub-routes to the fixture — automatically bumped it to **22**.
- `spec/functional_test/testers/scala/play_callees_spec.cr` analyzes the same fixture but **hardcodes** `:endpoints => 19`, and was missed by #2074.

Both testers emit the identical example description `[fixtures/scala/play/]`. In isolation only one tester loads (so each passes individually), but the full `just test` run executes both, and the stale `19` expectation fails. The analyzer is correct — it produces 22 endpoints; only the test expectation was out of date.

## Change

Bump the hardcoded count in `play_callees_spec.cr` from `19` to `22`. No analyzer/source changes.

## Verification

- `crystal spec spec/functional_test` → 19291 examples, **0 failures**
- `crystal spec spec/unit_test` → 3487 examples, **0 failures**

## Note for reviewers

When a shared fixture's endpoint count changes, sibling testers (`*_callees`, `*_sird`, etc.) pointed at the same fixture dir may hardcode counts independently — `grep -rn "fixtures/<path>" spec/functional_test/testers/` to catch them all.