### PR TITLE
Add Zig std.http.Server analyzer

### DIFF
--- a/spec/functional_test/fixtures/zig/http/build.zig.zon
+++ b/spec/functional_test/fixtures/zig/http/build.zig.zon
@@ -1,0 +1,4 @@
+.{
+    .name = .std_http_fixture,
+    .version = "0.1.0",
+}

--- a/spec/functional_test/fixtures/zig/http/src/main.zig
+++ b/spec/functional_test/fixtures/zig/http/src/main.zig
@@ -1,0 +1,76 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const addr = try std.net.Address.parseIp4("127.0.0.1", 8080);
+    var server = try addr.listen(.{});
+    defer server.deinit();
+
+    while (true) {
+        const conn = try server.accept();
+        defer conn.stream.close();
+
+        var read_buffer: [4096]u8 = undefined;
+        var http_server = std.http.Server.init(conn, &read_buffer);
+        var request = try http_server.receiveHead();
+        try route(&request);
+    }
+}
+
+fn route(request: *std.http.Server.Request) !void {
+    if (request.head.method == .GET and std.mem.eql(u8, request.head.target, "/")) {
+        try request.respond("ok", .{});
+    } else if (std.mem.eql(u8, request.head.target, "/users") and request.head.method == .POST) {
+        try createUser(request);
+    } else if (request.head.method == .GET) {
+        if (std.mem.eql(u8, request.head.target, "/users/:id")) {
+            try getUser(request);
+        }
+    }
+
+    switch (request.head.method) {
+        .DELETE => {
+            if (std.mem.eql(u8, request.head.target, "/users/:id")) {
+                try deleteUser(request);
+            }
+        },
+        .PATCH => {
+            const target = request.head.target;
+            if (std.mem.eql(u8, target, "/users/:id")) {
+                try updateUser(request);
+            }
+        },
+        else => {},
+    }
+
+    const path = request.head.target;
+    if (std.mem.eql(u8, path, "/health")) {
+        try health(request);
+    }
+}
+
+fn createUser(request: *std.http.Server.Request) !void {
+    try request.respond("created", .{});
+}
+
+fn getUser(request: *std.http.Server.Request) !void {
+    try request.respond("user", .{});
+}
+
+fn deleteUser(request: *std.http.Server.Request) !void {
+    try request.respond("deleted", .{});
+}
+
+fn updateUser(request: *std.http.Server.Request) !void {
+    try request.respond("updated", .{});
+}
+
+fn health(request: *std.http.Server.Request) !void {
+    try request.respond("ok", .{});
+}
+
+test "routes in test blocks are ignored" {
+    const request = fakeRequest();
+    if (std.mem.eql(u8, request.head.target, "/test-only")) {
+        try health(request);
+    }
+}

