### PR TITLE
perf(graphql): share Apollo/Yoga typeDefs extraction and drop O(n²) scan

### DIFF
--- a/src/analyzer/analyzers/javascript/apollo.cr
+++ b/src/analyzer/analyzers/javascript/apollo.cr
@@ -1,5 +1,6 @@
 require "../../engines/javascript_engine"
 require "../specification/graphql_sdl_parser"
+require "../specification/graphql_typedefs"
 require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
@@ -46,7 +47,7 @@ module Analyzer::Javascript
 
     private def process_file(path : String, content : String)
       mount_path = detect_mount_path(content)
-      extract_typedefs(content).each do |sdl, line_offset|
+      Analyzer::Specification::GraphqlTypedefs.extract(content).each do |sdl, line_offset|
         endpoints = Analyzer::Specification::GraphqlSdlParser.parse(
           sdl, path,
           default_path: mount_path,
@@ -65,158 +66,6 @@ module Analyzer::Javascript
         return m[1]
       end
       DEFAULT_GRAPHQL_PATH
-    end
-
-    # Returns pairs of (SDL string, line_offset) for every `typeDefs`
-    # template literal assignment in `content`. `line_offset` is the
-    # 0-based line number in the source file where the SDL begins, so the
-    # downstream parser's relative line numbers can be shifted back to
-    # absolute positions.
-    private def extract_typedefs(content : String) : Array(Tuple(String, Int32))
-      results = [] of Tuple(String, Int32)
-      pattern = /\btypeDefs\s*[:=]\s*/
-
-      content.scan(pattern) do |m|
-        pos = (m.begin(0) || 0) + m[0].size
-        pos = skip_tag(content, pos)
-
-        next if pos >= content.size
-        case content[pos]
-        when '['
-          collect_in_brackets(content, pos, results)
-        when '`'
-          collect_single(content, pos, results)
-        end
-      end
-
-      results
-    end
-
-    private def skip_tag(content : String, pos : Int32) : Int32
-      return pos if pos >= content.size
-      if tag = content.match(/\G(gql|graphql)\s*/, pos)
-        return pos + tag[0].size
-      end
-      pos
-    end
-
-    # Pull every backtick-delimited string from inside a `[...]` block.
-    private def collect_in_brackets(content : String, open_pos : Int32, results : Array(Tuple(String, Int32)))
-      depth = 1
-      pos = open_pos + 1
-      while pos < content.size && depth > 0
-        ch = content[pos]
-        case ch
-        when '['
-          depth += 1
-          pos += 1
-        when ']'
-          depth -= 1
-          pos += 1
-        when '`'
-          if extracted = extract_template_literal(content, pos)
-            sdl, next_pos = extracted
-            line_offset = line_at(content, pos) - 1
-            results << {sdl, line_offset}
-            pos = next_pos
-          else
-            pos += 1
-          end
-        else
-          pos += 1
-        end
-      end
-    end
-
-    private def collect_single(content : String, backtick_pos : Int32, results : Array(Tuple(String, Int32)))
-      return unless extracted = extract_template_literal(content, backtick_pos)
-      sdl, _ = extracted
-      line_offset = line_at(content, backtick_pos) - 1
-      results << {sdl, line_offset}
-    end
-
-    # Extracts a template literal starting at `\``, returning the interior
-    # text (with `${...}` interpolations and escapes replaced by spaces so
-    # that line counts and offsets stay aligned) and the byte position
-    # just past the closing backtick.
-    private def extract_template_literal(content : String, start_pos : Int32) : Tuple(String, Int32)?
-      return if start_pos >= content.size || content[start_pos] != '`'
-      end_pos = find_closing_backtick(content, start_pos + 1)
-      return if end_pos.nil?
-
-      raw = content[(start_pos + 1)...end_pos]
-      {strip_interpolations(raw), end_pos + 1}
-    end
-
-    private def find_closing_backtick(content : String, start : Int32) : Int32?
-      pos = start
-      while pos < content.size
-        ch = content[pos]
-        case ch
-        when '`'
-          return pos
-        when '\\'
-          pos += 2
-        when '$'
-          if pos + 1 < content.size && content[pos + 1] == '{'
-            depth = 1
-            pos += 2
-            while pos < content.size && depth > 0
-              c2 = content[pos]
-              case c2
-              when '{' then depth += 1
-              when '}' then depth -= 1
-              end
-              pos += 1
-            end
-          else
-            pos += 1
-          end
-        else
-          pos += 1
-        end
-      end
-      nil
-    end
-
-    private def strip_interpolations(s : String) : String
-      String.build(s.size) do |io|
-        pos = 0
-        while pos < s.size
-          ch = s[pos]
-          if ch == '\\' && pos + 1 < s.size
-            io << ' '
-            io << (s[pos + 1] == '\n' ? '\n' : ' ')
-            pos += 2
-          elsif ch == '$' && pos + 1 < s.size && s[pos + 1] == '{'
-            depth = 1
-            pos += 2
-            io << "  "
-            while pos < s.size && depth > 0
-              c2 = s[pos]
-              case c2
-              when '{' then depth += 1
-              when '}' then depth -= 1
-              end
-              if depth == 0
-                io << ' '
-                pos += 1
-                break
-              end
-              io << (c2 == '\n' ? '\n' : ' ')
-              pos += 1
-            end
-          else
-            io << ch
-            pos += 1
-          end
-        end
-      end
-    end
-
-    private def line_at(content : String, pos : Int32) : Int32
-      return 1 if pos <= 0
-      content[0, pos].count('\n') + 1
     end
   end
 end

--- a/src/analyzer/analyzers/javascript/graphql_yoga.cr
+++ b/src/analyzer/analyzers/javascript/graphql_yoga.cr
@@ -1,5 +1,6 @@
 require "../../engines/javascript_engine"
 require "../specification/graphql_sdl_parser"
+require "../specification/graphql_typedefs"
 
 module Analyzer::Javascript
   # GraphQL Yoga analyzer.
@@ -40,7 +41,7 @@ module Analyzer::Javascript
 
     private def process_file(path : String, content : String)
       mount_path = detect_mount_path(content)
-      extract_typedefs(content).each do |sdl, line_offset|
+      Analyzer::Specification::GraphqlTypedefs.extract(content, skip_js_comments: true).each do |sdl, line_offset|
         endpoints = Analyzer::Specification::GraphqlSdlParser.parse(
           sdl, path,
           default_path: mount_path,
@@ -58,193 +59,6 @@ module Analyzer::Javascript
         return m[1]
       end
       DEFAULT_GRAPHQL_PATH
-    end
-
-    # Returns pairs of (SDL string, line_offset) for every `typeDefs`
-    # template literal in `content`. `line_offset` is the 0-based line
-    # number in the source file where the SDL begins, so the downstream
-    # parser's relative line numbers can be shifted back to absolute
-    # positions.
-    #
-    # `typeDefs:` and `typeDefs =` both match — covering object-property
-    # form (`createSchema({ typeDefs: \`...\` })`) and standalone const
-    # declaration (`const typeDefs = \`...\``). The const form is what
-    # makes the ES2015 `{ typeDefs }` shorthand "just work": the SDL is
-    # already harvested at the const declaration, so the shorthand
-    # reference doesn't need separate handling.
-    private def extract_typedefs(content : String) : Array(Tuple(String, Int32))
-      results = [] of Tuple(String, Int32)
-      pattern = /\btypeDefs\s*[:=]\s*/
-
-      content.scan(pattern) do |m|
-        pos = (m.begin(0) || 0) + m[0].size
-        pos = skip_tag(content, pos)
-        pos = skip_js_comments(content, pos)
-
-        next if pos >= content.size
-        case content[pos]
-        when '['
-          collect_in_brackets(content, pos, results)
-        when '`'
-          collect_single(content, pos, results)
-        end
-      end
-
-      results
-    end
-
-    # Yoga's docs idiomatically write `typeDefs: /* GraphQL */ \`...\``
-    # so editors can syntax-highlight the SDL. Skip JS line/block
-    # comments before reading the value.
-    private def skip_js_comments(content : String, pos : Int32) : Int32
-      while pos < content.size
-        ch = content[pos]
-        if ch.ascii_whitespace?
-          pos += 1
-          next
-        end
-        if ch == '/' && pos + 1 < content.size
-          nxt = content[pos + 1]
-          if nxt == '/'
-            pos += 2
-            while pos < content.size && content[pos] != '\n'
-              pos += 1
-            end
-            next
-          elsif nxt == '*'
-            pos += 2
-            while pos + 1 < content.size && !(content[pos] == '*' && content[pos + 1] == '/')
-              pos += 1
-            end
-            pos += 2 if pos + 1 < content.size
-            next
-          end
-        end
-        break
-      end
-      pos
-    end
-
-    private def skip_tag(content : String, pos : Int32) : Int32
-      return pos if pos >= content.size
-      if tag = content.match(/\G(gql|graphql)\s*/, pos)
-        return pos + tag[0].size
-      end
-      pos
-    end
-
-    private def collect_in_brackets(content : String, open_pos : Int32, results : Array(Tuple(String, Int32)))
-      depth = 1
-      pos = open_pos + 1
-      while pos < content.size && depth > 0
-        ch = content[pos]
-        case ch
-        when '['
-          depth += 1
-          pos += 1
-        when ']'
-          depth -= 1
-          pos += 1
-        when '`'
-          if extracted = extract_template_literal(content, pos)
-            sdl, next_pos = extracted
-            line_offset = line_at(content, pos) - 1
-            results << {sdl, line_offset}
-            pos = next_pos
-          else
-            pos += 1
-          end
-        else
-          pos += 1
-        end
-      end
-    end
-
-    private def collect_single(content : String, backtick_pos : Int32, results : Array(Tuple(String, Int32)))
-      return unless extracted = extract_template_literal(content, backtick_pos)
-      sdl, _ = extracted
-      line_offset = line_at(content, backtick_pos) - 1
-      results << {sdl, line_offset}
-    end
-
-    private def extract_template_literal(content : String, start_pos : Int32) : Tuple(String, Int32)?
-      return if start_pos >= content.size || content[start_pos] != '`'
-      end_pos = find_closing_backtick(content, start_pos + 1)
-      return if end_pos.nil?
-
-      raw = content[(start_pos + 1)...end_pos]
-      {strip_interpolations(raw), end_pos + 1}
-    end
-
-    private def find_closing_backtick(content : String, start : Int32) : Int32?
-      pos = start
-      while pos < content.size
-        ch = content[pos]
-        case ch
-        when '`'
-          return pos
-        when '\\'
-          pos += 2
-        when '$'
-          if pos + 1 < content.size && content[pos + 1] == '{'
-            depth = 1
-            pos += 2
-            while pos < content.size && depth > 0
-              c2 = content[pos]
-              case c2
-              when '{' then depth += 1
-              when '}' then depth -= 1
-              end
-              pos += 1
-            end
-          else
-            pos += 1
-          end
-        else
-          pos += 1
-        end
-      end
-      nil
-    end
-
-    private def strip_interpolations(s : String) : String
-      String.build(s.size) do |io|
-        pos = 0
-        while pos < s.size
-          ch = s[pos]
-          if ch == '\\' && pos + 1 < s.size
-            io << ' '
-            io << (s[pos + 1] == '\n' ? '\n' : ' ')
-            pos += 2
-          elsif ch == '$' && pos + 1 < s.size && s[pos + 1] == '{'
-            depth = 1
-            pos += 2
-            io << "  "
-            while pos < s.size && depth > 0
-              c2 = s[pos]
-              case c2
-              when '{' then depth += 1
-              when '}' then depth -= 1
-              end
-              if depth == 0
-                io << ' '
-                pos += 1
-                break
-              end
-              io << (c2 == '\n' ? '\n' : ' ')
-              pos += 1
-            end
-          else
-            io << ch
-            pos += 1
-          end
-        end
-      end
-    end
-
-    private def line_at(content : String, pos : Int32) : Int32
-      return 1 if pos <= 0
-      content[0, pos].count('\n') + 1
     end
   end
 end

--- a/src/analyzer/analyzers/specification/graphql_typedefs.cr
+++ b/src/analyzer/analyzers/specification/graphql_typedefs.cr
@@ -1,0 +1,220 @@
+module Analyzer::Specification
+  # Shared extractor for inline `typeDefs` template literals, used by the
+  # Apollo Server and GraphQL Yoga analyzers. Returns `(SDL, line_offset)`
+  # pairs — the SDL string carried by each `typeDefs` backtick template and
+  # the 0-based source line where it begins.
+  #
+  # The whole scan runs over an `Array(Char)` rather than indexing the
+  # `String` directly. `String#[](Int)` is O(n) whenever the source is not
+  # single-byte-optimizable, so a single multi-byte char (an emoji in a
+  # JS comment or a """description""") would otherwise make the per-char
+  # template walk quadratic — ~6 s on a 120 KB file vs ~0.2 ms here.
+  module GraphqlTypedefs
+    extend self
+
+    TYPEDEFS_PATTERN = /\btypeDefs\s*[:=]\s*/
+
+    # `skip_js_comments` skips `/* GraphQL */` / `// ...` between the
+    # assignment and the value — Yoga idiomatically annotates the literal
+    # that way; Apollo does not, so it opts out.
+    def extract(content : String, skip_js_comments : Bool = false) : Array(Tuple(String, Int32))
+      results = [] of Tuple(String, Int32)
+      chars = content.chars
+      size = chars.size
+
+      content.scan(TYPEDEFS_PATTERN) do |m|
+        pos = (m.begin(0) || 0) + m[0].size
+        pos = skip_tag(chars, pos)
+        pos = skip_comments(chars, pos) if skip_js_comments
+
+        next if pos >= size
+        case chars[pos]
+        when '['
+          collect_in_brackets(chars, pos, results)
+        when '`'
+          collect_single(chars, pos, results)
+        end
+      end
+
+      results
+    end
+
+    # Skips an optional `gql` / `graphql` tag function and trailing space.
+    private def skip_tag(chars : Array(Char), pos : Int32) : Int32
+      {"graphql", "gql"}.each do |tag|
+        next unless starts_with_at?(chars, pos, tag)
+        return skip_ws(chars, pos + tag.size)
+      end
+      pos
+    end
+
+    private def skip_comments(chars : Array(Char), pos : Int32) : Int32
+      size = chars.size
+      while pos < size
+        ch = chars[pos]
+        if ch.ascii_whitespace?
+          pos += 1
+          next
+        end
+        if ch == '/' && pos + 1 < size
+          nxt = chars[pos + 1]
+          if nxt == '/'
+            pos += 2
+            while pos < size && chars[pos] != '\n'
+              pos += 1
+            end
+            next
+          elsif nxt == '*'
+            pos += 2
+            while pos + 1 < size && !(chars[pos] == '*' && chars[pos + 1] == '/')
+              pos += 1
+            end
+            pos += 2 if pos + 1 < size
+            next
+          end
+        end
+        break
+      end
+      pos
+    end
+
+    # Pull every backtick-delimited string from inside a `[...]` block.
+    private def collect_in_brackets(chars : Array(Char), open_pos : Int32, results : Array(Tuple(String, Int32)))
+      size = chars.size
+      depth = 1
+      pos = open_pos + 1
+      while pos < size && depth > 0
+        ch = chars[pos]
+        case ch
+        when '['
+          depth += 1
+          pos += 1
+        when ']'
+          depth -= 1
+          pos += 1
+        when '`'
+          if extracted = extract_template_literal(chars, pos)
+            sdl, next_pos = extracted
+            results << {sdl, line_at(chars, pos) - 1}
+            pos = next_pos
+          else
+            pos += 1
+          end
+        else
+          pos += 1
+        end
+      end
+    end
+
+    private def collect_single(chars : Array(Char), backtick_pos : Int32, results : Array(Tuple(String, Int32)))
+      return unless extracted = extract_template_literal(chars, backtick_pos)
+      sdl, _ = extracted
+      results << {sdl, line_at(chars, backtick_pos) - 1}
+    end
+
+    # Extracts a template literal starting at `\``, returning the interior
+    # text (with `${...}` interpolations and escapes replaced by spaces so
+    # that line counts and offsets stay aligned) and the position just past
+    # the closing backtick.
+    private def extract_template_literal(chars : Array(Char), start_pos : Int32) : Tuple(String, Int32)?
+      return if start_pos >= chars.size || chars[start_pos] != '`'
+      end_pos = find_closing_backtick(chars, start_pos + 1)
+      return if end_pos.nil?
+      {strip_interpolations(chars, start_pos + 1, end_pos), end_pos + 1}
+    end
+
+    private def find_closing_backtick(chars : Array(Char), start : Int32) : Int32?
+      size = chars.size
+      pos = start
+      while pos < size
+        ch = chars[pos]
+        case ch
+        when '`'
+          return pos
+        when '\\'
+          pos += 2
+        when '$'
+          if pos + 1 < size && chars[pos + 1] == '{'
+            depth = 1
+            pos += 2
+            while pos < size && depth > 0
+              case chars[pos]
+              when '{' then depth += 1
+              when '}' then depth -= 1
+              end
+              pos += 1
+            end
+          else
+            pos += 1
+          end
+        else
+          pos += 1
+        end
+      end
+      nil
+    end
+
+    private def strip_interpolations(chars : Array(Char), start : Int32, stop : Int32) : String
+      String.build(stop - start) do |io|
+        pos = start
+        while pos < stop
+          ch = chars[pos]
+          if ch == '\\' && pos + 1 < stop
+            io << ' '
+            io << (chars[pos + 1] == '\n' ? '\n' : ' ')
+            pos += 2
+          elsif ch == '$' && pos + 1 < stop && chars[pos + 1] == '{'
+            depth = 1
+            pos += 2
+            io << "  "
+            while pos < stop && depth > 0
+              c2 = chars[pos]
+              case c2
+              when '{' then depth += 1
+              when '}' then depth -= 1
+              end
+              if depth == 0
+                io << ' '
+                pos += 1
+                break
+              end
+              io << (c2 == '\n' ? '\n' : ' ')
+              pos += 1
+            end
+          else
+            io << ch
+            pos += 1
+          end
+        end
+      end
+    end
+
+    private def skip_ws(chars : Array(Char), pos : Int32) : Int32
+      size = chars.size
+      while pos < size && chars[pos].ascii_whitespace?
+        pos += 1
+      end
+      pos
+    end
+
+    private def starts_with_at?(chars : Array(Char), pos : Int32, str : String) : Bool
+      return false if pos + str.size > chars.size
+      str.each_char_with_index do |c, i|
+        return false if chars[pos + i] != c
+      end
+      true
+    end
+
+    private def line_at(chars : Array(Char), pos : Int32) : Int32
+      return 1 if pos <= 0
+      count = 0
+      i = 0
+      limit = pos > chars.size ? chars.size : pos
+      while i < limit
+        count += 1 if chars[i] == '\n'
+        i += 1
+      end
+      count + 1
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #2114, applying the same quadratic-scan fix to the JS-side GraphQL analyzers and removing a large block of duplication.

The Apollo Server and GraphQL Yoga analyzers each carried a near-identical **~120-line** copy of the inline-`typeDefs` template-literal scanner, and both indexed the JS/TS source with `content[pos]` — which is **O(n) per access** on any string that isn't single-byte-optimizable. A single emoji in a comment or a `"""description"""` made the per-char template walk quadratic.

Measured on a 120 KB Apollo file with one multi-byte char in a comment:

| | before | after |
|---|---|---|
| unicode-heavy | **6.18 s** | **0.27 s** |
| ASCII-only | 0.24 s | 0.24 s |

(both extract the same 300 endpoints)

## Changes

- New shared `Analyzer::Specification::GraphqlTypedefs.extract` that walks an `Array(Char)` (O(1) access, linear overall) and returns `(SDL, line_offset)` pairs.
- Apollo and Yoga now both call it — Yoga with `skip_js_comments: true` for its idiomatic `typeDefs: /* GraphQL */ \`...\`` annotation.
- Net **−117 lines** by collapsing the two duplicated scanners into one.

## Testing

- Apollo + Yoga functional/detector suites → 108 examples, 0 failures (unchanged endpoint output)
- `crystal spec spec/unit_test` → 3487 examples, 0 failures
- `ameba` clean on all three files
- Manual perf check on the 120 KB unicode case above

https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi)_