### PR TITLE
perf: linear-scan rewrite of JSLiteralScanner and JSLexer token accumulation

### DIFF
--- a/spec/unit_test/utils/js_literal_scanner_spec.cr
+++ b/spec/unit_test/utils/js_literal_scanner_spec.cr
@@ -199,4 +199,63 @@ describe Noir::JSLiteralScanner do
       idx.should be_nil
     end
   end
+
+  describe "edge cases pinned across the linear-scan rewrite" do
+    it "treats slash after identifier as division inside paren content" do
+      result = Noir::JSLiteralScanner.extract_paren_content("(a / b / c)", 1)
+      result = result.should_not be_nil
+      result.content.should eq("a / b / c")
+      result.end_pos.should eq(10)
+    end
+
+    it "skips regex with escaped slash and flags after an operator" do
+      result = Noir::JSLiteralScanner.extract_paren_content("(x = /a\\/b/gi)", 1)
+      result = result.should_not be_nil
+      result.content.should eq("x = /a\\/b/gi")
+      result.end_pos.should eq(13)
+    end
+
+    it "keeps the historical past-the-end position for unterminated strings" do
+      result = Noir::JSLiteralScanner.extract_paren_content("('ab", 1)
+      result = result.should_not be_nil
+      result.content.should eq("'ab")
+      result.end_pos.should eq(5)
+    end
+
+    it "matches braces across a keyword-context regex containing a brace" do
+      idx = Noir::JSLiteralScanner.find_matching_brace("{ return /}/ }", 0)
+      idx.should eq(13)
+    end
+
+    it "returns nil for a brace opened before an unterminated string" do
+      idx = Noir::JSLiteralScanner.find_matching_brace("{ \"ab", 0)
+      idx.should be_nil
+    end
+  end
+
+  describe "non-ASCII content (char-index API)" do
+    it "extracts paren content containing multi-byte chars" do
+      result = Noir::JSLiteralScanner.extract_paren_content("(한글 'x(y)' z)", 1)
+      result = result.should_not be_nil
+      result.content.should eq("한글 'x(y)' z")
+      result.end_pos.should eq(12)
+    end
+
+    it "strips comments containing multi-byte chars" do
+      res = Noir::JSLiteralScanner.try_skip_literal("// 한글\nx", 0, "")
+      res = res.should_not be_nil
+      res[:content].should eq("")
+      res[:pos].should eq(5)
+    end
+
+    it "finds matching brace past a multi-byte comment" do
+      idx = Noir::JSLiteralScanner.find_matching_brace("{ // 주석 }\n}", 0)
+      idx.should eq(10)
+    end
+
+    it "ignores parens inside strings holding emoji" do
+      idx = Noir::JSLiteralScanner.find_matching_paren("(f(\"🎉)\") )", 0)
+      idx.should eq(9)
+    end
+  end
 end

--- a/src/analyzer/analyzers/swift/hummingbird.cr
+++ b/src/analyzer/analyzers/swift/hummingbird.cr
@@ -884,15 +884,16 @@ module Analyzer::Swift
     # is labeled, e.g. `to:`/`atPath:`).
     private def first_positional_arg(args : String) : String?
       depth = 0
-      slice = ""
-      args.each_char do |char|
-        case char
-        when '(', '[', '<' then depth += 1
-        when ')', ']', '>' then depth -= 1
-        when ','
-          break if depth == 0
+      slice = String.build do |io|
+        args.each_char do |char|
+          case char
+          when '(', '[', '<' then depth += 1
+          when ')', ']', '>' then depth -= 1
+          when ','
+            break if depth == 0
+          end
+          io << char
         end
-        slice += char
       end
       slice = slice.strip
       return if slice.empty?

--- a/src/minilexers/js_lexer.cr
+++ b/src/minilexers/js_lexer.cr
@@ -155,15 +155,19 @@ module Noir
       # start_pos = @position
       advance # Skip the opening quote
 
