### PR TITLE
Remove unused leftover constants across the analyzers

### DIFF
--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -14,7 +14,6 @@ module Analyzer::Java
     REGEX_ROUTE_METHOD_HANDLER = /\.route\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*this::([\w$]+)\s*\)/i
     REGEX_ROUTE_ANY_HANDLER    = /(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
     REGEX_ROUTE_SUB_ROUTER     = /(\w+)\.route\s*\(([^)]*)\)\s*\.subRouter\s*\(/i
-    REGEX_ROUTER_INSTANCE      = /Router\s+(\w+)\s*=\s*Router\.router\(\s*[^)]*\s*\)/
     REGEX_MOUNTSUBPATH         = /(\w+)\.mountSubRouter\s*\(([^)]*)\)/i
     REGEX_STATIC_HANDLER_ROUTE = /(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\([^;]*StaticHandler\.create\s*\(/im
     HTTP_METHODS               = %w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE]

--- a/src/analyzer/analyzers/lua/lor.cr
+++ b/src/analyzer/analyzers/lua/lor.cr
@@ -29,7 +29,6 @@ module Analyzer::Lua
     # memoize the route matcher per app/router-variable alternation.
     @route_regexes = Hash(String, Regex).new
 
-    SUPPORTED_VERBS = %w[get post put delete patch head options trace]
     # `app:all(...)` matches every method; surface the common five (the same
     # fallback set the Lapis `app:match` analyzer uses).
     ALL_VERBS = %w[GET POST PUT DELETE PATCH]

--- a/src/analyzer/analyzers/php/hyperf.cr
+++ b/src/analyzer/analyzers/php/hyperf.cr
@@ -19,8 +19,6 @@ module Analyzer::Php
       "HeadMapping"    => "HEAD",
     }
 
-    PROCEDURAL_VERBS = %w[get post put patch delete options head]
-
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -10,9 +10,8 @@ module Analyzer::Python
     @visited_app_config_paths = Set(::String).new
 
     # Regular expressions for extracting Django URL configurations
-    REGEX_ROOT_URLCONF  = /\s*ROOT_URLCONF\s*=\s*r?['"]([^'"\\]*)['"]/
-    REGEX_ROUTE_MAPPING = /\b(?:url|path|re_path|register)\s*\(\s*r?['"]([^"']*)['"][^,]*,\s*([^),]*)/
-    REGEX_INCLUDE_URLS  = /\binclude\s*\(\s*r?['"]([^'"\\]*)['"]/
+    REGEX_ROOT_URLCONF = /\s*ROOT_URLCONF\s*=\s*r?['"]([^'"\\]*)['"]/
+    REGEX_INCLUDE_URLS = /\binclude\s*\(\s*r?['"]([^'"\\]*)['"]/
 
     # `def get(...)` / `async def post(...)` method heads in class-based
     # views. Precompiled — an interpolated literal would be recompiled on

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -17,16 +17,6 @@ module Analyzer::Rust
   # subtree for the warp::* call shapes, and assembles a single
   # `Endpoint` from them.
   class Warp < RustEngine
-    VERB_TO_METHOD = {
-      "get"     => "GET",
-      "post"    => "POST",
-      "put"     => "PUT",
-      "delete"  => "DELETE",
-      "patch"   => "PATCH",
-      "head"    => "HEAD",
-      "options" => "OPTIONS",
-    }
-
     @external_handler_callee_cache = {} of String => Array(Noir::RustCalleeExtractor::Entry)
     @external_handler_miss_cache = Set(String).new
     @external_handler_callee_cache_mutex = Mutex.new

--- a/src/analyzer/analyzers/specification/aws_cloudformation.cr
+++ b/src/analyzer/analyzers/specification/aws_cloudformation.cr
@@ -6,7 +6,6 @@ module Analyzer::Specification
     SAM_FUNCTION_TYPE     = "AWS::Serverless::Function"
     APIGW_RESOURCE_TYPE   = "AWS::ApiGateway::Resource"
     APIGW_METHOD_TYPE     = "AWS::ApiGateway::Method"
-    APIGW_RESTAPI_TYPE    = "AWS::ApiGateway::RestApi"
     APIGW_RESOURCE_PARENT = "ParentId"
 
     record ApigwResource, name : String, path_part : String, parent : String?

--- a/src/analyzer/analyzers/specification/nginx.cr
+++ b/src/analyzer/analyzers/specification/nginx.cr
@@ -9,7 +9,6 @@ module Analyzer::Specification
     LISTEN_TLS_RE   = /\bssl\b|\bhttp2\b/
     LISTEN_RE       = /^listen\b/
     METHOD_BLOCK_RE = /^if\s*\(\s*\$request_method\s*=\s*([A-Z]+)\s*\)/
-    PROXY_PASS_RE   = /^proxy_pass\s+([^;]+);?/
 
     def analyze
       spec_files = CodeLocator.instance.all("nginx-spec")

--- a/src/analyzer/analyzers/specification/wsdl.cr
+++ b/src/analyzer/analyzers/specification/wsdl.cr
@@ -4,7 +4,6 @@ require "../../../models/analyzer"
 
 module Analyzer::Specification
   class WSDL < Analyzer
-    SOAP11_NS        = "http://schemas.xmlsoap.org/wsdl/soap/"
     SOAP12_NS        = "http://schemas.xmlsoap.org/wsdl/soap12/"
     MAX_IMPORT_DEPTH = 8
 

--- a/src/analyzer/analyzers/typescript/trpc.cr
+++ b/src/analyzer/analyzers/typescript/trpc.cr
@@ -107,12 +107,6 @@ module Analyzer::Typescript
       result
     end
 
-    ROUTER_HINTS = [
-      "router(",
-      "router (",
-      "createTRPCRouter",
-    ]
-
     PROCEDURE_HINTS = [
       ".query(",
       ".query (",


### PR DESCRIPTION
## Description

Closes #2165.

Nine class-level constants are defined but never referenced anywhere in the codebase — each has exactly one repo-wide occurrence (its own definition). They're leftovers from refactors where the logic was inlined or replaced. Removing them is a cosmetic cleanup with no parsing-behavior change.

Each was grep-verified to occur exactly once before removal:

| File | Constant |
|------|----------|
| `src/analyzer/analyzers/specification/aws_cloudformation.cr` | `APIGW_RESTAPI_TYPE` |
| `src/analyzer/analyzers/rust/warp.cr` | `VERB_TO_METHOD` |
| `src/analyzer/analyzers/python/django.cr` | `REGEX_ROUTE_MAPPING` |
| `src/analyzer/analyzers/java/vertx.cr` | `REGEX_ROUTER_INSTANCE` |
| `src/analyzer/analyzers/specification/nginx.cr` | `PROXY_PASS_RE` |
| `src/analyzer/analyzers/php/hyperf.cr` | `PROCEDURAL_VERBS` |
| `src/analyzer/analyzers/lua/lor.cr` | `SUPPORTED_VERBS` |
| `src/analyzer/analyzers/typescript/trpc.cr` | `ROUTER_HINTS` |
| `src/analyzer/analyzers/specification/wsdl.cr` | `SOAP11_NS` |

Sibling constants in the same files remain in use, confirming these specific ones are genuine orphans.

## Verification

- `crystal tool format` — clean (only re-aligned `django.cr`'s remaining assignment group)
- `shards build` — passes
- `crystal run lib/ameba/bin/ameba.cr` on the 9 changed files — `0 failures`
- `crystal spec` for every affected analyzer's functional tests (warp, django, vertx, hyperf, lor, trpc, aws_cloudformation, nginx, wsdl) — `606 examples, 0 failures`