### PR TITLE
perf(crystal): cache-first reads, hoist per-file interpolated regexes, union static gate

### DIFF
--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -261,23 +261,33 @@ module Analyzer::Crystal
       # Process other public folders
       @public_folders.each do |base, folder|
         next if @static_disabled_bases.includes?(base)
+
+        # `folder` is fixed for this outer iteration, but the interpolated
+        # regex below used to be rebuilt (a full PCRE2 JIT compile) on every
+        # file the folder contains. Precompute it once per folder instead of
+        # once per file, and escape the discovered name since it comes from
+        # arbitrary source text and may contain regex metacharacters.
+        nested_folder = folder.includes?("/")
+        folder_path = nested_folder ? (folder.ends_with?("/") ? folder : "#{folder}/") : ""
+        folder_re = if nested_folder
+                      /\/#{Regex.escape(folder.split("/").last)}\/(.*)/
+                    else
+                      /\/#{Regex.escape(folder)}\/(.*)/
+                    end
+
         get_public_dir_files(base, folder).each do |file|
           # Extract relative path from the custom folder
-          if folder.includes?("/")
+          if nested_folder
             # For absolute paths or paths with directories
-            folder_path = folder.ends_with?("/") ? folder : "#{folder}/"
             if file.starts_with?(folder_path)
               relative_path = file.sub(folder_path, "")
               @result << Endpoint.new("/#{relative_path}", "GET")
-            else
+            elsif file =~ folder_re
               # Try to find the folder component in the path
-              folder_name = folder.split("/").last
-              if file =~ /\/#{folder_name}\/(.*)/
-                relative_path = $1
-                @result << Endpoint.new("/#{relative_path}", "GET")
-              end
+              relative_path = $1
+              @result << Endpoint.new("/#{relative_path}", "GET")
             end
-          elsif file =~ /\/#{folder}\/(.*)/
+          elsif file =~ folder_re
             # For simple folder names (no slashes)
             relative_path = $1
             @result << Endpoint.new("/#{relative_path}", "GET")

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -9,6 +9,11 @@ module Analyzer::Crystal
     NAMESPACE_PATTERN = /^(\s*)namespace\s+["']([^"']*)["']\s+do\b/
     # `resources "/posts", PostController[, only: …][, except: …]`.
     RESOURCES_PATTERN = /^\s*resources\s+["']([^"']+)["']\s*,\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\s*(.*)$/
+    # `serve_static false` / `serve_static(false)` — checked on every source
+    # line, so the two fixed OR-ed `String#includes?` substring scans are
+    # precompiled into a single regex union (one PCRE2 JIT scan per line
+    # instead of two naive substring scans).
+    SERVE_STATIC_DISABLED_RE = Regex.union("serve_static false", "serve_static(false)")
 
     # Amber's `resources` macro expands to the seven RESTful routes below
     # (update is registered for both PUT and PATCH). `resource` (singular)
@@ -105,7 +110,7 @@ module Analyzer::Crystal
           end
         end
 
-        if line.includes?("serve_static false") || line.includes?("serve_static(false)")
+        if line.matches?(SERVE_STATIC_DISABLED_RE)
           @static_disabled_bases << file_base
         end
 

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -41,15 +41,9 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = [] of String
       file_base = configured_base_for(path)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line do |line|
-          lines << line
-        end
-      end
-      lines = mask_crystal_heredocs(lines)
+      lines = mask_crystal_heredocs(read_file_content(path).lines)
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -11,14 +11,8 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = [] of String
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line do |line|
-          lines << line
-        end
-      end
-      lines = mask_crystal_heredocs(lines)
+      lines = mask_crystal_heredocs(read_file_content(path).lines)
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new

--- a/src/analyzer/analyzers/crystal/http.cr
+++ b/src/analyzer/analyzers/crystal/http.cr
@@ -11,14 +11,8 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = [] of String
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line do |line|
-          lines << line
-        end
-      end
-      lines = mask_crystal_heredocs(lines)
+      lines = mask_crystal_heredocs(read_file_content(path).lines)
 
       last_endpoint : Endpoint? = nil
 

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -11,6 +11,11 @@ module Analyzer::Crystal
     # `get "/…", {{namespace}}::Videos, :videos` — substituting it back lets
     # those routes resolve their controller and carry callees.
     MACRO_VAR_PATTERN = /\{\{\s*(\w+)\s*=\s*([A-Za-z_][\w:]*)\s*\}\}/
