### PR TITLE
perf(java/jaxrs): memoize derivative-project check per root (fix O(n²) detect)

### DIFF
--- a/src/detector/detectors/java/jaxrs.cr
+++ b/src/detector/detectors/java/jaxrs.cr
@@ -7,6 +7,19 @@ module Detector::Java
     # framework, not as plain JAX-RS.
     DERIVATIVE_MARKERS = ["io.quarkus", "io.dropwizard"]
 
+    # `derivative_project?` answers a project-wide question — "does any
+    # Java file under this root pull in Quarkus/Dropwizard?" — whose
+    # answer is identical for every file that shares a root. The detector
+    # instance is shared across the whole scan, so memoise per root.
+    # Without this the glob+read sweep ran once per `.java` file, making
+    # JAX-RS detection O(java_files²): on a Spring project jaxrs never
+    # matches, so it never short-circuits and re-globbed + re-read the
+    # entire source tree for every single file (~9.8s on a 686-file
+    # project). Keyed by root so sibling projects in a monorepo still
+    # resolve independently.
+    @derivative_cache = {} of String => Bool
+    @derivative_cache_mutex = Mutex.new
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".java")
       return false if DERIVATIVE_MARKERS.any? { |marker| file_contents.includes?(marker) }
@@ -24,16 +37,29 @@ module Detector::Java
 
     private def derivative_project?(filename : String) : Bool
       root = project_root_for(filename)
+      @derivative_cache_mutex.synchronize do
+        cached = @derivative_cache[root]?
+        return cached unless cached.nil?
+        result = compute_derivative_project(root)
+        @derivative_cache[root] = result
+        result
+      end
+    end
+
+    private def compute_derivative_project(root : String) : Bool
       java_glob = File.join(root, "src/main/java/**/*.java")
       fallback_glob = File.join(root, "**/*.java")
       candidates = Dir.glob(java_glob)
       candidates = Dir.glob(fallback_glob) if candidates.empty?
 
+      locator = CodeLocator.instance
       candidates.any? do |path|
         next false unless File.file?(path)
 
         begin
-          content = File.read(path)
+          # The detector pass already read most of these files; reuse the
+          # cached content so the one-time sweep avoids a second disk read.
+          content = locator.content_for(path) || File.read(path)
           DERIVATIVE_MARKERS.any? { |marker| content.includes?(marker) }
         rescue
           false


### PR DESCRIPTION
## Problem
The JAX-RS detector's `derivative_project?` ran `Dir.glob(root/**/*.java)` **and `File.read` of every matched file once per `.java` file** in the project. On a non-derivative project (e.g. Spring) jaxrs never matches, so it never short-circuits via `detected_flags` and re-globbed + re-read the entire source tree for *every* file scanned — **O(java_files²) disk I/O**.

## Fix
The check answers a project-wide question whose result is identical for every file under a given `/src/main/java/` root, so memoize it per root (mutex-guarded class-body ivar — same pattern as `analyzer.cr`; reuses the CodeLocator content cache for the one-time sweep). Detection output is unchanged: same per-root evaluation, computed once instead of N times.

## Measured (`--release`, median-of-3)
| | before | after |
|---|---|---|
| run/halo full scan | 11.9s | **1.5s** (sys 6.26s→0.11s) |
| jaxrs detector alone, 686 java files | 9.8s | **0.3s** |

Endpoints identical (halo 471→471). Full `crystal spec` passes (22778 examples, 0 failures); jaxrs/quarkus/dropwizard suppression specs (233 examples) green.