### PR TITLE
perf(javascript): fix O(n^2) char scans in nextjs/hono/express/restify/nestjs, union detection gates

### DIFF
--- a/src/analyzer/analyzers/javascript/adonisjs.cr
+++ b/src/analyzer/analyzers/javascript/adonisjs.cr
@@ -4,11 +4,12 @@ require "../../../miniparsers/js_route_extractor"
 
 module Analyzer::Javascript
   class Adonisjs < Analyzer
-    JS_EXTENSIONS  = [".js", ".mjs", ".cjs", ".ts"]
-    ADONIS_MARKERS = [
-      "@adonisjs/core",
-      "@ioc:Adonis",
-    ]
+    JS_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts"]
+    # Precompiled once — a single PCRE2-JIT scan replaces two naive
+    # String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal, so it is provably equivalent
+    # to the OR-of-includes? it replaces.
+    ADONIS_MARKERS_RE = Regex.union("@adonisjs/core", "@ioc:Adonis")
 
     def analyze
       file_list = all_files()
@@ -17,7 +18,7 @@ module Analyzer::Javascript
         next unless JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
         content = read_file_content(path)
-        next unless ADONIS_MARKERS.any? { |m| content.includes?(m) }
+        next unless content.matches?(ADONIS_MARKERS_RE)
         # Reuse the shared JS test-stub gate so `*.spec.ts` /
         # `*.test.ts` (japa, vitest, jest) AdonisJS test scaffolds
         # don't leak. adonisjs/core's own repo parks ~19 phantom

--- a/src/analyzer/analyzers/javascript/apollo.cr
+++ b/src/analyzer/analyzers/javascript/apollo.cr
@@ -21,8 +21,11 @@ module Analyzer::Javascript
 
     # File-level signals that mark a JS/TS file as Apollo-relevant. The
     # parallel_file_scan walks every JS/TS source, so we gate with a cheap
-    # substring check before doing the heavier SDL extraction.
-    APOLLO_HINTS = ["@apollo/server", "apollo-server", "ApolloServer"]
+    # substring check before doing the heavier SDL extraction. Precompiled
+    # once — a single PCRE2-JIT scan replaces three naive String#includes?
+    # substring scans. Regex.union auto-escapes each literal, so it is
+    # provably equivalent to the OR-of-includes? it replaces.
+    APOLLO_HINTS_RE = Regex.union("@apollo/server", "apollo-server", "ApolloServer")
 
     def analyze
       parallel_file_scan do |path|
@@ -42,7 +45,7 @@ module Analyzer::Javascript
     end
 
     private def apollo_in_file?(content : String) : Bool
-      APOLLO_HINTS.any? { |hint| content.includes?(hint) }
+      content.matches?(APOLLO_HINTS_RE)
     end
 
     private def process_file(path : String, content : String)

