### PR TITLE
Improve Kotlin analyzer route coverage

### DIFF
--- a/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/http4k_extractor_ts_spec.cr
@@ -110,4 +110,42 @@ describe Noir::TreeSitterHttp4kExtractor do
     ping = routes.find! { |r| r.path == "/ping" }
     ping.has_body?.should be_false
   end
+
+  it "mounts contract routes added inside a prefixed contract block" do
+    helper = <<-KT
+      import org.http4k.contract.ContractRoute
+      import org.http4k.contract.meta
+      import org.http4k.core.Method.POST
+
+      fun KnockKnock(): ContractRoute {
+          return "/knock" meta {
+              summary = "User enters"
+          } bindContract POST to userEntry
+      }
+      KT
+
+    mount = <<-KT
+      import org.http4k.contract.contract
+      import org.http4k.core.Method.GET
+      import org.http4k.routing.bind
+      import org.http4k.routing.routes
+
+      val api = "/api" bind routes(
+          "/oauth/callback" bind GET to callback,
+          contract {
+              descriptionPath = "/api-docs"
+              routes += KnockKnock()
+          }
+      )
+      KT
+
+    contract_routes = Noir::TreeSitterHttp4kExtractor.extract_contract_route_functions(helper)
+    routes = Noir::TreeSitterHttp4kExtractor.extract_routes(mount, contract_routes: contract_routes)
+
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/oauth/callback"},
+      {"GET", "/api/api-docs"},
+      {"POST", "/api/knock"},
+    ])
+  end
 end

--- a/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr
@@ -156,6 +156,31 @@ describe Noir::TreeSitterKotlinRouteExtractor do
     routes.map(&.path).should eq(["/api/users"])
   end
 
+  it "treats a bare path identifier argument as a positional constant" do
+    source = <<-KT
+      package com.example
+
+      import com.example.MovieController.Companion.path
+
+      @RestController
+      @RequestMapping(path)
+      class MovieController {
+          @GetMapping
+          fun list(): String = ""
+
+          companion object {
+              const val path = "/api/movies"
+          }
+      }
+      KT
+
+    constants = Noir::TreeSitterKotlinRouteExtractor.extract_string_constants(source)
+    routes = Noir::TreeSitterKotlinRouteExtractor.extract_routes(source, constants)
+    routes.map { |r| {r.verb, r.path} }.should eq([
+      {"GET", "/api/movies"},
+    ])
+  end
+
   it "collapses an empty method path onto the class prefix" do
     # Kotlin Spring controllers routinely do
     # `@RequestMapping("/api/article")` on the class and `@GetMapping`

--- a/src/analyzer/analyzers/kotlin/http4k.cr
+++ b/src/analyzer/analyzers/kotlin/http4k.cr
@@ -10,32 +10,50 @@ module Analyzer::Kotlin
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
+      kotlin_files = file_list.select do |path|
+        File.exists?(path) &&
+          path.ends_with?(".#{KOTLIN_EXTENSION}") &&
+          !KotlinEngine.test_path?(path)
+      end
+      file_contents = Hash(String, String).new
       string_constants_by_base = Hash(String, Hash(String, String)).new do |hash, key|
         hash[key] = Hash(String, String).new
       end
-      file_list.each do |path|
-        next unless File.exists?(path)
-        next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
-
+      contract_routes_by_base = Hash(String, Hash(String, Array(Noir::TreeSitterHttp4kExtractor::Route))).new do |hash, key|
+        hash[key] = Hash(String, Array(Noir::TreeSitterHttp4kExtractor::Route)).new
+      end
+      kotlin_files.each do |path|
         string_constants = string_constants_by_base[configured_base_for(path)]
-        Noir::TreeSitterHttp4kExtractor.extract_string_constants(read_file_content(path)).each do |name, value|
+        content = file_contents[path] = read_file_content(path)
+        Noir::TreeSitterHttp4kExtractor.extract_string_constants(content).each do |name, value|
           next unless fully_qualified_constant?(name)
 
           string_constants[name] ||= value
         end
       end
 
-      file_list.each do |path|
-        next unless File.exists?(path)
-        next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
+      kotlin_files.each do |path|
+        content = file_contents[path]
+        next unless content.includes?("bindContract")
 
-        content = read_file_content(path)
+        base = configured_base_for(path)
+        string_constants = string_constants_by_base[base]? || Hash(String, String).new
+        Noir::TreeSitterHttp4kExtractor.extract_contract_route_functions(content, string_constants, include_callees: include_callee).each do |name, routes|
+          contract_routes_by_base[base][name] ||= [] of Noir::TreeSitterHttp4kExtractor::Route
+          contract_routes_by_base[base][name].concat(routes)
+        end
+      end
+
+      kotlin_files.each do |path|
+        content = file_contents[path]
         next unless content.includes?(HTTP4K_MARKER)
 
