### PR TITLE
Improve Ruby analyzer non-production path filtering

### DIFF
--- a/spec/functional_test/fixtures/ruby/grape/spec/shared/fake_routes.rb
+++ b/spec/functional_test/fixtures/ruby/grape/spec/shared/fake_routes.rb
@@ -1,0 +1,5 @@
+class SpecOnlyAPI < Grape::API
+  get "/spec-only" do
+    "not production"
+  end
+end

--- a/spec/functional_test/fixtures/ruby/rails/spec/dummy/config/routes.rb
+++ b/spec/functional_test/fixtures/ruby/rails/spec/dummy/config/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  get "/dummy-spec-route", to: "dummy#index"
+end

--- a/spec/functional_test/fixtures/ruby/webrick/spec/support/fake_server.rb
+++ b/spec/functional_test/fixtures/ruby/webrick/spec/support/fake_server.rb
@@ -1,0 +1,7 @@
+require "webrick"
+
+server = WEBrick::HTTPServer.new
+
+server.mount_proc "/spec-helper" do |_req, res|
+  res.body = "not production"
+end

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -34,10 +34,7 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")
-        # Skip Minitest / RSpec test files — Grape's own
-        # `spec/grape/**/*_spec.rb` defines ~117 phantom routes
-        # that exercise the DSL via `Grape::API.new`.
-        next if RubyEngine.ruby_test_path?(path)
+        next if ruby_non_production_path?(path)
         content = read_file_content(path)
         next unless grape_api_file?(content, index.classes)
         mount_prefix = grape_file_mount_prefix(content, index)
@@ -74,7 +71,7 @@ module Analyzer::Ruby
 
       all_files.each do |path|
         next unless path.ends_with?(".rb")
-        next if RubyEngine.ruby_test_path?(path)
+        next if ruby_non_production_path?(path)
         next if File.directory?(path)
         content = read_file_content(path)
         # Only base-class definitions (`Grape::API`) and aggregators

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -97,7 +97,7 @@ module Analyzer::Ruby
     @known_files = Set(String).new
 
     def analyze
-      files = all_files
+      files = all_files.reject { |file| ruby_non_production_path?(file) }
       @known_files = Set(String).new(files)
       @engine_mount_prefixes = build_engine_mount_map(files)
 

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -26,10 +26,7 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb")
-        # Skip Minitest / RSpec test files — Roda's own
-        # `spec/plugin/*_spec.rb` parks ~46 phantom routes that
-        # exercise the routing tree via `Roda` subclasses.
-        next if RubyEngine.ruby_test_path?(path)
+        next if ruby_non_production_path?(path)
         analyze_file(path, include_callee)
       end
 

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -7,12 +7,7 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
-        # Minitest (`*_test.rb`) and RSpec (`*_spec.rb`) suites both
-        # register Sinatra routes from inline test apps purely to
-        # exercise the framework. Sinatra's own repo accounts for
-        # ~145 such routes; production code never adopts either
-        # filename convention so the suffix check is safe.
-        next if RubyEngine.ruby_test_path?(path)
+        next if ruby_non_production_path?(path)
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           lines = file.each_line.to_a
           active_route_endpoints = [] of Endpoint

--- a/src/analyzer/analyzers/ruby/webrick.cr
+++ b/src/analyzer/analyzers/ruby/webrick.cr
@@ -17,7 +17,7 @@ module Analyzer::Ruby
     # - Extracts params only from the handler body (query/header/cookie + form/json on body for mutating verbs).
     # - Skips FileHandler mounts (static).
     # - Supports req/request, res/response naming.
