### PR TITLE
perf(perl): hoist catalyst config regex, union cli gate, cache-first mojolicious

### DIFF
--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -381,8 +381,31 @@ module Analyzer::Perl
       overrides
     end
 
+    # Crystal recompiles an interpolated regex literal on every evaluation (a
+    # full PCRE2 JIT compile). `config_value` is only ever called with key
+    # "namespace" or "path" (see `collect_controller_configs`, which itself
+    # runs once per file from `analyze`/`analyze_content` and again from
+    # `collect_actions`), so precompile both key's pattern sets once at load
+    # time instead of rebuilding+recompiling five regexes per call.
+    CONFIG_VALUE_PATTERNS = {
+      "namespace" => [
+        /namespace\s*=>\s*q\{([^}]*)\}/,
+        /namespace\s*=>\s*q\(([^)]*)\)/,
+        /namespace\s*=>\s*q\/([^\/]*)\//,
+        /namespace\s*=>\s*'([^']*)'/,
+        /namespace\s*=>\s*"([^"]*)"/,
+      ],
+      "path" => [
+        /path\s*=>\s*q\{([^}]*)\}/,
+        /path\s*=>\s*q\(([^)]*)\)/,
+        /path\s*=>\s*q\/([^\/]*)\//,
+        /path\s*=>\s*'([^']*)'/,
+        /path\s*=>\s*"([^"]*)"/,
+      ],
+    }
+
     private def config_value(statement : String, key : String) : String?
-      patterns = [
+      patterns = CONFIG_VALUE_PATTERNS[key]? || [
         /#{key}\s*=>\s*q\{([^}]*)\}/,
         /#{key}\s*=>\s*q\(([^)]*)\)/,
         /#{key}\s*=>\s*q\/([^\/]*)\//,

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -27,6 +27,13 @@ module Analyzer::Perl
     MARKERS = /\buse\s+Getopt::(?:Long|Std)\b|\bGetOptions\s*\(|\bgetopts?\s*\(|\buse\s+App::Cmd\b|\bMooseX::Getopt\b|\$ARGV\s*\[\s*\d+\s*\]|\buse\s+Getopt::Long::Descriptive\b|\bdescribe_options\s*\(|\buse\s+MooX::Options\b/
     WEB_RE  = /\buse\s+(?:Mojolicious|Mojo::|Dancer2?|Catalyst|Plack|Dancer)\b/
 
+    # One precompiled `Regex.union` scan (PCRE2 JIT) replaces three separate
+    # `String#includes?` scans of the same buffer -- Crystal's `includes?` is
+    # not Boyer-Moore accelerated, so a single regex pass over `lower` is
+    # cheaper than three. Equivalent to the OR-of-substrings it replaces
+    # (union escapes each literal).
+    CLI_TEST_PATH_RE = Regex.union("/t/", "/test/", "_test.")
+
     def analyze
       endpoints = {} of String => Endpoint
       [".pl", ".pm"].each do |ext|
@@ -107,8 +114,7 @@ module Analyzer::Perl
     end
 
     private def cli_test_path?(path : String) : Bool
-      lower = path.downcase
-      lower.includes?("/t/") || lower.includes?("/test/") || lower.includes?("_test.")
+      path.downcase.matches?(CLI_TEST_PATH_RE)
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -57,12 +57,8 @@ module Analyzer::Perl
       # accounts for ~1100 phantom endpoints).
       return [] of Endpoint if perl_test_path?(path, ext)
 
-      endpoints = [] of Endpoint
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        endpoints.concat(analyze_content(content, path, include_callee, controller_callees))
-      end
-      endpoints
+      content = read_file_content(path)
+      analyze_content(content, path, include_callee, controller_callees)
     end
 
     def analyze_content(content : String,


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **perl** analyzers (per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `catalyst.cr` | A | `config_value` rebuilt 5 interpolated `/#{key}=>.../` regexes per call inside a per-line loop → precompiled `CONFIG_VALUE_PATTERNS` hash (keys are always `namespace`/`path`); interpolated build kept as a defensive fallback |
| `cli.cr` | B | `cli_test_path?` 3 chained `includes?` → one `Regex.union` const + `matches?` |
| `mojolicious.cr` | C | `analyze_file` swapped direct `File.open(...).gets_to_end` for cache-first `read_file_content` |
| `dancer2.cr` | D | verified already-optimal |

## Test plan
- `crystal spec spec/functional_test/testers/perl/` → **514 examples, 0 failures**.
- Full `just test` (combined with clojure+elixir) → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 4 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>