### PR TITLE
perf(go): fix connect_rpc O(n^2) scan, drop gozero dead fallback, union gates

### DIFF
--- a/src/analyzer/analyzers/go/cli.cr
+++ b/src/analyzer/analyzers/go/cli.cr
@@ -26,6 +26,10 @@ module Analyzer::Go
       "github.com/alecthomas/kingpin",
       "gopkg.in/alecthomas/kingpin.v2",
     ]
+    # `FRAMEWORK_IMPORTS.any? { |m| content.includes?(m) }` re-scans the
+    # whole file once per marker (used at two call sites below); one
+    # precompiled `Regex.union` (PCRE2 JIT) checks all nine in a single pass.
+    FRAMEWORK_IMPORTS_RE = Regex.union(FRAMEWORK_IMPORTS)
 
     # --- builtin flag / argv -------------------------------------------------
     # The flag name is always the FIRST quoted string in the call: the `*Var`
@@ -127,7 +131,7 @@ module Analyzer::Go
           binary = go_binary_name(modules, path)
           root_url = "cli://#{binary}"
           lines = content.lines
-          framework_cli = FRAMEWORK_IMPORTS.any? { |marker| content.includes?(marker) }
+          framework_cli = content.matches?(FRAMEWORK_IMPORTS_RE)
           # stdlib flag / os.Args / raw os.Getenv only describe a CLI surface
           # when this file isn't really an HTTP server using flags for config.
           # An explicit CLI framework (cobra/urfave/...) overrides that — a
@@ -166,25 +170,34 @@ module Analyzer::Go
     # A file is part of the CLI surface when it imports a CLI framework or
     # uses the stdlib flag package / os.Args directly.
     private def cli_evidence?(content : String) : Bool
-      return true if FRAMEWORK_IMPORTS.any? { |m| content.includes?(m) }
+      return true if content.matches?(FRAMEWORK_IMPORTS_RE)
       return true if content.includes?("\"flag\"") &&
                      (content.matches?(BUILTIN_FLAG_RE) || content.includes?("flag.Parse(") ||
                      content.matches?(BUILTIN_ARG_RE) || content.matches?(BUILTIN_ARGS_RE))
       content.matches?(OS_ARG_INDEX_RE)
     end
 
+    # Five markers OR-ed as a standalone boolean gate for `cli_parse_point?`
+    # below — one precompiled `Regex.union` (PCRE2 JIT) replaces the
+    # separate `content.includes?` scan each used to make over the same
+    # buffer. kong/kingpin/mitchellh are deliberately excluded (see the
+    # comment in `cli_parse_point?`).
+    CLI_PARSE_POINT_RE = Regex.union(
+      "github.com/spf13/cobra",
+      "github.com/urfave/cli",
+      "github.com/alexflint/go-arg",
+      "github.com/jessevdk/go-flags",
+      "flag.Parse(",
+    )
+
     # A real argv/flag parse point — used to gate raw os.Getenv reads so a
     # web app's config reads don't masquerade as a CLI surface.
     private def cli_parse_point?(content : String) : Bool
-      return true if content.includes?("github.com/spf13/cobra")
-      return true if content.includes?("github.com/urfave/cli")
-      return true if content.includes?("github.com/alexflint/go-arg")
-      return true if content.includes?("github.com/jessevdk/go-flags")
       # kong/kingpin/mitchellh's own scans attribute their env vars
       # precisely (struct tag / .Envar() / scoped Run() body) — they
       # deliberately don't opt into the raw root-level os.Getenv fallback
       # below, which would double-attribute (or mis-scope) those reads.
-      return true if content.includes?("flag.Parse(")
+      return true if content.matches?(CLI_PARSE_POINT_RE)
       return true if content.matches?(OS_ARG_INDEX_RE)
       content.includes?("os.Args")
     end

--- a/src/analyzer/analyzers/go/connect_rpc.cr
+++ b/src/analyzer/analyzers/go/connect_rpc.cr
@@ -141,9 +141,16 @@ module Analyzer::Go
     end
 
     private def parse_proto(content : String, file_path : String, mounts : Hash(ServiceMountKey, ServiceMount))
+      # `extract_brace_block` below walks position-by-position; a plain
+      # `String#[](Int)` re-decodes UTF-8 from the start on every call once
+      # the string has any multi-byte char, making that walk O(n^2) on
+      # non-ASCII `.proto` content (comments/strings often carry one).
+      # Precompute the char array once per file — shared by every message
+      # and service block extraction below — for O(1) positional reads.
+      chars = content.chars
       package = parse_package(content)
-      messages = parse_messages(content)
-      parse_services(content, file_path, package, messages, mounts)
+      messages = parse_messages(content, chars)
+      parse_services(content, chars, file_path, package, messages, mounts)
     end
 
     private def parse_package(content : String) : String
@@ -154,7 +161,7 @@ module Analyzer::Go
       end
     end
 
