### PR TITLE
fix(graphql): kill quadratic SDL scan and phantom operation endpoints

### DIFF
--- a/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
+++ b/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
@@ -3,55 +3,173 @@ require "../../../models/endpoint"
 require "json"
 require "log"
 
-# Define the regex as a top-level constant in this file
-OPERATION_REGEX = Regex.new("(query|mutation|subscription)\\s+([_A-Za-z][_0-9A-Za-z]*)")
-
+# Parses GraphQL *operation documents* (`query Foo { ... }`,
+# `mutation Bar { ... }`, `subscription Baz { ... }`) carried in `.graphql`
+# files and emits one `/graphql` endpoint per named top-level operation.
+#
+# SDL schema documents are handled separately by the `graphql_sdl`
+# analyzer; this analyzer deliberately reports nothing for them.
 module InternalGraphqlParser
+  # Keywords that introduce a top-level operation definition.
+  OPERATION_KEYWORDS = {"query", "mutation", "subscription"}
+
   def self.parse_content(path : String, file_content : String) : Array(Endpoint)
     results = [] of Endpoint
 
-    file_content.each_line.with_index do |line, index|
-      current_offset = 0
-      while match_data = OPERATION_REGEX.match(line, current_offset)
-        operation_type_capture = match_data.captures[0]?
-        operation_name_capture = match_data.captures[1]?
+    # Materialize into an Array(Char) for O(1) positional access. Indexing a
+    # String is O(n) when it is not single-byte-optimizable, so a single
+    # multi-byte char (an emoji in a description, say) would otherwise make
+    # this scan quadratic.
+    chars = file_content.chars
+    n = chars.size
+    i = 0
+    line = 1
+    depth = 0
 
-        if operation_type_capture && operation_name_capture
-          operation_type = operation_type_capture
-          operation_name = operation_name_capture
-
-          endpoint_url = "/graphql"
-          endpoint_method = "POST"
-          param_value_hash = {operation_type => operation_name}
-          param_value_json = param_value_hash.to_json
-          param_name = "graphql_operation_#{operation_type}_#{operation_name}"
-
-          param = Param.new(param_name, param_value_json, "json")
-          details = Details.new(PathInfo.new(path, index + 1))
-          endpoint = Endpoint.new(endpoint_url, endpoint_method, details)
-          endpoint.push_param(param)
-          results << endpoint
+    while i < n
+      c = chars[i]
+      case c
+      when '\n'
+        line += 1
+        i += 1
+      when '#'
+        # Line comment: skip to (but not past) the newline.
+        while i < n && chars[i] != '\n'
+          i += 1
         end
-
-        full_match_string = match_data[0]?
-        if full_match_string
-          found_at_index = line.index(full_match_string, current_offset)
-          if found_at_index
-            match_length = full_match_string.bytesize
-            current_offset = found_at_index + match_length
-            if match_length == 0
-              current_offset = found_at_index + 1
-            end
-          else
-            current_offset += 1 # Fallback
+      when '"'
+        # String / block-string literal: skip it so keywords appearing as
+        # prose inside a """description""" never look like operations.
+        i, consumed_newlines = skip_string(chars, i, n)
+        line += consumed_newlines
+      when '{'
+        depth += 1
+        i += 1
+      when '}'
+        depth -= 1 if depth > 0
+        i += 1
+      else
+        # An operation definition only ever appears at the top level
+        # (brace depth 0). Requiring depth 0 rejects fields named
+        # `query`/`subscription` inside a selection set and the
+        # `schema { query: Root }` mapping in an SDL document.
+        if depth == 0 && (i == 0 || !ident_char?(chars[i - 1])) && (keyword = keyword_at(chars, i, n))
+          new_i, new_line, op_name = read_operation_name(chars, i + keyword.size, n, line)
+          if op_name
+            results << build_endpoint(path, keyword, op_name, line)
+            line = new_line
+            i = new_i
+            next
           end
-        else
-          current_offset += 1 # Fallback
         end
-        break if current_offset >= line.bytesize
+        i += 1
       end
     end
+
     results
