### PR TITLE
chore(typos): allow 'sade' (JS CLI framework) to fix main spellcheck

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -35,6 +35,9 @@ directoryes = "directoryes"
 # `look-alikes` (plural of look-alike) in a vapor fixture comment; typos
 # mis-flags the hyphen-split `alikes` token as `alike`/`likes`.
 alikes = "alikes"
+# `sade` is a JavaScript CLI framework (referenced by the js_cli analyzer);
+# typos mis-flags it as `sad`.
+sade = "sade"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
The Tier-1 CLI analyzer PR (#2230) references the **sade** JavaScript CLI framework, which the `typos` spellchecker mis-flags as `sad`. #2230 auto-merged on the unprotected `main` before this was caught, so `main`'s typos check is currently red. This adds `sade` to the `typos.toml` allowlist (alongside the existing framework-name exceptions) to make it green again.