### PR TITLE
feat(passive-scan): suppress empty-value and env() helper secret false positives

### DIFF
--- a/spec/unit_test/passive_scan/false_positive_spec.cr
+++ b/spec/unit_test/passive_scan/false_positive_spec.cr
@@ -56,5 +56,26 @@ describe NoirPassiveScan::FalsePositive do
       # whole-value reference rule.
       NoirPassiveScan::FalsePositive.secret_reference?(%(password = "P$ssw0rd-Real-Value-123")).should be_false
     end
+
+    it "suppresses empty assignment values (.env.example / config stubs)" do
+      NoirPassiveScan::FalsePositive.secret_reference?("AWS_ACCESS_KEY_ID=").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("AWS_SECRET_ACCESS_KEY=  ").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("GITHUB_TOKEN:").should be_true
+    end
+
+    it "suppresses single-argument env() helper calls (Laravel/Symfony/Rails)" do
+      NoirPassiveScan::FalsePositive.secret_reference?(%(            'key' => env('AWS_ACCESS_KEY_ID'),)).should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?(%(    'secret' => env("AWS_SECRET_ACCESS_KEY"),)).should be_true
+    end
+
+    it "keeps a two-argument env() call whose default could be a literal" do
+      # `env('KEY', 'maybe-a-real-default')` must not be suppressed — the
+      # second argument can hold a hard-coded fallback secret.
+      NoirPassiveScan::FalsePositive.secret_reference?(%('key' => env('AWS_ACCESS_KEY_ID', 'AKIAREALFALLBACKKEY1'))).should be_false
+    end
+
+    it "keeps a populated value that uses the => hash-arrow separator" do
+      NoirPassiveScan::FalsePositive.secret_reference?(%('key' => 'AKIAIOSFODNN7REALKEYX')).should be_false
+    end
   end
 end

--- a/src/passive_scan/false_positive.cr
+++ b/src/passive_scan/false_positive.cr
@@ -38,19 +38,30 @@ module NoirPassiveScan
       "Sys.getenv",
     ]
 
-    # Captures the value to the right of the first `=` or `:` separator,
-    # trimming surrounding whitespace. Lines with no assignment separator
-    # (e.g. a bare `-----BEGIN RSA PRIVATE KEY-----`) never match, so PEM
-    # blocks and similar literals fall through untouched.
-    ASSIGNMENT_VALUE = /[:=]\s*(.+?)\s*$/
+    # Captures the value to the right of the first assignment separator
+    # (`:`, `=`, or the PHP/Ruby hash arrow `=>`), trimming surrounding
+    # whitespace. Lines with no assignment separator (e.g. a bare
+    # `-----BEGIN RSA PRIVATE KEY-----`) never match, so PEM blocks and
+    # similar literals fall through untouched.
+    ASSIGNMENT_VALUE = /(?::|=>?)\s*(.+?)\s*$/
+
+    # Same separators as ASSIGNMENT_VALUE but with an *empty* value —
+    # `AWS_ACCESS_KEY_ID=` / `password:` in a `.env.example` or config
+    # template. An empty value cannot carry a secret, so a keyword match
+    # on such a line is always a false positive.
+    EMPTY_ASSIGNMENT = /(?::|=>?)\s*$/
 
     # Whole-value forms that are references or placeholders, never
     # literals: shell/template variable substitutions (`$VAR`, `${VAR}`,
-    # `${{ … }}`, `$(…)`, `%VAR%`, `{{ … }}`) and angle-bracket
-    # placeholders (`<your-token>`). Anchored so it only fires when the
-    # *entire* value is a reference — a real secret that merely contains
-    # a `$` (e.g. `P$ssw0rd…`) is not matched.
-    PURE_REFERENCE = /\A(?:\$\{?\{?[A-Za-z_][\w.\- ]*\}?\}?|\$\(.+\)|%[A-Za-z_]\w*%|\{\{.+\}\}|<[^>]+>)\z/
+    # `${{ … }}`, `$(…)`, `%VAR%`, `{{ … }}`), angle-bracket placeholders
+    # (`<your-token>`), and single-argument env-helper calls
+    # (`env('AWS_ACCESS_KEY_ID')`, common in Laravel/Symfony/Rails config).
+    # Anchored so it only fires when the *entire* value is a reference — a
+    # real secret that merely contains a `$` (e.g. `P$ssw0rd…`) is not
+    # matched. The env-call form is deliberately single-argument: a
+    # two-argument `env('K', 'default')` could hide a literal default, so
+    # it is left to fall through.
+    PURE_REFERENCE = /\A(?:\$\{?\{?[A-Za-z_][\w.\- ]*\}?\}?|\$\(.+\)|%[A-Za-z_]\w*%|\{\{.+\}\}|<[^>]+>|env\(\s*['"][^'",]+['"]\s*\))\z/
 
     # True when `line` exposes its secret-bearing value only through an
     # indirection (env read / templating) or a placeholder — i.e. there
@@ -62,6 +73,9 @@ module NoirPassiveScan
 
       # Runtime environment-variable accessors.
       return true if ENV_ACCESSOR_MARKERS.any? { |marker| line.includes?(marker) }
+
+      # Empty assignment value — `.env.example` / config template stub.
+      return true if line.matches?(EMPTY_ASSIGNMENT)
 
       # Value position is itself a reference / placeholder.
       if match = line.match(ASSIGNMENT_VALUE)


### PR DESCRIPTION
## Summary

Follow-up to #2108. Scanning real Laravel projects surfaced two more runtime-indirection false positives in the secret scanner:

- **Empty assignment values** — `.env.example` / config stubs like `AWS_ACCESS_KEY_ID=` or `password:`. An empty value cannot carry a secret, so a keyword hit there is always a false positive.
- **Single-argument `env()` helper calls** — `env('AWS_ACCESS_KEY_ID')`, the Laravel/Symfony/Rails idiom for reading config from the environment.

## Approach

Extends `NoirPassiveScan::FalsePositive`:
- assignment-value parser now also recognises the PHP/Ruby hash arrow (`=>`)
- new `EMPTY_ASSIGNMENT` short-circuit for empty values
- single-argument `env('NAME')` form added to the whole-value reference set

The same invariant from #2108 holds — **never hide a real literal.** The `env()` form is deliberately single-argument: a two-argument `env('K', 'default')` could hide a hard-coded default, so it falls through untouched.

## Validation (cloned real repos)

| repo | before | after | notes |
|------|--------|-------|-------|
| laravel/laravel | 20 | 0 | all `.env.example` empty stubs + `env('…')` config reads suppressed |
| pallets/flask | 0 | 0 | unchanged |
| expressjs/express | 0 | 0 | unchanged |
| gin-gonic/gin | 1 | 1 | real `-----BEGIN RSA PRIVATE KEY-----` still reported ✅ |

A control fixture of 8 real-shaped literal secrets (AWS, GitHub, OpenAI, Slack, PEM) remains fully detected — no false negatives introduced.

## Tests

- New `FalsePositive` specs: empty values, single-arg `env()`, two-arg `env()` kept, `=>`-separated literal kept.
- Full unit suite green (3503 examples, 0 failures); `crystal tool format --check` + `ameba` clean.

https://claude.ai/code/session_016pH4ELCk2Anmkdzij2ZZCt

---
_Generated by [Claude Code](https://claude.ai/code/session_016pH4ELCk2Anmkdzij2ZZCt)_