### PR TITLE
Use idiomatic .empty? checks in send_proxy

### DIFF
--- a/src/deliver/send_proxy.cr
+++ b/src/deliver/send_proxy.cr
@@ -14,10 +14,10 @@ class SendWithProxy < Deliver
       wg.add(1)
       spawn do
         begin
-          if endpoint.params.size > 0
+          unless endpoint.params.empty?
             endpoint_hash = endpoint.params_to_hash
             is_json = false
-            body = if endpoint_hash["json"].size > 0
+            body = if !endpoint_hash["json"].empty?
                      is_json = true
                      endpoint_hash["json"]
                    else

--- a/src/deliver/send_proxy.cr
+++ b/src/deliver/send_proxy.cr
@@ -14,7 +14,7 @@ class SendWithProxy < Deliver
       wg.add(1)
       spawn do
         begin
-          unless endpoint.params.empty?
+          if !endpoint.params.empty?
             endpoint_hash = endpoint.params_to_hash
             is_json = false
             body = if !endpoint_hash["json"].empty?


### PR DESCRIPTION
Replaces `.size > 0` with `.empty?` in `src/deliver/send_proxy.cr` to match the idiomatic Crystal style used consistently throughout the rest of the codebase.

- `endpoint.params.size > 0` changed to `unless endpoint.params.empty?`
- `endpoint_hash["json"].size > 0` changed to `!endpoint_hash["json"].empty?`

Fixes #1089 