### PR TITLE
perf(rust): fix salvo O(n^2) char scan, union includes? evidence gates

### DIFF
--- a/src/analyzer/analyzers/rust/actix_web.cr
+++ b/src/analyzer/analyzers/rust/actix_web.cr
@@ -14,6 +14,10 @@ module Analyzer::Rust
     HTTP_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options"}
     alias GlobalFunctionEntry = NamedTuple(name: String, path: String, hints: Array(String), params_text: String?, callees: Array(Noir::RustCalleeExtractor::Entry))
 
+    # Precompiled union for analyze_file's builder-pass evidence gate, so it
+    # costs a single PCRE2 match instead of two naive substring scans.
+    BUILDER_PASS_EVIDENCE_RE = Regex.union(".route(", "resource(")
+
     # Cross-file scope registrations: `web::scope("/auth").service(mod::handler)`
     # frequently mounts a `#[get("/x")]` handler that lives in a *different*
     # file (the scope tree sits in `main.rs` / a router-setup module, the
@@ -105,7 +109,7 @@ module Analyzer::Rust
         # attribute-macro-only handler file — so the added scope-prefix
         # machinery costs nothing where it can't apply. `resource(` is needed
         # for the verb-less `web::resource("/p").to(handler)` form.
-        if source.includes?(".route(") || source.includes?("resource(")
+        if source.matches?(BUILDER_PASS_EVIDENCE_RE)
           scope_prefixes = collect_scope_prefixes(root, source, test_regions)
           function_index = build_function_index(root, source)
           # Map each builder route back to the `.configure`d fn that encloses

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -18,6 +18,11 @@ module Analyzer::Rust
     alias HandlerContext = NamedTuple(params: Array(Param), callees: Array(Noir::RustCalleeExtractor::Entry))
     alias ByteRange = Tuple(Int32, Int32)
 
+    # Precompiled union for build_cross_nest_index's per-file evidence gate,
+    # so it costs a single PCRE2 match instead of three naive substring
+    # scans.
+    CROSS_NEST_EVIDENCE_RE = Regex.union(".nest(", ".nest_api_service(", ".merge(")
+
     # Verbs accepted as the inner handler call (`get(...)`, `post(...)`,
     # …). Anything outside this set is treated as `GET` to match the
     # legacy fallback the regex analyzer used. `any` covers
@@ -1162,7 +1167,7 @@ module Analyzer::Rust
         next unless File.exists?(fpath) && File.extname(fpath) == ".rs"
         next if RustEngine.test_path?(fpath)
         src = read_file_content(fpath)
-        next unless src.includes?(".nest(") || src.includes?(".nest_api_service(") || src.includes?(".merge(")
+        next unless src.matches?(CROSS_NEST_EVIDENCE_RE)
         base = configured_base_for(fpath)
         begin
           test_regions = RustEngine.collect_cfg_test_regions(src)

--- a/src/analyzer/analyzers/rust/axum.cr
+++ b/src/analyzer/analyzers/rust/axum.cr
@@ -1056,6 +1056,11 @@ module Analyzer::Rust
 
     UTOIPA_VERBS = Set{"get", "post", "put", "delete", "patch", "head", "options", "trace"}
 
+    # Precompiled union for build_utoipa_prefix_index's per-file evidence
+    # gate, so it costs a single PCRE2 match instead of two naive substring
+    # scans.
+    UTOIPA_INDEX_EVIDENCE_RE = Regex.union("OpenApiRouter", ".routes(")
+
     # Emit an endpoint for every `#[utoipa::path(method, path = "/x")]`
     # handler in the file, composed with the OpenApiRouter nest prefix the
     # handler is registered under.
@@ -1431,7 +1436,7 @@ module Analyzer::Rust
         next if RustEngine.test_path?(fpath)
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
-        next unless src.includes?("OpenApiRouter") || src.includes?(".routes(")
+        next unless src.matches?(UTOIPA_INDEX_EVIDENCE_RE)
         file_mod = primary_module(fpath)
         begin
           test_regions = RustEngine.collect_cfg_test_regions(src)

