### PR TITLE
fix(cli): address Tier-3 CLI analyzer review findings (8 confirmed)

### DIFF
--- a/src/analyzer/analyzers/clojure/cli.cr
+++ b/src/analyzer/analyzers/clojure/cli.cr
@@ -6,7 +6,7 @@ module Analyzer::Clojure
   # *command-line-args* / (System/getenv). Line-scan, merged by URL.
   class Cli < Analyzer
     TOOLS_CLI_LONG = /"--([A-Za-z0-9][\w-]*)/
-    TOOLS_CLI_SPEC = /\[\s*(?:"-[A-Za-z0-9]"|nil)\s+"--/
+    TOOLS_CLI_SPEC = /\[\s*(?:(?:"-[A-Za-z0-9]"|nil)\s+)?"--/
     MATIC_COMMAND  = /:command\s+"([^"]+)"/
     MATIC_OPTION   = /:option\s+"([A-Za-z0-9][\w-]*)"/
     NTH_ARGS       = /\(\s*nth\s+(?:\*command-line-args\*|args)\s+(\d+)/
@@ -34,11 +34,10 @@ module Analyzer::Clojure
                 current_url = "#{root_url}/#{m[1]}"
                 fetch_endpoint(endpoints, current_url, path, line_no)
               end
-              # tools.cli option vector: ["-p" "--port PORT" ...]
+              # tools.cli option vectors: ["-p" "--port PORT" ...]. `scan` so
+              # several vectors on one line (and the long-only form) all surface.
               if line.matches?(TOOLS_CLI_SPEC)
-                if lm = line.match(TOOLS_CLI_LONG)
-                  fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(lm[1], "", "flag"))
-                end
+                line.scan(TOOLS_CLI_LONG) { |lm| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(lm[1], "", "flag")) }
               end
               if m = line.match(MATIC_OPTION)
                 fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1], "", "flag"))

--- a/src/analyzer/analyzers/dart/cli.cr
+++ b/src/analyzer/analyzers/dart/cli.cr
@@ -5,12 +5,14 @@ module Analyzer::Dart
   # endpoints: the args package (ArgParser / CommandRunner) plus
   # main(List<String>) argv and Platform.environment. Line-scan, merged by URL.
   class Cli < Analyzer
