### PR TITLE
Fix Kubernetes Ingress default method

### DIFF
--- a/spec/functional_test/testers/specification/k8s_ingress_spec.cr
+++ b/spec/functional_test/testers/specification/k8s_ingress_spec.cr
@@ -1,9 +1,9 @@
 require "../../func_spec.cr"
 
 expected_endpoints = [
-  Endpoint.new("/v1/users", "ANY"),
-  Endpoint.new("/admin", "ANY"),
-  Endpoint.new("/metrics", "ANY"),
+  Endpoint.new("/v1/users", "GET"),
+  Endpoint.new("/admin", "GET"),
+  Endpoint.new("/metrics", "GET"),
 ]
 
 FunctionalTester.new("fixtures/specification/k8s_ingress/", {

--- a/spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
+++ b/spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
@@ -40,7 +40,7 @@ describe "Kubernetes Ingress Analyzer" do
 
     endpoints.map(&.url).sort!.should eq ["/v1/users", "/v1/users/.*"]
     endpoints.each do |e|
-      e.method.should eq "ANY"
+      e.method.should eq "GET"
       tag_descriptions(e, "ingress-host").should eq ["api.example.com"]
     end
   end
@@ -130,6 +130,7 @@ describe "Kubernetes Ingress Analyzer" do
       YAML
 
     endpoints.map(&.url).sort!.should eq ["/", "/"]
+    endpoints.map(&.method).should eq ["GET", "GET"]
     tag_descriptions(endpoints[0], "ingress-source").should eq ["default-backend"]
     tag_descriptions(endpoints[1], "ingress-source").should eq ["rule"]
   end

--- a/src/analyzer/analyzers/specification/k8s_ingress.cr
+++ b/src/analyzer/analyzers/specification/k8s_ingress.cr
@@ -2,7 +2,7 @@ require "../../../models/analyzer"
 
 module Analyzer::Specification
   class K8sIngress < Analyzer
-    METHOD_ANY         = "ANY"
+    DEFAULT_METHOD     = "GET"
     REWRITE_ANNOTATION = "nginx.ingress.kubernetes.io/rewrite-target"
     DEFAULT_PATH_TYPE  = "ImplementationSpecific"
     API_VERSION_LINE   = /(?m)^[ \t-]*apiVersion:\s*["']?(?:networking\.k8s\.io\/[^"'\s#]+|extensions\/v1beta1)["']?\s*(?:#.*)?$/
@@ -126,7 +126,7 @@ module Analyzer::Specification
     end
 
     private def emit_endpoint(path : String, path_type : String, host : String, tls_hosts : Set(String), details : Details, origin : String = "rule")
-      endpoint = Endpoint.new(path, METHOD_ANY, details)
+      endpoint = Endpoint.new(path, DEFAULT_METHOD, details)
       endpoint.add_tag(Tag.new("ingress-path-type", path_type.downcase, "k8s_ingress_analyzer"))
       endpoint.add_tag(Tag.new("ingress-host", host, "k8s_ingress_analyzer")) unless host.empty?
       endpoint.add_tag(Tag.new("ingress-source", origin, "k8s_ingress_analyzer"))


### PR DESCRIPTION
## Summary
- default Kubernetes Ingress endpoints to GET instead of synthetic ANY
- update unit and functional expectations for Ingress paths/defaultBackend

## Tests
- crystal spec spec/unit_test/analyzer/specification/k8s_ingress_spec.cr
- crystal spec spec/functional_test/testers/specification/k8s_ingress_spec.cr
- crystal tool format --check src/analyzer/analyzers/specification/k8s_ingress.cr spec/unit_test/analyzer/specification/k8s_ingress_spec.cr spec/functional_test/testers/specification/k8s_ingress_spec.cr
- just test
- just build