### PR TITLE
fix(analyzer/postman): normalize dynamic variables in paths to path params

### DIFF
--- a/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
+++ b/spec/unit_test/analyzer/specification/graphql_sdl_spec.cr
@@ -140,7 +140,7 @@ describe "GraphQL SDL Analyzer" do
     # `oldArg` / `newArg` are arguments, not fields — they must not leak as endpoints.
     endpoints.map(&.url).any?(&.includes?("newArg")).should be_false
 
-    with_args = endpoints.find! { |e| e.url.ends_with?("withDeprecatedArg") }
+    with_args = endpoints.find!(&.url.ends_with?("withDeprecatedArg"))
     with_args.params.reject(&.name.starts_with?("graphql_")).map(&.name).should eq ["oldArg", "newArg"]
   end
 

--- a/spec/unit_test/analyzer/specification/postman_spec.cr
+++ b/spec/unit_test/analyzer/specification/postman_spec.cr
@@ -256,6 +256,31 @@ describe "Postman Analyzer" do
     public_ep.params.any? { |p| p.name == "Authorization" }.should be_false
   end
 
+  it "normalizes Postman dynamic variables in the path to path params" do
+    endpoints = analyze_postman <<-JSON
+      {
+        "info": {
+          "name": "Dynamic Var Collection",
+          "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+        },
+        "item": [
+          {
+            "name": "Anything",
+            "request": {
+              "method": "GET",
+              "url": "https://api.example.com/anything/{{$guid}}"
+            }
+          }
+        ]
+      }
+      JSON
+
+    endpoints.size.should eq 1
+    endpoint = endpoints.first
+    endpoint.url.should eq "/anything/:guid"
+    param_tuples(endpoint).should contain({"guid", "", "path"})
+  end
+
   it "does not share details between requests in one collection" do
     endpoints = analyze_postman <<-JSON
       {

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -325,7 +325,10 @@ module Analyzer::Specification
       stripped = strip_query_and_fragment(path.strip)
       return "" if stripped.empty?
 
-      normalized = stripped.gsub(/\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}/) do
+      # The optional `$` covers Postman dynamic variables such as `{{$guid}}`
+      # or `{{$randomInt}}`, which are runtime-generated path segments and
+      # should be treated as path parameters rather than left literal.
+      normalized = stripped.gsub(/\{\{\s*\$?([A-Za-z0-9_.-]+)\s*\}\}/) do
         ":#{$1.split(".").last}"
       end
       normalized = normalized.gsub(/\{([A-Za-z_][A-Za-z0-9_.-]*)\}/) { ":#{$1}" }


### PR DESCRIPTION
## Summary

Follow-up in the Postman/Insomnia fidelity series (#2112, #2123).

Postman dynamic variables — `{{$guid}}`, `{{$randomInt}}`, `{{$timestamp}}`, `{{$randomFirstName}}`, … — carry a `$` prefix that the path-normalization regex did not accept. As a result a path segment like `/anything/{{$guid}}` was emitted **verbatim** (a literal `{{$guid}}` in the endpoint URL) instead of being treated as a templated path parameter.

The fix accepts the optional `$` so those segments normalize to `:guid`, consistent with how regular collection variables (`{{userId}}` → `:userId`) are already handled. `extract_path_vars` then surfaces the corresponding `guid` path param.

## Validation
Against the upstream `Kong/insomnia` importer fixture `postman/faker-vars-v2_1-input.json` (`path: ["anything", "{{$guid}}"]`):

| | before | after |
|---|---|---|
| URL | `/anything/{{$guid}}` | `/anything/:guid` |
| path params | – | `guid` |

This was the only endpoint left containing an unresolved `{{…}}` token in a ~70-collection corpus scan.

## Note: bundled lint fix
This branch also includes a one-line, behavior-neutral `style(spec/graphql_sdl)` commit fixing an **ameba `Style/VerboseBlock` violation that already exists on `main`** (`graphql_sdl_spec.cr:143`). That violation makes the `lint` CI job fail for *every* open PR, so it is fixed here to unblock CI.

## Testing
- New unit test covering dynamic-variable path normalization.
- `crystal spec spec/unit_test` → 3531 examples, 0 failures.
- `crystal spec spec/functional_test` → 19399 examples, 0 failures.
- `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01JCkuLjj2peTDDDKvaFHkBW