-    private def parse_messages(content : String) : Hash(String, MessageFields)
+    private def parse_messages(content : String, chars : Array(Char)) : Hash(String, MessageFields)
       messages = {} of String => MessageFields
 
       content.scan(/message\s+(\w+)\s*\{/m) do |match|
@@ -162,7 +169,7 @@ module Analyzer::Go
         start_pos = match.begin(0) || 0
         brace_pos = content.index('{', start_pos)
         next if brace_pos.nil?
-        msg_body = extract_brace_block(content, brace_pos)
+        msg_body = extract_brace_block(content, chars, brace_pos)
         next if msg_body.nil?
 
         fields = [] of Param
@@ -184,25 +191,30 @@ module Analyzer::Go
       messages
     end
 
-    private def parse_services(content : String, file_path : String, package : String, messages : Hash(String, MessageFields), mounts : Hash(ServiceMountKey, ServiceMount))
+    private def parse_services(content : String, chars : Array(Char), file_path : String, package : String, messages : Hash(String, MessageFields), mounts : Hash(ServiceMountKey, ServiceMount))
       content.scan(/service\s+(\w+)\s*\{/m) do |service_match|
         service_name = service_match[1]
         start_pos = service_match.begin(0) || 0
         brace_pos = content.index('{', start_pos)
         next if brace_pos.nil?
-        service_body = extract_brace_block(content, brace_pos)
+        service_body = extract_brace_block(content, chars, brace_pos)
         next if service_body.nil?
 
         parse_rpc_methods(service_body, file_path, package, service_name, messages, content, mounts)
       end
     end
 
-    private def extract_brace_block(content : String, open_pos : Int32) : String?
+    # `content` is still used for the bulk comment/string skips below (single
+    # `String#index` calls that jump straight to the target position, not a
+    # per-char walk); `chars` backs every incremental positional read so the
+    # walk stays O(1) per step regardless of encoding.
+    private def extract_brace_block(content : String, chars : Array(Char), open_pos : Int32) : String?
       depth = 0
       pos = open_pos
       in_string = false
-      while pos < content.size
-        ch = content[pos]
+      size = chars.size
+      while pos < size
+        ch = chars[pos]
         if in_string
           # A quote closes the string only when preceded by an EVEN number of
           # backslashes (so `\\"` = literal backslash + terminator toggles, but
@@ -210,21 +222,21 @@ module Analyzer::Go
           if ch == '"'
             bs = 0
             bp = pos - 1
-            while bp >= 0 && content[bp] == '\\'
+            while bp >= 0 && chars[bp] == '\\'
               bs += 1
               bp -= 1
             end
             in_string = false if bs.even?
           end
-        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '/'
+        elsif ch == '/' && pos + 1 < size && chars[pos + 1] == '/'
           # Line comment: skip to EOL so a stray `}` or `"` can't shift state.
           nl = content.index('\n', pos)
-          pos = nl.nil? ? content.size : nl
+          pos = nl.nil? ? size : nl
           next
-        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '*'
+        elsif ch == '/' && pos + 1 < size && chars[pos + 1] == '*'
           # Block comment: skip to the closing */.
           close = content.index("*/", pos + 2)
-          pos = close.nil? ? content.size : close + 2
+          pos = close.nil? ? size : close + 2
           next
         elsif ch == '"'
           in_string = true
@@ -232,7 +244,7 @@ module Analyzer::Go
           depth += 1
         elsif ch == '}'
           depth -= 1
-          return content[(open_pos + 1)..(pos - 1)] if depth == 0
+          return chars[(open_pos + 1)..(pos - 1)].join if depth == 0
         end
         pos += 1
       end

--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -148,8 +148,20 @@ module Analyzer::Go
       end
     end
 
+    # Cheap pre-filter for `analyze_param_line`, called on EVERY line of
+    # every fasthttp file (not just route lines). Union of every literal
+    # substring any of the six scans below requires to possibly match —
+    # a single precompiled `Regex.union` (PCRE2 JIT) pass replaces six
+    # unconditional `String#scan` regex attempts on lines that can't
+    # possibly contain a param accessor.
+    PARAM_LINE_SIGNAL_RE = Regex.union(
+      "QueryArgs", "PostArgs", "Request.Header", "FormValue", "UserValue",
+      "PostBody", ".Request.Body(",
+    )
+
     private def analyze_param_line(line : String) : Array(Param)
       params = [] of Param
+      return params unless line.matches?(PARAM_LINE_SIGNAL_RE)
 
       # QueryArgs().Peek("param") or QueryArgs().Get("param")
       line.scan(/(?:QueryArgs|PostArgs)\(\)\.(?:Peek|PeekMulti|Get|GetAll)\s*\(\s*"([^"]+)"\s*\)/) do |match|

--- a/src/analyzer/analyzers/go/gozero.cr
+++ b/src/analyzer/analyzers/go/gozero.cr
@@ -204,8 +204,10 @@ module Analyzer::Go
                    else                  "query"
                    end
 
-      accessor_regex = PARAM_ACCESSOR_PATTERNS[pattern]? || /#{Regex.escape(pattern)}\(\s*"([^"]+)"/
-      if match = line.match(accessor_regex)
+      # `get_param` is only ever called with one of the five patterns
+      # `PARAM_ACCESSOR_PATTERNS` was built from (see the loop above), so
+      # this lookup always hits — no interpolated-regex fallback needed.
+      if match = line.match(PARAM_ACCESSOR_PATTERNS[pattern])
         return Param.new(match[1], "", param_type)
       end
       Param.new("", "", "")


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **go** analyzers (19 files; follows #2258). 15/19 verified already-optimal.

| analyzer | tier | change |
|---|---|---|
| `connect_rpc.cr` | A | O(n²) per-char scan in proto brace-block extraction → thread `content.chars` |
| `gozero.cr` | B | drop the confirmed-dead interpolated-regex fallback in `get_param` (fixed table covers all call sites) |
| `cli.cr` | B | union-gate the repeated multi-marker `includes?` scans (`FRAMEWORK_IMPORTS`, `cli_parse_point?`) |
| `fasthttp.cr` | B | gate the 6 unconditional per-line param `scan`s behind a cheap `Regex.union` pre-check |
| 15 others | D | verified already-optimal (precompiled tables, cache-first reads, callee gating) |

## Test plan
- `crystal spec spec/functional_test/testers/go/` → **1782 examples, 0 failures**; unit superset **2066, 0 failures**.
- Full `just test` (with java+mobile) → **3681 + 20967, 0 failures**.
- format clean; `ameba` → 19 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>