### PR TITLE
Add debug logging to silent rescue blocks in the specification analyzers

### DIFF
--- a/src/analyzer/analyzers/specification/burp.cr
+++ b/src/analyzer/analyzers/specification/burp.cr
@@ -154,7 +154,8 @@ module Analyzer::Specification
           query = uri.query
           normalized = path.empty? ? "/" : path
           normalized = "#{normalized}?#{query}" if query && !query.empty?
-        rescue
+        rescue e
+          logger.debug "Failed to parse Burp target URL '#{target}': #{e}"
         end
       end
 
@@ -239,7 +240,8 @@ module Analyzer::Specification
             push_unique(endpoint, Param.new(key, "", "json"))
           end
         end
-      rescue
+      rescue e
+        logger.debug "Failed to parse Burp JSON body for #{endpoint.url}: #{e}"
       end
     end
 

--- a/src/analyzer/analyzers/specification/caido.cr
+++ b/src/analyzer/analyzers/specification/caido.cr
@@ -159,7 +159,8 @@ module Analyzer::Specification
           if h = parsed.as_h?
             h.each { |k, _| params << Param.new(k, "", "json") }
           end
-        rescue
+        rescue e
+          logger.debug "Failed to parse Caido JSON body: #{e}"
         end
       when content_type.includes?("application/x-www-form-urlencoded")
         body_str = String.new(body_bytes, encoding: "UTF-8", invalid: :skip)

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -337,7 +337,8 @@ module Analyzer::Specification
           uri = URI.parse(stripped)
           path = uri.path
           return normalize_path(path.empty? ? "/" : path)
-        rescue
+        rescue e
+          logger.debug "Failed to parse Insomnia URL '#{stripped}': #{e}"
         end
       elsif stripped =~ /^[A-Za-z][A-Za-z0-9+.-]*:\/\//
         return ""
@@ -363,7 +364,8 @@ module Analyzer::Specification
       begin
         uri = URI.parse(url_string)
         query = uri.query || ""
-      rescue
+      rescue e
+        logger.debug "Failed to parse Insomnia query URL '#{url_string}': #{e}"
       end
 
       if query.empty?
@@ -430,7 +432,8 @@ module Analyzer::Specification
       if h = parsed.as_h?
         h.each { |k, _| add_param(params, k, "", "json") }
       end
-    rescue
+    rescue e
+      logger.debug "Failed to parse Insomnia JSON body: #{e}"
     end
 
     private def process_json_auth(auth : JSON::Any, params : Array(Param))

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -235,7 +235,8 @@ module Analyzer::Specification
         if path = uri.path
           return normalize_path(path) unless path.empty?
         end
-      rescue
+      rescue e
+        logger.debug "Failed to parse Postman URL '#{stripped}': #{e}"
       end
 
       if scheme_idx = stripped.index("://")
@@ -292,7 +293,8 @@ module Analyzer::Specification
         URI::Params.parse(query).each do |key, value|
           params << Param.new(key, value, "query") unless key.empty?
         end
-      rescue
+      rescue e
+        logger.debug "Failed to parse Postman query params from '#{url_string}': #{e}"
       end
       params
     end

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -39,7 +39,8 @@ module Analyzer::Specification
           extract_dynamic_config_rules(data).each { |rule| parse_rule(rule, details, seen) }
           extract_compose_label_rules(data).each { |rule| parse_rule(rule, details, seen) }
           extract_ingress_route_rules(data).each { |rule| parse_rule(rule, details, seen) }
-        rescue
+        rescue e
+          logger.debug "Failed to parse Traefik YAML document: #{e}"
         end
       end
     end

--- a/src/analyzer/analyzers/specification/wsdl.cr
+++ b/src/analyzer/analyzers/specification/wsdl.cr
@@ -306,7 +306,8 @@ module Analyzer::Specification
         if uri.scheme && uri.host
           return uri.path || ""
         end
-      rescue
+      rescue e
+        logger.debug "Failed to parse WSDL location '#{location}': #{e}"
       end
       location
     end

--- a/src/analyzer/analyzers/specification/zap_sites_tree.cr
+++ b/src/analyzer/analyzers/specification/zap_sites_tree.cr
@@ -50,7 +50,8 @@ module Analyzer::Specification
                 param_name = param.split("=")[0]
                 params << Param.new(param_name.to_s, "", "form")
               end
-            rescue
+            rescue e
+              logger.debug "Failed to parse ZAP query params for #{path}: #{e}"
             end
           end
 


### PR DESCRIPTION
## Description

Closes #2166.

Several specification analyzers wrap `URI.parse` / `JSON.parse` / YAML-walk calls in empty `rescue\nend` bodies, so a malformed URL or body inside an otherwise-valid spec is silently skipped with no trace. This binds the exception and adds a `logger.debug` line so these near-misses surface under `--debug`.

Behavior is unchanged — each rescue still falls through to its existing graceful skip; only `--debug` visibility is added. Raw request bodies are intentionally **not** logged (only the exception and, where useful, an in-scope URL/path). The `logger` getter is inherited from the base `Analyzer`.

Sites touched (10 rescue blocks across 7 analyzers):

| File | Sites |
|------|-------|
| `burp.cr` | target URL parse, JSON body parse |
| `insomnia.cr` | URL path extract, query-param extract, JSON body parse |
| `postman.cr` | URL path extract, query-param parse |
| `caido.cr` | JSON body parse |
| `traefik.cr` | YAML document parse |
| `wsdl.cr` | SOAP location parse |
| `zap_sites_tree.cr` | query-param split loop |

## Verification

- `crystal tool format` — no-op (correct indentation)
- `shards build` — passes
- `crystal run lib/ameba/bin/ameba.cr` on the 7 changed files — `0 failures`
- functional specs for all 7 analyzers — `246 examples, 0 failures`