### PR TITLE
perf(csharp): memoize per-alias interpolated regexes, fix O(n^2) scans, gate callee-only work

### DIFF
--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -19,37 +19,36 @@ module Analyzer::CSharp
       route_config_file = locator.get("cs-apinet-mvc-routeconfig")
 
       # Analyze RouteConfig.cs for route definitions
-      if File.exists?("#{route_config_file}")
-        File.open("#{route_config_file}", "r", encoding: "utf-8", invalid: :skip) do |file|
-          maproute_check = false
-          maproute_buffer = ""
+      route_config_path = "#{route_config_file}"
+      if File.exists?(route_config_path)
+        maproute_check = false
+        maproute_buffer = ""
 
-          file.each_line.with_index do |line, index|
-            if line.includes? ".MapRoute("
-              maproute_check = true
-              maproute_buffer = line
-            end
+        read_file_content(route_config_path).each_line.with_index do |line, index|
+          if line.includes? ".MapRoute("
+            maproute_check = true
+            maproute_buffer = line
+          end
 
-            if line.includes? ");"
-              maproute_check = false
-              unless maproute_buffer.empty?
-                buffer = maproute_buffer.gsub(/[\r\n]/, "")
-                buffer = buffer.gsub(/\s+/, "")
-                buffer.split(",").each do |item|
-                  if item.includes? "url:"
-                    url = item.gsub(/url:/, "").gsub(/"/, "")
-                    details = Details.new(PathInfo.new(route_config_file, index + 1))
-                    @result << Endpoint.new("/#{url}", "GET", details)
-                  end
+          if line.includes? ");"
+            maproute_check = false
+            unless maproute_buffer.empty?
+              buffer = maproute_buffer.gsub(/[\r\n]/, "")
+              buffer = buffer.gsub(/\s+/, "")
+              buffer.split(",").each do |item|
+                if item.includes? "url:"
+                  url = item.gsub(/url:/, "").gsub(/"/, "")
+                  details = Details.new(PathInfo.new(route_config_file, index + 1))
+                  @result << Endpoint.new("/#{url}", "GET", details)
                 end
-
-                maproute_buffer = ""
               end
-            end
 
-            if maproute_check
-              maproute_buffer += line
+              maproute_buffer = ""
             end
+          end
+
+          if maproute_check
+            maproute_buffer += line
           end
         end
       end

--- a/src/analyzer/analyzers/csharp/aspnet_mvc.cr
+++ b/src/analyzer/analyzers/csharp/aspnet_mvc.cr
@@ -130,13 +130,20 @@ module Analyzer::CSharp
             url = build_url(controller_route_prefix, action_route, controller_name, action_name)
             details = Details.new(PathInfo.new(file, i + 1))
             endpoint = Endpoint.new(url, http_method, details)
-            body_block = extract_method_block(lines, masked_lines, end_index)
 
             parameters.each do |param|
               endpoint.params << param
             end
 
-            attach_csharp_callees(endpoint, body_block, file, end_index + 1, include_callee, skip_first_line: true)
+            # Unlike aspnet_core_mvc, this analyzer parses params from the
+            # signature only, so `body_block` exists purely to feed callee
+            # extraction — skip building it on the default scan path where
+            # `attach_csharp_callees` is a no-op anyway (`include_callee`
+            # false).
+            if include_callee
+              body_block = extract_method_block(lines, masked_lines, end_index)
+              attach_csharp_callees(endpoint, body_block, file, end_index + 1, include_callee, skip_first_line: true)
+            end
             @result << endpoint
 
             # Reset to default after processing the method

--- a/src/analyzer/analyzers/csharp/httplistener.cr
+++ b/src/analyzer/analyzers/csharp/httplistener.cr
@@ -17,6 +17,24 @@ module Analyzer::CSharp
     METHOD_LITERAL_RE = /@?"([A-Za-z]+)"/
     STRING_LITERAL_RE = /@?"([^"]*)"/
 