-      string_value = ""
-      while @current_char != quote_char && @current_char != '\0'
-        # Handle escape sequences
-        if @current_char == '\\' && (peek == quote_char || peek == '\\')
+      # String::Builder instead of per-char `String#+` — the concat form
+      # reallocated the whole accumulated value on every char, turning long
+      # literals quadratic.
+      string_value = String.build do |io|
+        while @current_char != quote_char && @current_char != '\0'
+          # Handle escape sequences
+          if @current_char == '\\' && (peek == quote_char || peek == '\\')
+            advance
+          end
+
+          io << @current_char
           advance
         end
-
-        string_value += @current_char
-        advance
       end
 
       # Skip the closing quote
@@ -173,11 +177,11 @@ module Noir
     end
 
     private def tokenize_number
-      number = ""
-
-      while '0' <= @current_char <= '9' || @current_char == '.'
-        number += @current_char
-        advance
+      number = String.build do |io|
+        while '0' <= @current_char <= '9' || @current_char == '.'
+          io << @current_char
+          advance
+        end
       end
 
       add_token(:number, number)
@@ -186,15 +190,19 @@ module Noir
     private def tokenize_template_literal
       advance # Skip the opening backtick
 
-      template_value = ""
-      while @current_char != '`' && @current_char != '\0'
-        # Handle escape sequences
-        if @current_char == '\\' && (peek == '`' || peek == '\\')
+      # Template literals carry the largest payloads (CSS-in-JS, GraphQL,
+      # inline HTML can be tens of KB) — per-char `String#+` made them
+      # quadratic.
+      template_value = String.build do |io|
+        while @current_char != '`' && @current_char != '\0'
+          # Handle escape sequences
+          if @current_char == '\\' && (peek == '`' || peek == '\\')
+            advance
+          end
+
+          io << @current_char
           advance
         end
-
-        template_value += @current_char
-        advance
       end
 
       # Skip the closing backtick
@@ -204,15 +212,15 @@ module Noir
     end
 
     private def tokenize_identifier
-      identifier = ""
-
-      while ('a' <= @current_char <= 'z') ||
-            ('A' <= @current_char <= 'Z') ||
-            ('0' <= @current_char <= '9') ||
-            @current_char == '_' ||
-            @current_char == '$'
-        identifier += @current_char
-        advance
+      identifier = String.build do |io|
+        while ('a' <= @current_char <= 'z') ||
+              ('A' <= @current_char <= 'Z') ||
+              ('0' <= @current_char <= '9') ||
+              @current_char == '_' ||
+              @current_char == '$'
+          io << @current_char
+          advance
+        end
       end
 
       # Check if it's a keyword
@@ -275,29 +283,30 @@ module Noir
     private def tokenize_regex
       advance # Skip opening /
 
-      regex_pattern = ""
       in_char_class = false
 
-      while @current_char != '\0'
-        # Check for end of regex (only if not in character class)
-        break if @current_char == '/' && !in_char_class
+      regex_pattern = String.build do |io|
+        while @current_char != '\0'
+          # Check for end of regex (only if not in character class)
+          break if @current_char == '/' && !in_char_class
 
-        if @current_char == '\\' # Handle escape sequences
-          regex_pattern += @current_char
-          advance
-          regex_pattern += @current_char if @current_char != '\0'
-          advance
-        elsif @current_char == '[' && !in_char_class
-          in_char_class = true
-          regex_pattern += @current_char
-          advance
-        elsif @current_char == ']' && in_char_class
-          in_char_class = false
-          regex_pattern += @current_char
-          advance
-        else
-          regex_pattern += @current_char
-          advance
+          if @current_char == '\\' # Handle escape sequences
+            io << @current_char
+            advance
+            io << @current_char if @current_char != '\0'
+            advance
+          elsif @current_char == '[' && !in_char_class
+            in_char_class = true
+            io << @current_char
+            advance
+          elsif @current_char == ']' && in_char_class
+            in_char_class = false
+            io << @current_char
+            advance
+          else
+            io << @current_char
+            advance
+          end
         end
       end
 

