### PR TITLE
Add debug logging to silent rescue blocks in the specification detectors

### DIFF
--- a/src/detector/detectors/specification/asyncapi.cr
+++ b/src/detector/detectors/specification/asyncapi.cr
@@ -18,7 +18,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("asyncapi-json", filename)
           end
-        rescue
+        rescue e
+          logger.debug "AsyncAPI JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         begin
@@ -29,7 +30,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("asyncapi-yaml", filename)
           end
-        rescue
+        rescue e
+          logger.debug "AsyncAPI YAML detection failed for #{filename}: #{e}"
         end
       end
 

--- a/src/detector/detectors/specification/har.cr
+++ b/src/detector/detectors/specification/har.cr
@@ -16,7 +16,8 @@ module Detector::Specification
               locator.push("har-path", filename)
               return true
             end
-          rescue
+          rescue e
+            logger.debug "HAR detection failed for #{filename}: #{e}"
           end
         end
       end

--- a/src/detector/detectors/specification/insomnia.cr
+++ b/src/detector/detectors/specification/insomnia.cr
@@ -19,7 +19,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("insomnia-json", filename)
           end
-        rescue
+        rescue e
+          logger.debug "Insomnia JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         return false unless file_contents.includes?(".insomnia.rest/")
@@ -37,7 +38,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("insomnia-yaml", filename)
           end
-        rescue
+        rescue e
+          logger.debug "Insomnia YAML detection failed for #{filename}: #{e}"
         end
       end
 

--- a/src/detector/detectors/specification/kong.cr
+++ b/src/detector/detectors/specification/kong.cr
@@ -14,7 +14,8 @@ module Detector::Specification
           CodeLocator.instance.push("kong-spec", filename)
           return true
         end
-      rescue
+      rescue e
+        logger.debug "Kong detection failed for #{filename}: #{e}"
       end
 
       false

--- a/src/detector/detectors/specification/oas2.cr
+++ b/src/detector/detectors/specification/oas2.cr
@@ -17,7 +17,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("swagger-json", filename)
           end
-        rescue
+        rescue e
+          logger.debug "OAS2 JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         begin
@@ -27,7 +28,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("swagger-yaml", filename)
           end
-        rescue
+        rescue e
+          logger.debug "OAS2 YAML detection failed for #{filename}: #{e}"
         end
       end
 

--- a/src/detector/detectors/specification/oas3.cr
+++ b/src/detector/detectors/specification/oas3.cr
@@ -17,7 +17,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("oas3-json", filename)
           end
-        rescue
+        rescue e
+          logger.debug "OAS3 JSON detection failed for #{filename}: #{e}"
         end
       elsif filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         begin
@@ -27,7 +28,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("oas3-yaml", filename)
           end
-        rescue
+        rescue e
+          logger.debug "OAS3 YAML detection failed for #{filename}: #{e}"
         end
       end
 

--- a/src/detector/detectors/specification/postman.cr
+++ b/src/detector/detectors/specification/postman.cr
@@ -23,7 +23,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("postman-json", filename)
           end
-        rescue
+        rescue e
+          logger.debug "Postman detection failed for #{filename}: #{e}"
         end
       end
 

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -14,7 +14,8 @@ module Detector::Specification
               check = true
               locator = CodeLocator.instance
               locator.push("raml-spec", filename)
-            rescue
+            rescue e
+              logger.debug "RAML detection failed for #{filename}: #{e}"
             end
           end
         end

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -15,7 +15,8 @@ module Detector::Specification
             locator = CodeLocator.instance
             locator.push("zap-sites-tree", filename)
           end
-        rescue
+        rescue e
+          logger.debug "ZAP sites-tree detection failed for #{filename}: #{e}"
         end
       end
 


### PR DESCRIPTION
## Description

Closes #2167.

The specification-format detectors wrap their `JSON.parse` / `YAML.parse` calls in `begin ... rescue\nend` with completely empty rescue bodies, so a spec-looking-but-unparseable file vanishes from detection with no diagnostic. This binds the exception and adds one `logger.debug` line per rescue, explaining why a near-miss spec file was not picked up.

Detection behavior is **byte-identical** — each rescue still falls through to its existing graceful skip; only `--debug` visibility is added. The `logger` getter is inherited from the base `Detector`. This mirrors the already-merged rescue-logging fixes.

Files touched (13 rescue blocks across 9 detectors):

`oas3.cr`, `oas2.cr`, `asyncapi.cr`, `insomnia.cr` (JSON + YAML paths each), `har.cr`, `kong.cr`, `postman.cr`, `raml.cr`, `zap_sites_tree.cr`.

In `zap_sites_tree.cr` the `YAML.parse` is outside the begin/rescue — only the existing empty rescue body was touched, as noted in the issue.

## Verification

- `crystal tool format` — no-op (correct indentation)
- `shards build` — passes
- `crystal run lib/ameba/bin/ameba.cr` on `src/detector/detectors/specification/` — `36 inspected, 0 failures`
- `crystal spec spec/unit_test/detector/specification/` — `145 examples, 0 failures`
- functional detection specs for all 9 formats — `617 examples, 0 failures`