### PR TITLE
Improve Java analyzer performance and FP/FN accuracy

### DIFF
--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -7,7 +7,11 @@ require "../../../miniparsers/java_route_extractor_ts"
 
 module Analyzer::Java
   class Armeria < Analyzer
-    REGEX_SERVER_CODE_BLOCK = /Server\s*\.builder\(\s*\)\s*\.[^;]*build\(\)\s*\./
+    # Anchor only — the chain body is bounded by a depth-aware scan so
+    # semicolons inside lambda/anonymous-class bodies do not truncate
+    # the match, and a trailing `.` after `build()` is not required
+    # (`Server s = Server.builder()...build();`).
+    REGEX_SERVER_BUILDER = /Server\s*\.builder\(\s*\)/
     alias RouteEntry = Tuple(String, String)
     alias ScopedClassKey = Tuple(String, String)
 
@@ -53,33 +57,42 @@ module Analyzer::Java
                       analyze_annotated_service(path, content, base, annotated_service_prefixes)
                     end
 
-                    # Server.builder()-style routes (regex-scoped — the
-                    # builder chain isn't worth a dedicated TS walk yet).
+                    # Server.builder()-style routes (regex-anchored, then
+                    # depth-scanned — the builder chain isn't worth a
+                    # dedicated TS walk yet).
                     details = Details.new(PathInfo.new(path))
                     # Both the string-constant table (a full tree-sitter
                     # parse) and the non-code mask (a char walk) are only
-                    # needed once a `Server.builder()...build()` chain is
-                    # actually present. Most files are annotated services
-                    # with no builder chain at all, so build both lazily
-                    # on the first match to avoid parsing every file twice.
+                    # needed once a `Server.builder()` anchor is present.
+                    # Most files are annotated services with no builder
+                    # chain at all, so build both lazily on the first match
+                    # to avoid parsing every file twice.
                     #
                     # The mask marks char offsets inside string literals or
                     # comments, letting us drop builder chains that only
                     # appear in documentation (e.g. a Kotlin `@Description`
-                    # value or a Java text block) — a real FP source.
+                    # value or a Java text block) — a real FP source. The
+                    # same mask is reused when scanning the extracted block
+                    # so commented-out `.service`/`.route()` calls inside an
+                    # otherwise-live chain are not reported.
                     non_code_mask = nil.as(Array(Bool)?)
                     constants = nil.as(Hash(String, String)?)
-                    content.scan(REGEX_SERVER_CODE_BLOCK) do |server_codeblock_match|
-                      start = server_codeblock_match.begin(0)
-                      if start
-                        mask = (non_code_mask ||= build_non_code_mask(content))
-                        next if start < mask.size && mask[start]
-                      end
-                      server_codeblock = server_codeblock_match[0]
+                    content.scan(REGEX_SERVER_BUILDER) do |builder_match|
+                      start = builder_match.begin(0)
+                      next unless start
+                      after_builder = builder_match.end(0)
+                      next unless after_builder
+
+                      mask = (non_code_mask ||= build_non_code_mask(content))
+                      next if start < mask.size && mask[start]
+
+                      finish = scan_server_builder_statement_end(content, after_builder, mask)
+                      next unless finish && finish >= start
+                      server_codeblock = content[start..finish]
 
                       resolved_constants = constants ||= (path.ends_with?(".java") ? Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content) : Hash(String, String).new)
-                      collect_service_routes(server_codeblock, resolved_constants, details, service_with_routes_index, base)
-                      collect_builder_routes(server_codeblock, resolved_constants, details)
+                      collect_service_routes(server_codeblock, resolved_constants, details, service_with_routes_index, base, mask, start)
+                      collect_builder_routes(server_codeblock, resolved_constants, details, mask, start)
                     end
                   end
                 rescue File::NotFoundError
@@ -116,14 +129,16 @@ module Analyzer::Java
 
     private def collect_builder_routes(server_codeblock : String,
                                        constants : Hash(String, String),
-                                       details : Details)
+                                       details : Details,
+                                       non_code_mask : Array(Bool)? = nil,
+                                       block_start : Int32 = 0)
       emitted = Set(Tuple(String, String)).new
 
-      route_chain_expressions(server_codeblock).each do |expr|
+      route_chain_expressions(server_codeblock, non_code_mask, block_start).each do |expr|
         collect_route_expression(expr, constants, details, emitted)
       end
 
-      call_argument_expressions(server_codeblock, ".withRoute").each do |expr|
+      call_argument_expressions(server_codeblock, ".withRoute", non_code_mask, block_start).each do |expr|
         collect_route_expression(expr, constants, details, emitted)
       end
     end
@@ -181,11 +196,17 @@ module Analyzer::Java
       @result << Endpoint.new(path, method, details)
     end
 
-    private def route_chain_expressions(code : String) : Array(String)
+    private def route_chain_expressions(code : String,
+                                        non_code_mask : Array(Bool)? = nil,
+                                        base_offset : Int32 = 0) : Array(String)
       expressions = [] of String
       offset = 0
 
       while found = code.index(".route()", offset)
+        if masked_offset?(non_code_mask, base_offset + found)
+          offset = found + 8
+          next
+        end
         build_idx = code.index(".build", found)
         break unless build_idx
         open_idx = code.index('(', build_idx)
@@ -202,11 +223,18 @@ module Analyzer::Java
       expressions
     end
 
-    private def call_argument_expressions(code : String, marker : String) : Array(String)
+    private def call_argument_expressions(code : String,
+                                          marker : String,
+                                          non_code_mask : Array(Bool)? = nil,
+                                          base_offset : Int32 = 0) : Array(String)
       expressions = [] of String
       offset = 0
 
       while found = code.index(marker, offset)
+        if masked_offset?(non_code_mask, base_offset + found)
+          offset = found + marker.size
+          next
+        end
         open_idx = code.index('(', found)
         break unless open_idx
         close_idx = find_matching_delimiter(code, open_idx, '(', ')')
@@ -248,11 +276,16 @@ module Analyzer::Java
                                        constants : Hash(String, String),
                                        details : Details,
                                        service_with_routes_index : Hash(ScopedClassKey, Array(RouteEntry)),
-                                       base : String)
+                                       base : String,
+                                       non_code_mask : Array(Bool)? = nil,
+                                       block_start : Int32 = 0)
       emitted = Set(Tuple(String, String)).new
       offset = 0
       while found = server_codeblock.index(".service", offset)
         offset = found + 8
+        if masked_offset?(non_code_mask, block_start + found)
+          next
+        end
         suffix = server_codeblock[found..]
         method_name =
           if suffix.starts_with?(".serviceIf")
@@ -601,6 +634,61 @@ module Analyzer::Java
       tail = expr[start..]?.to_s.strip
       args << tail unless tail.empty?
       args
+    end
+
+    # True when absolute_offset falls inside a string/comment per mask.
+    private def masked_offset?(mask : Array(Bool)?, absolute_offset : Int32) : Bool
+      return false unless mask
+      absolute_offset >= 0 && absolute_offset < mask.size && mask[absolute_offset]
+    end
+
+    # From the char after `Server.builder()`, walk forward tracking
+    # paren/brace/bracket depth while skipping string/comment offsets via
+    # `mask`. The statement ends at the first `;` at depth 0 — so
+    # semicolons inside lambda bodies do not truncate the chain, and
+    # both `.build().start()` and assignment-form `.build();` work.
+    private def scan_server_builder_statement_end(content : String,
+                                                  from : Int32,
+                                                  mask : Array(Bool)) : Int32?
+      paren = 0
+      brace = 0
+      bracket = 0
+      i = from
+      n = content.size
+
+      while i < n
+        if i < mask.size && mask[i]
+          i += 1
+          next
+        end
+
+        case content[i]
+        when '('
+          paren += 1
+        when ')'
+          paren -= 1 if paren > 0
+        when '{'
+          brace += 1
+        when '}'
+          brace -= 1 if brace > 0
+        when '['
+          bracket += 1
+        when ']'
+          bracket -= 1 if bracket > 0
+        when ';'
+          if paren == 0 && brace == 0 && bracket == 0
+            return i > from ? i - 1 : nil
+          end
+        end
+        i += 1
+      end
+
+      # No terminating `;` (truncated input) — accept the balanced rest.
+      if paren == 0 && brace == 0 && bracket == 0 && from < n
+        return n - 1
+      end
+
+      nil
     end
 
     # Marks character offsets that fall inside a string literal or a

--- a/src/analyzer/analyzers/java/armeria.cr
+++ b/src/analyzer/analyzers/java/armeria.cr
@@ -205,18 +205,18 @@ module Analyzer::Java
       while found = code.index(".route()", offset)
         if masked_offset?(non_code_mask, base_offset + found)
           offset = found + 8
-          next
-        end
-        build_idx = code.index(".build", found)
-        break unless build_idx
-        open_idx = code.index('(', build_idx)
-        break unless open_idx
-        close_idx = find_matching_delimiter(code, open_idx, '(', ')')
-        if close_idx
-          expressions << code[found..close_idx]
-          offset = close_idx + 1
         else
-          offset = open_idx + 1
+          build_idx = code.index(".build", found)
+          break unless build_idx
+          open_idx = code.index('(', build_idx)
+          break unless open_idx
+          close_idx = find_matching_delimiter(code, open_idx, '(', ')')
+          if close_idx
+            expressions << code[found..close_idx]
+            offset = close_idx + 1
+          else
+            offset = open_idx + 1
+          end
         end
       end
 
@@ -233,16 +233,16 @@ module Analyzer::Java
       while found = code.index(marker, offset)
         if masked_offset?(non_code_mask, base_offset + found)
           offset = found + marker.size
-          next
-        end
-        open_idx = code.index('(', found)
-        break unless open_idx
-        close_idx = find_matching_delimiter(code, open_idx, '(', ')')
-        if close_idx
-          expressions << code[(open_idx + 1)...close_idx]
-          offset = close_idx + 1
         else
-          offset = open_idx + 1
+          open_idx = code.index('(', found)
+          break unless open_idx
+          close_idx = find_matching_delimiter(code, open_idx, '(', ')')
+          if close_idx
+            expressions << code[(open_idx + 1)...close_idx]
+            offset = close_idx + 1
+          else
+            offset = open_idx + 1
+          end
         end
       end
 

--- a/src/analyzer/analyzers/java/cli.cr
+++ b/src/analyzer/analyzers/java/cli.cr
@@ -26,7 +26,13 @@ module Analyzer::Java
 
     # commons-cli (no subcommands; flags on root).
     ADD_OPTION_LL = /\.addOption\s*\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,/
-    LONG_OPT      = /\.longOpt\s*\(\s*"([^"]+)"/
+    # Current (non-deprecated) `addOption(String opt, boolean hasArg, String
+    # description)` overload used for short-only flags. The `true|false`
+    # literal gate in the 2nd argument position guarantees this never
+    # overlaps with ADD_OPTION_LL above (which requires a quoted string
+    # there), so a given call is matched by exactly one of the two.
+    ADD_OPTION_SHORT = /\.addOption\s*\(\s*"([^"]+)"\s*,\s*(?:true|false)\s*,/
+    LONG_OPT         = /\.longOpt\s*\(\s*"([^"]+)"/
 
     GET_ENV = /\bSystem\.getenv\s*\(\s*"([^"]+)"\s*\)/
 
@@ -54,7 +60,7 @@ module Analyzer::Java
         next unless File.exists?(path)
 
         begin
-          content = read_file_content(path)
+          content = strip_comments(read_file_content(path))
           next unless LIB_MARKERS.any? { |m| content.includes?(m) } || content.matches?(/@Command\b|@Parameter\b|new\s+JCommander|new\s+CmdLineParser|new\s+Options\s*\(/)
 
           binary = java_binary_name(content, path)
@@ -140,6 +146,8 @@ module Analyzer::Java
         # commons-cli (root flags).
         if m = line.match(ADD_OPTION_LL)
           fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[2], "", "flag"))
+        elsif m = line.match(ADD_OPTION_SHORT)
+          fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
         end
         if m = line.match(LONG_OPT)
           fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
@@ -206,6 +214,72 @@ module Analyzer::Java
       return if tokens.empty?
       long = tokens.find(&.starts_with?("--"))
       (long || tokens.first).lstrip('-')
