### PR TITLE
Consolidate duplicated Haskell strip_haskell_comments into shared Helper

### DIFF
--- a/src/analyzer/analyzers/haskell/haskell_helper.cr
+++ b/src/analyzer/analyzers/haskell/haskell_helper.cr
@@ -1,0 +1,82 @@
+module Analyzer::Haskell
+  # Shared helpers for the Haskell framework analyzers (Scotty, Servant).
+  module Helper
+    extend self
+
+    # Blank out `--` line comments and nested `{- -}` block comments while
+    # PRESERVING newlines/offsets, so a multi-line comment doesn't collapse
+    # lines and shift every later endpoint's reported line number.
+    def strip_haskell_comments(text : String) : String
+      result = String::Builder.new
+      chars = text.chars
+      i = 0
+      brace_depth = 0
+      in_string = false
+
+      while i < chars.size
+        c = chars[i]
+
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            result << c
+            result << chars[i + 1]
+            i += 2
+            next
+          elsif c == '"'
+            in_string = false
+            result << c
+            i += 1
+            next
+          else
+            result << c
+            i += 1
+            next
+          end
+        end
+
+        if brace_depth == 0 && c == '"'
+          in_string = true
+          result << c
+          i += 1
+          next
+        end
+
+        if i + 1 < chars.size && c == '{' && chars[i + 1] == '-'
+          brace_depth += 1
+          result << ' '
+          result << ' '
+          i += 2
+          while i < chars.size && brace_depth > 0
+            if i + 1 < chars.size && chars[i] == '-' && chars[i + 1] == '}'
+              brace_depth -= 1
+              result << ' '
+              result << ' '
+              i += 2
+            elsif i + 1 < chars.size && chars[i] == '{' && chars[i + 1] == '-'
+              brace_depth += 1
+              result << ' '
+              result << ' '
+              i += 2
+            else
+              result << (chars[i] == '\n' ? '\n' : ' ')
+              i += 1
+            end
+          end
+          next
+        end
+
+        if brace_depth == 0 && i + 1 < chars.size && c == '-' && chars[i + 1] == '-'
+          while i < chars.size && chars[i] != '\n'
+            i += 1
+          end
+          next
+        end
+
+        result << c
+        i += 1
+      end
+
+      result.to_s
+    end
+  end
+end

--- a/src/analyzer/analyzers/haskell/scotty.cr
+++ b/src/analyzer/analyzers/haskell/scotty.cr
@@ -70,7 +70,7 @@ module Analyzer::Haskell
                                 content : String,
                                 include_callee : Bool,
                                 handler_bodies : HandlerBodies)
-      cleaned = strip_haskell_comments(content)
+      cleaned = Helper.strip_haskell_comments(content)
       lines = cleaned.lines
       idx = 0
 