--- a/src/utils/js_literal_scanner.cr
+++ b/src/utils/js_literal_scanner.cr
@@ -2,6 +2,16 @@ module Noir
   # JSLiteralScanner provides utilities for scanning JavaScript source code
   # while properly skipping string literals, comments, template literals, and regex.
   # This ensures parenthesis/brace matching doesn't get confused by literals.
+  #
+  # Implementation note: every public entry point takes CHAR indices and
+  # returns CHAR indices (callers slice with char-based `String#[]`). The
+  # scanners themselves run over an indexed char source instead of probing
+  # the string with `String#[](Int)` — which is O(index) once a string
+  # contains any multi-byte UTF-8 — and accumulate through `String::Builder`
+  # instead of per-char `String#+`, which reallocated the whole prefix on
+  # every append. ASCII content (the overwhelmingly common case) scans its
+  # byte slice with zero allocation; non-ASCII content pays one up-front
+  # `chars` materialization and stays linear.
   module JSLiteralScanner
     # Result of scanning with literal awareness
     struct ScanResult
@@ -16,228 +26,322 @@ module Noir
     REGEX_PRECEDING_KEYWORDS = ["return", "case", "throw", "in", "of", "typeof", "instanceof", "void", "delete", "new"]
 
     # Characters that can precede a regex literal (operators/punctuation expecting expression)
-    REGEX_PRECEDING_CHARS = ['(', '[', '{', ',', ':', ';', '=', '!', '&', '|', '?', '+', '-', '*', '%', '<', '>', '~', '^']
+    REGEX_PRECEDING_CHARS = Set{'(', '[', '{', ',', ':', ';', '=', '!', '&', '|', '?', '+', '-', '*', '%', '<', '>', '~', '^'}
+
+    # The regex-context checks only ever look at the tail of the scanned
+    # output: the last non-whitespace char, and `ends_with?` against the
+    # keywords above (longest: "instanceof", 10 chars). A rolling window of
+    # this size replaces re-materializing the whole accumulated prefix on
+    # every '/' encountered.
+    KEYWORD_WINDOW = 12
 
     # Extract content between parentheses while skipping literals
     # Returns the content inside the parentheses (not including the parens)
     def self.extract_paren_content(content : String, start_pos : Int32) : ScanResult?
       return unless start_pos < content.size
 
-      result = ""
-      paren_depth = 1
-      pos = start_pos
-
-      while pos < content.size && paren_depth > 0
-        char = content[pos]
-
-        # Try to skip literals
-        skip_result = try_skip_literal(content, pos, result)
-        if skip_result
-          result = skip_result[:content]
-          pos = skip_result[:pos]
-          next
-        end
-
-        # Track parentheses depth
-        if char == '('
-          paren_depth += 1
-        elsif char == ')'
-          paren_depth -= 1
-          break if paren_depth == 0
-        end
-
-        result += char
-        pos += 1
+      if single_byte?(content)
+        extract_paren_content_impl(content.to_slice, start_pos)
+      else
+        extract_paren_content_impl(content.chars, start_pos)
       end
-
-      ScanResult.new(result, pos)
     end
 
     # Try to skip a literal at the current position
     # Returns updated content string and position if a literal was skipped, nil otherwise
     def self.try_skip_literal(content : String, pos : Int32, accumulated : String) : NamedTuple(content: String, pos: Int32)?
