### PR TITLE
refactor: consolidate duplicated helpers across subsystems

### DIFF
--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -735,42 +735,12 @@ module Analyzer::Perl
       normalized.size > 1 && normalized.ends_with?("/") ? normalized.rchop : normalized
     end
 
-    private def perl_test_path?(path : String, ext : String) : Bool
-      return true if ext == ".t"
-      return true if path.includes?("/t/")
-      false
-    end
-
     private def catalyst_source_file?(path : String) : Bool
       ext = File.extname(path)
       return false unless ext == ".pl" || ext == ".pm" ||
                           ext == ".psgi" || ext == ".t"
       return false if perl_test_path?(path, ext)
       true
-    end
-
-    private def sanitize_perl_lines(lines : Array(String)) : Array(String)
-      in_pod = false
-      ended = false
-      lines.map do |line|
-        stripped = line.lstrip
-        if ended
-          ""
-        elsif stripped.starts_with?("__END__") || stripped.starts_with?("__DATA__")
-          ended = true
-          ""
-        elsif in_pod
-          if stripped.starts_with?("=cut")
-            in_pod = false
-          end
-          ""
-        elsif stripped.size >= 2 && stripped[0] == '=' && stripped[1].ascii_letter?
-          in_pod = true
-          ""
-        else
-          line
-        end
-      end
     end
 
     private def brace_delta(line : String) : Int32

--- a/src/analyzer/analyzers/perl/dancer2.cr
+++ b/src/analyzer/analyzers/perl/dancer2.cr
@@ -347,38 +347,9 @@ module Analyzer::Perl
       offsets
     end
 
-    private def perl_test_path?(path : String, ext : String) : Bool
-      return true if ext == ".t"
-      return true if path.includes?("/t/")
-      false
-    end
-
     # POD blocks (`=head1` ... `=cut`) and `__END__`/`__DATA__` sections
     # are documentation/data, not code. Blank them while preserving the
     # original line count so endpoint line numbers stay aligned with the
     # source file.
-    private def sanitize_perl_lines(lines : Array(String)) : Array(String)
-      in_pod = false
-      ended = false
-      lines.map do |line|
-        stripped = line.lstrip
-        if ended
-          ""
-        elsif stripped.starts_with?("__END__") || stripped.starts_with?("__DATA__")
-          ended = true
-          ""
-        elsif in_pod
-          if stripped.starts_with?("=cut")
-            in_pod = false
-          end
-          ""
-        elsif stripped.size >= 2 && stripped[0] == '=' && stripped[1].ascii_letter?
-          in_pod = true
-          ""
-        else
-          line
-        end
-      end
-    end
   end
 end

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -113,38 +113,6 @@ module Analyzer::Perl
       endpoints
     end
 
-    # POD blocks (`=head1` ... `=cut`) and `__END__`/`__DATA__` sections
-    # are documentation/data, not code. Real-world Mojolicious modules
-    # (e.g. `Mojolicious::Plugin::Minion::Admin`) ship example
-    # `app->routes->any('/...')` calls inside their POD, which would
-    # otherwise be picked up as live routes. We blank those lines while
-    # preserving the original line count so endpoint line numbers stay
-    # aligned with the source file.
-    private def sanitize_perl_lines(lines : Array(String)) : Array(String)
-      in_pod = false
-      ended = false
-      lines.map do |line|
-        stripped = line.lstrip
-        if ended
-          ""
-        elsif stripped.starts_with?("__END__") || stripped.starts_with?("__DATA__")
-          ended = true
-          ""
-        elsif in_pod
-          if stripped.starts_with?("=cut")
-            in_pod = false
-          end
-          ""
-        elsif stripped.size >= 2 && stripped[0] == '=' && stripped[1].ascii_letter?
-          # POD directives: =head1, =head2, =item, =over, =pod, =for, =begin, =encoding ...
-          in_pod = true
-          ""
-        else
-          line
-        end
-      end
-    end
-
     private def index_controller_callees : ControllerCalleeIndex
       callees = ControllerCalleeIndex.new
 

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -65,12 +65,6 @@ module Analyzer::Perl
       endpoints
     end
 
