### PR TITLE
fix(analyzer/python): detect multi-value params and Litestar empty/list paths

### DIFF
--- a/spec/functional_test/fixtures/python/aiohttp_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/aiohttp_multivalue/app.py
@@ -1,0 +1,12 @@
+from aiohttp import web
+
+
+async def items(request):
+    tag = request.query.getall('tag')
+    kind = request.query.getone('kind')
+    trace = request.headers.getall('X-Trace')
+    return web.json_response({})
+
+
+app = web.Application()
+app.add_routes([web.get('/items', items)])

--- a/spec/functional_test/fixtures/python/bottle_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/bottle_multivalue/app.py
@@ -1,0 +1,13 @@
+from bottle import Bottle, request
+
+app = Bottle()
+
+
+@app.post('/tags')
+def add_tags():
+    # Bottle MultiDicts expose getall/getone for repeated keys.
+    tag = request.forms.getall('tag')
+    name = request.query.getall('name')
+    # Negative: keys() is a dict-API method, not a parameter.
+    all_keys = list(request.query.keys())
+    return 'ok'

--- a/spec/functional_test/fixtures/python/django_multivalue/app/views.py
+++ b/spec/functional_test/fixtures/python/django_multivalue/app/views.py
@@ -1,0 +1,10 @@
+from django.http import HttpResponse
+
+
+def search(request):
+    # request.GET is a QueryDict; getlist reads repeated keys (?tags=a&tags=b).
+    tags = request.GET.getlist('tags')
+    q = request.GET.get('q')
+    # Negative: a dynamic key must not be reported.
+    dynamic = request.GET.get(some_key)
+    return HttpResponse(q)

--- a/spec/functional_test/fixtures/python/django_multivalue/proj/settings.py
+++ b/spec/functional_test/fixtures/python/django_multivalue/proj/settings.py
@@ -1,0 +1,2 @@
+ROOT_URLCONF = 'proj.urls'
+STATIC_URL = '/static/'

--- a/spec/functional_test/fixtures/python/django_multivalue/proj/urls.py
+++ b/spec/functional_test/fixtures/python/django_multivalue/proj/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from app import views
+
+urlpatterns = [
+    path('search/', views.search),
+]

--- a/spec/functional_test/fixtures/python/flask_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/flask_multivalue/app.py
@@ -1,0 +1,22 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+
+@app.route('/search', methods=['GET'])
+def search():
+    # .get() (single value) already worked; .getlist() (repeated keys,
+    # ?tags=a&tags=b) is the regression target.
+    q = request.args.get('q')
+    tags = request.args.getlist('tags')
+    # Negatives: a dynamic (non-literal) key and a dict-API method must
+    # NOT be reported as request parameters.
+    dynamic = request.args.get(user_supplied_key)
+    all_keys = list(request.args.keys())
+    return jsonify({'q': q, 'tags': tags, 'dynamic': dynamic, 'all_keys': all_keys})
+
+
+@app.route('/bulk', methods=['POST'])
+def bulk():
+    names = request.form.getlist('names')
+    return jsonify({'names': names})

--- a/spec/functional_test/fixtures/python/litestar_empty_path/app.py
+++ b/spec/functional_test/fixtures/python/litestar_empty_path/app.py
@@ -1,0 +1,33 @@
+from litestar import Controller, get, post, Litestar
+from pydantic import BaseModel
+
+
+class ItemCreate(BaseModel):
+    name: str
+
+
+# Bare @get()/@post() default to path="" → "/".
+@get()
+async def index() -> dict:
+    return {}
+
+
+@post(sync_to_thread=False)
+async def create_root() -> dict:
+    return {}
+
+
+class ItemController(Controller):
+    path = "/items"
+
+    # Empty method path joins with controller prefix → "/items".
+    @get()
+    async def list_items(self) -> list:
+        return []
+
+    @post()
+    async def create_item(self, data: ItemCreate) -> dict:
+        return {}
+
+
+app = Litestar(route_handlers=[index, create_root, ItemController])

--- a/spec/functional_test/fixtures/python/litestar_list_paths/app.py
+++ b/spec/functional_test/fixtures/python/litestar_list_paths/app.py
@@ -1,0 +1,15 @@
+from litestar import get, Litestar
+
+
+# List-of-paths form: one endpoint per path string.
+@get(["/", "/index"])
+async def index() -> dict:
+    return {}
+
+
+@get(path=["/health", "/healthz", "/status"])
+async def health() -> dict:
+    return {"ok": True}
+
+
+app = Litestar(route_handlers=[index, health])