-      char = content[pos]
-
-      # Skip single-line comments
-      if char == '/' && pos + 1 < content.size && content[pos + 1] == '/'
-        while pos < content.size && content[pos] != '\n'
-          pos += 1
-        end
-        return {content: accumulated, pos: pos}
-      end
-
-      # Skip multi-line comments
-      if char == '/' && pos + 1 < content.size && content[pos + 1] == '*'
-        pos += 2
-        while pos + 1 < content.size && !(content[pos] == '*' && content[pos + 1] == '/')
-          pos += 1
-        end
-        pos += 2 if pos + 1 < content.size
-        return {content: accumulated, pos: pos}
-      end
-
-      # Skip string literals (single/double quotes)
-      if char == '"' || char == '\''
-        result = accumulated + char
-        quote = char
-        pos += 1
-        while pos < content.size && content[pos] != quote
-          if content[pos] == '\\' && pos + 1 < content.size
-            result += content[pos]
-            pos += 1
-          end
-          result += content[pos] if pos < content.size
-          pos += 1
-        end
-        result += content[pos] if pos < content.size && content[pos] == quote
-        pos += 1
-        return {content: result, pos: pos}
-      end
-
-      # Skip template literals
-      if char == '`'
-        result = accumulated + char
-        pos += 1
-        while pos < content.size && content[pos] != '`'
-          if content[pos] == '\\' && pos + 1 < content.size
-            result += content[pos]
-            pos += 1
-          end
-          result += content[pos] if pos < content.size
-          pos += 1
-        end
-        result += content[pos] if pos < content.size && content[pos] == '`'
-        pos += 1
-        return {content: result, pos: pos}
-      end
-
-      # Skip regex literals
-      if char == '/' && looks_like_regex?(accumulated, content, pos)
-        result = accumulated + char
-        pos += 1
-        in_char_class = false
-        while pos < content.size
-          rc = content[pos]
-          break if rc == '/' && !in_char_class
-          if rc == '\\' && pos + 1 < content.size
-            result += rc
-            pos += 1
-            result += content[pos] if pos < content.size
-            pos += 1
-          elsif rc == '[' && !in_char_class
-            in_char_class = true
-            result += rc
-            pos += 1
-          elsif rc == ']' && in_char_class
-            in_char_class = false
-            result += rc
-            pos += 1
-          else
-            result += rc
-            pos += 1
-          end
-        end
-        result += content[pos] if pos < content.size && content[pos] == '/'
-        pos += 1
-        # Skip regex flags
-        while pos < content.size && content[pos].in?('g', 'i', 'm', 's', 'u', 'y', 'd')
-          result += content[pos]
-          pos += 1
-        end
-        return {content: result, pos: pos}
-      end
-
-      nil
-    end
-
-    # Determine if '/' at current position likely starts a regex literal
-    private def self.looks_like_regex?(accumulated : String, content : String, pos : Int32) : Bool
-      # Check last non-whitespace char in accumulated content
-      last_char = accumulated.rstrip.chars.last?
-      return true if last_char && REGEX_PRECEDING_CHARS.includes?(last_char)
-
-      # Check if preceded by keyword
+      # Rebuild the rolling tail window the scan core keys regex detection
+      # off from the caller-provided accumulated prefix.
       stripped = accumulated.rstrip
-      REGEX_PRECEDING_KEYWORDS.each do |keyword|
-        return true if stripped.ends_with?(keyword)
-      end
+      window = (stripped.size > KEYWORD_WINDOW ? stripped[(stripped.size - KEYWORD_WINDOW)..] : stripped).chars
+      pending_ws = [] of Char
 
-      false
+      new_pos = nil.as(Int32?)
+      appended = String.build do |io|
+        new_pos = if single_byte?(content)
+                    scan_literal(content.to_slice, content.size, pos, io, window, pending_ws)
+                  else
+                    scan_literal(content.chars, content.size, pos, io, window, pending_ws)
+                  end
+      end
+      end_pos = new_pos
+      return unless end_pos
+
+      {content: appended.empty? ? accumulated : accumulated + appended, pos: end_pos}
     end
 
     # Find matching closing brace, skipping literals
     def self.find_matching_brace(content : String, open_brace_idx : Int32) : Int32?
-      brace_count = 1
-      idx = open_brace_idx + 1
-
-      while idx < content.size && brace_count > 0
-        # Try to skip literals (use empty string since we don't need accumulated content)
-        skip_result = try_skip_literal_simple(content, idx)
-        if skip_result
-          idx = skip_result
-          next
-        end
-
-        case content[idx]
-        when '{'
-          brace_count += 1
-        when '}'
-          brace_count -= 1
-        end
-        idx += 1
-
-        return idx - 1 if brace_count == 0
+      if single_byte?(content)
+        find_matching_impl(content.to_slice, open_brace_idx, '{', '}')
+      else
+        find_matching_impl(content.chars, open_brace_idx, '{', '}')
       end
