### PR TITLE
Consolidate Python slash-collapse path helpers into shared module

### DIFF
--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -1,6 +1,7 @@
 require "../../../miniparsers/python_route_extractor"
 require "../../../miniparsers/python_route_extractor_ts"
 require "../../engines/python_engine"
+require "./python_helper"
 
 module Analyzer::Python
   class Aiohttp < PythonEngine
@@ -157,7 +158,7 @@ module Analyzer::Python
             prefixes = route_table_prefixes[deco.router_name]? || [""]
             if deco.attribute_name == "view"
               prefixes.each do |prefix|
-                class_view_routes[path] << {join_paths(prefix, deco.path), deco.decorator_line, deco.def_name}
+                class_view_routes[path] << {Helper.join_paths(prefix, deco.path), deco.decorator_line, deco.def_name}
               end
               next
             end
@@ -170,7 +171,7 @@ module Analyzer::Python
                   path,
                   lines,
                   def_line,
-                  join_paths(prefix, deco.path),
+                  Helper.join_paths(prefix, deco.path),
                   deco_method,
                   deco.decorator_line,
                   definition_base_path: current_base_path,
@@ -217,7 +218,7 @@ module Analyzer::Python
                 route_path = orig_match[1]
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+                handler_routes[path] << {Helper.join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
               end
             end
 
@@ -234,7 +235,7 @@ module Analyzer::Python
                 static_path = orig_match[1]
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                full_path = static_route_path(join_paths(prefix, static_path))
+                full_path = static_route_path(Helper.join_paths(prefix, static_path))
                 result << Endpoint.new(full_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
               end
             end
@@ -255,7 +256,7 @@ module Analyzer::Python
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
                 expand_aiohttp_methods(method).each do |expanded_method|
-                  handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
+                  handler_routes[path] << {Helper.join_paths(prefix, route_path), expanded_method, line_index, handler_name}
                 end
               end
             end
@@ -273,7 +274,7 @@ module Analyzer::Python
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
                 expand_aiohttp_methods(method).each do |expanded_method|
-                  handler_routes[path] << {join_paths(prefix, route_path), expanded_method, line_index, handler_name}
+                  handler_routes[path] << {Helper.join_paths(prefix, route_path), expanded_method, line_index, handler_name}
                 end
               end
             end
@@ -289,7 +290,7 @@ module Analyzer::Python
                 route_path = orig_match[1]
               end
               prefixes_for_receiver(receiver, app_prefixes).each do |prefix|
-                class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
+                class_view_routes[path] << {Helper.join_paths(prefix, route_path), line_index, class_name}
               end
             end
 
@@ -309,7 +310,7 @@ module Analyzer::Python
                 route_path = web_match[2]
                 handler_name = web_match[3]
                 prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
-                  handler_routes[path] << {join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
+                  handler_routes[path] << {Helper.join_paths(prefix, route_path), method_name.upcase, line_index, handler_name}
                 end
               end
             end
@@ -324,7 +325,7 @@ module Analyzer::Python
                 route_path = view_match[1]
                 class_name = view_match[2].split(".").last
                 prefixes_for_add_routes_call(effective_line, app_prefixes, route_list_prefixes, line_index).each do |prefix|
-                  class_view_routes[path] << {join_paths(prefix, route_path), line_index, class_name}
+                  class_view_routes[path] << {Helper.join_paths(prefix, route_path), line_index, class_name}
                 end
               end
             end
@@ -722,7 +723,7 @@ module Analyzer::Python
           parent_prefixes = prefixes[parent]? || [""]
           prefixes[child] ||= [] of ::String
           parent_prefixes.each do |parent_prefix|
-            child_prefix = join_paths(parent_prefix, mount_prefix)
+            child_prefix = Helper.join_paths(parent_prefix, mount_prefix)
             unless prefixes[child].includes?(child_prefix)
               prefixes[child] << child_prefix
               changed = true
@@ -871,23 +872,10 @@ module Analyzer::Python
       normalized.split(".").last
     end
 
-    private def join_paths(prefix : ::String, path : ::String) : ::String
-      return normalize_path(path) if prefix.empty?
-      return normalize_path(prefix) if path.empty?
-
-      normalize_path("#{prefix}/#{path}")
-    end
-
     private def static_route_path(path : ::String) : ::String
-      normalized = normalize_path(path)
+      normalized = Helper.normalize_path(path)
       normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
       normalized == "/" ? "/*" : "#{normalized}/*"
-    end
-
-    private def normalize_path(path : ::String) : ::String
-      normalized = path.gsub(/\/+/, "/")
-      normalized = "/#{normalized}" unless normalized.starts_with?("/")
-      normalized
     end
 
     DICT_ACCESSORS = {

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -1,6 +1,7 @@
 require "../../../miniparsers/python_route_extractor"
 require "../../../miniparsers/python_route_extractor_ts"
 require "../../engines/python_engine"
+require "./python_helper"
 
 module Analyzer::Python
   class Bottle < PythonEngine
@@ -79,7 +80,7 @@ module Analyzer::Python
                 path,
                 lines,
                 line_index: deco.decorator_line,
-                route_path: join_paths(prefix, deco.path),
+                route_path: Helper.join_paths(prefix, deco.path),
                 extra_params: extra_params,
                 definition_base_path: current_base_path,
                 source: file_content
@@ -177,7 +178,7 @@ module Analyzer::Python
           path,
           lines,
           line_index,
-          join_paths(prefix, route_path),
+          Helper.join_paths(prefix, route_path),
           route_match[2],
           callback_name,
           definition_base_path: definition_base_path,
@@ -223,7 +224,7 @@ module Analyzer::Python
 
           prefixes[child_router] ||= [] of ::String
           parent_prefixes.each do |parent_prefix|
-            composed_prefix = join_paths(parent_prefix, mount_prefix)
+            composed_prefix = Helper.join_paths(parent_prefix, mount_prefix)
             next if prefixes[child_router].includes?(composed_prefix)
 
             prefixes[child_router] << composed_prefix
@@ -438,19 +439,6 @@ module Analyzer::Python
       end
 
       nil
-    end
-
-    private def join_paths(prefix : ::String, path : ::String) : ::String
-      return normalize_path(path) if prefix.empty?
-      return normalize_path(prefix) if path.empty?
-
-      normalize_path("#{prefix}/#{path}")
-    end
-
-    private def normalize_path(path : ::String) : ::String
-      normalized = path.gsub(/\/+/, "/")
-      normalized = "/#{normalized}" unless normalized.starts_with?("/")
-      normalized
     end
 
     # Walk forward from `def_index` collecting lines at strictly greater

--- a/src/analyzer/analyzers/python/python_helper.cr
+++ b/src/analyzer/analyzers/python/python_helper.cr
@@ -1,0 +1,22 @@
+module Analyzer::Python
+  # Shared path helpers for the Python framework analyzers. Kept
+  # framework-agnostic so each analyzer can opt in without duplicating
+  # the slash-collapse / leading-slash conventions.
+  module Helper
+    extend self
+
+    # Collapse repeated slashes and ensure a single leading slash.
+    def normalize_path(path : ::String) : ::String
+      normalized = path.gsub(/\/+/, "/")
+      normalized = "/#{normalized}" unless normalized.starts_with?("/")
+      normalized
+    end
+
+    def join_paths(prefix : ::String, path : ::String) : ::String
+      return normalize_path(path) if prefix.empty?
+      return normalize_path(prefix) if path.empty?
+
+      normalize_path("#{prefix}/#{path}")
+    end
+  end
+end

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -1,6 +1,7 @@
 require "../../../miniparsers/python_route_extractor"
 require "../../../miniparsers/python_route_extractor_ts"
 require "../../engines/python_engine"
+require "./python_helper"
 
 module Analyzer::Python
   class Sanic < PythonEngine
@@ -412,7 +413,7 @@ module Analyzer::Python
 
           registration_prefixes.each do |registration_prefix|
             full_prefix = compose_sanic_prefix(router_name, registration_prefix, prefix, blueprint_group_prefixes, blueprint_versions)
-            endpoint_path = static_route_path(join_paths(full_prefix, static_path))
+            endpoint_path = static_route_path(Helper.join_paths(full_prefix, static_path))
             result << Endpoint.new(endpoint_path, "GET", Details.new(PathInfo.new(path, line_index + 1)))
           end
         end
@@ -819,9 +820,9 @@ module Analyzer::Python
                                      group_prefixes : Hash(::String, ::String),
                                      versions : Hash(::String, ::String),
                                      route_version : ::String? = nil) : ::String
-      base = join_paths(group_prefixes[router_name]? || "", join_paths(registration_prefix, prefix))
+      base = Helper.join_paths(group_prefixes[router_name]? || "", Helper.join_paths(registration_prefix, prefix))
       version = route_version || versions[router_name]?
-      version && !version.empty? ? join_paths("/v#{version}", base) : base
+      version && !version.empty? ? Helper.join_paths("/v#{version}", base) : base
     end
 
     private def fetch_file_content(path : ::String) : ::String
@@ -908,7 +909,7 @@ module Analyzer::Python
       # Create endpoints for each method
       methods.each do |http_method|
         # Create endpoint with the prefix
-        full_path = normalize_sanic_path_params(join_paths(prefix, route_path))
+        full_path = normalize_sanic_path_params(Helper.join_paths(prefix, route_path))
         filtered_params = get_filtered_params(http_method, params.dup)
         endpoint = Endpoint.new(full_path, http_method, filtered_params)
         endpoint.protocol = "ws" if route_attr == "websocket"
@@ -928,23 +929,10 @@ module Analyzer::Python
       }
     end
 
-    private def join_paths(prefix : ::String, path : ::String) : ::String
-      return normalize_path(path) if prefix.empty?
-      return normalize_path(prefix) if path.empty?
-
-      normalize_path("#{prefix}/#{path}")
-    end
-
     private def static_route_path(path : ::String) : ::String
-      normalized = normalize_path(path)
+      normalized = Helper.normalize_path(path)
       normalized = normalized[0...-1] if normalized.ends_with?("/") && normalized != "/"
       normalized == "/" ? "/*" : "#{normalized}/*"
-    end
-
-    private def normalize_path(path : ::String) : ::String
-      normalized = path.gsub(/\/+/, "/")
-      normalized = "/#{normalized}" unless normalized.starts_with?("/")
-      normalized
     end
 
     private def normalize_sanic_path_params(path : ::String) : ::String


### PR DESCRIPTION
## Summary

Extracts byte-identical `normalize_path` and `join_paths` helpers from the `sanic`, `bottle`, and `aiohttp` analyzers into a shared `Analyzer::Python::Helper` module, following the existing `dart_helper.cr` pattern.

## Changes

- Add `src/analyzer/analyzers/python/python_helper.cr` with slash-collapse helpers
- Update `sanic.cr`, `bottle.cr`, and `aiohttp.cr` to `require "./python_helper"` and call `Helper.join_paths` / `Helper.normalize_path`
- Remove duplicated private helper definitions from the three analyzers

## Out of scope (intentionally untouched)

- `falcon.cr` and `robyn.cr` — their `normalize_path` methods perform param-template normalization, not slash collapsing
- Top-level `join_paths(*paths : String)` in `analyzer.cr`
- `static_route_path` (shared by sanic/aiohttp but not bottle)

## Verification

- `just build`
- `crystal spec spec/functional_test/testers/python/` — 2128 examples, 0 failures
- `crystal tool format`

Fixes #2183