### PR TITLE
fix(analyzer/specification): reduce Postman/Insomnia false negatives (auth + raw bodies)

### DIFF
--- a/spec/unit_test/analyzer/specification/insomnia_spec.cr
+++ b/spec/unit_test/analyzer/specification/insomnia_spec.cr
@@ -72,6 +72,40 @@ describe "Insomnia Analyzer" do
     graphql.details.code_paths.map(&.path).should_not contain("UsersController.kt")
   end
 
+  it "does not drop requests whose body is a raw string (legacy exports)" do
+    endpoints = analyze_insomnia_json <<-JSON
+      {
+        "_type": "export",
+        "__export_format": 4,
+        "resources": [
+          {
+            "_id": "req_1",
+            "_type": "request",
+            "name": "Create User",
+            "method": "POST",
+            "url": "https://api.example.com/users",
+            "body": "{\\"foo\\": \\"bar\\"}"
+          },
+          {
+            "_id": "req_2",
+            "_type": "request",
+            "name": "Plain Body",
+            "method": "POST",
+            "url": "https://api.example.com/notes",
+            "body": "Hello World!"
+          }
+        ]
+      }
+      JSON
+
+    endpoints.map(&.url).sort.should eq ["/notes", "/users"]
+    users = endpoints.find!(&.url.==("/users"))
+    users.params.map { |p| {p.name, p.param_type} }.should contain({"foo", "json"})
+
+    notes = endpoints.find!(&.url.==("/notes"))
+    notes.params.should be_empty
+  end
+
   it "does not share details between v5 requests in one collection" do
     endpoints = analyze_insomnia_yaml <<-YAML
       type: collection.insomnia.rest/5.0

--- a/spec/unit_test/analyzer/specification/insomnia_spec.cr
+++ b/spec/unit_test/analyzer/specification/insomnia_spec.cr
@@ -98,7 +98,7 @@ describe "Insomnia Analyzer" do
       }
       JSON
 
-    endpoints.map(&.url).sort.should eq ["/notes", "/users"]
+    endpoints.map(&.url).sort!.should eq ["/notes", "/users"]
     users = endpoints.find!(&.url.==("/users"))
     users.params.map { |p| {p.name, p.param_type} }.should contain({"foo", "json"})
 

--- a/spec/unit_test/analyzer/specification/postman_spec.cr
+++ b/spec/unit_test/analyzer/specification/postman_spec.cr
@@ -174,6 +174,88 @@ describe "Postman Analyzer" do
     graphql_params.should contain({"id", "123", "json"})
   end
 
