### PR TITLE
perf: stop recompiling per-name regexes and merge proven multi-pass detector scans

### DIFF
--- a/spec/unit_test/detector/specification/apisix_spec.cr
+++ b/spec/unit_test/detector/specification/apisix_spec.cr
@@ -89,4 +89,17 @@ describe "Detect APISIX route config" do
 
     instance.detect("openapi.json", content).should be_false
   end
+
+  it "rejects OpenAPI-ish content whose markers only appear as substrings" do
+    # "security" contains "uri" as a bare substring; the word-bounded guard
+    # must not let a large spec like this reach the full JSON parse.
+    content = <<-JSON
+      {
+        "swagger": "2.0",
+        "paths": {"/routes": {"get": {"security": [], "plugins-doc": true}}}
+      }
+      JSON
+
+    instance.detect("swagger.json", content).should be_false
+  end
 end

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -738,12 +738,26 @@ module Analyzer::Php
       nil
     end
 
+    # Hoisted patterns for `extract_resource_route_calls` /
+    # `extract_resource_action_filter` — both call sites pass literal
+    # names ("resource"/"apiResource", "only"/"except"), and the previous
+    # `Regex.new` interpolation recompiled the pattern on every call
+    # (per file, and per resource statement respectively).
+    RESOURCE_CALL_RES = {
+      "resource"    => Regex.new("Route::resource\\s*\\(\\s*['\"]([^'\"]+)['\"]", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE),
+      "apiResource" => Regex.new("Route::apiResource\\s*\\(\\s*['\"]([^'\"]+)['\"]", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE),
+    }
+    ACTION_FILTER_RES = {
+      "only"   => Regex.new("->\\s*only\\s*\\((.*?)\\)", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE),
+      "except" => Regex.new("->\\s*except\\s*\\((.*?)\\)", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE),
+    }
+
     private def extract_resource_route_calls(content : String,
                                              method_name : String,
                                              skip_ranges : Array(Range(Int32, Int32)),
                                              lexer : Noir::PhpLexer) : Array(ResourceRouteCall)
       calls = [] of ResourceRouteCall
-      regex = Regex.new("Route::#{method_name}\\s*\\(\\s*['\"]([^'\"]+)['\"]", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE)
+      regex = RESOURCE_CALL_RES[method_name]
       pos = 0
 
       while route_match = content.match(regex, pos)
@@ -775,7 +789,7 @@ module Analyzer::Php
     end
 
     private def extract_resource_action_filter(statement : String, filter_name : String) : Array(String)?
-      match = statement.match(Regex.new("->\\s*#{filter_name}\\s*\\((.*?)\\)", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE))
+      match = statement.match(ACTION_FILTER_RES[filter_name])
       return unless match
 
       actions = [] of String

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -1632,8 +1632,18 @@ module Analyzer::Python
     # `path=` is given, so the caller falls back to the Namespace's own
     # `path=`/name. This is the authoritative mount point in flask-restx
     # and overrides the namespace definition's default.
+    # Memoized `<api>.add_namespace(<ns>, ...)` patterns — the interpolated
+    # literal used to recompile on every occurrence, while the
+    # (api instance, namespace var) pairs of an app are a small set.
+    @@add_namespace_res = {} of ::String => Regex
+    @@add_namespace_mutex = Mutex.new
+
     private def extract_add_namespace_path(ns_line : ::String, api_instance_name : ::String, ns_var : ::String) : ::String?
-      call_match = ns_line.match /#{Regex.escape(api_instance_name)}\.add_namespace\(#{Regex.escape(ns_var)},(.*)\)/
+      call_re = @@add_namespace_mutex.synchronize do
+        @@add_namespace_res["#{api_instance_name} #{ns_var}"] ||=
+          /#{Regex.escape(api_instance_name)}\.add_namespace\(#{Regex.escape(ns_var)},(.*)\)/
+      end
+      call_match = ns_line.match(call_re)
       return unless call_match
       args = call_match[1]
       if kw = args.match /path=[rf]?['"]([^'"]*)['"]/

--- a/src/detector/detectors/javascript/nextjs.cr
+++ b/src/detector/detectors/javascript/nextjs.cr
@@ -2,6 +2,11 @@ require "../../../models/detector"
 
 module Detector::Javascript
   class Nextjs < Detector
