### PR TITLE
feat(cli): detect 34 more popular CLI libraries across 17 languages (#2203)

### DIFF
--- a/spec/functional_test/fixtures/clojure/cli_babashka/taskrunner.clj
+++ b/spec/functional_test/fixtures/clojure/cli_babashka/taskrunner.clj
@@ -1,0 +1,20 @@
+(ns taskrunner.core
+  (:require [babashka.cli :as cli]))
+
+(defn run-cmd [{:keys [opts]}]
+  (println "starting on port" (:port opts)))
+
+(defn build-cmd [{:keys [opts]}]
+  (println "building" (:tag opts)))
+
+(def table
+  [{:cmds ["run"]
+    :fn run-cmd
+    :spec {:port {:coerce :long}
+           :verbose {:coerce :boolean}}}
+   {:cmds ["build"]
+    :fn build-cmd
+    :spec {:tag {:coerce :string}}}])
+
+(defn -main [& args]
+  (cli/dispatch table args))

--- a/spec/functional_test/fixtures/clojure/cli_babashka_scoping/tool.clj
+++ b/spec/functional_test/fixtures/clojure/cli_babashka_scoping/tool.clj
@@ -1,0 +1,28 @@
+(ns tool.core
+  (:require [babashka.cli :as cli]))
+
+(defn start-cmd [{:keys [opts]}]
+  (println "starting docker container" (:detach opts)))
+
+(defn stop-cmd [{:keys [opts]}]
+  (println "stopping docker container" (:force opts)))
+
+;; Map literals are unordered — this entry's :spec deliberately precedes its
+;; :cmds sibling, and :cmds itself has two segments ("docker" "start").
+(def table
+  [{:spec {:detach {:coerce :boolean}
+           :verbose {:desc "extra logging"}}
+    :cmds ["docker" "start"]
+    :fn start-cmd}
+   {:cmds ["docker" "stop"]
+    :spec {:force {:coerce :boolean}}
+    :fn stop-cmd}])
+
+;; Unrelated map shaped like a babashka.cli option entry, declared after the
+;; last dispatch entry. It is NOT inside any :spec map, so it must never be
+;; attributed to tool/docker/stop (or anywhere else).
+(def log-opts
+  {:level {:coerce :keyword}})
+
+(defn -main [& args]
+  (cli/dispatch table args))

--- a/spec/functional_test/fixtures/clojure/cli_environ/reporter.clj
+++ b/spec/functional_test/fixtures/clojure/cli_environ/reporter.clj
@@ -1,0 +1,12 @@
+(ns reporter.core
+  (:require [clojure.tools.cli :refer [parse-opts]]
+            [environ.core :refer [env]]))
+
+(def cli-options
+  [["-v" "--verbose" "Verbose output"]])
+
+(defn -main [& args]
+  (let [{:keys [options]} (parse-opts args cli-options)
+        db-url  (env :database-url)
+        api-key (env :api-key)]
+    (println "connecting to" db-url "with" api-key "verbose?" (:verbose options))))

--- a/spec/functional_test/fixtures/clojure/cli_environ_alias_fp/toolkit.clj
+++ b/spec/functional_test/fixtures/clojure/cli_environ_alias_fp/toolkit.clj
@@ -1,0 +1,19 @@
+(ns myapp.toolkit
+  (:require [clojure.tools.cli :refer [parse-opts]]
+            [environ.core :as environ]))
+
+(def cli-options
+  [["-t" "--timeout SECONDS" "Timeout in seconds"]])
+
+;; `env` here is just a local fn param (a very common Clojure idiom for "the
+;; current config map") — nothing to do with environ.core, which was only
+;; ever required under the `environ` alias below.
+(defn ->config [env]
+  (env :timeout))
+
+(defn db-url []
+  (environ/env :database-url))
+
+(defn -main [& args]
+  (let [{:keys [options]} (parse-opts args cli-options)]
+    (->config options)))

--- a/spec/functional_test/fixtures/clojure/cli_environ_fp/config.clj
+++ b/spec/functional_test/fixtures/clojure/cli_environ_fp/config.clj
@@ -1,0 +1,5 @@
+(ns myapp.config
+  (:require [environ.core :refer [env]]))
+
+(def db-url (env :database-url))
+(def api-key (env :api-key))

--- a/spec/functional_test/fixtures/clojure/cli_environ_fp/handler.clj
+++ b/spec/functional_test/fixtures/clojure/cli_environ_fp/handler.clj
@@ -1,0 +1,9 @@
+(ns myapp.handler
+  (:require [ring.adapter.jetty :refer [run-jetty]]
+            [myapp.config :as config]))
+
+(defn app [request]
+  {:status 200 :body (str "db=" config/db-url)})
+
+(defn -main [& args]
+  (run-jetty app {:port 3000}))

--- a/spec/functional_test/fixtures/cpp/cli_absl_fp/server.cpp
+++ b/spec/functional_test/fixtures/cpp/cli_absl_fp/server.cpp
@@ -1,0 +1,17 @@
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include <map>
+#include <string>
+
+// Space before the paren (valid C++, some macro-invocation style guides use
+// it) must still be detected and extracted.
+ABSL_FLAG (int32_t, port, 8080, "port to listen on");
+
+// A template type with a top-level comma must not truncate/misparse the
+// name field.
+ABSL_FLAG(std::map<std::string, int>, weights, {}, "weights map");
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  return 0;
+}

--- a/spec/functional_test/fixtures/cpp/cli_argparse_fp/mytool.cpp
+++ b/spec/functional_test/fixtures/cpp/cli_argparse_fp/mytool.cpp
@@ -1,0 +1,19 @@
+#include <argparse/argparse.hpp>
+
+// Unrelated helper that builds its own local ArgumentParser, declared above
+// main. Its options must never leak into the real root's endpoint, and it
+// must never be mistaken for the root itself just because it comes first
+// in the file.
+argparse::ArgumentParser make_common_parser() {
+  argparse::ArgumentParser common("common");
+  common.add_argument("--log-level");
+  return common;
+}
+
+int main(int argc, char** argv) {
+  argparse::ArgumentParser program("mytool");
+  program.add_argument("-v", "--verbose");
+  program.add_argument("--config");
+  program.parse_args(argc, argv);
+  return 0;
+}

--- a/spec/functional_test/fixtures/cpp/cli_argparse_sub/git.cpp
+++ b/spec/functional_test/fixtures/cpp/cli_argparse_sub/git.cpp
@@ -1,0 +1,15 @@
+#include <argparse/argparse.hpp>
+
+// Declare-then-register style: the subcommand parser is declared and wired
+// up via add_subparser *before* the root option/parse_args lines appear, to
+// prove attribution doesn't depend on source order.
+int main(int argc, char** argv) {
+  argparse::ArgumentParser program("git");
+  argparse::ArgumentParser commit_cmd("commit");
+  commit_cmd.add_argument("-m", "--message");
+  program.add_subparser(commit_cmd);
+
+  program.add_argument("--verbose");
+  program.parse_args(argc, argv);
+  return 0;
+}

--- a/spec/functional_test/fixtures/csharp/cli_cocona/Program.cs
+++ b/spec/functional_test/fixtures/csharp/cli_cocona/Program.cs
@@ -1,0 +1,14 @@
+using System;
+using Cocona;
+
+var app = CoconaApp.Create();
+
+app.AddCommand("greet", ([Option('n')] string name, [Argument] string message) =>
+{
+    var token = Environment.GetEnvironmentVariable("COCONA_TOKEN");
+    Console.WriteLine($"Hello {name}: {message}");
+});
+
+app.AddCommand("bye", () => Console.WriteLine("bye"));
+
+app.Run();

--- a/spec/functional_test/fixtures/csharp/cli_cocona/cli_cocona.csproj
+++ b/spec/functional_test/fixtures/csharp/cli_cocona/cli_cocona.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>coconatool</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/cli_cocona_multi/Program.cs
+++ b/spec/functional_test/fixtures/csharp/cli_cocona_multi/Program.cs
@@ -1,0 +1,13 @@
+using System;
+using Cocona;
+
+var app = CoconaApp.Create();
+
+// Several option/argument params on ONE inline-lambda line: every one
+// must surface, not just the first (regression for line.scan fix).
+app.AddCommand("run", ([Option('n')] string name, [Option('c')] int count, [Argument] string target) =>
+{
+    Console.WriteLine($"{name} {count} {target}");
+});
+
+app.Run();

--- a/spec/functional_test/fixtures/csharp/cli_cocona_multi/cli_cocona_multi.csproj
+++ b/spec/functional_test/fixtures/csharp/cli_cocona_multi/cli_cocona_multi.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>coconamulti</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/cli_mcmaster/Program.cs
+++ b/spec/functional_test/fixtures/csharp/cli_mcmaster/Program.cs
@@ -1,0 +1,38 @@
+using System;
+using McMaster.Extensions.CommandLineUtils;
+
+[Subcommand(typeof(PushCommand))]
+class Program
+{
+    [Option("-n|--name")]
+    public string Name { get; set; }
+
+    [Argument(0)]
+    public string Input { get; set; }
+
+    static int Main(string[] args)
+    {
+        var token = Environment.GetEnvironmentVariable("MCM_TOKEN");
+        return CommandLineApplication.Execute<Program>(args);
+    }
+
+    private void OnExecute()
+    {
+        Console.WriteLine($"{Name}: {Input}");
+    }
+}
+
+[Command("push")]
+class PushCommand
+{
+    [Option("-f|--force")]
+    public bool Force { get; set; }
+
+    [Argument(0, "remote")]
+    public string Remote { get; set; }
+
+    private void OnExecute()
+    {
+        Console.WriteLine($"Pushing to {Remote}");
+    }
+}

--- a/spec/functional_test/fixtures/csharp/cli_mcmaster/cli_mcmaster.csproj
+++ b/spec/functional_test/fixtures/csharp/cli_mcmaster/cli_mcmaster.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>mcmastertool</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/fixtures/csharp/cli_mcmaster_desc/Program.cs
+++ b/spec/functional_test/fixtures/csharp/cli_mcmaster_desc/Program.cs
@@ -1,0 +1,12 @@
+using System;
+using McMaster.Extensions.CommandLineUtils;
+
+class Program
+{
+    [Argument(0, Description = "the remote repository to push to")]
+    public string Remote { get; set; }
+
+    static int Main(string[] args) => CommandLineApplication.Execute<Program>(args);
+
+    private void OnExecute() => Console.WriteLine(Remote);
+}

--- a/spec/functional_test/fixtures/csharp/cli_mcmaster_desc/cli_mcmaster_desc.csproj
+++ b/spec/functional_test/fixtures/csharp/cli_mcmaster_desc/cli_mcmaster_desc.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>mcmdesc</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/spec/functional_test/fixtures/go/cli_kingpin/go.mod
+++ b/spec/functional_test/fixtures/go/cli_kingpin/go.mod
@@ -1,0 +1,5 @@
+module kingpindemo
+
+go 1.21
+
+require github.com/alecthomas/kingpin/v2 v2.4.0

--- a/spec/functional_test/fixtures/go/cli_kingpin/main.go
+++ b/spec/functional_test/fixtures/go/cli_kingpin/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	app       = kingpin.New("kingpindemo", "A demo kingpin CLI application.")
+	verbose   = app.Flag("verbose", "Enable verbose output.").Bool()
+	deployCmd = app.Command("deploy", "Deploy the application.")
+	target    = deployCmd.Arg("target", "Deployment target.").String()
+	token     = deployCmd.Flag("token", "API token.").Envar("KINGPIN_TOKEN").String()
+)
+
+func main() {
+	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
+	case deployCmd.FullCommand():
+		fmt.Println(*target, *token, *verbose)
+	}
+}

--- a/spec/functional_test/fixtures/go/cli_kong/go.mod
+++ b/spec/functional_test/fixtures/go/cli_kong/go.mod
@@ -1,0 +1,5 @@
+module kongdemo
+
+go 1.21
+
+require github.com/alecthomas/kong v0.9.0

--- a/spec/functional_test/fixtures/go/cli_kong/main.go
+++ b/spec/functional_test/fixtures/go/cli_kong/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kong"
+)
+
+var CLI struct {
+	Verbose bool     `help:"Enable verbose logging." short:"v"`
+	Serve   ServeCmd `cmd:"" help:"Start the server."`
+}
+
+type ServeCmd struct {
+	Host  string `arg:"" help:"Host to bind."`
+	Port  int    `help:"Port to listen on." default:"8080"`
+	Token string `help:"API token." env:"KONG_API_TOKEN"`
+}
+
+func main() {
+	ctx := kong.Parse(&CLI)
+	switch ctx.Command() {
+	case "serve <host>":
+		fmt.Println("serving")
+	}
+}

--- a/spec/functional_test/fixtures/go/cli_kong_fp/go.mod
+++ b/spec/functional_test/fixtures/go/cli_kong_fp/go.mod
@@ -1,0 +1,5 @@
+module kongfpdemo
+
+go 1.21
+
+require github.com/alecthomas/kong v0.9.0

--- a/spec/functional_test/fixtures/go/cli_kong_fp/main.go
+++ b/spec/functional_test/fixtures/go/cli_kong_fp/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"github.com/kelseyhightower/envconfig"
+)
+
+var CLI struct {
+	Verbose bool     `help:"Enable verbose logging." short:"v"`
+	Serve   ServeCmd `cmd:"" help:"Start the server."`
+}
+
+type ServeCmd struct {
+	Host  string `arg:"" help:"Host to bind."`
+	Port  int    `help:"Port to listen on." default:"8080"`
+	Token string `help:"API token." env:"KONG_API_TOKEN"`
+}
+
+// ClientConfig is parsed by envconfig, not kong — it just happens to share
+// kong's common struct-tag keys (env/default). It must never be merged
+// onto the kong CLI's root command.
+type ClientConfig struct {
+	Timeout int `env:"HTTP_TIMEOUT" default:"30"`
+}
+
+func main() {
+	ctx := kong.Parse(&CLI)
+
+	var cfg ClientConfig
+	envconfig.Process("client", &cfg)
+
+	switch ctx.Command() {
+	case "serve <host>":
+		fmt.Println("serving", cfg.Timeout)
+	}
+}

--- a/spec/functional_test/fixtures/go/cli_kong_ptr/go.mod
+++ b/spec/functional_test/fixtures/go/cli_kong_ptr/go.mod
@@ -1,0 +1,5 @@
+module kongptrdemo
+
+go 1.21
+
+require github.com/alecthomas/kong v0.9.0

--- a/spec/functional_test/fixtures/go/cli_kong_ptr/main.go
+++ b/spec/functional_test/fixtures/go/cli_kong_ptr/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kong"
+)
+
+var CLI struct {
+	Verbose bool      `help:"Enable verbose logging." short:"v"`
+	Serve   *ServeCmd `cmd:"" help:"Start the server."`
+}
+
+type ServeCmd struct {
+	Host  string `arg:"" help:"Host to bind."`
+	Port  int    `help:"Port to listen on." default:"8080"`
+	Token string `help:"API token." env:"KONG_API_TOKEN"`
+}
+
+func main() {
+	ctx := kong.Parse(&CLI)
+	switch ctx.Command() {
+	case "serve <host>":
+		fmt.Println("serving")
+	}
+}

--- a/spec/functional_test/fixtures/go/cli_mitchellh/go.mod
+++ b/spec/functional_test/fixtures/go/cli_mitchellh/go.mod
@@ -1,0 +1,5 @@
+module mitchellhdemo
+
+go 1.21
+
+require github.com/mitchellh/cli v1.1.5

--- a/spec/functional_test/fixtures/go/cli_mitchellh/main.go
+++ b/spec/functional_test/fixtures/go/cli_mitchellh/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mitchellh/cli"
+)
+
+type DeployCommand struct{}
+
+func (c *DeployCommand) Run(args []string) int {
+	fs := flag.NewFlagSet("deploy", flag.ContinueOnError)
+	var target string
+	fs.StringVar(&target, "target", "", "deployment target")
+	fs.Parse(args)
+
+	token := os.Getenv("MITCHELLH_TOKEN")
+	fmt.Println(target, token)
+	return 0
+}
+
+func (c *DeployCommand) Help() string     { return "deploy the application" }
+func (c *DeployCommand) Synopsis() string { return "deploy the app" }
+
+func main() {
+	c := cli.NewCLI("mitchellhdemo", "1.0.0")
+	c.Commands = map[string]cli.CommandFactory{
+		"deploy": func() (cli.Command, error) {
+			return &DeployCommand{}, nil
+		},
+	}
+
+	exitStatus, err := c.Run()
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(exitStatus)
+}

--- a/spec/functional_test/fixtures/go/cli_mitchellh_fp/go.mod
+++ b/spec/functional_test/fixtures/go/cli_mitchellh_fp/go.mod
@@ -1,0 +1,5 @@
+module mitchellhfpdemo
+
+go 1.21
+
+require github.com/mitchellh/cli v1.1.5

--- a/spec/functional_test/fixtures/go/cli_mitchellh_fp/main.go
+++ b/spec/functional_test/fixtures/go/cli_mitchellh_fp/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mitchellh/cli"
+)
+
+type DeployCommand struct{}
+
+func (c *DeployCommand) Run(args []string) int {
+	fs := flag.NewFlagSet("deploy", flag.ContinueOnError)
+	var target string
+	fs.StringVar(&target, "target", "", "deployment target")
+	fs.Parse(args)
+
+	token := os.Getenv("MITCHELLH_TOKEN")
+	fmt.Println(target, token)
+	return 0
+}
+
+func (c *DeployCommand) Help() string     { return "deploy the application" }
+func (c *DeployCommand) Synopsis() string { return "deploy the app" }
+
+// AdminCommand is never registered in c.Commands below — adminHelper is a
+// standalone helper unrelated to the CLI's command factory map. Its own
+// Run() must never be attributed to the deploy command.
+type AdminCommand struct{}
+
+func (c *AdminCommand) Run(args []string) int {
+	token := os.Getenv("ADMIN_TOKEN")
+	fmt.Println("admin", token)
+	return 0
+}
+
+func (c *AdminCommand) Help() string     { return "admin helper" }
+func (c *AdminCommand) Synopsis() string { return "admin" }
+
+func main() {
+	c := cli.NewCLI("mitchellhfpdemo", "1.0.0")
+	c.Commands = map[string]cli.CommandFactory{
+		// The command is built via an intermediate variable (idiomatic Go
+		// when the command needs field initialization), not a direct
+		// `return &DeployCommand{}, nil`.
+		"deploy": func() (cli.Command, error) {
+			cmd := &DeployCommand{}
+			return cmd, nil
+		},
+	}
+
+	exitStatus, err := c.Run()
+	if err != nil {
+		fmt.Println(err)
+	}
+	os.Exit(exitStatus)
+}
+
+// adminHelper is an ordinary function, not a CommandFactory closure — its
+// `return &AdminCommand{}, nil` line must not be attributed to any command
+// registered above it in the file.
+func adminHelper() (cli.Command, error) {
+	return &AdminCommand{}, nil
+}

--- a/spec/functional_test/fixtures/groovy/cli_commons_cli/tool.groovy
+++ b/spec/functional_test/fixtures/groovy/cli_commons_cli/tool.groovy
@@ -1,0 +1,9 @@
+import org.apache.commons.cli.*
+
+Options options = new Options()
+options.addOption(Option.builder("f").longOpt("file").hasArg().desc("input file").build())
+options.addOption(Option.builder().longOpt("verbose").desc("verbose output").build()); options.addOption(Option.builder("q").longOpt("quiet").desc("quiet mode").build())
+
+CommandLine cmd = new DefaultParser().parse(options, args)
+def token = System.getenv('CLI_TOKEN')
+println token

--- a/spec/functional_test/fixtures/groovy/cli_jcommander/tool.groovy
+++ b/spec/functional_test/fixtures/groovy/cli_jcommander/tool.groovy
@@ -1,0 +1,30 @@
+import com.beust.jcommander.JCommander
+import com.beust.jcommander.Parameter
+
+class MainArgs {
+    @Parameter(names = ["-f", "--file"], description = "input file")
+    String file
+}
+
+class AddCommand {
+    @Parameter(names = ["-m", "--message"], description = "commit message")
+    String message
+}
+
+class RemoveCommand {
+    @Parameter(names = ["-r", "--recursive"], description = "recursive removal")
+    boolean recursive
+}
+
+def mainArgs = new MainArgs()
+def addCommand = new AddCommand()
+
+JCommander jc = JCommander.newBuilder()
+    .addObject(mainArgs)
+    .addCommand('add', addCommand)
+    .addCommand('remove', new RemoveCommand())
+    .build()
+
+jc.parse(args)
+def token = System.getenv('JC_TOKEN')
+println token

--- a/spec/functional_test/fixtures/haskell/cli_turtle/tool.hs
+++ b/spec/functional_test/fixtures/haskell/cli_turtle/tool.hs
@@ -1,0 +1,16 @@
+module Main where
+
+import Turtle (options, optText, optInt, optPath, switch, arg, argText)
+import System.Environment (lookupEnv)
+
+parser = (,,,,) <$> optText "name" 'n' "your name"
+                <*> optInt "age" 'a' "your age"
+                <*> optPath "config" 'c' "config file"
+                <*> switch "verbose" 'v' "be verbose"
+                <*> argText "target" "target host"
+
+main :: IO ()
+main = do
+  (name, age, cfg, verbose, target) <- options "Greeting script" parser
+  _ <- lookupEnv "GREETING_TOKEN"
+  return ()

--- a/spec/functional_test/fixtures/haskell/cli_turtle_fp/tool.hs
+++ b/spec/functional_test/fixtures/haskell/cli_turtle_fp/tool.hs
@@ -1,0 +1,40 @@
+module Main where
+
+import Turtle (options, optText, argText, arg, argInt)
+import qualified Turtle
+import Text.Read (readMaybe)
+import qualified Data.Text as Text
+import System.Environment (lookupEnv)
+
+-- arg count "deprecated" old code
+
+-- | Locally-defined dispatch helper that happens to share Turtle.switch's
+-- name; unrelated to CLI option parsing (Turtle.switch is used qualified
+-- below, so there is no name clash).
+switch :: String -> Bool
+switch "on" = True
+switch "staging" = False
+switch _ = False
+
+logMessage :: Int -> String -> String -> IO ()
+logMessage code level msg = putStrLn (show code ++ " [" ++ level ++ "] " ++ msg)
+
+emitWarning :: IO ()
+emitWarning = do
+  let arg = 42
+      level = "WARN"
+  logMessage arg level "urgent"
+
+parser = (,,,,) <$> optText "name" 'n' "your name"
+                <*> Turtle.switch "verbose" 'v' "be verbose"
+                <*> argText "target" "target host"
+                <*> argInt "retries" "number of retries"
+                <*> arg (readMaybe . Text.unpack) "count" "how many times"
+
+main :: IO ()
+main = do
+  (name, verbose, target, retries, count) <- options "Greeting script" parser
+  emitWarning
+  putStrLn (if switch "staging" then "staging" else "prod")
+  _ <- lookupEnv "GREETING_TOKEN"
+  return ()

--- a/spec/functional_test/fixtures/java/cli_jopt_simple/src/App.java
+++ b/spec/functional_test/fixtures/java/cli_jopt_simple/src/App.java
@@ -1,0 +1,14 @@
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import java.util.Arrays;
+
+public class App {
+    public static void main(String[] args) {
+        OptionParser parser = new OptionParser();
+        parser.accepts("verbose", "enable verbose output");
+        parser.acceptsAll(Arrays.asList("h", "help"), "show help").forHelp();
+
+        OptionSet options = parser.parse(args);
+        String token = System.getenv("APP_TOKEN");
+    }
+}

--- a/spec/functional_test/fixtures/java/cli_jopt_simple_fp/src/App.java
+++ b/spec/functional_test/fixtures/java/cli_jopt_simple_fp/src/App.java
@@ -1,0 +1,25 @@
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+
+public class App {
+    // Unrelated helper class that happens to also define an `accepts(...)`
+    // method. Its receiver (`matcher`) is never bound to `new OptionParser(...)`,
+    // so calls on it must NOT be attributed as a CLI flag.
+    static class FormatMatcher {
+        boolean accepts(String fmt) {
+            return fmt.equals("csv");
+        }
+    }
+
+    public static void main(String[] args) {
+        OptionParser parser = new OptionParser();
+        parser.accepts("topic", "the topic to publish");
+
+        FormatMatcher matcher = new FormatMatcher();
+        if (matcher.accepts("csv")) {
+            System.out.println("csv format");
+        }
+
+        OptionSet options = parser.parse(args);
+    }
+}

--- a/spec/functional_test/fixtures/java/cli_optionparser_generic_fp/src/ReportBuilder.java
+++ b/spec/functional_test/fixtures/java/cli_optionparser_generic_fp/src/ReportBuilder.java
@@ -1,0 +1,19 @@
+import java.util.Map;
+
+// No jopt library import anywhere in this file/project — `OptionParser`
+// here is the app's own report-options parsing helper, unrelated to any
+// third-party CLI parsing library. Must NOT be tagged as java_cli.
+public class ReportBuilder {
+    static class OptionParser {
+        OptionParser(Map<String, String> settings) {
+        }
+
+        void process() {
+        }
+    }
+
+    void build(Map<String, String> settings) {
+        OptionParser parser = new OptionParser(settings);
+        parser.process();
+    }
+}

--- a/spec/functional_test/fixtures/javascript/cli_arg/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_arg/cli.js
@@ -1,0 +1,13 @@
+const arg = require('arg');
+
+const args = arg({
+  '--name': String,
+  '--verbose': Boolean,
+  '--port': Number,
+  '-n': '--name',
+  '-v': '--verbose',
+});
+
+const token = process.env.API_TOKEN;
+
+console.log(args, token);

