### PR TITLE
Improve Go net/http params and PocketBase route coverage

### DIFF
--- a/spec/functional_test/fixtures/go/http_crossfile_params/go.mod
+++ b/spec/functional_test/fixtures/go/http_crossfile_params/go.mod
@@ -1,0 +1,3 @@
+module example.com/http-crossfile-params
+
+go 1.22

--- a/spec/functional_test/fixtures/go/http_crossfile_params/handlers.go
+++ b/spec/functional_test/fixtures/go/http_crossfile_params/handlers.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type handler struct{}
+
+func (h *handler) index(w http.ResponseWriter, r *http.Request) {
+	_ = r.URL.Query().Get("next")
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *handler) getEntries(w http.ResponseWriter, r *http.Request) {
+	h.findEntries(w, r)
+}
+
+func (h *handler) findEntries(w http.ResponseWriter, r *http.Request) {
+	_ = request.QueryStringParamList(r, "status")
+	_ = r.URL.Query().Get("starred")
+	_ = r.PathValue("entryID")
+	configureFilters(r)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *handler) createEntry(w http.ResponseWriter, r *http.Request) {
+	var payload map[string]any
+	_ = json.NewDecoder(r.Body).Decode(&payload)
+	_ = r.Header.Get("X-Trace-ID")
+	_ = r.FormValue("title")
+	w.WriteHeader(http.StatusCreated)
+}
+
+func configureFilters(r *http.Request) {
+	_ = request.HasQueryParam(r, "before")
+}
+
+var request requestHelpers
+
+type requestHelpers struct{}
+
+func (requestHelpers) QueryStringParamList(_ *http.Request, _ string) []string {
+	return nil
+}
+
+func (requestHelpers) HasQueryParam(_ *http.Request, _ string) bool {
+	return false
+}

--- a/spec/functional_test/fixtures/go/http_crossfile_params/routes.go
+++ b/spec/functional_test/fixtures/go/http_crossfile_params/routes.go
@@ -1,0 +1,14 @@
+package main
+
+import "net/http"
+
+func main() {
+	mux := http.NewServeMux()
+	h := &handler{}
+
+	mux.HandleFunc("GET /{$}", h.index)
+	mux.HandleFunc("GET /v1/entries", h.getEntries)
+	mux.HandleFunc("POST /v1/entries", h.createEntry)
+
+	http.ListenAndServe(":8080", mux)
+}

--- a/spec/functional_test/fixtures/go/pocketbase/no_import_routes.go
+++ b/spec/functional_test/fixtures/go/pocketbase/no_import_routes.go
@@ -1,0 +1,15 @@
+// PocketBase route files can receive a router group from a hook/event
+// without importing pocketbase/tools/router in that file. The analyzer
+// should still scan the package once another file identifies the package
+// as PocketBase-backed.
+package main
+
+func bindNoImportRoutes(rg RouterGroup) {
+	uiGroup := rg.Group("/_")
+	uiGroup.GET("/extensions.js", listFoos)
+}
+
+type RouterGroup interface {
+	Group(string) RouterGroup
+	GET(string, any)
+}