+    # Single-pass union of the four Next.js import forms (`require("next")`,
+    # `require("next/...")`, `from "next"`, `from "next/..."`) — previously
+    # four separate whole-file scans per JS/TS source.
+    NEXT_IMPORT = /require\(['"]next(?:\/[^'"]+)?['"]\)|from\s+['"]next(?:\/[^'"]+)?['"]/
+
     def detect(filename : String, file_contents : String) : Bool
       # Check for Next.js config files
       if filename.ends_with?("next.config.js") ||
@@ -44,10 +49,7 @@ module Detector::Javascript
       if (filename.ends_with?(".js") || filename.ends_with?(".jsx") ||
          filename.ends_with?(".ts") || filename.ends_with?(".tsx") ||
          filename.ends_with?(".mjs")) &&
-         (file_contents.match(/require\(['"]next['"]\)/) ||
-         file_contents.match(/require\(['"]next\/[^'"]+['"]\)/) ||
-         file_contents.match(/from\s+['"]next['"]/) ||
-         file_contents.match(/from\s+['"]next\/[^'"]+['"]/))
+         file_contents.matches?(NEXT_IMPORT)
         return true
       end
 

--- a/src/detector/detectors/php/cli.cr
+++ b/src/detector/detectors/php/cli.cr
@@ -21,6 +21,10 @@ module Detector::Php
     WP_ADD_COMMAND    = /WP_CLI::add_command\s*\(/
     WP_COMMAND_CLASS  = /extends\s+WP_CLI_Command\b/
 
+    # NOTE: deliberately kept as a sequential `||` chain. A single
+    # `Regex.union` of these 12 patterns benchmarked 1.38× SLOWER on
+    # non-matching PHP content — each pattern's distinctive literal keeps
+    # PCRE2's fast scan, which the wide alternation defeats.
     def detect(filename : String, file_contents : String) : Bool
       return false unless filename.ends_with?(".php")
       file_contents.matches?(USE_SF_CONSOLE) || file_contents.matches?(SF_COMMAND) ||

--- a/src/detector/detectors/ruby/cli.cr
+++ b/src/detector/detectors/ruby/cli.cr
@@ -22,6 +22,17 @@ module Detector::Ruby
     CLAMP_SUBCLASS   = /<\s*Clamp::Command\b/
     DRY_CLI_SUBCLASS = /<\s*Dry::CLI::Command\b/
 
+    # Single-pass union of every source marker above (the two thor require
+    # forms were bare `includes?` probes; `Regex.union` escapes string
+    # arguments literally). The previous chain scanned the whole file up to
+    # 11 times on non-CLI Ruby sources — the common case.
+    CLI_MARKER = Regex.union(
+      REQUIRE_OPTPARSE, OPTION_PARSER, THOR_SUBCLASS,
+      "require \"thor\"", "require 'thor'",
+      GLI_APP, SLOP_USE, TTY_OPTION, COMMANDER_USE, ARGV_INDEX,
+      OPTIMIST_USE, CLAMP_SUBCLASS, DRY_CLI_SUBCLASS,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       base = File.basename(filename)
       if base == "Gemfile" || filename.ends_with?(".gemspec")
@@ -29,15 +40,7 @@ module Detector::Ruby
       end
 
       return false unless filename.ends_with?(".rb")
-      return true if file_contents.matches?(REQUIRE_OPTPARSE) || file_contents.matches?(OPTION_PARSER)
-      return true if file_contents.matches?(THOR_SUBCLASS) || file_contents.includes?("require \"thor\"") || file_contents.includes?("require 'thor'")
-      return true if file_contents.matches?(GLI_APP) || file_contents.matches?(SLOP_USE) ||
-                     file_contents.matches?(TTY_OPTION) || file_contents.matches?(COMMANDER_USE)
-      return true if file_contents.matches?(ARGV_INDEX)
-      return true if file_contents.matches?(OPTIMIST_USE) || file_contents.matches?(CLAMP_SUBCLASS) ||
-                     file_contents.matches?(DRY_CLI_SUBCLASS)
-
-      false
+      file_contents.matches?(CLI_MARKER)
     end
 
     def applicable?(filename : String) : Bool

--- a/src/detector/detectors/rust/cli.cr
+++ b/src/detector/detectors/rust/cli.cr
@@ -7,6 +7,10 @@ module Detector::Rust
   # `std::env::var(...)` (config reads, common in web crates) does not qualify.
   class Cli < Detector
     CLI_CRATES = ["clap", "structopt", "argh", "bpaf", "pico-args", "getopts"]
+    # Single-pass alternation over CLI_CRATES — the previous per-crate
+    # interpolated literal recompiled (and rescanned) once per crate for
+    # every Cargo.toml.
+    CARGO_CLI_DEP = /(?m)^\s*(?:clap|structopt|argh|bpaf|pico\-args|getopts)\b/
 
     DERIVE_PARSER    = /#\[\s*derive\s*\([^)]*\b(?:Parser|Subcommand|Args)\b/
     DERIVE_STRUCTOPT = /#\[\s*derive\s*\([^)]*\bStructOpt\b/
@@ -15,16 +19,22 @@ module Detector::Rust
     BUILDER_CMD      = /\bCommand::new\s*\(/
     ENV_ARGS         = /\b(?:std::)?env::args(?:_os)?\s*\(/
 
+    # Single-pass union of the standalone source markers (the clap-builder
+    # check below stays separate: it is gated on `includes?("clap")`). The
+    # previous chain scanned the whole file up to 5 times on non-CLI Rust
+    # sources — the common case.
+    SOURCE_MARKER = Regex.union(
+      DERIVE_PARSER, DERIVE_STRUCTOPT, DERIVE_ARGH, USE_CLI_LIB, ENV_ARGS,
+    )
+
     def detect(filename : String, file_contents : String) : Bool
       if File.basename(filename) == "Cargo.toml"
         return file_contents.includes?("dependencies") &&
-          CLI_CRATES.any? { |crate| file_contents.matches?(/(?m)^\s*#{Regex.escape(crate)}\b/) }
+          file_contents.matches?(CARGO_CLI_DEP)
       end
 
       return false unless filename.ends_with?(".rs")
-      return true if file_contents.matches?(DERIVE_PARSER) || file_contents.matches?(DERIVE_STRUCTOPT) ||
-                     file_contents.matches?(DERIVE_ARGH) || file_contents.matches?(USE_CLI_LIB)
-      return true if file_contents.matches?(ENV_ARGS)
+      return true if file_contents.matches?(SOURCE_MARKER)
       # `Command::new(` alone is clap-builder only when clap is in use.
       return true if file_contents.includes?("clap") && file_contents.matches?(BUILDER_CMD)
 

--- a/src/detector/detectors/specification/apisix.cr
+++ b/src/detector/detectors/specification/apisix.cr
@@ -89,10 +89,21 @@ module Detector::Specification
       !!(text && !text.empty?)
     end
 
+    # Word-bounded guard markers. The accepted shapes require actual
+    # `routes` / `uri`(`uris`) / `upstream_id` or `plugins` keys, which
+    # always appear word-bounded in the raw document (`"uri":` / `uri:`),
+    # so `\b` keeps the guard a necessary condition while no longer
+    # tripping on substrings — the bare `includes?("uri")` matched
+    # "security" and made large OpenAPI JSON specs pay a full redundant
+    # parse here on every scan (this detector is non-idempotent).
+    ROUTES_MARKER  = /\broutes\b/
+    URI_MARKER     = /\buris?\b/
+    PAYLOAD_MARKER = /\bupstream_id\b|\bplugins\b/
+
     private def apisix_candidate?(content : String) : Bool
-      content.includes?("routes") &&
-        (content.includes?("uri") || content.includes?("uris")) &&
-        (content.includes?("upstream_id") || content.includes?("plugins"))
+      content.matches?(ROUTES_MARKER) &&
+        content.matches?(URI_MARKER) &&
+        content.matches?(PAYLOAD_MARKER)
     end
   end
 end

--- a/src/miniparsers/js_http_route_extractor.cr
+++ b/src/miniparsers/js_http_route_extractor.cr
@@ -529,19 +529,40 @@ module Noir
       end
     end
 
+    # Memoized per-ref scan patterns. These interpolated literals used to be
+    # recompiled on every call — once per scanned if-condition — while ref
+    # cardinality per file is tiny ("req.method", "req.url", a destructured
+    # local), so compile each (pattern, ref) pair once process-wide.
+    @@ref_scan_res = {} of String => Regex
+    @@ref_scan_mutex = Mutex.new
+
+    private def self.memo_ref_regex(kind : String, ref : String, & : String -> Regex) : Regex
+      @@ref_scan_mutex.synchronize do
+        @@ref_scan_res["#{kind}:#{ref}"] ||= yield ref_pattern(ref)
+      end
+    end
+
     private def self.extract_methods(condition : String, refs : Array(String)) : Array(String)
       methods = [] of String
       refs.each do |ref|
-        ref_re = ref_pattern(ref)
-        condition.scan(/#{ref_re}(?:\s*\.\s*toUpperCase\s*\(\s*\))?\s*(?:===|==)\s*['"]([A-Za-z]+)['"]/i) do |match|
+        eq_re = memo_ref_regex("m-eq", ref) do |ref_re|
+          /#{ref_re}(?:\s*\.\s*toUpperCase\s*\(\s*\))?\s*(?:===|==)\s*['"]([A-Za-z]+)['"]/i
+        end
+        condition.scan(eq_re) do |match|
           method = normalize_method(match[1])
           methods << method unless method.empty?
         end
-        condition.scan(/['"]([A-Za-z]+)['"]\s*(?:===|==)\s*#{ref_re}(?:\s*\.\s*toUpperCase\s*\(\s*\))?/i) do |match|
+        rev_re = memo_ref_regex("m-rev", ref) do |ref_re|
+          /['"]([A-Za-z]+)['"]\s*(?:===|==)\s*#{ref_re}(?:\s*\.\s*toUpperCase\s*\(\s*\))?/i
+        end
+        condition.scan(rev_re) do |match|
           method = normalize_method(match[1])
           methods << method unless method.empty?
         end
-        condition.scan(/\[\s*([^\]]+)\]\s*\.\s*includes\s*\(\s*#{ref_re}\s*\)/i) do |match|
+        inc_re = memo_ref_regex("m-inc", ref) do |ref_re|
+          /\[\s*([^\]]+)\]\s*\.\s*includes\s*\(\s*#{ref_re}\s*\)/i
+        end
+        condition.scan(inc_re) do |match|
           match[1].scan(/['"]([A-Za-z]+)['"]/) do |method_match|
             method = normalize_method(method_match[1])
             methods << method unless method.empty?
@@ -555,20 +576,31 @@ module Noir
     private def self.extract_paths(condition : String, refs : Array(String)) : Array(String)
       paths = [] of String
       refs.each do |ref|
-        ref_re = ref_pattern(ref)
-        condition.scan(/#{ref_re}\s*(?:===|==)\s*['"`]([^'"`]+)['"`]/) do |match|
+        eq_re = memo_ref_regex("p-eq", ref) do |ref_re|
+          /#{ref_re}\s*(?:===|==)\s*['"`]([^'"`]+)['"`]/
+        end
+        condition.scan(eq_re) do |match|
           path = normalize_path(match[1])
           paths << path unless path.empty?
         end
-        condition.scan(/['"`]([^'"`]+)['"`]\s*(?:===|==)\s*#{ref_re}/) do |match|
+        rev_re = memo_ref_regex("p-rev", ref) do |ref_re|
+          /['"`]([^'"`]+)['"`]\s*(?:===|==)\s*#{ref_re}/
+        end
+        condition.scan(rev_re) do |match|
           path = normalize_path(match[1])
           paths << path unless path.empty?
         end
-        condition.scan(/#{ref_re}\s*\.\s*startsWith\s*\(\s*['"`]([^'"`]+)['"`]/) do |match|
+        starts_re = memo_ref_regex("p-starts", ref) do |ref_re|
+          /#{ref_re}\s*\.\s*startsWith\s*\(\s*['"`]([^'"`]+)['"`]/
+        end
+        condition.scan(starts_re) do |match|
           path = normalize_path(match[1])
           paths << path unless path.empty?
         end
-        condition.scan(/\[\s*([^\]]+)\]\s*\.\s*includes\s*\(\s*#{ref_re}\s*\)/) do |match|
+        inc_re = memo_ref_regex("p-inc", ref) do |ref_re|
+          /\[\s*([^\]]+)\]\s*\.\s*includes\s*\(\s*#{ref_re}\s*\)/
+        end
+        condition.scan(inc_re) do |match|
           match[1].scan(/['"`]([^'"`]+)['"`]/) do |path_match|
             path = normalize_path(path_match[1])
             paths << path unless path.empty?
@@ -581,7 +613,10 @@ module Noir
 
     private def self.expression_matches_ref?(expression : String, refs : Array(String)) : Bool
       refs.any? do |ref|
-        expression.matches?(/^\s*#{ref_pattern(ref)}\s*$/)
+        expr_re = memo_ref_regex("expr", ref) do |ref_re|
+          /^\s*#{ref_re}\s*$/
+        end
+        expression.matches?(expr_re)
       end
     end
 

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -56,13 +56,25 @@ class Detector
     true
   end
 
+  # Per-gem regex memos for `gemfile_dependency?`/`gemspec_dependency?`.
+  # The interpolated literals used to recompile on every call — the Ruby
+  # CLI detector alone probes 8 gems against every Gemfile/gemspec, and
+  # each framework detector adds its own. Gem-name cardinality is a tiny
+  # static set, so cache the compiled patterns process-wide.
+  @@gemfile_dependency_res = {} of String => Regex
+  @@gemspec_dependency_res = {} of String => Regex
+  @@dependency_res_mutex = Mutex.new
+
   # Tolerant matcher for a Gemfile `gem "<name>"` line. Accepts both the
   # bare and parenthesized call forms with arbitrary spacing — `gem 'x'`,
   # `gem "x"`, `gem('x')`, `gem( "x" )` — and a trailing version
   # constraint, while still requiring the closing quote right after the
   # name so `gem 'sinatra'` never matches `gem 'sinatra-contrib'`.
   def gemfile_dependency?(file_contents : String, gem_name : String) : Bool
-    file_contents.matches?(/\bgem\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/)
+    re = @@dependency_res_mutex.synchronize do
+      @@gemfile_dependency_res[gem_name] ||= /\bgem\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/
+    end
+    file_contents.matches?(re)
   end
 
   # Tolerant matcher for a gemspec runtime dependency on `<name>`, in
@@ -71,7 +83,10 @@ class Detector
   # `spec.add_runtime_dependency "railties"`, neither of which the old
   # `"add_dependency 'sinatra'"` substring markers matched.
   def gemspec_dependency?(file_contents : String, gem_name : String) : Bool
-    file_contents.matches?(/\badd(?:_runtime)?_dependency\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/)
+    re = @@dependency_res_mutex.synchronize do
+      @@gemspec_dependency_res[gem_name] ||= /\badd(?:_runtime)?_dependency\s*\(?\s*['"]#{Regex.escape(gem_name)}['"]/
+    end
+    file_contents.matches?(re)
   end
 
   getter name, logger


### PR DESCRIPTION
## Summary

Second PR of the detectors/analyzers perf series (after #2294). One review lens: **no regex compiled in a loop, no unproven multi-pass scans.**

### Recompile removal (interpolated literals / `Regex.new` rebuilt per call)

| Site | Before | After |
|---|---|---|
| `models/detector.cr` `gemfile_dependency?`/`gemspec_dependency?` | recompiled per call — ruby_cli alone probes 8 gems against every Gemfile | memoized per gem name |
| `detector/rust/cli.cr` Cargo.toml probe | 6 per-crate compiles + 6 scans | one hoisted `CARGO_CLI_DEP` alternation, 1 scan |
| `miniparsers/js_http_route_extractor.cr` | 7 per-ref patterns + expression probe recompiled **per scanned if-condition** | memoized per (pattern, ref) |
| `analyzers/php/laravel.cr` | `Route::resource`/`apiResource` per file, `->only`/`->except` per resource statement | constant tables |
| `analyzers/python/flask.cr` `add_namespace` | per occurrence | memoized per (api, ns) |

### Multi-pass merges — each gated on `Benchmark.ips` (200KB non-matching fixture content, release build)

| Detector | Result | Action |
|---|---|---|
| `ruby/cli` 13-probe chain → `Regex.union` | **2.02× faster** | merged |
| `rust/cli` 5-probe source chain → union | **1.13× faster** | merged |
| `javascript/nextjs` 4 import scans → 1 alternation | **3.31× faster** | merged |
| `php/cli` 12-probe chain → union | **1.38× slower** (loses PCRE2 literal fast path) | **kept sequential**, documented in code |

### Guard precision (follow-up from the #2294 gate analysis)

`specification/apisix.cr`: word-bounded guard markers. The bare `includes?("uri")` matched **"security"**, so any large OpenAPI JSON also containing `routes`/`plugins` substrings paid a full redundant `JSON.parse` in this non-idempotent detector on every scan — measured ~116 ms for the 4.1 MB kubernetes swagger.json. The `\b`-bounded markers remain a necessary-condition superset of the accepted shapes (keys always appear word-bounded as `"uri":` / `uri:`), so results are unchanged.

## Regression testing

- All unions are pure boolean ORs of the identical patterns — semantics preserved by construction
- Full `spec/unit_test` (3,704) + `spec/functional_test` (21,088): **0 failures**
- **Binary diff over all ~620 functional fixture apps** (json `-T` pass + plain `--include path,techs,callee --ai-context` pass, jq-normalized), main vs branch: **zero diffs**
- New unit spec pins the apisix guard against substring-only markers
- `just check` clean