### PR TITLE
fix(analyzer/go): reduce FP/FN in route extraction and param binding

### DIFF
--- a/spec/functional_test/fixtures/go/echo/server.go
+++ b/spec/functional_test/fixtures/go/echo/server.go
@@ -68,5 +68,8 @@ func main() {
 		},
 	)
 
+	// Single-file static registration (must be recognized as a public entry)
+	e.File("/robots.txt", "static/robots.txt")
+
 	e.Logger.Fatal(e.Start(":1323"))
 }

--- a/spec/functional_test/fixtures/go/echo/static/robots.txt
+++ b/spec/functional_test/fixtures/go/echo/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:

--- a/spec/functional_test/fixtures/go/gf/main.go
+++ b/spec/functional_test/fixtures/go/gf/main.go
@@ -48,6 +48,12 @@ func main() {
 		v1.PUT("/update", func(r *ghttp.Request) {
 		    r.Response.Write("update")
 		})
+
+		// Catch-all method registration (RouterGroup.ALL). Must surface
+		// as an endpoint — gf.cr folds the verb to GET.
+		group.ALL("/health", func(r *ghttp.Request) {
+			r.Response.Write("ok")
+		})
 	})
 
 	// Mixed case methods test

--- a/spec/functional_test/fixtures/go/gin/handlers.go
+++ b/spec/functional_test/fixtures/go/gin/handlers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -28,10 +29,12 @@ func setupAdditionalRoutes(r *gin.Engine) {
 		c.JSON(http.StatusOK, nil)
 	})
 
-	// Multiple query params
+	// Multiple query params — DefaultQuery with a nested call in the
+	// default-value argument must still extract the param name.
 	r.GET("/search", func(c *gin.Context) {
 		_ = c.Query("q")
-		_ = c.DefaultQuery("page", "1")
+		n := 1
+		_ = c.DefaultQuery("page", strconv.Itoa(n))
 		_ = c.Query("limit")
 		c.JSON(http.StatusOK, nil)
 	})

--- a/spec/functional_test/fixtures/go/gin/server.go
+++ b/spec/functional_test/fixtures/go/gin/server.go
@@ -73,6 +73,17 @@ func main() {
 		},
 	)
 
+	// Root route registered directly on the engine with an empty path.
+	// Regression guard: base_prefix=="" and raw_path=="" must resolve to
+	// "/" instead of vanishing entirely.
+	r.GET("", func(c *gin.Context) {
+		c.JSON(http.StatusOK, "root")
+	})
+
+	// Single-file static registration — must emit the URL prefix as a
+	// GET endpoint (not via directory globbing).
+	r.StaticFile("/favicon.ico", "./favicon.ico")
+
 	r.Static("/public", "public")
 	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
 }

--- a/spec/functional_test/fixtures/go/hertz/main.go
+++ b/spec/functional_test/fixtures/go/hertz/main.go
@@ -48,6 +48,14 @@ func main() {
 		_ = ctx.FormValue("name")
 	})
 
+	// BindQuery binds a struct from query params. Must surface a single
+	// generic body/json indicator — not a fabricated query param named
+	// "&input" from the accessor-loop matching Query( inside BindQuery(.
+	h.GET("/search", func(c context.Context, ctx *app.RequestContext) {
+		var input map[string]string
+		_ = ctx.BindQuery(&input)
+	})
+
 	h.Static("/public", "./public")
 
 	h.Spin()

--- a/spec/functional_test/fixtures/go/httprouter/server.go
+++ b/spec/functional_test/fixtures/go/httprouter/server.go
@@ -63,5 +63,11 @@ func main() {
 		fmt.Fprintf(w, "Key: %s, Session: %s", apiKey, session.Value)
 	})
 
+	// Idiomatic http.MethodX constant form — must resolve to PUT instead
+	// of dropping the Handle call when the method is not a string literal.
+	router.Handle(http.MethodPut, "/hello/:name", func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		fmt.Fprintf(w, "Hello %s", ps.ByName("name"))
+	})
+
 	http.ListenAndServe(":8080", router)
 }

--- a/spec/functional_test/fixtures/go/mux/server.go
+++ b/spec/functional_test/fixtures/go/mux/server.go
@@ -88,5 +88,11 @@ func main() {
 		fmt.Fprintf(w, "profile view")
 	}).Methods(http.MethodGet, http.MethodHead)
 
+	// BuildOnly routes never match real requests (URL reverse templates
+	// only). Must not be emitted as live endpoints.
+	r.Path("/articles/{category}/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "article")
+	}).Name("article").BuildOnly()
+
 	http.ListenAndServe(":8080", r)
 }

