### PR TITLE
test: add direct contract tests for join_path utility

### DIFF
--- a/spec/unit_test/utils/utils_spec.cr
+++ b/spec/unit_test/utils/utils_spec.cr
@@ -124,3 +124,29 @@ describe "escape_glob_path" do
     escape_glob_path("/x/{a}[b]*?\\c").should eq("/x/\\{a\\}\\[b\\]\\*\\?\\\\c")
   end
 end
+
+describe "join_path" do
+  it "joins two segments" do
+    join_path("/api", "users").should eq("/api/users")
+  end
+
+  it "collapses a double slash at the boundary" do
+    join_path("/api", "/users").should eq("/api/users")
+  end
+
+  it "strips trailing slashes from segments" do
+    join_path("api/", "/v1/").should eq("/api/v1")
+  end
+
+  it "skips empty segments" do
+    join_path("", "users").should eq("/users")
+  end
+
+  it "joins three segments (variadic)" do
+    join_path("a", "b", "c").should eq("/a/b/c")
+  end
+
+  it "always prepends a leading slash" do
+    join_path("noslash").should eq("/noslash")
+  end
+end


### PR DESCRIPTION
PR to closes #2191 

## Description

This PR adds a dedicated unit test suite (`describe "join_path"`) to `utils_spec.cr` to directly verify the URL path segment composition of the global variadic `join_path` helper. 

While almost every other helper in `src/utils/utils.cr` already possessed explicit tests, `join_path` was the lone exception. This is a low-risk, test-only addition that brings full coverage consistency to the utility module.

### Changes
- **`spec/unit_test/utils/utils_spec.cr`**:
  - Appended test cases verifying double slash collapsing, trailing slash stripping, empty segment skipping, variadic joining, and leading slash enforcement.

### Verification
- Verified passing locally via `crystal spec spec/unit_test/utils/utils_spec.cr`.
- Ran `crystal tool format`.