### PR TITLE
Improve Python framework route accuracy

### DIFF
--- a/spec/functional_test/fixtures/python/django/blog/urls.py
+++ b/spec/functional_test/fixtures/python/django/blog/urls.py
@@ -132,6 +132,14 @@ urlpatterns = [
         r'widget/delete',
         views.WidgetDeleteView.as_view(),
         name='widget_delete'),
+    path(
+        r'api/token/',
+        views.ApiTokenView.as_view(),
+        name='api_token'),
+    path(
+        r'api/account/',
+        views.AccountRetrieveUpdateAPIView.as_view(),
+        name='api_account'),
     re_path(
         r'^legacy/(?P<legacy_id>[0-9]+)/$',
         views.legacy_detail,

--- a/spec/functional_test/fixtures/python/django/blog/views.py
+++ b/spec/functional_test/fixtures/python/django/blog/views.py
@@ -18,6 +18,8 @@ from django.views.generic.list import ListView
 from haystack.views import SearchView
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
+from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.views import APIView
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from blog.models import Article, Category, LinkShowType, Links, Tag
@@ -455,6 +457,21 @@ class WidgetDeleteView(DeleteView):
     # Django's generic DeleteView serves GET (confirm) + POST (delete),
     # never the HTTP DELETE verb.
     model = Article
+
+
+class ApiTokenView(APIView):
+    def post(self, request):
+        token = request.data.get("token")
+        return HttpResponse(token)
+
+
+class AccountRetrieveUpdateAPIView(RetrieveUpdateAPIView):
+    def retrieve(self, request, *args, **kwargs):
+        return HttpResponse("account")
+
+    def update(self, request, *args, **kwargs):
+        display_name = request.data.get("display_name")
+        return HttpResponse(display_name)
 
 def legacy_detail(request, legacy_id):
     preview = request.GET.get('preview')

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/factory.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/api/routes/factory.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/probe")
+def read_factory_probe():
+    return {"ok": True}

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/core/factory.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/core/factory.py
@@ -1,0 +1,5 @@
+from app.core.factory_settings import FactorySettings
+
+
+def get_factory_settings() -> FactorySettings:
+    return FactorySettings()

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/core/factory_settings.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/core/factory_settings.py
@@ -1,0 +1,5 @@
+from pydantic_settings import BaseSettings
+
+
+class FactorySettings(BaseSettings):
+    api_prefix: str = "/factory"

--- a/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/main.py
+++ b/spec/functional_test/fixtures/python/fastapi_settings_prefix/app/main.py
@@ -4,10 +4,13 @@
 # expression and emitted garbage URLs like `/settings.API_V1_STR/...`.
 from fastapi import Depends, FastAPI
 
+from app.api.routes import factory
 from app.api.main import api_router
 from app.core.config import settings
+from app.core.factory import get_factory_settings
 
 API_PREFIX = settings.API_V1_STR
+factory_settings = get_factory_settings()
 
 app = FastAPI()
 app.include_router(
@@ -15,3 +18,4 @@ app.include_router(
     prefix=API_PREFIX,
     dependencies=[Depends(lambda: True)],
 )
+app.include_router(factory.router, prefix=factory_settings.api_prefix)

--- a/spec/functional_test/testers/python/django_drf_callees_spec.cr
+++ b/spec/functional_test/testers/python/django_drf_callees_spec.cr
@@ -4,16 +4,16 @@ expected_endpoints = [
   Endpoint.new("/api/articles/", "GET", [
     Param.new("status", "", "query"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.query_params.get", line: 34))
-    ep.push_callee(Callee.new("HttpResponse", line: 35))
+    ep.push_callee(Callee.new("request.query_params.get", line: 36))
+    ep.push_callee(Callee.new("HttpResponse", line: 37))
   end,
 
   Endpoint.new("/api/articles/{article_id}/publish/", "POST", [
     Param.new("reason", "", "form"),
     Param.new("article_id", "", "path"),
   ]).tap do |ep|
-    ep.push_callee(Callee.new("request.data.get", line: 43))
-    ep.push_callee(Callee.new("HttpResponse", line: 44))
+    ep.push_callee(Callee.new("request.data.get", line: 45))
+    ep.push_callee(Callee.new("HttpResponse", line: 46))
   end,
 ]
 

--- a/spec/functional_test/testers/python/django_spec.cr
+++ b/spec/functional_test/testers/python/django_spec.cr
@@ -147,6 +147,13 @@ expected_endpoints = [
   # DeleteView → GET (confirm) + POST (delete), never HTTP DELETE.
   Endpoint.new("/widget/delete", "GET"),
   Endpoint.new("/widget/delete", "POST"),
+  # DRF APIView honors explicitly defined HTTP methods only.
+  Endpoint.new("/api/token/", "POST", [Param.new("token", "", "form")]),
+  # DRF RetrieveUpdateAPIView maps retrieve/update to GET/PUT/PATCH,
+  # and request.data inside update must not create a stray POST.
+  Endpoint.new("/api/account/", "GET"),
+  Endpoint.new("/api/account/", "PUT", [Param.new("display_name", "", "form")]),
+  Endpoint.new("/api/account/", "PATCH", [Param.new("display_name", "", "form")]),
   Endpoint.new("/legacy/{legacy_id}/", "GET", [
     Param.new("preview", "", "query"),
     Param.new("legacy_id", "", "path"),

--- a/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
+++ b/spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr
@@ -15,6 +15,9 @@ expected_endpoints = [
   # Simple f-string prefixes with resolvable constants should keep
   # their concrete segment instead of being dropped or emitted raw.
   Endpoint.new("/api/v1/dynamic/v1/probe", "GET"),
+  # fastapi-realworld style local settings factory:
+  # `settings = get_app_settings(); prefix=settings.api_prefix`.
+  Endpoint.new("/factory/probe", "GET"),
 ]
 
 FunctionalTester.new("fixtures/python/fastapi_settings_prefix/", {

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -1336,23 +1336,29 @@ module Analyzer::Python
           class_define_line = lines[0]
           lines = lines[1..]
 
-          # Determine implicit HTTP methods based on class name
-          if class_define_line.includes? "Form"
-            suspicious_http_methods << "GET"
-            suspicious_http_methods << "POST"
-          elsif class_define_line.includes? "Delete"
-            # Django's generic `DeleteView` serves the confirmation page
-            # on GET and performs the delete on POST — it does NOT expose
-            # the HTTP DELETE verb. Emitting DELETE here was a false
-            # positive on every `class X(DeleteView)` (wagtail: 5). A view
-            # that genuinely handles HTTP DELETE defines `def delete(self,
-            # request, ...)`, which the explicit method-def scan below
-            # already picks up, so real DELETE endpoints are unaffected.
-            suspicious_http_methods << "POST"
-          elsif class_define_line.includes? "Create"
-            suspicious_http_methods << "POST"
-          elsif class_define_line.includes? "Update"
-            suspicious_http_methods << "POST"
+          drf_generic_class = false
+          if drf_methods = default_drf_generic_view_methods(class_define_line)
+            drf_generic_class = true
+            suspicious_http_methods = drf_methods
+          else
+            # Determine implicit HTTP methods based on class name
+            if class_define_line.includes? "Form"
+              suspicious_http_methods << "GET"
+              suspicious_http_methods << "POST"
+            elsif class_define_line.includes? "Delete"
+              # Django's generic `DeleteView` serves the confirmation page
+              # on GET and performs the delete on POST — it does NOT expose
+              # the HTTP DELETE verb. Emitting DELETE here was a false
+              # positive on every `class X(DeleteView)` (wagtail: 5). A view
+              # that genuinely handles HTTP DELETE defines `def delete(self,
+              # request, ...)`, which the explicit method-def scan below
+              # already picks up, so real DELETE endpoints are unaffected.
+              suspicious_http_methods << "POST"
+            elsif class_define_line.includes? "Create"
+              suspicious_http_methods << "POST"
+            elsif class_define_line.includes? "Update"
+              suspicious_http_methods << "POST"
+            end
           end
 
           body_start_line = content[0, class_start_index].count('\n')
@@ -1363,19 +1369,19 @@ module Analyzer::Python
           method_params = Hash(String, Array(Param)).new do |hash, key|
             hash[key] = [] of Param
           end
-          current_http_method : String? = nil
+          current_http_methods : Array(String)? = nil
 
           # Check HTTP methods in class methods
           lines.each_with_index do |line, offset|
             method_function_match = line.match(REGEX_CBV_METHOD_DEF)
             any_method_function_match = line.match(/\s+(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
             if !any_method_function_match.nil?
-              current_http_method = nil
+              current_http_methods = nil
             end
 
             if !method_function_match.nil?
               method_name = method_function_match[1].upcase
-              current_http_method = method_name
+              current_http_methods = [method_name]
               suspicious_http_methods << method_name
               method_lines[method_name] = body_start_line + offset + 2
 
@@ -1388,15 +1394,31 @@ module Analyzer::Python
                   source: content
                 )
               end
+            elsif drf_generic_class && any_method_function_match && (drf_methods = drf_generic_action_http_methods(any_method_function_match[1]))
+              current_http_methods = drf_methods
+              drf_methods.each do |method_name|
+                next unless suspicious_http_methods.includes?(method_name)
+                method_lines[method_name] ||= body_start_line + offset + 2
+              end
             end
 
-            extract_params_from_line(line, suspicious_http_methods).each do |param|
-              if method_name = current_http_method
-                method_params[method_name] << param
-              else
+            if method_names = current_http_methods
+              scan_methods = method_names.dup
+              extract_params_from_line(line, scan_methods).each do |param|
+                method_names.each do |mapped_method_name|
+                  next unless suspicious_http_methods.includes?(mapped_method_name)
+                  method_params[mapped_method_name] << param
+                end
+              end
+            else
+              extract_params_from_line(line, suspicious_http_methods).each do |param|
                 common_params << param
               end
             end
+          end
+
+          if suspicious_http_methods.empty?
+            return endpoints
           end
 
           suspicious_http_methods.uniq.each do |http_method_name|
@@ -1416,6 +1438,47 @@ module Analyzer::Python
 
       # Default to GET method
       [Endpoint.new(url, "GET", Details.new(PathInfo.new(filepath)))]
+    end
+
+    private def default_drf_generic_view_methods(class_define_line : ::String) : Array(::String)?
+      return unless class_define_line.includes?("APIView")
+
+      if class_define_line.includes?("RetrieveUpdateDestroyAPIView")
+        ["GET", "PUT", "PATCH", "DELETE"]
+      elsif class_define_line.includes?("RetrieveUpdateAPIView")
+        ["GET", "PUT", "PATCH"]
+      elsif class_define_line.includes?("RetrieveDestroyAPIView")
+        ["GET", "DELETE"]
+      elsif class_define_line.includes?("ListCreateAPIView")
+        ["GET", "POST"]
+      elsif class_define_line.includes?("RetrieveAPIView")
+        ["GET"]
+      elsif class_define_line.includes?("ListAPIView")
+        ["GET"]
+      elsif class_define_line.includes?("CreateAPIView")
+        ["POST"]
+      elsif class_define_line.includes?("UpdateAPIView")
+        ["PUT", "PATCH"]
+      elsif class_define_line.includes?("DestroyAPIView")
+        ["DELETE"]
+      else
+        [] of ::String
+      end
+    end
+
+    private def drf_generic_action_http_methods(method_name : ::String) : Array(::String)?
+      case method_name
+      when "list", "retrieve"
+        ["GET"]
+      when "create"
+        ["POST"]
+      when "update"
+        ["PUT", "PATCH"]
+      when "partial_update"
+        ["PATCH"]
+      when "destroy"
+        ["DELETE"]
+      end
     end
 
     private def extract_drf_viewset_endpoints(route_base : ::String, filepath : ::String, class_name : ::String) : Array(Endpoint)

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -698,7 +698,120 @@ module Analyzer::Python
         return local
       end
 
+      if local_attr = resolve_local_factory_attribute(expr, source, import_modules, depth)
+        return local_attr
+      end
+
       resolve_constant_value(expr, import_modules)
+    end
+
+    private def resolve_local_factory_attribute(expression : ::String,
+                                                source : ::String,
+                                                import_modules : Hash(::String, Tuple(::String, Int32)),
+                                                depth : Int32) : ::String?
+      return if depth > 3
+      attr_match = expression.match(/^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$/)
+      return unless attr_match
+
+      object_name, attr_name = attr_match[1], attr_match[2]
+      call_match = source.match(/^\s*#{Regex.escape(object_name)}\s*(?::[^=]+)?=\s*([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*\(/m)
+      return unless call_match
+
+      callee = call_match[1]
+      callee_root = callee.split(".", 2)[0]
+      callee_name = callee.split(".")[-1]
+      if imported = import_modules[callee_root]?
+        module_path = imported.first
+        return resolve_attribute_from_file(module_path, attr_name, callee_name, depth + 1) unless module_path.empty?
+      end
+
+      nil
+    end
+
+    private def resolve_attribute_from_file(module_path : ::String,
+                                            attr_name : ::String,
+                                            factory_name : ::String?,
+                                            depth : Int32) : ::String?
+      return if depth > 4
+      return unless File.exists?(module_path)
+
+      module_source = read_file_content(module_path)
+      if value = resolve_attribute_default_in_source(module_source, attr_name)
+        return value
+      end
+
+      if factory_name
+        if return_type = extract_function_return_annotation(module_source, factory_name)
+          if value = resolve_class_attribute_from_file(module_path, module_source, return_type, attr_name, depth + 1)
+            return value
+          end
+        end
+      end
+
+      nil
+    end
+
+    private def resolve_class_attribute_from_file(module_path : ::String,
+                                                  module_source : ::String,
+                                                  class_name : ::String,
+                                                  attr_name : ::String,
+                                                  depth : Int32) : ::String?
+      return if depth > 4
+
+      if value = resolve_class_attribute_default(module_source, class_name, attr_name)
+        return value
+      end
+
+      import_modules = imported_modules_for_resolution(module_path, module_source)
+      if imported = import_modules[class_name]?
+        imported_path = imported.first
+        return if imported_path.empty? || imported_path == module_path
+        imported_source = read_file_content(imported_path)
+        return resolve_class_attribute_from_file(imported_path, imported_source, class_name, attr_name, depth + 1)
+      end
+
+      nil
+    end
+
+    private def imported_modules_for_resolution(module_path : ::String, module_source : ::String) : Hash(::String, Tuple(::String, Int32))
+      merged = Hash(::String, Tuple(::String, Int32)).new
+      candidate_bases = [] of ::String
+      base_paths.each do |base_path|
+        candidate_bases << base_path if path_under_root?(module_path, base_path)
+      end
+      candidate_bases << File.dirname(module_path)
+
+      candidate_bases.uniq.each do |base_path|
+        find_fastapi_imported_modules(base_path, module_path, module_source).each do |name, import_info|
+          merged[name] = import_info unless merged.has_key?(name)
+        end
+      end
+
+      merged
+    end
+
+    private def extract_function_return_annotation(source : ::String, function_name : ::String) : ::String?
+      match = source.match(/^\s*def\s+#{Regex.escape(function_name)}\s*\([^)]*\)\s*->\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/m)
+      match ? match[1] : nil
+    end
+
+    private def resolve_attribute_default_in_source(source : ::String, attr_name : ::String) : ::String?
+      pattern = /^\s*#{Regex.escape(attr_name)}\s*(?::[^=]+)?=\s*['"]([^'"]*)['"]/m
+      if match = source.match(pattern)
+        return match[1]
+      end
+
+      nil
+    end
+
+    private def resolve_class_attribute_default(source : ::String, class_name : ::String, attr_name : ::String) : ::String?
+      class_start = source.index(/class\s+#{Regex.escape(class_name)}\s*[\(:]/)
+      return unless class_start
+
+      class_codeblock = parse_code_block(source[class_start..])
+      return unless class_codeblock
+
+      resolve_attribute_default_in_source(class_codeblock, attr_name)
     end
 
     private def resolve_f_string(value : ::String,


### PR DESCRIPTION
## Summary
- tighten Django CBV handling for DRF `APIView` and generic views so explicit `post/delete/...` methods and `RetrieveUpdateAPIView`-style inherited methods produce the correct HTTP surface
- keep request-body parameter extraction scoped to the current DRF method instead of adding unrelated POST/PUT/PATCH endpoints
- resolve FastAPI prefixes from local settings factories such as `settings = get_app_settings(); prefix=settings.api_prefix`
- add Django and FastAPI regression fixtures for the real-world patterns above

## Open-source app checks
- `nsidnev/fastapi-realworld-example-app`: recovered `/api/...` routes from `settings.api_prefix` (combined scan now includes the code-derived `/api` routes alongside Postman-derived routes)
- `gothinkster/django-realworld-example-app`: reduced FP endpoints from 31 to 20 by removing unsupported DRF methods on `APIView`/generic views
- `gothinkster/flask-realworld-example-app`: stayed stable at 19 endpoints

## Validation
- `just build`
- `just test`
- `crystal spec spec/functional_test/testers/python/django_spec.cr spec/functional_test/testers/python/django_drf_callees_spec.cr spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr`
- `crystal tool format --check`
- `lib/ameba/bin/ameba.cr src/analyzer/analyzers/python/django.cr src/analyzer/analyzers/python/fastapi.cr spec/functional_test/testers/python/django_spec.cr spec/functional_test/testers/python/django_drf_callees_spec.cr spec/functional_test/testers/python/fastapi_settings_prefix_spec.cr`

Note: full `just check` was attempted, but the full-project Ameba process was terminated by signal 15 before completion; the format check and changed-file Ameba pass both succeeded.