--- a/spec/functional_test/fixtures/python/quart_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/quart_multivalue/app.py
@@ -1,0 +1,10 @@
+from quart import Quart, request, jsonify
+
+app = Quart(__name__)
+
+
+@app.route('/search', methods=['GET'])
+async def search():
+    ids = request.args.getlist('ids')
+    category = request.args.get('category')
+    return jsonify({'ids': ids, 'category': category})

--- a/spec/functional_test/fixtures/python/sanic_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/sanic_multivalue/app.py
@@ -1,0 +1,16 @@
+from sanic import Sanic, response
+
+app = Sanic("mvapp")
+
+
+@app.get('/search')
+async def search(request):
+    ids = request.args.getlist('ids')
+    tag = request.args.get('tag')
+    return response.json({})
+
+
+@app.post('/bulk')
+async def bulk(request):
+    names = request.form.getlist('names')
+    return response.json({})

--- a/spec/functional_test/fixtures/python/starlette_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/starlette_multivalue/app.py
@@ -1,0 +1,12 @@
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+async def filter_items(request):
+    tags = request.query_params.getlist('tag')
+    return JSONResponse({})
+
+
+routes = [Route('/filter', filter_items)]
+app = Starlette(routes=routes)

--- a/spec/functional_test/fixtures/python/tornado_multivalue/app.py
+++ b/spec/functional_test/fixtures/python/tornado_multivalue/app.py
@@ -1,0 +1,22 @@
+import tornado.web
+
+
+class SearchHandler(tornado.web.RequestHandler):
+    def get(self):
+        q = self.get_query_argument("q")
+        tag = self.get_query_arguments("tag")
+        user = self.get_secure_cookie("user")
+        self.write("ok")
+
+
+class TagHandler(tornado.web.RequestHandler):
+    def post(self):
+        ids = self.get_body_arguments("id")
+        self.write("ok")
+
+
+def make_app():
+    return tornado.web.Application([
+        (r"/search", SearchHandler),
+        (r"/tags", TagHandler),
+    ])