+    end
+
+    # Replaces `//` line comments and `/* */` block comments with spaces
+    # (newlines preserved) so a commented-out @Option/@Parameter/addOption/
+    # etc. call is never mistaken for a live one, while keeping every real
+    # line number stable for PathInfo reporting. String and char literals
+    # are tracked so `//` or `/*` inside a literal (e.g. a URL default value
+    # `"http://x//y"`) is never treated as a comment opener.
+    private def strip_comments(text : String) : String
+      result = String::Builder.new
+      chars = text.chars
+      i = 0
+      in_string = false
+      string_quote = '\0'
+
+      while i < chars.size
+        c = chars[i]
+
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            result << c
+            result << chars[i + 1]
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '"' || c == '\''
+          in_string = true
+          string_quote = c
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '/'
+          while i < chars.size && chars[i] != '\n'
+            result << ' '
+            i += 1
+          end
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '*'
+          result << "  "
+          i += 2
+          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
+            result << (chars[i] == '\n' ? '\n' : ' ')
+            i += 1
+          end
+          if i + 1 < chars.size
+            result << "  "
+            i += 2
+          end
+          next
+        end
+
+        result << c
+        i += 1
+      end
+
+      result.to_s
     end
 
     private def fetch_endpoint(endpoints : Hash(String, Endpoint), url : String,

--- a/src/analyzer/analyzers/java/dropwizard.cr
+++ b/src/analyzer/analyzers/java/dropwizard.cr
@@ -8,11 +8,22 @@ module Analyzer::Java
   # Dropwizard ships Jersey under the hood, so JAX-RS resource
   # classes are the routing surface. This analyzer drives the shared
   # `TreeSitterJaxRsExtractor` against files in project roots that
-  # carry the `io.dropwizard` marker. Resource classes are often pure
-  # JAX-RS and do not import Dropwizard directly.
+  # carry a Dropwizard framework-bootstrap reference. Resource
+  # classes are often pure JAX-RS and do not import Dropwizard
+  # directly.
   class Dropwizard < Analyzer
-    JAVA_EXTENSION    = "java"
-    DROPWIZARD_MARKER = "io.dropwizard"
+    JAVA_EXTENSION = "java"
+
+    # A bare `io.dropwizard` substring also matches Dropwizard's
+    # standalone utility modules (io.dropwizard.util.Duration,
+    # io.dropwizard.validation.*, io.dropwizard.jackson.*) that ship
+    # explicitly for use outside the Dropwizard web framework/server
+    # stack. Restrict project classification to actual bootstrap
+    # symbols (the `Application` base class, the `Bootstrap`/
+    # `Environment` setup types, and the `AssetsBundle` helper) so a
+    # plain JAX-RS/RESTEasy project that merely borrows one of those
+    # helpers isn't misclassified as a Dropwizard project.
+    DROPWIZARD_BOOTSTRAP_MARKER_RE = /io\.dropwizard\.(?:core\.)?(?:Application\b|setup\.(?:Bootstrap|Environment)\b)|io\.dropwizard\.assets\.AssetsBundle\b/
 
     private struct DropwizardPathConfig
       getter application_context_path : String
@@ -45,7 +56,7 @@ module Analyzer::Java
         content = read_file_content(path)
 
         path_config = path_configs[project_root]? || DropwizardPathConfig.new
-        if content.includes?(DROPWIZARD_MARKER)
+        if content.includes?("AssetsBundle")
           extract_asset_bundle_endpoints(content, path_config.application_context_path, path).each do |endpoint|
             @result << endpoint
           end
@@ -118,7 +129,7 @@ module Analyzer::Java
         next unless path.ends_with?(".#{JAVA_EXTENSION}")
 
         content = read_file_content(path)
-        roots << project_root_for(path) if content.includes?(DROPWIZARD_MARKER)
+        roots << project_root_for(path) if content.matches?(DROPWIZARD_BOOTSTRAP_MARKER_RE)
       end
 
       roots

--- a/src/analyzer/analyzers/java/httpserver.cr
+++ b/src/analyzer/analyzers/java/httpserver.cr
@@ -24,6 +24,7 @@ module Analyzer::Java
     JAVA_EXTENSION = "java"
     PACKAGE_MARKER = "com.sun.net.httpserver"
     CREATE_CONTEXT = "createContext"
+    SET_HANDLER    = "setHandler"
     HANDLE_METHOD  = "handle"
     HTTP_METHODS   = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"]
     # Verbs that carry a request body — the body param is attached only
@@ -93,7 +94,7 @@ module Analyzer::Java
           next unless name_node
           next unless Noir::TreeSitter.node_text(name_node, content) == CREATE_CONTEXT
 
-          handle_create_context(node, content, path, constants, class_index, method_index, include_callee)
+          handle_create_context(node, content, path, constants, class_index, method_index, root, include_callee)
         end
       end
     rescue e
@@ -106,6 +107,7 @@ module Analyzer::Java
                                       constants : Hash(String, String),
                                       class_index : Hash(String, LibTreeSitter::TSNode),
                                       method_index : Hash(String, LibTreeSitter::TSNode),
+                                      root : LibTreeSitter::TSNode,
                                       include_callee : Bool)
       args = Noir::TreeSitter.field(call, "arguments")
       return unless args
@@ -123,7 +125,14 @@ module Analyzer::Java
 
       line = Noir::TreeSitter.node_start_row(call) + 1
       handler_arg = arg_nodes[1]?
-      body = handler_arg ? resolve_handler_body(handler_arg, content, class_index, method_index) : nil
+      # Single-arg `createContext(path)` — look for a later
+      # `ctx.setHandler(...)` on the assigned HttpContext variable.
+      if handler_arg.nil?
+        if ctx_var = context_variable_for_create(call, content, root)
+          handler_arg = find_set_handler_arg(ctx_var, call, content, root)
+        end
+      end
+      body = handler_arg ? resolve_handler_body(handler_arg, content, class_index, method_index, root) : nil
 
       methods = ["GET"]
       header_params = [] of String
@@ -158,7 +167,11 @@ module Analyzer::Java
     private def resolve_handler_body(handler : LibTreeSitter::TSNode,
                                      content : String,
                                      class_index : Hash(String, LibTreeSitter::TSNode),
-                                     method_index : Hash(String, LibTreeSitter::TSNode)) : LibTreeSitter::TSNode?
+                                     method_index : Hash(String, LibTreeSitter::TSNode),
+                                     root : LibTreeSitter::TSNode,
+                                     depth : Int32 = 0) : LibTreeSitter::TSNode?
+      return if depth > 8
+
       case Noir::TreeSitter.node_type(handler)
       when "lambda_expression"
         Noir::TreeSitter.field(handler, "body")
@@ -178,11 +191,158 @@ module Analyzer::Java
           method ? Noir::TreeSitter.field(method, "body") : nil
         end
       when "method_reference"
-        # `App::handle`, `this::serve`, `ClassName::method`.
-        method_name = Noir::TreeSitter.node_text(handler, content).split("::").last.strip
-        method_node = method_index[method_name]?
+        # `App::handle`, `this::serve`, `ClassName::method`. Prefer the
+        # qualifier's class body when the left-hand side names a known
+        # class so same-named methods in different classes don't collide
+        # via the flat method_index.
+        parts = Noir::TreeSitter.node_text(handler, content).split("::", 2)
+        method_name = parts.last.strip.gsub(/\A<[^>]+>\s*/, "")
+        return if method_name.empty?
+
+        method_node : LibTreeSitter::TSNode? = nil
+        if parts.size == 2
+          qualifier = parts[0].strip
+          if !qualifier.empty? && qualifier != "this" && !qualifier.includes?("(")
+            class_name = simple_name(qualifier)
+            if class_node = class_index[class_name]?
+              method_node = find_method_in_class(class_node, content, method_name)
+            end
+          end
+        end
+        method_node ||= method_index[method_name]?
         method_node ? Noir::TreeSitter.field(method_node, "body") : nil
+      when "identifier"
+        # `HttpHandler h = exchange -> {...}; createContext("/x", h)`.
+        name = Noir::TreeSitter.node_text(handler, content)
+        return if name.empty?
+        if init = find_local_handler_initializer(handler, name, content, root)
+          resolve_handler_body(init, content, class_index, method_index, root, depth + 1)
+        end
       end