-
-      nil
     end
 
     # Find matching closing paren, skipping literals
     def self.find_matching_paren(content : String, open_paren_idx : Int32) : Int32?
-      paren_count = 1
-      idx = open_paren_idx + 1
-
-      while idx < content.size && paren_count > 0
-        # Try to skip literals
-        skip_result = try_skip_literal_simple(content, idx)
-        if skip_result
-          idx = skip_result
-          next
-        end
-
-        case content[idx]
-        when '('
-          paren_count += 1
-        when ')'
-          paren_count -= 1
-        end
-        idx += 1
-
-        return idx - 1 if paren_count == 0
+      if single_byte?(content)
+        find_matching_impl(content.to_slice, open_paren_idx, '(', ')')
+      else
+        find_matching_impl(content.chars, open_paren_idx, '(', ')')
       end
-
-      nil
     end
 
-    # Simplified literal skip that doesn't accumulate content - just returns new position
-    private def self.try_skip_literal_simple(content : String, pos : Int32) : Int32?
-      char = content[pos]
+    # --- indexed char access (ASCII byte slice / char array) ---
+
+    # O(1) ASCII probe: a UTF-8 string is all-ASCII iff its char count
+    # equals its byte count, and `String#size` is computed once per string
+    # then cached. (`String#ascii_only?` instead re-scans every byte on
+    # each call, which would put an O(n) toll on every dispatch — measured
+    # as an 86× slowdown on repeated brace matching over the same file.)
+    private def self.single_byte?(content : String) : Bool
+      content.bytesize == content.size
+    end
+
+    private def self.chr(src : Bytes, i : Int32) : Char
+      # Only reached through the `single_byte?` fast path, so every byte is
+      # a valid single-byte char.
+      src[i].unsafe_chr
+    end
+
+    private def self.chr(src : Array(Char), i : Int32) : Char
+      src[i]
+    end
+
+    private def self.word_string(src : Bytes, from : Int32, to : Int32) : String
+      String.new(src[from, to - from])
+    end
+
+    private def self.word_string(src : Array(Char), from : Int32, to : Int32) : String
+      src[from...to].join
+    end
+
+    # --- core scanners ---
+
+    private def self.extract_paren_content_impl(src, start_pos : Int32) : ScanResult
+      size = src.size
+      paren_depth = 1
+      pos = start_pos
+      window = Array(Char).new(KEYWORD_WINDOW)
+      pending_ws = Array(Char).new(KEYWORD_WINDOW)
+
+      result = String.build do |io|
+        while pos < size && paren_depth > 0
+          # Try to skip literals
+          if skip_pos = scan_literal(src, size, pos, io, window, pending_ws)
+            pos = skip_pos
+            next
+          end
+
+          char = chr(src, pos)
+
+          # Track parentheses depth
+          if char == '('
+            paren_depth += 1
+          elsif char == ')'
+            paren_depth -= 1
+            break if paren_depth == 0
+          end
+
+          emit(io, window, pending_ws, char)
+          pos += 1
+        end
+      end
+
+      ScanResult.new(result, pos)
+    end
+
+    # Skips (and where applicable, appends) one comment/string/template/
+    # regex literal starting at `pos`. Returns the resume position, or nil
+    # when `pos` does not start a literal. Comments are consumed without
+    # appending; string/template/regex text is appended through `emit` so
+    # the regex-context window stays in sync with the emitted output.
+    private def self.scan_literal(src, size : Int32, pos : Int32, io : String::Builder,
+                                  window : Array(Char), pending_ws : Array(Char)) : Int32?
+      char = chr(src, pos)
 
       # Skip single-line comments
