### PR TITLE
perf(zig): collapse chained includes? detection gates into precompiled Regex.union

### DIFF
--- a/src/analyzer/analyzers/zig/http.cr
+++ b/src/analyzer/analyzers/zig/http.cr
@@ -19,6 +19,16 @@ module Analyzer::Zig
     TARGET_PRONG_RE    = /"((?:[^"\\]|\\.)*)"\s*=>/
     IF_RE              = /(?:^|[^A-Za-z0-9_])if\s*\(/
 
+    # Whole-file detection gate, evaluated once per `.zig` file. `String#matches?`
+    # (PCRE2 JIT) is faster than the naive `String#includes?` char scan, and
+    # `STD_IMPORT_RE` folds the two-way OR into a single scan. Each matcher is
+    # equivalent to the literal substring test it replaces.
+    STD_HTTP_SERVER_RE = /std\.http\.Server/
+    STD_IMPORT_RE      = Regex.union("@import(\"std\")", "std.http")
+    RECEIVE_HEAD_RE    = /\.receiveHead\(/
+    HEAD_TARGET_RE     = /\.head\.target/
+    RESPOND_RE         = /\.respond\(/
+
     alias IfBlock = NamedTuple(cond_start: Int32, cond_end: Int32, body_open: Int32, body_close: Int32)
     alias MethodContext = NamedTuple(method: String, body_open: Int32, body_close: Int32)
     alias RouteHit = NamedTuple(url: String, offset: Int32)
@@ -39,11 +49,11 @@ module Analyzer::Zig
     end
 
     private def std_http_server_file?(content : String) : Bool
-      return true if content.includes?("std.http.Server")
+      return true if content.matches?(STD_HTTP_SERVER_RE)
 
-      has_std = content.includes?("@import(\"std\")") || content.includes?("std.http")
-      has_server_flow = content.includes?(".receiveHead(") && content.includes?(".head.target")
-      has_response = content.includes?(".respond(")
+      has_std = content.matches?(STD_IMPORT_RE)
+      has_server_flow = content.matches?(RECEIVE_HEAD_RE) && content.matches?(HEAD_TARGET_RE)
+      has_response = content.matches?(RESPOND_RE)
 
       has_std && has_server_flow && has_response
     end

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -28,6 +28,10 @@ module Analyzer::Zig
     # is idiomatic. The `@"…"` alternative keeps that form from being dropped.
     ROUTE_RE  = /(\w+)\s*\.\s*(get|post|put|delete|head|patch|trace|options|connect|all)\s*\(\s*"(\/[^"]*)"\s*,\s*(@"[^"]*"|[A-Za-z_][\w.]*)/
     METHOD_RE = /(\w+)\s*\.\s*method\s*\(\s*"([^"]*)"\s*,\s*"(\/[^"]*)"\s*,\s*(@"[^"]*"|[A-Za-z_][\w.]*)/
+    # Cheap routing-signal gate: one precompiled `Regex.union` scan (PCRE2
+    # JIT) instead of two naive `String#includes?` char scans. Equivalent to
+    # `includes?("(\"/") || includes?(".group(")`.
+    ROUTE_SIGNAL_RE = Regex.union("(\"/", ".group(")
 
     def analyze
       include_callee = callees_needed?
@@ -43,7 +47,7 @@ module Analyzer::Zig
         # argument, or a `.group(` call) instead of the framework name so
         # those files are still scanned. The analyzer only runs at all when
         # the project is already detected as httpz.
-        next unless content.includes?("(\"/") || content.includes?(".group(")
+        next unless content.matches?(ROUTE_SIGNAL_RE)
         process_file(path, content, include_callee)
       end
 

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -61,6 +61,11 @@ module Analyzer::Zig
     ROUTE_CONST_RE  = /pub\s+const\s+@"(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+(\/[^"]*)"/
     STRUCT_DECL_RE  = /(?:^|[^A-Za-z0-9_.])(?:pub\s+)?const\s+([A-Za-z_]\w*)\s*=\s*struct\s*\{/
     IMPORT_RE       = /(?:pub\s+)?(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*@import\(\s*"([^"]+\.zig)"\s*\)/
+    # Cheap whole-file route gate. One precompiled `Regex.union` scan (PCRE2
+    # JIT) replaces five naive `String#includes?` char scans and rejects a
+    # non-route file in a single pass instead of running all five. Equivalent
+    # to the OR-of-substrings it replaces (union escapes each literal).
+    ROUTE_FILE_RE = Regex.union("tk.Route", ".group(", ".router(", "pub fn @\"", "pub const @\"")
 
     private record GroupFrame, prefix : String, close : Int32
     # A `.router(...)` mount targeting a controller file. `scope` is the struct
@@ -88,9 +93,7 @@ module Analyzer::Zig
     end
 
     private def route_file?(content : String) : Bool
-      content.includes?("tk.Route") || content.includes?(".group(") ||
-        content.includes?(".router(") || content.includes?("pub fn @\"") ||
-        content.includes?("pub const @\"")
+      content.matches?(ROUTE_FILE_RE)
     end
 
     # alias identifier => absolute file it `@import`s.

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -27,7 +27,11 @@ module Analyzer::Zig
     # reached through a namespace re-export (`Endpoints.UserWeb.init("/u")`),
     # and the meaningful key is the final segment (`UserWeb`), which is itself
     # preceded by a `.`.
-    INIT_RE         = /(?<![A-Za-z0-9_])([A-Za-z_]\w*)\.init\s*\(([^()]*)\)/
+    INIT_RE = /(?<![A-Za-z0-9_])([A-Za-z_]\w*)\.init\s*\(([^()]*)\)/
+    # Cheap path-binding gate: one precompiled `Regex.union` scan (PCRE2 JIT)
+    # in place of two naive `String#includes?` char scans. Equivalent to
+    # `includes?(".path") || includes?(".init(")`.
+    PATH_OR_INIT_RE = Regex.union(".path", ".init(")
     LITERAL_PATH_RE = /\.path\s*=\s*"([^"]*)"/
     HANDLE_FUNC_RE  = /\.\s*handle_func(_unbound)?\s*\(/
     IMPORT_RE       = /(?:pub\s+)?(?:const|var)\s+([A-Za-z_]\w*)\s*=\s*@import\(\s*"([^"]+\.zig)"\s*\)/