--- a/spec/functional_test/testers/python/aiohttp_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/aiohttp_multivalue_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Regression test: aiohttp MultiDict/CIMultiDict expose `getall`/`getone`
+# for repeated keys. The param extractor previously matched only `.get(`.
+expected_endpoints = [
+  Endpoint.new("/items", "GET", [
+    Param.new("tag", "", "query"),
+    Param.new("kind", "", "query"),
+    Param.new("X-Trace", "", "header"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/aiohttp_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/bottle_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/bottle_multivalue_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+# Regression test: Bottle MultiDicts expose `getall`/`getone` for repeated
+# keys. The param extractor previously matched only `.get(`.
+expected_endpoints = [
+  Endpoint.new("/tags", "POST", [
+    Param.new("tag", "", "form"),
+    Param.new("name", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/bottle_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+
+describe "Bottle multi-value accessor negatives" do
+  it "does not report dict-API methods as params" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/bottle_multivalue/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find! { |ep| ep.method == "POST" && ep.url == "/tags" }
+    names = endpoint.params.map(&.name)
+    names.should_not contain("all_keys")
+    names.should_not contain("keys")
+  end
+end

--- a/spec/functional_test/testers/python/django_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/django_multivalue_spec.cr
@@ -1,0 +1,32 @@
+require "../../func_spec.cr"
+
+# Regression test: Django QueryDict exposes `getlist("key")` for repeated
+# keys. The param extractor previously matched only `.get(`.
+expected_endpoints = [
+  Endpoint.new("/search/", "GET", [
+    Param.new("tags", "", "query"),
+    Param.new("q", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/django_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+
+describe "Django multi-value accessor negatives" do
+  it "does not report dynamic keys as params" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/django_multivalue/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/search/" }
+    names = endpoint.params.map(&.name)
+    names.should_not contain("some_key")
+    names.should_not contain("dynamic")
+  end
+end

--- a/spec/functional_test/testers/python/flask_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/flask_multivalue_spec.cr
@@ -1,0 +1,37 @@
+require "../../func_spec.cr"
+
+# Regression test: Werkzeug request MultiDicts expose `getlist("key")` for
+# repeated keys (`?tags=a&tags=b`) alongside `get`. The param extractor
+# previously matched only `.get(`, so `getlist` params were missed.
+expected_endpoints = [
+  Endpoint.new("/search", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("tags", "", "query"),
+  ]),
+  Endpoint.new("/bulk", "POST", [
+    Param.new("names", "", "form"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/flask_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests
+
+describe "Flask multi-value accessor negatives" do
+  it "does not report dynamic keys or dict-API methods as params" do
+    options = ConfigInitializer.new.default_options
+    options["base"] = YAML::Any.new([YAML::Any.new("./spec/functional_test/fixtures/python/flask_multivalue/")])
+    options["nolog"] = YAML::Any.new(true)
+
+    app = NoirRunner.new(options)
+    app.detect
+    app.analyze
+
+    endpoint = app.endpoints.find! { |ep| ep.method == "GET" && ep.url == "/search" }
+    names = endpoint.params.map(&.name)
+    names.should_not contain("user_supplied_key")
+    names.should_not contain("all_keys")
+    names.should_not contain("keys")
+  end
+end

--- a/spec/functional_test/testers/python/litestar_empty_path_spec.cr
+++ b/spec/functional_test/testers/python/litestar_empty_path_spec.cr
@@ -1,0 +1,16 @@
+require "../../func_spec.cr"
+
+# Regression test: Litestar defaults an omitted path to "" (joined with any
+# controller prefix). Previously `@get()` / `@get(sync_to_thread=False)` and
+# controller methods without a path were dropped entirely (0 endpoints).
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/", "POST"),
+  Endpoint.new("/items", "GET"),
+  Endpoint.new("/items", "POST", [Param.new("data", "", "json")]),
+]
+
+FunctionalTester.new("fixtures/python/litestar_empty_path/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/litestar_list_paths_spec.cr
+++ b/spec/functional_test/testers/python/litestar_list_paths_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+# Regression test: Litestar accepts a list of path strings
+# (`@get(["/a", "/b"])`, `@get(path=["/a", "/b"])`) and registers one
+# route per entry. Previously the list form was not recognized and the
+# handler was dropped.
+expected_endpoints = [
+  Endpoint.new("/", "GET"),
+  Endpoint.new("/index", "GET"),
+  Endpoint.new("/health", "GET"),
+  Endpoint.new("/healthz", "GET"),
+  Endpoint.new("/status", "GET"),
+]
+
+FunctionalTester.new("fixtures/python/litestar_list_paths/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/quart_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/quart_multivalue_spec.cr
@@ -1,0 +1,15 @@
+require "../../func_spec.cr"
+
+# Regression test: Quart/Werkzeug MultiDicts expose `getlist("key")` for
+# repeated keys. The param extractor previously matched only `.get(`.
+expected_endpoints = [
+  Endpoint.new("/search", "GET", [
+    Param.new("ids", "", "query"),
+    Param.new("category", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/quart_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/sanic_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/sanic_multivalue_spec.cr
@@ -1,0 +1,18 @@
+require "../../func_spec.cr"
+
+# Regression test: Sanic RequestParameters expose `getlist("key")` for
+# repeated keys. The param extractor previously matched only `.get(`.
+expected_endpoints = [
+  Endpoint.new("/search", "GET", [
+    Param.new("ids", "", "query"),
+    Param.new("tag", "", "query"),
+  ]),
+  Endpoint.new("/bulk", "POST", [
+    Param.new("names", "", "form"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/sanic_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/starlette_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/starlette_multivalue_spec.cr
@@ -1,0 +1,14 @@
+require "../../func_spec.cr"
+
+# Regression test: Starlette QueryParams/Headers expose `getlist("key")` for
+# repeated keys. The param extractor previously matched only `.get(`.
+expected_endpoints = [
+  Endpoint.new("/filter", "GET", [
+    Param.new("tag", "", "query"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/starlette_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/spec/functional_test/testers/python/tornado_multivalue_spec.cr
+++ b/spec/functional_test/testers/python/tornado_multivalue_spec.cr
@@ -1,0 +1,21 @@
+require "../../func_spec.cr"
+
+# Regression test: Tornado RequestHandler multi-value / scoped accessors
+# (`get_query_argument(s)`, `get_body_arguments`, `get_secure_cookie`) were
+# previously missed; only `get_argument(s)` / `get_body_argument` / `get_cookie`
+# were handled.
+expected_endpoints = [
+  Endpoint.new("/search", "GET", [
+    Param.new("q", "", "query"),
+    Param.new("tag", "", "query"),
+    Param.new("user", "", "cookie"),
+  ]),
+  Endpoint.new("/tags", "POST", [
+    Param.new("id", "", "form"),
+  ]),
+]
+
+FunctionalTester.new("fixtures/python/tornado_multivalue/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints).perform_tests

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -897,14 +897,21 @@ module Analyzer::Python
           match_info_bracket: /#{rp}\.match_info\s*\[\s*['"]([^'"]+)['"]\s*\]/,
           match_info_get: /#{rp}\.match_info\.get\s*\(\s*['"]([^'"]+)['"]/,
           query_bracket: /#{rp}\.(?:rel_url\.)?query\s*\[\s*['"]([^'"]+)['"]\s*\]/,
-          query_get: /#{rp}\.(?:rel_url\.)?query\.get\s*\(\s*['"]([^'"]+)['"]/,
+          # `.get(`, `.getall(`, `.getone(`: aiohttp's query is a
+          # multidict.MultiDict exposing `getall`/`getone` for repeated
+          # keys, reading the same first-arg key as `get`.
+          query_get: /#{rp}\.(?:rel_url\.)?query\.get(?:all|one)?\s*\(\s*['"]([^'"]+)['"]/,
           json_assign: /([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{rp}\.json\s*\(/,
           json_await: /await\s+#{rp}\.json\s*\(/,
           post_assign: /([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*await\s+#{rp}\.post\s*\(/,
           post_await: /await\s+#{rp}\.post\s*\(/,
           dict: DICT_ACCESSORS.map do |accessor, param_type|
+            # `request.headers` is a CIMultiDict exposing `getall`/`getone`
+            # for repeated keys; `.get(?:all|one)?` reads the same first-arg
+            # key. `request.cookies` has no such methods, so widening it is
+            # inert (no real `cookies.getall(...)` call to match).
             {accessor, param_type,
-             /#{rp}\.#{accessor}\.get\s*\(\s*['"]([^'"]+)['"]/,
+             /#{rp}\.#{accessor}\.get(?:all|one)?\s*\(\s*['"]([^'"]+)['"]/,
              /#{rp}\.#{accessor}\s*\[\s*['"]([^'"]+)['"]\s*\]/}
           end,
         )

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -484,7 +484,12 @@ module Analyzer::Python
     # Tuple shape: {noir_param_type, get_re, bracket_re, attribute_re}
     DICT_ACCESSOR_PATTERNS = DICT_ACCESSORS.map do |accessor, param_type|
       {param_type,
-       /request\.#{accessor}\.get\s*\(\s*['"]([^'"]+)['"]/,
+      # `.get(`, `.getall(`, `.getone(`: Bottle's request MultiDicts
+      # (`request.query`, `request.forms`, …) expose `getall`/`getone`
+      # for repeated keys, reading the same first-arg key as `get`.
+      # (The bare `.getall`/`.getone` attribute form stays blocklisted
+      #  by DICT_METHOD_NAMES below, so no key-less double count.)
+       /request\.#{accessor}\.get(?:all|one)?\s*\(\s*['"]([^'"]+)['"]/,
        /request\.#{accessor}\s*\[\s*['"]([^'"]+)['"]\s*\]/,
        /request\.#{accessor}\.([A-Za-z_][A-Za-z0-9_]*)\b/}
     end

--- a/src/analyzer/analyzers/python/django.cr
+++ b/src/analyzer/analyzers/python/django.cr
@@ -58,7 +58,10 @@ module Analyzer::Python
         tuple[0],
         tuple[1],
         Regex.new("request\\.#{field_name}\\[[rf]?['\"]([^'\"]*)['\"]\\]"),
-        Regex.new("request\\.#{field_name}\\.get\\([rf]?['\"]([^'\"]*)['\"]"),
+        # `.get(` and `.getlist(`: Django's QueryDict (`request.GET`,
+        # `request.POST`) exposes `getlist("key")` for repeated keys
+        # (`?tag=a&tag=b`), reading the same first-arg key as `get`.
+        Regex.new("request\\.#{field_name}\\.get(?:list)?\\([rf]?['\"]([^'\"]*)['\"]"),
       }
     end
 

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -27,11 +27,16 @@ module Analyzer::Python
     # (profiling: ~50% of the analyzer). The field names are a fixed set,
     # so precompile the access patterns once here and reuse them.
     # Tuple shape: {noir_param_type, bracket_access_regex, get_access_regex}
+    # The get-access pattern accepts `.get(` and `.getlist(`: Werkzeug's
+    # request MultiDicts (`request.args`, `request.form`, …) expose
+    # `getlist("key")` as the standard accessor for repeated keys
+    # (`?tag=a&tag=b`), and it reads the same first string argument as the
+    # key — so `.get(?:list)?` captures both without a separate pattern.
     REQUEST_PARAM_FIELD_PATTERNS = REQUEST_PARAM_FIELDS.map do |field_name, tuple|
       {
         tuple[1],
         Regex.new("request\\.#{field_name}\\[[rf]?['\"]([^'\"]*)['\"]\\]"),
-        Regex.new("request\\.#{field_name}\\.get\\([rf]?['\"]([^'\"]*)['\"]"),
+        Regex.new("request\\.#{field_name}\\.get(?:list)?\\([rf]?['\"]([^'\"]*)['\"]"),
       }
     end
 

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -12,10 +12,15 @@ module Analyzer::Python
     # variants every listener/stream endpoint was silently dropped.
     DECORATOR_REGEX = /@(get|post|put|patch|delete|head|options|route|websocket(?:_listener|_stream)?)\s*\(([^)]*)/
     # Path literal inside a decorator. Litestar accepts both a positional
-    # path and an explicit `path=` keyword argument.
-    DECORATOR_PATH_REGEX    = /^\s*[rf]?['"]([^'"]*)['"]/
-    DECORATOR_PATH_KW_REGEX = /path\s*=\s*[rf]?['"]([^'"]*)['"]/
-    HTTP_METHOD_KW_REGEX    = /http_method\s*=\s*(?:\[([^\]]*)\]|['"]([^'"]+)['"])/
+    # path and an explicit `path=` keyword argument. List forms
+    # (`@get(["/a", "/b"])`, `@get(path=["/a", "/b"])`) and omitted paths
+    # (`@get()`, `@get(sync_to_thread=False)` → default `""` / `/`) are
+    # handled by `extract_decorator_paths`.
+    DECORATOR_PATH_REGEX      = /^\s*[rf]?['"]([^'"]*)['"]/
+    DECORATOR_PATH_KW_REGEX   = /path\s*=\s*[rf]?['"]([^'"]*)['"]/
+    DECORATOR_PATH_LIST_REGEX = /^\s*\[([^\]]*)\]/
+    DECORATOR_PATH_LIST_KW_RE = /path\s*=\s*\[([^\]]*)\]/
+    HTTP_METHOD_KW_REGEX      = /http_method\s*=\s*(?:\[([^\]]*)\]|['"]([^'"]+)['"])/
     # Router(path="/prefix", route_handlers=[...])
     ROUTER_REGEX = /(#{PYTHON_VAR_NAME_REGEX})\s*=\s*Router\s*\(([^)]*)\)/m
     # Path param: {name} or {name:type}. Litestar uses the :type suffix
@@ -110,9 +115,8 @@ module Analyzer::Python
           decorator = match[1].downcase
           body = match[2]
 
-          path_match = body.match(DECORATOR_PATH_REGEX) || body.match(DECORATOR_PATH_KW_REGEX)
-          next unless path_match
-          route_path = path_match[1]
+          # One or more route paths: scalar literal, list, or default "".
+          route_paths = extract_decorator_paths(body)
 
           methods = [] of ::String
           websocket_route = decorator.starts_with?("websocket")
@@ -141,23 +145,17 @@ module Analyzer::Python
             end
           end
 
-          full_path = "#{prefix}#{route_path}"
-          full_path = "/#{full_path}" unless full_path.starts_with?("/")
-          full_path = full_path.gsub(/\/+/, "/")
-          full_path = full_path.gsub(TYPED_PATH_PARAM_REGEX) { |_| "{#{$~[1]}}" }
-
-          path_params = extract_path_params(full_path)
-
           # Parse the handler body once and share between param and
           # callee extraction — both used to call `parse_code_block`
-          # independently, costing 2 parses per handler.
+          # independently, costing 2 parses per handler. Shared across
+          # multi-path list decorators (same handler, several paths).
           handler_body = if hl = handler_line
                            parse_code_block(lines[hl..])
                          end
-          handler_params = handler_line ? extract_handler_params(lines, handler_line, full_path, handler_body) : [] of Param
 
           # Build once per handler — a decorator can emit multiple
-          # endpoints when @route(http_method=[...]) lists several verbs.
+          # endpoints when @route(http_method=[...]) lists several verbs
+          # and/or when path is a list of strings.
           handler_callees = if handler_body && (hl = handler_line)
                               build_callees_from(
                                 handler_body,
@@ -170,22 +168,50 @@ module Analyzer::Python
                               [] of Callee
                             end
 
-          methods.uniq.each do |method|
-            params = [] of Param
-            path_params.each { |p| params << p }
-            handler_params.each do |p|
-              next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
-              params << p
-            end
+          route_paths.each do |route_path|
+            full_path = "#{prefix}#{route_path}"
+            full_path = "/#{full_path}" unless full_path.starts_with?("/")
+            full_path = full_path.gsub(/\/+/, "/")
+            full_path = full_path.gsub(TYPED_PATH_PARAM_REGEX) { |_| "{#{$~[1]}}" }
 
-            details = Details.new(PathInfo.new(path, line_index + 1))
-            endpoint = Endpoint.new(full_path, method, params, details)
-            endpoint.protocol = "ws" if websocket_route
-            handler_callees.each { |c| endpoint.push_callee(c) }
-            result << endpoint
+            path_params = extract_path_params(full_path)
+            handler_params = handler_line ? extract_handler_params(lines, handler_line, full_path, handler_body) : [] of Param
+
+            methods.uniq.each do |method|
+              params = [] of Param
+              path_params.each { |p| params << p }
+              handler_params.each do |p|
+                next if params.any? { |existing| existing.name == p.name && existing.param_type == p.param_type }
+                params << p
+              end
+
+              details = Details.new(PathInfo.new(path, line_index + 1))
+              endpoint = Endpoint.new(full_path, method, params, details)
+              endpoint.protocol = "ws" if websocket_route
+              handler_callees.each { |c| endpoint.push_callee(c) }
+              result << endpoint
+            end
           end
         end
       end
+    end
+
+    # Resolve the path argument(s) of a Litestar HTTP/WS decorator body.
+    # Returns at least one path string. An omitted path defaults to `""`
+    # (Litestar joins it with the controller prefix, or yields `/` when
+    # bare) so `@get()` / `@get(sync_to_thread=False)` are not dropped.
+    private def extract_decorator_paths(body : ::String) : Array(::String)
+      if list_match = body.match(DECORATOR_PATH_LIST_REGEX) || body.match(DECORATOR_PATH_LIST_KW_RE)
+        paths = [] of ::String
+        list_match[1].scan(/[rf]?['"]([^'"]*)['"]/) { |m| paths << m[1] }
+        return paths unless paths.empty?
+      end
+
+      if path_match = body.match(DECORATOR_PATH_REGEX) || body.match(DECORATOR_PATH_KW_REGEX)
+        return [path_match[1]]
+      end
+
+      [""]
     end
 
     # Walk forward from the decorator line to locate the first function

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -36,7 +36,10 @@ module Analyzer::Python
       {
         tuple[1],
         Regex.new("request\\.#{field_name}\\[[rf]?['\"]([^'\"]*)['\"]\\]"),
-        Regex.new("request\\.#{field_name}\\.get\\([rf]?['\"]([^'\"]*)['\"]"),
+        # `.get(` and `.getlist(`: Quart mirrors Werkzeug's request
+        # MultiDicts, where `getlist("key")` is the standard accessor for
+        # repeated keys and reads the same first-arg key as `get`.
+        Regex.new("request\\.#{field_name}\\.get(?:list)?\\([rf]?['\"]([^'\"]*)['\"]"),
       }
     end
 

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -44,7 +44,10 @@ module Analyzer::Python
     REQUEST_PARAM_FIELD_PATTERNS = REQUEST_PARAM_FIELDS.map do |field, tuple|
       {"request.#{field}",
        tuple[1],
-       /request\.#{field}(?:\.get)?\(['"']([^'"']+)['"']\)/,
+       # `request.args('x')`, `request.args.get('x')` and
+       # `request.args.getlist('x')`: Sanic's RequestParameters exposes
+       # `getlist` for repeated keys, reading the same first-arg key.
+       /request\.#{field}(?:\.get(?:list)?)?\(['"']([^'"']+)['"']\)/,
        /request\.#{field}\[['"']([^'"']+)['"']\]/}
     end
 

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -948,8 +948,11 @@ module Analyzer::Python
     private def request_attr_regexes(request_name : ::String, attr : ::String) : Tuple(Regex, Regex)
       @attr_regex_cache[{request_name, attr}] ||= begin
         rp = Regex.escape(request_name)
+        # `.get(` and `.getlist(`: Starlette's QueryParams / Headers are
+        # multidicts exposing `getlist("key")` for repeated keys, reading
+        # the same first-arg key as `get`.
         {/#{rp}\.#{attr}\[\s*[rf]?['"]([^'"]+)['"]\s*\]/,
-         /#{rp}\.#{attr}\.get\(\s*[rf]?['"]([^'"]+)['"]/}
+         /#{rp}\.#{attr}\.get(?:list)?\(\s*[rf]?['"]([^'"]+)['"]/}
       end
     end
 

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -700,20 +700,22 @@ module Analyzer::Python
     end
 
     private def extract_tornado_params(line : ::String, params : Array(Param))
-      # self.get_argument("param_name")
-      if match = line.match /self\.get_argument\(["']([^"']+)["']/
+      # Query args: self.get_argument / get_arguments (multi-value) and the
+      # query-scoped self.get_query_argument / get_query_arguments variants.
+      if match = line.match /self\.get_(?:query_)?arguments?\(["']([^"']+)["']/
         param_name = match[1]
         params << Param.new(param_name, "", "query")
       end
 
-      # self.get_body_argument("param_name")
-      if match = line.match /self\.get_body_argument\(["']([^"']+)["']/
+      # Form args: self.get_body_argument / get_body_arguments (multi-value).
+      if match = line.match /self\.get_body_arguments?\(["']([^"']+)["']/
         param_name = match[1]
         params << Param.new(param_name, "", "form")
       end
 
-      # self.get_cookie("cookie_name")
-      if match = line.match /self\.get_cookie\(["']([^"']+)["']/
+      # Cookies: self.get_cookie and the signed variants
+      # self.get_secure_cookie / get_signed_cookie (renamed in Tornado 6.3).
+      if match = line.match /self\.get_(?:secure_|signed_)?cookie\(["']([^"']+)["']/
         param_name = match[1]
         params << Param.new(param_name, "", "cookie")
       end
@@ -722,12 +724,6 @@ module Analyzer::Python
       if match = line.match /self\.request\.headers\.get\(["']([^"']+)["']/
         param_name = match[1]
         params << Param.new(param_name, "", "header")
-      end
-
-      # self.get_arguments("param_name") — plural form for multi-value query params
-      if match = line.match /self\.get_arguments\(["']([^"']+)["']/
-        param_name = match[1]
-        params << Param.new(param_name, "", "query")
       end
 
       # JSON body parsing: tornado.escape.json_decode or json.loads


### PR DESCRIPTION
## Summary
- Widen Python request-param accessors so multi-value / scoped helpers are detected: Flask/Quart/Django/Sanic/Starlette `getlist`, Bottle/aiohttp `getall`/`getone`, Tornado `get_query_argument(s)`, `get_body_arguments`, `get_secure_cookie`.
- Teach Litestar to keep handlers with an omitted path (default `/`, including controller prefix join) and to emit one endpoint per path for list forms (`@get(["/a", "/b"])`, `path=[...]`).
- Add focused regression fixtures and functional specs for all of the above (including negative cases for dynamic keys / dict-API methods where relevant).

## Test plan
- [x] `crystal tool format` on modified analyzers
- [x] `just build`
- [x] `crystal spec spec/functional_test/testers/python/` — 2233 examples, 0 failures
- [x] Manual `./bin/noir -b` scans of new multivalue / Litestar fixtures