### PR TITLE
refactor(java): consolidate duplicated join_paths into shared helper module

### DIFF
--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -292,7 +292,7 @@ module Analyzer::Java
         if !service_routes.empty? && (method_name == "service" || method_name == "serviceUnder")
           base_path = method_name == "serviceUnder" ? endpoint : ""
           service_routes.each do |entry|
-            emit_builder_route(entry[0], join_paths(base_path, entry[1]), details, emitted)
+            emit_builder_route(entry[0], Helper.join_paths(base_path, entry[1]), details, emitted)
           end
           next
         end
@@ -758,7 +758,7 @@ module Analyzer::Java
       prefixes = [] of String
       registration_prefixes.each do |registration_prefix|
         class_prefixes.each do |class_prefix|
-          prefixes << join_paths(registration_prefix, class_prefix)
+          prefixes << Helper.join_paths(registration_prefix, class_prefix)
         end
       end
       prefixes.uniq
@@ -816,7 +816,7 @@ module Analyzer::Java
 
         prefixes.each do |prefix|
           route_paths.each do |route_path|
-            url_path = join_paths(prefix, route_path)
+            url_path = Helper.join_paths(prefix, route_path)
             parameters = collect_method_params(method, content, url_path, constants, current_class, dto_index)
             endpoint = Endpoint.new(url_path, http_method, parameters, details)
             collect_method_callees(method, content, path).each do |(name, callee_path, callee_line)|
@@ -1137,12 +1137,6 @@ module Analyzer::Java
           endpoint.push_param(Param.new(param_name, "", "path"))
         end
       end
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/analyzer/analyzers/java/java_helper.cr
+++ b/src/analyzer/analyzers/java/java_helper.cr
@@ -1,0 +1,14 @@
+module Analyzer::Java
+  # Shared helpers for the JVM-Java framework analyzers. Kept
+  # framework-agnostic so each analyzer can reuse the common
+  # path/string conventions without duplicating them.
+  module Helper
+    extend self
+
+    def join_paths(prefix : String, suffix : String) : String
+      return suffix if prefix.empty?
+      return prefix.rstrip('/') if suffix.empty?
+      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
+    end
+  end
+end

--- a/src/analyzer/analyzers/java/javalin.cr
+++ b/src/analyzer/analyzers/java/javalin.cr
@@ -61,7 +61,7 @@ module Analyzer::Java
         constants = string_constants_for(content)
         collect_static_file_endpoints(content, constants).each do |entry|
           endpoint_path, line = entry
