### PR TITLE
perf: linear char scanning in Groovy literal scanner and node:http walkers

### DIFF
--- a/spec/unit_test/utils/groovy_literal_scanner_spec.cr
+++ b/spec/unit_test/utils/groovy_literal_scanner_spec.cr
@@ -169,5 +169,30 @@ describe Noir::GroovyLiteralScanner do
         Noir::GroovyLiteralScanner.skip_literal("$foo", 0).should be_nil
       end
     end
+
+    context "Array(Char) source (linear non-ASCII path)" do
+      it "agrees with the String overload across every position of a non-ASCII snippet" do
+        content = %(def greet = "안녕하세요 🎉" ; assert /한글\\/regex/ ; x = '값')
+        chars = content.chars
+        chars.size.times do |i|
+          Noir::GroovyLiteralScanner.skip_literal(chars, i).should eq(
+            Noir::GroovyLiteralScanner.skip_literal(content, i)
+          ), "mismatch at position #{i}"
+        end
+      end
+
+      it "returns char indices for a quoted literal holding multi-byte chars" do
+        content = "x = \"한글 문자열\" tail"
+        result = Noir::GroovyLiteralScanner.skip_literal(content.chars, 4)
+        result.should eq(content.index(" tail"))
+      end
+
+      it "detects slashy strings after keywords with multi-byte context" do
+        content = "리턴값 = 0; return /패턴/"
+        pos = content.index!("/")
+        result = Noir::GroovyLiteralScanner.skip_literal(content.chars, pos)
+        result.should eq(content.size)
+      end
+    end
   end
 end

--- a/src/analyzer/analyzers/groovy/grails.cr
+++ b/src/analyzer/analyzers/groovy/grails.cr
@@ -257,7 +257,7 @@ module Analyzer::Groovy
       while i < chars.size
         c = chars[i]
 
-        if literal_end = Noir::GroovyLiteralScanner.skip_literal(body, i)
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(chars, i)
           i = literal_end
           next
         end
@@ -566,7 +566,7 @@ module Analyzer::Groovy
       depth = 1
       i = open_idx + 1
       while i < chars.size && depth > 0
-        if literal_end = Noir::GroovyLiteralScanner.skip_literal(text, i)
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(chars, i)
           i = literal_end
           next
         end
@@ -674,7 +674,7 @@ module Analyzer::Groovy
       i += 1
 
       while i < chars.size && depth > 0
-        if literal_end = Noir::GroovyLiteralScanner.skip_literal(text, i)
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(chars, i)
           i = literal_end
           next
         end
@@ -713,7 +713,7 @@ module Analyzer::Groovy
       while i < size
         c = chars[i]
 
-        if literal_end = Noir::GroovyLiteralScanner.skip_literal(text, i)
+        if literal_end = Noir::GroovyLiteralScanner.skip_literal(chars, i)
           append_source_range(result, chars, i, literal_end)
           i = literal_end
           next

--- a/src/miniparsers/groovy_callee_extractor.cr
+++ b/src/miniparsers/groovy_callee_extractor.cr
@@ -98,34 +98,40 @@ module Noir::GroovyCalleeExtractor
   end
 
   private def strip_non_code(body : String) : String
+    # Walk a materialized chars array: `String#[](Int)` re-seeks from byte 0
+    # on every access once `body` holds a multi-byte char (O(n) per access,
+    # O(n^2) for this whole-body walk). Char offsets and emitted output are
+    # unchanged.
+    chars = body.chars
+    size = chars.size
     index = 0
     stripped = String::Builder.new
 
-    while index < body.size
-      char = body[index]
+    while index < size
+      char = chars[index]
 
-      if index + 1 < body.size && char == '/' && body[index + 1] == '/'
-        append_blanks_until_line_end(stripped, body, index)
+      if index + 1 < size && char == '/' && chars[index + 1] == '/'
+        append_blanks_until_line_end(stripped, chars, index)
         index += 2
-        while index < body.size && body[index] != '\n'
+        while index < size && chars[index] != '\n'
           index += 1
         end
         next
       end
 