+  it "extracts request-level auth as parameters" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Auth Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": [
+          {
+            "name": "Bearer",
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/bearer",
+              "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "abc" } ] }
+            }
+          },
+          {
+            "name": "ApiKeyQuery",
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/apikey",
+              "auth": { "type": "apikey", "apikey": [
+                { "key": "key", "value": "X-Api-Key" },
+                { "key": "value", "value": "secret" },
+                { "key": "in", "value": "query" }
+              ] }
+            }
+          },
+          {
+            "name": "Basic v2.0 object form",
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/basic",
+              "auth": { "type": "basic", "basic": { "username": "u", "password": "p" } }
+            }
+          }
+        ]
+      }
+      JSON
+
+    bearer = endpoints.find!(&.url.==("/bearer"))
+    param_tuples(bearer).should contain({"Authorization", "Bearer abc", "header"})
+
+    apikey = endpoints.find!(&.url.==("/apikey"))
+    param_tuples(apikey).should contain({"X-Api-Key", "secret", "query"})
+
+    basic = endpoints.find!(&.url.==("/basic"))
+    param_tuples(basic).should contain({"Authorization", "", "header"})
+  end
+
+  it "inherits collection-level auth and lets requests override with noauth" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Inherited Auth Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "root" } ] },
+        "item": [
+          {
+            "name": "Inherits",
+            "request": { "method": "GET", "url": "https://api.example.com/inherits" }
+          },
+          {
+            "name": "Opts out",
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/public",
+              "auth": { "type": "noauth" }
+            }
+          }
+        ]
+      }
+      JSON
+
+    inherits = endpoints.find!(&.url.==("/inherits"))
+    param_tuples(inherits).should contain({"Authorization", "Bearer root", "header"})
+
+    public_ep = endpoints.find!(&.url.==("/public"))
+    public_ep.params.any? { |p| p.name == "Authorization" }.should be_false
+  end
+
   it "does not share details between requests in one collection" do
     endpoints = analyze_postman <<-JSON
       {

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -1,5 +1,6 @@
 require "../../../models/analyzer"
 require "../../../utils/http_symbols"
+require "uri"
 
 module Analyzer::Specification
   class Insomnia < Analyzer
@@ -127,6 +128,15 @@ module Analyzer::Specification
     end
 
     private def process_v4_body(body : JSON::Any, params : Array(Param))
+      # Older Insomnia exports (formats 2/3) store the request body as a raw
+      # string instead of an object. Attempt to parse it as JSON so that body
+      # params are still surfaced, and bail out gracefully otherwise.
+      if text = body.as_s?
+        process_json_body_text(text, params)
+        return
+      end
+      return unless body.as_h?
+
       mime = (body["mimeType"]?.try(&.as_s?) || "").downcase
       case
       when mime.includes?("application/json")
@@ -268,6 +278,13 @@ module Analyzer::Specification
     end
 
     private def process_v5_body(body : YAML::Any, params : Array(Param))
+      # Guard against bodies serialized as scalars rather than mappings.
+      if text = body.as_s?
+        process_json_body_text(text, params)
+        return
+      end
+      return unless body.as_h?
+
       mime = (body["mimeType"]?.try(&.as_s?) || "").downcase
       case
       when mime.includes?("application/json")

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -16,7 +16,7 @@ module Analyzer::Specification
             begin
               # Process items (requests) in the collection
               if json_obj["item"]?
-                process_items(json_obj["item"], postman_file, collect_variables(json_obj["variable"]?))
+                process_items(json_obj["item"], postman_file, collect_variables(json_obj["variable"]?), "", json_obj["auth"]?)
               end
             rescue e
               @logger.debug "Exception processing #{postman_file}"
@@ -29,7 +29,7 @@ module Analyzer::Specification
       @result
     end
 
-    private def process_items(items, source_path : String, variables : Hash(String, String), folder_path = "")
+    private def process_items(items, source_path : String, variables : Hash(String, String), folder_path = "", inherited_auth : JSON::Any? = nil)
       item_array = items.as_a?
       return unless item_array
 
@@ -39,13 +39,15 @@ module Analyzer::Specification
 
           # Check if it's a folder (has nested items) or a request
           if item["item"]?
-            # It's a folder, recurse into it
+            # It's a folder, recurse into it. A folder may declare its own auth,
+            # which overrides the collection/parent auth for everything beneath it.
             folder_name = item["name"]?.try(&.to_s) || ""
             new_path = folder_path.empty? ? folder_name : "#{folder_path}/#{folder_name}"
-            process_items(item["item"], source_path, item_variables, new_path)
+            folder_auth = item["auth"]? || inherited_auth
+            process_items(item["item"], source_path, item_variables, new_path, folder_auth)
           elsif item["request"]?
             # It's a request, process it
-            process_request(item, source_path, item_variables)
+            process_request(item, source_path, item_variables, inherited_auth)
           end
         rescue e
           @logger.debug "Exception processing item"
@@ -54,7 +56,7 @@ module Analyzer::Specification
       end
     end
 
-    private def process_request(item, source_path : String, variables : Hash(String, String))
+    private def process_request(item, source_path : String, variables : Hash(String, String), inherited_auth : JSON::Any? = nil)
       request = item["request"]
 
       if request_url = request.as_s?
@@ -63,6 +65,7 @@ module Analyzer::Specification
         url_path = extract_path_from_url(resolved_url)
         extract_query_params(resolved_url).each { |param| add_param(params, param) }
         extract_path_vars(url_path).each { |name| add_param(params, Param.new(name, "", "path")) }
+        apply_auth(inherited_auth, params)
         @result << Endpoint.new(url_path, "GET", params, Details.new(PathInfo.new(source_path))) unless url_path.empty?
         return
       end
@@ -162,6 +165,10 @@ module Analyzer::Specification
           end
         end
       end
+
+      # Authentication. A request-level `auth` block overrides any auth
+      # inherited from the enclosing folder/collection.
+      apply_auth(request["auth"]? || inherited_auth, params)
 
       # Create endpoint
       if !url_path.empty?
@@ -345,6 +352,59 @@ module Analyzer::Specification
 
     private def unresolved_variable_segment?(segment : String) : Bool
       segment.matches?(/\A\{\{\s*[^}]+\s*\}\}\z/)
