### PR TITLE
feat(passive-scan): suppress documentation placeholder secret values

### DIFF
--- a/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
@@ -140,7 +140,7 @@ describe "GraphQL SDL Analyzer" do
     # `oldArg` / `newArg` are arguments, not fields — they must not leak as endpoints.
     endpoints.map(&.url).any?(&.includes?("newArg")).should be_false
 
-    with_args = endpoints.find! { |e| e.url.ends_with?("withDeprecatedArg") }
+    with_args = endpoints.find!(&.url.ends_with?("withDeprecatedArg"))
     with_args.params.reject(&.name.starts_with?("graphql_")).map(&.name).should eq ["oldArg", "newArg"]
   end
 

--- a/spec/unit_test/passive_scan/false_positive_spec.cr
+++ b/spec/unit_test/passive_scan/false_positive_spec.cr
@@ -182,5 +182,22 @@ describe NoirPassiveScan::FalsePositive do
     it "keeps a populated value that uses the => hash-arrow separator" do
       NoirPassiveScan::FalsePositive.secret_reference?(%('key' => 'AKIAIOSFODNN7REALKEYX')).should be_false
     end
+
+    it "suppresses documentation placeholder values" do
+      NoirPassiveScan::FalsePositive.secret_reference?("AWS_ACCESS_KEY_ID=your-access-key-id").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("AWS_SECRET_ACCESS_KEY=your-secret-access-key").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("API_KEY=your_api_key").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("GITHUB_TOKEN=<token> pnpm changeset version").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("SECRET=changeme").should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?(%(    with_env DATABASE_URL: nil, RAILS_ENV: "development" do)).should be_true
+      NoirPassiveScan::FalsePositive.secret_reference?("TOKEN=xxxxxxxx").should be_true
+    end
+
+    it "keeps real values that merely begin with similar letters" do
+      # Must not over-match: a real-looking value is not a placeholder.
+      NoirPassiveScan::FalsePositive.secret_reference?("DATABASE_URL=postgres://user:pass@host/db").should be_false
+      NoirPassiveScan::FalsePositive.secret_reference?(%(GITHUB_TOKEN=ghp_1234567890abcdefghijklmnopqrstuvwx)).should be_false
+      NoirPassiveScan::FalsePositive.secret_reference?("PROJECT=changelog-service").should be_false
+    end
   end
 end

--- a/src/passive_scan/false_positive.cr
+++ b/src/passive_scan/false_positive.cr
@@ -87,6 +87,19 @@ module NoirPassiveScan
     # it is left to fall through.
     PURE_REFERENCE = /\A(?:\$\{?\{?[A-Za-z_][\w.\- ]*\}?\}?|\$\(.+\)|%[A-Za-z_]\w*%|\{\{.+\}\}|<[^>]+>|env\(\s*['"][^'",]+['"]\s*\))\z/
 
+    # Documentation/template placeholder *values* — what a reader is told
+    # to replace, never a real secret. Matched at the *start* of the value
+    # so a `KEY=<token> …` or `KEY=your-access-key-id` example is caught
+    # even with trailing text:
+    #   - angle-bracket stubs (`<token>`, `<your-key>`)
+    #   - `your-…` / `your_…` (`your-access-key-id`, `your_api_key`)
+    #   - explicit "replace this" / "insert your" prose
+    #   - bare null / dummy tokens (`nil`, `null`, `none`, `changeme`,
+    #     `placeholder`, `redacted`, `xxxx…`, `****`)
+    # All are forms a genuine high-entropy literal can never take, so this
+    # only removes false positives.
+    PLACEHOLDER_VALUE = /\A(?:<[^>]*>|your[-_ ]|insert[-_ ]your|replace[-_ ](?:me|this|with)|(?:changeme|change[-_]me|replaceme|replace[-_]me|placeholder|redacted|dummy|todo|fixme|none|null|nil|undefined|x{4,}|\*{4,})\b)/i
+
     # True when `line` exposes its secret-bearing value only through an
     # indirection (env read / templating) or a placeholder — i.e. there
     # is no literal secret on the line to leak.
@@ -105,6 +118,7 @@ module NoirPassiveScan
       if match = line.match(ASSIGNMENT_VALUE)
         value = strip_wrapping_quotes(match[1])
         return true if value.matches?(PURE_REFERENCE)
+        return true if value.matches?(PLACEHOLDER_VALUE)
       end
 
       false


### PR DESCRIPTION
## Summary

Fourth follow-up (after #2108, #2113, #2121). Scanning Directus and Strapi surfaced README / `.env.example` examples that assign a secret variable a **placeholder** the reader is meant to replace:

```
AWS_ACCESS_KEY_ID=your-access-key-id
AWS_SECRET_ACCESS_KEY=your-secret-access-key
GITHUB_TOKEN=<token> pnpm changeset version
DATABASE_URL: nil
```

## Approach

Adds a `PLACEHOLDER_VALUE` check to the value inspection in `secret_reference?`, matched at the **start** of the value so a leading placeholder is caught even with trailing text:

- angle-bracket stubs (`<token>`, `<your-key>`)
- `your-…` / `your_…` (`your-access-key-id`, `your_api_key`)
- explicit "insert your" / "replace this" prose
- bare null / dummy tokens (`nil`, `null`, `none`, `changeme`, `placeholder`, `redacted`, `xxxx…`, `****`)

All are forms a genuine high-entropy literal can never take, so this is **false-positive-only** — same invariant as the prior PRs. Care is taken not to over-match: `changelog-service`, `postgres://user:pass@host/db`, and `ghp_…` literals are kept.

## Validation (cloned real repos)

| repo | before | after | notes |
|------|--------|-------|-------|
| strapi/strapi | 10 | 6 | 4 `your-*` doc placeholders dropped; remaining are PEM test fixtures + a `$VAR` self-reference |
| directus/directus | 3 | 2 | leading `<token>` example dropped |
| rails/rails | 25 | 23 | `DATABASE_URL: nil` dropped |

An 8-secret control fixture (AWS, GitHub, OpenAI, Slack, PEM) stays fully detected — no false negatives.

## Note: bundled CI lint fix

This branch also includes one unrelated commit — `ci(lint): use short block notation in graphql_sdl_spec`. ameba's `Style/VerboseBlock` flags `graphql_sdl_spec.cr:143` on current `main` (introduced by #2125), which fails the `lint` job for **every** open PR. The one-line short-block rewrite (behaviour identical) restores a green lint so this PR — and others — can merge. Happy to split it out if preferred.

## Tests

- New `secret_reference?` specs: `your-*`, `<token> …`, `changeme`, `DATABASE_URL: nil`, `xxxx…` suppressed; `changelog-service` / `postgres://…` / `ghp_…` kept.
- Full suite green — unit 3530, functional 19357, 0 failures; `crystal tool format --check` + `ameba` clean.

https://claude.ai/code/session_016pH4ELCk2Anmkdzij2ZZCt