+    end
+
+    # Local-variable declaration whose name matches `name` and whose
+    # initializer is a resolvable handler expression. Scoped to the
+    # enclosing method when one can be found; returns nil unless exactly
+    # one candidate is present.
+    private def find_local_handler_initializer(ref : LibTreeSitter::TSNode,
+                                               name : String,
+                                               content : String,
+                                               root : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      scope = enclosing_method_body(ref, root) || root
+      matches = [] of LibTreeSitter::TSNode
+
+      walk(scope) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "local_variable_declaration"
+        Noir::TreeSitter.each_named_child(node) do |child|
+          next unless Noir::TreeSitter.node_type(child) == "variable_declarator"
+          name_node = Noir::TreeSitter.field(child, "name")
+          value = Noir::TreeSitter.field(child, "value")
+          next unless name_node && value
+          next unless Noir::TreeSitter.node_text(name_node, content) == name
+
+          case Noir::TreeSitter.node_type(value)
+          when "lambda_expression", "object_creation_expression", "method_reference"
+            matches << value
+          end
+        end
+      end
+
+      matches.size == 1 ? matches.first : nil
+    end
+
+    # Variable that the `createContext` call was assigned to, if any —
+    # `HttpContext ctx = server.createContext(...)` or `ctx = ...`.
+    private def context_variable_for_create(call : LibTreeSitter::TSNode,
+                                            content : String,
+                                            root : LibTreeSitter::TSNode) : String?
+      call_start = LibTreeSitter.ts_node_start_byte(call)
+      call_end = LibTreeSitter.ts_node_end_byte(call)
+      scope = enclosing_method_body(call, root) || root
+      found : String? = nil
+
+      walk(scope) do |node|
+        case Noir::TreeSitter.node_type(node)
+        when "variable_declarator"
+          value = Noir::TreeSitter.field(node, "value")
+          next unless value
+          next unless LibTreeSitter.ts_node_start_byte(value) == call_start &&
+                      LibTreeSitter.ts_node_end_byte(value) == call_end
+          if name_node = Noir::TreeSitter.field(node, "name")
+            found = Noir::TreeSitter.node_text(name_node, content)
+          end
+        when "assignment_expression"
+          left = Noir::TreeSitter.field(node, "left")
+          right = Noir::TreeSitter.field(node, "right")
+          next unless left && right
+          next unless LibTreeSitter.ts_node_start_byte(right) == call_start &&
+                      LibTreeSitter.ts_node_end_byte(right) == call_end
+          if Noir::TreeSitter.node_type(left) == "identifier"
+            found = Noir::TreeSitter.node_text(left, content)
+          end
+        end
+      end
+
+      found
+    end
+
+    # First `var.setHandler(handlerExpr)` call after `createContext` in
+    # the same enclosing method (or whole file when no method is found).
+    private def find_set_handler_arg(var_name : String,
+                                     after : LibTreeSitter::TSNode,
+                                     content : String,
+                                     root : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      after_end = LibTreeSitter.ts_node_end_byte(after)
+      scope = enclosing_method_body(after, root) || root
+      found : LibTreeSitter::TSNode? = nil
+
+      walk(scope) do |node|
+        next if found
+        next unless Noir::TreeSitter.node_type(node) == "method_invocation"
+        next if LibTreeSitter.ts_node_start_byte(node) < after_end
+
+        name_node = Noir::TreeSitter.field(node, "name")
+        next unless name_node
+        next unless Noir::TreeSitter.node_text(name_node, content) == SET_HANDLER
+
+        object = Noir::TreeSitter.field(node, "object")
+        next unless object
+        next unless Noir::TreeSitter.node_text(object, content) == var_name
+
+        args = Noir::TreeSitter.field(node, "arguments")
+        next unless args
+        if handler = argument_nodes(args)[0]?
+          found = handler
+        end
+      end
+
+      found
+    end
+
+    # Smallest method_declaration body that fully encloses `node`, used to
+    # scope local-var / setHandler lookups without a parent-pointer API.
+    private def enclosing_method_body(node : LibTreeSitter::TSNode,
+                                      root : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
+      target_start = LibTreeSitter.ts_node_start_byte(node)
+      target_end = LibTreeSitter.ts_node_end_byte(node)
+      best : LibTreeSitter::TSNode? = nil
+      best_span = UInt32::MAX
+
+      walk(root) do |candidate|
+        next unless Noir::TreeSitter.node_type(candidate) == "method_declaration"
+        c_start = LibTreeSitter.ts_node_start_byte(candidate)
+        c_end = LibTreeSitter.ts_node_end_byte(candidate)
+        next unless c_start <= target_start && c_end >= target_end
+        span = c_end - c_start
+        if span < best_span
+          best_span = span
+          best = candidate
+        end
+      end
+
+      method_node = best
+      return unless method_node
+      Noir::TreeSitter.field(method_node, "body")
     end
 
     private def anonymous_class_body(node : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?

--- a/src/analyzer/analyzers/java/jsp.cr
+++ b/src/analyzer/analyzers/java/jsp.cr
@@ -101,13 +101,25 @@ module Analyzer::Java
         content = read_file_content(path)
         next unless servlet_source?(content)
 
-        methods = extract_servlet_http_methods(content)
-        next if methods.empty?
+        base_path = configured_base_for(path)
+        package_name = java_package_name(content)
 
-        if class_name = java_class_name(content)
-          base_path = configured_base_for(path)
+        # One .java file can declare multiple HttpServlet subclasses (each
+        # mapped separately via web.xml). Scope method extraction to each
+        # class body so later classes are not dropped or given the first
+        # class's params.
+        content.scan(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)\b[^{]*\bextends\s+HttpServlet\b/) do |match|
+          class_name = match[1]
+          class_end = match.end(0) || 0
+          brace_index = content.index('{', class_end)
+          next unless brace_index
+
+          class_body = extract_balanced_block(content, brace_index)
+          methods = extract_servlet_http_methods(class_body)
+          next if methods.empty?
+
           servlet_methods[{base_path, class_name}] = methods
-          if package_name = java_package_name(content)
+          if package_name
             servlet_methods[{base_path, "#{package_name}.#{class_name}"}] = methods
           end
         end
@@ -195,11 +207,20 @@ module Analyzer::Java
       endpoints = [] of Endpoint
       return endpoints unless content.includes?("@WebServlet")
 
-      methods = extract_servlet_http_methods(content)
-      return endpoints if methods.empty?
-
-      content_without_comments(content).scan(/@WebServlet\s*(?:\((.*?)\))?\s*(?:public\s+|protected\s+|private\s+)?(?:final\s+|abstract\s+)?class\s+\w+/m) do |match|
+      # Work on comment-stripped content so match offsets align with the
+      # class-body slice we feed to extract_servlet_http_methods. Multiple
+      # @WebServlet classes in one file each get their own method/params set.
+      cleaned = content_without_comments(content)
+      cleaned.scan(/@WebServlet\s*(?:\((.*?)\))?\s*(?:public\s+|protected\s+|private\s+)?(?:final\s+|abstract\s+)?class\s+\w+/m) do |match|
         annotation_body = match[1]? || ""
+        class_end = match.end(0) || 0
+        brace_index = cleaned.index('{', class_end)
+        next unless brace_index
+
+        class_body = extract_balanced_block(cleaned, brace_index)
+        methods = extract_servlet_http_methods(class_body)
+        next if methods.empty?
+
         extract_servlet_url_patterns(annotation_body).each do |pattern|
           methods.each do |method, params|
             add_endpoint(endpoints, pattern, method, params, details)
@@ -258,6 +279,40 @@ module Analyzer::Java
             add_endpoint(endpoints, normalize_servlet_pattern(pattern), method, params, details)
           end
         end
+      end
+
+      # Root welcome-file alias: a request to `/` is served by the first
+      # matching root-level welcome JSP. Only handle simple filenames (no
+      # path separators) so we do not invent per-directory `/sub/` aliases.
+      welcome_files = doc.xpath_nodes("//*[local-name()='welcome-file-list']/*[local-name()='welcome-file']")
+        .map(&.content.strip)
+        .reject(&.empty?)
+
+      welcome_files.each do |welcome_file|
+        next if welcome_file.includes?("/") || welcome_file.includes?("\\")
+        next unless welcome_file.ends_with?(".jsp")
+
+        expected_path = "/#{welcome_file}"
+        matched = false
+
+        all_files.each do |jsp_path|
+          next unless File.extname(jsp_path) == ".jsp"
+          next unless configured_base_for(jsp_path) == base_path
+
+          relative_path = get_relative_path(base_path, jsp_path)
+          next if web_inf_jsp?(relative_path)
+          next unless jsp_request_path(relative_path) == expected_path
+
+          jsp_content = read_file_content(jsp_path)
+          params = extract_params(jsp_content)
+          add_endpoint(endpoints, "/", "GET", params, details)
+          matched = true
+          break
+        rescue File::NotFoundError
+          logger.debug "File not found: #{jsp_path}"
+        end
+
+        break if matched
       end
 
       endpoints

--- a/src/analyzer/analyzers/java/play.cr
+++ b/src/analyzer/analyzers/java/play.cr
@@ -201,9 +201,9 @@ module Analyzer::Java
       params = [] of String
       method_pattern = case kind
                        when :header
-                         "(?:header|getHeaders\\(\\)\\s*\\.\\s*get)"
+                         "(?:header|getHeader|(?:headers|getHeaders)\\(\\)\\s*\\.\\s*get)"
                        when :cookie
-                         "(?:cookie|cookies\\(\\)\\s*\\.\\s*get)"
+                         "(?:cookie|getCookie|cookies\\(\\)\\s*\\.\\s*get)"
                        else
                          return params
                        end

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -325,20 +325,20 @@ module Analyzer::Java
       route_bases = reactive_route_bases(content)
       method_callees = include_callee ? reactive_route_method_callees(content, path) : [] of ReactiveMethodCallees
 
-      content.scan(/@Route\b\s*(?:\((.*?)\))?/m) do |match|
-        offset = match.begin(0) || 0
-        body = match[1]? || ""
+      each_reactive_route_annotation(content) do |offset, end_offset, body|
         next if reactive_failure_route?(body)
 
-        method_name = route_method_name_after(content, match.end(0) || offset)
+        method_name = route_method_name_after(content, end_offset)
         next if method_name.empty?
 
         route_path = reactive_route_path(body, method_name)
+        next if route_path.nil?
+
         base_path = route_bases.find { |base| offset >= base.start_offset && offset <= base.end_offset }.try(&.path) || ""
         endpoint_path = Helper.join_paths(http_root_path, Helper.join_paths(base_path, route_path))
         line = content[0...offset].count('\n') + 1
         details = Details.new(PathInfo.new(path, line))
-        params = reactive_route_params(content, match.end(0) || offset, endpoint_path)
+        params = reactive_route_params(content, end_offset, endpoint_path)
 
         reactive_route_methods(body).each do |method|
           next if endpoints.any? { |endpoint| endpoint.url == endpoint_path && endpoint.method == method }
@@ -352,6 +352,44 @@ module Analyzer::Java
       end
 
       endpoints
+    end
+
+    # Locate each `@Route` annotation with a delimiter-balanced argument
+    # scan so values containing `)` (common in `regex=` capture groups)
+    # do not truncate the body. Skips `@RouteBase` via a word-boundary
+    # check after the `@Route` prefix.
+    private def each_reactive_route_annotation(content : String, & : Int32, Int32, String ->)
+      offset = 0
+      while idx = content.index("@Route", offset)
+        name_end = idx + 6 # length of "@Route"
+        if name_end < content.size
+          ch = content[name_end]
+          if ch.alphanumeric? || ch == '_'
+            offset = name_end
+            next
+          end
+        end
+
+        cursor = name_end
+        while cursor < content.size && content[cursor].ascii_whitespace?
+          cursor += 1
+        end
+
+        body = ""
+        end_offset = cursor
+        if cursor < content.size && content[cursor] == '('
+          close_idx = find_matching_delimiter(content, cursor, '(', ')')
+          unless close_idx
+            offset = cursor + 1
+            next
+          end
+          body = content[(cursor + 1)...close_idx]
+          end_offset = close_idx + 1
+        end
+
+        yield idx, end_offset, body
+        offset = end_offset
+      end
     end
 
     private def reactive_route_method_callees(content : String, path : String) : Array(ReactiveMethodCallees)
@@ -413,12 +451,28 @@ module Analyzer::Java
       bases
     end
 
-    private def reactive_route_path(annotation_body : String, method_name : String) : String
+    # Resolve the route path for a `@Route` annotation. Explicit
+    # `path=`/`value=` wins. When only `regex=` is set, Quarkus
+    # registers via `routeWithRegex` and never derives a method-name
+    # path — surface the regex pattern itself (or nil if unreadable)
+    # rather than inventing a literal path. With neither path nor
+    # regex, fall back to Quarkus's dashify of the method name.
+    private def reactive_route_path(annotation_body : String, method_name : String) : String?
       if path = reactive_annotation_path(annotation_body)
         return normalize_route_path(path)
       end
 
-      normalize_route_path(method_name)
+      if regex = reactive_annotation_regex(annotation_body)
+        # Surface the pattern as-is (may start with escapes like `\/…`,
+        # not a filesystem-style path that needs a leading `/`).
+        return regex
+      end
+
+      # Bare `regex=` with an unreadable value must not fall through
+      # to the method-name path — Quarkus never registers that path.
+      return nil if annotation_body.match(/\bregex\s*=/)
+
+      normalize_route_path(dashify(method_name))
     end
 
     private def reactive_annotation_path(annotation_body : String) : String?
@@ -429,6 +483,29 @@ module Analyzer::Java
 
       if match = body.match(/(?:path|value)\s*=\s*(["'][^"']+["'])/m)
         string_literal_value(match[1])
+      end
+    end
+
+    private def reactive_annotation_regex(annotation_body : String) : String?
+      if match = annotation_body.match(/\bregex\s*=\s*(["'][^"']+["'])/m)
+        string_literal_value(match[1])
+      end
+    end
+
+    # Quarkus `ReactiveRoutesProcessor.dashify`: insert '-' before any
+    # interior (not first/last) uppercase char and lower-case every
+    # char. `getItemList` → `get-item-list`.
+    private def dashify(name : String) : String
+      return name if name.empty?
+
+      String.build do |io|
+        last = name.size - 1
+        name.each_char_with_index do |char, index|
+          if index > 0 && index < last && char.ascii_uppercase?
+            io << '-'
+          end
+          io << char.downcase
+        end
       end
     end
 

--- a/src/analyzer/analyzers/java/quarkus.cr
+++ b/src/analyzer/analyzers/java/quarkus.cr
@@ -362,33 +362,30 @@ module Analyzer::Java
       offset = 0
       while idx = content.index("@Route", offset)
         name_end = idx + 6 # length of "@Route"
-        if name_end < content.size
-          ch = content[name_end]
-          if ch.alphanumeric? || ch == '_'
-            offset = name_end
-            next
+        if name_end < content.size && (content[name_end].alphanumeric? || content[name_end] == '_')
+          # Longer annotation name (`@RouteBase`, `@RouteFilter`, …).
+          offset = name_end
+        else
+          cursor = name_end
+          while cursor < content.size && content[cursor].ascii_whitespace?
+            cursor += 1
+          end
+
+          if cursor < content.size && content[cursor] == '('
+            if close_idx = find_matching_delimiter(content, cursor, '(', ')')
+              end_offset = close_idx + 1
+              yield idx, end_offset, content[(cursor + 1)...close_idx]
+              offset = end_offset
+            else
+              # Unbalanced `(` — skip past it without yielding.
+              offset = cursor + 1
+            end
+          else
+            # Bare `@Route` with no argument list.
+            yield idx, cursor, ""
+            offset = cursor
           end
         end
-
-        cursor = name_end
-        while cursor < content.size && content[cursor].ascii_whitespace?
-          cursor += 1
-        end
-
-        body = ""
-        end_offset = cursor
-        if cursor < content.size && content[cursor] == '('
-          close_idx = find_matching_delimiter(content, cursor, '(', ')')
-          unless close_idx
-            offset = cursor + 1
-            next
-          end
-          body = content[(cursor + 1)...close_idx]
-          end_offset = close_idx + 1
-        end
-
-        yield idx, end_offset, body
-        offset = end_offset
       end
     end
 
@@ -470,7 +467,7 @@ module Analyzer::Java
 
       # Bare `regex=` with an unreadable value must not fall through
       # to the method-name path — Quarkus never registers that path.
-      return nil if annotation_body.match(/\bregex\s*=/)
+      return if annotation_body.match(/\bregex\s*=/)
 
       normalize_route_path(dashify(method_name))
     end

--- a/src/analyzer/analyzers/java/spark.cr
+++ b/src/analyzer/analyzers/java/spark.cr
@@ -31,7 +31,7 @@ module Analyzer::Java
       },
       nest_methods: Set{"path"},
       transparent_methods: Set{"before", "after", "afterAfter"},
-      query_methods: Set{"queryParams", "queryParamOrDefault", "queryParamsValues"},
+      query_methods: Set{"queryParams", "queryParamOrDefault", "queryParamsValues", "queryMap"},
       header_methods: Set{"headers"},
       cookie_methods: Set{"cookie"},
       body_methods: Set{"body", "bodyAsBytes"},

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -177,6 +177,19 @@ module Analyzer::Java
               visible_meta_mappings = visible_meta_annotation_mappings(path, content, package_name, meta_annotation_index)
               imports = java_imports(content)
 
+              # The file's String-constant table is identical for every
+              # route in the file, so build it once here and thread it into
+              # the per-route parameter walks (and the WebSocket branches
+              # below) instead of rebuilding it — a full recursive tree walk
+              # — on every emitted route.
+              file_constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+
+              # The method-declaration index used to resolve callee call
+              # sites is likewise file-scoped; build it once (only when
+              # callees are requested) and reuse it across every route in
+              # the file rather than rebuilding it per route.
+              file_decl_index = include_callee ? Noir::JavaCalleeExtractor.build_method_decl_index(root, content) : nil
+
               Noir::TreeSitterJavaRouteExtractor.extract_routes_from(root, content, visible_meta_mappings).each do |route|
                 is_feign_client = feign_clients.includes?(route.class_name)
                 is_http_exchange_client = http_exchange_clients.includes?(route.class_name)
@@ -190,7 +203,7 @@ module Analyzer::Java
                 # "json" rather than inheriting "form".
 
                 parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
-                  root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index, route.line
+                  root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index, route.line, constants: file_constants
                 )
                 merge_route_condition_params(parameters, route.params)
 
@@ -215,7 +228,7 @@ module Analyzer::Java
                 # other analyzer's first-cut honest scope.
                 if include_callee && !(route.class_name.empty? || route.method_name.empty?)
                   Noir::JavaCalleeExtractor.callees_in_method(
-                    root, content, path, route.class_name, route.method_name, route.line
+                    root, content, path, route.class_name, route.method_name, route.line, decl_index: file_decl_index
                   ).each do |entry|
                     name, callee_path, callee_line = entry
                     endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
@@ -263,7 +276,7 @@ module Analyzer::Java
                       # empty interface method.
                       if include_callee && !(implementation.class_name.empty? || entry_route.method_name.empty?)
                         Noir::JavaCalleeExtractor.callees_in_method(
-                          root, content, path, implementation.class_name, entry_route.method_name
+                          root, content, path, implementation.class_name, entry_route.method_name, decl_index: file_decl_index
                         ).each do |callee_entry|
                           name, callee_path, callee_line = callee_entry
                           endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
@@ -277,7 +290,7 @@ module Analyzer::Java
               end
 
               if has_websocket_bindings
-                constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+                constants = file_constants
                 collect_stomp_endpoints(content, constants).each do |entry|
                   endpoint_path, line = entry
                   endpoint = Endpoint.new(join_paths(configured_base_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
@@ -287,7 +300,7 @@ module Analyzer::Java
               end
 
               if has_message_mapping_bindings
-                constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+                constants = file_constants
                 collect_message_mapping_endpoints(root, content, constants, stomp_application_prefixes).each do |entry|
                   verb, destination, line = entry
                   endpoint = Endpoint.new(destination, verb, Details.new(PathInfo.new(path, line)))
@@ -297,7 +310,7 @@ module Analyzer::Java
               end
 
               if has_resource_handler_bindings
-                constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+                constants = file_constants
                 collect_resource_handler_endpoints(content, constants).each do |entry|
                   endpoint_path, line = entry
                   @result << Endpoint.new(join_paths(configured_base_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -242,6 +242,11 @@ module Analyzer::Java
                 implementation.interface_names.each do |interface_name|
                   visible_interface_routes(interface_route_index, path, package_name, imports, interface_name).each do |entry|
                     entry_route = entry.route
+                    # Concrete @Override that re-declares its own mapping
+                    # annotation shadows the interface's method-level
+                    # mapping (Spring closest-annotation-wins). The direct
+                    # scan already emitted that route — skip the duplicate.
+                    next if implementation.annotated_method_names.includes?(entry_route.method_name)
                     implementation.paths.each do |implementation_path|
                       inherited_path = join_paths(implementation_path, entry_route.path)
                       parameter_format = nil

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -661,7 +661,12 @@ module Analyzer::Java
       end
 
       key = "#{method} #{normalized}"
-      return if @result.any? { |endpoint| "#{endpoint.method} #{endpoint.url}" == key }
+      # Dedup by "METHOD url" against an O(1) key set rather than a linear
+      # scan of the whole accumulated result — add_route is the only writer
+      # to @result, so the set mirrors it exactly. Keeps route registration
+      # O(n) instead of O(n^2) in the total struts2 endpoint count.
+      seen_keys = (@seen_route_keys ||= Set(String).new)
+      return unless seen_keys.add?(key)
 
       endpoint = Endpoint.new(normalized, method, route_params, Details.new(PathInfo.new(file_path, line)))
       callees.each { |callee| endpoint.push_callee(callee) }

--- a/src/analyzer/analyzers/java/vertx.cr
+++ b/src/analyzer/analyzers/java/vertx.cr
@@ -13,10 +13,23 @@ module Analyzer::Java
     REGEX_ROUTER_ROUTE_HANDLER = /router\.(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
     REGEX_ROUTE_METHOD_HANDLER = /\.route\s*\(\s*["\']([^"\']*)["\']\s*\)\s*\.\s*(get|post|put|delete|patch|head|options|connect|trace)\s*\(\s*this::([\w$]+)\s*\)/i
     REGEX_ROUTE_ANY_HANDLER    = /(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\(\s*this::([\w$]+)\s*\)/i
+    # Bare `route(path).handler(...)` — candidate set for lambda/terminal
+    # handlers; method-ref form is handled by REGEX_ROUTE_ANY_HANDLER.
+    REGEX_ROUTE_HANDLER_OPEN   = /(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\(/i
     REGEX_ROUTE_SUB_ROUTER     = /(\w+)\.route\s*\(([^)]*)\)\s*\.subRouter\s*\(/i
     REGEX_MOUNTSUBPATH         = /(\w+)\.mountSubRouter\s*\(([^)]*)\)/i
     REGEX_STATIC_HANDLER_ROUTE = /(\w+)\.route\s*\(([^)]*)\)\s*\.handler\s*\([^;]*StaticHandler\.create\s*\(/im
-    HTTP_METHODS               = %w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE]
+    # Outbound client types — same verb names as Router, never server routes.
+    REGEX_CLIENT_TYPE_DECL  = /\b(?:WebClient|HttpClient|WebClientSession)\s+(\w+)\b/
+    REGEX_WEBCLIENT_ASSIGN  = /\b(\w+)\s*=\s*WebClient\s*\.\s*(?:create|wrap)\s*\(/
+    REGEX_HTTPCLIENT_ASSIGN = /\b(\w+)\s*=\s*\w+\s*\.\s*createHttpClient\s*\(/
+    # Unambiguous query accessors on RoutingContext (not getParam/pathParam).
+    REGEX_QUERY_PARAM      = /\.\s*queryParam\s*\(\s*["']([^"']+)["']\s*\)/
+    REGEX_QUERY_PARAMS_GET = /\.\s*queryParams\s*\(\s*\)\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/
+    HTTP_METHODS           = %w[GET POST PUT DELETE PATCH HEAD OPTIONS CONNECT TRACE]
+    # Response-terminating RoutingContext/response calls used to distinguish
+    # real route handlers from pass-through middleware lambdas (`.next()`).
+    TERMINAL_HANDLER_MARKERS = [".end(", ".json(", ".redirect(", ".sendFile(", ".fail("]
 
     private struct RouteCandidate
       getter router_name : String
@@ -67,7 +80,15 @@ module Analyzer::Java
 
                     callees_by_route = include_callee ? extract_method_reference_callees(content, path) : {} of String => Array(Callee)
                     constants = path.ends_with?(".java") ? Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content) : Hash(String, String).new
-                    route_candidates = extract_route_candidates(content, constants)
+                    client_names = client_receivers(content)
+                    route_candidates = extract_route_candidates(content, constants, client_names)
+                    # Only resolve handler bodies when unambiguous query accessors appear.
+                    query_params_by_route = if content.includes?("queryParam")
+                                              method_bodies = extract_method_bodies(content)
+                                              extract_query_params_by_route(content, constants, method_bodies, client_names)
+                                            else
+                                              {} of String => Array(String)
+                                            end
                     mounts = extract_mounts(content, constants)
                     mounted_routers = Set(String).new
                     mounts.each { |mount| mounted_routers << mount.child_router }
@@ -76,6 +97,7 @@ module Analyzer::Java
                       next if mounted_routers.includes?(route.router_name)
 
                       found = build_endpoint(route.endpoint, route.method, details)
+                      attach_query_params(found, query_params_by_route, route.method, route.endpoint)
                       attach_callees(found, callees_by_route, route.method, route.endpoint)
                       @result << found
                     end
@@ -88,6 +110,7 @@ module Analyzer::Java
                       child_routes.each do |child|
                         endpoint = Helper.join_paths(mount.endpoint, child.endpoint)
                         found = build_endpoint(endpoint, child.method, details)
+                        attach_query_params(found, query_params_by_route, child.method, child.endpoint)
                         attach_callees(found, callees_by_route, child.method, child.endpoint)
                         @result << found
                       end
@@ -108,13 +131,16 @@ module Analyzer::Java
       @result
     end
 
-    private def extract_route_candidates(content : String, constants : Hash(String, String)) : Array(RouteCandidate)
+    private def extract_route_candidates(content : String, constants : Hash(String, String), client_names : Set(String)) : Array(RouteCandidate)
       candidates = [] of RouteCandidate
 
-      # Find direct router method calls like router.get("/path", handler)
+      # Find direct router method calls like router.get("/path", handler).
+      # Skip receivers known to be outbound HTTP clients (WebClient etc.).
       content.scan(REGEX_ROUTER_ROUTE) do |match|
         next if match.size < 4
         router_name = match[1]
+        next if client_names.includes?(router_name)
+
         method = match[2].upcase
         endpoint = resolve_route_path_arg(first_top_level_arg(match[3]), constants)
 
@@ -128,6 +154,8 @@ module Analyzer::Java
       content.scan(REGEX_ROUTE_METHOD) do |match|
         next if match.size < 4
         router_name = match[1]
+        next if client_names.includes?(router_name)
+
         endpoint = resolve_route_path_arg(first_top_level_arg(match[2]), constants)
         method = match[3].upcase
 
@@ -141,6 +169,8 @@ module Analyzer::Java
       content.scan(REGEX_ROUTE_HTTP_METHOD) do |match|
         next if match.size < 3
         router_name = match[1]
+        next if client_names.includes?(router_name)
+
         args = split_top_level_args(match[2])
         next unless args.size >= 2
 
@@ -154,17 +184,47 @@ module Analyzer::Java
       end
 
       # A Vert.x Route without `.method(...)` or `route(HttpMethod, ...)`
-      # matches all HTTP methods. Only capture explicit method-reference
-      # handlers here to avoid promoting common middleware routes such as
-      # BodyHandler into standalone endpoints.
+      # matches all HTTP methods. Method-reference handlers are always
+      # treated as real endpoints; inline lambdas are promoted only when
+      # the body terminates the response and is not pass-through middleware
+      # (see terminal_handler_body?).
       content.scan(REGEX_ROUTE_ANY_HANDLER) do |match|
         next if match.size < 3
         router_name = match[1]
+        next if client_names.includes?(router_name)
+
         args = split_top_level_args(match[2])
         next unless args.size == 1
 
         endpoint = resolve_route_path_arg(args[0], constants)
         next if endpoint.nil? || endpoint.empty?
+
+        candidates << RouteCandidate.new(router_name, "ANY", endpoint)
+      end
+
+      content.scan(REGEX_ROUTE_HANDLER_OPEN) do |match|
+        next if match.size < 3
+        router_name = match[1]
+        next if client_names.includes?(router_name)
+
+        args = split_top_level_args(match[2])
+        next unless args.size == 1
+
+        endpoint = resolve_route_path_arg(args[0], constants)
+        next if endpoint.nil? || endpoint.empty?
+
+        open_idx = (match.end || 1) - 1
+        close_idx = find_matching_paren(content, open_idx)
+        next unless close_idx
+
+        handler_arg = content[(open_idx + 1)...close_idx].strip
+        # Method refs are already captured by REGEX_ROUTE_ANY_HANDLER.
+        next if handler_arg.matches?(/\Athis::[\w$]+\s*\z/)
+        # BodyHandler/StaticHandler/etc. — no lambda arrow.
+        next unless handler_arg.includes?("->")
+
+        body = lambda_body_of(handler_arg)
+        next unless body && terminal_handler_body?(body)
 
         candidates << RouteCandidate.new(router_name, "ANY", endpoint)
       end
@@ -222,6 +282,265 @@ module Analyzer::Java
       # spelling but never carry a slash-prefixed first argument, so the
       # leading-slash gate filters them out without a type-tracking pass.
       candidates.select { |candidate| vertx_route_path?(candidate.endpoint) }.uniq!
+    end
+
+    # Identifiers declared/assigned as outbound Vert.x HTTP clients. Their
+    # `.get/.post/...` calls share Router's method spelling but are not
+    # server-side routes. Default remains "treat as router" for any name
+    # not proven to be a client (preserves factory-returned routers).
+    private def client_receivers(content : String) : Set(String)
+      names = Set(String).new
+      content.scan(REGEX_CLIENT_TYPE_DECL) { |match| names << match[1] }
+      content.scan(REGEX_WEBCLIENT_ASSIGN) { |match| names << match[1] }
+      content.scan(REGEX_HTTPCLIENT_ASSIGN) { |match| names << match[1] }
+      names
+    end
+
+    # Classic Router path params are `:name` only. `{name}` is OpenAPI-style
+    # and is a literal segment on the classic API — do not classify as path.
+    private def extract_path_parameters(path : String, endpoint : Endpoint)
+      path.scan(/:(\w+)/) do |match|
+        next unless match.size > 1
+        param_name = match[1]
+        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "path" }
+          endpoint.push_param(Param.new(param_name, "", "path"))
+        end
+      end
+    end
+
+    private def extract_method_bodies(content : String) : Hash(String, String)
+      bodies = {} of String => String
+      begin
+        Noir::TreeSitter.parse_java(content) do |root|
+          walk_method_declarations(root) do |method|
+            name_node = Noir::TreeSitter.field(method, "name")
+            next unless name_node
+
+            method_name = Noir::TreeSitter.node_text(name_node, content)
+            next if bodies.has_key?(method_name)
+
+            body = Noir::TreeSitter.field(method, "body")
+            next unless body
+
+            bodies[method_name] = Noir::TreeSitter.node_text(body, content)
+          end
+        end
+      rescue
+        # Kotlin / non-Java sources fall back to empty; inline lambdas still work.
+      end
+      bodies
+    end
+
+    # Map route_key(method, path) -> query param names from the route's handler.
+    private def extract_query_params_by_route(content : String,
+                                              constants : Hash(String, String),
+                                              method_bodies : Hash(String, String),
+                                              client_names : Set(String)) : Hash(String, Array(String))
+      result = {} of String => Array(String)
+
+      content.scan(REGEX_ROUTER_ROUTE) do |match|
+        next if match.size < 4
+        next if client_names.includes?(match[1])
+
+        method = match[2].upcase
+        endpoint = resolve_route_path_arg(first_top_level_arg(match[3]), constants)
+        next if !method.in?(HTTP_METHODS)
+        next if endpoint.nil? || endpoint.empty? || !vertx_route_path?(endpoint)
+
+        if body = resolve_handler_after(content, match.end || 0, method_bodies)
+          params = scan_query_params(body)
+          result[route_key(method, endpoint)] = params unless params.empty?
+        end
+      end
+
+      content.scan(REGEX_ROUTER_ROUTE_HANDLER) do |match|
+        next if match.size < 4
+        method = match[1].upcase
+        endpoint = match[2]
+        handler_name = match[3]
+        next if endpoint.empty? || handler_name.empty?
+        next unless vertx_route_path?(endpoint)
+
+        if body = method_bodies[handler_name]?
+          params = scan_query_params(body)
+          result[route_key(method, endpoint)] = params unless params.empty?
+        end
+      end
+
+      content.scan(REGEX_ROUTE_METHOD) do |match|
+        next if match.size < 4
+        next if client_names.includes?(match[1])
+
+        endpoint = resolve_route_path_arg(first_top_level_arg(match[2]), constants)
+        method = match[3].upcase
+        next if !method.in?(HTTP_METHODS)
+        next if endpoint.nil? || endpoint.empty? || !vertx_route_path?(endpoint)
+
+        open_idx = (match.end || 1) - 1
+        close_idx = find_matching_paren(content, open_idx)
+        next unless close_idx
+
+        handler_arg = content[(open_idx + 1)...close_idx]
+        if body = resolve_handler_arg(handler_arg, method_bodies)
+          params = scan_query_params(body)
+          result[route_key(method, endpoint)] = params unless params.empty?
+        end
+      end
+
+      content.scan(REGEX_ROUTE_HTTP_METHOD) do |match|
+        next if match.size < 3
+        next if client_names.includes?(match[1])
+
+        args = split_top_level_args(match[2])
+        next unless args.size >= 2
+
+        method = resolve_http_method_arg(args[0])
+        endpoint = resolve_route_path_arg(args[1], constants)
+        next if method.nil? || !method.in?(HTTP_METHODS)
+        next if endpoint.nil? || endpoint.empty? || !vertx_route_path?(endpoint)
+
+        if body = resolve_handler_after(content, match.end || 0, method_bodies)
+          params = scan_query_params(body)
+          result[route_key(method, endpoint)] = params unless params.empty?
+        end
+      end
+
+      content.scan(REGEX_ROUTE_ANY_HANDLER) do |match|
+        next if match.size < 4
+        args = split_top_level_args(match[2])
+        next unless args.size == 1
+
+        endpoint = resolve_route_path_arg(args[0], constants)
+        handler_name = match[3]
+        next if endpoint.nil? || endpoint.empty? || handler_name.empty?
+        next unless vertx_route_path?(endpoint)
+
+        if body = method_bodies[handler_name]?
+          params = scan_query_params(body)
+          result[route_key("ANY", endpoint)] = params unless params.empty?
+        end
+      end
+
+      content.scan(REGEX_ROUTE_HANDLER_OPEN) do |match|
+        next if match.size < 3
+        next if client_names.includes?(match[1])
+
+        args = split_top_level_args(match[2])
+        next unless args.size == 1
+
+        endpoint = resolve_route_path_arg(args[0], constants)
+        next if endpoint.nil? || endpoint.empty? || !vertx_route_path?(endpoint)
+
+        open_idx = (match.end || 1) - 1
+        close_idx = find_matching_paren(content, open_idx)
+        next unless close_idx
+
+        handler_arg = content[(open_idx + 1)...close_idx]
+        if body = resolve_handler_arg(handler_arg, method_bodies)
+          # Only associate query params with ANY routes we would emit
+          # (terminal lambda) or method-ref bodies already handled above.
+          next if handler_arg.strip.matches?(/\Athis::[\w$]+\s*\z/)
+          next unless handler_arg.includes?("->")
+          next unless terminal_handler_body?(body)
+
+          params = scan_query_params(body)
+          result[route_key("ANY", endpoint)] = params unless params.empty?
+        end
+      end
+
+      result
+    end
+
+    private def resolve_handler_after(content : String, start : Int32, method_bodies : Hash(String, String)) : String?
+      i = start
+      while i < content.size && content[i].ascii_whitespace?
+        i += 1
+      end
+      rest = content[i..]
+      return unless m = rest.match(/\A\.\s*handler\s*\(/i)
+
+      open_idx = i + (m.end || 1) - 1
+      close_idx = find_matching_paren(content, open_idx)
+      return unless close_idx
+
+      resolve_handler_arg(content[(open_idx + 1)...close_idx], method_bodies)
+    end
+
+    private def resolve_handler_arg(handler_arg : String, method_bodies : Hash(String, String)) : String?
+      arg = handler_arg.strip
+      if m = arg.match(/\Athis::([\w$]+)\s*\z/)
+        return method_bodies[m[1]]?
+      end
+      lambda_body_of(arg)
+    end
+
+    private def lambda_body_of(handler_arg : String) : String?
+      return unless arrow = handler_arg.index("->")
+
+      handler_arg[(arrow + 2)..].strip
+    end
+
+    private def scan_query_params(body : String) : Array(String)
+      params = [] of String
+      body.scan(REGEX_QUERY_PARAM) do |match|
+        name = match[1]
+        params << name unless params.includes?(name)
+      end
+      body.scan(REGEX_QUERY_PARAMS_GET) do |match|
+        name = match[1]
+        params << name unless params.includes?(name)
+      end
+      params
+    end
+
+    private def terminal_handler_body?(body : String) : Bool
+      return false if body.includes?(".next(")
+
+      TERMINAL_HANDLER_MARKERS.any? { |marker| body.includes?(marker) }
+    end
+
+    private def attach_query_params(endpoint : Endpoint, query_params_by_route : Hash(String, Array(String)), method : String, route : String)
+      names = query_params_by_route[route_key(method, route)]?
+      return unless names
+
+      names.each do |name|
+        unless endpoint.params.any? { |p| p.name == name && p.param_type == "query" }
+          endpoint.push_param(Param.new(name, "", "query"))
+        end
+      end
+    end
+
+    private def find_matching_paren(code : String, open_idx : Int32) : Int32?
+      depth = 1
+      in_string = false
+      quote = '\0'
+      escape = false
+
+      code.each_char_with_index do |char, idx|
+        next if idx <= open_idx
+
+        if in_string
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            in_string = false
+          end
+        else
+          case char
+          when '"', '\''
+            in_string = true
+            quote = char
+          when '('
+            depth += 1
+          when ')'
+            depth -= 1
+            return idx if depth.zero?
+          end
+        end
+      end
+      nil
     end
 
     # Vert.x Web requires path-string routes to begin with `/` (regex
@@ -389,24 +708,6 @@ module Analyzer::Java
       endpoint = Endpoint.new(path, method, details)
       extract_path_parameters(path, endpoint)
       endpoint
-    end
-
-    private def extract_path_parameters(path : String, endpoint : Endpoint)
-      path.scan(/:(\w+)/) do |match|
-        next unless match.size > 1
-        param_name = match[1]
-        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "path" }
-          endpoint.push_param(Param.new(param_name, "", "path"))
-        end
-      end
-
-      path.scan(/\{(\w+)\}/) do |match|
-        next unless match.size > 1
-        param_name = match[1]
-        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "path" }
-          endpoint.push_param(Param.new(param_name, "", "path"))
-        end
-      end
     end
 
     private def extract_method_reference_callees(content : String, path : String) : Hash(String, Array(Callee))

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -44,12 +44,14 @@ module Analyzer::Java
     alias PageMountIndex = Hash(ScopedClassKey, Array(String))
     alias RestRouteIndex = Hash(ScopedClassKey, Array(RestRoute))
     alias RestMountIndex = Hash(ScopedClassKey, RestMount)
+    alias ClassFileIndex = Hash(ScopedClassKey, FileInfo)
 
     @include_callee : Bool = false
 
     def analyze
       @include_callee = callees_needed?
       files = java_files_with_content
+      class_index = build_class_file_index(files)
       page_mounts = PageMountIndex.new { |hash, key| hash[key] = [] of String }
       rest_routes = RestRouteIndex.new { |hash, key| hash[key] = [] of RestRoute }
       rest_mounts = RestMountIndex.new
@@ -63,7 +65,7 @@ module Analyzer::Java
 
       files.each do |file|
         collect_mount_path_annotations(file, page_mounts, seen)
-        collect_mount_calls(file, page_mounts, rest_routes, seen)
+        collect_mount_calls(file, page_mounts, rest_routes, class_index, seen)
         collect_mapper_mounts(file, page_mounts, seen)
         collect_local_page_mount_helpers(file, page_mounts, seen)
         collect_rest_lambda_mounts(file, seen)
@@ -88,6 +90,12 @@ module Analyzer::Java
         content = read_file_content(path)
         next unless WICKET_MARKERS.any? { |marker| content.includes?(marker) }
 
+        # Blank // and /* */ comments (preserving newlines / offsets) so
+        # regex mount scanners never treat commented-out mountPage /
+        # @MountPath / etc. as live. String literals stay intact so
+        # values like "http://" are not misread as comment openers.
+        content = strip_comments(content)
+
         files << {
           path:      path,
           content:   content,
@@ -97,6 +105,17 @@ module Analyzer::Java
       end
 
       files
+    end
+
+    private def build_class_file_index(files : Array(FileInfo)) : ClassFileIndex
+      index = ClassFileIndex.new
+      files.each do |file|
+        file[:content].scan(/\bclass\s+([A-Za-z_][A-Za-z0-9_]*)\b/) do |match|
+          key = scoped_class_key(file, match[1])
+          index[key] ||= file
+        end
+      end
+      index
     end
 
     private def scoped_class_key(file : FileInfo, class_name : String) : ScopedClassKey
@@ -140,6 +159,7 @@ module Analyzer::Java
     private def collect_mount_calls(file : FileInfo,
                                     page_mounts : PageMountIndex,
                                     rest_routes : RestRouteIndex,
+                                    class_index : ClassFileIndex,
                                     seen : Set(String))
       {"mountPage", "mountPackage", "mountResource"}.each do |method_name|
         scan_method_calls(file[:content], method_name) do |args, offset|
@@ -152,7 +172,7 @@ module Analyzer::Java
           normalized = normalize_mount_path(mount_path)
 
           if method_name == "mountResource"
-            if resource_key = rest_resource_class_key(args, file[:base], rest_routes)
+            if resource_key = rest_resource_class_key(args, file[:base], rest_routes, class_index)
               if routes = rest_routes[resource_key]?
                 routes.each do |route|
                   add_endpoint(join_mount_paths(normalized, route[:path]), route[:file_path], route[:line], seen, route[:method], route[:callees], route[:params])
@@ -770,7 +790,39 @@ module Analyzer::Java
       ""
     end
 
-    private def rest_resource_class_key(source : String, base : String, rest_routes : RestRouteIndex) : ScopedClassKey?
+    # Resolve the rest resource class referenced by a mountResource(...)
+    # argument list. Direct `new RestClass(...)` / `RestClass.class` hits
+    # are preferred; when the mount wires a named ResourceReference
+    # subclass instead, one-hop-resolve through that reference class's
+    # body — same base only, so multi_base isolation is preserved.
+    private def rest_resource_class_key(source : String,
+                                        base : String,
+                                        rest_routes : RestRouteIndex,
+                                        class_index : ClassFileIndex? = nil) : ScopedClassKey?
+      if key = rest_resource_class_key_direct(source, base, rest_routes)
+        return key
+      end
+
+      return nil unless class_index
+
+      source.scan(/\bnew\s+([A-Za-z_][A-Za-z0-9_.]*)\s*(?:<[^;()]*>)?\s*\(/) do |match|
+        ref_class = match[1].split('.').last
+        ref_key = scoped_class_key(base, ref_class)
+        next unless ref_file = class_index[ref_key]?
+
+        # No further hops: only re-scan the reference class body for a
+        # direct rest resource class (avoids cross-base / multi-hop drift).
+        if key = rest_resource_class_key_direct(ref_file[:content], base, rest_routes)
+          return key
+        end
+      end
+
+      nil
+    end
+
+    private def rest_resource_class_key_direct(source : String,
+                                               base : String,
+                                               rest_routes : RestRouteIndex) : ScopedClassKey?
       source.scan(/\bnew\s+([A-Za-z_][A-Za-z0-9_.]*)\s*(?:<[^;()]*>)?\s*\(/) do |match|
         class_name = match[1].split('.').last
         key = scoped_class_key(base, class_name)
@@ -1029,6 +1081,71 @@ module Analyzer::Java
 
     private def line_for_offset(content : String, offset : Int32) : Int32
       content[0...offset].count('\n') + 1
+    end
+
+    # Blank `//` line comments and `/* */` block comments while preserving
+    # every newline so `line_for_offset` stays correct. String and char
+    # literals are tracked so `//` or `/*` inside a literal (e.g.
+    # `"http://x//y"`) is never treated as a comment opener. Mirrors
+    # `Analyzer::Java::Cli#strip_comments`.
+    private def strip_comments(text : String) : String
+      result = String::Builder.new
+      chars = text.chars
+      i = 0
+      in_string = false
+      string_quote = '\0'
+
+      while i < chars.size
+        c = chars[i]
+
+        if in_string
+          if c == '\\' && i + 1 < chars.size
+            result << c
+            result << chars[i + 1]
+            i += 2
+            next
+          end
+          in_string = false if c == string_quote
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '"' || c == '\''
+          in_string = true
+          string_quote = c
+          result << c
+          i += 1
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '/'
+          while i < chars.size && chars[i] != '\n'
+            result << ' '
+            i += 1
+          end
+          next
+        end
+
+        if c == '/' && i + 1 < chars.size && chars[i + 1] == '*'
+          result << "  "
+          i += 2
+          while i + 1 < chars.size && !(chars[i] == '*' && chars[i + 1] == '/')
+            result << (chars[i] == '\n' ? '\n' : ' ')
+            i += 1
+          end
+          if i + 1 < chars.size
+            result << "  "
+            i += 2
+          end
+          next
+        end
+
+        result << c
+        i += 1
+      end
+
+      result.to_s
     end
   end
 end

--- a/src/analyzer/analyzers/java/wicket.cr
+++ b/src/analyzer/analyzers/java/wicket.cr
@@ -803,7 +803,7 @@ module Analyzer::Java
         return key
       end
 
-      return nil unless class_index
+      return unless class_index
 
       source.scan(/\bnew\s+([A-Za-z_][A-Za-z0-9_.]*)\s*(?:<[^;()]*>)?\s*\(/) do |match|
         ref_class = match[1].split('.').last

--- a/src/ext/tree_sitter/tree_sitter.cr
+++ b/src/ext/tree_sitter/tree_sitter.cr
@@ -62,6 +62,24 @@ lib LibTreeSitter
   fun ts_node_start_point(node : TSNode) : TSPoint
   fun ts_node_end_point(node : TSNode) : TSPoint
   fun ts_node_is_null(node : TSNode) : Bool
+  fun ts_node_is_named(node : TSNode) : Bool
+
+  # ----- Tree cursor -----
+  # Visits children in O(1) amortised per step (goto_next_sibling),
+  # versus `ts_node_named_child(node, i)` which re-walks the sibling
+  # list from the start on every call (O(index)). Layout mirrors
+  # `TSTreeCursor` in api.h exactly: {tree, id, context[3]}.
+  struct TSTreeCursor
+    tree : Void*
+    id : Void*
+    context : LibC::UInt[3]
+  end
+
+  fun ts_tree_cursor_new(node : TSNode) : TSTreeCursor
+  fun ts_tree_cursor_delete(cursor : TSTreeCursor*)
+  fun ts_tree_cursor_current_node(cursor : TSTreeCursor*) : TSNode
+  fun ts_tree_cursor_goto_first_child(cursor : TSTreeCursor*) : Bool
+  fun ts_tree_cursor_goto_next_sibling(cursor : TSTreeCursor*) : Bool
 
   # ----- Query API -----
   struct TSQueryCapture
@@ -266,11 +284,50 @@ module Noir::TreeSitter
     LibTreeSitter.ts_node_is_null(child) ? nil : child
   end
 
+  # Above this many named children, switch from indexed access to a
+  # tree cursor. `ts_node_named_child(node, i)` is O(i) (it re-walks the
+  # sibling list each call), so the indexed loop is O(n^2) in the child
+  # count; a cursor walks each child in O(1) amortised but costs one
+  # allocation to set up. Small nodes stay on the allocation-free
+  # indexed path; wide nodes (large class bodies, `program` roots on big
+  # files) take the cursor and avoid the quadratic. Both paths yield the
+  # exact same named children in the same order.
+  NAMED_CHILD_CURSOR_THRESHOLD = 8
+
   # Iterates named children without allocating an array.
+  #
+  # The cursor path lives in a separate `@[NoInline]` method on purpose:
+  # these extractors recurse through `each_named_child`'s block, so any
+  # local this method reserves (notably the 32-byte `TSTreeCursor` and
+  # the `ensure` machinery) is paid at every recursion level. Keeping the
+  # cursor out of this frame preserves the tiny original frame for the
+  # common narrow-node path, so deeply nested inputs don't overflow the
+  # stack (guarded by spec/unit_test/miniparser/extractor_recursion_depth_spec).
   def self.each_named_child(node : LibTreeSitter::TSNode, &)
     count = LibTreeSitter.ts_node_named_child_count(node)
-    count.times do |i|
-      yield LibTreeSitter.ts_node_named_child(node, i.to_u32)
+    return if count == 0
+
+    if count <= NAMED_CHILD_CURSOR_THRESHOLD
+      count.times do |i|
+        yield LibTreeSitter.ts_node_named_child(node, i.to_u32)
+      end
+    else
+      each_named_child_via_cursor(node) { |child| yield child }
+    end
+  end
+
+  @[NoInline]
+  private def self.each_named_child_via_cursor(node : LibTreeSitter::TSNode, &)
+    cursor = LibTreeSitter.ts_tree_cursor_new(node)
+    begin
+      has_child = LibTreeSitter.ts_tree_cursor_goto_first_child(pointerof(cursor))
+      while has_child
+        child = LibTreeSitter.ts_tree_cursor_current_node(pointerof(cursor))
+        yield child if LibTreeSitter.ts_node_is_named(child)
+        has_child = LibTreeSitter.ts_tree_cursor_goto_next_sibling(pointerof(cursor))
+      end
+    ensure
+      LibTreeSitter.ts_tree_cursor_delete(pointerof(cursor))
     end
   end
 

--- a/src/miniparsers/java_callee_extractor.cr
+++ b/src/miniparsers/java_callee_extractor.cr
@@ -43,7 +43,8 @@ module Noir::JavaCalleeExtractor
                         file_path : String,
                         class_name : String,
                         method_name : String,
-                        target_line : Int32? = nil) : Array(Tuple(String, String, Int32))
+                        target_line : Int32? = nil,
+                        decl_index : Hash(String, Int32?)? = nil) : Array(Tuple(String, String, Int32))
     sink = [] of Tuple(String, String, Int32)
     return sink if class_name.empty? || method_name.empty?
 
@@ -52,7 +53,11 @@ module Noir::JavaCalleeExtractor
     body = Noir::TreeSitter.field(method_node, "body")
     return sink unless body
 
-    decl_index = build_method_decl_index(root, source)
+    # The method-declaration index is file-scoped; callers that resolve
+    # callees for many routes in one file (spring.cr) build it once and
+    # pass it in. The nil default recomputes it, preserving every other
+    # call site.
+    resolved_decl_index = decl_index || build_method_decl_index(root, source)
 
     walk(body) do |n|
       node_type = Noir::TreeSitter.node_type(n)
@@ -60,7 +65,7 @@ module Noir::JavaCalleeExtractor
       name = callee_text(n, source)
       next if name.empty?
       row = Noir::TreeSitter.node_start_row(n)
-      resolved_line = resolve_same_file_line(n, source, decl_index)
+      resolved_line = resolve_same_file_line(n, source, resolved_decl_index)
       sink << {name, file_path, resolved_line || (row + 1)}
     end
     sink
@@ -217,8 +222,8 @@ module Noir::JavaCalleeExtractor
   # which overload to point at. Conservative by design — overloads,
   # qualified non-`this` calls, and missing declarations all stay at
   # call site.
-  private def build_method_decl_index(root : LibTreeSitter::TSNode,
-                                      source : String) : Hash(String, Int32?)
+  def build_method_decl_index(root : LibTreeSitter::TSNode,
+                              source : String) : Hash(String, Int32?)
     index = {} of String => Int32?
     walk(root) do |n|
       next unless Noir::TreeSitter.node_type(n) == "method_declaration"

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -254,12 +254,17 @@ module Noir
                                        verb : String,
                                        parameter_format : String?,
                                        class_fields : Hash(String, Array(FieldInfo)),
-                                       target_line : Int32? = nil) : Array(Param)
+                                       target_line : Int32? = nil,
+                                       constants : Hash(String, String)? = nil) : Array(Param)
       method = find_method(root, source, class_name, method_name, target_line)
       return [] of Param unless method
-      constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
+      # `constants` is file-scoped and identical for every route in a
+      # file. Callers that emit many routes per file (spring.cr) build it
+      # once and pass it in; the nil default keeps every other analyzer's
+      # call site working by recomputing it here.
+      resolved_constants = constants || TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
       model_attributes = model_attribute_suppliers(root, source, class_name)
-      collect_method_params(method, source, verb, parameter_format, class_fields, constants, class_name, model_attributes)
+      collect_method_params(method, source, verb, parameter_format, class_fields, resolved_constants, class_name, model_attributes)
     end
 
     # Find `@*Mapping` annotation on (class_name, method_name) and

--- a/src/miniparsers/java_parameter_extractor_ts.cr
+++ b/src/miniparsers/java_parameter_extractor_ts.cr
@@ -856,6 +856,16 @@ module Noir
             ann_kind = :cookie
             ann_node = ann
             break
+          when "RequestPart"
+            # `@RequestPart` doesn't change binding semantics (a part
+            # still binds like an implicit form/query value, or expands
+            # a DTO's fields) — only capture the annotation node so the
+            # name-resolution walk below can pick up an explicit
+            # `@RequestPart("doc")` / `value = "doc"` part name instead
+            # of falling back to the Java variable name. Deliberately
+            # doesn't set `ann_kind` or `break`: the implicit-binding
+            # format inference further down stays untouched.
+            ann_node = ann
           end
         end
       end
@@ -873,6 +883,19 @@ module Noir
       end
 
       effective_format = parameter_format
+      # A carried-over "json"/"header"/"cookie" format came from a
+      # *previous* parameter's own annotation (`@RequestBody`,
+      # `@RequestHeader`, `@CookieValue`) and describes how that
+      # parameter was bound — it says nothing about how Spring binds
+      # *this*, un-annotated one. Drop it here so the un-annotated
+      # branch below recomputes the correct verb-based format ("form"
+      # on POST, "query" otherwise) instead of mislabeling this
+      # parameter with the previous one's transport. "query" is left
+      # sticky on purpose: it already matches the implicit-binding
+      # default and existing fixtures rely on the carry-over.
+      if ann_kind.nil? && (effective_format == "json" || effective_format == "header" || effective_format == "cookie")
+        effective_format = nil
+      end
       case ann_kind
       when :body
         effective_format = effective_format.nil? ? "json" : effective_format
@@ -937,7 +960,7 @@ module Noir
         sink << Param.new(parameter_name, default_value || "", effective_format)
       elsif SERVLET_REQUEST_TYPES.includes?(type_name)
         scan_servlet_body(method, source, arg_name, effective_format, sink)
-      elsif fields = class_fields[type_name]?
+      elsif fields = class_fields[type_name]? || class_fields[collection_element_type(type_name)]?
         # `@RequestBody` is deserialised by Jackson, which populates every
         # non-static instance field by reflection (and via
         # all-args/`@Builder` constructors) regardless of setter
@@ -993,6 +1016,26 @@ module Noir
         base = base[(idx + 1)..]
       end
       base.downcase
+    end
+
+    # Case-preserving counterpart to `simple_param_base`: strips the same
+    # single-argument collection/`Optional` wrapper and array/varargs
+    # brackets, but keeps the original casing so the result can be used
+    # as a `class_fields` DTO-index lookup key (which is indexed by the
+    # class's exact simple name, e.g. "ItemDto", not "itemdto"). Lets
+    # `@RequestBody List<ItemDto> items` / `@RequestBody ItemDto[] items`
+    # resolve to the same field set as a bare `@RequestBody ItemDto item`.
+    private def collection_element_type(type_name : String) : String
+      base = type_name.strip
+      if match = base.match(/\A(?:java\.util\.)?(?:List|Set|Collection|Iterable|Optional)\s*<\s*(.+?)\s*>\z/)
+        base = match[1].strip
+      end
+      base = base.gsub(/\[\s*\]/, "")
+      base = base.rstrip(". ")
+      if idx = base.rindex('.')
+        base = base[(idx + 1)..]
+      end
+      base
     end
 
     # Resolve either a string literal, a local Java constant, or a

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -79,8 +79,15 @@ module Noir
       getter verbs : Array(String)
       getter params : Array(Param)
       getter line : Int32
+      # Method names on the concrete controller that already carry a
+      # direct Spring mapping annotation (@GetMapping / @RequestMapping /
+      # meta-mapping, …). Interface-derived routes for these names must
+      # be skipped: Spring's merged-annotation lookup stops at the
+      # concrete override once it supplies its own mapping.
+      getter annotated_method_names : Set(String)
 
-      def initialize(@class_name, @interface_names, @paths, @verbs, @params, @line)
+      def initialize(@class_name, @interface_names, @paths, @verbs, @params, @line,
+                     @annotated_method_names = Set(String).new)
       end
     end
 
@@ -280,7 +287,9 @@ module Noir
           paths = mapping.paths
           paths = [""] if paths.empty?
           implementations << ControllerInterfaceImplementation.new(
-            class_name, interface_names, paths, mapping.verbs, mapping.params, Noir::TreeSitter.node_start_row(node)
+            class_name, interface_names, paths, mapping.verbs, mapping.params,
+            Noir::TreeSitter.node_start_row(node),
+            spring_mapping_method_names(node, source, meta_mappings)
           )
         end
       end
@@ -288,6 +297,35 @@ module Noir
       Noir::TreeSitter.each_named_child(node) do |child|
         walk_controller_interface_implementations(child, source, implementations, constants, meta_mappings, depth + 1)
       end
+    end
+
+    # Method names in `class_decl` whose declarations carry a Spring
+    # mapping annotation (direct or meta). Used to suppress inherited
+    # interface routes that the concrete override re-annotates.
+    private def spring_mapping_method_names(class_decl : LibTreeSitter::TSNode,
+                                            source : String,
+                                            meta_mappings : Hash(String, ClassMapping)) : Set(String)
+      names = Set(String).new
+      return names unless body = Noir::TreeSitter.field(class_decl, "body")
+
+      Noir::TreeSitter.each_named_child(body) do |member|
+        next unless Noir::TreeSitter.node_type(member) == "method_declaration"
+
+        method_name = ""
+        if name_node = Noir::TreeSitter.field(member, "name")
+          method_name = Noir::TreeSitter.node_text(name_node, source)
+        end
+        next if method_name.empty?
+
+        each_annotation(member, source) do |ann_name, _args_node, _line|
+          if ANNOTATION_VERBS.has_key?(ann_name) || meta_mappings.has_key?(ann_name)
+            names << method_name
+            break
+          end
+        end
+      end
+
+      names
     end
 
     private def class_simple_name(class_decl : LibTreeSitter::TSNode, source : String) : String

--- a/src/miniparsers/jaxrs_extractor_ts.cr
+++ b/src/miniparsers/jaxrs_extractor_ts.cr
@@ -54,14 +54,15 @@ module Noir
     # to the same param formats. Listing both here keeps the
     # Quarkus analyzer a thin detector layer on top of this extractor.
     PARAM_ANNOTATION_FORMAT = {
-      "QueryParam"  => "query",
-      "HeaderParam" => "header",
-      "CookieParam" => "cookie",
-      "FormParam"   => "form",
-      "RestQuery"   => "query",
-      "RestHeader"  => "header",
-      "RestCookie"  => "cookie",
-      "RestForm"    => "form",
+      "QueryParam"    => "query",
+      "HeaderParam"   => "header",
+      "CookieParam"   => "cookie",
+      "FormParam"     => "form",
+      "FormDataParam" => "form", # Jersey multipart (org.glassfish.jersey.media.multipart)
+      "RestQuery"     => "query",
+      "RestHeader"    => "header",
+      "RestCookie"    => "cookie",
+      "RestForm"      => "form",
     }
 
     # `@PathParam` skip-list — Quarkus's `@RestPath` is a drop-in
@@ -328,6 +329,9 @@ module Noir
       collect_implemented_interface_routes(decl, source, class_path, class_consumes,
         dto_index, bean_index, routes, include_callees, local_class_index,
         local_constants, subresource_sources, current_file, local_visited)
+      collect_superclass_routes(decl, source, class_path, class_consumes,
+        dto_index, bean_index, routes, include_callees, local_class_index,
+        local_constants, subresource_sources, current_file, local_visited)
     end
 
     private def collect_implemented_interface_routes(decl : LibTreeSitter::TSNode,
@@ -362,6 +366,68 @@ module Noir
             class_path, class_consumes, dto_index, bean_index, routes, include_callees,
             subresource_sources, visited, method_excludes)
         end
+      end
+    end
+
+    # Inherit HTTP-verb methods from an abstract/concrete superclass
+    # (`extends SuperClass`). JAX-RS only inherits *method*-level
+    # annotations from a superclass — never the superclass's class-level
+    # `@Path` — so the subclass's own `class_path` is used as `base_path`
+    # without re-joining any superclass path. Methods the subclass
+    # already re-annotates are excluded to avoid double emission.
+    private def collect_superclass_routes(decl : LibTreeSitter::TSNode,
+                                          source : String,
+                                          class_path : String,
+                                          class_consumes : String?,
+                                          dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
+                                          bean_index : Hash(String, Array(Param)),
+                                          routes : Array(Route),
+                                          include_callees : Bool,
+                                          class_index : Hash(String, LibTreeSitter::TSNode),
+                                          constants : Hash(String, String),
+                                          subresource_sources : Hash(String, SourceEntry),
+                                          current_file : String?,
+                                          visited : Set(String))
+      return unless Noir::TreeSitter.node_type(decl) == "class_declaration"
+
+      super_name = extended_class_name(decl, source)
+      return unless super_name
+
+      method_excludes = jaxrs_annotated_method_names(decl, source)
+      if super_decl = class_index[super_name]?
+        collect_class_routes(super_decl, source, dto_index, bean_index, routes, include_callees,
+          base_path: class_path, inherited_consumes: class_consumes,
+          class_index: class_index, constants: constants, subresource_sources: subresource_sources,
+          current_file: current_file, visited: visited, method_excludes: method_excludes)
+      elsif source_entry = subresource_sources[super_name]?
+        super_source_path, super_source = source_entry
+        collect_cross_file_superclass(super_name, super_source_path, super_source,
+          class_path, class_consumes, dto_index, bean_index, routes, include_callees,
+          subresource_sources, visited, method_excludes)
+      end
+    end
+
+    private def collect_cross_file_superclass(super_name : String,
+                                              super_path : String,
+                                              super_source : String,
+                                              class_path : String,
+                                              class_consumes : String?,
+                                              dto_index : Hash(String, Array(TreeSitterJavaParameterExtractor::FieldInfo)),
+                                              bean_index : Hash(String, Array(Param)),
+                                              routes : Array(Route),
+                                              include_callees : Bool,
+                                              subresource_sources : Hash(String, SourceEntry),
+                                              visited : Set(String),
+                                              method_excludes : Set(String))
+      Noir::TreeSitter.parse_java(super_source) do |root|
+        classes = collect_classes(root, super_source)
+        super_decl = classes[super_name]?
+        next unless super_decl
+        constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, super_source)
+        collect_class_routes(super_decl, super_source, dto_index, bean_index, routes, include_callees,
+          base_path: class_path, inherited_consumes: class_consumes,
+          class_index: classes, constants: constants, subresource_sources: subresource_sources,
+          current_file: super_path, visited: visited, method_excludes: method_excludes)
       end
     end
 
@@ -503,6 +569,28 @@ module Noir
       end
       names.uniq!
       names
+    end
+
+    # Single superclass from `extends SuperClass` (or `extends SuperClass
+    # implements ...`). Returns the simple type name, or nil when the
+    # class does not extend anything.
+    private def extended_class_name(class_decl : LibTreeSitter::TSNode, source : String) : String?
+      header = Noir::TreeSitter.node_text(class_decl, source)
+      if body_start = header.index('{')
+        header = header[...body_start]
+      end
+
+      match = header.match(/\bextends\s+([A-Za-z_][\w.$]*(?:\s*<[^;{]*>)?)/)
+      return unless match
+
+      type_name = strip_generic_arguments(match[1].strip)
+      return if type_name.empty?
+      type_name = type_name.split(/\s+/).first? || type_name
+      if idx = type_name.rindex('.')
+        type_name[(idx + 1)..]
+      else
+        type_name
+      end
     end
 
     private def split_top_level_commas(text : String) : Array(String)

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -489,13 +489,19 @@ module Noir
       bodies
     end
 
-    private def walk_method_declarations(node : LibTreeSitter::TSNode, &block : LibTreeSitter::TSNode ->)
+    private def walk_method_declarations(node : LibTreeSitter::TSNode, depth : Int32 = 0, &block : LibTreeSitter::TSNode ->)
+      # Bound recursion like the sibling `walk`/`scan_handler` walkers in
+      # this file. Real code never nests method declarations anywhere near
+      # MAX_AST_DEPTH, so this is output-preserving; it only stops runaway
+      # recursion on pathologically deep input (see extractor_recursion_depth_spec).
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
       if Noir::TreeSitter.node_type(node) == "method_declaration"
         block.call(node)
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk_method_declarations(child, &block)
+        walk_method_declarations(child, depth + 1, &block)
       end
     end
 

--- a/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
+++ b/src/miniparsers/jvm_lambda_dsl_extractor_ts.cr
@@ -113,7 +113,8 @@ module Noir
       Noir::TreeSitter.parse_java(source) do |root|
         constants = TreeSitterJavaRouteExtractor.extract_string_constants_from(root, source)
         method_bodies = method_body_index(root, source)
-        walk(root, source, "", config, routes, constants, method_bodies, 0, include_callees)
+        handler_vars = handler_variable_index(root, source, method_bodies)
+        walk(root, source, "", config, routes, constants, method_bodies, handler_vars, 0, include_callees)
       end
       routes
     end
@@ -127,6 +128,7 @@ module Noir
                      routes : Array(Route),
                      constants : Hash(String, String),
                      method_bodies : Hash(String, LibTreeSitter::TSNode),
+                     handler_vars : Hash(String, LibTreeSitter::TSNode),
                      depth : Int32,
                      include_callees : Bool)
       return if depth > Noir::TreeSitter::MAX_AST_DEPTH
@@ -137,13 +139,13 @@ module Noir
         name = method_invocation_method_name(node, source)
         case
         when verb = config.verb_methods[name]?
-          emit_route(node, source, verb, prefix, config, routes, constants, method_bodies, include_callees)
+          emit_route(node, source, verb, prefix, config, routes, constants, method_bodies, handler_vars, include_callees)
           return
         when config.websocket_methods.includes?(name)
-          emit_route(node, source, "GET", prefix, config, routes, constants, method_bodies, include_callees, protocol: "ws")
+          emit_route(node, source, "GET", prefix, config, routes, constants, method_bodies, handler_vars, include_callees, protocol: "ws")
           return
         when config.handler_methods.includes?(name)
-          emit_handler_route(node, source, prefix, config, routes, constants, method_bodies, include_callees)
+          emit_handler_route(node, source, prefix, config, routes, constants, method_bodies, handler_vars, include_callees)
           return
         when config.crud_methods.includes?(name)
           emit_crud_routes(node, source, prefix, routes, constants)
@@ -152,19 +154,19 @@ module Noir
           path_arg = first_string_argument(node, source, constants)
           new_prefix = path_arg ? join_paths(prefix, path_arg) : prefix
           if body = lambda_body_in_args(node)
-            walk(body, source, new_prefix, config, routes, constants, method_bodies, depth + 1, include_callees)
+            walk(body, source, new_prefix, config, routes, constants, method_bodies, handler_vars, depth + 1, include_callees)
           end
           return
         when config.transparent_methods.includes?(name)
           if body = lambda_body_in_args(node)
-            walk(body, source, prefix, config, routes, constants, method_bodies, depth + 1, include_callees)
+            walk(body, source, prefix, config, routes, constants, method_bodies, handler_vars, depth + 1, include_callees)
           end
           return
         end
       end
 
       Noir::TreeSitter.each_named_child(node) do |child|
-        walk(child, source, prefix, config, routes, constants, method_bodies, depth + 1, include_callees)
+        walk(child, source, prefix, config, routes, constants, method_bodies, handler_vars, depth + 1, include_callees)
       end
     end
 
@@ -176,13 +178,14 @@ module Noir
                            routes : Array(Route),
                            constants : Hash(String, String),
                            method_bodies : Hash(String, LibTreeSitter::TSNode),
+                           handler_vars : Hash(String, LibTreeSitter::TSNode),
                            include_callees : Bool,
                            protocol : String = "http")
-      return unless route_invocation?(call, source, config)
+      return unless route_invocation?(call, source, config, handler_vars)
 
       path_arg = first_string_argument(call, source, constants)
       if path_arg.nil?
-        return if prefix.empty? || !pathless_handler_argument?(call)
+        return if prefix.empty? || !first_argument_is_handler?(call, source, handler_vars)
         path_arg = ""
       end
 
@@ -197,7 +200,10 @@ module Noir
       has_body = false
       callees = [] of Tuple(String, Int32)
 
-      body = lambda_body_in_args(call) || method_reference_body_in_args(call, source, method_bodies)
+      body = lambda_body_in_args(call) ||
+             method_reference_body_in_args(call, source, method_bodies) ||
+             object_creation_handler_body_in_args(call, source) ||
+             identifier_handler_body_in_args(call, source, handler_vars)
       if body
         scan_handler(body, source, config, constants, 0) do |kind, value|
           case kind
@@ -234,11 +240,12 @@ module Noir
                                    routes : Array(Route),
                                    constants : Hash(String, String),
                                    method_bodies : Hash(String, LibTreeSitter::TSNode),
+                                   handler_vars : Hash(String, LibTreeSitter::TSNode),
                                    include_callees : Bool)
       verb = first_http_method_argument(call, source)
       return unless verb
 
-      emit_route(call, source, verb, prefix, config, routes, constants, method_bodies, include_callees)
+      emit_route(call, source, verb, prefix, config, routes, constants, method_bodies, handler_vars, include_callees)
     end
 
     private def emit_crud_routes(call : LibTreeSitter::TSNode,
@@ -298,11 +305,17 @@ module Noir
             block.call(:form, value)
           end
         when config.header_methods.includes?(name)
-          if value = first_string_argument(node, source, constants)
+          # `header(name, value)` is Javalin's response-SETTER overload
+          # (`headerAsClass` has no such overload — it's always a
+          # 2-arg read of name + Class, so it's exempt from this gate).
+          # Bare `header(name)` is the request-read path.
+          if (name != "header" || single_argument_call?(node)) && (value = first_string_argument(node, source, constants))
             block.call(:header, value)
           end
         when config.cookie_methods.includes?(name)
-          if value = first_string_argument(node, source, constants)
+          # `cookie(name, value[, maxAge])` is Javalin's response-setter
+          # overload; bare `cookie(name)` is the request-read path.
+          if (name != "cookie" || single_argument_call?(node)) && (value = first_string_argument(node, source, constants))
             block.call(:cookie, value)
           end
         when config.body_typed_methods.includes?(name)
@@ -435,6 +448,15 @@ module Noir
       nil
     end
 
+    # True when `call` has exactly one argument. Used to tell apart
+    # Javalin's `header`/`cookie` request-read overload (1 arg) from
+    # their response-setter overloads (2+ args: name, value[, maxAge]).
+    private def single_argument_call?(call : LibTreeSitter::TSNode) : Bool
+      args = argument_list_node(call)
+      return false unless args
+      LibTreeSitter.ts_node_named_child_count(args) == 1
+    end
+
     # Pull the lambda's body (`block` or expression) out of the
     # call's argument list. Returns nil if no lambda is passed.
     private def lambda_body_in_args(call : LibTreeSitter::TSNode) : LibTreeSitter::TSNode?
@@ -474,6 +496,59 @@ module Noir
       nil
     end
 
+    # Anonymous `new Handler() { public void handle(Context ctx) {...} }`
+    # bodies for param scanning (Javalin).
+    private def object_creation_handler_body_in_args(call : LibTreeSitter::TSNode,
+                                                     source : String) : LibTreeSitter::TSNode?
+      args = argument_list_node(call)
+      return unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "object_creation_expression"
+        if body = object_creation_handle_body(arg, source)
+          return body
+        end
+      end
+
+      nil
+    end
+
+    private def object_creation_handle_body(creation : LibTreeSitter::TSNode,
+                                            source : String) : LibTreeSitter::TSNode?
+      Noir::TreeSitter.each_named_child(creation) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "class_body"
+
+        Noir::TreeSitter.each_named_child(child) do |member|
+          next unless Noir::TreeSitter.node_type(member) == "method_declaration"
+          name_node = Noir::TreeSitter.field(member, "name")
+          next unless name_node
+          next unless Noir::TreeSitter.node_text(name_node, source) == "handle"
+          if body = Noir::TreeSitter.field(member, "body")
+            return body
+          end
+        end
+      end
+
+      nil
+    end
+
+    private def identifier_handler_body_in_args(call : LibTreeSitter::TSNode,
+                                                source : String,
+                                                handler_vars : Hash(String, LibTreeSitter::TSNode)) : LibTreeSitter::TSNode?
+      args = argument_list_node(call)
+      return unless args
+
+      Noir::TreeSitter.each_named_child(args) do |arg|
+        next unless Noir::TreeSitter.node_type(arg) == "identifier"
+        name = Noir::TreeSitter.node_text(arg, source)
+        if body = handler_vars[name]?
+          return body
+        end
+      end
+
+      nil
+    end
+
     private def method_body_index(root : LibTreeSitter::TSNode, source : String) : Hash(String, LibTreeSitter::TSNode)
       bodies = Hash(String, LibTreeSitter::TSNode).new
 
@@ -487,6 +562,72 @@ module Noir
       end
 
       bodies
+    end
+
+    # Local variables declared as `Handler` (or `*Handler`) whose
+    # initializer is a lambda / method reference / anonymous Handler
+    # class. Used both to accept `app.get("/x", handlerVar)` as a real
+    # route (see `functional_handler_argument?`) and to scan the
+    # resolved body for params. Keyed by simple variable name; first
+    # declaration wins (same-file ambiguity is rare and kept stable).
+    private def handler_variable_index(root : LibTreeSitter::TSNode,
+                                       source : String,
+                                       method_bodies : Hash(String, LibTreeSitter::TSNode)) : Hash(String, LibTreeSitter::TSNode)
+      bodies = Hash(String, LibTreeSitter::TSNode).new
+
+      walk_local_variable_declarations(root) do |decl|
+        type_node = Noir::TreeSitter.field(decl, "type")
+        next unless type_node
+        next unless handler_type_name?(Noir::TreeSitter.node_text(type_node, source))
+
+        Noir::TreeSitter.each_named_child(decl) do |child|
+          next unless Noir::TreeSitter.node_type(child) == "variable_declarator"
+          name_node = Noir::TreeSitter.field(child, "name")
+          value_node = Noir::TreeSitter.field(child, "value")
+          next unless name_node && value_node
+
+          var_name = Noir::TreeSitter.node_text(name_node, source)
+          next if var_name.empty?
+          next if bodies.has_key?(var_name)
+
+          if body = handler_initializer_body(value_node, source, method_bodies)
+            bodies[var_name] = body
+          end
+        end
+      end
+
+      bodies
+    end
+
+    private def handler_type_name?(type_text : String) : Bool
+      simple = type_text.strip
+      if lt = simple.index('<')
+        simple = simple[...lt].strip
+      end
+      if dot = simple.rindex('.')
+        simple = simple[(dot + 1)..]
+      end
+      simple == "Handler" || simple.ends_with?("Handler")
+    end
+
+    private def handler_initializer_body(init : LibTreeSitter::TSNode,
+                                         source : String,
+                                         method_bodies : Hash(String, LibTreeSitter::TSNode)) : LibTreeSitter::TSNode?
+      case Noir::TreeSitter.node_type(init)
+      when "lambda_expression"
+        Noir::TreeSitter.each_named_child(init) do |child|
+          ty = Noir::TreeSitter.node_type(child)
+          next if ty == "identifier" || ty == "formal_parameters" || ty == "inferred_parameters"
+          return child
+        end
+      when "method_reference"
+        method_name = Noir::TreeSitter.node_text(init, source).split("::").last?.to_s
+        method_name = method_name.gsub(/\A<[^>]+>/, "")
+        return method_bodies[method_name]? unless method_name.empty?
+      when "object_creation_expression"
+        return object_creation_handle_body(init, source)
+      end
+      nil
     end
 
     private def walk_method_declarations(node : LibTreeSitter::TSNode, depth : Int32 = 0, &block : LibTreeSitter::TSNode ->)
@@ -505,18 +646,62 @@ module Noir
       end
     end
 
-    private def pathless_handler_argument?(call : LibTreeSitter::TSNode) : Bool
+    private def walk_local_variable_declarations(node : LibTreeSitter::TSNode, depth : Int32 = 0, &block : LibTreeSitter::TSNode ->)
+      return if depth > Noir::TreeSitter::MAX_AST_DEPTH
+
+      if Noir::TreeSitter.node_type(node) == "local_variable_declaration"
+        block.call(node)
+      end
+
+      Noir::TreeSitter.each_named_child(node) do |child|
+        walk_local_variable_declarations(child, depth + 1, &block)
+      end
+    end
+
+    private def pathless_handler_argument?(call : LibTreeSitter::TSNode,
+                                           source : String = "",
+                                           handler_vars : Hash(String, LibTreeSitter::TSNode) = {} of String => LibTreeSitter::TSNode) : Bool
       args = argument_list_node(call)
       return false unless args
 
       Noir::TreeSitter.each_named_child(args) do |arg|
         case Noir::TreeSitter.node_type(arg)
-        when "lambda_expression", "method_reference"
+        when "lambda_expression", "method_reference",
+             "object_creation_expression", "class_literal"
           return true
+        when "identifier"
+          return true if !source.empty? && handler_vars.has_key?(Noir::TreeSitter.node_text(arg, source))
         end
       end
 
       false
+    end
+
+    # Like `pathless_handler_argument?`, but only true when the
+    # handler is the FIRST argument — Javalin's genuine no-path
+    # `get(ctx -> {...})` idiom. Used by `emit_route`'s no-path
+    # fallback: when the first argument is instead an unresolved
+    # expression followed by a lambda/method reference (Spark's
+    # `get(dynamicPath, (req, res) -> ...)`), a path WAS intended but
+    # couldn't be statically resolved, so the route must be dropped
+    # rather than collapsed onto the enclosing prefix.
+    private def first_argument_is_handler?(call : LibTreeSitter::TSNode,
+                                           source : String = "",
+                                           handler_vars : Hash(String, LibTreeSitter::TSNode) = {} of String => LibTreeSitter::TSNode) : Bool
+      args = argument_list_node(call)
+      return false unless args
+      return false if LibTreeSitter.ts_node_named_child_count(args) == 0
+
+      first = LibTreeSitter.ts_node_named_child(args, 0_u32)
+      case Noir::TreeSitter.node_type(first)
+      when "lambda_expression", "method_reference",
+           "object_creation_expression", "class_literal"
+        true
+      when "identifier"
+        !source.empty? && handler_vars.has_key?(Noir::TreeSitter.node_text(first, source))
+      else
+        false
+      end
     end
 
     private def route_like_invocation?(call : LibTreeSitter::TSNode,
@@ -534,16 +719,18 @@ module Noir
     #   * it's unqualified (`get("/x", ...)`) — `import static
     #     spark.Spark.*` style, never a method on a user object;
     #   * it carries a functional handler argument (lambda, method
-    #     reference, anonymous class, or class literal) — collection
-    #     mutators pass plain values, never handlers;
+    #     reference, anonymous class, class literal, or a local
+    #     `Handler`-typed variable) — collection mutators pass plain
+    #     values, never handlers;
     #   * its receiver is an allowlisted router (Spark's `redirect`),
     #     which lets the all-string-literal redirect forms through.
     private def route_invocation?(call : LibTreeSitter::TSNode,
                                   source : String,
-                                  config : Config) : Bool
+                                  config : Config,
+                                  handler_vars : Hash(String, LibTreeSitter::TSNode) = {} of String => LibTreeSitter::TSNode) : Bool
       receiver = Noir::TreeSitter.field(call, "object")
       return true unless receiver
-      return true if functional_handler_argument?(call)
+      return true if functional_handler_argument?(call, source, handler_vars)
       config.router_receivers.includes?(receiver_key(receiver, source))
     end
 
@@ -553,7 +740,9 @@ module Noir
       Noir::TreeSitter.node_text(receiver, source).split('.').last.strip
     end
 
-    private def functional_handler_argument?(call : LibTreeSitter::TSNode) : Bool
+    private def functional_handler_argument?(call : LibTreeSitter::TSNode,
+                                             source : String = "",
+                                             handler_vars : Hash(String, LibTreeSitter::TSNode) = {} of String => LibTreeSitter::TSNode) : Bool
       args = argument_list_node(call)
       return false unless args
 
@@ -562,6 +751,8 @@ module Noir
         when "lambda_expression", "method_reference",
              "object_creation_expression", "class_literal"
           return true
+        when "identifier"
+          return true if !source.empty? && handler_vars.has_key?(Noir::TreeSitter.node_text(arg, source))
         end
       end
 

--- a/src/miniparsers/micronaut_extractor_ts.cr
+++ b/src/miniparsers/micronaut_extractor_ts.cr
@@ -65,7 +65,19 @@ module Noir
 
     INJECTED_PARAM_TYPES = Set{
       "authentication", "httprequest", "httpheaders", "pageable",
-      "principal", "x509authentication",
+      "principal", "x509authentication", "httpparameters", "cookies",
+      "basicauth",
+    }
+
+    # Single-argument reactive/async/optional wrappers that Micronaut
+    # unwraps transparently when binding `@Body` (and implicit-body)
+    # parameters — e.g. `@Body Mono<Book> book` carries the same
+    # wire-level fields as `@Body Book book`. Resolving through these
+    # lets DTO expansion see the real element type instead of the
+    # wrapper's bare name.
+    REACTIVE_BODY_WRAPPER_TYPES = Set{
+      "mono", "single", "maybe", "flowable", "observable", "flux",
+      "publisher", "completablefuture", "optional",
     }
 
     FORM_FILE_PARAM_TYPES = Set{
@@ -848,11 +860,50 @@ module Noir
     private def leaf_type_name(node : LibTreeSitter::TSNode, source : String) : String
       ty = Noir::TreeSitter.node_type(node)
       return Noir::TreeSitter.node_text(node, source) if ty == "type_identifier"
+
+      if ty == "generic_type"
+        if outer = generic_type_outer_name(node, source)
+          if REACTIVE_BODY_WRAPPER_TYPES.includes?(outer.downcase)
+            if inner = generic_type_first_argument_leaf(node, source)
+              return inner unless inner.empty?
+            end
+          end
+        end
+      end
+
       Noir::TreeSitter.each_named_child(node) do |child|
         leaf = leaf_type_name(child, source)
         return leaf unless leaf.empty?
       end
       ""
+    end
+
+    # The bare type name a `generic_type` node is parameterizing, e.g.
+    # `Mono` in `Mono<Book>` or `Optional` in `java.util.Optional<Book>`.
+    private def generic_type_outer_name(node : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        case Noir::TreeSitter.node_type(child)
+        when "type_identifier"
+          return Noir::TreeSitter.node_text(child, source)
+        when "scoped_type_identifier"
+          return last_segment(Noir::TreeSitter.node_text(child, source))
+        end
+      end
+      nil
+    end
+
+    # The first concrete `type_arguments` entry of a `generic_type`
+    # node, resolved down to its leaf type name (recursing through
+    # further nested wrappers, e.g. `Mono<Optional<Book>>`).
+    private def generic_type_first_argument_leaf(node : LibTreeSitter::TSNode, source : String) : String?
+      Noir::TreeSitter.each_named_child(node) do |child|
+        next unless Noir::TreeSitter.node_type(child) == "type_arguments"
+        Noir::TreeSitter.each_named_child(child) do |arg|
+          leaf = leaf_type_name(arg, source)
+          return leaf unless leaf.empty?
+        end
+      end
+      nil
     end
 
     private def annotation_string_arg(args : LibTreeSitter::TSNode?,


### PR DESCRIPTION
## Summary
- **Performance**: eliminate per-route quadratic work in the Java analyzer family (`each_named_child` tree-cursor walk, Spring string-constant table hoisted per file, shared callee method index, O(1) Struts2 route dedup). Measured ~20% wall-clock reduction on a 600-file Spring/JAX-RS/Micronaut corpus.
- **Accuracy**: fix verified false positives and false negatives across CLI, HttpServer, JSP, Vert.x, Armeria, Spark/Javalin, Quarkus, JAX-RS, Micronaut, Dropwizard, Play, Spring parameter/route extractors, and Wicket—without changing the existing fixture endpoint inventory.
- **Safety gate**: full unit + functional suites pass (0 failures); method+url inventory across all 46 Java fixtures remains byte-identical to the pre-FP/FN baseline so existing detections are preserved.

## Notable FP fixes
- CLI / Wicket: comment-aware scanning so commented annotations/mounts are not reported
- Dropwizard: classify only on real bootstrap symbols (not standalone `io.dropwizard.*` util modules)
- Spring params: stop sticky `json`/`header`/`cookie` format leakage onto unannotated parameters
- Spring routes: skip interface-derived routes when the concrete override re-annotates the method
- Javalin: do not treat response-setter `header`/`cookie` overloads as request reads
- Spark: do not collapse unresolved dynamic paths onto the enclosing `path()` prefix
- Vert.x: ignore WebClient/HttpClient receivers; stop treating `{name}` as classic Router path params

## Notable FN fixes
- commons-cli short-only `addOption(opt, hasArg, desc)`
- HttpServer: class-scoped method references, local handler variables, `createContext` + `setHandler`
- JSP: per-class servlet methods; `welcome-file-list` → `GET /`
- Quarkus: dashify default path; `regex=` attribute; balanced `@Route(...)` parsing
- JAX-RS: abstract superclass verb methods; Jersey `@FormDataParam`
- Micronaut: unwrap reactive/async body wrappers; skip injected bag types
- Spring: `@RequestPart` explicit names; `@RequestBody List<Dto>` / array expansion
- Play: `getHeader` / `headers().get` / `getCookie`
- Spark: `queryMap`; Javalin anonymous/local `Handler` param extraction
- Armeria: builder chains with interior semicolons / assignment form; comment-aware route collection

## Test plan
- [x] `just build`
- [x] `just test` (unit + functional, 0 failures)
- [x] Java functional suite: 1917 examples, 0 failures
- [x] Endpoint inventory (method+url) identical across all Java fixtures vs pre-change baseline
- [ ] CI green on this PR