### PR TITLE
fix: rename template-splice example so the typos checker passes

### DIFF
--- a/spec/unit_test/detector/specification/nginx_spec.cr
+++ b/spec/unit_test/detector/specification/nginx_spec.cr
@@ -51,10 +51,10 @@ describe "Detect Nginx config" do
   end
 
   it "detects location assembled by template-action removal" do
-    # `strip_template_actions` splices `loca{{ … }}tion` back together, so
+    # `strip_template_actions` splices `loc{{ … }}ation` back together, so
     # the SHAPE_GUARD fast path must not reject template files on the raw
     # (marker-less) content.
-    instance.detect("weird.tmpl", "loca{{ .X }}tion /v1 { proxy_pass http://up; }\n").should be_true
+    instance.detect("weird.tmpl", "loc{{ .X }}ation /v1 { proxy_pass http://up; }\n").should be_true
   end
 
   it "rejects nginx-looking words inside comments" do

--- a/src/detector/detectors/specification/nginx.cr
+++ b/src/detector/detectors/specification/nginx.cr
@@ -11,7 +11,7 @@ module Detector::Specification
     # Whole-content necessary-condition guard for `nginx_shape?`: a line can
     # only match LOCATION_RE if "location" appears in the raw content — or
     # if a template action is spliced out of the middle of the word
-    # (`loca{{x}}tion`), which the `\{\{` disjunct keeps on the slow path.
+    # (`loc{{x}}ation`), which the `\{\{` disjunct keeps on the slow path.
     # Comment stripping only truncates lines, so it can never assemble the
     # keyword. Skips the per-line walk for the vast majority of `.conf` /
     # `.tmpl` files that carry no location block.


### PR DESCRIPTION
The Spell checker workflow has been failing on `main` since #2294: the nginx guard comment and spec used `loca{{x}}tion` as the template-splice example, and `typos` flags the `loca` fragment as a typo of `local`.

Renamed the example fragment to `loc{{x}}ation` (3 sites) — `strip_template_actions` still splices it back to `location`, so the pinned guard behavior is unchanged (nginx detector spec passes; `typos .` clean locally).