### PR TITLE
perf(analyzer): read spec files through the CodeLocator content cache

### DIFF
--- a/src/analyzer/analyzers/specification/asyncapi.cr
+++ b/src/analyzer/analyzers/specification/asyncapi.cr
@@ -28,7 +28,7 @@ module Analyzer::Specification
         jsons.each do |path|
           next unless File.exists?(path)
           details = Details.new(PathInfo.new(path))
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           process_json(JSON.parse(content), details, path)
         rescue e
           @logger.debug "Exception parsing AsyncAPI #{path}"
@@ -40,7 +40,7 @@ module Analyzer::Specification
         yamls.each do |path|
           next unless File.exists?(path)
           details = Details.new(PathInfo.new(path))
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           process_yaml(YAML.parse(content), details, path)
         rescue e
           @logger.debug "Exception parsing AsyncAPI #{path}"

--- a/src/analyzer/analyzers/specification/burp.cr
+++ b/src/analyzer/analyzers/specification/burp.cr
@@ -17,7 +17,7 @@ module Analyzer::Specification
       burp_files.each do |path|
         next unless File.exists?(path)
         begin
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           process_file(content, path)
         rescue e
           @logger.debug "Failed to parse Burp sitemap #{path}: #{e.message}"

--- a/src/analyzer/analyzers/specification/caido.cr
+++ b/src/analyzer/analyzers/specification/caido.cr
@@ -12,7 +12,7 @@ module Analyzer::Specification
       caido_files.each do |path|
         next unless File.exists?(path)
         details = Details.new(PathInfo.new(path))
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
 
         begin
           data = JSON.parse(content)

--- a/src/analyzer/analyzers/specification/envoy.cr
+++ b/src/analyzer/analyzers/specification/envoy.cr
@@ -21,7 +21,7 @@ module Analyzer::Specification
         yaml_files.each do |path|
           next unless File.exists?(path)
           details = Details.new(PathInfo.new(path))
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           begin
             process_yaml(YAML.parse(content), details)
           rescue e
@@ -36,7 +36,7 @@ module Analyzer::Specification
         json_files.each do |path|
           next unless File.exists?(path)
           details = Details.new(PathInfo.new(path))
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           begin
             process_json(JSON.parse(content), details)
           rescue e

--- a/src/analyzer/analyzers/specification/graphql_sdl.cr
+++ b/src/analyzer/analyzers/specification/graphql_sdl.cr
@@ -19,7 +19,7 @@ module Analyzer::Specification
       sdl_files.each do |sdl_file|
         next unless File.exists?(sdl_file)
         begin