-    ADD_OPTION   = /\.addOption\s*\(\s*['"]([^'"]+)['"]/
-    ADD_FLAG     = /\.addFlag\s*\(\s*['"]([^'"]+)['"]/
-    ADD_COMMAND  = /\.addCommand\s*\(\s*['"]([^'"]+)['"]/
-    RUNNER_NAME  = /\bget\s+name\s*=>\s*['"]([^'"]+)['"]/
-    ARGS_IDX     = /\bargs\s*\[\s*(\d+)\s*\]/
-    PLATFORM_ENV = /Platform\.environment\s*\[\s*['"]([^'"]+)['"]\s*\]/
+    ARGPARSER_VAR  = /(\w+)\s*=\s*ArgParser\s*\(/
+    SUBCOMMAND_VAR = /(\w+)\s*=\s*\w+\s*\.\s*addCommand\s*\(\s*['"]([^'"]+)['"]/
+    ADD_COMMAND    = /\.addCommand\s*\(\s*['"]([^'"]+)['"]/
+    ADD_OPTION     = /(\w+)\s*\.\s*addOption\s*\(\s*['"]([^'"]+)['"]/
+    ADD_FLAG       = /(\w+)\s*\.\s*addFlag\s*\(\s*['"]([^'"]+)['"]/
+    RUNNER_NAME    = /\bget\s+name\s*=>\s*['"]([^'"]+)['"]/
+    ARGS_IDX       = /\bargs\s*\[\s*(\d+)\s*\]/
+    PLATFORM_ENV   = /Platform\.environment\s*\[\s*['"]([^'"]+)['"]\s*\]/
 
     MARKERS = /package:args\/|package:dcli\/|\bArgParser\s*\(|\bCommandRunner\b|\bextends\s+Command\b|main\s*\(\s*List<String>/
     WEB_RE  = /package:shelf\/|package:dart_frog|package:angel3|package:alfred|\bHttpServer\.bind\b/
@@ -37,11 +39,20 @@ module Analyzer::Dart
     end
 
     private def scan(lines, path, root_url, endpoints, emit_env)
-      current_url = root_url
+      current_url = root_url            # cursor for CommandRunner `get name`
+      var_urls = {} of String => String # ArgParser / addCommand variables
       lines.each_with_index do |line, index|
         line_no = index + 1
 
-        if m = line.match(ADD_COMMAND)
+        if m = line.match(ARGPARSER_VAR)
+          var_urls[m[1]] = root_url
+        end
+        if m = line.match(SUBCOMMAND_VAR)
+          url = "#{root_url}/#{m[2]}"
+          var_urls[m[1]] = url
+          current_url = url
+          fetch_endpoint(endpoints, url, path, line_no)
+        elsif m = line.match(ADD_COMMAND)
           current_url = "#{root_url}/#{m[1]}"
           fetch_endpoint(endpoints, current_url, path, line_no)
         end
@@ -49,11 +60,14 @@ module Analyzer::Dart
           current_url = "#{root_url}/#{m[1]}"
           fetch_endpoint(endpoints, current_url, path, line_no)
         end
+        # Options/flags attribute by receiver variable (root parser vs a
+        # subcommand var); CommandRunner's `argParser.addOption` falls back to
+        # the current `get name` cursor.
         if m = line.match(ADD_OPTION)
-          fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+          fetch_endpoint(endpoints, var_urls[m[1]]? || current_url, path, line_no).push_param(Param.new(m[2], "", "flag"))
         end
         if m = line.match(ADD_FLAG)
-          fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+          fetch_endpoint(endpoints, var_urls[m[1]]? || current_url, path, line_no).push_param(Param.new(m[2], "", "flag"))
         end
         if m = line.match(ARGS_IDX)
           fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new("arg#{m[1]}", "", "argument"))

--- a/src/analyzer/analyzers/elixir/cli.cr
+++ b/src/analyzer/analyzers/elixir/cli.cr
@@ -26,11 +26,12 @@ module Analyzer::Elixir
             next unless content.matches?(MARKERS)
             root_url = "cli://#{cli_binary_name(path)}"
             emit_env = !content.matches?(WEB_RE)
-            root = fetch_endpoint(endpoints, root_url, path, 1)
 
-            # switches:[...] keyword list (may span lines).
-            if m = content.match(SWITCHES)
-              m[1].scan(SWITCH_KEY) { |sm| root.push_param(Param.new(sm[1], "", "flag")) }
+            # Every `switches: [...]` keyword list (a file may dispatch several
+            # OptionParser.parse calls). Endpoint is created lazily so a bare
+            # `System.argv` file with no switches/env emits nothing.
+            content.scan(SWITCHES) do |m|
+              m[1].scan(SWITCH_KEY) { |sm| fetch_endpoint(endpoints, root_url, path, 1).push_param(Param.new(sm[1], "", "flag")) }
             end
 
             content.each_line.with_index do |line, index|

--- a/src/analyzer/analyzers/haskell/cli.cr
+++ b/src/analyzer/analyzers/haskell/cli.cr
@@ -25,18 +25,23 @@ module Analyzer::Haskell
             next unless content.matches?(MARKERS)
             root_url = "cli://#{cli_binary_name(path)}"
             emit_env = !content.matches?(WEB_RE)
-            current_url = root_url
             content.each_line.with_index do |line, index|
               line_no = index + 1
+              # optparse-applicative defines subcommand option parsers in
+              # separate top-level bindings, so a sticky cursor would
+              # misattribute later root globals. Scope a `command "x"` only to
+              # options on the SAME line (the common inline shape); otherwise
+              # attribute to the root.
+              target = root_url
               if m = line.match(COMMAND)
-                current_url = "#{root_url}/#{m[1]}"
-                fetch_endpoint(endpoints, current_url, path, line_no)
+                target = "#{root_url}/#{m[1]}"
+                fetch_endpoint(endpoints, target, path, line_no)
               end
               if m = line.match(LONG)
-                fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "flag"))
               end
               if m = line.match(ARGUMENT)
-                fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1].downcase, "", "argument"))
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1].downcase, "", "argument"))
               end
               if emit_env
                 line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -27,11 +27,20 @@ module Analyzer::Perl
             next unless content.matches?(MARKERS)
             root_url = "cli://#{cli_binary_name(path)}"
             emit_env = !content.matches?(WEB_RE)
-            has_getoptions = content.includes?("GetOptions")
+            in_getoptions = false
+            go_depth = 0
             content.each_line.with_index do |line, index|
               line_no = index + 1
-              if has_getoptions && (m = line.match(GETOPT_KEY))
-                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              # Only treat `"key" => \ref` pairs as flags inside the
+              # GetOptions(...) call, so unrelated reference hashes elsewhere
+              # in the file don't leak as bogus flags.
+              in_getoptions = true if line.includes?("GetOptions") && line.includes?("(")
+              if in_getoptions
+                line.scan(GETOPT_KEY) { |m| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag")) }
+              end
+              if in_getoptions
+                go_depth += line.count('(') - line.count(')')
+                in_getoptions = false if go_depth <= 0
               end
               if m = line.match(GETOPTS)
                 parse_getopt_short(m[1], fetch_endpoint(endpoints, root_url, path, line_no))

--- a/src/analyzer/analyzers/scala/cli.cr
+++ b/src/analyzer/analyzers/scala/cli.cr
@@ -28,18 +28,32 @@ module Analyzer::Scala
           next unless content.matches?(MARKERS)
           root_url = "cli://#{cli_binary_name(path)}"
           emit_env = !content.matches?(WEB_RE)
-          current_url = root_url
+          pending_cmd_url = root_url
+          in_children = false
+          children_depth = 0
           content.each_line.with_index do |line, index|
             line_no = index + 1
             if (m = line.match(SCOPT_CMD)) || (m = line.match(DEC_CMD))
-              current_url = "#{root_url}/#{m[1]}"
-              fetch_endpoint(endpoints, current_url, path, line_no)
+              pending_cmd_url = "#{root_url}/#{m[1]}"
+              fetch_endpoint(endpoints, pending_cmd_url, path, line_no)
             end
+            # scopt scopes a subcommand's opts inside `.children( ... )`; only
+            # there do options bind to the subcommand. Outside, they (and any
+            # trailing root opts after the block) bind to the root.
+            in_children = true if line.includes?(".children(")
+            target = in_children ? pending_cmd_url : root_url
             if (m = line.match(SCOPT_OPT)) || (m = line.match(DEC_OPT)) || (m = line.match(DEC_FLAG))
-              fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "flag"))
             end
             if (m = line.match(SCOPT_ARG)) || (m = line.match(DEC_ARG))