+  end
+
+  # Reads the operation name (if any) following an operation keyword and
+  # validates that what follows is genuinely an operation definition — the
+  # name must be followed by a variable list `(`, a directive `@`, or the
+  # selection set `{`. Returns the cursor/line just past the name plus the
+  # parsed name, or a nil name when this is not a named operation.
+  private def self.read_operation_name(chars : Array(Char), pos : Int32, n : Int32, line : Int32) : Tuple(Int32, Int32, String?)
+    cur = pos
+    cur_line = line
+    while cur < n && separator?(chars[cur])
+      cur_line += 1 if chars[cur] == '\n'
+      cur += 1
+    end
+    return {pos, line, nil} unless cur < n && ident_start?(chars[cur])
+
+    name_end = cur
+    while name_end < n && ident_char?(chars[name_end])
+      name_end += 1
+    end
+    name = String.build { |s| (cur...name_end).each { |k| s << chars[k] } }
+
+    # Peek the first significant char after the name; a real operation has a
+    # variable list, a directive, or a selection set there.
+    peek = name_end
+    while peek < n && separator?(chars[peek])
+      peek += 1
+    end
+    return {pos, line, nil} unless peek < n && {'(', '@', '{'}.includes?(chars[peek])
+
+    {name_end, cur_line, name}
+  end
+
+  private def self.build_endpoint(path : String, operation_type : String, operation_name : String, line : Int32) : Endpoint
+    param_value_json = {operation_type => operation_name}.to_json
+    param_name = "graphql_operation_#{operation_type}_#{operation_name}"
+    param = Param.new(param_name, param_value_json, "json")
+    details = Details.new(PathInfo.new(path, line))
+    endpoint = Endpoint.new("/graphql", "POST", details)
+    endpoint.push_param(param)
+    endpoint
+  end
+
+  # Skips a `"..."` or `"""..."""` literal starting at `chars[i] == '"'`.
+  # Returns the cursor just past the closing quote and the number of
+  # newlines consumed (so callers can keep their line counter accurate).
+  private def self.skip_string(chars : Array(Char), i : Int32, n : Int32) : Tuple(Int32, Int32)
+    newlines = 0
+    if i + 2 < n && chars[i + 1] == '"' && chars[i + 2] == '"'
+      i += 3
+      while i < n
+        if i + 2 < n && chars[i] == '"' && chars[i + 1] == '"' && chars[i + 2] == '"'
+          return {i + 3, newlines}
+        end
+        newlines += 1 if chars[i] == '\n'
+        i += 1
+      end
+      {i, newlines}
+    else
+      i += 1
+      while i < n
+        ch = chars[i]
+        if ch == '\\' && i + 1 < n
+          i += 2
+        elsif ch == '"'
+          return {i + 1, newlines}
+        else
+          newlines += 1 if ch == '\n'
+          i += 1
+        end
+      end
+      {i, newlines}
+    end
+  end
+
+  private def self.keyword_at(chars : Array(Char), i : Int32, n : Int32) : String?
+    OPERATION_KEYWORDS.each do |kw|
+      ksize = kw.size
+      next if i + ksize > n
+      matched = true
+      kw.each_char_with_index do |kc, off|
+        if chars[i + off] != kc
+          matched = false
+          break
+        end
+      end
+      next unless matched
+      after = i + ksize
+      return kw if after >= n || !ident_char?(chars[after])
+    end
+    nil
+  end
+
+  private def self.ident_char?(c : Char) : Bool
+    c.ascii_alphanumeric? || c == '_'
+  end
+
+  private def self.ident_start?(c : Char) : Bool
+    c.ascii_letter? || c == '_'
+  end
+
+  private def self.separator?(c : Char) : Bool
+    c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ','
   end
 end
 

--- a/src/analyzer/analyzers/specification/graphql_sdl_parser.cr
+++ b/src/analyzer/analyzers/specification/graphql_sdl_parser.cr
@@ -266,48 +266,62 @@ module Analyzer::Specification
 
     # ---------- low-level parsers ----------
 
+    # Replaces every comment and string literal with position-preserving
+    # whitespace so the downstream grammar never has to reason about them.
+    #
+    # The input is first materialized into an `Array(Char)` so positional
+    # access is O(1). Indexing a `String` directly (`content[i]`) is O(n)
+    # whenever the document is not single-byte-optimizable — a single
+    # multi-byte char (e.g. an emoji in a `"""description"""`) turns the
+    # whole scan quadratic, which on real schemas like GitHub's 360 KB SDL
+    # meant ~100 s instead of ~20 ms. The returned string is ASCII-only
+    # (any stray non-ASCII char — which GraphQL only ever permits inside
+    # strings/comments anyway — is mapped to a space), so every subsequent
+    # positional pass over `sanitized` stays single-byte-optimizable too.
     private def strip_comments(content : String) : String
