### PR TITLE
fix(analyzer/insomnia): expand composite environment variables in URLs

### DIFF
--- a/spec/unit_test/analyzer/specification/insomnia_spec.cr
+++ b/spec/unit_test/analyzer/specification/insomnia_spec.cr
@@ -106,6 +106,43 @@ describe "Insomnia Analyzer" do
     notes.params.should be_empty
   end
 
+  it "fully expands composite environment variables in URLs" do
+    endpoints = analyze_insomnia_json <<-JSON
+      {
+        "_type": "export",
+        "__export_format": 4,
+        "resources": [
+          {
+            "_id": "env_base",
+            "_type": "environment",
+            "name": "Base",
+            "data": { "base_url": "{{ scheme }}://{{ host }}{{ base_path }}" }
+          },
+          {
+            "_id": "env_values",
+            "_type": "environment",
+            "name": "Values",
+            "data": { "scheme": "https", "host": "api.example.com", "base_path": "/v2" }
+          },
+          {
+            "_id": "req_1",
+            "_type": "request",
+            "name": "Pet",
+            "method": "GET",
+            "url": "{{ base_url }}/pet/{{ petId }}"
+          }
+        ]
+      }
+      JSON
+
+    endpoints.size.should eq 1
+    endpoint = endpoints.first
+    endpoint.url.should eq "/v2/pet/:petId"
+    endpoint.params.map(&.name).should contain("petId")
+    endpoint.params.map(&.name).should_not contain("host")
+    endpoint.params.map(&.name).should_not contain("base_path")
+  end
+
   it "does not share details between v5 requests in one collection" do
     endpoints = analyze_insomnia_yaml <<-YAML
       type: collection.insomnia.rest/5.0

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -312,10 +312,20 @@ module Analyzer::Specification
     # parser can still strip them out.
     private def resolve_vars(input : String, env : Hash(String, String)) : String
       return input if input.empty? || env.empty?
-      input.gsub(/\{\{\s*(?:_\.)?([A-Za-z0-9_.-]+)\s*\}\}/) do |match|
-        name = $1
-        env.fetch(name, match)
+      # Iterate so composite variables expand fully. Insomnia commonly defines
+      # a base URL as `{{scheme}}://{{host}}{{base_path}}`, so a single pass
+      # would leave `{{host}}`/`{{base_path}}` behind and turn them into bogus
+      # path segments (e.g. `/:host:base_path/...`).
+      resolved = input
+      3.times do
+        previous = resolved
+        resolved = resolved.gsub(/\{\{\s*(?:_\.)?([A-Za-z0-9_.-]+)\s*\}\}/) do |match|
+          name = $1
+          env.fetch(name, match)
+        end
+        break if resolved == previous
       end
+      resolved
     end
 
     private def extract_path_from_url(url_string : String) : String


### PR DESCRIPTION
## Summary

Follow-up to #2112. Fixes a false-positive / wrong-URL class in the Insomnia analyzer caused by single-pass variable substitution.

Insomnia very commonly defines a base URL as a composite of other environment variables, e.g.:

```
base_url = {{scheme}}://{{host}}{{base_path}}
```

`resolve_vars` substituted only **once**, so after expanding `{{base_url}}` the inner `{{host}}` / `{{base_path}}` tokens survived and were normalized into bogus path segments — producing URLs like `/:host:base_path/pet` and phantom `host` / `base_path` path params.

The fix iterates the substitution (bounded to 3 passes, matching the existing Postman analyzer) until the string stabilizes.

## Validation
Against the upstream `Kong/insomnia` fixture `insomnia-inso/.../insomnia-v4/insomnia_v4.json` (which defines `base_url = {{ scheme }}://{{ host }}{{ base_path }}`):

| | before | after |
|---|---|---|
| `{{base_url}}/pet` | `/:host:base_path/pet` | `/v2/pet` |
| `{{base_url}}/store/order/{{orderId}}` | `/:host:base_path/store/order/:orderId` | `/v2/store/order/:orderId` |

A corpus re-scan (~70 real collections) shows zero remaining Insomnia endpoints containing unresolved `{{…}}` tokens or bogus `:host`/`:base_path` segments.

## Testing
- New unit test covering composite-variable expansion.
- `crystal spec spec/unit_test` → 3519 examples, 0 failures.
- `crystal spec spec/functional_test` → 19337 examples, 0 failures.
- `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01JCkuLjj2peTDDDKvaFHkBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCkuLjj2peTDDDKvaFHkBW)_