-          content = File.read(sdl_file, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(sdl_file)
           GraphqlSdlParser.parse(content, sdl_file).each { |ep| @result << ep }
         rescue e
           @logger.debug "GraphQL SDL: failed to parse #{sdl_file}"

--- a/src/analyzer/analyzers/specification/insomnia.cr
+++ b/src/analyzer/analyzers/specification/insomnia.cr
@@ -13,7 +13,7 @@ module Analyzer::Specification
       if json_files.is_a?(Array(String))
         json_files.each do |path|
           next unless File.exists?(path)
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           begin
             process_v4(JSON.parse(content), path)
           rescue e
@@ -27,7 +27,7 @@ module Analyzer::Specification
       if yaml_files.is_a?(Array(String))
         yaml_files.each do |path|
           next unless File.exists?(path)
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
           begin
             process_v5(YAML.parse(content), path)
           rescue e

--- a/src/analyzer/analyzers/specification/kong.cr
+++ b/src/analyzer/analyzers/specification/kong.cr
@@ -10,7 +10,7 @@ module Analyzer::Specification
         next unless File.exists?(path)
 
         details = Details.new(PathInfo.new(path))
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         begin
           process_doc(YAML.parse(content), details)
         rescue e

--- a/src/analyzer/analyzers/specification/oas2.cr
+++ b/src/analyzer/analyzers/specification/oas2.cr
@@ -330,7 +330,7 @@ module Analyzer::Specification
     private def process_json(swagger_json : String)
       return unless File.exists?(swagger_json)
       details = Details.new(PathInfo.new(swagger_json))
-      content = File.read(swagger_json, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(swagger_json)
       json_obj = JSON.parse(content)
       base_path = ""
       begin
@@ -397,7 +397,7 @@ module Analyzer::Specification
     private def process_yaml(swagger_yaml : String)
       return unless File.exists?(swagger_yaml)
       details = Details.new(PathInfo.new(swagger_yaml))
-      content = File.read(swagger_yaml, encoding: "utf-8", invalid: :skip)
+      content = read_file_content(swagger_yaml)
       yaml_obj = parse_yaml(content)
       base_path = ""
       begin

--- a/src/analyzer/analyzers/specification/oas3.cr
+++ b/src/analyzer/analyzers/specification/oas3.cr
@@ -424,7 +424,7 @@ module Analyzer::Specification
         oas3_jsons.each do |oas3_json|
           if File.exists?(oas3_json)
             details = Details.new(PathInfo.new(oas3_json))
-            content = File.read(oas3_json, encoding: "utf-8", invalid: :skip)
+            content = read_file_content(oas3_json)
             json_obj = JSON.parse(content)
 
             base_path = @url
@@ -444,7 +444,7 @@ module Analyzer::Specification
         oas3_yamls.each do |oas3_yaml|
           if File.exists?(oas3_yaml)
             details = Details.new(PathInfo.new(oas3_yaml))
-            content = File.read(oas3_yaml, encoding: "utf-8", invalid: :skip)
+            content = read_file_content(oas3_yaml)
             yaml_obj = parse_yaml(content)
 
             base_path = @url

--- a/src/analyzer/analyzers/specification/postman.cr
+++ b/src/analyzer/analyzers/specification/postman.cr
@@ -10,7 +10,7 @@ module Analyzer::Specification
       if postman_files.is_a?(Array(String))
         postman_files.each do |postman_file|
           if File.exists?(postman_file)
-            content = File.read(postman_file, encoding: "utf-8", invalid: :skip)
+            content = read_file_content(postman_file)
             json_obj = JSON.parse(content)
 
             begin

--- a/src/analyzer/analyzers/specification/raml.cr
+++ b/src/analyzer/analyzers/specification/raml.cr
@@ -18,7 +18,7 @@ module Analyzer::Specification
       if raml_specs.is_a?(Array(String))
         raml_specs.each do |raml_spec|
           next unless File.exists?(raml_spec)
-          content = File.read(raml_spec, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(raml_spec)
 
           # Only root API documents (`#%RAML 1.0` / `#%RAML 0.8`) describe
           # endpoints. Fragments — Library, Trait, ResourceType, DataType,
@@ -538,7 +538,7 @@ module Analyzer::Specification
       return {node: node, source_dir: source_dir} unless File.exists?(expanded)
 
       {
-        node:       YAML.parse(File.read(expanded, encoding: "utf-8", invalid: :skip)),
+        node:       YAML.parse(read_file_content(expanded)),
         source_dir: File.dirname(expanded),
       }
     rescue

--- a/src/analyzer/analyzers/specification/smithy.cr
+++ b/src/analyzer/analyzers/specification/smithy.cr
@@ -55,7 +55,7 @@ module Analyzer::Specification
 
       spec_files.each do |file|
         begin
-          content = File.read(file, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(file)
         rescue File::NotFoundError
           @logger.debug "Smithy spec not found during analysis, skipping: #{file}"
           next

--- a/src/analyzer/analyzers/specification/traefik.cr
+++ b/src/analyzer/analyzers/specification/traefik.cr
@@ -12,7 +12,7 @@ module Analyzer::Specification
         files.each do |path|
           next unless File.exists?(path)
           details = Details.new(PathInfo.new(path))
-          content = File.read(path, encoding: "utf-8", invalid: :skip)
+          content = read_file_content(path)
 
           begin
             if path.ends_with?(".toml")

--- a/src/analyzer/analyzers/specification/vercel.cr
+++ b/src/analyzer/analyzers/specification/vercel.cr
@@ -14,7 +14,7 @@ module Analyzer::Specification
       config_files.each do |path|
         next unless File.exists?(path)
         details = Details.new(PathInfo.new(path))
-        content = File.read(path, encoding: "utf-8", invalid: :skip)
+        content = read_file_content(path)
         begin
           process_config(JSON.parse(content), details)
         rescue e

--- a/src/analyzer/analyzers/specification/zap_sites_tree.cr
+++ b/src/analyzer/analyzers/specification/zap_sites_tree.cr
@@ -11,7 +11,7 @@ module Analyzer::Specification
         sites_trees.each do |sites_tree|
           if File.exists?(sites_tree)
             details = Details.new(PathInfo.new(sites_tree))
-            content = File.read(sites_tree, encoding: "utf-8", invalid: :skip)
+            content = read_file_content(sites_tree)
             yaml_obj = YAML.parse(content)
 
             begin


### PR DESCRIPTION
## Summary

Final PR of the perf series (#2294–#2299). All **21 remaining direct `File.read` sites** in the specification analyzers (oas2, oas3, asyncapi, raml, traefik, burp, smithy, vercel, graphql_sdl, postman, caido, insomnia, envoy, kong, zap_sites_tree) re-read files from disk that the detector pass already loaded and registered in `CodeLocator`. They now go through the existing `Analyzer#read_file_content` helper — cache hit first, `File.read` fallback for over-budget files. The helper's doc comment was already inviting exactly this migration.

**Behavior identical by construction:** every replaced site used `File.read(path, encoding: "utf-8", invalid: :skip)` — exactly the normalization both the detector's cached read (`detector.cr`) and the helper's fallback apply, so all three paths agree on every input including invalid UTF-8.

## Regression testing

- Full `spec/unit_test` (3,716) + `spec/functional_test` (21,093): 0 failures
- Main-vs-branch binary diff over all ~620 fixture apps (both passes): **zero diffs**
- `just check` clean