### PR TITLE
perf(detector): guard spec detectors before YAML/JSON parsing

### DIFF
--- a/spec/unit_test/detector/specification/envoy_spec.cr
+++ b/spec/unit_test/detector/specification/envoy_spec.cr
@@ -1,0 +1,48 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/specification/*"
+require "../../../../src/models/code_locator"
+
+describe "Detect Envoy route config" do
+  options = create_test_options
+  instance = Detector::Specification::Envoy.new options
+
+  yaml = <<-YAML
+    route_config:
+      name: local_route
+      virtual_hosts:
+        - name: backend
+          domains: ["*"]
+          routes:
+            - match:
+                prefix: /v1/users
+    YAML
+
+  it "detects envoy yaml route config" do
+    locator = CodeLocator.instance
+    locator.clear "envoy-yaml"
+
+    instance.detect("envoy.yaml", yaml).should be_true
+    locator.all("envoy-yaml").should eq ["envoy.yaml"]
+  end
+
+  it "detects envoy json route config" do
+    locator = CodeLocator.instance
+    locator.clear "envoy-json"
+
+    json = %({"virtual_hosts":[{"name":"backend","domains":["*"]}]})
+    instance.detect("envoy.json", json).should be_true
+    locator.all("envoy-json").should eq ["envoy.json"]
+  end
+
+  it "rejects yaml without virtual_hosts/domains markers" do
+    instance.detect("app.yaml", "version: '3.9'\nservices:\n  app:\n    image: test").should be_false
+  end
+
+  it "rejects invalid yaml that carries the markers" do
+    instance.detect("broken.yaml", "virtual_hosts:\n  - domains: [broken").should be_false
+  end
+
+  it "rejects invalid json that carries the markers" do
+    instance.detect("broken.json", %({"virtual_hosts":[{"domains":)).should be_false
+  end
+end

--- a/spec/unit_test/detector/specification/istio_virtualservice_spec.cr
+++ b/spec/unit_test/detector/specification/istio_virtualservice_spec.cr
@@ -36,4 +36,9 @@ describe "Detect Istio VirtualService manifest" do
       YAML
     instance.detect("dr.yaml", src).should be_false
   end
+
+  it "rejects invalid yaml that carries both markers" do
+    src = "apiVersion: networking.istio.io/v1\nkind: VirtualService\nspec: [broken"
+    instance.detect("broken.yaml", src).should be_false
+  end
 end

--- a/spec/unit_test/detector/specification/k8s_gateway_api_spec.cr
+++ b/spec/unit_test/detector/specification/k8s_gateway_api_spec.cr
@@ -34,4 +34,9 @@ describe "Detect Kubernetes Gateway API manifests" do
       YAML
     instance.detect("gateway.yaml", src).should be_false
   end
+
+  it "rejects invalid yaml that carries both markers" do
+    src = "apiVersion: gateway.networking.k8s.io/v1\nkind: HTTPRoute\nspec: [broken"
+    instance.detect("broken.yaml", src).should be_false
+  end
 end

--- a/spec/unit_test/detector/specification/kong_spec.cr
+++ b/spec/unit_test/detector/specification/kong_spec.cr
@@ -42,4 +42,27 @@ describe "Detect Kong declarative config" do
     instance.detect("kong.yml", content)
     locator.all("kong-spec").should eq(["kong.yml"])
   end
+
+  it "rejects unrelated yaml without kong markers" do
+    content = <<-YAML
+      version: "3.9"
+      services:
+        app:
+          image: test
+      YAML
+
+    instance.detect("docker-compose.yml", content).should be_false
+  end
+
+  it "rejects invalid yaml that carries a kong marker" do
+    instance.detect("broken.yml", "_format_version: \"3.0\"\n  services: [broken").should be_false
+  end
+
+  it "rejects marker-bearing yaml that is not a kong document" do
+    content = <<-YAML
+      notes: mentions _format_version in a value only
+      YAML
+
+    instance.detect("notes.yml", content).should be_false
+  end
 end

--- a/spec/unit_test/detector/specification/nginx_spec.cr
+++ b/spec/unit_test/detector/specification/nginx_spec.cr
@@ -50,6 +50,13 @@ describe "Detect Nginx config" do
     instance.detect("config.conf", "key = value\nfoo = bar\n").should be_false
   end
 
+  it "detects location assembled by template-action removal" do
+    # `strip_template_actions` splices `loca{{ … }}tion` back together, so
+    # the SHAPE_GUARD fast path must not reject template files on the raw
+    # (marker-less) content.
+    instance.detect("weird.tmpl", "loca{{ .X }}tion /v1 { proxy_pass http://up; }\n").should be_true
+  end
+
   it "rejects nginx-looking words inside comments" do
     instance.detect("comment.conf", <<-CONF).should be_false
       # server {

--- a/spec/unit_test/detector/specification/raml_spec.cr
+++ b/spec/unit_test/detector/specification/raml_spec.cr
@@ -15,4 +15,12 @@ describe "Detect RAML" do
     instance.detect("app.yaml", "#%RAML\nApp: 1")
     locator.all("raml-spec").should eq(["app.yaml"])
   end
+
+  it "rejects yaml without the RAML header" do
+    instance.detect("app.yaml", "App: 1").should be_false
+  end
+
+  it "rejects invalid yaml with the RAML header" do
+    instance.detect("app.yaml", "#%RAML\nApp: [broken").should be_false
+  end
 end

--- a/spec/unit_test/detector/specification/serverless_framework_spec.cr
+++ b/spec/unit_test/detector/specification/serverless_framework_spec.cr
@@ -50,4 +50,12 @@ describe "Detect Serverless Framework config" do
   it "ignores unrelated filenames" do
     instance.detect("config.yml", yaml).should be_false
   end
+
+  it "rejects invalid yaml" do
+    instance.detect("serverless.yml", "service: my-api\nfunctions: [broken").should be_false
+  end
+
+  it "rejects invalid json" do
+    instance.detect("serverless.json", %({"service":"my-api",)).should be_false
+  end
 end

--- a/spec/unit_test/detector/specification/traefik_spec.cr
+++ b/spec/unit_test/detector/specification/traefik_spec.cr
@@ -47,4 +47,18 @@ describe "Detect Traefik dynamic config" do
   it "rejects unrelated yaml" do
     instance.detect("app.yaml", "version: '3.9'\nservices:\n  app:\n    image: test").should be_false
   end
+
+  it "rejects marker-bearing yaml that is not a traefik config" do
+    content = <<-YAML
+      network:
+        routers:
+          - model: home
+      YAML
+
+    instance.detect("inventory.yaml", content).should be_false
+  end
+
+  it "rejects invalid yaml even when it carries a traefik label" do
+    instance.detect("broken.yaml", "labels:\n  - traefik.http.routers.api.rule: [broken").should be_false
+  end
 end

--- a/spec/unit_test/detector/specification/zap_sites_tree_spec.cr
+++ b/spec/unit_test/detector/specification/zap_sites_tree_spec.cr
@@ -27,4 +27,21 @@ describe "Detect ZAP Sites Tree" do
     instance.detect("sites.yaml", content)
     locator.all("zap-sites-tree").should eq(["sites.yaml"])
   end
+
+  it "rejects yaml without the Sites marker" do
+    content = <<-YAML
+      - node: something-else
+        children: []
+      YAML
+
+    instance.detect("tree.yml", content).should be_false
+  end
+
+  it "rejects marker-bearing yaml with a different shape" do
+    instance.detect("notes.yml", "note: Sites are mentioned here only").should be_false
+  end
+
+  it "rejects invalid yaml that carries the marker" do
+    instance.detect("broken.yml", "- node: Sites\n  children: [broken").should be_false
+  end
 end

--- a/src/detector/detectors/java/jsp.cr
+++ b/src/detector/detectors/java/jsp.cr
@@ -2,6 +2,14 @@ require "../../../models/detector"
 
 module Detector::Java
   class Jsp < Detector
+    # Necessary-condition guard for the `.xml` branch: comment stripping
+    # only removes text, so a marker absent from the raw content is also
+    # absent from the stripped copy — the whole-file `gsub` allocation can
+    # be skipped for the (overwhelmingly common) XML file without JSP
+    # markers. (A marker split mid-token by an XML comment would defeat
+    # this; no real deployment descriptor does that.)
+    XML_MARKER = /<jsp-file>|JspServlet/
+
     def detect(filename : String, file_contents : String) : Bool
       # Any .jsp file is part of JSP attack surface
       return true if filename.ends_with?(".jsp")
@@ -15,6 +23,7 @@ module Detector::Java
       end
 
       if filename.ends_with?(".xml")
+        return false unless file_contents.matches?(XML_MARKER)
         xml_without_comments = file_contents.gsub(/<!--.*?-->/m, "")
         return xml_without_comments.includes?("<jsp-file>") ||
           !!xml_without_comments.match(/<servlet-class>\s*[^<]*\bJspServlet\b[^<]*<\/servlet-class>/)

--- a/src/detector/detectors/specification/azure_functions.cr
+++ b/src/detector/detectors/specification/azure_functions.cr
@@ -8,8 +8,10 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless valid_json?(file_contents)
+      # Substring guard before the full JSON parse — both must pass, so the
+      # cheaper check goes first.
       return false unless file_contents.includes?("httpTrigger")
+      return false unless valid_json?(file_contents)
 
       CodeLocator.instance.push("azure-functions-spec", filename)
       true

--- a/src/detector/detectors/specification/envoy.cr
+++ b/src/detector/detectors/specification/envoy.cr
@@ -8,16 +8,14 @@ module Detector::Specification
     def detect(filename : String, file_contents : String) : Bool
       return false unless file_contents.includes?("virtual_hosts") && file_contents.includes?("domains")
 
-      if (filename.ends_with?(".yaml") || filename.ends_with?(".yml")) && valid_yaml?(file_contents)
-        data = YAML.parse(file_contents)
-        if find_virtual_hosts_yaml(data)
+      if filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+        if (data = yaml_any?(file_contents)) && find_virtual_hosts_yaml(data)
           locator = CodeLocator.instance
           locator.push("envoy-yaml", filename)
           return true
         end
-      elsif filename.ends_with?(".json") && valid_json?(file_contents)
-        data = JSON.parse(file_contents)
-        if find_virtual_hosts_json(data)
+      elsif filename.ends_with?(".json")
+        if (data = json_any?(file_contents)) && find_virtual_hosts_json(data)
           locator = CodeLocator.instance
           locator.push("envoy-json", filename)
           return true

--- a/src/detector/detectors/specification/istio_virtualservice.cr
+++ b/src/detector/detectors/specification/istio_virtualservice.cr
@@ -8,8 +8,12 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless valid_yaml_documents?(file_contents)
+      # Substring guard first: the full `YAML.parse_all` below only runs on
+      # the rare manifest that actually mentions Istio, instead of on every
+      # YAML file of the scan (this detector is non-idempotent, so there is
+      # no early-exit). Both checks must pass, so the order is free.
       return false unless virtual_service_present?(file_contents)
+      return false unless valid_yaml_documents?(file_contents)
 
       CodeLocator.instance.push("istio-virtualservice-spec", filename)
       true

--- a/src/detector/detectors/specification/k8s_gateway_api.cr
+++ b/src/detector/detectors/specification/k8s_gateway_api.cr
@@ -8,8 +8,12 @@ module Detector::Specification
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless valid_yaml_documents?(file_contents)
+      # Substring guard first: the full `YAML.parse_all` below only runs on
+      # the rare manifest that actually mentions the Gateway API, instead of
+      # on every YAML file of the scan (this detector is non-idempotent, so
+      # there is no early-exit). Both checks must pass, so the order is free.
       return false unless route_present?(file_contents)
+      return false unless valid_yaml_documents?(file_contents)
 
       CodeLocator.instance.push("k8s-gateway-api-spec", filename)
       true

--- a/src/detector/detectors/specification/kong.cr
+++ b/src/detector/detectors/specification/kong.cr
@@ -4,12 +4,20 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Kong < Detector
+    # Necessary-condition guard: both accepted shapes require one of these
+    # literals somewhere in the document (`deck_shape?` needs a
+    # `_format_version` key, `kic_shape?` an apiVersion containing
+    # `configuration.konghq.com/`), so any YAML file without them can skip
+    # the full parse. This detector is non-idempotent and previously parsed
+    # every YAML file of the scan twice (`valid_yaml?` + `YAML.parse`).
+    KONG_MARKER = /_format_version|configuration\.konghq\.com\//
+
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
-      return false unless valid_yaml?(file_contents)
+      return false unless file_contents.matches?(KONG_MARKER)
+      return false unless data = yaml_any?(file_contents)
 
       begin
-        data = YAML.parse(file_contents)
         if kong_doc?(data)
           CodeLocator.instance.push("kong-spec", filename)
           return true

--- a/src/detector/detectors/specification/nginx.cr
+++ b/src/detector/detectors/specification/nginx.cr
@@ -8,6 +8,14 @@ module Detector::Specification
     # repositories that render Nginx configs from templates.
     EXTENSIONS  = {".conf", ".tmpl", ".template"}
     LOCATION_RE = /^\s*location\s+(?:(?:=|~\*|~|\^~)\s+)?\S+/
+    # Whole-content necessary-condition guard for `nginx_shape?`: a line can
+    # only match LOCATION_RE if "location" appears in the raw content — or
+    # if a template action is spliced out of the middle of the word
+    # (`loca{{x}}tion`), which the `\{\{` disjunct keeps on the slow path.
+    # Comment stripping only truncates lines, so it can never assemble the
+    # keyword. Skips the per-line walk for the vast majority of `.conf` /
+    # `.tmpl` files that carry no location block.
+    SHAPE_GUARD = /location|\{\{/
 
     def detect(filename : String, file_contents : String) : Bool
       return false unless applicable?(filename)
@@ -32,6 +40,8 @@ module Detector::Specification
     end
 
     private def nginx_shape?(content : String) : Bool
+      return false unless content.matches?(SHAPE_GUARD)
+
       # Include fragments often contain only `location` blocks, so scan
       # executable directives instead of requiring a top-level server/http block.
       content.each_line do |raw|

--- a/src/detector/detectors/specification/raml.cr
+++ b/src/detector/detectors/specification/raml.cr
@@ -8,15 +8,13 @@ module Detector::Specification
       check = false
       if filename.ends_with?(".raml") || filename.ends_with?(".yaml") || filename.ends_with?(".yml")
         if file_contents.includes?("#%RAML")
+          # `valid_yaml?` already proves the content parses; the previous
+          # second `YAML.parse` (result discarded) doubled the cost for
+          # nothing.
           if valid_yaml?(file_contents)
-            begin
-              YAML.parse(file_contents)
-              check = true
-              locator = CodeLocator.instance
-              locator.push("raml-spec", filename)
-            rescue e
-              logger.debug "RAML detection failed for #{filename}: #{e}"
-            end
+            check = true
+            locator = CodeLocator.instance
+            locator.push("raml-spec", filename)
           end
         end
       end

--- a/src/detector/detectors/specification/serverless_framework.cr
+++ b/src/detector/detectors/specification/serverless_framework.cr
@@ -11,19 +11,11 @@ module Detector::Specification
 
       base = File.basename(filename)
       if base.ends_with?(".json")
-        return false unless valid_json?(file_contents)
-        begin
-          return false unless serverless_doc?(JSON.parse(file_contents))
-        rescue
-          return false
-        end
+        return false unless data = json_any?(file_contents)
+        return false unless serverless_doc?(data)
       else
-        return false unless valid_yaml?(file_contents)
-        begin
-          return false unless serverless_doc?(YAML.parse(file_contents))
-        rescue
-          return false
-        end
+        return false unless data = yaml_any?(file_contents)
+        return false unless serverless_doc?(data)
       end
 
       CodeLocator.instance.push("serverless-framework-spec", filename)

--- a/src/detector/detectors/specification/traefik.cr
+++ b/src/detector/detectors/specification/traefik.cr
@@ -4,19 +4,29 @@ require "../../../models/code_locator"
 
 module Detector::Specification
   class Traefik < Detector
+    # Necessary-condition guard for the YAML branch: every accepted shape
+    # requires one of these literals in the raw document — a `routers` key
+    # (`traefik_dynamic_config?`, and the `traefik.http.routers.` label
+    # fallback contains it too), a `kind: IngressRoute`, or a
+    # `traefik.io/` apiVersion. Any YAML file without them skips the full
+    # parse (this detector is non-idempotent and previously parsed every
+    # YAML file of the scan twice).
+    YAML_MARKER = /routers|IngressRoute|traefik\.io\//
+
     def detect(filename : String, file_contents : String) : Bool
       check = false
 
       if filename.ends_with?(".toml")
         check = file_contents.includes?("[http.routers.") && file_contents.includes?("rule")
-      elsif (filename.ends_with?(".yaml") || filename.ends_with?(".yml")) && valid_yaml?(file_contents)
-        begin
-          data = YAML.parse(file_contents)
-          check = traefik_dynamic_config?(data) ||
-                  ingress_route?(data) ||
-                  file_contents.includes?("traefik.http.routers.")
-        rescue
-          check = file_contents.includes?("traefik.http.routers.")
+      elsif (filename.ends_with?(".yaml") || filename.ends_with?(".yml")) && file_contents.matches?(YAML_MARKER)
+        if data = yaml_any?(file_contents)
+          begin
+            check = traefik_dynamic_config?(data) ||
+                    ingress_route?(data) ||
+                    file_contents.includes?("traefik.http.routers.")
+          rescue
+            check = file_contents.includes?("traefik.http.routers.")
+          end
         end
       end
 

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -7,8 +7,11 @@ module Detector::Specification
   class ZapSitesTree < Detector
     def detect(filename : String, file_contents : String) : Bool
       check = false
-      if (filename.ends_with?(".yaml") || filename.ends_with?(".yml")) && valid_yaml?(file_contents)
-        data = YAML.parse(file_contents)
+      # The accepted shape requires a "node" value containing "Sites", so
+      # the literal must appear in the raw document — guard before the full
+      # parse (this detector is non-idempotent and previously parsed every
+      # YAML file of the scan twice).
+      if applicable?(filename) && file_contents.includes?("Sites") && (data = yaml_any?(file_contents))
         begin
           if data[0]["node"].as_s.includes? "Sites"
             check = true

--- a/src/utils/json.cr
+++ b/src/utils/json.cr
@@ -6,3 +6,12 @@ def valid_json?(content : String) : Bool
 rescue
   false
 end
+
+# Strict `JSON.parse`-or-nil. Replaces the `valid_json?(content)` +
+# `JSON.parse(content)` idiom in detectors, which parsed the same
+# content twice per file.
+def json_any?(content : String) : JSON::Any?
+  JSON.parse(content)
+rescue
+  nil
+end

--- a/src/utils/yaml.cr
+++ b/src/utils/yaml.cr
@@ -7,6 +7,15 @@ rescue
   false
 end
 
+# Strict `YAML.parse`-or-nil. Replaces the `valid_yaml?(content)` +
+# `YAML.parse(content)` idiom in detectors, which paid for two full
+# libyaml passes over the same content per file.
+def yaml_any?(content : String) : YAML::Any?
+  YAML.parse(content)
+rescue
+  nil
+end
+
 # Parses YAML, recovering from a stray-tab failure that libyaml (Crystal's
 # YAML backend) is stricter about than most other parsers.
 #


### PR DESCRIPTION
## Summary

Non-idempotent specification detectors ran a full YAML parse — often **twice**, via the `valid_yaml?` + `YAML.parse` idiom — on **every** `.yaml`/`.yml` file for the entire scan (no early-exit, by contract). On k8s/Helm-heavy repositories this dominated detector-phase cost: up to 8 full libyaml parses per YAML file per scan.

This PR makes every accepted shape's literal marker a cheap necessary-condition guard that runs **before** parsing, and parses at most **once** via new `yaml_any?`/`json_any?` (parse-or-nil) helpers:

| Detector | Before | After |
|---|---|---|
| `kong`, `zap_sites_tree`, `traefik` | no guard + double parse | marker guard + single parse |
| `istio_virtualservice`, `k8s_gateway_api` | `YAML.parse_all` before the `includes?` guard | guard reordered before parse |
| `envoy`, `serverless_framework` | valid-then-reparse (2 parses) | single parse-or-nil |
| `raml` | validate + discard-reparse | single validation |
| `azure_functions` | parse before `httpTrigger` guard | guard reordered |
| `java_jsp` | whole-file comment-strip `gsub` on every `.xml` | marker guard first |
| `nginx` | per-line comment/template walk on every `.conf`/`.tmpl` | whole-content `location|\{\{` guard first (the `\{\{` disjunct keeps template-spliced `loca{{x}}tion` on the slow path) |

Guards are necessary-condition supersets of each accept condition, so results are unchanged by construction.

## Benchmarks (release builds, hyperfine)

| Corpus | main | branch | Δ |
|---|---|---|---|
| kubeflow/manifests (1,130 YAML files) | 1.797 s ± 0.016 | **1.075 s ± 0.040** | **1.67× faster** |
| noir functional fixtures (mixed) | 1.357 s ± 0.025 | 1.328 s ± 0.013 | neutral (±noise) |

## Regression testing

- Full `spec/unit_test` (3,703) + `spec/functional_test` (21,088): **0 failures**
- **Binary diff over all ~620 functional fixture apps**, main vs branch, two passes each (`-f json --no-log -T` and `-f plain --no-log --include path,techs,callee --ai-context`, jq-normalized): **zero diffs**
- New unit specs pin the guard paths: marker-less rejection, invalid-YAML-carrying-marker, template-spliced nginx `location`, and a new `envoy_spec.cr` (previously had no unit spec)
- `just check` (format + ameba) clean