### PR TITLE
Add a unit spec for Noir::PathScope

### DIFF
--- a/spec/unit_test/utils/path_scope_spec.cr
+++ b/spec/unit_test/utils/path_scope_spec.cr
@@ -1,0 +1,78 @@
+require "../../spec_helper"
+require "../../../src/utils/path_scope"
+
+describe Noir::PathScope do
+  describe ".normalize_root" do
+    it "strips a trailing slash from a normalized root" do
+      Noir::PathScope.normalize_root("/app/").should eq("/app")
+    end
+
+    it "leaves a root without a trailing slash unchanged" do
+      Noir::PathScope.normalize_root("/app").should eq("/app")
+    end
+  end
+
+  describe ".under_root?" do
+    it "matches a path under its root" do
+      Noir::PathScope.under_root?("/app/x", "/app").should be_true
+    end
+
+    it "matches a path equal to its root" do
+      Noir::PathScope.under_root?("/app", "/app").should be_true
+    end
+
+    it "respects path boundaries (does not match a sibling prefix)" do
+      Noir::PathScope.under_root?("/app2/x", "/app").should be_false
+    end
+
+    it "treats an empty root as matching everything" do
+      Noir::PathScope.under_root?("/anything", "").should be_true
+    end
+
+    it "normalizes a root with a trailing slash before comparing" do
+      Noir::PathScope.under_root?("/app/x", "/app/").should be_true
+    end
+  end
+
+  describe ".under_normalized_root?" do
+    it "matches an expanded path beneath an already-normalized root" do
+      Noir::PathScope.under_normalized_root?("/app/x", "/app").should be_true
+    end
+
+    it "does not match a sibling prefix" do
+      Noir::PathScope.under_normalized_root?("/app2/x", "/app").should be_false
+    end
+  end
+
+  describe ".longest_base" do
+    it "picks the most specific containing base" do
+      Noir::PathScope.longest_base("/app/api/x", ["/app", "/app/api"]).should eq("/app/api")
+    end
+
+    it "returns the original (non-normalized) base string" do
+      Noir::PathScope.longest_base("/app/api/x", ["/app/api/"]).should eq("/app/api/")
+    end
+
+    it "returns nil when no base contains the path" do
+      Noir::PathScope.longest_base("/other/x", ["/app", "/app/api"]).should be_nil
+    end
+  end
+
+  describe ".relative_under" do
+    it "returns the path remainder beneath the base" do
+      Noir::PathScope.relative_under("/app/api/x.cr", "/app").should eq("api/x.cr")
+    end
+
+    it "returns the basename when the path is outside the base" do
+      Noir::PathScope.relative_under("/other/x.cr", "/app").should eq("x.cr")
+    end
+
+    it "returns the basename when no base is given" do
+      Noir::PathScope.relative_under("/other/x.cr", nil).should eq("x.cr")
+    end
+
+    it "returns the basename when the path equals the base" do
+      Noir::PathScope.relative_under("/app", "/app").should eq("app")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Closes #2164.

`Noir::PathScope` is a pure, dependency-free module of path-boundary helpers used across file discovery and monorepo scoping, but it had no direct test coverage. This adds `spec/unit_test/utils/path_scope_spec.cr`, mirroring the structurally identical sibling `url_path_spec.cr`, and locks in the documented boundary semantics for all five public methods.

Coverage (16 examples):
- `normalize_root` — trailing-slash stripping
- `under_root?` — under-match, exact-match, the `/app` vs `/app2` boundary, empty-root-matches-everything, trailing-slash normalization
- `under_normalized_root?` — direct boundary check + sibling-prefix rejection
- `longest_base` — longest match wins, returns the original (non-normalized) base string, `nil` when none contains the path
- `relative_under` — remainder beneath base, basename fallback when outside / when base is nil / when path equals base

Tests-only; no production code change.

### Note for maintainers
While writing this I noticed the filesystem-root (`/`) special-casing in `path_scope.cr` is effectively dead: it compares `expanded == File::SEPARATOR`, but `File::SEPARATOR` is a `Char` (`'/'`), not a `String`, so the guard is always `false` and `normalize_root("/")` returns `""`. I deliberately scoped this **tests-only** PR to the documented, working contracts and did not assert (or fix) the `/`-root behavior. Happy to open a separate issue/PR for that if you'd like.

## Verification

- `crystal tool format` — clean
- `crystal run lib/ameba/bin/ameba.cr` on the new spec — `0 failures`
- `crystal spec spec/unit_test/utils/path_scope_spec.cr` — `16 examples, 0 failures`
- `crystal spec spec/unit_test` (full unit suite) — `3631 examples, 0 failures`