### PR TITLE
Remove unused analyzer helpers

### DIFF
--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -204,14 +204,6 @@ module Analyzer::Php
       tokens
     end
 
-    private def extract_methods_from_annotation_context(context : String) : Array(String)
-      extract_methods_from_symfony_context(context)
-    end
-
-    private def extract_methods_from_attribute_context(context : String) : Array(String)
-      extract_methods_from_symfony_context(context)
-    end
-
     private def analyze_yaml_routes(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -1171,30 +1171,6 @@ module Analyzer::Ruby
       parts.join("/")
     end
 
-    # Build URL for a `get :action` inside member/collection blocks. For
-    # member: uses the parent resource's `name/1` prefix; for collection:
-    # strips the trailing `/1` so the action sits on the index URL.
-    private def member_collection_url(stack : Array(Frame), action : String, in_collection : Bool) : String?
-      resources_idx = nil
-      stack.each_with_index do |f, i|
-        resources_idx = i if f.kind == :resources
-      end
-      return if resources_idx.nil?
-
-      parts = [] of String
-      stack[0, resources_idx].each do |f|
-        parts << f.path unless f.path.empty?
-      end
-      rf = stack[resources_idx]
-      seg = rf.path
-      if in_collection && seg.ends_with?("/1")
-        seg = seg[0, seg.size - 2]
-      end
-      parts << seg unless seg.empty?
-      parts << action
-      "/" + parts.join("/")
-    end
-
     def controller_to_endpoint(
       path : String,
       @url : String,


### PR DESCRIPTION
## Summary
- remove unused Symfony annotation/attribute helper wrappers
- remove unused Rails member/collection URL helper

## Tests
- crystal tool format --check src/analyzer/analyzers/php/symfony.cr src/analyzer/analyzers/ruby/rails.cr
- crystal spec spec/functional_test/testers/php/symfony_spec.cr spec/functional_test/testers/php/symfony_callees_spec.cr spec/functional_test/testers/ruby/rails_spec.cr spec/functional_test/testers/ruby/rails_advanced_spec.cr spec/functional_test/testers/ruby/rails_callees_spec.cr
- crystal run lib/ameba/bin/ameba.cr -- src/analyzer/analyzers/php/symfony.cr src/analyzer/analyzers/ruby/rails.cr
- git diff --check

Fixes #2187
