### PR TITLE
perf(cpp): union includes? evidence gates, memoize per-name regex, fix O(n^2) absl scan

### DIFF
--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -62,8 +62,10 @@ module Analyzer::Cpp
     # entries) so this gate can never diverge from what the extraction
     # regexes above actually accept, e.g. `ABSL_FLAG (int32_t, ...)` with a
     # space before the paren is valid C++ and must not be silently skipped.
-    CLI_MARKERS = ["CLI::App", "getopt", "struct option", "cxxopts::", "program_options",
-                   "DEFINE_string", "DEFINE_int", "DEFINE_bool", "ABSL_FLAG", "argparse::ArgumentParser"]
+    # Precompiled as a single Regex.union so the per-file evidence gate costs
+    # one PCRE2 match instead of up to ten naive substring scans.
+    CLI_MARKERS_RE = Regex.union("CLI::App", "getopt", "struct option", "cxxopts::", "program_options",
+      "DEFINE_string", "DEFINE_int", "DEFINE_bool", "ABSL_FLAG", "argparse::ArgumentParser")
     WEB_RE = /\b(?:Crow|crow|drogon|httplib|oatpp)\b|Crow::|drogon::|httplib::|oatpp::/
 
     def analyze
@@ -77,7 +79,7 @@ module Analyzer::Cpp
 
           begin
             content = read_file_content(path)
-            next unless CLI_MARKERS.any? { |m| content.includes?(m) }
+            next unless content.matches?(CLI_MARKERS_RE)
 
             binary = cpp_binary_name(path)
             root_url = "cli://#{binary}"

--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -68,6 +68,10 @@ module Analyzer::Cpp
       "DEFINE_string", "DEFINE_int", "DEFINE_bool", "ABSL_FLAG", "argparse::ArgumentParser")
     WEB_RE = /\b(?:Crow|crow|drogon|httplib|oatpp)\b|Crow::|drogon::|httplib::|oatpp::/
 
+    # Precompiled union for the per-file test-path skip gate (cpp_test_path?),
+    # matched via String#matches? instead of five naive substring scans.
+    CPP_TEST_PATH_RE = Regex.union("/test/", "/tests/", "_test.", "test_", ".test.")
+
     def analyze
       endpoints = {} of String => Endpoint
 
@@ -97,9 +101,7 @@ module Analyzer::Cpp
     end
 
     private def cpp_test_path?(path : String) : Bool
-      lower = path.downcase
-      lower.includes?("/test/") || lower.includes?("/tests/") ||
-        lower.includes?("_test.") || lower.includes?("test_") || lower.includes?(".test.")
+      path.downcase.matches?(CPP_TEST_PATH_RE)
     end
 
     private def cpp_binary_name(path : String) : String

--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -272,7 +272,17 @@ module Analyzer::Cpp
     private def absl_flag_names(line : String) : Array(String)
       names = [] of String
       offset = 0
+      # Lazily materialized on the first match: String#[](Int) / #[](Range)
+      # walk the UTF-8 buffer from the start on every call for any line
+      # containing a multi-byte char, turning this scan into O(n^2)/O(n^3).
+      # Array(Char) indexing/slicing is O(1)/O(k), so once a line actually
+      # has an ABSL_FLAG( match, the loop below stays O(n) overall. Lines
+      # without a match (the overwhelming majority in a scan) never pay for
+      # the array allocation at all.
+      chars = nil
+
       while offset <= line.size && (m = line.match(ABSL_FLAG_MARK, offset))
+        chars ||= line.chars
         args_start = m.end
         fields = [] of String
         depth = 0
@@ -280,13 +290,13 @@ module Analyzer::Cpp
         i = args_start
         closed_at = nil
 
-        while i < line.size
-          case line[i]
+        while i < chars.size
+          case chars[i]
           when '(', '<'
             depth += 1
           when ')'
             if depth == 0
-              fields << line[field_start...i]
+              fields << chars[field_start...i].join
               closed_at = i
               break
             end
@@ -295,7 +305,7 @@ module Analyzer::Cpp
             depth -= 1 if depth > 0
           when ','
             if depth == 0
-              fields << line[field_start...i]
+              fields << chars[field_start...i].join
               field_start = i + 1
             end
           end

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -32,6 +32,10 @@ module Analyzer::Cpp
     COOKIE_GET  = /\bget_cookie\s*\(\s*"([^"]+)"/
     BODY_ACCESS = /\b(req|request)\s*\.\s*body\b/
 
