### PR TITLE
perf(python): memoize per-instance/keyword regexes, hoist verb tables, fix O(n^2) scans, cache-first reads

### DIFF
--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -119,258 +119,259 @@ module Analyzer::Python
           next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            file_content = file.gets_to_end
-            lines = file_content.lines
-            next unless aiohttp_relevant_source?(file_content)
+          # Prefer the detector-cached content over a fresh disk read;
+          # falls back to File.read (same encoding: utf-8, invalid: :skip)
+          # when the file wasn't cached.
+          file_content = read_file_content(path)
+          lines = file_content.lines
+          next unless aiohttp_relevant_source?(file_content)
 
-            import_modules = find_imported_modules(current_base_path, path, file_content)
-            app_prefixes = collect_app_prefixes(lines)
-            route_table_prefixes = collect_route_table_prefixes(lines, app_prefixes)
-            route_list_prefixes = collect_route_list_prefixes(lines, app_prefixes)
-            route_aliases = Hash(::String, ::String).new
+          import_modules = find_imported_modules(current_base_path, path, file_content)
+          app_prefixes = collect_app_prefixes(lines)
+          route_table_prefixes = collect_route_table_prefixes(lines, app_prefixes)
+          route_list_prefixes = collect_route_list_prefixes(lines, app_prefixes)
+          route_aliases = Hash(::String, ::String).new
 
-            handler_routes[path] ||= [] of Tuple(::String, ::String, Int32, ::String)
-            class_view_routes[path] ||= [] of Tuple(::String, Int32, ::String)
+          handler_routes[path] ||= [] of Tuple(::String, ::String, Int32, ::String)
+          class_view_routes[path] ||= [] of Tuple(::String, Int32, ::String)
 
-            # Tree-sitter pre-pass for Style B decorators. aiohttp's
-            # `@routes.route("METHOD", "/path")` has a method-first signature
-            # that the generic extractor would misread as path="METHOD", so
-            # we skip any decoration whose attribute is literally `route`
-            # and fall back to a dedicated regex below for that shape only.
-            view_attributes = {"view" => "GET"}
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: view_attributes).each do |deco|
-              next if deco.attribute_name == "route"
-              prefixes = route_table_prefixes[deco.router_name]? || [""]
-              if deco.attribute_name == "view"
-                prefixes.each do |prefix|
-                  class_view_routes[path] << {join_paths(prefix, deco.path), deco.decorator_line, deco.def_name}
-                end
-                next
-              end
-
+          # Tree-sitter pre-pass for Style B decorators. aiohttp's
+          # `@routes.route("METHOD", "/path")` has a method-first signature
+          # that the generic extractor would misread as path="METHOD", so
+          # we skip any decoration whose attribute is literally `route`
+          # and fall back to a dedicated regex below for that shape only.
+          view_attributes = {"view" => "GET"}
+          Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: view_attributes).each do |deco|
+            next if deco.attribute_name == "route"
+            prefixes = route_table_prefixes[deco.router_name]? || [""]
+            if deco.attribute_name == "view"
               prefixes.each do |prefix|
