### PR TITLE
fix(grpc): ignore commented-out declarations to cut false positives

### DIFF
--- a/spec/functional_test/fixtures/specification/grpc/comments.proto
+++ b/spec/functional_test/fixtures/specification/grpc/comments.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package comments.v1;
+
+message NoteRequest {
+  string note_id = 1;
+  string body = 2;
+}
+
+message NoteResponse {
+  string note_id = 1;
+}
+
+// A commented-out service block must not be detected as a live service.
+// service GhostService {
+//   rpc GhostMethod(NoteRequest) returns (NoteResponse) {}
+// }
+
+/*
+service BlockGhostService {
+  rpc BlockGhostMethod(NoteRequest) returns (NoteResponse) {}
+}
+*/
+
+service NoteService {
+  // rpc CommentedOut(NoteRequest) returns (NoteResponse) {}
+  /* rpc BlockCommentedOut(NoteRequest) returns (NoteResponse) {} */
+
+  // The only real method in this file.
+  rpc CreateNote(NoteRequest) returns (NoteResponse) {}
+}

--- a/spec/functional_test/testers/specification/grpc_spec.cr
+++ b/spec/functional_test/testers/specification/grpc_spec.cr
@@ -65,6 +65,11 @@ expected_endpoints = [
     Param.new("name", "", "path"),
     Param.new("user_id", "", "query"),
   ]),
+  # Commented-out services/methods must be ignored; only the real rpc remains.
+  Endpoint.new("/comments.v1.NoteService/CreateNote", "POST", [
+    Param.new("note_id", "", "json"),
+    Param.new("body", "", "json"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/specification/grpc/", {

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -22,9 +22,69 @@ module Analyzer::Specification
     end
 
     private def parse_proto(content : String, file_path : String)
-      package = parse_package(content)
-      messages = parse_messages(content)
-      parse_services(content, file_path, package, messages)
+      # Strip comments before any structural parsing so a commented-out
+      # `service` / `rpc` / `message` declaration is never mistaken for a
+      # live definition (a false-positive source). Newlines are preserved,
+      # so reported line numbers stay accurate.
+      clean = strip_comments(content)
+      package = parse_package(clean)
+      messages = parse_messages(clean)
+      parse_services(clean, file_path, package, messages)
+    end
+
+    # Replaces `//` line comments and `/* */` block comments with spaces
+    # while preserving string literals, the total length, and every newline
+    # (so positions/line numbers in the cleaned copy match the original).
+    private def strip_comments(content : String) : String
+      chars = content.chars
+      size = chars.size
+      String.build(content.bytesize) do |io|
+        pos = 0
+        in_string = false
+        while pos < size
+          ch = chars[pos]
+          if in_string
+            io << ch
+            if ch == '"'
+              # A quote closes the string only when preceded by an EVEN
+              # number of backslashes (`\\"` toggles, `\"` does not).
+              bs = 0
+              bp = pos - 1
+              while bp >= 0 && chars[bp] == '\\'
+                bs += 1
+                bp -= 1
+              end
+              in_string = false if bs.even?
+            end
+            pos += 1
+          elsif ch == '/' && pos + 1 < size && chars[pos + 1] == '/'
+            # Line comment: blank to EOL, leaving the newline for the next loop.
+            while pos < size && chars[pos] != '\n'
+              io << ' '
+              pos += 1
+            end
+          elsif ch == '/' && pos + 1 < size && chars[pos + 1] == '*'
+            # Block comment: blank through the closing `*/`, keeping newlines.
+            io << ' ' << ' '
+            pos += 2
+            while pos < size && !(chars[pos] == '*' && pos + 1 < size && chars[pos + 1] == '/')
+              io << (chars[pos] == '\n' ? '\n' : ' ')
+              pos += 1
+            end
+            if pos < size
+              io << ' ' << ' '
+              pos += 2
+            end
+          elsif ch == '"'
+            in_string = true
+            io << ch
+            pos += 1
+          else
+            io << ch
+            pos += 1
+          end
+        end
+      end
     end
 
     private def parse_package(content : String) : String
@@ -39,7 +99,7 @@ module Analyzer::Specification
       messages = {} of String => MessageFields
 
       # Find message blocks using brace matching (supports nested messages/enums)
-      content.scan(/message\s+(\w+)\s*\{/m) do |match|
+      content.scan(/\bmessage\s+(\w+)\s*\{/m) do |match|
         msg_name = match[1]
         start_pos = match.begin(0) || 0
         brace_pos = content.index('{', start_pos)
@@ -70,7 +130,7 @@ module Analyzer::Specification
 
     private def parse_services(content : String, file_path : String, package : String, messages : Hash(String, MessageFields))
       # Find service blocks using brace matching
-      content.scan(/service\s+(\w+)\s*\{/m) do |service_match|
+      content.scan(/\bservice\s+(\w+)\s*\{/m) do |service_match|
         service_name = service_match[1]
         start_pos = service_match.begin(0) || 0
         brace_pos = content.index('{', start_pos)
@@ -125,7 +185,7 @@ module Analyzer::Specification
 
     private def parse_rpc_methods(service_body : String, file_path : String, package : String, service_name : String, messages : Hash(String, MessageFields), full_content : String)
       # Find each rpc definition and its associated options block
-      service_body.scan(/rpc\s+(\w+)\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)\s*returns\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)/m) do |rpc_match|
+      service_body.scan(/\brpc\s+(\w+)\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)\s*returns\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)/m) do |rpc_match|
         method_name = rpc_match[1]
         request_streaming = !rpc_match[2]?.nil?
         request_type = rpc_match[3]


### PR DESCRIPTION
## Summary

The gRPC specification analyzer scanned **raw** `.proto` content for `service`, `rpc`, and `message` declarations. As a result a commented-out `rpc`/`service` — in either `//` line or `/* */` block form — was reported as a live endpoint (a false positive).

This is the first of several small improvements aimed at lowering the gRPC analyzer's FP/FN rate (validated against `grpc-ecosystem/grpc-gateway` and `googleapis/googleapis`).

### Repro (before)

```proto
service ProbeService {
  // rpc OldRemoved(RealRequest) returns (RealRequest) {}
  /* rpc BlockCommented(RealRequest) returns (RealRequest) {} */
  rpc RealMethod(RealRequest) returns (RealRequest) {}
}
```

Previously produced **three** endpoints (`OldRemoved`, `BlockCommented`, `RealMethod`); now produces only `RealMethod`.

## Changes

- Add `strip_comments` that blanks `//` and `/* */` comments while preserving string literals, total length, and every newline (so reported line numbers stay accurate).
- Parse package/messages/services on the comment-stripped copy.
- Anchor the `service` / `rpc` / `message` keyword scans with `\b` so the keywords aren't matched inside larger identifiers.

## Tests

- New `comments.proto` fixture covering commented-out services/methods in both comment styles; only the single real rpc is detected.
- `crystal spec spec/functional_test/testers/specification/grpc_spec.cr` → all green (90 examples).
- `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6)_