### PR TITLE
chore(analyzer/go/fasthttp): remove dead legacy route-line scanner

### DIFF
--- a/src/analyzer/analyzers/go/fasthttp.cr
+++ b/src/analyzer/analyzers/go/fasthttp.cr
@@ -115,39 +115,6 @@ module Analyzer::Go
       path.gsub(/\{([a-zA-Z0-9_]+)\??(?::[^{}]+)?\}/) { "{#{$1}}" }
     end
 
-    private def analyze_route_line(line : String, details : Details) : Endpoint
-      # Pattern 1: Direct handler registration with router
-      # router.GET("/path", handler) or router.POST("/path", handler)
-      # Route path must start with "/" to be a valid HTTP endpoint
-      if match = line.match(/(?:router|r|app|server)\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"(\/[^"]*)"\s*,/)
-        path = match[1]
-        method = extract_method_from_router_call(line)
-        return Endpoint.new(path, method, details)
-      end
-
-      # Pattern 2: fasthttprouter patterns
-      # router.GET("/path", handler)
-      # Route path must start with "/" to be a valid HTTP endpoint
-      if match = line.match(/\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(\s*"(\/[^"]*)"\s*,/)
-        path = match[1]
-        method = extract_method_from_router_call(line)
-        return Endpoint.new(path, method, details)
-      end
-
-      # Pattern 3: Direct fasthttp.ListenAndServe with switch statements for routes
-      # This would require more complex analysis, for now we focus on router patterns
-
-      Endpoint.new("", "")
-    end
-
-    private def extract_method_from_router_call(line : String) : String
-      if match = line.match(/\.(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)/)
-        match[0].gsub(".", "").upcase
-      else
-        ""
-      end
-    end
-
     # Cheap pre-filter for `analyze_param_line`, called on EVERY line of
     # every fasthttp file (not just route lines). Union of every literal
     # substring any of the six scans below requires to possibly match —


### PR DESCRIPTION
## Summary

Removes the dead legacy regex-based route scanner left over after the fasthttp Go analyzer was migrated to `TreeSitterGoRouteExtractor`.

Deleted methods:
- `analyze_route_line` — never called after tree-sitter migration
- `extract_method_from_router_call` — helper only used by the above

`analyze` continues to build endpoints from `TreeSitterGoRouteExtractor.extract_routes` and still uses `normalize_fasthttp_path` + `analyze_param_line`.

## Testing

```bash
crystal spec spec/functional_test/testers/go/fasthttp_spec.cr \
             spec/functional_test/testers/go/fasthttp_optional_spec.cr \
             spec/functional_test/testers/go/fasthttp_callees_spec.cr
```

130 examples, 0 failures

Closes #2185