-        string_constants = string_constants_by_base[configured_base_for(path)]? || Hash(String, String).new
-        Noir::TreeSitterHttp4kExtractor.extract_routes(content, string_constants, include_callees: include_callee).each do |route|
+        base = configured_base_for(path)
+        string_constants = string_constants_by_base[base]? || Hash(String, String).new
+        contract_routes = contract_routes_by_base[base]? || Hash(String, Array(Noir::TreeSitterHttp4kExtractor::Route)).new
+        Noir::TreeSitterHttp4kExtractor.extract_routes(
+          content, string_constants, include_callees: include_callee, contract_routes: contract_routes
+        ).each do |route|
           @result << build_endpoint(route, path)
         end
       end

--- a/src/analyzer/analyzers/kotlin/ktor.cr
+++ b/src/analyzer/analyzers/kotlin/ktor.cr
@@ -9,20 +9,22 @@ module Analyzer::Kotlin
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       file_list = all_files()
+      kotlin_files = file_list.select do |path|
+        File.exists?(path) &&
+          path.ends_with?(".#{KOTLIN_EXTENSION}") &&
+          !KotlinEngine.test_path?(path)
+      end
+      file_contents = Hash(String, String).new
       string_constants_by_base = Hash(String, Hash(String, String)).new do |hash, key|
         hash[key] = Hash(String, String).new
       end
       raw_resources_by_base = Hash(String, Array(Noir::TreeSitterKotlinKtorRouteExtractor::RawResource)).new do |hash, key|
         hash[key] = [] of Noir::TreeSitterKotlinKtorRouteExtractor::RawResource
       end
-      file_list.each do |path|
-        next unless File.exists?(path)
-        next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
-
+      kotlin_files.each do |path|
         base = configured_base_for(path)
         string_constants = string_constants_by_base[base]
-        content = read_file_content(path)
+        content = file_contents[path] = read_file_content(path)
         Noir::TreeSitterKotlinKtorRouteExtractor.extract_string_constants(content).each do |name, value|
           next unless fully_qualified_constant?(name)
 
@@ -42,12 +44,8 @@ module Analyzer::Kotlin
         resource_paths_by_base[base] = Noir::TreeSitterKotlinKtorRouteExtractor.compose_resource_paths(raw_resources)
       end
 
-      file_list.each do |path|
-        next unless File.exists?(path)
-        next unless path.ends_with?(".#{KOTLIN_EXTENSION}")
-        next if KotlinEngine.test_path?(path)
-
-        content = read_file_content(path)
+      kotlin_files.each do |path|
+        content = file_contents[path]
         next unless potential_ktor_route_file?(content)
 
         base = configured_base_for(path)

--- a/src/miniparsers/http4k_extractor_ts.cr
+++ b/src/miniparsers/http4k_extractor_ts.cr
@@ -70,15 +70,35 @@ module Noir
                      @query_params, @header_params, @form_params,
                      @callees)
       end
+
+      def with_path(path : String) : Route
+        Route.new(@verb, path, @line, @has_body, @query_params, @header_params, @form_params, @callees)
+      end
     end
 
-    def extract_routes(source : String, string_constants = Hash(String, String).new, *, include_callees : Bool = false) : Array(Route)
+    def extract_routes(source : String,
+                       string_constants = Hash(String, String).new,
+                       *,
+                       include_callees : Bool = false,
+                       contract_routes = Hash(String, Array(Route)).new) : Array(Route)
       routes = [] of Route
       local_string_constants = extract_string_constants(source)
       Noir::TreeSitter.parse_kotlin(source) do |root|
-        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees, false)
+        walk(root, source, "", routes, string_constants, local_string_constants, 0, include_callees, false, contract_routes)
       end
       routes
+    end
+
+    def extract_contract_route_functions(source : String,
+                                         string_constants = Hash(String, String).new,
+                                         *,
+                                         include_callees : Bool = false) : Hash(String, Array(Route))
+      routes_by_function = Hash(String, Array(Route)).new
+      local_string_constants = extract_string_constants(source)
+      Noir::TreeSitter.parse_kotlin(source) do |root|
+        collect_contract_route_functions(root, source, routes_by_function, string_constants, local_string_constants, include_callees, 0)
+      end
+      routes_by_function
     end
 
     def extract_string_constants(source : String) : Hash(String, String)
@@ -132,12 +152,13 @@ module Noir
                      local_string_constants : Hash(String, String),
                      depth : Int32,
                      include_callees : Bool,
-                     in_routes : Bool)
+                     in_routes : Bool,
+                     contract_routes : Hash(String, Array(Route)))
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
 
       ty = Noir::TreeSitter.node_type(node)
 
