### PR TITLE
ci(typos): allowlist `alikes` from vapor fixture comment

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -32,6 +32,9 @@ nin = "nin"
 # the *incorrect* plural forms (contrasted with the y->ies rule).
 directorys = "directorys"
 directoryes = "directoryes"
+# `look-alikes` (plural of look-alike) in a vapor fixture comment; typos
+# mis-flags the hyphen-split `alikes` token as `alike`/`likes`.
+alikes = "alikes"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
## Why

The `typos` CI job currently fails on `main`:

```
error: `alikes` should be `alike`, `likes`
  ╭▸ ./spec/functional_test/fixtures/swift/vapor/routes.swift:4:24
```

`typos` splits the `look-alikes` plural in the vapor fixture comment on the hyphen and flags the `alikes` token as a misspelling.

## What

Add `alikes = "alikes"` to the `[default.extend-words]` allowlist in `typos.toml`. This is the same fix included in the v1.1.0 release PR (#2099), pulled out so `main` CI goes green now.