--- a/spec/functional_test/testers/go/http_crossfile_params_spec.cr
+++ b/spec/functional_test/testers/go/http_crossfile_params_spec.cr
@@ -1,0 +1,23 @@
+require "../../func_spec.cr"
+
+expected_endpoints = [
+  Endpoint.new("/", "GET", [
+    Param.new("next", "", "query"),
+  ]),
+  Endpoint.new("/v1/entries", "GET", [
+    Param.new("status", "", "query"),
+    Param.new("starred", "", "query"),
+    Param.new("entryID", "", "path"),
+    Param.new("before", "", "query"),
+  ]),
+  Endpoint.new("/v1/entries", "POST", [
+    Param.new("body", "", "json"),
+    Param.new("X-Trace-ID", "", "header"),
+    Param.new("title", "", "form"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/http_crossfile_params/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/go/pocketbase_spec.cr
+++ b/spec/functional_test/testers/go/pocketbase_spec.cr
@@ -13,6 +13,7 @@ expected_endpoints = [
   Endpoint.new("/bars/", "GET"),
   Endpoint.new("/bars/", "POST"),
   Endpoint.new("/bars/{id}", "DELETE", [Param.new("id", "", "path")]),
+  Endpoint.new("/_/extensions.js", "GET"),
 ]
 
 FunctionalTester.new("fixtures/go/pocketbase/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../../../src/miniparsers/go_route_extractor_ts"
+require "../../../src/miniparsers/go_request_param_extractor"
 
 describe Noir::TreeSitterGoRouteExtractor do
   it "extracts every verb route in the Gin fixture with resolved group prefixes" do
@@ -846,6 +847,81 @@ describe Noir::TreeSitterGoRouteExtractor do
       {"ANY", "/legacy"},
       {"GET", "/items/{id}"},
       {"POST", "/items"},
+    ].sort)
+  end
+
+  it "normalizes Go 1.22 ServeMux end-of-path wildcard patterns" do
+    source = <<-GO
+      package main
+      import "net/http"
+      func main() {
+          mux := http.NewServeMux()
+          mux.HandleFunc("GET /{$}", showRoot)
+          mux.HandleFunc("GET /admin/{$}", showAdminRoot)
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(source)
+    routes.map { |r| {r.verb, r.path} }.sort!.should eq([
+      {"GET", "/"},
+      {"GET", "/admin/"},
+    ].sort)
+  end
+
+  it "extracts request params from resolved net/http handler and helper bodies" do
+    route_source = <<-GO
+      package api
+      import "net/http"
+      func Routes() {
+          mux := http.NewServeMux()
+          mux.HandleFunc("GET /v1/entries", handler.getEntriesHandler)
+      }
+      GO
+
+    handler_source = <<-GO
+      package api
+      import "net/http"
+      type handler struct{}
+      func (h *handler) getEntriesHandler(w http.ResponseWriter, r *http.Request) {
+          h.findEntries(w, r)
+      }
+      func (h *handler) findEntries(w http.ResponseWriter, r *http.Request) {
+          status := request.QueryStringParamList(r, "status")
+          _ = status
+          _ = r.URL.Query().Get("starred")
+          _ = r.PathValue("entryID")
+          _ = r.Header.Get("X-Auth-Token")
+          configureFilters(r)
+      }
+      func configureFilters(r *http.Request) {
+          _ = request.HasQueryParam(r, "before")
+      }
+      GO
+
+    routes = Noir::TreeSitterGoRouteExtractor.extract_net_http_routes(route_source)
+    route_rows = Set(Int32).new
+    route_methods = Hash(Int32, String).new
+    routes.each do |route|
+      route_rows << route.line
+      route_methods[route.line] = route.verb
+    end
+    external_methods = Noir::GoCalleeExtractor.collect_method_bodies(handler_source, "handler.go")
+    external_functions = Noir::GoCalleeExtractor.collect_function_bodies(handler_source, "handler.go")
+
+    params = Noir::GoRequestParamExtractor.params_for_routes(
+      route_source,
+      route_rows,
+      route_methods,
+      external_functions,
+      external_methods
+    )
+
+    params[routes.first.line].map { |p| {p.name, p.param_type} }.sort!.should eq([
+      {"X-Auth-Token", "header"},
+      {"before", "query"},
+      {"entryID", "path"},
+      {"starred", "query"},
+      {"status", "query"},
     ].sort)
   end
 

--- a/src/analyzer/analyzers/go/http.cr
+++ b/src/analyzer/analyzers/go/http.cr
@@ -1,4 +1,5 @@
 require "../../engines/go_engine"
+require "../../../miniparsers/go_request_param_extractor"
 
 module Analyzer::Go
   class Http < GoEngine
@@ -12,6 +13,15 @@ module Analyzer::Go
       package_function_bodies = collect_package_function_bodies(file_contents)
       package_method_bodies = collect_package_controller_method_bodies(file_contents)
       framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
+      route_dirs = Set(String).new
+      file_contents.each do |path, content|
+        dir = File.dirname(path)
+        if framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["HandleFunc", "Handle"])
+          route_dirs << dir
+        end
+      end
+      request_function_bodies = Noir::GoRequestParamExtractor.package_function_bodies_for_dirs(file_contents, route_dirs)
+      request_method_bodies = Noir::GoRequestParamExtractor.package_method_bodies_for_dirs(file_contents, route_dirs)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         WaitGroup.wait do |wg|
@@ -45,10 +55,17 @@ module Analyzer::Go
 
                     # Resolve 1-hop callees for every route (see Gin/Mux).
                     route_rows = Set(Int32).new
-                    routes_by_line.each_key { |row| route_rows << row }
+                    route_methods_by_row = Hash(Int32, String).new
+                    routes_by_line.each do |row, routes|
+                      route_rows << row
+                      route_methods_by_row[row] = routes.first.verb
+                    end
                     external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
                     external_methods = ts_controller_method_bodies_for_directory(package_method_bodies, dir)
                     callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns, external_methods)
+                    request_fns = Noir::GoRequestParamExtractor.function_bodies_for_directory(request_function_bodies, dir)
+                    request_methods = Noir::GoRequestParamExtractor.method_bodies_for_directory(request_method_bodies, dir)
+                    params_by_route = Noir::GoRequestParamExtractor.params_for_routes(content, route_rows, route_methods_by_row, request_fns, request_methods)
 
                     lines.each_with_index do |line, index|
                       details = Details.new(PathInfo.new(path, index + 1))
@@ -67,6 +84,9 @@ module Analyzer::Go
                                 name, callee_path, callee_line = entry
                                 new_endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                               end
+                            end
+                            if params = params_by_route[route.line]?
+                              params.each { |param| add_param_to_endpoint(param, new_endpoint) }
                             end
                             result << new_endpoint
                             last_endpoint = new_endpoint

--- a/src/analyzer/analyzers/go/pocketbase.cr
+++ b/src/analyzer/analyzers/go/pocketbase.cr
@@ -12,8 +12,9 @@ module Analyzer::Go
 
     def analyze
       public_dirs = [] of Hash(String, String)
-      package_groups, file_contents = collect_package_groups_ts
+      package_groups, file_contents = collect_package_groups_ts(import_marker: IMPORT_MARKER)
       package_function_bodies = collect_package_function_bodies(file_contents)
+      framework_dirs = framework_package_dirs(file_contents, IMPORT_MARKER)
       channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
       begin
         WaitGroup.wait do |wg|
@@ -33,9 +34,10 @@ module Analyzer::Go
                   next if GoEngine.go_test_file?(path)
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
-                    next unless content.includes?(IMPORT_MARKER)
+                    dir = File.dirname(path)
+                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, [] of String)
 
-                    cross_file_groups = ts_groups_for_directory(package_groups, File.dirname(path))
+                    cross_file_groups = ts_groups_for_directory(package_groups, dir)
                     ts_routes = Noir::TreeSitterGoRouteExtractor.extract_routes(content, cross_file_groups)
                     routes_by_line = Hash(Int32, Array(Noir::TreeSitterGoRouteExtractor::Route)).new
                     ts_routes.each do |r|
@@ -45,7 +47,7 @@ module Analyzer::Go
 
                     route_rows = Set(Int32).new
                     routes_by_line.each_key { |row| route_rows << row }
-                    external_fns = ts_function_bodies_for_directory(package_function_bodies, File.dirname(path))
+                    external_fns = ts_function_bodies_for_directory(package_function_bodies, dir)
                     callees_by_route = Noir::GoCalleeExtractor.callees_for_routes_if(callees_needed?, content, path, route_rows, external_fns)
 
                     lines = content.lines

--- a/src/miniparsers/go_request_param_extractor.cr
+++ b/src/miniparsers/go_request_param_extractor.cr
@@ -1,0 +1,453 @@
+require "../ext/tree_sitter/tree_sitter"
+require "../models/endpoint"
+require "./go_callee_extractor"
+
+module Noir::GoRequestParamExtractor
+  extend self
+
+  MAX_HELPER_DEPTH = 3
+
+  def package_function_bodies_for_dirs(file_contents : Hash(String, String),
+                                       dirs : Set(String)) : Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody))
+    bodies = Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody)).new
+    return bodies if dirs.empty?
+
+    file_contents.each do |path, content|
+      dir = File.dirname(path)
+      next unless dirs.includes?(dir)
+      next unless content.includes?("func ")
+      fns = Noir::GoCalleeExtractor.collect_function_bodies(content, path)
+      next if fns.empty?
+      bodies[dir] ||= Hash(String, Noir::GoCalleeExtractor::FunctionBody).new
+      fns.each { |name, fb| bodies[dir][name] ||= fb }
+    end
+
+    bodies
+  end
+
+  def package_method_bodies_for_dirs(file_contents : Hash(String, String),
+                                     dirs : Set(String)) : Hash(String, Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)))
+    bodies = Hash(String, Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))).new
+    return bodies if dirs.empty?
+
+    file_contents.each do |path, content|
+      dir = File.dirname(path)
+      next unless dirs.includes?(dir)
+      next unless content.includes?("func (")
+      methods = Noir::GoCalleeExtractor.collect_method_bodies(content, path)
+      next if methods.empty?
+      dir_map = (bodies[dir] ||= Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)).new)
+      methods.each do |name, list|
+        (dir_map[name] ||= [] of Noir::GoCalleeExtractor::FunctionBody).concat(list)
+      end
+    end
+
+    bodies
+  end
+
+  def function_bodies_for_directory(package_bodies : Hash(String, Hash(String, Noir::GoCalleeExtractor::FunctionBody)),
+                                    dir : String) : Hash(String, Noir::GoCalleeExtractor::FunctionBody)
+    package_bodies[dir]? || Hash(String, Noir::GoCalleeExtractor::FunctionBody).new
+  end
+
+  def method_bodies_for_directory(package_bodies : Hash(String, Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))),
+                                  dir : String) : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))
+    package_bodies[dir]? || Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)).new
+  end
+
+  def params_for_routes(source : String,
+                        route_rows : Set(Int32),
+                        route_methods : Hash(Int32, String),
+                        external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                        external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))) : Hash(Int32, Array(Param))
+    by_route = Hash(Int32, Array(Param)).new
+    return by_route if route_rows.empty?
+
+    cache = Hash(String, Array(Param)).new
+    Noir::TreeSitter.parse_go(source) do |root|
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "call_expression"
+        row = Noir::TreeSitter.node_start_row(node)
+        next unless route_rows.includes?(row)
+
+        http_method = route_methods[row]? || ""
+        params = [] of Param
+        find_handler_args(node).each do |handler_arg|
+          collect_params_for_handler_arg(
+            unwrap_handler_arg(handler_arg, source),
+            source,
+            http_method,
+            external_functions,
+            external_methods,
+            cache,
+            Set(String).new,
+            params
+          )
+        end
+        by_route[row] = dedupe_params(params) unless params.empty?
+      end
+    end
+
+    by_route
+  end
+
+  private def collect_params_for_handler_arg(handler_arg : LibTreeSitter::TSNode,
+                                             source : String,
+                                             http_method : String,
+                                             external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                             external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)),
+                                             cache : Hash(String, Array(Param)),
+                                             visiting : Set(String),
+                                             sink : Array(Param))
+    case Noir::TreeSitter.node_type(handler_arg)
+    when "func_literal"
+      if body = Noir::TreeSitter.field(handler_arg, "body")
+        collect_params_in_body(body, source, http_method, external_functions, external_methods, cache, visiting, sink, 0)
+      end
+    when "identifier"
+      name = Noir::TreeSitter.node_text(handler_arg, source)
+      if fn = external_functions[name]?
+        append_function_params(fn, http_method, external_functions, external_methods, cache, visiting, sink, 0)
+      end
+    when "selector_expression"
+      append_selector_handler_params(handler_arg, source, http_method, external_functions, external_methods, cache, visiting, sink)
+    when "call_expression"
+      if candidate = fallback_handler_arg_from_call(handler_arg, source, external_functions, external_methods)
+        collect_params_for_handler_arg(
+          unwrap_handler_arg(candidate, source),
+          source,
+          http_method,
+          external_functions,
+          external_methods,
+          cache,
+          visiting,
+          sink
+        )
+      end
+    end
+  end
+
+  private def append_selector_handler_params(handler_arg : LibTreeSitter::TSNode,
+                                             source : String,
+                                             http_method : String,
+                                             external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                             external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)),
+                                             cache : Hash(String, Array(Param)),
+                                             visiting : Set(String),
+                                             sink : Array(Param))
+    field = Noir::TreeSitter.field(handler_arg, "field")
+    return unless field
+
+    method_name = Noir::TreeSitter.node_text(field, source)
+    if (methods = external_methods[method_name]?) && methods.size == 1
+      append_function_params(methods.first, http_method, external_functions, external_methods, cache, visiting, sink, 0)
+    end
+  end
+
+  private def append_function_params(fn : Noir::GoCalleeExtractor::FunctionBody,
+                                     http_method : String,
+                                     external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                     external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)),
+                                     cache : Hash(String, Array(Param)),
+                                     visiting : Set(String),
+                                     sink : Array(Param),
+                                     depth : Int32)
+    key = "#{fn.file_path}:#{fn.start_row}:#{http_method}"
+    if cached = cache[key]?
+      cached.each { |param| push_param(sink, param) }
+      return
+    end
+
+    visit_key = "#{fn.file_path}:#{fn.start_row}"
+    return if visiting.includes?(visit_key)
+    visiting << visit_key
+
+    params = [] of Param
+    wrapped = "package _noir_params_wrap\n#{fn.source}\n"
+    Noir::TreeSitter.parse_go(wrapped) do |root|
+      Noir::TreeSitter.each_named_child(root) do |child|
+        ty = Noir::TreeSitter.node_type(child)
+        next unless ty == "function_declaration" || ty == "method_declaration"
+        if body = Noir::TreeSitter.field(child, "body")
+          collect_params_in_body(body, wrapped, http_method, external_functions, external_methods, cache, visiting, params, depth)
+          break
+        end
+      end
+    end
+
+    visiting.delete(visit_key)
+    cache[key] = dedupe_params(params)
+    cache[key].each { |param| push_param(sink, param) }
+  end
+
+  private def collect_params_in_body(body : LibTreeSitter::TSNode,
+                                     source : String,
+                                     http_method : String,
+                                     external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                     external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)),
+                                     cache : Hash(String, Array(Param)),
+                                     visiting : Set(String),
+                                     sink : Array(Param),
+                                     depth : Int32)
+    walk(body) do |node|
+      next unless Noir::TreeSitter.node_type(node) == "call_expression"
+
+      extract_params_from_call(node, source, http_method).each do |param|
+        push_param(sink, param)
+      end
+
+      next if depth >= MAX_HELPER_DEPTH
+      if fn = helper_function_body_for_call(node, source, external_functions, external_methods)
+        append_function_params(fn, http_method, external_functions, external_methods, cache, visiting, sink, depth + 1)
+      end
+    end
+  end
+
+  private def extract_params_from_call(call : LibTreeSitter::TSNode,
+                                       source : String,
+                                       http_method : String) : Array(Param)
+    params = [] of Param
+    call_text = Noir::TreeSitter.node_text(call, source)
+
+    if call_text.matches?(/json\.NewDecoder\([^)]*\.Body\)\s*\.\s*Decode/) ||
+       call_text.matches?(/(?:io|ioutil)\.ReadAll\([^)]*\.Body\)/)
+      params << Param.new("body", "", "json")
+    end
+
+    append_regex_param(params, call_text, /\.URL\s*\.\s*Query\s*\(\s*\)\s*\.\s*Get\s*\(\s*["`]([^"`]+)["`]/, "query")
+    append_regex_param(params, call_text, /\.PostForm\s*\.\s*Get\s*\(\s*["`]([^"`]+)["`]/, "form")
+    append_regex_param(params, call_text, /\.Form\s*\.\s*Get\s*\(\s*["`]([^"`]+)["`]/, form_value_param_type(http_method))
+    append_regex_param(params, call_text, /\.PostFormValue\s*\(\s*["`]([^"`]+)["`]/, "form")
+    append_regex_param(params, call_text, /\.FormValue\s*\(\s*["`]([^"`]+)["`]/, form_value_param_type(http_method))
+    append_regex_param(params, call_text, /\.Header\s*\.\s*Get\s*\(\s*["`]([^"`]+)["`]/, "header")
+    append_regex_param(params, call_text, /\.Cookie\s*\(\s*["`]([^"`]+)["`]/, "cookie")
+    append_regex_param(params, call_text, /\.PathValue\s*\(\s*["`]([^"`]+)["`]/, "path")
+
+    leaf = call_function_leaf(call, source)
+    if param_type = helper_param_type(leaf, http_method)
+      if name = first_string_arg(call, source)
+        params << Param.new(name, "", param_type)
+      end
+    end
+
+    dedupe_params(params)
+  end
+
+  private def append_regex_param(params : Array(Param), call_text : String, regex : Regex, param_type : String)
+    if match = call_text.match(regex)
+      params << Param.new(match[1], "", param_type)
+    end
+  end
+
+  private def helper_function_body_for_call(call : LibTreeSitter::TSNode,
+                                            source : String,
+                                            external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                            external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))) : Noir::GoCalleeExtractor::FunctionBody?
+    function = Noir::TreeSitter.field(call, "function")
+    return unless function
+
+    case Noir::TreeSitter.node_type(function)
+    when "identifier"
+      name = Noir::TreeSitter.node_text(function, source)
+      external_functions[name]?
+    when "selector_expression"
+      field = Noir::TreeSitter.field(function, "field")
+      return unless field
+      method_name = Noir::TreeSitter.node_text(field, source)
+      return if helper_param_type(method_name, "") || method_name == "Get" || method_name == "Decode"
+      if (methods = external_methods[method_name]?) && methods.size == 1
+        methods.first
+      end
+    end
+  end
+
+  private def helper_param_type(name : String, http_method : String) : String?
+    case name
+    when "HasQueryParam"
+      "query"
+    when "PathValue", "PathParam", "URLParam"
+      "path"
+    else
+      if name.matches?(/^Query[A-Za-z0-9_]*Param(?:List)?$/)
+        "query"
+      elsif name.matches?(/^Route[A-Za-z0-9_]*Param$/)
+        "path"
+      elsif name.matches?(/^Path[A-Za-z0-9_]*Param$/)
+        "path"
+      elsif name.matches?(/^Form[A-Za-z0-9_]*Param$/)
+        form_value_param_type(http_method)
+      elsif name.matches?(/^Header[A-Za-z0-9_]*Param$/)
+        "header"
+      elsif name.matches?(/^Cookie[A-Za-z0-9_]*Param$/)
+        "cookie"
+      end
+    end
+  end
+
+  private def form_value_param_type(http_method : String) : String
+    case http_method
+    when "GET", "HEAD", ""
+      "query"
+    else
+      "form"
+    end
+  end
+
+  private def first_string_arg(call : LibTreeSitter::TSNode, source : String) : String?
+    args = Noir::TreeSitter.field(call, "arguments")
+    return unless args
+
+    Noir::TreeSitter.each_named_child(args) do |arg|
+      if string_literal_node?(arg)
+        return decode_string_literal(arg, source)
+      end
+    end
+
+    nil
+  end
+
+  private def find_handler_args(call : LibTreeSitter::TSNode) : Array(LibTreeSitter::TSNode)
+    found = [] of LibTreeSitter::TSNode
+    args = Noir::TreeSitter.field(call, "arguments")
+    return found unless args
+
+    first = true
+    Noir::TreeSitter.each_named_child(args) do |arg|
+      if first
+        first = false
+        next
+      end
+      next if string_literal_node?(arg)
+      found << arg
+    end
+
+    found
+  end
+
+  private def fallback_handler_arg_from_call(call : LibTreeSitter::TSNode,
+                                             source : String,
+                                             external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                             external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))) : LibTreeSitter::TSNode?
+    args = Noir::TreeSitter.field(call, "arguments")
+    return unless args
+
+    Noir::TreeSitter.each_named_child(args) do |arg|
+      next if string_literal_node?(arg)
+      candidate = unwrap_handler_arg(arg, source)
+      return candidate if handler_candidate?(candidate, source, external_functions, external_methods)
+    end
+
+    nil
+  end
+
+  private def handler_candidate?(node : LibTreeSitter::TSNode,
+                                 source : String,
+                                 external_functions : Hash(String, Noir::GoCalleeExtractor::FunctionBody),
+                                 external_methods : Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody))) : Bool
+    case Noir::TreeSitter.node_type(node)
+    when "func_literal", "call_expression"
+      true
+    when "identifier"
+      external_functions.has_key?(Noir::TreeSitter.node_text(node, source))
+    when "selector_expression"
+      field = Noir::TreeSitter.field(node, "field")
+      return false unless field
+      methods = external_methods[Noir::TreeSitter.node_text(field, source)]?
+      !methods.nil? && methods.size == 1
+    else
+      false
+    end
+  end
+
+  private def unwrap_handler_arg(arg : LibTreeSitter::TSNode, source : String, depth : Int32 = 0) : LibTreeSitter::TSNode
+    return arg if depth > 4
+    return arg unless Noir::TreeSitter.node_type(arg) == "call_expression"
+
+    function = Noir::TreeSitter.field(arg, "function")
+    wrapper_name = function ? call_text(function, source) : ""
+    return arg unless handler_wrapper_call?(wrapper_name)
+
+    args = Noir::TreeSitter.field(arg, "arguments")
+    return arg unless args
+
+    inner : LibTreeSitter::TSNode? = nil
+    Noir::TreeSitter.each_named_child(args) do |child|
+      next if string_literal_node?(child)
+      inner = child
+      break unless wrapper_name == "append"
+    end
+
+    if found = inner
+      unwrap_handler_arg(found, source, depth + 1)
+    else
+      arg
+    end
+  end
+
+  private def handler_wrapper_call?(name : String) : Bool
+    return true if name == "append"
+    return true if name == "HandlerFunc" || name.ends_with?(".HandlerFunc")
+    return true if name == "StripPrefix" || name.ends_with?(".StripPrefix")
+    return true if name == "Use" || name.ends_with?(".Use")
+    false
+  end
+
+  private def call_function_leaf(call : LibTreeSitter::TSNode, source : String) : String
+    function = Noir::TreeSitter.field(call, "function")
+    return "" unless function
+    case Noir::TreeSitter.node_type(function)
+    when "identifier"
+      Noir::TreeSitter.node_text(function, source)
+    when "selector_expression"
+      field = Noir::TreeSitter.field(function, "field")
+      field ? Noir::TreeSitter.node_text(field, source) : ""
+    else
+      ""
+    end
+  end
+
+  private def call_text(node : LibTreeSitter::TSNode, source : String) : String
+    case Noir::TreeSitter.node_type(node)
+    when "identifier"
+      Noir::TreeSitter.node_text(node, source)
+    when "selector_expression"
+      operand = Noir::TreeSitter.field(node, "operand")
+      field = Noir::TreeSitter.field(node, "field")
+      return "" unless operand && field
+      left = call_text(operand, source)
+      left.empty? ? Noir::TreeSitter.node_text(field, source) : "#{left}.#{Noir::TreeSitter.node_text(field, source)}"
+    else
+      ""
+    end
+  end
+
+  private def string_literal_node?(node : LibTreeSitter::TSNode) : Bool
+    ty = Noir::TreeSitter.node_type(node)
+    ty == "interpreted_string_literal" || ty == "raw_string_literal"
+  end
+
+  private def decode_string_literal(node : LibTreeSitter::TSNode, source : String) : String
+    text = Noir::TreeSitter.node_text(node, source)
+    return text[1...-1] if text.size >= 2 && ((text.starts_with?("\"") && text.ends_with?("\"")) || (text.starts_with?("`") && text.ends_with?("`")))
+    text
+  end
+
+  private def dedupe_params(params : Array(Param)) : Array(Param)
+    deduped = [] of Param
+    params.each { |param| push_param(deduped, param) }
+    deduped
+  end
+
+  private def push_param(params : Array(Param), param : Param)
+    return if param.name.empty? || param.param_type.empty?
+    return if params.any? { |existing| existing.name == param.name && existing.param_type == param.param_type }
+    params << param
+  end
+
+  private def walk(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    block.call(node)
+    Noir::TreeSitter.each_named_child(node) do |child|
+      walk(child, &block)
+    end
+  end
+end

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -3240,8 +3240,18 @@ module Noir
 
       return unless path.starts_with?("/")
       path = "/#{path}" unless path.starts_with?("/")
+      path = normalize_net_http_pattern_path(path)
 
       Route.new(router_name, verb, path, raw_path, handler_text, Noir::TreeSitter.node_start_row(call))
+    end
+
+    # Go 1.22 ServeMux uses `{$}` as a special end-of-path wildcard.
+    # `GET /{$}` matches exactly `/`, not a literal `/{ $ }` endpoint.
+    private def normalize_net_http_pattern_path(path : String) : String
+      return path unless path.ends_with?("{$}")
+
+      normalized = path[0, path.size - "{$}".size]
+      normalized.empty? ? "/" : normalized
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add a Go request parameter extractor for stdlib `net/http` routes that resolves handler methods/functions and follows same-package helpers for query/form/header/cookie/path/body parameters.
- Normalize Go 1.22 ServeMux `{$}` end-of-path wildcard patterns so `GET /{$}` reports `/` instead of a literal `/{$}` endpoint.
- Broaden PocketBase route coverage to same-package route files that do not import `pocketbase/tools/router`, while keeping the group pre-pass gated by the framework import marker.

## OSS checks
- `flipped-aurora/gin-vue-admin`: 208 Go endpoints, no zap/slog-derived suspicious `/error`, `/mode`, or `/{$}` URLs.
- `miniflux/v2`: `GET /v1/entries` now includes 19 query params from handler/helper bodies; `/{$}` false-positive count is 0.
- `pocketbase/pocketbase`: now finds `GET /_/extensions.js` and `GET /_/{path...}` from route files without the router import.

## Tests
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache crystal spec spec/unit_test/miniparser/go_route_extractor_ts_spec.cr spec/unit_test/analyzer/go_engine_spec.cr spec/functional_test/testers/go`
- `CRYSTAL_CACHE_DIR=/tmp/noir-crystal-cache just test`
- `just build`
- `crystal tool format --check`
- `lib/ameba/bin/ameba.cr <changed files>`

Note: full `just check` reached Ameba's full-repo inspection and was terminated by signal 15 in this environment after several minutes; format check and changed-file Ameba lint both pass.
