### PR TITLE
fix(tagger/file_upload): match `media` only as a whole path segment

### DIFF
--- a/spec/unit_test/tagger/taggers/file_upload_spec.cr
+++ b/spec/unit_test/tagger/taggers/file_upload_spec.cr
@@ -258,5 +258,29 @@ describe "FileUploadTagger" do
       endpoint.tags.size.should eq(1)
       endpoint.tags[0].name.should eq("file_upload")
     end
+
+    it "does not tag a media-* config route as an upload" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      # koel `PUT /api/settings/media-path` sets the media-library
+      # directory — `media` here is a sub-token of `media-path`, not a
+      # `/media` upload collection.
+      endpoint = Endpoint.new("/api/settings/media-path", "PUT")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(0)
+    end
+
+    it "still tags a standalone /media collection upload" do
+      tagger = FileUploadTagger.new(default_tagger_options)
+
+      endpoint = Endpoint.new("/api/media", "POST")
+
+      tagger.perform([endpoint])
+
+      endpoint.tags.size.should eq(1)
+      endpoint.tags[0].name.should eq("file_upload")
+    end
   end
 end

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -29,9 +29,17 @@ class FileUploadTagger < Tagger
   UPLOAD_METHODS     = Set{"POST", "PUT", "PATCH"}
   UPLOAD_PATH_PARTS  = Set{
     "upload", "uploads", "attach", "attachment", "attachments",
-    "import", "imports", "avatar", "photo", "photos", "media",
+    "import", "imports", "avatar", "photo", "photos",
     "file", "files", "image", "images", "picture", "pictures",
   }
+
+  # `media` is matched only as a whole `/media` path segment, never as a
+  # loose sub-token. As a loose token (split on `-`/`_`) it fired on
+  # config/feature routes that merely contain the word but upload nothing:
+  # `/settings/media-path` (a media-directory setting, e.g. koel),
+  # `/social-media`, `/media-library`. A standalone `/media` collection
+  # (`POST /media`) still tags.
+  SEGMENT_ONLY_PATH_PARTS = Set{"media"}
 
   def initialize(options : Hash(String, YAML::Any))
     super
@@ -80,7 +88,16 @@ class FileUploadTagger < Tagger
 
   private def upload_url?(url : String) : Bool
     parts = url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
-    parts.any? { |part| UPLOAD_PATH_PARTS.includes?(part) }
+    return true if parts.any? { |part| UPLOAD_PATH_PARTS.includes?(part) }
+    segment_only_upload?(url)
+  end
+
+  # Whole-segment-only path words: matched against `/`-delimited segments
+  # (after dropping the query/fragment) so they don't fire as a sub-token
+  # of a compound like `media-path`.
+  private def segment_only_upload?(url : String) : Bool
+    path = url.split("?", 2)[0].split("#", 2)[0]
+    path.downcase.split("/").any? { |seg| SEGMENT_ONLY_PATH_PARTS.includes?(seg) }
   end
 
   private def normalize_param_name(name : String) : String


### PR DESCRIPTION
## Summary

Reduces a **false positive** in the `file_upload` tagger.

`media` lived in the loose-split `UPLOAD_PATH_PARTS`, so it matched as a **sub-token** of any compound containing the word — none of which upload anything:

- `/settings/media-path` — a media-directory *setting* (observed on a fresh clone of **koel**: `PUT /api/settings/media-path` was mis-tagged `file_upload`)
- `/social-media`
- `/media-library`

## Change

Move `media` to a whole-`/`-segment check (`SEGMENT_ONLY_PATH_PARTS`), mirroring the segment-scoped matching the `debug` and `oauth` taggers already use. Now only a standalone `/media` collection (`POST /media`) tags; compounds like `media-path` do not. All other upload path words keep the loose-split behaviour.

## Verification

- koel: `PUT /api/settings/media-path` is no longer tagged `file_upload` (5 → 4 tags); the real uploads (`/api/upload`, `/api/artist/{id}/image`, `/api/duplicate-uploads`) still tag.
- Added 2 regression specs: `media-path` config route not tagged; standalone `POST /media` still tagged.
- `crystal spec spec/unit_test/tagger/` green; `crystal tool format --check` and `ameba` clean.

Builds on #2109 (already merged).

https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M)_