### PR TITLE
fix(tagger/go_security): don't tag static-asset routes under a root/global scope

### DIFF
--- a/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
+++ b/spec/unit_test/tagger/framework_taggers/go_security_spec.cr
@@ -226,4 +226,47 @@ describe "GoSecurityTagger" do
 
     FileUtils.rm_rf(tmpdir)
   end
+
+  it "exempts static-asset routes from a global root cors scope" do
+    # Models gotify: a global `r.Use(cors.New(...))` plus static routes
+    # served off the engine (the SPA shell / `/static/*`). CORS is global,
+    # so API routes are tagged, but the static assets — registered outside
+    # the middleware chain — must not be.
+    #  1 package main
+    #  2 func main() {
+    #  3   r := gin.New()
+    #  4   r.GET("/index.html", indexHandler)
+    #  5   r.GET("/static/*filepath", staticHandler)
+    #  6   r.Use(cors.New(corsConfig))
+    #  7   r.GET("/api/data", dataHandler)
+    #  8 }
+    tmpdir = File.tempname("go_sec_static")
+    Dir.mkdir_p(tmpdir)
+    file = File.join(tmpdir, "main.go")
+    File.write(file, [
+      "package main",
+      "func main() {",
+      "    r := gin.New()",
+      "    r.GET(\"/index.html\", indexHandler)",
+      "    r.GET(\"/static/*filepath\", staticHandler)",
+      "    r.Use(cors.New(corsConfig))",
+      "    r.GET(\"/api/data\", dataHandler)",
+      "}",
+    ].join("\n"))
+
+    opts = create_test_options
+    opts["base"] = YAML::Any.new(tmpdir)
+    seed_file_map(tmpdir)
+
+    index = go_endpoint(file, 4, "/index.html", "GET", "go_gin")
+    static = go_endpoint(file, 5, "/static/*filepath", "GET", "go_gin")
+    api = go_endpoint(file, 7, "/api/data", "GET", "go_gin")
+    GoSecurityTagger.new(opts).perform([index, static, api])
+
+    tag_named(index, "cors").should be_nil
+    tag_named(static, "cors").should be_nil
+    tag_named(api, "cors").should_not be_nil
+
+    FileUtils.rm_rf(tmpdir)
+  end
 end

--- a/src/models/framework_tagger.cr
+++ b/src/models/framework_tagger.cr
@@ -92,4 +92,37 @@ class FrameworkTagger < Tagger
     @logger.debug "FrameworkTagger: Failed to read file #{path}: #{ex.message}"
     nil
   end
+
+  # Static-asset file extensions. A route ending in one of these serves a
+  # static file off the web server, not a guarded API route.
+  STATIC_ASSET_EXTENSIONS = %w[
+    .html .htm .js .mjs .cjs .css .map .ico .png .jpg .jpeg .gif .svg .webp
+    .avif .bmp .woff .woff2 .ttf .otf .eot .wasm
+  ]
+
+  # Well-known public files served at the web root.
+  STATIC_PUBLIC_FILES = Set{
+    "favicon.ico", "robots.txt", "manifest.json", "asset-manifest.json",
+    "sitemap.xml", "service-worker.js", "sw.js", "browserconfig.xml",
+  }
+
+  # A static-file / SPA-shell route, recognized conservatively: the SPA
+  # root, a catch-all wildcard mount (`/static/*filepath`, `/*any`), a
+  # well-known public file, or a static-asset extension. Taggers use this to
+  # exempt such routes from broad root/global middleware scopes, where the
+  # signal is noise (or a false positive for assets registered outside the
+  # middleware chain) rather than a meaningful per-endpoint review target.
+  def static_asset_route?(url : String) : Bool
+    path = url.split("?", 2)[0].split("#", 2)[0].downcase
+    return true if path == "/" || path.empty?
+
+    segments = path.split("/").reject(&.empty?)
+    # Catch-all wildcard — the shape of a static-file server / SPA fallback
+    # (`r.Static`, `r.StaticFS`, a NoRoute SPA handler), not a REST route.
+    return true if segments.any?(&.starts_with?("*"))
+
+    last = segments[-1]? || ""
+    return true if STATIC_PUBLIC_FILES.includes?(last)
+    STATIC_ASSET_EXTENSIONS.any? { |ext| last.ends_with?(ext) }
+  end
 end

--- a/src/tagger/framework_taggers/go/go_auth.cr
+++ b/src/tagger/framework_taggers/go/go_auth.cr
@@ -42,19 +42,6 @@ class GoAuthTagger < FrameworkTagger
     /\bGF[Aa]uth\b/,
   ]
 
