### PR TITLE
perf(swift): eliminate O(n^2) non-ASCII char scans, union route gates, cache-first reads

### DIFF
--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -473,6 +473,12 @@ module Analyzer::Swift
     # `var body: some RouterMiddleware<Context>` / `func routes() -> some
     # RouterMiddleware<Context>` — the controller body that hosts the DSL.
     DSL_BODY_RE = /\bsome\s+RouterMiddleware\b/
+    # Whole-file DSL-presence gate, evaluated once per line to decide whether
+    # the (expensive) DSL scan runs at all. One precompiled `Regex.union`
+    # scan (PCRE2 JIT) replaces three naive `String#includes?` char scans per
+    # line; union auto-escapes each literal so it is provably equivalent to
+    # the OR-of-substrings it replaces.
+    DSL_PRESENCE_RE = Regex.union("RouterBuilder", "RouterMiddleware", "RouteGroup")
 
     # One nesting level of the DSL. `:builder`/`:group` scopes emit routes;
     # `:handler` (a route's trailing closure) and `:other` (struct/func/etc.
@@ -488,9 +494,7 @@ module Analyzer::Swift
 
     private def collect_dsl_route_hits(stripped_lines : Array(String), original_lines : Array(String)) : Array(RouteHit)
       hits = [] of RouteHit
-      return hits unless stripped_lines.any? do |l|
-                           l.includes?("RouterBuilder") || l.includes?("RouterMiddleware") || l.includes?("RouteGroup")
-                         end
+      return hits unless stripped_lines.any?(&.matches?(DSL_PRESENCE_RE))
 
       stack = [] of DslScope
       pending : DslScope? = nil

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -283,12 +283,20 @@ module Analyzer::Swift
                                    paren_depth : Int32,
                                    start_col : Int32,
                                    hits : Array(RouteHit))
+      # `chars` avoids per-index `String#[]`: on non-ASCII lines each direct
+      # `line[i]` re-walks from byte 0 to locate the char offset, making this
+      # scan O(n^2). Materializing the char array once keeps the dominant
+      # per-character walk O(1)-indexed. The `.` branch below still slices
+      # `line[i..]` for its lookahead match — left as-is, since that regex is
+      # `^`-anchored to "start of the remaining text" and only fires at `.`
+      # positions (bounded by dot count on the line, not every character).
+      chars = line.chars
       i = start_col
       closed = false
       stop = line.size
 
-      while i < line.size
-        char = line[i]
+      while i < chars.size
+        char = chars[i]
 
         if paren_depth > 0
           case char

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -1028,14 +1028,20 @@ module Analyzer::Swift
     end
 
     private def call_arguments(line : String, args_start : Int32) : Tuple(String, Int32)?
+      # `chars` avoids per-index `String#[]`: on non-ASCII lines each direct
+      # `line[index]` re-walks from byte 0 to locate the char offset, making
+      # this scan O(n^2). Materializing the char array once keeps indexed
+      # access O(1) and the whole scan O(n); the single closing slice below
+      # (`line[args_start...index]`) is unchanged and still O(n) once.
+      chars = line.chars
       depth = 1
       in_string = false
       escaped = false
       quote = '"'
       index = args_start
 
-      while index < line.size
-        char = line[index]
+      while index < chars.size
+        char = chars[index]
 
         if in_string
           if escaped

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -28,6 +28,13 @@ module Analyzer::Swift
     TYPE_DECL_PATTERN = /\b(?:struct|class|extension|actor|enum)\s+([A-Za-z_]\w*)/
     alias ScopedPrefixKey = Tuple(String, String)
 
+    # `route_definition?` runs on every scanned line (route detection, param
+    # lookahead, body-boundary checks). One precompiled `Regex.union` scan
+    # (PCRE2 JIT) replaces seven naive `String#includes?` char scans; union
+    # auto-escapes each literal so it is provably equivalent to the
+    # OR-of-substrings it replaces.
+    ROUTE_CALL_RE = Regex.union(".get(", ".post(", ".put(", ".delete(", ".patch(", ".head(", ".on(")
+
     # A route hit discovered by the chain scanner.
     record RouteHit,
       method : String,