-      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees, in_routes)
+      if ty == "infix_expression" && handle_bind(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees, in_routes, contract_routes)
         return
       end
 
@@ -145,12 +166,16 @@ module Noir
         # Arguments of a `routes(...)` call are inside the routing
         # block — a bare `VERB to handler` arg there is a real route
         # bound to the current prefix (the verbs-under-path idiom).
-        walk_routes_args(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees, true)
+        walk_routes_args(node, source, prefix, routes, string_constants, local_string_constants, depth, include_callees, true, contract_routes)
         return
       end
 
+      if ty == "call_expression" && call_function_name(node, source) == "contract"
+        emit_contract_routes(node, source, prefix, routes, contract_routes)
+      end
+
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, in_routes)
+        walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, in_routes, contract_routes)
       end
     end
 
@@ -169,7 +194,8 @@ module Noir
                             local_string_constants : Hash(String, String),
                             depth : Int32,
                             include_callees : Bool,
-                            in_routes : Bool) : Bool
+                            in_routes : Bool,
+                            contract_routes : Hash(String, Array(Route))) : Bool
       lhs, op, rhs = infix_parts(node, source)
       return false unless lhs && rhs
 
@@ -221,11 +247,46 @@ module Noir
         path_text = resolve_string_value(lhs, source, string_constants, local_string_constants)
         return false unless path_text
         new_prefix = join_paths(prefix, path_text)
-        walk_routes_args(rhs, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true)
+        walk_routes_args(rhs, source, new_prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, true, contract_routes)
         true
       else
         false
       end
+    end
+
+    private def emit_contract_routes(node : LibTreeSitter::TSNode,
+                                     source : String,
+                                     prefix : String,
+                                     routes : Array(Route),
+                                     contract_routes : Hash(String, Array(Route)))
+      line = Noir::TreeSitter.node_start_row(node)
+      contract_description_paths(node, source).each do |path|
+        routes << Route.new("GET", join_paths(prefix, path), line, false, [] of String, [] of String, [] of String, [] of Tuple(String, Int32))
+      end
+
+      contract_route_references(node, source).each do |name|
+        next unless helper_routes = contract_routes[name]?
+
+        helper_routes.each do |route|
+          routes << route.with_path(join_paths(prefix, route.path))
+        end
+      end
+    end
+
+    private def contract_description_paths(node : LibTreeSitter::TSNode, source : String) : Array(String)
+      paths = [] of String
+      Noir::TreeSitter.node_text(node, source).scan(/\bdescriptionPath\s*=\s*"([^"]+)"/) do |match|
+        paths << match[1]
+      end
+      paths
+    end
+
+    private def contract_route_references(node : LibTreeSitter::TSNode, source : String) : Array(String)
+      refs = [] of String
+      Noir::TreeSitter.node_text(node, source).scan(/\broutes\s*\+=\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(/) do |match|
+        refs << match[1]
+      end
+      refs
     end
 
     # Build and append a Route from a verb, full path, and handler
@@ -296,16 +357,48 @@ module Noir
                                  local_string_constants : Hash(String, String),
                                  depth : Int32,
                                  include_callees : Bool,
-                                 in_routes : Bool)
+                                 in_routes : Bool,
+                                 contract_routes : Hash(String, Array(Route)))
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
       args = call_value_arguments(call)
       return unless args
       Noir::TreeSitter.each_named_child(args) do |arg|
         next unless Noir::TreeSitter.node_type(arg) == "value_argument"
         Noir::TreeSitter.each_named_child(arg) do |child|
-          walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, in_routes)
+          walk(child, source, prefix, routes, string_constants, local_string_constants, depth + 1, include_callees, in_routes, contract_routes)
         end
       end
+    end
+
+    private def collect_contract_route_functions(node : LibTreeSitter::TSNode,
+                                                 source : String,
+                                                 routes_by_function : Hash(String, Array(Route)),
+                                                 string_constants : Hash(String, String),
+                                                 local_string_constants : Hash(String, String),
+                                                 include_callees : Bool,
+                                                 depth : Int32)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+      if Noir::TreeSitter.node_type(node) == "function_declaration"
+        name = function_name(node, source)
+        if !name.empty? && Noir::TreeSitter.node_text(node, source).includes?("bindContract")
+          routes = [] of Route
+          walk(node, source, "", routes, string_constants, local_string_constants, 0, include_callees, true, Hash(String, Array(Route)).new)
+          routes_by_function[name] = routes unless routes.empty?
+        end
+        return
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        collect_contract_route_functions(child, source, routes_by_function, string_constants, local_string_constants, include_callees, depth + 1)
+      end
+    end
+
+    private def function_name(func : LibTreeSitter::TSNode, source : String) : String
+      Noir::TreeSitter.each_named_child(func) do |child|
+        return Noir::TreeSitter.node_text(child, source) if Noir::TreeSitter.node_type(child) == "simple_identifier"
+      end
+      ""
     end
 
     # ---- handler-body scan ------------------------------------------

