### PR TITLE
perf(ruby): memoize/hoist interpolated regexes in webrick & rails, union gates, cache-first reads

### DIFF
--- a/src/analyzer/analyzers/ruby/cli.cr
+++ b/src/analyzer/analyzers/ruby/cli.cr
@@ -81,6 +81,12 @@ module Analyzer::Ruby
     # Web frameworks: their ENV reads are config, not a CLI surface.
     WEB_FRAMEWORK_RE = /(?:^|\n)\s*require\s+["'](?:sinatra|rails|action_controller|active_record|grape|hanami|roda|rack|rackup|puma|unicorn|thin)\b|<\s*(?:Sinatra::Base|Grape::API|ApplicationController)\b|Rails\.application/
 
+    # `cli_evidence?` runs once per .rb file and OR-ed four String#includes?
+    # scans as a standalone boolean gate. Folded into one precompiled union
+    # so the literal-marker half of the gate costs a single PCRE2 match
+    # instead of up to four naive substring scans.
+    CLI_EVIDENCE_MARKERS_RE = Regex.union("OptionParser.new", "GLI::App", "TTY::Option", "Commander::Methods")
+
     def analyze
       endpoints = {} of String => Endpoint
 
@@ -117,11 +123,8 @@ module Analyzer::Ruby
 
     private def cli_evidence?(content : String) : Bool
       content.matches?(THOR_SUBCLASS) ||
-        content.includes?("OptionParser.new") ||
-        content.includes?("GLI::App") ||
+        content.matches?(CLI_EVIDENCE_MARKERS_RE) ||
         content.matches?(/\bSlop\.(?:parse|new)\b/) ||
-        content.includes?("TTY::Option") ||
-        content.includes?("Commander::Methods") ||
         content.matches?(ARGV_INDEX) ||
         content.matches?(OPTIMIST_CALL) ||
         content.matches?(CLAMP_SUBCLASS) ||

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -4,6 +4,12 @@ module Analyzer::Ruby
   class Grape < RubyEngine
     GRAPE_VERBS = ["get", "post", "put", "delete", "patch", "head", "options"]
 
+    # `build_grape_index`'s whole-tree pre-pass gate OR-ed two
+    # String#includes? scans over every file's content as a standalone
+    # boolean gate. Folded into one precompiled union so it costs a single
+    # PCRE2 match instead of up to two naive substring scans per file.
+    GRAPE_OR_MOUNT_MARKER_RE = Regex.union("Grape", "mount ")
+
     # Crystal recompiles an interpolated regex literal (`/^#{verb}.../`)
     # on every evaluation — ~11000x slower than a precompiled one — so
     # matching the verb DSL inside the per-line loop used to recompile
@@ -80,7 +86,7 @@ module Analyzer::Ruby
         # `< Base` against the resolved class set. Restricting the whole-tree
         # pre-pass to these two markers keeps it off the thousands of
         # unrelated `.rb` files in a large repo.
-        next unless content.includes?("Grape") || content.includes?("mount ")
+        next unless content.matches?(GRAPE_OR_MOUNT_MARKER_RE)
         next unless content.includes?("class ") && content.includes?("<")
 
         # Edges are collected for every `class X < Y`, but the

--- a/src/analyzer/analyzers/ruby/hanami.cr
+++ b/src/analyzer/analyzers/ruby/hanami.cr
@@ -38,56 +38,54 @@ module Analyzer::Ruby
     private def parse_routes_file(path : String, framework_root : String, include_callee : Bool)
       stack = [] of RouteFrame
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        hanami_logical_lines(file).each do |line, index|
-          if closes_block?(line)
-            stack.pop unless stack.empty?
-            next
-          end
+      hanami_logical_lines(read_file_content(path)).each do |line, index|
+        if closes_block?(line)
+          stack.pop unless stack.empty?
+          next
+        end
 
-          opens_block = opens_route_block?(line)
-          details = Details.new(PathInfo.new(path, index + 1))
+        opens_block = opens_route_block?(line)
+        details = Details.new(PathInfo.new(path, index + 1))
 
-          if mounted = mount_endpoint(line, stack, details)
-            @result << mounted
-            next
-          end
+        if mounted = mount_endpoint(line, stack, details)
+          @result << mounted
+          next
+        end
 
-          if neutral_block?(line)
-            stack << RouteFrame.new if opens_block
-            next
-          end
+        if neutral_block?(line)
+          stack << RouteFrame.new if opens_block
+          next
+        end
 
-          if frame = slice_frame(line)
-            stack << frame if opens_block
-            next
-          end
+        if frame = slice_frame(line)
+          stack << frame if opens_block
+          next
+        end
 
-          if frame = prefix_frame(line, ["namespace", "scope"])
-            stack << frame if opens_block
-            next
-          end
+        if frame = prefix_frame(line, ["namespace", "scope"])
+          stack << frame if opens_block
+          next
+        end
 
-          if resource = resource_call(line)
-            routes, nested_frame = expand_resource(resource, stack, details)
-            routes.each { |route| attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee) }
-            @result.concat(routes.map(&.endpoint))
-            stack << nested_frame if opens_block
-            next
-          end
+        if resource = resource_call(line)
+          routes, nested_frame = expand_resource(resource, stack, details)
+          routes.each { |route| attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee) }
+          @result.concat(routes.map(&.endpoint))
+          stack << nested_frame if opens_block
+          next
+        end
 