-          @result << Endpoint.new(join_paths(context_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
+          @result << Endpoint.new(Helper.join_paths(context_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
         end
       end
 
@@ -82,7 +82,7 @@ module Analyzer::Java
       end
 
       details = Details.new(PathInfo.new(path, route.line + 1))
-      endpoint = Endpoint.new(join_paths(context_path, route.path), route.verb, params, details)
+      endpoint = Endpoint.new(Helper.join_paths(context_path, route.path), route.verb, params, details)
       endpoint.protocol = route.protocol
 
       # 1-hop callees out of the handler lambda body. The Route
@@ -158,7 +158,7 @@ module Analyzer::Java
 
     private def static_mount_path(hosted_path : String) : String
       normalized = normalize_optional_path(hosted_path)
-      normalized.empty? ? "/**" : join_paths(normalized, "**")
+      normalized.empty? ? "/**" : Helper.join_paths(normalized, "**")
     end
 
     private def context_path_for(content : String) : String
@@ -300,12 +300,6 @@ module Analyzer::Java
         after_idx += 1
       end
       after_idx < content.size && content[after_idx] == '('
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/analyzer/analyzers/java/jaxrs.cr
+++ b/src/analyzer/analyzers/java/jaxrs.cr
@@ -59,7 +59,7 @@ module Analyzer::Java
           Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources, include_callees: include_callee).each do |route|
             line = route.line + 1
             details = Details.new(PathInfo.new(route.file_path || path, line))
-            endpoint_path = route.protocol == "ws" ? route.path : join_paths(application_base_path, route.path)
+            endpoint_path = route.protocol == "ws" ? route.path : Helper.join_paths(application_base_path, route.path)
             endpoint = Endpoint.new(endpoint_path, route.verb, route.params, details)
             endpoint.protocol = route.protocol
             route.callees.each do |name, callee_line|
@@ -150,12 +150,6 @@ module Analyzer::Java
         return base_paths[key]
       end
       ""
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
 
     private def project_root_for(path : String) : String

--- a/src/analyzer/analyzers/java/micronaut.cr
+++ b/src/analyzer/analyzers/java/micronaut.cr
@@ -59,7 +59,7 @@ module Analyzer::Java
 
       path_configs.each do |_project_root, config|
         config.static_resource_mappings.each do |mapping|
-          @result << Endpoint.new(join_paths(config.context_path, mapping), "GET")
+          @result << Endpoint.new(Helper.join_paths(config.context_path, mapping), "GET")
         end
       end
 
@@ -81,7 +81,7 @@ module Analyzer::Java
         Noir::TreeSitterMicronautExtractor.extract_routes(content, dto_index, include_callees: include_callee).each do |route|
           line = route.line + 1
           details = Details.new(PathInfo.new(path, line))
-          endpoint = Endpoint.new(join_paths(base_path, route.path), route.verb, route.params, details)
+          endpoint = Endpoint.new(Helper.join_paths(base_path, route.path), route.verb, route.params, details)
           endpoint.protocol = route.protocol
           route.callees.each do |(name, callee_line)|
             endpoint.push_callee(Callee.new(name, path: path, line: callee_line))
@@ -94,9 +94,9 @@ module Analyzer::Java
             visible_interface_routes(interface_route_index, path, package_name, imports, interface_name).each do |entry|
               entry_route = entry.route
               implementation.paths.each do |implementation_path|
-                inherited_path = join_paths(implementation_path, entry_route.path)
+                inherited_path = Helper.join_paths(implementation_path, entry_route.path)
                 details = Details.new(PathInfo.new(entry.path, entry_route.line + 1))
-                endpoint = Endpoint.new(join_paths(base_path, inherited_path), entry_route.verb, entry_route.params, details)
+                endpoint = Endpoint.new(Helper.join_paths(base_path, inherited_path), entry_route.verb, entry_route.params, details)
                 endpoint.protocol = entry_route.protocol
                 entry_route.callees.each do |name, callee_line|
                   endpoint.push_callee(Callee.new(name, path: entry.path, line: callee_line))
@@ -304,12 +304,6 @@ module Analyzer::Java
       trimmed = path.strip
       return "" if trimmed.empty? || trimmed == "/"
       trimmed.starts_with?("/") ? trimmed : "/#{trimmed}"
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
   end
 end

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -336,7 +336,7 @@ module Analyzer::Java
           include_prefix = include_match[1]
           include_target = include_match[2]
           if included_path = resolve_included_routes_file(include_target, routes_by_key, path)
-            process_routes_file(included_path, controller_methods, routes_by_key, join_paths(prefix, include_prefix), seen)
+            process_routes_file(included_path, controller_methods, routes_by_key, Helper.join_paths(prefix, include_prefix), seen)
           end
           next
         end
@@ -345,7 +345,7 @@ module Analyzer::Java
         # Example: GET /users/:id controllers.Users.show(id: Long)
         if route_match = stripped_line.match(/^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+([^\s]+)\s+(.+)/)
           method = route_match[1]
-          route_path = join_paths(prefix, route_match[2])
+          route_path = Helper.join_paths(prefix, route_match[2])
           action = route_match[3]
 
           endpoint = create_endpoint(route_path, method, path, index + 1)
@@ -364,12 +364,6 @@ module Analyzer::Java
       end
 
       seen.delete(path)
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
 
     # Extract path parameters from route pattern

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -76,7 +76,7 @@ module Analyzer::Java
           Noir::TreeSitterJaxRsExtractor.extract_routes_from(root, content, dto_index, bean_index, subresource_sources, include_callees: include_callee).each do |route|
             line = route.line + 1
             details = Details.new(PathInfo.new(route.file_path || path, line))
-            endpoint = Endpoint.new(join_paths(configured_base_path, route.path), route.verb, route.params, details)
+            endpoint = Endpoint.new(Helper.join_paths(configured_base_path, route.path), route.verb, route.params, details)
             endpoint.protocol = route.protocol
             route.callees.each do |name, callee_line|
               endpoint.push_callee(Callee.new(name, path: route.file_path || path, line: callee_line))
@@ -165,12 +165,6 @@ module Analyzer::Java
       ""
     end
 
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
-    end
-
     private def path_configs_for(file_list : Array(String)) : Hash(String, QuarkusPathConfig)
       configs = Hash(String, QuarkusPathConfig).new
       project_roots = Set(String).new
@@ -253,7 +247,7 @@ module Analyzer::Java
                                          application_base_path : String) : String
       config = configs[project_root_for(path)]? || QuarkusPathConfig.new
       rest_base = application_base_path.empty? ? config.rest_path : application_base_path
-      join_paths(config.http_root_path, rest_base)
+      Helper.join_paths(config.http_root_path, rest_base)
     end
 
     private def project_root_for(path : String) : String
@@ -286,13 +280,13 @@ module Analyzer::Java
         next if relative_path.empty?
 
         details = Details.new(PathInfo.new(file))
-        endpoint_path = join_paths(config.http_root_path, "/#{relative_path}")
+        endpoint_path = Helper.join_paths(config.http_root_path, "/#{relative_path}")
         endpoints << Endpoint.new(endpoint_path, "GET", details)
 
         if File.basename(relative_path) == config.static_index_page
           directory = File.dirname(relative_path)
           directory_path = directory == "." ? "/" : "/#{directory}/"
-          index_endpoint_path = join_paths(config.http_root_path, directory_path)
+          index_endpoint_path = Helper.join_paths(config.http_root_path, directory_path)
           next if endpoints.any? { |endpoint| endpoint.url == index_endpoint_path && endpoint.method == "GET" }
 
           endpoints << Endpoint.new(index_endpoint_path, "GET", details)
@@ -341,7 +335,7 @@ module Analyzer::Java
 
         route_path = reactive_route_path(body, method_name)
         base_path = route_bases.find { |base| offset >= base.start_offset && offset <= base.end_offset }.try(&.path) || ""
-        endpoint_path = join_paths(http_root_path, join_paths(base_path, route_path))
+        endpoint_path = Helper.join_paths(http_root_path, Helper.join_paths(base_path, route_path))
         line = content[0...offset].count('\n') + 1
         details = Details.new(PathInfo.new(path, line))
         params = reactive_route_params(content, match.end(0) || offset, endpoint_path)

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -86,7 +86,7 @@ module Analyzer::Java
                       next unless child_routes
 
                       child_routes.each do |child|
-                        endpoint = join_paths(mount.endpoint, child.endpoint)
+                        endpoint = Helper.join_paths(mount.endpoint, child.endpoint)
                         found = build_endpoint(endpoint, child.method, details)
                         attach_callees(found, callees_by_route, child.method, child.endpoint)
                         @result << found
@@ -383,12 +383,6 @@ module Analyzer::Java
       value.size >= 2 &&
         ((value.starts_with?('"') && value.ends_with?('"')) ||
           (value.starts_with?("'") && value.ends_with?("'")))
-    end
-
-    private def join_paths(prefix : String, suffix : String) : String
-      return suffix if prefix.empty?
-      return prefix.rstrip('/') if suffix.empty?
-      "#{prefix.rstrip('/')}/#{suffix.lstrip('/')}"
     end
 
     private def build_endpoint(path : String, method : String, details : Details) : Endpoint


### PR DESCRIPTION
Closes #2181. Consolidate duplicated join_paths definitions in seven Java analyzers (armeria, javalin, jaxrs, micronaut, play, quarkus, vertx) into Analyzer::Java::Helper.