--- a/src/analyzer/analyzers/rust/rocket.cr
+++ b/src/analyzer/analyzers/rust/rocket.cr
@@ -17,6 +17,10 @@ module Analyzer::Rust
     alias RouteLeaf = Tuple(String, String?)
     alias MountEntry = Tuple(String, Symbol, Array(RouteLeaf), String?, String, String)
 
+    # Precompiled union for build_mount_index's per-file evidence gate, so it
+    # costs a single PCRE2 match instead of three naive substring scans.
+    MOUNT_INDEX_EVIDENCE_RE = Regex.union("routes!", ".mount(", "routes as")
+
     # Cross-file `.mount()` prefix composition. A Rocket handler's real URL
     # is its `#[get("/x")]` attribute path prefixed by the base it is mounted
     # under — but the `.mount("/api", routes![...])` call lives in `main.rs`
@@ -105,7 +109,7 @@ module Analyzer::Rust
         next if RustEngine.test_path?(path)
         base = configured_base_for(path)
         src = read_file_content(path)
-        next unless src.includes?("routes!") || src.includes?(".mount(") || src.includes?("routes as")
+        next unless src.matches?(MOUNT_INDEX_EVIDENCE_RE)
         file_mod = primary_module(path)
         begin
           test_regions = RustEngine.collect_cfg_test_regions(src)

--- a/src/analyzer/analyzers/rust/rwf.cr
+++ b/src/analyzer/analyzers/rust/rwf.cr
@@ -23,6 +23,11 @@ module Analyzer::Rust
   # fragment and scan it too, mapping line numbers back onto the file.
   class Rwf < RustEngine
     HTTP_METHODS = %w[GET POST PUT DELETE PATCH HEAD OPTIONS]
