### PR TITLE
fix(docs): preserve image aspect ratio under max-width

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -179,7 +179,10 @@ p { margin: 0; text-wrap: pretty; }
 a { color: var(--accent-text); text-decoration: none; }
 a:hover { text-decoration: underline; text-underline-offset: 0.2em; }
 
-img, svg, picture, video { display: block; max-width: 100%; }
+/* height: auto is required when HTML width/height attributes are present.
+   Without it, max-width shrinks the width while the height attribute stays
+   fixed, so content images (e.g. running.png) render stretched. */
+img, svg, picture, video { display: block; max-width: 100%; height: auto; }
 
 code, kbd, pre, samp { font-family: var(--font-mono); }
 


### PR DESCRIPTION
## Summary
- Docs content images with HTML `width`/`height` (e.g. `running.png` on Get Started → Your First Scan) were stretched when the column was narrower than the intrinsic width.
- Root cause: global CSS used `max-width: 100%` without `height: auto`, so the HTML height attribute stayed fixed while width shrank.
- Fix: add `height: auto` to the media reset in `docs/static/css/style.css`. HTML dimensions stay for CLS / aspect-ratio hints; fixed-size UI assets (logo, avatars, mascot, bento tiles) keep their more specific height rules.

## Test plan
- [ ] Open https://owasp-noir.github.io/noir/get_started/running/ after deploy and confirm `running.png` is not vertically stretched
- [ ] Spot-check other docs pages with screenshots (AI Power, passive scan rule, deliver, HTML report)
- [ ] Confirm header logo, mascot callout, and landing bento images still size correctly