-      if index + 1 < body.size && char == '/' && body[index + 1] == '*'
+      if index + 1 < size && char == '/' && chars[index + 1] == '*'
         end_index = index + 2
-        while end_index + 1 < body.size && !(body[end_index] == '*' && body[end_index + 1] == '/')
+        while end_index + 1 < size && !(chars[end_index] == '*' && chars[end_index + 1] == '/')
           end_index += 1
         end
-        end_index += 2 if end_index + 1 < body.size
-        append_blanks(stripped, body, index, end_index)
+        end_index += 2 if end_index + 1 < size
+        append_blanks(stripped, chars, index, end_index)
         index = end_index
         next
       end
 
-      if literal_end = Noir::GroovyLiteralScanner.skip_literal(body, index)
-        append_blanks(stripped, body, index, literal_end)
+      if literal_end = Noir::GroovyLiteralScanner.skip_literal(chars, index)
+        append_blanks(stripped, chars, index, literal_end)
         index = literal_end
         next
       end
@@ -137,18 +143,18 @@ module Noir::GroovyCalleeExtractor
     stripped.to_s
   end
 
-  private def append_blanks_until_line_end(stripped : String::Builder, body : String, start : Int32)
+  private def append_blanks_until_line_end(stripped : String::Builder, chars : Array(Char), start : Int32)
     index = start
-    while index < body.size && body[index] != '\n'
+    while index < chars.size && chars[index] != '\n'
       stripped << ' '
       index += 1
     end
   end
 
-  private def append_blanks(stripped : String::Builder, body : String, start : Int32, finish : Int32)
+  private def append_blanks(stripped : String::Builder, chars : Array(Char), start : Int32, finish : Int32)
     index = start
-    while index < finish && index < body.size
-      stripped << (body[index] == '\n' ? '\n' : ' ')
+    while index < finish && index < chars.size
+      stripped << (chars[index] == '\n' ? '\n' : ' ')
       index += 1
     end
   end

--- a/src/miniparsers/js_http_route_extractor.cr
+++ b/src/miniparsers/js_http_route_extractor.cr
@@ -269,29 +269,34 @@ module Noir
     end
 
     private def self.arrow_params(content : String, start_pos : Int32, arrow_idx : Int32) : String
+      # Backward walk over a materialized chars array — `String#[](Int)`
+      # re-seeks from byte 0 per access once `content` holds a multi-byte
+      # char, and `find_open_paren_backward` can walk arbitrarily far left.
+      # One O(n) materialization per candidate handler keeps it linear.
+      chars = content.chars
       left_end = arrow_idx - 1
-      while left_end >= start_pos && content[left_end].whitespace?
+      while left_end >= start_pos && chars[left_end].whitespace?
         left_end -= 1
       end
 
-      if left_end >= start_pos && content[left_end] == ')'
-        if left_open = find_open_paren_backward(content, left_end)
+      if left_end >= start_pos && chars[left_end] == ')'
+        if left_open = find_open_paren_backward(chars, left_end)
           return content[(left_open + 1)...left_end]
         end
       end
 
       left_start = left_end
-      while left_start >= start_pos && identifier_char?(content[left_start])
+      while left_start >= start_pos && identifier_char?(chars[left_start])
         left_start -= 1
       end
       content[(left_start + 1)..left_end]
     end
 
-    private def self.find_open_paren_backward(content : String, close_idx : Int32) : Int32?
+    private def self.find_open_paren_backward(chars : Array(Char), close_idx : Int32) : Int32?
       depth = 0
       i = close_idx
       while i >= 0
-        case content[i]
+        case chars[i]
         when ')'
           depth += 1
         when '('
@@ -760,6 +765,10 @@ module Noir
 
     private def self.split_top_level(content : String, start_pos : Int32, end_pos : Int32, delimiter : Char) : Array(Tuple(String, Int32))
       args = [] of Tuple(String, Int32)
+      # Chars-array walk (see arrow_params) — this scans a whole argument
+      # span at absolute offsets into the file, so per-access String
+      # re-seeking made it O(span x file) on non-ASCII sources.
+      chars = content.chars
       arg_start = start_pos
       depth = 0
       quote : Char? = nil