--- a/src/analyzer/analyzers/javascript/cli.cr
+++ b/src/analyzer/analyzers/javascript/cli.cr
@@ -102,7 +102,12 @@ module Analyzer::Javascript
     WEB_FRAMEWORK_RE = /(?:require\s*\(\s*|from\s+)['"](?:express|fastify|koa|@hapi\/hapi|@nestjs\/[\w-]+|next|nuxt|hono|@hono\/[\w-]+|restify|@adonisjs\/[\w-]+|elysia|polka|connect|h3|@sveltejs\/[\w-]+|@remix-run\/[\w-]+|apollo-server|@apollo\/server)['"]/
     WEB_LISTEN_RE    = /\.\s*listen\s*\(|\bcreateServer\s*\(/
 
-    CLI_MARKERS = ["commander", "yargs", "cac", "meow", "minimist", "clipanion", "@oclif", "sade", "parseArgs", "Deno.args", "Bun.argv"]
+    # Precompiled once — a single PCRE2-JIT scan replaces up to eleven
+    # naive String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal (including the dots in
+    # "Deno.args"/"Bun.argv"), so it is provably equivalent to the
+    # OR-of-includes? it replaces.
+    CLI_MARKERS_RE = Regex.union("commander", "yargs", "cac", "meow", "minimist", "clipanion", "@oclif", "sade", "parseArgs", "Deno.args", "Bun.argv")
 
     def analyze
       package_names = collect_package_names
@@ -138,7 +143,7 @@ module Analyzer::Javascript
     end
 
     private def cli_evidence?(content : String) : Bool
-      CLI_MARKERS.any? { |m| content.includes?(m) } || content.matches?(ARGV_SLICE) ||
+      content.matches?(CLI_MARKERS_RE) || content.matches?(ARGV_SLICE) ||
         content.matches?(LIB_IMPORT_ONLY_RE)
     end
 

--- a/src/analyzer/analyzers/javascript/elysia.cr
+++ b/src/analyzer/analyzers/javascript/elysia.cr
@@ -3,8 +3,13 @@ require "../../../miniparsers/elysia_extractor_ts"
 
 module Analyzer::Javascript
   class Elysia < Analyzer
-    JS_EXTENSIONS  = [".js", ".mjs", ".cjs", ".ts"]
-    ELYSIA_MARKERS = ["from 'elysia'", "from \"elysia\"", "require('elysia')", "require(\"elysia\")"]
+    JS_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts"]
+    # Precompiled once — a single PCRE2-JIT scan replaces four naive
+    # String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal (including the parens in
+    # "require('elysia')"), so it is provably equivalent to the
+    # OR-of-includes? it replaces.
+    ELYSIA_MARKERS_RE = Regex.union("from 'elysia'", "from \"elysia\"", "require('elysia')", "require(\"elysia\")")
 
     def analyze
       file_list = all_files()
@@ -13,7 +18,7 @@ module Analyzer::Javascript
         next unless JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
         content = read_file_content(path)
-        next unless ELYSIA_MARKERS.any? { |m| content.includes?(m) }
+        next unless content.matches?(ELYSIA_MARKERS_RE)
 
         include_callee = callees_needed?
         Noir::TreeSitterElysiaExtractor.extract_routes(content, include_callee).each do |route|

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -992,13 +992,18 @@ module Analyzer::Javascript
       collect_static_paths(path, content, static_dirs, :express)
     end
 
+    # Precompiled once — a single PCRE2-JIT scan replaces six naive
+    # String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal, so this is provably
+    # equivalent to the OR-of-includes? it replaces.
+    EXPRESS_SOURCE_RE = Regex.union(
+      "require('express')", "require(\"express\")",
+      "from 'express'", "from \"express\"",
+      "express()", "express.Router("
+    )
+
     private def express_source?(content : String) : Bool
-      content.includes?("require('express')") ||
-        content.includes?("require(\"express\")") ||
-        content.includes?("from 'express'") ||
-        content.includes?("from \"express\"") ||
-        content.includes?("express()") ||
-        content.includes?("express.Router(")
+      content.matches?(EXPRESS_SOURCE_RE)
     end
 
     # Scan for router mount patterns and store them in CodeLocator

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -168,8 +168,13 @@ module Analyzer::Javascript
       escaped = false
       i = start_pos
 
+      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
+      # string isn't single_byte_optimizable? (any non-ASCII char), making
+      # this O(n^2) on a large non-ASCII handler body. Index a
+      # pre-materialized Char array instead — same semantics, O(1) lookup.
+      chars = content.chars
       while i < end_pos
-        char = content[i]
+        char = chars[i]
 
         if quote
           if escaped

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -82,7 +82,11 @@ module Analyzer::Javascript
 
     # Markers that a file configures `@fastify/autoload`. Both the scoped
     # package and the legacy bare name are matched so older projects work.
-    AUTOLOAD_MARKERS = ["@fastify/autoload", "fastify-autoload"]
+    # Precompiled once — a single PCRE2-JIT scan replaces two naive
+    # String#includes? substring scans. Regex.union auto-escapes each
+    # literal, so it is provably equivalent to the OR-of-includes? it
+    # replaces.
+    AUTOLOAD_MARKERS_RE = Regex.union("@fastify/autoload", "fastify-autoload")
 
     # A directory `@fastify/autoload` registers. `dir_prefix` records the
     # config's `dirNameRoutePrefix` — when it is `false`, subdirectories
@@ -109,7 +113,7 @@ module Analyzer::Javascript
       all_files.each do |path|
         next unless ExpressConstants::JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
         content = read_file_content(path)
-        next unless AUTOLOAD_MARKERS.any? { |m| content.includes?(m) }
+        next unless content.matches?(AUTOLOAD_MARKERS_RE)
         next unless content.includes?("dir")
 
         base_dir = File.dirname(File.expand_path(path))

--- a/src/analyzer/analyzers/javascript/graphql_yoga.cr
+++ b/src/analyzer/analyzers/javascript/graphql_yoga.cr
@@ -20,7 +20,11 @@ module Analyzer::Javascript
     DEFAULT_GRAPHQL_PATH = "/graphql"
 
     # Cheap content hints used to gate the heavier SDL extraction.
-    YOGA_HINTS = ["graphql-yoga", "createYoga"]
+    # Precompiled once — a single PCRE2-JIT scan replaces two naive
+    # String#includes? substring scans. Regex.union auto-escapes each
+    # literal, so it is provably equivalent to the OR-of-includes? it
+    # replaces.
+    YOGA_HINTS_RE = Regex.union("graphql-yoga", "createYoga")
 
     def analyze
       parallel_file_scan do |path|
@@ -36,7 +40,7 @@ module Analyzer::Javascript
     end
 
     private def yoga_in_file?(content : String) : Bool
-      YOGA_HINTS.any? { |hint| content.includes?(hint) }
+      content.matches?(YOGA_HINTS_RE)
     end
 
     private def process_file(path : String, content : String)

--- a/src/analyzer/analyzers/javascript/hapi.cr
+++ b/src/analyzer/analyzers/javascript/hapi.cr
@@ -4,7 +4,12 @@ require "../../../miniparsers/hapi_extractor_ts"
 module Analyzer::Javascript
   class Hapi < Analyzer
     JS_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts"]
-    HAPI_MARKERS  = ["@hapi/hapi", "require('hapi')", "require(\"hapi\")", "from 'hapi'", "from \"hapi\""]
+    # Precompiled once — a single PCRE2-JIT scan replaces five naive
+    # String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal (including the parens in
+    # "require('hapi')"), so it is provably equivalent to the
+    # OR-of-includes? it replaces.
+    HAPI_MARKERS_RE = Regex.union("@hapi/hapi", "require('hapi')", "require(\"hapi\")", "from 'hapi'", "from \"hapi\"")
 
     def analyze
       file_list = all_files()
@@ -13,7 +18,7 @@ module Analyzer::Javascript
         next unless JS_EXTENSIONS.any? { |ext| path.ends_with?(ext) }
 
         content = read_file_content(path)
-        next unless HAPI_MARKERS.any? { |m| content.includes?(m) }
+        next unless content.matches?(HAPI_MARKERS_RE)
 
         include_callee = callees_needed?
         Noir::TreeSitterHapiExtractor.extract_routes(content, include_callee).each do |route|

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -5,7 +5,6 @@ require "./express/router_mount_scanner"
 
 module Analyzer::Javascript
   class Hono < JavascriptEngine
-    ON_ROUTE_CALL_HINTS   = [".on(", ".on ("]
     ON_ROUTE_CALL_PATTERN = /\.(?:\s|\n|\r)*on(?:\s|\n|\r)*\(/
 
     def analyze
@@ -56,8 +55,13 @@ module Analyzer::Javascript
     end
 
     private def on_route_candidate?(content : String) : Bool
-      ON_ROUTE_CALL_HINTS.any? { |hint| content.includes?(hint) } ||
-        content.matches?(ON_ROUTE_CALL_PATTERN)
+      # `ON_ROUTE_CALL_PATTERN` already matches both ".on(" and ".on ("
+      # (its `(?:\s|\n|\r)*` groups allow zero-or-more whitespace around
+      # "on"), so the two former String#includes? checks ahead of it were
+      # a strictly redundant pre-filter — and per this project's own
+      # benchmarking, Crystal's naive includes? scan is slower than a
+      # PCRE2-JIT matches? call, so the "pre-gate" was a pure regression.
+      content.matches?(ON_ROUTE_CALL_PATTERN)
     end
 
     private def extract_on_routes(path : String,
@@ -181,8 +185,13 @@ module Analyzer::Javascript
       escaped = false
       i = start_pos
 
+      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
+      # string isn't single_byte_optimizable? (any non-ASCII char), making
+      # this O(n^2) on a large non-ASCII handler body. Index a
+      # pre-materialized Char array instead — same semantics, O(1) lookup.
+      chars = content.chars
       while i < end_pos
-        char = content[i]
+        char = chars[i]
 
         if quote
           if escaped

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -680,9 +680,15 @@ module Analyzer::Javascript
       idx = line_start_for_index(content, route_decorator_start)
       block_start = idx
 
+      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
+      # string isn't single_byte_optimizable? (any non-ASCII char). This
+      # walks backward line-by-line over the (possibly large) controller
+      # class content once per route decorator, so index a
+      # pre-materialized Char array instead — same semantics, O(1) lookup.
+      chars = content.chars
       while idx > 0
         previous_end = idx - 1
-        while previous_end >= 0 && content[previous_end] == '\n'
+        while previous_end >= 0 && chars[previous_end] == '\n'
           previous_end -= 1
         end
         break if previous_end < 0
@@ -700,7 +706,10 @@ module Analyzer::Javascript
 
     private def line_start_for_index(content : String, index : Int32) : Int32
       pos = index
-      while pos > 0 && content[pos - 1] != '\n'
+      # Same non-ASCII O(n^2) risk as above — index a pre-materialized
+      # Char array instead of re-decoding content[pos - 1] every step.
+      chars = content.chars
+      while pos > 0 && chars[pos - 1] != '\n'
         pos -= 1
       end
       pos
@@ -748,29 +757,35 @@ module Analyzer::Javascript
 
     private def skip_decorators_and_whitespace(content : String, start_pos : Int32) : Int32
       idx = start_pos
+      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
+      # string isn't single_byte_optimizable? (any non-ASCII char), making
+      # this O(n^2) when walked once per route decorator in a large
+      # non-ASCII controller class. Index a pre-materialized Char array
+      # instead — same semantics, O(1) lookup.
+      chars = content.chars
       loop do
-        while idx < content.size && content[idx].whitespace?
+        while idx < chars.size && chars[idx].whitespace?
           idx += 1
         end
-        break if idx >= content.size || content[idx] != '@'
+        break if idx >= chars.size || chars[idx] != '@'
 
         name_end = idx + 1
-        while name_end < content.size && (content[name_end].alphanumeric? || content[name_end] == '_' || content[name_end] == '$')
+        while name_end < chars.size && (chars[name_end].alphanumeric? || chars[name_end] == '_' || chars[name_end] == '$')
           name_end += 1
         end
 
         scan = name_end
-        while scan < content.size && content[scan].whitespace?
+        while scan < chars.size && chars[scan].whitespace?
           scan += 1
         end
 
-        if scan < content.size && content[scan] == '('
+        if scan < chars.size && chars[scan] == '('
           close = Noir::JSRouteExtractor.find_matching_paren(content, scan)
           break unless close
           idx = close + 1
         else
           newline = content.index('\n', scan)
-          idx = newline ? newline + 1 : content.size
+          idx = newline ? newline + 1 : chars.size
         end
       end
       idx

--- a/src/analyzer/analyzers/javascript/nestjs.cr
+++ b/src/analyzer/analyzers/javascript/nestjs.cr
@@ -174,12 +174,18 @@ module Analyzer::Javascript
       logger.debug "Error analyzing NestJS file #{path}: #{e.message}"
     end
 
+    # Precompiled once — a single PCRE2-JIT scan replaces five naive
+    # String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal, so this is provably
+    # equivalent to the OR-of-includes? it replaces.
+    NESTJS_BOOTSTRAP_RE = Regex.union(
+      "NestFactory.create",
+      "from '@nestjs/core'", "from \"@nestjs/core\"",
+      "require('@nestjs/core')", "require(\"@nestjs/core\")"
+    )
+
     private def nestjs_bootstrap_source?(content : String) : Bool
-      content.includes?("NestFactory.create") ||
-        content.includes?("from '@nestjs/core'") ||
-        content.includes?("from \"@nestjs/core\"") ||
-        content.includes?("require('@nestjs/core')") ||
-        content.includes?("require(\"@nestjs/core\")")
+      content.matches?(NESTJS_BOOTSTRAP_RE)
     end
 
     # Detect `app.setGlobalPrefix('api', { exclude: [...] })`.

--- a/src/analyzer/analyzers/javascript/nextjs.cr
+++ b/src/analyzer/analyzers/javascript/nextjs.cr
@@ -298,8 +298,14 @@ module Analyzer::Javascript
       return if open_pos.nil?
       depth = 1
       i = open_pos + 1
-      while i < content.size && depth > 0
-        case content[i]
+      # `content[i]` re-decodes UTF-8 from byte 0 on every call once the
+      # string isn't single_byte_optimizable? (any non-ASCII char), making
+      # this depth-scan O(n^2) on a large non-ASCII handler body. Index a
+      # pre-materialized Char array instead — same char-by-char semantics,
+      # O(1) per lookup.
+      chars = content.chars
+      while i < chars.size && depth > 0
+        case chars[i]
         when '{'
           depth += 1
         when '}'

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -47,11 +47,16 @@ module Analyzer::Javascript
       result
     end
 
+    # Precompiled once — a single PCRE2-JIT scan replaces four naive
+    # String#includes? substring scans over the whole file content.
+    # Regex.union auto-escapes each literal, so this is provably
+    # equivalent to the OR-of-includes? it replaces.
+    CLIENT_LIBRARY_RE = Regex.union(
+      "restify-clients", "createJSONClient(", "createStringClient(", "createHttpClient("
+    )
+
     private def client_library_file?(content : String) : Bool
-      content.includes?("restify-clients") ||
-        content.includes?("createJSONClient(") ||
-        content.includes?("createStringClient(") ||
-        content.includes?("createHttpClient(")
+      content.matches?(CLIENT_LIBRARY_RE)
     end
 
     # Process static directories and add endpoints for each file

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -207,10 +207,16 @@ module Analyzer::Javascript
             function_end = function_start + 1
 
             open_braces = 1
-            while open_braces > 0 && function_end < content.size
-              if content[function_end] == '{'
+            # `content[function_end]` re-decodes UTF-8 from byte 0 on every
+            # call once the string isn't single_byte_optimizable? (any
+            # non-ASCII char), making this O(n^2) on a large non-ASCII
+            # file. Index a pre-materialized Char array instead — same
+            # semantics, O(1) lookup.
+            chars = content.chars
+            while open_braces > 0 && function_end < chars.size
+              if chars[function_end] == '{'
                 open_braces += 1
-              elsif content[function_end] == '}'
+              elsif chars[function_end] == '}'
                 open_braces -= 1
               end
               function_end += 1


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **javascript** analyzers (~20 files; follows #2258). ~10 verified already-optimal.

| tier | analyzers | change |
|---|---|---|
| A | nextjs, hono, express, restify, nestjs | fix O(n²) per-char `String[i]` scans in body/arg/decorator walkers → `Array(Char)` (nestjs fix also covers `Typescript::Nestjs`, which inherits it) |
| B | express, restify, nestjs, apollo, graphql_yoga, elysia, hapi, adonisjs, fastify, cli | fold chained `includes?` source/marker detection gates into `Regex.union` consts |
| D | astro, fresh, http, koa, nitro, nuxtjs, remix, sveltekit, express_constants, router_mount_scanner | verified already-optimal (hoisted verb consts, `cached_regex`, byte-level scanners, sanctioned single gates) |

Flagged for follow-up (out of this scope): `src/utils/js_literal_scanner.cr` has the same O(n²) `content[idx]` pattern used by many JS analyzers via `JSRouteExtractor.find_matching_brace/paren` — the highest-value remaining JS-pipeline fix.

## Test plan
- `crystal spec spec/functional_test/testers/javascript/` → **2603 examples, 0 failures**; combined with TS-nestjs + detector/tagger specs → **2863, 0 failures**.
- Full `just test` (with php+ts) → **3681 unit + 20967 functional, 0 failures**.
- format clean; `ameba` → 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>