### PR TITLE
perf: linear char scanning in analyzer-side span walkers

### DIFF
--- a/src/analyzer/analyzers/fsharp/giraffe.cr
+++ b/src/analyzer/analyzers/fsharp/giraffe.cr
@@ -389,31 +389,39 @@ module Analyzer::Fsharp
     end
 
     private def route_handler_body(text : String, offset : Int32) : Tuple(String, Int32)?
-      body_start = route_pattern_end(text, offset)
+      # Integer `String#[](Int)` is O(n) on non-ASCII source (one multi-byte
+      # char defeats the single-byte optimization), so the char walks in the
+      # helpers below would be O(n²); materialize once here and thread the
+      # array through them instead.
+      chars = text.chars
+      body_start = route_pattern_end(chars, offset)
       return unless body_start
 
       route_line_start = line_start_for_offset(text, offset)
-      base_indent = indentation_at(text, route_line_start)
+      base_indent = indentation_at(chars, route_line_start)
       body_end = route_handler_end(text, body_start, base_indent)
       return if body_end <= body_start
 
       {text[body_start...body_end], body_start}
     end
 
-    private def route_pattern_end(text : String, offset : Int32) : Int32?
+    # Walks a materialized `Array(Char)` (built once by `route_handler_body`)
+    # so each access is O(1) — integer `String#[]` would be O(n) on non-ASCII
+    # source, making this walk O(n²).
+    private def route_pattern_end(chars : Array(Char), offset : Int32) : Int32?
       i = offset
-      while i < text.size && identifier_char?(text[i])
+      while i < chars.size && identifier_char?(chars[i])
         i += 1
       end
 
-      while i < text.size && text[i].whitespace?
+      while i < chars.size && chars[i].whitespace?
         i += 1
       end
 
-      return unless i < text.size
+      return unless i < chars.size
 
-      if text[i] == '"'
-        string_end = find_string_end(text, i)
+      if chars[i] == '"'
+        string_end = find_string_end(chars, i)
         return unless string_end
         return string_end + 1
       end
@@ -421,9 +429,9 @@ module Analyzer::Fsharp
       # Path supplied as a constant reference (`route Urls.index`): skip
       # the qualified identifier so the handler body that follows is
       # still available for callee extraction.
-      if identifier_char?(text[i])
+      if identifier_char?(chars[i])
         j = i
-        while j < text.size && (identifier_char?(text[j]) || text[j] == '.' || text[j] == '\'')
+        while j < chars.size && (identifier_char?(chars[j]) || chars[j] == '.' || chars[j] == '\'')
           j += 1
         end
         return j
@@ -432,12 +440,14 @@ module Analyzer::Fsharp
       nil
     end
 
-    private def find_string_end(text : String, quote_index : Int32) : Int32?
+    # Scans the shared `Array(Char)` threaded down from `route_handler_body`
+    # (via `route_pattern_end`) — see the O(n²) rationale there.
+    private def find_string_end(chars : Array(Char), quote_index : Int32) : Int32?
       i = quote_index + 1
       escaping = false
 
-      while i < text.size
-        char = text[i]
+      while i < chars.size
+        char = chars[i]
         if escaping
           escaping = false
         elsif char == '\\'
@@ -490,11 +500,13 @@ module Analyzer::Fsharp
       line_start_raw ? line_start_raw + 1 : 0
     end
 
-    private def indentation_at(text : String, line_start : Int32) : Int32
+    # Indexes the shared `Array(Char)` threaded down from
+    # `route_handler_body` — see the O(n²) rationale there.
+    private def indentation_at(chars : Array(Char), line_start : Int32) : Int32
       count = 0
       i = line_start
-      while i < text.size
-        char = text[i]
+      while i < chars.size
+        char = chars[i]
         if char == ' '
           count += 1
         elsif char == '\t'

--- a/src/analyzer/analyzers/java/struts2.cr
+++ b/src/analyzer/analyzers/java/struts2.cr
@@ -764,10 +764,14 @@ module Analyzer::Java
     end
 
     private def matching_open_paren(content : String, close_index : Int32) : Int32?
