### PR TITLE
perf(clojure): fold chained includes? source-detection gates into Regex.union

### DIFF
--- a/src/analyzer/analyzers/clojure/compojure.cr
+++ b/src/analyzer/analyzers/clojure/compojure.cr
@@ -35,6 +35,11 @@ module Analyzer::Clojure
       ":header-params" => "header",
     }
     CLOJURE_EXTENSIONS = {".clj", ".cljc", ".cljs"}
+    # Whole-file detection gate, evaluated once per candidate file.
+    # `String#matches?` (PCRE2 JIT) replaces four naive `String#includes?`
+    # char scans with a single pass; `Regex.union` auto-escapes each literal,
+    # so it is provably equivalent to the OR-of-substrings it replaces.
+    COMPOJURE_SOURCE_RE = Regex.union("compojure.core", "compojure.api", "defroutes", "(context")
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
@@ -56,10 +61,7 @@ module Analyzer::Clojure
     end
 
     private def compojure_source?(content : String) : Bool
-      content.includes?("compojure.core") ||
-        content.includes?("compojure.api") ||
-        content.includes?("defroutes") ||
-        content.includes?("(context")
+      content.matches?(COMPOJURE_SOURCE_RE)
     end
 
     private def scan_forms(source : String, start_index : Int32, end_index : Int32, prefix : String, path : String, include_callee : Bool)

--- a/src/analyzer/analyzers/clojure/pedestal.cr
+++ b/src/analyzer/analyzers/clojure/pedestal.cr
@@ -33,6 +33,12 @@ module Analyzer::Clojure
       "any"     => "ANY",
     }
 
+    # Whole-file detection gate, evaluated once per candidate file.
+    # `String#matches?` (PCRE2 JIT) replaces five naive `String#includes?`
+    # char scans with a single pass; `Regex.union` auto-escapes each literal,
+    # so it is provably equivalent to the OR-of-substrings it replaces.
+    PEDESTAL_SOURCE_RE = Regex.union("io.pedestal", "pedestal.service", "pedestal.route", "defroutes", "table-routes")
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       all_files.each do |path|
@@ -58,11 +64,7 @@ module Analyzer::Clojure
     end
 
     private def pedestal_source?(content : String) : Bool
-      content.includes?("io.pedestal") ||
-        content.includes?("pedestal.service") ||
-        content.includes?("pedestal.route") ||
-        content.includes?("defroutes") ||
-        content.includes?("table-routes")
+      content.matches?(PEDESTAL_SOURCE_RE)
     end
 
     private def walk_forms(source : String,

--- a/src/analyzer/analyzers/clojure/reitit.cr
+++ b/src/analyzer/analyzers/clojure/reitit.cr
@@ -32,6 +32,12 @@ module Analyzer::Clojure
       ":form"   => "form",
     }
 
+    # Whole-file detection gate, evaluated once per candidate file.
+    # `String#matches?` (PCRE2 JIT) replaces two naive `String#includes?`
+    # char scans with a single pass; `Regex.union` auto-escapes each literal,
+    # so it is provably equivalent to the OR-of-substrings it replaces.
+    REITIT_SOURCE_RE = Regex.union("reitit.", "metosin/reitit")
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       all_files.each do |path|
@@ -57,7 +63,7 @@ module Analyzer::Clojure
       # split across namespaces that only pull a coercion/middleware ns
       # (`reitit.coercion.spec`, `reitit.ring.coercion`, …) rather than the
       # core/ring/http entry points, so match the family broadly.
-      content.includes?("reitit.") || content.includes?("metosin/reitit")
+      content.matches?(REITIT_SOURCE_RE)
     end
 
     # Iterate forms looking for route-shaped vectors. A vector is

--- a/src/analyzer/analyzers/clojure/ring.cr
+++ b/src/analyzer/analyzers/clojure/ring.cr
@@ -18,6 +18,13 @@ module Analyzer::Clojure
       "any"     => "ANY",
     }
 
+    # Whole-file detection gates, evaluated once per candidate file.
+    # `String#matches?` (PCRE2 JIT) replaces the naive `String#includes?`
+    # char scans with a single pass; `Regex.union` auto-escapes each literal,
+    # so each is provably equivalent to the OR-of-substrings it replaces.
+    RING_EXCLUDE_RE = Regex.union("compojure.core", "defroutes")
+    RING_SIGNAL_RE  = Regex.union(":request-method", ":uri")
+
     def analyze
       all_files.each do |path|
         next unless clojure_file?(path)
@@ -41,9 +48,8 @@ module Analyzer::Clojure
     private def ring_source?(content : String) : Bool
       # Compojure files are handled by the Compojure analyzer; skipping them
       # avoids double extraction when both analyzers run on the same project.
-      return false if content.includes?("compojure.core")
-      return false if content.includes?("defroutes")
-      content.includes?(":request-method") || content.includes?(":uri")
+      return false if content.matches?(RING_EXCLUDE_RE)
+      content.matches?(RING_SIGNAL_RE)
     end
 
     # `case`/`condp` clauses use literal vector keys like `[:get "/users"]`.


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **clojure** analyzers (per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `ring.cr` | B | `ring_source?` 4 chained `includes?` → two `Regex.union` consts (exclude + signal), original short-circuit order preserved |
| `compojure.cr` / `pedestal.cr` / `reitit.cr` | B | source-detection gate (4/5/2 chained `includes?`) → one precompiled `Regex.union` const + `matches?` |
| `cli.cr` | D | verified already-optimal (byte-offset scanners, fixed regex consts, cache-first reads) |

## Test plan
- `crystal spec spec/functional_test/testers/clojure/` → **410 examples, 0 failures**.
- Full `just test` (combined with elixir+perl) → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 5 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>