### PR TITLE
feat(grpc): support additional_bindings colon/array forms and custom verbs

### DIFF
--- a/spec/functional_test/fixtures/specification/grpc/gateway_bindings.proto
+++ b/spec/functional_test/fixtures/specification/grpc/gateway_bindings.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package gw.v1;
+
+import "google/api/annotations.proto";
+
+message ItemRequest {
+  string item_id = 1;
+  string name = 2;
+}
+
+message ItemResponse {
+  string item_id = 1;
+}
+
+service ItemService {
+  // Colon-form additional_bindings with a second binding on a different path.
+  rpc GetItem(ItemRequest) returns (ItemResponse) {
+    option (google.api.http) = {
+      get: "/v1/items/{item_id}"
+      additional_bindings: {
+        get: "/v1/items/by-name/{name}"
+      }
+    };
+  }
+
+  // Array-form additional_bindings: [ { ... }, { ... } ].
+  rpc UpdateItem(ItemRequest) returns (ItemResponse) {
+    option (google.api.http) = {
+      put: "/v1/items/{item_id}"
+      body: "*"
+      additional_bindings: [
+        {
+          patch: "/v1/items/{item_id}"
+          body: "*"
+        },
+        {
+          patch: "/v2/items/{item_id}"
+          body: "*"
+        }
+      ]
+    };
+  }
+
+  // custom: { kind, path } binding maps to a non-standard HTTP method.
+  rpc WatchItem(ItemRequest) returns (ItemResponse) {
+    option (google.api.http) = {
+      custom: {
+        kind: "HEAD"
+        path: "/v1/items/{item_id}/watch"
+      }
+    };
+  }
+}

--- a/spec/functional_test/testers/specification/grpc_spec.cr
+++ b/spec/functional_test/testers/specification/grpc_spec.cr
@@ -70,6 +70,32 @@ expected_endpoints = [
     Param.new("note_id", "", "json"),
     Param.new("body", "", "json"),
   ]),