-    private def perl_test_path?(path : String, ext : String) : Bool
-      return true if ext == ".t"
-      return true if path.includes?("/t/")
-      false
-    end
-
     def analyze_content(content : String,
                         file_path : String,
                         include_callee : Bool = false,

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -29,5 +29,40 @@ module Analyzer::Perl
         logger.debug e
       end
     end
+
+    # Perl test files live in `.t` scripts or under a `/t/` directory.
+    protected def perl_test_path?(path : String, ext : String) : Bool
+      return true if ext == ".t"
+      return true if path.includes?("/t/")
+      false
+    end
+
+    # Blank out POD blocks (`=foo ... =cut`) and everything after
+    # `__END__` / `__DATA__`, preserving line alignment so downstream
+    # line/brace bookkeeping stays correct. Analyzers with bespoke
+    # sanitization may override this.
+    protected def sanitize_perl_lines(lines : Array(String)) : Array(String)
+      in_pod = false
+      ended = false
+      lines.map do |line|
+        stripped = line.lstrip
+        if ended
+          ""
+        elsif stripped.starts_with?("__END__") || stripped.starts_with?("__DATA__")
+          ended = true
+          ""
+        elsif in_pod
+          if stripped.starts_with?("=cut")
+            in_pod = false
+          end
+          ""
+        elsif stripped.size >= 2 && stripped[0] == '=' && stripped[1].ascii_letter?
+          in_pod = true
+          ""
+        else
+          line
+        end
+      end
+    end
   end
 end

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -57,6 +57,7 @@ module Analyzer::Perl
           end
           ""
         elsif stripped.size >= 2 && stripped[0] == '=' && stripped[1].ascii_letter?
+          # POD directives: =head1, =head2, =item, =over, =pod, =for, =begin, =encoding ...
           in_pod = true
           ""
         else

--- a/src/llm/acp/client.cr
+++ b/src/llm/acp/client.cr
@@ -1,6 +1,7 @@
 require "acp"
 require "json"
 require "log"
+require "../response_cleanup"
 
 module LLM
   # ACP-backed client wrapper for communicating with local AI agents.
@@ -206,7 +207,7 @@ module LLM
     end
 
     private def clean_response(raw : String) : String
-      raw.gsub("```json", "").gsub("```", "").strip
+      LLM.strip_json_fences(raw)
     end
   end
 end

--- a/src/llm/general/client.cr
+++ b/src/llm/general/client.cr
@@ -1,6 +1,7 @@
 require "json"
 require "uri"
 require "http/client"
+require "../response_cleanup"
 
 module LLM
   # General OpenAI-compatible LLM client
@@ -88,7 +89,7 @@ module LLM
       end
       response_json = JSON.parse(response.body)
 
-      response_json["choices"][0]["message"]["content"].to_s.gsub("```json", "").gsub("```", "").strip
+      LLM.strip_json_fences(response_json["choices"][0]["message"]["content"].to_s)
     rescue e : Exception
       STDERR.puts "WARNING: AI API error (#{e.message})"
       ""
@@ -151,7 +152,7 @@ module LLM
     end
 
     private def self.clean_content(text : String) : String
-      text.gsub("```json", "").gsub("```", "").strip
+      LLM.strip_json_fences(text)
     end
 
     private def ensure_chat_completions_path(url : String) : String

--- a/src/llm/response_cleanup.cr
+++ b/src/llm/response_cleanup.cr
@@ -1,0 +1,8 @@
+module LLM
+  # Strip the markdown ```json / ``` code fences that LLM providers sometimes
+  # wrap JSON responses in, and trim surrounding whitespace. Shared by every
+  # provider client so the cleanup rule has a single home.
+  def self.strip_json_fences(text : String) : String
+    text.gsub("```json", "").gsub("```", "").strip
+  end
+end

--- a/src/miniparsers/callee_extractor_base.cr
+++ b/src/miniparsers/callee_extractor_base.cr
@@ -27,7 +27,7 @@ module Noir
     # Drop duplicate (name, path, line) entries, preserving first-seen order.
     # Entry is a value tuple, so set membership compares by value; this is
     # equivalent to the former per-extractor string-key and Array#uniq forms.
-    def dedup_entries(entries : Array(Entry)) : Array(Entry)
+    private def dedup_entries(entries : Array(Entry)) : Array(Entry)
       seen = Set(Entry).new
       entries.select { |entry| seen.add?(entry) }
     end

--- a/src/miniparsers/callee_extractor_base.cr
+++ b/src/miniparsers/callee_extractor_base.cr
@@ -1,0 +1,35 @@
+require "../models/endpoint"
+
+module Noir
+  # Shared skeleton for the per-language callee extractors. Each extractor is
+  #
+  #     module Noir::FooCalleeExtractor
+  #       extend self
+  #       include Noir::CalleeExtractorBase
+  #       # ...language-specific scan_line / skip_callee? / regex tables...
+  #     end
+  #
+  # and supplies only the language-specific scanning. The generic glue — the
+  # Entry tuple shape, attaching collected callees to an endpoint, and
+  # de-duplicating them — lives here so a change to the Callee contract lands
+  # once instead of being copy-pasted across every extractor.
+  module CalleeExtractorBase
+    # A discovered callee: (name, file path, 1-based line number).
+    alias Entry = Tuple(String, String, Int32)
+
+    # Attach collected callees to an endpoint as Callee records.
+    def attach_to(endpoint : Endpoint, callees : Array(Entry))
+      callees.each do |name, path, line|
+        endpoint.push_callee(Callee.new(name, path: path, line: line))
+      end
+    end
+
+    # Drop duplicate (name, path, line) entries, preserving first-seen order.
+    # Entry is a value tuple, so set membership compares by value; this is
+    # equivalent to the former per-extractor string-key and Array#uniq forms.
+    def dedup_entries(entries : Array(Entry)) : Array(Entry)
+      seen = Set(Entry).new
+      entries.select { |entry| seen.add?(entry) }
+    end
+  end
+end

--- a/src/miniparsers/clojure_callee_extractor.cr
+++ b/src/miniparsers/clojure_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::ClojureCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "def", "defn", "defmacro", "fn", "let", "letfn", "if", "if-not",
@@ -36,12 +36,6 @@ module Noir::ClojureCalleeExtractor
     result = Hash(String, Array(Entry)).new
     scan_function_definitions(source, 0, source.bytesize, file_path, result)
     result
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_function_definitions(source : String,
@@ -376,10 +370,5 @@ module Noir::ClojureCalleeExtractor
 
   private def whitespace?(char : Char) : Bool
     char.whitespace?
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/cpp_callee_extractor.cr
+++ b/src/miniparsers/cpp_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::CppCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
@@ -42,12 +42,6 @@ module Noir::CppCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def extract_block_after(source : String, start_index : Int32, limit : Int32 = source.bytesize) : Tuple(String, Int32)?
@@ -336,10 +330,5 @@ module Noir::CppCalleeExtractor
     end
 
     limit - 1
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/crystal_callee_extractor.cr
+++ b/src/miniparsers/crystal_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::CrystalCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "abstract", "alias", "annotation", "as", "asm", "begin",
@@ -27,12 +27,6 @@ module Noir::CrystalCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -81,18 +75,5 @@ module Noir::CrystalCalleeExtractor
     end
 
     line
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/csharp_callee_extractor.cr
+++ b/src/miniparsers/csharp_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::CSharpCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "as", "async", "await", "base", "case", "catch", "checked", "default",
@@ -68,12 +68,6 @@ module Noir::CSharpCalleeExtractor
     dedup_entries(entries)
   end
 
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
-  end
-
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
     code = line.strip
     return if code.empty?
@@ -119,18 +113,5 @@ module Noir::CSharpCalleeExtractor
     end
 
     line
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/dart_callee_extractor.cr
+++ b/src/miniparsers/dart_callee_extractor.cr
@@ -1,9 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::DartCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
-  alias Entry = Tuple(String, String, Int32)
   alias BodyInfo = Tuple(String, Int32, Int32)
   alias StripState = NamedTuple(block_comment: Bool, triple_quote: Char)
 
@@ -39,12 +40,6 @@ module Noir::DartCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def extract_body_after(source : String, start_index : Int32, limit : Int32 = source.bytesize) : BodyInfo?
@@ -374,10 +369,5 @@ module Noir::DartCalleeExtractor
     end
 
     limit - 1
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/elixir_callee_extractor.cr
+++ b/src/miniparsers/elixir_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::ElixirCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "after", "alias", "and", "case", "catch", "cond", "def", "defdelegate",
@@ -30,12 +30,6 @@ module Noir::ElixirCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -87,9 +81,5 @@ module Noir::ElixirCalleeExtractor
     end
 
     stripped.to_s
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    entries.uniq
   end
 end

--- a/src/miniparsers/fsharp_callee_extractor.cr
+++ b/src/miniparsers/fsharp_callee_extractor.cr
@@ -1,9 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::FsharpCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
-  alias Entry = Tuple(String, String, Int32)
   alias StripState = NamedTuple(block_comment_depth: Int32, triple_string: Bool)
 
   INITIAL_STATE = {
@@ -44,12 +45,6 @@ module Noir::FsharpCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -170,10 +165,5 @@ module Noir::FsharpCalleeExtractor
     end
 
     chars.size - 1
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/groovy_callee_extractor.cr
+++ b/src/miniparsers/groovy_callee_extractor.cr
@@ -1,10 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 require "../utils/groovy_literal_scanner"
 
 module Noir::GroovyCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "as", "assert", "break", "case", "catch", "class", "const", "continue",
@@ -30,12 +30,6 @@ module Noir::GroovyCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -157,10 +151,5 @@ module Noir::GroovyCalleeExtractor
       stripped << (body[index] == '\n' ? '\n' : ' ')
       index += 1
     end
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -1,9 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::HaskellCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
-  alias Entry = Tuple(String, String, Int32)
   alias FunctionBody = NamedTuple(name: String, body: String, path: String, start_line: Int32)
 
   RESERVED = Set{
@@ -93,12 +94,6 @@ module Noir::HaskellCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -321,10 +316,5 @@ module Noir::HaskellCalleeExtractor
       index += 1
     end
     chars.size
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/js_callee_extractor.cr
+++ b/src/miniparsers/js_callee_extractor.cr
@@ -1,7 +1,9 @@
 require "../ext/tree_sitter/tree_sitter"
+require "./callee_extractor_base"
 
 module Noir::JSCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
   HTTP_VERB_METHODS = {
     "get"     => "GET",
@@ -32,7 +34,6 @@ module Noir::JSCalleeExtractor
     "cachedEventHandler",
   }
 
-  alias Entry = Tuple(String, String, Int32)
   alias Definitions = Hash(String, Int32?)
 
   def callees_for_routes(source : String, file_path : String) : Hash(String, Array(Entry))
@@ -750,19 +751,6 @@ module Noir::JSCalleeExtractor
   private def same_node?(left : LibTreeSitter::TSNode, right : LibTreeSitter::TSNode) : Bool
     LibTreeSitter.ts_node_start_byte(left) == LibTreeSitter.ts_node_start_byte(right) &&
       LibTreeSitter.ts_node_end_byte(left) == LibTreeSitter.ts_node_end_byte(right)
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 
   private def decode_string(node : LibTreeSitter::TSNode, source : String) : String

--- a/src/miniparsers/lua_callee_extractor.cr
+++ b/src/miniparsers/lua_callee_extractor.cr
@@ -1,9 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::LuaCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
-  alias Entry = Tuple(String, String, Int32)
   alias FunctionBody = NamedTuple(body: String, path: String, start_line: Int32)
 
   RESERVED = Set{
@@ -87,12 +88,6 @@ module Noir::LuaCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def extract_function_after(source : String,
@@ -684,10 +679,5 @@ module Noir::LuaCalleeExtractor
       cursor += 1
     end
     indent
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/objc_callee_extractor.cr
+++ b/src/miniparsers/objc_callee_extractor.cr
@@ -1,4 +1,5 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 require "./swift_callee_extractor"
 
 # Best-effort 1-hop callee extraction for Objective-C method bodies. Mirrors
@@ -10,8 +11,7 @@ require "./swift_callee_extractor"
 # uses the same `//`, `/* */`, and `"..."` lexical forms).
 module Noir::ObjcCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   # Keywords and primitive type names that can sit where a selector / call
   # name would, but are never a 1-hop callee.
@@ -63,13 +63,5 @@ module Noir::ObjcCalleeExtractor
   private def add_entry(entries : Array(Entry), name : String, file_path : String, line_number : Int32)
     return if name.empty? || RESERVED.includes?(name) || MEMORY_SELECTORS.includes?(name)
     entries << {name, file_path, line_number}
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      seen.add?(key)
-    end
   end
 end

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -1,9 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::PerlCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
-  alias Entry = Tuple(String, String, Int32)
   alias SubBody = NamedTuple(body: String, path: String, start_line: Int32)
 
   RESERVED = Set{
@@ -44,12 +45,6 @@ module Noir::PerlCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def controller_action_callees(source : String, file_path : String) : Hash(String, Array(Entry))
@@ -488,10 +483,5 @@ module Noir::PerlCalleeExtractor
       end
       index += 1
     end
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(Entry).new
-    entries.select { |entry| seen.add?(entry) }
   end
 end

--- a/src/miniparsers/php_callee_extractor.cr
+++ b/src/miniparsers/php_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::PhpCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "array", "catch", "class", "clone", "declare", "die", "echo",
@@ -29,12 +29,6 @@ module Noir::PhpCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -164,18 +158,5 @@ module Noir::PhpCalleeExtractor
     end
 
     {sanitized, in_block_comment}
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::RubyCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "alias", "and", "begin", "break", "case", "class", "def",
@@ -34,12 +34,6 @@ module Noir::RubyCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
@@ -127,18 +121,5 @@ module Noir::RubyCalleeExtractor
     end
 
     stripped.to_s
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/rust_callee_extractor.cr
+++ b/src/miniparsers/rust_callee_extractor.cr
@@ -1,10 +1,10 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 require "./rust_callee_extractor_ts"
 
 module Noir::RustCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   # Kept as a public constant for any external caller that still
   # consults the reserved set; the active implementation lives on
@@ -18,12 +18,6 @@ module Noir::RustCalleeExtractor
   # analyzers don't need to change.
   def callees_for_body(body : String, file_path : String, start_line : Int32) : Array(Entry)
     Noir::RustCalleeExtractorTS.callees_for_body_text(body, file_path, start_line)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def strip_comment(line : String, in_block_comment : Bool = false, preserve_strings : Bool = false) : String

--- a/src/miniparsers/rust_callee_extractor_ts.cr
+++ b/src/miniparsers/rust_callee_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../ext/tree_sitter/tree_sitter"
+require "./callee_extractor_base"
 
 # Tree-sitter-backed Rust callee extractor. Replaces the regex
 # line-scanner in `Noir::RustCalleeExtractor` with an AST walker over
@@ -20,8 +21,7 @@ require "../ext/tree_sitter/tree_sitter"
 # `Noir::GoCalleeExtractor`.
 module Noir::RustCalleeExtractorTS
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   # Rust keywords + commonly-aliased control-flow constructors that
   # surface as `call_expression`s but carry no useful callee signal.

--- a/src/miniparsers/scala_callee_extractor.cr
+++ b/src/miniparsers/scala_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::ScalaCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "abstract", "case", "catch", "class", "def", "do", "else",
@@ -44,12 +44,6 @@ module Noir::ScalaCalleeExtractor
 
     scan_code(code.to_s, file_path, start_line, line_offsets, entries)
     dedup_entries(entries.sort_by(&.[0]).map(&.[1]))
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def strip_comment(line : String, block_comment_depth : Int32 = 0, in_multiline_string : Bool = false) : String
@@ -189,18 +183,5 @@ module Noir::ScalaCalleeExtractor
 
     last = name.split('.').last
     RESERVED.includes?(last)
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/swift_callee_extractor.cr
+++ b/src/miniparsers/swift_callee_extractor.cr
@@ -1,9 +1,9 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 module Noir::SwiftCalleeExtractor
   extend self
-
-  alias Entry = Tuple(String, String, Int32)
+  include Noir::CalleeExtractorBase
 
   RESERVED = Set{
     "as", "associatedtype", "break", "case", "catch", "class",
@@ -35,12 +35,6 @@ module Noir::SwiftCalleeExtractor
     end
 
     dedup_entries(entries)
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   def strip_comment(line : String, in_block_comment : Bool = false) : String
@@ -163,18 +157,5 @@ module Noir::SwiftCalleeExtractor
   private def control_flow_condition?(line : String, name_start : Int32) : Bool
     prefix = line[0...name_start].strip
     !!prefix.match(/\b(if|guard|while|for|switch|catch|else|do)$/)
-  end
-
-  private def dedup_entries(entries : Array(Entry)) : Array(Entry)
-    seen = Set(String).new
-    entries.select do |name, path, line|
-      key = "#{name}\0#{path}\0#{line}"
-      if seen.includes?(key)
-        false
-      else
-        seen.add(key)
-        true
-      end
-    end
   end
 end

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -1,4 +1,5 @@
 require "../models/endpoint"
+require "./callee_extractor_base"
 
 # Shared structural helper for the Zig framework analyzers (jetzig, zap,
 # httpz, tokamak). Zig has no vendored tree-sitter grammar in noir, so the
@@ -18,10 +19,10 @@ require "../models/endpoint"
 # anywhere in the file can't turn the per-character loops into O(n²).
 module Noir::ZigCalleeExtractor
   extend self
+  include Noir::CalleeExtractorBase
 
   # (name, path, line) — mirrors the other callee extractors' tuple so the
   # `attach_to` helper can feed `Endpoint#push_callee` directly.
-  alias Entry = Tuple(String, String, Int32)
   alias FunctionBody = NamedTuple(body: String, path: String, start_line: Int32)
   alias FunctionInfo = NamedTuple(name: String, body: String, start_line: Int32, open: Int32, close: Int32)
 
@@ -176,12 +177,6 @@ module Noir::ZigCalleeExtractor
     end
 
     entries
-  end
-
-  def attach_to(endpoint : Endpoint, callees : Array(Entry))
-    callees.each do |name, path, line|
-      endpoint.push_callee(Callee.new(name, path: path, line: line))
-    end
   end
 
   # ---- filtering -----------------------------------------------------------

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -21,8 +21,6 @@ module Noir::ZigCalleeExtractor
   extend self
   include Noir::CalleeExtractorBase
 
-  # (name, path, line) — mirrors the other callee extractors' tuple so the
-  # `attach_to` helper can feed `Endpoint#push_callee` directly.
   alias FunctionBody = NamedTuple(body: String, path: String, start_line: Int32)
   alias FunctionInfo = NamedTuple(name: String, body: String, start_line: Int32, open: Int32, close: Int32)
 

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -149,15 +149,7 @@ class Analyzer
     end
   end
 
-  macro define_getter_methods(names)
-    {% for name, index in names %}
-      def {{ name.id }}
-        @{{ name.id }}
-      end
-    {% end %}
-  end
-
-  define_getter_methods [result, base_path, base_paths, url, logger]
+  getter result, base_path, base_paths, url, logger
 end
 
 class FileAnalyzer < Analyzer

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -74,13 +74,5 @@ class Detector
     file_contents.matches?(/\badd(?:_runtime)?_dependency\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/)
   end
 
-  macro define_getter_methods(names)
-    {% for name, index in names %}
-      def {{ name.id }}
-        @{{ name.id }}
-      end
-    {% end %}
-  end
-
-  define_getter_methods [name, logger]
+  getter name, logger
 end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -33,15 +33,7 @@ class NoirRunner
   @passive_scans : Array(PassiveScan)
   @passive_results : Array(PassiveScanResult)
 
-  macro define_getter_methods(names)
-    {% for name, index in names %}
-      def {{ name.id }}
-        @{{ name.id }}
-      end
-    {% end %}
-  end
-
-  define_getter_methods [options, techs, endpoints, logger, passive_results]
+  getter options, techs, endpoints, logger, passive_results
 
   def initialize(options)
     @options = options

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -299,13 +299,5 @@ class OutputBuilder
     end
   end
 
-  macro define_getter_methods(names)
-    {% for name, index in names %}
-      def {{ name.id }}
-        @{{ name.id }}
-      end
-    {% end %}
-  end
-
-  define_getter_methods [logger, output_file]
+  getter logger, output_file
 end

--- a/src/models/tagger.cr
+++ b/src/models/tagger.cr
@@ -29,4 +29,18 @@ class Tagger
 
     endpoints
   end
+
+  # Split a URL into lowercased, separator-delimited segments. Shared by the
+  # path-keyword taggers. Taggers needing scheme-stripping or other tweaks
+  # (e.g. debug) override this locally.
+  private def url_parts(url : String) : Array(String)
+    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
+  end
+
+  # Canonical parameter-name normalization (lowercase, hyphen -> underscore).
+  # Taggers with bespoke normalization (admin's strip-all, pii's camelCase
+  # splitter) override this locally.
+  private def normalize_param_name(name : String) : String
+    name.downcase.tr("-", "_")
+  end
 end

--- a/src/options.cr
+++ b/src/options.cr
@@ -9,6 +9,18 @@ private def append_to_yaml_array(hash : Hash(String, YAML::Any), key : String, v
   hash[key] = YAML::Any.new(arr)
 end
 
+# Append a value onto a comma-separated string option, accumulating across
+# repeated flags instead of overwriting (so `--flag a --flag b` keeps both).
+# When `reset_if` equals the current value — e.g. an untouched default list —
+# the accumulation starts fresh so the first user value replaces the default
+# rather than appending to it.
+private def append_to_csv_option(hash : Hash(String, YAML::Any), key : String, value : String, reset_if : String? = nil)
+  existing = (hash[key]? || YAML::Any.new("")).to_s
+  existing = "" if reset_if && existing == reset_if
+  combined = existing.empty? ? value : "#{existing},#{value}"
+  hash[key] = YAML::Any.new(combined)
+end
+
 # Pre-scan ARGV for `--config-file PATH` / `--config-file=PATH` so
 # `run_options_parser` can hand the path to ConfigInitializer
 # before any YAML is read. Returns the last occurrence (matching
@@ -269,9 +281,7 @@ def run_options_parser
       # Accumulate same as --exclude-path / --use-taggers / -t etc.
       # so users can repeat the flag (`--exclude-codes 404
       # --exclude-codes 500`) without losing the first value.
-      existing = (noir_options["exclude_codes"]? || YAML::Any.new("")).to_s
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["exclude_codes"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "exclude_codes", v)
     end
     parser.on "--exclude-path PATTERN", "Exclude files by glob (e.g. *.test.js,*_test.go; repeatable)" do |v|
       # Storage is a comma-separated string (the detector splits on
@@ -279,9 +289,7 @@ def run_options_parser
       # the first via plain `=`. Concatenate instead so users can
       # repeat the flag OR pack patterns into one comma list — both
       # shapes accumulate to the same final list.
-      existing = (noir_options["exclude_path"]? || YAML::Any.new("")).to_s
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["exclude_path"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "exclude_path", v)
     end
     parser.on "--include LIST", "Enrich plain output (comma-separated: path,techs,callee)" do |v|
       apply_include_list(noir_options, v)
@@ -339,9 +347,7 @@ def run_options_parser
       # `--use-taggers` value. Pre-fix `--use-taggers hunt
       # --use-taggers cors` silently dropped `hunt` because the
       # second assignment overwrote the first.
-      existing = (noir_options["use_taggers"]? || YAML::Any.new("")).to_s
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["use_taggers"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "use_taggers", v)
     end
 
     # PROBE — fire HTTP requests against the endpoints noir just
@@ -430,12 +436,7 @@ def run_options_parser
       # first `--ai-native-tools-allowlist openai` would land
       # appended onto the default list ("openai,anthropic,gemini,…
       # ,openai") instead of replacing it.
-      defaults_csv = LLM::NativeToolCalling.default_allowlist_csv
-      existing_any = noir_options["ai_native_tools_allowlist"]?
-      existing = existing_any.try(&.to_s) || ""
-      existing = "" if existing == defaults_csv
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["ai_native_tools_allowlist"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "ai_native_tools_allowlist", v, reset_if: LLM::NativeToolCalling.default_allowlist_csv)
     end
     parser.on "--ai-max-token N", "Max tokens per request" do |v|
       validated = positive_int_or_die!("--ai-max-token", v)
@@ -470,19 +471,13 @@ def run_options_parser
     # dropped tech. `--only-techs` and `--exclude-techs` had the
     # same shape.
     parser.on "-t LIST", "--techs rails,php", "Add these techs to the analyzer set (in addition to auto-detected ones; repeatable)" do |v|
-      existing = (noir_options["techs"]? || YAML::Any.new("")).to_s
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["techs"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "techs", v)
     end
     parser.on "--only-techs LIST", "Restrict auto-detection to these tech detectors (repeatable)" do |v|
-      existing = (noir_options["only_techs"]? || YAML::Any.new("")).to_s
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["only_techs"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "only_techs", v)
     end
     parser.on "--exclude-techs LIST", "Drop these techs from the final result after detection (repeatable)" do |v|
-      existing = (noir_options["exclude_techs"]? || YAML::Any.new("")).to_s
-      combined = existing.empty? ? v : "#{existing},#{v}"
-      noir_options["exclude_techs"] = YAML::Any.new(combined)
+      append_to_csv_option(noir_options, "exclude_techs", v)
     end
 
     parser.separator "\n CONFIG:".colorize(:blue)

--- a/src/tagger/taggers/account_recovery.cr
+++ b/src/tagger/taggers/account_recovery.cr
@@ -81,10 +81,6 @@ class AccountRecoveryTagger < Tagger
     end
   end
 
-  private def url_parts(url : String) : Array(String)
-    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
-  end
-
   # Match `two-factor` / `second-factor` / `multi-factor` (and their `_` or
   # no-separator spellings) as whole slash segments, without the generic
   # separator split fragmenting them into benign tokens. Exact membership
@@ -95,9 +91,5 @@ class AccountRecoveryTagger < Tagger
     path.downcase.split("/").any? do |segment|
       STRONG_SQUISHED_SEGMENTS.includes?(segment.gsub(/[^a-z0-9]/, ""))
     end
-  end
-
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
   end
 end

--- a/src/tagger/taggers/crypto.cr
+++ b/src/tagger/taggers/crypto.cr
@@ -89,12 +89,4 @@ class CryptoTagger < Tagger
       end
     end
   end
-
-  private def url_parts(url : String) : Array(String)
-    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
-  end
-
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
 end

--- a/src/tagger/taggers/debug.cr
+++ b/src/tagger/taggers/debug.cr
@@ -105,8 +105,4 @@ class DebugTagger < Tagger
       url
     end
   end
-
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
 end

--- a/src/tagger/taggers/file_upload.cr
+++ b/src/tagger/taggers/file_upload.cr
@@ -99,8 +99,4 @@ class FileUploadTagger < Tagger
     path = url.split("?", 2)[0].split("#", 2)[0]
     path.downcase.split("/").any? { |seg| SEGMENT_ONLY_PATH_PARTS.includes?(seg) }
   end
-
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
 end

--- a/src/tagger/taggers/jwt.cr
+++ b/src/tagger/taggers/jwt.cr
@@ -89,10 +89,6 @@ class JwtTagger < Tagger
     !!value.match(/\AeyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*\z/)
   end
 
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
-
   private def auth_url?(url : String) : Bool
     parts = url.downcase.tr("-", "_").split(/[\/\.]+/).reject(&.empty?)
     parts.any? { |part| AUTH_PATH_PARTS.includes?(part) }

--- a/src/tagger/taggers/oauth.cr
+++ b/src/tagger/taggers/oauth.cr
@@ -83,10 +83,6 @@ class OAuthTagger < Tagger
     end
   end
 
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
-
   # The URL's path with scheme/host/query/fragment stripped and lowercased.
   private def path_only(url : String) : String
     path = url.strip

--- a/src/tagger/taggers/payment.cr
+++ b/src/tagger/taggers/payment.cr
@@ -79,12 +79,4 @@ class PaymentTagger < Tagger
       end
     end
   end
-
-  private def url_parts(url : String) : Array(String)
-    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
-  end
-
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
 end

--- a/src/tagger/taggers/webhook.cr
+++ b/src/tagger/taggers/webhook.cr
@@ -107,12 +107,4 @@ class WebhookTagger < Tagger
     return true if matched.any? { |part| !CALLBACK_PARTS.includes?(part) }
     parts.none? { |part| AUTH_CALLBACK_SEGMENTS.includes?(part) }
   end
-
-  private def url_parts(url : String) : Array(String)
-    url.downcase.split(/[\/\-_\.]+/).reject(&.empty?)
-  end
-
-  private def normalize_param_name(name : String) : String
-    name.downcase.tr("-", "_")
-  end
 end


### PR DESCRIPTION
## Summary

A structural-refactoring pass driven by a multi-agent audit of the codebase. This PR lands the **semantics-neutral consolidations only** — copy-pasted boilerplate that already had (or wanted) a single home is now centralized, with **no change to any analyzer/detection output**.

Net **−327 lines** across 40 files (a multi-agent self-review pass is folded in: it completed the callee-extractor consolidation to all 20 line-scan extractors and removed a redundant Perl sanitizer the first pass missed).

Closes #2180 — the Perl-engine consolidation here hoists `sanitize_perl_lines` into `PerlEngine` and deletes the three byte-identical analyzer copies, which is exactly that good-first-issue's task. (It's the only open `good first issue` this PR invalidates — checked all 13; the sibling Perl `underscore` consolidation #2171 and the other consolidate/remove issues touch different helpers/files and stay open for newcomers.)

## What changed

| Area | Before | After |
|------|--------|-------|
| **Callee extractors** | identical `Entry` alias + `attach_to` + `dedup_entries` copy-pasted across **20** `*_callee_extractor` modules | shared `Noir::CalleeExtractorBase` mixin (`include`d via `extend self`) |
| **Taggers** | byte-identical `url_parts` / `normalize_param_name` in 4–8 taggers | hoisted to the `Tagger` base; divergent variants (admin/pii/debug) keep local overrides |
| **LLM clients** | ` ```json ` fence-strip triplicated (general ×2, acp ×1) | shared `LLM.strip_json_fences` |
| **`options.cr`** | 7 hand-rolled comma-accumulation snippets | single `append_to_csv_option` helper |
| **Perl engine** | identical `perl_test_path?` + `sanitize_perl_lines` in 3 analyzers | hoisted to `PerlEngine`; all 3 analyzers inherit it |
| **Models** | `define_getter_methods` macro copy-pasted into 4 classes | Crystal's built-in `getter` |

The three former `dedup_entries` flavors (`Set(Entry)` / string-key / `Array#uniq`) are equivalent for the value-tuple `Entry`, so dedup output is identical.

## Verification

- ✅ `crystal spec spec/unit_test` — 3643 examples, 0 failures
- ✅ `crystal spec spec/functional_test` — 19809 examples, 0 failures
- ✅ `crystal tool format --check` — clean
- ✅ `ameba` — 1574 inspected, 0 failures
- ✅ `shards build --release --no-debug --production` — green

## Recommended follow-ups (NOT in this PR)

The audit surfaced higher-impact items that are out of scope here because they either change behavior or are larger moves. Listed for a maintainer decision:

**Safe, high value (separate small PRs):**
- **Tech-registry integrity spec** — framework identity lives in 5–6 hand-maintained parallel lists with no linkage. The audit found two live drifts: `zap_sites_tree` is an analyzer+detector with **no `TECHS` entry** (so `-t`/`--only-techs` silently no-op it and it's absent from `noir list`/docs), and `:graphql` is dead `TECHS` metadata with no analyzer/detector. A consistency spec turns this whole class into a CI failure.
- **`--ai-context sources` CLI bug** — `sources` is a fully-emittable feature bucket but the CLI validator rejects it; the feature vocabulary is duplicated across options/augmentor/output_builder and should derive from one constant.

**Larger structural (worth doing, more review):**
- Derive `CALLEE_SUPPORTED_TECHS` / `AI_CONTEXT_GUARD_SUPPORTED_TECHS` from per-tech flags in `TECHS`.
- `FileScanEngine` base for the `analyze` + `parallel_file_scan` skeleton duplicated across ~9 engines.
- Split god-files: `go_route_extractor_ts.cr` (3257 lines, ~12 frameworks), `optimizer.cr` (985), `mobile/linker.cr` (1072) — all namespace-preservingly.
- Consolidate the ~17 byte-identical `join_paths` copies into a named `URLPath` helper (semantics-sensitive — migrate only the identical ones).