-          if route = root_endpoint(line, stack, details)
-            attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee)
-            @result << route.endpoint
-            stack << RouteFrame.new if opens_block
-            next
-          end
+        if route = root_endpoint(line, stack, details)
+          attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee)
+          @result << route.endpoint
+          stack << RouteFrame.new if opens_block
+          next
+        end
 
-          if route = verb_endpoint(line, stack, details)
-            attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee)
-            @result << route.endpoint
-            stack << RouteFrame.new if opens_block
-          end
+        if route = verb_endpoint(line, stack, details)
+          attach_action_context(route.endpoint, route.target, framework_root, stack, include_callee)
+          @result << route.endpoint
+          stack << RouteFrame.new if opens_block
         end
       end
     end
@@ -101,12 +99,12 @@ module Analyzer::Ruby
     # never opened and all of the route's params/callees are dropped.
     # Returns {logical_line, first_line_index} pairs; comments are stripped
     # and strings preserved, mirroring the per-line parse.
-    private def hanami_logical_lines(file) : Array(Tuple(String, Int32))
+    private def hanami_logical_lines(content : String) : Array(Tuple(String, Int32))
       result = [] of Tuple(String, Int32)
       buffer = ""
       buffer_index = 0
 
-      file.each_line.with_index do |raw_line, index|
+      content.each_line.with_index do |raw_line, index|
         line = Noir::RubyCalleeExtractor.strip_comment(raw_line, preserve_strings: true).strip
         next if line.empty?
 
@@ -146,10 +144,7 @@ module Analyzer::Ruby
     def scan_action_file(endpoint : Endpoint, action_path : String, include_callee : Bool = false)
       return unless File.exists?(action_path)
 