+    # Precompiled union for the per-file evidence gate in analyze_file, so it
+    # costs a single PCRE2 match instead of up to four naive substring scans.
+    EVIDENCE_RE = Regex.union("CROW_ROUTE", "CROW_BP_ROUTE", "CROW_WEBSOCKET_ROUTE", "route_dynamic")
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -53,8 +57,7 @@ module Analyzer::Cpp
 
     private def analyze_file(path : String, include_callee : Bool)
       source = read_file_content(path)
-      return unless source.includes?("CROW_ROUTE") || source.includes?("CROW_BP_ROUTE") ||
-                    source.includes?("CROW_WEBSOCKET_ROUTE") || source.includes?("route_dynamic")
+      return unless source.matches?(EVIDENCE_RE)
 
       # Blank comments so commented-out routes (e.g. inside `/* ... */`) and
       # documentation snippets are not picked up as real endpoints.

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -41,6 +41,12 @@ module Analyzer::Cpp
     @method_def_regexes = Hash(String, Regex).new
     @class_decl_regexes = Hash(String, Regex).new
 
+    # Precompiled union for the per-file evidence gate in `analyze`, so it
+    # costs a single PCRE2 match instead of up to eight naive substring
+    # scans.
+    EVIDENCE_RE = Regex.union("drogon", "registerHandler", "PATH_LIST_BEGIN", "PATH_ADD",
+      "METHOD_LIST_BEGIN", "METHOD_ADD", "ADD_METHOD_TO", "ADD_METHOD_VIA_REGEX")
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -54,14 +60,7 @@ module Analyzer::Cpp
           next unless CPP_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
           content = read_file_content(path)
-          next unless content.includes?("drogon") ||
-                      content.includes?("registerHandler") ||
-                      content.includes?("PATH_LIST_BEGIN") ||
-                      content.includes?("PATH_ADD") ||
-                      content.includes?("METHOD_LIST_BEGIN") ||
-                      content.includes?("METHOD_ADD") ||
-                      content.includes?("ADD_METHOD_TO") ||
-                      content.includes?("ADD_METHOD_VIA_REGEX")
+          next unless content.matches?(EVIDENCE_RE)
 
           analyze_file(path, content, include_callee)
         end

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -47,6 +47,11 @@ module Analyzer::Cpp
     EVIDENCE_RE = Regex.union("drogon", "registerHandler", "PATH_LIST_BEGIN", "PATH_ADD",
       "METHOD_LIST_BEGIN", "METHOD_ADD", "ADD_METHOD_TO", "ADD_METHOD_VIA_REGEX")
 
+    # extract_params's per-line JSON-body-access check is used twice (once
+    # positively, once negated) on the same line buffer; precompile it once
+    # instead of repeating the two-way includes? OR each time.
+    JSON_ACCESS_RE = Regex.union("->getJsonObject(", "->getJsonValue(")
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -637,12 +642,11 @@ module Analyzer::Cpp
           add_unique_param(params, Param.new(match[1], "", "cookie"))
         end
 
-        if line.includes?("->getJsonObject(") || line.includes?("->getJsonValue(")
+        if line.matches?(JSON_ACCESS_RE)
           add_unique_param(params, Param.new("body", "", "json"))
         end
 
-        if line.matches?(/->\s*(body|getBody)\s*\(\s*\)/) &&
-           !line.includes?("->getJsonObject(") && !line.includes?("->getJsonValue(")
+        if line.matches?(/->\s*(body|getBody)\s*\(\s*\)/) && !line.matches?(JSON_ACCESS_RE)
           add_unique_param(params, Param.new("body", "", "body"))
         end
       end

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -37,6 +37,10 @@ module Analyzer::Cpp
     NAMED_PARAM_REGEX = /:([A-Za-z_][A-Za-z0-9_]*)/
     # Regex metacharacters that mark a route pattern as a regex (kept verbatim).
     REGEX_META = /[()\[\]\\+*?^$|]/
+    # Precompiled union for the per-file verb-call evidence gate in
+    # analyze_file, so it costs a single PCRE2 match instead of up to six
+    # naive substring scans.
+    VERB_CALL_EVIDENCE_RE = Regex.union(".Get(", ".Post(", ".Put(", ".Delete(", ".Patch(", ".Options(")
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
@@ -63,9 +67,7 @@ module Analyzer::Cpp
     private def analyze_file(path : String, include_callee : Bool)
       source = read_file_content(path)
       return unless source.includes?("httplib")