-      if char == '/' && pos + 1 < content.size && content[pos + 1] == '/'
-        while pos < content.size && content[pos] != '\n'
+      if char == '/' && pos + 1 < size && chr(src, pos + 1) == '/'
+        while pos < size && chr(src, pos) != '\n'
           pos += 1
         end
         return pos
       end
 
       # Skip multi-line comments
-      if char == '/' && pos + 1 < content.size && content[pos + 1] == '*'
+      if char == '/' && pos + 1 < size && chr(src, pos + 1) == '*'
         pos += 2
-        while pos + 1 < content.size && !(content[pos] == '*' && content[pos + 1] == '/')
+        while pos + 1 < size && !(chr(src, pos) == '*' && chr(src, pos + 1) == '/')
           pos += 1
         end
-        pos += 2 if pos + 1 < content.size
+        pos += 2 if pos + 1 < size
+        return pos
+      end
+
+      # Skip string literals (single/double quotes)
+      if char == '"' || char == '\''
+        quote = char
+        emit(io, window, pending_ws, char)
+        pos += 1
+        while pos < size && chr(src, pos) != quote
+          if chr(src, pos) == '\\' && pos + 1 < size
+            emit(io, window, pending_ws, chr(src, pos))
+            pos += 1
+          end
+          emit(io, window, pending_ws, chr(src, pos)) if pos < size
+          pos += 1
+        end
+        emit(io, window, pending_ws, quote) if pos < size && chr(src, pos) == quote
+        pos += 1
+        return pos
+      end
+
+      # Skip template literals
+      if char == '`'
+        emit(io, window, pending_ws, char)
+        pos += 1
+        while pos < size && chr(src, pos) != '`'
+          if chr(src, pos) == '\\' && pos + 1 < size
+            emit(io, window, pending_ws, chr(src, pos))
+            pos += 1
+          end
+          emit(io, window, pending_ws, chr(src, pos)) if pos < size
+          pos += 1
+        end
+        emit(io, window, pending_ws, '`') if pos < size && chr(src, pos) == '`'
+        pos += 1
+        return pos
+      end
+
+      # Skip regex literals
+      if char == '/' && looks_like_regex?(window)
+        emit(io, window, pending_ws, char)
+        pos += 1
+        in_char_class = false
+        while pos < size
+          rc = chr(src, pos)
+          break if rc == '/' && !in_char_class
+          if rc == '\\' && pos + 1 < size
+            emit(io, window, pending_ws, rc)
+            pos += 1
+            emit(io, window, pending_ws, chr(src, pos)) if pos < size
+            pos += 1
+          elsif rc == '[' && !in_char_class
+            in_char_class = true
+            emit(io, window, pending_ws, rc)
+            pos += 1
+          elsif rc == ']' && in_char_class
+            in_char_class = false
+            emit(io, window, pending_ws, rc)
+            pos += 1
+          else
+            emit(io, window, pending_ws, rc)
+            pos += 1
+          end
+        end
+        emit(io, window, pending_ws, '/') if pos < size && chr(src, pos) == '/'
+        pos += 1
+        # Skip regex flags
+        while pos < size && chr(src, pos).in?('g', 'i', 'm', 's', 'u', 'y', 'd')
+          emit(io, window, pending_ws, chr(src, pos))
+          pos += 1
+        end
+        return pos
+      end
+
+      nil
+    end
+
+    # Appends `char` to the output and keeps the regex-context window
+    # aligned with the rstrip'd output tail: trailing whitespace is held in
+    # `pending_ws` and only flushed into the window once a non-whitespace
+    # char follows (matching what `accumulated.rstrip` used to observe).
+    private def self.emit(io : String::Builder, window : Array(Char), pending_ws : Array(Char), char : Char)
+      io << char
+      if char.whitespace?
+        pending_ws.shift if pending_ws.size >= KEYWORD_WINDOW
+        pending_ws << char
+      else
+        unless pending_ws.empty?
+          pending_ws.each { |ws| window << ws }
+          pending_ws.clear
+        end
+        window << char
+        while window.size > KEYWORD_WINDOW
+          window.shift
+        end
+      end
+    end
+
+    # Determine if '/' at current position likely starts a regex literal.
+    # `window` is the rstrip'd tail of the scanned output — enough for both
+    # the last-char probe and the keyword `ends_with?` probe.
+    private def self.looks_like_regex?(window : Array(Char)) : Bool
+      last_char = window.last?
+      return true if last_char && REGEX_PRECEDING_CHARS.includes?(last_char)
+
+      REGEX_PRECEDING_KEYWORDS.each do |keyword|
+        return true if window_ends_with?(window, keyword)
+      end
+
+      false
+    end
+
+    private def self.window_ends_with?(window : Array(Char), keyword : String) : Bool
+      return false if window.size < keyword.size
+      offset = window.size - keyword.size
+      keyword.each_char_with_index do |ch, i|
+        return false unless window[offset + i] == ch
+      end
+      true
+    end
+
+    private def self.find_matching_impl(src, open_idx : Int32, open_char : Char, close_char : Char) : Int32?
+      size = src.size
+      count = 1
+      idx = open_idx + 1
+
+      while idx < size && count > 0
+        # Try to skip literals
+        if skip_idx = simple_literal_end(src, size, idx)
+          idx = skip_idx
+          next
+        end
+
+        case chr(src, idx)
+        when open_char
+          count += 1
+        when close_char
+          count -= 1
+        end
+        idx += 1
+
+        return idx - 1 if count == 0
+      end
+
+      nil
+    end
+
+    # Simplified literal skip that doesn't accumulate content - just returns new position
+    private def self.simple_literal_end(src, size : Int32, pos : Int32) : Int32?
+      char = chr(src, pos)
+
+      # Skip single-line comments
+      if char == '/' && pos + 1 < size && chr(src, pos + 1) == '/'
+        while pos < size && chr(src, pos) != '\n'
+          pos += 1
+        end
+        return pos
+      end
+
+      # Skip multi-line comments
+      if char == '/' && pos + 1 < size && chr(src, pos + 1) == '*'
+        pos += 2
+        while pos + 1 < size && !(chr(src, pos) == '*' && chr(src, pos + 1) == '/')
+          pos += 1
+        end
+        pos += 2 if pos + 1 < size
         return pos
       end
 