--- a/spec/functional_test/fixtures/javascript/cli_arg/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_arg/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "argdemo",
+  "version": "1.0.0",
+  "bin": {
+    "argdemo": "cli.js"
+  },
+  "dependencies": {
+    "arg": "^5.0.2"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_citty/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_citty/cli.js
@@ -1,0 +1,32 @@
+import { defineCommand, runMain } from 'citty';
+
+const main = defineCommand({
+  meta: {
+    name: 'greet',
+    version: '1.0.0',
+  },
+  args: {
+    verbose: {
+      type: 'boolean',
+      alias: 'v',
+    },
+  },
+  subCommands: {
+    serve: defineCommand({
+      args: {
+        port: {
+          type: 'string',
+        },
+      },
+      run({ args }) {
+        console.log(args.port);
+      },
+    }),
+  },
+  run({ args }) {
+    const token = process.env.API_TOKEN;
+    console.log(args.verbose, token);
+  },
+});
+
+runMain(main);

--- a/spec/functional_test/fixtures/javascript/cli_citty/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_citty/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cittydemo",
+  "version": "1.0.0",
+  "bin": {
+    "cittydemo": "cli.js"
+  },
+  "dependencies": {
+    "citty": "^0.1.6"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_citty_var_subcommand/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_citty_var_subcommand/cli.js
@@ -1,0 +1,20 @@
+import { defineCommand, runMain } from 'citty';
+
+const serveCommand = defineCommand({
+  args: {
+    port: {
+      type: 'string',
+    },
+  },
+  run({ args }) {
+    console.log(args.port);
+  },
+});
+
+const main = defineCommand({
+  subCommands: {
+    serve: serveCommand,
+  },
+});
+
+runMain(main);

--- a/spec/functional_test/fixtures/javascript/cli_citty_var_subcommand/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_citty_var_subcommand/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cittyvardemo",
+  "version": "1.0.0",
+  "bin": {
+    "cittyvardemo": "cli.js"
+  },
+  "dependencies": {
+    "citty": "^0.1.6"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_command_line_args/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_command_line_args/cli.js
@@ -1,0 +1,13 @@
+const commandLineArgs = require('command-line-args');
+
+const optionDefinitions = [
+  { name: 'verbose', alias: 'v', type: Boolean },
+  { name: 'port', alias: 'p', type: Number },
+  { name: 'file', type: String, defaultOption: true },
+];
+
+const options = commandLineArgs(optionDefinitions);
+
+const token = process.env.API_TOKEN;
+
+console.log(options, token);

--- a/spec/functional_test/fixtures/javascript/cli_command_line_args/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_command_line_args/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "claddemo",
+  "version": "1.0.0",
+  "bin": {
+    "claddemo": "cli.js"
+  },
+  "dependencies": {
+    "command-line-args": "^5.2.1"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_command_line_args_fp/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_command_line_args_fp/cli.js
@@ -1,0 +1,17 @@
+const commandLineArgs = require('command-line-args');
+
+const optionDefinitions = [
+  { name: 'verbose', alias: 'v', type: Boolean },
+];
+
+const options = commandLineArgs(optionDefinitions);
+
+// Unrelated content-field schema (Payload CMS / Keystone-style), NOT a CLI
+// option list — regression guard for the CLA scoping bug: this must not
+// leak "email"/"age" onto the cli:// endpoint as phantom flags.
+const fields = [
+  { name: 'email', type: 'text' },
+  { name: 'age', type: 'number' },
+];
+
+console.log(options, fields);

--- a/spec/functional_test/fixtures/javascript/cli_command_line_args_fp/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_command_line_args_fp/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cladfpdemo",
+  "version": "1.0.0",
+  "bin": {
+    "cladfpdemo": "cli.js"
+  },
+  "dependencies": {
+    "command-line-args": "^5.2.1"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_command_line_args_multiline/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_command_line_args_multiline/cli.js
@@ -1,0 +1,17 @@
+const commandLineArgs = require('command-line-args');
+
+const optionDefinitions = [
+  {
+    name: 'verbose',
+    alias: 'v',
+    type: Boolean,
+  },
+  {
+    name: 'port',
+    alias: 'p',
+    type: Number,
+  },
+];
+
+const options = commandLineArgs(optionDefinitions);
+console.log(options);

--- a/spec/functional_test/fixtures/javascript/cli_command_line_args_multiline/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_command_line_args_multiline/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "clamultilinedemo",
+  "version": "1.0.0",
+  "bin": {
+    "clamultilinedemo": "cli.js"
+  },
+  "dependencies": {
+    "command-line-args": "^5.2.1"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_getopts/cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_getopts/cli.js
@@ -1,0 +1,16 @@
+const getopts = require('getopts');
+
+const options = getopts(process.argv.slice(2), {
+  alias: {
+    h: 'help',
+  },
+  default: {
+    port: 3000,
+  },
+  boolean: ['verbose'],
+  string: ['name'],
+});
+
+const token = process.env.API_TOKEN;
+
+console.log(options, token);

--- a/spec/functional_test/fixtures/javascript/cli_getopts/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_getopts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "getoptsdemo",
+  "version": "1.0.0",
+  "bin": {
+    "getoptsdemo": "cli.js"
+  },
+  "dependencies": {
+    "getopts": "^2.3.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_getopts_fp/package.json
+++ b/spec/functional_test/fixtures/javascript/cli_getopts_fp/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "getoptsfpdemo",
+  "version": "1.0.0",
+  "bin": {
+    "getoptsfpdemo": "real-cli.js"
+  },
+  "dependencies": {
+    "commander": "^11.0.0"
+  }
+}

--- a/spec/functional_test/fixtures/javascript/cli_getopts_fp/printToken.js
+++ b/spec/functional_test/fixtures/javascript/cli_getopts_fp/printToken.js
@@ -1,0 +1,6 @@
+// Old shell wrapper used getopts for flag parsing; now just env-driven.
+// Regression guard: the bare word "getopts" in this comment must not be
+// enough to treat this file as CLI-parsing evidence.
+module.exports = function printToken() {
+  console.log(process.env.API_TOKEN);
+};

--- a/spec/functional_test/fixtures/javascript/cli_getopts_fp/real-cli.js
+++ b/spec/functional_test/fixtures/javascript/cli_getopts_fp/real-cli.js
@@ -1,0 +1,2 @@
+const { program } = require('commander');
+program.option('-v, --verbose').parse();

--- a/spec/functional_test/fixtures/kotlin/cli_picocli/tool.kt
+++ b/spec/functional_test/fixtures/kotlin/cli_picocli/tool.kt
@@ -1,0 +1,38 @@
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import java.util.concurrent.Callable
+import kotlin.system.exitProcess
+
+@Command(name = "tool", mixinStandardHelpOptions = true, subcommands = [Serve::class])
+class Tool : Callable<Int> {
+    @Option(names = ["-v", "--verbose"], description = ["enable verbose logging"])
+    var verbose: Boolean = false
+
+    @Option(names = ["--config"], description = ["config path"])
+    var config: String? = null
+
+    override fun call(): Int {
+        val token = System.getenv("API_TOKEN")
+        return 0
+    }
+}
+
+@Command(name = "serve")
+class Serve : Callable<Int> {
+    @Option(names = ["-p", "--port"], description = ["port to listen on"])
+    var port: Int = 8080
+
+    @Parameters(index = "0", description = ["config file"])
+    lateinit var config: String
+
+    override fun call(): Int {
+        return 0
+    }
+}
+
+fun main(args: Array<String>) {
+    val exitCode = CommandLine(Tool()).execute(*args)
+    exitProcess(exitCode)
+}

--- a/spec/functional_test/fixtures/kotlin/cli_picocli_multiline/multitool.kt
+++ b/spec/functional_test/fixtures/kotlin/cli_picocli_multiline/multitool.kt
@@ -1,0 +1,25 @@
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import java.util.concurrent.Callable
+
+@Command(name = "multitool")
+class MultiTool : Callable<Int> {
+    override fun call(): Int = 0
+}
+
+// Wrapped command annotation, plus annotation-and-property on the same line.
+@Command(
+    name = "serve",
+    description = ["start the server"]
+)
+class Serve : Callable<Int> {
+    @Option(names = ["-p", "--port"]) var port: Int = 8080
+    @Parameters(index = "0") lateinit var target: String
+    override fun call(): Int = 0
+}
+
+fun main(args: Array<String>) {
+    CommandLine(MultiTool()).execute(*args)
+}

--- a/spec/functional_test/fixtures/lua/cli_cliargs/tool.lua
+++ b/spec/functional_test/fixtures/lua/cli_cliargs/tool.lua
@@ -1,0 +1,11 @@
+local cli = require("cliargs")
+
+cli:set_name("mytool")
+cli:add_argument("INPUT", "path to input file")
+cli:add_option("-o, --output=DEST", "path to output file", "out.txt")
+cli:add_flag("-v, --verbose", "enable verbose output")
+
+local token = os.getenv("API_TOKEN")
+
+local args, err = cli:parse()
+print(token, args, err)

--- a/spec/functional_test/fixtures/lua/cli_cliargs_fp/app.lua
+++ b/spec/functional_test/fixtures/lua/cli_cliargs_fp/app.lua
@@ -1,0 +1,24 @@
+-- Real cliargs CLI parsing, with no set_name call on the actual cliargs
+-- instance, so the binary name must fall back to the file stem ("app").
+local cli = require("cliargs")
+cli:add_argument("INPUT", "path to input file")
+cli:add_option("-o, --output=DEST", "path to output file", "out.txt")
+
+-- Unrelated object with a same-named set_name method. Its receiver ("logger")
+-- was never bound to require("cliargs"), so this must NOT influence the
+-- binary name of the cli:// endpoint below.
+local logger = {}
+function logger:set_name(n) self.name = n end
+logger:set_name("audit-logger")
+
+-- Unrelated object with same-named add_option/add_flag methods (e.g. a menu
+-- or settings-panel builder). Its receiver ("menu") was never bound to
+-- require("cliargs"), so these must NOT be merged into the cli:// params.
+local menu = {}
+function menu:add_option(name, desc) end
+function menu:add_flag(name, desc) end
+menu:add_option("theme", "ui theme")
+menu:add_flag("dark_mode", "enable dark mode")
+
+local args, err = cli:parse()
+print(args, err)

--- a/spec/functional_test/fixtures/perl/cli_describe_options_modifiers_fp/tool.pl
+++ b/spec/functional_test/fixtures/perl/cli_describe_options_modifiers_fp/tool.pl
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Getopt::Long::Descriptive;
+
+my ($opt, $usage) = describe_options(
+    '%c %o',
+    ['verbose!' => 'be verbose (negatable)'],
+    ['count+'   => 'increase verbosity'],
+);
+
+print "ok\n" if $opt->verbose;

--- a/spec/functional_test/fixtures/perl/cli_getopt_long_descriptive/tool.pl
+++ b/spec/functional_test/fixtures/perl/cli_getopt_long_descriptive/tool.pl
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Getopt::Long::Descriptive;
+
+my ($opt, $usage) = describe_options(
+    '%c %o',
+    ['verbose|v' => 'be verbose'],
+    ['name=s'    => 'name to use'],
+    ['help'      => 'print usage', {shortcircuit => 1}],
+);
+
+my $token = $ENV{API_TOKEN};
+my $first = $ARGV[0];
+
+print $usage->text if $opt->help;
+print "$token $first\n" if $opt->verbose;

--- a/spec/functional_test/fixtures/perl/cli_moox_options/myapp.pm
+++ b/spec/functional_test/fixtures/perl/cli_moox_options/myapp.pm
@@ -1,0 +1,26 @@
+package MyApp;
+use MooX::Options;
+
+option 'verbose' => (
+    is  => 'ro',
+    doc => 'be verbose',
+);
+
+option 'name' => (
+    is       => 'ro',
+    format   => 's',
+    required => 1,
+    doc      => 'name to use',
+);
+
+my $token = $ENV{API_TOKEN};
+
+sub run {
+    my ($self) = @_;
+    print "$token\n" if $self->verbose;
+    print $self->name, "\n";
+}
+
+__PACKAGE__->new_with_options->run;
+
+1;

--- a/spec/functional_test/fixtures/perl/cli_moox_options_fp/tool.pl
+++ b/spec/functional_test/fixtures/perl/cli_moox_options_fp/tool.pl
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Getopt::Long;
+
+my $port;
+GetOptions("port=i" => \$port);
+
+# Unrelated bareword sub literally named `option`, nothing to do with the
+# MooX options-declaration library. This file has no dependency on it.
+sub option {
+    my ($name, %args) = @_;
+    return $args{default};
+}
+
+my $t = option 'timeout' => (default => 30);
+
+print "$port $t\n";

--- a/spec/functional_test/fixtures/php/cli_artisan_fp/SendMail.php
+++ b/spec/functional_test/fixtures/php/cli_artisan_fp/SendMail.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+// Reviewer regression: the officially-documented Laravel
+// `{arg : description}` / `{--flag : description}` signature syntax must
+// yield clean `user`/`queue` param names, not the whole
+// " : description" suffix. The command below never calls
+// $this->argument()/$this->option() by literal name, so the described
+// tokens are the ONLY source of these params.
+class SendMail extends Command
+{
+    protected $signature = 'mail:send {user : The ID of the user} {--queue : Whether the job should be queued}';
+
+    public function handle()
+    {
+        return 0;
+    }
+}

--- a/spec/functional_test/fixtures/php/cli_robo_fp/RoboFile.php
+++ b/spec/functional_test/fixtures/php/cli_robo_fp/RoboFile.php
@@ -1,0 +1,30 @@
+<?php
+
+use Robo\Tasks;
+
+// Reviewer regression: the `@command` docblock tag must bind ONLY to the
+// very next method signature. It must never stay sticky for the rest of
+// the file, so it must not attach to a preceding constructor or to a
+// later untagged helper method.
+class RoboFile extends Tasks
+{
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @command foo:bar
+     */
+    public function fooBar($arg)
+    {
+        return $this->formatOutput($arg, 'prefix:');
+    }
+
+    // Not a Robo command, just a private helper used by fooBar. Its
+    // params must never leak into foo:bar's param list.
+    protected function formatOutput($text, $prefix)
+    {
+        return $prefix . $text;
+    }
+}

--- a/spec/functional_test/fixtures/php/cli_wp_cli_fp/command.php
+++ b/spec/functional_test/fixtures/php/cli_wp_cli_fp/command.php
@@ -1,0 +1,21 @@
+<?php
+
+// Reviewer regression: WP-CLI param extraction must be scoped to the
+// specific method that is the registered command's callback (the one
+// whose OWN signature is `($args, $assoc_args)`), never to the whole
+// class body — an unrelated helper that happens to reuse `$args` as a
+// local variable name must not pollute the command's param list.
+WP_CLI::add_command('foo bar', 'Foo_Bar_Command');
+
+class Foo_Bar_Command {
+    function bar($args, $assoc_args) {
+        $name = $args[0];
+        $format = $assoc_args['format'];
+    }
+
+    // unrelated private helper, its own local var is also named $args
+    private function build_report($args) {
+        $summary = $args[7];
+        return $summary;
+    }
+}

--- a/spec/functional_test/fixtures/python/cli_absl/abslapp.py
+++ b/spec/functional_test/fixtures/python/cli_absl/abslapp.py
@@ -1,0 +1,16 @@
+from absl import app, flags
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string("name", "world", "Who to greet.")
+flags.DEFINE_integer("port", 8080, "Port to bind.")
+flags.DEFINE_bool("verbose", False, "Enable verbose output.")
+flags.DEFINE_enum("mode", "dev", ["dev", "prod"], "Run mode.")
+
+
+def main(argv):
+    print(f"Hello {FLAGS.name} on port {FLAGS.port} ({FLAGS.mode})")
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/spec/functional_test/fixtures/python/cli_cleo/cleotool.py
+++ b/spec/functional_test/fixtures/python/cli_cleo/cleotool.py
@@ -1,0 +1,35 @@
+import os
+
+from cleo.application import Application
+from cleo.commands.command import Command
+from cleo.helpers import argument, option
+
+
+class GreetCommand(Command):
+    name = "greet"
+    description = "Greets someone"
+
+    arguments = [
+        argument("name", description="Who do you want to greet", optional=True),
+    ]
+    options = [
+        option("yell", "y", description="Shout the greeting", flag=True),
+    ]
+
+    def handle(self) -> int:
+        name = self.argument("name")
+        if self.option("yell"):
+            name = name.upper()
+        token = os.getenv("CLEO_TOKEN")
+        self.line(f"Hello {name} ({token})")
+        return 0
+
+
+def main() -> int:
+    application = Application()
+    application.add(GreetCommand())
+    return application.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/functional_test/fixtures/python/cli_cleo_attribution_fp/greettool.py
+++ b/spec/functional_test/fixtures/python/cli_cleo_attribution_fp/greettool.py
@@ -1,0 +1,36 @@
+from cleo.commands.command import Command
+from cleo.helpers import argument
+
+
+class GreetCommand(Command):
+    description = "Greets someone"
+
+    def setup(self):
+        # A local variable that textually looks like the class-level `name`
+        # attribute, but lives inside a method body — must never hijack the
+        # command's URL.
+        name = "temp-setup-value"
+        print(name)
+
+    name = "greet"
+
+    arguments = [
+        argument("name", description="Who do you want to greet", optional=True),
+    ]
+
+    def handle(self) -> int:
+        name = self.argument("name")
+        print(f"Hello {name}")
+        return 0
+
+
+def main() -> int:
+    from cleo.application import Application
+
+    application = Application()
+    application.add(GreetCommand())
+    return application.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/functional_test/fixtures/python/cli_cleo_nested_fp/factory.py
+++ b/spec/functional_test/fixtures/python/cli_cleo_nested_fp/factory.py
@@ -1,0 +1,23 @@
+import os
+
+from cleo.commands.command import Command
+
+
+def make_command():
+    # A Command subclass declared inside a factory function (nested/indented
+    # scope). scan_cleo's extraction regex is anchored to column 0, so this
+    # is never resolved into a real subcommand — cli_entrypoint? must agree
+    # and not treat this file as a CLI surface on the strength of this class
+    # alone.
+    class DynamicCmd(Command):
+        name = "dynamic"
+
+        def handle(self):
+            return 0
+
+    return DynamicCmd
+
+
+# Unrelated env read belonging to ordinary application config, not a real
+# CLI entry point. Must NOT surface as a `cli://` endpoint.
+api_key = os.getenv("SOME_UNRELATED_API_KEY")

--- a/spec/functional_test/fixtures/ruby/cli_clamp/clamp_app.rb
+++ b/spec/functional_test/fixtures/ruby/cli_clamp/clamp_app.rb
@@ -1,0 +1,25 @@
+require 'clamp'
+
+class ClampApp < Clamp::Command
+  option "--verbose", :flag, "Enable verbose output"
+  parameter "FILE", "input file"
+
+  subcommand "serve", "Start the server" do
+    option ["-p", "--port"], "PORT", "port to bind"
+
+    def execute
+      puts "serving"
+    end
+  end
+
+  def execute
+    # Ordinary local-variable assignment reusing the word "option" — must
+    # NOT be mistaken for the `option "--flag", ...` DSL call (regression
+    # for the CLAMP_OPTION_LONG false-positive).
+    option = default? ? "--json" : "--text"
+    puts option
+  end
+end
+
+token = ENV["CLAMP_TOKEN"]
+ClampApp.run

--- a/spec/functional_test/fixtures/ruby/cli_dry_cli/dry_cli_app.rb
+++ b/spec/functional_test/fixtures/ruby/cli_dry_cli/dry_cli_app.rb
@@ -1,0 +1,17 @@
+require 'dry/cli'
+
+module MyCLI
+  class Build < Dry::CLI::Command
+    desc "Build the project"
+
+    option :force, type: :boolean, default: false
+    argument :target, required: true
+
+    def call(target:, **)
+      puts "Building #{target}"
+    end
+  end
+end
+
+token = ENV["DRY_CLI_TOKEN"]
+Dry::CLI.new(MyCLI).call

--- a/spec/functional_test/fixtures/ruby/cli_optimist/optimist_app.rb
+++ b/spec/functional_test/fixtures/ruby/cli_optimist/optimist_app.rb
@@ -1,0 +1,9 @@
+require 'optimist'
+
+opts = Optimist::options do
+  opt :name, "Your name", type: :string
+  opt :verbose, "Verbose mode"
+end
+
+api_key = ENV["OPTIMIST_API_KEY"]
+puts opts[:name], api_key

--- a/spec/functional_test/fixtures/rust/cli_getopts/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/cli_getopts/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "getoptsdemo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+getopts = "0.2"

--- a/spec/functional_test/fixtures/rust/cli_getopts/src/main.rs
+++ b/spec/functional_test/fixtures/rust/cli_getopts/src/main.rs
@@ -1,0 +1,21 @@
+use getopts::Options;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mut opts = Options::new();
+    opts.optopt("o", "output", "output file name", "NAME");
+    opts.optflag("h", "help", "print this help menu");
+    opts.reqopt("c", "config", "config file path", "FILE");
+
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => panic!("{}", f.to_string()),
+    };
+
+    let token = std::env::var("API_TOKEN").unwrap();
+
+    if matches.opt_present("h") {
+        println!("help");
+    }
+    println!("{}", token);
+}

--- a/spec/functional_test/fixtures/rust/cli_getopts_fp/Cargo.toml
+++ b/spec/functional_test/fixtures/rust/cli_getopts_fp/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "getoptsqualdemo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+getopts = "0.2"

--- a/spec/functional_test/fixtures/rust/cli_getopts_fp/src/main.rs
+++ b/spec/functional_test/fixtures/rust/cli_getopts_fp/src/main.rs
@@ -1,0 +1,42 @@
+use getopts;
+
+// Unrelated struct that happens to expose a method named `optflag`, with a
+// receiver variable that is never bound via `Options::new()`. Its calls must
+// NOT be attributed as CLI flags — only the real getopts receiver (`opts`)
+// should surface params.
+struct FeatureToggle {
+    enabled: bool,
+}
+
+impl FeatureToggle {
+    fn optflag(&mut self, name: &str, note: &str) {
+        println!("toggling {} ({})", name, note);
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Fully-qualified type annotation (`getopts::Options`) instead of the
+    // bare `Options` — a legitimate style when a file only does
+    // `use getopts;` rather than `use getopts::Options;`.
+    let mut opts: getopts::Options = getopts::Options::new();
+    opts.optopt("o", "output", "output file name", "NAME");
+    opts.optflag("h", "help", "print this help menu");
+    opts.reqopt("c", "config", "config file path", "FILE");
+
+    let mut toggle = FeatureToggle { enabled: false };
+    toggle.optflag("unrelated-noise", "second arg");
+
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => m,
+        Err(f) => panic!("{}", f.to_string()),
+    };
+
+    let token = std::env::var("API_TOKEN").unwrap();
+
+    if matches.opt_present("h") {
+        println!("help");
+    }
+    println!("{}", token);
+}

--- a/spec/functional_test/fixtures/scala/cli_scallop/tool.scala
+++ b/spec/functional_test/fixtures/scala/cli_scallop/tool.scala
@@ -1,0 +1,20 @@
+import org.rogach.scallop._
+
+class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val verbose = opt[Boolean]("verbose")
+
+  val serve = new Subcommand("serve") {
+    val port = opt[Int]("port")
+    val file = trailArg[String]()
+  }
+  addSubcommand(serve)
+  verify()
+}
+
+object Tool {
+  def main(args: Array[String]): Unit = {
+    val conf = new Conf(args)
+    val token = sys.env("API_TOKEN")
+    println(token)
+  }
+}

--- a/spec/functional_test/fixtures/scala/cli_scallop_object_fp/tool.scala
+++ b/spec/functional_test/fixtures/scala/cli_scallop_object_fp/tool.scala
@@ -1,0 +1,20 @@
+import org.rogach.scallop._
+
+class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val verbose = opt[Boolean]("verbose")
+
+  object serve extends Subcommand("serve") {
+    val port = opt[Int]()
+    val file = trailArg[String]()
+  }
+  addSubcommand(serve)
+  verify()
+}
+
+object Tool {
+  def main(args: Array[String]): Unit = {
+    val conf = new Conf(args)
+    val token = sys.env("API_TOKEN")
+    println(token)
+  }
+}

--- a/spec/functional_test/fixtures/scala/cli_twitter/tool.scala
+++ b/spec/functional_test/fixtures/scala/cli_twitter/tool.scala
@@ -1,0 +1,11 @@
+import com.twitter.app.App
+
+object Tool extends App {
+  val retries = flag[Int]("retries", 3, "number of retries")
+  val verbose = flag[Boolean]("verbose", false, "enable verbose output")
+
+  def main(): Unit = {
+    val token = sys.env("API_TOKEN")
+    println(token)
+  }
+}

--- a/spec/functional_test/fixtures/zig/cli_args/tool.zig
+++ b/spec/functional_test/fixtures/zig/cli_args/tool.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+const argsParser = @import("args");
+
+const Options = struct {
+    help: bool = false,
+    verbose: bool = false,
+    output: ?[]const u8 = null,
+
+    pub const shorthands = .{
+        .h = "help",
+        .v = "verbose",
+        .o = "output",
+    };
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    const options = try argsParser.parseForCurrentProcess(Options, allocator, .print);
+    defer options.deinit();
+
+    const token = std.process.getEnvVarOwned(allocator, "API_TOKEN");
+    _ = token;
+    _ = options;
+}

--- a/spec/functional_test/fixtures/zig/cli_args_bare_import_fp/tool.zig
+++ b/spec/functional_test/fixtures/zig/cli_args_bare_import_fp/tool.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+// A local module happens to be named "args" but has nothing to do with
+// process argv parsing (e.g. template/macro argument expansion). It must
+// never be treated as zig-args evidence: no `parseForCurrentProcess`/`parse`
+// call bound to this alias exists anywhere in the file, so no `cli://`
+// endpoint should be emitted for it.
+const args = @import("args");
+
+pub fn expandTemplateArgs(raw: []const u8) []const u8 {
+    return args.expand(raw);
+}
+
+pub fn main() !void {
+    std.debug.print("hi\n", .{});
+}

--- a/spec/functional_test/fixtures/zig/cli_args_fp/tool.zig
+++ b/spec/functional_test/fixtures/zig/cli_args_fp/tool.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const argsParser = @import("args");
+const uri = @import("uri.zig");
+
+// Unrelated struct + unrelated `.parse` call on a DIFFERENT receiver than
+// the zig-args alias. This must never be mistaken for the CLI's option
+// struct: `host`/`port` must never appear as flags, and it must not steal
+// the "first match" slot from the real argsParser.parseForCurrentProcess
+// call below.
+const NetConfig = struct {
+    host: []const u8,
+    port: u16,
+};
+
+const Options = struct {
+    help: bool = false,
+    verbose: bool = false,
+
+    pub const shorthands = .{
+        .h = "help",
+        .v = "verbose",
+    };
+};
+
+fn loadConfig(raw: []const u8, allocator: std.mem.Allocator) !NetConfig {
+    return uri.parse(NetConfig, raw, allocator);
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    const options = try argsParser.parseForCurrentProcess(Options, allocator, .print);
+    defer options.deinit();
+    _ = options;
+}

--- a/spec/functional_test/fixtures/zig/cli_yazap/tool.zig
+++ b/spec/functional_test/fixtures/zig/cli_yazap/tool.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const yazap = @import("yazap");
+const App = yazap.App;
+const Arg = yazap.Arg;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    var app = App.init(allocator, "tool", "Example CLI tool");
+    defer app.deinit();
+
+    var root_cmd = app.rootCommand();
+    try root_cmd.addArg(Arg.booleanOption("verbose", 'v', "Enable verbose output"));
+    try root_cmd.addArg(Arg.positional("input", "Input file", null));
+
+    var build_cmd = app.createCommand("build", "Build the project");
+    try build_cmd.addArg(Arg.booleanOption("release", 'r', "Build in release mode"));
+    try build_cmd.addArg(Arg.singleValueOption("output", 'o', "Output path"));
+    try root_cmd.addSubcommand(build_cmd);
+
+    const matches = try app.parseProcess();
+    _ = matches;
+
+    const token = std.process.getEnvVarOwned(allocator, "API_TOKEN");
+    _ = token;
+}

--- a/spec/functional_test/fixtures/zig/cli_yazap_fp/tool.zig
+++ b/spec/functional_test/fixtures/zig/cli_yazap_fp/tool.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const yazap = @import("yazap");
+const App = yazap.App;
+const Arg = yazap.Arg;
+
+// The generic `cmd` variable is reused across two subcommands. Flags added
+// to `cmd` BEFORE it is reassigned must resolve to the command that was
+// bound to it AT THAT LINE (build), never to whichever command is assigned
+// LAST in the file (test).
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    var app = App.init(allocator, "tool", "Example CLI tool");
+    defer app.deinit();
+
+    var cmd = app.createCommand("build", "Build the project");
+    try cmd.addArg(Arg.booleanOption("release", 'r', "Build in release mode"));
+
+    cmd = app.createCommand("test", "Run tests");
+    try cmd.addArg(Arg.booleanOption("verbose", 'v', "Verbose output"));
+
+    const matches = try app.parseProcess();
+    _ = matches;
+}

