### PR TITLE
Expand synthetic ANY methods in request consumers

### DIFF
--- a/spec/unit_test/deliver/send_proxy_spec.cr
+++ b/spec/unit_test/deliver/send_proxy_spec.cr
@@ -84,6 +84,21 @@ describe SendWithProxy do
     end
   end
 
+  it "expands synthetic ANY endpoints before routing through the proxy" do
+    proxy = StubProxy.new
+    begin
+      ep = Endpoint.new("http://example.test/wildcard", "ANY")
+      sender = SendWithProxy.new(base_deliver_options(proxy.url))
+      sender.run([ep])
+
+      methods = proxy.requests.map(&.[:method]).sort!
+      methods.should eq(WILDCARD_HTTP_METHODS.sort)
+      methods.includes?("ANY").should be_false
+    ensure
+      proxy.close
+    end
+  end
+
   it "swallows proxy connection errors so the batch finishes" do
     # Point at a port nobody's listening on. send_proxy must rescue
     # the connect failure and not hang the WaitGroup.

--- a/spec/unit_test/deliver/send_req_spec.cr
+++ b/spec/unit_test/deliver/send_req_spec.cr
@@ -149,6 +149,22 @@ describe SendReq do
     end
   end
 
+  it "expands synthetic ANY endpoints before sending requests" do
+    server = CapturingServer.new
+    begin
+      ep = Endpoint.new(server.url_for("/wildcard"), "ANY")
+
+      sender = SendReq.new(base_deliver_options)
+      sender.run([ep])
+
+      methods = server.requests.map(&.[:method]).sort!
+      methods.should eq(WILDCARD_HTTP_METHODS.sort)
+      methods.includes?("ANY").should be_false
+    ensure
+      server.close
+    end
+  end
+
   it "applies matchers before sending and skips non-matching endpoints" do
     server = CapturingServer.new
     begin

--- a/spec/unit_test/output_builder/curl_spec.cr
+++ b/spec/unit_test/output_builder/curl_spec.cr
@@ -49,4 +49,23 @@ describe "OutputBuilderCurl" do
     put_line.should contain("--data-raw 'name=Updated Product&price=99.99'")
     put_line.should contain("-H 'Content-Type: application/x-www-form-urlencoded'")
   end
+
+  it "expands synthetic ANY methods into concrete curl commands" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderCurl.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/wildcard", "ANY")])
+    lines = builder.io.to_s.split("\n").reject(&.empty?)
+
+    lines.size.should eq(WILDCARD_HTTP_METHODS.size)
+    lines.map { |line| line.split("'")[1] }.should eq(WILDCARD_HTTP_METHODS)
+    lines.any?(&.includes?("'ANY'")).should be_false
+  end
 end

--- a/spec/unit_test/output_builder/httpie_spec.cr
+++ b/spec/unit_test/output_builder/httpie_spec.cr
@@ -59,4 +59,23 @@ describe "OutputBuilderHttpie" do
     put_line.should contain("/api/products")
     put_line.should contain("'name=Updated Product'")
   end
+
+  it "expands synthetic ANY methods into concrete httpie commands" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHttpie.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/wildcard", "ANY")])
+    lines = builder.io.to_s.split("\n").reject(&.empty?)
+
+    lines.size.should eq(WILDCARD_HTTP_METHODS.size)
+    lines.map { |line| line.split("'")[1] }.should eq(WILDCARD_HTTP_METHODS)
+    lines.any?(&.includes?("'ANY'")).should be_false
+  end
 end

--- a/spec/unit_test/output_builder/powershell_spec.cr
+++ b/spec/unit_test/output_builder/powershell_spec.cr
@@ -60,4 +60,23 @@ describe "OutputBuilderPowershell" do
     put_line.should contain("name=Updated Product")
     put_line.should contain("application/x-www-form-urlencoded")
   end
+
+  it "expands synthetic ANY methods into concrete PowerShell commands" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderPowershell.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/wildcard", "ANY")])
+    lines = builder.io.to_s.split("\n").reject(&.empty?)
+
+    lines.size.should eq(WILDCARD_HTTP_METHODS.size)
+    lines.map { |line| line.split("\"")[1] }.should eq(WILDCARD_HTTP_METHODS)
+    lines.any?(&.includes?("\"ANY\"")).should be_false
+  end
 end

