### PR TITLE
perf(java): fix O(n^2) char scans, memoize/union gates, cache-first config reads

### DIFF
--- a/src/analyzer/analyzers/java/httpserver.cr
+++ b/src/analyzer/analyzers/java/httpserver.cr
@@ -48,6 +48,12 @@ module Analyzer::Java
     RE_HEADER = /getRequestHeaders\s*\(\s*\)\s*\.\s*(?:getFirst|get)\s*\(\s*"([^"]+)"/
     RE_BODY   = /getRequestBody\s*\(\s*\)/
 
+    # `detect_methods` interpolates the discovered `getRequestMethod()`
+    # variable name into 4 regexes; common names (`method`, `m`, ...) recur
+    # across handlers and files, so memoize per name instead of paying a
+    # fresh PCRE2 JIT compile on every handler that assigns to that name.
+    @method_var_regexes = Hash(String, Tuple(Regex, Regex, Regex, Regex)).new
+
     def analyze
       include_callee = callees_needed?
 
@@ -225,11 +231,17 @@ module Analyzer::Java
       end
 
       method_vars.each do |var|
-        escaped = Regex.escape(var)
-        scan_into(text, /\b#{escaped}\s*\.\s*equals(?:IgnoreCase)?\s*\(\s*"([A-Za-z]+)"/, verbs)
-        scan_into(text, /\b#{escaped}\s*==\s*"([A-Za-z]+)"/, verbs)
-        scan_into(text, /"([A-Za-z]+)"\s*\.\s*equals(?:IgnoreCase)?\s*\(\s*#{escaped}\s*\)/, verbs)
-        scan_into(text, /"([A-Za-z]+)"\s*==\s*#{escaped}/, verbs)
+        equals_re, eq_re, equals_rhs_re, eq_rhs_re = @method_var_regexes[var] ||= begin
+          escaped = Regex.escape(var)
+          {/\b#{escaped}\s*\.\s*equals(?:IgnoreCase)?\s*\(\s*"([A-Za-z]+)"/,
+           /\b#{escaped}\s*==\s*"([A-Za-z]+)"/,
+           /"([A-Za-z]+)"\s*\.\s*equals(?:IgnoreCase)?\s*\(\s*#{escaped}\s*\)/,
+           /"([A-Za-z]+)"\s*==\s*#{escaped}/}
+        end
+        scan_into(text, equals_re, verbs)
+        scan_into(text, eq_re, verbs)
+        scan_into(text, equals_rhs_re, verbs)
+        scan_into(text, eq_rhs_re, verbs)
       end
 
       collect_switch_verbs(text, method_vars, verbs)

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -9,6 +9,14 @@ module Analyzer::Java
     JAVA_EXTENSION = "java"
     alias ApplicationBaseKey = Tuple(String, String)
 
+    # `jaxrs_or_websocket_source?` gates the per-file tree-sitter parse;
+    # one precompiled `Regex.union` scan (PCRE2 JIT, auto-escapes each
+    # literal) replaces 5 separate `String#includes?` passes over the
+    # same buffer.
+    JAXRS_OR_WEBSOCKET_SOURCE_RE = Regex.union(
+      "jakarta.ws.rs", "javax.ws.rs", "jakarta.websocket", "javax.websocket", "@ServerEndpoint"
+    )
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
@@ -120,11 +128,7 @@ module Analyzer::Java
     end
 
     private def jaxrs_or_websocket_source?(content : String) : Bool
-      content.includes?("jakarta.ws.rs") ||
-        content.includes?("javax.ws.rs") ||
-        content.includes?("jakarta.websocket") ||
-        content.includes?("javax.websocket") ||
-        content.includes?("@ServerEndpoint")
+      content.matches?(JAXRS_OR_WEBSOCKET_SOURCE_RE)
     end
 
     private def add_application_package(application_packages : Hash(String, Array(ApplicationBaseKey)),

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -424,19 +424,22 @@ module Analyzer::Java
     end
 
     private def extract_balanced_block(content : String, open_index : Int32) : String
+      # Scan by CHARACTER via `each_char_with_index`, not a manual
+      # `while i < content.size; content[i]` loop: this walks a whole
+      # servlet handler body, and Crystal's String#[] is O(n) per access on
+      # non-ASCII content, making the old indexed loop O(n^2) in the worst
+      # case. One forward pass here keeps it O(n) regardless of encoding.
       depth = 0
-      i = open_index
 
-      while i < content.size
-        case content[i]
+      content.each_char_with_index do |char, i|
+        next if i < open_index
+        case char
         when '{'
           depth += 1
         when '}'
           depth -= 1
           return content[open_index..i] if depth == 0
         end
-
-        i += 1
       end
 
       content[open_index..]

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -53,14 +53,12 @@ module Analyzer::Java
                   if File.exists?(path) && File.extname(path) == ".jsp"
                     next if web_inf_jsp?(relative_path)
 
-                    File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-                      content = file.gets_to_end
-                      params_query = extract_params(content)
-                      details = Details.new(PathInfo.new(path))
-                      result << Endpoint.new(jsp_request_path(relative_path), "GET", params_query, details)
-                      extract_form_endpoints(content, details).each do |endpoint|
-                        result << endpoint
-                      end
+                    content = read_file_content(path)
+                    params_query = extract_params(content)
+                    details = Details.new(PathInfo.new(path))
+                    result << Endpoint.new(jsp_request_path(relative_path), "GET", params_query, details)
+                    extract_form_endpoints(content, details).each do |endpoint|
+                      result << endpoint
                     end
                   elsif File.exists?(path) && File.extname(path) == ".java"
                     content = read_file_content(path)

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -230,7 +230,7 @@ module Analyzer::Java
 
     private def read_properties(path : String) : Hash(String, String)
       values = Hash(String, String).new
-      File.each_line(path) do |line|
+      read_file_content(path).each_line do |line|
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?("#") || stripped.starts_with?("!")
 
@@ -244,7 +244,7 @@ module Analyzer::Java
     end
 
     private def merge_yaml_path_config(values : Hash(String, String), path : String)
-      flatten_yaml_values(values, YAML.parse(File.read(path)))
+      flatten_yaml_values(values, YAML.parse(read_file_content(path)))
     rescue
       nil
     end

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -134,14 +134,21 @@ module Analyzer::Java
       base_paths
     end
 
+    # `quarkus_route_source?`/`jaxrs_source?` gate per-file tree-sitter
+    # parses; one precompiled `Regex.union` scan (PCRE2 JIT, auto-escapes
+    # each literal) each replaces the chained `String#includes?` passes
+    # over the same buffer.
+    JAXRS_SOURCE_RE         = Regex.union("jakarta.ws.rs", "javax.ws.rs")
+    QUARKUS_ROUTE_SOURCE_RE = Regex.union(
+      "jakarta.ws.rs", "javax.ws.rs", "org.jboss.resteasy.reactive", "io.quarkus.vertx.web.Route"
+    )
+
     private def quarkus_route_source?(content : String) : Bool
-      jaxrs_source?(content) ||
-        content.includes?("org.jboss.resteasy.reactive") ||
-        content.includes?("io.quarkus.vertx.web.Route")
+      content.matches?(QUARKUS_ROUTE_SOURCE_RE)
     end
 
     private def jaxrs_source?(content : String) : Bool
-      content.includes?("jakarta.ws.rs") || content.includes?("javax.ws.rs")
+      content.matches?(JAXRS_SOURCE_RE)
     end
 
     private def application_base_path_for(path : String,

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -203,7 +203,7 @@ module Analyzer::Java
 
     private def read_properties(path : String) : Hash(String, String)
       values = Hash(String, String).new
-      File.each_line(path) do |line|
+      read_file_content(path).each_line do |line|
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?("#") || stripped.starts_with?("!")
 
@@ -232,7 +232,7 @@ module Analyzer::Java
     end
 
     private def yaml_string_value(path : String, *keys : String) : String?
-      value = YAML.parse(File.read(path))
+      value = YAML.parse(read_file_content(path))
       keys.each do |key|
         value = value[key]
       end

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -95,7 +95,7 @@ module Analyzer::Java
             application_yml_path = File.join(path, "main/resources/application.yml")
             if File.exists?(application_yml_path)
               begin
-                config = YAML.parse(File.read(application_yml_path))
+                config = YAML.parse(read_file_content(application_yml_path))
                 spring = config["spring"]
                 webflux = spring["webflux"]
                 webflux_base_path = webflux["base-path"]
@@ -111,7 +111,7 @@ module Analyzer::Java
             application_properties_path = File.join(path, "main/resources/application.properties")
             if File.exists?(application_properties_path)
               begin
-                properties = File.read(application_properties_path)
+                properties = read_file_content(application_properties_path)
                 base_path = properties.match(/spring\.webflux\.base-path\s*=\s*(.*)/)
                 if base_path
                   webflux_base_path = base_path[1]
@@ -1231,7 +1231,7 @@ module Analyzer::Java
 
     private def read_properties(path : String) : Hash(String, String)
       values = Hash(String, String).new
-      File.each_line(path) do |line|
+      read_file_content(path).each_line do |line|
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?("#") || stripped.starts_with?("!")
 
@@ -1254,7 +1254,7 @@ module Analyzer::Java
     end
 
     private def yaml_string_value(path : String, *keys : String) : String?
-      value = YAML.parse(File.read(path))
+      value = YAML.parse(read_file_content(path))
       keys.each do |key|
         value = value[key]
       end

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -8,7 +8,12 @@ module Analyzer::Java
   class Struts2 < Analyzer
     STRUTS_CONFIG_BASENAMES = Set{"struts.xml", "struts-plugin.xml", "struts-deferred.xml"}
     DEFAULT_LOCATORS        = ["action", "actions", "struts", "struts2"]
-    REST_METHODS            = {
+
+    # `struts_java_source?` gates the per-file convention-action scan; one
+    # precompiled `Regex.union` scan (PCRE2 JIT, auto-escapes each literal)
+    # replaces 4 separate `String#includes?` passes over the same buffer.
+    STRUTS_JAVA_SOURCE_RE = Regex.union("org.apache.struts2", "com.opensymphony.xwork2", "@Action", "@Namespace")
+    REST_METHODS          = {
       "index"         => {"GET", ""},
       "show"          => {"GET", "/:id"},
       "edit"          => {"GET", "/:id/edit"},
@@ -406,11 +411,7 @@ module Analyzer::Java
     end
 
     private def struts_java_source?(content : String, config : ConventionConfig) : Bool
-      content.includes?("org.apache.struts2") ||
-        content.includes?("com.opensymphony.xwork2") ||
-        content.includes?("@Action") ||
-        content.includes?("@Namespace") ||
-        config.rest_enabled?
+      content.matches?(STRUTS_JAVA_SOURCE_RE) || config.rest_enabled?
     end
 
     private def classes_in(content : String, package_name : String) : Array(JavaClass)

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -719,13 +719,18 @@ module Analyzer::Java
     end
 
     private def matching_brace(content : String, open_index : Int32) : Int32?
+      # Scan by CHARACTER via `each_char_with_index`, not a manual
+      # `while index < content.size; content[index]` loop: this walks a
+      # whole class body (can be the entire remainder of a large file), and
+      # Crystal's String#[] is O(n) per access on non-ASCII content, making
+      # the old indexed loop O(n^2) in the worst case. One forward pass here
+      # keeps it O(n) regardless of encoding.
       depth = 0
       in_string : Char? = nil
       escaped = false
 
-      index = open_index
-      while index < content.size
-        char = content[index]
+      content.each_char_with_index do |char, index|
+        next if index < open_index
         if in_string
           if escaped
             escaped = false
@@ -742,7 +747,6 @@ module Analyzer::Java
           depth -= 1
           return index if depth == 0
         end
-        index += 1
       end
       nil
     end

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -960,13 +960,16 @@ module Analyzer::Java
     end
 
     private def find_matching_paren(code : String, open_idx : Int32) : Int32?
+      # Scan by CHARACTER (not index-into-String-per-step): `code[index]` in a
+      # manual `while` loop is O(n) per access on non-ASCII content (Crystal
+      # can't fast-path multi-byte indexing), making the whole scan O(n^2) on
+      # a large non-ASCII file. `each_char_with_index` walks the string once.
       depth = 1
-      index = open_idx + 1
       in_string = false
       escape = false
 
-      while index < code.size
-        char = code[index]
+      code.each_char_with_index do |char, index|
+        next if index <= open_idx
         if in_string
           if escape
             escape = false
@@ -975,7 +978,6 @@ module Analyzer::Java
           elsif char == '"'
             in_string = false
           end
-          index += 1
           next
         end
 
@@ -988,19 +990,19 @@ module Analyzer::Java
           depth -= 1
           return index if depth.zero?
         end
-        index += 1
       end
       nil
     end
 
     private def find_matching_brace(code : String, open_idx : Int32) : Int32?
+      # See `find_matching_paren` above: single forward pass instead of
+      # per-index `code[i]` lookups, which are O(n^2) on non-ASCII content.
       depth = 1
-      index = open_idx + 1
       in_string = false
       escape = false
 
-      while index < code.size
-        char = code[index]
+      code.each_char_with_index do |char, index|
+        next if index <= open_idx
         if in_string
           if escape
             escape = false
@@ -1009,7 +1011,6 @@ module Analyzer::Java
           elsif char == '"'
             in_string = false
           end
-          index += 1
           next
         end
 
@@ -1022,7 +1023,6 @@ module Analyzer::Java
           depth -= 1
           return index if depth.zero?
         end
-        index += 1
       end
       nil
     end


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **java** analyzers (15 files; follows #2258). 7/15 verified already-optimal.

| analyzer | tier | change |
|---|---|---|
| `wicket.cr` / `struts2.cr` / `jsp.cr` | A | eliminate O(n²) non-ASCII char scans in delimiter/brace/handler-body matching → `each_char_with_index` |
| `httpserver.cr` | A | memoize `detect_methods`' 4 per-variable-name interpolated regexes |
| `jaxrs.cr` / `struts2.cr` / `quarkus.cr` | B | fold source-detection `includes?` chains into `Regex.union` gates |
| `micronaut.cr` / `quarkus.cr` / `spring.cr` / `jsp.cr` | C | cache-first `read_file_content` for config/jsp reads |
| `spark.cr` / `cli.cr` / `dropwizard.cr` / `vertx.cr` / `play.cr` / `armeria.cr` / `javalin.cr` | D | verified already-optimal |

Bounded char-index advances (spring, struts2 annotation lists) left as-is; `Dir.glob` one-shot config reads left as-is.

## Test plan
- `crystal spec spec/functional_test/testers/java/` → **1917 examples, 0 failures**; extended **1976, 0 failures**.
- Full `just test` (with go+mobile) → **3681 + 20967, 0 failures**.
- format clean; `ameba` → 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>