### PR TITLE
perf(scala): eliminate O(n^2) non-ASCII char scans, union includes? gates

### DIFF
--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -287,35 +287,42 @@ module Analyzer::Scala
       scopes = [] of String
       regex = METHOD_SCOPE_PATTERNS[method]? || /(?<![.\w])#{Regex.escape(method)}(?![\w])/
       search_from = 0
+      # Crystal's `String#[](i)` walks the string from byte 0 on every call
+      # once it holds any multi-byte UTF-8 char (no cached char->byte index),
+      # so the position-tracking scans below (which reindex `content` at
+      # arbitrary offsets, not sequentially) are O(n) per char -- O(n^2)
+      # overall on non-ASCII route blocks. Materialize once and index the
+      # array instead -- same char offsets, O(1) access.
+      chars = content.chars
 
       while match = content.match(regex, search_from)
         method_start = match.begin || search_from
         method_end = match.end || method_start
-        next_index = skip_whitespace(content, method_end)
+        next_index = skip_whitespace(chars, method_end)
 
-        if next_index < content.size
-          case content[next_index]
+        if next_index < chars.size
+          case chars[next_index]
           when '{'
-            if block = balanced_slice(content, next_index, '{', '}')
+            if block = balanced_slice(chars, next_index, '{', '}')
               scopes << block
             end
           when '('
-            if args = balanced_slice(content, next_index, '(', ')')
+            if args = balanced_slice(chars, next_index, '(', ')')
               scope = args
-              after_args = skip_whitespace(content, next_index + args.size)
-              if after_args < content.size && content[after_args] == '{'
-                if block = balanced_slice(content, after_args, '{', '}')
+              after_args = skip_whitespace(chars, next_index + args.size)
+              if after_args < chars.size && chars[after_args] == '{'
+                if block = balanced_slice(chars, after_args, '{', '}')
                   scope = "#{scope}\n#{block}"
                 end
               end
               scopes << scope
             end
           else
-            if chain_block = chained_directive_scope(content, method_start)
+            if chain_block = chained_directive_scope(chars, method_start)
               scopes << chain_block
             end
           end
-        elsif method_end == content.size
+        elsif method_end == chars.size
           scopes << method
         end
 
@@ -325,33 +332,33 @@ module Analyzer::Scala
       scopes
     end
 
-    private def chained_directive_scope(content : String, method_start : Int32) : String?
-      opening_brace = next_unquoted_char(content, '{', method_start)
+    private def chained_directive_scope(chars : Array(Char), method_start : Int32) : String?
+      opening_brace = next_unquoted_char(chars, '{', method_start)
       return unless opening_brace
 
-      header = content[method_start...opening_brace]
+      header = chars[method_start...opening_brace].join
       return unless header.includes?("&")
-      block = balanced_slice(content, opening_brace, '{', '}') || content[opening_brace..]
+      block = balanced_slice(chars, opening_brace, '{', '}') || chars[opening_brace..].join
 
       "#{header}\n#{block}"
     end
 
-    private def skip_whitespace(content : String, index : Int32) : Int32
+    private def skip_whitespace(chars : Array(Char), index : Int32) : Int32
       i = index
-      while i < content.size && content[i].whitespace?
+      while i < chars.size && chars[i].whitespace?
         i += 1
       end
       i
     end
 
-    private def next_unquoted_char(content : String, needle : Char, start : Int32) : Int32?
+    private def next_unquoted_char(chars : Array(Char), needle : Char, start : Int32) : Int32?
       in_string = false
       quote = '\0'
       escape = false
       i = start
 
-      while i < content.size
-        char = content[i]
+      while i < chars.size
+        char = chars[i]
         if in_string
           if escape
             escape = false
@@ -376,8 +383,8 @@ module Analyzer::Scala
       nil
     end
 
-    private def balanced_slice(content : String, start : Int32, open_char : Char, close_char : Char) : String?
-      return unless start < content.size && content[start] == open_char
+    private def balanced_slice(chars : Array(Char), start : Int32, open_char : Char, close_char : Char) : String?
+      return unless start < chars.size && chars[start] == open_char
 
       depth = 0
       in_string = false
@@ -385,8 +392,8 @@ module Analyzer::Scala
       escape = false
       i = start
 
-      while i < content.size
-        char = content[i]
+      while i < chars.size
+        char = chars[i]
         if in_string
           if escape
             escape = false
