### PR TITLE
fix(tagger/go_auth): don't tag static-asset routes under a root-group .Use

### DIFF
--- a/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_auth_spec.cr
@@ -2,6 +2,35 @@ require "file_utils"
 require "../../../spec_helper"
 require "../../../../src/tagger/tagger"
 
+# Write `fixture_lines` to a temp Go file, run GoAuthTagger against a single
+# endpoint at `url`/`method` whose route is recorded at `line`, and return
+# the (now possibly tagged) endpoint.
+def run_go_auth(fixture_lines : Array(String), url : String, method : String, line : Int32) : Endpoint
+  CodeLocator.instance.clear_all
+  tmpdir = File.tempname("go_rootgroup")
+  Dir.mkdir_p(tmpdir)
+  file = File.join(tmpdir, "main.go")
+  File.write(file, fixture_lines.join("\n"))
+
+  # The group-middleware pre-scan enumerates `.go` files via the file map,
+  # so register the fixture there (mirrors the other GoAuthTagger specs).
+  locator = CodeLocator.instance
+  Dir.glob("#{tmpdir}/**/*").each do |f|
+    next if File.directory?(f)
+    locator.push("file_map", f)
+  end
+
+  noir_options = create_test_options
+  noir_options["base"] = YAML::Any.new(tmpdir)
+  details = Details.new(PathInfo.new(file, line))
+  details.technology = "go_gin"
+  endpoint = Endpoint.new(url, method, [] of Param, details)
+
+  GoAuthTagger.new(noir_options).perform([endpoint])
+  FileUtils.rm_rf(tmpdir)
+  endpoint
+end
+
 describe "GoAuthTagger" do
   fixture_base = "#{__DIR__}/../../../functional_test/fixtures/go/gin_auth"
   main_path = "#{fixture_base}/main.go"
@@ -173,5 +202,67 @@ describe "GoAuthTagger (expanded targets)" do
     endpoint.tags[0].description.should contain("AuthMiddleware")
 
     FileUtils.rm_rf(tmpdir)
+  end
+end
+
+# A root/empty group (`g.Group("")` / `g.Group("/")`) with a chained
+# `.Use(auth)` is recorded with prefix "/", which `prefix_covers?` matches
+# against every endpoint. In gin that middleware only guards the group's
+# own routes, NOT engine-level static-asset routes — so the broad scope
+# must not tag the SPA shell / `/static/*` / favicon (the gotify FP).
+describe "GoAuthTagger (root-group static-asset exemption)" do
+  # Models the gotify shape: public static routes registered on the engine,
+  # then a root/empty group that applies auth middleware to its own routes.
+  #  1 package main
+  #  2 func main() {
+  #  3   g := gin.New()
+  #  4   g.GET("/index.html", indexHandler)
+  #  5   g.GET("/static/*filepath", staticHandler)
+  #  6   g.GET("/favicon.ico", iconHandler)
+  #  7   clientAuth := g.Group("")
+  #  8   clientAuth.Use(AuthMiddleware())
+  #  9   clientAuth.GET("/data", dataHandler)
+  # 10 }
+  root_group_fixture = [
+    "package main",
+    "func main() {",
+    "  g := gin.New()",
+    "  g.GET(\"/index.html\", indexHandler)",
+    "  g.GET(\"/static/*filepath\", staticHandler)",
+    "  g.GET(\"/favicon.ico\", iconHandler)",
+    "  clientAuth := g.Group(\"\")",
+    "  clientAuth.Use(AuthMiddleware())",
+    "  clientAuth.GET(\"/data\", dataHandler)",
+    "}",
+  ]
+
+  {"/index.html" => 4, "/static/*filepath" => 5, "/favicon.ico" => 6}.each do |url, line|
+    it "does not tag static-asset route #{url} under a root-group .Use" do
+      endpoint = run_go_auth(root_group_fixture, url, "GET", line)
+      endpoint.tags.any? { |t| t.name == "auth" }.should be_false
+    end
+  end
+
+  it "still tags a non-static route covered only by the root-group scope" do
+    # `/data` lives far from the `.Use` line (no inline match), so it is
+    # tagged purely via the group scope — proving the exemption is narrow
+    # and does not drop genuinely protected routes.
+    endpoint = run_go_auth(root_group_fixture, "/data", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_true
+  end
+
+  it "still tags a static route under a truly global engine .Use(auth)" do
+    # `r.Use(auth)` (no enclosing group) is a real global middleware: every
+    # subsequently registered route, static or not, is guarded. The
+    # exemption is scoped to root *groups*, so global coverage is unchanged.
+    global = [
+      "package main",
+      "func main() {",
+      "  r := gin.New()",
+      "  r.Use(AuthMiddleware())",
+      "}",
+    ]
+    endpoint = run_go_auth(global, "/index.html", "GET", 30)
+    endpoint.tags.any? { |t| t.name == "auth" }.should be_true
   end
 end

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -42,10 +42,23 @@ class GoAuthTagger < FrameworkTagger
     /\bGF[Aa]uth\b/,
   ]
 