@@ -278,79 +278,6 @@ module Analyzer::Haskell
 
       m = trimmed.match(/\A([a-z_][A-Za-z0-9_']*)\s*$/)
       m ? m[1] : nil
-    end
-
-    private def strip_haskell_comments(text : String) : String
-      result = String::Builder.new
-      chars = text.chars
-      i = 0
-      brace_depth = 0
-      in_string = false
-
-      while i < chars.size
-        c = chars[i]
-
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            result << c
-            result << chars[i + 1]
-            i += 2
-            next
-          elsif c == '"'
-            in_string = false
-            result << c
-            i += 1
-            next
-          else
-            result << c
-            i += 1
-            next
-          end
-        end
-
-        if brace_depth == 0 && c == '"'
-          in_string = true
-          result << c
-          i += 1
-          next
-        end
-
-        if i + 1 < chars.size && c == '{' && chars[i + 1] == '-'
-          brace_depth += 1
-          result << ' '
-          result << ' '
-          i += 2
-          while i < chars.size && brace_depth > 0
-            if i + 1 < chars.size && chars[i] == '-' && chars[i + 1] == '}'
-              brace_depth -= 1
-              result << ' '
-              result << ' '
-              i += 2
-            elsif i + 1 < chars.size && chars[i] == '{' && chars[i + 1] == '-'
-              brace_depth += 1
-              result << ' '
-              result << ' '
-              i += 2
-            else
-              result << (chars[i] == '\n' ? '\n' : ' ')
-              i += 1
-            end
-          end
-          next
-        end
-
-        if brace_depth == 0 && i + 1 < chars.size && c == '-' && chars[i + 1] == '-'
-          while i < chars.size && chars[i] != '\n'
-            i += 1
-          end
-          next
-        end
-
-        result << c
-        i += 1
-      end
-
-      result.to_s
     end
   end
 end

--- a/src/analyzer/analyzers/haskell/servant.cr
+++ b/src/analyzer/analyzers/haskell/servant.cr
@@ -108,7 +108,7 @@ module Analyzer::Haskell
 
     private def extract_server_binding_targets(content : String) : Array(NamedTuple(name: String, target: String))
       targets = [] of NamedTuple(name: String, target: String)
-      cleaned = strip_haskell_comments(content)
+      cleaned = Helper.strip_haskell_comments(content)
 
       cleaned.each_line do |line|
         match = line.match(/^\s*([a-z_][A-Za-z0-9_']*)\s*::.*\bServer(?:T)?\b\s*(.*)$/)
@@ -130,7 +130,7 @@ module Analyzer::Haskell
 
     private def extract_type_aliases(content : String) : Array(NamedTuple(name: String, body: String, line: Int32))
       results = [] of NamedTuple(name: String, body: String, line: Int32)
-      cleaned = strip_haskell_comments(content)
+      cleaned = Helper.strip_haskell_comments(content)
       lines = cleaned.lines
 
       i = 0
@@ -187,7 +187,7 @@ module Analyzer::Haskell
     # treats it exactly like a `type X = ...` API.
     private def extract_record_routes(content : String) : Array(NamedTuple(name: String, body: String, line: Int32))
       results = [] of NamedTuple(name: String, body: String, line: Int32)
-      cleaned = strip_haskell_comments(content)
+      cleaned = Helper.strip_haskell_comments(content)
       lines = cleaned.lines
 
       i = 0
@@ -292,82 +292,6 @@ module Analyzer::Haskell
       return true if starts_with_whitespace?(line)
       stripped = line.lstrip
       stripped.starts_with?(":<|>") || stripped.starts_with?(":>")
-    end
-
-    private def strip_haskell_comments(text : String) : String
-      result = String::Builder.new
-      chars = text.chars
-      i = 0
-      brace_depth = 0
-      in_string = false
-
-      while i < chars.size
-        c = chars[i]
-
-        if in_string
-          if c == '\\' && i + 1 < chars.size
-            result << c
-            result << chars[i + 1]
-            i += 2
-            next
-          elsif c == '"'
-            in_string = false
-            result << c
-            i += 1
-            next
-          else
-            result << c
-            i += 1
-            next
-          end
-        end
-
-        if brace_depth == 0 && c == '"'
-          in_string = true
-          result << c
-          i += 1
-          next
-        end
-
-        if i + 1 < chars.size && c == '{' && chars[i + 1] == '-'
-          # Replace the comment with whitespace, PRESERVING newlines, so a
-          # multi-line `{- -}` doesn't collapse lines and shift every later
-          # endpoint's reported line number (mirrors scotty.cr).
-          brace_depth += 1
-          result << ' '
-          result << ' '
-          i += 2
-          while i < chars.size && brace_depth > 0
-            if i + 1 < chars.size && chars[i] == '-' && chars[i + 1] == '}'
-              brace_depth -= 1
-              result << ' '
-              result << ' '
-              i += 2
-            elsif i + 1 < chars.size && chars[i] == '{' && chars[i + 1] == '-'
-              brace_depth += 1
-              result << ' '
-              result << ' '
-              i += 2
-            else
-              result << (chars[i] == '\n' ? '\n' : ' ')
-              i += 1
-            end
-          end
-          next
-        end
-
-        if brace_depth == 0 && i + 1 < chars.size && c == '-' && chars[i + 1] == '-'
-          while i < chars.size && chars[i] != '\n'
-            i += 1
-          end
-          next
-        end
-
-        result << c
-        i += 1
-      end
-
-      result.to_s
     end
 
     private def referenced_aliases(body : String, known_names : Array(String)) : Array(String)


### PR DESCRIPTION
## Summary

- Extract the byte-identical `strip_haskell_comments` char-scanner from `scotty.cr` and `servant.cr` into a new `Analyzer::Haskell::Helper` module
- Update call sites to use `Helper.strip_haskell_comments(content)`
- Follows the existing `Analyzer::Dart::Helper` pattern (`extend self`, glob-loaded via `require "./analyzers/**"`)

## Why

Scotty and Servant each carried a private copy of the same 72-line comment stripper. Consolidating removes ~150 lines of duplication without changing behavior — the scanner deliberately preserves newlines/byte offsets so endpoint line numbers stay accurate.

## Test plan

- [x] `just build`
- [x] Haskell Scotty/Servant functional tests (178 examples, 0 failures)

Fixes #2182