### PR TITLE
Use ENV.has_key? for ZAP API key check

### DIFF
--- a/src/models/delivers/zap.cr
+++ b/src/models/delivers/zap.cr
@@ -5,7 +5,7 @@ class ZAP
   API_ACCESS = "/JSON/core/action/accessUrl"
 
   def initialize(@endpoint)
-    if ENV.keys.includes? "ZAP_API_KEY"
+    if ENV.has_key?("ZAP_API_KEY")
       @apikey = ENV["ZAP_API_KEY"].to_s
     else
       @apikey = ""


### PR DESCRIPTION
## What changed

Swapped the ZAP API key presence check from `ENV.keys.includes?` to `ENV.has_key?`. It avoids building the keys array just to check one name and matches the other ENV checks already in the codebase.

Closes #2188

## Checks

- `git grep -n 'ENV.keys.includes' -- src`\n- `git grep -n 'ENV.has_key?("ZAP_API_KEY")' -- src/models/delivers/zap.cr`\n- `git diff --check`