+  # Static-asset file extensions. A route ending in one of these serves a
+  # static file off the engine, not a guarded API route.
+  STATIC_ASSET_EXTENSIONS = %w[
+    .html .htm .js .mjs .cjs .css .map .ico .png .jpg .jpeg .gif .svg .webp
+    .avif .bmp .woff .woff2 .ttf .otf .eot .wasm
+  ]
+
+  # Well-known public files served at the web root.
+  STATIC_PUBLIC_FILES = Set{
+    "favicon.ico", "robots.txt", "manifest.json", "asset-manifest.json",
+    "sitemap.xml", "service-worker.js", "sw.js", "browserconfig.xml",
+  }
+
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "go_auth"
-    @middleware_scopes = [] of {prefix: String, middleware: String, description: String}
+    @middleware_scopes = [] of {prefix: String, middleware: String, description: String, root_group: Bool}
   end
 
   def self.target_techs : Array(String)
@@ -105,28 +118,16 @@ class GoAuthTagger < FrameworkTagger
         match = stripped.match(pattern)
         if match
           middleware_name = match[1]
-          prefix = normalize_prefix(group_stack)
-          prefix = "/" if prefix.empty?
-          @middleware_scopes << {
-            prefix:      prefix,
-            middleware:  middleware_name,
-            description: "Protected by Go middleware #{middleware_name}",
-          }
+          add_middleware_scope(group_stack, middleware_name, "Protected by Go middleware #{middleware_name}")
         end
       end
 
       # Check for JWT library middleware
       JWT_PATTERNS.each do |pattern|
         if stripped.matches?(pattern) && stripped.includes?(".Use")
-          prefix = normalize_prefix(group_stack)
-          prefix = "/" if prefix.empty?
           jwt_match = stripped.match(pattern)
           jwt_name = jwt_match ? jwt_match[0] : "JWT"
-          @middleware_scopes << {
-            prefix:      prefix,
-            middleware:  jwt_name,
-            description: "Protected by Go JWT middleware (#{jwt_name})",
-          }
+          add_middleware_scope(group_stack, jwt_name, "Protected by Go JWT middleware (#{jwt_name})")
         end
       end
     end
@@ -195,16 +196,62 @@ class GoAuthTagger < FrameworkTagger
     end
   end
 
+  # Record a group-level middleware scope. `prefix == "/"` arises two ways:
+  # a bare engine-level `.Use(...)` (empty group stack → truly global, every
+  # subsequently registered route is guarded) or an explicit root/empty
+  # *group* `g.Group("")` / `g.Group("/")` with a chained `.Use(...)`. Only
+  # the latter is a sub-group whose middleware does not reach engine-level
+  # static routes, so flag it to scope the coverage refinement below.
+  private def add_middleware_scope(group_stack : Array(String), middleware : String, description : String)
+    prefix = normalize_prefix(group_stack)
+    root_group = !group_stack.empty? && prefix == "/"
+    @middleware_scopes << {
+      prefix:      prefix,
+      middleware:  middleware,
+      description: description,
+      root_group:  root_group,
+    }
+  end
+
   private def check_middleware_scopes(endpoint : Endpoint) : String?
     url = endpoint.url
 
     @middleware_scopes.each do |scope|
