### PR TITLE
Reuse ALLOWED_HTTP_METHODS constant in Deliver

### DIFF
--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -1,6 +1,7 @@
 require "colorize"
 require "./logger"
 require "../utils/utils"
+require "../utils/http_symbols"
 
 class Deliver
   @logger : NoirLogger
@@ -152,9 +153,8 @@ class Deliver
     else
       # Check if pattern is just a method name
       upper_pattern = pattern.upcase
-      http_methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "CONNECT", "QUERY"]
 
-      if http_methods.includes?(upper_pattern)
+      if ALLOWED_HTTP_METHODS.includes?(upper_pattern)
         endpoint.method.upcase == upper_pattern
       else
         # Backward compatibility: check URL


### PR DESCRIPTION
## Description

Closes #2168.

`Deliver` builds an inline `http_methods` array (`src/models/deliver.cr`) holding the same 10 verbs as the shared `ALLOWED_HTTP_METHODS` constant already defined in `src/utils/http_symbols.cr`. The only difference is HEAD/OPTIONS ordering, which is irrelevant for the `.includes?(upper_pattern)` membership check, so reusing the constant removes the duplicated literal with no behavioral effect.

```crystal
# before
http_methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE", "CONNECT", "QUERY"]
if http_methods.includes?(upper_pattern)

# after
if ALLOWED_HTTP_METHODS.includes?(upper_pattern)
```

A `require "../utils/http_symbols"` is added since `deliver.cr` did not previously pull it in. `src/optimizer/optimizer.cr`'s `get_allowed_methods` is intentionally left untouched — it is a deliberate superset (adds ANY/PUBLISH/SUBSCRIBE/SEND/RECEIVE).

## Verification

- `crystal tool format` — clean
- `shards build` — passes
- `crystal run lib/ameba/bin/ameba.cr` on `deliver.cr` — `0 failures`
- `crystal spec spec/unit_test/models/deliver_spec.cr` — `21 examples, 0 failures`