### PR TITLE
perf(php): byte-level rewrites of laminas/slim/yii scanners, cache-first reads, union gates

### DIFF
--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -22,10 +22,8 @@ module Analyzer::Php
       endpoints = [] of Endpoint
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       begin
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          content = file.gets_to_end
-          endpoints = analyze_routes_content(content, "", path, include_callee)
-        end
+        content = read_file_content(path)
+        endpoints = analyze_routes_content(content, "", path, include_callee)
       rescue e
         logger.debug "Error analyzing routes file #{path}: #{e}"
       end

--- a/src/analyzer/analyzers/php/codeigniter.cr
+++ b/src/analyzer/analyzers/php/codeigniter.cr
@@ -34,11 +34,9 @@ module Analyzer::Php
       endpoints = [] of Endpoint
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       begin
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          content = file.gets_to_end
-          endpoints.concat(analyze_routes_content(content, "", path, include_callee, "App\\Controllers"))
-          endpoints.concat(analyze_ci3_routes(content, path))
-        end
+        content = read_file_content(path)
+        endpoints.concat(analyze_routes_content(content, "", path, include_callee, "App\\Controllers"))
+        endpoints.concat(analyze_ci3_routes(content, path))
       rescue e
         logger.debug "Error analyzing routes file #{path}: #{e}"
       end

--- a/src/analyzer/analyzers/php/hyperf.cr
+++ b/src/analyzer/analyzers/php/hyperf.cr
@@ -24,10 +24,8 @@ module Analyzer::Php
       return endpoints unless path.ends_with?(".php")
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        next unless hyperf_relevant?(content)
-
+      content = read_file_content(path)
+      if hyperf_relevant?(content)
         endpoints.concat(analyze_annotation_routes(content, path, include_callee))
         endpoints.concat(analyze_procedural_routes(content, "", path, include_callee))
       end

--- a/src/analyzer/analyzers/php/hyperf.cr
+++ b/src/analyzer/analyzers/php/hyperf.cr
@@ -37,8 +37,11 @@ module Analyzer::Php
     # aren't part of a Hyperf project. Project-wide scans still feed unrelated
     # PHP through this analyzer.
     private def hyperf_relevant?(content : String) : Bool
+      # `content.includes?("Hyperf\\HttpServer")` used to be ORed in here
+      # too, but any string containing that substring necessarily contains
+      # "Hyperf\\" — the check was dead weight, always scanning the whole
+      # buffer a second time for a condition the first check already covers.
       content.includes?("Hyperf\\") ||
