### PR TITLE
Fix `--techs` description and document `--only-techs` on tech-commands page

### DIFF
--- a/docs/content/usage/supported/tech-commands/index.ko.md
+++ b/docs/content/usage/supported/tech-commands/index.ko.md
@@ -10,14 +10,21 @@ sort_by = "weight"
 
 ## 플래그
 
-*   `--techs <TECHS>`: 지정된 기술만 스캔합니다 (쉼표로 구분, 예: `rails,django`).
+*   `--techs <TECHS>`: 자동 감지된 기술에 더해 지정한 기술을 분석 대상에 추가합니다 (쉼표로 구분, 예: `rails,django`).
+*   `--only-techs <TECHS>`: 자동 감지를 지정한 기술 감지기로만 제한합니다 (쉼표로 구분, 예: `rails,django`).
 *   `--exclude-techs <TECHS>`: 지정된 기술을 스캔에서 제외합니다.
-*   `--list-techs`: Noir가 지원하는 모든 기술 목록을 표시합니다.
+*   `noir list techs`: Noir가 지원하는 모든 기술 목록을 표시합니다.
 
 ### 특정 기술 포함
 
 ```bash
 noir scan . --techs rails
+```
+
+### 자동 감지를 특정 기술로 제한
+
+```bash
+noir scan . --only-techs rails
 ```
 
 ### 특정 기술 제외

--- a/docs/content/usage/supported/tech-commands/index.md
+++ b/docs/content/usage/supported/tech-commands/index.md
@@ -10,14 +10,21 @@ Noir can include or exclude specific technologies during scanning, letting you f
 
 ## Flags
 
-*   `--techs <TECHS>`: Only scan the specified technologies (comma-separated, e.g., `rails,django`).
+*   `--techs <TECHS>`: Add these techs to the analyzer set in addition to auto-detected ones (comma-separated, e.g., `rails,django`).
+*   `--only-techs <TECHS>`: Restrict auto-detection to these tech detectors (comma-separated, e.g., `rails,django`).
 *   `--exclude-techs <TECHS>`: Exclude the specified technologies from the scan.
-*   `--list-techs`: List all technologies Noir supports.
+*   `noir list techs`: List all technologies Noir supports.
 
 ### Include specific technologies
 
 ```bash
 noir scan . --techs rails
+```
+
+### Restrict auto-detection to specific technologies
+
+```bash
+noir scan . --only-techs rails
 ```
 
 ### Exclude specific technologies


### PR DESCRIPTION
## Description

Closes #2170.

The "Managing Technology Scopes" docs page described `--techs` as "Only scan the specified technologies" — but that is actually what `--only-techs` does. Per `src/options.cr`:

- `--techs` → "Add these techs to the analyzer set (in addition to auto-detected ones; repeatable)"
- `--only-techs` → "Restrict auto-detection to these tech detectors (repeatable)"

`--only-techs` was missing from the page entirely, and the deprecated v0 flag `--list-techs` was still listed.

This PR:
- Rewords `--techs` to match its real behavior.
- Documents the previously-missing `--only-techs` flag, with an example.
- Replaces `--list-techs` with the v1 form `noir list techs`.

Applied to both the English page and its Korean pair (`index.ko.md`). Examples use this page's existing `noir scan .` convention.

## Verification

Documentation-only; no code or behavior change. Wording transcribed verbatim from the `src/options.cr` help strings and the authoritative distinction in `docs/content/get_started/running/index.md`. Diff reviewed for EN/KO parity.