### PR TITLE
Document the `noir cache purge <days>` action on the CLI Commands page

### DIFF
--- a/docs/content/usage/cli_commands/_index.ko.md
+++ b/docs/content/usage/cli_commands/_index.ko.md
@@ -24,6 +24,7 @@ noir <command> [arguments] [flags]
 | `noir list formats`    | 지원하는 출력 형식 목록                                 |
 | `noir cache info`      | LLM 캐시 디렉토리, 항목 수, 크기 표시                   |
 | `noir cache clear`     | 캐시된 AI 응답 전체 삭제                                |
+| `noir cache purge <days>` | N일보다 오래된 캐시 항목 삭제                         |
 | `noir config show`     | 활성 설정 파일 출력                                     |
 | `noir config edit`     | `$VISUAL` / `$EDITOR` 로 설정 파일 열기                 |
 | `noir config init`     | 기본 설정 파일 생성 (멱등)                              |
@@ -120,6 +121,7 @@ noir list formats     # 지원하는 모든 출력 형식
 ```bash
 noir cache info       # 경로, 항목 수, 총 크기
 noir cache clear      # 캐시된 AI 응답 전체 삭제
+noir cache purge 30   # 30일보다 오래된 항목 삭제
 ```
 
 스캔 도중 캐시 제어는 그대로 `noir scan` 에 있습니다. `--cache-disable`

--- a/docs/content/usage/cli_commands/_index.md
+++ b/docs/content/usage/cli_commands/_index.md
@@ -24,6 +24,7 @@ noir <command> [arguments] [flags]
 | `noir list formats`    | List supported output formats                           |
 | `noir cache info`      | Show LLM cache directory, entry count, and size         |
 | `noir cache clear`     | Remove every cached AI response                         |
+| `noir cache purge <days>` | Remove cached entries older than N days              |
 | `noir config show`     | Print the active config file                            |
 | `noir config edit`     | Open the config file in `$VISUAL` / `$EDITOR`           |
 | `noir config init`     | Create the default config file (idempotent)             |
@@ -119,6 +120,7 @@ noir list formats     # every supported output format
 ```bash
 noir cache info       # location, entry count, total size
 noir cache clear      # remove every cached AI response
+noir cache purge 30   # remove entries older than 30 days
 ```
 
 In-scan controls stay on `noir scan`: `--cache-disable` skips the cache


### PR DESCRIPTION
## Summary

Documents the existing `noir cache purge <days>` action on the CLI Commands reference page (EN + KO), bringing it in line with `noir cache -h` and the migrate guide.

## Changes

- Add `noir cache purge <days>` row to the Quick Reference table
- Add `noir cache purge 30` example to the `## Cache` bash block
- Apply the same updates to the Korean docs

Closes #2189