-              fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(m[1], "", "argument"))
+              fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "argument"))
+            end
+            if in_children
+              children_depth += line.count('(') - line.count(')')
+              if children_depth <= 0
+                in_children = false
+                children_depth = 0
+              end
             end
             if emit_env
               line.scan(SYS_ENV) do |em|

--- a/src/analyzer/analyzers/zig/cli.cr
+++ b/src/analyzer/analyzers/zig/cli.cr
@@ -8,9 +8,10 @@ module Analyzer::Zig
     # zig-clap multiline param string lines (each begins with `\\`).
     CLAP_FLAG = /\\\\\s*(?:-[A-Za-z0-9]\s*,\s*)?--([A-Za-z0-9][\w-]*)/
     CLAP_ARG  = /\\\\\s*<([A-Za-z_]\w*)>/
-    # zig-cli struct literals.
+    # zig-cli struct literals. (Only flags are extracted: a `.name` literal is
+    # ambiguous between the app name, a subcommand, and a positional-arg name,
+    # so subcommand extraction from zig-cli is a follow-up.)
     CLI_LONG = /\.long_name\s*=\s*"(-{0,2}[A-Za-z0-9][\w-]*)"/
-    CLI_NAME = /\.name\s*=\s*"([A-Za-z0-9][\w.-]*)"/
     # builtin.
     ARGS_IDX = /\bargs\s*\[\s*(\d+)\s*\]/
     GET_ENV  = /\b(?:std\.process\.getEnvVarOwned\s*\(\s*[\w.]+\s*,\s*"([^"]+)"|(?:std\.)?posix\.getenv\s*\(\s*"([^"]+)")/
@@ -40,9 +41,6 @@ module Analyzer::Zig
             end
             if m = line.match(CLI_LONG)
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1].lstrip('-'), "", "flag"))
-            elsif m = line.match(CLI_NAME)
-              # The first .name is the app/binary; later ones are subcommands.
-              fetch_endpoint(endpoints, "#{root_url}/#{m[1]}", path, line_no) unless m[1] == binary
             end
             if m = line.match(ARGS_IDX)
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new("arg#{m[1]}", "", "argument")) unless m[1] == "0"


### PR DESCRIPTION
Follow-up to the multi-agent self-review of the Tier-3 CLI analyzers (#2234, merged). 8 CONFIRMED findings, all fixed and verified against reproducing fixtures.

| # | Lang | Bug → Fix |
| :- | :- | :- |
| 1 | Elixir | Eager root endpoint → a bare `System.argv` file emitted an empty `cli://<bin>`. Now created lazily (only when a param attaches). |
| 2 | Dart | Sticky cursor mis-attributed a root `addOption` declared **after** `addCommand` to the subcommand. Now **receiver-variable mapped** (root parser vs subcommand var), with a `get name` cursor fallback for CommandRunner. |
| 3 | Elixir | Only the **first** `switches: [...]` list was parsed. Now scans all. |
| 4 | Zig | zig-cli `.name` literals produced **phantom subcommands** (the app name and positional-arg names leaked). Dropped `.name` subcommand extraction; `.long_name` flags kept; zig-clap unaffected. |
| 5 | Haskell | Sticky `command` cursor mis-attributed later root globals to the last subcommand. Now **line-local** (a `command "x"` scopes only same-line options; optparse defines parsers non-locally). |
| 6 | Scala | Sticky cursor mis-attributed trailing root options to the last subcommand. Now scopes options to the `.children( ... )` block via paren depth. |
| 7 | Perl | `"key" => \ref` flag extraction ran over the whole file → unrelated reference hashes leaked as flags. Now scoped to inside the `GetOptions(...)` call, and `scan` per line. |
| 8 | Clojure | The long-only tools.cli option vector (`["--config CONFIG"]`) was dropped by an over-strict gate. Now accepted, and `scan` so multiple vectors per line surface. |

The recurring theme (Dart/Haskell/Scala) is the same receiver-blind / sticky-cursor class the C#/C++/JS reviews surfaced: a "global option after a subcommand" mis-attributes. Each is now receiver-mapped or scope-bounded.

Verified: each fix reproduced and confirmed; the 10 Tier-3 fixtures still pass. Full suite green: **3670 unit + 20219 functional, 0 failures**; `crystal tool format` + `ameba` + `typos` clean.