### PR TITLE
feat: npm package configuration and binary installation script

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,26 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/install.js
+++ b/install.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+// For NPM publishing purposes
+
+const fs = require("fs");
+const path = require("path");
+
+const version = require("./package.json").version;
+
+const platform = process.platform;
+const arch = process.arch;
+
+function getAssetName() {
+    if (platform === "linux" && arch === "x64") {
+        return `noir-v${version}-linux-x86_64`;
+    }
+
+    if (platform === "linux" && arch === "arm64") {
+        return `noir-v${version}-linux-arm64`;
+    }
+
+    if (platform === "darwin" && arch === "arm64") {
+        return `noir-v${version}-osx-arm64`;
+    }
+
+    if (platform === "darwin" && arch === "x64") {
+        return `noir-v${version}-osx-x86_64`;
+    }
+
+    throw new Error(`Unsupported platform: ${platform} ${arch}`);
+}
+
+(async () => {
+    const asset = getAssetName();
+
+    const downloadUrl =
+        `https://github.com/owasp-noir/noir/releases/download/v${version}/${asset}`;
+
+    const binDir = path.join(__dirname, "bin");
+    const output = path.join(binDir, "noir");
+
+    fs.mkdirSync(binDir, { recursive: true });
+
+    console.log(`Downloading ${asset}...`);
+
+    const response = await fetch(downloadUrl);
+
+    if (!response.ok) {
+        throw new Error(`Download failed (${response.status})`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    fs.writeFileSync(output, buffer);
+    fs.chmodSync(output, 0o755);
+
+    console.log("Binary installed.");
+})().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@owasp-noir/noir",
+    "version": "1.1.0",
+    "description": "OWASP Noir CLI",
+    "license": "MIT",
+    "bin": {
+        "noir": "./bin/noir"
+    },
+    "scripts": {
+        "postinstall": "node install.js"
+    },
+    "files": [
+        "install.js"
+    ],
+    "engines": {
+        "node": ">=18"
+    }
+}


### PR DESCRIPTION
Related to the discussion in #1861.

It's only for reference, just a draft. 

`publish-npm.yml` -  ensures that the npm package stays in sync with our GitHub releases.

`package.json` & `install.js` - We publish a tiny "wrapper" package to npm so Node.js/JavaScript developers can install Noir using `npm install -g @owasp-noir/noir` or `npx @owasp-noir/noir -b .`

### Security:
The `--provenance` flag in yml is a supply-chain security feature. It uses GitHub Actions secure identity token to cryptographically sign the published package. This is related to [Trusted Publishing](https://docs.npmjs.com/trusted-publishers), and aligns with github's [npm supply-chain security recommendations](https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/)

@hahwul @ksg97031 
I'm looking forward to hear your thoughts and any suggestions for improving this approach.