@@ -245,8 +349,8 @@ module Noir
       if char == '"' || char == '\''
         quote = char
         pos += 1
-        while pos < content.size && content[pos] != quote
-          if content[pos] == '\\' && pos + 1 < content.size
+        while pos < size && chr(src, pos) != quote
+          if chr(src, pos) == '\\' && pos + 1 < size
             pos += 2
           else
             pos += 1
@@ -259,8 +363,8 @@ module Noir
       # Skip template literals
       if char == '`'
         pos += 1
-        while pos < content.size && content[pos] != '`'
-          if content[pos] == '\\' && pos + 1 < content.size
+        while pos < size && chr(src, pos) != '`'
+          if chr(src, pos) == '\\' && pos + 1 < size
             pos += 2
           else
             pos += 1
@@ -274,10 +378,10 @@ module Noir
       if char == '/'
         # Look back for regex-preceding context
         prev_idx = pos - 1
-        while prev_idx > 0 && content[prev_idx].whitespace?
+        while prev_idx > 0 && chr(src, prev_idx).whitespace?
           prev_idx -= 1
         end
-        prev_char = prev_idx >= 0 ? content[prev_idx] : '('
+        prev_char = prev_idx >= 0 ? chr(src, prev_idx) : '('
 
         # Check for punctuation or extract previous word for keyword check
         is_regex = REGEX_PRECEDING_CHARS.includes?(prev_char)
@@ -285,11 +389,11 @@ module Noir
         unless is_regex
           word_end = prev_idx + 1
           word_start = prev_idx
-          while word_start > 0 && (content[word_start - 1].alphanumeric? || content[word_start - 1] == '_')
+          while word_start > 0 && (chr(src, word_start - 1).alphanumeric? || chr(src, word_start - 1) == '_')
             word_start -= 1
           end
           if word_start < word_end