--- a/spec/unit_test/utils/http_symbols_spec.cr
+++ b/spec/unit_test/utils/http_symbols_spec.cr
@@ -40,4 +40,19 @@ describe "http_symbols test" do
   it "QUERY" do
     get_symbol("QUERY").should eq(:query)
   end
+
+  it "expands synthetic wildcard methods to concrete HTTP methods" do
+    expand_synthetic_http_methods("ANY").should eq(WILDCARD_HTTP_METHODS)
+    expand_synthetic_http_methods("all").should eq(WILDCARD_HTTP_METHODS)
+    expand_synthetic_http_methods("*").should eq(WILDCARD_HTTP_METHODS)
+  end
+
+  it "keeps explicit methods as a single concrete method" do
+    expand_synthetic_http_methods("post").should eq(["POST"])
+  end
+
+  it "only returns methods that active delivery can send" do
+    requestable_http_methods("ANY").should eq(WILDCARD_HTTP_METHODS)
+    requestable_http_methods("SEARCH").should eq([] of String)
+  end
 end

--- a/src/deliver/send_proxy.cr
+++ b/src/deliver/send_proxy.cr
@@ -11,47 +11,49 @@ class SendWithProxy < Deliver
 
     applied_endpoints.each do |endpoint|
       next if endpoint.mobile? # can't replay an app deep link through an HTTP proxy
-      wg.add(1)
-      spawn do
-        begin
-          if !endpoint.params.empty?
-            endpoint_hash = endpoint.params_to_hash
-            is_json = false
-            body = if !endpoint_hash["json"].empty?
-                     is_json = true
-                     endpoint_hash["json"]
-                   else
-                     endpoint_hash["form"]
-                   end
+      requestable_http_methods(endpoint.method).each do |request_method|
+        wg.add(1)
+        spawn do
+          begin
+            if !endpoint.params.empty?
+              endpoint_hash = endpoint.params_to_hash
+              is_json = false
+              body = if !endpoint_hash["json"].empty?
+                       is_json = true
+                       endpoint_hash["json"]
+                     else
+                       endpoint_hash["form"]
+                     end
 
-            Crest::Request.execute(
-              method: get_symbol(endpoint.method),
-              url: endpoint.url,
-              p_addr: proxy_url.host,
-              p_port: proxy_url.port,
-              tls: OpenSSL::SSL::Context::Client.insecure,
-              user_agent: "Noir/#{Noir::VERSION}",
-              params: endpoint_hash["query"],
-              headers: @headers,
-              form: body,
-              json: is_json
-            )
-          else
-            Crest::Request.execute(
-              method: get_symbol(endpoint.method),
-              url: endpoint.url,
-              p_addr: proxy_url.host,
-              p_port: proxy_url.port,
-              headers: @headers,
-              tls: OpenSSL::SSL::Context::Client.insecure,
-              user_agent: "Noir/#{Noir::VERSION}"
-            )
+              Crest::Request.execute(
+                method: get_symbol(request_method),
+                url: endpoint.url,
+                p_addr: proxy_url.host,
+                p_port: proxy_url.port,
+                tls: OpenSSL::SSL::Context::Client.insecure,
+                user_agent: "Noir/#{Noir::VERSION}",
+                params: endpoint_hash["query"],
+                headers: @headers,
+                form: body,
+                json: is_json
+              )
+            else
+              Crest::Request.execute(
+                method: get_symbol(request_method),
+                url: endpoint.url,
+                p_addr: proxy_url.host,
+                p_port: proxy_url.port,
+                headers: @headers,
+                tls: OpenSSL::SSL::Context::Client.insecure,
+                user_agent: "Noir/#{Noir::VERSION}"
+              )
+            end
+          rescue e
+            @logger.debug "Exception during proxy delivery"
+            @logger.debug_sub e
+          ensure
+            wg.done
           end
-        rescue e
-          @logger.debug "Exception during proxy delivery"
-          @logger.debug_sub e
-        ensure
-          wg.done
         end
       end
     end

--- a/src/deliver/send_req.cr
+++ b/src/deliver/send_req.cr
@@ -10,43 +10,45 @@ class SendReq < Deliver
 
     applied_endpoints.each do |endpoint|
       next if endpoint.mobile? # can't HTTP-probe an app deep link