--- a/spec/functional_test/testers/clojure/cli_spec.cr
+++ b/spec/functional_test/testers/clojure/cli_spec.cr
@@ -14,3 +14,70 @@ endpoints = [
   ]),
 ]
 FunctionalTester.new("fixtures/clojure/cli_tools/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+babashka_endpoints = [
+  build.call("cli://taskrunner/run", [
+    Param.new("port", "", "flag"),
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://taskrunner/build", [
+    Param.new("tag", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/clojure/cli_babashka/", {:techs => 1, :endpoints => babashka_endpoints.size}, babashka_endpoints).perform_tests
+
+# Regression for babashka.cli dispatch-table attribution/extraction bugs:
+#   - `:spec` deliberately precedes its own `:cmds` sibling (map literals are
+#     unordered) — options must still land on the entry that structurally
+#     encloses them, never a sticky "last :cmds seen" cursor.
+#   - `:cmds ["docker" "start"]` is a two-segment subcommand and must not
+#     collapse to `cli://tool/docker` (losing "start" vs "stop").
+#   - `:verbose {:desc "..."}` has no `:coerce` key and must still surface.
+#   - the unrelated `log-opts` map (`{:level {:coerce :keyword}}`), declared
+#     after the last dispatch entry and outside any `:spec` map, must never
+#     be attributed to any endpoint.
+babashka_scoping_endpoints = [
+  build.call("cli://tool/docker/start", [
+    Param.new("detach", "", "flag"),
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://tool/docker/stop", [
+    Param.new("force", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/clojure/cli_babashka_scoping/", {:techs => 1, :endpoints => babashka_scoping_endpoints.size}, babashka_scoping_endpoints).perform_tests
+
+# environ.core only ever annotates params on a `cli://` endpoint another,
+# CLI-specific marker (here clojure.tools.cli) already established — it must
+# never gate CLI detection on its own (see cli_environ_fp below).
+environ_endpoints = [
+  build.call("cli://reporter", [
+    Param.new("verbose", "", "flag"),
+    Param.new("DATABASE_URL", "", "env"),
+    Param.new("API_KEY", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/clojure/cli_environ/", {:techs => 1, :endpoints => environ_endpoints.size}, environ_endpoints).perform_tests
+
+# Regression: a bare `environ.core` require is a generic 12-factor
+# config-reading pattern used by web apps/workers just as much as CLIs (same
+# category as bare System/getenv). `config.clj` here has no CLI-specific
+# marker at all — only `handler.clj` (a different file) pulls in Ring — so
+# this must detect 0 clojure_cli techs and emit 0 cli:// endpoints, even
+# though `handler.clj` still gets picked up as a Ring app.
+FunctionalTester.new("fixtures/clojure/cli_environ_fp/", {
+  :techs     => 1,
+  :endpoints => 0,
+}, [] of Endpoint).perform_tests
+
+# Regression: `environ.core` required under an alias (`:as environ`, not
+# `:refer [env]`) must not make a bare `(env ...)` call — here just an
+# ordinary local fn param shadowing the name "env" — look like an environ
+# lookup. Only the "timeout" flag from clojure.tools.cli should surface;
+# neither a bogus TIMEOUT nor DATABASE_URL env param should appear.
+environ_alias_endpoints = [
+  build.call("cli://toolkit", [
+    Param.new("timeout", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/clojure/cli_environ_alias_fp/", {:techs => 1, :endpoints => environ_alias_endpoints.size}, environ_alias_endpoints).perform_tests

--- a/spec/functional_test/testers/cpp/cli_spec.cr
+++ b/spec/functional_test/testers/cpp/cli_spec.cr
@@ -24,3 +24,53 @@ FunctionalTester.new("fixtures/cpp/cli_cli11/", {
   :techs     => 1,
   :endpoints => endpoints.size,
 }, endpoints).perform_tests
+
+# argparse false-positive regression: a helper function's own local
+# ArgumentParser (declared textually before main's) must not be mistaken
+# for the root, and its --log-level option must not leak into the real
+# root's endpoint. Only the actual root (bound via .parse_args(argc, argv))
+# surfaces, with exactly its own flags.
+argparse_fp_endpoints = [
+  build.call("cli://mytool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("config", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/cli_argparse_fp/", {
+  :techs     => 1,
+  :endpoints => argparse_fp_endpoints.size,
+}, argparse_fp_endpoints).perform_tests
+
+# argparse subcommand binding, declare-then-register order: the subcommand
+# parser is declared and linked via add_subparser *before* the root's own
+# add_argument/parse_args lines, proving attribution doesn't depend on
+# source order.
+argparse_sub_endpoints = [
+  build.call("cli://git", [
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://git/commit", [
+    Param.new("message", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/cli_argparse_sub/", {
+  :techs     => 1,
+  :endpoints => argparse_sub_endpoints.size,
+}, argparse_sub_endpoints).perform_tests
+
+# Abseil Flags: ABSL_FLAG with a space before the paren must still be
+# detected/extracted, and a template type with a top-level comma
+# (std::map<std::string, int>) must not truncate the name field.
+absl_fp_endpoints = [
+  build.call("cli://server", [
+    Param.new("port", "", "flag"),
+    Param.new("weights", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/cpp/cli_absl_fp/", {
+  :techs     => 1,
+  :endpoints => absl_fp_endpoints.size,
+}, absl_fp_endpoints).perform_tests

--- a/spec/functional_test/testers/csharp/cli_spec.cr
+++ b/spec/functional_test/testers/csharp/cli_spec.cr
@@ -22,3 +22,68 @@ FunctionalTester.new("fixtures/csharp/cli_systemcommandline/", {
   :techs     => 1,
   :endpoints => endpoints.size,
 }, endpoints).perform_tests
+
+# McMaster.Extensions.CommandLineUtils (attribute-driven: [Option]/[Argument]
+# properties + [Command] subcommand + [Subcommand])
+mcmaster_endpoints = [
+  build.call("cli://mcmastertool", [
+    Param.new("name", "", "flag"),
+    Param.new("Input", "", "argument"),
+    Param.new("MCM_TOKEN", "", "env"),
+  ]),
+  build.call("cli://mcmastertool/push", [
+    Param.new("force", "", "flag"),
+    Param.new("remote", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/csharp/cli_mcmaster/", {
+  :techs     => 1,
+  :endpoints => mcmaster_endpoints.size,
+}, mcmaster_endpoints).perform_tests
+
+# Cocona (minimal-API style: app.AddCommand("name", ([Option]/[Argument]
+# params) => ...))
+cocona_endpoints = [
+  build.call("cli://coconatool", [
+    Param.new("COCONA_TOKEN", "", "env"),
+  ]),
+  build.call("cli://coconatool/greet", [
+    Param.new("name", "", "flag"),
+    Param.new("message", "", "argument"),
+  ]),
+  build.call("cli://coconatool/bye", [] of Param),
+]
+
+FunctionalTester.new("fixtures/csharp/cli_cocona/", {
+  :techs     => 1,
+  :endpoints => cocona_endpoints.size,
+}, cocona_endpoints).perform_tests
+
+# Regression: several [Option]/[Argument] on ONE inline-lambda line must all
+# surface (the old line.match captured only the first attribute per line).
+cocona_multi_endpoints = [
+  build.call("cli://coconamulti/run", [
+    Param.new("name", "", "flag"),
+    Param.new("count", "", "flag"),
+    Param.new("target", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/csharp/cli_cocona_multi/", {
+  :techs     => 1,
+  :endpoints => cocona_multi_endpoints.size,
+}, cocona_multi_endpoints).perform_tests
+
+# Regression: `[Argument(0, Description = "free text")]` must resolve to the
+# annotated property name, not grab the space-containing description string.
+mcmaster_desc_endpoints = [
+  build.call("cli://mcmdesc", [
+    Param.new("Remote", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/csharp/cli_mcmaster_desc/", {
+  :techs     => 1,
+  :endpoints => mcmaster_desc_endpoints.size,
+}, mcmaster_desc_endpoints).perform_tests

--- a/spec/functional_test/testers/go/cli_spec.cr
+++ b/spec/functional_test/testers/go/cli_spec.cr
@@ -73,3 +73,157 @@ FunctionalTester.new("fixtures/go/cli_urfave/", {
   :techs     => 1,
   :endpoints => urfave_endpoints.size,
 }, urfave_endpoints).perform_tests
+
+# --- kong (struct-tag CLI: cmd/arg/env/default field tags) -----------------
+kong_endpoints = [
+  build.call("cli://kongdemo", [
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://kongdemo/serve", [
+    Param.new("host", "", "argument"),
+    Param.new("port", "", "flag"),
+    Param.new("token", "", "flag"),
+    Param.new("KONG_API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/cli_kong/", {
+  :techs     => 1,
+  :endpoints => kong_endpoints.size,
+}, kong_endpoints).perform_tests
+
+# --- kingpin (fluent Flag/Arg/Command builder, receiver-scoped) ------------
+kingpin_endpoints = [
+  build.call("cli://kingpindemo", [
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://kingpindemo/deploy", [
+    Param.new("target", "", "argument"),
+    Param.new("token", "", "flag"),
+    Param.new("KINGPIN_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/cli_kingpin/", {
+  :techs     => 1,
+  :endpoints => kingpin_endpoints.size,
+}, kingpin_endpoints).perform_tests
+
+# --- mitchellh/cli (Commands map of factories, Run()-scoped flags) ---------
+mitchellh_endpoints = [
+  build.call("cli://mitchellhdemo/deploy", [
+    Param.new("target", "", "flag"),
+    Param.new("MITCHELLH_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/cli_mitchellh/", {
+  :techs     => 1,
+  :endpoints => mitchellh_endpoints.size,
+}, mitchellh_endpoints).perform_tests
+
+# --- kong: unrelated struct with common tag keys must not leak onto root ---
+# ClientConfig is parsed by envconfig (not kong) but shares kong's tag keys
+# (env/default). Its `timeout`/`HTTP_TIMEOUT` must never appear anywhere —
+# regression for the `type_urls[current_type]? || root_url` fallback that
+# used to merge any unrecognized struct onto the CLI root.
+kong_fp_endpoints = [
+  build.call("cli://kongfpdemo", [
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://kongfpdemo/serve", [
+    Param.new("host", "", "argument"),
+    Param.new("port", "", "flag"),
+    Param.new("token", "", "flag"),
+    Param.new("KONG_API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/cli_kong_fp/", {
+  :techs     => 1,
+  :endpoints => kong_fp_endpoints.size,
+}, kong_fp_endpoints).perform_tests
+
+# --- kong: pointer-typed cmd:"" subcommand field ----------------------------
+# `Serve *ServeCmd `cmd:""`` (valid kong syntax for optional subcommands)
+# must resolve its own flags/args onto /serve, not leak them onto root.
+kong_ptr_endpoints = [
+  build.call("cli://kongptrdemo", [
+    Param.new("verbose", "", "flag"),
+  ]),
+  build.call("cli://kongptrdemo/serve", [
+    Param.new("host", "", "argument"),
+    Param.new("port", "", "flag"),
+    Param.new("token", "", "flag"),
+    Param.new("KONG_API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/cli_kong_ptr/", {
+  :techs     => 1,
+  :endpoints => kong_ptr_endpoints.size,
+}, kong_ptr_endpoints).perform_tests
+
+# --- mitchellh/cli: intermediate-variable return + unrelated function ------
+# DeployCommand is returned via `cmd := &DeployCommand{}; return cmd, nil`
+# (idiomatic when the command needs field initialization) instead of the
+# single-expression `return &DeployCommand{}, nil`. A later, unrelated
+# `adminHelper` function returning `&AdminCommand{}, nil` must never be
+# attributed to /deploy — regression for the sticky `pending_key` cursor
+# that used to leak past the closing of the map literal.
+mitchellh_fp_endpoints = [
+  build.call("cli://mitchellhfpdemo/deploy", [
+    Param.new("target", "", "flag"),
+    Param.new("MITCHELLH_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/go/cli_mitchellh_fp/", {
+  :techs     => 1,
+  :endpoints => mitchellh_fp_endpoints.size,
+}, mitchellh_fp_endpoints).perform_tests
+
+# FunctionalTester only asserts that EXPECTED params are present on an
+# endpoint (a subset match) and that the total endpoint COUNT matches — it
+# never asserts that an endpoint's param list contains NOTHING else. That
+# means a leaked param merged onto an endpoint that already has legitimate
+# params (e.g. root's pre-existing "verbose") would silently pass the
+# blocks above even on the old buggy code. Assert the exact negative
+# directly so these regressions truly fail on the old fallback/sticky-cursor
+# behavior and pass only once the leak is gone.
+describe "go CLI attribution false-positive guards" do
+  it "does not leak an unrelated envconfig-tagged struct's fields onto the kong root command" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/go/cli_kong_fp/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    root = app.endpoints.find! { |ep| ep.url == "cli://kongfpdemo" }
+    root.params.map(&.name).should_not contain("timeout")
+    root.params.map(&.name).should_not contain("HTTP_TIMEOUT")
+    root.params.size.should eq(1)
+
+    serve = app.endpoints.find! { |ep| ep.url == "cli://kongfpdemo/serve" }
+    serve.params.map(&.name).should_not contain("timeout")
+    serve.params.map(&.name).should_not contain("HTTP_TIMEOUT")
+  end
+
+  it "does not leak an unrelated function's return type onto a mitchellh/cli command via a stale pending_key cursor" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/go/cli_mitchellh_fp/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    app.endpoints.map(&.url).should_not contain("cli://mitchellhfpdemo/admin")
+
+    deploy = app.endpoints.find! { |ep| ep.url == "cli://mitchellhfpdemo/deploy" }
+    deploy.params.map(&.name).should_not contain("ADMIN_TOKEN")
+    deploy.params.size.should eq(2)
+  end
+end

--- a/spec/functional_test/testers/groovy/cli_spec.cr
+++ b/spec/functional_test/testers/groovy/cli_spec.cr
@@ -14,3 +14,44 @@ endpoints = [
   ]),
 ]
 FunctionalTester.new("fixtures/groovy/cli_clibuilder/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+# JCommander: @Parameter fields, addObject() root binding, and both
+# addCommand subcommand registration styles -- inline `addCommand("name",
+# new Class())` and declare-then-register `addCommand("name", var)` where
+# `var` was assigned via `def var = new Class()` earlier in the file.
+# Regression for: sub-command flags silently collapsing into the root
+# endpoint when only the declare-then-register form is used.
+jcommander_endpoints = [
+  build.call("cli://tool", [
+    Param.new("file", "", "flag"),
+    Param.new("JC_TOKEN", "", "env"),
+  ]),
+  build.call("cli://tool/add", [
+    Param.new("message", "", "flag"),
+  ]),
+  build.call("cli://tool/remove", [
+    Param.new("recursive", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/groovy/cli_jcommander/", {
+  :techs     => 1,
+  :endpoints => jcommander_endpoints.size,
+}, jcommander_endpoints).perform_tests
+
+# Commons CLI: Option.builder("short").longOpt(...), the long-only
+# Option.builder() form (no short name at all), and two Option.builder(...)
+# chains on the same source line separated by `;`. Regression for: the
+# long-only form being silently dropped, and only the first of several
+# same-line options being captured.
+commons_cli_endpoints = [
+  build.call("cli://tool", [
+    Param.new("file", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("quiet", "", "flag"),
+    Param.new("CLI_TOKEN", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/groovy/cli_commons_cli/", {
+  :techs     => 1,
+  :endpoints => commons_cli_endpoints.size,
+}, commons_cli_endpoints).perform_tests

--- a/spec/functional_test/testers/haskell/cli_spec.cr
+++ b/spec/functional_test/testers/haskell/cli_spec.cr
@@ -15,3 +15,41 @@ endpoints = [
   build.call("cli://tool/serve", [Param.new("host", "", "flag")]),
 ]
 FunctionalTester.new("fixtures/haskell/cli_optparse/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+turtle_endpoints = [
+  build.call("cli://tool", [
+    Param.new("name", "", "flag"),
+    Param.new("age", "", "flag"),
+    Param.new("config", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("target", "", "argument"),
+    Param.new("GREETING_TOKEN", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/haskell/cli_turtle/", {:techs => 1, :endpoints => turtle_endpoints.size}, turtle_endpoints).perform_tests
+
+# Regression coverage for the Tier-3 hardening review: a genuine Turtle CLI
+# file that ALSO contains adjacent code which used to trip the old
+# TURTLE_SWITCH / TURTLE_ARG_FN regexes (a locally-defined `switch` string
+# dispatcher, a stale `-- arg ...` comment, and a call site literally
+# `logMessage arg level "urgent"`), plus real Turtle.Options idioms the old
+# regexes missed (argInt, and `arg` with a parenthesized/dot-composed
+# reader). Only the genuine CLI params must appear -- "urgent", "deprecated",
+# "on", and "staging" must never show up as params.
+turtle_fp_endpoints = [
+  build.call("cli://tool", [
+    Param.new("name", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("target", "", "argument"),
+    Param.new("retries", "", "argument"),
+    Param.new("count", "", "argument"),
+    Param.new("GREETING_TOKEN", "", "env"),
+  ]),
+]
+turtle_fp_tester = FunctionalTester.new("fixtures/haskell/cli_turtle_fp/", {:techs => 1, :endpoints => turtle_fp_endpoints.size}, turtle_fp_endpoints)
+turtle_fp_tester.perform_tests
+
+it "does not leak bogus params from adjacent non-Turtle code into the Turtle CLI endpoint" do
+  endpoint = turtle_fp_tester.app.endpoints.find! { |e| e.method == "CLI" && e.url == "cli://tool" }
+  endpoint.params.map(&.name).sort!.should eq ["GREETING_TOKEN", "count", "name", "retries", "target", "verbose"]
+end

--- a/spec/functional_test/testers/java/cli_spec.cr
+++ b/spec/functional_test/testers/java/cli_spec.cr
@@ -40,3 +40,43 @@ FunctionalTester.new("fixtures/java/cli_jcommander/", {
   :techs     => 1,
   :endpoints => jcommander_endpoints.size,
 }, jcommander_endpoints).perform_tests
+
+# jopt-simple (root flags only, no subcommands): `.accepts("flag")` and
+# `.acceptsAll(Arrays.asList("h", "help"), ...)` (first alias) on the tracked
+# `OptionParser` variable, plus gated System.getenv.
+jopt_simple_endpoints = [
+  build.call("cli://App", [
+    Param.new("verbose", "", "flag"),
+    Param.new("h", "", "flag"),
+    Param.new("APP_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/java/cli_jopt_simple/", {
+  :techs     => 1,
+  :endpoints => jopt_simple_endpoints.size,
+}, jopt_simple_endpoints).perform_tests
+
+# Regression (attribution false positive): a genuine jopt-simple parser bound
+# to `parser` sits alongside an unrelated `FormatMatcher.accepts(String)`
+# method called as `matcher.accepts("csv")`. Only the real `.accepts("topic")`
+# on the tracked `parser` variable may surface as a flag — "csv" from the
+# untracked `matcher` receiver must NOT appear.
+jopt_simple_fp_endpoints = [
+  build.call("cli://App", [
+    Param.new("topic", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/java/cli_jopt_simple_fp/", {
+  :techs     => 1,
+  :endpoints => jopt_simple_fp_endpoints.size,
+}, jopt_simple_fp_endpoints).perform_tests
+
+# Regression (detector false positive): a class literally named `OptionParser`
+# with no `joptsimple.` import anywhere must NOT be tagged java_cli — the
+# generic class name alone isn't a reliable jopt-simple signal.
+FunctionalTester.new("fixtures/java/cli_optionparser_generic_fp/", {
+  :techs     => 0,
+  :endpoints => 0,
+}, [] of Endpoint).perform_tests

--- a/spec/functional_test/testers/javascript/cli_spec.cr
+++ b/spec/functional_test/testers/javascript/cli_spec.cr
@@ -40,3 +40,172 @@ FunctionalTester.new("fixtures/javascript/cli_yargs/", {
   :techs     => 1,
   :endpoints => yargs_endpoints.size,
 }, yargs_endpoints).perform_tests
+
+# --- arg (object-schema flags, quoted-string aliases skipped) --------------
+arg_endpoints = [
+  build.call("cli://argdemo", [
+    Param.new("name", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("port", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_arg/", {
+  :techs     => 1,
+  :endpoints => arg_endpoints.size,
+}, arg_endpoints).perform_tests
+
+# --- command-line-args (option-definitions array + defaultOption) ----------
+command_line_args_endpoints = [
+  build.call("cli://claddemo", [
+    Param.new("verbose", "", "flag"),
+    Param.new("port", "", "flag"),
+    Param.new("file", "", "argument"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_command_line_args/", {
+  :techs     => 1,
+  :endpoints => command_line_args_endpoints.size,
+}, command_line_args_endpoints).perform_tests
+
+# --- getopts (alias/default/boolean/string option-config) ------------------
+getopts_endpoints = [
+  build.call("cli://getoptsdemo", [
+    Param.new("help", "", "flag"),
+    Param.new("port", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("name", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_getopts/", {
+  :techs     => 1,
+  :endpoints => getopts_endpoints.size,
+}, getopts_endpoints).perform_tests
+
+# --- citty (defineCommand args + nested subCommands) ------------------------
+citty_endpoints = [
+  build.call("cli://cittydemo", [
+    Param.new("verbose", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+  build.call("cli://cittydemo/serve", [
+    Param.new("port", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_citty/", {
+  :techs     => 1,
+  :endpoints => citty_endpoints.size,
+}, citty_endpoints).perform_tests
+
+# --- command-line-args false-positive regression ----------------------------
+# A real `commandLineArgs(optionDefinitions)` call sits alongside an unrelated
+# array of `{ name, type }` content-field objects; the unrelated array must
+# never leak "email"/"age" onto the endpoint as phantom flags (CLA_OPTION_RE
+# used to be an unscoped whole-file scan).
+cla_fp_endpoints = [
+  build.call("cli://cladfpdemo", [
+    Param.new("verbose", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_command_line_args_fp/", {
+  :techs     => 1,
+  :endpoints => cla_fp_endpoints.size,
+}, cla_fp_endpoints).perform_tests
+
+describe "command-line-args scoping keeps unrelated fields out" do
+  tester = FunctionalTester.new("fixtures/javascript/cli_command_line_args_fp/", {
+    :techs => 1,
+  }, [] of Endpoint)
+
+  locator = CodeLocator.instance
+  locator.clear_all
+  tester.app.detect
+  tester.app.analyze
+
+  endpoint = tester.app.endpoints.find { |ep| ep.url == "cli://cladfpdemo" }
+
+  it "does not leak the unrelated 'email'/'age' field-schema keys as flags" do
+    endpoint.should_not be_nil
+    if endpoint
+      bogus = endpoint.params.select { |p| {"email", "age"}.includes?(p.name) }
+      bogus.size.should eq(0)
+    end
+  end
+end
+
+# --- command-line-args multi-line (Prettier-style) option entries ----------
+# Each option object is spread across multiple lines instead of a single
+# line; both flags must still be extracted (CLA_OPTION_RE used to require
+# `name:` and `type:` on the very same physical line).
+cla_multiline_endpoints = [
+  build.call("cli://clamultilinedemo", [
+    Param.new("verbose", "", "flag"),
+    Param.new("port", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_command_line_args_multiline/", {
+  :techs     => 1,
+  :endpoints => cla_multiline_endpoints.size,
+}, cla_multiline_endpoints).perform_tests
+
+# --- getopts bare-substring false-positive regression -----------------------
+# A real commander-based CLI file sits alongside an unrelated module whose
+# only connection to "getopts" is the bare word inside a comment (no
+# `require('getopts')`/`getopts(...)` call at all). That file must not be
+# treated as CLI evidence, so its `process.env.API_TOKEN` read must not be
+# attached to the shared cli:// endpoint as a phantom env param.
+getopts_fp_endpoints = [
+  build.call("cli://getoptsfpdemo", [
+    Param.new("verbose", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_getopts_fp/", {
+  :techs     => 1,
+  :endpoints => getopts_fp_endpoints.size,
+}, getopts_fp_endpoints).perform_tests
+
+describe "bare 'getopts' substring does not grant CLI evidence" do
+  tester = FunctionalTester.new("fixtures/javascript/cli_getopts_fp/", {
+    :techs => 1,
+  }, [] of Endpoint)
+
+  locator = CodeLocator.instance
+  locator.clear_all
+  tester.app.detect
+  tester.app.analyze
+
+  endpoint = tester.app.endpoints.find { |ep| ep.url == "cli://getoptsfpdemo" }
+
+  it "does not attach API_TOKEN from the getopts-comment-only file" do
+    endpoint.should_not be_nil
+    if endpoint
+      bogus = endpoint.params.select { |p| p.name == "API_TOKEN" }
+      bogus.size.should eq(0)
+    end
+  end
+end
+
+# --- citty variable-referenced subcommand attribution -----------------------
+# `serve: serveCommand` (a top-level `const serveCommand = defineCommand({...})`
+# referenced by identifier) must resolve to its own `cli://<binary>/serve`
+# endpoint instead of falling back to root (CITTY_SUBCOMMAND_RE used to only
+# recognize the inline `key: defineCommand({ ... })` nesting pattern).
+citty_var_endpoints = [
+  build.call("cli://cittyvardemo/serve", [
+    Param.new("port", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/javascript/cli_citty_var_subcommand/", {
+  :techs     => 1,
+  :endpoints => citty_var_endpoints.size,
+}, citty_var_endpoints).perform_tests

--- a/spec/functional_test/testers/kotlin/cli_spec.cr
+++ b/spec/functional_test/testers/kotlin/cli_spec.cr
@@ -25,3 +25,38 @@ FunctionalTester.new("fixtures/kotlin/cli_clikt/", {
   :techs     => 1,
   :endpoints => endpoints.size,
 }, endpoints).perform_tests
+
+# picocli (@Command root + subcommand, @Option/@Parameters, System.getenv)
+picocli_endpoints = [
+  build.call("cli://tool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("config", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+  build.call("cli://tool/serve", [
+    Param.new("port", "", "flag"),
+    Param.new("config", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/kotlin/cli_picocli/", {
+  :techs     => 1,
+  :endpoints => picocli_endpoints.size,
+}, picocli_endpoints).perform_tests
+
+# Regression: a wrapped multi-line @Command(...) must still open its own
+# subcommand (not leak its flags onto the previous command), and an
+# annotation-with-property on the same line (`@Option(...) var port: Int`)
+# must resolve against that same-line property.
+picocli_multiline_endpoints = [
+  build.call("cli://multitool", [] of Param),
+  build.call("cli://multitool/serve", [
+    Param.new("port", "", "flag"),
+    Param.new("target", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/kotlin/cli_picocli_multiline/", {
+  :techs     => 1,
+  :endpoints => picocli_multiline_endpoints.size,
+}, picocli_multiline_endpoints).perform_tests

--- a/spec/functional_test/testers/lua/cli_spec.cr
+++ b/spec/functional_test/testers/lua/cli_spec.cr
@@ -19,3 +19,24 @@ endpoints = [
   ]),
 ]
 FunctionalTester.new("fixtures/lua/cli_argparse/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+cliargs_endpoints = [
+  build.call("cli://mytool", [
+    Param.new("INPUT", "", "argument"),
+    Param.new("output", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/lua/cli_cliargs/", {:techs => 1, :endpoints => cliargs_endpoints.size}, cliargs_endpoints).perform_tests
+
+# Regression: an unrelated `logger:set_name(...)` and `menu:add_option/add_flag(...)`
+# whose receivers were never bound to require("cliargs") must not leak into
+# the cli:// endpoint's URL or params (attribution false positives).
+cliargs_fp_endpoints = [
+  build.call("cli://app", [
+    Param.new("INPUT", "", "argument"),
+    Param.new("output", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/lua/cli_cliargs_fp/", {:techs => 1, :endpoints => cliargs_fp_endpoints.size}, cliargs_fp_endpoints).perform_tests

--- a/spec/functional_test/testers/perl/cli_spec.cr
+++ b/spec/functional_test/testers/perl/cli_spec.cr
@@ -15,3 +15,45 @@ endpoints = [
   ]),
 ]
 FunctionalTester.new("fixtures/perl/cli_getopt/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+descriptive_endpoints = [
+  build.call("cli://tool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("name", "", "flag"),
+    Param.new("help", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+    Param.new("arg0", "", "argument"),
+  ]),
+]
+FunctionalTester.new("fixtures/perl/cli_getopt_long_descriptive/", {:techs => 1, :endpoints => descriptive_endpoints.size}, descriptive_endpoints).perform_tests
+
+moox_endpoints = [
+  build.call("cli://myapp", [
+    Param.new("verbose", "", "flag"),
+    Param.new("name", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/perl/cli_moox_options/", {:techs => 1, :endpoints => moox_endpoints.size}, moox_endpoints).perform_tests
+
+# Regression: an unrelated bareword sub named `option` (nothing to do with
+# MooX::Options) must NOT leak a bogus "timeout" flag when the file never
+# does `use MooX::Options`. Only the real GetOptions("port=i") flag should
+# surface.
+moox_fp_endpoints = [
+  build.call("cli://tool", [
+    Param.new("port", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/perl/cli_moox_options_fp/", {:techs => 1, :endpoints => moox_fp_endpoints.size}, moox_fp_endpoints).perform_tests
+
+# Regression: Getopt::Long::Descriptive suffix modifiers (!, +) must be
+# stripped from the reported flag name instead of leaking as "verbose!" /
+# "count+".
+descriptive_modifiers_endpoints = [
+  build.call("cli://tool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("count", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/perl/cli_describe_options_modifiers_fp/", {:techs => 1, :endpoints => descriptive_modifiers_endpoints.size}, descriptive_modifiers_endpoints).perform_tests

--- a/spec/functional_test/testers/php/cli_spec.cr
+++ b/spec/functional_test/testers/php/cli_spec.cr
@@ -22,3 +22,90 @@ FunctionalTester.new("fixtures/php/cli_symfony/", {
   :techs     => 3,
   :endpoints => endpoints.size,
 }, endpoints).perform_tests
+
+# Robo (`@command` docblock tag) regression: the tag must bind ONLY to the
+# very next method signature, never stay sticky for the rest of the file.
+# fixtures/php/cli_robo_fp/RoboFile.php has a constructor BEFORE the first
+# `@command` tag and an untagged helper method (formatOutput) AFTER the
+# tagged command (fooBar) — neither may contribute params to any endpoint.
+robo_endpoints = [
+  build.call("cli://cli_robo_fp/foo:bar", [
+    Param.new("arg", "", "argument"),
+  ]),
+  # php_pure's generic per-file GET pseudo-endpoint (no framework marker
+  # is present here to suppress it, unlike the Laravel/Symfony fixtures).
+  Endpoint.new("/RoboFile.php", "GET"),
+]
+
+robo_tester = FunctionalTester.new("fixtures/php/cli_robo_fp/", {
+  :techs     => 2,
+  :endpoints => robo_endpoints.size,
+}, robo_endpoints)
+robo_tester.perform_tests
+
+it "does not attach the constructor's or the untagged helper's params to the Robo command" do
+  ep = robo_tester.app.endpoints.find { |e| e.url == "cli://cli_robo_fp/foo:bar" }
+  ep.should_not be_nil
+  ep.try(&.params.map(&.name)).should eq(["arg"])
+  # No root `cli://cli_robo_fp` endpoint should exist (the constructor,
+  # which runs before any `@command` tag, must not fall back to it).
+  robo_tester.app.endpoints.any? { |e| e.url == "cli://cli_robo_fp" }.should be_false
+end
+
+# WP-CLI regression: `$args`/`$assoc_args` reads must be scoped to the
+# specific method whose OWN signature is the conventional
+# `($args, $assoc_args)` callback, never the whole class body.
+# fixtures/php/cli_wp_cli_fp/command.php has an unrelated private helper
+# (build_report) that also uses a local variable named `$args` — its
+# `$args[7]` read must not leak into the registered command's params.
+wp_cli_endpoints = [
+  build.call("cli://cli_wp_cli_fp/foo bar", [
+    Param.new("arg0", "", "argument"),
+    Param.new("format", "", "flag"),
+  ]),
+  # php_pure's generic per-file GET pseudo-endpoint (no framework marker
+  # is present here to suppress it, unlike the Laravel/Symfony fixtures).
+  Endpoint.new("/command.php", "GET"),
+]
+
+wp_cli_tester = FunctionalTester.new("fixtures/php/cli_wp_cli_fp/", {
+  :techs     => 2,
+  :endpoints => wp_cli_endpoints.size,
+}, wp_cli_endpoints)
+wp_cli_tester.perform_tests
+
+it "does not leak the unrelated helper's $args[7] into the WP-CLI command's params" do
+  ep = wp_cli_tester.app.endpoints.find { |e| e.url == "cli://cli_wp_cli_fp/foo bar" }
+  ep.should_not be_nil
+  ep.try(&.params.map(&.name).sort).should eq(["arg0", "format"])
+end
+
+# Laravel Artisan regression: the idiomatic `{arg : description}` /
+# `{--flag : description}` signature syntax must yield clean param names,
+# not the whole " : description" suffix baked into the name.
+# fixtures/php/cli_artisan_fp/SendMail.php never calls
+# $this->argument()/$this->option() by literal name, so the described
+# `$signature` tokens are the ONLY source of these params.
+artisan_endpoints = [
+  build.call("cli://cli_artisan_fp/mail:send", [
+    Param.new("user", "", "argument"),
+    Param.new("queue", "", "flag"),
+  ]),
+]
+
+artisan_tester = FunctionalTester.new("fixtures/php/cli_artisan_fp/", {
+  :techs     => 3,
+  :endpoints => artisan_endpoints.size,
+}, artisan_endpoints)
+artisan_tester.perform_tests
+
+it "strips the ' : description' suffix from described Artisan signature tokens" do
+  ep = artisan_tester.app.endpoints.find { |e| e.url == "cli://cli_artisan_fp/mail:send" }
+  ep.should_not be_nil
+  names = ep.try(&.params.map(&.name)).not_nil!
+  names.should eq(["user", "queue"])
+  names.each do |name|
+    name.should_not contain(" ")
+    name.should_not contain(":")
+  end
+end

--- a/spec/functional_test/testers/python/cli_spec.cr
+++ b/spec/functional_test/testers/python/cli_spec.cr
@@ -61,3 +61,62 @@ FunctionalTester.new("fixtures/python/cli_typer/", {
   :techs     => 1,
   :endpoints => typer_endpoints.size,
 }, typer_endpoints).perform_tests
+
+# --- absl-py (Abseil flags: a single flat flag namespace) -------------------
+absl_endpoints = [
+  build.call("cli://abslapp", [
+    Param.new("name", "", "flag"),
+    Param.new("port", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("mode", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/cli_absl/", {
+  :techs     => 1,
+  :endpoints => absl_endpoints.size,
+}, absl_endpoints).perform_tests
+
+# --- Cleo (Command subclass + self.argument/self.option readback) ----------
+cleo_endpoints = [
+  build.call("cli://cleotool", [
+    Param.new("CLEO_TOKEN", "", "env"),
+  ]),
+  build.call("cli://cleotool/greet", [
+    Param.new("name", "", "argument"),
+    Param.new("yell", "", "flag"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/cli_cleo/", {
+  :techs     => 1,
+  :endpoints => cleo_endpoints.size,
+}, cleo_endpoints).perform_tests
+
+# --- Cleo attribution regression: a same-named local variable inside a
+# method body (defined ABOVE the real `name = "..."` class attribute) must
+# not hijack the resolved command URL. Only the class's direct-member
+# `name = "greet"` counts; `setup`'s local `name = "temp-setup-value"` does
+# not. -----------------------------------------------------------------------
+cleo_attribution_fp_endpoints = [
+  build.call("cli://greettool/greet", [
+    Param.new("name", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/cli_cleo_attribution_fp/", {
+  :techs     => 1,
+  :endpoints => cleo_attribution_fp_endpoints.size,
+}, cleo_attribution_fp_endpoints).perform_tests
+
+# --- Cleo false-positive regression: a `class Foo(Command)` nested inside a
+# factory function is never resolved by scan_cleo's column-0-anchored
+# extraction, so cli_entrypoint? must not treat the file as a CLI surface on
+# the strength of that class alone. Without the fix this used to emit a
+# bogus `cli://factory` endpoint carrying an unrelated env var purely because
+# the entrypoint gate and the extractor disagreed on what counts as a class
+# declaration. -----------------------------------------------------------
+FunctionalTester.new("fixtures/python/cli_cleo_nested_fp/", {
+  :techs     => 1,
+  :endpoints => 0,
+}, [] of Endpoint).perform_tests

--- a/spec/functional_test/testers/ruby/cli_spec.cr
+++ b/spec/functional_test/testers/ruby/cli_spec.cr
@@ -39,3 +39,67 @@ FunctionalTester.new("fixtures/ruby/cli_optparse/", {
   :techs     => 1,
   :endpoints => optparse_endpoints.size,
 }, optparse_endpoints).perform_tests
+
+# --- Optimist (flat `opt` declarations + ENV) ------------------------------
+optimist_endpoints = [
+  build.call("cli://optimist_app", [
+    Param.new("name", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("OPTIMIST_API_KEY", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/ruby/cli_optimist/", {
+  :techs     => 1,
+  :endpoints => optimist_endpoints.size,
+}, optimist_endpoints).perform_tests
+
+# --- Clamp (option/parameter + nested subcommand block + ENV) -------------
+clamp_endpoints = [
+  build.call("cli://clamp_app", [
+    Param.new("verbose", "", "flag"),
+    Param.new("file", "", "argument"),
+    Param.new("CLAMP_TOKEN", "", "env"),
+  ]),
+  build.call("cli://clamp_app/serve", [
+    Param.new("port", "", "flag"),
+  ]),
+]
+
+clamp_tester = FunctionalTester.new("fixtures/ruby/cli_clamp/", {
+  :techs     => 1,
+  :endpoints => clamp_endpoints.size,
+}, clamp_endpoints)
+clamp_tester.perform_tests
+
+# Regression: `option = default? ? "--json" : "--text"` inside the top-level
+# `execute` method is an ordinary local-variable assignment, not a call into
+# Clamp's `option "--flag", ...` DSL. CLAMP_OPTION_LONG must not treat the
+# bare word "option" followed eventually by a quoted "--flag"-looking string
+# as a DSL declaration, or it would attribute a phantom "json"/"text" flag
+# to the root command.
+it "does not attribute a bogus flag from a stray 'option' local variable (Clamp FP regression)" do
+  root = clamp_tester.app.endpoints.find { |e| e.url == "cli://clamp_app" }
+  root.should_not be_nil
+  if root
+    param_names = root.params.map(&.name)
+    param_names.should_not contain("json")
+    param_names.should_not contain("text")
+  end
+end
+
+# --- dry-cli (Dry::CLI::Command subclass = subcommand + ENV) --------------
+dry_cli_endpoints = [
+  build.call("cli://dry_cli_app", [
+    Param.new("DRY_CLI_TOKEN", "", "env"),
+  ]),
+  build.call("cli://dry_cli_app/build", [
+    Param.new("force", "", "flag"),
+    Param.new("target", "", "argument"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/ruby/cli_dry_cli/", {
+  :techs     => 1,
+  :endpoints => dry_cli_endpoints.size,
+}, dry_cli_endpoints).perform_tests

--- a/spec/functional_test/testers/rust/cli_spec.cr
+++ b/spec/functional_test/testers/rust/cli_spec.cr
@@ -29,3 +29,41 @@ FunctionalTester.new("fixtures/rust/cli_clap/", {
   :techs     => 1,
   :endpoints => clap_endpoints.size,
 }, clap_endpoints).perform_tests
+
+# --- getopts (flat builder API: optopt/optflag/reqopt + env) ---------------
+getopts_endpoints = [
+  build.call("cli://getoptsdemo", [
+    Param.new("output", "", "flag"),
+    Param.new("help", "", "flag"),
+    Param.new("config", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/rust/cli_getopts/", {
+  :techs     => 1,
+  :endpoints => getopts_endpoints.size,
+}, getopts_endpoints).perform_tests
+
+# --- getopts FP: fully-qualified type annotation (`getopts::Options`) ------
+# Regression for the reviewer finding: GETOPTS_NEW_RE previously required the
+# bare word "Options" immediately after the colon in a type annotation, so
+# `let mut opts: getopts::Options = getopts::Options::new();` (legitimate
+# when a file only does `use getopts;` rather than `use getopts::Options;`)
+# failed to bind the receiver and every subsequent opts.optopt/optflag/reqopt
+# call was silently dropped (a false negative). The fixture also carries an
+# unrelated `Options` struct of its own to prove the getopts receiver map
+# doesn't cross-bind to it.
+getopts_qualified_endpoints = [
+  build.call("cli://getoptsqualdemo", [
+    Param.new("output", "", "flag"),
+    Param.new("help", "", "flag"),
+    Param.new("config", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/rust/cli_getopts_fp/", {
+  :techs     => 1,
+  :endpoints => getopts_qualified_endpoints.size,
+}, getopts_qualified_endpoints).perform_tests

--- a/spec/functional_test/testers/scala/cli_spec.cr
+++ b/spec/functional_test/testers/scala/cli_spec.cr
@@ -14,3 +14,81 @@ endpoints = [
   build.call("cli://tool/serve", [Param.new("file", "", "argument")]),
 ]
 FunctionalTester.new("fixtures/scala/cli_scopt/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+# Scallop (org.rogach.scallop): `val serve = new Subcommand("serve") { ... }`
+# idiom. Regression for a reviewer finding: Scallop's bare `opt[T]("name")`
+# is textually identical to scopt's `opt[T]("name")`, so an ungated scopt
+# extractor would also fire on this file and attach the subcommand-only
+# `port`/`file` params to the root `cli://tool` endpoint even though
+# Scallop's own subcommand scoping correctly binds them to `cli://tool/serve`
+# only. Reproduced against a deliberately ungated build: root came back with
+# params [verbose, port, API_TOKEN] instead of [verbose, API_TOKEN].
+scallop_endpoints = [
+  build.call("cli://tool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+  build.call("cli://tool/serve", [
+    Param.new("port", "", "flag"),
+    Param.new("file", "", "argument"),
+  ]),
+]
+scallop_tester = FunctionalTester.new("fixtures/scala/cli_scallop/", {:techs => 1, :endpoints => scallop_endpoints.size}, scallop_endpoints)
+scallop_tester.perform_tests
+
+describe "scala scallop: subcommand-only opts must not leak onto the root endpoint" do
+  it "cli://tool does not contain the subcommand-scoped 'port'/'file' params" do
+    root = scallop_tester.app.endpoints.find { |e| e.url == "cli://tool" }
+    root.should_not be_nil
+    names = root.not_nil!.params.map(&.name)
+    names.should_not contain("port")
+    names.should_not contain("file")
+  end
+end
+
+# Scallop's idiomatic `object serve extends Subcommand("serve") { ... }` form
+# (shown in Scallop's own docs) plus the macro-based inferred-name overload
+# `opt[T]()` (name taken from the enclosing `val`). Regression for a reviewer
+# finding: a scope-detection regex that only recognized the `val x =
+# Subcommand(...)` idiom silently merged this subcommand's flags into the
+# root and never created a `cli://tool/serve` endpoint at all. Reproduced
+# against a deliberately narrowed SCALLOP_SUBCMD regex: single root endpoint
+# with params [verbose, port, file, API_TOKEN], no /serve endpoint.
+scallop_object_endpoints = [
+  build.call("cli://tool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+  build.call("cli://tool/serve", [
+    Param.new("port", "", "flag"),
+    Param.new("file", "", "argument"),
+  ]),
+]
+scallop_object_tester = FunctionalTester.new("fixtures/scala/cli_scallop_object_fp/", {:techs => 1, :endpoints => scallop_object_endpoints.size}, scallop_object_endpoints)
+scallop_object_tester.perform_tests
+
+describe "scala scallop: 'object x extends Subcommand(...)' idiom creates a scoped subcommand endpoint" do
+  it "cli://tool/serve exists and cli://tool does not contain its params" do
+    endpoints_found = scallop_object_tester.app.endpoints
+    serve = endpoints_found.find { |e| e.url == "cli://tool/serve" }
+    serve.should_not be_nil
+
+    root = endpoints_found.find { |e| e.url == "cli://tool" }
+    root.should_not be_nil
+    names = root.not_nil!.params.map(&.name)
+    names.should_not contain("port")
+    names.should_not contain("file")
+  end
+end
+
+# com.twitter.app: `flag[T]("name", ...)` always takes an explicit name (no
+# reflection/macro-based no-arg overload the way Scallop infers names from a
+# `val`), so only the explicitly-named form is exercised here.
+twitter_endpoints = [
+  build.call("cli://tool", [
+    Param.new("retries", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/scala/cli_twitter/", {:techs => 1, :endpoints => twitter_endpoints.size}, twitter_endpoints).perform_tests

--- a/spec/functional_test/testers/zig/cli_spec.cr
+++ b/spec/functional_test/testers/zig/cli_spec.cr
@@ -16,3 +16,60 @@ endpoints = [
   ]),
 ]
 FunctionalTester.new("fixtures/zig/cli_clap/", {:techs => 1, :endpoints => endpoints.size}, endpoints).perform_tests
+
+args_endpoints = [
+  build.call("cli://tool", [
+    Param.new("help", "", "flag"),
+    Param.new("verbose", "", "flag"),
+    Param.new("output", "", "flag"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+]
+FunctionalTester.new("fixtures/zig/cli_args/", {:techs => 1, :endpoints => args_endpoints.size}, args_endpoints).perform_tests
+
+yazap_endpoints = [
+  build.call("cli://tool", [
+    Param.new("verbose", "", "flag"),
+    Param.new("input", "", "argument"),
+    Param.new("API_TOKEN", "", "env"),
+  ]),
+  build.call("cli://tool/build", [
+    Param.new("release", "", "flag"),
+    Param.new("output", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/zig/cli_yazap/", {:techs => 1, :endpoints => yazap_endpoints.size}, yazap_endpoints).perform_tests
+
+# Regression: an unrelated `.parse(NetConfig, ...)` call on a receiver that
+# is NOT the zig-args alias (and an unrelated struct) must not hijack
+# extraction or steal the "first match" slot from the real
+# argsParser.parseForCurrentProcess(Options, ...) call. `host`/`port` must
+# never appear, and the real `help`/`verbose` fields must still be found.
+args_fp_endpoints = [
+  build.call("cli://tool", [
+    Param.new("help", "", "flag"),
+    Param.new("verbose", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/zig/cli_args_fp/", {:techs => 1, :endpoints => args_fp_endpoints.size}, args_fp_endpoints).perform_tests
+
+# Regression: a generic yazap receiver variable (`cmd`) reused across two
+# subcommands. The flag added to `cmd` BEFORE it is reassigned must resolve
+# to the command bound to it AT THAT LINE ("build"), not to whichever
+# command is assigned LAST in the file ("test") -- `build` must keep
+# `release` and must NOT also pick up `verbose`.
+yazap_fp_endpoints = [
+  build.call("cli://tool/build", [
+    Param.new("release", "", "flag"),
+  ]),
+  build.call("cli://tool/test", [
+    Param.new("verbose", "", "flag"),
+  ]),
+]
+FunctionalTester.new("fixtures/zig/cli_yazap_fp/", {:techs => 1, :endpoints => yazap_fp_endpoints.size}, yazap_fp_endpoints).perform_tests
+
+# Regression: a bare `@import("args")` used for something unrelated to
+# process argv parsing (no parseForCurrentProcess/parse call bound to the
+# alias anywhere in the file) must not seed a zero-evidence `cli://<binary>`
+# root endpoint.
+FunctionalTester.new("fixtures/zig/cli_args_bare_import_fp/", {:techs => 1, :endpoints => 0}, [] of Endpoint).perform_tests

--- a/src/analyzer/analyzers/clojure/cli.cr
+++ b/src/analyzer/analyzers/clojure/cli.cr
@@ -2,7 +2,8 @@ require "../../../models/analyzer"
 
 module Analyzer::Clojure
   # Surfaces the command-line attack surface of Clojure programs as `cli://`
-  # endpoints: clojure.tools.cli option specs, cli-matic config, and
+  # endpoints: clojure.tools.cli option specs, cli-matic config,
+  # babashka.cli spec/dispatch tables, environ.core env lookups, and
   # *command-line-args* / (System/getenv). Line-scan, merged by URL.
   class Cli < Analyzer
     TOOLS_CLI_LONG = /"--([A-Za-z0-9][\w-]*)/
@@ -11,8 +12,19 @@ module Analyzer::Clojure
     MATIC_OPTION   = /:option\s+"([A-Za-z0-9][\w-]*)"/
     NTH_ARGS       = /\(\s*nth\s+(?:\*command-line-args\*|args)\s+(\d+)/
     GET_ENV        = /\(\s*System\/getenv\s+"([^"]+)"/
+    # Whole `:cmds [...]` vector (may hold several segments, e.g. `["docker" "start"]`).
+    BB_CMDS = /:cmds\s+\[([^\]]*)\]/
+    # `env` bound bare from environ.core: `(:require [environ.core :refer [env]])`.
+    # Never trust an alias (`:as environ`) or an unrelated local/param named `env`.
+    ENVIRON_REFER_ENV = /environ\.core\s*:refer\s*\[[^\]]*\benv\b/
+    ENVIRON_ENV       = /\(\s*env\s+:([A-Za-z][\w-]*)/
 
-    MARKERS = /clojure\.tools\.cli\b|\(\s*(?:[\w.-]+\/)?parse-opts\b|\bcli-matic\b|\*command-line-args\*/
+    # NOTE: environ.core is intentionally absent here. It's a generic
+    # 12-factor config-reading library used by web apps/workers/services just
+    # as much as CLIs (same category as bare System/getenv, below) — it must
+    # never gate CLI detection on its own. It only annotates params on a
+    # `cli://` endpoint some OTHER marker below already established.
+    MARKERS = /clojure\.tools\.cli\b|\(\s*(?:[\w.-]+\/)?parse-opts\b|\bcli-matic\b|\*command-line-args\*|\bbabashka\.cli\b/
     WEB_RE  = /\b(?:compojure|ring\.adapter|reitit|io\.pedestal|httpkit|aleph)\b/
 
     def analyze
@@ -27,7 +39,19 @@ module Analyzer::Clojure
             next unless content.matches?(MARKERS)
             root_url = "cli://#{cli_binary_name(path)}"
             emit_env = !content.matches?(WEB_RE)
+            environ_env_ok = content.matches?(ENVIRON_REFER_ENV)
             current_url = root_url
+
+            # babashka.cli dispatch tables are parsed structurally (brace
+            # extents), not via a line-ordered sticky cursor: map literals are
+            # unordered, so `:spec` can precede its own `:cmds` sibling, and a
+            # stale cursor would misattribute options to the wrong (or a
+            # previous) subcommand. Each `:spec` map's options are only ever
+            # attributed to the `:cmds` entry that structurally encloses it.
+            if content.includes?("babashka.cli")
+              collect_babashka_dispatch(content, root_url, path, endpoints)
+            end
+
             content.each_line.with_index do |line, index|
               line_no = index + 1
               if m = line.match(MATIC_COMMAND)
@@ -47,6 +71,14 @@ module Analyzer::Clojure
               end
               if emit_env
                 line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }
+                # environ.core: (env :database-url) reads DATABASE_URL (env var,
+                # system property, or .lein-env) — surface the conventional
+                # upper-snake env var name it resolves to. Only once we've
+                # confirmed `env` is actually environ.core's var (environ_env_ok),
+                # never for an aliased require or an unrelated `env` binding.
+                if environ_env_ok
+                  line.scan(ENVIRON_ENV) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1].upcase.gsub('-', '_'), "", "env")) }
+                end
               end
             end
           rescue e
@@ -80,6 +112,154 @@ module Analyzer::Clojure
         ep.protocol = "cli"
         ep
       end
+    end
+
+    # Finds every babashka.cli dispatch-table entry (`{:cmds [...] :spec {...}}`)
+    # by brace extent rather than line order, then attributes each `:spec`
+    # map's options only to the entry that structurally contains it.
+    private def collect_babashka_dispatch(content : String, root_url : String, path : String,
+                                           endpoints : Hash(String, Endpoint)) : Nil
+      pairs = brace_pairs(content)
+
+      entries = [] of {Int32, Int32, String}
+      content.scan(BB_CMDS) do |m|
+        match_start = m.byte_begin(0)
+        match_end = m.byte_end(0)
+        segments = m[1].scan(/"([^"\\]*)"/).map { |sm| sm[1] }
+        next if segments.empty?
+        enclosing = pairs.select { |(o, c)| o <= match_start && c >= match_end }.min_by? { |(o, c)| c - o }
+        next unless enclosing
+        o, c = enclosing
+        entries << {o, c, segments.join("/")}
+      end
+
+      # A dispatch entry surfaces its `cli://root/cmd` endpoint even if its
+      # `:spec` map is empty/absent (e.g. a bare `help` subcommand).
+      entries.each do |(o, _, segments)|
+        fetch_endpoint(endpoints, "#{root_url}/#{segments}", path, line_number_for(content, o))
+      end
+
+      content.scan(/:spec\s*(\{)/) do |m|
+        spec_open = m.byte_begin(1)
+        spec_close = find_matching_delimiter(content, spec_open, '{', '}', content.bytesize)
+        owner = entries.find { |(o, c, _)| o <= spec_open && spec_close <= c }
+        target_url = owner ? "#{root_url}/#{owner[2]}" : root_url
+        spec_options(content, spec_open, spec_close).each do |(opt_name, key_pos)|
+          fetch_endpoint(endpoints, target_url, path, line_number_for(content, key_pos)).push_param(Param.new(opt_name, "", "flag"))
+        end
+      end
+    end
+
+    # Direct (depth-1) `:key {...}` children of a `:spec` map — i.e. the
+    # option entries themselves, never a nested sub-map inside one of those
+    # option entries (e.g. babashka.cli's `:validate {:fn ... :ex-msg ...}`).
+    # Matching the general `:key {...}` shape (not requiring `:coerce`) also
+    # picks up untyped/default-string options like `{:desc "..."}`.
+    private def spec_options(content : String, spec_open : Int32, spec_close : Int32) : Array({String, Int32})
+      results = [] of {String, Int32}
+      i = spec_open + 1
+      depth = 1
+      while i < spec_close
+        char = content.byte_at(i).unsafe_chr
+        case char
+        when ';'
+          i = skip_comment(content, i, spec_close)
+        when '"'
+          i = skip_string(content, i, spec_close)
+        when '{'
+          depth += 1
+        when '}'
+          depth -= 1
+        when ':'
+          if depth == 1
+            rest = content.byte_slice(i, spec_close - i)
+            if km = rest.match(/\A:([A-Za-z][\w-]*)\s*\{/)
+              results << {km[1], i}
+            end
+          end
+        end
+        i += 1
+      end
+      results
+    end
+
+    # Every matched `{...}` pair in `content`, as byte-offset (open, close).
+    private def brace_pairs(content : String) : Array({Int32, Int32})
+      pairs = [] of {Int32, Int32}
+      stack = [] of Int32
+      i = 0
+      limit = content.bytesize
+      while i < limit
+        char = content.byte_at(i).unsafe_chr
+        case char
+        when ';'
+          i = skip_comment(content, i, limit)
+        when '"'
+          i = skip_string(content, i, limit)
+        when '{'
+          stack.push(i)
+        when '}'
+          if open = stack.pop?
+            pairs << {open, i}
+          end
+        end
+        i += 1
+      end
+      pairs
+    end
+
+    private def skip_comment(source : String, index : Int32, limit : Int32) : Int32
+      i = index
+      while i < limit && source.byte_at(i).unsafe_chr != '\n'
+        i += 1
+      end
+      i
+    end
+
+    private def skip_string(source : String, index : Int32, limit : Int32) : Int32
+      i = index + 1
+      escaping = false
+
+      while i < limit
+        char = source.byte_at(i).unsafe_chr
+        if escaping
+          escaping = false
+        elsif char == '\\'
+          escaping = true
+        elsif char == '"'
+          return i
+        end
+        i += 1
+      end
+
+      limit - 1
+    end
+
+    private def find_matching_delimiter(source : String, index : Int32, open_char : Char, close_char : Char, limit : Int32) : Int32
+      depth = 0
+      i = index
+
+      while i < limit
+        char = source.byte_at(i).unsafe_chr
+        case char
+        when ';'
+          i = skip_comment(source, i, limit)
+        when '"'
+          i = skip_string(source, i, limit)
+        when open_char
+          depth += 1
+        when close_char
+          depth -= 1
+          return i if depth == 0
+        end
+        i += 1
+      end
+
+      index
+    end
+
+    private def line_number_for(source : String, index : Int32) : Int32
+      source.byte_slice(0, index).count('\n') + 1
     end
   end
 end

--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -5,7 +5,8 @@ module Analyzer::Cpp
   # endpoints: one endpoint per (sub)command with named options
   # (param_type "flag"), positional arguments ("argument") and consumed
   # environment variables ("env"). Covers CLI11, getopt/getopt_long, cxxopts,
-  # boost::program_options and gflags, plus gated getenv reads.
+  # boost::program_options, gflags, Abseil Flags and p-ranav/argparse, plus
+  # gated getenv reads.
   #
   # Line-scan analyzer (Go/Ruby/Rust CLI house style) merging endpoints by
   # URL. There is no C++ engine, so it subclasses Analyzer directly.
@@ -21,6 +22,19 @@ module Analyzer::Cpp
     ADD_OPTION     = /(\w+)\s*(?:\.|->)\s*add_option\s*\(\s*"([^"]+)"/
     ADD_FLAG       = /(\w+)\s*(?:\.|->)\s*add_flag\s*\(\s*"([^"]+)"/
 
+    # p-ranav/argparse. Declare-then-register style: an ArgumentParser
+    # variable's role (root vs subcommand) is only known once it's observed
+    # either as the receiver of `.parse_args(argc, argv)` / owner side of
+    # `.add_subparser(...)`, or by elimination when it's the file's only
+    # declared parser. Resolved once per file in `resolve_argparse_vars`
+    # before options are attributed, so declaration order in the file never
+    # decides which parser is root (a helper-function-local parser can never
+    # be mistaken for the real root).
+    ARGPARSE_DECL      = /\bargparse::ArgumentParser\s+(\w+)\s*\(\s*"([^"]+)"/
+    ARGPARSE_ADD_ARG   = /(\w+)\s*(?:\.|->)\s*add_argument\s*\(\s*"([^"]+)"(?:\s*,\s*"([^"]+)")?/
+    ARGPARSE_SUBPARSER = /(\w+)\s*(?:\.|->)\s*add_subparser\s*\(\s*(\w+)\s*\)/
+    ARGPARSE_PARSE     = /(\w+)\s*(?:\.|->)\s*parse_args\s*\(\s*argc\s*,\s*argv\s*\)/
+
     # getopt_long struct option entries + short spec.
     LONG_OPT_ENTRY = /\{\s*"([A-Za-z0-9][\w-]*)"\s*,\s*(?:no_argument|required_argument|optional_argument|\d)/
     GETOPT_CALL    = /\bgetopt(?:_long)?\s*\([^,]+,[^,]+,\s*"([^"]*)"/
@@ -34,10 +48,22 @@ module Analyzer::Cpp
     # gflags.
     GFLAGS_DEF = /\bDEFINE_(?:string|int32|int64|bool|double|uint32|uint64)\s*\(\s*(\w+)/
 
+    # Abseil Flags. `ABSL_FLAG(type, name, default, help)` — the type is
+    # matched with a depth-aware manual scan (see `absl_flag_names`) rather
+    # than a character-class regex, so a template type with a top-level
+    # comma (e.g. `std::map<std::string,int>`) doesn't truncate/misparse the
+    # name field.
+    ABSL_FLAG_MARK = /\bABSL_FLAG\s*\(/
+
     GETENV   = /\b(?:std::)?getenv\s*\(\s*"([^"]+)"/
     ARGV_IDX = /\bargv\s*\[\s*(\d+)\s*\]/
 
-    CLI_MARKERS = ["CLI::App", "getopt", "struct option", "cxxopts::", "program_options", "DEFINE_string", "DEFINE_int", "DEFINE_bool"]
+    # Whitespace-tolerant substring markers (no trailing "(" on macro-style
+    # entries) so this gate can never diverge from what the extraction
+    # regexes above actually accept, e.g. `ABSL_FLAG (int32_t, ...)` with a
+    # space before the paren is valid C++ and must not be silently skipped.
+    CLI_MARKERS = ["CLI::App", "getopt", "struct option", "cxxopts::", "program_options",
+                   "DEFINE_string", "DEFINE_int", "DEFINE_bool", "ABSL_FLAG", "argparse::ArgumentParser"]
     WEB_RE      = /\b(?:Crow|crow|drogon|httplib|oatpp)\b|Crow::|drogon::|httplib::|oatpp::/
 
     def analyze
@@ -88,6 +114,7 @@ module Analyzer::Cpp
                      endpoints : Hash(String, Endpoint), emit_env : Bool)
       current_url = root_url            # cursor for bare add_subcommand chains
       var_urls = {} of String => String # CLI11 App / subcommand variables
+      argparse_var_urls = resolve_argparse_vars(lines, path, root_url, endpoints)
       in_opts_block = false
 
       lines.each_with_index do |line, index|
@@ -136,9 +163,26 @@ module Analyzer::Cpp
         end
         in_opts_block = false if in_opts_block && line.includes?(";")
 
+        # p-ranav/argparse add_argument("-v","--verbose") / add_argument("input"),
+        # attributed by the receiver variable. Strict lookup: a receiver that
+        # `resolve_argparse_vars` never bound to a root/subcommand url (e.g. a
+        # parser built by an unrelated helper function) is dropped rather than
+        # falling back to the file's root — no stray-match root fallback.
+        if m = line.match(ARGPARSE_ADD_ARG)
+          if url = argparse_var_urls[m[1]]?
+            raw = m[3]? ? "#{m[2]},#{m[3]}" : m[2]
+            push_named(endpoints, url, path, line_no, raw)
+          end
+        end
+
         # gflags.
         if m = line.match(GFLAGS_DEF)
           fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+        end
+
+        # Abseil Flags: ABSL_FLAG(type, name, default, help) — root flags.
+        absl_flag_names(line).each do |name|
+          fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
         end
 
         # raw argv positionals. `scan` so every argv[N] on one line surfaces
@@ -155,6 +199,113 @@ module Analyzer::Cpp
           end
         end
       end
+    end
+
+    # Resolves p-ranav/argparse ArgumentParser variables to their root/
+    # subcommand urls in a single pre-pass over the whole file, so that
+    # declaration order (a helper function's local parser declared above
+    # `main`) can never decide which variable is the real root — only an
+    # explicit linking call can:
+    #   - a var seen as the receiver of `.parse_args(argc, argv)` (and never
+    #     itself a subparser child) is root;
+    #   - otherwise a var seen as the owner (receiver) side of
+    #     `.add_subparser(child)` (and never itself a child) is root;
+    #   - otherwise, if there is exactly one declared parser that is never a
+    #     child, it's root by elimination (the common no-subcommands case).
+    # A parser var that resolves to neither role (e.g. a factory helper's
+    # local parser, never linked or parsed) is left unbound — its
+    # add_argument calls are dropped in `scan` rather than mis-attributed.
+    private def resolve_argparse_vars(lines : Array(String), path : String, root_url : String,
+                                      endpoints : Hash(String, Endpoint)) : Hash(String, String)
+      declared = {} of String => String     # var -> display name
+      links = [] of Tuple(String, String, Int32) # parent_var, child_var, line_no
+      parse_vars = [] of String
+
+      lines.each_with_index do |line, index|
+        if m = line.match(ARGPARSE_DECL)
+          declared[m[1]] = m[2] unless declared.has_key?(m[1])
+        end
+        if m = line.match(ARGPARSE_SUBPARSER)
+          links << {m[1], m[2], index + 1}
+        end
+        if m = line.match(ARGPARSE_PARSE)
+          parse_vars << m[1]
+        end
+      end
+
+      var_urls = {} of String => String
+      return var_urls if declared.empty?
+
+      child_vars = links.map { |l| l[1] }
+      owner_vars = links.map { |l| l[0] }
+
+      root_var = parse_vars.find { |v| declared.has_key?(v) && !child_vars.includes?(v) }
+      root_var ||= owner_vars.find { |v| declared.has_key?(v) && !child_vars.includes?(v) }
+      if root_var.nil?
+        candidates = declared.keys.reject { |v| child_vars.includes?(v) }
+        root_var = candidates.first if candidates.size == 1
+      end
+      return var_urls if root_var.nil?
+
+      var_urls[root_var] = root_url
+      links.each do |link|
+        parent, child, line_no = link
+        next unless parent == root_var # single-level subcommand nesting only
+        next unless name = declared[child]?
+        url = "#{root_url}/#{name}"
+        var_urls[child] = url
+        fetch_endpoint(endpoints, url, path, line_no)
+      end
+      var_urls
+    end
+
+    # Extracts flag names from `ABSL_FLAG(type, name, default, help)` on a
+    # line via a depth-aware manual scan rather than a character-class
+    # regex, so a template type containing a top-level comma (e.g.
+    # `std::map<std::string,int>`) doesn't break extraction of the name
+    # field: `<`/`(` open a nesting level, `>`/`)` close one, and only a
+    # comma at depth 0 separates macro arguments.
+    private def absl_flag_names(line : String) : Array(String)
+      names = [] of String
+      offset = 0
+      while offset <= line.size && (m = line.match(ABSL_FLAG_MARK, offset))
+        args_start = m.end.not_nil!
+        fields = [] of String
+        depth = 0
+        field_start = args_start
+        i = args_start
+        closed_at = nil
+
+        while i < line.size
+          case line[i]
+          when '(', '<'
+            depth += 1
+          when ')'
+            if depth == 0
+              fields << line[field_start...i]
+              closed_at = i
+              break
+            end
+            depth -= 1
+          when '>'
+            depth -= 1 if depth > 0
+          when ','
+            if depth == 0
+              fields << line[field_start...i]
+              field_start = i + 1
+            end
+          end
+          i += 1
+        end
+
+        if fields.size >= 2
+          name = fields[1].strip
+          names << name if name.matches?(/\A\w+\z/)
+        end
+
+        offset = closed_at ? closed_at + 1 : args_start + 1
+      end
+      names
     end
 
     # A CLI11 add_option name starting with `-` is an option/flag; otherwise

--- a/src/analyzer/analyzers/csharp/cli.cr
+++ b/src/analyzer/analyzers/csharp/cli.cr
@@ -7,7 +7,8 @@ module Analyzer::CSharp
   # (param_type "flag"), positional arguments ("argument") and consumed
   # environment variables ("env"). Covers `Main(string[] args)` /
   # GetCommandLineArgs / GetEnvironmentVariable plus System.CommandLine,
-  # CommandLineParser, CliFx and Spectre.Console.Cli.
+  # CommandLineParser, CliFx, Spectre.Console.Cli,
+  # McMaster.Extensions.CommandLineUtils and Cocona.
   #
   # Line-scan analyzer (Go/Ruby/Rust CLI house style) merging endpoints by
   # URL. Subclasses Analyzer directly (there is no C# engine) and reuses
@@ -27,11 +28,25 @@ module Analyzer::CSharp
     NEW_OPTION      = /\bnew\s+Option(?:<[^>]*>)?\s*\(\s*@?"([^"]+)"/
     NEW_ARGUMENT    = /\bnew\s+Argument(?:<[^>]*>)?\s*\(\s*@?"([^"]+)"/
 
-    # Attribute-driven libs (CommandLineParser / CliFx / Spectre / airline-ish).
+    # Attribute-driven libs (CommandLineParser / CliFx / Spectre / airline-ish
+    # / McMaster.Extensions.CommandLineUtils / Cocona).
     VERB_ATTR   = /\[\s*(?:Verb|Command)\s*\(\s*@?"([^"]+)"/
     ADD_COMMAND = /\.AddCommand(?:<[^>]+>)?\s*\(\s*@?"([^"]+)"/
-    OPTION_ATTR = /\[\s*(?:Option|CommandOption)\s*\(([^\]]*)\)/
+    # Parenthesized body is optional so a bare `[Option]` (McMaster/Cocona,
+    # name taken from the annotated member) is matched too.
+    OPTION_ATTR = /\[\s*(?:Option|CommandOption)\s*(?:\(([^\]]*)\))?\s*\]/
     PARAM_ATTR  = /\[\s*CommandParameter\s*\(([^\]]*)\)/
+
+    # McMaster / Cocona: `[Argument(0)]` / `[Argument(0, "name")]` /
+    # bare `[Argument]` (Cocona lambda params). Body may hold an explicit
+    # quoted name; when absent we fall back to the annotated property or
+    # parameter name (same line or the line right below).
+    ARGUMENT_ATTR = /\[\s*Argument\s*(?:\(([^\]]*)\))?\s*\]/
+    # Trailing "type name" right after a matched attribute's tail (an
+    # optional leftover "]" is skipped first since Option/Argument attr
+    # regexes above don't always consume it).
+    PROPERTY_TRAILING = /\A\s*\]?\s*(?:public\s+)?\S+\s+(\w+)/
+    PROPERTY_NEXTLINE = /\A\s*(?:public\s+)?\S+\s+(\w+)\s*[{;,)]/
 
     # builtin.
     GET_ENV      = /\bEnvironment\.GetEnvironmentVariable\s*\(\s*@?"([^"]+)"/
@@ -43,10 +58,13 @@ module Analyzer::CSharp
     # comment), qualifying a web app as a framework CLI and leaking its env
     # reads. CommandLineParser is matched via its `using CommandLine` /
     # `CommandLine.Parser` namespace forms instead (same shape the cs_cli
-    # detector uses).
-    CLI_LIB_MARKERS = ["System.CommandLine", "CliFx", "Spectre.Console.Cli"]
-    CLP_NAMESPACE   = /\busing\s+CommandLine\b|\bCommandLine\.Parser\b|\bParser\.Default\.ParseArguments\b/
-    WEB_HOST_RE     = /\bWebApplication\.(?:Create(?:Builder|SlimBuilder|EmptyBuilder)?|CreateDefault)\b|\bnew\s+HttpListener\b|\.MapGet\s*\(|\.MapControllers\s*\(|\[\s*ApiController\s*\]|:\s*ControllerBase\b|\bHost\.CreateDefaultBuilder\b/
+    # detector uses). Cocona is matched via its `using Cocona` / `CoconaApp.*`
+    # forms for the same reason ("Cocona" alone is specific enough as a
+    # substring, but we keep the same regex shape for consistency).
+    CLI_LIB_MARKERS  = ["System.CommandLine", "CliFx", "Spectre.Console.Cli", "McMaster.Extensions.CommandLineUtils"]
+    CLP_NAMESPACE    = /\busing\s+CommandLine\b|\bCommandLine\.Parser\b|\bParser\.Default\.ParseArguments\b/
+    COCONA_NAMESPACE = /\busing\s+Cocona\b|\bCoconaApp\.(?:Create|Run)\b/
+    WEB_HOST_RE      = /\bWebApplication\.(?:Create(?:Builder|SlimBuilder|EmptyBuilder)?|CreateDefault)\b|\bnew\s+HttpListener\b|\.MapGet\s*\(|\.MapControllers\s*\(|\[\s*ApiController\s*\]|:\s*ControllerBase\b|\bHost\.CreateDefaultBuilder\b/
 
     def analyze
       assemblies = collect_csproj_names
@@ -65,7 +83,7 @@ module Analyzer::CSharp
           root_url = "cli://#{binary}"
           framework_cli = cli_library?(content)
           emit_builtin = framework_cli || !content.matches?(WEB_HOST_RE)
-          scan(content.lines, path, binary, root_url, endpoints, emit_builtin)
+          scan(content.lines, path, binary, root_url, endpoints, emit_builtin, framework_cli)
         rescue e
           logger.debug "Error analyzing #{path}: #{e}"
           next
@@ -77,7 +95,8 @@ module Analyzer::CSharp
     end
 
     private def cli_library?(content : String) : Bool
-      CLI_LIB_MARKERS.any? { |m| content.includes?(m) } || content.matches?(CLP_NAMESPACE)
+      CLI_LIB_MARKERS.any? { |m| content.includes?(m) } ||
+        content.matches?(CLP_NAMESPACE) || content.matches?(COCONA_NAMESPACE)
     end
 
     private def cli_evidence?(content : String) : Bool
@@ -101,7 +120,8 @@ module Analyzer::CSharp
     end
 
     private def scan(lines : Array(String), path : String, binary : String,
-                     root_url : String, endpoints : Hash(String, Endpoint), emit_builtin : Bool)
+                     root_url : String, endpoints : Hash(String, Endpoint), emit_builtin : Bool,
+                     framework_cli : Bool)
       current_url = root_url            # cursor for the attribute-driven path
       var_urls = {} of String => String # System.CommandLine command variables
 
@@ -151,8 +171,19 @@ module Analyzer::CSharp
           current_url = "#{root_url}/#{m[1]}"
           fetch_endpoint(endpoints, current_url, path, line_no)
         end
-        if m = line.match(OPTION_ATTR)
-          if name = attr_option_name(m[1])
+        # `scan` (not `match`) so several `[Option(...)]` on one line — e.g.
+        # Cocona's inline-lambda `([Option('n')] string name, [Option('a')] int
+        # age)` — all surface, not just the first.
+        line.scan(OPTION_ATTR) do |m|
+          name = m[1]?.try { |body| attr_option_name(body) }
+          # McMaster/Cocona bare short-option form (`[Option('n')]`) or fully
+          # bare `[Option]` carries no literal name; fall back to the annotated
+          # property/parameter name. Restricted to files with a recognized
+          # CLI-lib marker so a stray same-named attribute can't leak a param.
+          if !name && framework_cli
+            name = trailing_member_name(line, m.end, lines, index)
+          end
+          if name
             fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(name, "", "flag"))
           end
         end
@@ -160,6 +191,17 @@ module Analyzer::CSharp
           # Spectre [CommandArgument(0, "<name>")] -> argument by label.
           if lbl = m[1].match(/[<\[]([A-Za-z0-9_-]+)[>\]]/)
             fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(lbl[1], "", "argument"))
+          end
+        end
+        if framework_cli
+          # McMaster `[Argument(0)]` / `[Argument(0, "name")]` and Cocona's
+          # bare `[Argument]` lambda-parameter form; `scan` so multiple
+          # positional params declared on one lambda line all surface.
+          line.scan(ARGUMENT_ATTR) do |m|
+            name = attr_argument_name(m[1]?) || trailing_member_name(line, m.end, lines, index)
+            if name
+              fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(name, "", "argument"))
+            end
           end
         end
 
@@ -202,6 +244,37 @@ module Analyzer::CSharp
         end
       end
       long || short
+    end
+
+    # McMaster `[Argument(0, "name")]` carries an explicit quoted name;
+    # bare `[Argument(0)]` / Cocona's `[Argument]` do not (nil -> caller
+    # falls back to the annotated member name).
+    private def attr_argument_name(body : String?) : String?
+      return nil unless body
+      # Only a space-free double-quoted token is an explicit argument name;
+      # skip McMaster's `Description = "some help text"` named-property form
+      # (mirrors attr_option_name), falling back to the member name otherwise.
+      body.scan(/"([^"]+)"/) do |m|
+        return m[1] unless m[1].includes?(' ')
+      end
+      nil
+    end
+
+    # Fallback for attributes with no literal name (`[Option('n')]`,
+    # `[Argument]`): reads the type+name of the property/parameter the
+    # attribute annotates, either trailing on the same line (skipping a
+    # leftover "]" that Option/Argument attr regexes don't consume) or, if
+    # the attribute is alone on its line, the line right below it.
+    private def trailing_member_name(line : String, match_end : Int32,
+                                     lines : Array(String), index : Int32) : String?
+      tail = line[match_end..]
+      if pm = tail.match(PROPERTY_TRAILING)
+        return pm[1]
+      end
+      if (index + 1) < lines.size && (pm2 = lines[index + 1].match(PROPERTY_NEXTLINE))
+        return pm2[1]
+      end
+      nil
     end
 
     private def collect_csproj_names : Array(Tuple(String, String))

--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -7,7 +7,7 @@ module Analyzer::Go
   # (param_type "flag"), positional arguments ("argument"), and consumed
   # environment variables ("env"). Covers the stdlib `flag` package +
   # `os.Args` + `os.Getenv`/`os.LookupEnv`, plus the cobra, urfave/cli,
-  # pflag, go-arg and go-flags ecosystems.
+  # pflag, go-arg, go-flags, kong, kingpin and mitchellh/cli ecosystems.
   #
   # This is a line-scan analyzer (the house style for non-tree-sitter Go
   # adapters, e.g. fasthttp). Endpoints are merged by URL across files so a
@@ -21,6 +21,10 @@ module Analyzer::Go
       "github.com/alexflint/go-arg",
       "github.com/jessevdk/go-flags",
       "github.com/spf13/pflag",
+      "github.com/alecthomas/kong",
+      "github.com/mitchellh/cli",
+      "github.com/alecthomas/kingpin",
+      "gopkg.in/alecthomas/kingpin.v2",
     ]
 
     # --- builtin flag / argv -------------------------------------------------
@@ -57,6 +61,52 @@ module Analyzer::Go
     GOFLAGS_LONG_RE = /`[^`]*\blong:"([^"]+)"/
     GOFLAGS_ENV_RE  = /`[^`]*\benv:"([^"]+)"/
 
+    # A bare unindented `}` closes the top-level struct/func block it
+    # belongs to (the gofmt convention this line-scan relies on for
+    # kong's `type X struct {}` and mitchellh/cli's `func (...) Run(...) {}`
+    # scoping below).
+    TOPLEVEL_BRACE_CLOSE_RE = /^\}\s*$/
+
+    # --- kong (struct-tag CLI) ------------------------------------------------
+    # Root/subcommand fields are declared as struct fields; a `cmd:""` tag
+    # marks a field as a subcommand whose own flags/args live in that
+    # field's named struct type, an `arg:""` tag marks a positional, and an
+    # `env:""` tag additionally binds the field to an environment variable.
+    KONG_TYPE_DECL_RE = /^type\s+(\w+)\s+struct\s*\{/
+    KONG_FIELD_RE     = /^\s*([A-Z]\w*)\s+([\w.\[\]*]+)\s+`([^`]*)`/
+    KONG_TAG_KEY_RE   = /\b(?:cmd|arg|env|default|help)\s*:\s*"/
+    KONG_CMD_TAG_RE   = /\bcmd\s*:\s*"[^"]*"/
+    KONG_ARG_TAG_RE   = /\barg\s*:\s*"[^"]*"/
+    KONG_ENV_TAG_RE   = /\benv\s*:\s*"([^"]+)"/
+    KONG_NAME_TAG_RE  = /\bname\s*:\s*"([^"]+)"/
+
+    # --- kingpin (fluent Flag/Arg/Command builder) ---------------------------
+    # `app := kingpin.New(...)` seeds the root receiver; `cmd := app.Command(...)`
+    # (or `sub := cmd.Command(...)` for nesting) maps a new receiver var onto
+    # a command URL, and `.Flag(...)`/`.Arg(...)` calls on a *known* receiver
+    # attribute a param to that command — never to a sticky "current" command.
+    KINGPIN_NEW_RE     = /(\w+)\s*:?=\s*kingpin\.New\s*\(/
+    KINGPIN_COMMAND_RE = /(\w+)\s*:?=\s*(\w+)\s*\.\s*Command\s*\(\s*"([^"]+)"/
+    KINGPIN_FLAG_RE    = /(\w+)\s*\.\s*Flag\s*\(\s*"([^"]+)"\s*,/
+    KINGPIN_ARG_RE     = /(\w+)\s*\.\s*Arg\s*\(\s*"([^"]+)"\s*,/
+    KINGPIN_ENVAR_RE   = /\.\s*Envar\s*\(\s*"([^"]+)"\s*\)/
+
+    # --- mitchellh/cli (Commands map of factories) ----------------------------
+    # `c.Commands = map[string]cli.CommandFactory{"name": func() (cli.Command,
+    # error) { return &FooCommand{}, nil }}` maps each map key to the
+    # concrete command type it instantiates; that type's own `Run` method is
+    # then scanned (scoped to its own body) for `flag.FlagSet`-style
+    # `*Var` registrations and raw env reads.
+    MITCHELLH_KEY_RE    = /^\s*"([^"]+)"\s*:\s*func\s*\(\s*\)\s*\(cli\.Command,\s*error\)\s*\{/
+    MITCHELLH_RETURN_RE = /return\s+&(\w+)\{/
+    # `cmd := &DeployCommand{}` followed later (within the SAME closure) by
+    # `return cmd, nil` — the idiomatic form used whenever the command needs
+    # field initialization, as common as the single-expression `return &X{}`.
+    MITCHELLH_VAR_ASSIGN_RE = /(\w+)\s*:=\s*&(\w+)\{/
+    MITCHELLH_RETURN_VAR_RE = /return\s+(\w+)\s*,/
+    MITCHELLH_RUN_FUNC_RE   = /^func\s*\(\s*\w+\s+\*?(\w+)\)\s*Run\s*\(/
+    MITCHELLH_FLAGVAR_RE    = /\b\w+\.(?:StringVar|IntVar|Int64Var|BoolVar|Float64Var|DurationVar)\s*\(\s*&?[\w.]+\s*,\s*"([^"]+)"/
+
     # An HTTP listen call in the same file means env reads are most likely
     # server config, not a CLI surface — suppress raw env there.
     HTTP_LISTEN_RE = /\b(?:http|fasthttp)\.ListenAndServe(?:TLS)?\s*\(|\.(?:ListenAndServe|RunTLS)\s*\(/
@@ -91,6 +141,18 @@ module Analyzer::Go
           scan_lines(lines, path, binary, root_url, endpoints, cobra_cmd_urls,
             emit_stdlib, has_cli_parse)
           scan_struct_tags(content, path, root_url, endpoints)
+
+          if content.includes?("github.com/alecthomas/kong")
+            scan_kong(lines, path, root_url, endpoints, kong_cmd_type_urls(lines, root_url))
+          end
+
+          if content.includes?("github.com/alecthomas/kingpin") || content.includes?("gopkg.in/alecthomas/kingpin.v2")
+            scan_kingpin(lines, path, endpoints, kingpin_cmd_urls(lines, root_url))
+          end
+
+          if content.includes?("github.com/mitchellh/cli")
+            scan_mitchellh(lines, path, root_url, endpoints)
+          end
         rescue e
           logger.debug "Error analyzing #{path}: #{e}"
           next
@@ -118,6 +180,10 @@ module Analyzer::Go
       return true if content.includes?("github.com/urfave/cli")
       return true if content.includes?("github.com/alexflint/go-arg")
       return true if content.includes?("github.com/jessevdk/go-flags")
+      # kong/kingpin/mitchellh's own scans attribute their env vars
+      # precisely (struct tag / .Envar() / scoped Run() body) — they
+      # deliberately don't opt into the raw root-level os.Getenv fallback
+      # below, which would double-attribute (or mis-scope) those reads.
       return true if content.includes?("flag.Parse(")
       return true if content.matches?(OS_ARG_INDEX_RE)
       content.includes?("os.Args")
@@ -327,6 +393,266 @@ module Analyzer::Go
           endpoint.push_param(Param.new(part.lchop("env:"), "", "env"))
         elsif part == "positional"
           endpoint.push_param(Param.new("args", "", "argument"))
+        end
+      end
+    end
+
+    # --- kong ------------------------------------------------------------------
+
+    # Converts an exported Go field name into kong's default kebab-case
+    # flag/command label (e.g. "ApiToken" -> "api-token"). An explicit
+    # `name:"..."` tag always wins over this derivation.
+    private def kong_kebab(name : String) : String
+      String.build do |sb|
+        name.each_char_with_index do |ch, i|
+          sb << '-' if ch.uppercase? && i > 0
+          sb << ch.downcase
+        end
+      end
+    end
+
+    private def kong_field_label(field_name : String, tag : String) : String
+      if nm = tag.match(KONG_NAME_TAG_RE)
+        nm[1]
+      else
+        kong_kebab(field_name)
+      end
+    end
+
+    # Kong subcommand fields are frequently pointer-typed (`Serve *ServeCmd
+    # `cmd:""``, a common idiom for optional subcommands) as well as
+    # value-typed (`Serve ServeCmd `cmd:""``). Strip the leading `*` so both
+    # forms resolve to the same type-map key as the `type ServeCmd struct {`
+    # declaration itself (which never carries a pointer sigil).
+    private def kong_strip_ptr(type_name : String) : String
+      type_name.starts_with?('*') ? type_name[1..] : type_name
+    end
+
+    # Maps each `cmd:""`-tagged field's struct TYPE to its command URL, so
+    # the fields declared inside that type's own `type Foo struct {}` block
+    # (scanned separately below) attribute onto the right subcommand instead
+    # of the root.
+    private def kong_cmd_type_urls(lines : Array(String), root_url : String) : Hash(String, String)
+      urls = {} of String => String
+      lines.each do |line|
+        next unless m = line.match(KONG_FIELD_RE)
+        tag = m[3]
+        next unless tag.matches?(KONG_CMD_TAG_RE)
+        urls[kong_strip_ptr(m[2])] = "#{root_url}/#{kong_field_label(m[1], tag)}"
+      end
+      urls
+    end
+
+    # Single forward pass, scoped by the unindented `type Foo struct {` /
+    # `}` pair currently open (nil means "inside the root CLI struct").
+    #
+    # A struct whose name never appears as a `cmd:""`-tagged field's type is
+    # NOT part of the kong CLI tree — it's some other library's struct that
+    # merely happens to share a common tag key (env/default/help are also
+    # used by envconfig, cleanenv, etc.). Such fields are dropped entirely
+    # rather than falling back to the root command, so an unrelated config
+    # struct can never contaminate `cli://<binary>`.
+    private def scan_kong(lines : Array(String), path : String, root_url : String,
+                          endpoints : Hash(String, Endpoint), type_urls : Hash(String, String))
+      current_type : String? = nil
+
+      lines.each_with_index do |line, index|
+        line_no = index + 1
+
+        if m = line.match(KONG_TYPE_DECL_RE)
+          current_type = m[1]
+          if url = type_urls[current_type]?
+            fetch_endpoint(endpoints, url, path, line_no)
+          end
+          next
+        end
+        if current_type && line.matches?(TOPLEVEL_BRACE_CLOSE_RE)
+          current_type = nil
+          next
+        end
+
+        next unless m = line.match(KONG_FIELD_RE)
+        tag = m[3]
+        next unless tag.matches?(KONG_TAG_KEY_RE)
+
+        if current_type
+          next unless scope_url = type_urls[current_type]?
+        else
+          scope_url = root_url
+        end
+
+        if tag.matches?(KONG_CMD_TAG_RE)
+          fetch_endpoint(endpoints, type_urls[kong_strip_ptr(m[2])]? || scope_url, path, line_no)
+        elsif tag.matches?(KONG_ARG_TAG_RE)
+          ep = fetch_endpoint(endpoints, scope_url, path, line_no)
+          ep.push_param(Param.new(kong_field_label(m[1], tag), "", "argument"))
+        else
+          ep = fetch_endpoint(endpoints, scope_url, path, line_no)
+          ep.push_param(Param.new(kong_field_label(m[1], tag), "", "flag"))
+        end
+
+        if em = tag.match(KONG_ENV_TAG_RE)
+          ep = fetch_endpoint(endpoints, scope_url, path, line_no)
+          ep.push_param(Param.new(em[1], "", "env"))
+        end
+      end
+    end
+
+    # --- kingpin -----------------------------------------------------------------
+
+    # Maps every receiver variable that is genuinely part of the kingpin
+    # chain (the root `app` plus every `Command(...)`-declared subcommand)
+    # onto its command URL. Built as two forward passes so a subcommand can
+    # itself parent a nested subcommand declared further down the file.
+    private def kingpin_cmd_urls(lines : Array(String), root_url : String) : Hash(String, String)
+      urls = {} of String => String
+      lines.each do |line|
+        if m = line.match(KINGPIN_NEW_RE)
+          urls[m[1]] = root_url
+        end
+      end
+      lines.each do |line|
+        next unless m = line.match(KINGPIN_COMMAND_RE)
+        next unless parent_url = urls[m[2]]?
+        urls[m[1]] = "#{parent_url}/#{m[3]}"
+      end
+      urls
+    end
+
+    # Flags/args only attribute when their receiver is a *known* kingpin
+    # var (root app or a mapped command) — never a sticky "last command".
+    private def scan_kingpin(lines : Array(String), path : String,
+                             endpoints : Hash(String, Endpoint), cmd_urls : Hash(String, String))
+      lines.each_with_index do |line, index|
+        line_no = index + 1
+
+        if m = line.match(KINGPIN_COMMAND_RE)
+          if url = cmd_urls[m[1]]?
+            fetch_endpoint(endpoints, url, path, line_no)
+          end
+        end
+
+        if m = line.match(KINGPIN_FLAG_RE)
+          if url = cmd_urls[m[1]]?
+            ep = fetch_endpoint(endpoints, url, path, line_no)
+            ep.push_param(Param.new(m[2], "", "flag"))
+            if em = line.match(KINGPIN_ENVAR_RE)
+              ep.push_param(Param.new(em[1], "", "env"))
+            end
+          end
+        end
+
+        if m = line.match(KINGPIN_ARG_RE)
+          if url = cmd_urls[m[1]]?
+            ep = fetch_endpoint(endpoints, url, path, line_no)
+            ep.push_param(Param.new(m[2], "", "argument"))
+          end
+        end
+      end
+    end
+
+    # --- mitchellh/cli -----------------------------------------------------------
+
+    # Maps each command factory's concrete return type (e.g. `&DeployCommand{}`)
+    # to its command URL, keyed off the map literal's own string key. Each
+    # key's return type is resolved by a search strictly SCOPED to that
+    # factory closure's own brace-tracked body — never a global "last seen"
+    # cursor — so a closure whose return type can't be resolved (or that
+    # returns via an intermediate variable declared in an unusual way) is
+    # simply abandoned instead of leaking into unrelated code later in the
+    # file.
+    private def mitchellh_cmd_type_urls(lines : Array(String), root_url : String) : Hash(String, String)
+      urls = {} of String => String
+      lines.each_with_index do |line, index|
+        next unless m = line.match(MITCHELLH_KEY_RE)
+        key = m[1]
+        if return_type = resolve_mitchellh_factory_return_type(lines, index)
+          urls[return_type] = "#{root_url}/#{key}"
+        end
+      end
+      urls
+    end
+
+    # Scans forward from a CommandFactory closure's opening line (the
+    # `"key": func() (cli.Command, error) {` line), bounded by that
+    # closure's own matching `}`, for the concrete command type it returns —
+    # either directly (`return &X{}, nil`) or via an intermediate variable
+    # (`cmd := &X{}` ... `return cmd, nil`, an idiomatic pattern whenever the
+    # command needs field initialization). Returns nil (never a fallback)
+    # if the closure closes without a resolvable return.
+    private def resolve_mitchellh_factory_return_type(lines : Array(String), start : Int32) : String?
+      depth = 0
+      local_vars = {} of String => String
+      index = start
+
+      while index < lines.size
+        line = lines[index]
+
+        if m = line.match(MITCHELLH_RETURN_RE)
+          return m[1]
+        end
+        if m = line.match(MITCHELLH_VAR_ASSIGN_RE)
+          local_vars[m[1]] = m[2]
+        end
+        if m = line.match(MITCHELLH_RETURN_VAR_RE)
+          if t = local_vars[m[1]]?
+            return t
+          end
+        end
+
+        line.each_char do |ch|
+          depth += 1 if ch == '{'
+          depth -= 1 if ch == '}'
+        end
+        break if depth <= 0 && index > start # closure closed, nothing resolved
+        index += 1
+        break if index - start > 200 # safety bound for malformed input
+      end
+      nil
+    end
+
+    private def mitchellh_cmd_keys(lines : Array(String)) : Array(Tuple(String, Int32))
+      keys = [] of Tuple(String, Int32)
+      lines.each_with_index do |line, index|
+        if m = line.match(MITCHELLH_KEY_RE)
+          keys << {m[1], index + 1}
+        end
+      end
+      keys
+    end
+
+    # Every map key becomes an endpoint up front (a command with no flags of
+    # its own still surfaces), then a second pass scoped to each mapped
+    # type's own `Run` method body picks up FlagSet `*Var` registrations and
+    # raw env reads.
+    private def scan_mitchellh(lines : Array(String), path : String, root_url : String,
+                               endpoints : Hash(String, Endpoint))
+      type_urls = mitchellh_cmd_type_urls(lines, root_url)
+      mitchellh_cmd_keys(lines).each do |key, line_no|
+        fetch_endpoint(endpoints, "#{root_url}/#{key}", path, line_no)
+      end
+
+      current_url : String? = nil
+      lines.each_with_index do |line, index|
+        line_no = index + 1
+
+        if m = line.match(MITCHELLH_RUN_FUNC_RE)
+          current_url = type_urls[m[1]]?
+          next
+        end
+        if current_url && line.matches?(TOPLEVEL_BRACE_CLOSE_RE)
+          current_url = nil
+          next
+        end
+        next unless url = current_url
+
+        if m = line.match(MITCHELLH_FLAGVAR_RE)
+          ep = fetch_endpoint(endpoints, url, path, line_no)
+          ep.push_param(Param.new(m[1], "", "flag"))
+        end
+        line.scan(OS_GETENV_RE) do |env_match|
+          ep = fetch_endpoint(endpoints, url, path, line_no)
+          ep.push_param(Param.new(env_match[1], "", "env"))
         end
       end
     end

--- a/src/analyzer/analyzers/groovy/cli.cr
+++ b/src/analyzer/analyzers/groovy/cli.cr
@@ -2,9 +2,22 @@ require "../../../models/analyzer"
 
 module Analyzer::Groovy
   # Surfaces the command-line attack surface of Groovy programs as `cli://`
-  # endpoints: the built-in CliBuilder (and picocli @Option) plus
-  # System.getenv. Line-scan; root attribution (CliBuilder is flat), merged
-  # by URL.
+  # endpoints: the built-in CliBuilder (and picocli @Option), JCommander
+  # (@Parameter / addCommand subcommands) and Commons CLI (Option.builder /
+  # addOption), plus System.getenv. Line-scan; attribution for JCommander
+  # subcommands additionally uses a per-file pre-scan (variable -> class ->
+  # command name) so it can resolve both the inline
+  # `addCommand("name", new Class())` form and the more common
+  # declare-then-register `addCommand("name", instance)` form. Root
+  # attribution otherwise (CliBuilder/Commons CLI are flat), merged by URL.
+  #
+  # NOTE: like CliBuilder, this is a per-file analyzer. When a JCommander
+  # subcommand class lives in its own file (registration call in one file,
+  # `@Parameter` fields in another), the class-to-command mapping built here
+  # won't span files, so that subcommand's fields fall back to that file's
+  # own root endpoint instead of being attributed under the real
+  # subcommand's URL. A cross-file pre-pass would be needed to close that
+  # gap; not attempted here.
   class Cli < Analyzer
     CLI_OPT     = /\bcli\.([A-Za-z_]\w*)\s*\(([^)]*)/
     LONGOPT     = /longOpt:\s*['"]([^'"]+)['"]/
@@ -19,6 +32,24 @@ module Analyzer::Groovy
     MARKERS = /\bnew\s+CliBuilder\b|\bCliBuilder\s*\(|@picocli|@Command\b/
     WEB_RE  = /\bimport\s+(?:grails|org\.springframework)\b|@Controller\b|@RestController\b/
 
+    # --- JCommander -----------------------------------------------------
+    # Gated on library-specific constructs only (never a bare `@Parameter`,
+    # which is too generic on its own) so unrelated annotations/classes
+    # named similarly don't light this up.
+    JC_MARKER      = /\bimport\s+com\.beust\.jcommander\b|\bnew\s+JCommander\s*\(|\bJCommander\.newBuilder\s*\(/
+    JC_PARAMETER   = /@Parameter\s*\(([^)]*)\)/
+    CLASS_DECL     = /\bclass\s+([A-Za-z_]\w*)/
+    VAR_NEW_DECL   = /\b[A-Za-z_]\w*\s+([A-Za-z_]\w*)\s*=\s*new\s+([A-Za-z_]\w*)\s*\(/
+    JC_ADD_CMD_STR   = /\.addCommand\s*\(\s*['"]([^'"]+)['"]\s*,\s*new\s+([A-Za-z_]\w*)\s*\(/
+    JC_ADD_CMD_VAR   = /\.addCommand\s*\(\s*['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*)\s*\)/
+    JC_COMMAND_NAMES = /@Parameters\s*\([^)]*\bcommandNames\s*=\s*\{?\s*['"]([^'"]+)['"]/
+
+    # --- Commons CLI ------------------------------------------------------
+    CLI_MARKER          = /\bimport\s+org\.apache\.commons\.cli\b|\bOption\.builder\s*\(/
+    COMMONS_CLI_BUILDER = /Option\.builder\s*\(\s*(?:['"]([^'"]*)['"])?\s*\)/
+    COMMONS_CLI_LONGOPT = /\.longOpt\s*\(\s*['"]([^'"]+)['"]/
+    COMMONS_CLI_ADD_OPT = /\.addOption\s*\(\s*['"]([^'"]+)['"]\s*,\s*['"]([^'"]+)['"]\s*,/
+
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".groovy").each do |path|
@@ -27,22 +58,65 @@ module Analyzer::Groovy
         next unless File.exists?(path)
         begin
           content = read_file_content(path)
-          next unless content.matches?(MARKERS)
+          has_clibuilder = content.matches?(MARKERS)
+          has_jcommander = content.matches?(JC_MARKER)
+          has_commonscli = content.matches?(CLI_MARKER)
+          next unless has_clibuilder || has_jcommander || has_commonscli
+
           root_url = "cli://#{cli_binary_name(path)}"
           emit_env = !content.matches?(WEB_RE)
+          subcommand_for_class = has_jcommander ? build_subcommand_map(content) : Hash(String, String).new
+
+          class_stack = [] of NamedTuple(name: String, depth: Int32)
+          depth = 0
+
           content.each_line.with_index do |line, index|
             line_no = index + 1
-            if m = line.match(CLI_OPT)
-              unless NON_OPTION.includes?(m[1])
-                name = line.match(LONGOPT).try(&.[1]) || m[1]
-                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+
+            if has_jcommander
+              if m = line.match(CLASS_DECL)
+                class_stack << {name: m[1], depth: depth}
+              end
+              depth += line.count('{') - line.count('}')
+              while !class_stack.empty? && depth <= class_stack.last[:depth]
+                class_stack.pop
               end
             end
-            if m = line.match(OPTION_ATTR)
-              if name = picocli_name(m[1])
-                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+
+            if has_clibuilder
+              if m = line.match(CLI_OPT)
+                unless NON_OPTION.includes?(m[1])
+                  name = line.match(LONGOPT).try(&.[1]) || m[1]
+                  fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+                end
+              end
+              if m = line.match(OPTION_ATTR)
+                if name = picocli_name(m[1])
+                  fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+                end
               end
             end
+
+            if has_jcommander
+              if m = line.match(JC_PARAMETER)
+                if name = picocli_name(m[1])
+                  klass = class_stack.last?.try(&.[:name])
+                  cmd = klass ? subcommand_for_class[klass]? : nil
+                  target_url = cmd ? "#{root_url}/#{cmd}" : root_url
+                  fetch_endpoint(endpoints, target_url, path, line_no).push_param(Param.new(name, "", "flag"))
+                end
+              end
+            end
+
+            if has_commonscli
+              commons_cli_option_names(line).each do |name|
+                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+              end
+              line.scan(COMMONS_CLI_ADD_OPT) do |m|
+                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[2], "", "flag"))
+              end
+            end
+
             if emit_env
               line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }
             end
@@ -56,9 +130,90 @@ module Analyzer::Groovy
       @result
     end
 
+    # Builds a class-name -> command-name map for JCommander subcommands,
+    # resolving both:
+    #   .addCommand("name", new SomeClass())                (inline)
+    #   .addCommand("name", someVar)                         (declare-then-register,
+    #      where `someVar` was previously assigned via `... someVar = new SomeClass(...)`)
+    #   .addCommand(new SomeClass())                         (single-arg, name comes
+    #      from that class's own @Parameters(commandNames = "...") annotation)
+    private def build_subcommand_map(content : String) : Hash(String, String)
+      var_class = {} of String => String
+      content.each_line do |line|
+        if m = line.match(VAR_NEW_DECL)
+          var_class[m[1]] = m[2]
+        end
+      end
+
+      subcommand_for_class = {} of String => String
+      content.each_line do |line|
+        if m = line.match(JC_ADD_CMD_STR)
+          subcommand_for_class[m[2]] = m[1]
+        elsif m = line.match(JC_ADD_CMD_VAR)
+          if klass = var_class[m[2]]?
+            subcommand_for_class[klass] = m[1]
+          end
+        end
+      end
+
+      # Fallback for single-arg addCommand(new Class()) registrations: use
+      # the class's own @Parameters(commandNames = "...") annotation, when
+      # present, for classes not already resolved above.
+      pending_name = nil
+      content.each_line do |line|
+        if m = line.match(JC_COMMAND_NAMES)
+          pending_name = m[1]
+        elsif m = line.match(CLASS_DECL)
+          if pending_name
+            subcommand_for_class[m[1]] ||= pending_name
+            pending_name = nil
+          end
+        end
+      end
+
+      subcommand_for_class
+    end
+
+    # Extracts option names from every `Option.builder(...)` call on a line
+    # (there may be several, chained with `;`), pairing each with its own
+    # following `.longOpt("...")` call rather than the whole line's first
+    # match. Prefers the long name; falls back to the short name.
+    private def commons_cli_option_names(line : String) : Array(String)
+      names = [] of String
+      positions = [] of Int32
+      cursor = 0
+      while idx = line.index("Option.builder", cursor)
+        positions << idx
+        cursor = idx + 1
+      end
+      return names if positions.empty?
+
+      positions.each_with_index do |pos, i|
+        seg_end = i + 1 < positions.size ? positions[i + 1] : line.size
+        segment = line[pos, seg_end - pos]
+        if name = commons_cli_name(segment)
+          names << name
+        end
+      end
+      names
+    end
+
+    private def commons_cli_name(segment : String) : String?
+      short = nil
+      if m = segment.match(COMMONS_CLI_BUILDER)
+        short = m[1]?
+      end
+      if lm = segment.match(COMMONS_CLI_LONGOPT)
+        long = lm[1]
+        return long unless long.empty?
+      end
+      return short if short && !short.empty?
+      nil
+    end
+
     private def picocli_name(body : String) : String?
       tokens = [] of String
-      body.scan(/"(--?[A-Za-z0-9][\w-]*)"/) { |m| tokens << m[1] }
+      body.scan(/["'](--?[A-Za-z0-9][\w-]*)["']/) { |m| tokens << m[1] }
       return if tokens.empty?
       (tokens.find(&.starts_with?("--")) || tokens.first).lstrip('-')
     end

--- a/src/analyzer/analyzers/haskell/cli.cr
+++ b/src/analyzer/analyzers/haskell/cli.cr
@@ -2,15 +2,44 @@ require "../../../models/analyzer"
 
 module Analyzer::Haskell
   # Surfaces the command-line attack surface of Haskell programs as `cli://`
-  # endpoints: optparse-applicative (long/argument/command) plus getEnv reads.
-  # Line-scan, merged by URL.
+  # endpoints: optparse-applicative (long/argument/command), turtle
+  # (Turtle.Options: optText/optInt/optPath/switch/arg/argText) plus getEnv
+  # reads. Line-scan, merged by URL.
   class Cli < Analyzer
     LONG     = /(?<![A-Za-z0-9_'])long\s+"([A-Za-z0-9][\w-]*)"/
     ARGUMENT = /(?<![A-Za-z0-9_'])argument\b.*?\bmetavar\s+"([A-Za-z0-9][\w-]*)"/
     COMMAND  = /(?<![A-Za-z0-9_'])command\s+"([A-Za-z0-9][\w-]*)"/
     GET_ENV  = /(?<![A-Za-z0-9_'])(?:getEnv|lookupEnv)\s+"([A-Za-z0-9_]\w*)"/
 
-    MARKERS = /\bimport\s+(?:qualified\s+)?Options\.Applicative\b|\b(?:execParser|strOption|subparser|hsubparser)\b|\bimport\s+(?:qualified\s+)?System\.Console\.(?:GetOpt|CmdArgs)\b|\bgetArgs\b/
+    # Turtle.Options: optText/optInt/optPath/... and switch take the flag
+    # name as their own first quoted argument (no `long "..."` wrapper),
+    # so these need dedicated regexes distinct from LONG above.
+    TURTLE_OPT = /(?<![A-Za-z0-9_'])opt(?:Text|Int|Integer|Double|Path|Read|Bool)\s+"([A-Za-z0-9][\w-]*)"/
+    # `switch` is a bare, extremely common Haskell identifier (also used by
+    # optparse-applicative itself, and as a plain string-pattern dispatch
+    # function). Real Turtle usage is always the full 3-argument shape
+    # `switch "name" 'c' "desc"`; require the trailing short-char + description
+    # so we don't fire on unrelated `switch "x" = ...` equations.
+    TURTLE_SWITCH = /(?<![A-Za-z0-9_'])switch\s+"([A-Za-z0-9][\w-]*)"\s+'.'\s+"[^"]*"/
+    # argText plus the type-suffixed positional combinators, mirroring the
+    # TURTLE_OPT alternation above.
+    TURTLE_ARG = /(?<![A-Za-z0-9_'])arg(?:Text|Int|Integer|Double|Read|Path)\s+"([A-Za-z0-9][\w-]*)"/
+    # `arg` (the generic reader-based combinator) is an even more common bare
+    # word than `switch` (ordinary local variables/parameters are routinely
+    # named `arg`). Real usage is always `arg <reader> "name" "desc"`: the
+    # reader is an identifier/qualified-name or a parenthesized expression,
+    # and BOTH the name and description string literals are required -- a
+    # stray `f arg x "str"` call/comment only has one trailing string and
+    # won't match.
+    TURTLE_ARG_FN = /(?<![A-Za-z0-9_'])arg\s+(?:[A-Za-z_][\w.']*|\([^()]*\))\s+"([A-Za-z0-9][\w-]*)"\s+"[^"]*"/
+
+    # Turtle re-exports Turtle.Options from the top-level Turtle module,
+    # which is used pervasively for plain shell scripting too, so gate on
+    # either the qualified submodule import or an explicit `options` name
+    # in the unqualified import list, never a bare `import Turtle`.
+    TURTLE_MARKERS = /\bimport\s+(?:qualified\s+)?Turtle\.Options\b|\bimport\s+(?:qualified\s+)?Turtle\b\s*\([^)]*\boptions\b[^)]*\)/
+
+    MARKERS = /\bimport\s+(?:qualified\s+)?Options\.Applicative\b|\b(?:execParser|strOption|subparser|hsubparser)\b|\bimport\s+(?:qualified\s+)?System\.Console\.(?:GetOpt|CmdArgs)\b|\bgetArgs\b|#{TURTLE_MARKERS}/
     WEB_RE  = /\bimport\s+(?:qualified\s+)?(?:Web\.Scotty|Servant|Yesod|Network\.Wai)\b/
 
     def analyze
@@ -25,8 +54,12 @@ module Analyzer::Haskell
             next unless content.matches?(MARKERS)
             root_url = "cli://#{cli_binary_name(path)}"
             emit_env = !content.matches?(WEB_RE)
-            content.each_line.with_index do |line, index|
+            content.each_line.with_index do |raw_line, index|
               line_no = index + 1
+              # Strip trailing `-- ...` line comments before matching so
+              # commented-out/stale code (e.g. `-- arg count "old" "x"`)
+              # never contributes bogus params.
+              line = strip_line_comment(raw_line)
               # optparse-applicative defines subcommand option parsers in
               # separate top-level bindings, so a sticky cursor would
               # misattribute later root globals. Scope a `command "x"` only to
@@ -42,6 +75,18 @@ module Analyzer::Haskell
               end
               if m = line.match(ARGUMENT)
                 fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1].downcase, "", "argument"))
+              end
+              if m = line.match(TURTLE_OPT)
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              end
+              if m = line.match(TURTLE_SWITCH)
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              end
+              if m = line.match(TURTLE_ARG)
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "argument"))
+              end
+              if m = line.match(TURTLE_ARG_FN)
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "argument"))
               end
               if emit_env
                 line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }
@@ -64,6 +109,35 @@ module Analyzer::Haskell
         return parent unless parent.empty?
       end
       stem
+    end
+
+    # Truncates a line at the start of a `--` line comment, ignoring any
+    # `--` that appears inside a double-quoted string literal. Naive (no
+    # handling of nested block comments or non-string escapes beyond `\"`)
+    # but sufficient to keep stale/commented-out code from feeding the
+    # option/argument extractors above.
+    private def strip_line_comment(line : String) : String
+      in_string = false
+      escaped = false
+      chars = line.chars
+      chars.each_with_index do |c, i|
+        if in_string
+          if escaped
+            escaped = false
+          elsif c == '\\'
+            escaped = true
+          elsif c == '"'
+            in_string = false
+          end
+        else
+          if c == '"'
+            in_string = true
+          elsif c == '-' && chars[i + 1]? == '-'
+            return chars[0...i].join
+          end
+        end
+      end
+      line
     end
 
     private def cli_test_path?(path : String) : Bool

--- a/src/analyzer/analyzers/java/cli.cr
+++ b/src/analyzer/analyzers/java/cli.cr
@@ -6,7 +6,7 @@ module Analyzer::Java
   # endpoints: one endpoint per (sub)command with named options
   # (param_type "flag"), positional arguments ("argument") and consumed
   # environment variables ("env"). Covers picocli, args4j, JCommander,
-  # commons-cli and airline, plus gated System.getenv reads.
+  # commons-cli, airline and jopt-simple, plus gated System.getenv reads.
   #
   # Line-scan analyzer (Go/Ruby/Rust CLI house style) merging endpoints by
   # URL. Subclasses Analyzer directly (JavaEngine is a module) and uses
@@ -30,7 +30,19 @@ module Analyzer::Java
 
     GET_ENV = /\bSystem\.getenv\s*\(\s*"([^"]+)"\s*\)/
 
-    LIB_MARKERS      = ["picocli.", "org.kohsuke.args4j", "com.beust.jcommander", "org.apache.commons.cli", "com.github.rvesse.airline", "io.airlift.airline"]
+    # jopt-simple (no subcommands; flags land on root, like commons-cli).
+    # `.accepts("flag")`/`.acceptsAll(List.of("f","flag"))` are only real CLI
+    # flags when called on a variable that was actually bound to
+    # `new OptionParser(...)` — jopt-simple's `OptionParser` isn't the only
+    # class with an `accepts(...)` method (e.g. a `FormatMatcher.accepts(fmt)`
+    # helper), so the receiver is tracked per-file in the same forward pass
+    # and matches on an untracked receiver are dropped rather than attributed
+    # to the root command.
+    JOPT_PARSER_DECL = /\b(\w+)\s*=\s*new\s+OptionParser\s*\(/
+    JOPT_ACCEPTS     = /\b(\w+)\.accepts\s*\(\s*"([^"]+)"/
+    JOPT_ACCEPTS_ALL = /\b(\w+)\.acceptsAll\s*\(\s*(?:Arrays\.asList|List\.of|Collections\.singletonList)\s*\(\s*"([^"]+)"/
+
+    LIB_MARKERS      = ["picocli.", "org.kohsuke.args4j", "com.beust.jcommander", "org.apache.commons.cli", "com.github.rvesse.airline", "io.airlift.airline", "joptsimple."]
     WEB_FRAMEWORK_RE = /\bimport\s+(?:org\.springframework|jakarta\.ws\.rs|javax\.ws\.rs|io\.quarkus|io\.micronaut|io\.javalin|io\.vertx|com\.linecorp\.armeria|io\.dropwizard|spark\.|org\.apache\.struts)/
 
     def analyze
@@ -78,6 +90,7 @@ module Analyzer::Java
                      root_url : String, endpoints : Hash(String, Endpoint), emit_env : Bool)
       current_url = root_url
       pending_argument = false
+      jopt_vars = Set(String).new
 
       lines.each_with_index do |line, index|
         line_no = index + 1
@@ -130,6 +143,25 @@ module Analyzer::Java
         end
         if m = line.match(LONG_OPT)
           fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+        end
+
+        # jopt-simple (root flags). Track `x = new OptionParser(...)` bindings
+        # as they're seen, then only attribute `.accepts(...)`/`.acceptsAll(...)`
+        # to a CLI flag when the receiver is a tracked parser variable — a
+        # same-named `accepts`/`acceptsAll` method on an unrelated object must
+        # not be attributed here.
+        if m = line.match(JOPT_PARSER_DECL)
+          jopt_vars << m[1]
+        end
+        if m = line.match(JOPT_ACCEPTS_ALL)
+          if jopt_vars.includes?(m[1])
+            fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[2], "", "flag"))
+          end
+        end
+        if m = line.match(JOPT_ACCEPTS)
+          if jopt_vars.includes?(m[1])
+            fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[2], "", "flag"))
+          end
         end
 
         # positional args (picocli @Parameters / args4j @Argument / airline

--- a/src/analyzer/analyzers/javascript/cli.cr
+++ b/src/analyzer/analyzers/javascript/cli.cr
@@ -6,8 +6,9 @@ module Analyzer::Javascript
   # (Node, Deno, Bun) as `cli://` endpoints: one endpoint per (sub)command
   # with named options (param_type "flag"), positional arguments ("argument")
   # and consumed environment variables ("env"). Covers the `util.parseArgs`
-  # builtin plus commander, yargs, cac, sade, meow and minimist. A single
-  # analyzer scans every JS/TS extension so a `.ts` CLI isn't double-counted.
+  # builtin plus commander, yargs, cac, sade, meow, minimist, arg,
+  # command-line-args, getopts and citty. A single analyzer scans every JS/TS
+  # extension so a `.ts` CLI isn't double-counted.
   class Cli < JavascriptEngine
     SOURCE_EXTS = [".js", ".mjs", ".cjs", ".jsx", ".ts", ".mts", ".cts", ".tsx"]
 
@@ -30,6 +31,61 @@ module Analyzer::Javascript
     PARSEARGS_HEADER  = /\boptions\s*:\s*\{/
     MEOW_FLAGS_HEADER = /\bflags\s*:\s*\{/
     OBJECT_KEY_RE     = /^\s*['"]?([A-Za-z_$][\w$-]*)['"]?\s*:/
+
+    # arg: `arg({ '--name': String, '-n': '--name' })`. Keys whose value is a
+    # quoted string are aliases pointing at the canonical flag and are
+    # skipped so an alias doesn't surface as a second, meaningless flag.
+    ARG_CALL_RE = /\barg\s*\(\s*\{/
+    ARG_KEY_RE  = /^\s*['"](-{1,2}[A-Za-z][\w-]*)['"]\s*:\s*(.+?),?\s*$/
+
+    # command-line-args: `commandLineArgs(optionDefinitions)` referencing a
+    # separately-declared `const optionDefinitions = [...]` array (the
+    # library's own documented convention), or an inline
+    # `commandLineArgs([...])` array. Matching is bounded to the resolved
+    # array's own brackets (never a whole-file scan) so an unrelated
+    # same-shaped object literal elsewhere in the file (e.g. a content-field
+    # schema) is never picked up as a bogus flag, and each `{...}` entry is
+    # scanned as its own brace-bounded block so Prettier-style
+    # multi-line-per-key formatting isn't silently dropped.
+    CLA_ARRAY_ASSIGN_RE = /^\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*\[/
+    CLA_CALL_VAR_RE     = /\bcommandLineArgs\s*\(\s*([A-Za-z_$][\w$]*)\s*[,)]/
+    CLA_CALL_INLINE_RE  = /\bcommandLineArgs\s*\(\s*\[/
+    CLA_NAME_RE         = /\bname\s*:\s*['"]([A-Za-z0-9_-]+)['"]/
+    CLA_TYPE_KEY_RE     = /\btype\s*:/
+
+    # getopts: `getopts(process.argv.slice(2), { alias: {...}, default: {...},
+    # boolean: [...], string: [...] })`. Bounded to the call's own parens so
+    # unrelated `alias`/`default` object literals elsewhere aren't picked up.
+    GETOPTS_CALL_RE        = /\bgetopts\s*\(/
+    GETOPTS_ALIAS_HEADER   = /\balias\s*:\s*\{/
+    GETOPTS_DEFAULT_HEADER = /\bdefault\s*:\s*\{/
+    GETOPTS_BOOLEAN_HEADER = /\bboolean\s*:\s*\[/
+    GETOPTS_STRING_HEADER  = /\bstring\s*:\s*\[/
+    OBJECT_VALUE_RE        = /^\s*['"]?[A-Za-z_$][\w$-]*['"]?\s*:\s*['"]([A-Za-z0-9_-]+)['"]/
+    STRING_LIT_RE          = /['"]([A-Za-z0-9_.\/-]+)['"]/
+
+    # citty: `serve: defineCommand({ args: { port: { type: 'string' } } })`.
+    # Subcommands nest their own `defineCommand` object inside `subCommands`,
+    # so args are attributed via a brace-depth stack (never a sticky cursor).
+    CITTY_SUBCOMMAND_RE = /^\s*['"]?([A-Za-z_$][\w$-]*)['"]?\s*:\s*defineCommand\s*\(\s*\{/
+    CITTY_ARGS_HEADER   = /\bargs\s*:\s*\{/
+
+    # citty also allows each subcommand to be declared as its own top-level
+    # `const NAME = defineCommand({...})` and merely referenced by identifier
+    # inside `subCommands: { key: NAME }`, instead of nesting the
+    # `defineCommand` call inline. `resolve_citty_var_subcommands` resolves
+    # those same-file references so `args:` inside NAME's block attributes to
+    # `<root>/<key>` rather than falling back to root.
+    CITTY_DEFINE_ASSIGN_RE  = /^\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*defineCommand\s*\(\s*\{/
+    CITTY_SUBCOMMANDS_HEADER = /\bsubCommands\s*:\s*\{/
+    CITTY_SUBCOMMAND_REF_RE  = /^\s*['"]?([A-Za-z_$][\w$-]*)['"]?\s*:\s*([A-Za-z_$][\w$]*)\s*,?\s*$/
+
+    # `require('arg')` / `from 'arg'`, and likewise for getopts/citty/
+    # command-line-args — these are short/generic tokens too easy to trip as
+    # a bare substring (e.g. bash's own `getopts` builtin, a stray comment,
+    # or an ordinary identifier fragment), so they require an actual import
+    # statement rather than `content.includes?`.
+    LIB_IMPORT_ONLY_RE = /(?:require\s*\(\s*|from\s+)['"](?:arg|getopts|citty|command-line-args)['"]/
 
     # A fresh statement that chains command/option/argument off an identifier
     # (`program.option(...)`, `cli.command(...)`) starts at the root program,
@@ -82,7 +138,8 @@ module Analyzer::Javascript
     end
 
     private def cli_evidence?(content : String) : Bool
-      CLI_MARKERS.any? { |m| content.includes?(m) } || content.matches?(ARGV_SLICE)
+      CLI_MARKERS.any? { |m| content.includes?(m) } || content.matches?(ARGV_SLICE) ||
+        content.matches?(LIB_IMPORT_ONLY_RE)
     end
 
     private def js_test_or_vendor?(path : String) : Bool
@@ -93,6 +150,27 @@ module Analyzer::Javascript
     private def scan(lines : Array(String), path : String, root_url : String,
                      endpoints : Hash(String, Endpoint), emit_env : Bool)
       current_url = root_url
+
+      # citty subcommand context: a stack of (url, brace-depth-at-which-this
+      # subcommand's own `defineCommand({` opened). Args attach to the
+      # innermost context still open at the current depth, never to a sticky
+      # last-seen command.
+      citty_stack = [] of Tuple(String, Int32)
+      brace_depth = 0
+
+      # citty subcommands declared as a separate `const NAME = defineCommand`
+      # and referenced by identifier from `subCommands: { key: NAME }` (see
+      # CITTY_DEFINE_ASSIGN_RE) — resolved once up front from the whole file
+      # since the reference can precede or follow the declaration.
+      var_subcommand_ranges = resolve_citty_var_subcommands(lines, root_url)
+      var_subcommand_ranges.each { |(s, _e, u)| fetch_endpoint(endpoints, u, path, s + 1) }
+
+      # command-line-args option-definition arrays declared separately from
+      # the `commandLineArgs(...)` call and referenced by identifier — built
+      # forward as `const NAME = [...]` assignments are seen, so a lookup at
+      # the call site only ever resolves an array already declared earlier in
+      # the same file (never a later reassignment silently taking over).
+      cla_array_bounds = {} of String => Tuple(Int32, Int32)
 
       index = 0
       while index < lines.size
@@ -135,6 +213,63 @@ module Analyzer::Javascript
           end
         end
 
+        # arg: `arg({ '--name': String, '-n': '--name' })` -> root flags.
+        if line.matches?(ARG_CALL_RE)
+          arg_flags(lines, index).each do |name|
+            fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+          end
+        end
+
+        # command-line-args: track `const NAME = [...]` array declarations so
+        # a later `commandLineArgs(NAME)` reference can be resolved to the
+        # exact array it passes (never a whole-file regex scan).
+        if m = line.match(CLA_ARRAY_ASSIGN_RE)
+          cla_array_bounds[m[1]] = {index, brace_bounded_end(lines, index, '[', ']')}
+        end
+
+        # command-line-args: `commandLineArgs([{ name: 'x', type: Boolean }])`
+        # (inline array) or `commandLineArgs(optionDefinitions)` (reference to
+        # an array declared earlier in this file, per the library's own
+        # documented convention).
+        if line.matches?(CLA_CALL_INLINE_RE)
+          arr_end = brace_bounded_end(lines, index, '[', ']')
+          cla_option_entries(lines, index, arr_end).each do |(name, ptype)|
+            fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", ptype))
+          end
+        elsif m = line.match(CLA_CALL_VAR_RE)
+          if bounds = cla_array_bounds[m[1]]?
+            cla_option_entries(lines, bounds[0], bounds[1]).each do |(name, ptype)|
+              fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", ptype))
+            end
+          end
+        end
+
+        # getopts: `getopts(argv, { alias, default, boolean, string })`.
+        if line.matches?(GETOPTS_CALL_RE)
+          block_end = brace_bounded_end(lines, index, '(', ')')
+          getopts_flags(lines, index, block_end).each do |name|
+            fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "flag"))
+          end
+        end
+
+        # citty: `name: defineCommand({ ... })` opens a subcommand context;
+        # args attach to the innermost open context (root when the stack is
+        # empty), scoped by brace depth rather than a sticky cursor.
+        pending_citty_url = nil
+        if m = line.match(CITTY_SUBCOMMAND_RE)
+          sub_url = "#{root_url}/#{m[1]}"
+          fetch_endpoint(endpoints, sub_url, path, line_no)
+          pending_citty_url = sub_url
+        end
+        if line.matches?(CITTY_ARGS_HEADER)
+          ctx_url = citty_stack.last?.try(&.[0])
+          ctx_url ||= var_subcommand_ranges.find { |(s, e, _u)| index >= s && index <= e }.try(&.[2])
+          ctx_url ||= root_url
+          collect_object_keys(lines, index).each do |key|
+            fetch_endpoint(endpoints, ctx_url, path, line_no).push_param(Param.new(key, "", "flag"))
+          end
+        end
+
         # Runtime argv markers -> ensure a root endpoint exists.
         if line.matches?(DENO_ARGS) || line.matches?(BUN_ARGV) || line.matches?(ARGV_SLICE)
           fetch_endpoint(endpoints, root_url, path, line_no)
@@ -148,6 +283,20 @@ module Analyzer::Javascript
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "env"))
             end
           end
+        end
+
+        line.each_char do |ch|
+          if ch == '{'
+            brace_depth += 1
+          elsif ch == '}'
+            brace_depth -= 1
+            while (top = citty_stack.last?) && brace_depth < top[1]
+              citty_stack.pop
+            end
+          end
+        end
+        if pending_citty_url
+          citty_stack.push({pending_citty_url, brace_depth})
         end
 
         index += 1
@@ -196,6 +345,204 @@ module Analyzer::Javascript
         break if index - start > 200
       end
       keys
+    end
+
+    # Like `collect_object_keys`, but captures each entry's quoted string
+    # *value* instead of its key (used for `alias: { h: 'help' }`, where the
+    # canonical flag name is the value, not the short-flag key).
+    private def collect_object_values(lines : Array(String), start : Int32) : Array(String)
+      values = [] of String
+      depth = 0
+      seen_open = false
+      index = start
+      while index < lines.size
+        line = lines[index]
+        if seen_open && depth == 1 && (m = line.match(OBJECT_VALUE_RE))
+          values << m[1]
+        end
+        line.each_char do |ch|
+          if ch == '{'
+            depth += 1
+            seen_open = true
+          elsif ch == '}'
+            depth -= 1
+          end
+        end
+        break if seen_open && depth <= 0
+        index += 1
+        break if index - start > 200
+      end
+      values
+    end
+
+    # Collects every quoted string literal inside the `[...]` array that
+    # opens on/after `start` (e.g. `boolean: ['verbose', 'dry-run']`).
+    private def collect_bracket_strings(lines : Array(String), start : Int32) : Array(String)
+      values = [] of String
+      depth = 0
+      seen_open = false
+      index = start
+      while index < lines.size
+        line = lines[index]
+        line.scan(STRING_LIT_RE) { |sm| values << sm[1] }
+        line.each_char do |ch|
+          if ch == '['
+            depth += 1
+            seen_open = true
+          elsif ch == ']'
+            depth -= 1
+          end
+        end
+        break if seen_open && depth <= 0
+        index += 1
+        break if index - start > 200
+      end
+      values
+    end
+
+    # Finds the index of the line where the balanced pair opened on `start`
+    # (counting `open_ch`/`close_ch`, e.g. `(`/`)`) closes.
+    private def brace_bounded_end(lines : Array(String), start : Int32, open_ch : Char, close_ch : Char) : Int32
+      depth = 0
+      seen_open = false
+      index = start
+      while index < lines.size
+        lines[index].each_char do |ch|
+          if ch == open_ch
+            depth += 1
+            seen_open = true
+          elsif ch == close_ch
+            depth -= 1
+          end
+        end
+        break if seen_open && depth <= 0
+        index += 1
+        break if index - start > 400
+      end
+      index < lines.size ? index : lines.size - 1
+    end
+
+    # Extracts (name, param_type) pairs from each top-level `{...}` entry in
+    # the command-line-args option array bounded by [start, stop] (inclusive
+    # line indices). Each entry is scanned as its own brace-bounded block —
+    # never a single-line regex — so Prettier-style multi-line-per-key
+    # formatting (`{\n  name: 'x',\n  type: Boolean,\n}`) is captured too.
+    private def cla_option_entries(lines : Array(String), start : Int32, stop : Int32) : Array(Tuple(String, String))
+      results = [] of Tuple(String, String)
+      depth = 0
+      in_entry = false
+      entry_lines = [] of String
+      index = start
+      while index <= stop && index < lines.size
+        line = lines[index]
+        line.each_char do |ch|
+          if ch == '{'
+            depth += 1
+            in_entry = true
+          elsif ch == '}'
+            depth -= 1
+          end
+        end
+        entry_lines << line if in_entry
+        if in_entry && depth == 0
+          text = entry_lines.join(" ")
+          if (nm = text.match(CLA_NAME_RE)) && text.matches?(CLA_TYPE_KEY_RE)
+            ptype = text.includes?("defaultOption") ? "argument" : "flag"
+            results << {nm[1], ptype}
+          end
+          entry_lines = [] of String
+          in_entry = false
+        end
+        index += 1
+      end
+      results
+    end
+
+    # citty also allows a subcommand to be declared as its own top-level
+    # `const NAME = defineCommand({...})` and merely referenced by identifier
+    # from `subCommands: { key: NAME }`, instead of nesting the
+    # `defineCommand` call inline. Resolves those same-file references to
+    # (start_line, end_line, url) so the block's `args:` header attributes to
+    # `<root>/<key>` rather than falling back to root. Cross-file / lazy
+    # subcommand references (`serve: () => import('./serve')...`) aren't
+    # resolvable from a single file and are intentionally left unhandled.
+    private def resolve_citty_var_subcommands(lines : Array(String), root_url : String) : Array(Tuple(Int32, Int32, String))
+      var_bounds = {} of String => Tuple(Int32, Int32)
+      lines.each_with_index do |line, idx|
+        if m = line.match(CITTY_DEFINE_ASSIGN_RE)
+          var_bounds[m[1]] = {idx, brace_bounded_end(lines, idx, '{', '}')}
+        end
+      end
+      return [] of Tuple(Int32, Int32, String) if var_bounds.empty?
+
+      resolved = [] of Tuple(Int32, Int32, String)
+      index = 0
+      while index < lines.size
+        if lines[index].matches?(CITTY_SUBCOMMANDS_HEADER)
+          block_end = brace_bounded_end(lines, index, '{', '}')
+          ((index + 1)..block_end).each do |i|
+            next unless i < lines.size
+            if m = lines[i].match(CITTY_SUBCOMMAND_REF_RE)
+              if bounds = var_bounds[m[2]]?
+                resolved << {bounds[0], bounds[1], "#{root_url}/#{m[1]}"}
+              end
+            end
+          end
+          index = block_end
+        end
+        index += 1
+      end
+      resolved
+    end
+
+    # arg: `arg({ '--name': String, '-n': '--name' })`. Keys whose value is a
+    # quoted string reference another flag (an alias) and are skipped.
+    private def arg_flags(lines : Array(String), start : Int32) : Array(String)
+      flags = [] of String
+      depth = 0
+      seen_open = false
+      index = start
+      while index < lines.size
+        line = lines[index]
+        if seen_open && depth == 1 && (m = line.match(ARG_KEY_RE))
+          value = m[2].strip
+          flags << m[1].lstrip('-') unless value.starts_with?('\'') || value.starts_with?('"')
+        end
+        line.each_char do |ch|
+          if ch == '{'
+            depth += 1
+            seen_open = true
+          elsif ch == '}'
+            depth -= 1
+          end
+        end
+        break if seen_open && depth <= 0
+        index += 1
+        break if index - start > 200
+      end
+      flags
+    end
+
+    # getopts: extracts flag names out of the option-config object passed as
+    # the 2nd argument, bounded to the `getopts(...)` call itself so a
+    # same-named `alias`/`default` object elsewhere in the file isn't picked
+    # up.
+    private def getopts_flags(lines : Array(String), start : Int32, block_end : Int32) : Array(String)
+      block = lines[start..block_end]
+      flags = [] of String
+      if idx = block.index { |l| l.matches?(GETOPTS_ALIAS_HEADER) }
+        flags.concat(collect_object_values(block, idx))
+      end
+      if idx = block.index { |l| l.matches?(GETOPTS_DEFAULT_HEADER) }
+        flags.concat(collect_object_keys(block, idx))
+      end
+      if idx = block.index { |l| l.matches?(GETOPTS_BOOLEAN_HEADER) }
+        flags.concat(collect_bracket_strings(block, idx))
+      end
+      if idx = block.index { |l| l.matches?(GETOPTS_STRING_HEADER) }
+        flags.concat(collect_bracket_strings(block, idx))
+      end
+      flags.uniq
     end
 
     # Maps each package.json directory to its CLI binary name (the `bin` key,

--- a/src/analyzer/analyzers/kotlin/cli.cr
+++ b/src/analyzer/analyzers/kotlin/cli.cr
@@ -5,8 +5,8 @@ module Analyzer::Kotlin
   # Surfaces the command-line attack surface of Kotlin programs as `cli://`
   # endpoints: one endpoint per (sub)command with named options
   # (param_type "flag"), positional arguments ("argument") and consumed
-  # environment variables ("env"). Covers clikt and kotlinx-cli plus gated
-  # System.getenv reads.
+  # environment variables ("env"). Covers clikt, kotlinx-cli and picocli
+  # plus gated System.getenv reads.
   #
   # Line-scan analyzer (Go/Ruby/Rust CLI house style) merging endpoints by
   # URL. Subclasses Analyzer directly (KotlinEngine is a module) and uses
@@ -25,9 +25,22 @@ module Analyzer::Kotlin
     KX_OPTION   = /\bby\s+\w*\.?option\s*\(\s*ArgType\.\w+\s*,\s*"([^"]+)"/
     KX_ARGUMENT = /\bby\s+\w*\.?argument\s*\(\s*ArgType\.\w+\s*,\s*"([^"]+)"/
 
+    # picocli: annotations sit on the line above the class/property they
+    # decorate (`@Command(name = "serve")` \n `class Serve : Callable<Int>`),
+    # so a one-line lookahead resolves each pending annotation.
+    # A `@Command(` may wrap across lines once `description`/`subcommands` are
+    # added, so the annotation start is matched with a bounded body-join
+    # instead of requiring the close paren on the same line.
+    PICOCLI_COMMAND_START = /@Command\s*\(/
+    PICOCLI_NAME     = /\bname\s*=\s*"([^"]+)"/
+    PICOCLI_CLASS    = /\bclass\s+(\w+)\b/
+    PICOCLI_OPTION   = /@Option\s*\(([^)]*)\)/
+    PICOCLI_PARAMS   = /@Parameters\b/
+    PICOCLI_PROPERTY = /\b(?:var|val)\s+(\w+)\s*:/
+
     GET_ENV = /\bSystem\.getenv\s*\(\s*"([^"]+)"\s*\)/
 
-    LIB_MARKERS      = ["com.github.ajalt.clikt", "kotlinx.cli"]
+    LIB_MARKERS      = ["com.github.ajalt.clikt", "kotlinx.cli", "picocli.CommandLine"]
     WEB_FRAMEWORK_RE = /\bimport\s+(?:org\.springframework|io\.ktor|org\.http4k)/
 
     def analyze
@@ -67,8 +80,51 @@ module Analyzer::Kotlin
                      root_url : String, endpoints : Hash(String, Endpoint), emit_env : Bool)
       current_url = root_url
 
+      # picocli pending-annotation state: annotations decorate the class or
+      # property declared on the *next* line, so each is resolved with a
+      # single-line lookahead (never a sticky cursor across commands).
+      awaiting_picocli_command = false
+      pending_picocli_command_name = nil.as(String?)
+      picocli_command_wait = 0
+      awaiting_picocli_flag = false
+      pending_picocli_flag_name = nil.as(String?)
+      awaiting_picocli_positional = false
+
       lines.each_with_index do |line, index|
         line_no = index + 1
+
+        # Resolve any picocli annotation pending from the previous line(s). A
+        # wrapped `@Command(...)` puts its class several lines below its
+        # annotation, so wait (bounded) for the next class rather than
+        # clearing after a single line — while staying bounded so flags never
+        # leak onto a stale command if no class ever follows.
+        if awaiting_picocli_command
+          if m = line.match(PICOCLI_CLASS)
+            name = pending_picocli_command_name || m[1].downcase
+            current_url = name == binary ? root_url : "#{root_url}/#{name}"
+            fetch_endpoint(endpoints, current_url, path, line_no)
+            awaiting_picocli_command = false
+            pending_picocli_command_name = nil
+          else
+            picocli_command_wait += 1
+            awaiting_picocli_command = false if picocli_command_wait > 8
+          end
+        end
+
+        if awaiting_picocli_flag
+          if m = line.match(PICOCLI_PROPERTY)
+            name = pending_picocli_flag_name || camel_to_kebab(m[1])
+            fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(name, "", "flag"))
+          end
+          awaiting_picocli_flag = false
+        end
+
+        if awaiting_picocli_positional
+          if m = line.match(PICOCLI_PROPERTY)
+            fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(camel_to_kebab(m[1]), "", "argument"))
+          end
+          awaiting_picocli_positional = false
+        end
 
         # clikt command class: name= or the class name lower-cased; the class
         # whose name matches the binary is the root.
@@ -103,12 +159,65 @@ module Analyzer::Kotlin
           fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "argument"))
         end
 
+        # picocli: queue the annotation so it resolves against the class/
+        # property it decorates. The name= is read from the (possibly
+        # multi-line) annotation body; the property may sit inline on the same
+        # line or on the next one.
+        if line.matches?(PICOCLI_COMMAND_START)
+          body = picocli_join_body(lines, index)
+          pending_picocli_command_name = body.match(PICOCLI_NAME).try(&.[1])
+          awaiting_picocli_command = true
+          picocli_command_wait = 0
+        end
+        if m = line.match(PICOCLI_OPTION)
+          long = option_long(m[1])
+          if pm = line[m.end..].match(PICOCLI_PROPERTY)
+            fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(long || camel_to_kebab(pm[1]), "", "flag"))
+          else
+            pending_picocli_flag_name = long
+            awaiting_picocli_flag = true
+          end
+        end
+        if m = line.match(PICOCLI_PARAMS)
+          if pm = line[m.end..].match(PICOCLI_PROPERTY)
+            fetch_endpoint(endpoints, current_url, path, line_no).push_param(Param.new(camel_to_kebab(pm[1]), "", "argument"))
+          else
+            awaiting_picocli_positional = true
+          end
+        end
+
         if emit_env
           line.scan(GET_ENV) do |env_match|
             fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(env_match[1], "", "env"))
           end
         end
       end
+    end
+
+    # Joins a picocli annotation body starting at the `(` on `lines[start]`
+    # through the matching `)`, so a `@Command(` whose `name = "..."` wraps
+    # onto a later line is still captured. Bounded to a few lines.
+    private def picocli_join_body(lines : Array(String), start : Int32) : String
+      text = String::Builder.new
+      depth = 0
+      started = false
+      li = start
+      while li < lines.size && li - start <= 10
+        lines[li].each_char do |ch|
+          if ch == '('
+            depth += 1
+            started = true
+          elsif ch == ')'
+            depth -= 1
+            return text.to_s if started && depth == 0
+          else
+            text << ch if started && depth >= 1
+          end
+        end
+        text << ' '
+        li += 1
+      end
+      text.to_s
     end
 
     # clikt `option("-v", "--verbose")` → prefer the long name; nil when the

--- a/src/analyzer/analyzers/lua/cli.cr
+++ b/src/analyzer/analyzers/lua/cli.cr
@@ -3,8 +3,9 @@ require "../../../models/analyzer"
 module Analyzer::Lua
   # Surfaces the command-line attack surface of Lua programs as `cli://`
   # endpoints: the argparse library (option/flag/argument/command, attributed
-  # by receiver variable) plus `arg` indexing and os.getenv. Line-scan,
-  # merged by URL.
+  # by receiver variable), the cliargs (lua_cliargs) library
+  # (add_argument/add_option/add_flag, attributed by receiver variable), plus
+  # `arg` indexing and os.getenv. Line-scan, merged by URL.
   class Cli < Analyzer
     ARGPARSE_CTOR = /(?:local\s+)?([A-Za-z_]\w*)\s*=\s*argparse\s*\(\s*(?:['"]([^'"]*)['"])?/
     SUBCOMMAND    = /(?:local\s+)?(?:([A-Za-z_]\w*)\s*=\s*)?([A-Za-z_]\w*)\s*:\s*command\s*\(\s*['"]([^'"]+)['"]/
@@ -13,7 +14,13 @@ module Analyzer::Lua
     ARG_IDX       = /\barg\s*\[\s*(\d+)\s*\]/
     GET_ENV       = /\bos\.getenv\s*\(\s*['"]([^'"]+)['"]/
 
-    MARKERS = /\brequire\s*\(?\s*['"]argparse['"]|\bargparse\s*\(|\barg\s*\[\s*\d+\s*\]/
+    CLIARGS_CTOR   = /(?:local\s+)?([A-Za-z_]\w*)\s*=\s*require\s*\(?\s*['"]cliargs['"]/
+    CLIARGS_NAME   = /([A-Za-z_]\w*)\s*:\s*set_name\s*\(\s*['"]([^'"]+)['"]/
+    CLIARGS_ARG    = /([A-Za-z_]\w*)\s*:\s*add_argument\s*\(\s*['"]([^'"]+)['"]/
+    CLIARGS_OPTION = /([A-Za-z_]\w*)\s*:\s*add_option\s*\(\s*['"]([^'"]+)['"]/
+    CLIARGS_FLAG   = /([A-Za-z_]\w*)\s*:\s*add_flag\s*\(\s*['"]([^'"]+)['"]/
+
+    MARKERS = /\brequire\s*\(?\s*['"]argparse['"]|\bargparse\s*\(|\barg\s*\[\s*\d+\s*\]|\brequire\s*\(?\s*['"]cliargs['"]/
     WEB_RE  = /\brequire\s*\(?\s*['"](?:lapis|lor)['"]/
 
     def analyze
@@ -25,9 +32,38 @@ module Analyzer::Lua
         begin
           content = read_file_content(path)
           next unless content.matches?(MARKERS)
-          # binary: argparse("name") if present, else file stem.
-          name_match = content.match(/argparse\s*\(\s*['"]([^'"]+)['"]/)
-          binary = name_match ? name_match[1] : cli_binary_name(path)
+
+          # Pre-scan: variables actually bound to `require("cliargs")`.
+          # set_name/add_argument/add_option/add_flag are only trusted when
+          # their receiver is one of these — never a same-named method on an
+          # unrelated table (e.g. a `logger:set_name(...)` or a
+          # `menu:add_option(...)` that happens to sit in the same file).
+          cliargs_vars = Set(String).new
+          content.each_line do |line|
+            if m = line.match(CLIARGS_CTOR)
+              cliargs_vars << m[1]
+            end
+          end
+
+          # binary: argparse("name") if present, else cliargs :set_name("name")
+          # on a tracked cliargs receiver, else file stem.
+          argparse_name = content.match(/argparse\s*\(\s*['"]([^'"]+)['"]/)
+          cliargs_name = nil
+          unless argparse_name
+            content.scan(CLIARGS_NAME) do |m|
+              if cliargs_vars.includes?(m[1])
+                cliargs_name = m
+                break
+              end
+            end
+          end
+          binary = if argparse_name
+                     argparse_name[1]
+                   elsif cliargs_name
+                     cliargs_name[2]
+                   else
+                     cli_binary_name(path)
+                   end
           root_url = "cli://#{binary}"
           emit_env = !content.matches?(WEB_RE)
           var_urls = {} of String => String
@@ -42,14 +78,26 @@ module Analyzer::Lua
               var_urls[m[1]] = url if m[1]?
               fetch_endpoint(endpoints, url, path, line_no)
             end
-            if m = line.match(OPTION)
-              fetch_endpoint(endpoints, var_urls[m[1]]? || root_url, path, line_no).push_param(Param.new(opt_long(m[2]), "", "flag"))
+            if (m = line.match(OPTION)) && var_urls.has_key?(m[1])
+              fetch_endpoint(endpoints, var_urls[m[1]], path, line_no).push_param(Param.new(opt_long(m[2]), "", "flag"))
             end
-            if m = line.match(ARGUMENT)
-              fetch_endpoint(endpoints, var_urls[m[1]]? || root_url, path, line_no).push_param(Param.new(m[2], "", "argument"))
+            if (m = line.match(ARGUMENT)) && var_urls.has_key?(m[1])
+              fetch_endpoint(endpoints, var_urls[m[1]], path, line_no).push_param(Param.new(m[2], "", "argument"))
             end
             if m = line.match(ARG_IDX)
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new("arg#{m[1]}", "", "argument"))
+            end
+            if m = line.match(CLIARGS_CTOR)
+              var_urls[m[1]] = root_url
+            end
+            if (m = line.match(CLIARGS_ARG)) && var_urls.has_key?(m[1])
+              fetch_endpoint(endpoints, var_urls[m[1]], path, line_no).push_param(Param.new(m[2], "", "argument"))
+            end
+            if (m = line.match(CLIARGS_OPTION)) && var_urls.has_key?(m[1])
+              fetch_endpoint(endpoints, var_urls[m[1]], path, line_no).push_param(Param.new(cliargs_opt_long(m[2]), "", "flag"))
+            end
+            if (m = line.match(CLIARGS_FLAG)) && var_urls.has_key?(m[1])
+              fetch_endpoint(endpoints, var_urls[m[1]], path, line_no).push_param(Param.new(cliargs_opt_long(m[2]), "", "flag"))
             end
             if emit_env
               line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }
@@ -69,6 +117,15 @@ module Analyzer::Lua
       tokens = raw.split(/\s+/)
       long = tokens.find(&.starts_with?("--")) || tokens.find(&.starts_with?("-")) || tokens.first?
       (long || raw).lstrip('-')
+    end
+
+    # cliargs alias spec ("-o, --output=DEST" / "-v, --[no-]verbose") -> long name.
+    private def cliargs_opt_long(raw : String) : String
+      tokens = raw.split(',').map(&.strip)
+      long = tokens.find(&.starts_with?("--")) || tokens.find(&.starts_with?("-")) || tokens.first?
+      name = (long || raw).lstrip('-')
+      name = name.gsub("[no-]", "")
+      name.split('=').first
     end
 
     private def cli_binary_name(path : String) : String

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -2,17 +2,29 @@ require "../../../models/analyzer"
 
 module Analyzer::Perl
   # Surfaces the command-line attack surface of Perl programs as `cli://`
-  # endpoints: Getopt::Long (GetOptions) / Getopt::Std (getopts) plus @ARGV
-  # indexing and %ENV. Line-scan; root attribution (these libs are flat),
-  # merged by URL.
+  # endpoints: Getopt::Long (GetOptions) / Getopt::Std (getopts) /
+  # Getopt::Long::Descriptive (describe_options) / MooX::Options (option)
+  # plus @ARGV indexing and %ENV. Line-scan; root attribution (these libs
+  # are flat), merged by URL.
   class Cli < Analyzer
     # GetOptions("port=i" => \$port) — the spec string bound to a reference.
     GETOPT_KEY = /["']([a-zA-Z][\w-]*)[^"']*["']\s*=>\s*\\/
     GETOPTS    = /\bgetopts?\s*\(\s*['"]([^'"]*)['"]/
     ARGV_IDX   = /\$ARGV\s*\[\s*(\d+)\s*\]/
     ENV_READ   = /\$ENV\{\s*['"]?([A-Za-z_]\w*)['"]?\s*\}/
+    # describe_options('%c %o', ['verbose|v' => 'be verbose'], ...) — each
+    # array-ref's leading quoted spec string. Only the leading identifier is
+    # captured so Getopt::Long::Descriptive suffix modifiers (|alias, =s,
+    # !, +, :i, ...) don't leak into the reported flag name.
+    DESCRIBE_OPT_SPEC = /\[\s*['"]([a-zA-Z][\w-]*)[^'"]*['"]/
+    # option 'name' => (is => 'ro', ...); — MooX::Options attribute decl.
+    # Only extracted when `use MooX::Options` was actually seen in the file,
+    # so an unrelated bareword sub/call literally named `option` elsewhere
+    # doesn't get misattributed as a MooX::Options flag.
+    MOOX_OPTION = /\boption\s+['"]([a-zA-Z][\w-]*)['"]\s*=>/
+    MOOX_MARKER = /\buse\s+MooX::Options\b/
 
-    MARKERS = /\buse\s+Getopt::(?:Long|Std)\b|\bGetOptions\s*\(|\bgetopts?\s*\(|\buse\s+App::Cmd\b|\bMooseX::Getopt\b|\$ARGV\s*\[\s*\d+\s*\]/
+    MARKERS = /\buse\s+Getopt::(?:Long|Std)\b|\bGetOptions\s*\(|\bgetopts?\s*\(|\buse\s+App::Cmd\b|\bMooseX::Getopt\b|\$ARGV\s*\[\s*\d+\s*\]|\buse\s+Getopt::Long::Descriptive\b|\bdescribe_options\s*\(|\buse\s+MooX::Options\b/
     WEB_RE  = /\buse\s+(?:Mojolicious|Mojo::|Dancer2?|Catalyst|Plack|Dancer)\b/
 
     def analyze
@@ -27,8 +39,11 @@ module Analyzer::Perl
             next unless content.matches?(MARKERS)
             root_url = "cli://#{cli_binary_name(path)}"
             emit_env = !content.matches?(WEB_RE)
+            uses_moox_options = content.matches?(MOOX_MARKER)
             in_getoptions = false
             go_depth = 0
+            in_describe_options = false
+            do_depth = 0
             content.each_line.with_index do |line, index|
               line_no = index + 1
               # Only treat `"key" => \ref` pairs as flags inside the
@@ -50,6 +65,22 @@ module Analyzer::Perl
               end
               if emit_env
                 line.scan(ENV_READ) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }
+              end
+              # Only treat `[ 'spec' => ... ]` array-refs as option specs
+              # inside the describe_options(...) call, so unrelated array
+              # literals elsewhere in the file don't leak as bogus flags.
+              in_describe_options = true if line.includes?("describe_options") && line.includes?("(")
+              if in_describe_options
+                line.scan(DESCRIBE_OPT_SPEC) { |m| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag")) }
+              end
+              if in_describe_options
+                do_depth += line.count('(') - line.count(')')
+                in_describe_options = false if do_depth <= 0
+              end
+              if uses_moox_options
+                if m = line.match(MOOX_OPTION)
+                  fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+                end
               end
             end
           rescue e

--- a/src/analyzer/analyzers/php/cli.cr
+++ b/src/analyzer/analyzers/php/cli.cr
@@ -5,7 +5,8 @@ module Analyzer::Php
   # Surfaces the command-line attack surface of PHP programs as `cli://`
   # endpoints: one endpoint per (sub)command with named options
   # (param_type "flag"), positional arguments ("argument") and consumed
-  # environment variables ("env"). Covers Symfony Console plus builtin
+  # environment variables ("env"). Covers Symfony Console, Laravel Artisan
+  # (`$signature`), Robo (`@command` docblocks) and WP-CLI, plus builtin
   # getopt / $argv / $_ENV / getenv.
   #
   # Line-scan analyzer (Go/Ruby/Rust CLI house style) merging endpoints by
@@ -27,6 +28,30 @@ module Analyzer::Php
 
     WEB_FRAMEWORK_RE = /\buse\s+(?:Illuminate\\(?:Foundation|Http|Routing)|Symfony\\Bundle\\FrameworkBundle|Symfony\\Component\\HttpFoundation|Symfony\\Component\\HttpKernel|Slim\\(?:App|Factory)|Laminas\\(?:Mvc|Mezzio)|Mezzio\\|Cake\\(?:Routing|Http)|Hyperf\\HttpServer)\b|extends\s+AbstractController\b/
 
+    # Laravel Artisan: `protected $signature = '...'`. The value is the
+    # Symfony-Console-flavored mini-grammar Artisan parses itself:
+    # `name {arg} {arg? : desc} {arg=default} {--flag} {--flag=default : desc}`.
+    ARTISAN_SIGNATURE = /protected\s+(?:static\s+)?\$signature\s*=\s*(['"])((?:\\.|(?!\1).)*)\1/
+    ARTISAN_TOKEN     = /\{\s*([^{}]*?)\s*\}/
+
+    # Robo (consolidation/Robo task runner): a `@command <name>` docblock
+    # tag binds to the *very next* method signature only — never sticky.
+    ROBO_MARKER        = /Robo\\Tasks\b/
+    ROBO_COMMAND_TAG   = /@command\s+(\S+)/
+    ROBO_FUNCTION_LINE = /\bfunction\s+\w+\s*\(([^)]*)\)/
+
+    # WP-CLI: `WP_CLI::add_command('foo bar', 'Foo_Bar_Command')` registers
+    # a class as a command. Only the method whose OWN signature is the
+    # conventional `($args, $assoc_args)` callback is scanned for params —
+    # never the whole class body.
+    WP_MARKER            = /WP_CLI(?:_Command)?\b/
+    WP_ADD_COMMAND       = /WP_CLI::add_command\s*\(\s*(['"])((?:\\.|(?!\1).)*)\1\s*,\s*(?:new\s+)?['"]?(\w+)/
+    WP_CLASS_LINE        = /\bclass\s+(\w+)/
+    WP_METHOD_LINE       = /\bfunction\s+\w+\s*\((?=[^)]*\$args\b)(?=[^)]*\$assoc_args\b)[^)]*\)/
+    WP_ARGS_INDEX        = /\$args\s*\[\s*(\d+)\s*\]/
+    WP_ASSOC_ARG_BRACKET = /\$assoc_args\s*\[\s*['"]([^'"]+)['"]\s*\]/
+    WP_FLAG_VALUE        = /get_flag_value\s*\(\s*\$assoc_args\s*,\s*['"]([^'"]+)['"]/
+
     def analyze
       endpoints = {} of String => Endpoint
 
@@ -42,7 +67,12 @@ module Analyzer::Php
           binary = php_binary_name(path)
           root_url = "cli://#{binary}"
           emit_env = !content.matches?(WEB_FRAMEWORK_RE)
-          scan(content.lines, path, root_url, endpoints, emit_env)
+          lines = content.lines
+
+          scan(lines, path, root_url, endpoints, emit_env)
+          scan_artisan(lines, path, root_url, endpoints) if content.matches?(ARTISAN_SIGNATURE)
+          scan_robo(lines, path, root_url, endpoints) if content.matches?(ROBO_MARKER)
+          scan_wp_cli(lines, path, root_url, endpoints) if content.matches?(WP_MARKER)
         rescue e
           logger.debug "Error analyzing #{path}: #{e}"
           next
@@ -56,7 +86,9 @@ module Analyzer::Php
     private def cli_evidence?(content : String) : Bool
       content.includes?("Symfony\\Component\\Console") || content.matches?(/\bextends\s+Command\b/) ||
         content.matches?(AS_COMMAND) || content.matches?(GETOPT) || content.matches?(ARGV_INDEX) ||
-        content.includes?("League\\CLImate") || content.includes?("Minicli\\")
+        content.includes?("League\\CLImate") || content.includes?("Minicli\\") ||
+        content.matches?(ARTISAN_SIGNATURE) || content.matches?(ROBO_MARKER) ||
+        content.matches?(WP_ADD_COMMAND) || content.matches?(/extends\s+WP_CLI_Command\b/)
     end
 
     private def php_binary_name(path : String) : String
@@ -111,6 +143,163 @@ module Analyzer::Php
           end
         end
       end
+    end
+
+    # Laravel Artisan `protected $signature = '...'` mini-grammar. The
+    # first whitespace-delimited token is the command name; every
+    # `{...}` token after it is an argument (or `--`-prefixed option).
+    # Each token may carry an idiomatic ` : description` suffix that must
+    # be stripped before any of the `=`/`?`/`*` modifier handling, or the
+    # extracted name ends up containing the whole description string.
+    private def scan_artisan(lines : Array(String), path : String, root_url : String,
+                             endpoints : Hash(String, Endpoint))
+      lines.each_with_index do |line, index|
+        line_no = index + 1
+        next unless m = line.match(ARTISAN_SIGNATURE)
+
+        parse_artisan_signature(m[2], path, root_url, endpoints, line_no)
+      end
+    end
+
+    private def parse_artisan_signature(signature : String, path : String, root_url : String,
+                                        endpoints : Hash(String, Endpoint), line_no : Int32)
+      parts = signature.strip.split(/\s+/, 2)
+      name = parts[0]?
+      return if name.nil? || name.empty?
+
+      url = "#{root_url}/#{name}"
+      endpoint = fetch_endpoint(endpoints, url, path, line_no)
+      return if parts.size < 2
+
+      parts[1].scan(ARTISAN_TOKEN) do |tm|
+        token = tm[1].strip
+        next if token.empty?
+
+        # Strip the ` : description` suffix first — everything downstream
+        # (option/default/modifier parsing) must see only the bare token.
+        token = token.split(/\s*:\s*/, 2)[0].strip
+        next if token.empty?
+
+        is_option = token.starts_with?("--")
+        token = token[2..] if is_option
+        # `{--Q|queue}` shortcut syntax: keep the long form.
+        token = token.split('|').last if token.includes?('|')
+        # Strip default value (`name=default`) and optional/array markers.
+        token = token.split('=', 2)[0]
+        token = token.rstrip("?*")
+        token = token.strip
+        next if token.empty?
+
+        endpoint.push_param(Param.new(token, "", is_option ? "flag" : "argument"))
+      end
+    end
+
+    # Robo (`consolidation/robo`) `@command <name>` docblock tag. It binds
+    # ONLY to the very next `function` signature encountered — never left
+    # sticky across the rest of the file — so an untagged helper method
+    # (or a constructor preceding the first tagged command) never inherits
+    # another command's params.
+    private def scan_robo(lines : Array(String), path : String, root_url : String,
+                          endpoints : Hash(String, Endpoint))
+      pending_command : String? = nil
+
+      lines.each_with_index do |line, index|
+        line_no = index + 1
+
+        if m = line.match(ROBO_COMMAND_TAG)
+          pending_command = m[1]
+          next
+        end
+
+        next unless cmd = pending_command
+        next unless m = line.match(ROBO_FUNCTION_LINE)
+
+        url = "#{root_url}/#{cmd}"
+        endpoint = fetch_endpoint(endpoints, url, path, line_no)
+        m[1].scan(/\$(\w+)/) do |pm|
+          endpoint.push_param(Param.new(pm[1], "", "argument"))
+        end
+        # Consumed — a later untagged function must not reuse this command.
+        pending_command = nil
+      end
+    end
+
+    # WP-CLI class-command registration. `WP_CLI::add_command('name',
+    # 'ClassName')` may appear before OR after the class body
+    # (declare-then-register is idiomatic), so registrations and param
+    # extraction are collected independently and reconciled at the end.
+    # Params are only ever read from the method whose own parameter list
+    # is the conventional `($args, $assoc_args)` callback signature —
+    # never from unrelated methods elsewhere in the same class.
+    private def scan_wp_cli(lines : Array(String), path : String, root_url : String,
+                            endpoints : Hash(String, Endpoint))
+      registrations = [] of {String, String, Int32}
+      class_params = Hash(String, Array(Param)).new
+
+      current_class : String? = nil
+      index = 0
+      while index < lines.size
+        line = lines[index]
+
+        if m = line.match(WP_CLASS_LINE)
+          current_class = m[1]
+        end
+
+        if (cls = current_class) && line.match(WP_METHOD_LINE)
+          body, consumed = extract_brace_body(lines, index)
+          params = class_params[cls] ||= [] of Param
+          body.each_line do |body_line|
+            body_line.scan(WP_ARGS_INDEX) { |am| params << Param.new("arg#{am[1]}", "", "argument") }
+            body_line.scan(WP_ASSOC_ARG_BRACKET) { |am| params << Param.new(am[1], "", "flag") }
+            body_line.scan(WP_FLAG_VALUE) { |am| params << Param.new(am[1], "", "flag") }
+          end
+          index += consumed
+          next
+        end
+
+        if m = line.match(WP_ADD_COMMAND)
+          registrations << {m[2], m[3], index + 1}
+        end
+
+        index += 1
+      end
+
+      registrations.each do |(cmd_name, cls, reg_line_no)|
+        params = class_params[cls]?
+        next unless params
+
+        url = "#{root_url}/#{cmd_name}"
+        endpoint = fetch_endpoint(endpoints, url, path, reg_line_no)
+        params.each { |p| endpoint.push_param(p) }
+      end
+    end
+
+    # Char-level brace matcher starting at `lines[start_index]`. Returns
+    # the `{...}` body text (including braces) and the number of lines it
+    # spans, so single-line method bodies (`function bar(...) { ... }`,
+    # the common WP-CLI style) are handled the same as multi-line ones.
+    private def extract_brace_body(lines : Array(String), start_index : Int32) : {String, Int32}
+      depth = 0
+      started = false
+      body = String::Builder.new
+      idx = start_index
+
+      while idx < lines.size
+        lines[idx].each_char do |ch|
+          if ch == '{'
+            depth += 1
+            started = true
+          elsif ch == '}'
+            depth -= 1
+          end
+          body << ch if started
+        end
+        body << '\n'
+        idx += 1
+        break if started && depth <= 0
+      end
+
+      {body.to_s, idx - start_index}
     end
 
     private def parse_getopt_short(spec : String, endpoint : Endpoint)

--- a/src/analyzer/analyzers/python/cli.cr
+++ b/src/analyzer/analyzers/python/cli.cr
@@ -6,7 +6,8 @@ module Analyzer::Python
   # endpoints: one endpoint per (sub)command, with named options
   # (param_type "flag"), positional arguments ("argument"), and consumed
   # environment variables ("env"). Covers stdlib argparse / getopt /
-  # sys.argv plus click, typer, fire and docopt.
+  # sys.argv plus click, typer, fire, docopt, Abseil (absl-py) flags, and
+  # Cleo commands.
   #
   # Line-scan analyzer (the house style for non-tree-sitter Python adapters,
   # e.g. bottle). Endpoints are merged by URL so options registered across
@@ -45,6 +46,34 @@ module Analyzer::Python
     GETOPT_RE         = /getopt\.getopt\s*\([^,]+,\s*[rf]?["']([^"']*)["']\s*(?:,\s*\[([^\]]*)\])?/
     FIRE_RE           = /\bfire\.Fire\s*\(\s*(\w+)/
 
+    # Abseil (absl-py): flags.DEFINE_* calls register a single flat flag
+    # namespace consumed via FLAGS.<name> after app.run(main) — there is no
+    # subcommand concept, so every flag attaches to the binary's root URL.
+    ABSL_DEFINE_CALL_RE = /\bflags\.DEFINE_(?:string|integer|bool|boolean|float|enum|list|multi_string|multi_integer|multi_enum)\s*\(/
+    ABSL_DEFINE_NAME_RE = /\bflags\.DEFINE_(?:string|integer|bool|boolean|float|enum|list|multi_string|multi_integer|multi_enum)\s*\(\s*[rf]?["']([^"']+)["']/
+
+    # Cleo: a Command subclass declares its subcommand name as a class
+    # attribute, then reads its own arguments/options back out by name
+    # inside its methods (self.argument("x") / self.option("y")) — that
+    # readback call is also the most reliable textual anchor for the
+    # option/argument name itself.
+    CLEO_IMPORT_RE = /(?:^|\n)\s*(?:import\s+cleo\b|from\s+cleo(?:\.\w+)*\s+import\b)/
+    # `^` in Crystal/PCRE without the multiline flag anchors to the start of
+    # the whole subject, not each line — fine for the per-line `line.match`
+    # use in scan_cleo below, but a separate (?:^|\n)-anchored variant is
+    # needed to test this against the full multi-line file content. Both
+    # variants are column-0 anchored (no `\s*` before `class`) so the
+    # entrypoint gate below matches exactly what scan_cleo can extract — a
+    # `class Foo(Command)` nested inside a function/method (indented) is
+    # never resolved by scan_cleo, so it must not satisfy the gate either,
+    # or the file gets treated as a CLI entrypoint with no real command found
+    # (scan_stdlib then fires unconditionally on an unrelated env/argv read).
+    CLEO_COMMAND_CLASS_RE          = /^class\s+(\w+)\s*\(\s*Command\b/
+    CLEO_COMMAND_CLASS_ANYWHERE_RE = /(?:^|\n)class\s+\w+\s*\(\s*Command\b/
+    CLEO_NAME_ATTR_RE              = /^\s*name\s*=\s*[rf]?["']([^"']+)["']/
+    CLEO_ARGUMENT_CALL_RE          = /\bself\.argument\s*\(\s*[rf]?["']([^"']+)["']/
+    CLEO_OPTION_CALL_RE            = /\bself\.option\s*\(\s*[rf]?["']([^"']+)["']/
+
     def analyze
       python_files = get_files_by_extension(".py")
       endpoints = {} of String => Endpoint
@@ -66,6 +95,8 @@ module Analyzer::Python
             scan_argparse(lines, path, binary, root_url, endpoints)
             scan_click(lines, path, root_url, endpoints)
             scan_typer(lines, path, root_url, endpoints)
+            scan_absl(lines, path, root_url, endpoints)
+            scan_cleo(lines, path, root_url, endpoints)
             scan_stdlib(content, lines, path, root_url, endpoints)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
@@ -87,6 +118,8 @@ module Analyzer::Python
       return true if content.includes?("fire.Fire")
       return true if content.includes?("getopt.getopt")
       return true if content.includes?("docopt")
+      return true if content.matches?(ABSL_DEFINE_CALL_RE)
+      return true if content.matches?(CLEO_IMPORT_RE) && content.matches?(CLEO_COMMAND_CLASS_ANYWHERE_RE)
       content.matches?(SYS_ARGV_RE) && content.matches?(MAIN_GUARD_RE)
     end
 
@@ -318,6 +351,94 @@ module Analyzer::Python
         break if index - def_index > 80 # safety bound
       end
       buffer.to_s
+    end
+
+    # absl-py: flags.DEFINE_* has no receiver/scope to attribute — every
+    # declared flag is a global, consumed via FLAGS.<name> anywhere in the
+    # program — so every match simply attaches to the binary's root URL.
+    # Joins a multi-line call (the name may land on its own continuation
+    # line) the same way scan_argparse joins add_argument.
+    private def scan_absl(lines : Array(String), path : String, root_url : String,
+                          endpoints : Hash(String, Endpoint))
+      index = 0
+      while index < lines.size
+        line = lines[index]
+        unless line.matches?(ABSL_DEFINE_CALL_RE)
+          index += 1
+          next
+        end
+        start = index
+        logical = line
+        while parens_unbalanced?(logical) && index + 1 < lines.size && index - start < 10
+          index += 1
+          logical += " " + lines[index]
+        end
+        if m = logical.match(ABSL_DEFINE_NAME_RE)
+          fetch_endpoint(endpoints, root_url, path, start + 1).push_param(Param.new(m[1], "", "flag"))
+        end
+        index += 1
+      end
+    end
+
+    # Cleo: each `class FooCommand(Command):` is a subcommand keyed by its
+    # `name = "..."` class attribute. Scope every self.argument()/
+    # self.option() readback found anywhere in the class body (covers
+    # handle() and any helper methods) to that command's URL — never a
+    # sticky cursor, so a second command class can't inherit stray params.
+    private def scan_cleo(lines : Array(String), path : String, root_url : String,
+                          endpoints : Hash(String, Endpoint))
+      index = 0
+      while index < lines.size
+        line = lines[index]
+        unless m = line.match(CLEO_COMMAND_CLASS_RE)
+          index += 1
+          next
+        end
+        class_indent = line.size - line.lstrip.size
+        body_start = index + 1
+        body_end = body_start
+        while body_end < lines.size
+          candidate = lines[body_end]
+          stripped = candidate.strip
+          if stripped.empty? || stripped.starts_with?("#")
+            body_end += 1
+            next
+          end
+          break if candidate.size - candidate.lstrip.size <= class_indent
+          body_end += 1
+        end
+
+        # Only the class's direct-member indentation (the indentation of its
+        # first non-blank/non-comment body line) counts as a class attribute.
+        # A `name = "..."` local variable inside a nested method body sits
+        # deeper than that and must not hijack the command's URL.
+        name = nil
+        member_indent = nil
+        (body_start...body_end).each do |i|
+          body_line = lines[i]
+          stripped = body_line.strip
+          next if stripped.empty? || stripped.starts_with?("#")
+          indent = body_line.size - body_line.lstrip.size
+          member_indent ||= indent
+          next unless indent == member_indent
+          if nm = body_line.match(CLEO_NAME_ATTR_RE)
+            name = nm[1]
+            break
+          end
+        end
+
+        if name
+          url = "#{root_url}/#{name}"
+          ep = fetch_endpoint(endpoints, url, path, body_start + 1)
+          (body_start...body_end).each do |i|
+            body_line = lines[i]
+            body_line.scan(CLEO_ARGUMENT_CALL_RE) { |am| ep.push_param(Param.new(am[1], "", "argument")) }
+            body_line.scan(CLEO_OPTION_CALL_RE) { |om| ep.push_param(Param.new(om[1], "", "flag")) }
+          end
+        end
+
+        index = body_end
+      end
     end
 
     # stdlib: raw env reads (gated), sys.argv positionals, getopt, fire.

--- a/src/analyzer/analyzers/ruby/cli.cr
+++ b/src/analyzer/analyzers/ruby/cli.cr
@@ -6,14 +6,15 @@ module Analyzer::Ruby
   # endpoints: one endpoint per (sub)command, with named options
   # (param_type "flag"), positional arguments ("argument") and consumed
   # environment variables ("env"). Covers stdlib OptionParser / ARGV plus
-  # Thor, GLI, Slop, TTY::Option and the commander gem.
+  # Thor, GLI, Slop, TTY::Option, the commander gem, Optimist, Clamp and
+  # dry-cli.
   #
   # Line-scan analyzer (house style for non-tree-sitter Ruby adapters),
   # merging endpoints by URL across files.
   class Cli < RubyEngine
     # OptionParser: `opts.on("-p", "--port PORT")` — prefer the long name.
     OPTPARSE_LONG  = /\.on\s*\(?[^)]*?["'](-{2}[A-Za-z0-9][\w-]*)/
-    OPTPARSE_SHORT = /\.on\s*\(\s*["'](-[A-Za-z0-9])(?:["' ]|\))/
+    OPTPARSE_SHORT = /\.on\s*\(\s*["'](-[A-Za-z0-9])(["' ]|\))/
 
     # Thor DSL.
     THOR_SUBCLASS = /<\s*Thor\b/
@@ -42,6 +43,37 @@ module Analyzer::Ruby
     ENV_INDEX  = /\bENV\s*\[\s*["']([^"']+)["']\s*\]/
     ENV_FETCH  = /\bENV\.fetch\s*\(\s*["']([^"']+)["']/
 
+    # Optimist: `opt :name, "desc", type: :string` — a flat parser (no
+    # subcommand DSL), gated on the block-opening call so a bare local
+    # variable/method named `opt` elsewhere doesn't false-positive.
+    OPTIMIST_CALL = /\bOptimist(?:::|\.)options\b/
+    OPTIMIST_OPT  = /^\s*opt\s+:([A-Za-z0-9_]+)/
+
+    # Clamp: `class Foo < Clamp::Command` with `option`/`parameter` DSL and
+    # optional nested `subcommand "name", "desc" do ... end` blocks. The DSL
+    # call's first argument (the switch name or an array of switch names)
+    # must appear immediately after `option` + whitespace — a `(?=["'\[])`
+    # lookahead — so an unrelated local/instance variable assignment like
+    # `option = default? ? "--json" : "--text"` cannot masquerade as the
+    # DSL call just because a dash-prefixed quoted string appears somewhere
+    # later on the line. Mirrors CLAMP_PARAMETER, which already requires the
+    # quote directly after the keyword.
+    CLAMP_SUBCLASS     = /<\s*Clamp::Command\b/
+    CLAMP_SUBCOMMAND   = /^(\s*)subcommand\s+["']([A-Za-z0-9][\w-]*)["'][^\n]*\bdo\s*$/
+    CLAMP_OPTION_LONG  = /^\s*option\s+(?=["'\[])[^\n]*?["'](-{2}[A-Za-z0-9][\w-]*)["']/
+    CLAMP_OPTION_SHORT = /^\s*option\s+(?=["'\[])[^\n]*?["'](-[A-Za-z0-9])["']/
+    CLAMP_PARAMETER    = /^\s*parameter\s+["']\[?([A-Za-z0-9_]+)/
+
+    # dry-cli: `class Build < Dry::CLI::Command` with `option`/`argument`
+    # DSL; each subclass is its own (sub)command. DRY_CLI_MARKER (unanchored)
+    # is for whole-content evidence checks; DRY_CLI_CLASS (line-anchored, to
+    # capture indent) is for the per-line scan — `^` in Crystal only matches
+    # the very start of a multi-line string, not after every `\n`.
+    DRY_CLI_MARKER   = /<\s*Dry::CLI::Command\b/
+    DRY_CLI_CLASS    = /^(\s*)class\s+([A-Za-z0-9_]+)\s*<\s*Dry::CLI::Command\b/
+    DRY_CLI_OPTION   = /^\s*option\s+:([A-Za-z0-9_]+)/
+    DRY_CLI_ARGUMENT = /^\s*argument\s+:([A-Za-z0-9_]+)/
+
     # Program-name hints.
     COMMANDER_PROGRAM = /\bprogram\s+:name\s*,\s*["']([^"']+)["']/
     OPTPARSE_BANNER   = /banner\s*=\s*["']Usage:\s*(\S+)/
@@ -65,9 +97,12 @@ module Analyzer::Ruby
             root_url = "cli://#{binary}"
             lines = content.lines
             thor = content.matches?(THOR_SUBCLASS)
+            clamp = content.matches?(CLAMP_SUBCLASS)
+            dry_cli = content.matches?(DRY_CLI_MARKER)
+            optimist = content.matches?(OPTIMIST_CALL)
             emit_env = !content.matches?(WEB_FRAMEWORK_RE)
 
-            scan(lines, path, root_url, endpoints, thor, emit_env)
+            scan(lines, path, root_url, endpoints, thor, emit_env, clamp, dry_cli, optimist)
           rescue e
             logger.debug "Error analyzing #{path}: #{e}"
             next
@@ -87,7 +122,10 @@ module Analyzer::Ruby
         content.matches?(/\bSlop\.(?:parse|new)\b/) ||
         content.includes?("TTY::Option") ||
         content.includes?("Commander::Methods") ||
-        content.matches?(ARGV_INDEX)
+        content.matches?(ARGV_INDEX) ||
+        content.matches?(OPTIMIST_CALL) ||
+        content.matches?(CLAMP_SUBCLASS) ||
+        content.matches?(DRY_CLI_MARKER)
     end
 
     private def ruby_binary_name(content : String, path : String) : String
@@ -106,16 +144,34 @@ module Analyzer::Ruby
     end
 
     private def scan(lines : Array(String), path : String, root_url : String,
-                     endpoints : Hash(String, Endpoint), thor : Bool, emit_env : Bool)
+                     endpoints : Hash(String, Endpoint), thor : Bool, emit_env : Bool,
+                     clamp : Bool, dry_cli : Bool, optimist : Bool)
       pending_desc : String? = nil
       pending_thor_opts = [] of String
       block_cmd_url = root_url
       thor_private = false
       no_commands_indent : Int32? = nil
+      clamp_sub_indent : Int32? = nil
+      clamp_sub_url = root_url
+      dry_cli_indent : Int32? = nil
+      dry_cli_url : String? = nil
 
       lines.each_with_index do |line, index|
         line_no = index + 1
 
+        # NOTE: `thor`/`clamp`/`dry_cli`/`optimist` are mutually exclusive
+        # branches — intentionally one-DSL-per-file, matching the existing
+        # TTY::Option-vs-Thor precedent above. A file that (unusually) mixes
+        # markers for two of these frameworks only has the first-checked
+        # framework's option/argument declarations scanned; the other
+        # framework's class still gets a root/command endpoint (via
+        # `cli_evidence?`/`DEF_RE`/etc. where applicable) but its
+        # `option`/`parameter`/`argument` lines are silently skipped rather
+        # than merged. This is a deliberate simplification: real-world Ruby
+        # CLI files essentially never combine two CLI DSLs in one file, and
+        # per-line (rather than per-file) dispatch would require detecting
+        # which framework's *block* a given line sits in, which the
+        # line-scan house style doesn't support today.
         if thor
           # Thor's task rules: `no_commands do ... end` bodies and methods
           # below a bare `private` are helpers, not commands. Track both so
@@ -151,6 +207,54 @@ module Analyzer::Ruby
               pending_desc = nil
               pending_thor_opts.clear
             end
+          end
+        elsif clamp
+          # Clamp: `option`/`parameter` attach to the innermost open
+          # `subcommand "name" do ... end` block (indent-scoped, never a
+          # sticky cursor), falling back to the root command.
+          if sc = line.match(CLAMP_SUBCOMMAND)
+            clamp_sub_indent = sc[1].size
+            clamp_sub_url = "#{root_url}/#{sc[2]}"
+            fetch_endpoint(endpoints, clamp_sub_url, path, line_no)
+          elsif (indent = clamp_sub_indent) && (em = line.match(/^(\s*)end\b/)) && em[1].size <= indent
+            clamp_sub_indent = nil
+            clamp_sub_url = root_url
+          end
+
+          if m = line.match(CLAMP_OPTION_LONG)
+            fetch_endpoint(endpoints, clamp_sub_url, path, line_no).push_param(Param.new(m[1].lstrip('-'), "", "flag"))
+          elsif m = line.match(CLAMP_OPTION_SHORT)
+            fetch_endpoint(endpoints, clamp_sub_url, path, line_no).push_param(Param.new(m[1].lstrip('-'), "", "flag"))
+          end
+          if m = line.match(CLAMP_PARAMETER)
+            fetch_endpoint(endpoints, clamp_sub_url, path, line_no).push_param(Param.new(m[1].downcase, "", "argument"))
+          end
+        elsif dry_cli
+          # dry-cli: each `class Xxx < Dry::CLI::Command` is its own
+          # (sub)command; `option`/`argument` attach to the innermost open
+          # class body (indent-scoped), never a sticky cursor.
+          if cm = line.match(DRY_CLI_CLASS)
+            dry_cli_indent = cm[1].size
+            new_command_url = "#{root_url}/#{cm[2].downcase}"
+            dry_cli_url = new_command_url
+            fetch_endpoint(endpoints, new_command_url, path, line_no)
+          elsif (indent = dry_cli_indent) && (em = line.match(/^(\s*)end\b/)) && em[1].size <= indent
+            dry_cli_indent = nil
+            dry_cli_url = nil
+          end
+
+          if url = dry_cli_url
+            if m = line.match(DRY_CLI_OPTION)
+              fetch_endpoint(endpoints, url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+            elsif m = line.match(DRY_CLI_ARGUMENT)
+              fetch_endpoint(endpoints, url, path, line_no).push_param(Param.new(m[1], "", "argument"))
+            end
+          end
+        elsif optimist
+          # Optimist has no subcommand DSL: every `opt` declaration is a
+          # flat, root-level flag.
+          if m = line.match(OPTIMIST_OPT)
+            fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
           end
         else
           # TTY::Option DSL (option/flag/keyword/argument) — only outside a

--- a/src/analyzer/analyzers/rust/cli.cr
+++ b/src/analyzer/analyzers/rust/cli.cr
@@ -6,7 +6,8 @@ module Analyzer::Rust
   # endpoints: one endpoint per (sub)command with named options
   # (param_type "flag"), positional arguments ("argument") and consumed
   # environment variables ("env"). Covers `std::env::args`/`var` plus the
-  # clap / structopt / argh derive macros.
+  # clap / structopt / argh derive macros and the getopts builder API
+  # (`Options::new()` + `opts.optopt`/`optflag`/`optflagopt`/`optmulti`/`reqopt`).
   #
   # Scope notes (follow-ups): the clap *builder* API (`Command::new(...)
   # .arg(Arg::new(...))`) is only recognized as a CLI signal, not parsed into
@@ -36,6 +37,17 @@ module Analyzer::Rust
     # builtin.
     ENV_VAR_RE  = /\b(?:std::)?env::var(?:_os)?\s*\(\s*"([^"]+)"/
     ENV_ARGS_RE = /\b(?:std::)?env::args(?:_os)?\s*\(/
+
+    # getopts: a flat (no-subcommand) builder API. `let mut opts =
+    # Options::new();` binds a receiver variable, then `opts.optopt(short,
+    # long, desc, hint)` / `optflag(short, long, desc)` /
+    # `optflagopt(short, long, desc, hint)` / `optmulti(short, long, desc,
+    # hint)` / `reqopt(short, long, desc, hint)` register each option on it.
+    # The optional type-annotation group tolerates a `getopts::` prefix
+    # (`let mut opts: getopts::Options = ...`), matching the same prefix
+    # already tolerated before `Options::new`.
+    GETOPTS_NEW_RE  = /\blet\s+(?:mut\s+)?(\w+)(?:\s*:\s*(?:getopts::)?Options)?\s*=\s*(?:getopts::)?Options::new\s*\(\s*\)/
+    GETOPTS_CALL_RE = /\b(\w+)\.(?:optopt|reqopt|optflagopt|optflag|optmulti)\s*\(\s*"([^"]*)"\s*,\s*"([^"]*)"/
 
     # Web crates: their env::var reads are config, not a CLI surface.
     WEB_CRATE_RE = /\buse\s+(?:axum|actix_web|rocket|warp|tide|poem|salvo|gotham|loco_rs|hyper|tonic|tower_http)\b|::serve\s*\(|HttpServer::new|TcpListener::bind/
@@ -68,7 +80,7 @@ module Analyzer::Rust
 
     private def cli_evidence?(content : String) : Bool
       content.matches?(DERIVE_RE) && content.matches?(/\b(?:Parser|Subcommand|Args|StructOpt|FromArgs)\b/) ||
-        content.matches?(/\buse\s+(?:clap|structopt|argh|bpaf|pico_args)\b|\b(?:clap|structopt|argh|bpaf|pico_args)::/) ||
+        content.matches?(/\buse\s+(?:clap|structopt|argh|bpaf|pico_args|getopts)\b|\b(?:clap|structopt|argh|bpaf|pico_args|getopts)::/) ||
         content.matches?(ENV_ARGS_RE) ||
         (content.includes?("clap") && content.matches?(BUILDER_NEW))
     end
@@ -90,6 +102,11 @@ module Analyzer::Rust
       current_cmd = root_url
       pending_derive : String? = nil
       pending_attr : Tuple(Symbol, String)? = nil # {:clap|:argh, body}
+      # getopts has no subcommand concept: a receiver-variable map (not a
+      # sticky cursor) links each `Options::new()` binding to the command
+      # URL its `opt*` calls should attach to (always root_url today, but
+      # keeps the same variable-scoping shape as the other CLI analyzers).
+      getopts_vars = {} of String => String
 
       lines.each_with_index do |line, index|
         entry_depth = depth
@@ -137,6 +154,22 @@ module Analyzer::Rust
           elsif (attr = pending_attr) && (fm = stripped.match(FIELD_RE))
             apply_field(attr, fm[1], current_cmd, path, line_no, endpoints)
             pending_attr = nil
+          end
+        end
+
+        # getopts: bind `let mut opts = Options::new();` to the current
+        # binary's root command, then attribute each `opts.optopt(...)` /
+        # `optflag(...)` / `optflagopt(...)` / `optmulti(...)` / `reqopt(...)`
+        # call to that same receiver via the variable map.
+        if nm = line.match(GETOPTS_NEW_RE)
+          getopts_vars[nm[1]] = root_url
+        end
+        if cm = line.match(GETOPTS_CALL_RE)
+          if url = getopts_vars[cm[1]]?
+            short = cm[2]
+            long = cm[3]
+            name = long.empty? ? short : long
+            fetch_endpoint(endpoints, url, path, line_no).push_param(Param.new(name, "", "flag")) unless name.empty?
           end
         end
 

--- a/src/analyzer/analyzers/scala/cli.cr
+++ b/src/analyzer/analyzers/scala/cli.cr
@@ -2,9 +2,19 @@ require "../../../models/analyzer"
 
 module Analyzer::Scala
   # Surfaces the command-line attack surface of Scala programs as `cli://`
-  # endpoints: scopt and decline (options/args/subcommands) plus sys.env
-  # reads. Line-scan, merged by URL.
+  # endpoints: scopt/decline (options/args/subcommands), Scallop
+  # (ScallopConf options/args/subcommands), com.twitter.app (flags), and
+  # sys.env reads. Line-scan, merged by URL.
+  #
+  # Each library is gated on its own distinct import/marker, and only that
+  # library's regex family runs against the file. This matters because
+  # Scallop's bare `opt[T]("name")` call is textually identical to scopt's
+  # `opt[T]("name")` -- without per-library gating, scopt's extractor would
+  # also fire on Scallop code and attach subcommand-only flags to the root
+  # endpoint even though Scallop's own subcommand scoping correctly bound
+  # them to the subcommand.
   class Cli < Analyzer
+    # --- scopt / decline -----------------------------------------------
     SCOPT_OPT = /\bopt\[[^\]]*\]\s*\(\s*(?:'[A-Za-z0-9]'\s*,\s*)?"([^"]+)"/
     SCOPT_ARG = /\barg\[[^\]]*\]\s*\(\s*"<?([A-Za-z0-9][\w-]*)>?"/
     SCOPT_CMD = /\bcmd\s*\(\s*"([^"]+)"/
@@ -12,9 +22,37 @@ module Analyzer::Scala
     DEC_FLAG  = /\bOpts\.flag\s*\(\s*"([^"]+)"/
     DEC_ARG   = /\bOpts\.argument(?:\[[^\]]*\])?\s*\(\s*"<?([A-Za-z0-9][\w-]*)>?"/
     DEC_CMD   = /\bCommand\s*\(\s*"([^"]+)"/
-    SYS_ENV   = /\bsys\.env\s*(?:\(\s*"([^"]+)"|\.get\s*\(\s*"([^"]+)")/
 
-    MARKERS = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b/
+    SCOPT_DECLINE_MARKER = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b/
+
+    # --- Scallop (org.rogach.scallop) -----------------------------------
+    # `opt[T]`/`trailArg[T]` take an explicit name, or (via a Scallop macro)
+    # infer it from the enclosing `val` when the name is omitted -- this is
+    # a real, documented Scallop feature, unlike com.twitter.app's `flag`.
+    #
+    # Subcommands are declared either as `val x = (new )?Subcommand("name")
+    # { ... }` or the idiomatic `object x extends Subcommand("name") { ... }`
+    # shown in Scallop's own docs; both open their scope with a `{` on the
+    # same line, closed via brace-depth tracking.
+    SCALLOP_SUBCMD       = /\b(?:val\s+\w+\s*=\s*(?:new\s+)?Subcommand\s*\(\s*"([^"]+)"|object\s+\w+\s+extends\s+Subcommand\s*\(\s*"([^"]+)")/
+    SCALLOP_OPT_NAMED    = /\bopt\[[^\]]*\]\s*\(\s*"([^"]+)"/
+    SCALLOP_OPT_INFERRED = /\bval\s+(\w+)\s*=\s*opt\[[^\]]*\]\s*\(\s*(?!")/
+    SCALLOP_ARG_NAMED    = /\btrailArg\[[^\]]*\]\s*\(\s*"([^"]+)"/
+    SCALLOP_ARG_INFERRED = /\bval\s+(\w+)\s*=\s*trailArg\[[^\]]*\]\s*\(\s*(?!")/
+
+    SCALLOP_MARKER = /\borg\.rogach\.scallop\b|\bScallopConf\b/
+
+    # --- com.twitter.app --------------------------------------------------
+    # `flag[T]("name", ...)` always requires an explicit name -- there is no
+    # reflection/macro-based no-arg overload the way Scallop infers names
+    # from a `val`, so only the explicitly-named form is extracted.
+    TWITTER_FLAG = /\bflag\[[^\]]*\]\s*\(\s*"([^"]+)"/
+
+    TWITTER_MARKER = /\bcom\.twitter\.app\b/
+
+    SYS_ENV = /\bsys\.env\s*(?:\(\s*"([^"]+)"|\.get\s*\(\s*"([^"]+)")/
+
+    MARKERS = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b|\borg\.rogach\.scallop\b|\bScallopConf\b|\bcom\.twitter\.app\b/
     WEB_RE  = /\bimport\s+(?:akka\.http|play\.api|org\.http4s|cask|com\.twitter\.finatra|com\.linecorp\.armeria|zhttp|zio\.http)\b/
 
     def analyze
@@ -28,33 +66,89 @@ module Analyzer::Scala
           next unless content.matches?(MARKERS)
           root_url = "cli://#{cli_binary_name(path)}"
           emit_env = !content.matches?(WEB_RE)
+
+          # Decide, once per file, which library families are actually
+          # present so their (textually overlapping) regexes never run
+          # against a file that uses a different library.
+          has_scopt_decline = content.matches?(SCOPT_DECLINE_MARKER)
+          has_scallop = content.matches?(SCALLOP_MARKER)
+          has_twitter = content.matches?(TWITTER_MARKER)
+
           pending_cmd_url = root_url
           in_children = false
           children_depth = 0
+
+          pending_scallop_url = root_url
+          in_subcommand = false
+          subcommand_depth = 0
+
           content.each_line.with_index do |line, index|
             line_no = index + 1
-            if (m = line.match(SCOPT_CMD)) || (m = line.match(DEC_CMD))
-              pending_cmd_url = "#{root_url}/#{m[1]}"
-              fetch_endpoint(endpoints, pending_cmd_url, path, line_no)
-            end
-            # scopt scopes a subcommand's opts inside `.children( ... )`; only
-            # there do options bind to the subcommand. Outside, they (and any
-            # trailing root opts after the block) bind to the root.
-            in_children = true if line.includes?(".children(")
-            target = in_children ? pending_cmd_url : root_url
-            if (m = line.match(SCOPT_OPT)) || (m = line.match(DEC_OPT)) || (m = line.match(DEC_FLAG))
-              fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "flag"))
-            end
-            if (m = line.match(SCOPT_ARG)) || (m = line.match(DEC_ARG))
-              fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "argument"))
-            end
-            if in_children
-              children_depth += line.count('(') - line.count(')')
-              if children_depth <= 0
-                in_children = false
-                children_depth = 0
+
+            if has_scopt_decline
+              if (m = line.match(SCOPT_CMD)) || (m = line.match(DEC_CMD))
+                pending_cmd_url = "#{root_url}/#{m[1]}"
+                fetch_endpoint(endpoints, pending_cmd_url, path, line_no)
+              end
+              # scopt scopes a subcommand's opts inside `.children( ... )`;
+              # only there do options bind to the subcommand. Outside, they
+              # (and any trailing root opts after the block) bind to root.
+              in_children = true if line.includes?(".children(")
+              target = in_children ? pending_cmd_url : root_url
+              if (m = line.match(SCOPT_OPT)) || (m = line.match(DEC_OPT)) || (m = line.match(DEC_FLAG))
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              end
+              if (m = line.match(SCOPT_ARG)) || (m = line.match(DEC_ARG))
+                fetch_endpoint(endpoints, target, path, line_no).push_param(Param.new(m[1], "", "argument"))
+              end
+              if in_children
+                children_depth += line.count('(') - line.count(')')
+                if children_depth <= 0
+                  in_children = false
+                  children_depth = 0
+                end
               end
             end
+
+            if has_scallop
+              if m = line.match(SCALLOP_SUBCMD)
+                name = m[1]? || m[2]?
+                if name
+                  pending_scallop_url = "#{root_url}/#{name}"
+                  fetch_endpoint(endpoints, pending_scallop_url, path, line_no)
+                  in_subcommand = true
+                end
+              end
+              # Subcommand bodies open their scope with a `{` on the same
+              # line as the `Subcommand(...)`/`extends Subcommand(...)`
+              # declaration; opts/args stay bound to it via brace-depth
+              # tracking until the matching `}`.
+              starget = in_subcommand ? pending_scallop_url : root_url
+              if m = line.match(SCALLOP_OPT_NAMED)
+                fetch_endpoint(endpoints, starget, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              elsif m = line.match(SCALLOP_OPT_INFERRED)
+                fetch_endpoint(endpoints, starget, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              end
+              if m = line.match(SCALLOP_ARG_NAMED)
+                fetch_endpoint(endpoints, starget, path, line_no).push_param(Param.new(m[1], "", "argument"))
+              elsif m = line.match(SCALLOP_ARG_INFERRED)
+                fetch_endpoint(endpoints, starget, path, line_no).push_param(Param.new(m[1], "", "argument"))
+              end
+              if in_subcommand
+                subcommand_depth += line.count('{') - line.count('}')
+                if subcommand_depth <= 0
+                  in_subcommand = false
+                  subcommand_depth = 0
+                end
+              end
+            end
+
+            if has_twitter
+              if m = line.match(TWITTER_FLAG)
+                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              end
+            end
+
             if emit_env
               line.scan(SYS_ENV) do |em|
                 name = em[1]? || em[2]?

--- a/src/analyzer/analyzers/zig/cli.cr
+++ b/src/analyzer/analyzers/zig/cli.cr
@@ -2,8 +2,9 @@ require "../../../models/analyzer"
 
 module Analyzer::Zig
   # Surfaces the command-line attack surface of Zig programs as `cli://`
-  # endpoints: zig-clap param strings and zig-cli literals plus std.process
-  # argv / env reads. Line-scan, merged by URL.
+  # endpoints: zig-clap param strings, zig-cli literals, zig-args struct
+  # fields, yazap App/Arg builder calls, plus std.process argv / env reads.
+  # Line-scan, merged by URL.
   class Cli < Analyzer
     # zig-clap multiline param string lines (each begins with `\\`).
     CLAP_FLAG = /\\\\\s*(?:-[A-Za-z0-9]\s*,\s*)?--([A-Za-z0-9][\w-]*)/
@@ -16,7 +17,48 @@ module Analyzer::Zig
     ARGS_IDX = /\bargs\s*\[\s*(\d+)\s*\]/
     GET_ENV  = /\b(?:std\.process\.getEnvVarOwned\s*\(\s*[\w.]+\s*,\s*"([^"]+)"|(?:std\.)?posix\.getenv\s*\(\s*"([^"]+)")/
 
-    MARKERS = /@import\s*\(\s*"cli"\s*\)|@import\s*\(\s*"clap"\s*\)|\b(?:std\.)?process\.argsAlloc\s*\(|\bclap\.(?:parseParamsComptime|parse)\b|\bcli\.(?:Command|App|Runner)\b/
+    # zig-args: `argsParser.parseForCurrentProcess(Options, allocator, .print)`
+    # / `argsParser.parse(Options, &iterator, allocator, .print)`. The
+    # receiver MUST be the local alias bound to `@import("args")` (captured
+    # via ARGS_IMPORT_ALIAS_RE below) -- otherwise an unrelated `.parse(...)`
+    # call on some other receiver (e.g. a URI parser also exposing a `parse`
+    # method) could be mistaken for the CLI's option struct. The type name is
+    # resolved to its `const <Name> = struct { ... };` declaration (or, for
+    # an inline anonymous struct literal, the call site itself) and every
+    # top-level field becomes a flag.
+    ARGS_IMPORT_ALIAS_RE = /\b(?:pub\s+)?const\s+(\w+)\s*=\s*@import\s*\(\s*"args"\s*\)/
+    ARGS_FIELD_RE        = /^\s*([A-Za-z_]\w*)\s*:/
+
+    # yazap: `App.init(...)`, `app.rootCommand()`, `app.createCommand("name", ...)`
+    # and `<receiver>.addArg(Arg.positional/booleanOption/singleValueOption(...))`.
+    # Receiver variables are mapped to their command URL incrementally, in
+    # the SAME forward pass as the addArg scan (see `analyze` below), so a
+    # variable reused across subcommands (e.g. a generic `cmd`) resolves to
+    # whichever command was assigned to it as of that line, never a
+    # whole-file map where a later reassignment retroactively overwrites an
+    # earlier addArg's receiver.
+    YAZAP_ROOT_RE    = /(\w+)\s*=\s*\w+\.rootCommand\s*\(\s*\)/
+    YAZAP_SUBCMD_RE  = /(\w+)\s*=\s*\w+\.createCommand\s*\(\s*"([^"]+)"/
+    YAZAP_ADD_ARG_RE = /(\w+)\.addArg\s*\(\s*Arg\.(positional|booleanOption|singleValueOption)\s*\(\s*"([^"]+)"/
+
+    MARKERS = /@import\s*\(\s*"cli"\s*\)|@import\s*\(\s*"clap"\s*\)|@import\s*\(\s*"args"\s*\)|@import\s*\(\s*"yazap"\s*\)|\b(?:std\.)?process\.argsAlloc\s*\(|\bclap\.(?:parseParamsComptime|parse)\b|\bcli\.(?:Command|App|Runner)\b/
+    # The subset of MARKERS that is either library-specific API usage or a
+    # bare import that pre-dates this file's zig-args/yazap support (kept
+    # as-is: an established, non-regressed convention elsewhere in this
+    # analyzer). A file matching only via a bare `@import("args")` or
+    # `@import("yazap")` -- with no corresponding API call anywhere in the
+    # file -- is NOT proof of a CLI surface (a project can vendor an
+    # unrelated module that happens to be named "args"), so it must not
+    # seed a zero-evidence `cli://<binary>` root endpoint.
+    # yazap doesn't need a separate evidence constant here: its bare
+    # `@import("yazap")` alone never seeds an endpoint either, because
+    # YAZAP_ROOT_RE / YAZAP_SUBCMD_RE / YAZAP_ADD_ARG_RE (used later, in the
+    # same forward pass) only call fetch_endpoint when they find a genuine
+    # rootCommand/createCommand/addArg call -- so an import with no real
+    # yazap usage naturally yields zero endpoints once the root pre-seed
+    # below is gated on STRONG_MARKERS.
+    STRONG_MARKERS = /@import\s*\(\s*"cli"\s*\)|@import\s*\(\s*"clap"\s*\)|\b(?:std\.)?process\.argsAlloc\s*\(|\bclap\.(?:parseParamsComptime|parse)\b|\bcli\.(?:Command|App|Runner)\b/
+    ARGS_IMPORT_RE = /@import\s*\(\s*"args"\s*\)/
     WEB_RE  = /@import\s*\(\s*"(?:zap|jetzig|httpz|tokamak)"\s*\)/
 
     def analyze
@@ -31,8 +73,20 @@ module Analyzer::Zig
           binary = cli_binary_name(path)
           root_url = "cli://#{binary}"
           emit_env = !content.matches?(WEB_RE)
-          fetch_endpoint(endpoints, root_url, path, 1)
-          content.each_line.with_index do |line, index|
+          lines = content.each_line.to_a
+
+          # Only pre-seed the root endpoint unconditionally for the
+          # established markers; a bare args/yazap import needs the
+          # alias/API-usage evidence resolved below first (see
+          # STRONG_MARKERS comment above).
+          has_strong_marker = content.matches?(STRONG_MARKERS)
+          fetch_endpoint(endpoints, root_url, path, 1) if has_strong_marker
+
+          args_alias = content.matches?(ARGS_IMPORT_RE) ? zig_args_alias(lines) : nil
+          scan_zig_args(lines, path, root_url, endpoints, args_alias) if args_alias
+          yazap_cmd_urls = {} of String => String
+
+          lines.each_with_index do |line, index|
             line_no = index + 1
             if m = line.match(CLAP_FLAG)
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
@@ -44,6 +98,23 @@ module Analyzer::Zig
             end
             if m = line.match(ARGS_IDX)
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new("arg#{m[1]}", "", "argument")) unless m[1] == "0"
+            end
+            # Update the receiver->URL map for this line BEFORE resolving
+            # addArg below, so the map always reflects the state as of the
+            # current line (not a whole-file precompute that a later
+            # reassignment could retroactively overwrite).
+            if m = line.match(YAZAP_ROOT_RE)
+              yazap_cmd_urls[m[1]] = root_url
+            elsif m = line.match(YAZAP_SUBCMD_RE)
+              cmd_url = "#{root_url}/#{m[2]}"
+              yazap_cmd_urls[m[1]] = cmd_url
+              fetch_endpoint(endpoints, cmd_url, path, line_no)
+            end
+            if m = line.match(YAZAP_ADD_ARG_RE)
+              url = yazap_cmd_urls[m[1]]? || root_url
+              ep = fetch_endpoint(endpoints, url, path, line_no)
+              param_type = m[2] == "positional" ? "argument" : "flag"
+              ep.push_param(Param.new(m[3], "", param_type))
             end
             if emit_env
               line.scan(GET_ENV) do |em|
@@ -59,6 +130,89 @@ module Analyzer::Zig
       end
       endpoints.each_value { |ep| @result << ep }
       @result
+    end
+
+    # Finds the local identifier bound to `@import("args")`, e.g. `argsParser`
+    # in `const argsParser = @import("args");`. Returns nil if the file
+    # doesn't declare one (no `@import("args")` evidence to extract from).
+    private def zig_args_alias(lines : Array(String)) : String?
+      lines.each do |line|
+        if m = line.match(ARGS_IMPORT_ALIAS_RE)
+          return m[1]
+        end
+      end
+      nil
+    end
+
+    # zig-args: locates the Options struct passed to parseForCurrentProcess /
+    # parse and surfaces each top-level field as a flag on the root command.
+    # Only receivers bound to the file's local `@import("args")` alias
+    # (`alias_name`, resolved by the caller via `zig_args_alias`) are
+    # honored -- an unbound `.parse(...)` call on some other receiver (e.g.
+    # a URI parser also named "parse") is never mistaken for the CLI's
+    # option struct. All alias-bound calls are unioned (push_param dedups by
+    # name+type) instead of keeping only the first match, so a file with
+    # more than one legitimate parse call doesn't silently drop fields from
+    # the others.
+    private def scan_zig_args(lines : Array(String), path : String, root_url : String,
+                              endpoints : Hash(String, Endpoint), alias_name : String)
+      named_re  = Regex.new("\\b#{Regex.escape(alias_name)}\\.(?:parseForCurrentProcess|parse)\\s*\\(\\s*([A-Za-z_]\\w*)\\s*[,)]")
+      inline_re = Regex.new("\\b#{Regex.escape(alias_name)}\\.(?:parseForCurrentProcess|parse)\\s*\\(\\s*struct\\s*\\{")
+
+      lines.each_with_index do |line, index|
+        if m = line.match(named_re)
+          struct_start = find_struct_start(lines, m[1])
+          next unless struct_start
+          fields = zig_args_struct_fields(lines, struct_start)
+          next if fields.empty?
+          ep = fetch_endpoint(endpoints, root_url, path, index + 1)
+          fields.each { |f| ep.push_param(Param.new(f, "", "flag")) }
+        elsif line.matches?(inline_re)
+          fields = zig_args_struct_fields(lines, index)
+          next if fields.empty?
+          ep = fetch_endpoint(endpoints, root_url, path, index + 1)
+          fields.each { |f| ep.push_param(Param.new(f, "", "flag")) }
+        end
+      end
+    end
+
+    # Finds the line index of `const <type_name> = struct {` (optionally
+    # `pub`/`packed`/`extern`), scanning the whole file since the type is
+    # usually declared above the parse call that references it.
+    private def find_struct_start(lines : Array(String), type_name : String) : Int32?
+      pattern = Regex.new("\\bconst\\s+#{Regex.escape(type_name)}\\b\\s*=\\s*(?:packed\\s+|extern\\s+)?struct\\s*\\{")
+      lines.each_with_index do |line, index|
+        return index if line.matches?(pattern)
+      end
+      nil
+    end
+
+    # Collects top-level field names of the struct literal opening on
+    # `start_index`, stopping at the matching closing brace so nested blocks
+    # (e.g. `pub const shorthands = .{...}`) never contribute a field.
+    private def zig_args_struct_fields(lines : Array(String), start_index : Int32) : Array(String)
+      fields = [] of String
+      depth = 0
+      seen_open = false
+      index = start_index
+      while index < lines.size
+        line = lines[index]
+        line.each_char do |ch|
+          if ch == '{'
+            depth += 1
+            seen_open = true
+          elsif ch == '}'
+            depth -= 1
+          end
+        end
+        if seen_open && depth == 1 && (m = line.match(ARGS_FIELD_RE))
+          fields << m[1]
+        end
+        break if seen_open && depth <= 0
+        index += 1
+        break if index - start_index > 200 # safety bound for malformed input
+      end
+      fields
     end
 
     private def cli_binary_name(path : String) : String

--- a/src/detector/detectors/clojure/cli.cr
+++ b/src/detector/detectors/clojure/cli.cr
@@ -1,10 +1,14 @@
 require "../../../models/detector"
 
 module Detector::Clojure
-  # Detects Clojure command-line apps via clojure.tools.cli, cli-matic, or
-  # *command-line-args*. Never gates on bare (System/getenv) (Ring config).
+  # Detects Clojure command-line apps via clojure.tools.cli, cli-matic,
+  # babashka.cli, or *command-line-args*. Never gates on bare
+  # (System/getenv) or bare environ.core (Ring/worker config reads both) —
+  # environ.core is a generic 12-factor config library used just as much by
+  # web apps and services, so it only annotates params on a `cli://`
+  # endpoint one of the markers below already established.
   class Cli < Detector
-    MARKERS = /clojure\.tools\.cli\b|\(\s*(?:[\w.-]+\/)?parse-opts\b|\bcli-matic\b|\*command-line-args\*/
+    MARKERS = /clojure\.tools\.cli\b|\(\s*(?:[\w.-]+\/)?parse-opts\b|\bcli-matic\b|\*command-line-args\*|\bbabashka\.cli\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)

--- a/src/detector/detectors/cpp/cli.cr
+++ b/src/detector/detectors/cpp/cli.cr
@@ -3,21 +3,25 @@ require "../../../models/detector"
 module Detector::Cpp
   # Detects C++ command-line applications, gated on a CLI library / parser
   # construct (CLI11, getopt/getopt_long, cxxopts, boost::program_options,
-  # gflags) — not on bare `main(int argc, char** argv)`, which every C++
-  # program (servers included) has.
+  # gflags, Abseil Flags, p-ranav/argparse) — not on bare
+  # `main(int argc, char** argv)`, which every C++ program (servers
+  # included) has.
   class Cli < Detector
-    EXTS     = [".cpp", ".cc", ".cxx", ".c++", ".hpp", ".hh", ".hxx"]
-    CLI11    = /\bCLI::App\b|include\s*[<"]CLI\/CLI\.hpp/
-    GETOPT   = /\bgetopt(?:_long)?\s*\(|\bstruct\s+option\b/
-    CXXOPTS  = /\bcxxopts::/
-    BOOST_PO = /\bprogram_options\b/
-    GFLAGS   = /\bDEFINE_(?:string|int32|int64|bool|double|uint32|uint64)\s*\(/
+    EXTS      = [".cpp", ".cc", ".cxx", ".c++", ".hpp", ".hh", ".hxx"]
+    CLI11     = /\bCLI::App\b|include\s*[<"]CLI\/CLI\.hpp/
+    GETOPT    = /\bgetopt(?:_long)?\s*\(|\bstruct\s+option\b/
+    CXXOPTS   = /\bcxxopts::/
+    BOOST_PO  = /\bprogram_options\b/
+    GFLAGS    = /\bDEFINE_(?:string|int32|int64|bool|double|uint32|uint64)\s*\(/
+    ABSL_FLAG = /\bABSL_FLAG\s*\(/
+    ARGPARSE  = /\bargparse::ArgumentParser\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless EXTS.any? { |ext| filename.ends_with?(ext) }
       file_contents.matches?(CLI11) || file_contents.matches?(GETOPT) ||
         file_contents.matches?(CXXOPTS) || file_contents.matches?(BOOST_PO) ||
-        file_contents.matches?(GFLAGS)
+        file_contents.matches?(GFLAGS) || file_contents.matches?(ABSL_FLAG) ||
+        file_contents.matches?(ARGPARSE)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/csharp/cli.cr
+++ b/src/detector/detectors/csharp/cli.cr
@@ -2,13 +2,14 @@ require "../../../models/detector"
 
 module Detector::CSharp
   # Detects C# command-line applications: programs using a CLI library
-  # (System.CommandLine, CommandLineParser, CliFx, Spectre.Console.Cli) or a
+  # (System.CommandLine, CommandLineParser, CliFx, Spectre.Console.Cli,
+  # McMaster.Extensions.CommandLineUtils, Cocona) or a
   # `static Main(string[] args)` / GetCommandLineArgs entry point. Gates the C#
   # CLI analyzer. A web host (ASP.NET / HttpListener) suppresses the builtin
   # signals so a server's `Main`/env reads don't masquerade as a CLI.
   class Cli < Detector
-    CLI_LIB   = /\busing\s+(?:System\.CommandLine|CommandLine|CliFx|Spectre\.Console\.Cli)\b/
-    LIB_USAGE = /\bnew\s+RootCommand\s*\(|\bnew\s+CommandApp\b|\bCliApplicationBuilder\s*\(|\bParser\.Default\.ParseArguments\b|\[\s*Verb\s*\(|\[\s*CommandOption\s*\(|\[\s*CommandArgument\s*\(/
+    CLI_LIB   = /\busing\s+(?:System\.CommandLine|CommandLine|CliFx|Spectre\.Console\.Cli|McMaster\.Extensions\.CommandLineUtils|Cocona)\b/
+    LIB_USAGE = /\bnew\s+RootCommand\s*\(|\bnew\s+CommandApp\b|\bCliApplicationBuilder\s*\(|\bParser\.Default\.ParseArguments\b|\[\s*Verb\s*\(|\[\s*CommandOption\s*\(|\[\s*CommandArgument\s*\(|\bCommandLineApplication\.Execute\b|\[\s*Subcommand\s*\(|\bCoconaApp\.(?:Create|Run)\b/
     WEB_HOST  = /\bWebApplication\.(?:Create(?:Builder|SlimBuilder|EmptyBuilder)?|CreateDefault)\b|\bnew\s+HttpListener\b|\.MapGet\s*\(|\.MapPost\s*\(|\.MapControllers\s*\(|\[\s*ApiController\s*\]|:\s*ControllerBase\b|\bHost\.CreateDefaultBuilder\b/
     MAIN_ARGS = /\bstatic\s+(?:async\s+)?(?:int|void|Task(?:<int>)?)\s+Main\s*\(\s*string\s*\[\s*\]\s+\w+\s*\)/
     GET_ARGS  = /\bEnvironment\.GetCommandLineArgs\s*\(/

--- a/src/detector/detectors/go/cli.cr
+++ b/src/detector/detectors/go/cli.cr
@@ -3,9 +3,9 @@ require "../../../models/detector"
 module Detector::Go
   # Detects Go command-line applications: programs that parse argv / flags
   # through the stdlib `flag` package or a CLI framework (cobra, urfave/cli,
-  # go-arg, go-flags, pflag), or that index `os.Args` directly. Gates the Go
-  # CLI analyzer, which surfaces the argv / flag / env attack surface as
-  # `cli://` endpoints.
+  # go-arg, go-flags, pflag, kong, kingpin, mitchellh/cli), or that index
+  # `os.Args` directly. Gates the Go CLI analyzer, which surfaces the argv /
+  # flag / env attack surface as `cli://` endpoints.
   class Cli < Detector
     # CLI framework import paths. Presence of any of these — in go.mod or a
     # source import block — is a strong, unambiguous CLI signal.
@@ -15,6 +15,10 @@ module Detector::Go
       "github.com/alexflint/go-arg",
       "github.com/jessevdk/go-flags",
       "github.com/spf13/pflag",
+      "github.com/alecthomas/kong",
+      "github.com/mitchellh/cli",
+      "github.com/alecthomas/kingpin",
+      "gopkg.in/alecthomas/kingpin.v2",
     ]
 
     # A real call into the stdlib `flag` package (not just the bare token

--- a/src/detector/detectors/groovy/cli.cr
+++ b/src/detector/detectors/groovy/cli.cr
@@ -1,10 +1,12 @@
 require "../../../models/detector"
 
 module Detector::Groovy
-  # Detects Groovy command-line apps via the built-in CliBuilder or picocli
-  # annotations. Never gates on bare System.getenv (Grails config).
+  # Detects Groovy command-line apps via the built-in CliBuilder, picocli
+  # annotations, JCommander or Commons CLI. Gated on library-specific
+  # constructs/imports only (never a bare generic token) so unrelated code
+  # doesn't light this up. Never gates on bare System.getenv (Grails config).
   class Cli < Detector
-    MARKERS = /\bnew\s+CliBuilder\b|\bCliBuilder\s*\(|@picocli|@Command\b/
+    MARKERS = /\bnew\s+CliBuilder\b|\bCliBuilder\s*\(|@picocli|@Command\b|\bimport\s+com\.beust\.jcommander\b|\bnew\s+JCommander\s*\(|\bJCommander\.newBuilder\s*\(|\bimport\s+org\.apache\.commons\.cli\b|\bOption\.builder\s*\(/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".groovy")

--- a/src/detector/detectors/haskell/cli.cr
+++ b/src/detector/detectors/haskell/cli.cr
@@ -2,10 +2,17 @@ require "../../../models/detector"
 
 module Detector::Haskell
   # Detects Haskell command-line apps via optparse-applicative, cmdargs,
-  # System.Console.GetOpt, or System.Environment.getArgs. Never gates on bare
-  # getEnv/lookupEnv (Scotty/Servant config).
+  # System.Console.GetOpt, System.Environment.getArgs, or turtle's
+  # Turtle.Options. Never gates on bare getEnv/lookupEnv (Scotty/Servant
+  # config).
   class Cli < Detector
-    MARKERS = /\bimport\s+(?:qualified\s+)?Options\.Applicative\b|\b(?:execParser|customExecParser|strOption|subparser|hsubparser)\b|\bimport\s+(?:qualified\s+)?System\.Console\.(?:GetOpt|CmdArgs)\b|\bimport\s+(?:qualified\s+)?System\.Environment\b/
+    # Turtle re-exports Turtle.Options from the top-level Turtle module,
+    # which is used pervasively for plain shell scripting too, so gate on
+    # either the qualified submodule import or an explicit `options` name
+    # in the unqualified import list, never a bare `import Turtle`.
+    TURTLE_MARKERS = /\bimport\s+(?:qualified\s+)?Turtle\.Options\b|\bimport\s+(?:qualified\s+)?Turtle\b\s*\([^)]*\boptions\b[^)]*\)/
+
+    MARKERS = /\bimport\s+(?:qualified\s+)?Options\.Applicative\b|\b(?:execParser|customExecParser|strOption|subparser|hsubparser)\b|\bimport\s+(?:qualified\s+)?System\.Console\.(?:GetOpt|CmdArgs)\b|\bimport\s+(?:qualified\s+)?System\.Environment\b|#{TURTLE_MARKERS}/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".hs") || filename.ends_with?(".lhs")

--- a/src/detector/detectors/java/cli.cr
+++ b/src/detector/detectors/java/cli.cr
@@ -13,8 +13,15 @@ module Detector::Java
       "org.apache.commons.cli",
       "com.github.rvesse.airline",
       "io.airlift.airline",
+      "joptsimple.",
     ]
 
+    # NOTE: deliberately no `new\s+OptionParser\s*\(` alternative here — jopt-simple's
+    # `OptionParser` is a common, generic class name apps also give their own
+    # options-parsing helpers (e.g. a video/report settings `OptionParser`). Genuine
+    # jopt-simple usage always requires `import joptsimple.*` or a `joptsimple.`
+    # fully-qualified reference, which LIB_IMPORTS already covers — adding a bare
+    # class-name pattern here would mistag unrelated classes as `java_cli`.
     USAGE = /\bnew\s+Options\s*\(\s*\)|\bOption\.builder\s*\(|\bnew\s+JCommander\s*\(|\bJCommander\.newBuilder\s*\(|\bnew\s+CmdLineParser\s*\(|\bnew\s+CommandLine\s*\(/
 
     def detect(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/javascript/cli.cr
+++ b/src/detector/detectors/javascript/cli.cr
@@ -3,11 +3,12 @@ require "../../../models/detector"
 module Detector::Javascript
   # Detects JavaScript/TypeScript command-line applications: programs using a
   # CLI framework (commander, yargs, cac, meow, minimist, clipanion, oclif,
-  # sade, …), the Node `util.parseArgs` builtin, the Deno/Bun argv runtimes,
-  # or the canonical `process.argv.slice(2)` parse. Gates the JS CLI
-  # analyzer. Bare `process.argv` / `process.env` are too common to qualify.
+  # sade, arg, command-line-args, getopts, citty, …), the Node
+  # `util.parseArgs` builtin, the Deno/Bun argv runtimes, or the canonical
+  # `process.argv.slice(2)` parse. Gates the JS CLI analyzer. Bare
+  # `process.argv` / `process.env` are too common to qualify.
   class Cli < Detector
-    CLI_LIB_IMPORT = /(?:require\s*\(\s*|from\s+)['"](?:commander|yargs(?:\/(?:yargs|helpers))?|cac|meow|minimist|mri|arg|clipanion|@oclif\/(?:core|command)|sade|gluegun)['"]/
+    CLI_LIB_IMPORT = /(?:require\s*\(\s*|from\s+)['"](?:commander|yargs(?:\/(?:yargs|helpers))?|cac|meow|minimist|mri|arg|clipanion|@oclif\/(?:core|command)|sade|gluegun|command-line-args|getopts|citty)['"]/
 
     PARSE_ARGS = /\bparseArgs\s*\(\s*\{/
     DENO_ARGS  = /\bDeno\.args\b/

--- a/src/detector/detectors/kotlin/cli.cr
+++ b/src/detector/detectors/kotlin/cli.cr
@@ -1,11 +1,11 @@
 require "../../../models/detector"
 
 module Detector::Kotlin
-  # Detects Kotlin command-line applications. Gated on clikt / kotlinx-cli
-  # imports or their constructs — NOT on bare `fun main(args)`, which Spring
-  # Boot and most Kotlin apps have.
+  # Detects Kotlin command-line applications. Gated on clikt / kotlinx-cli /
+  # picocli imports or their constructs — NOT on bare `fun main(args)`, which
+  # Spring Boot and most Kotlin apps have.
   class Cli < Detector
-    LIB_IMPORTS = ["com.github.ajalt.clikt", "kotlinx.cli"]
+    LIB_IMPORTS = ["com.github.ajalt.clikt", "kotlinx.cli", "picocli.CommandLine"]
     USAGE       = /:\s*CliktCommand\b|\bArgParser\s*\(/
 
     def detect(filename : String, file_contents : String) : Bool

--- a/src/detector/detectors/lua/cli.cr
+++ b/src/detector/detectors/lua/cli.cr
@@ -1,10 +1,11 @@
 require "../../../models/detector"
 
 module Detector::Lua
-  # Detects Lua command-line apps via the argparse library or explicit `arg`
-  # indexing. Never gates on bare os.getenv (lapis/lor config).
+  # Detects Lua command-line apps via the argparse library, the cliargs
+  # (lua_cliargs) library, or explicit `arg` indexing. Never gates on bare
+  # os.getenv (lapis/lor config).
   class Cli < Detector
-    MARKERS = /\brequire\s*\(?\s*['"]argparse['"]|\bargparse\s*\(|\barg\s*\[\s*\d+\s*\]/
+    MARKERS = /\brequire\s*\(?\s*['"]argparse['"]|\bargparse\s*\(|\barg\s*\[\s*\d+\s*\]|\brequire\s*\(?\s*['"]cliargs['"]/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".lua")

--- a/src/detector/detectors/perl/cli.cr
+++ b/src/detector/detectors/perl/cli.cr
@@ -2,10 +2,10 @@ require "../../../models/detector"
 
 module Detector::Perl
   # Detects Perl command-line apps via Getopt::Long / Getopt::Std, App::Cmd,
-  # MooseX::Getopt, or explicit @ARGV indexing. Never gates on bare %ENV
-  # (Mojolicious/Dancer2 config).
+  # MooseX::Getopt, Getopt::Long::Descriptive, MooX::Options, or explicit
+  # @ARGV indexing. Never gates on bare %ENV (Mojolicious/Dancer2 config).
   class Cli < Detector
-    MARKERS = /\buse\s+Getopt::(?:Long|Std)\b|\bGetOptions\s*\(|\bgetopts?\s*\(|\buse\s+App::Cmd\b|\bMooseX::Getopt\b|\$ARGV\s*\[\s*\d+\s*\]/
+    MARKERS = /\buse\s+Getopt::(?:Long|Std)\b|\bGetOptions\s*\(|\bgetopts?\s*\(|\buse\s+App::Cmd\b|\bMooseX::Getopt\b|\$ARGV\s*\[\s*\d+\s*\]|\buse\s+Getopt::Long::Descriptive\b|\bdescribe_options\s*\(|\buse\s+MooX::Options\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)

--- a/src/detector/detectors/php/cli.cr
+++ b/src/detector/detectors/php/cli.cr
@@ -4,23 +4,31 @@ module Detector::Php
   # Detects PHP command-line applications. SOURCE-anchored only (never
   # composer.json, where `symfony/console` is a transitive web dependency):
   # a Symfony Console command class / use, Laravel Zero, League CLImate,
-  # Minicli, or builtin getopt / $argv indexing.
+  # Minicli, Laravel Artisan (`$signature`), Robo (`Robo\Tasks`), WP-CLI
+  # (`WP_CLI::add_command` / `WP_CLI_Command`), or builtin getopt / $argv
+  # indexing.
   class Cli < Detector
-    USE_SF_CONSOLE = /\buse\s+Symfony\\Component\\Console\b/
-    SF_COMMAND     = /\bclass\s+\w+\s+extends\s+(?:\\?Symfony\\Component\\Console\\Command\\)?Command\b/
-    AS_COMMAND     = /#\[\s*AsCommand\b/
-    LARAVEL_ZERO   = /\buse\s+LaravelZero\\Framework\b/
-    CLIMATE        = /\buse\s+League\\CLImate\\CLImate\b/
-    MINICLI        = /\buse\s+Minicli\\(?:App|Command)\b/
-    GETOPT         = /\bgetopt\s*\(/
-    ARGV_INDEX     = /\$argv\s*\[/
+    USE_SF_CONSOLE    = /\buse\s+Symfony\\Component\\Console\b/
+    SF_COMMAND        = /\bclass\s+\w+\s+extends\s+(?:\\?Symfony\\Component\\Console\\Command\\)?Command\b/
+    AS_COMMAND        = /#\[\s*AsCommand\b/
+    LARAVEL_ZERO      = /\buse\s+LaravelZero\\Framework\b/
+    CLIMATE           = /\buse\s+League\\CLImate\\CLImate\b/
+    MINICLI           = /\buse\s+Minicli\\(?:App|Command)\b/
+    GETOPT            = /\bgetopt\s*\(/
+    ARGV_INDEX        = /\$argv\s*\[/
+    ARTISAN_SIGNATURE = /protected\s+(?:static\s+)?\$signature\s*=\s*['"]/
+    ROBO_MARKER       = /Robo\\Tasks\b/
+    WP_ADD_COMMAND    = /WP_CLI::add_command\s*\(/
+    WP_COMMAND_CLASS  = /extends\s+WP_CLI_Command\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".php")
       file_contents.matches?(USE_SF_CONSOLE) || file_contents.matches?(SF_COMMAND) ||
         file_contents.matches?(AS_COMMAND) || file_contents.matches?(LARAVEL_ZERO) ||
         file_contents.matches?(CLIMATE) || file_contents.matches?(MINICLI) ||
-        file_contents.matches?(GETOPT) || file_contents.matches?(ARGV_INDEX)
+        file_contents.matches?(GETOPT) || file_contents.matches?(ARGV_INDEX) ||
+        file_contents.matches?(ARTISAN_SIGNATURE) || file_contents.matches?(ROBO_MARKER) ||
+        file_contents.matches?(WP_ADD_COMMAND) || file_contents.matches?(WP_COMMAND_CLASS)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/python/cli.cr
+++ b/src/detector/detectors/python/cli.cr
@@ -2,15 +2,15 @@ require "../../../models/detector"
 
 module Detector::Python
   # Detects Python command-line applications: programs that parse argv via
-  # argparse / getopt or a CLI framework (click, typer, fire, docopt).
-  # Gates the Python CLI analyzer, which surfaces the argv / option / env
-  # attack surface as `cli://` endpoints.
+  # argparse / getopt or a CLI framework (click, typer, fire, docopt, absl-py
+  # flags, Cleo). Gates the Python CLI analyzer, which surfaces the argv /
+  # option / env attack surface as `cli://` endpoints.
   #
   # Detection is intentionally import-anchored. A bare `import sys`
   # (sys.argv) is far too common to treat as CLI evidence on its own, so it
   # is only honored inside the analyzer when paired with a `__main__` guard.
   class Cli < Detector
-    CLI_IMPORT_RE = /(?:^|\n)\s*(?:import|from)\s+(?:argparse|click|typer|fire|docopt|getopt)\b/
+    CLI_IMPORT_RE = /(?:^|\n)\s*(?:import|from)\s+(?:argparse|click|typer|fire|docopt|getopt|absl|cleo)\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".py")

--- a/src/detector/detectors/ruby/cli.cr
+++ b/src/detector/detectors/ruby/cli.cr
@@ -3,11 +3,12 @@ require "../../../models/detector"
 module Detector::Ruby
   # Detects Ruby command-line applications: programs that parse argv via the
   # stdlib OptionParser, a `< Thor` subclass, or a CLI gem (gli, slop,
-  # tty-option, commander), or that index ARGV directly. Gates the Ruby CLI
-  # analyzer. Intentionally import/usage-anchored: bare `ENV[...]` or a plain
-  # `ARGV` reference (without an index) is too common in web apps to qualify.
+  # tty-option, commander, optimist, clamp, dry-cli), or that index ARGV
+  # directly. Gates the Ruby CLI analyzer. Intentionally import/usage-anchored:
+  # bare `ENV[...]` or a plain `ARGV` reference (without an index) is too
+  # common in web apps to qualify.
   class Cli < Detector
-    CLI_GEMS = ["thor", "gli", "slop", "tty-option", "commander"]
+    CLI_GEMS = ["thor", "gli", "slop", "tty-option", "commander", "optimist", "clamp", "dry-cli"]
 
     REQUIRE_OPTPARSE = /\brequire\s+["']optparse["']/
     OPTION_PARSER    = /\bOptionParser\.new\b/
@@ -17,6 +18,9 @@ module Detector::Ruby
     TTY_OPTION       = /\binclude\s+TTY::Option\b/
     COMMANDER_USE    = /\binclude\s+Commander::Methods\b/
     ARGV_INDEX       = /\bARGV\s*\[\s*\d+\s*\]/
+    OPTIMIST_USE     = /\bOptimist(?:::|\.)options\b/
+    CLAMP_SUBCLASS   = /<\s*Clamp::Command\b/
+    DRY_CLI_SUBCLASS = /<\s*Dry::CLI::Command\b/
 
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
@@ -30,6 +34,8 @@ module Detector::Ruby
       return true if file_contents.matches?(GLI_APP) || file_contents.matches?(SLOP_USE) ||
                      file_contents.matches?(TTY_OPTION) || file_contents.matches?(COMMANDER_USE)
       return true if file_contents.matches?(ARGV_INDEX)
+      return true if file_contents.matches?(OPTIMIST_USE) || file_contents.matches?(CLAMP_SUBCLASS) ||
+                     file_contents.matches?(DRY_CLI_SUBCLASS)
 
       false
     end

--- a/src/detector/detectors/rust/cli.cr
+++ b/src/detector/detectors/rust/cli.cr
@@ -2,16 +2,16 @@ require "../../../models/detector"
 
 module Detector::Rust
   # Detects Rust command-line applications: crates depending on a CLI library
-  # (clap, structopt, argh, bpaf, pico-args) or source that derives a parser /
-  # uses `std::env::args()`. Gates the Rust CLI analyzer. Bare
+  # (clap, structopt, argh, bpaf, pico-args, getopts) or source that derives a
+  # parser / uses `std::env::args()`. Gates the Rust CLI analyzer. Bare
   # `std::env::var(...)` (config reads, common in web crates) does not qualify.
   class Cli < Detector
-    CLI_CRATES = ["clap", "structopt", "argh", "bpaf", "pico-args"]
+    CLI_CRATES = ["clap", "structopt", "argh", "bpaf", "pico-args", "getopts"]
 
     DERIVE_PARSER    = /#\[\s*derive\s*\([^)]*\b(?:Parser|Subcommand|Args)\b/
     DERIVE_STRUCTOPT = /#\[\s*derive\s*\([^)]*\bStructOpt\b/
     DERIVE_ARGH      = /#\[\s*derive\s*\([^)]*\bFromArgs\b/
-    USE_CLI_LIB      = /\buse\s+(?:clap|structopt|argh|bpaf|pico_args)\b|\b(?:clap|structopt|argh|bpaf|pico_args)::/
+    USE_CLI_LIB      = /\buse\s+(?:clap|structopt|argh|bpaf|pico_args|getopts)\b|\b(?:clap|structopt|argh|bpaf|pico_args|getopts)::/
     BUILDER_CMD      = /\bCommand::new\s*\(/
     ENV_ARGS         = /\b(?:std::)?env::args(?:_os)?\s*\(/
 

--- a/src/detector/detectors/scala/cli.cr
+++ b/src/detector/detectors/scala/cli.cr
@@ -1,10 +1,10 @@
 require "../../../models/detector"
 
 module Detector::Scala
-  # Detects Scala command-line apps via scopt, decline, or mainargs. Never
-  # gates on bare sys.env (Akka/Play config).
+  # Detects Scala command-line apps via scopt, decline, mainargs, Scallop, or
+  # com.twitter.app. Never gates on bare sys.env (Akka/Play config).
   class Cli < Detector
-    MARKERS = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bimport\s+com\.monovore\.decline|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b|@main\b/
+    MARKERS = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bimport\s+com\.monovore\.decline|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b|@main\b|\borg\.rogach\.scallop\b|\bScallopConf\b|\bcom\.twitter\.app\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".scala") || filename.ends_with?(".sc")

--- a/src/detector/detectors/zig/cli.cr
+++ b/src/detector/detectors/zig/cli.cr
@@ -1,10 +1,11 @@
 require "../../../models/detector"
 
 module Detector::Zig
-  # Detects Zig command-line apps via zig-cli, zig-clap, or std.process argv
-  # parsing. Never gates on bare getEnvMap (zap/jetzig/httpz config).
+  # Detects Zig command-line apps via zig-cli, zig-clap, zig-args, yazap, or
+  # std.process argv parsing. Never gates on bare getEnvMap (zap/jetzig/httpz
+  # config).
   class Cli < Detector
-    MARKERS = /@import\s*\(\s*"cli"\s*\)|@import\s*\(\s*"clap"\s*\)|\b(?:std\.)?process\.argsAlloc\s*\(|\bclap\.(?:parseParamsComptime|parse)\b|\bcli\.(?:Command|App|Runner)\b/
+    MARKERS = /@import\s*\(\s*"cli"\s*\)|@import\s*\(\s*"clap"\s*\)|@import\s*\(\s*"args"\s*\)|@import\s*\(\s*"yazap"\s*\)|\b(?:std\.)?process\.argsAlloc\s*\(|\bclap\.(?:parseParamsComptime|parse)\b|\bcli\.(?:Command|App|Runner)\b/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".zig")

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2544,9 +2544,9 @@ module NoirTechs
       },
     },
     :php_cli => {
-      :framework => "CLI (symfony/console / getopt)",
+      :framework => "CLI (symfony/console / getopt / artisan / wp-cli / robo)",
       :language  => "PHP",
-      :similar   => ["php-cli", "php_cli", "symfony-console", "getopt", "climate", "minicli"],
+      :similar   => ["php-cli", "php_cli", "symfony-console", "getopt", "climate", "minicli", "artisan", "illuminate-console", "wp-cli", "robo"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -3393,9 +3393,9 @@ module NoirTechs
       },
     },
     :rust_cli => {
-      :framework => "CLI (std::env / clap / structopt / argh)",
+      :framework => "CLI (std::env / clap / structopt / argh / getopts)",
       :language  => "Rust",
-      :similar   => ["rust-cli", "rust_cli", "clap", "structopt", "argh", "bpaf", "pico-args"],
+      :similar   => ["rust-cli", "rust_cli", "clap", "structopt", "argh", "bpaf", "pico-args", "getopts"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1212,9 +1212,9 @@ module NoirTechs
       },
     },
     :haskell_cli => {
-      :framework => "CLI (optparse-applicative / cmdargs / GetOpt)",
+      :framework => "CLI (optparse-applicative / cmdargs / GetOpt / turtle)",
       :language  => "Haskell",
-      :similar   => ["haskell-cli", "haskell_cli", "optparse-applicative", "cmdargs"],
+      :similar   => ["haskell-cli", "haskell_cli", "optparse-applicative", "cmdargs", "turtle"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1359,9 +1359,9 @@ module NoirTechs
       },
     },
     :java_cli => {
-      :framework => "CLI (picocli / args4j / JCommander / commons-cli / airline)",
+      :framework => "CLI (picocli / args4j / JCommander / commons-cli / airline / JOpt Simple)",
       :language  => "Java",
-      :similar   => ["java-cli", "java_cli", "picocli", "args4j", "jcommander", "commons-cli", "airline"],
+      :similar   => ["java-cli", "java_cli", "picocli", "args4j", "jcommander", "commons-cli", "airline", "jopt-simple", "joptsimple"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1176,9 +1176,9 @@ module NoirTechs
       },
     },
     :groovy_cli => {
-      :framework => "CLI (CliBuilder / picocli)",
+      :framework => "CLI (CliBuilder / picocli / commons-cli / JCommander)",
       :language  => "Groovy",
-      :similar   => ["groovy-cli", "groovy_cli", "clibuilder", "picocli"],
+      :similar   => ["groovy-cli", "groovy_cli", "clibuilder", "picocli", "commons-cli", "jcommander"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -3231,9 +3231,9 @@ module NoirTechs
       },
     },
     :ruby_cli => {
-      :framework => "CLI (OptionParser / Thor / GLI / Slop / TTY::Option)",
+      :framework => "CLI (OptionParser / Thor / GLI / Slop / TTY::Option / Optimist / Clamp / dry-cli)",
       :language  => "Ruby",
-      :similar   => ["ruby-cli", "ruby_cli", "thor", "optparse", "optionparser", "gli", "slop", "tty-option"],
+      :similar   => ["ruby-cli", "ruby_cli", "thor", "optparse", "optionparser", "gli", "slop", "tty-option", "optimist", "clamp", "dry-cli"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2850,9 +2850,9 @@ module NoirTechs
       },
     },
     :python_cli => {
-      :framework => "CLI (argparse / click / typer / fire / docopt / getopt)",
+      :framework => "CLI (argparse / click / typer / fire / docopt / getopt / absl / cleo)",
       :language  => "Python",
-      :similar   => ["python-cli", "python_cli", "argparse", "click", "typer", "fire", "docopt"],
+      :similar   => ["python-cli", "python_cli", "argparse", "click", "typer", "fire", "docopt", "absl", "abseil", "cleo"],
       :supported => {
         :endpoint => true,
         # CLI endpoints carry the synthetic "CLI" verb, not an HTTP method,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -100,9 +100,9 @@ module NoirTechs
       },
     },
     :cpp_cli => {
-      :framework => "CLI (CLI11 / getopt / cxxopts / boost.program_options / gflags)",
+      :framework => "CLI (CLI11 / getopt / cxxopts / boost.program_options / gflags / Abseil Flags / argparse)",
       :language  => "C++",
-      :similar   => ["cpp-cli", "cpp_cli", "cli11", "getopt", "cxxopts", "program_options", "gflags"],
+      :similar   => ["cpp-cli", "cpp_cli", "cli11", "getopt", "cxxopts", "program_options", "gflags", "abseil", "absl-flags", "argparse"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -172,9 +172,9 @@ module NoirTechs
       },
     },
     :clojure_cli => {
-      :framework => "CLI (clojure.tools.cli / cli-matic)",
+      :framework => "CLI (clojure.tools.cli / cli-matic / environ / babashka.cli)",
       :language  => "Clojure",
-      :similar   => ["clojure-cli", "clojure_cli", "tools.cli", "cli-matic"],
+      :similar   => ["clojure-cli", "clojure_cli", "tools.cli", "cli-matic", "environ", "babashka-cli", "babashka.cli"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -784,9 +784,9 @@ module NoirTechs
       },
     },
     :perl_cli => {
-      :framework => "CLI (Getopt::Long / Getopt::Std / App::Cmd)",
+      :framework => "CLI (Getopt::Long / Getopt::Std / App::Cmd / Getopt::Long::Descriptive / MooX::Options)",
       :language  => "Perl",
-      :similar   => ["perl-cli", "perl_cli", "getopt::long", "getopt::std", "app::cmd"],
+      :similar   => ["perl-cli", "perl_cli", "getopt::long", "getopt::std", "app::cmd", "getopt::long::descriptive", "moox::options"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2187,9 +2187,9 @@ module NoirTechs
       },
     },
     :kotlin_cli => {
-      :framework => "CLI (clikt / kotlinx-cli)",
+      :framework => "CLI (clikt / kotlinx-cli / picocli)",
       :language  => "Kotlin",
-      :similar   => ["kotlin-cli", "kotlin_cli", "clikt", "kotlinx-cli"],
+      :similar   => ["kotlin-cli", "kotlin_cli", "clikt", "kotlinx-cli", "picocli"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -874,9 +874,9 @@ module NoirTechs
       },
     },
     :go_cli => {
-      :framework => "CLI (flag / cobra / urfave / pflag / go-arg / go-flags)",
+      :framework => "CLI (flag / cobra / urfave / pflag / go-arg / go-flags / kong / kingpin / mitchellh)",
       :language  => "Go",
-      :similar   => ["go-cli", "go_cli", "cobra", "urfave", "go-arg", "go-flags", "pflag"],
+      :similar   => ["go-cli", "go_cli", "cobra", "urfave", "go-arg", "go-flags", "pflag", "kong", "kingpin", "mitchellh-cli"],
       :supported => {
         :endpoint => true,
         # CLI endpoints carry the synthetic "CLI" verb, not an HTTP method,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -3555,9 +3555,9 @@ module NoirTechs
       },
     },
     :scala_cli => {
-      :framework => "CLI (scopt / decline / mainargs)",
+      :framework => "CLI (scopt / decline / mainargs / scallop / twitter-util)",
       :language  => "Scala",
-      :similar   => ["scala-cli", "scala_cli", "scopt", "decline", "mainargs"],
+      :similar   => ["scala-cli", "scala_cli", "scopt", "decline", "mainargs", "scallop", "twitter-util", "util-app"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1575,9 +1575,9 @@ module NoirTechs
       },
     },
     :lua_cli => {
-      :framework => "CLI (argparse)",
+      :framework => "CLI (argparse / lua_cliargs)",
       :language  => "Lua",
-      :similar   => ["lua-cli", "lua_cli", "argparse"],
+      :similar   => ["lua-cli", "lua_cli", "argparse", "cliargs", "lua_cliargs"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -1665,9 +1665,9 @@ module NoirTechs
       },
     },
     :js_cli => {
-      :framework => "CLI (parseArgs / commander / yargs / cac / meow / minimist)",
+      :framework => "CLI (parseArgs / commander / yargs / cac / meow / minimist / citty / arg / command-line-args / getopts)",
       :language  => "JavaScript",
-      :similar   => ["js-cli", "js_cli", "commander", "yargs", "cac", "meow", "minimist", "oclif", "clipanion", "sade"],
+      :similar   => ["js-cli", "js_cli", "commander", "yargs", "cac", "meow", "minimist", "oclif", "clipanion", "sade", "citty", "arg", "command-line-args", "getopts"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -424,9 +424,9 @@ module NoirTechs
       },
     },
     :cs_cli => {
-      :framework => "CLI (System.CommandLine / CommandLineParser / CliFx / Spectre.Console)",
+      :framework => "CLI (System.CommandLine / CommandLineParser / CliFx / Spectre.Console / McMaster / Cocona)",
       :language  => "C#",
-      :similar   => ["cs-cli", "cs_cli", "csharp-cli", "system.commandline", "commandlineparser", "clifx", "spectre.console"],
+      :similar   => ["cs-cli", "cs_cli", "csharp-cli", "system.commandline", "commandlineparser", "clifx", "spectre.console", "mcmaster", "commandlineutils", "cocona"],
       :supported => {
         :endpoint => true,
         :method   => false,

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -2079,9 +2079,9 @@ module NoirTechs
       },
     },
     :zig_cli => {
-      :framework => "CLI (zig-cli / zig-clap / std.process)",
+      :framework => "CLI (zig-cli / zig-clap / std.process / yazap / zig-args)",
       :language  => "Zig",
-      :similar   => ["zig-cli", "zig_cli", "clap", "zig-clap"],
+      :similar   => ["zig-cli", "zig_cli", "clap", "zig-clap", "yazap", "zig-args"],
       :supported => {
         :endpoint => true,
         :method   => false,


### PR DESCRIPTION
## Summary

Extends the CLI app endpoint detection from #2203 to cover **34 popular argument-parsing libraries that the original issue's per-language tables missed**, across **17 languages**. Each library becomes `cli://` endpoints (one per (sub)command) with `flag` / `argument` / `env` params, exactly like the existing `*_cli` analyzers.

This started as a research pass: for every already-covered language, we swept the ecosystem for widely-used CLI libraries **not** in #2203 (GitHub stars / registry downloads / notable adopters), then kept only the popular, cleanly-detectable ones.

## Libraries added

| Language | Added | How detected |
|---|---|---|
| **Go** | Kong · Kingpin · mitchellh/cli | struct tags / fluent builder / `CommandFactory` map |
| **PHP** | Laravel Artisan · WP-CLI · Robo | `$signature` grammar / `WP_CLI::add_command` / `@command` docblocks |
| **JavaScript/TS** | citty · command-line-args · arg · getopts | `defineCommand` / option-object arrays / spec object |
| **Ruby** | Optimist · Clamp · dry-cli | `opt :name` / `option "--flag"` / argument·option DSL |
| **C++** | Abseil Flags · p-ranav/argparse | `ABSL_FLAG(...)` / `.add_argument(...)` |
| **Scala** | Scallop · com.twitter.app | `opt[T]`/`trailArg` / `flag[T]("...")` |
| **C#** | McMaster.CommandLineUtils · Cocona | `[Option]`/`[Argument]`/`[Command]` attributes |
| **Groovy** | Apache Commons CLI · JCommander | `addOption`/`Option.builder` / `@Parameter` |
| **Python** | absl-py · Cleo | `flags.DEFINE_*` / class `name=` + `self.argument`/`self.option` |
| **Clojure** | environ · babashka/cli | gated `(env :key)` / `:spec`·`:cmds` maps |
| **Zig** | yazap · zig-args | `Arg.positional`/`…Option` / Options-struct fields |
| **Perl** | Getopt::Long::Descriptive · MooX::Options | `describe_options(...)` / `option '...'` DSL |
| **Java** | JOpt Simple | `parser.accepts("...")` |
| **Kotlin** | picocli | `@Command`/`@Option`/`@Parameters` |
| **Rust** | getopts | `opts.optopt`/`optflag`/`optmulti` |
| **Haskell** | turtle | `optText`/`switch`/`argText` |
| **Lua** | lua_cliargs | `cli:add_option`/`add_flag`/`add_argument` |

Each `*_cli` tech's `framework` label and `similar` aliases in `src/techs/techs.cr` were extended so `--only-techs <lib>` works for the new names. No new techs were added — every library folds into the existing `<lang>_cli` tech.

## Correctness / anti-false-positive

The dominant risk for CLI detection is false positives (a web app or ordinary library that merely reads an env var or has a `main()` must not emit `cli://` endpoints). Every addition went through an adversarial per-language review that specifically hunted for FP and mis-attribution bugs; the findings were fixed and **locked in with regression fixtures**. Representative hardening:

- **Import-gated markers**, never bare tokens (e.g. `getopts` / `environ` require a real import, not a substring match).
- **Receiver/scope-bound attribution** instead of a sticky "last-seen command" cursor (Go mitchellh, Zig yazap/zig-args, Java JOpt, Lua cliargs, Clojure babashka, Kotlin picocli, PHP Robo/WP-CLI, …), so a global option written after a subcommand isn't mis-attributed.
- **Per-library scoping** so one library's regex doesn't also match another's identical-looking syntax (e.g. Scallop vs scopt).
- **Bounded extraction** (`command-line-args` object bound to its call; C# multi-`[Option]`-per-line via `scan`; C# `[Argument(0, Description="…")]` no longer grabs the help text; Kotlin multi-line `@Command` + inline `@Option` property).
- Idiom coverage added where a naive matcher produced false negatives (Scala `object … extends Subcommand`, Groovy declare-then-register, wrapped Kotlin annotations).

## Testing

- Full suite green: **24,648 examples, 0 failures, 0 errors** (`crystal spec`).
- Each language ships positive fixtures for every new library **plus** FP/attribution regression fixtures that fail on the pre-fix analyzer and pass after.
- CLI endpoints stay excluded from HTTP delivers / OpenAPI / active probing (unchanged `non_http?` plumbing).

## Notes

- Commits are one work-unit per language, co-authored with @ksg97031.
- `just dsup` (supported-docs regeneration) is intentionally left out of this PR to avoid pulling in unrelated metadata drift, matching the earlier CLI PRs.

Part of #2203.