-  # Static-asset file extensions. A route ending in one of these serves a
-  # static file off the engine, not a guarded API route.
-  STATIC_ASSET_EXTENSIONS = %w[
-    .html .htm .js .mjs .cjs .css .map .ico .png .jpg .jpeg .gif .svg .webp
-    .avif .bmp .woff .woff2 .ttf .otf .eot .wasm
-  ]
-
-  # Well-known public files served at the web root.
-  STATIC_PUBLIC_FILES = Set{
-    "favicon.ico", "robots.txt", "manifest.json", "asset-manifest.json",
-    "sitemap.xml", "service-worker.js", "sw.js", "browserconfig.xml",
-  }
-
   def initialize(options : Hash(String, YAML::Any))
     super
     @name = "go_auth"
@@ -232,26 +219,6 @@ class GoAuthTagger < FrameworkTagger
     end
 
     nil
-  end
-
-  # A static-file / SPA-shell route, recognized conservatively: the SPA
-  # root, a gin catch-all wildcard mount (`/static/*filepath`, `/*any`), a
-  # well-known public file, or a static-asset extension. Used only to exempt
-  # these from a broad root-*group* auth scope, never from an inline,
-  # specific-prefix, or truly global (`engine.Use`) auth signal.
-  private def static_asset_route?(url : String) : Bool
-    path = url.split("?", 2)[0].split("#", 2)[0].downcase
-    return true if path == "/" || path.empty?
-
-    segments = path.split("/").reject(&.empty?)
-    # gin catch-all wildcard — the shape of a static-file server / SPA
-    # fallback (`r.Static`, `r.StaticFS`, a NoRoute SPA handler), not a
-    # REST route.
-    return true if segments.any?(&.starts_with?("*"))
-
-    last = segments[-1]? || ""
-    return true if STATIC_PUBLIC_FILES.includes?(last)
-    STATIC_ASSET_EXTENSIONS.any? { |ext| last.ends_with?(ext) }
   end
 
   # Segment-aware prefix match so "/api" guards "/api/x" but not "/apiv2".

--- a/src/tagger/framework_taggers/go/go_security.cr
+++ b/src/tagger/framework_taggers/go/go_security.cr
@@ -179,6 +179,16 @@ class GoSecurityTagger < FrameworkTagger
 
     @middleware_scopes.each do |scope|
       next unless prefix_covers?(scope[:prefix], endpoint.url)
+
+      # A broad root/global ("/") scope sweeps in static-asset routes (the
+      # SPA shell, `/static/*`, favicon, `*.js`/`*.css`) that are either
+      # served outside the middleware chain (e.g. registered before a global
+      # `g.Use(cors.New(...))`, as in gotify) or simply aren't a meaningful
+      # CORS/CSRF/headers review target. Skip them — inline route middleware
+      # and specific-prefix scopes are unaffected, so a genuinely guarded
+      # asset route keeps its tag.
+      next if scope[:prefix] == "/" && static_asset_route?(endpoint.url)
+
       endpoint.add_tag(Tag.new(scope[:tag], scope[:description], "go_security"))
     end
   end


### PR DESCRIPTION
## Summary

Reduces a **false positive** in the `go_security` framework tagger, mirroring the `go_auth` fix in #2128.

On a fresh clone of [gotify/server](https://github.com/gotify/server), a global `g.Use(cors.New(...))` caused **every** endpoint to be tagged `cors` — including static routes served off the engine that don't actually carry the middleware:

```
GET /              cors   ← FP (SPA shell, registered before the global .Use)
GET /index.html    cors   ← FP
GET /manifest.json cors   ← FP
GET /static/*any   cors   ← FP
```

These assets are either registered **outside the middleware chain** (before the global `.Use`, so CORS never applies) or simply aren't a meaningful CORS/CSRF/headers review target.

## Change

- Skip static-asset routes when a broad root/global (`/`) security scope would otherwise tag them.
- Inline route middleware and specific-prefix group scopes are **unaffected**, so a genuinely guarded asset route keeps its tag.
- The static-asset heuristic (SPA root, catch-all wildcard mounts, known public files, static extensions) is promoted from `go_auth`'s private copy to the shared `FrameworkTagger` base class and reused by both taggers (DRY, no behaviour change to `go_auth`).

## Verification

- gotify: `go_security` `cors` tags drop **30 → 26**, removing exactly the four public static routes; every CORS-bearing API route keeps its tag. `go_auth` is unchanged (auth tags still 26).
- gin-realworld / gin-examples: still 0 `go_security` tags (no regression).
- `crystal spec spec/unit_test/tagger/` → 508 examples, 0 failures; `spec/unit_test/models/` → 183, 0 failures. `crystal tool format --check` and `ameba` clean.

Follow-up to #2128.

https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcndY2gaggQ79P91zAxL1M)_