+
+    # Precompiled union for collect_route_macro_fragments' per-macro
+    # evidence gate, so it costs a single PCRE2 match instead of four naive
+    # substring scans.
+    ROUTE_MACRO_EVIDENCE_RE = Regex.union("route", "crud", "rest", "wildcard")
     # `crud!` / `rest!` register the standard REST surface. `:id` is the
     # resource identifier param RWF uses for the member routes.
     REST_ROUTES = [
@@ -289,7 +294,7 @@ module Analyzer::Rust
         end
         next unless tt = token_tree
         text = Noir::TreeSitter.node_text(tt, source)
-        next unless text.includes?("route") || text.includes?("crud") || text.includes?("rest") || text.includes?("wildcard")
+        next unless text.matches?(ROUTE_MACRO_EVIDENCE_RE)
         # A `vec!` body sitting inside a mounted engine's `Engine::new(...)`
         # inherits that engine's mount prefix.
         tt_byte = LibTreeSitter.ts_node_start_byte(tt).to_i

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -30,6 +30,11 @@ module Analyzer::Rust
     alias ScopedNameKey = Tuple(String, String)
     alias PrefixEdge = Tuple(ScopedNameKey, String)
 
+    # Precompiled union for build_fn_external_prefixes' per-file evidence
+    # gate, so it costs a single PCRE2 match instead of two naive substring
+    # scans.
+    FN_EDGE_EVIDENCE_RE = Regex.union(".push(", ".unshift(")
+
     # Cross-function router composition. Salvo apps build their tree with
     # builder fns mounted via `.push(build_system_route())`, where
     # `build_system_route()` lives in another file and returns a nested
@@ -668,7 +673,7 @@ module Analyzer::Rust
         next if RustEngine.test_path?(fpath)
         base = configured_base_for(fpath)
         src = read_file_content(fpath)
-        next unless src.includes?(".push(") || src.includes?(".unshift(")
+        next unless src.matches?(FN_EDGE_EVIDENCE_RE)
         begin
           test_regions = RustEngine.collect_cfg_test_regions(src)
           Noir::TreeSitter.parse_rust(src) do |root|

--- a/src/analyzer/analyzers/rust/salvo.cr
+++ b/src/analyzer/analyzers/rust/salvo.cr
@@ -457,30 +457,35 @@ module Analyzer::Rust
     # the placeholder early.
     private def canonicalize_salvo_path(route : String) : String
       return route unless route.includes?('{')
+      # Array(Char) indexing/slicing is O(1)/O(k); String#[](Int)/#[](Range)
+      # walk the UTF-8 buffer from the start on every call for any route
+      # containing a multi-byte char, which would otherwise turn this scan
+      # into O(n^2).
+      chars = route.chars
       String.build do |io|
         i = 0
-        while i < route.size
-          if route[i] == '{'
+        while i < chars.size
+          if chars[i] == '{'
             depth = 1
             j = i + 1
-            while j < route.size && depth > 0
-              depth += 1 if route[j] == '{'
-              depth -= 1 if route[j] == '}'
+            while j < chars.size && depth > 0
+              depth += 1 if chars[j] == '{'
+              depth -= 1 if chars[j] == '}'
               j += 1
             end
             if depth > 0
               # Unbalanced '{' (no matching '}'): emit the rest verbatim rather
               # than dropping the final char / producing an empty `{}`.
-              io << route[i..]
+              chars[i..].each { |c| io << c }
               break
             end
-            inner = route[(i + 1)...(j - 1)]
+            inner = chars[(i + 1)...(j - 1)].join
             stars = inner.starts_with?("**") ? "**" : inner.starts_with?("*") ? "*" : ""
             name = inner.lstrip('*').split(/[:|]/, 2).first
             io << "{#{stars}#{name}}"
             i = j
           else
-            io << route[i]
+            io << chars[i]
             i += 1
           end
         end

--- a/src/analyzer/analyzers/rust/warp.cr
+++ b/src/analyzer/analyzers/rust/warp.cr
@@ -21,6 +21,11 @@ module Analyzer::Rust
     @external_handler_miss_cache = Set(String).new
     @external_handler_callee_cache_mutex = Mutex.new
 
+    # Precompiled union for collect_warp_mounts' per-function-body evidence
+    # check, so it costs a single PCRE2 match instead of two naive substring
+    # scans.
+    ROUTE_FN_EVIDENCE_RE = Regex.union("warp::path(", "warp::path!")
+
     def analyze
       @external_handler_callee_cache_mutex.synchronize do
         @external_handler_callee_cache.clear
@@ -127,7 +132,7 @@ module Analyzer::Rust
         # leaf. `warp::path::param`/`::end` don't match `warp::path(`.
         if body
           btext = Noir::TreeSitter.node_text(body, source)
-          route_fns << name if btext.includes?("warp::path(") || btext.includes?("warp::path!")
+          route_fns << name if btext.matches?(ROUTE_FN_EVIDENCE_RE)
         end
       end
 


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **rust** analyzers (11 files; follows #2258). 6/11 verified already-optimal.

| analyzer | tier | change |
|---|---|---|
| `salvo.cr` | A/B | `canonicalize_salvo_path` per-char `String[i]` O(n²) → `Array(Char)`; union the `build_fn_external_prefixes` gate |
| `axum.cr` | B | union the `build_cross_nest_index` + `build_utoipa_prefix_index` evidence gates (before project-wide parses) |
| `rocket.cr` / `warp.cr` / `actix_web.cr` / `rwf.cr` | B | union chained `includes?` evidence gates before tree-sitter re-parses |
| `cli.cr` / `tide.cr` / `loco.cr` / `gotham.cr` / `poem.cr` | D | verified already-optimal (precompiled `EXTRACTOR_PARAM_RES` table, cache-first reads, callee gating) |

## Test plan
- `crystal spec spec/functional_test/testers/rust/` → **1537 examples, 0 failures**; unit specs **53, 0 failures**.
- Full `just test` (with kotlin) → **3681 unit + 20967 functional, 0 failures**.
- format clean; `ameba` → 11 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>