### PR TITLE
perf: harmonize residual direct file reads to cache-first read_file_content (Wave Z)

### DIFF
--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -142,7 +142,7 @@ module Analyzer::Java
     end
 
     private def read_path_config(path : String) : DropwizardPathConfig
-      root = YAML.parse(File.read(path))
+      root = YAML.parse(read_file_content(path))
       server = root["server"]?
       return DropwizardPathConfig.new unless server
 

--- a/src/analyzer/analyzers/kotlin/spring.cr
+++ b/src/analyzer/analyzers/kotlin/spring.cr
@@ -660,7 +660,7 @@ module Analyzer::Kotlin
 
     private def read_properties(path : String) : Hash(String, String)
       values = Hash(String, String).new
-      File.each_line(path) do |line|
+      read_file_content(path).each_line do |line|
         stripped = line.strip
         next if stripped.empty? || stripped.starts_with?("#") || stripped.starts_with?("!")
 

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -24,7 +24,7 @@ module Analyzer::Scala
     PATH_DIRECTIVE_RE = /(?<![.\w])path[A-Za-z]*/
 
     def analyze_file(path : String) : Array(Endpoint)
-      content = File.read(path)
+      content = read_file_content(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
     end
 

--- a/src/analyzer/analyzers/scala/scalatra.cr
+++ b/src/analyzer/analyzers/scala/scalatra.cr
@@ -36,7 +36,7 @@ module Analyzer::Scala
 
     def analyze_file(path : String) : Array(Endpoint)
       return [] of Endpoint if scalatra_test_path?(path)
-      content = File.read(path)
+      content = read_file_content(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
     end
 
@@ -50,7 +50,7 @@ module Analyzer::Scala
         next unless File.exists?(path) && File.extname(path) == ".scala"
         next if scalatra_test_path?(path)
         begin
-          content = File.read(path)
+          content = read_file_content(path)
         rescue
           next
         end

--- a/src/analyzer/analyzers/scala/tapir.cr
+++ b/src/analyzer/analyzers/scala/tapir.cr
@@ -52,7 +52,7 @@ module Analyzer::Scala
     )
 
     def analyze_file(path : String) : Array(Endpoint)
-      content = File.read(path)
+      content = read_file_content(path)
       extract_routes_from_content(path, content)
     end
 

--- a/src/analyzer/analyzers/scala/zio_http.cr
+++ b/src/analyzer/analyzers/scala/zio_http.cr
@@ -6,7 +6,7 @@ module Analyzer::Scala
     MATCHER_IDENTS = %w[int long string uuid boolean bool trailing]
 
     def analyze_file(path : String) : Array(Endpoint)
-      content = File.read(path)
+      content = read_file_content(path)
       extract_routes_from_content(path, content, any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?))
     end
 


### PR DESCRIPTION
## Summary

Final pass of the analyzer performance sweep (follows #2258). A whole-tree regression re-grep across `src/analyzer/analyzers/` confirmed **no reintroduced interpolated-regex-in-loop** (the one remaining dynamic-name `.match` in `tornado.cr` is guarded by `starts_with?` + returns on first match — the sanctioned low-cardinality pattern). It surfaced the last residual direct-disk reads that the per-file "apply the first tier only" discipline skipped on files that already received a Tier-A/B fix:

| file | site | change |
|---|---|---|
| `scala/zio_http.cr` / `akka.cr` / `tapir.cr` / `scalatra.cr` | `analyze_file` (+ scalatra `build_mount_prefixes`) | `File.read(path)` → `read_file_content(path)` (identical to the http4s swap in #2260) |
| `java/dropwizard.cr` | `read_path_config` | `YAML.parse(File.read(path))` → `read_file_content` |
| `kotlin/spring.cr` | `read_properties` | `File.each_line(path)` → `read_file_content(path).each_line` |

`read_file_content` returns the detector-populated cache when present (skipping a redundant disk read) and otherwise falls back to `File.read(..., encoding: "utf-8", invalid: :skip)`. Byte-identical on all valid UTF-8 (every fixture passes) and aligns invalid-byte handling with the rest of the codebase.

**Left as-is:** `crystal/kemal.cr`'s `File.read_lines` (no encoding arg) — swapping would change invalid-UTF-8 handling, so it's not a detection-neutral swap.

## Test plan
- scala + java + kotlin functional specs → **3221 examples, 0 failures**.
- Full `just test` → **3681 unit + 20967 functional, 0 failures**.
- `crystal tool format --check` clean; `ameba` → 6 inspected, 0 failures; `typos` clean.

Co-authored-by: ksg97031 <ksg97031@gmail.com>