@@ -767,7 +776,7 @@ module Noir
       i = start_pos
 
       while i < end_pos
-        char = content[i]
+        char = chars[i]
         if quote
           if escaped
             escaped = false
@@ -789,21 +798,24 @@ module Noir
           depth -= 1 if depth > 0
         when delimiter
           if depth == 0
-            args << normalized_arg(content, arg_start, i)
+            args << normalized_arg(content, chars, arg_start, i)
             arg_start = i + 1
           end
         end
         i += 1
       end
 
-      args << normalized_arg(content, arg_start, end_pos)
+      args << normalized_arg(content, chars, arg_start, end_pos)
       args
     end
 
-    private def self.normalized_arg(content : String, start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
-      start_idx = skip_whitespace(content, start_pos)
+    private def self.normalized_arg(content : String, chars : Array(Char), start_pos : Int32, end_pos : Int32) : Tuple(String, Int32)
+      start_idx = start_pos
+      while start_idx < chars.size && chars[start_idx].whitespace?
+        start_idx += 1
+      end
       stop_idx = end_pos
-      while stop_idx > start_idx && content[stop_idx - 1].whitespace?
+      while stop_idx > start_idx && chars[stop_idx - 1].whitespace?
         stop_idx -= 1
       end
 

--- a/src/utils/groovy_literal_scanner.cr
+++ b/src/utils/groovy_literal_scanner.cr
@@ -1,6 +1,13 @@
 module Noir::GroovyLiteralScanner
   extend self
 
+  # Every scanner below is generic over an indexed char source: `String`
+  # (existing callers; O(1) per access only while the content is pure
+  # ASCII) or `Array(Char)` (hot callers that already materialized a chars
+  # array for their own scan loop — String#[](Int) re-seeks from byte 0 on
+  # every access once the content holds a multi-byte char, so passing the
+  # chars array keeps the whole walk linear on non-ASCII sources).
+
   SLASHY_PRECEDING_CHARS = [
     '(', '[', '{', ',', ':', ';', '=', '!', '&', '|', '?',
     '+', '-', '*', '%', '<', '>', '~',
@@ -10,7 +17,7 @@ module Noir::GroovyLiteralScanner
     "assert", "case", "in", "return", "throw",
   }
 
-  def skip_literal(content : String, pos : Int32) : Int32?
+  def skip_literal(content, pos : Int32) : Int32?
     return if pos >= content.size
 
     char = content[pos]
@@ -23,11 +30,11 @@ module Noir::GroovyLiteralScanner
     nil
   end
 
-  private def dollar_slashy_start?(content : String, pos : Int32) : Bool
+  private def dollar_slashy_start?(content, pos : Int32) : Bool
     pos + 1 < content.size && content[pos] == '$' && content[pos + 1] == '/'
   end
 
-  private def triple_quote_start?(content : String, pos : Int32, quote : Char) : Bool
+  private def triple_quote_start?(content, pos : Int32, quote : Char) : Bool
     return false unless quote == '"' || quote == '\''
 
     pos + 2 < content.size &&
@@ -36,7 +43,7 @@ module Noir::GroovyLiteralScanner
       content[pos + 2] == quote
   end
 
-  private def slashy_start?(content : String, pos : Int32) : Bool
+  private def slashy_start?(content, pos : Int32) : Bool
     return false unless content[pos] == '/'
     return false if pos + 1 < content.size && {'/', '*', '='}.includes?(content[pos + 1])
 
@@ -50,7 +57,7 @@ module Noir::GroovyLiteralScanner
     SLASHY_PRECEDING_KEYWORDS.includes?(word)
   end
 
-  private def previous_nonspace_index(content : String, pos : Int32) : Int32?
+  private def previous_nonspace_index(content, pos : Int32) : Int32?
     index = pos - 1
     while index >= 0
       return index unless content[index].whitespace?
@@ -59,21 +66,29 @@ module Noir::GroovyLiteralScanner
     nil
   end
 
-  private def previous_word(content : String, word_end : Int32) : String
+  private def previous_word(content, word_end : Int32) : String
     end_exclusive = word_end + 1
     index = word_end
     while index >= 0 && identifier_char?(content[index])
       index -= 1
     end
 
-    content[(index + 1)...end_exclusive]
+    word_at(content, (index + 1)...end_exclusive)
+  end
+
+  private def word_at(content : String, range : Range(Int32, Int32)) : String
+    content[range]
+  end
+
+  private def word_at(content : Array(Char), range : Range(Int32, Int32)) : String
+    content[range].join
   end
 
   private def identifier_char?(char : Char) : Bool
     char.alphanumeric? || char == '_' || char == '$'
   end
 
-  private def skip_quoted(content : String, pos : Int32, quote : Char) : Int32
+  private def skip_quoted(content, pos : Int32, quote : Char) : Int32
     index = pos + 1
     while index < content.size
       if content[index] == '\\' && index + 1 < content.size
@@ -91,7 +106,7 @@ module Noir::GroovyLiteralScanner
     content.size
   end
 
-  private def skip_triple_quote(content : String, pos : Int32, quote : Char) : Int32
+  private def skip_triple_quote(content, pos : Int32, quote : Char) : Int32
     index = pos + 3
     while index + 2 < content.size
       if content[index] == quote &&
@@ -107,7 +122,7 @@ module Noir::GroovyLiteralScanner
     content.size
   end
 
-  private def skip_dollar_slashy(content : String, pos : Int32) : Int32
+  private def skip_dollar_slashy(content, pos : Int32) : Int32
     index = pos + 2
     while index + 1 < content.size
       if content[index] == '/' &&
@@ -122,7 +137,7 @@ module Noir::GroovyLiteralScanner
     content.size
   end
 
-  private def skip_slashy(content : String, pos : Int32) : Int32
+  private def skip_slashy(content, pos : Int32) : Int32
     index = pos + 1
     while index < content.size
       if content[index] == '\\' && index + 1 < content.size
@@ -138,7 +153,7 @@ module Noir::GroovyLiteralScanner
     content.size
   end
 
-  private def escaped?(content : String, pos : Int32) : Bool
+  private def escaped?(content, pos : Int32) : Bool
     backslashes = 0
     index = pos - 1
     while index >= 0 && content[index] == '\\'
@@ -149,7 +164,7 @@ module Noir::GroovyLiteralScanner
     backslashes.odd?
   end
 
-  private def escaped_dollar_slashy_delimiter?(content : String, start : Int32, slash_pos : Int32) : Bool
+  private def escaped_dollar_slashy_delimiter?(content, start : Int32, slash_pos : Int32) : Bool
     slash_pos > start + 2 && content[slash_pos - 1] == '$'
   end
 end


### PR DESCRIPTION
## Summary

Fifth PR of the perf series (#2294 #2295 #2296 #2297) — first half of the remaining `String#[](Int)` sweep, covering shared utils + miniparsers. Crystal's `String#[](Int)` re-seeks from byte 0 on every access once the content holds a multi-byte UTF-8 char, so whole-span index loops were **O(n²) on non-ASCII sources**.

- **`utils/groovy_literal_scanner.cr`** — generalized over an indexed char source: `String` (existing callers, unchanged behavior) or `Array(Char)`. All four `grails.cr` call sites and the Groovy callee extractor already materialize a chars array for their own scan loops (from an earlier fix) but still passed the `String` down — the scanner itself was the remaining quadratic hotspot. They now pass the chars array.
- **`miniparsers/groovy_callee_extractor.cr`** — `strip_non_code` + `append_blanks*` walk a materialized chars array (whole method body per call).
- **`miniparsers/js_http_route_extractor.cr`** — `split_top_level` / `normalized_arg` / `arrow_params` / `find_open_paren_backward` walk chars arrays; they scan argument spans at **absolute file offsets**, making them O(span × file) on non-ASCII `node:http` sources.

## Regression testing

- New unit specs pin the `Array(Char)` overload against the `String` overload **across every position** of a non-ASCII snippet, plus multi-byte quoted/slashy cases
- Full `spec/unit_test` (3,716) + `spec/functional_test` (21,093): 0 failures
- Main-vs-branch binary diff over all ~620 fixture apps (both passes): **zero diffs**
- `just check` clean