+  # Colon-form additional_bindings: primary + secondary binding.
+  Endpoint.new("/v1/items/{item_id}", "GET", [
+    Param.new("item_id", "", "path"),
+    Param.new("name", "", "query"),
+  ]),
+  Endpoint.new("/v1/items/by-name/{name}", "GET", [
+    Param.new("name", "", "path"),
+    Param.new("item_id", "", "query"),
+  ]),
+  # Array-form additional_bindings: primary PUT + two PATCH bindings.
+  Endpoint.new("/v1/items/{item_id}", "PUT", [
+    Param.new("item_id", "", "path"),
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/v1/items/{item_id}", "PATCH", [
+    Param.new("item_id", "", "path"),
+    Param.new("name", "", "json"),
+  ]),
+  Endpoint.new("/v2/items/{item_id}", "PATCH", [
+    Param.new("item_id", "", "path"),
+    Param.new("name", "", "json"),
+  ]),
+  # custom: { kind, path } maps to a non-standard HTTP method (HEAD).
+  Endpoint.new("/v1/items/{item_id}/watch", "HEAD", [
+    Param.new("item_id", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/specification/grpc/", {

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -143,6 +143,16 @@ module Analyzer::Specification
     end
 
     private def extract_brace_block(content : String, open_pos : Int32) : String?
+      close = find_matching_delimiter(content, open_pos, '{', '}')
+      return if close.nil?
+      content[(open_pos + 1)..(close - 1)]
+    end
+
+    # Index of the delimiter that closes the `open_char` at `open_pos`, or nil
+    # if unbalanced. String literals and `//` / `/* */` comments are skipped so
+    # a delimiter inside them can't shift the depth. Works for `{}` and `[]`
+    # (the array form of `additional_bindings`).
+    private def find_matching_delimiter(content : String, open_pos : Int32, open_char : Char, close_char : Char) : Int32?
       depth = 0
       pos = open_pos
       in_string = false
@@ -161,7 +171,7 @@ module Analyzer::Specification
             in_string = false if bs.even?
           end
         elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '/'
-          # Line comment: skip to EOL so a stray `}` or `"` can't shift state.
+          # Line comment: skip to EOL so a stray delimiter can't shift state.
           nl = content.index('\n', pos)
           pos = nl.nil? ? content.size : nl
           next
@@ -172,11 +182,11 @@ module Analyzer::Specification
           next
         elsif ch == '"'
           in_string = true
-        elsif ch == '{'
+        elsif ch == open_char
           depth += 1
-        elsif ch == '}'
+        elsif ch == close_char
           depth -= 1
-          return content[(open_pos + 1)..(pos - 1)] if depth == 0
+          return pos if depth == 0
         end
         pos += 1
       end
@@ -245,9 +255,10 @@ module Analyzer::Specification
               gateway_params << Param.new(path_match[1], "", "path")
             end
 
-            # Determine how remaining message fields map to params
+            # Determine how remaining message fields map to params. HEAD, like
+            # GET/DELETE, carries no request body, so its fields go to the query.
             body_field = mapping[:body]?
-            is_query_method = http_method == "GET" || http_method == "DELETE"
+            is_query_method = http_method == "GET" || http_method == "DELETE" || http_method == "HEAD"
 
             if body_field && !body_field.empty? && body_field != "*"
               # Specific field is the body
@@ -279,56 +290,128 @@ module Analyzer::Specification
       end
     end
 
-    private def parse_http_annotations(options_block : String) : Array(NamedTuple(method: String, path: String, body: String?))
-      mappings = [] of NamedTuple(method: String, path: String, body: String?)
+    alias HttpMapping = NamedTuple(method: String, path: String, body: String?)
 
-      # Match google.api.http option
+    private def parse_http_annotations(options_block : String) : Array(HttpMapping)
+      mappings = [] of HttpMapping
+
+      # Only the google.api.http option contributes HTTP routes. Scope to its
+      # value block so a sibling option (e.g. openapiv2_operation, which can
+      # also carry strings) can't leak a phantom method/path.
       return mappings unless options_block.includes?("google.api.http")
+      rule_body = extract_http_rule_block(options_block)
+      return mappings if rule_body.nil?
 
-      # Restrict the primary rule's `body:` to the portion before any
-      # additional_bindings, so a body declared only inside a binding does not
-      # leak into the parent mapping (mis-classifying its fields as JSON body).
+      # The primary rule lives before the first additional_bindings; restrict
+      # its `body:`/method scan there so a binding's body doesn't leak up.
       primary_scope =
-        if ab_idx = options_block.index("additional_bindings")
-          options_block[0...ab_idx]
+        if ab_idx = rule_body.index("additional_bindings")
+          rule_body[0...ab_idx]
         else
-          options_block
+          rule_body
         end
-
-      body_value : String? = nil
-      if body_match = primary_scope.match(/body\s*:\s*"([^"]*)"/)
-        body_value = body_match[1]
+      if primary = extract_rule_mapping(primary_scope)
+        mappings << primary
       end
 
-      # Match HTTP method patterns
-      {% for http_method in ["get", "post", "put", "delete", "patch"] %}
-        if match = options_block.match(/{{ http_method.id }}\s*:\s*"([^"]*)"/)
-          mappings << {method: {{ http_method.upcase }}, path: match[1], body: body_value}
-        end
-      {% end %}
-
-      # Match additional_bindings using brace-aware extraction
-      if options_block.includes?("additional_bindings")
-        options_block.scan(/additional_bindings\s*\{/) do |binding_start|
-          binding_brace_pos = options_block.index('{', binding_start.begin(0) || 0)
-          next if binding_brace_pos.nil?
-          binding_body = extract_brace_block(options_block, binding_brace_pos)
-          next if binding_body.nil?
-
-          binding_body_value : String? = nil
-          if bb_match = binding_body.match(/body\s*:\s*"([^"]*)"/)
-            binding_body_value = bb_match[1]
-          end
-
-          {% for http_method in ["get", "post", "put", "delete", "patch"] %}
-            if match = binding_body.match(/{{ http_method.id }}\s*:\s*"([^"]*)"/)
-              mappings << {method: {{ http_method.upcase }}, path: match[1], body: binding_body_value}
-            end
-          {% end %}
+      # additional_bindings come in three textual shapes, all valid:
+      #   additional_bindings { ... }      (no colon — googleapis style)
+      #   additional_bindings: { ... }     (colon — grpc-gateway style)
+      #   additional_bindings: [ {...}, {...} ]   (array of bindings)
+      each_additional_binding_body(rule_body) do |binding_body|
+        if mapping = extract_rule_mapping(binding_body)
+          mappings << mapping
         end
       end
 
       mappings