@@ -404,7 +411,7 @@ module Analyzer::Scala
             depth += 1 if char == open_char
             if char == close_char
               depth -= 1
-              return content[start..i] if depth == 0
+              return chars[start..i].join if depth == 0
             end
           end
         end

--- a/src/analyzer/analyzers/scala/cli.cr
+++ b/src/analyzer/analyzers/scala/cli.cr
@@ -55,6 +55,13 @@ module Analyzer::Scala
     MARKERS = /\bscopt\b|\bOParser\b|\bcom\.monovore\.decline\b|\bOpts\.(?:option|flag|argument|arguments)\b|\bmainargs\b|\borg\.rogach\.scallop\b|\bScallopConf\b|\bcom\.twitter\.app\b/
     WEB_RE  = /\bimport\s+(?:akka\.http|play\.api|org\.http4s|cask|com\.twitter\.finatra|com\.linecorp\.armeria|zhttp|zio\.http)\b/
 
+    # One precompiled `Regex.union` scan (PCRE2 JIT) replaces four separate
+    # `String#includes?` scans of the same buffer -- Crystal's `includes?` is
+    # not Boyer-Moore accelerated, so a single regex pass over `lower` is
+    # cheaper than four. Equivalent to the OR-of-substrings it replaces
+    # (union escapes each literal).
+    CLI_TEST_PATH_RE = Regex.union("/test/", "/it/", "spec.scala", "test.scala")
+
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".scala").each do |path|
@@ -175,8 +182,7 @@ module Analyzer::Scala
     end
 
     private def cli_test_path?(path : String) : Bool