-      lines = [] of String
-      File.open(action_path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        lines = file.each_line.to_a
-      end
+      lines = read_file_content(action_path).each_line.to_a
 
       scan_action_params(endpoint, lines)
       attach_handle_callees(endpoint, action_path, lines) if include_callee

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -779,26 +779,24 @@ module Analyzer::Ruby
       bracket_depth = 0
       brace_depth = 0
 
-      File.open(routes_path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        file.each_line do |raw_line|
-          stripped = strip_inline_comment(raw_line).strip
-          next if stripped.empty?
+      read_file_content(routes_path).each_line do |raw_line|
+        stripped = strip_inline_comment(raw_line).strip
+        next if stripped.empty?
 
-          buffer = buffer.empty? ? stripped : "#{buffer} #{stripped}"
-          delta = delimiter_delta(stripped)
-          paren_depth += delta[0]
-          bracket_depth += delta[1]
-          brace_depth += delta[2]
+        buffer = buffer.empty? ? stripped : "#{buffer} #{stripped}"
+        delta = delimiter_delta(stripped)
+        paren_depth += delta[0]
+        bracket_depth += delta[1]
+        brace_depth += delta[2]
 
-          next if paren_depth > 0 || bracket_depth > 0 || brace_depth > 0
-          next if stripped.ends_with?(",")
+        next if paren_depth > 0 || bracket_depth > 0 || brace_depth > 0
+        next if stripped.ends_with?(",")
 
-          lines << buffer
-          buffer = ""
-          paren_depth = 0
-          bracket_depth = 0
-          brace_depth = 0
-        end
+        lines << buffer
+        buffer = ""
+        paren_depth = 0
+        bracket_depth = 0
+        brace_depth = 0
       end
 
       lines << buffer unless buffer.empty?
@@ -1285,76 +1283,73 @@ module Analyzer::Ruby
         return empty
       end
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |controller_file|
-        controller_content = controller_file.gets_to_end
-        param_type = "json" if controller_content.includes?("render json:")
-        callees_by_action = extract_action_callees(controller_content, path) if callees_needed?
+      controller_content = read_file_content(path)
+      param_type = "json" if controller_content.includes?("render json:")
+      callees_by_action = extract_action_callees(controller_content, path) if callees_needed?
 
-        controller_file.rewind
-        this_method = ""
+      this_method = ""
 
-        controller_file.each_line.with_index do |raw_line, index|
-          line = strip_inline_comment(raw_line)
+      controller_content.each_line.with_index do |raw_line, index|
+        line = strip_inline_comment(raw_line)
 
-          if line.includes?("def ")
-            func_name = line.split("def ", 2)[1].split("(")[0].split(";")[0].strip
-            func_name = func_name.lchop("self.").strip
-            unless func_name.empty?
-              this_method = func_name
-              defined_actions << func_name
-              action_lines[func_name] = index + 1
-              method_bodies[this_method] ||= [] of String
-            end
-          end
-
-          unless this_method.empty?
+        if line.includes?("def ")
+          func_name = line.split("def ", 2)[1].split("(")[0].split(";")[0].strip
+          func_name = func_name.lchop("self.").strip
+          unless func_name.empty?
+            this_method = func_name
+            defined_actions << func_name
+            action_lines[func_name] = index + 1
             method_bodies[this_method] ||= [] of String
-            method_bodies[this_method] << line
           end
+        end
 
-          if pm = line.match(/permit\s*\(([^)]*)\)/)
-            pm[1].split(',').each do |raw|
-              name = raw.gsub(/[:\s'"]/, "")
-              next if name.empty? || this_method.empty?
-              # A permit list entry is always a lowercase symbol/string key
-              # (`:title`, `tag_ids`). Splat-of-constant args
-              # (`permit(*PERMITTED_PARAMS)`, `permit(:a, *Filter::KEYS)`)
-              # and the garbage left by naive comma-splitting of nested
-              # `key: [...]` forms survive the quote/colon strip as
-              # `*PERMITTED_PARAMS` / `*FilterKEYS` / `address[city`. Drop
-              # anything that isn't a clean identifier so those don't leak
-              # in as fabricated param names.
-              next unless name.matches?(/\A[a-z_][a-z0-9_]*\z/)
-              params_body_by_action[this_method] ||= [] of Param
-              params_body_by_action[this_method] << Param.new(name, "", param_type)
-              params_query_by_action[this_method] ||= [] of Param
-              params_query_by_action[this_method] << Param.new(name, "", "query")
-            end
-          end
+        unless this_method.empty?
+          method_bodies[this_method] ||= [] of String
+          method_bodies[this_method] << line
+        end
 
-          line.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
-            name = (m[1]? || m[2]?).to_s.strip
+        if pm = line.match(/permit\s*\(([^)]*)\)/)
+          pm[1].split(',').each do |raw|
+            name = raw.gsub(/[:\s'"]/, "")
             next if name.empty? || this_method.empty?
+            # A permit list entry is always a lowercase symbol/string key
+            # (`:title`, `tag_ids`). Splat-of-constant args
+            # (`permit(*PERMITTED_PARAMS)`, `permit(:a, *Filter::KEYS)`)
+            # and the garbage left by naive comma-splitting of nested
+            # `key: [...]` forms survive the quote/colon strip as
+            # `*PERMITTED_PARAMS` / `*FilterKEYS` / `address[city`. Drop
+            # anything that isn't a clean identifier so those don't leak
+            # in as fabricated param names.
+            next unless name.matches?(/\A[a-z_][a-z0-9_]*\z/)
             params_body_by_action[this_method] ||= [] of Param
             params_body_by_action[this_method] << Param.new(name, "", param_type)
             params_query_by_action[this_method] ||= [] of Param
             params_query_by_action[this_method] << Param.new(name, "", "query")
           end
+        end
 
-          if hm = line.match(/request\.headers\[\s*['"]([^'"]+)['"]\s*\]/)
-            name = hm[1].strip
-            if !name.empty? && !this_method.empty?
-              params_method[this_method] ||= [] of Param
-              params_method[this_method] << Param.new(name, "", "header")
-            end
-          end
+        line.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+          name = (m[1]? || m[2]?).to_s.strip
+          next if name.empty? || this_method.empty?
+          params_body_by_action[this_method] ||= [] of Param
+          params_body_by_action[this_method] << Param.new(name, "", param_type)
+          params_query_by_action[this_method] ||= [] of Param
+          params_query_by_action[this_method] << Param.new(name, "", "query")
+        end
 
-          line.scan(/cookies(?:\.(?:signed|encrypted))?\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |cm|
-            name = (cm[1]? || cm[2]?).to_s.strip
-            next if name.empty? || this_method.empty?
+        if hm = line.match(/request\.headers\[\s*['"]([^'"]+)['"]\s*\]/)
+          name = hm[1].strip
+          if !name.empty? && !this_method.empty?
             params_method[this_method] ||= [] of Param
-            params_method[this_method] << Param.new(name, "", "cookie")
+            params_method[this_method] << Param.new(name, "", "header")
           end
+        end
+
+        line.scan(/cookies(?:\.(?:signed|encrypted))?\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |cm|
+          name = (cm[1]? || cm[2]?).to_s.strip
+          next if name.empty? || this_method.empty?
+          params_method[this_method] ||= [] of Param
+          params_method[this_method] << Param.new(name, "", "cookie")
         end
       end
 

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -55,6 +55,18 @@ module Analyzer::Ruby
       {"DELETE", "/oauth/authorized_applications/:id", "authorized_applications", "destroy"},
     ]
 
+    # `parse_options` runs on most DSL lines of every routes.rb file (scope,
+    # namespace, resources, member/collection actions, verb routes, match) —
+    # i.e. once per line in the main route-parsing hot loop. It used to build
+    # two `Regex.new("...#{value_pattern}...")` regexes from scratch on every
+    # call even though `value_pattern` is a fixed literal that never varies —
+    # Crystal doesn't cache/memoize a `Regex.new(String)` call the way it
+    # embeds a non-interpolated regex *literal* at compile time. Precompile
+    # both patterns once at class load instead.
+    PARSE_OPTIONS_VALUE_PATTERN = "nil|['\"][^'\"]+['\"]|:[a-zA-Z_]\\w*|\\[[^\\]]*\\]|%i[\\[\\(][^\\]\\)]*[\\]\\)]|%w[\\[\\(][^\\]\\)]*[\\]\\)]"
+    PARSE_OPTIONS_KEY_VALUE_RE  = Regex.new("(\\w+):\\s*(#{PARSE_OPTIONS_VALUE_PATTERN})")
+    PARSE_OPTIONS_HASHROCKET_RE = Regex.new(":(\\w+)\\s*=>\\s*(#{PARSE_OPTIONS_VALUE_PATTERN})")
+
     struct Frame
       property kind : Symbol
       property path : String
@@ -1120,14 +1132,13 @@ module Analyzer::Ruby
 
     private def parse_options(line : String) : Hash(String, String)
       result = {} of String => String
-      value_pattern = "nil|['\"][^'\"]+['\"]|:[a-zA-Z_]\\w*|\\[[^\\]]*\\]|%i[\\[\\(][^\\]\\)]*[\\]\\)]|%w[\\[\\(][^\\]\\)]*[\\]\\)]"
       # capture key: "value", key: :symbol, key: [..], key: %i[..], and
       # older hash-rocket forms like :only => [:index].
-      line.scan(Regex.new("(\\w+):\\s*(#{value_pattern})")) do |m|
+      line.scan(PARSE_OPTIONS_KEY_VALUE_RE) do |m|
         key = m[1]
         result[key] = normalize_option_value(m[2])
       end
-      line.scan(Regex.new(":(\\w+)\\s*=>\\s*(#{value_pattern})")) do |m|
+      line.scan(PARSE_OPTIONS_HASHROCKET_RE) do |m|
         key = m[1]
         result[key] = normalize_option_value(m[2])
       end

--- a/src/analyzer/analyzers/ruby/roda.cr
+++ b/src/analyzer/analyzers/ruby/roda.cr
@@ -19,6 +19,12 @@ module Analyzer::Ruby
       {verb, /\br\.#{verb}\b\s*(?:do\b|\{|\/|$)/}
     end
 
+    # `analyze_file`'s per-file evidence gate OR-ed two String#includes?
+    # scans as a standalone boolean gate. Folded into one precompiled union
+    # so it costs a single PCRE2 match instead of up to two naive substring
+    # scans per file.
+    RODA_EVIDENCE_RE = Regex.union("Roda", "route do")
+
     alias PrefixEntry = NamedTuple(depth: Int32, segments: Array(String), path_params: Array(String))
 
     def analyze
@@ -35,7 +41,7 @@ module Analyzer::Ruby
 
     private def analyze_file(path : String, include_callee : Bool)
       content = read_file_content(path)
-      return unless content.includes?("Roda") || content.includes?("route do")
+      return unless content.matches?(RODA_EVIDENCE_RE)
 
       lines = content.lines
       in_route = false

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -8,71 +8,69 @@ module Analyzer::Ruby
       parallel_file_scan do |path|
         next unless path.ends_with?(".rb") || path.ends_with?(".ru")
         next if ruby_non_production_path?(path)
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          lines = file.each_line.to_a
-          active_route_endpoints = [] of Endpoint
-          active_route_depth = nil.as(Int32?)
-          prefix_stack = [] of NamedTuple(depth: Int32, path: String)
-          depth = 0
-          lines.each_with_index do |line, index|
-            next unless line.valid_encoding?
-            # Skip Ruby comment lines — `sinatra-contrib/lib/sinatra/
-            # namespace.rb` and similar library sources keep DSL
-            # examples (`#     get '/dashboard' do`) inside RDoc
-            # comments. They look identical to real route
-            # registrations to the line-based matcher.
-            stripped = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: true).strip
-            next if stripped.empty? || stripped.starts_with?('#')
+        lines = read_file_content(path).each_line.to_a
+        active_route_endpoints = [] of Endpoint
+        active_route_depth = nil.as(Int32?)
+        prefix_stack = [] of NamedTuple(depth: Int32, path: String)
+        depth = 0
+        lines.each_with_index do |line, index|
+          next unless line.valid_encoding?
+          # Skip Ruby comment lines — `sinatra-contrib/lib/sinatra/
+          # namespace.rb` and similar library sources keep DSL
+          # examples (`#     get '/dashboard' do`) inside RDoc
+          # comments. They look identical to real route
+          # registrations to the line-based matcher.
+          stripped = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: true).strip
+          next if stripped.empty? || stripped.starts_with?('#')
 
-            line_delta = sinatra_depth_delta(line)
+          line_delta = sinatra_depth_delta(line)
 
-            if ns = stripped.match(/^namespace\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s*(?:do\b|\{)/)
-              prefix_stack << {depth: depth + 1, path: ns[1]}
+          if ns = stripped.match(/^namespace\s*\(?\s*['"]([^'"]+)['"]\s*\)?\s*(?:do\b|\{)/)
+            prefix_stack << {depth: depth + 1, path: ns[1]}
+          end
+
+          route_endpoints = line_to_endpoints(stripped)
+          unless route_endpoints.empty?
+            route_endpoints.each do |endpoint|
+              endpoint.url = sinatra_prefixed_path(prefix_stack, endpoint.url)
+              details = Details.new(PathInfo.new(path, index + 1))
+              endpoint.details = details
+              attach_route_callees(endpoint, lines, index, path) if include_callee
+              @result << endpoint
             end
 
-            route_endpoints = line_to_endpoints(stripped)
-            unless route_endpoints.empty?
-              route_endpoints.each do |endpoint|
-                endpoint.url = sinatra_prefixed_path(prefix_stack, endpoint.url)
-                details = Details.new(PathInfo.new(path, index + 1))
-                endpoint.details = details
-                attach_route_callees(endpoint, lines, index, path) if include_callee
-                @result << endpoint
-              end
-
-              if line_delta > 0
-                active_route_endpoints = route_endpoints
-                active_route_depth = depth + 1
-              else
-                active_route_endpoints = [] of Endpoint
-                active_route_depth = nil
-              end
-            end
-
-            line_to_params(stripped).each do |param|
-              target_endpoints = if route_endpoints.empty?
-                                   if (route_depth = active_route_depth) && !active_route_endpoints.empty? && depth >= route_depth
-                                     active_route_endpoints
-                                   else
-                                     [] of Endpoint
-                                   end
-                                 else
-                                   route_endpoints
-                                 end
-
-              target_endpoints.each do |endpoint|
-                endpoint.push_param(param)
-              end
-            end
-
-            depth += line_delta
-            while !prefix_stack.empty? && prefix_stack.last[:depth] > depth
-              prefix_stack.pop
-            end
-            if (route_depth = active_route_depth) && depth < route_depth
+            if line_delta > 0
+              active_route_endpoints = route_endpoints
+              active_route_depth = depth + 1
+            else
               active_route_endpoints = [] of Endpoint
               active_route_depth = nil
             end
+          end
+
+          line_to_params(stripped).each do |param|
+            target_endpoints = if route_endpoints.empty?
+                                 if (route_depth = active_route_depth) && !active_route_endpoints.empty? && depth >= route_depth
+                                   active_route_endpoints
+                                 else
+                                   [] of Endpoint
+                                 end
+                               else
+                                 route_endpoints
+                               end
+
+            target_endpoints.each do |endpoint|
+              endpoint.push_param(param)
+            end
+          end
+
+          depth += line_delta
+          while !prefix_stack.empty? && prefix_stack.last[:depth] > depth
+            prefix_stack.pop
+          end
+          if (route_depth = active_route_depth) && depth < route_depth
+            active_route_endpoints = [] of Endpoint
+            active_route_depth = nil
           end
         end
       end

--- a/src/analyzer/analyzers/ruby/webrick.cr
+++ b/src/analyzer/analyzers/ruby/webrick.cr
@@ -30,6 +30,15 @@ module Analyzer::Ruby
       "do_options" => "OPTIONS",
     }
 
+    # `extract_webrick_params` builds a `/#{Regex.escape(var)}\[...\]/`
+    # subscript matcher for each variable name it discovers (the LHS of a
+    # `parse_query(...)`/`JSON.parse(...)` assignment). Crystal recompiles an
+    # interpolated regex literal on every evaluation, and common variable
+    # names (`p`, `data`, `body`) repeat across many handler bodies in a
+    # single scan, so memoize the compiled regex per name instead of
+    # rebuilding it every time the same name reappears.
+    @var_subscript_regex_cache = Hash(String, Regex).new
+
     def analyze
       include_callee = callees_needed?
 
@@ -288,7 +297,7 @@ module Analyzer::Ruby
           form_vars << m[1] unless form_vars.includes?(m[1])
         end
         form_vars.each do |var|
-          clean.scan(/#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |mm|
+          clean.scan(var_subscript_regex(var)) do |mm|
             name = mm[1].strip
             next if name.empty? || seen.includes?("form:#{name}")
             params << Param.new(name, "", "form")
@@ -302,7 +311,7 @@ module Analyzer::Ruby
           json_vars << m[1] unless json_vars.includes?(m[1])
         end
         json_vars.each do |var|
-          clean.scan(/#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/) do |mm|
+          clean.scan(var_subscript_regex(var)) do |mm|
             name = mm[1].strip
             next if name.empty? || seen.includes?("json:#{name}")
             params << Param.new(name, "", "json")
@@ -319,6 +328,12 @@ module Analyzer::Ruby
       end
 
       params
+    end
+
+    # Memoized per-name compiled matcher for `var['k']` subscripts (see the
+    # `@var_subscript_regex_cache` note above).
+    private def var_subscript_regex(var : String) : Regex
+      @var_subscript_regex_cache[var] ||= /#{Regex.escape(var)}\s*\[\s*['"]([^'"]+)['"]\s*\]/
     end
   end
 end

--- a/src/analyzer/analyzers/ruby/webrick.cr
+++ b/src/analyzer/analyzers/ruby/webrick.cr
@@ -45,6 +45,12 @@ module Analyzer::Ruby
     # scans per file.
     WEBRICK_EVIDENCE_RE = Regex.union("webrick", "WEBrick", "mount_proc")
 
+    # `extract_webrick_params`'s per-line cookie-scan gate OR-ed two
+    # String#includes? scans as a standalone boolean gate. Folded into one
+    # precompiled union so it costs a single PCRE2 match instead of up to
+    # two naive substring scans per line of the handler body.
+    COOKIE_LINE_GATE_RE = Regex.union("cookies", ".name")
+
     # `extract_webrick_params` builds a `/#{Regex.escape(var)}\[...\]/`
     # subscript matcher for each variable name it discovers (the LHS of a
     # `parse_query(...)`/`JSON.parse(...)` assignment). Crystal recompiles an
@@ -279,7 +285,7 @@ module Analyzer::Ruby
       # cookies: req.cookies.find { |c| c.name == 'session' } or similar literal near cookies
       # Use line-scoped to avoid cross-line greedy match.
       clean.each_line do |ln|
-        next unless ln.includes?("cookies") || ln.includes?(".name")
+        next unless ln.matches?(COOKIE_LINE_GATE_RE)
         ln.scan(/(?:req|request)\.cookies[^\n]*['"]([^'"]+)['"]/) do |m|
           name = m[1].strip
           next if name.empty? || seen.includes?("cookie:#{name}")

--- a/src/analyzer/analyzers/ruby/webrick.cr
+++ b/src/analyzer/analyzers/ruby/webrick.cr
@@ -30,6 +30,15 @@ module Analyzer::Ruby
       "do_options" => "OPTIONS",
     }
 
+    # `extract_verbs_from_handler_body`'s per-verb loop OR-ed four
+    # String#includes? scans (with string interpolation) over the handler
+    # body for each of the seven fixed HTTP verbs — up to 28 naive substring
+    # scans per call. The verb set never changes, so precompile one
+    # Regex.union per verb at class load instead.
+    VERB_GUARD_MARKERS = ["get", "post", "put", "patch", "delete", "head", "options"].to_h do |v|
+      {v, Regex.union("\"#{v}\"", "'#{v}'", v.upcase, ":#{v}")}
+    end
+
     # `extract_webrick_params` builds a `/#{Regex.escape(var)}\[...\]/`
     # subscript matcher for each variable name it discovers (the LHS of a
     # `parse_query(...)`/`JSON.parse(...)` assignment). Crystal recompiles an
@@ -221,11 +230,9 @@ module Analyzer::Ruby
       b = body.downcase
       has_method_check = b.includes?("request_method")
 
-      ["get", "post", "put", "patch", "delete", "head", "options"].each do |v|
+      VERB_GUARD_MARKERS.each do |v, marker_re|
         if has_method_check
-          if b.includes?("\"#{v}\"") || b.includes?("'#{v}'") || b.includes?(v.upcase) || b.includes?(":#{v}")
-            verbs << v.upcase
-          end
+          verbs << v.upcase if b.matches?(marker_re)
         end
       end
       # If the block is unconditional (plain mount_proc without method guard), verbs will be empty -> caller defaults to GET

--- a/src/analyzer/analyzers/ruby/webrick.cr
+++ b/src/analyzer/analyzers/ruby/webrick.cr
@@ -39,6 +39,12 @@ module Analyzer::Ruby
       {v, Regex.union("\"#{v}\"", "'#{v}'", v.upcase, ":#{v}")}
     end
 
+    # `analyze`'s per-file evidence gate OR-ed three String#includes? scans
+    # as a standalone boolean gate. Folded into one precompiled union so it
+    # costs a single PCRE2 match instead of up to three naive substring
+    # scans per file.
+    WEBRICK_EVIDENCE_RE = Regex.union("webrick", "WEBrick", "mount_proc")
+
     # `extract_webrick_params` builds a `/#{Regex.escape(var)}\[...\]/`
     # subscript matcher for each variable name it discovers (the LHS of a
     # `parse_query(...)`/`JSON.parse(...)` assignment). Crystal recompiles an
@@ -60,7 +66,7 @@ module Analyzer::Ruby
         next if ruby_non_production_path?(path)
         content = read_file_content(path)
         # Gate early on webrick signals (avoid unnecessary work + comment-only noise)
-        next unless content.includes?("webrick") || content.includes?("WEBrick") || content.includes?("mount_proc")
+        next unless content.matches?(WEBRICK_EVIDENCE_RE)
         process_webrick_file(path, content, servlet_index, include_callee)
       end
 


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **ruby** analyzers (flagship group; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `webrick.cr` | A/B | memoize per-name subscript regex in `extract_webrick_params`; precompute per-verb `Regex.union` guard table (was 4×7 interpolated `includes?` combos per call); collapse evidence + cookie-line `includes?` gates into unions |
| `rails.cr` | A/C | hoist `parse_options`'s two `Regex.new("...#{fixed}...")` out of the per-line hot path to consts; cache-first reads for routes + controller files (dropped a redundant rewind-read). The 4 rails_ai_context `.line` assertions verified unchanged |
| `cli.cr` / `grape.cr` / `roda.cr` | B | collapse chained `includes?` evidence/file gates into `Regex.union` |
| `hanami.cr` / `sinatra.cr` | C | cache-first `read_file_content` |

## Test plan
- ruby functional + unit specs → **1079 examples, 0 failures**.
- Full repo `crystal spec` → **24648 examples, 0 failures**; `just test` (with csharp) → **3681 + 20967, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 7 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>