### PR TITLE
perf(js_lexer): index Array(Char) instead of the String (fix O(n²) tokenizer)

### DIFF
--- a/src/minilexers/js_lexer.cr
+++ b/src/minilexers/js_lexer.cr
@@ -15,13 +15,21 @@ module Noir
 
   # JSLexer is a simple JavaScript lexer for route detection
   class JSLexer
-    @source : String
+    @chars : Array(Char)
+    @size : Int32
     @position : Int32 = 0
     @current_char : Char = '\0'
     @tokens : Array(JSToken) = [] of JSToken
 
-    def initialize(@source : String)
-      @current_char = @source[@position]? || '\0'
+    def initialize(source : String)
+      # Index an Array(Char) rather than the String directly: `String#[]`
+      # resolves a char index to a byte offset (O(index) on non-ASCII
+      # content), so the cursor walk was O(n²) per file. Converting once
+      # up front makes every `@chars[@position]` O(1). Mirrors the
+      # PhpLexer / CSharpLexer approach.
+      @chars = source.chars
+      @size = @chars.size
+      @current_char = @position < @size ? @chars[@position] : '\0'
     end
 
     def tokenize : Array(JSToken)
@@ -101,11 +109,11 @@ module Noir
 
     private def advance
       @position += 1
-      @current_char = @source[@position]? || '\0'
+      @current_char = @position < @size ? @chars[@position] : '\0'
     end
 
     private def peek
-      @source[@position + 1]? || '\0'
+      @position + 1 < @size ? @chars[@position + 1] : '\0'
     end
 
     private def skip_whitespace


### PR DESCRIPTION
## Problem
`JSLexer` stored the file as a `String` and advanced its cursor with `@source[@position]`. `String#[]` resolves a char index to a byte offset, which is **O(index) on any file containing non-ASCII bytes** (i18n strings, comments, emoji) — so tokenizing one file was **O(n²)**. The JS/TS analyzers (Express, etc.) run the lexer over every `.js`/`.ts` file, and `char_index_to_byte_index` dominated the profile on real apps.

## Fix
Convert the source to an `Array(Char)` once in the constructor and index that (O(1)), mirroring the existing `PhpLexer` / `CSharpLexer`. Token positions remain char offsets, so output is byte-identical.

## Measured (`--release`, median-of-3)
| app | before | after | endpoints |
|---|---|---|---|
| directus | 5.4s | **3.6s** (1.5×) | 276 → 276 |
| documenso | 1.7s | **1.4s** | 363 → 363 |

Full `crystal spec` passes (22778 examples, 0 failures); 2757 JS/TS functional specs unchanged.