-      String.build(content.size) do |io|
+      chars = content.chars
+      size = chars.size
+      String.build(content.bytesize) do |io|
         i = 0
-        while i < content.size
-          ch = content[i]
+        while i < size
+          ch = chars[i]
           case ch
           when '#'
-            while i < content.size && content[i] != '\n'
+            while i < size && chars[i] != '\n'
               io << ' '
               i += 1
             end
           when '"'
-            if i + 2 < content.size && content[i + 1] == '"' && content[i + 2] == '"'
+            if i + 2 < size && chars[i + 1] == '"' && chars[i + 2] == '"'
               io << "   "
               i += 3
-              while i + 2 < content.size && !(content[i] == '"' && content[i + 1] == '"' && content[i + 2] == '"')
-                io << (content[i] == '\n' ? '\n' : ' ')
+              while i + 2 < size && !(chars[i] == '"' && chars[i + 1] == '"' && chars[i + 2] == '"')
+                io << (chars[i] == '\n' ? '\n' : ' ')
                 i += 1
               end
-              if i + 2 < content.size
+              if i + 2 < size
                 io << "   "
                 i += 3
               end
             else
               io << ' '
               i += 1
-              while i < content.size && content[i] != '"'
-                if content[i] == '\\' && i + 1 < content.size
+              while i < size && chars[i] != '"'
+                if chars[i] == '\\' && i + 1 < size
                   io << "  "
                   i += 2
                 else
-                  io << (content[i] == '\n' ? '\n' : ' ')
+                  io << (chars[i] == '\n' ? '\n' : ' ')
                   i += 1
                 end
               end
-              if i < content.size
+              if i < size
                 io << ' '
                 i += 1
               end
             end
           else
-            io << ch
+            io << (ch.ascii? ? ch : ' ')
             i += 1
           end
         end


### PR DESCRIPTION
## Summary

Two correctness/performance fixes for the GraphQL analyzers, validated against a 442-file corpus of real schemas/operations (graphql-js, apollo-server, graphql-yoga, hasura/graphql-engine, graphiql, gatsby) and cross-checked field-for-field against `graphql-js` as a gold standard.

### 1. `perf(graphql-sdl)` — avoid O(n²) UTF-8 scan in `strip_comments`

The SDL pre-pass indexed the raw document with `content[i]`, which is **O(n) per access** whenever the string is not single-byte-optimizable. A single multi-byte char (e.g. the 👍 emoji inside a `"""description"""`) made the whole comment/string-stripping pass quadratic.

On GitHub's public ~360 KB schema this meant **~100 seconds**; after the fix it's **~25 ms** (≈4000×), with byte-identical endpoint output. The document is now materialized into an `Array(Char)` for O(1) access and the sanitized result is ASCII-only, so every downstream positional pass stays fast too.

### 2. `fix(graphql-ops)` — only report genuine top-level operations

The operation-document analyzer matched `(query|mutation|subscription)` + name *anywhere on a line*, so it invented endpoints from:
- prose inside `"""descriptions"""` ("the **subscription status**", "**query for**", …)
- the `schema { query: Root }` mapping in SDL files

On GitHub's schema alone that was **15 phantom operations**; corpus-wide it was 23 false positives.

The scan now walks the document once, skipping string/comment literals and tracking brace depth, and only treats an operation keyword as a definition when it sits at depth 0 and is followed by a name plus a variable list / directive / selection set. Output now matches `graphql-js` **exactly** across the corpus — zero false positives, zero false negatives on every parseable operation document. The `Array(Char)` scan also keeps this pass linear on multi-byte input.

## Testing

- `crystal spec spec/unit_test` → 3487 examples, 0 failures
- GraphQL functional tests (sdl / apollo / yoga / file_based) → 152 examples, 0 failures
- `ameba` clean on both changed files
- Differential check vs `graphql-js` over 442 files: SDL fields and named operations match exactly (only deliberately-malformed `schema_testdata/err/*` fixtures differ, where noir's lenient recovery is intentional)

https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi)_