### PR TITLE
Use idiomatic `unless x.nil?` instead of `if !x.nil?`

### DIFF
--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -353,7 +353,7 @@ module Analyzer::Javascript
         if line.includes?("@Controller")
           joined = join_decorator_header(lines, index)
           base_paths = parse_controller_decorator(joined[:text], literal_values)
-          if !base_paths.nil?
+          unless base_paths.nil?
             current_base_paths = base_paths
             current_versions = parse_controller_versions(joined[:text])
             current_content.clear

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -1236,9 +1236,9 @@ module Analyzer::Python
 
       # Function Based View
       function_start_index = content.index /(?:async\s+)?def\s+#{function_or_class_name}\s*\(/
-      if !function_start_index.nil?
+      unless function_start_index.nil?
         function_codeblock = parse_code_block(content[function_start_index..])
-        if !function_codeblock.nil?
+        unless function_codeblock.nil?
           lines = function_codeblock.split "\n"
           function_define_line = lines[0]
           lines = lines[1..]
@@ -1248,7 +1248,7 @@ module Analyzer::Python
           # directly above the def) so a method-restricting decorator
           # under, say, `@login_required` is still seen.
           index = content_lines.index(function_define_line)
-          if !index.nil?
+          unless index.nil?
             restricted_methods = nil
             index -= 1
             while index >= 0
