### PR TITLE
Expand synthetic ANY methods for Postman output

### DIFF
--- a/spec/unit_test/models/noir_update_status_codes_spec.cr
+++ b/spec/unit_test/models/noir_update_status_codes_spec.cr
@@ -13,11 +13,13 @@ end
 
 # Test Runner that mocks external requests
 class TestNoirRunner < NoirRunner
+  property last_request_method : Symbol?
   property last_request_params : Hash(String, String)?
   property last_request_body : Hash(String, String)?
   property last_request_json : Bool?
 
   def perform_request(method, url, params = {} of String => String, form = {} of String => String, json = false)
+    @last_request_method = method
     @last_request_params = params
     @last_request_body = form
     @last_request_json = json
@@ -107,5 +109,14 @@ describe "NoirRunner#update_status_codes" do
     body["data"].should eq("value")
 
     runner.last_request_json.should be_true
+  end
+
+  it "uses GET as the representative status probe for synthetic ANY methods" do
+    runner = TestNoirRunner.new(options)
+    runner.endpoints << Endpoint.new("http://example.com/200", "ANY")
+
+    runner.update_status_codes
+
+    runner.last_request_method.should eq(:get)
   end
 end

--- a/spec/unit_test/output_builder/postman_spec.cr
+++ b/spec/unit_test/output_builder/postman_spec.cr
@@ -134,4 +134,26 @@ describe "OutputBuilderPostman" do
     collection = JSON.parse(output)
     collection["variable"][0]["value"].as_s.should eq("https://api.example.com")
   end
+
+  it "expands synthetic ANY methods into concrete collection items" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+      "url"     => YAML::Any.new(""),
+    }
+    builder = OutputBuilderPostman.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/wildcard", "ANY")])
+    collection = JSON.parse(builder.io.to_s)
+    items = collection["item"].as_a
+    methods = items.map(&.["request"].["method"].as_s)
+
+    methods.should eq(WILDCARD_HTTP_METHODS)
+    methods.includes?("ANY").should be_false
+    items.map(&.["name"].as_s).should eq(WILDCARD_HTTP_METHODS.map { |method| "#{method} /wildcard" })
+  end
 end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -210,10 +210,16 @@ class NoirRunner
     end
 
     @endpoints.each do |endpoint|
+      request_method = requestable_http_methods(endpoint.method).first?
+      unless request_method
+        final << endpoint
+        next
+      end
+
       begin
         if endpoint.params.empty?
           response = perform_request(
-            get_symbol(endpoint.method),
+            get_symbol(request_method),
             endpoint.url
           )
           endpoint.details.status_code = response.status_code
@@ -231,7 +237,7 @@ class NoirRunner
                  end
 
           response = perform_request(
-            get_symbol(endpoint.method),
+            get_symbol(request_method),
             endpoint.url,
             endpoint_hash["query"],
             body,

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -1,5 +1,6 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "../utils/http_symbols"
 require "uri"
 require "json"
 
@@ -141,28 +142,30 @@ class OutputBuilderPostman < OutputBuilder
         } of String => JSON::Any
       end
 
-      # Build request object
-      request = {
-        "method" => JSON::Any.new(endpoint.method),
-        "header" => JSON::Any.new(headers),
-        "url"    => JSON::Any.new(url_obj),
-      } of String => JSON::Any
+      expand_synthetic_http_methods(endpoint.method).each do |method|
+        # Build request object
+        request = {
+          "method" => JSON::Any.new(method),
+          "header" => JSON::Any.new(headers),
+          "url"    => JSON::Any.new(url_obj),
+        } of String => JSON::Any
 
-      if body
-        request["body"] = JSON::Any.new(body)
+        if body
+          request["body"] = JSON::Any.new(body)
+        end
+
+        # Build item
+        item = {
+          "name"    => JSON::Any.new("#{method} #{uri.path}"),
+          "request" => JSON::Any.new(request),
+        } of String => JSON::Any
+
+        if description = noir_ai_context_description(endpoint) || noir_callees_description(endpoint)
+          item["description"] = JSON::Any.new(description)
+        end
+
+        items << item
       end
-
-      # Build item
-      item = {
-        "name"    => JSON::Any.new("#{endpoint.method} #{uri.path}"),
-        "request" => JSON::Any.new(request),
-      } of String => JSON::Any
-
-      if description = noir_ai_context_description(endpoint) || noir_callees_description(endpoint)
-        item["description"] = JSON::Any.new(description)
-      end
-
-      items << item
     end
 
     # Build collection


### PR DESCRIPTION
## Summary
- expand synthetic wildcard methods into concrete Postman collection items
- avoid using synthetic ANY as the request method for status-code probing
- keep endpoint method metadata unchanged outside request-producing consumers

## Tests
- crystal spec spec/unit_test/output_builder/postman_spec.cr spec/unit_test/models/noir_update_status_codes_spec.cr
- just test
- just build
- just check