-            prev_word = content[word_start...word_end]
+            prev_word = word_string(src, word_start, word_end)
             is_regex = REGEX_PRECEDING_KEYWORDS.includes?(prev_word)
           end
         end
@@ -297,23 +401,23 @@ module Noir
         if is_regex
           pos += 1
           in_char_class = false
-          while pos < content.size
-            break if content[pos] == '/' && !in_char_class
-            if content[pos] == '\\' && pos + 1 < content.size
+          while pos < size
+            break if chr(src, pos) == '/' && !in_char_class
+            if chr(src, pos) == '\\' && pos + 1 < size
               pos += 2
-            elsif content[pos] == '[' && !in_char_class
+            elsif chr(src, pos) == '[' && !in_char_class
               in_char_class = true
               pos += 1
-            elsif content[pos] == ']' && in_char_class
+            elsif chr(src, pos) == ']' && in_char_class
               in_char_class = false
               pos += 1
             else
               pos += 1
             end
           end
-          pos += 1 if pos < content.size
+          pos += 1 if pos < size
           # Skip regex flags
-          while pos < content.size && content[pos].in?('g', 'i', 'm', 's', 'u', 'y', 'd')
+          while pos < size && chr(src, pos).in?('g', 'i', 'm', 's', 'u', 'y', 'd')
             pos += 1
           end
           return pos


### PR DESCRIPTION
## Summary

Third PR of the perf series (#2294, #2295). `JSLiteralScanner` — the literal-aware brace/paren matcher behind the **express / fastify / fresh / tanstack** analyzers and the express router-mount scanner — was quadratic on two independent axes:

1. **Accumulation** (quadratic even on pure ASCII): `extract_paren_content`/`try_skip_literal` built output via per-char `String#+` and re-copied the **whole accumulated prefix** on every literal encountered; `looks_like_regex?` re-materialized `accumulated.rstrip.chars` on every `/`.
2. **Indexing** (quadratic on non-ASCII): every scanner probed `content[pos]`, which is O(index) once the file contains any multi-byte UTF-8 char.

## The rewrite

- Public API and **char-index semantics unchanged** (callers slice with char-based `String#[]`)
- All-ASCII content (the common case) scans its **byte slice, zero allocation**; non-ASCII pays one up-front `chars` materialization and stays linear
- Output accumulates through `String::Builder`; regex-context detection tracks a 12-char rolling tail window instead of reprocessing the prefix
- Same treatment for the remaining per-char `String#+` accumulators: `JSLexer` token values (template literals in real JS carry tens of KB) and Hummingbird's `first_positional_arg`

**Gotcha for future reference:** the ASCII fast path is gated on `bytesize == size` (O(1) — `size` is cached per string) instead of `String#ascii_only?`, which re-scans every byte per call and benchmarked as an **86× slowdown** on repeated brace matching over the same file.

## Benchmarks (release, old vs new)

Express-like 108 KB corpus, 1,600 call sites:

| Operation | old | new | Δ |
|---|---|---|---|
| `find_matching_brace` ASCII (all sites) | 473 µs | 147 µs | **3.2×** |
| `find_matching_brace` non-ASCII (all sites) | 6.57 s | 300 ms | **21.9×** |
| `extract_paren_content` 100 KB args | 207 ms | 378 µs | **548×** (2.34 GB → 257 kB allocs) |

## Regression testing

- **Per-site equivalence check** old-vs-new over *every* brace/paren position of both corpora (content + end positions): **0 mismatches**
- Spec suite extended with pinned edge cases (regex-vs-division, escaped-slash regex + flags, unterminated-literal past-the-end position, keyword-context regex containing a brace) and non-ASCII char-index cases — **golden-verified**: the same 34 specs pass against the OLD implementation at merge-base
- Full `spec/unit_test` (3,713) + `spec/functional_test` (21,088): 0 failures
- Main-vs-branch binary diff over all ~620 fixture apps (both passes): **zero diffs**
- `just check` clean