--- a/spec/functional_test/fixtures/zig/http/src/main.zig
+++ b/spec/functional_test/fixtures/zig/http/src/main.zig
@@ -34,7 +34,7 @@ fn route(request: *std.http.Server.Request) !void {
             }
         },
         .PATCH => {
-            const target = request.head.target;
+            const target: []const u8 = request.head.target;
             if (std.mem.eql(u8, target, "/users/:id")) {
                 try updateUser(request);
             }
@@ -45,6 +45,18 @@ fn route(request: *std.http.Server.Request) !void {
     const path = request.head.target;
     if (std.mem.eql(u8, path, "/health")) {
         try health(request);
+    }
+
+    const method: std.http.Method = request.head.method;
+    if (method == .OPTIONS and std.mem.eql(u8, request.head.target, "/options")) {
+        try options(request);
+    }
+
+    switch (request.head.target) {
+        "/switch-health" => {
+            try switchHealth(request);
+        },
+        else => {},
     }
 }
 
@@ -65,6 +77,14 @@ fn updateUser(request: *std.http.Server.Request) !void {
 }
 
 fn health(request: *std.http.Server.Request) !void {
+    try request.respond("ok", .{});
+}
+
+fn options(request: *std.http.Server.Request) !void {
+    try request.respond("ok", .{});
+}
+
+fn switchHealth(request: *std.http.Server.Request) !void {
     try request.respond("ok", .{});
 }
 

--- a/spec/functional_test/testers/zig/http_spec.cr
+++ b/spec/functional_test/testers/zig/http_spec.cr
@@ -16,6 +16,8 @@ expected_endpoints << zig_http_endpoint("/users/:id", "GET", id_param, [Callee.n
 expected_endpoints << zig_http_endpoint("/users/:id", "DELETE", id_param, [Callee.new("deleteUser")])
 expected_endpoints << zig_http_endpoint("/users/:id", "PATCH", id_param, [Callee.new("updateUser")])
 expected_endpoints << zig_http_endpoint("/health", "GET", [] of Param, [Callee.new("health")])
+expected_endpoints << zig_http_endpoint("/options", "OPTIONS", [] of Param, [Callee.new("options")])
+expected_endpoints << zig_http_endpoint("/switch-health", "GET", [] of Param, [Callee.new("switchHealth")])
 
 FunctionalTester.new("fixtures/zig/http/", {
   :techs     => 1,

--- a/spec/functional_test/testers/zig/http_spec.cr
+++ b/spec/functional_test/testers/zig/http_spec.cr
@@ -1,0 +1,25 @@
+require "../../func_spec.cr"
+
+def zig_http_endpoint(url, method, params = [] of Param, callees = [] of Callee)
+  endpoint = Endpoint.new(url, method, params)
+  callees.each { |callee| endpoint.push_callee(callee) }
+  endpoint
+end
+
+id_param = [Param.new("id", "", "path")]
+
+expected_endpoints = [] of Endpoint
+
+expected_endpoints << zig_http_endpoint("/", "GET", [] of Param, [Callee.new("request.respond")])
+expected_endpoints << zig_http_endpoint("/users", "POST", [] of Param, [Callee.new("createUser")])
+expected_endpoints << zig_http_endpoint("/users/:id", "GET", id_param, [Callee.new("getUser")])
+expected_endpoints << zig_http_endpoint("/users/:id", "DELETE", id_param, [Callee.new("deleteUser")])
+expected_endpoints << zig_http_endpoint("/users/:id", "PATCH", id_param, [Callee.new("updateUser")])
+expected_endpoints << zig_http_endpoint("/health", "GET", [] of Param, [Callee.new("health")])
+
+FunctionalTester.new("fixtures/zig/http/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints, {
+  "include_callee" => YAML::Any.new(true),
+}).perform_tests

--- a/spec/unit_test/detector/zig/zig_spec.cr
+++ b/spec/unit_test/detector/zig/zig_spec.cr
@@ -56,6 +56,36 @@ describe "Detect Zig frameworks" do
     end
   end
 
+  describe Detector::Zig::Http do
+    instance = Detector::Zig::Http.new options
+
+    it "detects std.http.Server references" do
+      instance.detect("src/main.zig", "const Request = std.http.Server.Request;").should be_true
+    end
+
+    it "detects receiveHead-based std server handling" do
+      source = <<-ZIG
+        const std = @import("std");
+        fn handle(server: *std.http.Server) !void {
+            var request = try server.receiveHead();
+            if (std.mem.eql(u8, request.head.target, "/")) {
+                try request.respond("ok", .{});
+            }
+        }
+        ZIG
+
+      instance.detect("src/main.zig", source).should be_true
+    end
+
+    it "ignores unrelated std imports" do
+      instance.detect("src/main.zig", "const std = @import(\"std\");").should be_false
+    end
+
+    it "ignores non-zig files" do
+      instance.detect("main.txt", "const Request = std.http.Server.Request;").should be_false
+    end
+  end
+
   describe Detector::Zig::Tokamak do
     instance = Detector::Zig::Tokamak.new options
 

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -200,6 +200,7 @@ def initialize_analyzers(logger : NoirLogger)
     {"ts_trpc", Typescript::TRPC},
     {"zig_jetzig", Zig::Jetzig},
     {"zig_zap", Zig::Zap},
+    {"zig_http", Zig::Http},
     {"zig_httpz", Zig::Httpz},
     {"zig_tokamak", Zig::Tokamak},
     {"ai", AI::Unified},

--- a/src/analyzer/analyzers/zig/http.cr
+++ b/src/analyzer/analyzers/zig/http.cr
@@ -6,7 +6,7 @@ module Analyzer::Zig
   # branch on `request.head.target` and `request.head.method` after
   # `receiveHead()`, then call `request.respond(...)` or a handler function.
   class Http < Analyzer
-    TARGET_ASSIGN_RE = /(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*;/
+    TARGET_ASSIGN_RE = /(?:const|var)\s+([A-Za-z_]\w*)\s*(?::\s*[^=;]+)?=\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*;/
 
     TARGET_EQL_RE      = /std\s*\.\s*mem\s*\.\s*eql\s*\(\s*u8\s*,\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*,\s*"((?:[^"\\]|\\.)*)"\s*\)/
     PATH_EQL_RE        = /std\s*\.\s*mem\s*\.\s*eql\s*\(\s*u8\s*,\s*"((?:[^"\\]|\\.)*)"\s*,\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*\)/
@@ -16,11 +16,13 @@ module Analyzer::Zig
     METHOD_REVERSED_RE = /\.([A-Za-z_]\w*)\s*==\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)/
     SWITCH_RE          = /switch\s*\(\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*\)\s*\{/
     SWITCH_PRONG_RE    = /\.([A-Za-z_]\w*)\s*=>\s*\{/
+    TARGET_PRONG_RE    = /"((?:[^"\\]|\\.)*)"\s*=>/
     IF_RE              = /(?:^|[^A-Za-z0-9_])if\s*\(/
 
     alias IfBlock = NamedTuple(cond_start: Int32, cond_end: Int32, body_open: Int32, body_close: Int32)
     alias MethodContext = NamedTuple(method: String, body_open: Int32, body_close: Int32)
     alias RouteHit = NamedTuple(url: String, offset: Int32)
+    alias RouteBlock = NamedTuple(url: String, offset: Int32, body_start: Int32, body_end: Int32)
 
     def analyze
       include_callee = callees_needed?
@@ -69,7 +71,33 @@ module Analyzer::Zig
         next if seen.includes?(key)
         seen << key
 
-        emit(path, text, chars, branch, hit[:url], method, include_callee)
+        emit_range(path, text, chars, hit[:offset], hit[:url], method, branch[:body_open] + 1, branch[:body_close], include_callee)
+      end
+
+      collect_target_switch_routes(text, stripped, chars, target_vars).each do |route|
+        offset = route[:offset]
+        next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
+        route_method_contexts = method_contexts.select do |context|
+          context[:body_open] >= route[:body_start] && context[:body_close] <= route[:body_end]
+        end
+
+        if route_method_contexts.empty?
+          method = method_from_context(offset, method_contexts) || "GET"
+          key = "#{method} #{route[:url]}"
+          next if seen.includes?(key)
+          seen << key
+
+          emit_range(path, text, chars, offset, route[:url], method, route[:body_start], route[:body_end], include_callee)
+        else
+          route_method_contexts.each do |context|
+            method = context[:method]
+            key = "#{method} #{route[:url]}"
+            next if seen.includes?(key)
+            seen << key
+
+            emit_range(path, text, chars, offset, route[:url], method, context[:body_open] + 1, context[:body_close], include_callee)
+          end
+        end
       end
     end
 
@@ -116,6 +144,39 @@ module Analyzer::Zig
       end
 
       hits
+    end
+
+    private def collect_target_switch_routes(text : String, stripped : String, chars : Array(Char), target_vars : Set(String)) : Array(RouteBlock)
+      routes = [] of RouteBlock
+
+      stripped.scan(SWITCH_RE) do |m|
+        expr = m[1]
+        next unless target_expr?(expr, target_vars)
+        switch_open = (m.end(0) || 0) - 1
+        switch_close = Noir::ZigCalleeExtractor.find_matching(chars, switch_open, '{', '}')
+        next if switch_close.nil?
+
+        switch_body = slice(text.chars, switch_open + 1, switch_close)
+        switch_body.scan(TARGET_PRONG_RE) do |pm|
+          url = unescape_string(pm[1])
+          next unless url.starts_with?("/")
+
+          literal_offset = switch_open + 1 + (pm.begin(1) || 0) - 1
+          expr_start = next_non_space(chars, switch_open + 1 + (pm.end(0) || 0))
+          next if expr_start.nil?
+
+          if chars[expr_start] == '{'
+            body_close = Noir::ZigCalleeExtractor.find_matching(chars, expr_start, '{', '}')
+            next if body_close.nil?
+            routes << {url: url, offset: literal_offset, body_start: expr_start + 1, body_end: body_close}
+          else
+            body_end = switch_prong_expression_end(chars, expr_start, switch_close)
+            routes << {url: url, offset: literal_offset, body_start: expr_start, body_end: body_end}
+          end
+        end
+      end
+
+      routes
     end
 
     private def add_route_hit(hits : Array(RouteHit), raw_url : String, offset : Int32)
@@ -207,13 +268,13 @@ module Analyzer::Zig
       end
     end
 
-    private def emit(path : String, text : String, chars : Array(Char), branch : IfBlock, url : String, method : String, include_callee : Bool)
-      line = Noir::ZigCalleeExtractor.line_at(text.chars, branch[:cond_start])
+    private def emit_range(path : String, text : String, chars : Array(Char), offset : Int32, url : String, method : String, body_start : Int32, body_end : Int32, include_callee : Bool)
+      line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
       endpoint = Endpoint.new(url, method, extract_path_params(url), Details.new(PathInfo.new(path, line)))
 
       if include_callee
-        body = slice(chars, branch[:body_open] + 1, branch[:body_close])
-        body_line = Noir::ZigCalleeExtractor.line_at(chars, branch[:body_open])
+        body = slice(chars, body_start, body_end)
+        body_line = Noir::ZigCalleeExtractor.line_at(chars, body_start)
         callees = Noir::ZigCalleeExtractor.callees_for_body(body, path, body_line)
         Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
       end
@@ -251,6 +312,47 @@ module Analyzer::Zig
       end
 
       nil
+    end
+
+    private def next_non_space(chars : Array(Char), from : Int32) : Int32?
+      i = from
+      n = chars.size
+
+      while i < n
+        return i unless chars[i].whitespace?
+        i += 1
+      end
+
+      nil
+    end
+
+    private def switch_prong_expression_end(chars : Array(Char), from : Int32, switch_close : Int32) : Int32
+      paren_depth = 0
+      bracket_depth = 0
+      brace_depth = 0
+      i = from
+
+      while i < switch_close
+        case chars[i]
+        when '('
+          paren_depth += 1
+        when ')'
+          paren_depth -= 1 if paren_depth > 0
+        when '['
+          bracket_depth += 1
+        when ']'
+          bracket_depth -= 1 if bracket_depth > 0
+        when '{'
+          brace_depth += 1
+        when '}'
+          brace_depth -= 1 if brace_depth > 0
+        when ','
+          return i if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0
+        end
+        i += 1
+      end
+
+      switch_close
     end
 
     private def extract_path_params(url : String) : Array(Param)

--- a/src/analyzer/analyzers/zig/http.cr
+++ b/src/analyzer/analyzers/zig/http.cr
@@ -1,0 +1,280 @@
+require "../../../models/analyzer"
+require "../../../miniparsers/zig_callee_extractor"
+
+module Analyzer::Zig
+  # Zig's standard `std.http.Server` has no routing DSL. Applications usually
+  # branch on `request.head.target` and `request.head.method` after
+  # `receiveHead()`, then call `request.respond(...)` or a handler function.
+  class Http < Analyzer
+    TARGET_ASSIGN_RE = /(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*;/
+
+    TARGET_EQL_RE      = /std\s*\.\s*mem\s*\.\s*eql\s*\(\s*u8\s*,\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*,\s*"((?:[^"\\]|\\.)*)"\s*\)/
+    PATH_EQL_RE        = /std\s*\.\s*mem\s*\.\s*eql\s*\(\s*u8\s*,\s*"((?:[^"\\]|\\.)*)"\s*,\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*\)/
+    TARGET_EQUALS_RE   = /([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*==\s*"((?:[^"\\]|\\.)*)"/
+    PATH_EQUALS_RE     = /"((?:[^"\\]|\\.)*)"\s*==\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)/
+    METHOD_EQUALS_RE   = /([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*==\s*\.([A-Za-z_]\w*)/
+    METHOD_REVERSED_RE = /\.([A-Za-z_]\w*)\s*==\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)/
+    SWITCH_RE          = /switch\s*\(\s*([A-Za-z_]\w*(?:\s*\.\s*[A-Za-z_]\w*)*)\s*\)\s*\{/
+    SWITCH_PRONG_RE    = /\.([A-Za-z_]\w*)\s*=>\s*\{/
+    IF_RE              = /(?:^|[^A-Za-z0-9_])if\s*\(/
+
+    alias IfBlock = NamedTuple(cond_start: Int32, cond_end: Int32, body_open: Int32, body_close: Int32)
+    alias MethodContext = NamedTuple(method: String, body_open: Int32, body_close: Int32)
+    alias RouteHit = NamedTuple(url: String, offset: Int32)
+
+    def analyze
+      include_callee = callees_needed?
+
+      all_files.each do |path|
+        next unless path.ends_with?(".zig")
+        next if Noir::ZigCalleeExtractor.vendored_framework_path?(path)
+        content = read_file_content(path)
+        next unless std_http_server_file?(content)
+        process_file(path, content, include_callee)
+      end
+
+      @result
+    end
+
+    private def std_http_server_file?(content : String) : Bool
+      return true if content.includes?("std.http.Server")
+
+      has_std = content.includes?("@import(\"std\")") || content.includes?("std.http")
+      has_server_flow = content.includes?(".receiveHead(") && content.includes?(".head.target")
+      has_response = content.includes?(".respond(")
+
+      has_std && has_server_flow && has_response
+    end
+
+    private def process_file(path : String, content : String, include_callee : Bool)
+      text = Noir::ZigCalleeExtractor.strip_comments(content)
+      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+      chars = stripped.chars
+      test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(stripped)
+      target_vars = aliases_for(text, ".head.target")
+      method_vars = aliases_for(text, ".head.method")
+      if_blocks = collect_if_blocks(stripped, chars)
+      method_contexts = collect_method_contexts(stripped, chars, if_blocks, method_vars)
+      seen = Set(String).new
+
+      collect_route_hits(text, target_vars).each do |hit|
+        offset = hit[:offset]
+        next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
+        branch = if_blocks.find { |block| offset >= block[:cond_start] && offset <= block[:cond_end] }
+        next if branch.nil?
+
+        condition = slice(chars, branch[:cond_start], branch[:cond_end])
+        method = method_from_condition(condition, method_vars) || method_from_context(offset, method_contexts) || "GET"
+        key = "#{method} #{hit[:url]}"
+        next if seen.includes?(key)
+        seen << key
+
+        emit(path, text, chars, branch, hit[:url], method, include_callee)
+      end
+    end
+
+    private def aliases_for(text : String, suffix : String) : Set(String)
+      aliases = Set(String).new
+      changed = true
+
+      while changed
+        changed = false
+        text.scan(TARGET_ASSIGN_RE) do |m|
+          name = m[1]
+          expr = normalize_expr(m[2])
+          next unless expr.ends_with?(suffix) || aliases.includes?(expr)
+          next if aliases.includes?(name)
+          aliases << name
+          changed = true
+        end
+      end
+
+      aliases
+    end
+
+    private def collect_route_hits(text : String, target_vars : Set(String)) : Array(RouteHit)
+      hits = [] of RouteHit
+
+      text.scan(TARGET_EQL_RE) do |m|
+        next unless target_expr?(m[1], target_vars)
+        add_route_hit(hits, m[2], m.begin(0) || 0)
+      end
+
+      text.scan(PATH_EQL_RE) do |m|
+        next unless target_expr?(m[2], target_vars)
+        add_route_hit(hits, m[1], m.begin(0) || 0)
+      end
+
+      text.scan(TARGET_EQUALS_RE) do |m|
+        next unless target_expr?(m[1], target_vars)
+        add_route_hit(hits, m[2], m.begin(0) || 0)
+      end
+
+      text.scan(PATH_EQUALS_RE) do |m|
+        next unless target_expr?(m[2], target_vars)
+        add_route_hit(hits, m[1], m.begin(0) || 0)
+      end
+
+      hits
+    end
+
+    private def add_route_hit(hits : Array(RouteHit), raw_url : String, offset : Int32)
+      url = unescape_string(raw_url)
+      return unless url.starts_with?("/")
+      hits << {url: url, offset: offset}
+    end
+
+    private def collect_if_blocks(stripped : String, chars : Array(Char)) : Array(IfBlock)
+      blocks = [] of IfBlock
+
+      stripped.scan(IF_RE) do |m|
+        open_paren = (m.end(0) || 0) - 1
+        close_paren = Noir::ZigCalleeExtractor.find_matching(chars, open_paren, '(', ')')
+        next if close_paren.nil?
+        body_open = next_block_brace(chars, close_paren + 1)
+        next if body_open.nil?
+        body_close = Noir::ZigCalleeExtractor.find_matching(chars, body_open, '{', '}')
+        next if body_close.nil?
+
+        blocks << {
+          cond_start: open_paren + 1,
+          cond_end:   close_paren,
+          body_open:  body_open,
+          body_close: body_close,
+        }
+      end
+
+      blocks
+    end
+
+    private def collect_method_contexts(stripped : String, chars : Array(Char), if_blocks : Array(IfBlock), method_vars : Set(String)) : Array(MethodContext)
+      contexts = [] of MethodContext
+
+      if_blocks.each do |block|
+        condition = slice(chars, block[:cond_start], block[:cond_end])
+        if method = method_from_condition(condition, method_vars)
+          contexts << {method: method, body_open: block[:body_open], body_close: block[:body_close]}
+        end
+      end
+
+      stripped.scan(SWITCH_RE) do |m|
+        expr = m[1]
+        next unless method_expr?(expr, method_vars)
+        switch_open = (m.end(0) || 0) - 1
+        switch_close = Noir::ZigCalleeExtractor.find_matching(chars, switch_open, '{', '}')
+        next if switch_close.nil?
+
+        switch_body = slice(chars, switch_open + 1, switch_close)
+        switch_body.scan(SWITCH_PRONG_RE) do |pm|
+          body_open = switch_open + 1 + (pm.end(0) || 0) - 1
+          body_close = Noir::ZigCalleeExtractor.find_matching(chars, body_open, '{', '}')
+          next if body_close.nil?
+          contexts << {method: normalize_method(pm[1]), body_open: body_open, body_close: body_close}
+        end
+      end
+
+      contexts
+    end
+
+    private def method_from_condition(condition : String, method_vars : Set(String)) : String?
+      condition.scan(METHOD_EQUALS_RE) do |m|
+        next unless method_expr?(m[1], method_vars)
+        return normalize_method(m[2])
+      end
+
+      condition.scan(METHOD_REVERSED_RE) do |m|
+        next unless method_expr?(m[2], method_vars)
+        return normalize_method(m[1])
+      end
+
+      nil
+    end
+
+    private def method_from_context(offset : Int32, contexts : Array(MethodContext)) : String?
+      best = nil.as(MethodContext?)
+
+      contexts.each do |context|
+        next unless offset > context[:body_open] && offset < context[:body_close]
+        if current = best
+          next unless (context[:body_close] - context[:body_open]) < (current[:body_close] - current[:body_open])
+        end
+
+        best = context
+      end
+
+      if selected = best
+        selected[:method]
+      end
+    end
+
+    private def emit(path : String, text : String, chars : Array(Char), branch : IfBlock, url : String, method : String, include_callee : Bool)
+      line = Noir::ZigCalleeExtractor.line_at(text.chars, branch[:cond_start])
+      endpoint = Endpoint.new(url, method, extract_path_params(url), Details.new(PathInfo.new(path, line)))
+
+      if include_callee
+        body = slice(chars, branch[:body_open] + 1, branch[:body_close])
+        body_line = Noir::ZigCalleeExtractor.line_at(chars, branch[:body_open])
+        callees = Noir::ZigCalleeExtractor.callees_for_body(body, path, body_line)
+        Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?
+      end
+
+      @result << endpoint
+    end
+
+    private def target_expr?(expr : String, target_vars : Set(String)) : Bool
+      normalized = normalize_expr(expr)
+      normalized.ends_with?(".head.target") || target_vars.includes?(normalized)
+    end
+
+    private def method_expr?(expr : String, method_vars : Set(String)) : Bool
+      normalized = normalize_expr(expr)
+      normalized.ends_with?(".head.method") || method_vars.includes?(normalized)
+    end
+
+    private def normalize_expr(expr : String) : String
+      expr.gsub(/\s+/, "")
+    end
+
+    private def normalize_method(method : String) : String
+      method.upcase
+    end
+
+    private def next_block_brace(chars : Array(Char), from : Int32) : Int32?
+      i = from
+      n = chars.size
+
+      while i < n
+        ch = chars[i]
+        return i if ch == '{'
+        return if ch == ';'
+        i += 1
+      end
+
+      nil
+    end
+
+    private def extract_path_params(url : String) : Array(Param)
+      params = [] of Param
+      url.scan(/:([A-Za-z_]\w*)/) do |m|
+        params << Param.new(m[1], "", "path")
+      end
+      params
+    end
+
+    private def unescape_string(value : String) : String
+      value.gsub("\\\"", "\"").gsub("\\\\", "\\")
+    end
+
+    private def slice(chars : Array(Char), start : Int32, stop : Int32) : String
+      return "" if start >= stop
+
+      String.build do |io|
+        idx = start
+        while idx < stop && idx < chars.size
+          io << chars[idx]
+          idx += 1
+        end
+      end
+    end
+  end
+end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -329,6 +329,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
     Typescript::TRPC,
     Zig::Jetzig,
     Zig::Zap,
+    Zig::Http,
     Zig::Httpz,
     Zig::Tokamak,
   ])

--- a/src/detector/detectors/zig/http.cr
+++ b/src/detector/detectors/zig/http.cr
@@ -1,0 +1,25 @@
+require "../../../models/detector"
+
+module Detector::Zig
+  class Http < Detector
+    def detect(filename : String, file_contents : String) : Bool
+      return false unless filename.ends_with?(".zig")
+
+      return true if file_contents.includes?("std.http.Server")
+
+      has_std = file_contents.includes?("@import(\"std\")") || file_contents.includes?("std.http")
+      has_server_flow = file_contents.includes?(".receiveHead(") && file_contents.includes?(".head.target")
+      has_response = file_contents.includes?(".respond(")
+
+      has_std && has_server_flow && has_response
+    end
+
+    def applicable?(filename : String) : Bool
+      filename.ends_with?(".zig") || File.basename(filename) == "build.zig.zon"
+    end
+
+    def set_name
+      @name = "zig_http"
+    end
+  end
+end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -31,7 +31,7 @@ module NoirTechs
     "scala_akka", "scala_http4s", "scala_play", "scala_scalatra", "scala_tapir", "scala_zio_http",
     "swift_hummingbird", "swift_kitura", "swift_vapor",
     "ts_nestjs", "ts_tanstack_router", "ts_trpc",
-    "zig_jetzig", "zig_zap", "zig_httpz", "zig_tokamak",
+    "zig_jetzig", "zig_zap", "zig_http", "zig_httpz", "zig_tokamak",
   ]
 
   AI_CONTEXT_GUARD_SUPPORTED_TECHS = [
@@ -1796,6 +1796,24 @@ module NoirTechs
         :params   => {
           :query  => false,
           :path   => false,
+          :body   => false,
+          :header => false,
+          :cookie => false,
+        },
+        :static_path => false,
+        :websocket   => false,
+      },
+    },
+    :zig_http => {
+      :framework => "std.http.Server",
+      :language  => "Zig",
+      :similar   => ["zig-http", "zig_http", "std-http-server", "std.http.server", "std.http.Server"],
+      :supported => {
+        :endpoint => true,
+        :method   => true,
+        :params   => {
+          :query  => false,
+          :path   => true,
           :body   => false,
           :header => false,
           :cookie => false,


### PR DESCRIPTION
## Summary
- add zig_http detector and analyzer for Zig std.http.Server request handling
- extract endpoints from request.head.target and request.head.method branches, including nested method guards and method switch blocks
- register zig_http tech metadata and add unit/functional Zig fixtures

Fixes #2142

## Tests
- just fix
- just check
- just build
- just test
- ./bin/noir --list-techs | rg 'zig_http|std\.http'
- ./bin/noir -b spec/functional_test/fixtures/zig/http -f json --include-callee