@@ -1270,7 +1270,7 @@ module Analyzer::Python
               else
                 HTTP_METHODS.each do |http_method_name|
                   method_name_match = preceding_definition.downcase.match /[^a-zA-Z0-9](#{http_method_name})[^a-zA-Z0-9]/
-                  if !method_name_match.nil?
+                  unless method_name_match.nil?
                     suspicious_http_methods << http_method_name.upcase
                   end
                 end
@@ -1289,7 +1289,7 @@ module Analyzer::Python
               suspicious_code = line.split("request.method")[1].strip
               HTTP_METHODS.each do |http_method_name|
                 method_name_match = suspicious_code.downcase.match /['"](#{http_method_name})['"]/
-                if !method_name_match.nil?
+                unless method_name_match.nil?
                   suspicious_http_methods << http_method_name.upcase
                 end
               end
@@ -1328,9 +1328,9 @@ module Analyzer::Python
 
       # Class Based View
       class_start_index = content.index /class\s+#{function_or_class_name}\s*[\(:]/
-      if !class_start_index.nil?
+      unless class_start_index.nil?
         class_codeblock = parse_python_class_codeblock(content, class_start_index) || parse_code_block(content[class_start_index..])
-        if !class_codeblock.nil?
+        unless class_codeblock.nil?
           lines = class_codeblock.split "\n"
           class_define_line = lines[0]
           lines = lines[1..]
@@ -1374,7 +1374,7 @@ module Analyzer::Python
           lines.each_with_index do |line, offset|
             method_function_match = line.match(REGEX_CBV_METHOD_DEF)
             any_method_function_match = line.match(/\s+(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/)
-            if !any_method_function_match.nil?
+            unless any_method_function_match.nil?
               current_http_methods = nil
             end
 
@@ -1816,7 +1816,7 @@ module Analyzer::Python
               end
 
               # If a specific parameter is found, allow the corresponding methods
-              if !field_methods.nil?
+              unless field_methods.nil?
                 field_methods.each do |field_method|
                   if !endpoint_methods.includes? field_method
                     endpoint_methods << field_method

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -73,7 +73,7 @@ module Analyzer::Python
               effective_line = coalesce_constructor_call(codelines, index, original_line, "APIRouter")
               line = effective_line.gsub(" ", "")
               match = line.includes?("FastAPI(") ? line.match(FASTAPI_INSTANCE_RE) : nil
-              if !match.nil?
+              unless match.nil?
                 fastapi_instance_name = match[1]
                 if include_router_map.has_key?(path)
                   include_router_map[path][fastapi_instance_name] ||= Router.new("")
@@ -100,7 +100,7 @@ module Analyzer::Python
 
               # https://fastapi.tiangolo.com/tutorial/bigger-applications/
               match = line.includes?("APIRouter(") ? line.match(APIROUTER_INSTANCE_RE) : nil
-              if !match.nil?
+              unless match.nil?
                 prefix = ""
                 router_instance_name = match[1]
                 if param_codes = effective_line.split("APIRouter", 2)[1]?
@@ -189,7 +189,7 @@ module Analyzer::Python
 
                 # Parsing extra params
                 function_definition = parse_function_def(codelines, def_line)
-                if !function_definition.nil?
+                unless function_definition.nil?
                   function_params = function_definition.params
                   if function_params.size > 0
                     function_params.each do |param|

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1530,7 +1530,7 @@ module Analyzer::Python
         # Extract parameters from the expect decorator
         # https://flask-restx.readthedocs.io/en/latest/swagger.html#the-api-expect-decorator
         expect_match = lines[codeline_index].match /\s*@.+\.expect\(\s*(#{DOT_NATION})/
-        if !expect_match.nil?
+        unless expect_match.nil?
           parser = get_parser(path)
           if parser.@global_variables.has_key?(expect_match[1])
             gv = parser.@global_variables[expect_match[1]]

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -180,7 +180,7 @@ module Analyzer::Python
             matches = codeblock_line.scan(get_regex)
           end
 
-          if !matches.nil?
+          unless matches.nil?
             matches.each do |match|
               if match.size > 0
                 params << Param.new(match[1], "", "json")

--- a/src/miniparsers/import_graph.cr
+++ b/src/miniparsers/import_graph.cr
@@ -348,7 +348,7 @@ module Noir::ImportGraph::Python
 
       unless imports.empty?
         round_bracket_index = line.index('(')
-        if !round_bracket_index.nil?
+        unless round_bracket_index.nil?
           # Parse `import (\n a,\n b,\n c)` pattern — track
           # bytes from the opening `(` to the matching `)`.
           index = offset + round_bracket_index + 1

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -194,7 +194,7 @@ class FileAnalyzer < Analyzer
 
               @@hooks.each do |hook|
                 file_results = hook.call(path, @url)
-                if !file_results.nil?
+                unless file_results.nil?
                   file_results.each do |file_result|
                     @result << file_result
                   end

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -82,7 +82,7 @@ class OutputBuilder
       end
     end
 
-    if !params.nil?
+    unless params.nil?
       params.each do |param|
         if param.param_type == "query"
           if first_query

--- a/src/output_builder/only-tag.cr
+++ b/src/output_builder/only-tag.cr
@@ -5,7 +5,7 @@ class OutputBuilderOnlyTag < OutputBuilder
   def print(endpoints : Array(Endpoint))
     tags = [] of Tag
     endpoints.each do |endpoint|
-      if !endpoint.tags.nil?
+      unless endpoint.tags.nil?
         endpoint.tags.each do |tag|
           tags << tag
         end


### PR DESCRIPTION
## Description

Closes #2169.

Replaces the negated-nil `if !x.nil?` form with the idiomatic Crystal `unless x.nil?` at **simple single-condition block-`if` sites** across the analyzers, output builders, models, and miniparsers. The codebase already prefers `unless x.nil?`, so this is a consistency cleanup with identical nil-narrowing semantics.

**Scope discipline:** only clean single-condition sites were converted (19 in total). Intentionally left as `if !x.nil?`:
- compound conditions (`&& / ||`)
- `elsif` branches
- inline-modifier `… if !x.nil?`
- any block that carries an `else`/`elsif` — converting those would produce an `unless … else`, which is non-idiomatic and flagged by Ameba's `Style/UnlessElse`.

(7 sites that initially matched the simple pattern but turned out to have an `else`/`elsif` were caught by Ameba and reverted.)

## Verification

- `crystal tool format` — clean
- `shards build` — passes
- `crystal run lib/ameba/bin/ameba.cr` on all changed files — `0 failures`
- `crystal spec spec/unit_test` — `3615 examples, 0 failures`
- `crystal spec spec/functional_test` — `19809 examples, 0 failures`