--- a/src/miniparsers/kotlin_route_extractor_ts.cr
+++ b/src/miniparsers/kotlin_route_extractor_ts.cr
@@ -1522,6 +1522,10 @@ module Noir
         if kind == :keyword
           next unless key == "value" || key == "path"
           collect_string_values(value_node, source, keyword, string_constants, local_string_constants)
+        elsif kind == :bare_identifier
+          if value = local_string_constants[key]?
+            positional << value unless value.empty?
+          end
         else
           collect_string_values(value_node, source, positional, string_constants, local_string_constants)
         end
@@ -1530,23 +1534,35 @@ module Noir
       keyword.empty? ? positional : keyword
     end
 
-    # Return `{:keyword | :positional, key_or_nil, value_node}`.
+    # Return `{:keyword | :positional | :bare_identifier, key_or_nil, value_node}`.
     private def classify_value_argument(arg : LibTreeSitter::TSNode, source : String) : Tuple(Symbol, String, LibTreeSitter::TSNode?)
+      children = [] of LibTreeSitter::TSNode
+      Noir::TreeSitter.each_named_child(arg) do |child|
+        children << child
+      end
+      if children.size <= 1
+        child = children.first?
+        if child && Noir::TreeSitter.node_type(child) == "simple_identifier"
+          return {:bare_identifier, Noir::TreeSitter.node_text(child, source), child}
+        end
+        return {:positional, "", child}
+      end
+
       key = ""
       value : LibTreeSitter::TSNode? = nil
       named = false
-      Noir::TreeSitter.each_named_child(arg) do |child|
-        case Noir::TreeSitter.node_type(child)
+      children.each do |entry|
+        case Noir::TreeSitter.node_type(entry)
         when "simple_identifier"
           if named
             # second identifier is actually the value expression
-            value = child
+            value = entry
           else
-            key = Noir::TreeSitter.node_text(child, source)
+            key = Noir::TreeSitter.node_text(entry, source)
             named = true
           end
         else
-          value = child if value.nil?
+          value = entry if value.nil?
         end
       end
       {named ? :keyword : :positional, key, value}


### PR DESCRIPTION
## Summary
- Fix Kotlin Spring `@RequestMapping(path)` handling when `path` is a bare local/companion const, avoiding collapsed root-level routes.
- Add http4k contract route indexing so `contract { routes += Helper() }` mounts `bindContract` routes under the surrounding prefix and surfaces `descriptionPath`.
- Cache Kotlin file lists and source content in Ktor/http4k analyzers so constant/resource and route passes do not repeatedly filter/read the same files.

## Open-source sample checks
Scanned with the freshly built local `./bin/noir` and `--only-techs`:
- `selimatasoy/kotlin-ktor-rest-api` (`kotlin_ktor`): 5 endpoints
- `kwencel/spring-boot-backend-showcase` (`kotlin_spring`): 14 endpoints; Spring companion const prefixes now resolve to `/api/movies` and `/api/shows`
- `http4k/http4k-by-example` (`kotlin_http4k`): 11 endpoints; newly recovers `/api/api-docs`, `/api/whoIsThere`, `/api/bye`, `/api/knock`
- `alisabzevari/kotlin-http4k-realworld-example-app` (`kotlin_http4k`): 22 endpoints

## Tests
- `crystal spec spec/unit_test/miniparser/http4k_extractor_ts_spec.cr spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr spec/unit_test/miniparser/kotlin_ktor_route_extractor_ts_spec.cr`
- `crystal spec spec/functional_test/testers/kotlin/http4k_spec.cr`
- `crystal spec spec/functional_test/testers/kotlin/ktor_spec.cr`
- `crystal spec spec/functional_test/testers/kotlin/spring_spec.cr`
- `crystal tool format --check`
- `lib/ameba/bin/ameba.cr src/analyzer/analyzers/kotlin/http4k.cr src/analyzer/analyzers/kotlin/ktor.cr src/miniparsers/http4k_extractor_ts.cr src/miniparsers/kotlin_route_extractor_ts.cr spec/unit_test/miniparser/http4k_extractor_ts_spec.cr spec/unit_test/miniparser/kotlin_route_extractor_ts_spec.cr`
- `just build`

Notes:
- Full `just test` currently fails in unrelated Rust axum fixtures under `../clever-kilogram/...` (`/service/status`, `/internal/health` missing).
- Full `just check` reached Ameba over all 1568 files but the process was terminated by signal 15 in this environment; format check and changed-file Ameba pass.
