### PR TITLE
fix(graphql): cover .gql operation docs (FN) and de-quadratic the SDL detector

### DIFF
--- a/spec/functional_test/fixtures/specification/graphql_operations/api.gql
+++ b/spec/functional_test/fixtures/specification/graphql_operations/api.gql
@@ -1,0 +1,13 @@
+# Client operation document shipped as a .gql file.
+query GetUser {
+  user(id: "1") {
+    id
+    name
+  }
+}
+
+mutation CreateUser {
+  createUser(name: "Neo") {
+    id
+  }
+}

--- a/spec/functional_test/testers/specification/graphql_operations_spec.cr
+++ b/spec/functional_test/testers/specification/graphql_operations_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Operation documents shipped as a `.gql` file (not SDL) are picked up by
+# the file analyzer the same way `.graphql` operation documents are. Every
+# named top-level operation rides on a single `POST <base>/graphql`
+# endpoint (the optimizer dedupes on method + url), so both the query and
+# the mutation here surface as params on one endpoint.
+FunctionalTester.new("fixtures/specification/graphql_operations/", {
+  :techs     => 0,
+  :endpoints => 1,
+}, [
+  Endpoint.new("https://ex.com/graphql", "POST", [
+    Param.new("graphql_operation_query_GetUser", "", "json"),
+    Param.new("graphql_operation_mutation_CreateUser", "", "json"),
+  ]),
+], {"url" => YAML::Any.new("https://ex.com")}).perform_tests

--- a/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
+++ b/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
@@ -174,8 +174,9 @@ module InternalGraphqlParser
 end
 
 FileAnalyzer.add_hook(->(path : String, _url : String) : Array(Endpoint) {
-  # Only process .graphql files
-  return [] of Endpoint unless path.ends_with?(".graphql")
+  # Operation documents ship with either extension; `.graphqls` is
+  # SDL-only by convention and is left to the graphql_sdl analyzer.
+  return [] of Endpoint unless path.ends_with?(".graphql") || path.ends_with?(".gql")
 
   begin
     file_content = File.read(path, encoding: "utf-8", invalid: :skip)

--- a/src/detector/detectors/specification/graphql_sdl.cr
+++ b/src/detector/detectors/specification/graphql_sdl.cr
@@ -45,16 +45,23 @@ module Detector::Specification
 
     # Returns the "visible" code portion of the line (strings and comments excised)
     # and the updated string states for the *next* line.
+    #
+    # The line is materialized into an `Array(Char)` first: indexing a
+    # `String` by char position is O(n) on multi-byte input, so a single
+    # long unicode-bearing line (e.g. a one-line block-string description
+    # with an emoji) would otherwise make this scan quadratic.
     private def detection_line(line : String, in_block_string : Bool, in_string : Bool) : Tuple(String, Bool, Bool)
+      chars = line.chars
+      size = chars.size
       visible = String::Builder.new
       i = 0
       curr_block = in_block_string
       curr_str = in_string
 
-      while i < line.size
+      while i < size
         if curr_block
           # inside block string: skip until we see closing """
-          if i + 2 < line.size && line[i] == '"' && line[i + 1] == '"' && line[i + 2] == '"'
+          if i + 2 < size && chars[i] == '"' && chars[i + 1] == '"' && chars[i + 2] == '"'
             curr_block = false
             i += 3
             next
@@ -65,8 +72,8 @@ module Detector::Specification
 
         if curr_str
           # inside regular "string": skip until unescaped closing "
-          ch = line[i]
-          if ch == '\\' && i + 1 < line.size
+          ch = chars[i]
+          if ch == '\\' && i + 1 < size
             i += 2
             next
           end
@@ -80,9 +87,9 @@ module Detector::Specification
         end
 
         # not inside any string
-        ch = line[i]
+        ch = chars[i]
         if ch == '"'
-          if i + 2 < line.size && line[i + 1] == '"' && line[i + 2] == '"'
+          if i + 2 < size && chars[i + 1] == '"' && chars[i + 2] == '"'
             curr_block = true
             i += 3
             next


### PR DESCRIPTION
## Summary

Third round of GraphQL analyzer improvements (follows #2114, #2117), again validated against a 442-file corpus cross-checked with `graphql-js`.

### 1. `fix(graphql-ops)` — also scan `.gql` operation documents (false negative)

The operation-document analyzer only fired on `.graphql`, so client operation documents shipped as **`.gql`** produced no endpoints at all: the SDL detector rejects them (no SDL signals) and the file analyzer skipped the extension. This is a common convention — hasura/graphql-engine alone carries dozens of `request.gql` files.

Now `.gql` is accepted too (`.graphqls` stays SDL-only). The depth-aware, string/comment-stripping parser from #2114 already yields nothing for SDL documents, so `.gql` **schema** files stay free of phantom operations — verified against `graphql-js` across all **276 `.gql`** files in the corpus (zero diffs: operations extracted where present, nothing on schemas).

### 2. `perf(graphql-sdl)` — drop O(n²) line scan in the SDL detector

`detection_line()` indexed each line with `line[i]`, which is O(n) per access on non single-byte-optimizable input — the same trap fixed in the parser in #2114. One long line carrying a multi-byte char (e.g. a single-line `"""description"""` with an emoji) made the per-line scan quadratic: a 216 KB file with one such line took **~18.6 s** to classify, now **~4.6 ms**. Detection results are unchanged.

## Testing

- New functional fixture + spec for a `.gql` operation document
- `crystal spec spec/unit_test` (3499) + `spec/functional_test` (19305) → 0 failures
- `ameba` clean on both changed files
- Differential vs `graphql-js`: `.gql` ops match exactly across 276 files; SDL field extraction unchanged
- End-to-end: scanning the whole graphql-js repo (incl. the formerly-100 s emoji schema) now takes ~1.7 s

https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi)_