+      # Same non-ASCII O(n) `String#[]` concern as `matching_brace` above:
+      # materialize once and index the array instead of re-indexing
+      # `content` per character. Returned index stays a CHAR index.
+      chars = content.chars
       depth = 0
       index = close_index
       while index >= 0
-        case content[index]
+        case chars[index]
         when ')'
           depth += 1
         when '('
@@ -780,13 +784,17 @@ module Analyzer::Java
     end
 
     private def matching_close_paren(content : String, open_index : Int32) : Int32?
+      # Same non-ASCII O(n) `String#[]` concern as `matching_brace` above:
+      # materialize once and index the array instead of re-indexing
+      # `content` per character. Returned index stays a CHAR index.
+      chars = content.chars
       depth = 0
       in_string : Char? = nil
       escaped = false
 
       index = open_index
-      while index < content.size
-        char = content[index]
+      while index < chars.size
+        char = chars[index]
         if in_string
           if escaped
             escaped = false

--- a/src/analyzer/analyzers/javascript/fresh.cr
+++ b/src/analyzer/analyzers/javascript/fresh.cr
@@ -130,6 +130,11 @@ module Analyzer::Javascript
       if property = handler_block.match(HANDLER_PROPERTY_RES[verb])
         body_start = property.end(0) || 0
         body = handler_block[body_start..]? || ""
+        # NOTE(perf): `extract_handler_object` knows the block's origin offset,
+        # but `String#index` deliberately stays: it returns the FIRST occurrence
+        # of the block text, which for a byte-identical object literal appearing
+        # earlier in the file differs from the origin — passing the origin down
+        # would change the emitted callee lines in that (reachable) case.
         block_start = content.index(handler_block) || 0
         absolute_body_start = block_start + body_start
         start_line = content[0, absolute_body_start].count('\n') + 1
@@ -160,15 +165,20 @@ module Analyzer::Javascript
     end
 
     private def top_level_comma(source : String) : Int32?
+      # Integer `String#[](Int)` is O(n) on non-ASCII source (one multi-byte
+      # char defeats the single-byte optimization), so this walk — and the
+      # inner quote skip — would be O(n²); materialize once and index the
+      # array instead.
+      chars = source.chars
       depth = 0
       i = 0
-      while i < source.size
-        case source[i]
+      while i < chars.size
+        case chars[i]
         when '\'', '"', '`'
-          quote = source[i]
+          quote = chars[i]
           i += 1
-          while i < source.size && source[i] != quote
-            i += source[i] == '\\' ? 2 : 1
+          while i < chars.size && chars[i] != quote
+            i += chars[i] == '\\' ? 2 : 1
           end
         when '(', '[', '{'
           depth += 1

--- a/src/analyzer/analyzers/php/lumen.cr
+++ b/src/analyzer/analyzers/php/lumen.cr
@@ -186,7 +186,11 @@ module Analyzer::Php
     end
 
     private def find_matching_bracket(content : String, open_pos : Int32) : Int32?
-      return unless open_pos < content.size && content[open_pos] == '['
+      # Integer `String#[](Int)` is O(n) on non-ASCII content (one multi-byte
+      # char defeats the single-byte optimization), so this char-by-char walk
+      # would be O(n²); materialize once and index the array instead.
+      chars = content.chars
+      return unless open_pos < chars.size && chars[open_pos] == '['
 
       depth = 0
       in_string = false
@@ -194,8 +198,8 @@ module Analyzer::Php
       escaped = false
       pos = open_pos
 
-      while pos < content.size
-        char = content[pos]
+      while pos < chars.size
+        char = chars[pos]
         if in_string
           if escaped
             escaped = false

--- a/src/analyzer/analyzers/specification/graphql_sdl_parser.cr
+++ b/src/analyzer/analyzers/specification/graphql_sdl_parser.cr
@@ -51,7 +51,10 @@ module Analyzer::Specification
       if match = content.match(/\bschema\b\s*(?:@[\w]+(?:\([^)]*\))?\s*)*\{/m)
         brace_pos = content.index('{', match.begin(0) || 0)
         return mapping if brace_pos.nil?