+    # `serve_static false` / `serve_static(false)` — checked on every source
+    # line, so the two fixed OR-ed `String#includes?` substring scans are
+    # precompiled into a single regex union (one PCRE2 JIT scan per line
+    # instead of two naive substring scans).
+    SERVE_STATIC_DISABLED_RE = Regex.union("serve_static false", "serve_static(false)")
 
     @static_disabled_bases : Set(String) = Set(String).new
     @public_folders : Array(Tuple(String, String)) = [] of Tuple(String, String)
@@ -60,7 +65,7 @@ module Analyzer::Crystal
 
       lines.each_with_index do |line, index|
         # Collect public folder / serve_static info (used by post-pass)
-        if line.includes?("serve_static false") || line.includes?("serve_static(false)")
+        if line.matches?(SERVE_STATIC_DISABLED_RE)
           @static_disabled_bases << file_base
         end
 

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -192,20 +192,30 @@ module Analyzer::Crystal
 
       @public_folders.each do |base, folder|
         next if @static_disabled_bases.includes?(base)
+
+        # `folder` is fixed for this outer iteration, but the interpolated
+        # regex below used to be rebuilt (a full PCRE2 JIT compile) on every
+        # file the folder contains. Precompute it once per folder instead of
+        # once per file, and escape the discovered name since it comes from
+        # arbitrary source text and may contain regex metacharacters.
+        nested_folder = folder.includes?("/")
+        folder_path = nested_folder ? (folder.ends_with?("/") ? folder : "#{folder}/") : ""
+        folder_re = if nested_folder
+                      /\/#{Regex.escape(folder.split("/").last)}\/(.*)/
+                    else
+                      /\/#{Regex.escape(folder)}\/(.*)/
+                    end
+
         get_public_dir_files(base, folder).each do |file|
-          if folder.includes?("/")
-            folder_path = folder.ends_with?("/") ? folder : "#{folder}/"
+          if nested_folder
             if file.starts_with?(folder_path)
               relative_path = file.sub(folder_path, "")
               @result << Endpoint.new("/#{relative_path}", "GET")
-            else
-              folder_name = folder.split("/").last
-              if file =~ /\/#{folder_name}\/(.*)/
-                relative_path = $1
-                @result << Endpoint.new("/#{relative_path}", "GET")
-              end
+            elsif file =~ folder_re
+              relative_path = $1
+              @result << Endpoint.new("/#{relative_path}", "GET")
             end
-          elsif file =~ /\/#{folder}\/(.*)/
+          elsif file =~ folder_re
             relative_path = $1
             @result << Endpoint.new("/#{relative_path}", "GET")
           end

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -9,14 +9,8 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = [] of String
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line do |line|
-          lines << line
-        end
-      end
-      lines = mask_crystal_heredocs(lines)
+      lines = mask_crystal_heredocs(read_file_content(path).lines)
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       last_endpoint = Endpoint.new("", "")


### PR DESCRIPTION
## Summary

Detection-neutral performance sweep of the **crystal** framework analyzers (part of a per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `amber.cr` / `kemal.cr` | A | Hoist the interpolated public-folder regex `/\/#{folder}\/(.*)/` out of the per-file loop (was a full PCRE2 recompile per file; ~58× measured) and add `Regex.escape` on the discovered folder name |
| `amber.cr` / `kemal.cr` | B | Fold the `serve_static false`/`serve_static(false)` two-way `includes?` gate into one `Regex.union` const + `matches?` |
| `http.cr` / `grip.cr` / `lucky.cr` / `amber.cr` | C | Cache-first `read_file_content` instead of direct `File.open(...).each_line` (strict superset, byte-identical) |
| `cli.cr` / `marten.cr` | D | Verified already-optimal, no change |

`kemal.cr`'s `File.read_lines` (no encoding arg) was intentionally **left as-is** — swapping to `read_file_content` would change invalid-UTF-8 handling, so it's not detection-neutral (flagged for a separate look).

## Test plan
- `crystal spec spec/functional_test/testers/crystal/` + crystal unit specs → **516 examples, 0 failures** (byte-identical detection).
- Combined with the scala sweep: full `just test` → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 7 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>