-      wg.add(1)
-      spawn do
-        begin
-          if endpoint.params.size > 0
-            endpoint_hash = endpoint.params_to_hash
-            is_json = false
-            body = if endpoint_hash["json"].size > 0
-                     is_json = true
-                     endpoint_hash["json"]
-                   else
-                     endpoint_hash["form"]
-                   end
+      requestable_http_methods(endpoint.method).each do |request_method|
+        wg.add(1)
+        spawn do
+          begin
+            if endpoint.params.size > 0
+              endpoint_hash = endpoint.params_to_hash
+              is_json = false
+              body = if endpoint_hash["json"].size > 0
+                       is_json = true
+                       endpoint_hash["json"]
+                     else
+                       endpoint_hash["form"]
+                     end
 
-            Crest::Request.execute(
-              method: get_symbol(endpoint.method),
-              url: endpoint.url,
-              tls: OpenSSL::SSL::Context::Client.insecure,
-              user_agent: "Noir/#{Noir::VERSION}",
-              params: endpoint_hash["query"],
-              form: body,
-              headers: @headers,
-              json: is_json
-            )
-          else
-            Crest::Request.execute(
-              method: get_symbol(endpoint.method),
-              url: endpoint.url,
-              headers: @headers,
-              tls: OpenSSL::SSL::Context::Client.insecure,
-              user_agent: "Noir/#{Noir::VERSION}"
-            )
+              Crest::Request.execute(
+                method: get_symbol(request_method),
+                url: endpoint.url,
+                tls: OpenSSL::SSL::Context::Client.insecure,
+                user_agent: "Noir/#{Noir::VERSION}",
+                params: endpoint_hash["query"],
+                form: body,
+                headers: @headers,
+                json: is_json
+              )
+            else
+              Crest::Request.execute(
+                method: get_symbol(request_method),
+                url: endpoint.url,
+                headers: @headers,
+                tls: OpenSSL::SSL::Context::Client.insecure,
+                user_agent: "Noir/#{Noir::VERSION}"
+              )
+            end
+          rescue e
+            @logger.debug "Exception during request delivery"
+            @logger.debug_sub e
+          ensure
+            wg.done
           end
-        rescue e
-          @logger.debug "Exception during request delivery"
-          @logger.debug_sub e
-        ensure
-          wg.done
         end
       end
     end

--- a/src/output_builder/curl.cr
+++ b/src/output_builder/curl.cr
@@ -1,5 +1,6 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "../utils/http_symbols"
 
 class OutputBuilderCurl < OutputBuilder
   def print(endpoints : Array(Endpoint))
@@ -7,33 +8,35 @@ class OutputBuilderCurl < OutputBuilder
       next if endpoint.mobile? # mobile deep links aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
-      parts = ["curl", "-i", "-X", shell_quote(endpoint.method), shell_quote(baked[:url])]
+      expand_synthetic_http_methods(endpoint.method).each do |method|
+        parts = ["curl", "-i", "-X", shell_quote(method), shell_quote(baked[:url])]
 
-      unless baked[:body].empty?
-        if baked[:body_type] == "json"
-          parts << "--data-raw"
-          parts << shell_quote(baked[:body])
-          parts << "-H"
-          parts << shell_quote("Content-Type: application/json")
-        else
-          parts << "--data-raw"
-          parts << shell_quote(baked[:body])
-          parts << "-H"
-          parts << shell_quote("Content-Type: application/x-www-form-urlencoded")
+        unless baked[:body].empty?
+          if baked[:body_type] == "json"
+            parts << "--data-raw"
+            parts << shell_quote(baked[:body])
+            parts << "-H"
+            parts << shell_quote("Content-Type: application/json")
+          else
+            parts << "--data-raw"
+            parts << shell_quote(baked[:body])
+            parts << "-H"
+            parts << shell_quote("Content-Type: application/x-www-form-urlencoded")
+          end
         end
-      end
 
-      baked[:header].each do |header|
-        parts << "-H"
-        parts << shell_quote(header)
-      end
+        baked[:header].each do |header|
+          parts << "-H"
+          parts << shell_quote(header)
+        end
 
-      baked[:cookie].each do |cookie|
-        parts << "--cookie"
-        parts << shell_quote(cookie)
-      end
+        baked[:cookie].each do |cookie|
+          parts << "--cookie"
+          parts << shell_quote(cookie)
+        end
 
