### PR TITLE
perf(detector): collapse multi-regex JS/TS detectors into one precompiled Regex.union

### DIFF
--- a/src/detector/detectors/javascript/apollo.cr
+++ b/src/detector/detectors/javascript/apollo.cr
@@ -14,9 +14,13 @@ module Detector::Javascript
       /\bnew\s+ApolloServer\s*\(/,
     ]
 
+    # Single precompiled alternation of SIGNALS — one PCRE2 scan instead
+    # of one per signal.
+    SIGNAL = Regex.union(SIGNALS)
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      SIGNALS.any? { |re| file_contents.match(re) }
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/express.cr
+++ b/src/detector/detectors/javascript/express.cr
@@ -2,16 +2,19 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Express < Detector
+    # Single precompiled alternation — one PCRE2 scan over the file
+    # instead of up to four separate `.match` passes. Regex.union wraps
+    # each branch verbatim, so the boolean result is identical.
+    SIGNAL = Regex.union(
+      /require\(['"]express['"]\)/,
+      /from ['"]express['"]/,
+      /app\.use\(express\.json\(\)\)/,
+      /app\.use\(express\.urlencoded\(\{ extended: true \}\)\)/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")) &&
-         (file_contents.match(/require\(['"]express['"]\)/) ||
-         file_contents.match(/from ['"]express['"]/) ||
-         file_contents.match(/app\.use\(express\.json\(\)\)/) ||
-         file_contents.match(/app\.use\(express\.urlencoded\(\{ extended: true \}\)\)/))
-        true
-      else
-        false
-      end
+      return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/fastify.cr
+++ b/src/detector/detectors/javascript/fastify.cr
@@ -2,18 +2,19 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Fastify < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of five.
+    SIGNAL = Regex.union(
+      /require\(['"]fastify['"]\)/,
+      /from ['"]fastify['"]/,
+      /fastify\s*\(\s*\{/,
+      /fastify\.register\s*\(/,
+      /fastify\.(get|post|put|delete|patch|head|options)\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") ||
-         filename.ends_with?(".jsx") || filename.ends_with?(".tsx") || filename.ends_with?(".cjs")) &&
-         (file_contents.match(/require\(['"]fastify['"]\)/) ||
-         file_contents.match(/from ['"]fastify['"]/) ||
-         file_contents.match(/fastify\s*\(\s*\{/) ||
-         file_contents.match(/fastify\.register\s*\(/) ||
-         file_contents.match(/fastify\.(get|post|put|delete|patch|head|options)\s*\(/))
-        true
-      else
-        false
-      end
+      return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") ||
+                          filename.ends_with?(".jsx") || filename.ends_with?(".tsx") || filename.ends_with?(".cjs")
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/graphql_yoga.cr
+++ b/src/detector/detectors/javascript/graphql_yoga.cr
@@ -15,9 +15,13 @@ module Detector::Javascript
       /\bcreateYoga\s*\(/,
     ]
 
+    # Single precompiled alternation of SIGNALS — one PCRE2 scan instead
+    # of one per signal.
+    SIGNAL = Regex.union(SIGNALS)
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      SIGNALS.any? { |re| file_contents.match(re) }
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/hono.cr
+++ b/src/detector/detectors/javascript/hono.cr
@@ -2,11 +2,16 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Hono < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of three.
+    SIGNAL = Regex.union(
+      /require\(['"]hono['"]\)/,
+      /from ['"]hono['"]/,
+      /new\s+Hono\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       [".js", ".mjs", ".ts", ".jsx", ".tsx", ".cjs"].any? { |ext| filename.ends_with?(ext) } &&
-        !!(file_contents.match(/require\(['"]hono['"]\)/) ||
-          file_contents.match(/from ['"]hono['"]/) ||
-          file_contents.match(/new\s+Hono\s*\(/))
+        file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/koa.cr
+++ b/src/detector/detectors/javascript/koa.cr
@@ -2,18 +2,19 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Koa < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of six.
+    SIGNAL = Regex.union(
+      /require\(['"]koa['"]\)/,
+      /import Koa from ['"]koa['"]/,
+      /import Router from ['"]koa-router['"]/,
+      /require\(['"]koa-router['"]\)/,
+      /require\(['"]koa-[a-zA-Z0-9-]+['"]\)/,
+      /new Koa\(\)/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts")) &&
-         (file_contents.match(/require\(['"]koa['"]\)/) ||
-         file_contents.match(/import Koa from ['"]koa['"]/) ||
-         file_contents.match(/import Router from ['"]koa-router['"]/) ||
-         file_contents.match(/require\(['"]koa-router['"]\)/) ||
-         file_contents.match(/require\(['"]koa-[a-zA-Z0-9-]+['"]\)/) ||
-         file_contents.match(/new Koa\(\)/))
-        true
-      else
-        false
-      end
+      return false unless filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts")
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/nestjs.cr
+++ b/src/detector/detectors/javascript/nestjs.cr
@@ -2,19 +2,20 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nestjs < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of seven.
+    SIGNAL = Regex.union(
+      /require\(['"]@nestjs\/core['"]\)/,
+      /require\(['"]@nestjs\/common['"]\)/,
+      /import.*from ['"]@nestjs\/core['"]/,
+      /import.*from ['"]@nestjs\/common['"]/,
+      /@Controller\s*\(/,
+      /@Module\s*\(/,
+      /NestFactory\.create\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with?(".js") || filename.ends_with?(".jsx")) &&
-         (file_contents.match(/require\(['"]@nestjs\/core['"]\)/) ||
-         file_contents.match(/require\(['"]@nestjs\/common['"]\)/) ||
-         file_contents.match(/import.*from ['"]@nestjs\/core['"]/) ||
-         file_contents.match(/import.*from ['"]@nestjs\/common['"]/) ||
-         file_contents.match(/@Controller\s*\(/) ||
-         file_contents.match(/@Module\s*\(/) ||
-         file_contents.match(/NestFactory\.create\s*\(/))
-        true
-      else
-        false
-      end
+      return false unless filename.ends_with?(".js") || filename.ends_with?(".jsx")
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/javascript/nitro.cr
+++ b/src/detector/detectors/javascript/nitro.cr
@@ -2,6 +2,13 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nitro < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of three.
+    SIGNAL = Regex.union(
+      /require\(['"]nitropack['"]\)/,
+      /from ['"]nitropack['"]/,
+      /defineNitroConfig\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for Nitro config files
       if filename.ends_with?("nitro.config.js") || filename.ends_with?("nitro.config.ts")
@@ -10,9 +17,7 @@ module Detector::Javascript
 
       # Check for Nitro imports and patterns in JS/TS files
       if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts") || filename.ends_with?(".cjs")) &&
-         (file_contents.match(/require\(['"]nitropack['"]\)/) ||
-         file_contents.match(/from ['"]nitropack['"]/) ||
-         file_contents.match(/defineNitroConfig\s*\(/))
+         file_contents.matches?(SIGNAL)
         return true
       end
 

--- a/src/detector/detectors/javascript/nuxtjs.cr
+++ b/src/detector/detectors/javascript/nuxtjs.cr
@@ -2,6 +2,16 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nuxtjs < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of six.
+    SIGNAL = Regex.union(
+      /require\(['"]nuxt['"]\)/,
+      /import.*from ['"]nuxt['"]/,
+      /defineNuxtConfig\s*\(/,
+      /defineEventHandler\s*\(/,
+      /from ['"]#app['"]/,
+      /from ['"]@nuxt\//,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for Nuxt config files
       if filename.ends_with?("nuxt.config.js") || filename.ends_with?("nuxt.config.ts")
@@ -10,12 +20,7 @@ module Detector::Javascript
 
       # Check for Nuxt imports and patterns in JS/TS files
       if (filename.ends_with?(".js") || filename.ends_with?(".mjs") || filename.ends_with?(".ts")) &&
-         (file_contents.match(/require\(['"]nuxt['"]\)/) ||
-         file_contents.match(/import.*from ['"]nuxt['"]/) ||
-         file_contents.match(/defineNuxtConfig\s*\(/) ||
-         file_contents.match(/defineEventHandler\s*\(/) ||
-         file_contents.match(/from ['"]#app['"]/) ||
-         file_contents.match(/from ['"]@nuxt\//))
+         file_contents.matches?(SIGNAL)
         return true
       end
 

--- a/src/detector/detectors/typescript/nestjs.cr
+++ b/src/detector/detectors/typescript/nestjs.cr
@@ -2,19 +2,20 @@ require "../../../models/detector"
 
 module Detector::Typescript
   class Nestjs < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of seven.
+    SIGNAL = Regex.union(
+      /require\(['"]@nestjs\/core['"]\)/,
+      /require\(['"]@nestjs\/common['"]\)/,
+      /import.*from ['"]@nestjs\/core['"]/,
+      /import.*from ['"]@nestjs\/common['"]/,
+      /@Controller\s*\(/,
+      /@Module\s*\(/,
+      /NestFactory\.create\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with?(".ts") || filename.ends_with?(".tsx")) &&
-         (file_contents.match(/require\(['"]@nestjs\/core['"]\)/) ||
-         file_contents.match(/require\(['"]@nestjs\/common['"]\)/) ||
-         file_contents.match(/import.*from ['"]@nestjs\/core['"]/) ||
-         file_contents.match(/import.*from ['"]@nestjs\/common['"]/) ||
-         file_contents.match(/@Controller\s*\(/) ||
-         file_contents.match(/@Module\s*\(/) ||
-         file_contents.match(/NestFactory\.create\s*\(/))
-        true
-      else
-        false
-      end
+      return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/typescript/tanstack_router.cr
+++ b/src/detector/detectors/typescript/tanstack_router.cr
@@ -2,20 +2,21 @@ require "../../../models/detector"
 
 module Detector::Typescript
   class TanstackRouter < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of eight.
+    SIGNAL = Regex.union(
+      /import.*from ['"]@tanstack\/react-router['"]/,
+      /import.*from ['"]@tanstack\/router['"]/,
+      /require\(['"]@tanstack\/react-router['"]\)/,
+      /require\(['"]@tanstack\/router['"]\)/,
+      /createFileRoute\s*\(/,
+      /createRootRoute\s*\(/,
+      /createRoute\s*\(/,
+      /createRouter\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
-      if (filename.ends_with?(".ts") || filename.ends_with?(".tsx")) &&
-         (file_contents.match(/import.*from ['"]@tanstack\/react-router['"]/) ||
-         file_contents.match(/import.*from ['"]@tanstack\/router['"]/) ||
-         file_contents.match(/require\(['"]@tanstack\/react-router['"]\)/) ||
-         file_contents.match(/require\(['"]@tanstack\/router['"]\)/) ||
-         file_contents.match(/createFileRoute\s*\(/) ||
-         file_contents.match(/createRootRoute\s*\(/) ||
-         file_contents.match(/createRoute\s*\(/) ||
-         file_contents.match(/createRouter\s*\(/))
-        true
-      else
-        false
-      end
+      return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx")
+      file_contents.matches?(SIGNAL)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/typescript/trpc.cr
+++ b/src/detector/detectors/typescript/trpc.cr
@@ -2,6 +2,18 @@ require "../../../models/detector"
 
 module Detector::Typescript
   class TRPC < Detector
+    # Single precompiled alternation — one PCRE2 scan instead of eight.
+    SIGNAL = Regex.union(
+      /import[^'"`]+from\s+['"`]@trpc\/server(?:\/[^'"`]*)?['"`]/,
+      /require\(\s*['"`]@trpc\/server(?:\/[^'"`]*)?['"`]\s*\)/,
+      /import[^'"`]+from\s+['"`]@trpc\/next['"`]/,
+      /initTRPC\b/,
+      /createTRPCRouter\s*\(/,
+      /fetchRequestHandler\s*\(/,
+      /createNextApiHandler\s*\(/,
+      /trpcExpress\.createExpressMiddleware\s*\(/,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
                           filename.ends_with?(".cts") || filename.ends_with?(".mts") ||
@@ -13,14 +25,7 @@ module Detector::Typescript
         return file_contents.includes?("\"@trpc/server\"") || file_contents.includes?("\"@trpc/next\"")
       end
 
-      if file_contents.match(/import[^'"`]+from\s+['"`]@trpc\/server(?:\/[^'"`]*)?['"`]/) ||
-         file_contents.match(/require\(\s*['"`]@trpc\/server(?:\/[^'"`]*)?['"`]\s*\)/) ||
-         file_contents.match(/import[^'"`]+from\s+['"`]@trpc\/next['"`]/) ||
-         file_contents.match(/initTRPC\b/) ||
-         file_contents.match(/createTRPCRouter\s*\(/) ||
-         file_contents.match(/fetchRequestHandler\s*\(/) ||
-         file_contents.match(/createNextApiHandler\s*\(/) ||
-         file_contents.match(/trpcExpress\.createExpressMiddleware\s*\(/)
+      if file_contents.matches?(SIGNAL)
         return true
       end
 


### PR DESCRIPTION
## Change
The express/fastify/koa/hono/nestjs(js+ts)/nitro/nuxtjs/tanstack/trpc/apollo/graphql_yoga detectors each ran 3–8 separate `file_contents.match(/.../)` passes over the whole file. `Regex.union` wraps every branch verbatim into a single precompiled alternation, so **one PCRE2 scan replaces N** — the boolean result is identical.

## Why a combined regex (not a substring pre-gate)
Crystal's `String#includes?` is a naive O(n·m) scan and is actually **~3.6–4.6× slower than a PCRE2 `matches?`**, so a cheap-substring pre-gate *regresses* detection. A single combined regex is the right shape.

Micro-bench (44KB file, koa's 6 patterns): 6× separate `matches?` 81µs · **1× union 27µs (~3×)** · includes? pre-gate 108µs.

## Verification
Detection-neutral — 2757 JS/TS functional specs pass unchanged; full `crystal spec` green (22778 examples). Scan-level impact is modest (the unchanged includes?-based detectors + analysis dominate), so this is primarily a correctness-preserving cleanup with a per-detector speedup.