### PR TITLE
refactor: remove hardcoded agent grep-snippet truncation length

### DIFF
--- a/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
+++ b/src/analyzer/analyzers/llm_analyzers/unified_ai.cr
@@ -19,6 +19,7 @@ module Analyzer::AI
     AGENT_TOOL_CACHE_MAX_ENTRIES       = 96
     AGENT_CONTEXT_MAX_DYNAMIC_MESSAGES = 16
     AGENT_CONTEXT_MAX_CHARS            = 100 * 1024
+    AGENT_GREP_SNIPPET_MAX_CHARS       = 220
     AGENT_DEFAULT_FILE_PATTERN         = "*.{go,py,js,ts,java,rb,php,cs,cr,kt,rs,swift,scala,graphql}"
     VALID_METHODS                      = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]
     VALID_PARAM_TYPES                  = ["query", "json", "form", "header", "cookie", "path"]
@@ -667,7 +668,7 @@ module Analyzer::AI
                 next unless regex_matches_with_timeout?(regex, line)
 
                 snippet = line.strip
-                snippet = snippet[0, 220] if snippet.size > 220
+                snippet = snippet[0, AGENT_GREP_SNIPPET_MAX_CHARS] if snippet.size > AGENT_GREP_SNIPPET_MAX_CHARS
                 matches << "#{agent_relative_path(file_path)}:#{line_number}: #{snippet}"
                 break if matches.size >= AGENT_TOOL_MAX_MATCHES
               end


### PR DESCRIPTION
PR to close #2193 

## Description

This PR extracts the hardcoded snippet truncation length `220` in `unified_ai.cr` into a named constant `AGENT_GREP_SNIPPET_MAX_CHARS` at the top of the class.

This is a behavior-preserving DRY polish that keeps the codebase consistent with the aligned constant patterns already established in this file, following the same idiom as previous extractions (#1100 / #1102).

### Changes
- **`src/analyzer/analyzers/llm_analyzers/unified_ai.cr`**:
  - Added `AGENT_GREP_SNIPPET_MAX_CHARS = 220` to the aligned constants block.
  - Replaced the two inline `220` literals on line 670.

### Verification
- Ran `crystal tool format`.
- Verified compiler checks pass.