+    end
+
+    # Surfaces authentication as request parameters so that auth-bearing
+    # endpoints are not under-reported. Mirrors the Insomnia analyzer:
+    # api keys become header/query params, token-based schemes become an
+    # `Authorization` header. `noauth` explicitly clears inherited auth.
+    private def apply_auth(auth : JSON::Any?, params : Array(Param))
+      return unless auth
+      return unless auth.as_h?
+
+      type = (auth["type"]?.try(&.as_s?) || "").downcase
+      return if type.empty? || type == "noauth"
+
+      fields = postman_auth_fields(auth, type)
+      case type
+      when "apikey"
+        name = fields["key"]? || ""
+        value = fields["value"]? || ""
+        location = (fields["in"]? || "header").downcase == "query" ? "query" : "header"
+        add_param(params, Param.new(name, value, location))
+      when "bearer"
+        token = fields["token"]? || ""
+        auth_value = token.empty? ? "" : "Bearer #{token}"
+        add_param(params, Param.new("Authorization", auth_value, "header"))
+      when "basic", "digest", "oauth1", "oauth2", "hawk", "ntlm", "awsv4", "edgegrid", "jwt", "akamai"
+        add_param(params, Param.new("Authorization", "", "header"))
+      end
+    end
+
+    # Postman serializes the auth parameters either as an array of
+    # `{key, value}` entries (v2.1) or as a plain object (v2.0). Normalize
+    # both into a flat string map.
+    private def postman_auth_fields(auth : JSON::Any, type : String) : Hash(String, String)
+      fields = {} of String => String
+      node = auth[type]?
+      return fields unless node
+
+      if entries = node.as_a?
+        entries.each do |entry|
+          next unless key = entry["key"]?.try(&.as_s?)
+          if value = scalar_to_s(entry["value"]?)
+            fields[key] = value
+          end
+        end
+      elsif hash = node.as_h?
+        hash.each do |key, value|
+          if str = scalar_to_s(value)
+            fields[key] = str
+          end
+        end
+      end
+
+      fields
     end
 
     private def collect_variables(node : JSON::Any?) : Hash(String, String)


### PR DESCRIPTION
## Summary

Improves the fidelity of the Insomnia and Postman specification analyzers to reduce false negatives. Both changes were validated against real export fixtures cloned from the upstream `Kong/insomnia` and `postmanlabs/postman-collection` repositories (≈70 collections).

### 1. `fix(insomnia)`: handle raw-string request bodies
Legacy Insomnia exports (export formats 2/3) serialize the request body as a **raw string** rather than a mapping. The analyzer assumed an object and raised `Expected Hash`, which bubbled up through the per-resource rescue and **discarded the entire request** — a false negative for every request in those exports.

- Guard the v4/v5 body handlers against scalar bodies.
- Parse string bodies as JSON so their params are still surfaced (non-JSON strings are ignored, so no false positives).
- `require "uri"` explicitly so the analyzer compiles in isolation.

### 2. `feat(postman)`: surface authentication as endpoint parameters
The Postman analyzer ignored the `auth` block entirely, so auth-bearing endpoints reported no auth parameters — a false negative, and an inconsistency with the Insomnia analyzer which already handles auth.

- `apikey` → header or query param (honoring the `in` field)
- `bearer` → `Authorization: Bearer <token>` header
- `basic`/`digest`/`oauth1`/`oauth2`/`hawk`/`ntlm`/`awsv4`/`edgegrid`/`jwt` → `Authorization` header
- Both the v2.1 array form and the v2.0 object form of the auth payload are supported.
- Auth is inherited collection → folder → request, with the nearest declaration winning and `noauth` clearing inherited auth (no over-reporting).

## Testing
- New unit tests for both analyzers (raw-string bodies, request/inherited/`noauth` auth, v2.0 + v2.1 forms).
- `crystal spec spec/unit_test` → 3490 examples, 0 failures.
- `crystal spec spec/functional_test` → 19291 examples, 0 failures.
- `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01JCkuLjj2peTDDDKvaFHkBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCkuLjj2peTDDDKvaFHkBW)_