--- a/spec/functional_test/testers/go/echo_spec.cr
+++ b/spec/functional_test/testers/go/echo_spec.cr
@@ -28,6 +28,8 @@ expected_endpoints = [
   Endpoint.new("/multiline", "GET", [
     Param.new("ml_param", "", "query"),
   ]),
+  # server.go: e.File single-file static registration
+  Endpoint.new("/robots.txt", "GET"),
   # handlers.go: PATCH method with path param
   Endpoint.new("/users/:id", "PATCH", [
     Param.new("id", "", "path"),

--- a/spec/functional_test/testers/go/gf_spec.cr
+++ b/spec/functional_test/testers/go/gf_spec.cr
@@ -20,6 +20,8 @@ expected_endpoints = [
   ]),
   Endpoint.new("/api/v1/migration", "GET"),
   Endpoint.new("/api/v1/update", "PUT"),
+  # group.ALL folds to GET in the gf analyzer
+  Endpoint.new("/api/health", "GET"),
   Endpoint.new("/mixed/get", "GET"),
   Endpoint.new("/mixed/post", "POST", [
     Param.new("field1", "", "form"),

--- a/spec/functional_test/testers/go/gin_spec.cr
+++ b/spec/functional_test/testers/go/gin_spec.cr
@@ -58,6 +58,12 @@ expected_endpoints = [
   Endpoint.new("/inventory", "POST", [
     Param.new("body", "", "json"),
   ]),
+  # server.go: root route registered with an empty path directly on the
+  # engine (unresolved/empty base_prefix) must surface as "/" instead of
+  # vanishing.
+  Endpoint.new("/", "GET"),
+  # server.go: StaticFile single-file registration
+  Endpoint.new("/favicon.ico", "GET"),
 ]
 
 FunctionalTester.new("fixtures/go/gin/", {

--- a/spec/functional_test/testers/go/hertz_spec.cr
+++ b/spec/functional_test/testers/go/hertz_spec.cr
@@ -23,6 +23,10 @@ expected_endpoints = [
     Param.new("id", "", "path"),
     Param.new("name", "", "form"),
   ]),
+  # BindQuery must not fabricate a query param from the bind target expression
+  Endpoint.new("/search", "GET", [
+    Param.new("body", "", "json"),
+  ]),
   Endpoint.new("/public/index.html", "GET"),
 ] + any_endpoints
 

--- a/spec/functional_test/testers/go/httprouter_spec.cr
+++ b/spec/functional_test/testers/go/httprouter_spec.cr
@@ -30,6 +30,10 @@ expected_endpoints = [
     Param.new("X-API-Key", "", "header"),
     Param.new("session_id", "", "cookie"),
   ]),
+  # server.go: Handle(http.MethodPut, ...) must resolve the constant to PUT
+  Endpoint.new("/hello/:name", "PUT", [
+    Param.new("name", "", "path"),
+  ]),
 ]
 
 FunctionalTester.new("fixtures/go/httprouter/", {

--- a/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
+++ b/spec/unit_test/miniparser/go_route_extractor_ts_spec.cr
@@ -15,6 +15,7 @@ describe Noir::TreeSitterGoRouteExtractor do
     # and the `authorized := r.Group("/")` + path-without-slash case.
     triples.should eq([
       {"DELETE", "/mixed-delete"},
+      {"GET", "/"},
       {"GET", "/admin"},
       {"GET", "/group/users"},
       {"GET", "/group/v1/migration"},

--- a/src/analyzer/analyzers/go/echo.cr
+++ b/src/analyzer/analyzers/go/echo.cr
@@ -36,7 +36,7 @@ module Analyzer::Go
                   if File.exists?(path)
                     content = file_contents[path]? || read_file_content(path)
                     dir = File.dirname(path)
-                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static"])
+                    next unless framework_route_source_candidate?(content, dir, framework_dirs, IMPORT_MARKER, ["Add", "Static", "File"])
                     lines = content.lines
                     last_endpoint = Endpoint.new("", "")
 
@@ -68,6 +68,11 @@ module Analyzer::Go
 
                     # `e.Static("/url", "./dir")` — same shape as Gin/Fiber/etc.
                     Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content).each do |sp|
+                      public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
+                    end
+
+                    # `e.File("/url", "disk/path")` — single-file static route.
+                    Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content, method_name: "File").each do |sp|
                       public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
                     end
 

--- a/src/analyzer/analyzers/go/gin.cr
+++ b/src/analyzer/analyzers/go/gin.cr
@@ -116,6 +116,17 @@ module Analyzer::Go
                       public_dirs << static_dir_entry(path, sp.url_prefix, sp.disk_path)
                     end
 
+                    # StaticFile / StaticFileFS register a single file URL —
+                    # emit the route directly. Do not feed them through
+                    # resolve_public_dirs (directory glob), which drops "/"
+                    # prefixes and skips common media extensions like .ico.
+                    ["StaticFile", "StaticFileFS"].each do |mn|
+                      Noir::TreeSitterGoRouteExtractor.extract_simple_statics(content, method_name: mn).each do |sp|
+                        sf_details = Details.new(PathInfo.new(path, sp.line + 1))
+                        result << Endpoint.new(sp.url_prefix, "GET", sf_details)
+                      end
+                    end
+
                     lines.each_with_index do |line, index|
                       # Skip lines inside an expanded router-builder body — its
                       # routes (and any params) are emitted, with the call-site
@@ -205,12 +216,19 @@ module Analyzer::Go
     end
 
     private def add_gin_param_patterns(line : String, target : Endpoint)
-      ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
-        if line.includes?("#{pattern}(")
-          add_param_to_endpoint(get_param(line), target)
+      # Bind*/ShouldBind* already contribute a single generic body param.
+      # Skip the accessor loop on those lines so `ShouldBindQuery(&x)` does
+      # not also fabricate a bogus query param named "&x".
+      is_bind_line = line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
+
+      unless is_bind_line
+        ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
+          if line.includes?("#{pattern}(")
+            add_param_to_endpoint(get_param(line), target)
+          end
         end
       end
-      if line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
+      if is_bind_line
         add_param_to_endpoint(Param.new("body", "", "json"), target)
       end
       # Read accessor only: `.Cookie("name")`. The `.Cookie(` anchor excludes
@@ -225,13 +243,17 @@ module Analyzer::Go
 
     private def add_gin_param_patterns_to_many(line : String, targets : Array(Endpoint))
       return if targets.empty?
-      ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
-        if line.includes?("#{pattern}(")
-          p = get_param(line)
-          targets.each { |t| add_param_to_endpoint(p, t) }
+      is_bind_line = line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
+
+      unless is_bind_line
+        ["Query", "PostForm", "GetHeader", "Param"].each do |pattern|
+          if line.includes?("#{pattern}(")
+            p = get_param(line)
+            targets.each { |t| add_param_to_endpoint(p, t) }
+          end
         end
       end
-      if line.matches?(/\.(?:Should)?Bind(?:JSON|XML|YAML|TOML|Query|Header|Uri|With)?\s*\(/)
+      if is_bind_line
         b = Param.new("body", "", "json")
         targets.each { |t| add_param_to_endpoint(b, t) }
       end
@@ -361,20 +383,11 @@ module Analyzer::Go
         param_type = "path"
       end
 
-      first = line.strip.split("(")
-      if first.size > 1
-        second = first[1].split(")")
-        if second.size > 1
-          if line.includes?("DefaultQuery") || line.includes?("DefaultPostForm")
-            param_name = second[0].split(",")[0].gsub("\"", "")
-            rtn = Param.new(param_name, "", param_type)
-          else
-            param_name = second[0].gsub("\"", "")
-            rtn = Param.new(param_name, "", param_type)
-          end
-
-          return rtn
-        end
+      # Capture only the accessor's first string-literal argument. Naive
+      # split("(")/split(")") desyncs when DefaultQuery/DefaultPostForm's
+      # default-value argument contains nested calls (e.g. strconv.Itoa(n)).
+      if match = line.match(/(?:Query|PostForm|GetHeader|Param)\s*\(\s*"([^"]*)"/)
+        return Param.new(match[1], "", param_type)
       end
 
       Param.new("", "", "")

--- a/src/analyzer/analyzers/go/hertz.cr
+++ b/src/analyzer/analyzers/go/hertz.cr
@@ -103,9 +103,17 @@ module Analyzer::Go
                         end
                       end
 
-                      ["Query", "PostForm", "GetHeader", "Param", "FormValue"].each do |pattern|
-                        if line.includes?("#{pattern}(")
-                          add_param_to_endpoint(get_param(line), last_endpoint)
+                      # Bind* helpers already contribute a single generic body
+                      # param below. Skip the accessor loop on those lines so
+                      # `BindQuery(&input)` does not also fabricate a bogus
+                      # query param named "&input" via the `Query(` substring.
+                      is_bind_line = line.matches?(/\.Bind(?:JSON|Query|Header|Form|Protobuf|And\w+)?\s*\(/)
+
+                      unless is_bind_line
+                        ["Query", "PostForm", "GetHeader", "Param", "FormValue"].each do |pattern|
+                          if line.includes?("#{pattern}(")
+                            add_param_to_endpoint(get_param(line), last_endpoint)
+                          end
                         end
                       end
 
@@ -122,7 +130,7 @@ module Analyzer::Go
                       # indicator — the bound struct's fields are not
                       # statically resolvable here. `And\w+` catches
                       # `BindAndValidate`.
-                      if line.matches?(/\.Bind(?:JSON|Query|Header|Form|Protobuf|And\w+)?\s*\(/)
+                      if is_bind_line
                         add_param_to_endpoint(Param.new("body", "", "json"), last_endpoint)
                       end
                     end

--- a/src/miniparsers/go_route_extractor_ts.cr
+++ b/src/miniparsers/go_route_extractor_ts.cr
@@ -1508,7 +1508,7 @@ module Noir
       end
 
       case name
-      when "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS",
+      when "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "ALL",
            "Get", "Post", "Put", "Delete", "Patch", "Head", "Options"
         return ChiCall::Verb
       end
@@ -2164,7 +2164,7 @@ module Noir
       base_prefix = closure_prefix_for(closure_groups, LibTreeSitter.ts_node_start_byte(call), router_name) ||
                     groups[router_name]? || ""
       base_prefix = join_paths(base_prefix, chain_prefix) unless chain_prefix.empty?
-      resolved = base_prefix.empty? ? raw_path : join_paths(base_prefix, raw_path)
+      resolved = base_prefix.empty? ? (raw_path.empty? ? "/" : raw_path) : join_paths(base_prefix, raw_path)
 
       # Fiber's `app.All(...)` is the same "match any method" intent
       # as Gin's `r.Any(...)` and Echo's `e.Any(...)`. Normalize so
@@ -2273,6 +2273,13 @@ module Noir
           elsif path_lit.nil?
             path_lit = decode_string_literal(arg, source)
           end
+        when "selector_expression"
+          # The idiomatic constant form `router.Handle(http.MethodPut,
+          # "/x", h)` — resolve via the shared http.MethodX helper.
+          if method_lit.nil?
+            candidate = decode_method_token(arg, source)
+            method_lit = candidate unless candidate.empty?
+          end
         else
           handler_text = Noir::TreeSitter.node_text(arg, source) if handler_text.empty? && !path_lit.nil?
         end
@@ -2330,6 +2337,13 @@ module Noir
             method_lit = decode_string_literal(arg, source)
           elsif path_lit.nil?
             path_lit = decode_string_literal(arg, source)
+          end
+        when "selector_expression"
+          # The idiomatic constant form `app.HandleMany(http.MethodGet,
+          # "/x", h)` — resolve via the shared http.MethodX helper.
+          if method_lit.nil?
+            candidate = decode_method_token(arg, source)
+            method_lit = candidate unless candidate.empty?
           end
         else
           handler_text = Noir::TreeSitter.node_text(arg, source) if handler_text.empty? && !path_lit.nil?
@@ -2466,6 +2480,7 @@ module Noir
       query_params = [] of String
       saw_registration = false
       saw_methods = false
+      build_only = false
       registration_line = Noir::TreeSitter.node_start_row(call)
       router_name = nil
 
@@ -2543,7 +2558,12 @@ module Noir
               end
             end
           end
-        when "Host", "Schemes", "Headers", "HeadersRegexp", "Name", "MatcherFunc", "BuildOnly"
+        when "BuildOnly"
+          # gorilla/mux guarantees a BuildOnly route never matches a real
+          # request — it exists solely to reverse-build URLs elsewhere.
+          # Suppress the whole chain rather than emit a phantom endpoint.
+          build_only = true
+        when "Host", "Schemes", "Headers", "HeadersRegexp", "Name", "MatcherFunc"
           # Metadata/matcher chain; keep peeling.
         else
           return empty
@@ -2562,6 +2582,7 @@ module Noir
         end
       end
 
+      return empty if build_only
       return empty unless router_name && raw_path && saw_registration
       return empty if handler_text.empty?
       verbs << (saw_methods ? "GET" : "ANY") if verbs.empty?


### PR DESCRIPTION
## Summary
- **Extractor core** (`go_route_extractor_ts`): empty-path verb routes resolve to `/`; `Handle`/`HandleMany` accept `http.MethodX`; gf `.ALL` is recognized; gorilla/mux `.BuildOnly()` routes are suppressed.
- **Framework adapters**: Hertz/Gin skip accessor loops on Bind/ShouldBind lines (no fabricated `&input` query params); Gin extracts nested `DefaultQuery` defaults; Gin `StaticFile`/`StaticFileFS` and Echo `e.File` emit single-file static endpoints.
- Regression fixtures and specs for gin, hertz, echo, gf, mux, and httprouter (Go functional 1798 + extractor unit 45 green).

## Test plan
- [x] `crystal spec spec/functional_test/testers/go/` (1798 examples)
- [x] `crystal spec spec/unit_test/miniparser/go_route_extractor_ts_spec.cr` (45 examples)
- [x] `just build`
- [ ] CI full suite on this PR