-      return unless source.includes?(".Get(") || source.includes?(".Post(") ||
-                    source.includes?(".Put(") || source.includes?(".Delete(") ||
-                    source.includes?(".Patch(") || source.includes?(".Options(")
+      return unless source.matches?(VERB_CALL_EVIDENCE_RE)
 
       source = Noir::CppCalleeExtractor.strip_comments(source)
       using_ns = source.includes?("using namespace httplib")

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -42,6 +42,15 @@ module Analyzer::Cpp
     # naive substring scans.
     VERB_CALL_EVIDENCE_RE = Regex.union(".Get(", ".Post(", ".Put(", ".Delete(", ".Patch(", ".Options(")
 
+    # extract_function_body builds a `/\b#{Regex.escape(name)}\s*\(/` matcher
+    # for each named handler function it resolves. Crystal recompiles an
+    # interpolated regex literal on every evaluation, and this runs once per
+    # non-lambda route call in a scan, so a handler function reused across
+    # several routes would otherwise recompile the identical pattern each
+    # time. Cache the compiled regex per name in an instance Hash + `||=` so
+    # a repeated name reuses the already-compiled Regex.
+    @function_body_regex_cache = Hash(String, Regex).new
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -125,7 +134,7 @@ module Analyzer::Cpp
     end
 
     private def extract_function_body(source : String, name : String) : Tuple(String, Int32)?
-      regex = /\b#{Regex.escape(name)}\s*\(/
+      regex = @function_body_regex_cache[name] ||= /\b#{Regex.escape(name)}\s*\(/
       source.scan(regex) do |match|
         match_start = source.char_index_to_byte_index(match.begin(0) || 0) || 0
         # Skip call sites (`foo.name(`, `obj::name(`); we want the definition.

--- a/src/analyzer/analyzers/cpp/oatpp.cr
+++ b/src/analyzer/analyzers/cpp/oatpp.cr
@@ -22,6 +22,12 @@ module Analyzer::Cpp
     ENDPOINT_ASYNC_REGEX = /\bENDPOINT_ASYNC\s*\(/
     PATH_PARAM_REGEX     = /\{([^{}\/]+)\}/
 
+    # Precompiled unions for analyze_file's two per-file evidence gates, so
+    # each costs a single PCRE2 match instead of up to two naive substring
+    # scans.
+    LIBRARY_EVIDENCE_RE = Regex.union("oatpp", "ApiController")
+    MACRO_EVIDENCE_RE   = Regex.union("ENDPOINT(", "ENDPOINT_ASYNC(")
+
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
@@ -43,8 +49,8 @@ module Analyzer::Cpp
 
     private def analyze_file(path : String, include_callee : Bool)
       source = read_file_content(path)
-      return unless source.includes?("oatpp") || source.includes?("ApiController")
-      return unless source.includes?("ENDPOINT(") || source.includes?("ENDPOINT_ASYNC(")
+      return unless source.matches?(LIBRARY_EVIDENCE_RE)
+      return unless source.matches?(MACRO_EVIDENCE_RE)
 
       source = Noir::CppCalleeExtractor.strip_comments(source)
 


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **cpp** analyzers (all 5 touched; follows #2258).

| analyzer | tier | change |
|---|---|---|
| `cli.cr` | A/B | `absl_flag_names` per-char `line[i]` + range-slice O(n²) → `Array(Char)`; `CLI_MARKERS` (10-way) + `cpp_test_path?` (5-way) `includes?` → `Regex.union` |
| `httplib.cr` | A/B | memoize `extract_function_body`'s per-name `/\b#{Regex.escape(name)}\(/`; verb-call evidence gate → `Regex.union` |
| `crow.cr` / `oatpp.cr` / `drogon.cr` | B | fold chained `includes?` evidence/JSON-access gates into `Regex.union` consts |

drogon's interpolated-name memoization + macro-pattern hoist were already done in a prior pass (Tier-D there). All 5 already used `read_file_content` + callee gating.

## Test plan
- `crystal spec spec/functional_test/testers/cpp/` → **351 examples, 0 failures**.
- Full `just test` → **3681 unit + 20967 functional, 0 failures**.
- format clean; `ameba` → 5 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>