### PR TITLE
ci(snap): drop redundant stage-packages from static build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,7 +56,10 @@ parts:
       - libgc-dev
       - liblzma-dev
       - libicu-dev
-    stage-packages:
-      - libssl3
-      - libxml2
-      - libevent-2.1-7t64
+    # No stage-packages: this part builds a fully static binary (--static +
+    # cc-wrapper), so libssl3/libxml2/libevent are linked in at build time and
+    # not needed at runtime. Staging them only bloated the snap and caused the
+    # store's USN scanner to flag the vendored (unused) libxml2 deb.
+    # Verify after building: `ldd prime/noir` should report "not a dynamic
+    # executable" (or list only linux-vdso/ld-linux). If any of these libs show
+    # up as a real dependency, add it back to a stage-packages: block.


### PR DESCRIPTION
## Why

The Snap Store's automated USN scanner keeps flagging this snap because
`libxml2` is present as a staged deb (most recently USN-8456-1). But
`noir` is compiled as a **fully static binary** (`--static` + the
`cc-wrapper` that appends `-lstdc++`), so `libssl3`, `libxml2` and
`libevent-2.1-7t64` are linked in at build time — the staged runtime
shared libraries are never used.

## What

- Remove the `stage-packages:` block (`libssl3`, `libxml2`,
  `libevent-2.1-7t64`).
- Add a comment explaining why, plus how to verify.

## Effect

- Smaller snap.
- Stops the recurring libxml2 USN notices for this snap (the scanner no
  longer sees a vendored deb). The statically-linked code still gets the
  patched `libxml2-dev` on any rebuild.

## Verify before publishing

After a snap build, the primed binary should be static:

```
ldd prime/noir   # expect: "not a dynamic executable"
```

If any of the removed libs shows up as a real dependency, add just that
one back under a `stage-packages:` block.