### PR TITLE
perf(dart): eliminate O(n^2) non-ASCII char scans, union includes? gates

### DIFF
--- a/src/analyzer/analyzers/dart/alfred.cr
+++ b/src/analyzer/analyzers/dart/alfred.cr
@@ -228,31 +228,35 @@ module Analyzer::Dart
       stmt_end = find_statement_end(cleaned, start)
       prefix = base_prefix
       i = start
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = cleaned.chars
 
       while i < stmt_end
-        while i < stmt_end && cleaned[i].whitespace?
+        while i < stmt_end && chars[i].whitespace?
           i += 1
         end
-        break unless i < stmt_end && cleaned[i] == '.'
+        break unless i < stmt_end && chars[i] == '.'
         i += 1
         cascade = false
-        if i < stmt_end && cleaned[i] == '.'
+        if i < stmt_end && chars[i] == '.'
           cascade = true
           i += 1
         end
-        while i < stmt_end && cleaned[i].whitespace?
+        while i < stmt_end && chars[i].whitespace?
           i += 1
         end
 
         name_start = i
-        while i < stmt_end && (cleaned[i].alphanumeric? || cleaned[i] == '_')
+        while i < stmt_end && (chars[i].alphanumeric? || chars[i] == '_')
           i += 1
         end
-        name = cleaned[name_start...i]
-        while i < stmt_end && cleaned[i].whitespace?
+        name = chars[name_start...i].join
+        while i < stmt_end && chars[i].whitespace?
           i += 1
         end
-        break unless i < stmt_end && cleaned[i] == '('
+        break unless i < stmt_end && chars[i] == '('
 
         open_paren = i
         close_paren = find_matching_paren(cleaned, open_paren)
@@ -387,15 +391,19 @@ module Analyzer::Dart
     # offset stays in CHAR space (consistent with `line_for_offset` and the
     # `char_index_to_byte_index` conversions used for callee extraction).
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = text.chars
       depth = 0
       i = open_idx
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -426,15 +434,16 @@ module Analyzer::Dart
     # the first `;` at bracket depth zero (or end of source). Used to bound
     # a `route()` cascade/chain walk so it can't run into the next statement.
     private def find_statement_end(text : String, start : Int32) : Int32
+      chars = text.chars
       depth = 0
       i = start
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -458,22 +467,23 @@ module Analyzer::Dart
         end
         i += 1
       end
-      text.size
+      chars.size
     end
 
     # Char index of the first comma at paren/brace/bracket depth zero
     # between `start` and `limit`, or nil when the call has a single
     # argument.
     private def first_top_level_comma(text : String, start : Int32, limit : Int32) : Int32?
+      chars = text.chars
       depth = 0
       i = start
       in_string = false
       string_quote = '\0'
 
       while i < limit
-        c = text[i]
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -503,6 +513,7 @@ module Analyzer::Dart
 
     private def split_top_level_args(text : String) : Array(String)
       result = [] of String
+      chars = text.chars
       depth_paren = 0
       depth_brace = 0
       depth_bracket = 0
@@ -512,10 +523,10 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -546,7 +557,7 @@ module Analyzer::Dart
           depth_angle -= 1 if depth_angle > 0
         when ','
           if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << text[start...i]
+            result << chars[start...i].join
             start = i + 1
           end
         else
@@ -554,7 +565,7 @@ module Analyzer::Dart
         end
         i += 1
       end
-      result << text[start..] if start <= text.size
+      result << chars[start..].join if start <= chars.size
       result
     end
 
@@ -563,8 +574,11 @@ module Analyzer::Dart
       limit = offset > content.size ? content.size : offset
       count = 1
       i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
+      # `each_char` walks the UTF-8 buffer once with a reader instead of
+      # re-scanning from byte 0 on every indexed `content[i]` access.
+      content.each_char do |c|
+        break if i >= limit
+        count += 1 if c == '\n'
         i += 1
       end
       count

--- a/src/analyzer/analyzers/dart/angel3.cr
+++ b/src/analyzer/analyzers/dart/angel3.cr
@@ -330,15 +330,19 @@ module Analyzer::Dart
     # ---------- source-string utilities ----------
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = text.chars
       depth = 0
       i = open_idx
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -366,15 +370,16 @@ module Analyzer::Dart
     end
 
     private def first_top_level_comma(text : String, start : Int32, limit : Int32) : Int32?
+      chars = text.chars
       depth = 0
       i = start
       in_string = false
       string_quote = '\0'
 
       while i < limit
-        c = text[i]
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -404,6 +409,7 @@ module Analyzer::Dart
 
     private def split_top_level_args(text : String) : Array(String)
       result = [] of String
+      chars = text.chars
       depth_paren = 0
       depth_brace = 0
       depth_bracket = 0