@@ -982,10 +989,7 @@ module Analyzer::Swift
 
     # Check if a line contains a route definition
     private def route_definition?(line : String) : Bool
-      (line.includes?(".get(") || line.includes?(".post(") ||
-        line.includes?(".put(") || line.includes?(".delete(") ||
-        line.includes?(".patch(") || line.includes?(".head(") ||
-        line.includes?(".on("))
+      line.matches?(ROUTE_CALL_RE)
     end
 
     private def attach_route_callees(lines : Array(String),

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -51,7 +51,7 @@ module Analyzer::Swift
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
       stripped_lines = strip_code_lines(lines)
       include_callee = callees_needed?
       handler_bodies = named_handler_bodies(lines)
@@ -739,7 +739,7 @@ module Analyzer::Swift
 
       files.each do |path|
         base = configured_base_for(path)
-        lines = strip_code_lines(File.read_lines(path, encoding: "utf-8", invalid: :skip))
+        lines = strip_code_lines(read_file_content(path).lines)
         lines.each do |line|
           if (func = line.match(FUNCTION_SIGNATURE_PATTERN)) && line.match(ROUTER_PARAM_PATTERN)
             route_methods_by_base[base] << func[1]
@@ -760,7 +760,7 @@ module Analyzer::Swift
                                                method_set : Set(String),
                                                assignments : Hash(ScopedPrefixKey, String),
                                                base : String)
-      original_lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      original_lines = read_file_content(path).lines
       stripped_lines = strip_code_lines(original_lines)
 
       merge_logical_lines(stripped_lines, original_lines) do |stripped, original|