+    # The collection name at each `collection_aliases` call site is always
+    # one of these three fixed HttpListener request surfaces, so precompile
+    # each alias-assignment matcher once at load time instead of rebuilding
+    # an interpolated regex literal (a full PCRE2 JIT compile) per source
+    # line of every scanned block.
+    COLLECTION_ALIAS_ASSIGNMENT_PATTERNS = ["QueryString", "Headers", "Cookies"].to_h do |name|
+      {name, /\b(?:var|NameValueCollection|CookieCollection)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*[^;]*\b#{name}\b/}
+    end
+
+    # `method_signal?`/`path_signal?` re-check every discovered alias
+    # against every source line, and `extract_indexer_params`/
+    # `extract_getter_params` re-check every alias against every emitted
+    # endpoint's block — memoize each alias's compiled boundary regex so a
+    # repeat lookup reuses the same instance instead of recompiling it.
+    @word_boundary_regex_memo = Hash(String, Regex).new
+    @indexer_param_regex_memo = Hash(String, Regex).new
+    @getter_param_regex_memo = Hash(String, Regex).new
+
     private class BranchContext
       property depth : Int32
       property methods : Array(String)
@@ -230,15 +248,19 @@ module Analyzer::CSharp
         text.includes?("RawUrl")
     end
 
+    private def word_boundary_regex(name : String) : Regex
+      @word_boundary_regex_memo[name] ||= /\b#{Regex.escape(name)}\b/
+    end
+
     private def method_signal?(text : String, method_vars : Array(String)) : Bool
       return true if text.includes?("HttpMethod")
-      method_vars.any? { |var| text.matches?(/\b#{Regex.escape(var)}\b/) }
+      method_vars.any? { |var| text.matches?(word_boundary_regex(var)) }
     end
 
     private def path_signal?(text : String, path_vars : Array(String)) : Bool
       return true if path_expression?(text)
       return true if text.includes?(".Url")
-      path_vars.any? { |var| text.matches?(/\b#{Regex.escape(var)}\b/) }
+      path_vars.any? { |var| text.matches?(word_boundary_regex(var)) }
     end
 
     private def extract_methods(line : String, method_vars : Array(String)) : Array(String)
@@ -489,20 +511,29 @@ module Analyzer::CSharp
 
     private def collection_aliases(block : String, collection_name : String) : Array(String)
       aliases = [collection_name]
+      pattern = COLLECTION_ALIAS_ASSIGNMENT_PATTERNS[collection_name]? ||
+                /\b(?:var|NameValueCollection|CookieCollection)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*[^;]*\b#{collection_name}\b/
       block.each_line do |line|
         next unless line.includes?(collection_name)
 
-        if match = line.match(/\b(?:var|NameValueCollection|CookieCollection)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*[^;]*\b#{collection_name}\b/)
+        if match = line.match(pattern)
           aliases << match[1] unless aliases.includes?(match[1])
         end
       end
       aliases
     end
 
+    private def indexer_param_regex(var : String) : Regex
+      @indexer_param_regex_memo[var] ||= /\b#{Regex.escape(var)}\s*\[\s*@?"([^"]+)"/
+    end
+
+    private def getter_param_regex(var : String) : Regex
+      @getter_param_regex_memo[var] ||= /\b#{Regex.escape(var)}\s*\.\s*(?:Get|GetValues|GetFirst)\s*\(\s*@?"([^"]+)"/
+    end
+
     private def extract_indexer_params(block : String, vars : Array(String), param_type : String, params : Array(Param))
       vars.each do |var|
-        escaped = Regex.escape(var)
-        block.scan(/\b#{escaped}\s*\[\s*@?"([^"]+)"/) do |match|
+        block.scan(indexer_param_regex(var)) do |match|
           name = match[1].strip
           params << Param.new(name, "", param_type) unless name.empty?
         end
@@ -511,8 +542,7 @@ module Analyzer::CSharp
 
     private def extract_getter_params(block : String, vars : Array(String), param_type : String, params : Array(Param))
       vars.each do |var|
-        escaped = Regex.escape(var)
-        block.scan(/\b#{escaped}\s*\.\s*(?:Get|GetValues|GetFirst)\s*\(\s*@?"([^"]+)"/) do |match|
+        block.scan(getter_param_regex(var)) do |match|
           name = match[1].strip
           params << Param.new(name, "", param_type) unless name.empty?
         end

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -280,17 +280,22 @@ module Analyzer::CSharp::MinimalApiSupport
     arrow_index = block.index("=>")
     return "" unless arrow_index
 
+    # Index over `Array(Char)` (O(1)) rather than `String#[](Int)`, which is
+    # O(n) per access on multi-byte source and turns these backward scans
+    # O(n^2) on a non-ASCII (CJK comment/string) inline lambda handler.
+    chars = block.chars
+
     end_index = arrow_index - 1
-    while end_index >= 0 && block[end_index].ascii_whitespace?
+    while end_index >= 0 && chars[end_index].ascii_whitespace?
       end_index -= 1
     end
     return "" if end_index < 0
 
-    if block[end_index] == ')'
+    if chars[end_index] == ')'
       depth = 0
       index = end_index
       while index >= 0
-        case block[index]
+        case chars[index]
         when ')'
           depth += 1
         when '('
@@ -304,7 +309,7 @@ module Analyzer::CSharp::MinimalApiSupport
     end
 
     start_index = end_index
-    while start_index >= 0 && (block[start_index].ascii_alphanumeric? || block[start_index] == '_')
+    while start_index >= 0 && (chars[start_index].ascii_alphanumeric? || chars[start_index] == '_')
       start_index -= 1
     end
     block[(start_index + 1)..end_index]
@@ -493,11 +498,15 @@ module Analyzer::CSharp::MinimalApiSupport
     open = block.index('(', m.begin)
     return [] of String unless open
 
+    # Index over `Array(Char)` (O(1)) rather than `String#[](Int)`, which is
+    # O(n) per access on multi-byte source and turns this paren-depth walk
+    # O(n^2) across a large inline lambda handler with non-ASCII content.
+    chars = block.chars
     depth = 0
     i = open
     close = -1
-    while i < block.size
-      case block[i]
+    while i < chars.size
+      case chars[i]
       when '('
         depth += 1
       when ')'


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **csharp** analyzers (flagship group; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `httplistener.cr` | A | memoize `method_signal?`/`path_signal?`/`collection_aliases`/indexer/getter regexes (were rebuilt `/\b#{Regex.escape(var)}\b/` per alias per line/endpoint) |
| `minimal_api_support.cr` | A | `extract_lambda_param_list`/`map_call_arguments` walked blocks via per-char `String[i]` (O(n²) on non-ASCII) → `Array(Char)` |
| `aspnet_mvc.cr` | C | gate `body_block` extraction behind `include_callee` (this analyzer only uses it to feed callees); cache-first read for RouteConfig.cs |
| `aspnet_core_mvc.cr` / `carter.cr` / `fastendpoints.cr` / `cli.cr` / `common.cr` / `minimal_apis.cr` | D | verified already-optimal (aspnet_core_mvc's body extraction is dual-purpose → left intact) |

## Test plan
- csharp functional + unit specs → **732 examples, 0 failures**.
- Full `just test` (with ruby) → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 9 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>