@@ -413,10 +419,10 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -447,7 +453,7 @@ module Analyzer::Dart
           depth_angle -= 1 if depth_angle > 0
         when ','
           if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << text[start...i]
+            result << chars[start...i].join
             start = i + 1
           end
         else
@@ -455,7 +461,7 @@ module Analyzer::Dart
         end
         i += 1
       end
-      result << text[start..] if start <= text.size
+      result << chars[start..].join if start <= chars.size
       result
     end
 
@@ -464,8 +470,11 @@ module Analyzer::Dart
       limit = offset > content.size ? content.size : offset
       count = 1
       i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
+      # `each_char` walks the UTF-8 buffer once with a reader instead of
+      # re-scanning from byte 0 on every indexed `content[i]` access.
+      content.each_char do |c|
+        break if i >= limit
+        count += 1 if c == '\n'
         i += 1
       end
       count

--- a/src/analyzer/analyzers/dart/cli.cr
+++ b/src/analyzer/analyzers/dart/cli.cr
@@ -17,6 +17,11 @@ module Analyzer::Dart
     MARKERS = /package:args\/|package:dcli\/|\bArgParser\s*\(|\bCommandRunner\b|\bextends\s+Command\b|main\s*\(\s*List<String>/
     WEB_RE  = /package:shelf\/|package:dart_frog|package:angel3|package:alfred|\bHttpServer\.bind\b/
 
+    # Per-path test-file gate. A precompiled `Regex.union` (PCRE2 JIT)
+    # replaces the two OR-ed `String#includes?` scans it used to run —
+    # provably equivalent since union auto-escapes each literal.
+    TEST_PATH_RE = Regex.union("/test/", "_test.")
+
     def analyze
       endpoints = {} of String => Endpoint
       get_files_by_extension(".dart").each do |path|
@@ -89,7 +94,7 @@ module Analyzer::Dart
 
     private def cli_test_path?(path : String) : Bool
       lower = path.downcase
-      lower.includes?("/test/") || lower.includes?("_test.")
+      lower.matches?(TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/dart/get_server.cr
+++ b/src/analyzer/analyzers/dart/get_server.cr
@@ -268,14 +268,18 @@ module Analyzer::Dart
     # Index of the first `:` outside any bracket/paren/string — the
     # separator of a named argument.
     private def top_level_colon(text : String) : Int32?
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = text.chars
       depth = 0
       i = 0
       in_string = false
       string_quote = '\0'
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -302,15 +306,16 @@ module Analyzer::Dart
     end
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
+      chars = text.chars
       depth = 0
       i = open_idx
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -339,6 +344,7 @@ module Analyzer::Dart
 
     private def split_top_level_args(text : String) : Array(String)
       result = [] of String
+      chars = text.chars
       depth_paren = 0
       depth_brace = 0
       depth_bracket = 0
@@ -348,10 +354,10 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -382,7 +388,7 @@ module Analyzer::Dart
           depth_angle -= 1 if depth_angle > 0
         when ','
           if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << text[start...i]
+            result << chars[start...i].join
             start = i + 1
           end
         else
@@ -390,7 +396,7 @@ module Analyzer::Dart
         end
         i += 1
       end
-      result << text[start..] if start <= text.size
+      result << chars[start..].join if start <= chars.size
       result
     end
 
@@ -399,8 +405,11 @@ module Analyzer::Dart
       limit = offset > content.size ? content.size : offset
       count = 1
       i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
+      # `each_char` walks the UTF-8 buffer once with a reader instead of
+      # re-scanning from byte 0 on every indexed `content[i]` access.
+      content.each_char do |c|
+        break if i >= limit
+        count += 1 if c == '\n'
         i += 1
       end
       count

--- a/src/analyzer/analyzers/dart/http.cr
+++ b/src/analyzer/analyzers/dart/http.cr
@@ -26,6 +26,11 @@ module Analyzer::Dart
     COOKIE_NAME_RE      = /\.cookies\b.*?\.name\s*==\s*r?["']([^"']+?)["']/
     BODY_READ_RE        = /utf8\s*\.\s*decoder\s*\.\s*bind\s*\([^\)]*\)|\.transform\s*\(\s*utf8\s*\.\s*decoder\s*\)|jsonDecode\s*\(/
 
+    # Whole-file detection gate, evaluated once per `.dart` file. A precompiled
+    # `Regex.union` (PCRE2 JIT) replaces the two OR-ed `String#includes?` scans
+    # it used to run — provably equivalent since union auto-escapes each literal.
+    HTTP_SURFACE_RE = Regex.union("HttpServer", "HttpRequest")
+
     alias MethodContext = NamedTuple(method: String, depth: Int32, params: Array(Param), switch_case: Bool)
     alias PathContext = NamedTuple(path: String, depth: Int32, params: Array(Param), switch_case: Bool)
     alias RouteContext = NamedTuple(endpoints: Array(Endpoint), depth: Int32)
@@ -65,7 +70,7 @@ module Analyzer::Dart
 
     private def http_file?(content : String) : Bool
       return false unless content.match(DART_IO_IMPORT_RE)
-      content.includes?("HttpServer") || content.includes?("HttpRequest")
+      content.matches?(HTTP_SURFACE_RE)
     end
 
     private def scan_file(content : String, path : String, include_callee : Bool) : Array(Endpoint)

--- a/src/analyzer/analyzers/dart/serverpod.cr
+++ b/src/analyzer/analyzers/dart/serverpod.cr
@@ -202,12 +202,16 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
       i = 0
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = body.chars
 
-      while i < body.size
-        c = body[i]
+      while i < chars.size
+        c = chars[i]
 
         if in_string
-          if c == '\\' && i + 1 < body.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -259,17 +263,21 @@ module Analyzer::Dart
     end
 
     private def method_name_before(body : String, paren_idx : Int32) : String?
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this backward scan O(n^2);
+      # index a materialized Array(Char) instead (O(1) per access).
+      chars = body.chars
       back = paren_idx - 1
-      while back >= 0 && body[back].whitespace?
+      while back >= 0 && chars[back].whitespace?
         back -= 1
       end
       name_end = back
-      while back >= 0 && (body[back].alphanumeric? || body[back] == '_')
+      while back >= 0 && (chars[back].alphanumeric? || chars[back] == '_')
         back -= 1
       end
       name_start = back + 1
       return if name_start > name_end
-      candidate = body[name_start..name_end]
+      candidate = chars[name_start..name_end].join
       return if candidate.empty?
       return unless candidate[0].lowercase? || candidate[0] == '_'
       return if RESERVED_DART_NAMES.includes?(candidate)
@@ -315,11 +323,15 @@ module Analyzer::Dart
 
     private def split_top_level_commas(text : String) : Array(String)
       parts = [] of String
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = text.chars
       depth = 0
       start = 0
       i = 0
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         case c
         when '<', '('
           depth += 1
@@ -327,7 +339,7 @@ module Analyzer::Dart
           depth -= 1 if depth > 0
         when ','
           if depth == 0
-            parts << text[start...i]
+            parts << chars[start...i].join
             start = i + 1
           end
         else
@@ -335,7 +347,7 @@ module Analyzer::Dart
         end
         i += 1
       end
-      parts << text[start..]
+      parts << chars[start..].join
       parts
     end
 
@@ -370,15 +382,19 @@ module Analyzer::Dart
     end
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = text.chars
       depth = 0
       i = open_idx
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -406,11 +422,12 @@ module Analyzer::Dart
     end
 
     private def extract_braced_block(text : String, start : Int32) : Tuple(String, Int32)?
+      chars = text.chars
       i = start
-      while i < text.size && text[i] != '{'
+      while i < chars.size && chars[i] != '{'
         i += 1
       end
-      return if i >= text.size
+      return if i >= chars.size
 
       body_start = i + 1
       depth = 1
@@ -418,10 +435,10 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
 
-      while i < text.size && depth > 0
-        c = text[i]
+      while i < chars.size && depth > 0
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -446,7 +463,7 @@ module Analyzer::Dart
       end
 
       return if depth != 0
-      {text[body_start...i], body_start}
+      {chars[body_start...i].join, body_start}
     end
 
     private def strip_dart_comments(text : String) : String
@@ -526,8 +543,11 @@ module Analyzer::Dart
       limit = offset > content.size ? content.size : offset
       count = 1
       i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
+      # `each_char` walks the UTF-8 buffer once with a reader instead of
+      # re-scanning from byte 0 on every indexed `content[i]` access.
+      content.each_char do |c|
+        break if i >= limit
+        count += 1 if c == '\n'
         i += 1
       end
       count

--- a/src/analyzer/analyzers/dart/shelf.cr
+++ b/src/analyzer/analyzers/dart/shelf.cr
@@ -346,22 +346,26 @@ module Analyzer::Dart
                               include_callee : Bool,
                               routes : Array(Route),
                               mounts : Array(Mount))
+      # `String#[]` re-walks from byte 0 on every call once the source
+      # contains any multi-byte char, turning this scan O(n^2); index a
+      # materialized Array(Char) instead (O(1) per access).
+      chars = cleaned.chars
       i = start_idx
       while i < end_idx - 1
         # Match `..name(` while ignoring `...` (spread).
-        if cleaned[i] == '.' && cleaned[i + 1] == '.' &&
-           !(i + 2 < cleaned.size && cleaned[i + 2] == '.')
+        if chars[i] == '.' && chars[i + 1] == '.' &&
+           !(i + 2 < chars.size && chars[i + 2] == '.')
           j = i + 2
-          j += 1 if j < cleaned.size && cleaned[j] == '?' # `..?name`
+          j += 1 if j < chars.size && chars[j] == '?' # `..?name`
           name_start = j
-          while j < cleaned.size && (cleaned[j].alphanumeric? || cleaned[j] == '_')
+          while j < chars.size && (chars[j].alphanumeric? || chars[j] == '_')
             j += 1
           end
-          name = cleaned[name_start...j]
-          while j < cleaned.size && cleaned[j].whitespace?
+          name = chars[name_start...j].join
+          while j < chars.size && chars[j].whitespace?
             j += 1
           end
-          if j < cleaned.size && cleaned[j] == '(' && relevant_method?(name)
+          if j < chars.size && chars[j] == '(' && relevant_method?(name)
             close_paren = find_matching_paren(cleaned, j)
             if close_paren && close_paren < end_idx
               handle_call(name, cleaned, j, close_paren, file_content, path, include_callee, routes, mounts)
@@ -569,6 +573,9 @@ module Analyzer::Dart
     # ---------- Source-string utilities ----------
 
     private def find_statement_end(text : String, start : Int32) : Int32
+      # See scan_cascades: index a materialized Array(Char) so this stays
+      # O(n) instead of O(n^2) on any source containing multi-byte chars.
+      chars = text.chars
       depth_paren = 0
       depth_brace = 0
       depth_bracket = 0
@@ -576,10 +583,10 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -611,19 +618,20 @@ module Analyzer::Dart
         end
         i += 1
       end
-      text.size
+      chars.size
     end
 
     private def find_matching_paren(text : String, open_idx : Int32) : Int32?
+      chars = text.chars
       depth = 0
       i = open_idx
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -652,6 +660,7 @@ module Analyzer::Dart
 
     private def split_top_level_args(text : String) : Array(String)
       result = [] of String
+      chars = text.chars
       depth_paren = 0
       depth_brace = 0
       depth_bracket = 0
@@ -661,10 +670,10 @@ module Analyzer::Dart
       in_string = false
       string_quote = '\0'
 
-      while i < text.size
-        c = text[i]
+      while i < chars.size
+        c = chars[i]
         if in_string
-          if c == '\\' && i + 1 < text.size
+          if c == '\\' && i + 1 < chars.size
             i += 2
             next
           end
@@ -695,7 +704,7 @@ module Analyzer::Dart
           depth_angle -= 1 if depth_angle > 0
         when ','
           if depth_paren == 0 && depth_brace == 0 && depth_bracket == 0 && depth_angle == 0
-            result << text[start...i]
+            result << chars[start...i].join
             start = i + 1
           end
         else
@@ -703,7 +712,7 @@ module Analyzer::Dart
         end
         i += 1
       end
-      result << text[start..] if start <= text.size
+      result << chars[start..].join if start <= chars.size
       result
     end
 
@@ -782,8 +791,11 @@ module Analyzer::Dart
       limit = offset > content.size ? content.size : offset
       count = 1
       i = 0
-      while i < limit
-        count += 1 if content[i] == '\n'
+      # `each_char` walks the UTF-8 buffer once with a reader instead of
+      # re-scanning from byte 0 on every indexed `content[i]` access.
+      content.each_char do |c|
+        break if i >= limit
+        count += 1 if c == '\n'
         i += 1
       end
       count


### PR DESCRIPTION
## Summary

Detection-neutral performance sweep of the **dart** framework analyzers (per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `shelf.cr` / `get_server.cr` / `angel3.cr` / `alfred.cr` / `serverpod.cr` | A | Materialize `content.chars` once and index the `Array(Char)` instead of per-char `String[i]` in `while` scan loops (`find_statement_end`, `find_matching_paren`, `split_top_level_args`, `line_for_offset`, …) — the string re-walks from byte 0 on every index once it holds a multi-byte char, i.e. O(n²) on non-ASCII source. `line_for_offset` now counts newlines via `each_char` with early `break` |
| `http.cr` / `cli.cr` | B | Fold OR-ed `String#includes?` detection gates into precompiled `Regex.union` consts + `matches?` |
| `dart_frog.cr` / `dart_helper.cr` | D | Verified already-optimal (cache-first reads, `each_char`/`Array(Char)` already used, single sanctioned `includes?` gates) |

Slice results are rejoined with `.join`; no signature/call-site changes. The shared `dart_callee_extractor.cr` already uses byte offsets (`byte_at`) and is immune.

## Test plan
- `crystal spec spec/functional_test/testers/dart/` + dart_helper unit spec → **577 examples, 0 failures** (byte-identical detection).
- Full `just test` on the merge state → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 9 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>