### PR TITLE
fix(graphql-sdl): stop argument-level directives from dropping/forging fields

### DIFF
--- a/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
@@ -119,6 +119,31 @@ describe "GraphQL SDL Analyzer" do
     ])
   end
 
+  it "parses fields whose arguments carry directives with parentheses" do
+    # Regression: the cursor was advanced to the first `)` after the argument
+    # list opened, but an argument's own directive (`@length(min: 1)`,
+    # `@deprecated(reason: ...)`) closes a paren first. That dropped the field
+    # (FN) and misread following argument names as fields (FP, e.g. `newArg`).
+    endpoints = analyze_sdl <<-SDL
+      type Query {
+        directiveArg(arg: String! @length(min: 1, max: 255, message: "x")): String
+        withDeprecatedArg(oldArg: Int @deprecated(reason: "old"), newArg: Int): String
+        plain: String
+      }
+      SDL
+
+    endpoints.map(&.url).should eq [
+      "/graphql#Query.directiveArg",
+      "/graphql#Query.withDeprecatedArg",
+      "/graphql#Query.plain",
+    ]
+    # `oldArg` / `newArg` are arguments, not fields — they must not leak as endpoints.
+    endpoints.map(&.url).any?(&.includes?("newArg")).should be_false
+
+    with_args = endpoints.find! { |e| e.url.ends_with?("withDeprecatedArg") }
+    with_args.params.reject(&.name.starts_with?("graphql_")).map(&.name).should eq ["oldArg", "newArg"]
+  end
+
   it "preserves trailing non-null marker on list types" do
     endpoints = analyze_sdl <<-SDL
       type Query {

--- a/src/analyzer/analyzers/specification/graphql_sdl_parser.cr
+++ b/src/analyzer/analyzers/specification/graphql_sdl_parser.cr
@@ -119,9 +119,15 @@ module Analyzer::Specification
         args = [] of NamedTuple(name: String, type: String)
         if cursor < body.size && body[cursor] == '('
           args_block = extract_paren_block(body, cursor)
-          if args_block
+          close = matching_close_index(body, cursor, '(', ')')
+          if args_block && close
             args = parse_arguments(args_block)
-            cursor = (body.index(')', cursor) || cursor) + 1
+            # Jump past the *matching* close paren, not the first ')': an
+            # argument's directive (`@length(min: 1)`, `@deprecated(...)`)
+            # carries its own parentheses, and stopping at the first ')'
+            # left the cursor mid-arguments — dropping the field and
+            # misreading later argument names as fields.
+            cursor = close + 1
           else
             cursor = advance_to_next_field(body, cursor)
             pos = cursor
@@ -356,6 +362,27 @@ module Analyzer::Specification
       nil
     end
 
+    # Index of the close char that matches the opener at `open_pos` (nested
+    # pairs counted), or nil when unbalanced. Unlike `String#index(close_ch)`
+    # it skips over inner pairs — needed so a field/directive argument list
+    # is not cut short at the first `)` belonging to a nested directive.
+    private def matching_close_index(content : String, open_pos : Int32,
+                                     open_ch : Char, close_ch : Char) : Int32?
+      depth = 0
+      pos = open_pos
+      while pos < content.size
+        ch = content[pos]
+        if ch == open_ch
+          depth += 1
+        elsif ch == close_ch
+          depth -= 1
+          return pos if depth == 0
+        end
+        pos += 1
+      end
+      nil
+    end
+
     private def skip_ws(content : String, pos : Int32) : Int32
       while pos < content.size && content[pos].ascii_whitespace?
         pos += 1
@@ -477,7 +504,7 @@ module Analyzer::Specification
           args_block = extract_paren_block(content, scan_pos)
           if args_block
             args_repr = "(#{args_block.strip})"
-            close = content.index(')', scan_pos)
+            close = matching_close_index(content, scan_pos, '(', ')')
             scan_pos = close ? close + 1 : scan_pos + 1
           end
         end


### PR DESCRIPTION
## Summary

Fourth round of GraphQL analyzer accuracy work (follows #2114, #2117, #2122). Found by expanding the differential corpus with **gqlgen**, **juniper**, and **strawberry** and diffing every schema against `graphql-js`.

When a field argument carried its own parenthesised directive, `parse_fields` advanced the cursor to the **first** `)` — which belongs to the directive, not the argument list:

```graphql
type Query {
  directiveArg(arg: String! @length(min: 1, max: 255)): String
  fieldWithDeprecatedArg(oldArg: Int @deprecated(reason: "old"), newArg: Int): String
}
```

The cursor stopped inside the argument list, so:
- the field was **dropped** (false negative — `directiveArg`, `fieldWithDeprecatedArg` vanished), and
- the remaining argument names were **misread as root fields** (false positive — `Query.arg2`, `Query.newArg`, …).

gqlgen's directive-heavy test schemas turned one 15-field `Query` into 4 garbage entries.

## Fix

Track the **matching** close paren (nested pairs counted) instead of the first `)`, in both the field argument list and `read_directives`.

## Testing

- New regression unit test for directive-bearing arguments
- `crystal spec spec/unit_test` (3499) + GraphQL functional suites → 0 failures
- `ameba` clean
- **Differential vs `graphql-js` over a 640-file, 9-project corpus** (graphql-js, apollo-server, graphql-yoga, hasura/graphql-engine, graphiql, gatsby, gqlgen, juniper, strawberry): SDL field extraction **142 checked / 0 diffs**, named-operation extraction **272 checked / 0 diffs**

https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1bac5RYzn34aBnCae1Usi)_