### PR TITLE
fix(tagger/file_upload): treat JSON media fields as references, not uploads

### DIFF
--- a/spec/unit_test/tagger/taggers/file_upload_spec.cr
+++ b/spec/unit_test/tagger/taggers/file_upload_spec.cr
@@ -227,5 +227,36 @@ describe "FileUploadTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "does not tag a JSON image-reference field as a file upload" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      # RealWorld `PUT /api/user` carries `image` as a profile-image URL
+      # string in the JSON body, not an uploaded file. A media word in a
+      # JSON/body payload on a non-upload URL must not trip the tagger.
+      endpoint = Endpoint.new("/api/user", "PUT", [
+        Param.new("username", "", "json"),
+        Param.new("image", "", "json"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "still tags a multipart form image field as a file upload" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      # When the media word is carried as a multipart `form` field it is a
+      # real upload even without an upload-ish URL.
+      endpoint = Endpoint.new("/api/profile", "POST", [
+        Param.new("image", "", "form"),
+      ])
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("file_upload")
+    end
   end
 end

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -2,11 +2,28 @@ require "../../models/tagger"
 require "../../models/endpoint"
 
 class FileUploadTagger < Tagger
+  # Param names that denote an actual uploaded file regardless of how the
+  # value is carried — a `filename`, an `attachment`, a `multipart`
+  # boundary. Safe to flag on any writable param type.
   WORDS = Set{
     "file", "files", "upload", "attachment", "attachments", "document", "documents",
-    "image", "images", "photo", "photos", "avatar", "media", "multipart",
-    "content_type", "filename", "content_disposition",
+    "multipart", "content_type", "filename", "content_disposition",
   }
+
+  # Media words that frequently name a *reference* — a profile-image URL,
+  # an avatar link — inside a JSON/body payload rather than an uploaded
+  # file. Treated as an upload only when carried as multipart form data
+  # (a `file`/`form` param) or corroborated by an upload-ish URL, so a
+  # JSON `{"image": "https://..."}` field (e.g. RealWorld's
+  # `PUT /user`) is not mis-tagged as a file upload.
+  MEDIA_WORDS = Set{
+    "image", "images", "photo", "photos", "avatar", "media",
+  }
+
+  # Form-style carriage: a genuine browser file upload arrives as a
+  # `file` param or a multipart `form` field. JSON/body media fields are
+  # almost always a URL/reference string.
+  MEDIA_UPLOAD_PARAM_TYPES = Set{"file", "form"}
 
   UPLOAD_PARAM_TYPES = Set{"file", "form", "body", "json"}
   UPLOAD_METHODS     = Set{"POST", "PUT", "PATCH"}
@@ -46,7 +63,12 @@ class FileUploadTagger < Tagger
     return true if param.param_type == "file"
 
     name = normalize_param_name(param.name)
-    WORDS.includes?(name) || name.ends_with?("_file") || name.ends_with?("_files")
+    return true if WORDS.includes?(name) || name.ends_with?("_file") || name.ends_with?("_files")
+
+    # Media words count as an upload only via multipart carriage. In a
+    # JSON/body payload they are almost always a URL/reference string, so
+    # `upload_url?`/`multipart_header?` must corroborate them instead.
+    MEDIA_WORDS.includes?(name) && MEDIA_UPLOAD_PARAM_TYPES.includes?(param.param_type)
   end
 
   private def multipart_header?(param : Param) : Bool


### PR DESCRIPTION
## Summary

Reduces a **false positive** in the `file_upload` tagger.

`image` / `images` / `photo` / `photos` / `avatar` / `media` carried in a **JSON or plain body** payload are almost always a URL/reference string — not an uploaded file. The canonical case is the RealWorld API's `PUT /user`, whose JSON body carries `image` as a profile-image **URL**. The tagger flagged any of these as a file upload regardless of how the value was carried.

## Change

- Split the media words out of the always-on `WORDS` set into a new `MEDIA_WORDS` set.
- `MEDIA_WORDS` only count as an upload when carried as multipart form data (`file`/`form` param type) or corroborated by an upload-ish URL / multipart header.
- Strong upload words (`file`, `files`, `upload`, `attachment(s)`, `document(s)`, `filename`, `multipart`, `content_type`, `content_disposition`) and the `_file`/`_files` suffix still tag on any writable param type — unchanged.
- Media-named **URLs** (`POST /api/images`, `PATCH /users/me/avatar`) still tag via the existing URL path check — unchanged.

## Verification

- Confirmed against a fresh clone of the Rails RealWorld example app: `PUT /api/user {image}` and `PATCH /api/user {image}` are no longer mis-tagged as `file_upload`.
- Added two regression specs: a JSON `image` reference field is not tagged; a multipart `form` `image` field still is.
- `crystal spec spec/unit_test/tagger/` → 496 examples, 0 failures. `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M)_