-      if prefix_covers?(scope[:prefix], url)
-        return scope[:description]
-      end
+      next unless prefix_covers?(scope[:prefix], url)
+
+      # A `.Use` on an explicit root/empty *group* (`g.Group("")` /
+      # `g.Group("/")`) creates a sub-group; in gin it does not reach
+      # engine-level static-asset routes (the SPA shell, `/static/*`,
+      # favicon, web-app manifest) registered directly on the engine. Those
+      # are public, so a broad root-group auth scope must not tag them —
+      # the main source of go_auth false positives (e.g. gotify tagging
+      # `/`, `/index.html`, `/static/*any`, `/manifest.json` as auth).
+      next if scope[:root_group] && static_asset_route?(url)
+
+      return scope[:description]
     end
 
     nil
+  end
+
+  # A static-file / SPA-shell route, recognized conservatively: the SPA
+  # root, a gin catch-all wildcard mount (`/static/*filepath`, `/*any`), a
+  # well-known public file, or a static-asset extension. Used only to exempt
+  # these from a broad root-*group* auth scope, never from an inline,
+  # specific-prefix, or truly global (`engine.Use`) auth signal.
+  private def static_asset_route?(url : String) : Bool
+    path = url.split("?", 2)[0].split("#", 2)[0].downcase
+    return true if path == "/" || path.empty?
+
+    segments = path.split("/").reject(&.empty?)
+    # gin catch-all wildcard — the shape of a static-file server / SPA
+    # fallback (`r.Static`, `r.StaticFS`, a NoRoute SPA handler), not a
+    # REST route.
+    return true if segments.any?(&.starts_with?("*"))
+
+    last = segments[-1]? || ""
+    return true if STATIC_PUBLIC_FILES.includes?(last)
+    STATIC_ASSET_EXTENSIONS.any? { |ext| last.ends_with?(ext) }
   end
 
   # Segment-aware prefix match so "/api" guards "/api/x" but not "/apiv2".


### PR DESCRIPTION
## Summary

Reduces a **false positive** in the `go_auth` framework tagger: public **static-asset routes were tagged `auth`**.

On a fresh clone of [gotify/server](https://github.com/gotify/server), the SPA shell and static files were mis-tagged as authenticated:

```
GET /              auth   ← FP
GET /index.html    auth   ← FP
GET /manifest.json auth   ← FP
GET /static/*any   auth   ← FP
```

## Root cause

A `.Use(authMiddleware)` chained onto an explicit **root/empty group** — `g.Group("")` / `g.Group("/")` (gotify's `clientAuth := g.Group(""); clientAuth.Use(...)`) — was recorded with prefix `/`, and `prefix_covers?("/", url)` matches **every** endpoint. But in gin that middleware only guards *that group's* routes; it does **not** reach engine-level static routes registered directly on the engine (often in a different file, e.g. gotify's `serve.go`). So the over-broad scope tagged public assets.

## Change

- Record whether a `/`-prefix scope came from an explicit **root group** (`group_stack` non-empty) versus a **truly global** `engine.Use(...)` (empty stack).
- For the root-group case **only**, skip endpoints that are clearly static-asset/SPA routes: the SPA root `/`, gin catch-all wildcard mounts (`/static/*filepath`, `/*any`), well-known public files (`favicon.ico`, `manifest.json`, …), and static-asset extensions (`.js`, `.css`, `.html`, `.ico`, …).

The exemption is deliberately narrow — it **never** applies to inline middleware, specific-prefix groups, or a truly global `engine.Use`, so no genuinely protected route loses its tag.

## Verification (no false negatives)

Diffed `auth` tags before/after on the full gotify clone: **30 → 26**, removing *exactly* the four public static routes. Every protected API route (`/application/*`, `/plugin/*`, `/user/*`, `/message/*`, `/current/user/password`, …) keeps its `auth` tag — **0 gained, 0 protected-route losses**.

Added 5 specs (3 static routes exempted under a root-group `.Use`; a non-static route still tagged via the same scope; a static route still tagged under a truly global `engine.Use`). `crystal spec spec/unit_test/tagger/` → 507 examples, 0 failures. `crystal tool format --check` and `ameba` clean.

https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M)_