-      ob_puts parts.join(" ")
+        ob_puts parts.join(" ")
+      end
     end
   end
 

--- a/src/output_builder/httpie.cr
+++ b/src/output_builder/httpie.cr
@@ -1,5 +1,6 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "../utils/http_symbols"
 require "json"
 
 class OutputBuilderHttpie < OutputBuilder
@@ -8,7 +9,7 @@ class OutputBuilderHttpie < OutputBuilder
       next if endpoint.mobile? # mobile deep links aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
-      parts = ["http"]
+      option_parts = [] of String
       request_items = [] of String
 
       unless baked[:body].empty?
@@ -24,17 +25,17 @@ class OutputBuilderHttpie < OutputBuilder
                 end
               end
             else
-              parts << "--raw"
-              parts << shell_quote(baked[:body])
+              option_parts << "--raw"
+              option_parts << shell_quote(baked[:body])
               request_items << shell_quote("Content-Type:application/json")
             end
           rescue
-            parts << "--raw"
-            parts << shell_quote(baked[:body])
+            option_parts << "--raw"
+            option_parts << shell_quote(baked[:body])
             request_items << shell_quote("Content-Type:application/json")
           end
         else
-          parts << "--form"
+          option_parts << "--form"
           form_parts = baked[:body].split('&')
           form_parts.each do |part|
             if part.includes?('=')
@@ -44,20 +45,24 @@ class OutputBuilderHttpie < OutputBuilder
         end
       end
 
-      parts << shell_quote(endpoint.method)
-      parts << shell_quote(baked[:url])
-      parts.concat(request_items)
+      expand_synthetic_http_methods(endpoint.method).each do |method|
+        parts = ["http"]
+        parts.concat(option_parts)
+        parts << shell_quote(method)
+        parts << shell_quote(baked[:url])
+        parts.concat(request_items)
 
-      baked[:header].each do |header|
-        parts << shell_quote(header)
+        baked[:header].each do |header|
+          parts << shell_quote(header)
+        end
+
+        unless baked[:cookie].empty?
+          cookie_value = baked[:cookie].join("; ")
+          parts << shell_quote("Cookie:#{cookie_value}")
+        end
+
+        ob_puts parts.join(" ")
       end
-
-      unless baked[:cookie].empty?
-        cookie_value = baked[:cookie].join("; ")
-        parts << shell_quote("Cookie:#{cookie_value}")
-      end
-
-      ob_puts parts.join(" ")
     end
   end
 

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -1,9 +1,10 @@
 require "json"
 require "uri"