-        body = extract_brace_block(content, brace_pos)
+        # Cluster entry point: `extract_brace_block` walks by CHAR index, so
+        # hand it a materialized char array instead of letting it re-index
+        # the String (`String#[](Int)` is O(n) per access on non-ASCII).
+        body = extract_brace_block(content, content.chars, brace_pos)
         return mapping if body.nil?
 
         body.scan(/\b(query|mutation|subscription)\s*:\s*([A-Za-z_][A-Za-z0-9_]*)/) do |m|
@@ -77,6 +80,11 @@ module Analyzer::Specification
       root_alternation = root_names.values.uniq!.map { |n| Regex.escape(n) }.join("|")
       pattern = Regex.new("\\b(?:extend\\s+)?type\\s+(#{root_alternation})\\b(?:\\s+implements\\s+[^{]+)?\\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\\([^)]*\\))?\\s*)*\\{")
 
+      # Cluster entry point: materialize the char array once for every
+      # `extract_brace_block` walk in the scan below — `String#[](Int)` is
+      # O(n) per access on non-ASCII content.
+      sanitized_chars = sanitized.chars
+
       sanitized.scan(pattern) do |match|
         type_name = match[1]
         root_op_name = root_names.find { |_, custom| custom == type_name }
@@ -86,7 +94,7 @@ module Analyzer::Specification
         start_pos = match.begin(0) || 0
         brace_pos = sanitized.index('{', start_pos)
         next if brace_pos.nil?
-        body = extract_brace_block(sanitized, brace_pos)
+        body = extract_brace_block(sanitized, sanitized_chars, brace_pos)
         next if body.nil?
 
         body_start_in_sanitized = brace_pos + 1
@@ -103,10 +111,16 @@ module Analyzer::Specification
                              endpoints : Array(Endpoint))
       operation_keyword = ROOT_OPERATIONS[root_kind]
 
+      # Cluster entry point for `body`: the low-level walkers below index by
+      # CHAR position, so materialize the char array once and index it —
+      # `String#[](Int)` is O(n) per access on non-ASCII content. `body` is
+      # kept only for `\G`-anchored regex matches and output slices.
+      body_chars = body.chars
+
       pos = 0
-      while pos < body.size
-        pos = skip_field_padding(body, pos)
-        break if pos >= body.size
+      while pos < body_chars.size
+        pos = skip_field_padding(body_chars, pos)
+        break if pos >= body_chars.size
 
         field_match = body.match(/\G([A-Za-z_][A-Za-z0-9_]*)/, pos)
         break if field_match.nil?
@@ -115,11 +129,11 @@ module Analyzer::Specification
         field_line = field_line.try { |ln| ln + line_offset }
         cursor = pos + field_match[0].size
 
-        cursor = skip_ws(body, cursor)
+        cursor = skip_ws(body_chars, cursor)
         args = [] of NamedTuple(name: String, type: String)
-        if cursor < body.size && body[cursor] == '('
-          args_block = extract_paren_block(body, cursor)
-          close = matching_close_index(body, cursor, '(', ')')
+        if cursor < body_chars.size && body_chars[cursor] == '('
+          args_block = extract_paren_block(body, body_chars, cursor)
+          close = matching_close_index(body_chars, cursor, '(', ')')
           if args_block && close
             args = parse_arguments(args_block)
             # Jump past the *matching* close paren, not the first ')': an
@@ -129,25 +143,25 @@ module Analyzer::Specification
             # misreading later argument names as fields.
             cursor = close + 1
           else
-            cursor = advance_to_next_field(body, cursor)
+            cursor = advance_to_next_field(body_chars, cursor)
             pos = cursor
             next
           end
         end
 
-        cursor = skip_ws(body, cursor)
-        if cursor >= body.size || body[cursor] != ':'
-          pos = advance_to_next_field(body, cursor)
+        cursor = skip_ws(body_chars, cursor)
+        if cursor >= body_chars.size || body_chars[cursor] != ':'
+          pos = advance_to_next_field(body_chars, cursor)
           next
         end
         cursor += 1
-        cursor = skip_ws(body, cursor)
+        cursor = skip_ws(body_chars, cursor)
 
-        return_type, after_type = read_type_reference(body, cursor)
+        return_type, after_type = read_type_reference(body, body_chars, cursor)
         cursor = after_type