--- a/src/analyzer/analyzers/swift/kitura.cr
+++ b/src/analyzer/analyzers/swift/kitura.cr
@@ -22,6 +22,13 @@ module Analyzer::Swift
     ROUTER_ASSIGN_PATTERN = /\b(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*Router\s*[(<]/
     ROUTER_PARAM_PATTERN  = /([A-Za-z_]\w*)\s*:\s*Router\b/
 
+    # `route_definition?` runs on every scanned line (route detection, param
+    # lookahead, body-boundary checks). One precompiled `Regex.union` scan
+    # (PCRE2 JIT) replaces six naive `String#includes?` char scans; union
+    # auto-escapes each literal so it is provably equivalent to the
+    # OR-of-substrings it replaces.
+    ROUTE_CALL_RE = Regex.union(".get(", ".post(", ".put(", ".delete(", ".patch(", ".all(")
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = read_file_content(path).lines
@@ -121,9 +128,7 @@ module Analyzer::Swift
 
     # Check if a line contains a route definition
     private def route_definition?(line : String) : Bool
-      (line.includes?(".get(") || line.includes?(".post(") ||
-        line.includes?(".put(") || line.includes?(".delete(") ||
-        line.includes?(".patch(") || line.includes?(".all("))
+      line.matches?(ROUTE_CALL_RE)
     end
 
     # Check if a line is a route definition but not a parameter access

--- a/src/analyzer/analyzers/swift/kitura.cr
+++ b/src/analyzer/analyzers/swift/kitura.cr
@@ -24,7 +24,7 @@ module Analyzer::Swift
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       handler_bodies = named_handler_bodies(lines)
       router_receivers = collect_router_receivers(lines)

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -399,12 +399,17 @@ module Analyzer::Swift
       # String-aware: only truncate at a `//` OUTSIDE a string literal, so a path
       # like "api//v2" or a "https://..." redirect arg isn't cut (which made
       # call_arguments fail and silently drop the route / group prefix).
+      #
+      # This runs on every scanned line, so per-index `line[index]` matters:
+      # on non-ASCII lines it re-walks from byte 0 each call, making the scan
+      # O(n^2). `chars` gives O(1) indexed access, keeping this O(n).
+      chars = line.chars
       in_string = false
       escaped = false
       quote = '"'
       index = 0
-      while index < line.size
-        char = line[index]
+      while index < chars.size
+        char = chars[index]
         if in_string
           if escaped
             escaped = false
@@ -416,7 +421,7 @@ module Analyzer::Swift
         elsif char == '"' || char == '\''
           in_string = true
           quote = char
-        elsif char == '/' && line[index + 1]? == '/'
+        elsif char == '/' && chars[index + 1]? == '/'
           return line[0...index]
         end
         index += 1

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -32,6 +32,13 @@ module Analyzer::Swift
     # is router-like.
     ROUTER_EXTENSION_PATTERN = /\bextension\s+(?:RoutesBuilder|Router)\b/
 
+    # `route_definition?` runs on every scanned line (route detection, param
+    # lookahead, body-boundary checks). One precompiled `Regex.union` scan
+    # (PCRE2 JIT) replaces six naive `String#includes?` char scans; union
+    # auto-escapes each literal so it is provably equivalent to the
+    # OR-of-substrings it replaces.
+    ROUTE_CALL_RE = Regex.union(".get(", ".post(", ".put(", ".delete(", ".patch(", ".on(")
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       lines = read_file_content(path).lines
@@ -153,9 +160,7 @@ module Analyzer::Swift
 
     # Check if a line contains a route definition
     private def route_definition?(line : String) : Bool
-      line.includes?(".get(") || line.includes?(".post(") ||
-        line.includes?(".put(") || line.includes?(".delete(") ||
-        line.includes?(".patch(") || line.includes?(".on(")
+      line.matches?(ROUTE_CALL_RE)
     end
 
     # Check if a line is a route definition but not a parameter access

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -34,7 +34,7 @@ module Analyzer::Swift
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = File.read_lines(path, encoding: "utf-8", invalid: :skip)
+      lines = read_file_content(path).lines
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       handler_bodies = named_handler_bodies(lines)
       prefix_by_receiver = {} of String => String

--- a/src/analyzer/analyzers/swift/vapor.cr
+++ b/src/analyzer/analyzers/swift/vapor.cr
@@ -316,14 +316,20 @@ module Analyzer::Swift
     end
 
     private def call_arguments(line : String, args_start : Int32) : Tuple(String, Int32)?
+      # `chars` avoids per-index `String#[]`: on non-ASCII lines each direct
+      # `line[index]` re-walks from byte 0 to locate the char offset, making
+      # this scan O(n^2). Materializing the char array once keeps indexed
+      # access O(1) and the whole scan O(n); the single closing slice below
+      # (`line[args_start...index]`) is unchanged and still O(n) once.
+      chars = line.chars
       depth = 1
       in_string = false
       escaped = false
       quote = '"'
       index = args_start
 
-      while index < line.size
-        char = line[index]
+      while index < chars.size
+        char = chars[index]
 
         if in_string
           if escaped


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **swift** framework analyzers (per-language series; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `vapor.cr` / `hummingbird.cr` | A | Materialize `line.chars` once and index `Array(Char)` instead of per-char `String[i]` in `while` scan loops (`call_arguments`, `code_line`, `scan_chain_segment`) — O(n²) on non-ASCII |
| `kitura.cr` / `vapor.cr` / `hummingbird.cr` | B | `route_definition?` (6/6/7 chained `includes?`) + hummingbird DSL-presence gate → precompiled `Regex.union` consts + `matches?` |
| `kitura.cr` / `vapor.cr` / `hummingbird.cr` | C | cache-first `read_file_content(...).lines` instead of direct `File.read_lines` |
| `cli.cr` | D | verified already-optimal |

`hummingbird.cr`'s `find_chain_start` was intentionally **left as-is**: a position-based `String#match(regex, pos)` would change what the lookbehind `(?<![.\w])` matches (verified with a repro), so it's not a detection-neutral swap.

## Test plan
- swift functional + unit specs → **270 examples, 0 failures** (byte-identical through every commit).
- Full `just test` → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>