### PR TITLE
feat(grpc): resolve request params across imported and qualified messages

### DIFF
--- a/spec/functional_test/fixtures/specification/grpc/imported_address_api.proto
+++ b/spec/functional_test/fixtures/specification/grpc/imported_address_api.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package shared.v1;
+
+import "imported_address_common.proto";
+import "google/api/annotations.proto";
+
+service AddressService {
+  // Request type lives in imported_address_common.proto and is referenced by
+  // its fully-qualified name; `city` must still surface as a query param.
+  rpc GetAddress(shared.v1.AddressRequest) returns (shared.v1.AddressResponse) {
+    option (google.api.http) = {
+      get: "/v1/addresses/{street}"
+    };
+  }
+}

--- a/spec/functional_test/fixtures/specification/grpc/imported_address_common.proto
+++ b/spec/functional_test/fixtures/specification/grpc/imported_address_common.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package shared.v1;
+
+// Message-only proto (no service): its types are imported by other files.
+message AddressRequest {
+  string street = 1;
+  string city = 2;
+}
+
+message AddressResponse {
+  string formatted = 1;
+}

--- a/spec/functional_test/testers/specification/grpc_spec.cr
+++ b/spec/functional_test/testers/specification/grpc_spec.cr
@@ -96,6 +96,12 @@ expected_endpoints = [
   Endpoint.new("/v1/items/{item_id}/watch", "HEAD", [
     Param.new("item_id", "", "path"),
   ]),
+  # Request message imported from another .proto and referenced by its
+  # fully-qualified name: `city` resolves to a query param across files.
+  Endpoint.new("/v1/addresses/{street}", "GET", [
+    Param.new("street", "", "path"),
+    Param.new("city", "", "query"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/specification/grpc/", {

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -8,11 +8,18 @@ module Analyzer::Specification
     def analyze
       locator = CodeLocator.instance
       proto_files = locator.all("grpc-proto")
+      return @result if proto_files.empty?
+
+      # Request/response messages are frequently defined in a separate
+      # (imported) `.proto`, so resolving params from the service file alone
+      # drops them. Build one registry from every `.proto` in scope, keyed by
+      # both simple and package-qualified name, and resolve against it.
+      registry = build_message_registry
 
       proto_files.each do |proto_file|
         begin
-          content = File.read(proto_file, encoding: "utf-8", invalid: :skip)
-          parse_proto(content, proto_file)
+          content = read_file_content(proto_file)
+          parse_proto(content, proto_file, registry)
         rescue File::NotFoundError
           @logger.debug "Proto file not found during analysis, skipping: #{proto_file}"
         end
@@ -21,15 +28,59 @@ module Analyzer::Specification
       @result
     end
 
-    private def parse_proto(content : String, file_path : String)
+    # Parses messages from every `.proto` file the detector registered (not
+    # just service files), so imported message types resolve. Each message is
+    # stored under its simple name and its `package.Name` qualified form.
+    private def build_message_registry : Hash(String, MessageFields)
+      registry = {} of String => MessageFields
+      CodeLocator.instance.files_by_extension(".proto").each do |proto_file|
+        begin
+          content = read_file_content(proto_file)
+        rescue File::NotFoundError
+          next
+        end
+        clean = strip_comments(content)
+        package = parse_package(clean)
+        parse_messages(clean).each do |name, fields|
+          registry[name] = fields
+          registry["#{package}.#{name}"] = fields unless package.empty?
+        end
+      end
+      registry
+    end
+
+    private def parse_proto(content : String, file_path : String, registry : Hash(String, MessageFields))
       # Strip comments before any structural parsing so a commented-out
       # `service` / `rpc` / `message` declaration is never mistaken for a
       # live definition (a false-positive source). Newlines are preserved,
       # so reported line numbers stay accurate.
       clean = strip_comments(content)
       package = parse_package(clean)
-      messages = parse_messages(clean)
-      parse_services(clean, file_path, package, messages)
+      parse_services(clean, file_path, package, registry)
+    end
+
+    # Resolves an rpc request type to its fields, tolerating leading dots,
+    # fully-qualified names, same-package relative names, and imported simple
+    # names. Same-package matches win over a bare simple-name match so two
+    # messages that share a simple name across packages don't cross over.
+    private def resolve_message(type_name : String, package : String, registry : Hash(String, MessageFields)) : MessageFields?
+      name = type_name.lstrip('.')
+      if name.includes?(".")
+        if fields = registry[name]?
+          return fields
+        end
+      else
+        unless package.empty?
+          if fields = registry["#{package}.#{name}"]?
+            return fields
+          end
+        end
+        if fields = registry[name]?
+          return fields
+        end
+      end
+      simple = name.includes?(".") ? name.rpartition(".")[2] : name
+      registry[simple]?
     end
 
     # Replaces `//` line comments and `/* */` block comments with spaces
@@ -128,7 +179,7 @@ module Analyzer::Specification
       messages
     end
 
-    private def parse_services(content : String, file_path : String, package : String, messages : Hash(String, MessageFields))
+    private def parse_services(content : String, file_path : String, package : String, registry : Hash(String, MessageFields))
       # Find service blocks using brace matching
       content.scan(/\bservice\s+(\w+)\s*\{/m) do |service_match|
         service_name = service_match[1]
@@ -138,7 +189,7 @@ module Analyzer::Specification
         service_body = extract_brace_block(content, brace_pos)
         next if service_body.nil?
 
-        parse_rpc_methods(service_body, file_path, package, service_name, messages, content)
+        parse_rpc_methods(service_body, file_path, package, service_name, registry, content)
       end
     end
 
@@ -193,7 +244,7 @@ module Analyzer::Specification
       nil
     end
 
-    private def parse_rpc_methods(service_body : String, file_path : String, package : String, service_name : String, messages : Hash(String, MessageFields), full_content : String)
+    private def parse_rpc_methods(service_body : String, file_path : String, package : String, service_name : String, registry : Hash(String, MessageFields), full_content : String)
       # Find each rpc definition and its associated options block
       service_body.scan(/\brpc\s+(\w+)\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)\s*returns\s*\(\s*(stream\s+)?(\.?\w+(?:\.\w+)*)\s*\)/m) do |rpc_match|
         method_name = rpc_match[1]
@@ -216,9 +267,9 @@ module Analyzer::Specification
         line_number = find_line_number(full_content, method_name)
         details = Details.new(PathInfo.new(file_path, line_number))
 
-        # Extract params from request message
+        # Extract params from request message (resolved across imported files)
         params = [] of Param
-        if msg_fields = messages[request_type]?
+        if msg_fields = resolve_message(request_type, package, registry)
           params = msg_fields.dup
         end
 


### PR DESCRIPTION
## Summary

A follow-up to #2110 and #2115, closing the last big **false-negative** source in the gRPC analyzer: dropped request parameters.

Request/response messages are routinely defined in a separate, imported `.proto`, and rpcs reference them by a **fully-qualified** name (`pkg.v1.FooRequest`) or a **leading-dot** form (`.pkg.Foo`). The analyzer only looked up the *simple* type name in the *current file's* message table, so those params were silently dropped — typically only the path params of a gRPC-Gateway route surfaced while the body/query fields went missing.

### Repro (before)

```proto
// common.proto  (package probe.v1, no service)
message GetThingRequest { string thing_id = 1; string locale = 2; }

// api.proto
rpc GetThing(probe.v1.GetThingRequest) returns (...) {
  option (google.api.http) = { get: "/v1/things/{thing_id}" };
}
```

- **Before:** `GET /v1/things/{thing_id}` → params `[path:thing_id]` (`locale` lost)
- **After:** params `[path:thing_id, query:locale]`

## Changes

- Build one message registry from **every** `.proto` the detector saw (via `files_by_extension`, which includes message-only imports), keyed by both simple and `package.Name` qualified form.
- New `resolve_message` tolerates leading dots, fully-qualified names, same-package relative names, and imported simple names. Same-package matches win, so two messages that share a simple name across packages don't cross over.
- `analyze` now returns early when there are no service files and builds the registry once per scan.

## Tests

- New `imported_address_common.proto` (message-only) + `imported_address_api.proto` (service referencing the imported type by FQ name); `city` now resolves to a query param across files.
- `crystal spec spec/functional_test/testers/specification/grpc_spec.cr` → green (130 examples).
- Full `crystal spec spec/functional_test` (19,337) + `spec/unit_test` (3,499), `crystal tool format --check`, and `ameba` all clean locally.
- Real-world: grpc-gateway's `Echo` (imported `sub.StringMessage`) recovers its `value` field. Registry build over all ~7k `googleapis` protos adds ~1s; no endpoint-count regression on spanner/firestore/pubsub.

https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6)_