+require "../utils/http_symbols"
 
 module OutputBuilderOasCommon
   VALID_OPERATION_METHODS = Set{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
-  ANY_OPERATION_METHODS   = %w[get post put patch delete options head trace]
+  ANY_OPERATION_METHODS   = WILDCARD_HTTP_METHODS.map(&.downcase)
 
   private def normalize_oas_path(raw_url : String) : String
     uri = URI.parse(raw_url)

--- a/src/output_builder/powershell.cr
+++ b/src/output_builder/powershell.cr
@@ -1,5 +1,6 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "../utils/http_symbols"
 
 class OutputBuilderPowershell < OutputBuilder
   def print(endpoints : Array(Endpoint))
@@ -7,46 +8,48 @@ class OutputBuilderPowershell < OutputBuilder
       next if endpoint.mobile? # mobile deep links aren't HTTP requests
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
-      cmd = "Invoke-WebRequest -Method \"#{escape_powershell(endpoint.method)}\" -Uri \"#{escape_powershell(baked[:url])}\""
+      expand_synthetic_http_methods(endpoint.method).each do |method|
+        cmd = "Invoke-WebRequest -Method \"#{escape_powershell(method)}\" -Uri \"#{escape_powershell(baked[:url])}\""
 
-      # Build headers hash including cookies
-      header_parts = [] of String
+        # Build headers hash including cookies
+        header_parts = [] of String
 
-      # Add cookies as Cookie header
-      if !baked[:cookie].empty?
-        cookie_header = baked[:cookie].map { |c| escape_powershell(c) }.join("; ")
-        header_parts << "\"Cookie\"=\"#{cookie_header}\""
-      end
-
-      # Add other headers
-      baked[:header].each do |h|
-        parts = h.split(": ", 2)
-        if parts.size == 2
-          header_parts << "\"#{escape_powershell(parts[0])}\"=\"#{escape_powershell(parts[1])}\""
-        else
-          header_parts << "\"#{escape_powershell(h)}\"=\"\""
+        # Add cookies as Cookie header
+        if !baked[:cookie].empty?
+          cookie_header = baked[:cookie].map { |c| escape_powershell(c) }.join("; ")
+          header_parts << "\"Cookie\"=\"#{cookie_header}\""
         end
-      end
 
-      # Add headers if present
-      if !header_parts.empty?
-        cmd += " -Headers @{#{header_parts.join("; ")}}"
-      end
-
-      # Add body
-      if !baked[:body].empty?
-        if baked[:body_type] == "json"
-          # Escape for PowerShell string
-          escaped_body = escape_powershell(baked[:body])
-          cmd += " -Body \"#{escaped_body}\" -ContentType \"application/json\""
-        else
-          # Form data
-          escaped_body = escape_powershell(baked[:body])
-          cmd += " -Body \"#{escaped_body}\" -ContentType \"application/x-www-form-urlencoded\""
+        # Add other headers
+        baked[:header].each do |h|
+          parts = h.split(": ", 2)
+          if parts.size == 2
+            header_parts << "\"#{escape_powershell(parts[0])}\"=\"#{escape_powershell(parts[1])}\""
+          else
+            header_parts << "\"#{escape_powershell(h)}\"=\"\""
+          end
         end
-      end
 
-      ob_puts cmd
+        # Add headers if present
+        if !header_parts.empty?
+          cmd += " -Headers @{#{header_parts.join("; ")}}"
+        end
+
+        # Add body
+        if !baked[:body].empty?
+          if baked[:body_type] == "json"
+            # Escape for PowerShell string
+            escaped_body = escape_powershell(baked[:body])
+            cmd += " -Body \"#{escaped_body}\" -ContentType \"application/json\""
+          else
+            # Form data
+            escaped_body = escape_powershell(baked[:body])
+            cmd += " -Body \"#{escaped_body}\" -ContentType \"application/x-www-form-urlencoded\""
+          end
+        end
+
+        ob_puts cmd
+      end
     end
   end
 

--- a/src/utils/http_symbols.cr
+++ b/src/utils/http_symbols.cr
@@ -1,3 +1,6 @@
+WILDCARD_HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD", "TRACE"]
+SYNTHETIC_ANY_METHODS = ["ANY", "ALL", "*"]
+
 def get_symbol(method : String)
   symbol = {
     "GET"     => :get,
@@ -19,4 +22,19 @@ ALLOWED_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEA
 
 def get_allowed_methods
   ALLOWED_HTTP_METHODS
+end
+
+def synthetic_any_method?(method : String) : Bool
+  SYNTHETIC_ANY_METHODS.includes?(method.upcase)
+end
+
+def expand_synthetic_http_methods(method : String) : Array(String)
+  normalized = method.upcase
+  return WILDCARD_HTTP_METHODS if synthetic_any_method?(normalized)
+
+  [normalized]
+end
+
+def requestable_http_methods(method : String) : Array(String)
+  expand_synthetic_http_methods(method).select { |candidate| ALLOWED_HTTP_METHODS.includes?(candidate) }
 end


### PR DESCRIPTION
## Summary
- add shared helpers for synthetic wildcard methods (`ANY`, `ALL`, `*`)
- expand synthetic wildcard methods into concrete HTTP methods for curl/httpie/PowerShell output
- expand synthetic wildcard methods before active request/proxy delivery, avoiding non-HTTP `ANY` requests
- reuse the shared wildcard method list for OpenAPI operation expansion

## ANY audit notes
- Go/Rust and several framework analyzers already fan out `any/all` routes internally.
- Several analyzers still preserve `ANY` as a synthetic endpoint method for route declarations that truly match multiple methods or have no method constraint.
- This PR keeps that internal model stable but prevents request-producing consumers from emitting or sending `ANY` as if it were a real HTTP method.

## Tests
- crystal spec spec/unit_test/utils/http_symbols_spec.cr spec/unit_test/output_builder/curl_spec.cr spec/unit_test/output_builder/httpie_spec.cr spec/unit_test/output_builder/powershell_spec.cr spec/unit_test/deliver/send_req_spec.cr spec/unit_test/deliver/send_proxy_spec.cr
- just test
- just check
- just build