-        content.includes?("Hyperf\\HttpServer") ||
         !!content.match(/\bRouter::(?:get|post|put|patch|delete|options|head|addRoute|addGroup)\s*\(/i) ||
         !!content.match(/#\[\s*(?:AutoController|Controller|Get|Post|Put|Patch|Delete|Options|Head|RequestMapping)/)
     end

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -4,6 +4,34 @@ module Analyzer::Php
   class Laminas < PhpEngine
     HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
 
+    # ASCII byte values for the structural characters the byte-level
+    # helpers below scan for. All are < 0x80, so they can never collide
+    # with a UTF-8 multi-byte continuation/lead byte (>= 0x80) — the same
+    # invariant `PhpEngine#find_matching_php_close_brace` relies on to scan
+    # raw bytes safely regardless of the file's encoding content.
+    private BYTE_SPACE     = ' '.ord.to_u8
+    private BYTE_NEWLINE   = '\n'.ord.to_u8
+    private BYTE_STAR      = '*'.ord.to_u8
+    private BYTE_SLASH     = '/'.ord.to_u8
+    private BYTE_HASH      = '#'.ord.to_u8
+    private BYTE_BACKSLASH = '\\'.ord.to_u8
+    private BYTE_DQUOTE    = '"'.ord.to_u8
+    private BYTE_SQUOTE    = '\''.ord.to_u8
+    private BYTE_LBRACKET  = '['.ord.to_u8
+    private BYTE_RBRACKET  = ']'.ord.to_u8
+    private BYTE_LPAREN    = '('.ord.to_u8
+    private BYTE_RPAREN    = ')'.ord.to_u8
+    private BYTE_LBRACE    = '{'.ord.to_u8
+    private BYTE_RBRACE    = '}'.ord.to_u8
+    private BYTE_COMMA     = ','.ord.to_u8
+    private BYTE_EQUAL     = '='.ord.to_u8
+    private BYTE_GT        = '>'.ord.to_u8
+
+    private def ascii_ws_byte?(byte : UInt8) : Bool
+      byte == 0x20_u8 || byte == 0x09_u8 || byte == 0x0A_u8 ||
+        byte == 0x0B_u8 || byte == 0x0C_u8 || byte == 0x0D_u8
+    end
+
     private struct PhpArrayEntry
       getter key, value, array_body
 
@@ -350,82 +378,90 @@ module Analyzer::Php
       methods.empty? ? HTTP_METHODS : methods
     end
 
+    # Byte-level scan for O(1) positional access instead of `String#[](Int)`,
+    # which is O(n) on strings containing multi-byte characters and turns a
+    # single call into O(n^2) — see `find_matching_delimiter` below for the
+    # same fix applied elsewhere in this file.
     private def split_top_level_args(content : String) : Array(String)
       args = [] of String
+      bytes = content.to_slice
       start = 0
       i = 0
       depth = 0
       in_string = false
-      quote = '\0'
+      quote = 0_u8
       escaped = false
+      size = bytes.size
 
-      while i < content.size
-        char = content[i]
+      while i < size
+        byte = bytes[i]
         if in_string
           if escaped
             escaped = false
-          elsif char == '\\'
+          elsif byte == BYTE_BACKSLASH
             escaped = true
-          elsif char == quote
+          elsif byte == quote
             in_string = false
           end
-        elsif char == '\'' || char == '"'
+        elsif byte == BYTE_SQUOTE || byte == BYTE_DQUOTE
           in_string = true
-          quote = char
-        elsif char == '[' || char == '(' || char == '{'
+          quote = byte
+        elsif byte == BYTE_LBRACKET || byte == BYTE_LPAREN || byte == BYTE_LBRACE
           depth += 1
-        elsif char == ']' || char == ')' || char == '}'
+        elsif byte == BYTE_RBRACKET || byte == BYTE_RPAREN || byte == BYTE_RBRACE
           depth -= 1 if depth > 0
-        elsif char == ',' && depth == 0
-          args << content[start...i].strip
+        elsif byte == BYTE_COMMA && depth == 0
+          args << String.new(bytes[start...i]).strip
           start = i + 1
         end
         i += 1
       end
 
-      args << content[start...content.size].strip if start < content.size
+      args << String.new(bytes[start...size]).strip if start < size
       args
     end
 
     private def parse_top_level_entries(content : String) : Array(PhpArrayEntry)
       entries = [] of PhpArrayEntry
+      bytes = content.to_slice
       pos = 0
+      size = bytes.size
 
-      while pos < content.size
-        pos = skip_ws_and_commas(content, pos)
-        break if pos >= content.size
+      while pos < size
+        pos = skip_ws_and_commas(bytes, pos)
+        break if pos >= size
 
-        key_info = read_php_string(content, pos)
+        key_info = read_php_string(bytes, pos)
         unless key_info
           pos += 1
           next
         end
 
         key, after_key = key_info
-        pos = skip_ws(content, after_key)
-        unless content[pos, 2]? == "=>"
+        pos = skip_ws(bytes, after_key)
+        unless pos + 1 < size && bytes[pos] == BYTE_EQUAL && bytes[pos + 1] == BYTE_GT
           pos = after_key
           next
         end
 
-        pos = skip_ws(content, pos + 2)
-        break if pos >= content.size
+        pos = skip_ws(bytes, pos + 2)
+        break if pos >= size
 
-        if array_start = array_value_start(content, pos)
-          close_pos = find_matching_delimiter(content, array_start)
+        if array_start = array_value_start(bytes, pos)
+          close_pos = find_matching_delimiter(bytes, array_start)
           unless close_pos
             pos += 1
             next
           end
 
-          entries << PhpArrayEntry.new(key, nil, content[(array_start + 1)...close_pos])
+          entries << PhpArrayEntry.new(key, nil, String.new(bytes[(array_start + 1)...close_pos]))
           pos = close_pos + 1
-        elsif value_info = read_php_string(content, pos)
+        elsif value_info = read_php_string(bytes, pos)
           value, after_value = value_info
           entries << PhpArrayEntry.new(key, value, nil)
           pos = after_value
         else
-          value, after_value = read_raw_value(content, pos)
+          value, after_value = read_raw_value(bytes, pos)
           entries << PhpArrayEntry.new(key, value, nil)
           pos = after_value
         end
@@ -434,132 +470,156 @@ module Analyzer::Php
       entries
     end
 
-    private def array_value_start(content : String, pos : Int32) : Int32?
-      return pos if content[pos]? == '['
+    private def array_value_start(bytes : Bytes, pos : Int32) : Int32?
+      return pos if pos < bytes.size && bytes[pos] == BYTE_LBRACKET
+      return unless ascii_ci_literal_at?(bytes, pos, "array")
 
-      if match = content[pos..].match(/\Aarray\s*\(/i)
-        return pos + match[0].size - 1
-      end
+      after = skip_ws(bytes, pos + 5)
+      return unless after < bytes.size && bytes[after] == BYTE_LPAREN
 
-      nil
+      after
     end
 
-    private def read_php_string(content : String, pos : Int32) : Tuple(String, Int32)?
-      quote = content[pos]?
-      return unless quote == '\'' || quote == '"'
+    # Case-insensitive match of an ASCII literal (e.g. "array") at `pos`.
+    private def ascii_ci_literal_at?(bytes : Bytes, pos : Int32, literal : String) : Bool
+      return false if pos + literal.bytesize > bytes.size
 
-      value = String.build do |io|
-        i = pos + 1
-        escaped = false
-        while i < content.size
-          char = content[i]
-          if escaped
-            io << char
-            escaped = false
-          elsif char == '\\'
-            escaped = true
-          elsif char == quote
-            return {io.to_s, i + 1}
-          else
-            io << char
-          end
-          i += 1
+      literal.each_byte.with_index do |lb, offset|
+        byte = bytes[pos + offset]
+        # ASCII-only downcase: clear bit 0x20 off an uppercase letter.
+        byte = byte + 0x20_u8 if byte >= 0x41_u8 && byte <= 0x5A_u8
+        return false unless byte == lb
+      end
+
+      true
+    end
+
+    private def read_php_string(bytes : Bytes, pos : Int32) : Tuple(String, Int32)?
+      return unless pos < bytes.size
+      quote = bytes[pos]
+      return unless quote == BYTE_SQUOTE || quote == BYTE_DQUOTE
+
+      io = IO::Memory.new
+      i = pos + 1
+      escaped = false
+      size = bytes.size
+      while i < size
+        byte = bytes[i]
+        if escaped
+          io.write_byte(byte)
+          escaped = false
+        elsif byte == BYTE_BACKSLASH
+          escaped = true
+        elsif byte == quote
+          return {io.to_s, i + 1}
+        else
+          io.write_byte(byte)
         end
+        i += 1
       end
 
-      {value, content.size}
+      {io.to_s, size}
     end
 
-    private def read_raw_value(content : String, pos : Int32) : Tuple(String, Int32)
+    private def read_raw_value(bytes : Bytes, pos : Int32) : Tuple(String, Int32)
       start = pos
       i = pos
       depth = 0
       in_string = false
-      quote = '\0'
+      quote = 0_u8
       escaped = false
+      size = bytes.size
 
-      while i < content.size
-        char = content[i]
+      while i < size
+        byte = bytes[i]
         if in_string
           if escaped
             escaped = false
-          elsif char == '\\'
+          elsif byte == BYTE_BACKSLASH
             escaped = true
-          elsif char == quote
+          elsif byte == quote
             in_string = false
           end
-        elsif char == '\'' || char == '"'
+        elsif byte == BYTE_SQUOTE || byte == BYTE_DQUOTE
           in_string = true
-          quote = char
-        elsif char == '[' || char == '(' || char == '{'
+          quote = byte
+        elsif byte == BYTE_LBRACKET || byte == BYTE_LPAREN || byte == BYTE_LBRACE
           depth += 1
-        elsif char == ']' || char == ')' || char == '}'
+        elsif byte == BYTE_RBRACKET || byte == BYTE_RPAREN || byte == BYTE_RBRACE
           break if depth == 0
           depth -= 1
-        elsif char == ',' && depth == 0
+        elsif byte == BYTE_COMMA && depth == 0
           break
         end
         i += 1
       end
 
-      {content[start...i].strip, i}
+      {String.new(bytes[start...i]).strip, i}
     end
 
-    private def find_matching_delimiter(content : String, open_pos : Int32) : Int32?
-      open_char = content[open_pos]?
-      close_char = case open_char
-                   when '[' then ']'
-                   when '(' then ')'
-                   when '{' then '}'
+    # Find the delimiter (`]`, `)`, or `}`) that matches the opener at
+    # `open_pos`, skipping delimiters inside strings and `//`, `#`,
+    # `/* */` comments. Byte-level scan for O(1) positional access — see
+    # `PhpEngine#find_matching_php_close_brace` for the equivalent fix
+    # applied to brace-only matching.
+    private def find_matching_delimiter(bytes : Bytes, open_pos : Int32) : Int32?
+      return unless open_pos < bytes.size
+
+      open_byte = bytes[open_pos]
+      close_byte = case open_byte
+                   when BYTE_LBRACKET then BYTE_RBRACKET
+                   when BYTE_LPAREN   then BYTE_RPAREN
+                   when BYTE_LBRACE   then BYTE_RBRACE
                    else
                      return
                    end
 
-      stack = [close_char]
+      stack = [close_byte]
       in_string = false
       in_line_comment = false
       in_block_comment = false
       escaped = false
-      quote = '\0'
+      quote = 0_u8
       pos = open_pos + 1
+      size = bytes.size
 
-      while pos < content.size
-        char = content[pos]
-        next_char = content[pos + 1]?
+      while pos < size
+        byte = bytes[pos]
+        next_byte = pos + 1 < size ? bytes[pos + 1] : 0_u8
 
         if in_line_comment
-          in_line_comment = false if char == '\n'
+          in_line_comment = false if byte == BYTE_NEWLINE
         elsif in_block_comment
-          if char == '*' && next_char == '/'
+          if byte == BYTE_STAR && next_byte == BYTE_SLASH
             in_block_comment = false
             pos += 1
           end
         elsif in_string
           if escaped
             escaped = false
-          elsif char == '\\'
+          elsif byte == BYTE_BACKSLASH
             escaped = true
-          elsif char == quote
+          elsif byte == quote
             in_string = false
           end
-        elsif char == '/' && next_char == '/'
+        elsif byte == BYTE_SLASH && next_byte == BYTE_SLASH
           in_line_comment = true
           pos += 1
-        elsif char == '/' && next_char == '*'
+        elsif byte == BYTE_SLASH && next_byte == BYTE_STAR
           in_block_comment = true
           pos += 1
-        elsif char == '#'
+        elsif byte == BYTE_HASH
           in_line_comment = true
-        elsif char == '"' || char == '\''
+        elsif byte == BYTE_DQUOTE || byte == BYTE_SQUOTE
           in_string = true
-          quote = char
-        elsif char == '['
-          stack << ']'
-        elsif char == '('
-          stack << ')'
-        elsif char == '{'
-          stack << '}'
-        elsif char == stack.last?
+          quote = byte
+        elsif byte == BYTE_LBRACKET
+          stack << BYTE_RBRACKET
+        elsif byte == BYTE_LPAREN
+          stack << BYTE_RPAREN
+        elsif byte == BYTE_LBRACE
+          stack << BYTE_RBRACE
+        elsif byte == stack.last?
           stack.pop
           return pos if stack.empty?
         end
@@ -570,62 +630,92 @@ module Analyzer::Php
       nil
     end
 
+    # Char-index overload for the top-level call sites (`route_blocks`,
+    # `extract_handler_body_with_end`, `analyze_programmatic_routes`) that
+    # only have a char position on hand. Converts once at the boundary
+    # instead of on every byte, then delegates to the byte-native version
+    # above.
+    private def find_matching_delimiter(content : String, open_pos : Int32) : Int32?
+      byte_pos = content.char_index_to_byte_index(open_pos)
+      return unless byte_pos
+
+      result = find_matching_delimiter(content.to_slice, byte_pos)
+      result ? content.byte_index_to_char_index(result) : nil
+    end
+
+    # Blank out `//`, `#` and `/* */` comment bodies (replacing each masked
+    # byte with a space; newlines are preserved) so the route-verb scans
+    # that run over the result never match syntax that only appears inside
+    # a comment.
+    #
+    # Byte-level scan for O(1) positional access — see
+    # `find_matching_delimiter` above. Nothing downstream compares this
+    # result's char count against the original `content` (every
+    # regex/index operation performed on it stays self-contained within
+    # the result itself), so masking a multi-byte comment character with
+    # one space per byte — rather than one space per character, as the
+    # previous char-based version did — is a safe, simpler substitute.
     private def strip_php_comments(content : String) : String
+      bytes = content.to_slice
       String.build do |io|
         in_string = false
         in_line_comment = false
         in_block_comment = false
         escaped = false
-        quote = '\0'
+        quote = 0_u8
         pos = 0
+        size = bytes.size
 
-        while pos < content.size
-          char = content[pos]
-          next_char = content[pos + 1]?
+        while pos < size
+          byte = bytes[pos]
+          next_byte = pos + 1 < size ? bytes[pos + 1] : 0_u8
 
           if in_line_comment
-            if char == '\n'
+            if byte == BYTE_NEWLINE
               in_line_comment = false
-              io << char
+              io.write_byte(byte)
             else
-              io << ' '
+              io.write_byte(BYTE_SPACE)
             end
           elsif in_block_comment
-            if char == '*' && next_char == '/'
+            if byte == BYTE_STAR && next_byte == BYTE_SLASH
               in_block_comment = false
-              io << "  "
+              io.write_byte(BYTE_SPACE)
+              io.write_byte(BYTE_SPACE)
               pos += 1
-            elsif char == '\n'
-              io << char
+            elsif byte == BYTE_NEWLINE
+              io.write_byte(byte)
             else
-              io << ' '
+              io.write_byte(BYTE_SPACE)
             end
           elsif in_string
-            io << char
+            io.write_byte(byte)
             if escaped
               escaped = false
-            elsif char == '\\'
+            elsif byte == BYTE_BACKSLASH
               escaped = true
-            elsif char == quote
+            elsif byte == quote
               in_string = false
             end
-          elsif char == '/' && next_char == '/'
+          elsif byte == BYTE_SLASH && next_byte == BYTE_SLASH
             in_line_comment = true
-            io << "  "
+            io.write_byte(BYTE_SPACE)
+            io.write_byte(BYTE_SPACE)
             pos += 1
-          elsif char == '/' && next_char == '*'
+          elsif byte == BYTE_SLASH && next_byte == BYTE_STAR
             in_block_comment = true
-            io << "  "
+            io.write_byte(BYTE_SPACE)
+            io.write_byte(BYTE_SPACE)
             pos += 1
-          elsif char == '#'
+          elsif byte == BYTE_HASH
             in_line_comment = true
-            io << ' '
-          elsif char == '"' || char == '\''
+            io.write_byte(BYTE_SPACE)
+          elsif byte == BYTE_DQUOTE || byte == BYTE_SQUOTE
             in_string = true
-            quote = char
-            io << char
+            quote = byte
+            io.write_byte(byte)
           else
-            io << char
+            io.write_byte(byte)
           end
 
           pos += 1
@@ -633,17 +723,17 @@ module Analyzer::Php
       end
     end
 
-    private def skip_ws(content : String, pos : Int32) : Int32
+    private def skip_ws(bytes : Bytes, pos : Int32) : Int32
       i = pos
-      while i < content.size && content[i].ascii_whitespace?
+      while i < bytes.size && ascii_ws_byte?(bytes[i])
         i += 1
       end
       i
     end
 
-    private def skip_ws_and_commas(content : String, pos : Int32) : Int32
+    private def skip_ws_and_commas(bytes : Bytes, pos : Int32) : Int32
       i = pos
-      while i < content.size && (content[i].ascii_whitespace? || content[i] == ',')
+      while i < bytes.size && (ascii_ws_byte?(bytes[i]) || bytes[i] == BYTE_COMMA)
         i += 1
       end
       i

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -54,9 +54,16 @@ module Analyzer::Php
       dedup_endpoints(endpoints)
     end
 
+    # Precompiled once at load: the three namespace markers used to be
+    # three separate `String#includes?` scans of the whole file ORed
+    # together. Crystal's `String#includes?` is measurably slower than a
+    # single precompiled `Regex#matches?` call, and this runs on every
+    # `.php` file fed into the analyzer during a project-wide scan.
+    NAMESPACE_MARKER_RE = /Laminas\\|Zend\\|Mezzio\\/
+
     private def laminas_relevant?(path : String, content : String) : Bool
       return true if path.includes?("/config/") && (content.includes?("'router'") || content.includes?("\"router\""))
-      return true if content.includes?("Laminas\\") || content.includes?("Zend\\") || content.includes?("Mezzio\\")
+      return true if content.matches?(NAMESPACE_MARKER_RE)
       return true if content.includes?("RouteStackInterface")
       !!content.match(/->(?:get|post|put|patch|delete|options|head|any|route)\s*\(\s*['"][^'"]+['"]/i)
     end

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -45,10 +45,8 @@ module Analyzer::Php
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        next unless laminas_relevant?(path, content)
-
+      content = read_file_content(path)
+      if laminas_relevant?(path, content)
         endpoints.concat(analyze_config_routes(path, content))
         endpoints.concat(analyze_programmatic_routes(path, content, include_callee))
       end

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -67,15 +67,13 @@ module Analyzer::Php
       endpoints = [] of Endpoint
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
       begin
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          content = file.gets_to_end
-          # `use App\Http\Controllers\...;` imports map the short class
-          # names used in route handlers back to their FQCNs so callee
-          # resolution can locate the controller file. Only parsed when
-          # callees/ai-context are requested.
-          imports = include_callee ? parse_use_imports(content) : EMPTY_IMPORTS
-          endpoints = analyze_routes_content(content, "", path, include_callee, imports: imports)
-        end
+        content = read_file_content(path)
+        # `use App\Http\Controllers\...;` imports map the short class
+        # names used in route handlers back to their FQCNs so callee
+        # resolution can locate the controller file. Only parsed when
+        # callees/ai-context are requested.
+        imports = include_callee ? parse_use_imports(content) : EMPTY_IMPORTS
+        endpoints = analyze_routes_content(content, "", path, include_callee, imports: imports)
       rescue e
         logger.debug "Error analyzing routes file #{path}: #{e}"
       end
@@ -86,42 +84,39 @@ module Analyzer::Php
 
     private def analyze_controller_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
+      content = read_file_content(path)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
+      # Look for Laravel Route attributes on controller methods
+      # e.g., #[Route('/users', methods: ['GET'])]
+      method_matches = content.scan(/#\[Route\s*\(([^]]*)\]\s*public\s+function\s+(\w+)/m)
+      method_matches.each do |match|
+        attribute_content = match[1] # This is the content of the attribute
 
-        # Look for Laravel Route attributes on controller methods
-        # e.g., #[Route('/users', methods: ['GET'])]
-        method_matches = content.scan(/#\[Route\s*\(([^]]*)\]\s*public\s+function\s+(\w+)/m)
-        method_matches.each do |match|
-          attribute_content = match[1] # This is the content of the attribute
+        path_match = attribute_content.match(/['"]([^'"]+)['"]/)
+        next unless path_match
 
-          path_match = attribute_content.match(/['"]([^'"]+)['"]/)
-          next unless path_match
+        route_path = path_match[1]
+        params = extract_brace_path_params(route_path)
+        details = Details.new(PathInfo.new(path))
 
-          route_path = path_match[1]
-          params = extract_brace_path_params(route_path)
-          details = Details.new(PathInfo.new(path))
-
-          methods = [] of String
-          methods_match = attribute_content.match(/methods:\s*\[([^\]]*)\]/i)
-          if methods_match
-            methods = extract_methods_from_array(methods_match[1])
-          else
-            # also check for single method: methods: 'POST' or methods: "POST"
-            method_match = attribute_content.match(/methods:\s*['"]([^'"]+)['"]/)
-            if method_match
-              methods << method_match[1].upcase
-            end
+        methods = [] of String
+        methods_match = attribute_content.match(/methods:\s*\[([^\]]*)\]/i)
+        if methods_match
+          methods = extract_methods_from_array(methods_match[1])
+        else
+          # also check for single method: methods: 'POST' or methods: "POST"
+          method_match = attribute_content.match(/methods:\s*['"]([^'"]+)['"]/)
+          if method_match
+            methods << method_match[1].upcase
           end
+        end
 
-          if methods.empty?
-            methods << "GET"
-          end
+        if methods.empty?
+          methods << "GET"
+        end
 
-          methods.each do |http_method|
-            endpoints << Endpoint.new(route_path, http_method, params, details.dup)
-          end
+        methods.each do |http_method|
+          endpoints << Endpoint.new(route_path, http_method, params, details.dup)
         end
       end
 

--- a/src/analyzer/analyzers/php/lumen.cr
+++ b/src/analyzer/analyzers/php/lumen.cr
@@ -21,9 +21,8 @@ module Analyzer::Php
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        next unless lumen_relevant?(content)
+      content = read_file_content(path)
+      if lumen_relevant?(content)
         endpoints = analyze_routes_content(content, "", path, include_callee)
       end
 

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -2,6 +2,14 @@ require "../../engines/php_engine"
 
 module Analyzer::Php
   class Php < PhpEngine
+    # Precompiled once at load. The per-line gate below used to be
+    # `allow_patterns.any? { |pattern| line.includes? pattern }` — 7
+    # `String#includes?` scans of the line per pattern. Crystal's
+    # `String#includes?` is measurably slower than a single precompiled
+    # `Regex#matches?` call, and this runs on every line of every `.php`
+    # file in the project, so the union regex is a straight win.
+    ALLOW_PATTERNS_RE = Regex.union(["$_GET", "$_POST", "$_REQUEST", "$_SERVER", "$_COOKIE", "$_FILES", "filter_input"])
+
     def analyze_file(path : String) : Array(Endpoint)
       return [] of Endpoint unless File.extname(path) == ".php"
 
@@ -9,59 +17,57 @@ module Analyzer::Php
       relative_path = get_relative_path(php_base_path_for(path), path)
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        params_query = [] of Param
-        params_body = [] of Param
-        methods = [] of String
+      content = read_file_content(path)
+      params_query = [] of Param
+      params_body = [] of Param
+      methods = [] of String
 
-        content.each_line do |line|
-          if allow_patterns.any? { |pattern| line.includes? pattern }
-            superglobal_matches = line.scan(/\$_(GET|POST|REQUEST|SERVER|COOKIE|FILES)\s*\[\s*['"]([^'"]+)['"]\s*\]/)
-            superglobal_matches.each do |match|
-              apply_param_reference(match[1], match[2], params_query, params_body, methods)
-            end
-
-            filter_input_matches = line.scan(/filter_input\s*\(\s*INPUT_(GET|POST|REQUEST|SERVER|COOKIE)\s*,\s*['"]([^'"]+)['"]/)
-            filter_input_matches.each do |match|
-              apply_param_reference(match[1], match[2], params_query, params_body, methods)
-            end
+      content.each_line do |line|
+        if line.matches?(ALLOW_PATTERNS_RE)
+          superglobal_matches = line.scan(/\$_(GET|POST|REQUEST|SERVER|COOKIE|FILES)\s*\[\s*['"]([^'"]+)['"]\s*\]/)
+          superglobal_matches.each do |match|
+            apply_param_reference(match[1], match[2], params_query, params_body, methods)
           end
-        rescue
-          next
-        end
 
-        # For the pure-PHP analyzer we are parameter-driven (not route-driven).
-        # A file with thousands of superglobal references (e.g. a large controller
-        # with many action methods) used to produce thousands of near-identical
-        # Endpoint objects for the same pseudo-path. The optimizer would later
-        # collapse them by (method, url) while merging params. Creating the
-        # duplicates up-front was extremely expensive on large files.
-        #
-        # We emit at most the POST pseudo-endpoint (when any POST/REQUEST/FILES
-        # reference was seen) plus the always-present GET pseudo-endpoint (for
-        # query/cookie/header params discovered in the file). We also deduplicate
-        # params by (name, param_type) in first-seen order so that the Endpoint
-        # objects we hand to later stages carry the same logical set that the
-        # optimizer would have produced. This is semantically identical to the
-        # previous behaviour for all observable outputs and test expectations,
-        # but avoids the O(N) explosion in intermediate objects.
-        #
-        # Note: unlike real framework analyzers, this one only ever contributes
-        # "POST" (or nothing) to the methods list; the GET is emitted separately.
-        # The wording is intentionally specific to avoid implying full multi-verb
-        # route support here.
-        distinct_methods = methods.uniq
-        query_params = unique_params_preserve_order(params_query)
-        body_params = unique_params_preserve_order(params_body)
-
-        details = Details.new(PathInfo.new(path))
-        distinct_methods.each do |method|
-          endpoints << Endpoint.new("/#{relative_path}", method, body_params, details)
+          filter_input_matches = line.scan(/filter_input\s*\(\s*INPUT_(GET|POST|REQUEST|SERVER|COOKIE)\s*,\s*['"]([^'"]+)['"]/)
+          filter_input_matches.each do |match|
+            apply_param_reference(match[1], match[2], params_query, params_body, methods)
+          end
         end
-        endpoints << Endpoint.new("/#{relative_path}", "GET", query_params, details)
-        attach_file_callees(endpoints, content, path) if include_callee
+      rescue
+        next
       end
+
+      # For the pure-PHP analyzer we are parameter-driven (not route-driven).
+      # A file with thousands of superglobal references (e.g. a large controller
+      # with many action methods) used to produce thousands of near-identical
+      # Endpoint objects for the same pseudo-path. The optimizer would later
+      # collapse them by (method, url) while merging params. Creating the
+      # duplicates up-front was extremely expensive on large files.
+      #
+      # We emit at most the POST pseudo-endpoint (when any POST/REQUEST/FILES
+      # reference was seen) plus the always-present GET pseudo-endpoint (for
+      # query/cookie/header params discovered in the file). We also deduplicate
+      # params by (name, param_type) in first-seen order so that the Endpoint
+      # objects we hand to later stages carry the same logical set that the
+      # optimizer would have produced. This is semantically identical to the
+      # previous behaviour for all observable outputs and test expectations,
+      # but avoids the O(N) explosion in intermediate objects.
+      #
+      # Note: unlike real framework analyzers, this one only ever contributes
+      # "POST" (or nothing) to the methods list; the GET is emitted separately.
+      # The wording is intentionally specific to avoid implying full multi-verb
+      # route support here.
+      distinct_methods = methods.uniq
+      query_params = unique_params_preserve_order(params_query)
+      body_params = unique_params_preserve_order(params_body)
+
+      details = Details.new(PathInfo.new(path))
+      distinct_methods.each do |method|
+        endpoints << Endpoint.new("/#{relative_path}", method, body_params, details)
+      end
+      endpoints << Endpoint.new("/#{relative_path}", "GET", query_params, details)
+      attach_file_callees(endpoints, content, path) if include_callee
 
       endpoints
     end

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -25,14 +25,18 @@ module Analyzer::Php
       endpoints
     end
 
+    # Precompiled once at load: these four markers used to be four separate
+    # `String#includes?` scans of the whole file ORed together. Crystal's
+    # `String#includes?` is measurably slower than a single precompiled
+    # `Regex#matches?` call, and this runs on every .php file fed into the
+    # analyzer during a project-wide scan.
+    RELEVANCE_MARKER_RE = /Slim\\|SlimFramework|AppFactory|RouteCollectorProxy/
+
     # Cheap pre-filter: avoid heavy regex work on files that clearly aren't
     # Slim. Any file that reaches this analyzer via detection is usually in
     # a Slim project, but project-wide scans still feed unrelated PHP here.
     private def slim_relevant?(content : String) : Bool
-      content.includes?("Slim\\") ||
-        content.includes?("SlimFramework") ||
-        content.includes?("AppFactory") ||
-        content.includes?("RouteCollectorProxy") ||
+      content.matches?(RELEVANCE_MARKER_RE) ||
         !!content.match(/\$\w+->(?:get|post|put|patch|delete|options|head|map|group)\s*\(/i)
     end
 

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -17,9 +17,8 @@ module Analyzer::Php
       return endpoints unless path.ends_with?(".php")
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        next unless slim_relevant?(content)
+      content = read_file_content(path)
+      if slim_relevant?(content)
         endpoints = analyze_routes_content(content, "", path, include_callee)
       end
 

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -2,6 +2,16 @@ require "../../engines/php_engine"
 
 module Analyzer::Php
   class Slim < PhpEngine
+    # ASCII byte values scanned by `find_matching_close_brace` below. Both
+    # are < 0x80, so they can never collide with a UTF-8 multi-byte
+    # continuation/lead byte (>= 0x80) — same invariant
+    # `PhpEngine#find_matching_php_close_brace` relies on.
+    private BYTE_LBRACE    = '{'.ord.to_u8
+    private BYTE_RBRACE    = '}'.ord.to_u8
+    private BYTE_DQUOTE    = '"'.ord.to_u8
+    private BYTE_SQUOTE    = '\''.ord.to_u8
+    private BYTE_BACKSLASH = '\\'.ord.to_u8
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")
@@ -198,29 +208,40 @@ module Analyzer::Php
       content[0...pos].count('\n')
     end
 
+    # Byte-level scan for O(1) positional access instead of the previous
+    # `String#[](Int)` per-character loop, which is O(n) on any string
+    # containing a multi-byte UTF-8 character and turned a single call into
+    # O(n^2) — see `PhpEngine#find_matching_php_close_brace` for the same
+    # fix applied to the shared brace matcher. `find_group_call` and
+    # `extract_handler_body_with_end` both call this over the full
+    # remainder of the file, so this is the hot path for any Slim routes
+    # file with non-ASCII content (e.g. CJK comments/strings).
     private def find_matching_close_brace(content : String, open_pos : Int32) : Int32?
-      return unless open_pos < content.size && content[open_pos] == '{'
+      bytes = content.to_slice
+      start = content.char_index_to_byte_index(open_pos)
+      return unless start && start < bytes.size && bytes[start] == BYTE_LBRACE
 
       depth = 0
       in_string = false
-      quote_char = '\0'
-      pos = open_pos
-      while pos < content.size
-        char = content[pos]
+      quote_byte = 0_u8
+      pos = start
+      size = bytes.size
+      while pos < size
+        byte = bytes[pos]
         if !in_string
-          case char
-          when '{'
+          case byte
+          when BYTE_LBRACE
             depth += 1
-          when '}'
+          when BYTE_RBRACE
             depth -= 1
-            return pos if depth == 0
-          when '"', '\''
+            return content.byte_index_to_char_index(pos) if depth == 0
+          when BYTE_DQUOTE, BYTE_SQUOTE
             in_string = true
-            quote_char = char
+            quote_byte = byte
           end
-        elsif char == '\\'
+        elsif byte == BYTE_BACKSLASH
           pos += 1
-        elsif char == quote_char
+        elsif byte == quote_byte
           in_string = false
         end
         pos += 1

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -31,79 +31,77 @@ module Analyzer::Php
     private def analyze_php_routes(path : String, include_callee : Bool) : Array(Endpoint)
       endpoints = [] of Endpoint
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
-        class_prefixes = extract_class_route_prefixes(content)
+      content = read_file_content(path)
+      class_prefixes = extract_class_route_prefixes(content)
 
-        # Look for route annotations (@Route) - more flexible pattern
-        # Track offset to find each match correctly
-        offset = 0
-        content.scan(/@Route\s*\((.*?)\)/m) do |match|
-          route_path = extract_symfony_route_path(match[1])
-          next unless route_path
+      # Look for route annotations (@Route) - more flexible pattern
+      # Track offset to find each match correctly
+      offset = 0
+      content.scan(/@Route\s*\((.*?)\)/m) do |match|
+        route_path = extract_symfony_route_path(match[1])
+        next unless route_path
 
-          full_match = match[0]
+        full_match = match[0]
 
-          # Find this specific match starting from current offset
-          route_start = content.index(full_match, offset)
-          if route_start
-            offset = route_start + full_match.size
-            next if route_applies_to_class?(content, offset)
+        # Find this specific match starting from current offset
+        route_start = content.index(full_match, offset)
+        if route_start
+          offset = route_start + full_match.size
+          next if route_applies_to_class?(content, offset)
 
-            # Extract methods from the annotation itself
-            methods = extract_methods_from_symfony_context(full_match)
-            methods = ["GET"] if methods.empty?
+          # Extract methods from the annotation itself
+          methods = extract_methods_from_symfony_context(full_match)
+          methods = ["GET"] if methods.empty?
 
-            method_body = extract_php_method_body_after(content, route_start)
+          method_body = extract_php_method_body_after(content, route_start)
 
-            full_path = build_full_path(class_prefix_for_position(class_prefixes, route_start), route_path)
-            params = extract_brace_path_params(full_path)
-            # Extract additional parameters from method body
-            params.concat(extract_method_params(method_body[0])) if method_body
+          full_path = build_full_path(class_prefix_for_position(class_prefixes, route_start), route_path)
+          params = extract_brace_path_params(full_path)
+          # Extract additional parameters from method body
+          params.concat(extract_method_params(method_body[0])) if method_body
 
-            details = Details.new(PathInfo.new(path))
+          details = Details.new(PathInfo.new(path))
 
-            methods.each do |method|
-              endpoint = Endpoint.new(full_path, method.upcase, params, details)
-              attach_method_callees(endpoint, method_body, path) if include_callee
-              endpoints << endpoint
-            end
+          methods.each do |method|
+            endpoint = Endpoint.new(full_path, method.upcase, params, details)
+            attach_method_callees(endpoint, method_body, path) if include_callee
+            endpoints << endpoint
           end
         end
+      end
 
-        # Look for route attributes (#[Route]) - PHP 8 style
-        # Track offset to find each match correctly
-        offset = 0
-        content.scan(/#\[Route\s*\((.*?)\)\]/m) do |match|
-          route_path = extract_symfony_route_path(match[1])
-          next unless route_path
+      # Look for route attributes (#[Route]) - PHP 8 style
+      # Track offset to find each match correctly
+      offset = 0
+      content.scan(/#\[Route\s*\((.*?)\)\]/m) do |match|
+        route_path = extract_symfony_route_path(match[1])
+        next unless route_path
 
-          full_match = match[0]
+        full_match = match[0]
 
-          # Find this specific match starting from current offset
-          route_start = content.index(full_match, offset)
-          if route_start
-            offset = route_start + full_match.size
-            next if route_applies_to_class?(content, offset)
+        # Find this specific match starting from current offset
+        route_start = content.index(full_match, offset)
+        if route_start
+          offset = route_start + full_match.size
+          next if route_applies_to_class?(content, offset)
 
-            # Extract methods from the attribute itself
-            methods = extract_methods_from_symfony_context(full_match)
-            methods = ["GET"] if methods.empty?
+          # Extract methods from the attribute itself
+          methods = extract_methods_from_symfony_context(full_match)
+          methods = ["GET"] if methods.empty?
 
-            method_body = extract_php_method_body_after(content, route_start)
+          method_body = extract_php_method_body_after(content, route_start)
 
-            full_path = build_full_path(class_prefix_for_position(class_prefixes, route_start), route_path)
-            params = extract_brace_path_params(full_path)
-            # Extract additional parameters from method body
-            params.concat(extract_method_params(method_body[0])) if method_body
+          full_path = build_full_path(class_prefix_for_position(class_prefixes, route_start), route_path)
+          params = extract_brace_path_params(full_path)
+          # Extract additional parameters from method body
+          params.concat(extract_method_params(method_body[0])) if method_body
 
-            details = Details.new(PathInfo.new(path))
+          details = Details.new(PathInfo.new(path))
 
-            methods.each do |method|
-              endpoint = Endpoint.new(full_path, method.upcase, params, details)
-              attach_method_callees(endpoint, method_body, path) if include_callee
-              endpoints << endpoint
-            end
+          methods.each do |method|
+            endpoint = Endpoint.new(full_path, method.upcase, params, details)
+            attach_method_callees(endpoint, method_body, path) if include_callee
+            endpoints << endpoint
           end
         end
       end
@@ -208,33 +206,31 @@ module Analyzer::Php
       endpoints = [] of Endpoint
 
       begin
-        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-          content = file.gets_to_end
+        content = read_file_content(path)
 
-          # Simple YAML route parsing for Symfony
-          # Look for patterns like:
-          # route_name:
-          #   path: /api/users/{id}
-          #   methods: [GET, POST]
+        # Simple YAML route parsing for Symfony
+        # Look for patterns like:
+        # route_name:
+        #   path: /api/users/{id}
+        #   methods: [GET, POST]
 
-          yaml = YAML.parse(content)
-          if routes = yaml.as_h?
-            routes.each_value do |route|
-              route_h = route.as_h?
-              next unless route_h
+        yaml = YAML.parse(content)
+        if routes = yaml.as_h?
+          routes.each_value do |route|
+            route_h = route.as_h?
+            next unless route_h
 
-              route_path = route_h[YAML::Any.new("path")]?.try(&.as_s?)
-              next unless route_path
+            route_path = route_h[YAML::Any.new("path")]?.try(&.as_s?)
+            next unless route_path
 
-              methods = extract_yaml_methods(route_h[YAML::Any.new("methods")]?)
-              methods = ["GET"] if methods.empty?
+            methods = extract_yaml_methods(route_h[YAML::Any.new("methods")]?)
+            methods = ["GET"] if methods.empty?
 
-              params = extract_brace_path_params(route_path)
-              details = Details.new(PathInfo.new(path))
+            params = extract_brace_path_params(route_path)
+            details = Details.new(PathInfo.new(path))
 
-              methods.each do |method|
-                endpoints << Endpoint.new(route_path, method.upcase, params, details)
-              end
+            methods.each do |method|
+              endpoints << Endpoint.new(route_path, method.upcase, params, details)
             end
           end
         end

--- a/src/analyzer/analyzers/php/thinkphp.cr
+++ b/src/analyzer/analyzers/php/thinkphp.cr
@@ -26,32 +26,30 @@ module Analyzer::Php
 
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
+      content = read_file_content(path)
 
-        # 1. Explicit Route definitions
-        if is_route
-          # Determine base prefix from multi-app route files (e.g. app/shop/route/app.php -> prefix is "/shop")
-          base_prefix = ""
-          if path.includes?("app/") || path.includes?("application/")
-            segments = path.split('/')
-            route_idx = segments.index("route")
-            if route_idx && route_idx > 1
-              parent = segments[route_idx - 1]
-              if parent != "app" && parent != "application"
-                base_prefix = "/" + camel_to_snake(parent)
-              end
+      # 1. Explicit Route definitions
+      if is_route
+        # Determine base prefix from multi-app route files (e.g. app/shop/route/app.php -> prefix is "/shop")
+        base_prefix = ""
+        if path.includes?("app/") || path.includes?("application/")
+          segments = path.split('/')
+          route_idx = segments.index("route")
+          if route_idx && route_idx > 1
+            parent = segments[route_idx - 1]
+            if parent != "app" && parent != "application"
+              base_prefix = "/" + camel_to_snake(parent)
             end
           end
-
-          endpoints.concat(analyze_routes_content(content, base_prefix, path, include_callee))
         end
 
-        # 2. Implicit Controller auto-routing
-        if is_controller
-          endpoints.concat(analyze_controller(path, content, include_callee))
-          endpoints.concat(analyze_annotation_routes(path, content, include_callee))
-        end
+        endpoints.concat(analyze_routes_content(content, base_prefix, path, include_callee))
+      end
+
+      # 2. Implicit Controller auto-routing
+      if is_controller
+        endpoints.concat(analyze_controller(path, content, include_callee))
+        endpoints.concat(analyze_annotation_routes(path, content, include_callee))
       end
 
       endpoints

--- a/src/analyzer/analyzers/php/thinkphp.cr
+++ b/src/analyzer/analyzers/php/thinkphp.cr
@@ -508,9 +508,21 @@ module Analyzer::Php
       params
     end
 
+    # Precompiled once at load. Both of these used to be several
+    # `String#includes?` scans of the (whole, unchanging) `context` buffer
+    # OR'd together, re-run once per regex match inside their enclosing
+    # `context.scan` loop below even though `context` never changes within
+    # a single `extract_request_params` call. Hoisting the check out of the
+    # loop and collapsing it into one precompiled Regex#matches? call turns
+    # an O(matches) full-buffer rescan into a single O(1) check per call.
+    INPUT_POST_EVIDENCE_RE = Regex.union(["post.", "->post(", "request()->post"])
+    ONLY_POST_EVIDENCE_RE  = Regex.union(["post.", "->post(", "request()->post", "$_POST", "postMore"])
+
     private def extract_request_params(context : String) : Array(Param)
       params = [] of Param
       seen = Set(String).new
+      input_post_evidence = context.matches?(INPUT_POST_EVIDENCE_RE)
+      only_post_evidence = context.matches?(ONLY_POST_EVIDENCE_RE)
 
       # 1. input('name') or input('get.name')
       context.scan(/input\s*\(\s*['"](?:get\.|post\.|param\.)?([^'"\/]+)[^'"]*['"]/) do |match|
@@ -521,7 +533,7 @@ module Analyzer::Php
                        "form"
                      elsif match[0].includes?("get.")
                        "query"
-                     elsif context.includes?("post.") || context.includes?("->post(") || context.includes?("request()->post")
+                     elsif input_post_evidence
                        "form"
                      else
                        "query"
@@ -586,7 +598,7 @@ module Analyzer::Php
         array_content.scan(/['"]([^'"]+)['"]/).each do |m|
           name = m[1]
           next if seen.includes?(name)
-          param_type = context.includes?("post.") || context.includes?("->post(") || context.includes?("request()->post") || context.includes?("$_POST") || context.includes?("postMore") ? "form" : "query"
+          param_type = only_post_evidence ? "form" : "query"
           params << Param.new(name, "", param_type)
           seen.add(name)
         end
@@ -609,12 +621,14 @@ module Analyzer::Php
       params
     end
 
+    # Precompiled once at load: five String#includes? scans of the whole
+    # method body OR'd together, replaced with a single Regex#matches?
+    # call (Crystal's String#includes? is measurably slower than a
+    # precompiled Regex).
+    BODY_POST_EVIDENCE_RE = Regex.union(["->post(", "post.", "request()->post", "$_POST", "isPost"])
+
     private def infer_methods_from_body(context : String) : Array(String)
-      touches_post = context.includes?("->post(") ||
-                     context.includes?("post.") ||
-                     context.includes?("request()->post") ||
-                     context.includes?("$_POST") ||
-                     context.includes?("isPost")
+      touches_post = context.matches?(BODY_POST_EVIDENCE_RE)
       touches_post ? ["GET", "POST"] : ["GET"]
     end
 

--- a/src/analyzer/analyzers/php/yii.cr
+++ b/src/analyzer/analyzers/php/yii.cr
@@ -60,6 +60,15 @@ module Analyzer::Php
 
     # Note: brace counting may be inaccurate if braces appear inside strings or comments.
     # A full PHP parser is out of scope; this is a best-effort implementation.
+    #
+    # Byte-level scan for O(1) positional access instead of the previous
+    # `String#[](Int)` per-character loop, which is O(n) on any string
+    # containing a multi-byte UTF-8 character and turned a single call into
+    # O(n^2) — this walks the *entire* `urlManager.rules` array (every
+    # route in the config file), so it's the hot path for a Yii2 config
+    # with non-ASCII content (e.g. CJK comments). `open_char`/`close_char`
+    # are always one of `[`/`]`/`(`/`)`, all ASCII (< 0x80), so they can
+    # never collide with a UTF-8 continuation/lead byte.
     private def extract_rules_section(content : String) : String?
       idx = content.index(/["']rules["']\s*=>\s*(?:\[|array\()/)
       return unless idx
@@ -68,13 +77,20 @@ module Analyzer::Php
       start = content.index(open_char, idx)
       return unless start
 
+      bytes = content.to_slice
+      byte_start = content.char_index_to_byte_index(start)
+      return unless byte_start
+
+      open_byte = open_char.ord.to_u8
+      close_byte = close_char.ord.to_u8
+      size = bytes.size
       depth = 1
-      pos = start + 1
-      while pos < content.size && depth > 0
-        case content[pos]
-        when open_char
+      pos = byte_start + 1
+      while pos < size && depth > 0
+        byte = bytes[pos]
+        if byte == open_byte
           depth += 1
-        when close_char
+        elsif byte == close_byte
           depth -= 1
           break if depth == 0
         end
@@ -82,7 +98,9 @@ module Analyzer::Php
       end
 
       return if depth != 0
-      content[(start + 1)...pos]
+      char_pos = content.byte_index_to_char_index(pos)
+      return unless char_pos
+      content[(start + 1)...char_pos]
     end
 
     private def detect_rules_brackets(content : String, idx : Int32) : Tuple(Char, Char)

--- a/src/analyzer/analyzers/php/yii.cr
+++ b/src/analyzer/analyzers/php/yii.cr
@@ -18,16 +18,14 @@ module Analyzer::Php
       return endpoints unless path.ends_with?(".php")
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
 
-      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
-        content = file.gets_to_end
+      content = read_file_content(path)
 
-        if path.includes?("config") && content.includes?("urlManager")
-          endpoints.concat(analyze_url_manager(path, content))
-        end
+      if path.includes?("config") && content.includes?("urlManager")
+        endpoints.concat(analyze_url_manager(path, content))
+      end
 
-        if path.ends_with?("Controller.php") || content.match(/class\s+\w+Controller\s+extends/)
-          endpoints.concat(analyze_controller(path, content, include_callee))
-        end
+      if path.ends_with?("Controller.php") || content.match(/class\s+\w+Controller\s+extends/)
+        endpoints.concat(analyze_controller(path, content, include_callee))
       end
 
       endpoints


### PR DESCRIPTION
## Summary
Detection-neutral perf sweep of the **php** analyzers (all 13 audited; follows #2258).

| tier | analyzers | change |
|---|---|---|
| A | laminas, slim, yii | byte-level rewrite of whole-buffer `String[i]` char loops (laminas mini-parser: `split_top_level_args`/`parse_top_level_entries`/`find_matching_delimiter`/`strip_php_comments`; slim brace matcher; yii `extract_rules_section`) — O(n²)→O(n) on non-ASCII |
| C | php, cakephp, codeigniter, laravel, laminas, hyperf, slim, lumen, thinkphp, yii, symfony | cache-first `read_file_content` for routes/controller/config reads |
| B | php, laminas, slim, hyperf, thinkphp | fold chained/loop-local `includes?` gates into `Regex.union`; drop hyperf dead redundant `includes?` |
| D | mautic, cli | verified already-optimal (PhpLexer, memoized regexes) |

## Test plan
- `crystal spec spec/functional_test/testers/php/` + php_engine unit → **1466 examples, 0 failures**.
- Full `just test` (with js+ts) → **3681 unit + 20967 functional, 0 failures**.
- format clean; `ameba` → 13 inspected, 0 failures.

Co-authored-by: ksg97031 <ksg97031@gmail.com>