### PR TITLE
fix(analyzer/raml): reduce false-positive params and fix annotated baseUri

### DIFF
--- a/spec/functional_test/fixtures/specification/raml_optional/api.raml
+++ b/spec/functional_test/fixtures/specification/raml_optional/api.raml
@@ -1,0 +1,23 @@
+#%RAML 1.0
+title: Optional and Pattern API
+version: v1
+baseUri:
+  value: https://api.example.com/v1
+  (redirectable): true
+mediaType: application/json
+
+/search:
+  get:
+    queryParameters:
+      q?: string
+      page?: integer
+      # Pattern properties are not real parameter names.
+      /^filter\[[a-z]+\]$/: string
+    headers:
+      If-None-Match?: string
+  post:
+    body:
+      application/json:
+        properties:
+          name: string
+          nickname?: string

--- a/spec/functional_test/testers/specification/raml_spec.cr
+++ b/spec/functional_test/testers/specification/raml_spec.cr
@@ -87,3 +87,23 @@ FunctionalTester.new("fixtures/specification/raml_advanced/", {
   :techs     => 1,
   :endpoints => advanced_endpoints.size,
 }, advanced_endpoints).perform_tests
+
+# Optional (`name?`) markers and `/regex/` pattern keys are not real
+# parameter names, and an annotated `baseUri` carries the URL under a
+# `value:` key. Each of these used to leak into the output.
+optional_endpoints = [
+  Endpoint.new("/v1/search", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("page", "", "query"),
+    Param.new("If-None-Match", "", "header"),
+  ]),
+  Endpoint.new("/v1/search", "POST", [
+    Param.new("name", "", "json"),
+    Param.new("nickname", "", "json"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/specification/raml_optional/", {
+  :techs     => 1,
+  :endpoints => optional_endpoints.size,
+}, optional_endpoints).perform_tests

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -234,7 +234,9 @@ module Analyzer::Specification
       if props_node = h[YAML::Any.new("properties")]?
         if props = props_node.as_h?
           props.each do |name, _|
-            add_param(params, Param.new(name.to_s, "", param_type))
+            if normalized = normalize_param_name(name.to_s)
+              add_param(params, Param.new(normalized, "", param_type))
+            end
           end
           return
         end
@@ -285,9 +287,24 @@ module Analyzer::Specification
       return unless h = node.as_h?
 
       h.each do |name, _|
-        next if name.to_s.includes?("<<")
-        add_param(params, Param.new(name.to_s, "", param_type))
+        if normalized = normalize_param_name(name.to_s)
+          add_param(params, Param.new(normalized, "", param_type))
+        end
       end
+    end
+
+    # RAML marks an optional property/parameter with a trailing `?` and
+    # lets map-typed properties be keyed on a `/regex/` pattern. Neither
+    # the `?` nor a pattern key is a real wire parameter name, so strip
+    # the former and drop the latter (along with `<<...>>` resource-type
+    # / trait template expressions). Returns `nil` when the key should
+    # not surface as a parameter at all.
+    private def normalize_param_name(raw : String) : String?
+      return if raw.includes?("<<")
+      return if raw.size > 1 && raw.starts_with?("/") && raw.ends_with?("/")
+
+      name = raw.ends_with?("?") ? raw[0...-1] : raw
+      name.empty? ? nil : name
     end
 
     private def add_param(params : Array(Param), param : Param)

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -59,7 +59,7 @@ module Analyzer::Specification
     # RAML `baseUri` may be a full URL; we keep just the path so endpoints
     # render in Noir's relative form, mirroring how OAS3 `servers` is handled.
     private def base_path_from(yaml_obj : YAML::Any) : String
-      base_uri = yaml_obj[YAML::Any.new("baseUri")]?.try(&.to_s) || ""
+      base_uri = base_uri_value(yaml_obj[YAML::Any.new("baseUri")]?)
       return "" if base_uri.empty?
       if base_uri.starts_with?("http")
         begin
@@ -70,6 +70,24 @@ module Analyzer::Specification
         end
       end
       base_uri.rstrip('/')
+    end
+
+    # `baseUri` is normally a scalar URL, but RAML lets you annotate it,
+    # in which case it becomes a map carrying the URL under `value:`
+    # (alongside annotation keys like `(redirectable)`). Pull the string
+    # out of either shape; rendering the map with `to_s` leaks a Crystal
+    # hash literal into every endpoint path.
+    private def base_uri_value(node : YAML::Any?) : String
+      return "" unless node
+      if s = node.as_s?
+        return s
+      end
+      if h = node.as_h?
+        if value = h[YAML::Any.new("value")]?
+          return value.as_s? || ""
+        end
+      end
+      ""
     end
 
     # Resources nest under each other in RAML. Each `/segment` key under a


### PR DESCRIPTION
## Summary

Improving the RAML analyzer's accuracy (lower FP/FN), validated against real-world specs cloned from [`raml-org/raml-examples`](https://github.com/raml-org/raml-examples). This first round targets three false-positive sources observed across those specs.

### Fixes

1. **Optional markers (`name?`) leaked into parameter names.** RAML denotes an optional property/parameter with a trailing `?`. The analyzer emitted `q?`, `page?`, `If-None-Match?`, `nickname?` etc. as literal param names. Now stripped.

2. **`/regex/` pattern keys surfaced as params.** RAML allows map-typed properties keyed on a pattern (e.g. `/^author\[[a-zA-Z]\]+$/`). These are not real wire parameters and are now dropped, consistent with the existing `<<...>>` template skipping.

3. **Annotated `baseUri` leaked a hash literal into paths.** When `baseUri` is annotated it becomes a map with the URL under `value:`. The analyzer rendered the whole node with `to_s`, producing paths like `/{"value" => "http://..."}/api`. It now extracts the URL from either the scalar or annotated-map shape.

### Before / after (`raml-examples/others/world-music-api`)

```
# before
GET /{"value" => "http:/{environment}.musicapi.com/{version}", "(rediractable)" => true}/api  [start?, page-size?, version]
# after
GET /{version}/api  [start, page-size, version]
```

### Tests

- New fixture `spec/functional_test/fixtures/specification/raml_optional/` plus functional assertions covering all three fixes.
- Full suite green: `3538` unit + `19415` functional examples, `0` failures. Format + Ameba clean.

https://claude.ai/code/session_01SqzKLsptYvp3H7zYF6T8n1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqzKLsptYvp3H7zYF6T8n1)_