-    # - Reuses RubyEngine helpers (parallel_file_scan, ruby_test_path?, extract_ruby_do_block, attach, normalize).
+    # - Reuses RubyEngine helpers (parallel_file_scan, ruby_non_production_path?, extract_ruby_do_block, attach, normalize).
     # - Does not chase runtime req.path branches inside handlers for sub-paths (keeps v1 conservative + matches issue examples).
 
     SERVLET_METHODS = {
@@ -39,7 +39,7 @@ module Analyzer::Ruby
 
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
-        next if RubyEngine.ruby_test_path?(path)
+        next if ruby_non_production_path?(path)
         content = read_file_content(path)
         # Gate early on webrick signals (avoid unnecessary work + comment-only noise)
         next unless content.includes?("webrick") || content.includes?("WEBrick") || content.includes?("mount_proc")
@@ -54,7 +54,7 @@ module Analyzer::Ruby
 
       all_files.each do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
-        next if RubyEngine.ruby_test_path?(path)
+        next if ruby_non_production_path?(path)
         next if File.directory?(path)
         next unless File.exists?(path)
 

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -38,6 +38,48 @@ module Analyzer::Ruby
       false
     end
 
+    RUBY_NON_PRODUCTION_DIRS = Set{
+      "spec", "test", "tests", "features",
+      "benchmark", "benchmarks", "examples",
+      "coverage", "tmp",
+    }
+
+    # Whole-tree Ruby analyzers (Sinatra/Grape/Roda/WEBrick) otherwise see
+    # Rack test helpers, benchmark apps, and framework examples as live
+    # services. Match these directories only relative to the configured scan
+    # root so noir's own fixture tree under `spec/functional_test/fixtures`
+    # is not accidentally skipped when the fixture directory itself is the
+    # base path.
+    protected def ruby_non_production_path?(path : String) : Bool
+      return true if RubyEngine.ruby_test_path?(path)
+
+      relative = ruby_relative_path(path).gsub('\\', '/')
+      RUBY_NON_PRODUCTION_DIRS.any? do |dir|
+        relative == dir || relative.starts_with?("#{dir}/") || relative.includes?("/#{dir}/")
+      end
+    end
+
+    private def ruby_relative_path(path : String) : String
+      normalized = normalized_configured_base_for(path)
+      return File.basename(path) unless normalized
+
+      expanded = CodeLocator.instance.expanded_path_for(path)
+      return File.basename(path) unless Noir::PathScope.under_normalized_root?(expanded, normalized)
+
+      relative = expanded[normalized.size..].lchop(File::SEPARATOR)
+      relative.empty? ? File.basename(path) : relative
+    end
+
+    private def normalized_configured_base_for(path : String) : String?
+      return @normalized_base_paths.first?.try(&.[1]) if @normalized_base_paths.size <= 1
+
+      base = configured_base_for(path)
+      @normalized_base_paths.each do |candidate, normalized|
+        return normalized if candidate == base
+      end
+      nil
+    end
+
     # Match the `<verb> "<path>"` idiom on a single line and return the first
     # endpoint found, or an empty endpoint if none match. Shared by Hanami
     # and Sinatra (Rails uses a different per-line-multi-match shape).


### PR DESCRIPTION
## Summary
- Add a shared Ruby analyzer filter for project-relative non-production paths (`spec/`, `test/`, `benchmark/`, etc.) while preserving Noir fixtures scanned from their own base path.
- Apply the filter to Rails file discovery and Ruby whole-tree analyzers (Sinatra, Grape, Roda, WEBrick).
- Add regression fixtures for Rails `spec/dummy`, Grape `spec/shared`, and WEBrick `spec/support` false positives.

## OSS corpus checks
Scanned shallow clones under `/tmp/noir-ruby-corpus` with the built local `./bin/noir`:
- `discourse/discourse`: 1749 -> 1748 endpoints; removed only `GET /sso` from `spec/support/...` (`ruby_webrick` FP). Rails endpoints stayed at 1728.
- `ruby-grape/grape`: 7 -> 0 endpoints; removed spec/benchmark example routes (`/legacy`, `/version`, `/api/v1`, `/votes`, `/test`, `/api/v1/hello`).
- `mastodon/mastodon`: 690 -> 690 endpoints.
- `gollum/gollum`: 23 -> 23 endpoints.
- `hanami/bookshelf`: 4 -> 4 endpoints.

Ruby analyzer-only timings after the change:
- Discourse Rails: 2.12s
- Mastodon Rails: 0.51s
- Gollum Sinatra: 0.06s
- Grape: 0.11s

## Verification
- `just build`
- `just test` (unit 3601 + functional 19743 examples)
- `crystal build spec/functional_test/testers/ruby/*_spec.cr -o /tmp/noir-ruby-spec && /tmp/noir-ruby-spec` (938 Ruby examples)
- `crystal tool format --check`
- `lib/ameba/bin/ameba.cr src/analyzer/engines/ruby_engine.cr src/analyzer/analyzers/ruby/sinatra.cr src/analyzer/analyzers/ruby/grape.cr src/analyzer/analyzers/ruby/roda.cr src/analyzer/analyzers/ruby/webrick.cr src/analyzer/analyzers/ruby/rails.cr`

Note: full `just check` now completes in this environment as well; an earlier run was interrupted during Ameba, and the rerun inspected 1568 files with 0 failures.
