### PR TITLE
perf(elixir): cache-first file reads in plug and phoenix analyzers

### DIFF
--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -86,7 +86,10 @@ module Analyzer::Elixir
       in_triple_double = false
       in_triple_single = false
 
-      content = File.open(path, "r", encoding: "utf-8", invalid: :skip, &.gets_to_end)
+      # `read_file_content` reuses the detector's already-cached bytes
+      # (same "utf-8"/`invalid: :skip` decoding as the `File.open` this
+      # replaced) instead of re-reading the file from disk here.
+      content = read_file_content(path)
       lines = content.lines
       current_module = extract_module_name(content)
 

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -14,19 +14,20 @@ module Analyzer::Elixir
       return [] of Endpoint if test_only_path?(path)
 
       endpoints = [] of Endpoint
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        # A Phoenix router is owned by the Phoenix analyzer, which
-        # understands `scope` prefixes, the `resources` macro, and the
-        # controller/action mapping. The bare `get "/path"` regex here
-        # would re-extract those same lines stripped of their scope
-        # prefix and minus every `resources`-generated route — degraded
-        # duplicates that pollute the result. Skip the file and let the
-        # Phoenix analyzer handle it.
-        next endpoints if phoenix_router?(content)
-        analyze_content(content, path).each do |endpoint|
-          endpoints << endpoint unless endpoint.method.empty?
-        end
+      # `read_file_content` reuses the detector's already-cached bytes
+      # (same "utf-8"/`invalid: :skip` decoding as the `File.open` this
+      # replaced) instead of re-reading the file from disk here.
+      content = read_file_content(path)
+      # A Phoenix router is owned by the Phoenix analyzer, which
+      # understands `scope` prefixes, the `resources` macro, and the
+      # controller/action mapping. The bare `get "/path"` regex here
+      # would re-extract those same lines stripped of their scope
+      # prefix and minus every `resources`-generated route — degraded
+      # duplicates that pollute the result. Skip the file and let the
+      # Phoenix analyzer handle it.
+      return endpoints if phoenix_router?(content)
+      analyze_content(content, path).each do |endpoint|
+        endpoints << endpoint unless endpoint.method.empty?
       end
       endpoints
     end


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **elixir** analyzers (per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `elixir_plug.cr` / `elixir_phoenix.cr` | C | `analyze_file` swapped direct `File.open(...).gets_to_end` for cache-first `read_file_content` (identical decode args; byte-identical) |
| `bandit.cr` / `cli.cr` | D | verified already-optimal (hoisted regex consts, no char loops, cache-first already used) |

Route-pattern tables were already precompiled in a prior sweep — no Tier A remained.

## Test plan
- `crystal spec spec/functional_test/testers/elixir/` → **469 examples, 0 failures**.
- Full `just test` (combined with clojure+perl) → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 4 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>