### PR TITLE
fix(tagger/oauth): tag param-less social-login flow handlers

### DIFF
--- a/spec/unit_test/tagger/taggers/oauth_spec.cr
+++ b/spec/unit_test/tagger/taggers/oauth_spec.cr
@@ -273,5 +273,53 @@ describe "OAuthTagger" do
 
       endpoint.tags.size.should eq(0)
     end
+
+    it "tags a param-less social-login callback under an auth context" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      # Laravel Socialite style (e.g. koel): the `code`/`state` params
+      # arrive at runtime and aren't statically extracted, but
+      # `/auth/<provider>/callback` is unambiguously an OAuth flow.
+      endpoint = Endpoint.new("/auth/google/callback", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "tags a param-less social-login redirect under an auth context" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/auth/google/redirect", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "tags an SSO callback handler with no extracted params" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/sso/callback", "GET")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("oauth")
+    end
+
+    it "does not tag a callback without an auth/SSO context segment" do
+      tagger = OAuthTagger.new(default_tagger_options)
+
+      # No auth/SSO context word in the path and no OAuth params — this is
+      # a payment IPN, not an OAuth sign-in flow.
+      endpoint = Endpoint.new("/payments/stripe/callback", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
   end
 end

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -18,6 +18,24 @@ class OAuthTagger < Tagger
   # parameters before flagging.
   WEAK_URL_PARTS = Set{"authorize", "authorization", "token", "callback"}
 
+  # Auth/SSO context segments that mark a `/callback`, `/authorize`, or
+  # `/redirect` handler as part of an OAuth/OIDC sign-in flow rather than a
+  # payment IPN or a post-action redirect. This mirrors the set the webhook
+  # tagger uses to *exclude* these same callbacks from being tagged as
+  # webhooks — keeping the two taggers consistent about what
+  # `/auth/<provider>/callback` is.
+  OAUTH_FLOW_CONTEXT_SEGMENTS = Set{
+    "oauth", "oauth2", "oauth20", "openid", "oidc",
+    "auth", "authentication", "sso",
+  }
+
+  # OAuth-flow verbs: the redirect out to the IdP (`/redirect`,
+  # `/authorize`) and the authorization-code handler coming back
+  # (`/callback`). Many social-login handlers expose no statically
+  # extractable params (the `code`/`state` arrive at runtime), so the
+  # param-corroborated checks below miss them.
+  OAUTH_FLOW_VERB_SEGMENTS = Set{"callback", "authorize", "authorization", "redirect"}
+
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "oauth"
@@ -51,7 +69,12 @@ class OAuthTagger < Tagger
           (weak_url && oauth_token_params?(param_names)) ||
           # The authorization-code redirect handler — `/callback` (or
           # `/auth/<provider>/callback`) receiving `code` + `state`.
-          oauth_callback?(parts, param_names)
+          oauth_callback?(parts, param_names) ||
+          # A param-less social-login flow handler under an auth/SSO
+          # context — `/auth/google/callback`, `/auth/google/redirect`,
+          # `/sso/callback`. The `code`/`state` params arrive at runtime,
+          # so the param checks above can't see them.
+          oauth_flow_path?(parts)
 
       if check
         tag = Tag.new("oauth", "Suspected OAuth endpoint for granting 3rd party access.", "Oauth")
@@ -100,6 +123,17 @@ class OAuthTagger < Tagger
   private def oauth_callback?(parts : Array(String), param_names : Set(String)) : Bool
     return false unless parts.includes?("callback")
     param_names.includes?("code") && param_names.includes?("state")
+  end
+
+  # An OAuth/OIDC sign-in flow handler identified by path alone: an
+  # auth/SSO context segment (`auth`, `sso`, `openid`, ...) together with a
+  # flow verb (`callback`, `authorize`, `redirect`). A bare `/callback` or
+  # `/payments/callback` lacks the context segment and is left to the
+  # param-corroborated checks (and the webhook tagger), so this only fires
+  # on unambiguous sign-in flows like `/auth/<provider>/callback`.
+  private def oauth_flow_path?(parts : Array(String)) : Bool
+    return false unless parts.any? { |part| OAUTH_FLOW_VERB_SEGMENTS.includes?(part) }
+    parts.any? { |part| OAUTH_FLOW_CONTEXT_SEGMENTS.includes?(part) }
   end
 
   private def oauth_authorization_params?(param_names : Set(String)) : Bool


### PR DESCRIPTION
## Summary

Reduces a **false negative** in the `oauth` tagger.

Social-login redirect/callback handlers (Laravel Socialite, Spring Security OAuth, Passport, etc.) receive `code`/`state` only at runtime, so static analysis extracts no params and the param-corroborated checks miss them. On a fresh clone of **koel**, `/auth/google/callback` and `/auth/google/redirect` went **untagged**, while `/auth/oidc/callback` was tagged only because `oidc` happens to be a strong segment.

## Change

Recognize a param-less OAuth/OIDC sign-in flow by **path alone**: an auth/SSO context segment (`auth`, `authentication`, `sso`, `oauth`, `oauth2`, `openid`, `oidc`) together with a flow-verb segment (`callback`, `authorize`, `authorization`, `redirect`).

This deliberately mirrors the segment set the **webhook tagger already uses to *exclude*** these same callbacks from being tagged as webhooks (`AUTH_CALLBACK_SEGMENTS`), keeping the two taggers consistent about what `/auth/<provider>/callback` is.

A bare `/callback` or `/payments/stripe/callback` lacks the context segment and is still left to the existing param checks (and the webhook tagger), so **no payment-IPN false positives** are introduced.

## Verification

- koel: `/auth/google/redirect` and `/auth/google/callback` are now tagged `oauth` alongside the existing `/auth/oidc/*` (2 → 4 oauth tags), with no new tags elsewhere.
- Cross-checked gin/django/rails/fastapi RealWorld + petclinic clones: no new oauth tags.
- Added 4 regression specs (positive: social callback/redirect, SSO callback; negative: payment callback without auth context).
- `crystal spec spec/unit_test/tagger/` → 498 examples, 0 failures. `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M)_