@@ -90,7 +94,7 @@ module Analyzer::Zig
           end
         end
 
-        next unless content.includes?(".path") || content.includes?(".init(")
+        next unless content.matches?(PATH_OR_INIT_RE)
 
         # Path literals/bindings inside `test { … }` blocks are unit-test
         # fixtures (the zap framework's own `test_auth.zig` binds `.path =


### PR DESCRIPTION
## Summary

First PR of a systematic, **detection-neutral** performance sweep across every source-code framework analyzer. This one covers the **zig** group. The pattern here: standalone whole-file detection gates that OR-ed several naive `String#includes?` char scans are replaced with a **precompiled `Regex.union` constant** matched via `String#matches?` (PCRE2 JIT). One JIT scan replaces up to five naive char scans and rejects non-matching files in a single pass; `Regex.union` auto-escapes each literal, so the result is provably equivalent to the OR-of-substrings it replaces.

## Per-analyzer audit

| analyzer | finding | change |
|---|---|---|
| `zig/tokamak.cr` | `route_file?` OR-ed 5 `includes?` per file | → `ROUTE_FILE_RE` union + `matches?` |
| `zig/http.cr` | `std_http_server_file?` used 6 `includes?` per file | → precompiled signal consts + `matches?`, 2-way OR folded into `STD_IMPORT_RE` union |
| `zig/zap.cr` | path-binding gate OR-ed 2 `includes?` | → `PATH_OR_INIT_RE` union + `matches?` |
| `zig/httpz.cr` | routing-signal gate OR-ed 2 `includes?` | → `ROUTE_SIGNAL_RE` union + `matches?` |
| `zig/jetzig.cr` | only single-`includes?` gates (sanctioned cheap pre-gate), cache-first reads | verified already-optimal, no change |
| `zig/cli.cr` | already uses precompiled `matches?` consts + cache-first reads | verified already-optimal, no change |

## Test plan

- Detection-neutral: `crystal spec spec/functional_test/testers/zig/` → **288 examples, 0 failures** (byte-identical endpoints on all zig fixtures).
- Full suite: `just test` → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` on touched files → 4 inspected, 0 failures; `typos` clean.

Co-authored-by: ksg97031 <ksg97031@gmail.com>