### PR TITLE
perf(mobile): union-gate unresolved-URL and build-var reference checks

### DIFF
--- a/src/analyzer/analyzers/mobile/android.cr
+++ b/src/analyzer/analyzers/mobile/android.cr
@@ -703,8 +703,14 @@ module Analyzer::Mobile
       path.gsub(/(?<!\$)\{([^}]+)\}/, ":\\1")
     end
 
+    # Per-endpoint gate, evaluated for every emitted deep-link/provider URL.
+    # `String#matches?` (PCRE2 JIT) replaces three OR-ed `String#includes?`
+    # scans with a single pass; `Regex.union` auto-escapes each literal, so
+    # it is provably equivalent to the OR-of-substrings it replaces.
+    UNRESOLVED_URL_RE = Regex.union("@string/", "@{", "${")
+
     private def mark_unresolved(endpoint : Endpoint, url : String)
-      return unless url.includes?("@string/") || url.includes?("@{") || url.includes?("${")
+      return unless url.matches?(UNRESOLVED_URL_RE)
       endpoint.add_tag(Tag.new("unresolved", "Contains an unresolved manifest reference", "android"))
     end
 

--- a/src/analyzer/analyzers/mobile/ios.cr
+++ b/src/analyzer/analyzers/mobile/ios.cr
@@ -99,6 +99,11 @@ module Analyzer::Mobile
     PBXPROJ_ASSIGN_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^;]*)\s*;\s*$/
     # `$(VAR)` / `${VAR}` build-setting reference.
     BUILD_VAR_RE = /\$[({]([A-Za-z_][A-Za-z0-9_]*)[)}]/
+    # Presence-only gate for the same reference syntax. One precompiled
+    # `Regex.union` scan (PCRE2 JIT) replaces the OR-ed
+    # `String#includes?("$(")` / `String#includes?("${")` pair used to
+    # short-circuit substitution/resolution below.
+    BUILD_VAR_REF_RE = Regex.union("$(", "${")
 
     # Loads build-setting definitions from the project's .xcconfig and
     # project.pbxproj files, so CFBundleURLSchemes placeholders can be resolved.
@@ -179,7 +184,7 @@ module Analyzer::Mobile
     # bounded depth. Unknown or cyclic references are kept verbatim and
     # filtered by `unresolved_build_var?` before endpoint creation.
     private def substitute_build_vars(value : String, vars : Hash(String, Array(String))) : Array(String)
-      return [value] unless value.includes?("$(") || value.includes?("${")
+      return [value] unless value.matches?(BUILD_VAR_REF_RE)
 
       resolved = [value]
       MAX_BUILD_VAR_SUBSTITUTION_DEPTH.times do
@@ -205,13 +210,13 @@ module Analyzer::Mobile
         break unless changed
 
         resolved = next_values
-        break unless resolved.any? { |candidate| candidate.includes?("$(") || candidate.includes?("${") }
+        break unless resolved.any?(&.matches?(BUILD_VAR_REF_RE))
       end
       resolved
     end
 
     private def unresolved_build_var?(value : String) : Bool
-      value.includes?("$(") || value.includes?("${")
+      value.matches?(BUILD_VAR_REF_RE)
     end
 
     # Associated-domain service prefixes that designate a URL entry point.


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **mobile** analyzers (follows #2258).

| analyzer | tier | change |
|---|---|---|
| `android.cr` | B | `mark_unresolved` 3 chained `includes?` (per emitted endpoint) → `UNRESOLVED_URL_RE = Regex.union(...)` + `matches?` |
| `ios.cr` | B | the `$(`/`${` build-var OR-gate (3 call sites) → shared `BUILD_VAR_REF_RE = Regex.union(...)` |
| `well_known.cr` | D | verified already-optimal |

`android.cr`'s single dynamic regex is already `Regex.escape`d and called ~4×/manifest (not in a loop) → Tier-D; `Dir.glob` config discovery and the combo cap-timing left as-is (detection-visible).

## Test plan
- mobile functional + unit specs → **216 + 86 + 20, 0 failures**.
- Full `just test` (with go+java) → **3681 + 20967, 0 failures**.
- format clean; `ameba` → 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>