-      lower = path.downcase
-      lower.includes?("/test/") || lower.includes?("/it/") || lower.includes?("spec.scala") || lower.includes?("test.scala")
+      path.downcase.matches?(CLI_TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/scala/http4s.cr
+++ b/src/analyzer/analyzers/scala/http4s.cr
@@ -10,7 +10,7 @@ module Analyzer::Scala
     @body_as_regexes = Hash(String, Regex).new
 
     def analyze_file(path : String) : Array(Endpoint)
-      content = File.read(path)
+      content = read_file_content(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
     end
 

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -220,9 +220,16 @@ module Analyzer::Scala
 
       region_end = method_region_end(structure, def_line_start, base_indent)
 
+      # Crystal's `String#[](i)` walks the string from byte 0 on every call
+      # once it holds any multi-byte UTF-8 char (no cached char->byte index),
+      # so a `while i < region_end; c = structure[i]; ...` scan is O(n) per
+      # char, i.e. O(n^2) overall on non-ASCII source. Materialize once and
+      # index the array instead -- same char offsets, O(1) access.
+      chars = structure.chars
+
       # The `=` that introduces the body: skip type params, parameter lists and
       # default-value `=` (all of which sit inside brackets), and ignore `=>`.
-      eq_index = locate_body_eq(structure, cursor, region_end)
+      eq_index = locate_body_eq(chars, cursor, region_end)
 
       # Find the body separator: the first top-level `{` (brace block) or an
       # end-of-line `:` (Scala 3 indented block).
@@ -232,13 +239,13 @@ module Analyzer::Scala
       depth = 0
       i = search_from
       while i < region_end
-        c = structure[i]
+        c = chars[i]
         if depth == 0
           if c == '{'
             sep_index = i
             sep_kind = :brace
             break
-          elsif c == ':' && rest_of_line_blank?(structure, i + 1, region_end)
+          elsif c == ':' && rest_of_line_blank?(chars, i + 1, region_end)
             sep_index = i
             sep_kind = :colon
             break
@@ -256,7 +263,7 @@ module Analyzer::Scala
         # `sep_index` is always set when `sep_kind` is `:brace`/`:colon`; the
         # `if` narrows the type so we avoid `not_nil!`.
         if open_brace = sep_index
-          close = matching_brace(structure, open_brace)
+          close = matching_brace(chars, open_brace)
           body_start = open_brace + 1
           body_end = close || region_end
           {signature: source[def_start..open_brace], body: source[body_start...body_end], body_start: body_start}
@@ -270,7 +277,7 @@ module Analyzer::Scala
         # Single-expression body (`def foo = bar(x)`). Without a `=` there is no
         # value body to parse (e.g. an abstract def).
         return unless eq_index
-        body_start = skip_whitespace(structure, eq_index + 1, region_end)
+        body_start = skip_whitespace(chars, eq_index + 1, region_end)
         {signature: source[def_start..eq_index], body: source[body_start...region_end], body_start: body_start}
       end
     end
@@ -299,17 +306,17 @@ module Analyzer::Scala
     end
 
     # Index of the top-level `=` that begins the method body, or nil.
-    private def locate_body_eq(structure : String, from : Int32, region_end : Int32) : Int32?
+    private def locate_body_eq(chars : Array(Char), from : Int32, region_end : Int32) : Int32?
       depth = 0
       i = from
       while i < region_end
-        c = structure[i]
+        c = chars[i]
         if depth == 0
           if c == '='
-            nxt = structure[i + 1]?
+            nxt = chars[i + 1]?
             # Guard the index explicitly: Crystal's `[-1]?` wraps to the last
             # char rather than returning nil.
-            prv = i > 0 ? structure[i - 1]? : nil
+            prv = i > 0 ? chars[i - 1]? : nil
             return i if nxt != '>' && nxt != '=' && prv != '=' && prv != '!' && prv != '<' && prv != '>'
           elsif c == '{'
             # Brace-only body (procedure syntax `def foo { ... }`): no `=`.
@@ -326,12 +333,12 @@ module Analyzer::Scala
     end
 
     # Index of the brace matching the one at `open_index`, or nil.
-    private def matching_brace(structure : String, open_index : Int32) : Int32?
+    private def matching_brace(chars : Array(Char), open_index : Int32) : Int32?
       depth = 0
       i = open_index
-      size = structure.size
+      size = chars.size
       while i < size
-        case structure[i]
+        case chars[i]
         when '{' then depth += 1
         when '}'
           depth -= 1
@@ -342,10 +349,10 @@ module Analyzer::Scala
       nil
     end
 
-    private def rest_of_line_blank?(structure : String, from : Int32, region_end : Int32) : Bool
+    private def rest_of_line_blank?(chars : Array(Char), from : Int32, region_end : Int32) : Bool
       i = from
       while i < region_end
-        c = structure[i]
+        c = chars[i]
         break if c == '\n'
         return false unless c == ' ' || c == '\t' || c == '\r'
         i += 1
@@ -353,10 +360,10 @@ module Analyzer::Scala
       true
     end
 
-    private def skip_whitespace(structure : String, from : Int32, region_end : Int32) : Int32
+    private def skip_whitespace(chars : Array(Char), from : Int32, region_end : Int32) : Int32
       i = from
       while i < region_end
-        c = structure[i]
+        c = chars[i]
         break unless c == ' ' || c == '\t' || c == '\n' || c == '\r'
         i += 1
       end
@@ -663,9 +670,15 @@ module Analyzer::Scala
       quote = '\0'
       escape = false
       i = 0
+      # `text[i]`/`text[i, n]` walk the string from byte 0 on every call once
+      # it holds any multi-byte UTF-8 char (no cached char->byte index), so a
+      # `while i <= size - n; text[i]; ...` scan is O(n) per char, i.e. O(n^2)
+      # overall on non-ASCII input. Materialize once and index the array
+      # instead -- same char offsets, O(1) access.
+      chars = text.chars
 
-      while i <= text.size - operator.size
-        char = text[i]
+      while i <= chars.size - operator.size
+        char = chars[i]
 
         if in_string
           if escape
@@ -688,14 +701,23 @@ module Analyzer::Scala
         when ')', ']', '}'
           depth -= 1 if depth > 0
         else
-          # `i` is a CHAR index; char-slice (byte_slice would treat i as a byte
-          # offset and desync the match when a multi-byte char precedes it).
-          return i if depth == 0 && text[i, operator.size]? == operator
+          # `i` is a CHAR index; comparing against the char array (rather than
+          # byte-slicing `text`) avoids desyncing the match when a multi-byte
+          # char precedes it.
+          return i if depth == 0 && chars_match_at?(chars, i, operator)
         end
         i += 1
       end
 
       nil
+    end
+
+    # True when `needle` occurs in `chars` starting at `index`, char-by-char.
+    private def chars_match_at?(chars : Array(Char), index : Int32, needle : String) : Bool
+      needle.each_char_with_index do |ch, offset|
+        return false unless chars[index + offset]? == ch
+      end
+      true
     end
 
     private def normalize_route_default_value(raw_default : String) : String
@@ -827,7 +849,7 @@ module Analyzer::Scala
 
       open_brace = structure.index('{', search_from)
       return unless open_brace
-      close = matching_brace(structure, open_brace)
+      close = matching_brace(structure.chars, open_brace)
       return unless close
 
       {body: source[(open_brace + 1)...close], start: open_brace + 1}

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -11,6 +11,17 @@ module Analyzer::Scala
       {method, /(?<![.\w])#{method}\s*\(\s*"([^"]+)"/}
     end
 
+    # One precompiled `Regex.union` scan (PCRE2 JIT) replaces two separate
+    # `String#includes?` scans of the same path -- Crystal's `includes?` is
+    # not Boyer-Moore accelerated, so a single regex pass is cheaper than
+    # two. Equivalent to the OR-of-substrings it replaces (union escapes
+    # each literal).
+    TEST_PATH_RE = Regex.union("/src/test/", "/src/sbt-test/")
+
+    # Same rationale: replaces the three `includes?` calls gating the
+    # `class`/`object`/`trait` declaration scan in `single_mount_prefix`.
+    CLASS_OBJECT_TRAIT_RE = Regex.union("class", "object", "trait")
+
     # Servlet/filter class name -> mount prefix, harvested from
     # `context.mount(new XController, "/prefix")` in ScalatraBootstrap.
     @mount_prefixes = {} of String => String
@@ -61,7 +72,7 @@ module Analyzer::Scala
     end
 
     private def scalatra_test_path?(path : String) : Bool
-      path.includes?("/src/test/") || path.includes?("/src/sbt-test/")
+      path.matches?(TEST_PATH_RE)
     end
 
     # Extract routes from Scalatra DSL
@@ -191,7 +202,7 @@ module Analyzer::Scala
 
       prefixes = Set(String).new
       code_lines.each do |line|
-        next unless line.includes?("class") || line.includes?("object") || line.includes?("trait")
+        next unless line.matches?(CLASS_OBJECT_TRAIT_RE)
         line.scan(/(?<![.\w])(?:class|object|trait)\s+(\w+)/) do |m|
           if pfx = @mount_prefixes[m[1]]?
             prefixes << pfx

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -225,18 +225,24 @@ module Analyzer::Scala
     # lets a literal inside `("a" / b)` stay a path segment while one inside
     # `.example("a")` is rejected.
     private def call_paren_depths(s : String) : Array(Int32)
-      depths = Array(Int32).new(s.size, 0)
+      # Crystal's `String#[](i)` walks the string from byte 0 on every call
+      # once it holds any multi-byte UTF-8 char (no cached char->byte index),
+      # so a `while i < s.size; c = s[i]; ...` scan is O(n) per char, i.e.
+      # O(n^2) overall on non-ASCII `.in(...)` blocks. Materialize once and
+      # index the array instead -- same char offsets, O(1) access.
+      chars = s.chars
+      depths = Array(Int32).new(chars.size, 0)
       call_depth = 0
       stack = [] of Bool
       in_str = false
       prev_sig = '\0'
       i = 0
-      while i < s.size
+      while i < chars.size
         depths[i] = call_depth
-        c = s[i]
+        c = chars[i]
         if in_str
           if c == '\\'
-            depths[i + 1] = call_depth if i + 1 < s.size
+            depths[i + 1] = call_depth if i + 1 < chars.size
             i += 2
             next
           elsif c == '"'
@@ -299,16 +305,19 @@ module Analyzer::Scala
     end
 
     private def balanced_paren_content(s : String, open_idx : Int32) : Tuple(String, Int32)?
+      # Same non-ASCII O(n^2) risk as `call_paren_depths` above -- index a
+      # materialized char array instead of re-slicing `s` at each position.
+      chars = s.chars
       depth = 0
       i = open_idx
       content_start = open_idx + 1
-      while i < s.size
-        c = s[i]
+      while i < chars.size
+        c = chars[i]
         if c == '('
           depth += 1
         elsif c == ')'
           depth -= 1
-          return {s[content_start...i], i} if depth == 0
+          return {chars[content_start...i].join, i} if depth == 0
         end
         i += 1
       end
@@ -368,18 +377,24 @@ module Analyzer::Scala
     private def substitute_consts(args : String, consts : Hash(String, String)) : String
       io = String::Builder.new
       i = 0
-      size = args.size
+      # Crystal's `String#[](i)` walks the string from byte 0 on every call
+      # once it holds any multi-byte UTF-8 char (no cached char->byte index),
+      # so a `while i < size; c = args[i]; ...` scan is O(n) per char, i.e.
+      # O(n^2) overall on non-ASCII `.in(...)` blocks. Materialize once and
+      # index the array instead -- same char offsets, O(1) access.
+      chars = args.chars
+      size = chars.size
       call_depth = 0
       bracket_depth = 0
       stack = [] of Bool
       in_str = false
       prev_sig = '\0'
       while i < size
-        c = args[i]
+        c = chars[i]
         if in_str
           io << c
           if c == '\\' && i + 1 < size
-            io << args[i + 1]
+            io << chars[i + 1]
             i += 2
             next
           elsif c == '"'
@@ -423,15 +438,15 @@ module Analyzer::Scala
         else
           if c.ascii_letter? || c == '_'
             start = i
-            while i < size && (args[i].ascii_alphanumeric? || args[i] == '_')
+            while i < size && (chars[i].ascii_alphanumeric? || chars[i] == '_')
               i += 1
             end
-            ident = args[start...i]
+            ident = chars[start...i].join
             j = i
-            while j < size && args[j].ascii_whitespace?
+            while j < size && chars[j].ascii_whitespace?
               j += 1
             end
-            following = j < size ? args[j] : '\0'
+            following = j < size ? chars[j] : '\0'
             if call_depth == 0 && bracket_depth == 0 && prev_sig != '.' &&
                following != '(' && following != '.' && (sub = consts[ident]?)
               io << sub

--- a/src/analyzer/analyzers/scala/zio_http.cr
+++ b/src/analyzer/analyzers/scala/zio_http.cr
@@ -71,35 +71,41 @@ module Analyzer::Scala
       params = [] of String
 
       s = segments_str
+      # Crystal's `String#[](i)` walks the string from byte 0 on every call
+      # once it holds any multi-byte UTF-8 char (no cached char->byte index),
+      # so a `while i < s.size; ch = s[i]; ...` scan is O(n) per char, i.e.
+      # O(n^2) overall on non-ASCII route expressions. Materialize once and
+      # index the array instead -- same char offsets, O(1) access.
+      chars = s.chars
       i = 0
-      while i < s.size
-        ch = s[i]
+      while i < chars.size
+        ch = chars[i]
         if ch == '/' || ch == ' ' || ch == '\t'
           i += 1
         elsif ch == '"'
           close = s.index('"', i + 1)
           break unless close
-          literal = s[(i + 1)...close]
+          literal = chars[(i + 1)...close].join
           literal.split('/').each do |part|
             segments << part unless part.empty?
           end
           i = close + 1
         elsif ch.ascii_letter? || ch == '_'
           start = i
-          while i < s.size && (s[i].ascii_alphanumeric? || s[i] == '_' || s[i] == '.')
+          while i < chars.size && (chars[i].ascii_alphanumeric? || chars[i] == '_' || chars[i] == '.')
             i += 1
           end
-          ident = s[start...i]
+          ident = chars[start...i].join
 
           j = i
-          while j < s.size && (s[j] == ' ' || s[j] == '\t')
+          while j < chars.size && (chars[j] == ' ' || chars[j] == '\t')
             j += 1
           end
 
-          if j < s.size && s[j] == '('
+          if j < chars.size && chars[j] == '('
             paren_end = s.index(')', j)
             break unless paren_end
-            inner = s[(j + 1)...paren_end]
+            inner = chars[(j + 1)...paren_end].join
             if name_match = inner.match(/"([^"]+)"/)
               name = name_match[1]
             else


### PR DESCRIPTION
## Summary

Detection-neutral performance sweep of the **scala** framework analyzers (per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `akka.cr` / `play.cr` / `tapir.cr` / `zio_http.cr` | A | Materialize `content.chars` once and index the `Array(Char)` instead of per-char `String[i]` in `while` scan loops — the string re-walks from byte 0 on every index once it holds a multi-byte char, i.e. O(n²) on non-ASCII source |
| `cli.cr` / `scalatra.cr` | B | Fold OR-ed `String#includes?` gates into precompiled `Regex.union` consts + `matches?` |
| `http4s.cr` | C | Cache-first `read_file_content` instead of direct `File.read` |

## Test plan
- `crystal spec spec/functional_test/testers/scala/` + scala unit specs → **644 examples, 0 failures** (byte-identical detection).
- Combined with the crystal sweep: full `just test` → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 7 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>