### PR TITLE
remove hardcoded AI-context label-length cap

### DIFF
--- a/src/ai_context/pattern_matcher.cr
+++ b/src/ai_context/pattern_matcher.cr
@@ -7,6 +7,10 @@ module NoirAIContext
   # produces `AIContextEntry` hits. Pure functions — no per-run state —
   # so `Builder` invokes them as module methods.
   module PatternMatcher
+    # Maximum length of an AI-context display label before it is
+    # compacted or truncated.
+    MAX_LABEL_CHARS = 64
+
     extend self
 
     def detect_from_patterns(name : String,
@@ -174,8 +178,8 @@ module NoirAIContext
     private def normalize_label(text : String) : String
       label = compact_function_signature_label(text) || text.split(/\s+\|\s+\d+:/, 2)[0]
       label = label.gsub(/\s+/, " ").strip
-      label = compact_annotation_label(label) if label.size > 64
-      label[0, Math.min(label.size, 64)]
+      label = compact_annotation_label(label) if label.size > MAX_LABEL_CHARS
+      label[0, Math.min(label.size, MAX_LABEL_CHARS)]
     end
 
     private def compact_function_signature_label(label : String) : String?


### PR DESCRIPTION
PR to closes #2194 

## Description

This PR extracts the hardcoded maximum display-label length `64` in `PatternMatcher#normalize_label` into a named module constant `MAX_LABEL_CHARS`.

This is a behavior-preserving DRY polish that aligns `pattern_matcher.cr` with the established naming conventions found in its sibling file `source_reader.cr` (e.g., `MAX_SNIPPET_CHARS`, `MAX_ROUTE_SCOPE_LINES`).

### Changes

* **`src/ai_context/pattern_matcher.cr`**:
* Defined `MAX_LABEL_CHARS = 64`.
* Replaced two inline literals with the new constant within `normalize_label`.



### Verification

* Formatted via `crystal tool format`.
* Behavior remains entirely identical; no functional risk.