### PR TITLE
fix(grpc): require a real service block in the detector to cut false positives

### DIFF
--- a/spec/unit_test/detector/specification/grpc_spec.cr
+++ b/spec/unit_test/detector/specification/grpc_spec.cr
@@ -1,0 +1,69 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/specification/*"
+require "../../../../src/models/code_locator"
+
+describe "Detect gRPC" do
+  options = create_test_options
+  instance = Detector::Specification::Grpc.new options
+
+  it "detects a .proto with a service block" do
+    content = <<-PROTO
+      syntax = "proto3";
+      service UserService {
+        rpc GetUser(GetUserRequest) returns (GetUserResponse) {}
+      }
+      PROTO
+
+    instance.detect("user.proto", content).should be_true
+  end
+
+  it "detects a service block split across lines" do
+    content = <<-PROTO
+      syntax = "proto3";
+      service HealthService
+      {
+        rpc Check(Req) returns (Resp);
+      }
+      PROTO
+
+    instance.detect("health.proto", content).should be_true
+  end
+
+  it "rejects a message-only proto whose field names contain 'service'/'rpc'" do
+    content = <<-PROTO
+      syntax = "proto3";
+      message ClientConfig {
+        string service_url = 1;
+        string service_account = 2;
+        int32 rpc_timeout_ms = 3;
+        bool enable_rpc_retry = 4;
+      }
+      PROTO
+
+    instance.detect("config.proto", content).should be_false
+  end
+
+  it "rejects a pure message proto" do
+    content = <<-PROTO
+      syntax = "proto3";
+      message Foo {
+        string bar = 1;
+      }
+      PROTO
+
+    instance.detect("types.proto", content).should be_false
+  end
+
+  it "applies only to .proto files" do
+    instance.applicable?("schema.proto").should be_true
+    instance.applicable?("schema.json").should be_false
+  end
+
+  it "registers the path in code_locator" do
+    content = "service S { rpc M(A) returns (B); }"
+    locator = CodeLocator.instance
+    locator.clear "grpc-proto"
+    instance.detect("svc.proto", content)
+    locator.all("grpc-proto").should eq(["svc.proto"])
+  end
+end

--- a/src/detector/detectors/specification/grpc.cr
+++ b/src/detector/detectors/specification/grpc.cr
@@ -3,13 +3,16 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Grpc < Detector
+    # A gRPC service is defined by a `service Name { ... }` block. Matching that
+    # structural marker — rather than the bare substrings "service"/"rpc", which
+    # also occur in ordinary field names like `service_url` or `rpc_timeout` —
+    # keeps message-only and config `.proto` files from being mislabeled as gRPC.
+    SERVICE_BLOCK = /\bservice\s+\w+\s*\{/
+
     def detect(filename : String, file_contents : String) : Bool
-      if filename.ends_with?(".proto")
-        if file_contents.includes?("service") || file_contents.includes?("rpc")
-          locator = CodeLocator.instance
-          locator.push("grpc-proto", filename)
-          return true
-        end
+      if filename.ends_with?(".proto") && file_contents.matches?(SERVICE_BLOCK)
+        CodeLocator.instance.push("grpc-proto", filename)
+        return true
       end
 
       false


### PR DESCRIPTION
## Summary

Completing the gRPC FP/FN pass (after #2110, #2115, #2119) with a **technology-level false-positive** fix in the detector.

The detector flagged any `.proto` containing the bare substring `"service"` **or** `"rpc"` as gRPC. Ordinary field names like `service_url`, `service_account`, or `rpc_timeout_ms` therefore mislabeled message-only / config protos as a gRPC technology (reporting "Detected 1 technologies → grpc" with zero endpoints).

### Repro (before)

```proto
// config.proto — no gRPC service at all
message ClientConfig {
  string service_url = 1;
  int32  rpc_timeout_ms = 2;
}
```

- **Before:** `Detected 1 technologies. └── grpc` (0 endpoints)
- **After:** `No technologies detected.`

## Changes

- Match the structural marker of a gRPC service — a `service Name { ... }` block (`\bservice\s+\w+\s*\{`) — instead of bare substrings. Field-name substrings no longer match because the keyword must be followed by an identifier and `{`.
- Message-only protos are still read for the cross-file param registry (via `files_by_extension`, added in #2119), so this only narrows the **technology flag**, not param resolution.
- Adds the **previously missing** gRPC detector unit test: real service blocks (incl. a multi-line form), rejection of `service`/`rpc` field-name substrings, pure message protos, applicability, and locator registration.

## Tests

- `crystal spec spec/unit_test/detector/specification/grpc_spec.cr` → green (6 examples, new).
- `crystal spec spec/functional_test/testers/specification/grpc_spec.cr` → green (130 examples; `techs => 1` unchanged).
- Full `crystal spec spec/functional_test` + `spec/unit_test`, `crystal tool format --check`, and `ameba` all clean locally.

https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BczTh7EUyyVhuGmaqRw8T6)_