### PR TITLE
Consolidate duplicated Perl underscore helper into shared module

### DIFF
--- a/spec/unit_test/analyzer/perl_helper_spec.cr
+++ b/spec/unit_test/analyzer/perl_helper_spec.cr
@@ -1,0 +1,17 @@
+require "../../spec_helper"
+require "../../../src/analyzer/analyzers/perl/perl_helper"
+
+describe Analyzer::Perl::Helper do
+  describe ".underscore" do
+    it "inserts underscores between lowercase/digit and uppercase runs" do
+      Analyzer::Perl::Helper.underscore("FooBar").should eq("foo_bar")
+      Analyzer::Perl::Helper.underscore("fooBarBaz").should eq("foo_bar_baz")
+      Analyzer::Perl::Helper.underscore("abc123Def").should eq("abc123_def")
+    end
+
+    it "leaves already-underscored names unchanged apart from downcasing" do
+      Analyzer::Perl::Helper.underscore("already_fine").should eq("already_fine")
+      Analyzer::Perl::Helper.underscore("ALLCAPS").should eq("allcaps")
+    end
+  end
+end

--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -1,4 +1,5 @@
 require "../../engines/perl_engine"
+require "./perl_helper"
 
 module Analyzer::Perl
   class Catalyst < PerlEngine
@@ -720,7 +721,7 @@ module Analyzer::Perl
       namespace = package_name.split(marker, 2)[1]
       return "" if namespace == "Root"
 
-      namespace.split("::").map { |part| underscore(part) }.join("/")
+      namespace.split("::").map { |part| Helper.underscore(part) }.join("/")
     end
 
     private def path_prefix(namespace : String, config : ControllerConfig) : String
@@ -733,10 +734,6 @@ module Analyzer::Perl
 
     private def namespace_path(namespace : String) : String
       namespace.empty? ? "" : "/#{namespace}"
-    end
-
-    private def underscore(name : String) : String
-      name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
     end
 
     private def clean_path_prefix(value : String) : String

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -1,4 +1,5 @@
 require "../../engines/perl_engine"
+require "./perl_helper"
 require "../../../miniparsers/perl_callee_extractor"
 
 module Analyzer::Perl
@@ -493,12 +494,8 @@ module Analyzer::Perl
 
     private def controller_key(controller : String) : String
       controller.gsub("::", "/").split('/').reject(&.empty?).map do |segment|
-        underscore(segment.gsub("-", "_"))
+        Helper.underscore(segment.gsub("-", "_"))
       end.join("/")
-    end
-
-    private def underscore(name : String) : String
-      name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
     end
 
     private def line_offsets(content : String) : Array(Int32)

--- a/src/analyzer/analyzers/perl/perl_helper.cr
+++ b/src/analyzer/analyzers/perl/perl_helper.cr
@@ -1,0 +1,12 @@
+module Analyzer::Perl
+  # Shared helpers for the Perl framework analyzers (Catalyst, Mojolicious,
+  # Dancer2). Kept framework-agnostic so each analyzer can opt in without
+  # duplicating string conventions.
+  module Helper
+    extend self
+
+    def underscore(name : String) : String
+      name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
+    end
+  end
+end

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -1,4 +1,5 @@
 require "../models/endpoint"
+require "../analyzer/analyzers/perl/perl_helper"
 require "./callee_extractor_base"
 
 module Noir::PerlCalleeExtractor
@@ -288,12 +289,8 @@ module Noir::PerlCalleeExtractor
     keys = Set(String).new
     segments = controller.split("::")
     keys << segments.map(&.downcase).join("/")
-    keys << segments.map { |segment| underscore(segment) }.join("/")
+    keys << segments.map { |segment| Analyzer::Perl::Helper.underscore(segment) }.join("/")
     keys.to_a
-  end
-
-  private def underscore(name : String) : String
-    name.gsub(/([a-z0-9])([A-Z])/, "\\1_\\2").downcase
   end
 
   private def find_keyword(chars : Array(Char), keyword : String, start_index : Int32, limit : Int32) : Int32?


### PR DESCRIPTION
## Summary

Extracts the identical `underscore(name)` camelCase-to-underscore helper duplicated across the Perl analyzers into a shared `Analyzer::Perl::Helper` module, mirroring the existing `dart_helper.cr` pattern.

Closes #2171

## Changes

- Add `src/analyzer/analyzers/perl/perl_helper.cr` with the shared helper (verbatim from the duplicated implementations — **not** Crystal stdlib `String#underscore`)
- Update `catalyst.cr` and `mojolicious.cr` to call `Helper.underscore(...)`
- Update `perl_callee_extractor.cr` to use the shared helper as well
- Add unit tests in `spec/unit_test/analyzer/perl_helper_spec.cr`

## Testing

- `just build` — pass
- `just test` — pass (3683 unit + 20967 functional examples, 0 failures)