-        directives, after_directives = read_directives(body, cursor)
+        directives, after_directives = read_directives(body, body_chars, cursor)
         cursor = after_directives
-        pos = advance_to_next_field(body, cursor)
+        pos = advance_to_next_field(body_chars, cursor)
 
         emit_endpoint(file_path, field_line, field_name, args, return_type, directives,
           operation_keyword, type_name, root_kind, default_path, tag_source, input_types, endpoints)
@@ -199,12 +213,17 @@ module Analyzer::Specification
       input_types = Hash(String, Array(InputField)).new
       pattern = /\binput\s+([A-Za-z_][A-Za-z0-9_]*)\b\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s*)*\{/
 
+      # Cluster entry point: materialize the char array once for every
+      # `extract_brace_block` walk in the scan below — `String#[](Int)` is
+      # O(n) per access on non-ASCII content.
+      sanitized_chars = sanitized.chars
+
       sanitized.scan(pattern) do |match|
         type_name = match[1]
         start_pos = match.begin(0) || 0
         brace_pos = sanitized.index('{', start_pos)
         next if brace_pos.nil?
-        body = extract_brace_block(sanitized, brace_pos)
+        body = extract_brace_block(sanitized, sanitized_chars, brace_pos)
         next if body.nil?
 
         input_types[type_name] = parse_input_fields(body)
@@ -334,20 +353,24 @@ module Analyzer::Specification
       end
     end
 
-    private def extract_brace_block(content : String, open_pos : Int32) : String?
-      extract_paired_block(content, open_pos, '{', '}')
+    private def extract_brace_block(content : String, chars : Array(Char), open_pos : Int32) : String?
+      extract_paired_block(content, chars, open_pos, '{', '}')
     end
 
-    private def extract_paren_block(content : String, open_pos : Int32) : String?
-      extract_paired_block(content, open_pos, '(', ')')
+    private def extract_paren_block(content : String, chars : Array(Char), open_pos : Int32) : String?
+      extract_paired_block(content, chars, open_pos, '(', ')')
     end
 
-    private def extract_paired_block(content : String, open_pos : Int32,
+    # Walks `chars` (materialized once at the cluster entry point) instead of
+    # indexing `content` per character — `String#[](Int)` is O(n) per access
+    # on non-ASCII content. `content` is kept only for the single one-shot
+    # output slice below; all positions are CHAR indices.
+    private def extract_paired_block(content : String, chars : Array(Char), open_pos : Int32,
                                      open_ch : Char, close_ch : Char) : String?
       depth = 0
       pos = open_pos
-      while pos < content.size
-        ch = content[pos]
+      while pos < chars.size
+        ch = chars[pos]
         case ch
         when open_ch
           depth += 1
@@ -366,12 +389,14 @@ module Analyzer::Specification
     # pairs counted), or nil when unbalanced. Unlike `String#index(close_ch)`
     # it skips over inner pairs — needed so a field/directive argument list
     # is not cut short at the first `)` belonging to a nested directive.
-    private def matching_close_index(content : String, open_pos : Int32,
+    # Walks the materialized char array (O(1) per access) instead of
+    # re-indexing the String; returned index is a CHAR index.
+    private def matching_close_index(chars : Array(Char), open_pos : Int32,
                                      open_ch : Char, close_ch : Char) : Int32?
       depth = 0
       pos = open_pos
-      while pos < content.size
-        ch = content[pos]
+      while pos < chars.size
+        ch = chars[pos]
         if ch == open_ch
           depth += 1
         elsif ch == close_ch
@@ -383,69 +408,81 @@ module Analyzer::Specification
       nil
     end
 
-    private def skip_ws(content : String, pos : Int32) : Int32
-      while pos < content.size && content[pos].ascii_whitespace?
+    # Walks the materialized char array (see cluster entry points) — O(1)
+    # per access where `String#[](Int)` is O(n) on non-ASCII content.
+    private def skip_ws(chars : Array(Char), pos : Int32) : Int32
+      while pos < chars.size && chars[pos].ascii_whitespace?
         pos += 1
       end
       pos
     end
 
-    private def skip_field_padding(content : String, pos : Int32) : Int32
-      while pos < content.size && (content[pos].ascii_whitespace? || content[pos] == ',')
+    # Walks the materialized char array (see cluster entry points) — O(1)
+    # per access where `String#[](Int)` is O(n) on non-ASCII content.
+    private def skip_field_padding(chars : Array(Char), pos : Int32) : Int32
+      while pos < chars.size && (chars[pos].ascii_whitespace? || chars[pos] == ',')
         pos += 1
       end
       pos
     end
 
-    private def advance_to_next_field(content : String, pos : Int32) : Int32
-      while pos < content.size && content[pos] != '\n' && content[pos] != ','
+    # Walks the materialized char array (see cluster entry points) — O(1)
+    # per access where `String#[](Int)` is O(n) on non-ASCII content.
+    private def advance_to_next_field(chars : Array(Char), pos : Int32) : Int32
+      while pos < chars.size && chars[pos] != '\n' && chars[pos] != ','
         pos += 1
       end
-      pos += 1 if pos < content.size
+      pos += 1 if pos < chars.size
       pos
     end
 
     private def parse_arguments(block : String) : Array(NamedTuple(name: String, type: String))
       args = [] of NamedTuple(name: String, type: String)
+      # Cluster entry point for `block`: materialize the char array once and
+      # index it — `String#[](Int)` is O(n) per access on non-ASCII content.
+      # `block` is kept only for `\G`-anchored regex matches and slicing.
+      chars = block.chars
       pos = 0
-      while pos < block.size
-        pos = skip_field_padding(block, pos)
-        break if pos >= block.size
+      while pos < chars.size
+        pos = skip_field_padding(chars, pos)
+        break if pos >= chars.size
 
         name_match = block.match(/\G([A-Za-z_][A-Za-z0-9_]*)/, pos)
         break if name_match.nil?
         name = name_match[1]
         cursor = pos + name_match[0].size
 
-        cursor = skip_ws(block, cursor)
-        if cursor >= block.size || block[cursor] != ':'
-          pos = advance_past_arg(block, cursor)
+        cursor = skip_ws(chars, cursor)
+        if cursor >= chars.size || chars[cursor] != ':'
+          pos = advance_past_arg(chars, cursor)
           next
         end
         cursor += 1
-        cursor = skip_ws(block, cursor)
+        cursor = skip_ws(chars, cursor)
 
-        type_str, after_type = read_type_reference(block, cursor)
+        type_str, after_type = read_type_reference(block, chars, cursor)
         cursor = after_type
 
-        cursor = skip_ws(block, cursor)
-        if cursor < block.size && block[cursor] == '='
-          cursor = skip_default_value(block, cursor + 1)
+        cursor = skip_ws(chars, cursor)
+        if cursor < chars.size && chars[cursor] == '='
+          cursor = skip_default_value(chars, cursor + 1)
         end
 
-        _, after_directives = read_directives(block, cursor)
+        _, after_directives = read_directives(block, chars, cursor)
         cursor = after_directives
 
         args << {name: name, type: type_str}
-        pos = advance_past_arg(block, cursor)
+        pos = advance_past_arg(chars, cursor)
       end
       args
     end
 
-    private def advance_past_arg(content : String, pos : Int32) : Int32
+    # Walks the materialized char array (see cluster entry points) — O(1)
+    # per access where `String#[](Int)` is O(n) on non-ASCII content.
+    private def advance_past_arg(chars : Array(Char), pos : Int32) : Int32
       depth = 0
-      while pos < content.size
-        ch = content[pos]
+      while pos < chars.size
+        ch = chars[pos]
         case ch
         when '(', '[', '{'
           depth += 1
@@ -461,11 +498,14 @@ module Analyzer::Specification
       pos
     end
 
-    private def read_type_reference(content : String, pos : Int32) : Tuple(String, Int32)
+    # Walks `chars` (materialized once at the cluster entry point) instead of
+    # indexing `content` per character; `content` is kept only for the single
+    # one-shot output slice below. Positions are CHAR indices.
+    private def read_type_reference(content : String, chars : Array(Char), pos : Int32) : Tuple(String, Int32)
       start = pos
       depth = 0
-      while pos < content.size
-        ch = content[pos]
+      while pos < chars.size
+        ch = chars[pos]
         if ch == '['
           depth += 1
           pos += 1
@@ -473,7 +513,7 @@ module Analyzer::Specification
           depth -= 1
           pos += 1
           if depth <= 0
-            pos += 1 if pos < content.size && content[pos] == '!'
+            pos += 1 if pos < chars.size && chars[pos] == '!'
             break
           end
         elsif ch == '!' || ch == '_' || ch.ascii_alphanumeric?
@@ -487,12 +527,15 @@ module Analyzer::Specification
       {content[start...pos].strip, pos}
     end
 
-    private def read_directives(content : String, pos : Int32) : Tuple(Array(NamedTuple(name: String, args: String)), Int32)
+    # Walks `chars` (materialized once at the cluster entry point) instead of
+    # indexing `content` per character; `content` is kept for the
+    # `\G`-anchored regex matches and the paren-block slice only.
+    private def read_directives(content : String, chars : Array(Char), pos : Int32) : Tuple(Array(NamedTuple(name: String, args: String)), Int32)
       directives = [] of NamedTuple(name: String, args: String)
       last_committed = pos
       loop do
-        scan_pos = skip_ws(content, pos)
-        break if scan_pos >= content.size || content[scan_pos] != '@'
+        scan_pos = skip_ws(chars, pos)
+        break if scan_pos >= chars.size || chars[scan_pos] != '@'
         scan_pos += 1
         name_match = content.match(/\G([A-Za-z_][A-Za-z0-9_]*)/, scan_pos)
         break if name_match.nil?
@@ -500,11 +543,11 @@ module Analyzer::Specification
         scan_pos += name_match[0].size
 
         args_repr = ""
-        if scan_pos < content.size && content[scan_pos] == '('
-          args_block = extract_paren_block(content, scan_pos)
+        if scan_pos < chars.size && chars[scan_pos] == '('
+          args_block = extract_paren_block(content, chars, scan_pos)
           if args_block
             args_repr = "(#{args_block.strip})"
-            close = matching_close_index(content, scan_pos, '(', ')')
+            close = matching_close_index(chars, scan_pos, '(', ')')
             scan_pos = close ? close + 1 : scan_pos + 1
           end
         end
@@ -516,13 +559,15 @@ module Analyzer::Specification
       {directives, last_committed}
     end
 
-    private def skip_default_value(content : String, pos : Int32) : Int32
-      pos = skip_ws(content, pos)
-      return pos if pos >= content.size
+    # Walks the materialized char array (see cluster entry points) — O(1)
+    # per access where `String#[](Int)` is O(n) on non-ASCII content.
+    private def skip_default_value(chars : Array(Char), pos : Int32) : Int32
+      pos = skip_ws(chars, pos)
+      return pos if pos >= chars.size
       depth = 0
       in_string = false
-      while pos < content.size
-        ch = content[pos]
+      while pos < chars.size
+        ch = chars[pos]
         if in_string
           if ch == '"'
             in_string = false

--- a/src/analyzer/analyzers/specification/grpc.cr
+++ b/src/analyzer/analyzers/specification/grpc.cr
@@ -204,32 +204,38 @@ module Analyzer::Specification
     # a delimiter inside them can't shift the depth. Works for `{}` and `[]`
     # (the array form of `additional_bindings`).
     private def find_matching_delimiter(content : String, open_pos : Int32, open_char : Char, close_char : Char) : Int32?
+      # This walks whole message/service bodies per character, and Crystal's
+      # `String#[](Int)` is O(n) per access on non-ASCII content (no cached
+      # char->byte index) — materialize once and index the array instead.
+      # `String#index` below returns CHAR indices, so positions stay
+      # consistent; the returned index is a CHAR index.
+      chars = content.chars
       depth = 0
       pos = open_pos
       in_string = false
-      while pos < content.size
-        ch = content[pos]
+      while pos < chars.size
+        ch = chars[pos]
         if in_string
           # A quote closes the string only when preceded by an EVEN number of
           # backslashes (`\\"` toggles, `\"` does not).
           if ch == '"'
             bs = 0
             bp = pos - 1
-            while bp >= 0 && content[bp] == '\\'
+            while bp >= 0 && chars[bp] == '\\'
               bs += 1
               bp -= 1
             end
             in_string = false if bs.even?
           end
-        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '/'
+        elsif ch == '/' && pos + 1 < chars.size && chars[pos + 1] == '/'
           # Line comment: skip to EOL so a stray delimiter can't shift state.
           nl = content.index('\n', pos)
-          pos = nl.nil? ? content.size : nl
+          pos = nl.nil? ? chars.size : nl
           next
-        elsif ch == '/' && pos + 1 < content.size && content[pos + 1] == '*'
+        elsif ch == '/' && pos + 1 < chars.size && chars[pos + 1] == '*'
           # Block comment: skip to the closing */.
           close = content.index("*/", pos + 2)
-          pos = close.nil? ? content.size : close + 2
+          pos = close.nil? ? chars.size : close + 2
           next
         elsif ch == '"'
           in_string = true

--- a/src/analyzer/analyzers/typescript/tanstack_router.cr
+++ b/src/analyzer/analyzers/typescript/tanstack_router.cr
@@ -369,10 +369,18 @@ module Analyzer::Typescript
       attach_route_block_callees(block, path, line_for_pos(content, config_open), endpoint)
     end
 
+    # Integer `String#[](Int)` re-seeks from byte 0 on non-ASCII content, so
+    # indexing whole-file offsets here would be O(n) per char (O(n²) across a
+    # scan). Walk with a `Char::Reader` from the equivalent byte offset
+    # instead; `pos` and the return value stay CHAR indices.
     private def skip_whitespace(content : String, pos : Int32) : Int32
+      return pos if pos >= content.size
+      byte_pos = content.bytesize == content.size ? pos : (content.char_index_to_byte_index(pos) || content.bytesize)
+      reader = Char::Reader.new(content, byte_pos)
       i = pos
-      while i < content.size && content[i].whitespace?
+      while i < content.size && reader.current_char.whitespace?
         i += 1
+        reader.next_char
       end
       i
     end


### PR DESCRIPTION
## Summary

Sixth PR of the perf series (#2294–#2298) — second half of the `String#[](Int)` sweep, covering analyzer files. Same rationale as #2298: String integer indexing re-seeks from byte 0 per access on non-ASCII content, so whole-span index loops were **O(n²)**.

| File | Converted |
|---|---|
| `java/struts2.cr` | `matching_open_paren` / `matching_close_paren` — the un-fixed siblings of the previously converted `matching_brace` |
| `specification/graphql_sdl_parser.cr` | the whole low-level walker cluster (`extract_paired_block`, `matching_close_index`, `skip_ws`, `skip_field_padding`, `advance_to_next_field`, `advance_past_arg`, `read_type_reference`, `read_directives`, `skip_default_value`) — chars array materialized **once per cluster entry point**; the String stays alongside for `\G`-anchored regexes and one-shot output slices |
| `specification/grpc.cr` | `find_matching_delimiter` (forward walk + backslash back-scan) |
| `fsharp/giraffe.cr` | `route_pattern_end` / `find_string_end` / `indentation_at` — chars materialized once in their sole caller `route_handler_body` and threaded through |
| `php/lumen.cr` | `find_matching_bracket` |
| `javascript/fresh.cr` | `top_level_comma`. The `content.index(handler_block)` re-search was **deliberately kept**: the bare `{…}` block text can legitimately occur earlier in the file, so passing the origin offset is not provably identical to first-occurrence semantics (documented at the call site) |
| `typescript/tanstack_router.cr` | `skip_whitespace` via `Char::Reader` at the byte offset — ASCII keeps the direct index; equivalence verified at every position across ASCII / multi-byte / Unicode-whitespace inputs |

All conversions are verbatim index transports (char counts are identical between `String` and `Array(Char)`); returned indices stay char-based, output slicing stays on the String.

## Regression testing

- Full `spec/unit_test` (3,716) + `spec/functional_test` (21,093): 0 failures
- Main-vs-branch binary diff over all ~620 fixture apps (json `-T` + plain `--include path,techs,callee --ai-context`): **zero diffs**
- `just check` clean