+    end
+
+    # Returns the value block of `option (google.api.http) = { ... }`, or nil
+    # when the annotation isn't in the supported brace form (e.g. the rarer
+    # `(google.api.http).get = "..."` field syntax). The prefix guard keeps us
+    # from latching onto a later, unrelated option's brace.
+    private def extract_http_rule_block(options_block : String) : String?
+      idx = options_block.index("google.api.http")
+      return if idx.nil?
+      after = idx + "google.api.http".size
+      brace_pos = options_block.index('{', after)
+      return if brace_pos.nil?
+      return unless options_block[after...brace_pos].matches?(/\A[\s)=]*\z/)
+      extract_brace_block(options_block, brace_pos)
+    end
+
+    # Extracts a single {method, path, body} mapping from one rule scope. Honors
+    # the five standard verbs and the `custom: { kind: "VERB" path: "..." }`
+    # form (HEAD/OPTIONS/TRACE and friends). Returns nil when no route is present.
+    private def extract_rule_mapping(scope : String) : HttpMapping?
+      body_value : String? = nil
+      if body_match = scope.match(/\bbody\s*:\s*"([^"]*)"/)
+        body_value = body_match[1]
+      end
+
+      # Word-boundary anchoring stops `widget:`/`path:` from matching `get`/`patch`.
+      candidates = [] of Tuple(Int32, String, String)
+      {% for http_method in ["get", "post", "put", "delete", "patch"] %}
+        if match = scope.match(/\b{{ http_method.id }}\s*:\s*"([^"]*)"/)
+          candidates << { (match.begin(0) || 0), {{ http_method.upcase }}, match[1] }
+        end
+      {% end %}
+      unless candidates.empty?
+        chosen = candidates.min_by { |c| c[0] }
+        return {method: chosen[1], path: chosen[2], body: body_value}
+      end
+
+      # custom: { kind: "<verb>" path: "<template>" }
+      if custom_match = scope.match(/\bcustom\s*:\s*\{/)
+        custom_brace = scope.index('{', custom_match.begin(0) || 0)
+        if custom_brace
+          if custom_body = extract_brace_block(scope, custom_brace)
+            kind_match = custom_body.match(/\bkind\s*:\s*"([^"]*)"/)
+            path_match = custom_body.match(/\bpath\s*:\s*"([^"]*)"/)
+            if kind_match && path_match && !kind_match[1].empty?
+              return {method: kind_match[1].upcase, path: path_match[1], body: body_value}
+            end
+          end
+        end
+      end
+
+      nil
+    end
+
+    # Yields each additional_bindings entry body, transparently handling the
+    # no-colon, colon, and array (`[ {...}, {...} ]`) forms.
+    private def each_additional_binding_body(rule_body : String, & : String ->)
+      keyword = "additional_bindings"
+      pos = 0
+      while idx = rule_body.index(keyword, pos)
+        cur = idx + keyword.size
+        # Skip whitespace and an optional ':' between the keyword and its value.
+        while cur < rule_body.size && (rule_body[cur].whitespace? || rule_body[cur] == ':')
+          cur += 1
+        end
+        pos = idx + keyword.size
+        next if cur >= rule_body.size
+
+        case rule_body[cur]
+        when '['
+          # Array form: iterate each top-level { ... } object inside the [ ... ].
+          array_close = find_matching_delimiter(rule_body, cur, '[', ']')
+          next if array_close.nil?
+          inner = rule_body[(cur + 1)...array_close]
+          obj_pos = 0
+          while obj_open = inner.index('{', obj_pos)
+            obj_close = find_matching_delimiter(inner, obj_open, '{', '}')
+            break if obj_close.nil?
+            yield inner[(obj_open + 1)...obj_close]
+            obj_pos = obj_close + 1
+          end
+        when '{'
+          if body = extract_brace_block(rule_body, cur)
+            yield body
+          end
+        end
+      end
     end
 
     private def find_line_number(content : String, method_name : String) : Int32?


### PR DESCRIPTION
## Summary

A follow-up to #2110, lowering the gRPC analyzer's **false-negative** rate on gRPC-Gateway annotations. Two classes of routes were under-counted:

1. **`additional_bindings` only parsed in one textual shape.** Only the no-colon `additional_bindings { ... }` form (googleapis style) was recognized. The colon form `additional_bindings: { ... }` and the array form `additional_bindings: [ {...}, {...} ]` (both used by `grpc-ecosystem/grpc-gateway`) were silently dropped.
2. **`custom` HTTP-method bindings were ignored.** `option (google.api.http) = { custom: { kind: "HEAD" path: "..." } }` was emitted as a *pure gRPC* method instead of an HTTP `HEAD`/`OPTIONS`/`TRACE` endpoint.

### Repro (grpc-gateway `a_bit_of_everything.proto`)

| rpc | before | after |
|-----|--------|-------|
| `Echo` (primary GET + additional POST + additional GET) | 2 routes | **3 routes** (the 2nd binding was lost) |
| `UpdateV2` (array form: PUT + 2× PATCH) | 2 routes | **3 routes** (`/v2a/...` was lost) |
| `Exists` / `CustomOptionsRequest` / `TraceRequest` | pure gRPC | **HEAD / OPTIONS / TRACE** HTTP routes |

## Changes

- Rewrite `parse_http_annotations` to scope strictly to the `google.api.http` value block (so a sibling option like `openapiv2_operation` can't leak a phantom method/path), parse the primary rule, then every additional binding across **all three** textual forms.
- New `extract_rule_mapping` resolves the verb from the five standard methods **or** `custom: { kind, path }`. Method-key scans are `\b`-anchored so `widget:`/`path:` can't masquerade as `get`/`patch`.
- Generalize the brace matcher into `find_matching_delimiter` (handles `{}` and `[]`, string/comment-aware) and express `extract_brace_block` in terms of it.
- `HEAD` now classifies request fields as query params, like `GET`/`DELETE`.

## Tests

- New `gateway_bindings.proto` fixture covering the colon form, the array form, and a `custom` HEAD binding.
- `crystal spec spec/functional_test/testers/specification/grpc_spec.cr` → green (124 examples).
- Full `crystal spec spec/functional_test` + `spec/unit_test`, `crystal tool format --check`, and `ameba` all clean locally.
- Manually verified no regression on `googleapis/googleapis` (no-colon form): spanner/firestore/pubsub endpoint counts unchanged.

https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6)_