-                deco.methods.uniq.each do |deco_method|
-                  def_line = deco.def_line >= 0 ? deco.def_line : deco.decorator_line
-                  next if def_line == deco.decorator_line
-                  emit_endpoint(
-                    path,
-                    lines,
-                    def_line,
-                    join_paths(prefix, deco.path),
-                    deco_method,
-                    deco.decorator_line,
-                    definition_base_path: current_base_path,
-                    source: file_content
-                  )
+                class_view_routes[path] << {join_paths(prefix, deco.path), deco.decorator_line, deco.def_name}
+              end
+              next
+            end
+
+            prefixes.each do |prefix|
+              deco.methods.uniq.each do |deco_method|
+                def_line = deco.def_line >= 0 ? deco.def_line : deco.decorator_line
+                next if def_line == deco.decorator_line
+                emit_endpoint(
+                  path,
+                  lines,
+                  def_line,
+                  join_paths(prefix, deco.path),
+                  deco_method,
+                  deco.decorator_line,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
+              end
+            end
+          end
+
+          lines.each_with_index do |line, line_index|
+            stripped = line.gsub(" ", "")
+
+            # Style B (continued): the method-first `@<router>.route("GET", "/path")`
+            # shape kept as regex because tree-sitter's generic route
+            # decoder assumes path-first.
+            aiohttp_route_deco = stripped.includes?(".route(") ? stripped.match(ROUTE_DECO_RE) : nil
+            if aiohttp_route_deco
+              method = aiohttp_route_deco[2].upcase
+              route_path = aiohttp_route_deco[3]
+              if orig_match = line.match(/@#{aiohttp_route_deco[1]}\s*\.\s*route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
+                route_path = orig_match[1]
+              end
+              expand_aiohttp_methods(method).each do |expanded_method|
+                process_decorator_route(
+                  path,
+                  lines,
+                  line_index,
+                  route_path,
+                  expanded_method,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
+              end
+            end
+
+            # Style A: app.router.add_<method>("/path", handler)
+            add_match = stripped.includes?(".add_") ? stripped.match(ADD_METHOD_RE) : nil
+            if add_match
+              receiver = add_match[1]
+              method_name = add_match[2]
+              route_path = add_match[3]
+              handler_name = add_match[4]
+              if (orig_re = ADD_METHOD_ORIG_RE[method_name]?) && (orig_match = line.match(orig_re))
+                route_path = orig_match[1]
+              end
+              prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+              end
+            end
+
+            # Static file route:
+            #   app.router.add_static("/static/", path="...")
+            # aiohttp serves all files below the mounted prefix, so expose
+            # it as a GET wildcard endpoint. Respect sub-app prefixes via
+            # the same receiver prefix table as imperative routes.
+            static_match = stripped.includes?(".add_static(") ? stripped.match(ADD_STATIC_RE) : nil
+            if static_match
+              receiver = static_match[1]
+              static_path = static_match[2]
+              if orig_match = line.match(/\.add_static\s*\(\s*[rf]?['"]([^'"]*)['"]/)
+                static_path = orig_match[1]
+              end
+              prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                full_path = static_route_path(join_paths(prefix, static_path))
+                result << Endpoint.new(full_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
+              end
+            end
+
+            # Style A: app.router.add_route("METHOD", "/path", handler)
+            if stripped.includes?(".add_route") && (alias_match = stripped.match(ROUTE_ALIAS_RE))
+              route_aliases[alias_match[1]] = alias_match[2]
+            end
+
+            add_route_match = stripped.includes?(".add_route(") ? stripped.match(ADD_ROUTE_RE) : nil
+            if add_route_match
+              receiver = add_route_match[1]
+              method = add_route_match[2].upcase
+              route_path = add_route_match[3]
+              handler_name = add_route_match[4]
+              if orig_match = line.match(/\.add_route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
+                route_path = orig_match[1]
+              end
+              prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                expand_aiohttp_methods(method).each do |expanded_method|
+                  handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
                 end
               end
             end
 
-            lines.each_with_index do |line, line_index|
-              stripped = line.gsub(" ", "")
-
-              # Style B (continued): the method-first `@<router>.route("GET", "/path")`
-              # shape kept as regex because tree-sitter's generic route
-              # decoder assumes path-first.
-              aiohttp_route_deco = stripped.includes?(".route(") ? stripped.match(ROUTE_DECO_RE) : nil
-              if aiohttp_route_deco
-                method = aiohttp_route_deco[2].upcase
-                route_path = aiohttp_route_deco[3]
-                if orig_match = line.match(/@#{aiohttp_route_deco[1]}\s*\.\s*route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
-                  route_path = orig_match[1]
-                end
+            # Style A alias:
+            #   add_route = app.router.add_route
+            #   add_route("GET", "/path", handler)
+            alias_route_match = stripped.includes?("(") ? stripped.match(ADD_ROUTE_ALIAS_RE) : nil
+            if alias_route_match && (receiver = route_aliases[alias_route_match[1]]?)
+              method = alias_route_match[2].upcase
+              route_path = alias_route_match[3]
+              handler_name = alias_route_match[4]
+              if orig_match = line.match(alias_route_origin_regex(alias_route_match[1]))
+                route_path = orig_match[1]
+              end
+              prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
                 expand_aiohttp_methods(method).each do |expanded_method|
-                  process_decorator_route(
-                    path,
-                    lines,
-                    line_index,
-                    route_path,
-                    expanded_method,
-                    definition_base_path: current_base_path,
-                    source: file_content
-                  )
+                  handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
                 end
               end
+            end
 
-              # Style A: app.router.add_<method>("/path", handler)
-              add_match = stripped.includes?(".add_") ? stripped.match(ADD_METHOD_RE) : nil
-              if add_match
-                receiver = add_match[1]
-                method_name = add_match[2]
-                route_path = add_match[3]
-                handler_name = add_match[4]
-                if (orig_re = ADD_METHOD_ORIG_RE[method_name]?) && (orig_match = line.match(orig_re))
-                  route_path = orig_match[1]
-                end
-                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+            # Style D: class-based views via
+            # `app.router.add_view("/path", ViewClass)`.
+            add_view_match = stripped.includes?(".add_view(") ? stripped.match(ADD_VIEW_RE) : nil
+            if add_view_match
+              receiver = add_view_match[1]
+              route_path = add_view_match[2]
+              class_name = add_view_match[3].split(".").last
+              if orig_match = line.match(/\.add_view\s*\(\s*[rf]?['"]([^'"]*)['"]/)
+                route_path = orig_match[1]
+              end
+              prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+                class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
+              end
+            end
+
+            # Style C: `web.<method>("/path", handler)` route entries that
+            # live inside `app.add_routes([...])` lists or in a
+            # standalone `routes = [...]` literal passed to
+            # `app.add_routes(routes)`. The list itself doesn't need
+            # tracking — every `web.<method>(...)` call only exists as a
+            # route declaration in real aiohttp code. Multi-line entries
+            # are coalesced by `join_until_python_call_closes` so the
+            # path/handler regex sees the full call.
+            if stripped.includes?("web.") && stripped.matches?(WEB_METHOD_GUARD_RE)
+              effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+              effective_line.scan(WEB_METHOD_RE) do |web_match|
+                next if web_match.size < 4
+                method_name = web_match[1]
+                route_path = web_match[2]
+                handler_name = web_match[3]
+                prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
                   handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
                 end
               end
+            end
 
-              # Static file route:
-              #   app.router.add_static("/static/", path="...")
-              # aiohttp serves all files below the mounted prefix, so expose
-              # it as a GET wildcard endpoint. Respect sub-app prefixes via
-              # the same receiver prefix table as imperative routes.
-              static_match = stripped.includes?(".add_static(") ? stripped.match(ADD_STATIC_RE) : nil
-              if static_match
-                receiver = static_match[1]
-                static_path = static_match[2]
-                if orig_match = line.match(/\.add_static\s*\(\s*[rf]?['"]([^'"]*)['"]/)
-                  static_path = orig_match[1]
-                end
-                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                  full_path = static_route_path(join_paths(prefix, static_path))
-                  result << Endpoint.new(full_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
-                end
-              end
-
-              # Style A: app.router.add_route("METHOD", "/path", handler)
-              if stripped.includes?(".add_route") && (alias_match = stripped.match(ROUTE_ALIAS_RE))
-                route_aliases[alias_match[1]] = alias_match[2]
-              end
-
-              add_route_match = stripped.includes?(".add_route(") ? stripped.match(ADD_ROUTE_RE) : nil
-              if add_route_match
-                receiver = add_route_match[1]
-                method = add_route_match[2].upcase
-                route_path = add_route_match[3]
-                handler_name = add_route_match[4]
-                if orig_match = line.match(/\.add_route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
-                  route_path = orig_match[1]
-                end
-                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                  expand_aiohttp_methods(method).each do |expanded_method|
-                    handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
-                  end
-                end
-              end
-
-              # Style A alias:
-              #   add_route = app.router.add_route
-              #   add_route("GET", "/path", handler)
-              alias_route_match = stripped.includes?("(") ? stripped.match(ADD_ROUTE_ALIAS_RE) : nil
-              if alias_route_match && (receiver = route_aliases[alias_route_match[1]]?)
-                method = alias_route_match[2].upcase
-                route_path = alias_route_match[3]
-                handler_name = alias_route_match[4]
-                if orig_match = line.match(alias_route_origin_regex(alias_route_match[1]))
-                  route_path = orig_match[1]
-                end
-                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                  expand_aiohttp_methods(method).each do |expanded_method|
-                    handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
-                  end
-                end
-              end
-
-              # Style D: class-based views via
-              # `app.router.add_view("/path", ViewClass)`.
-              add_view_match = stripped.includes?(".add_view(") ? stripped.match(ADD_VIEW_RE) : nil
-              if add_view_match
-                receiver = add_view_match[1]
-                route_path = add_view_match[2]
-                class_name = add_view_match[3].split(".").last
-                if orig_match = line.match(/\.add_view\s*\(\s*[rf]?['"]([^'"]*)['"]/)
-                  route_path = orig_match[1]
-                end
-                prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
+            # Style D: class-based views via `web.view("/path", ViewClass)`.
+            # aiohttp dispatches to async `get` / `post` / ... methods on
+            # the class, so emit one endpoint per method definition.
+            if stripped.includes?("web.view(")
+              effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+              effective_line.scan(WEB_VIEW_RE) do |view_match|
+                next if view_match.size < 3
+                route_path = view_match[1]
+                class_name = view_match[2].split(".").last
+                prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
                   class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
                 end
               end
-
-              # Style C: `web.<method>("/path", handler)` route entries that
-              # live inside `app.add_routes([...])` lists or in a
-              # standalone `routes = [...]` literal passed to
-              # `app.add_routes(routes)`. The list itself doesn't need
-              # tracking — every `web.<method>(...)` call only exists as a
-              # route declaration in real aiohttp code. Multi-line entries
-              # are coalesced by `join_until_python_call_closes` so the
-              # path/handler regex sees the full call.
-              if stripped.includes?("web.") && stripped.matches?(WEB_METHOD_GUARD_RE)
-                effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
-                effective_line.scan(WEB_METHOD_RE) do |web_match|
-                  next if web_match.size < 4
-                  method_name = web_match[1]
-                  route_path = web_match[2]
-                  handler_name = web_match[3]
-                  prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
-                    handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
-                  end
-                end
-              end
-
-              # Style D: class-based views via `web.view("/path", ViewClass)`.
-              # aiohttp dispatches to async `get` / `post` / ... methods on
-              # the class, so emit one endpoint per method definition.
-              if stripped.includes?("web.view(")
-                effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
-                effective_line.scan(WEB_VIEW_RE) do |view_match|
-                  next if view_match.size < 3
-                  route_path = view_match[1]
-                  class_name = view_match[2].split(".").last
-                  prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
-                    class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
-                  end
-                end
-              end
             end
+          end
 
-            # Resolve add_X handler references by finding their def lines.
-            handler_routes[path].each do |route_path, method, line_index, handler_name|
-              def_index = find_handler_def(lines, handler_name)
-              if def_index.nil?
-                if emit_external_handler_endpoint(
-                     path,
-                     route_path,
-                     method,
-                     line_index,
-                     handler_name,
-                     import_modules,
-                     definition_base_path: current_base_path
-                   )
-                  next
-                end
-
-                # Handler is defined in another module (common with
-                # `app.add_routes([web.get("/x", handler_from_other_file)])`).
-                # Emit the endpoint anyway with path params parsed from
-                # the route literal; the body-side param extraction is
-                # skipped because there's no local def to walk.
-                details = Details.new(PathInfo.new(path, line_index + 1))
-                endpoint = Endpoint.new(route_path, method, details)
-                route_path.scan(/\{(\w+)(?::[^}]+)?\}/) do |path_match|
-                  endpoint.push_param(Param.new(path_match[1], "", "path"))
-                end
-                result << endpoint
+          # Resolve add_X handler references by finding their def lines.
+          handler_routes[path].each do |route_path, method, line_index, handler_name|
+            def_index = find_handler_def(lines, handler_name)
+            if def_index.nil?
+              if emit_external_handler_endpoint(
+                   path,
+                   route_path,
+                   method,
+                   line_index,
+                   handler_name,
+                   import_modules,
+                   definition_base_path: current_base_path
+                 )
                 next
               end
-              emit_endpoint(
-                path,
-                lines,
-                def_index,
-                route_path,
-                method,
-                line_index,
-                definition_base_path: current_base_path,
-                source: file_content
-              )
-            end
 
-            # Resolve class-based `web.view(...)` registrations by finding
-            # HTTP verb methods on the referenced `web.View` subclass.
-            class_view_routes[path].each do |route_path, line_index, class_name|
-              emit_class_view_endpoints(
-                path,
-                lines,
-                route_path,
-                line_index,
-                class_name,
-                definition_base_path: current_base_path,
-                source: file_content
-              )
+              # Handler is defined in another module (common with
+              # `app.add_routes([web.get("/x", handler_from_other_file)])`).
+              # Emit the endpoint anyway with path params parsed from
+              # the route literal; the body-side param extraction is
+              # skipped because there's no local def to walk.
+              details = Details.new(PathInfo.new(path, line_index + 1))
+              endpoint = Endpoint.new(route_path, method, details)
+              route_path.scan(/\{(\w+)(?::[^}]+)?\}/) do |path_match|
+                endpoint.push_param(Param.new(path_match[1], "", "path"))
+              end
+              result << endpoint
+              next
             end
+            emit_endpoint(
+              path,
+              lines,
+              def_index,
+              route_path,
+              method,
+              line_index,
+              definition_base_path: current_base_path,
+              source: file_content
+            )
+          end
+
+          # Resolve class-based `web.view(...)` registrations by finding
+          # HTTP verb methods on the referenced `web.View` subclass.
+          class_view_routes[path].each do |route_path, line_index, class_name|
+            emit_class_view_endpoints(
+              path,
+              lines,
+              route_path,
+              line_index,
+              class_name,
+              definition_base_path: current_base_path,
+              source: file_content
+            )
           end
         end
       end

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -91,6 +91,17 @@ module Analyzer::Python
       @alias_route_origin_regex_cache[alias_name] ||= /^\s*#{Regex.escape(alias_name)}\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/
     end
 
+    # Method-first `@<router>.route("GET", "/path")` original-line
+    # matcher (recovers spaces the space-stripped line lost). The router
+    # name is discovered per decorator line, but real files reuse the
+    # same router variable (e.g. `routes`) across every such decorator,
+    # so memoize per name instead of rebuilding it on every match.
+    @route_deco_origin_regex_cache = Hash(::String, Regex).new
+
+    private def route_deco_origin_regex(router_name : ::String) : Regex
+      @route_deco_origin_regex_cache[router_name] ||= /@#{router_name}\s*\.\s*route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/
+    end
+
     # `<var>["key"]` / `<var>.get("key")` access patterns for variables
     # bound to `await request.json()` / `await request.post()`. The
     # variable name is discovered (dynamic but low-cardinality), so the
@@ -179,7 +190,7 @@ module Analyzer::Python
             if aiohttp_route_deco
               method = aiohttp_route_deco[2].upcase
               route_path = aiohttp_route_deco[3]
-              if orig_match = line.match(/@#{aiohttp_route_deco[1]}\s*\.\s*route\s*\(\s*[rf]?['"][A-Za-z*]+['"]\s*,\s*[rf]?['"]([^'"]*)['"]/)
+              if orig_match = line.match(route_deco_origin_regex(aiohttp_route_deco[1]))
                 route_path = orig_match[1]
               end
               expand_aiohttp_methods(method).each do |expanded_method|

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -59,87 +59,88 @@ module Analyzer::Python
           next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            file_content = file.gets_to_end
-            lines = file_content.lines
-            next unless lines.any?(&.includes?("bottle"))
+          # Prefer the detector-cached content over a fresh disk read;
+          # falls back to File.read (same encoding: utf-8, invalid: :skip)
+          # when the file wasn't cached.
+          file_content = read_file_content(path)
+          lines = file_content.lines
+          next unless lines.any?(&.includes?("bottle"))
 
-            router_prefixes = collect_router_prefixes(lines)
+          router_prefixes = collect_router_prefixes(lines)
 
-            # Tree-sitter pre-pass for Form 1 (`@<var>.route(...)` /
-            # `@<var>.<method>(...)`). Replaces the per-line regex sweep.
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
-              methods_literal = deco.methods.map { |m| "'#{m}'" }.join(",")
-              extra_params = "methods=[#{methods_literal}]"
-              prefixes = router_prefixes[deco.router_name]? || [""]
-              prefixes.each do |prefix|
-                process_route(
-                  path,
-                  lines,
-                  line_index: deco.decorator_line,
-                  route_path: join_paths(prefix, deco.path),
-                  extra_params: extra_params,
-                  definition_base_path: current_base_path,
-                  source: file_content
-                )
+          # Tree-sitter pre-pass for Form 1 (`@<var>.route(...)` /
+          # `@<var>.<method>(...)`). Replaces the per-line regex sweep.
+          Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
+            methods_literal = deco.methods.map { |m| "'#{m}'" }.join(",")
+            extra_params = "methods=[#{methods_literal}]"
+            prefixes = router_prefixes[deco.router_name]? || [""]
+            prefixes.each do |prefix|
+              process_route(
+                path,
+                lines,
+                line_index: deco.decorator_line,
+                route_path: join_paths(prefix, deco.path),
+                extra_params: extra_params,
+                definition_base_path: current_base_path,
+                source: file_content
+              )
+            end
+          end
+
+          # Form 2 still needs per-line regex — bare `@route("/path")` has
+          # no router object, so the tree-sitter extractor (which gates
+          # on `<router>.<attr>`) doesn't match it.
+          lines.each_with_index do |line, line_index|
+            effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+            stripped = effective_line.gsub(" ", "")
+            # `@deco` (contiguous in the source by both regex shapes) is a
+            # necessary condition for either match, so non-decorator lines
+            # skip the regex work entirely.
+            if stripped.includes?('@')
+              BARE_DECORATOR_PATTERNS.each do |deco_name, deco_guard, bare_re, orig_re, kw_re|
+                next unless stripped.includes?(deco_guard)
+                # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
+                if bare_match = stripped.match(bare_re)
+                  # Recover spaces in path via the original line.
+                  path_value = bare_match[1]
+                  if orig_match = effective_line.match(orig_re)
+                    path_value = orig_match[1]
+                  end
+                  extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
+                  process_route(
+                    path,
+                    lines,
+                    line_index,
+                    path_value,
+                    extra,
+                    definition_base_path: current_base_path,
+                    source: file_content
+                  )
+                elsif kw_path_match = effective_line.match(kw_re)
+                  extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
+                  process_route(
+                    path,
+                    lines,
+                    line_index,
+                    kw_path_match[1],
+                    extra,
+                    definition_base_path: current_base_path,
+                    source: file_content
+                  )
+                end
               end
             end
 
-            # Form 2 still needs per-line regex — bare `@route("/path")` has
-            # no router object, so the tree-sitter extractor (which gates
-            # on `<router>.<attr>`) doesn't match it.
-            lines.each_with_index do |line, line_index|
-              effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
-              stripped = effective_line.gsub(" ", "")
-              # `@deco` (contiguous in the source by both regex shapes) is a
-              # necessary condition for either match, so non-decorator lines
-              # skip the regex work entirely.
-              if stripped.includes?('@')
-                BARE_DECORATOR_PATTERNS.each do |deco_name, deco_guard, bare_re, orig_re, kw_re|
-                  next unless stripped.includes?(deco_guard)
-                  # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
-                  if bare_match = stripped.match(bare_re)
-                    # Recover spaces in path via the original line.
-                    path_value = bare_match[1]
-                    if orig_match = effective_line.match(orig_re)
-                      path_value = orig_match[1]
-                    end
-                    extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
-                    process_route(
-                      path,
-                      lines,
-                      line_index,
-                      path_value,
-                      extra,
-                      definition_base_path: current_base_path,
-                      source: file_content
-                    )
-                  elsif kw_path_match = effective_line.match(kw_re)
-                    extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
-                    process_route(
-                      path,
-                      lines,
-                      line_index,
-                      kw_path_match[1],
-                      extra,
-                      definition_base_path: current_base_path,
-                      source: file_content
-                    )
-                  end
-                end
-              end
-
-              if !line.lstrip.starts_with?("@") && effective_line.includes?(".route(")
-                process_programmatic_route(
-                  path,
-                  lines,
-                  line_index,
-                  effective_line,
-                  router_prefixes,
-                  definition_base_path: current_base_path,
-                  source: file_content
-                )
-              end
+            if !line.lstrip.starts_with?("@") && effective_line.includes?(".route(")
+              process_programmatic_route(
+                path,
+                lines,
+                line_index,
+                effective_line,
+                router_prefixes,
+                definition_base_path: current_base_path,
+                source: file_content
+              )
             end
           end
         end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -9,6 +9,15 @@ module Analyzer::Python
     @django_app_config_path_cache = Hash(::String, ::String).new
     @visited_app_config_paths = Set(::String).new
 
+    # `extract_python_keyword_expression` is called with a small, fixed
+    # set of recurring keywords ("route", "regex", "view", "prefix",
+    # "viewset", ...) once per URL-pattern/router-registration match, and
+    # internally re-evaluates the regex once per positional arg. Memoize
+    # the compiled Regex per keyword across the whole scan instead of
+    # rebuilding an identical PCRE2 pattern on every call (mirrors the
+    # @keyword_regex_cache pattern used by the other python analyzers).
+    @keyword_regex_cache = Hash(::String, Regex).new
+
     # Regular expressions for extracting Django URL configurations
     REGEX_ROOT_URLCONF = /\s*ROOT_URLCONF\s*=\s*r?['"]([^'"\\]*)['"]/
     REGEX_INCLUDE_URLS = /\binclude\s*\(\s*r?['"]([^'"\\]*)['"]/
@@ -17,6 +26,17 @@ module Analyzer::Python
     # views. Precompiled — an interpolated literal would be recompiled on
     # every line of every CBV class body.
     REGEX_CBV_METHOD_DEF = /\s+(?:async\s+)?def\s+(#{HTTP_METHODS.join("|")})\s*\(/
+
+    # HTTP_METHODS is a fixed 8-element table (from PythonEngine), so the
+    # decorator-stack scan and the `request.method == "..."` scan below
+    # (each an `HTTP_METHODS.each` loop run per decorator line / per
+    # function-body line) can look up a precompiled regex per method name
+    # instead of interpolating and recompiling one on every iteration.
+    # Purely a lookup-table hoist — the matched text/capture groups are
+    # unchanged, so it doesn't affect the line/offset values computed
+    # elsewhere in this file.
+    DECORATOR_METHOD_NAME_REGEXES = HTTP_METHODS.to_h { |m| {m, /[^a-zA-Z0-9](#{m})[^a-zA-Z0-9]/} }
+    REQUEST_METHOD_NAME_REGEXES   = HTTP_METHODS.to_h { |m| {m, /['"](#{m})['"]/} }
 
     # Map request parameters to their respective fields
     REQUEST_PARAM_FIELD_MAP = {
@@ -247,8 +267,11 @@ module Analyzer::Python
       url_base_path = File.dirname(django_urls.filepath)
       @visited_url_paths[django_urls.filepath] = true
 
-      file = File.open(django_urls.filepath, encoding: "utf-8", invalid: :skip)
-      content = file.gets_to_end
+      # Prefer the detector-cached content over a fresh disk read; falls
+      # back to File.read (same encoding: utf-8, invalid: :skip) when the
+      # file wasn't cached. Byte-identical either way, so the char-offset
+      # -> line-number math further down is unaffected.
+      content = read_file_content(django_urls.filepath)
       original_content = content
       package_map = find_imported_modules(@django_base_path, url_base_path, content)
       import_aliases = extract_python_import_aliases(original_content)
@@ -1138,9 +1161,14 @@ module Analyzer::Python
       string_match ? string_match[1] : nil
     end
 
+    private def keyword_expression_regex(keyword : ::String) : Regex
+      @keyword_regex_cache[keyword] ||= /^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m
+    end
+
     private def extract_python_keyword_expression(args : Array(::String), keyword : ::String) : ::String?
+      keyword_re = keyword_expression_regex(keyword)
       args.each do |arg|
-        keyword_match = arg.match(/^\s*#{Regex.escape(keyword)}\s*=\s*(.+)$/m)
+        keyword_match = arg.match(keyword_re)
         return keyword_match[1].strip if keyword_match
       end
 
@@ -1269,7 +1297,7 @@ module Analyzer::Python
                 methods.each { |m| restricted_methods << m unless restricted_methods.includes?(m) }
               else
                 HTTP_METHODS.each do |http_method_name|
-                  method_name_match = preceding_definition.downcase.match /[^a-zA-Z0-9](#{http_method_name})[^a-zA-Z0-9]/
+                  method_name_match = preceding_definition.downcase.match DECORATOR_METHOD_NAME_REGEXES[http_method_name]
                   unless method_name_match.nil?
                     suspicious_http_methods << http_method_name.upcase
                   end
@@ -1288,7 +1316,7 @@ module Analyzer::Python
             if line.includes? "request.method"
               suspicious_code = line.split("request.method")[1].strip
               HTTP_METHODS.each do |http_method_name|
-                method_name_match = suspicious_code.downcase.match /['"](#{http_method_name})['"]/
+                method_name_match = suspicious_code.downcase.match REQUEST_METHOD_NAME_REGEXES[http_method_name]
                 unless method_name_match.nil?
                   suspicious_http_methods << http_method_name.upcase
                 end

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -818,11 +818,17 @@ module Analyzer::Python
                                  source : ::String,
                                  import_modules : Hash(::String, Tuple(::String, Int32)),
                                  depth : Int32) : ::String?
+      # `String#[]` walks from the start on every call for non-ASCII
+      # content, so indexing `value` directly inside this while loop was
+      # O(n^2); `chars` (Array(Char)) gives O(1) random access instead.
+      # `value.index`/range-slice stay on `value` — they only run once
+      # per `{...}` placeholder found, not once per character.
+      chars = value.chars
       result = String.build do |io|
         index = 0
-        while index < value.size
-          if value[index] == '{'
-            if index + 1 < value.size && value[index + 1] == '{'
+        while index < chars.size
+          if chars[index] == '{'
+            if index + 1 < chars.size && chars[index + 1] == '{'
               io << '{'
               index += 2
               next
@@ -836,11 +842,11 @@ module Analyzer::Python
             return unless resolved
             io << resolved
             index = end_index + 1
-          elsif value[index] == '}' && index + 1 < value.size && value[index + 1] == '}'
+          elsif chars[index] == '}' && index + 1 < chars.size && chars[index + 1] == '}'
             io << '}'
             index += 2
           else
-            io << value[index]
+            io << chars[index]
             index += 1
           end
         end
@@ -869,12 +875,16 @@ module Analyzer::Python
       return unless match
 
       index = match.end
+      # `String#[]` walks from the start on every call for non-ASCII
+      # content, so indexing `call_tail` directly inside this while loop
+      # was O(n^2); `chars` gives O(1) random access instead.
+      chars = call_tail.chars
       expression = String.build do |io|
         depth = 0
         in_quote = nil
         escaped = false
-        while index < call_tail.size
-          ch = call_tail[index]
+        while index < chars.size
+          ch = chars[index]
           if in_quote
             io << ch
             if escaped
@@ -1164,8 +1174,14 @@ module Analyzer::Python
       in_quote = nil
       escaped = false
       index = 0
-      while index < input.size
-        ch = input[index]
+      # `String#[]` walks from the start on every call for non-ASCII
+      # content, so indexing `input` directly inside this while loop was
+      # O(n^2); `chars` gives O(1) random access instead. The
+      # `input[start...index]` slices below stay on `input` — they only
+      # run once per delimiter found, not once per character.
+      chars = input.chars
+      while index < chars.size
+        ch = chars[index]
         if in_quote
           if escaped
             escaped = false

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -64,6 +64,11 @@ module Analyzer::Python
     DOTTED_REFERENCE_RE = /^#{DOT_NATION}$/
     VIEW_ASSIGN_RE      = /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/
     ADD_URL_RULE_RE     = /(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\((.+)\)/m
+    # `view_func=` extractors for the add_url_rule scan below — same
+    # constant-only interpolation, hoisted so they aren't rebuilt on every
+    # `add_url_rule(...)` match found in a file.
+    VIEW_FUNC_AS_VIEW_RE = /view_func=(#{PYTHON_VAR_NAME_REGEX})\.as_view\([rf]?['"]([^'"]*)['"]\)/
+    VIEW_FUNC_VAR_RE     = /view_func=(#{PYTHON_VAR_NAME_REGEX})[,\)]/
 
     # flask_restful / flask-restx register class-based `Resource`s with
     # `api.add_resource(ResourceClass, "/url"[, "/url2"], endpoint=...)`.
@@ -80,6 +85,37 @@ module Analyzer::Python
     @parsers = Hash(::String, PythonParser).new
     @routes = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String))).new
     @class_views = Hash(::String, Array(Tuple(Int32, ::String, ::String, ::String, ::String, Array(::String)))).new
+
+    # `Api(...)`/`add_namespace(...)`/`routes=` registration matchers
+    # interpolate a discovered instance/blueprint name, so they can't be
+    # hoisted to class constants. They used to be rebuilt from scratch for
+    # every (matching line x known-instance) pair; the discovered-name set
+    # is small and stable per scan, so memoize the compiled regex per name
+    # instead (mirrors FastAPI's `instance_regexes` cache).
+    @api_from_instance_regex_cache = Hash(::String, Regex).new
+    @add_namespace_call_regex_cache = Hash(::String, Regex).new
+    @view_registration_regex_cache = Hash(::String, Regex).new
+    @view_registration_original_regex_cache = Hash(::String, Regex).new
+
+    private def api_from_instance_regex(instance_name : ::String) : Regex
+      @api_from_instance_regex_cache[instance_name] ||=
+        /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{instance_name}[,)]/
+    end
+
+    private def add_namespace_call_regex(api_instance_name : ::String) : Regex
+      @add_namespace_call_regex_cache[api_instance_name] ||=
+        /(#{api_instance_name})\.add_namespace\((#{PYTHON_VAR_NAME_REGEX})/
+    end
+
+    private def view_registration_regex(blueprint_name : ::String) : Regex
+      @view_registration_regex_cache[blueprint_name] ||=
+        /#{blueprint_name},routes=(.*)\)/
+    end
+
+    private def view_registration_original_regex(blueprint_name : ::String) : Regex
+      @view_registration_original_regex_cache[blueprint_name] ||=
+        /#{blueprint_name}\s*,\s*routes\s*=\s*(.*)\)/
+    end
 
     def analyze
       flask_instances = Hash(ScopedNameKey, ::String).new
@@ -216,7 +252,7 @@ module Analyzer::Python
                 flask_instances.each do |key, _prefix|
                   next unless key[0] == current_base_path
                   _flask_instance_name = key[1]
-                  api_match = api_line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_flask_instance_name}[,)]/
+                  api_match = api_line.match api_from_instance_regex(_flask_instance_name)
                   if api_match
                     api_instance_name = api_match[1]
                     api_instances[api_instance_name] ||= join_flask_paths(_prefix, api_kwarg_prefix)
@@ -227,7 +263,7 @@ module Analyzer::Python
                 blueprint_prefixes.each do |key, _prefix|
                   next unless key[0] == current_base_path
                   _blueprint_instance_name = key[1]
-                  api_match = api_line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{DOT_NATION})?=(?:flask_restx\.)?Api\((app=)?#{_blueprint_instance_name}[,)]/
+                  api_match = api_line.match api_from_instance_regex(_blueprint_instance_name)
                   if api_match
                     api_instance_name = api_match[1]
                     api_instances[api_instance_name] ||= join_flask_paths(_prefix, api_kwarg_prefix)
@@ -246,7 +282,7 @@ module Analyzer::Python
               # the call is present on this line (the match requires it).
               if ns_line.includes?(".add_namespace(")
                 api_instances.each do |_api_instance_name, _prefix|
-                  add_namespace_match = ns_line.match /(#{_api_instance_name})\.add_namespace\((#{PYTHON_VAR_NAME_REGEX})/
+                  add_namespace_match = ns_line.match add_namespace_call_regex(_api_instance_name)
                   if add_namespace_match
                     parser = get_parser(path)
                     if parser.@global_variables.has_key?(add_namespace_match[2])
@@ -280,10 +316,10 @@ module Analyzer::Python
                 blueprint_prefixes.each do |key, blueprint_prefix|
                   next unless key[0] == current_base_path
                   blueprint_name = key[1]
-                  view_registration_match = line.match /#{blueprint_name},routes=(.*)\)/
+                  view_registration_match = line.match view_registration_regex(blueprint_name)
                   if view_registration_match
                     # Re-extract route paths from original line to preserve spaces in paths
-                    original_registration_match = original_line.match /#{blueprint_name}\s*,\s*routes\s*=\s*(.*)\)/
+                    original_registration_match = original_line.match view_registration_original_regex(blueprint_name)
                     route_paths = original_registration_match ? original_registration_match[1] : view_registration_match[1]
                     route_paths.scan /['"]([^'"]*)['"]/ do |path_str_match|
                       if !path_str_match.nil? && path_str_match.size == 2
@@ -396,12 +432,12 @@ module Analyzer::Python
 
                 # Extract view_func: try keyword form, then positional form
                 # Keyword: view_func=ClassName.as_view('name') or view_func=view_var
-                view_func_match = args_str.match /view_func=(#{PYTHON_VAR_NAME_REGEX})\.as_view\([rf]?['"]([^'"]*)['"]\)/
+                view_func_match = args_str.match VIEW_FUNC_AS_VIEW_RE
                 if view_func_match
                   class_name = view_func_match[1]
                   view_name = view_func_match[2]
                 else
-                  view_var_match = args_str.match /view_func=(#{PYTHON_VAR_NAME_REGEX})[,\)]/
+                  view_var_match = args_str.match VIEW_FUNC_VAR_RE
                   if view_var_match
                     view_var = view_var_match[1]
                     if view_assignments.has_key?(view_var)
@@ -430,10 +466,15 @@ module Analyzer::Python
                     # Stop at keyword arguments
                     break if remaining.match /^#{PYTHON_VAR_NAME_REGEX}=/
                     # Match an expression, tracking paren depth to handle nested calls like .as_view('name')
+                    # `String#[]` walks from the start on every call for
+                    # non-ASCII content, so indexing `remaining` directly
+                    # inside this while loop was O(n^2) per segment;
+                    # `chars` gives O(1) random access instead.
                     paren_depth = 0
                     end_idx = 0
-                    while end_idx < remaining.size
-                      ch = remaining[end_idx]
+                    remaining_chars = remaining.chars
+                    while end_idx < remaining_chars.size
+                      ch = remaining_chars[end_idx]
                       if ch == '('
                         paren_depth += 1
                       elsif ch == ')'

--- a/src/analyzer/analyzers/python/http_server.cr
+++ b/src/analyzer/analyzers/python/http_server.cr
@@ -30,6 +30,22 @@ module Analyzer::Python
       "do_trace"   => "TRACE",
     }
 
+    # `query_vars`/`form_vars`/`json_vars` below hold a discovered (but
+    # low-cardinality — real code overwhelmingly reuses the same handful of
+    # conventional names like `qs`/`data`/`params`) variable name, so the
+    # bracket/`.get(...)` access matchers can't be hoisted to constants.
+    # Memoize the compiled pair per name across the whole scan instead of
+    # rebuilding it every time the name recurs (same handler-body shape
+    # across query/form/json access, so one cache serves all three).
+    @var_access_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
+
+    private def var_access_regexes(var : ::String) : Tuple(Regex, Regex)
+      @var_access_regex_cache[var] ||= {
+        /#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
+        /#{Regex.escape(var)}\.get\s*\(\s*[rf]?['"]([^'"]+)['"]/,
+      }
+    end
+
     def analyze
       python_files = get_files_by_extension(".py")
       base_paths.each do |current_base_path|
@@ -282,10 +298,11 @@ module Analyzer::Python
         query_vars << qv unless query_vars.includes?(qv)
       end
       query_vars.each do |var|
-        body.scan(/#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |mm|
+        bracket_re, get_re = var_access_regexes(var)
+        body.scan(bracket_re) do |mm|
           record.call(mm[1], "query")
         end
-        body.scan(/#{Regex.escape(var)}\.get\s*\(\s*[rf]?['"]([^'"]+)['"]/) do |mm|
+        body.scan(get_re) do |mm|
           record.call(mm[1], "query")
         end
       end
@@ -326,10 +343,11 @@ module Analyzer::Python
           form_vars << fv unless form_vars.includes?(fv)
         end
         form_vars.each do |var|
-          body.scan(/#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |mm|
+          bracket_re, get_re = var_access_regexes(var)
+          body.scan(bracket_re) do |mm|
             record.call(mm[1], "form")
           end
-          body.scan(/#{Regex.escape(var)}\.get\s*\(\s*[rf]?['"]([^'"]+)['"]/) do |mm|
+          body.scan(get_re) do |mm|
             record.call(mm[1], "form")
           end
         end
@@ -340,10 +358,11 @@ module Analyzer::Python
           json_vars << m[1] unless json_vars.includes?(m[1])
         end
         json_vars.each do |var|
-          body.scan(/#{Regex.escape(var)}\s*\[\s*[rf]?['"]([^'"]+)['"]\s*\]/) do |mm|
+          bracket_re, get_re = var_access_regexes(var)
+          body.scan(bracket_re) do |mm|
             record.call(mm[1], "json")
           end
-          body.scan(/#{Regex.escape(var)}\.get\s*\(\s*[rf]?['"]([^'"]+)['"]/) do |mm|
+          body.scan(get_re) do |mm|
             record.call(mm[1], "json")
           end
         end

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -55,6 +55,21 @@ module Analyzer::Python
     # working; the analyzer rewrites `protocol` to `"ws"` later.
     WEBSOCKET_ATTRIBUTES = {"websocket" => "GET"}
 
+    # Per-line route-discovery patterns. These interpolate only the
+    # PYTHON_VAR_NAME_REGEX/DOT_NATION constants, so an inline literal
+    # inside the per-line analyze loop recompiled an identical PCRE2
+    # pattern on every source line of every file. Compile once here; the
+    # `.to_s` expansion of the interpolated constants is byte-identical
+    # to the previous inline form, so matching behaviour is unchanged.
+    QUART_INSTANCE_RE       = /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:quart\.)?Quart\(/
+    VIEW_ASSIGN_RE          = /(#{PYTHON_VAR_NAME_REGEX})=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/
+    ADD_URL_RULE_SCAN_RE    = /(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\s*\((.*)\)\s*$/m
+    REGISTER_BLUEPRINT_RE   = /(#{PYTHON_VAR_NAME_REGEX})\.register_blueprint\((#{DOT_NATION})/
+    METHOD_VIEW_DIRECT_RE   = /view_func\s*=\s*(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/
+    METHOD_VIEW_VAR_RE      = /view_func\s*=\s*(#{PYTHON_VAR_NAME_REGEX})/
+    METHOD_VIEW_POS_VIEW_RE = /^\s*[rf]?['"][^'"]*['"]\s*,\s*[rf]?['"][^'"]*['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/
+    METHOD_VIEW_POS_VAR_RE  = /^\s*[rf]?['"][^'"]*['"]\s*,\s*[rf]?['"][^'"]*['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})(?:\s*,|\s*$)/
+
     @file_content_cache = Hash(::String, ::String).new
 
     # JSON-variable access patterns interpolate a discovered (dynamic but
@@ -125,20 +140,20 @@ module Analyzer::Python
             line = original_line.gsub(" ", "")
 
             # Identify Quart instance assignments: `app = Quart(__name__)`
-            quart_match = line.match /(#{PYTHON_VAR_NAME_REGEX})(?::#{PYTHON_VAR_NAME_REGEX})?=(?:quart\.)?Quart\(/
+            quart_match = line.match QUART_INSTANCE_RE
             if quart_match
               quart_instance_name = quart_match[1]
               api_instances[quart_instance_name] ||= ""
               quart_instances[quart_instance_name] ||= ""
             end
 
-            if view_assign_match = line.match(/(#{PYTHON_VAR_NAME_REGEX})=(#{PYTHON_VAR_NAME_REGEX})\.as_view\(/)
+            if view_assign_match = line.match(VIEW_ASSIGN_RE)
               view_assignments[view_assign_match[1]] = view_assign_match[2]
             end
 
             if line.includes?(".add_url_rule(")
               effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
-              effective_line.scan(/(#{PYTHON_VAR_NAME_REGEX})\.add_url_rule\s*\((.*)\)\s*$/m) do |rule_match|
+              effective_line.scan(ADD_URL_RULE_SCAN_RE) do |rule_match|
                 next if rule_match.size < 3
                 router_name = rule_match[1]
                 args = rule_match[2]
@@ -168,7 +183,7 @@ module Analyzer::Python
 
             # Identify Blueprint registration:
             #   `app.register_blueprint(bp, url_prefix="/api")`
-            register_blueprint_match = line.match /(#{PYTHON_VAR_NAME_REGEX})\.register_blueprint\((#{DOT_NATION})/
+            register_blueprint_match = line.match REGISTER_BLUEPRINT_RE
             if register_blueprint_match
               parent_name = register_blueprint_match[1]
               blueprint_name = register_blueprint_match[2]
@@ -381,19 +396,19 @@ module Analyzer::Python
     end
 
     private def extract_method_view_class(args : ::String, view_assignments : Hash(::String, ::String)) : ::String
-      if direct_match = args.match(/view_func\s*=\s*(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/)
+      if direct_match = args.match(METHOD_VIEW_DIRECT_RE)
         return direct_match[1]
       end
 
-      if variable_match = args.match(/view_func\s*=\s*(#{PYTHON_VAR_NAME_REGEX})/)
+      if variable_match = args.match(METHOD_VIEW_VAR_RE)
         return view_assignments[variable_match[1]]? || ""
       end
 
-      if positional_match = args.match(/^\s*[rf]?['"][^'"]*['"]\s*,\s*[rf]?['"][^'"]*['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})\.as_view\s*\(/)
+      if positional_match = args.match(METHOD_VIEW_POS_VIEW_RE)
         return positional_match[1]
       end
 
-      if positional_variable_match = args.match(/^\s*[rf]?['"][^'"]*['"]\s*,\s*[rf]?['"][^'"]*['"]\s*,\s*(#{PYTHON_VAR_NAME_REGEX})(?:\s*,|\s*$)/)
+      if positional_variable_match = args.match(METHOD_VIEW_POS_VAR_RE)
         return view_assignments[positional_variable_match[1]]? || ""
       end
 

--- a/src/analyzer/analyzers/python/robyn.cr
+++ b/src/analyzer/analyzers/python/robyn.cr
@@ -46,49 +46,50 @@ module Analyzer::Python
           next if path.includes?("/site-packages/")
           next if python_test_path?(path)
 
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            file_content = file.gets_to_end
-            next unless file_content.includes?("robyn")
-            lines = file_content.lines
+          # Prefer the detector-cached content over a fresh disk read;
+          # falls back to File.read (same encoding: utf-8, invalid: :skip)
+          # when the file wasn't cached.
+          file_content = read_file_content(path)
+          next unless file_content.includes?("robyn")
+          lines = file_content.lines
 
-            # Capture `name = Robyn(__file__)` and `name = SubRouter(__file__, "/prefix")`
-            # so prefix composition can resolve via include_router below.
-            collect_router_assignments(lines, router_prefixes)
+          # Capture `name = Robyn(__file__)` and `name = SubRouter(__file__, "/prefix")`
+          # so prefix composition can resolve via include_router below.
+          collect_router_assignments(lines, router_prefixes)
 
-            # `app.include_router(sub_router)` — propagate the SubRouter's
-            # prefix without rewriting the original entry; the SubRouter
-            # already owns its prefix.
-            scan_include_routers(lines, router_prefixes)
+          # `app.include_router(sub_router)` — propagate the SubRouter's
+          # prefix without rewriting the original entry; the SubRouter
+          # already owns its prefix.
+          scan_include_routers(lines, router_prefixes)
 
-            # Decorator-driven routes via tree-sitter (handles multi-line
-            # decorator headers cleanly).
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, nil, WEBSOCKET_ATTRIBUTES).each do |deco|
-              next unless router_prefixes.has_key?(deco.router_name)
-              attr = deco.attribute_name.downcase
-              next unless attr.in?(HTTP_METHOD_DECORATORS) || attr == "websocket"
+          # Decorator-driven routes via tree-sitter (handles multi-line
+          # decorator headers cleanly).
+          Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, nil, WEBSOCKET_ATTRIBUTES).each do |deco|
+            next unless router_prefixes.has_key?(deco.router_name)
+            attr = deco.attribute_name.downcase
+            next unless attr.in?(HTTP_METHOD_DECORATORS) || attr == "websocket"
 
-              http_method = attr == "websocket" ? "GET" : attr.upcase
-              prefix = router_prefixes[deco.router_name]
-              route_path = normalize_path(deco.path)
-              full_path = join_prefix(prefix, route_path)
+            http_method = attr == "websocket" ? "GET" : attr.upcase
+            prefix = router_prefixes[deco.router_name]
+            route_path = normalize_path(deco.path)
+            full_path = join_prefix(prefix, route_path)
 
-              params = [] of Param
-              # `:name` and `{name}` segments are path params.
-              full_path.scan(/\{([A-Za-z_][A-Za-z0-9_]*)\}/) do |m|
-                params << Param.new(m[1], "", "path")
-              end
-
-              def_index = deco.def_line >= 0 ? deco.def_line : Noir::PythonRouteExtractor.find_def_line(lines, deco.decorator_line)
-              if def_index >= 0 && def_index < lines.size
-                handler_body = extract_function_body(lines, def_index)
-                extract_body_params(handler_body).each { |p| params << p }
-              end
-
-              details = Details.new(PathInfo.new(path, deco.decorator_line + 1))
-              endpoint = Endpoint.new(full_path, http_method, params, details)
-              endpoint.protocol = "ws" if attr == "websocket"
-              result << endpoint
+            params = [] of Param
+            # `:name` and `{name}` segments are path params.
+            full_path.scan(/\{([A-Za-z_][A-Za-z0-9_]*)\}/) do |m|
+              params << Param.new(m[1], "", "path")
             end
+
+            def_index = deco.def_line >= 0 ? deco.def_line : Noir::PythonRouteExtractor.find_def_line(lines, deco.decorator_line)
+            if def_index >= 0 && def_index < lines.size
+              handler_body = extract_function_body(lines, def_index)
+              extract_body_params(handler_body).each { |p| params << p }
+            end
+
+            details = Details.new(PathInfo.new(path, deco.decorator_line + 1))
+            endpoint = Endpoint.new(full_path, http_method, params, details)
+            endpoint.protocol = "ws" if attr == "websocket"
+            result << endpoint
           end
         end
       end

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -80,73 +80,74 @@ module Analyzer::Python
           next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            file_content = file.gets_to_end
-            lines = file_content.lines
-            next unless lines.any?(&.includes?("sanic"))
-            api_instances = Hash(::String, ::String).new
-            path_api_instances[path] = api_instances
+          # Prefer the detector-cached content over a fresh disk read;
+          # falls back to File.read (same encoding: utf-8, invalid: :skip)
+          # when the file wasn't cached.
+          file_content = read_file_content(path)
+          lines = file_content.lines
+          next unless lines.any?(&.includes?("sanic"))
+          api_instances = Hash(::String, ::String).new
+          path_api_instances[path] = api_instances
 
-            # Tree-sitter pre-pass: parse once and harvest every
-            # `@<router>.route(...)` / `@<router>.<method>(...)` decorator
-            # plus every `<name> = (sanic.)?Blueprint(url_prefix=...)`
-            # declaration. Replaces the per-line regex sweep in the loop
-            # below and handles multi-line decorators for free.
-            Noir::TreeSitterPythonRouteExtractor.extract_blueprints(file_content, ["sanic"]).each do |bp|
-              blueprint_prefixes[bp.name] ||= bp.prefix
-              api_instances[bp.name] ||= bp.prefix
+          # Tree-sitter pre-pass: parse once and harvest every
+          # `@<router>.route(...)` / `@<router>.<method>(...)` decorator
+          # plus every `<name> = (sanic.)?Blueprint(url_prefix=...)`
+          # declaration. Replaces the per-line regex sweep in the loop
+          # below and handles multi-line decorators for free.
+          Noir::TreeSitterPythonRouteExtractor.extract_blueprints(file_content, ["sanic"]).each do |bp|
+            blueprint_prefixes[bp.name] ||= bp.prefix
+            api_instances[bp.name] ||= bp.prefix
+          end
+          collect_blueprint_registrations(file_content, blueprint_registration_prefixes, current_base_path)
+          collect_blueprint_groups_and_versions(file_content, blueprint_group_prefixes, blueprint_versions)
+          Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: {"websocket" => "GET"}).each do |decoration|
+            methods_literal = decoration.methods.map { |m| "'#{m}'" }.join(",")
+            extra_params = "methods=[#{methods_literal}]"
+            router_info = Tuple(Int32, ::String, ::String, ::String, ::String).new(decoration.decorator_line, path, decoration.path, extra_params, decoration.attribute_name)
+            @routes[decoration.router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+            @routes[decoration.router_name] << router_info
+          end
+
+          lines.each_with_index do |original_line, line_index|
+            line = original_line.gsub(" ", "") # remove spaces for easier regex matching
+
+            # Identify Sanic instance assignments (tree-sitter extractor
+            # doesn't cover this shape yet).
+            sanic_match = line.includes?("Sanic(") ? line.match(SANIC_INSTANCE_RE) : nil
+            if sanic_match
+              sanic_instance_name = sanic_match[1]
+              api_instances[sanic_instance_name] ||= ""
+              sanic_instances[sanic_instance_name] ||= ""
             end
-            collect_blueprint_registrations(file_content, blueprint_registration_prefixes, current_base_path)
-            collect_blueprint_groups_and_versions(file_content, blueprint_group_prefixes, blueprint_versions)
-            Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: {"websocket" => "GET"}).each do |decoration|
-              methods_literal = decoration.methods.map { |m| "'#{m}'" }.join(",")
-              extra_params = "methods=[#{methods_literal}]"
-              router_info = Tuple(Int32, ::String, ::String, ::String, ::String).new(decoration.decorator_line, path, decoration.path, extra_params, decoration.attribute_name)
-              @routes[decoration.router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
-              @routes[decoration.router_name] << router_info
+
+            if line.includes?(".add_route(")
+              effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+              if class_route_info = parse_programmatic_class_route(effective_line)
+                router_name, route_path, class_name, extra_params = class_route_info
+                @programmatic_class_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+                @programmatic_class_routes[router_name] << {line_index, path, route_path, extra_params, class_name}
+              elsif route_info = parse_programmatic_route(effective_line)
+                router_name, route_path, handler_name, extra_params = route_info
+                @programmatic_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+                @programmatic_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
+              end
             end
 
-            lines.each_with_index do |original_line, line_index|
-              line = original_line.gsub(" ", "") # remove spaces for easier regex matching
-
-              # Identify Sanic instance assignments (tree-sitter extractor
-              # doesn't cover this shape yet).
-              sanic_match = line.includes?("Sanic(") ? line.match(SANIC_INSTANCE_RE) : nil
-              if sanic_match
-                sanic_instance_name = sanic_match[1]
-                api_instances[sanic_instance_name] ||= ""
-                sanic_instances[sanic_instance_name] ||= ""
+            if line.includes?(".add_websocket_route(")
+              effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+              if route_info = parse_programmatic_websocket_route(effective_line)
+                router_name, route_path, handler_name, extra_params = route_info
+                @programmatic_websocket_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
+                @programmatic_websocket_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
               end
+            end
 
-              if line.includes?(".add_route(")
-                effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
-                if class_route_info = parse_programmatic_class_route(effective_line)
-                  router_name, route_path, class_name, extra_params = class_route_info
-                  @programmatic_class_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
-                  @programmatic_class_routes[router_name] << {line_index, path, route_path, extra_params, class_name}
-                elsif route_info = parse_programmatic_route(effective_line)
-                  router_name, route_path, handler_name, extra_params = route_info
-                  @programmatic_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
-                  @programmatic_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
-                end
-              end
-
-              if line.includes?(".add_websocket_route(")
-                effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
-                if route_info = parse_programmatic_websocket_route(effective_line)
-                  router_name, route_path, handler_name, extra_params = route_info
-                  @programmatic_websocket_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String, ::String, ::String)
-                  @programmatic_websocket_routes[router_name] << {line_index, path, route_path, extra_params, handler_name}
-                end
-              end
-
-              if line.includes?(".static(")
-                effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
-                if static_route_info = parse_static_route(effective_line)
-                  router_name, static_path = static_route_info
-                  @static_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String)
-                  @static_routes[router_name] << {line_index, path, static_path}
-                end
+            if line.includes?(".static(")
+              effective_line = python_paren_delta(original_line) > 0 ? join_until_python_call_closes(lines, line_index, original_line) : original_line
+              if static_route_info = parse_static_route(effective_line)
+                router_name, static_path = static_route_info
+                @static_routes[router_name] ||= [] of Tuple(Int32, ::String, ::String)
+                @static_routes[router_name] << {line_index, path, static_path}
               end
             end
           end

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -50,61 +50,62 @@ module Analyzer::Python
           next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
-          File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-            lines = file.each_line.to_a
-            next unless lines.any?(&.includes?("tornado"))
-            api_instances = Hash(::String, ::String).new
-            path_api_instances[path] = api_instances
+          # Goes through this analyzer's own memoized read_file_content
+          # (see below), which itself prefers the detector-cached content
+          # over a fresh disk read.
+          lines = read_file_content(path).lines
+          next unless lines.any?(&.includes?("tornado"))
+          api_instances = Hash(::String, ::String).new
+          path_api_instances[path] = api_instances
 
-            # Tornado's own source documents routing with
-            # `.. code-block:: python` examples inside module/class
-            # docstrings — routing.py literally shows
-            # `Application([(r"/app1/handler", Handler)])`. Those are not
-            # real routes. Flag every line that begins inside a
-            # triple-quoted string so the route-detection entry points
-            # below skip them.
-            docstring_line = compute_docstring_line_flags(lines)
+          # Tornado's own source documents routing with
+          # `.. code-block:: python` examples inside module/class
+          # docstrings — routing.py literally shows
+          # `Application([(r"/app1/handler", Handler)])`. Those are not
+          # real routes. Flag every line that begins inside a
+          # triple-quoted string so the route-detection entry points
+          # below skip them.
+          docstring_line = compute_docstring_line_flags(lines)
 
-            lines.each_with_index do |line, line_index|
-              next if docstring_line[line_index]
-              line = line.gsub(" ", "") # remove spaces for easier regex matching
+          lines.each_with_index do |line, line_index|
+            next if docstring_line[line_index]
+            line = line.gsub(" ", "") # remove spaces for easier regex matching
 
-              # Identify Tornado Application instance assignments
-              app_match = line.includes?("Application(") ? line.match(APP_INSTANCE_RE) : nil
-              if app_match
-                app_instance_name = app_match[1]
-                api_instances[app_instance_name] ||= ""
-                tornado_app_instances[app_instance_name] ||= ""
-              end
+            # Identify Tornado Application instance assignments
+            app_match = line.includes?("Application(") ? line.match(APP_INSTANCE_RE) : nil
+            if app_match
+              app_instance_name = app_match[1]
+              api_instances[app_instance_name] ||= ""
+              tornado_app_instances[app_instance_name] ||= ""
+            end
 
-              # Look for URL routing patterns in tornado.web.Application
-              # Pattern: [(r"/path", HandlerClass), ...]
-              if line.includes?("Application(") || line.includes?("Application([")
-                # Extract URL patterns from this and following lines
-                extract_url_patterns_from_application(lines, line_index, path, api_instances)
-              end
+            # Look for URL routing patterns in tornado.web.Application
+            # Pattern: [(r"/path", HandlerClass), ...]
+            if line.includes?("Application(") || line.includes?("Application([")
+              # Extract URL patterns from this and following lines
+              extract_url_patterns_from_application(lines, line_index, path, api_instances)
+            end
 
-              # Tornado apps commonly attach routes after Application()
-              # construction via app.add_handlers(host_pattern, handlers).
-              if line.includes?(".add_handlers(")
-                extract_url_patterns_from_add_handlers(lines, line_index, path)
-              end
+            # Tornado apps commonly attach routes after Application()
+            # construction via app.add_handlers(host_pattern, handlers).
+            if line.includes?(".add_handlers(")
+              extract_url_patterns_from_add_handlers(lines, line_index, path)
+            end
 
-              # Module-level handler lists registered from ELSEWHERE.
-              # Large Tornado apps (jupyterhub, jupyter-server, the
-              # tornado demos) define routes as a top-level
-              # `default_handlers = [(r"/api/x", XHandler), ...]` /
-              # `handlers = [...]` / `url_patterns = [...]` and aggregate
-              # the list in a different module, so there's no local
-              # `Application(...)` to anchor on — the entire API was
-              # missed (jupyterhub: 66 handler tuples → 0). Detect the
-              # assignment by its conventional name and extract its
-              # tuples directly; the handler-class gate in
-              # `extract_routes_from_lines` keeps non-route lists out.
-              list_match = line.includes?("=[") ? line.match(HANDLER_LIST_RE) : nil
-              if list_match && tornado_handler_list_name?(list_match[1])
-                extract_routes_from_lines(lines, line_index, path)
-              end
+            # Module-level handler lists registered from ELSEWHERE.
+            # Large Tornado apps (jupyterhub, jupyter-server, the
+            # tornado demos) define routes as a top-level
+            # `default_handlers = [(r"/api/x", XHandler), ...]` /
+            # `handlers = [...]` / `url_patterns = [...]` and aggregate
+            # the list in a different module, so there's no local
+            # `Application(...)` to anchor on — the entire API was
+            # missed (jupyterhub: 66 handler tuples → 0). Detect the
+            # assignment by its conventional name and extract its
+            # tuples directly; the handler-class gate in
+            # `extract_routes_from_lines` keeps non-route lists out.
+            list_match = line.includes?("=[") ? line.match(HANDLER_LIST_RE) : nil
+            if list_match && tornado_handler_list_name?(list_match[1])
+              extract_routes_from_lines(lines, line_index, path)
             end
           end
         end
@@ -185,11 +186,16 @@ module Analyzer::Python
       i = start_index
       while i < lines.size
         line = lines[i].strip
+        # `String#[]` walks from the start on every call for non-ASCII
+        # content (Crystal strings aren't fixed-width), so indexing it
+        # inside this while loop was O(n^2) per line. `chars` is an
+        # Array(Char) with O(1) random access; values are unchanged.
+        chars = line.chars
         line_idx = 0
-        while line_idx < line.size
-          c = line[line_idx]
+        while line_idx < chars.size
+          c = chars[line_idx]
           if in_triple_string
-            if line_idx + 2 < line.size && c == triple_string_char && line[line_idx + 1] == triple_string_char && line[line_idx + 2] == triple_string_char
+            if line_idx + 2 < chars.size && c == triple_string_char && chars[line_idx + 1] == triple_string_char && chars[line_idx + 2] == triple_string_char
               in_triple_string = false
               line_idx += 3
               next
@@ -197,7 +203,7 @@ module Analyzer::Python
             line_idx += 1
             next
           elsif in_string
-            if c == string_char && (line_idx == 0 || line[line_idx - 1] != '\\')
+            if c == string_char && (line_idx == 0 || chars[line_idx - 1] != '\\')
               in_string = false
             end
             line_idx += 1
@@ -205,7 +211,7 @@ module Analyzer::Python
           elsif c == '#'
             break
           elsif c == '"' || c == '\''
-            if line_idx + 2 < line.size && line[line_idx + 1] == c && line[line_idx + 2] == c
+            if line_idx + 2 < chars.size && chars[line_idx + 1] == c && chars[line_idx + 2] == c
               in_triple_string = true
               triple_string_char = c
               line_idx += 3
@@ -311,17 +317,21 @@ module Analyzer::Python
         line = lines[i].strip
         block_pieces << line
 
-        # Track bracket depth, skipping characters inside string literals and comments
+        # Track bracket depth, skipping characters inside string literals and comments.
+        # `String#[]` walks from the start on every call for non-ASCII
+        # content, so indexing `line` directly inside this while loop was
+        # O(n^2) per line; `chars` gives O(1) random access instead.
         in_comment = false
+        chars = line.chars
         line_index = 0
-        while line_index < line.size
-          c = line[line_index]
+        while line_index < chars.size
+          c = chars[line_index]
 
           if in_comment
             line_index += 1
             next
           elsif in_triple_string
-            if line_index + 2 < line.size && c == triple_string_char && line[line_index + 1] == triple_string_char && line[line_index + 2] == triple_string_char
+            if line_index + 2 < chars.size && c == triple_string_char && chars[line_index + 1] == triple_string_char && chars[line_index + 2] == triple_string_char
               in_triple_string = false
               line_index += 3
               next
@@ -329,7 +339,7 @@ module Analyzer::Python
             line_index += 1
             next
           elsif in_string
-            if c == string_char && (line_index == 0 || line[line_index - 1] != '\\')
+            if c == string_char && (line_index == 0 || chars[line_index - 1] != '\\')
               in_string = false
             end
             line_index += 1
@@ -338,7 +348,7 @@ module Analyzer::Python
             if c == '#'
               in_comment = true
             elsif c == '"' || c == '\''
-              if line_index + 2 < line.size && line[line_index + 1] == c && line[line_index + 2] == c
+              if line_index + 2 < chars.size && chars[line_index + 1] == c && chars[line_index + 2] == c
                 in_triple_string = true
                 triple_string_char = c
                 line_index += 3


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **python** framework analyzers (flagship group; follows #2258). All changes preserve byte-identical endpoint output; the django line/offset-computation path was deliberately **not** touched (only how regexes are built and how file bytes are obtained).

| analyzer | tier | change |
|---|---|---|
| `flask.cr` | A | memoize the `Api(...)`/`add_namespace(...)`/`routes=` per-instance regexes (rebuilt per matching-line × instance) into a per-name cache mirroring fastapi's `instance_regexes`; hoist `add_url_rule` view-func extractors to consts; fix an O(n²) positional-arg char scan |
| `django.cr` | A/C | memoize `extract_python_keyword_expression`'s per-arg regex; precompute `DECORATOR_METHOD_NAME_REGEXES`/`REQUEST_METHOD_NAME_REGEXES` (were rebuilt per `HTTP_METHODS.each` iteration); route `urls.py` read through `read_file_content`. **Offset/line math untouched — the 6 `.line`-asserting django specs pass unchanged** |
| `quart.cr` | A | hoist 8 per-line interpolated (constant-only) regexes to class constants (2 were unconditional per-line) |
| `tornado.cr` | A/C | fix O(n²) `line[i]` char scans in `join_multiline_call`/`extract_routes_from_lines`; cache-first read |
| `http_server.cr` | A | memoize per-variable access regexes in `extract_request_params` |
| `aiohttp.cr` | A/C | memoize method-first route-decorator regex; cache-first read |
| `fastapi.cr` | A | fix O(n²) non-ASCII char scans in `resolve_f_string`/`split_python_top_level`/keyword extractor |
| `bottle.cr` / `sanic.cr` / `robyn.cr` | C | cache-first `read_file_content` (rest already memoized) |
| `cli.cr` / `falcon.cr` / `litestar.cr` / `pyramid.cr` / `starlette.cr` | D | verified already-optimal |

Left untouched (flagged): django's `normalize_django_named_regex_groups` mixes char-index and `byte_slice` — risky to change without touching URL-normalization semantics.

## Test plan
- `crystal spec spec/functional_test/testers/python/` → **2128 examples, 0 failures**.
- 6 django `.line`-asserting specs in isolation → **377 examples, 0 failures** (before and after).
- Full `just test` → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 15 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>