### PR TITLE
perf: detection-neutral line-scan analyzer sweep across 12 languages

### DIFF
--- a/src/analyzer/analyzers/cpp/cli.cr
+++ b/src/analyzer/analyzers/cpp/cli.cr
@@ -70,7 +70,10 @@ module Analyzer::Cpp
 
     # Precompiled union for the per-file test-path skip gate (cpp_test_path?),
     # matched via String#matches? instead of five naive substring scans.
-    CPP_TEST_PATH_RE = Regex.union("/test/", "/tests/", "_test.", "test_", ".test.")
+    CPP_TEST_PATH_RE = Regex.new(
+      Regex.union("/test/", "/tests/", "_test.", "test_", ".test.").source,
+      Regex::Options::IGNORE_CASE
+    )
 
     def analyze
       endpoints = {} of String => Endpoint
@@ -101,7 +104,7 @@ module Analyzer::Cpp
     end
 
     private def cpp_test_path?(path : String) : Bool
-      path.downcase.matches?(CPP_TEST_PATH_RE)
+      path.matches?(CPP_TEST_PATH_RE)
     end
 
     private def cpp_binary_name(path : String) : String

--- a/src/analyzer/analyzers/cpp/crow.cr
+++ b/src/analyzer/analyzers/cpp/crow.cr
@@ -67,7 +67,10 @@ module Analyzer::Cpp
       bp_prefixes = source.includes?("CROW_BP_ROUTE") ? blueprint_prefixes(source) : nil
 
       lines.each_with_index do |line, index|
-        next if line.lstrip.starts_with?("//")
+        next unless line.includes?("CROW_ROUTE") ||
+                    line.includes?("CROW_BP_ROUTE") ||
+                    line.includes?("route_dynamic") ||
+                    line.includes?("CROW_WEBSOCKET_ROUTE")
 
         websocket = false
         if bp_match = line.match(BP_ROUTE_REGEX)
@@ -167,9 +170,11 @@ module Analyzer::Cpp
 
     private def line_start_offsets(source : String) : Array(Int32)
       offsets = [0]
+      ptr = source.to_unsafe
+      bytesize = source.bytesize
       index = 0
-      while index < source.bytesize
-        offsets << index + 1 if source.byte_at(index) == '\n'.ord
+      while index < bytesize
+        offsets << index + 1 if ptr[index] == 10
         index += 1
       end
       offsets

--- a/src/analyzer/analyzers/cpp/drogon.cr
+++ b/src/analyzer/analyzers/cpp/drogon.cr
@@ -626,6 +626,8 @@ module Analyzer::Cpp
       params = [] of Param
 
       lines.each do |line|
+        next unless line.includes?("->")
+
         if match = line.match(/->\s*getParameter\s*\(\s*"([^"]+)"/)
           add_unique_param(params, Param.new(match[1], "", "query"))
         end

--- a/src/analyzer/analyzers/cpp/httplib.cr
+++ b/src/analyzer/analyzers/cpp/httplib.cr
@@ -210,6 +210,12 @@ module Analyzer::Cpp
     private def collect_params(body : String) : Array(Param)
       params = [] of Param
       body.each_line do |line|
+        next unless line.includes?("param") ||
+                    line.includes?("value") ||
+                    line.includes?("header") ||
+                    line.includes?("path_params") ||
+                    line.includes?("body")
+
         line.scan(QUERY_ACCESSORS) { |m| add_param(params, Param.new(m[1], "", "query")) }
         line.scan(HEADER_ACCESSORS) { |m| add_param(params, Param.new(m[1], "", "header")) }
         line.scan(PATH_PARAM_ACCESS) { |m| add_param(params, Param.new(m[1], "", "path")) }

--- a/src/analyzer/analyzers/crystal/amber.cr
+++ b/src/analyzer/analyzers/crystal/amber.cr
@@ -45,7 +45,7 @@ module Analyzer::Crystal
 
       lines = mask_crystal_heredocs(read_file_content(path).lines)
 
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
       last_endpoint = Endpoint.new("", "")
 
@@ -297,8 +297,21 @@ module Analyzer::Crystal
       logger.debug e
     end
 
+    # Amber prefers `verb "/path", Controller, :action`. One combined
+    # PCRE2 scan replaces the previous 8 sequential controller-form
+    # scans; on miss, the shared simple-route helper covers the
+    # controller-less fallback (another single scan). Was 16 unguarded
+    # `.scan` calls per source line.
+    CONTROLLER_ROUTE_RE = /(?:^|[^.\w])(get|post|put|delete|patch|head|options|ws)\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:\w+/
+
     def line_to_param(content : String) : Param
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
+
+      # Most source lines never touch params; bail before the includes?/split
+      # chain when none of the Amber accessor prefixes appear.
+      return Param.new("", "", "") unless content.includes?("params") ||
+                                          content.includes?("request.") ||
+                                          content.includes?("context.request")
 
       # Amber uses params object for accessing parameters
       if content.includes? "params["
@@ -347,112 +360,22 @@ module Analyzer::Crystal
 
     def line_to_endpoint(content : String) : Endpoint
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
+      return Endpoint.new("", "") unless content.includes?('"') || content.includes?("'")
 
-      # Amber route definitions with controller and action
-      content.scan(/(?:^|[^.\w])get\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])post\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "POST")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])put\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PUT")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])delete\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "DELETE")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])patch\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PATCH")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])head\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "HEAD")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])options\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "OPTIONS")
-        end
-      end
-
-      # WebSocket support in Amber
-      content.scan(/(?:^|[^.\w])ws\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*\w+,\s*:(\w+)/) do |match|
-        if match.size > 1
-          endpoint = Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
+      # Controller-action form first (Amber's primary DSL).
+      if match = content.match(CONTROLLER_ROUTE_RE)
+        verb = match[1]
+        path = normalize_crystal_interpolation(match[2])
+        if verb == "ws"
+          endpoint = Endpoint.new(path, "GET")
           endpoint.protocol = "ws"
           return endpoint
         end
+        return Endpoint.new(path, verb.upcase)
       end
 
-      # Also support simple route definitions without controller (fallback)
-      content.scan(/(?:^|[^.\w])get\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])post\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "POST")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])put\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PUT")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])delete\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "DELETE")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])patch\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PATCH")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])head\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "HEAD")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])options\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "OPTIONS")
-        end
-      end
-
-      # WebSocket support in Amber
-      content.scan(/(?:^|[^.\w])ws\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          endpoint = Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-          endpoint.protocol = "ws"
-          return endpoint
-        end
-      end
-
-      Endpoint.new("", "")
+      # Simple `verb "/path"` fallback (shared engine helper).
+      match_crystal_simple_route(content)
     end
   end
 end

--- a/src/analyzer/analyzers/crystal/grip.cr
+++ b/src/analyzer/analyzers/crystal/grip.cr
@@ -2,19 +2,22 @@ require "../../engines/crystal_engine"
 
 module Analyzer::Crystal
   class Grip < CrystalEngine
-    # Crystal recompiles an interpolated regex literal on every evaluation
-    # (a full PCRE2 JIT compile). The verb set is fixed, so precompile the
-    # per-verb route matchers once at load time.
-    VERB_ROUTE_PATTERNS = %w[get post put patch delete options head].map do |method|
-      {method, /(?:^|[^.\w])#{method}\s+['"](.+?)['"]/}
-    end
+    # One combined PCRE2 scan replaces the previous 7 sequential per-verb
+    # matchers. Grip requires whitespace after the verb (`get "/x"`, not
+    # `get("/x")`) — the `\s+` keeps that shape, so `input "/x"` still
+    # cannot be read as `put "/x"`.
+    GRIP_ROUTE_RE = /(?:^|[^.\w])(get|post|put|patch|delete|options|head)\s+['"](.+?)['"]/
+
+    SCOPE_OPEN_RE = /^(\s*)scope\s+['"](.+?)['"].*\bdo\b/
+    SCOPE_END_RE  = /^(\s*)end\b/
+    WS_ROUTE_RE   = /(?:^|[^.\w])ws\s+['"](.+?)['"]/
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
 
       lines = mask_crystal_heredocs(read_file_content(path).lines)
 
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       actions = include_callee ? collect_controller_actions(lines, path) : Hash(String, Array(Noir::CrystalCalleeExtractor::Entry)).new
       last_endpoint = Endpoint.new("", "")
       scope_stack = [] of NamedTuple(prefix: String, indent: Int32)
@@ -23,7 +26,7 @@ module Analyzer::Crystal
         details = Details.new(PathInfo.new(path, index + 1))
 
         # Open a scope block, recording its indentation.
-        if scope_match = line.match(/^(\s*)scope\s+['"](.+?)['"].*\bdo\b/)
+        if line.includes?("scope") && (scope_match = line.match(SCOPE_OPEN_RE))
           scope_stack << {prefix: scope_match[2], indent: scope_match[1].size}
           next
         end
@@ -32,7 +35,7 @@ module Analyzer::Crystal
         # indentation of the `scope ... do` that opened it; inner if/case/def/do
         # `end`s sit at a deeper indent and must not pop the scope.
         unless scope_stack.empty?
-          if end_match = line.match(/^(\s*)end\b/)
+          if line.includes?("end") && (end_match = line.match(SCOPE_END_RE))
             if end_match[1].size == scope_stack.last[:indent]
               scope_stack.pop
               next
@@ -178,7 +181,10 @@ module Analyzer::Crystal
     end
 
     def line_to_param(content : String) : Param
-      # Grip context parameter parsing
+      # Grip context parameter parsing. Most lines never touch
+      # `context.fetch_*`; bail before the six includes? probes.
+      return Param.new("", "", "") unless content.includes?("context.fetch_")
+
       if content.includes?("context.fetch_path_params")
         # Extract parameter name from context.fetch_path_params["param_name"]
         if match = content.match(/context\.fetch_path_params\["(.+?)"\]/)
@@ -226,34 +232,32 @@ module Analyzer::Crystal
     end
 
     def line_to_endpoint(content : String, scopes : Array(String)) : Endpoint
+      # Quote gate first — no string literal means no route path.
+      return Endpoint.new("", "") unless content.includes?('"') || content.includes?("'")
+
       scope_prefix = scopes.join("")
 
       # Match HTTP method calls: get "/path", Controller
-      VERB_ROUTE_PATTERNS.each do |method, route_pattern|
-        if content.includes?("#{method} ") && content.includes?("\"")
-          # Require a token boundary so `input "/x"` isn't read as `put "/x"`.
-          if match = content.match(route_pattern)
-            path = normalize_crystal_interpolation(match[1])
-            full_path = scope_prefix + path
-            return Endpoint.new(full_path, method.upcase)
-          end
-        end
+      if match = content.match(GRIP_ROUTE_RE)
+        path = normalize_crystal_interpolation(match[2])
+        full_path = scope_prefix + path
+        return Endpoint.new(full_path, match[1].upcase)
       end
 
       Endpoint.new("", "")
     end
 
     def line_to_websocket(content : String, scopes : Array(String)) : Endpoint
+      return Endpoint.new("", "") unless content.includes?("ws") && (content.includes?('"') || content.includes?("'"))
+
       scope_prefix = scopes.join("")
 
-      if content.includes?("ws ") && content.includes?("\"")
-        if match = content.match(/(?:^|[^.\w])ws\s+['"](.+?)['"]/)
-          path = normalize_crystal_interpolation(match[1])
-          full_path = scope_prefix + path
-          endpoint = Endpoint.new(full_path, "GET")
-          endpoint.protocol = "ws"
-          return endpoint
-        end
+      if match = content.match(WS_ROUTE_RE)
+        path = normalize_crystal_interpolation(match[1])
+        full_path = scope_prefix + path
+        endpoint = Endpoint.new(full_path, "GET")
+        endpoint.protocol = "ws"
+        return endpoint
       end
 
       Endpoint.new("", "")

--- a/src/analyzer/analyzers/crystal/http.cr
+++ b/src/analyzer/analyzers/crystal/http.cr
@@ -70,16 +70,20 @@ module Analyzer::Crystal
     def line_to_param(content : String) : Param
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
 
-      if match = content.match(/context\.request\.query_params\[[^\]]*["']([^"'\]]+)["']/)
+      # HTTP::Server param accessors all live under `context.request.`;
+      # skip four PCRE2 scans when the prefix is absent.
+      return Param.new("", "", "") unless content.includes?("context.request.")
+
+      if content.includes?("query_params") && (match = content.match(/context\.request\.query_params\[[^\]]*["']([^"'\]]+)["']/))
         return Param.new(match[1], "", "query")
       end
-      if match = content.match(/context\.request\.form_params\[[^\]]*["']([^"'\]]+)["']/)
+      if content.includes?("form_params") && (match = content.match(/context\.request\.form_params\[[^\]]*["']([^"'\]]+)["']/))
         return Param.new(match[1], "", "form")
       end
-      if match = content.match(/context\.request\.headers\[[^\]]*["']([^"'\]]+)["']/)
+      if content.includes?("headers") && (match = content.match(/context\.request\.headers\[[^\]]*["']([^"'\]]+)["']/))
         return Param.new(match[1], "", "header")
       end
-      if match = content.match(/context\.request\.cookies\[[^\]]*["']([^"'\]]+)["']/)
+      if content.includes?("cookies") && (match = content.match(/context\.request\.cookies\[[^\]]*["']([^"'\]]+)["']/))
         return Param.new(match[1], "", "cookie")
       end
 
@@ -92,16 +96,23 @@ module Analyzer::Crystal
     def line_to_endpoint(content : String, in_path_case : Bool = false) : Endpoint
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
 
-      # method + path combined on same line (supports the common "if method && path" pattern)
-      if match = content.match(METHOD_THEN_PATH_RE)
-        return Endpoint.new(normalize_crystal_interpolation(match[2]), match[1])
-      end
-      if match = content.match(PATH_THEN_METHOD_RE)
-        return Endpoint.new(normalize_crystal_interpolation(match[1]), match[2])
+      # No string literal ⇒ no path to extract. Also skip heavy combined
+      # method/path regexes unless the request objects appear.
+      has_quote = content.includes?('"') || content.includes?("'")
+      return Endpoint.new("", "") unless has_quote
+
+      if content.includes?("request.method") && content.includes?("request.path")
+        # method + path combined on same line (supports the common "if method && path" pattern)
+        if match = content.match(METHOD_THEN_PATH_RE)
+          return Endpoint.new(normalize_crystal_interpolation(match[2]), match[1])
+        end
+        if match = content.match(PATH_THEN_METHOD_RE)
+          return Endpoint.new(normalize_crystal_interpolation(match[1]), match[2])
+        end
       end
 
       # if/elsif explicit path match (common in handlers)
-      if match = content.match(PATH_COMPARE_RE)
+      if content.includes?("request.path") && (match = content.match(PATH_COMPARE_RE))
         p = match[1]
         if valid_crystal_route_path?(p)
           return Endpoint.new(normalize_crystal_interpolation(p), "GET")
@@ -111,7 +122,7 @@ module Analyzer::Crystal
       # `when "/path"` — only when we have positively entered a `case ...request.path` block.
       # This avoids matching unrelated `case` / `when` statements that contain path-like strings
       # (e.g. `case status; when "/foo" ...` or documentation strings that leak past heredoc mask).
-      if in_path_case
+      if in_path_case && content.includes?("when")
         if match = content.match(WHEN_RE)
           p = match[1]
           if valid_crystal_route_path?(p)

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -35,27 +35,31 @@ module Analyzer::Crystal
 
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      lines = mask_crystal_heredocs(File.read_lines(path))
+      # Cache-first: prefer detector-warmed CodeLocator content. Valid
+      # UTF-8 is byte-identical to the previous File.read_lines path;
+      # invalid bytes now skip (matching every other Crystal analyzer)
+      # instead of raising.
+      lines = mask_crystal_heredocs(read_file_content(path).lines)
       file_base = configured_base_for(path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # Pre-scan: build mount_map (variable_name => mount_path) and resolve
       # compile-time macro variables used in controller references.
+      # Cheap substring gates skip the PCRE2 scan on the vast majority of
+      # lines that can't be mounts/routers/macro-vars.
       mount_map = {} of String => String
       router_vars = Set(String).new
       macro_vars = {} of String => String
 
       lines.each do |line|
-        if match = line.match(ROUTER_PATTERN)
+        if line.includes?("Kemal::Router") && (match = line.match(ROUTER_PATTERN))
           router_vars << match[1]
         end
-        if match = line.match(MOUNT_PATTERN)
+        if line.includes?("mount") && (match = line.match(MOUNT_PATTERN))
           mount_map[match[2]] = match[1]
         end
-        if include_callee
-          if match = line.match(MACRO_VAR_PATTERN)
-            macro_vars[match[1]] = match[2]
-          end
+        if include_callee && line.includes?("{{") && (match = line.match(MACRO_VAR_PATTERN))
+          macro_vars[match[1]] = match[2]
         end
       end
 
@@ -233,6 +237,10 @@ module Analyzer::Crystal
     def line_to_param(content : String) : Param
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
 
+      # Most source lines never touch params; bail before the chain of
+      # includes?/split probes when none of the accessor prefixes appear.
+      return Param.new("", "", "") unless content.includes?("env.") || content.includes?("cookies.")
+
       if content.includes? "env.params.query["
         param = content.split("env.params.query[")[1].split("]")[0].gsub("\"", "").gsub("'", "")
         return Param.new(param, "", "query")
@@ -267,59 +275,9 @@ module Analyzer::Crystal
     end
 
     def line_to_endpoint(content : String) : Endpoint
-      content = Noir::CrystalCalleeExtractor.strip_comment(content)
-
-      content.scan(/(?:^|[^.\w])get\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])post\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "POST")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])put\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PUT")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])delete\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "DELETE")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])patch\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PATCH")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])head\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "HEAD")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])options\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "OPTIONS")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])ws\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          endpoint = Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-          endpoint.protocol = "ws"
-          return endpoint
-        end
-      end
-
-      Endpoint.new("", "")
+      # Shared engine helper: precompiled per-verb patterns + includes?
+      # gates. Replaces 8 sequential unguarded .scan calls per source line.
+      match_crystal_simple_route(Noir::CrystalCalleeExtractor.strip_comment(content))
     end
   end
 end

--- a/src/analyzer/analyzers/crystal/lucky.cr
+++ b/src/analyzer/analyzers/crystal/lucky.cr
@@ -12,7 +12,7 @@ module Analyzer::Crystal
 
       lines = mask_crystal_heredocs(read_file_content(path).lines)
 
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       last_endpoint = Endpoint.new("", "")
 
       # Lucky's `param name : Type` macro declares a query parameter at the
@@ -174,8 +174,19 @@ module Analyzer::Crystal
       logger.debug e
     end
 
+    # Lucky uniquely registers TRACE routes. Shared engine verbs cover the
+    # rest; this is stitched in via `match_crystal_simple_route(..., extra:)`.
+    TRACE_ROUTE_PATTERN = /(?:^|[^.\w])trace\s*(?:\(\s*)?['"](.+?)['"]/
+    LUCKY_EXTRA_ROUTES  = [{"TRACE", TRACE_ROUTE_PATTERN}] of Tuple(String, Regex)
+
     def line_to_param(content : String) : Param
       content = Noir::CrystalCalleeExtractor.strip_comment(content)
+
+      # Most source lines never touch params; bail before the includes?/split
+      # chain when none of the Lucky accessor prefixes appear.
+      return Param.new("", "", "") unless content.includes?("params.") ||
+                                          content.includes?("request.") ||
+                                          content.includes?("cookies")
 
       if content.includes? "params.from_query[\""
         param = content.split("params.from_query[\"")[1].split("\"]")[0].gsub("\"", "").gsub("'", "")
@@ -216,53 +227,12 @@ module Analyzer::Crystal
     end
 
     def line_to_endpoint(content : String) : Endpoint
-      content = Noir::CrystalCalleeExtractor.strip_comment(content)
-
-      content.scan(/(?:^|[^.\w])get\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])post\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "POST")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])put\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PUT")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])delete\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "DELETE")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])patch\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "PATCH")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])trace\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          return Endpoint.new(normalize_crystal_interpolation(match[1]), "TRACE")
-        end
-      end
-
-      content.scan(/(?:^|[^.\w])ws\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        if match.size > 1
-          endpoint = Endpoint.new(normalize_crystal_interpolation(match[1]), "GET")
-          endpoint.protocol = "ws"
-          return endpoint
-        end
-      end
-
-      Endpoint.new("", "")
+      # Shared engine helper + Lucky's TRACE. Replaces 7 sequential
+      # unguarded .scan calls per source line.
+      match_crystal_simple_route(
+        Noir::CrystalCalleeExtractor.strip_comment(content),
+        extra: LUCKY_EXTRA_ROUTES
+      )
     end
   end
 end

--- a/src/analyzer/analyzers/crystal/marten.cr
+++ b/src/analyzer/analyzers/crystal/marten.cr
@@ -207,7 +207,7 @@ module Analyzer::Crystal
     end
 
     private def include_callee? : Bool
-      any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      callees_needed?
     end
 
     private def read_source_lines(path : String) : Array(String)

--- a/src/analyzer/analyzers/csharp/carter.cr
+++ b/src/analyzer/analyzers/csharp/carter.cr
@@ -27,17 +27,17 @@ module Analyzer::CSharp
         next unless content.includes?("ICarterModule")
 
         lines = content.lines
-        each_add_routes_block(lines) do |block_lines, block_start_index|
+        masked_lines = Noir::CSharpLexer.new(content).masked_lines
+        each_add_routes_block(lines, masked_lines) do |block_lines, block_start_index|
           group_prefixes = extract_map_group_prefixes(block_lines)
-          analyze_add_routes_block(block_lines, block_start_index, file, lines, group_prefixes, include_callee)
+          analyze_add_routes_block(block_lines, block_start_index, file, lines, masked_lines, group_prefixes, include_callee)
         end
       end
 
       @result
     end
 
-    private def each_add_routes_block(lines : Array(String), &)
-      masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
+    private def each_add_routes_block(lines : Array(String), masked_lines : Array(String), &)
       i = 0
       while i < lines.size
         line = lines[i]
@@ -89,7 +89,7 @@ module Analyzer::CSharp
       {collected, index}
     end
 
-    private def analyze_add_routes_block(block_lines : Array(String), block_start_index : Int32, file : String, file_lines : Array(String), group_prefixes : Hash(String, String), include_callee : Bool)
+    private def analyze_add_routes_block(block_lines : Array(String), block_start_index : Int32, file : String, file_lines : Array(String), masked_lines : Array(String), group_prefixes : Hash(String, String), include_callee : Bool)
       map_regex = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/m
       chained_group_map_regex = /MapGroup\s*\(\s*"([^"]+)"\s*\)\s*\.Map(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"]+)"/m
       map_methods_block_regex = /(?:\b([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*)?MapMethods\s*\(\s*"([^"]+)"\s*,\s*([\s\S]+?)=>/m
@@ -114,7 +114,7 @@ module Analyzer::CSharp
 
           if route && http_method
             extra_params = extract_params_from_block(block)
-            extra_params.concat(extract_bind_params_from_file(block, file_lines))
+            extra_params.concat(extract_bind_params_from_file(block, file_lines, masked_lines))
             endpoint = build_endpoint_from_route(route, http_method, file, absolute_index + 1, extra_params)
             if endpoint
               attach_csharp_callees(endpoint, block, file, absolute_index + 1, include_callee)
@@ -145,7 +145,7 @@ module Analyzer::CSharp
 
           if route && methods.size > 0
             extra_params = extract_params_from_block(block)
-            extra_params.concat(extract_bind_params_from_file(block, file_lines))
+            extra_params.concat(extract_bind_params_from_file(block, file_lines, masked_lines))
             methods.each do |method|
               endpoint = build_endpoint_from_route(route, method, file, absolute_index + 1, extra_params)
               if endpoint
@@ -261,11 +261,10 @@ module Analyzer::CSharp
       params.uniq(&.name)
     end
 
-    private def extract_bind_params_from_file(block : String, lines : Array(String)) : Array(Param)
+    private def extract_bind_params_from_file(block : String, lines : Array(String), masked_lines : Array(String)) : Array(Param)
       return [] of Param unless block.includes?("Bind(") || block.includes?("BindAsync(")
 
       params = [] of Param
-      masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
       lines.each_with_index do |line, index|
         next unless line.includes?("Bind(") || line.includes?("BindAsync(")
         next unless line.includes?("public") || line.includes?("private") || line.includes?("protected") || line.includes?("internal") || line.includes?("static")

--- a/src/analyzer/analyzers/csharp/minimal_api_support.cr
+++ b/src/analyzer/analyzers/csharp/minimal_api_support.cr
@@ -39,12 +39,13 @@ module Analyzer::CSharp::MinimalApiSupport
   private def analyze_minimal_api_content(file : String, content : String, include_callee : Bool)
     group_prefixes = extract_map_group_prefixes(content)
     lines = content.lines
+    masked_lines = Noir::CSharpLexer.new(content).masked_lines
 
     lines.each_with_index do |line, index|
       next unless route_builder_line?(line)
 
       block = extract_map_block(lines, index)
-      extract_endpoints_from_map_block(block, group_prefixes, file, index + 1, lines, include_callee).each do |endpoint|
+      extract_endpoints_from_map_block(block, group_prefixes, file, index + 1, lines, masked_lines, include_callee).each do |endpoint|
         @result << endpoint
       end
     end
@@ -61,12 +62,13 @@ module Analyzer::CSharp::MinimalApiSupport
                                                file : String,
                                                line : Int32,
                                                file_lines : Array(String),
+                                               masked_lines : Array(String),
                                                include_callee : Bool) : Array(Endpoint)
     route, methods = extract_route_and_methods(block, group_prefixes)
     return [] of Endpoint unless route && methods.size > 0
 
     extra_params = extract_params_from_block(block)
-    extra_params.concat(extract_bind_params_from_file(block, file_lines))
+    extra_params.concat(extract_bind_params_from_file(block, file_lines, masked_lines))
     extra_params.concat(extract_delegate_params(block, route, methods.first))
 
     # Method-group handlers — `MapGet("/items", GetItems)` — carry the route
@@ -76,9 +78,9 @@ module Analyzer::CSharp::MinimalApiSupport
     callee_block = block
     callee_line = line
     callee_skip_first = false
-    if handler = resolve_handler_method(block, file_lines)
+    if handler = resolve_handler_method(block, file_lines, masked_lines)
       sig, handler_block, handler_line, skip_first = handler
-      extra_params.concat(handler_signature_params(sig, route, methods.first, file_lines))
+      extra_params.concat(handler_signature_params(sig, route, methods.first, file_lines, masked_lines))
       callee_block = handler_block
       callee_line = handler_line
       callee_skip_first = skip_first
@@ -249,11 +251,10 @@ module Analyzer::CSharp::MinimalApiSupport
     params.uniq(&.name)
   end
 
-  private def extract_bind_params_from_file(block : String, lines : Array(String)) : Array(Param)
+  private def extract_bind_params_from_file(block : String, lines : Array(String), masked_lines : Array(String)) : Array(Param)
     return [] of Param unless block.includes?("Bind(") || block.includes?("BindAsync(")
 
     params = [] of Param
-    masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
     lines.each_with_index do |line, index|
       next unless line.includes?("Bind(") || line.includes?("BindAsync(")
       next unless line.includes?("public") || line.includes?("private") || line.includes?("protected") || line.includes?("internal") || line.includes?("static")
@@ -465,10 +466,10 @@ module Analyzer::CSharp::MinimalApiSupport
   # referenced method's signature + body. Returns
   # `{signature, body, body_start_line, skip_first_line}` or nil when the
   # handler is a lambda (already handled) or can't be found in this file.
-  private def resolve_handler_method(block : String, lines : Array(String)) : Tuple(String, String, Int32, Bool)?
+  private def resolve_handler_method(block : String, lines : Array(String), masked_lines : Array(String)) : Tuple(String, String, Int32, Bool)?
     name = handler_method_name(block)
     return unless name
-    locate_method_definition(name, lines)
+    locate_method_definition(name, lines, masked_lines)
   end
 
   # Pulls the handler argument out of the `Map*(...)` call and returns its
@@ -527,9 +528,8 @@ module Analyzer::CSharp::MinimalApiSupport
   # signature, body block, body start line (1-based) and whether the
   # callee scanner should skip the first body line. Skips the
   # registration call itself and assignment/call sites.
-  private def locate_method_definition(name : String, lines : Array(String)) : Tuple(String, String, Int32, Bool)?
+  private def locate_method_definition(name : String, lines : Array(String), masked_lines : Array(String)) : Tuple(String, String, Int32, Bool)?
     decl = /(?:public|private|internal|protected|static|async)\b[^;={(]*\b#{Regex.escape(name)}\s*\(/
-    masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
 
     lines.each_with_index do |line, idx|
       next unless line.includes?(name)
@@ -548,7 +548,7 @@ module Analyzer::CSharp::MinimalApiSupport
 
   # Builds params from a resolved handler's signature, reusing the delegate
   # binding rules and expanding `[AsParameters]` bundle types.
-  private def handler_signature_params(signature : String, route : String, http_method : String, lines : Array(String)) : Array(Param)
+  private def handler_signature_params(signature : String, route : String, http_method : String, lines : Array(String), masked_lines : Array(String)) : Array(Param)
     list = extract_balanced_param_list(signature)
     return [] of Param unless list
 
@@ -559,7 +559,7 @@ module Analyzer::CSharp::MinimalApiSupport
     params = [] of Param
     split_csharp_parameters(list).each do |pdef|
       if pdef.includes?("[AsParameters]") || pdef.includes?("[AsParameters ")
-        params.concat(expand_as_parameters(pdef, lines, route_params, http_method))
+        params.concat(expand_as_parameters(pdef, lines, masked_lines, route_params, http_method))
       elsif param = delegate_param_to_noir_param(pdef, route_params, http_method)
         params << param
       end
@@ -571,7 +571,7 @@ module Analyzer::CSharp::MinimalApiSupport
   # from the query/route/header — never the body. Expand to those members,
   # dropping the DI-service members (a bundle like `CatalogServices` yields
   # nothing, which is exactly right).
-  private def expand_as_parameters(param_def : String, lines : Array(String), route_params : Array(String), http_method : String) : Array(Param)
+  private def expand_as_parameters(param_def : String, lines : Array(String), masked_lines : Array(String), route_params : Array(String), http_method : String) : Array(Param)
     cleaned = param_def.gsub(/\[[^\]]*\]\s*/, "").strip
     type_token = cleaned.split(/\s+/).first?
     return [] of Param unless type_token
@@ -581,7 +581,7 @@ module Analyzer::CSharp::MinimalApiSupport
     return [] of Param if Common.csharp_service_type?(base)
 
     params = [] of Param
-    as_parameters_member_defs(base, lines).each do |member|
+    as_parameters_member_defs(base, lines, masked_lines).each do |member|
       param = as_parameters_member_to_param(member, route_params, http_method)
       params << param if param
     end
@@ -590,7 +590,7 @@ module Analyzer::CSharp::MinimalApiSupport
 
   # Returns the member definitions (primary-constructor params or public
   # auto-properties) of a record/class/struct used with `[AsParameters]`.
-  private def as_parameters_member_defs(type_name : String, lines : Array(String)) : Array(String)
+  private def as_parameters_member_defs(type_name : String, lines : Array(String), masked_lines : Array(String)) : Array(String)
     # Hoisted out of the loop: an interpolated regex literal recompiles
     # (PCRE2 JIT) on every evaluation, i.e. once per line.
     type_decl_regex = /\b(?:record|class|struct)\s+#{Regex.escape(type_name)}\b/
@@ -598,8 +598,6 @@ module Analyzer::CSharp::MinimalApiSupport
       l.includes?(type_name) && l.matches?(type_decl_regex)
     end
     return [] of String unless def_idx
-
-    masked_lines = Noir::CSharpLexer.new(lines.join('\n')).masked_lines
     defline = lines[def_idx]
     name_pos = defline.index(/\b#{Regex.escape(type_name)}\b/)
     paren = defline.index('(', name_pos || 0)

--- a/src/analyzer/analyzers/elixir/cli.cr
+++ b/src/analyzer/analyzers/elixir/cli.cr
@@ -8,7 +8,6 @@ module Analyzer::Elixir
   class Cli < Analyzer
     SWITCHES   = /switches:\s*\[([^\]]*)\]/
     SWITCH_KEY = /([a-z_]\w*):/
-    ARGV       = /\bSystem\.argv\b/
     GET_ENV    = /\bSystem\.(?:get_env|fetch_env!?)\s*\(\s*"([^"]+)"/
 
     MARKERS = /\bOptionParser\.(?:parse|parse!|next)\b|\bSystem\.argv\b|\bOptimus\.new!?\b/
@@ -16,33 +15,43 @@ module Analyzer::Elixir
 
     def analyze
       endpoints = {} of String => Endpoint
-      [".ex", ".exs"].each do |ext|
-        get_files_by_extension(ext).each do |path|
-          next if File.directory?(path)
-          next if cli_test_path?(path)
-          next unless File.exists?(path)
-          begin
-            content = read_file_content(path)
-            next unless content.matches?(MARKERS)
-            root_url = "cli://#{cli_binary_name(path)}"
-            emit_env = !content.matches?(WEB_RE)
+      files = get_files_by_extension(".ex") + get_files_by_extension(".exs")
 
-            # Every `switches: [...]` keyword list (a file may dispatch several
-            # OptionParser.parse calls). Endpoint is created lazily so a bare
-            # `System.argv` file with no switches/env emits nothing.
+      files.each do |path|
+        next if File.directory?(path)
+        next if cli_test_path?(path)
+        begin
+          content = read_file_content(path)
+          # Cheap reject before the full MARKERS regex: every alternative
+          # contains one of these literals.
+          next unless content.includes?("OptionParser") ||
+                      content.includes?("System.argv") ||
+                      content.includes?("Optimus")
+          next unless content.matches?(MARKERS)
+
+          root_url = "cli://#{cli_binary_name(path)}"
+          emit_env = !content.matches?(WEB_RE)
+
+          # Every `switches: [...]` keyword list (a file may dispatch several
+          # OptionParser.parse calls). Endpoint is created lazily so a bare
+          # `System.argv` file with no switches/env emits nothing.
+          if content.includes?("switches:")
             content.scan(SWITCHES) do |m|
               m[1].scan(SWITCH_KEY) { |sm| fetch_endpoint(endpoints, root_url, path, 1).push_param(Param.new(sm[1], "", "flag")) }
             end
-
-            content.each_line.with_index do |line, index|
-              if emit_env
-                line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, index + 1).push_param(Param.new(em[1], "", "env")) }
-              end
-            end
-          rescue e
-            logger.debug "Error analyzing #{path}: #{e}"
-            next
           end
+
+          # Env extraction is the only per-line work; skip the line walk
+          # entirely for web modules or files with no System env reads.
+          if emit_env && (content.includes?("get_env") || content.includes?("fetch_env"))
+            content.each_line.with_index do |line, index|
+              next unless line.includes?("get_env") || line.includes?("fetch_env")
+              line.scan(GET_ENV) { |em| fetch_endpoint(endpoints, root_url, path, index + 1).push_param(Param.new(em[1], "", "env")) }
+            end
+          end
+        rescue e
+          logger.debug "Error analyzing #{path}: #{e}"
+          next
         end
       end
       endpoints.each_value { |ep| @result << ep }

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -997,7 +997,7 @@ module Analyzer::Elixir
       return 0 if needle.empty?
       count = 0
       i = 0
-      while (j = text.index(needle, i))
+      while j = text.index(needle, i)
         count += 1
         i = j + needle.size
       end

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -11,6 +11,10 @@ module Analyzer::Elixir
     # Store mapping of route -> controller/action for parameter extraction
     @route_map : Hash(RouteMapKey, ControllerAction) = Hash(RouteMapKey, ControllerAction).new
     @route_macros : Hash(String, RouteMacro) = Hash(String, RouteMacro).new
+    # Reverse index built once after route discovery:
+    #   base -> normalized controller key -> action -> endpoints
+    # Replaces the previous per-controller O(|routes|) scan of `@result`.
+    @controller_endpoint_index = Hash(String, Hash(String, Hash(String, Array(Endpoint)))).new
 
     # `get`/`post`/… → its precompiled route regex. `add_standard_route` runs
     # once per verb per line of every `.ex` file; `Regex.new` there recompiled
@@ -83,10 +87,21 @@ module Analyzer::Elixir
       # First pass: collect routes via the engine's parallel file scan.
       super
 
+      # Build the controller→action reverse index once so the param pass
+      # is O(|controllers| + |routes|) rather than O(|controllers|·|routes|).
+      build_controller_endpoint_index
+
       # Second pass: extract parameters from controller files
       extract_controller_params
 
       @result
+    end
+
+    # Phoenix routers and controllers are always `.ex` modules. `.exs`
+    # scripts never register routes, so skip the extension the engine
+    # includes for Plug.
+    protected def elixir_source_files : Array(String)
+      get_files_by_extension(".ex")
     end
 
     def analyze_file(path : String) : Array(Endpoint)
@@ -115,12 +130,12 @@ module Analyzer::Elixir
         line = lines[index]
 
         if line.includes?("\"\"\"")
-          line.scan(/"""/).size.times { in_triple_double = !in_triple_double }
+          count_substring(line, "\"\"\"").times { in_triple_double = !in_triple_double }
           index += 1
           next
         end
         if line.includes?("'''")
-          line.scan(/'''/).size.times { in_triple_single = !in_triple_single }
+          count_substring(line, "'''").times { in_triple_single = !in_triple_single }
           index += 1
           next
         end
@@ -316,7 +331,8 @@ module Analyzer::Elixir
     def extract_controller_params
       # Find all controller files and extract parameters. Pulls from the
       # detector-built file_map so subtree pruning and --exclude-path
-      # apply to this pass too.
+      # apply to this pass too. Files are already registered in
+      # CodeLocator; skip the redundant `File.exists?` syscall.
       controller_files = get_files_by_extension(".ex").select do |path|
         next false unless path.ends_with?("_controller.ex")
         next false if elixir_test_path?(path)
@@ -324,8 +340,6 @@ module Analyzer::Elixir
       end
 
       controller_files.each do |controller_path|
-        next unless File.exists?(controller_path)
-
         begin
           content = read_file_content(controller_path)
           # Action heads always bind `conn` (see the signature matcher
@@ -341,6 +355,36 @@ module Analyzer::Elixir
         rescue e
           logger.debug "Error reading controller file #{controller_path}: #{e}"
         end
+      end
+    end
+
+    # Walk `@result` + `@route_map` once and group endpoints under every
+    # normalized controller key that `controller_refs_match?` would accept.
+    # Short mapped names (`UserController`) index under their last segment
+    # so an FQ lookup (`MyAppWeb.UserController`) still finds them; FQ
+    # mapped names only index under the full normalized form (matching
+    # the asymmetric equality rule in `controller_refs_match?`).
+    private def build_controller_endpoint_index : Nil
+      @controller_endpoint_index.clear
+
+      @result.each do |endpoint|
+        route_key = endpoint_route_map_key(endpoint)
+        next unless mapping = @route_map[route_key]?
+
+        base = route_key[0]
+        action = mapping.action
+        mapped = mapping.controller
+        norm = normalize_controller_ref(mapped)
+
+        by_base = @controller_endpoint_index[base] ||=
+          Hash(String, Hash(String, Array(Endpoint))).new
+        by_controller = by_base[norm] ||=
+          Hash(String, Array(Endpoint)).new { |h, k| h[k] = [] of Endpoint }
+        by_controller[action] << endpoint
+
+        # Short mappings are already a single segment after normalize.
+        # Nothing further to index. FQ mappings stay under the full key
+        # only — `controller_refs_match?` requires full equality for them.
       end
     end
 
@@ -369,6 +413,7 @@ module Analyzer::Elixir
       lines = content.lines
       include_callee = callees_needed?
       endpoints_by_action = endpoints_for_controller(controller_name, controller_path)
+      return if endpoints_by_action.empty?
 
       index = 0
       while index < lines.size
@@ -387,6 +432,12 @@ module Analyzer::Elixir
         end
         action_name = name_match[1]
 
+        matching_endpoints = endpoints_by_action[action_name]?
+        if matching_endpoints.nil? || matching_endpoints.empty?
+          index += 1
+          next
+        end
+
         # A controller action's first argument is always the connection,
         # but the head can pattern-match it (`def edit(conn = %{assigns:
         # …}, _params)`, `def show(%Plug.Conn{} = conn, params)`) and a
@@ -401,12 +452,6 @@ module Analyzer::Elixir
           next
         end
 
-        matching_endpoints = endpoints_by_action[action_name]? || [] of Endpoint
-        if matching_endpoints.empty?
-          index += 1
-          next
-        end
-
         # Find the end of the function block once per controller action.
         block_end = find_function_end(lines, body_start)
         if block_end == -1
@@ -416,11 +461,17 @@ module Analyzer::Elixir
 
         callees = include_callee ? callees_from_function_block(lines, body_start, block_end, controller_path) : nil
 
+        # `conn.params` type depends on the HTTP method (query vs form).
+        # Cache the extraction per distinct method so a multi-verb action
+        # (resources `update` → PUT+PATCH) only walks the body once per
+        # type, not once per endpoint.
+        params_by_method = {} of String => Array(Param)
+
         matching_endpoints.each do |endpoint|
           append_code_path(endpoint.details, PathInfo.new(controller_path, index + 1))
 
-          # Extract parameters from the function block
-          params = extract_params_from_function_block(lines, body_start, block_end, endpoint.method)
+          params = params_by_method[endpoint.method] ||=
+            extract_params_from_function_block(lines, body_start, block_end, endpoint.method)
           params.each { |param| endpoint.push_param(param) }
 
           attach_elixir_callees(endpoint, callees) if callees
@@ -465,10 +516,13 @@ module Analyzer::Elixir
     private def collect_route_macros : Nil
       @route_macros.clear
 
-      get_files_by_extension(".ex").each do |path|
-        next unless File.exists?(path)
-        next if elixir_test_path?(path)
+      files = get_files_by_extension(".ex").reject { |path| elixir_test_path?(path) }
+      mutex = Mutex.new
 
+      # Macro bodies are independent per file; merge under a mutex.
+      # Parallelism matters on large Phoenix trees where most files are
+      # rejected by the `defmacro` substring gate after a single read.
+      parallel_analyze(files) do |path|
         begin
           content = read_file_content(path)
           # Vast majority of `.ex` files never define macros. Cheap
@@ -477,8 +531,9 @@ module Analyzer::Elixir
 
           module_name = extract_module_name(content)
           lines = content.lines
-          index = 0
+          local = [] of Tuple(String, RouteMacro)
 
+          index = 0
           while index < lines.size
             line = lines[index]
             stripped = line.strip
@@ -508,10 +563,16 @@ module Analyzer::Elixir
               body_lines
             )
 
-            @route_macros[name] = route_macro
-            @route_macros["#{module_name}.#{name}"] = route_macro if module_name
+            local << {name, route_macro}
+            local << {"#{module_name}.#{name}", route_macro} if module_name
 
             index = macro_end + 1
+          end
+
+          unless local.empty?
+            mutex.synchronize do
+              local.each { |key, mc| @route_macros[key] = mc }
+            end
           end
         rescue e
           logger.debug "Error collecting Phoenix route macros from #{path}: #{e}"
@@ -745,15 +806,27 @@ module Analyzer::Elixir
       endpoints_by_action = Hash(String, Array(Endpoint)).new { |hash, key| hash[key] = [] of Endpoint }
       base = configured_base_for(controller_path)
 
-      @result.each do |endpoint|
-        route_key = endpoint_route_map_key(endpoint)
-        # Keep param extraction scoped to the controller's own base so a
-        # monorepo's sibling services don't borrow each other's params.
-        next unless route_key[0] == base
-        next unless mapping = @route_map[route_key]?
-        next unless controller_refs_match?(controller_name, mapping.controller)
+      by_base = @controller_endpoint_index[base]?
+      return endpoints_by_action unless by_base
 
-        endpoints_by_action[mapping.action] << endpoint
+      # Lookup under the full normalized name and, when it has a module
+      # prefix, under the last segment so short mapped controllers
+      # (`UserController`) still match an FQ module extract.
+      # Index keys already mirror `controller_refs_match?`: short mappings
+      # live under a single segment, FQ mappings only under the full form.
+      norm = normalize_controller_ref(controller_name)
+      keys = [norm]
+      if norm.includes?('.')
+        keys << (norm.split('.').last || norm)
+      end
+
+      keys.uniq.each do |key|
+        next unless by_controller = by_base[key]?
+        by_controller.each do |action, endpoints|
+          endpoints.each do |endpoint|
+            endpoints_by_action[action] << endpoint
+          end
+        end
       end
 
       endpoints_by_action
@@ -910,12 +983,25 @@ module Analyzer::Elixir
       extract_module_name(content)
     end
 
+    MODULE_NAME_RE = /^\s*defmodule\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s+do\b/m
+
     private def extract_module_name(content : String) : String?
-      content.each_line do |line|
-        if match = line.match(/^\s*defmodule\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s+do\b/)
-          return match[1]
-        end
+      # Single multiline search for the first `defmodule` instead of
+      # allocating an iterator over every line of large modules.
+      content.match(MODULE_NAME_RE).try(&.[1])
+    end
+
+    # Count non-overlapping occurrences of `needle` without allocating a
+    # MatchData array (`String#scan(…​).size`).
+    private def count_substring(text : String, needle : String) : Int32
+      return 0 if needle.empty?
+      count = 0
+      i = 0
+      while (j = text.index(needle, i))
+        count += 1
+        i = j + needle.size
       end
+      count
     end
 
     private def normalize_controller_ref(controller : String) : String

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -30,6 +30,19 @@ module Analyzer::Elixir
       {verb, Regex.new("(?:^|[^.\\w])#{verb}\\s*(?:\\(\\s*)?['\"]([^'\"]+)['\"]\\s*,\\s*([A-Z]\\w*(?:\\.[A-Za-z_]\\w*)*|unquote\\(\\s*\\w+\\s*\\))(?=\\s*[,)]|\\s*$)(?:\\s*,\\s*:(\\w+[!?]?))?")}
     end
 
+    # File-level gate for the route-extraction pass. Controllers, schemas,
+    # views, and most application modules never declare Phoenix routes, but
+    # `analyze_file` used to line-scan every `.ex` file anyway. Match the
+    # DSL shape (verb + optional paren + string/`unquote`/atom) so common
+    # non-route uses like `Map.get(` or `forget` do not force a full scan.
+    # Custom route macros collected in the first pass are checked by name
+    # separately in `may_contain_phoenix_routes?`.
+    PHOENIX_ROUTE_EVIDENCE_RE = /
+      \b(?:get|post|put|patch|delete|options|head|match|resources|scope|socket|live|live_dashboard|forward)
+      \s*(?:\(\s*)?(?:["']|unquote\b|:)
+      |\bdefmacro\s+
+    /x
+
     struct ControllerAction
       property controller : String
       property action : String
@@ -90,6 +103,10 @@ module Analyzer::Elixir
       # (same "utf-8"/`invalid: :skip` decoding as the `File.open` this
       # replaced) instead of re-reading the file from disk here.
       content = read_file_content(path)
+      # Controllers/schemas/views dominate a Phoenix tree and never carry
+      # route macros. Skip the per-line walk when nothing in the file can
+      # produce an endpoint (evidence regex + known custom macro names).
+      return endpoints unless may_contain_phoenix_routes?(content)
       lines = content.lines
       current_module = extract_module_name(content)
 
@@ -281,6 +298,7 @@ module Analyzer::Elixir
       # apply to this pass too.
       controller_files = get_files_by_extension(".ex").select do |path|
         next false unless path.ends_with?("_controller.ex")
+        next false if elixir_test_path?(path)
         base_paths.any? { |base| path_under_root?(path, base) }
       end
 
@@ -289,6 +307,11 @@ module Analyzer::Elixir
 
         begin
           content = read_file_content(controller_path)
+          # Action heads always bind `conn` (see the signature matcher
+          # below). Controllers that never mention it cannot contribute
+          # params, callees, or code-path attachments — skip them.
+          next unless content.includes?("conn")
+
           controller_name = File.basename(controller_path, ".ex")
           controller_module = extract_controller_module(content) || controller_name
 
@@ -298,6 +321,27 @@ module Analyzer::Elixir
           logger.debug "Error reading controller file #{controller_path}: #{e}"
         end
       end
+    end
+
+    # True when this source can contribute routes in the second pass.
+    # Combines the fixed DSL evidence regex with names of custom route
+    # macros discovered in `collect_route_macros`, including `use Mod`
+    # expansion sites for `defmacro __using__`.
+    private def may_contain_phoenix_routes?(content : String) : Bool
+      return true if content.matches?(PHOENIX_ROUTE_EVIDENCE_RE)
+
+      @route_macros.each_key do |key|
+        if key.ends_with?(".__using__")
+          mod = key[0, key.size - ".__using__".size]
+          return true if content.includes?("use #{mod}")
+        else
+          # Bare macro name only; FQ keys duplicate the same body.
+          next if key.includes?('.')
+          return true if content.includes?(key)
+        end
+      end
+
+      false
     end
 
     def extract_params_from_controller(content : String, controller_name : String, controller_path : String)
@@ -395,9 +439,14 @@ module Analyzer::Elixir
 
       get_files_by_extension(".ex").each do |path|
         next unless File.exists?(path)
+        next if elixir_test_path?(path)
 
         begin
           content = read_file_content(path)
+          # Vast majority of `.ex` files never define macros. Cheap
+          # substring gate before line-splitting and signature assembly.
+          next unless content.includes?("defmacro")
+
           module_name = extract_module_name(content)
           lines = content.lines
           index = 0

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -285,7 +285,12 @@ module Analyzer::Elixir
     # callee extractor's `strip_comment`, which discards quotes. A `#`
     # only opens a comment outside a string, so a `#` inside a quoted
     # path won't truncate the statement.
+    #
+    # No `#` → return the original slice (zero allocation). The common
+    # path for route / controller lines.
     private def strip_trailing_comment(line : String) : String
+      return line unless line.includes?('#')
+
       in_string = false
       escaped = false
       quote = '\0'
@@ -369,6 +374,13 @@ module Analyzer::Elixir
       while index < lines.size
         line = lines[index]
 
+        # `def`/`defp` is a rare token relative to body lines. Cheap
+        # substring gate before the two regexes.
+        unless line.includes?("def")
+          index += 1
+          next
+        end
+
         if line.matches?(/^\s*defp\s/) || !(name_match = line.match(/^\s*def\s+(\w+)\(/))
           index += 1
           next
@@ -442,7 +454,7 @@ module Analyzer::Elixir
         # The block opens at the first top-level `do` once the argument
         # list's parentheses are balanced; the paren guard keeps a `do`
         # buried in a default value or atom inside the args from firing.
-        if paren <= 0 && code.matches?(/\bdo\b(?!:)/)
+        if paren <= 0 && code.includes?("do") && code.matches?(/\bdo\b(?!:)/)
           return {buffer, i}
         end
         i += 1

--- a/src/analyzer/analyzers/elixir/elixir_phoenix.cr
+++ b/src/analyzer/analyzers/elixir/elixir_phoenix.cr
@@ -141,7 +141,11 @@ module Analyzer::Elixir
           next
         end
 
-        update_elixir_string_bindings(string_bindings, line)
+        # Bindings only change on assignments / `\\` defaults — skip the
+        # multi-regex update on every other line of a large router.
+        if line.includes?('=') || line.includes?("\\\\")
+          update_elixir_string_bindings(string_bindings, line)
+        end
 
         if !scope_stack.empty?
           if end_match = line.match(/^(\s*)end\b/)
@@ -154,16 +158,19 @@ module Analyzer::Elixir
           end
         end
 
-        if match = line.match(/^(\s*)scope\s*(?:\(\s*)?["']([^"']+)["'](?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
-          scope_stack << {prefix: match[2], module_prefix: match[3]? || "", indent: match[1].size}
-          index += 1
-          next
-        end
+        # Scope openers always contain the `scope` token.
+        if line.includes?("scope")
+          if match = line.match(/^(\s*)scope\s*(?:\(\s*)?["']([^"']+)["'](?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
+            scope_stack << {prefix: match[2], module_prefix: match[3]? || "", indent: match[1].size}
+            index += 1
+            next
+          end
 
-        if match = line.match(/^(\s*)scope\s*(?:\(\s*)?unquote\(\s*(\w+)\s*\)(?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
-          scope_stack << {prefix: string_bindings[match[2]]? || "", module_prefix: match[3]? || "", indent: match[1].size}
-          index += 1
-          next
+          if match = line.match(/^(\s*)scope\s*(?:\(\s*)?unquote\(\s*(\w+)\s*\)(?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
+            scope_stack << {prefix: string_bindings[match[2]]? || "", module_prefix: match[3]? || "", indent: match[1].size}
+            index += 1
+            next
+          end
         end
 
         scope_prefix = current_scope_prefix(scope_stack)
@@ -184,7 +191,7 @@ module Analyzer::Elixir
         # and can open a `do` block that nests child resources under a
         # `/:parent_id` member segment. Both need the whole logical
         # statement, so assemble it before extracting routes.
-        if line.matches?(/(?:^|[^.\w])resources\s*(?:\(\s*)?["']/)
+        if line.includes?("resources") && line.matches?(/(?:^|[^.\w])resources\s*(?:\(\s*)?["']/)
           statement, consumed = assemble_statement(lines, index)
           res_endpoints, nested_prefix = resources_from_statement(statement, scope_prefix, scope_module, base, string_bindings)
           res_endpoints.each do |endpoint|
@@ -235,20 +242,29 @@ module Analyzer::Elixir
     private def update_elixir_string_bindings(bindings : Hash(String, String),
                                               line : String,
                                               keyword_overrides : Hash(String, String)) : Nil
-      code = strip_trailing_comment(line).strip
+      # Callers already cheap-gate on `=` / `\\`; still bail when the
+      # stripped line has neither so nested macro expansion stays cheap.
+      return unless line.includes?('=') || line.includes?("\\\\")
 
-      if match = code.match(/^(\w+)\s*=\s*Keyword\.get\([^,]+,\s*:\w+\s*,\s*["']([^"']+)["']\s*\)/)
-        key = code.match(/Keyword\.get\([^,]+,\s*:(\w+)/).try(&.[1])
-        bindings[match[1]] = key.try { |name| keyword_overrides[name]? } || match[2]
-      elsif match = code.match(/^(\w+)\s*=\s*Keyword\.get\([^,]+,\s*:\w+\s*,\s*([A-Z]\w*(?:\.[A-Z]\w*)*)\s*\)/)
-        key = code.match(/Keyword\.get\([^,]+,\s*:(\w+)/).try(&.[1])
-        bindings[match[1]] = key.try { |name| keyword_overrides[name]? } || match[2]
+      code = strip_trailing_comment(line).strip
+      return if code.empty?
+
+      if code.includes?("Keyword.get")
+        if match = code.match(/^(\w+)\s*=\s*Keyword\.get\([^,]+,\s*:\w+\s*,\s*["']([^"']+)["']\s*\)/)
+          key = code.match(/Keyword\.get\([^,]+,\s*:(\w+)/).try(&.[1])
+          bindings[match[1]] = key.try { |name| keyword_overrides[name]? } || match[2]
+        elsif match = code.match(/^(\w+)\s*=\s*Keyword\.get\([^,]+,\s*:\w+\s*,\s*([A-Z]\w*(?:\.[A-Z]\w*)*)\s*\)/)
+          key = code.match(/Keyword\.get\([^,]+,\s*:(\w+)/).try(&.[1])
+          bindings[match[1]] = key.try { |name| keyword_overrides[name]? } || match[2]
+        end
       elsif match = code.match(/^(\w+)\s*=\s*["']([^"']+)["']/)
         bindings[match[1]] = match[2]
       end
 
-      code.scan(/(\w+)\s*\\\\\s*([A-Z]\w*(?:\.[A-Z]\w*)*)/) do |default_match|
-        bindings[default_match[1]] = default_match[2]
+      if code.includes?("\\\\")
+        code.scan(/(\w+)\s*\\\\\s*([A-Z]\w*(?:\.[A-Z]\w*)*)/) do |default_match|
+          bindings[default_match[1]] = default_match[2]
+        end
       end
     end
 
@@ -346,7 +362,7 @@ module Analyzer::Elixir
 
     def extract_params_from_controller(content : String, controller_name : String, controller_path : String)
       lines = content.lines
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       endpoints_by_action = endpoints_for_controller(controller_name, controller_path)
 
       index = 0
@@ -505,21 +521,29 @@ module Analyzer::Elixir
     end
 
     private def route_macro_invocation(line : String, current_module : String?) : RouteMacroInvocation?
+      # No macros collected → nothing to expand. Cheap reject for the
+      # common case (projects without custom route macros).
+      return if @route_macros.empty?
+
       code = strip_trailing_comment(line).strip
       return if code.empty?
 
-      if use_match = code.match(/^use\s+([A-Z]\w*(?:\.[A-Z]\w*)*)(?:\s*,\s*(.*))?$/)
-        route_macro = @route_macros["#{use_match[1]}.__using__"]?
-        return unless route_macro
+      if code.starts_with?("use ")
+        if use_match = code.match(/^use\s+([A-Z]\w*(?:\.[A-Z]\w*)*)(?:\s*,\s*(.*))?$/)
+          route_macro = @route_macros["#{use_match[1]}.__using__"]?
+          return unless route_macro
 
-        keyword_args = parse_keyword_args(use_match[2]? || "")
-        return RouteMacroInvocation.new(route_macro, [] of String, keyword_args)
+          keyword_args = parse_keyword_args(use_match[2]? || "")
+          return RouteMacroInvocation.new(route_macro, [] of String, keyword_args)
+        end
+        return
       end
 
       call_match = code.match(/^(?:(?<module>[A-Z]\w*(?:\.[A-Z]\w*)*)\.)?(?<name>[a-z_]\w*[!?]?)\s*(?:\((?<args>.*)\)|(?<bare>.*))?$/)
       return unless call_match
 
       name = call_match["name"]
+      # Most lines fail this lookup; check bare name first (O(1) hash).
       module_name = call_match["module"]?
       route_macro = if module_name
                       @route_macros["#{module_name}.#{name}"]?
@@ -643,7 +667,9 @@ module Analyzer::Elixir
           next
         end
 
-        update_elixir_string_bindings(bindings, line, invocation.keyword_args)
+        if line.includes?('=') || line.includes?("\\\\")
+          update_elixir_string_bindings(bindings, line, invocation.keyword_args)
+        end
 
         if !scope_stack.empty?
           if end_match = line.match(/^(\s*)end\b/)
@@ -656,26 +682,28 @@ module Analyzer::Elixir
           end
         end
 
-        if match = line.match(/^(\s*)scope\s*(?:\(\s*)?["']([^"']+)["'](?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
-          scope_stack << {prefix: match[2], module_prefix: match[3]? || "", indent: match[1].size}
-          index += 1
-          next
-        end
-
-        if match = line.match(/^(\s*)scope\s*(?:\(\s*)?unquote\(\s*(\w+)\s*\)(?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
-          unless prefix = bindings[match[2]]?
+        if line.includes?("scope")
+          if match = line.match(/^(\s*)scope\s*(?:\(\s*)?["']([^"']+)["'](?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
+            scope_stack << {prefix: match[2], module_prefix: match[3]? || "", indent: match[1].size}
             index += 1
             next
           end
-          scope_stack << {prefix: prefix, module_prefix: match[3]? || "", indent: match[1].size}
-          index += 1
-          next
+
+          if match = line.match(/^(\s*)scope\s*(?:\(\s*)?unquote\(\s*(\w+)\s*\)(?:\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?/)
+            unless prefix = bindings[match[2]]?
+              index += 1
+              next
+            end
+            scope_stack << {prefix: prefix, module_prefix: match[3]? || "", indent: match[1].size}
+            index += 1
+            next
+          end
         end
 
         scope_prefix = Noir::URLPath.join(outer_scope_prefix, current_scope_prefix(scope_stack))
         scope_module = combine_scope_modules(outer_scope_module, current_scope_module(scope_stack))
 
-        if line.matches?(/(?:^|[^.\w])resources\s*(?:\(\s*)?["']/)
+        if line.includes?("resources") && line.matches?(/(?:^|[^.\w])resources\s*(?:\(\s*)?["']/)
           statement, consumed = assemble_statement(route_macro.body_lines, index)
           res_endpoints, nested_prefix = resources_from_statement(statement, scope_prefix, scope_module, base, bindings)
           res_endpoints.each do |endpoint|
@@ -775,55 +803,73 @@ module Analyzer::Elixir
       # Extract parameters from the function block content
       (start_index..end_index).each do |i|
         line = lines[i]
+        # Most action lines are business logic with no param accessors.
+        # Five PCRE scans only run when a conn accessor or header helper
+        # is present.
+        has_conn = line.includes?("conn.")
+        has_header = line.includes?("get_req_header")
+        next unless has_conn || has_header
 
-        # Extract query parameters (conn.query_params["param"])
-        line.scan(/conn\.query_params\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_key = "query:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "query")
-            seen_params << param_key
+        if has_conn
+          # Extract query parameters (conn.query_params["param"])
+          if line.includes?("query_params")
+            line.scan(/conn\.query_params\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_key = "query:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", "query")
+                seen_params << param_key
+              end
+            end
           end
-        end
 
-        # Extract params (could be query for GET or form for POST/PUT/PATCH)
-        line.scan(/conn\.params\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_type = (method == "GET") ? "query" : "form"
-          param_key = "#{param_type}:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", param_type)
-            seen_params << param_key
+          # Extract params (could be query for GET or form for POST/PUT/PATCH)
+          if line.includes?("params[")
+            line.scan(/conn\.params\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_type = (method == "GET") ? "query" : "form"
+              param_key = "#{param_type}:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", param_type)
+                seen_params << param_key
+              end
+            end
           end
-        end
 
-        # Extract body parameters (conn.body_params["param"])
-        line.scan(/conn\.body_params\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_key = "form:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "form")
-            seen_params << param_key
+          # Extract body parameters (conn.body_params["param"])
+          if line.includes?("body_params")
+            line.scan(/conn\.body_params\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_key = "form:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", "form")
+                seen_params << param_key
+              end
+            end
+          end
+
+          # Extract cookie parameters (conn.cookies["cookie_name"])
+          if line.includes?("cookies")
+            line.scan(/conn\.cookies\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_key = "cookie:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", "cookie")
+                seen_params << param_key
+              end
+            end
           end
         end
 
         # Extract header parameters (get_req_header(conn, "header-name"))
-        line.scan(/get_req_header\(conn,\s*["']([^"']+)["']\)/) do |match|
-          param_name = match[1]
-          param_key = "header:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "header")
-            seen_params << param_key
-          end
-        end
-
-        # Extract cookie parameters (conn.cookies["cookie_name"])
-        line.scan(/conn\.cookies\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_key = "cookie:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "cookie")
-            seen_params << param_key
+        if has_header
+          line.scan(/get_req_header\(conn,\s*["']([^"']+)["']\)/) do |match|
+            param_name = match[1]
+            param_key = "header:#{param_name}"
+            unless seen_params.includes?(param_key)
+              params << Param.new(param_name, "", "header")
+              seen_params << param_key
+            end
           end
         end
       end
@@ -911,8 +957,12 @@ module Analyzer::Elixir
     # attribute sigil) so the path-parameter extractor recognises
     # it and the URL template reads cleanly. Mirrors the Python
     # f-string, Ruby `#{}`, PHP `$var`, and Crystal `#{}` fixes.
+    ELIXIR_INTERPOLATION_RE = /\#\{([^}]+)\}/
+
     private def normalize_elixir_interpolation(path : String) : String
-      path.gsub(/\#\{([^}]+)\}/) do |_|
+      # Most route literals have no `#{…}`; skip the PCRE gsub then.
+      return path unless path.includes?("\#{")
+      path.gsub(ELIXIR_INTERPOLATION_RE) do |_|
         token = $~[1].strip.lstrip('@')
         "{#{token}}"
       end
@@ -941,54 +991,59 @@ module Analyzer::Elixir
       endpoints = Array(Endpoint).new
 
       # Standard HTTP methods - extract controller and action info
-      add_standard_route(endpoints, line, "get", "GET", scope_prefix, scope_module, base, string_bindings)
-      add_standard_route(endpoints, line, "post", "POST", scope_prefix, scope_module, base, string_bindings)
-      add_standard_route(endpoints, line, "patch", "PATCH", scope_prefix, scope_module, base, string_bindings)
-      add_standard_route(endpoints, line, "put", "PUT", scope_prefix, scope_module, base, string_bindings)
-      add_standard_route(endpoints, line, "delete", "DELETE", scope_prefix, scope_module, base, string_bindings)
-      add_standard_route(endpoints, line, "options", "OPTIONS", scope_prefix, scope_module, base, string_bindings)
-      add_standard_route(endpoints, line, "head", "HEAD", scope_prefix, scope_module, base, string_bindings)
-
-      # Socket routes
-      line.scan(/(?:^|[^.\w])socket\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-        tmp = Endpoint.new(scoped_route_path(scope_prefix, match[1]), "GET")
-        tmp.protocol = "ws"
-        endpoints << tmp
+      STANDARD_ROUTE_METHODS.each do |verb, http_method|
+        add_standard_route(endpoints, line, verb, http_method, scope_prefix, scope_module, base, string_bindings)
       end
 
-      # LiveView routes
-      line.scan(/(?:^|[^.\w])live\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
-        endpoints << Endpoint.new(scoped_route_path(scope_prefix, match[1]), "GET")
-      end
-
-      # Phoenix.LiveDashboard and forwarded plugs expose mounted HTTP surfaces.
-      line.scan(/(?:^|[^.\w])live_dashboard\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        endpoints << Endpoint.new(scoped_route_path(scope_prefix, match[1]), "GET")
-      end
-
-      line.scan(/(?:^|[^.\w])forward\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
-        endpoints << Endpoint.new(scoped_route_path(scope_prefix, match[1]), "FORWARD")
-      end
-
-      if via_match = line.match(/(?:^|[^.\w])match\s*(?:\(\s*)?['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*,\s*:(\w+[!?]?)[^\]]*via:\s*\[([^\]]+)\]/)
-        path = scoped_route_path(scope_prefix, via_match[1])
-        controller = scoped_controller(scope_module, via_match[2])
-        controller_action = via_match[3]
-        via_match[4].scan(/:(\w+)/) do |method_match|
-          http_method = method_match[1].upcase
-          @route_map[route_map_key(base, http_method, path)] = ControllerAction.new(controller, controller_action)
-          endpoints << Endpoint.new(path, http_method)
+      # Socket / LiveView / dashboard / forward / match — each gated by a
+      # cheap substring so the common `get "/…"` lines skip the rest.
+      if line.includes?("socket")
+        line.scan(/(?:^|[^.\w])socket\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
+          tmp = Endpoint.new(scoped_route_path(scope_prefix, match[1]), "GET")
+          tmp.protocol = "ws"
+          endpoints << tmp
         end
       end
 
-      if match = line.match(/(?:^|[^.\w])match\s*(?:\(\s*)?:(\w+|\*)\s*,\s*['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*|unquote\(\s*\w+\s*\))\s*,\s*:(\w+[!?]?)/)
-        http_methods = match_route_methods(match[1])
-        path = scoped_route_path(scope_prefix, match[2])
-        controller_action = match[4]
-        controller = resolve_unquoted_ref(match[3], string_bindings)
-        http_methods.each do |http_method|
-          @route_map[route_map_key(base, http_method, path)] = ControllerAction.new(scoped_controller(scope_module, controller), controller_action) if controller
-          endpoints << Endpoint.new(path, http_method)
+      if line.includes?("live")
+        line.scan(/(?:^|[^.\w])live\s*(?:\(\s*)?['"](.+?)['"]\s*,\s*(.+?)\s*/) do |match|
+          endpoints << Endpoint.new(scoped_route_path(scope_prefix, match[1]), "GET")
+        end
+
+        if line.includes?("live_dashboard")
+          line.scan(/(?:^|[^.\w])live_dashboard\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
+            endpoints << Endpoint.new(scoped_route_path(scope_prefix, match[1]), "GET")
+          end
+        end
+      end
+
+      if line.includes?("forward")
+        line.scan(/(?:^|[^.\w])forward\s*(?:\(\s*)?['"](.+?)['"]/) do |match|
+          endpoints << Endpoint.new(scoped_route_path(scope_prefix, match[1]), "FORWARD")
+        end
+      end
+
+      if line.includes?("match")
+        if via_match = line.match(/(?:^|[^.\w])match\s*(?:\(\s*)?['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*,\s*:(\w+[!?]?)[^\]]*via:\s*\[([^\]]+)\]/)
+          path = scoped_route_path(scope_prefix, via_match[1])
+          controller = scoped_controller(scope_module, via_match[2])
+          controller_action = via_match[3]
+          via_match[4].scan(/:(\w+)/) do |method_match|
+            http_method = method_match[1].upcase
+            @route_map[route_map_key(base, http_method, path)] = ControllerAction.new(controller, controller_action)
+            endpoints << Endpoint.new(path, http_method)
+          end
+        end
+
+        if match = line.match(/(?:^|[^.\w])match\s*(?:\(\s*)?:(\w+|\*)\s*,\s*['"]([^'"]+)['"]\s*,\s*([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*|unquote\(\s*\w+\s*\))\s*,\s*:(\w+[!?]?)/)
+          http_methods = match_route_methods(match[1])
+          path = scoped_route_path(scope_prefix, match[2])
+          controller_action = match[4]
+          controller = resolve_unquoted_ref(match[3], string_bindings)
+          http_methods.each do |http_method|
+            @route_map[route_map_key(base, http_method, path)] = ControllerAction.new(scoped_controller(scope_module, controller), controller_action) if controller
+            endpoints << Endpoint.new(path, http_method)
+          end
         end
       end
 

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -33,13 +33,26 @@ module Analyzer::Elixir
     # this distinguishes the two even though both share `get`/`post`
     # route macros.
     private def phoenix_router?(content : String) : Bool
-      content.includes?("Phoenix.Router") ||
-        content.matches?(/\buse\s+[A-Z]\w*(?:\.[A-Z]\w*)*\s*,\s*:router\b/)
+      return true if content.includes?("Phoenix.Router")
+      # Cheap reject before the `:router` atom regex — most Plug modules
+      # never mention `use ` with a router tag.
+      return false unless content.includes?(":router")
+      content.matches?(/\buse\s+[A-Z]\w*(?:\.[A-Z]\w*)*\s*,\s*:router\b/)
     end
+
+    # File-level gate: Plug.Router only registers absolute paths via the
+    # verb/`match`/`forward` macros. Files with none of those tokens
+    # cannot contribute endpoints (models, views, plain modules).
+    PLUG_ROUTE_EVIDENCE_RE = /
+      \b(?:get|post|put|patch|delete|head|options|forward|match)
+      \s*(?:\(\s*)?["']
+    /x
 
     def analyze_content(content : String, file_path : String) : Array(Endpoint)
       endpoints = Array(Endpoint).new
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      return endpoints unless content.matches?(PLUG_ROUTE_EVIDENCE_RE)
+
+      include_callee = callees_needed?
 
       # Find all route blocks and extract params
       lines = content.lines

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -67,11 +67,11 @@ module Analyzer::Elixir
       in_triple_single = false
       lines.each_with_index do |line, index|
         if line.includes?("\"\"\"")
-          line.scan(/"""/).size.times { in_triple_double = !in_triple_double }
+          count_substring(line, "\"\"\"").times { in_triple_double = !in_triple_double }
           next
         end
         if line.includes?("'''")
-          line.scan(/'''/).size.times { in_triple_single = !in_triple_single }
+          count_substring(line, "'''").times { in_triple_single = !in_triple_single }
           next
         end
         next if in_triple_double || in_triple_single
@@ -277,6 +277,19 @@ module Analyzer::Elixir
     # doesn't begin with `/` is a misfire on some other string literal.
     private def plug_route_path?(path : String) : Bool
       path.starts_with?('/')
+    end
+
+    # Count non-overlapping occurrences of `needle` without allocating a
+    # MatchData array (`String#scan(…​).size`).
+    private def count_substring(text : String, needle : String) : Int32
+      return 0 if needle.empty?
+      count = 0
+      i = 0
+      while (j = text.index(needle, i))
+        count += 1
+        i = j + needle.size
+      end
+      count
     end
   end
 end

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -3,15 +3,11 @@ require "../../engines/elixir_engine"
 module Analyzer::Elixir
   class Plug < ElixirEngine
     def analyze_file(path : String) : Array(Endpoint)
+      # Extension and `*_test.exs` filtering live in ElixirEngine's
+      # `parallel_file_scan`; Plug only needs the remaining .ex/.exs
+      # split (.exs scripts still carry Plug.Router modules).
       ext = File.extname(path)
       return [] of Endpoint unless ext == ".ex" || ext == ".exs"
-      # Elixir convention: `*_test.exs` files are ExUnit test
-      # modules. They register routes (often via inline
-      # `Plug.Router`-using modules or `defmodule TestRouter do ... use
-      # Phoenix.Router`) purely to exercise the framework; the routes
-      # never serve real traffic. Phoenix's own repo and any
-      # `phx.gen.auth` scaffold's tests trip this hard.
-      return [] of Endpoint if test_only_path?(path)
 
       endpoints = [] of Endpoint
       # `read_file_content` reuses the detector's already-cached bytes
@@ -86,14 +82,6 @@ module Analyzer::Elixir
       end
 
       endpoints
-    end
-
-    # ExUnit's filename convention is rigid: every test module sits in
-    # a file named `*_test.exs`, and `mix test` ignores anything else.
-    # Skipping by suffix is safe because production code never adopts
-    # that name.
-    private def test_only_path?(path : String) : Bool
-      File.basename(path).ends_with?("_test.exs")
     end
 
     def extract_params_from_block(lines : Array(String), start_index : Int32, method : String, block_end : Int32? = nil) : Array(Param)

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -108,55 +108,70 @@ module Analyzer::Elixir
       # Extract parameters from the block content
       (start_index..end_index).each do |i|
         line = lines[i]
+        has_conn = line.includes?("conn.")
+        has_header = line.includes?("get_req_header")
+        next unless has_conn || has_header
 
-        # Extract query parameters (conn.query_params["param"] or conn.params["param"] for GET)
-        line.scan(/conn\.query_params\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_key = "query:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "query")
-            seen_params << param_key
+        if has_conn
+          # Extract query parameters (conn.query_params["param"] or conn.params["param"] for GET)
+          if line.includes?("query_params")
+            line.scan(/conn\.query_params\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_key = "query:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", "query")
+                seen_params << param_key
+              end
+            end
           end
-        end
 
-        # Extract params (could be query for GET or form for POST/PUT/PATCH)
-        line.scan(/conn\.params\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_type = (method == "GET") ? "query" : "form"
-          param_key = "#{param_type}:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", param_type)
-            seen_params << param_key
+          # Extract params (could be query for GET or form for POST/PUT/PATCH)
+          if line.includes?("params[")
+            line.scan(/conn\.params\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_type = (method == "GET") ? "query" : "form"
+              param_key = "#{param_type}:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", param_type)
+                seen_params << param_key
+              end
+            end
           end
-        end
 
-        # Extract body parameters (conn.body_params["param"] for POST/PUT/PATCH)
-        line.scan(/conn\.body_params\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_key = "form:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "form")
-            seen_params << param_key
+          # Extract body parameters (conn.body_params["param"] for POST/PUT/PATCH)
+          if line.includes?("body_params")
+            line.scan(/conn\.body_params\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_key = "form:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", "form")
+                seen_params << param_key
+              end
+            end
+          end
+
+          # Extract cookie parameters (conn.cookies["cookie_name"])
+          if line.includes?("cookies")
+            line.scan(/conn\.cookies\[["']([^"']+)["']\]/) do |match|
+              param_name = match[1]
+              param_key = "cookie:#{param_name}"
+              unless seen_params.includes?(param_key)
+                params << Param.new(param_name, "", "cookie")
+                seen_params << param_key
+              end
+            end
           end
         end
 
         # Extract header parameters (get_req_header(conn, "header-name"))
-        line.scan(/get_req_header\(conn,\s*["']([^"']+)["']\)/) do |match|
-          param_name = match[1]
-          param_key = "header:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "header")
-            seen_params << param_key
-          end
-        end
-
-        # Extract cookie parameters (conn.cookies["cookie_name"])
-        line.scan(/conn\.cookies\[["']([^"']+)["']\]/) do |match|
-          param_name = match[1]
-          param_key = "cookie:#{param_name}"
-          unless seen_params.includes?(param_key)
-            params << Param.new(param_name, "", "cookie")
-            seen_params << param_key
+        if has_header
+          line.scan(/get_req_header\(conn,\s*["']([^"']+)["']\)/) do |match|
+            param_name = match[1]
+            param_key = "header:#{param_name}"
+            unless seen_params.includes?(param_key)
+              params << Param.new(param_name, "", "header")
+              seen_params << param_key
+            end
           end
         end
       end
@@ -234,22 +249,24 @@ module Analyzer::Elixir
         end
       end
 
-      # Match match statements with method patterns
-      # match "/path", via: [:get, :post]
-      if via_match = line.match(/(?:^|[^.\w])match\s+["\']([^"\']+)["\'][^:]*via:\s*\[([^\]]+)\]/)
-        path = via_match[1]
-        if plug_route_path?(path)
-          via_match[2].scan(/:(\w+)/) do |method_match|
-            endpoints << Endpoint.new(path, method_match[1].upcase)
+      # Match match statements only when the token is present.
+      if line.includes?("match")
+        # match "/path", via: [:get, :post]
+        if via_match = line.match(/(?:^|[^.\w])match\s+["\']([^"\']+)["\'][^:]*via:\s*\[([^\]]+)\]/)
+          path = via_match[1]
+          if plug_route_path?(path)
+            via_match[2].scan(/:(\w+)/) do |method_match|
+              endpoints << Endpoint.new(path, method_match[1].upcase)
+            end
           end
         end
-      end
 
-      # Match simple match statements (defaults to GET)
-      unless line.includes?("via:")
-        line.scan(/(?:^|[^.\w])match\s+["\']([^"\']+)["\']/) do |match|
-          path = match[1]
-          endpoints << Endpoint.new(path, "GET") if plug_route_path?(path)
+        # Match simple match statements (defaults to GET)
+        unless line.includes?("via:")
+          line.scan(/(?:^|[^.\w])match\s+["\']([^"\']+)["\']/) do |match|
+            path = match[1]
+            endpoints << Endpoint.new(path, "GET") if plug_route_path?(path)
+          end
         end
       end
 

--- a/src/analyzer/analyzers/elixir/elixir_plug.cr
+++ b/src/analyzer/analyzers/elixir/elixir_plug.cr
@@ -285,7 +285,7 @@ module Analyzer::Elixir
       return 0 if needle.empty?
       count = 0
       i = 0
-      while (j = text.index(needle, i))
+      while j = text.index(needle, i)
         count += 1
         i = j + needle.size
       end

--- a/src/analyzer/analyzers/lua/lapis.cr
+++ b/src/analyzer/analyzers/lua/lapis.cr
@@ -113,10 +113,12 @@ module Analyzer::Lua
     private def detect_app_vars(cleaned : String) : Array(String)
       vars = Set(String).new
       vars << "app"
-      cleaned.scan(APP_VAR_RE) do |match|
-        name = match[1]
-        next if name == "local"
-        vars << name
+      if cleaned.includes?("lapis.Application")
+        cleaned.scan(APP_VAR_RE) do |match|
+          name = match[1]
+          next if name == "local"
+          vars << name
+        end
       end
       vars.to_a
     end
@@ -132,10 +134,12 @@ module Analyzer::Lua
     private def detect_app_paths(cleaned : String, app_vars : Array(String)) : Hash(String, String)
       known = app_vars.to_set
       paths = {} of String => String
-      cleaned.scan(APP_PATH_RE) do |match|
-        var = match[1]
-        next unless known.includes?(var)
-        paths[var] = match[3]
+      if cleaned.includes?(".path")
+        cleaned.scan(APP_PATH_RE) do |match|
+          var = match[1]
+          next unless known.includes?(var)
+          paths[var] = match[3]
+        end
       end
       paths
     end
@@ -149,7 +153,7 @@ module Analyzer::Lua
     # is the universal convention) and prefix the file's MoonScript
     # class actions with it.
     private def detect_moonscript_prefix(cleaned : String) : String
-      if match = cleaned.match(MOON_PATH_RE)
+      if cleaned.includes?("@path") && (match = cleaned.match(MOON_PATH_RE))
         match[2]
       else
         ""
@@ -277,6 +281,7 @@ module Analyzer::Lua
                                   cleaned : String,
                                   include_callee : Bool,
                                   handler_bodies : Hash(String, Noir::LuaCalleeExtractor::FunctionBody))
+      return unless cleaned.includes?("]") && cleaned.includes?("=")
       pattern = /\[\s*(['"])([^'"]+)\1\s*\]\s*=/
       cleaned.scan(pattern) do |match|
         url = match[2]
@@ -304,6 +309,7 @@ module Analyzer::Lua
     # regardless of what follows the `:` and inspect the action region to
     # recover the HTTP verbs (from a `respond_to` block) and callees.
     private def emit_moonscript_routes(path : String, content : String, cleaned : String, include_callee : Bool, moon_prefix : String)
+      return unless path.ends_with?(".moon")
       # Bracketed named routes `[name: "/path"]:` are unambiguous Lapis
       # syntax, so we accept any action body. Bare `"/path":` keys are
       # only treated as routes when the path is rooted and the body

--- a/src/analyzer/analyzers/lua/lor.cr
+++ b/src/analyzer/analyzers/lua/lor.cr
@@ -121,10 +121,12 @@ module Analyzer::Lua
     # `local x = require("a.b.c")` → { "x" => "a.b.c" }.
     private def detect_requires(cleaned : String) : Hash(String, String)
       map = {} of String => String
-      cleaned.scan(REQUIRE_RE) do |match|
-        name = match[1]
-        next if name == "local"
-        map[name] = match[3]
+      if cleaned.includes?("require")
+        cleaned.scan(REQUIRE_RE) do |match|
+          name = match[1]
+          next if name == "local"
+          map[name] = match[3]
+        end
       end
       map
     end
@@ -137,9 +139,13 @@ module Analyzer::Lua
     # leaking as phantom endpoints.
     private def detect_route_vars(cleaned : String) : Set(String)
       vars = Set(String).new
-      cleaned.scan(APP_VAR_RE) { |m| vars << m[1] unless m[1] == "local" }
-      cleaned.scan(ROUTER_VAR_RE) { |m| vars << m[1] unless m[1] == "local" }
-      cleaned.scan(USE_RECEIVER_RE) { |m| vars << m[1] }
+      if cleaned.includes?("lor")
+        cleaned.scan(APP_VAR_RE) { |m| vars << m[1] unless m[1] == "local" }
+        cleaned.scan(ROUTER_VAR_RE) { |m| vars << m[1] unless m[1] == "local" }
+      end
+      if cleaned.includes?("use")
+        cleaned.scan(USE_RECEIVER_RE) { |m| vars << m[1] }
+      end
       vars
     end
 

--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -615,30 +615,40 @@ module Analyzer::Perl
 
     private def extract_params_from_body(body : String, method : String) : Array(Param)
       params = [] of Param
+      # Action bodies without request accessors skip six PCRE2 scans.
+      return params unless body.includes?("->") && (body.includes?("req") || body.includes?("request"))
 
-      body.scan(/->\s*(?:req|request)\s*->\s*(?:query_params|query_parameters|parameters)\s*->\s*\{?\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
-        params << Param.new(match[1], "", "query")
+      if body.includes?("param")
+        body.scan(/->\s*(?:req|request)\s*->\s*(?:query_params|query_parameters|parameters)\s*->\s*\{?\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
+          params << Param.new(match[1], "", "query")
+        end
+
+        body.scan(/->\s*(?:req|request)\s*->\s*(?:body_params|body_parameters)\s*->\s*\{?\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
+          params << Param.new(match[1], "", "form")
+        end
+
+        body.scan(/->\s*(?:req|request)\s*->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |match|
+          param_type = (method == "GET" || method == "HEAD" || method == "OPTIONS") ? "query" : "form"
+          params << Param.new(match[1], "", param_type)
+        end
       end
 
-      body.scan(/->\s*(?:req|request)\s*->\s*(?:body_params|body_parameters)\s*->\s*\{?\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
-        params << Param.new(match[1], "", "form")
+      if body.includes?("body_data") || body.includes?("->data") || body.includes?("-> data")
+        body.scan(/->\s*(?:req|request)\s*->\s*(?:body_data|data)\s*->\s*\{?\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
+          params << Param.new(match[1], "", "json")
+        end
       end
 
-      body.scan(/->\s*(?:req|request)\s*->\s*(?:body_data|data)\s*->\s*\{?\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
-        params << Param.new(match[1], "", "json")
+      if body.includes?("header")
+        body.scan(/->\s*(?:req|request)\s*->\s*(?:header|headers\s*->\s*header)\s*\(\s*['"]([^'"]+)['"]/) do |match|
+          params << Param.new(match[1], "", "header")
+        end
       end
 
-      body.scan(/->\s*(?:req|request)\s*->\s*(?:header|headers\s*->\s*header)\s*\(\s*['"]([^'"]+)['"]/) do |match|
-        params << Param.new(match[1], "", "header")
-      end
-
-      body.scan(/->\s*(?:req|request)\s*->\s*cookies?\s*(?:->\s*\{|\(\s*)\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
-        params << Param.new(match[1], "", "cookie")
-      end
-
-      body.scan(/->\s*(?:req|request)\s*->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |match|
-        param_type = (method == "GET" || method == "HEAD" || method == "OPTIONS") ? "query" : "form"
-        params << Param.new(match[1], "", param_type)
+      if body.includes?("cookie")
+        body.scan(/->\s*(?:req|request)\s*->\s*cookies?\s*(?:->\s*\{|\(\s*)\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |match|
+          params << Param.new(match[1], "", "cookie")
+        end
       end
 
       params

--- a/src/analyzer/analyzers/perl/catalyst.cr
+++ b/src/analyzer/analyzers/perl/catalyst.cr
@@ -50,8 +50,11 @@ module Analyzer::Perl
         next unless catalyst_source_file?(path)
 
         content = read_file_content(path)
-        file_actions = collect_actions(content, path)
-        file_configs = collect_controller_configs(sanitize_perl_lines(content.lines))
+        # One sanitize + one config collect per file. Previously
+        # `collect_actions` re-sanitized and re-parsed configs for the
+        # action walk, then the outer call did both again for composition.
+        lines = sanitize_perl_lines(content.lines)
+        file_actions, file_configs = collect_actions_and_configs(content, lines, path)
         actions_mutex.synchronize do
           actions.concat(file_actions)
           file_configs.each { |pkg, cfg| configs[pkg] = cfg }
@@ -70,8 +73,8 @@ module Analyzer::Perl
     end
 
     def analyze_content(content : String, file_path : String) : Array(Endpoint)
-      actions = collect_actions(content, file_path)
-      configs = collect_controller_configs(sanitize_perl_lines(content.lines))
+      lines = sanitize_perl_lines(content.lines)
+      actions, configs = collect_actions_and_configs(content, lines, file_path)
       analyze_actions(compose_actions(actions, configs))
     end
 
@@ -215,9 +218,12 @@ module Analyzer::Perl
       sources
     end
 
-    private def collect_actions(content : String, file_path : String) : Array(RouteAction)
-      raw_lines = content.lines
-      lines = sanitize_perl_lines(raw_lines)
+    # Single-pass collect of route actions + controller configs from
+    # already-sanitized lines. Callers must not re-run `sanitize_perl_lines`
+    # or `collect_controller_configs` for the same file.
+    private def collect_actions_and_configs(content : String,
+                                            lines : Array(String),
+                                            file_path : String) : Tuple(Array(RouteAction), Hash(String, ControllerConfig))
       # Count braces over a string/comment/regex-stripped (line-aligned) view so
       # an unbalanced brace inside a literal can't truncate/extend a sub body.
       code_lines = code_only_lines(lines)
@@ -229,8 +235,13 @@ module Analyzer::Perl
 
       while index < lines.size
         line = lines[index]
-        if package_match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_:]*)\s*;/)
+        if line.includes?("package") && (package_match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_:]*)\s*;/))
           package_name = package_match[1]
+        end
+
+        unless line.includes?("sub")
+          index += 1
+          next
         end
 
         sub_match = line.match(/^\s*sub\s+([A-Za-z_][A-Za-z0-9_]*)\b(.*)$/)
@@ -281,7 +292,7 @@ module Analyzer::Perl
         index += 1
       end
 
-      actions
+      {actions, package_configs}
     end
 
     private def collect_controller_configs(lines : Array(String)) : Hash(String, ControllerConfig)
@@ -295,7 +306,7 @@ module Analyzer::Perl
 
       while index < lines.size
         line = lines[index]
-        if package_match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_:]*)\s*;/)
+        if line.includes?("package") && (package_match = line.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_:]*)\s*;/))
           package_name = package_match[1]
         end
 
@@ -303,7 +314,7 @@ module Analyzer::Perl
         # `with 'Role'` / `with ('A', 'B')` / multi-line `with\n  'A',\n  'B';`
         # — Moose role application. Roles are composition sources whose
         # chained actions belong to the consuming controller.
-        if stripped.matches?(/^with\b/)
+        if stripped.starts_with?("with") && stripped.matches?(/^with\b/)
           statement, index = accumulate_statement(lines, index)
           (roles[package_name] ||= [] of String).concat(extract_quoted_packages(statement))
           next

--- a/src/analyzer/analyzers/perl/cli.cr
+++ b/src/analyzer/analyzers/perl/cli.cr
@@ -58,19 +58,19 @@ module Analyzer::Perl
               # in the file don't leak as bogus flags.
               in_getoptions = true if line.includes?("GetOptions") && line.includes?("(")
               if in_getoptions
-                line.scan(GETOPT_KEY) { |m| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag")) }
-              end
-              if in_getoptions
+                if line.includes?("=>")
+                  line.scan(GETOPT_KEY) { |m| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag")) }
+                end
                 go_depth += line.count('(') - line.count(')')
                 in_getoptions = false if go_depth <= 0
               end
-              if m = line.match(GETOPTS)
+              if line.includes?("getopt") && (m = line.match(GETOPTS))
                 parse_getopt_short(m[1], fetch_endpoint(endpoints, root_url, path, line_no))
               end
-              if m = line.match(ARGV_IDX)
+              if line.includes?("ARGV") && (m = line.match(ARGV_IDX))
                 fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new("arg#{m[1]}", "", "argument"))
               end
-              if emit_env
+              if emit_env && line.includes?("ENV")
                 line.scan(ENV_READ) { |em| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(em[1], "", "env")) }
               end
               # Only treat `[ 'spec' => ... ]` array-refs as option specs
@@ -78,13 +78,13 @@ module Analyzer::Perl
               # literals elsewhere in the file don't leak as bogus flags.
               in_describe_options = true if line.includes?("describe_options") && line.includes?("(")
               if in_describe_options
-                line.scan(DESCRIBE_OPT_SPEC) { |opt_match| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(opt_match[1], "", "flag")) }
-              end
-              if in_describe_options
+                if line.includes?("[")
+                  line.scan(DESCRIBE_OPT_SPEC) { |opt_match| fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(opt_match[1], "", "flag")) }
+                end
                 do_depth += line.count('(') - line.count(')')
                 in_describe_options = false if do_depth <= 0
               end
-              if uses_moox_options
+              if uses_moox_options && line.includes?("option")
                 if m = line.match(MOOX_OPTION)
                   fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
                 end

--- a/src/analyzer/analyzers/perl/dancer2.cr
+++ b/src/analyzer/analyzers/perl/dancer2.cr
@@ -54,7 +54,7 @@ module Analyzer::Perl
     end
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       parallel_file_scan do |path|
         result.concat(analyze_file(path, include_callee))
       end
@@ -62,7 +62,7 @@ module Analyzer::Perl
     end
 
     def analyze_file(path : String) : Array(Endpoint)
-      analyze_file(path, any_to_bool(@options["include_callee"]?))
+      analyze_file(path, callees_needed?)
     end
 
     private def analyze_file(path : String, include_callee : Bool) : Array(Endpoint)
@@ -141,12 +141,18 @@ module Analyzer::Perl
       pod_blanked.each_with_index do |line, index|
         stripped = line.strip
         unless stripped.empty? || stripped.starts_with?('#')
-          if block = line.match(PREFIX_BLOCK_RE)
-            prefix_stack << {depth, normalize_prefix(block[2])}
-          elsif line.matches?(PREFIX_RESET_RE)
-            proc_prefix = ""
-          elsif (proc = line.match(PREFIX_PROC_RE)) && prefix_stack.empty?
-            proc_prefix = normalize_prefix(proc[2])
+          if stripped.includes?("prefix")
+            if block = line.match(PREFIX_BLOCK_RE)
+              prefix_stack << {depth, normalize_prefix(block[2])}
+            elsif line.matches?(PREFIX_RESET_RE)
+              proc_prefix = ""
+            elsif (proc = line.match(PREFIX_PROC_RE)) && prefix_stack.empty?
+              proc_prefix = normalize_prefix(proc[2])
+            else
+              line_to_routes(line, index, offsets[index], current_prefix(proc_prefix, prefix_stack)).each do |route|
+                routes << route
+              end
+            end
           else
             line_to_routes(line, index, offsets[index], current_prefix(proc_prefix, prefix_stack)).each do |route|
               routes << route
@@ -169,12 +175,16 @@ module Analyzer::Perl
 
     private def line_to_routes(line : String, index : Int32, offset : Int32, prefix : String) : Array(RouteHit)
       result = [] of RouteHit
-      handler = line.match(CODEREF_RE).try(&.[1])
+      leading = line.lstrip
+      # Route keywords sit at statement start; skip ordinary body lines.
+      return result unless dancer_route_lead?(leading)
+
+      handler = line.includes?("\\&") ? line.match(CODEREF_RE).try(&.[1]) : nil
 
       if m = line.match(VERB_STRING_RE)
         url = join_url(prefix, m[3])
         result << RouteHit.new(url, [http_method(m[1])], index, offset, handler)
-      elsif m = line.match(VERB_QR_RE)
+      elsif leading.includes?("qr") && (m = line.match(VERB_QR_RE))
         body = m[2]? || m[3]? || m[4]? || m[5]? || m[6]? || ""
         url = join_url(prefix, regex_route_path(body))
         result << RouteHit.new(url, [http_method(m[1])], index, offset, handler)
@@ -189,6 +199,13 @@ module Analyzer::Perl
       end
 
       result
+    end
+
+    private def dancer_route_lead?(leading : String) : Bool
+      leading.starts_with?("get") || leading.starts_with?("post") ||
+        leading.starts_with?("put") || leading.starts_with?("patch") ||
+        leading.starts_with?("options") || leading.starts_with?("del") ||
+        leading.starts_with?("any")
     end
 
     private def body_for_route(content : String,
@@ -249,42 +266,56 @@ module Analyzer::Perl
       params = [] of Param
       read_method = method == "GET" || method == "HEAD" || method == "OPTIONS"
 
-      body.scan(/\broute_parameters\s*->\s*(?:get(?:_all)?\s*\(\s*['"]([^'"]+)['"]|\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*))/) do |m|
-        name = m[1]? || m[2]?
-        params << Param.new(name, "", "path") if name
+      if body.includes?("route_parameters")
+        body.scan(/\broute_parameters\s*->\s*(?:get(?:_all)?\s*\(\s*['"]([^'"]+)['"]|\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*))/) do |m|
+          name = m[1]? || m[2]?
+          params << Param.new(name, "", "path") if name
+        end
       end
 
-      body.scan(/\bquery_parameters\s*->\s*(?:get(?:_all)?\s*\(\s*['"]([^'"]+)['"]|\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*))/) do |m|
-        name = m[1]? || m[2]?
-        params << Param.new(name, "", "query") if name
+      if body.includes?("query_parameters")
+        body.scan(/\bquery_parameters\s*->\s*(?:get(?:_all)?\s*\(\s*['"]([^'"]+)['"]|\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*))/) do |m|
+          name = m[1]? || m[2]?
+          params << Param.new(name, "", "query") if name
+        end
       end
 
-      body.scan(/\bbody_parameters\s*->\s*(?:get(?:_all)?\s*\(\s*['"]([^'"]+)['"]|\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*))/) do |m|
-        name = m[1]? || m[2]?
-        params << Param.new(name, "", "form") if name
+      if body.includes?("body_parameters")
+        body.scan(/\bbody_parameters\s*->\s*(?:get(?:_all)?\s*\(\s*['"]([^'"]+)['"]|\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*))/) do |m|
+          name = m[1]? || m[2]?
+          params << Param.new(name, "", "form") if name
+        end
       end
 
-      body.scan(/\bupload\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", "form")
+      if body.includes?("upload")
+        body.scan(/\bupload\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", "form")
+        end
       end
 
-      body.scan(/->\s*header\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", "header")
+      if body.includes?("header")
+        body.scan(/->\s*header\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", "header")
+        end
       end
 
-      body.scan(/\bcookies?\s*(?:->\s*\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)|\(\s*['"]([^'"]+)['"])/) do |m|
-        name = m[1]? || m[2]?
-        params << Param.new(name, "", "cookie") if name
+      if body.includes?("cookie")
+        body.scan(/\bcookies?\s*(?:->\s*\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)|\(\s*['"]([^'"]+)['"])/) do |m|
+          name = m[1]? || m[2]?
+          params << Param.new(name, "", "cookie") if name
+        end
       end
 
       # Legacy mixed-source accessors: `param('x')` and `params->{x}`.
       # Bucket by HTTP method since the source is ambiguous.
-      param_type = read_method ? "query" : "form"
-      body.scan(/(?<![:\w>])param\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", param_type)
-      end
-      body.scan(/\bparams\s*->\s*\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |m|
-        params << Param.new(m[1], "", param_type)
+      if body.includes?("param")
+        param_type = read_method ? "query" : "form"
+        body.scan(/(?<![:\w>])param\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", param_type)
+        end
+        body.scan(/\bparams\s*->\s*\{\s*['"]?([A-Za-z_][A-Za-z0-9_-]*)/) do |m|
+          params << Param.new(m[1], "", param_type)
+        end
       end
 
       params
@@ -341,6 +372,10 @@ module Analyzer::Perl
 
     private def line_offsets(content : String) : Array(Int32)
       offsets = [0]
+      # Character offsets — `extract_sub_after` indexes `source.chars` by
+      # Unicode character. Byte offsets diverge on non-ASCII content and
+      # skip past the handler `sub` (seen on the Dancer2 fixture's notify
+      # route once a UTF-8 comment appears earlier in the file).
       content.each_char_with_index do |char, index|
         offsets << index + 1 if char == '\n'
       end

--- a/src/analyzer/analyzers/perl/mojolicious.cr
+++ b/src/analyzer/analyzers/perl/mojolicious.cr
@@ -32,7 +32,7 @@ module Analyzer::Perl
     alias ControllerCalleeIndex = Hash(ControllerActionKey, Array(Noir::PerlCalleeExtractor::Entry))
 
     def analyze
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       controller_callees = include_callee ? index_controller_callees : ControllerCalleeIndex.new
 
       parallel_file_scan do |path|
@@ -42,7 +42,7 @@ module Analyzer::Perl
     end
 
     def analyze_file(path : String) : Array(Endpoint)
-      analyze_file(path, any_to_bool(@options["include_callee"]?), ControllerCalleeIndex.new)
+      analyze_file(path, callees_needed?, ControllerCalleeIndex.new)
     end
 
     private def analyze_file(path : String,
@@ -117,8 +117,12 @@ module Analyzer::Perl
         next if File.directory?(path)
         ext = File.extname(path)
         next unless ext == ".pl" || ext == ".pm" || ext == ".psgi" || ext == ".t"
-
+        next if perl_test_path?(path, ext)
+        # Controllers always declare `package …::Controller::…`; skip the
+        # full strip/scan on files that can't contribute action callees.
         content = read_file_content(path)
+        next unless content.includes?("::Controller::") || content.includes?("package")
+
         base_path = configured_base_for(path)
         Noir::PerlCalleeExtractor.controller_action_callees(content, path).each do |key, entries|
           callees[{base_path, key}] ||= entries
@@ -141,23 +145,34 @@ module Analyzer::Perl
                           path_vars : Hash(String, String)) : Array(Endpoint)
       result = [] of Endpoint
 
-      # Mojolicious::Lite: `get '/path' => ...`
-      if m = line.match(LITE_VERB_RE)
-        url = m[2]
-        result << build_endpoint(url, m[1]) unless disallowed_route_url?(url)
-      end
+      # Routes always carry a quoted path (including empty `''`). Most
+      # source lines don't — skip all five PCRE2 scans for them.
+      return result unless line.includes?("'") || line.includes?("\"")
 
-      # Mojolicious::Lite: `any '/path'` or `any [GET => 'POST'] => '/path'`
-      if m = line.match(LITE_ANY_RE)
-        url = m[2]
-        unless disallowed_route_url?(url)
-          methods_str = m[1]?
-          full = normalize_placeholders(url)
-          methods_for_any(methods_str).each do |verb|
-            result << Endpoint.new(full, verb)
+      leading = line.lstrip
+      # Mojolicious::Lite keywords sit at statement start.
+      if lite_route_lead?(leading)
+        # Mojolicious::Lite: `get '/path' => ...`
+        if m = line.match(LITE_VERB_RE)
+          url = m[2]
+          result << build_endpoint(url, m[1]) unless disallowed_route_url?(url)
+        end
+
+        # Mojolicious::Lite: `any '/path'` or `any [GET => 'POST'] => '/path'`
+        if m = line.match(LITE_ANY_RE)
+          url = m[2]
+          unless disallowed_route_url?(url)
+            methods_str = m[1]?
+            full = normalize_placeholders(url)
+            methods_for_any(methods_str).each do |verb|
+              result << Endpoint.new(full, verb)
+            end
           end
         end
       end
+
+      # Full-app DSL always uses `->verb(…)`.
+      return result unless line.includes?("->")
 
       # Full app: `$r->get('/path')` etc.
       if m = line.match(FULL_VERB_RE)
@@ -206,6 +221,16 @@ module Analyzer::Perl
       end
 
       result
+    end
+
+    # True when the (already lstripped) line could be a Mojolicious::Lite
+    # route keyword. Avoids running LITE_* regexes on ordinary statements.
+    private def lite_route_lead?(leading : String) : Bool
+      leading.starts_with?("get") || leading.starts_with?("post") ||
+        leading.starts_with?("put") || leading.starts_with?("patch") ||
+        leading.starts_with?("delete") || leading.starts_with?("del") ||
+        leading.starts_with?("options") || leading.starts_with?("head") ||
+        leading.starts_with?("websocket") || leading.starts_with?("any")
     end
 
     # `$ua->get('http://example.com/foo')` is a `Mojo::UserAgent` HTTP
@@ -411,26 +436,38 @@ module Analyzer::Perl
 
     private def extract_params_from_line(line : String, method : String) : Array(Param)
       params = [] of Param
+      # Param accessors all go through `->…param` / header / cookie.
+      return params unless line.includes?("->")
 
-      line.scan(/->\s*req\s*->\s*query_params\s*->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", "query")
+      if line.includes?("query_params")
+        line.scan(/->\s*req\s*->\s*query_params\s*->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", "query")
+        end
       end
 
-      line.scan(/->\s*req\s*->\s*body_params\s*->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", "form")
+      if line.includes?("body_params")
+        line.scan(/->\s*req\s*->\s*body_params\s*->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", "form")
+        end
       end
 
-      line.scan(/->\s*req\s*->\s*headers\s*->\s*header\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", "header")
+      if line.includes?("header")
+        line.scan(/->\s*req\s*->\s*headers\s*->\s*header\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", "header")
+        end
       end
 
-      line.scan(/->\s*(?:req\s*->\s*)?cookie\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        params << Param.new(m[1], "", "cookie")
+      if line.includes?("cookie")
+        line.scan(/->\s*(?:req\s*->\s*)?cookie\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          params << Param.new(m[1], "", "cookie")
+        end
       end
 
-      line.scan(/->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |m|
-        param_type = (method == "GET" || method == "HEAD" || method == "OPTIONS") ? "query" : "form"
-        params << Param.new(m[1], "", param_type)
+      if line.includes?("param")
+        line.scan(/->\s*param\s*\(\s*['"]([^'"]+)['"]/) do |m|
+          param_type = (method == "GET" || method == "HEAD" || method == "OPTIONS") ? "query" : "form"
+          params << Param.new(m[1], "", param_type)
+        end
       end
 
       params
@@ -500,6 +537,9 @@ module Analyzer::Perl
 
     private def line_offsets(content : String) : Array(Int32)
       offsets = [0]
+      # Character offsets — `extract_sub_after` / `source.chars` index by
+      # Unicode character, not UTF-8 byte. A byte walk breaks on non-ASCII
+      # POD/comments (real Mojolicious apps hit this constantly).
       content.each_char_with_index do |char, index|
         offsets << index + 1 if char == '\n'
       end

--- a/src/analyzer/analyzers/php/cakephp.cr
+++ b/src/analyzer/analyzers/php/cakephp.cr
@@ -20,7 +20,7 @@ module Analyzer::Php
 
     private def analyze_routes_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       begin
         content = read_file_content(path)
         endpoints = analyze_routes_content(content, "", path, include_callee)

--- a/src/analyzer/analyzers/php/cli.cr
+++ b/src/analyzer/analyzers/php/cli.cr
@@ -57,7 +57,10 @@ module Analyzer::Php
     # literals.
     CLI_HINT_RE = Regex.union(
       "Symfony\\Component\\Console",
-      "extends Command",
+      # Mirror cli_evidence?'s /extends\s+Command/ — a literal single space
+      # would let this superset gate reject a `extends<TAB>Command` file that
+      # the precise check would accept.
+      /extends\s+Command/,
       "AsCommand",
       "getopt",
       "$argv",

--- a/src/analyzer/analyzers/php/cli.cr
+++ b/src/analyzer/analyzers/php/cli.cr
@@ -52,27 +52,46 @@ module Analyzer::Php
     WP_ASSOC_ARG_BRACKET = /\$assoc_args\s*\[\s*['"]([^'"]+)['"]\s*\]/
     WP_FLAG_VALUE        = /get_flag_value\s*\(\s*\$assoc_args\s*,\s*['"]([^'"]+)['"]/
 
+    # Cheap file-level reject before the precise multi-regex evidence
+    # check. Every accepted CLI shape contains at least one of these
+    # literals.
+    CLI_HINT_RE = Regex.union(
+      "Symfony\\Component\\Console",
+      "extends Command",
+      "AsCommand",
+      "getopt",
+      "$argv",
+      "League\\CLImate",
+      "Minicli\\",
+      "$signature",
+      "Robo\\Tasks",
+      "WP_CLI",
+    )
+
     def analyze
       endpoints = {} of String => Endpoint
 
       get_files_by_extension(".php").each do |path|
         next if File.directory?(path)
         next if PhpEngine.test_path?(path)
-        next unless File.exists?(path)
 
         begin
           content = read_file_content(path)
+          next unless content.matches?(CLI_HINT_RE)
           next unless cli_evidence?(content)
 
           binary = php_binary_name(path)
           root_url = "cli://#{binary}"
           emit_env = !content.matches?(WEB_FRAMEWORK_RE)
+          has_artisan = content.matches?(ARTISAN_SIGNATURE)
+          has_robo = content.matches?(ROBO_MARKER)
+          has_wp = content.matches?(WP_MARKER)
           lines = content.lines
 
           scan(lines, path, root_url, endpoints, emit_env)
-          scan_artisan(lines, path, root_url, endpoints) if content.matches?(ARTISAN_SIGNATURE)
-          scan_robo(lines, path, root_url, endpoints) if content.matches?(ROBO_MARKER)
-          scan_wp_cli(lines, path, root_url, endpoints) if content.matches?(WP_MARKER)
+          scan_artisan(lines, path, root_url, endpoints) if has_artisan
+          scan_robo(lines, path, root_url, endpoints) if has_robo
+          scan_wp_cli(lines, path, root_url, endpoints) if has_wp
         rescue e
           logger.debug "Error analyzing #{path}: #{e}"
           next

--- a/src/analyzer/analyzers/php/codeigniter.cr
+++ b/src/analyzer/analyzers/php/codeigniter.cr
@@ -32,7 +32,7 @@ module Analyzer::Php
 
     private def analyze_routes_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       begin
         content = read_file_content(path)
         endpoints.concat(analyze_routes_content(content, "", path, include_callee, "App\\Controllers"))

--- a/src/analyzer/analyzers/php/hyperf.cr
+++ b/src/analyzer/analyzers/php/hyperf.cr
@@ -22,7 +22,7 @@ module Analyzer::Php
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
       if hyperf_relevant?(content)

--- a/src/analyzer/analyzers/php/laminas.cr
+++ b/src/analyzer/analyzers/php/laminas.cr
@@ -43,7 +43,7 @@ module Analyzer::Php
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")
 
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
       if laminas_relevant?(path, content)

--- a/src/analyzer/analyzers/php/laravel.cr
+++ b/src/analyzer/analyzers/php/laravel.cr
@@ -60,12 +60,14 @@ module Analyzer::Php
       # Match any `.php` under a `routes/` directory at any depth. Larger
       # apps group routes in subdirectories — snipe-it keeps per-resource
       # files in `routes/web/hardware.php`, `routes/web/users.php`, etc.
-      File.dirname(path).split('/').includes?("routes")
+      # Prefer substring checks over allocating a dirname split array.
+      path.includes?("/routes/") || path.includes?("\\routes\\") ||
+        File.basename(File.dirname(path)) == "routes"
     end
 
     private def analyze_routes_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
       begin
         content = read_file_content(path)
         # `use App\Http\Controllers\...;` imports map the short class

--- a/src/analyzer/analyzers/php/lumen.cr
+++ b/src/analyzer/analyzers/php/lumen.cr
@@ -19,7 +19,7 @@ module Analyzer::Php
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")
 
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
       if lumen_relevant?(content)
@@ -33,6 +33,8 @@ module Analyzer::Php
     # every unrelated `.php` file feeding into the analyzer.
     private def lumen_relevant?(content : String) : Bool
       return true if content.includes?("Laravel\\Lumen")
+      # Cheap reject: every Lumen route registration goes through `$router`.
+      return false unless content.includes?("$router")
       !!content.match(/\$router\s*->\s*(?:get|post|put|patch|delete|options|head|group|addRoute)\s*\(/i)
     end
 

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -15,27 +15,31 @@ module Analyzer::Php
 
       endpoints = [] of Endpoint
       relative_path = get_relative_path(php_base_path_for(path), path)
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
       params_query = [] of Param
       params_body = [] of Param
       methods = [] of String
 
-      content.each_line do |line|
-        if line.matches?(ALLOW_PATTERNS_RE)
-          superglobal_matches = line.scan(/\$_(GET|POST|REQUEST|SERVER|COOKIE|FILES)\s*\[\s*['"]([^'"]+)['"]\s*\]/)
-          superglobal_matches.each do |match|
-            apply_param_reference(match[1], match[2], params_query, params_body, methods)
-          end
+      # Pure-PHP still emits a GET pseudo-endpoint per file even when no
+      # superglobals are present. Only the per-line param walk is gated.
+      if content.includes?("$_") || content.includes?("filter_input")
+        content.each_line do |line|
+          if line.matches?(ALLOW_PATTERNS_RE)
+            superglobal_matches = line.scan(/\$_(GET|POST|REQUEST|SERVER|COOKIE|FILES)\s*\[\s*['"]([^'"]+)['"]\s*\]/)
+            superglobal_matches.each do |match|
+              apply_param_reference(match[1], match[2], params_query, params_body, methods)
+            end
 
-          filter_input_matches = line.scan(/filter_input\s*\(\s*INPUT_(GET|POST|REQUEST|SERVER|COOKIE)\s*,\s*['"]([^'"]+)['"]/)
-          filter_input_matches.each do |match|
-            apply_param_reference(match[1], match[2], params_query, params_body, methods)
+            filter_input_matches = line.scan(/filter_input\s*\(\s*INPUT_(GET|POST|REQUEST|SERVER|COOKIE)\s*,\s*['"]([^'"]+)['"]/)
+            filter_input_matches.each do |match|
+              apply_param_reference(match[1], match[2], params_query, params_body, methods)
+            end
           end
+        rescue
+          next
         end
-      rescue
-        next
       end
 
       # For the pure-PHP analyzer we are parameter-driven (not route-driven).

--- a/src/analyzer/analyzers/php/slim.cr
+++ b/src/analyzer/analyzers/php/slim.cr
@@ -15,7 +15,7 @@ module Analyzer::Php
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
       return endpoints unless path.ends_with?(".php")
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
       if slim_relevant?(content)
@@ -36,8 +36,11 @@ module Analyzer::Php
     # Slim. Any file that reaches this analyzer via detection is usually in
     # a Slim project, but project-wide scans still feed unrelated PHP here.
     private def slim_relevant?(content : String) : Bool
-      content.matches?(RELEVANCE_MARKER_RE) ||
-        !!content.match(/\$\w+->(?:get|post|put|patch|delete|options|head|map|group)\s*\(/i)
+      return true if content.matches?(RELEVANCE_MARKER_RE)
+      # Verb/map/group registrations are always `$var->method(`. Skip the
+      # heavier verb regex when no `->` call shape is present.
+      return false unless content.includes?("->")
+      !!content.match(/\$\w+->(?:get|post|put|patch|delete|options|head|map|group)\s*\(/i)
     end
 
     private def analyze_routes_content(content : String,

--- a/src/analyzer/analyzers/php/symfony.cr
+++ b/src/analyzer/analyzers/php/symfony.cr
@@ -9,9 +9,17 @@ module Analyzer::Php
       end
     end
 
+    # Symfony route configs also live in YAML under config/routes*.
+    # Extend the engine's default `.php`-only source set.
+    protected def php_source_files : Array(String)
+      get_files_by_extension(".php") +
+        get_files_by_extension(".yaml") +
+        get_files_by_extension(".yml")
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       endpoints = [] of Endpoint
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       # Analyze PHP controller files
       if path.ends_with?(".php")
@@ -32,6 +40,12 @@ module Analyzer::Php
       endpoints = [] of Endpoint
 
       content = read_file_content(path)
+      # Controllers/services without route attributes dominate a Symfony
+      # tree. Skip the annotation/attribute scans when neither form is
+      # present (`@Route` or `#[Route`).
+      return endpoints unless content.includes?("Route")
+      return endpoints unless content.includes?("@Route") || content.includes?("#[Route")
+
       class_prefixes = extract_class_route_prefixes(content)
 
       # Look for route annotations (@Route) - more flexible pattern
@@ -265,64 +279,74 @@ module Analyzer::Php
       params = [] of Param
       seen_params = Set(String).new
 
+      # Every accessor below is `$request->…`. Bodies that never touch
+      # the request object cannot contribute params.
+      return params unless method_body.includes?("$request")
+
       # Extract query parameters: $request->query->get('param')
-      query_matches = method_body.scan(/\$request->query->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)
-      query_matches.each do |match|
-        param_name = match[1]
-        unless seen_params.includes?(param_name)
-          params << Param.new(param_name, "", "query")
-          seen_params.add(param_name)
+      if method_body.includes?("query->get")
+        method_body.scan(/\$request->query->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/) do |match|
+          param_name = match[1]
+          unless seen_params.includes?(param_name)
+            params << Param.new(param_name, "", "query")
+            seen_params.add(param_name)
+          end
         end
       end
 
       # Extract request body/form parameters: $request->request->get('param')
-      request_matches = method_body.scan(/\$request->request->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)
-      request_matches.each do |match|
-        param_name = match[1]
-        unless seen_params.includes?(param_name)
-          params << Param.new(param_name, "", "form")
-          seen_params.add(param_name)
+      if method_body.includes?("request->get")
+        method_body.scan(/\$request->request->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/) do |match|
+          param_name = match[1]
+          unless seen_params.includes?(param_name)
+            params << Param.new(param_name, "", "form")
+            seen_params.add(param_name)
+          end
         end
       end
 
       # Extract header parameters: $request->headers->get('param')
-      header_matches = method_body.scan(/\$request->headers->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)
-      header_matches.each do |match|
-        param_name = match[1]
-        unless seen_params.includes?(param_name)
-          params << Param.new(param_name, "", "header")
-          seen_params.add(param_name)
+      if method_body.includes?("headers->get")
+        method_body.scan(/\$request->headers->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/) do |match|
+          param_name = match[1]
+          unless seen_params.includes?(param_name)
+            params << Param.new(param_name, "", "header")
+            seen_params.add(param_name)
+          end
         end
       end
 
       # Extract cookie parameters: $request->cookies->get('param')
-      cookie_matches = method_body.scan(/\$request->cookies->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)
-      cookie_matches.each do |match|
-        param_name = match[1]
-        unless seen_params.includes?(param_name)
-          params << Param.new(param_name, "", "cookie")
-          seen_params.add(param_name)
+      if method_body.includes?("cookies->get")
+        method_body.scan(/\$request->cookies->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/) do |match|
+          param_name = match[1]
+          unless seen_params.includes?(param_name)
+            params << Param.new(param_name, "", "cookie")
+            seen_params.add(param_name)
+          end
         end
       end
 
       # Extract file parameters: $request->files->get('param')
-      file_matches = method_body.scan(/\$request->files->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)
-      file_matches.each do |match|
-        param_name = match[1]
-        unless seen_params.includes?(param_name)
-          params << Param.new(param_name, "", "file")
-          seen_params.add(param_name)
+      if method_body.includes?("files->get")
+        method_body.scan(/\$request->files->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/) do |match|
+          param_name = match[1]
+          unless seen_params.includes?(param_name)
+            params << Param.new(param_name, "", "file")
+            seen_params.add(param_name)
+          end
         end
       end
 
       # Extract generic request parameters: $request->get('param')
       # This is ambiguous (could be query or body), so we mark it as query by default
-      generic_matches = method_body.scan(/\$request->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/)
-      generic_matches.each do |match|
-        param_name = match[1]
-        unless seen_params.includes?(param_name)
-          params << Param.new(param_name, "", "query")
-          seen_params.add(param_name)
+      if method_body.includes?("->get")
+        method_body.scan(/\$request->get\s*\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)/) do |match|
+          param_name = match[1]
+          unless seen_params.includes?(param_name)
+            params << Param.new(param_name, "", "query")
+            seen_params.add(param_name)
+          end
         end
       end
 

--- a/src/analyzer/analyzers/php/thinkphp.cr
+++ b/src/analyzer/analyzers/php/thinkphp.cr
@@ -24,7 +24,7 @@ module Analyzer::Php
       # neither explicit route definitions nor implicit controller classes.
       return endpoints unless is_route || is_controller
 
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
 

--- a/src/analyzer/analyzers/php/yii.cr
+++ b/src/analyzer/analyzers/php/yii.cr
@@ -16,7 +16,7 @@ module Analyzer::Php
       endpoints = [] of Endpoint
 
       return endpoints unless path.ends_with?(".php")
-      include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
+      include_callee = callees_needed?
 
       content = read_file_content(path)
 
@@ -24,7 +24,9 @@ module Analyzer::Php
         endpoints.concat(analyze_url_manager(path, content))
       end
 
-      if path.ends_with?("Controller.php") || content.match(/class\s+\w+Controller\s+extends/)
+      if path.ends_with?("Controller.php") ||
+         (content.includes?("Controller") && content.includes?("extends") &&
+         !!content.match(/class\s+\w+Controller\s+extends/))
         endpoints.concat(analyze_controller(path, content, include_callee))
       end
 

--- a/src/analyzer/analyzers/ruby/grape.cr
+++ b/src/analyzer/analyzers/ruby/grape.cr
@@ -170,6 +170,11 @@ module Analyzer::Ruby
 
     private def grape_api_file?(content : String, grape_classes : Set(String)) : Bool
       return true if content.includes?("Grape::API")
+      # With no Grape classes anywhere in the project, the per-line membership
+      # loop below can only ever miss, so skip it. This is the common case when
+      # the whole-tree scan runs over a non-Grape repo (e.g. a Rails app, where
+      # every controller is a `class X < ApplicationController`).
+      return false if grape_classes.empty?
       return false unless content.includes?("class ") && content.includes?("<")
       content.each_line do |raw_line|
         next unless m = raw_line.match(GRAPE_CLASS_DEF)

--- a/src/analyzer/analyzers/ruby/rails.cr
+++ b/src/analyzer/analyzers/ruby/rails.cr
@@ -1308,48 +1308,54 @@ module Analyzer::Ruby
           method_bodies[this_method] << line
         end
 
-        if pm = line.match(/permit\s*\(([^)]*)\)/)
-          pm[1].split(',').each do |raw|
-            name = raw.gsub(/[:\s'"]/, "")
+        # Every param source below is a `[ ... ]` subscript except `permit(...)`.
+        # A line with neither a '[' nor the literal 'permit' cannot match any of
+        # them, so skip the four regex ops — this runs on every line of every
+        # controller in the app.
+        if line.includes?('[') || line.includes?("permit")
+          if pm = line.match(/permit\s*\(([^)]*)\)/)
+            pm[1].split(',').each do |raw|
+              name = raw.gsub(/[:\s'"]/, "")
+              next if name.empty? || this_method.empty?
+              # A permit list entry is always a lowercase symbol/string key
+              # (`:title`, `tag_ids`). Splat-of-constant args
+              # (`permit(*PERMITTED_PARAMS)`, `permit(:a, *Filter::KEYS)`)
+              # and the garbage left by naive comma-splitting of nested
+              # `key: [...]` forms survive the quote/colon strip as
+              # `*PERMITTED_PARAMS` / `*FilterKEYS` / `address[city`. Drop
+              # anything that isn't a clean identifier so those don't leak
+              # in as fabricated param names.
+              next unless name.matches?(/\A[a-z_][a-z0-9_]*\z/)
+              params_body_by_action[this_method] ||= [] of Param
+              params_body_by_action[this_method] << Param.new(name, "", param_type)
+              params_query_by_action[this_method] ||= [] of Param
+              params_query_by_action[this_method] << Param.new(name, "", "query")
+            end
+          end
+
+          line.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
+            name = (m[1]? || m[2]?).to_s.strip
             next if name.empty? || this_method.empty?
-            # A permit list entry is always a lowercase symbol/string key
-            # (`:title`, `tag_ids`). Splat-of-constant args
-            # (`permit(*PERMITTED_PARAMS)`, `permit(:a, *Filter::KEYS)`)
-            # and the garbage left by naive comma-splitting of nested
-            # `key: [...]` forms survive the quote/colon strip as
-            # `*PERMITTED_PARAMS` / `*FilterKEYS` / `address[city`. Drop
-            # anything that isn't a clean identifier so those don't leak
-            # in as fabricated param names.
-            next unless name.matches?(/\A[a-z_][a-z0-9_]*\z/)
             params_body_by_action[this_method] ||= [] of Param
             params_body_by_action[this_method] << Param.new(name, "", param_type)
             params_query_by_action[this_method] ||= [] of Param
             params_query_by_action[this_method] << Param.new(name, "", "query")
           end
-        end
 
-        line.scan(/params\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
-          name = (m[1]? || m[2]?).to_s.strip
-          next if name.empty? || this_method.empty?
-          params_body_by_action[this_method] ||= [] of Param
-          params_body_by_action[this_method] << Param.new(name, "", param_type)
-          params_query_by_action[this_method] ||= [] of Param
-          params_query_by_action[this_method] << Param.new(name, "", "query")
-        end
-
-        if hm = line.match(/request\.headers\[\s*['"]([^'"]+)['"]\s*\]/)
-          name = hm[1].strip
-          if !name.empty? && !this_method.empty?
-            params_method[this_method] ||= [] of Param
-            params_method[this_method] << Param.new(name, "", "header")
+          if hm = line.match(/request\.headers\[\s*['"]([^'"]+)['"]\s*\]/)
+            name = hm[1].strip
+            if !name.empty? && !this_method.empty?
+              params_method[this_method] ||= [] of Param
+              params_method[this_method] << Param.new(name, "", "header")
+            end
           end
-        end
 
-        line.scan(/cookies(?:\.(?:signed|encrypted))?\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |cm|
-          name = (cm[1]? || cm[2]?).to_s.strip
-          next if name.empty? || this_method.empty?
-          params_method[this_method] ||= [] of Param
-          params_method[this_method] << Param.new(name, "", "cookie")
+          line.scan(/cookies(?:\.(?:signed|encrypted))?\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |cm|
+            name = (cm[1]? || cm[2]?).to_s.strip
+            next if name.empty? || this_method.empty?
+            params_method[this_method] ||= [] of Param
+            params_method[this_method] << Param.new(name, "", "cookie")
+          end
         end
       end
 

--- a/src/analyzer/analyzers/ruby/sinatra.cr
+++ b/src/analyzer/analyzers/ruby/sinatra.cr
@@ -141,6 +141,12 @@ module Analyzer::Ruby
     private def line_to_params(content : String) : Array(Param)
       params = [] of Param
 
+      # Every pattern below is a subscript read (`...[ ... ]`) except
+      # `params.fetch(...)`. A line carrying neither a `[` nor `fetch` cannot
+      # match any of the six regexes, so skip them wholesale — this runs on
+      # every line of every `.rb` file the whole-tree Sinatra scan walks.
+      return params unless content.includes?('[') || content.includes?("fetch")
+
       content.scan(/param\[\s*(?::(\w+)|['"]([^'"]+)['"])\s*\]/) do |m|
         name = (m[1]? || m[2]?).to_s.strip
         params << Param.new(name, "", "query") unless name.empty? || SINATRA_RESERVED_PARAMS.includes?(name)
@@ -203,12 +209,21 @@ module Analyzer::Ruby
     # (`/gollum/last_commit_info` surfaced as `/last_commit_info`). Modifier
     # forms (`forbid unless x`, `return if y`) sit mid-line, never at a
     # statement boundary, so they are correctly left uncounted.
+    # One `end` (-1) is the only closer; `do` (+1) and any statement-position
+    # keyword block (+1) are the openers. The three matchers are folded into a
+    # single ordered-alternation scan so each line takes one regex pass instead
+    # of three — this is the hottest per-line call in the whole-tree scan. The
+    # `\bend\b`/`\bdo\b` alternatives capture exactly "end"/"do"; the keyword
+    # alternative captures its `;`/leading-space prefix too, so the closer is
+    # identified by an exact-string test and everything else is an opener.
+    SINATRA_DEPTH_TOKEN_RE = /\bend\b|\bdo\b|(?:^|;)\s*(?:if|unless|case|begin|while|until|for|class|module|def)\b/
+
     private def sinatra_depth_delta(line : String) : Int32
       structure = Noir::RubyCalleeExtractor.strip_comment(line, preserve_strings: false)
       delta = structure.count('{') - structure.count('}')
-      structure.scan(/\bdo\b/) { delta += 1 }
-      structure.scan(/(?:^|;)\s*(?:if|unless|case|begin|while|until|for|class|module|def)\b/) { delta += 1 }
-      structure.scan(/\bend\b/) { delta -= 1 }
+      structure.scan(SINATRA_DEPTH_TOKEN_RE) do |m|
+        delta += m[0] == "end" ? -1 : 1
+      end
       delta
     end
   end

--- a/src/analyzer/analyzers/scala/akka.cr
+++ b/src/analyzer/analyzers/scala/akka.cr
@@ -211,66 +211,73 @@ module Analyzer::Scala
 
     # Extract parameters from a code block
     private def extract_params_from_block(endpoint : Endpoint, block : String)
-      # Extract single parameter: parameter("name") { ... }
-      block.scan(/parameter\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "query"))
-      end
-
-      # Extract symbol parameters: parameter('name) { ... }
-      block.scan(/parameter\s*\(\s*'(\w+)/) do |match|
-        param_name = match[1]
-        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
-          endpoint.push_param(Param.new(param_name, "", "query"))
-        end
-      end
-
-      # Extract Symbol("name") parameters.
-      block.scan(/parameter\s*\(\s*Symbol\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
-        param_name = match[1]
-        unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
-          endpoint.push_param(Param.new(param_name, "", "query"))
-        end
-      end
-
-      # Extract multiple parameters: parameters("name", "age") or parameters("name", "age".optional)
-      if params_match = block.match(/parameters\s*\(([^)]+)\)/)
-        params_content = params_match[1]
-        params_content.scan(/['"](\w+)['"]/) do |match|
-          param_name = match[1]
-          # Avoid duplicating parameters already added
-          unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
-            endpoint.push_param(Param.new(param_name, "", "query"))
-          end
+      # Extract query parameters
+      if block.includes?("parameter") || block.includes?("Symbol")
+        # Extract single parameter: parameter("name") { ... }
+        block.scan(/parameter\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+          endpoint.push_param(Param.new(match[1], "", "query"))
         end
 
-        params_content.scan(/'(\w+)/) do |match|
+        # Extract symbol parameters: parameter('name) { ... }
+        block.scan(/parameter\s*\(\s*'(\w+)/) do |match|
           param_name = match[1]
           unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
             endpoint.push_param(Param.new(param_name, "", "query"))
           end
         end
 
-        params_content.scan(/Symbol\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+        # Extract Symbol("name") parameters.
+        block.scan(/parameter\s*\(\s*Symbol\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
           param_name = match[1]
           unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
             endpoint.push_param(Param.new(param_name, "", "query"))
+          end
+        end
+
+        # Extract multiple parameters: parameters("name", "age") or parameters("name", "age".optional)
+        if params_match = block.match(/parameters\s*\(([^)]+)\)/)
+          params_content = params_match[1]
+          params_content.scan(/['"](\w+)['"]/) do |match|
+            param_name = match[1]
+            # Avoid duplicating parameters already added
+            unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+              endpoint.push_param(Param.new(param_name, "", "query"))
+            end
+          end
+
+          params_content.scan(/'(\w+)/) do |match|
+            param_name = match[1]
+            unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+              endpoint.push_param(Param.new(param_name, "", "query"))
+            end
+          end
+
+          params_content.scan(/Symbol\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+            param_name = match[1]
+            unless endpoint.params.any? { |p| p.name == param_name && p.param_type == "query" }
+              endpoint.push_param(Param.new(param_name, "", "query"))
+            end
           end
         end
       end
 
       # Extract request body: entity(as[User]) { ... }
-      if entity_match = block.match(/entity\s*\(\s*as\[([^\]]+)\]/)
-        endpoint.push_param(Param.new("body", entity_match[1], "json"))
+      if block.includes?("entity")
+        if entity_match = block.match(/entity\s*\(\s*as\[([^\]]+)\]/)
+          endpoint.push_param(Param.new("body", entity_match[1], "json"))
+        end
       end
 
       # Extract headers: headerValueByName("Authorization") { ... }
-      block.scan(/headerValueByName\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "header"))
-      end
+      if block.includes?("headerValue") || block.includes?("HeaderValue")
+        block.scan(/headerValueByName\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+          endpoint.push_param(Param.new(match[1], "", "header"))
+        end
 
-      # Extract optional headers: optionalHeaderValueByName("X-API-Key") { ... }
-      block.scan(/optionalHeaderValueByName\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
-        endpoint.push_param(Param.new(match[1], "", "header"))
+        # Extract optional headers: optionalHeaderValueByName("X-API-Key") { ... }
+        block.scan(/optionalHeaderValueByName\s*\(\s*['"]([^'"]+)['"]\s*\)/) do |match|
+          endpoint.push_param(Param.new(match[1], "", "header"))
+        end
       end
     end
 

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -193,7 +193,11 @@ module Analyzer::Scala
       in_multiline_string = false
       builder = String::Builder.new(content.bytesize)
       first = true
-      content.each_line do |line|
+      # Split on '\n' (not each_line, which chomps a trailing '\r'): a CRLF
+      # source must keep its '\r' bytes so `structure` stays byte-aligned 1:1
+      # with `content` — every downstream `content[start...end]` slice relies
+      # on that invariant.
+      content.split('\n').each do |line|
         if first
           first = false
         else

--- a/src/analyzer/analyzers/scala/play.cr
+++ b/src/analyzer/analyzers/scala/play.cr
@@ -127,36 +127,47 @@ module Analyzer::Scala
             cookies = [] of String
             body_type : String? = nil
 
-            # Extract headers: request.headers.get("Header-Name") or request.headers("Header-Name")
-            method_body.scan(/request\s*\.\s*headers(?:\s*\.\s*get)?\s*\(\s*["']([^"']+)["']\s*\)/) do |header_match|
-              headers << header_match[1] unless headers.includes?(header_match[1])
+            if method_body.includes?("headers")
+              # Extract headers: request.headers.get("Header-Name") or request.headers("Header-Name")
+              method_body.scan(/request\s*\.\s*headers(?:\s*\.\s*get)?\s*\(\s*["']([^"']+)["']\s*\)/) do |header_match|
+                headers << header_match[1] unless headers.includes?(header_match[1])
+              end
+
+              # Also match implicit request patterns: headers.get("Header-Name")
+              method_body.scan(/headers\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/) do |header_match|
+                headers << header_match[1] unless headers.includes?(header_match[1])
+              end
             end
 
-            # Also match implicit request patterns: headers.get("Header-Name")
-            method_body.scan(/headers\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/) do |header_match|
-              headers << header_match[1] unless headers.includes?(header_match[1])
-            end
+            if method_body.includes?("cookies")
+              # Extract cookies: request.cookies.get("cookie-name")
+              method_body.scan(/request\s*\.\s*cookies\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/) do |cookie_match|
+                cookies << cookie_match[1] unless cookies.includes?(cookie_match[1])
+              end
 
-            # Extract cookies: request.cookies.get("cookie-name")
-            method_body.scan(/request\s*\.\s*cookies\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/) do |cookie_match|
-              cookies << cookie_match[1] unless cookies.includes?(cookie_match[1])
-            end
-
-            # Also match: cookies.get("cookie-name")
-            method_body.scan(/cookies\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/) do |cookie_match|
-              cookies << cookie_match[1] unless cookies.includes?(cookie_match[1])
+              # Also match: cookies.get("cookie-name")
+              method_body.scan(/cookies\s*\.\s*get\s*\(\s*["']([^"']+)["']\s*\)/) do |cookie_match|
+                cookies << cookie_match[1] unless cookies.includes?(cookie_match[1])
+              end
             end
 
             # Extract body type: request.body.asJson, request.body.asFormUrlEncoded, parse.json, parse.form
             body_source = "#{method_signature}\n#{method_body}"
-            if body_source.match(/request\s*\.\s*body\s*\.\s*asJson|parse\s*\.\s*json|Json\s*\.\s*parse|\.body\s*\.\s*asJson|\.body\s*\.\s*asOpt|\.body\s*\.\s*as\s*\[/)
-              body_type = "json"
-            elsif body_source.match(/request\s*\.\s*body\s*\.\s*as(?:FormUrlEncoded|MultipartFormData)|parse\s*\.\s*(?:form|multipartFormData|tolerantFormUrlEncoded)/)
-              body_type = "form"
-            elsif body_source.match(/request\s*\.\s*body\s*\.\s*asXml|parse\s*\.\s*(?:xml|tolerantXml)/)
-              body_type = "xml"
-            elsif body_source.match(/request\s*\.\s*body\s*\.\s*as(?:Text|Raw|Bytes)|parse\s*\.\s*(?:text|raw|tolerantText)/)
-              body_type = "body"
+            if body_source.includes?("body") || body_source.includes?("parse") ||
+               body_source.includes?("xml") || body_source.includes?("Xml") ||
+               body_source.includes?("json") || body_source.includes?("Json") ||
+               body_source.includes?("form") || body_source.includes?("Form") ||
+               body_source.includes?("multipart") || body_source.includes?("text") ||
+               body_source.includes?("raw")
+              if body_source.match(/request\s*\.\s*body\s*\.\s*asJson|parse\s*\.\s*json|Json\s*\.\s*parse|\.body\s*\.\s*asJson|\.body\s*\.\s*asOpt|\.body\s*\.\s*as\s*\[/)
+                body_type = "json"
+              elsif body_source.match(/request\s*\.\s*body\s*\.\s*as(?:FormUrlEncoded|MultipartFormData)|parse\s*\.\s*(?:form|multipartFormData|tolerantFormUrlEncoded)/)
+                body_type = "form"
+              elsif body_source.match(/request\s*\.\s*body\s*\.\s*asXml|parse\s*\.\s*(?:xml|tolerantXml)/)
+                body_type = "xml"
+              elsif body_source.match(/request\s*\.\s*body\s*\.\s*as(?:Text|Raw|Bytes)|parse\s*\.\s*(?:text|raw|tolerantText)/)
+                body_type = "body"
+              end
             end
 
             full_method_name = package_name.empty? ? "#{class_name}.#{method_name}" : "#{package_name}.#{class_name}.#{method_name}"
@@ -180,12 +191,16 @@ module Analyzer::Scala
     private def blank_non_code(content : String) : String
       block_depth = 0
       in_multiline_string = false
-      builder = String::Builder.new
-      lines = content.split('\n')
-      lines.each_with_index do |line, index|
+      builder = String::Builder.new(content.bytesize)
+      first = true
+      content.each_line do |line|
+        if first
+          first = false
+        else
+          builder << '\n'
+        end
         stripped, block_depth, in_multiline_string = Noir::ScalaCalleeExtractor.strip_non_code_with_state(line, block_depth, in_multiline_string)
         builder << stripped
-        builder << '\n' unless index == lines.size - 1
       end
       builder.to_s
     end

--- a/src/analyzer/analyzers/zig/cli.cr
+++ b/src/analyzer/analyzers/zig/cli.cr
@@ -88,35 +88,40 @@ module Analyzer::Zig
 
           lines.each_with_index do |line, index|
             line_no = index + 1
-            if m = line.match(CLAP_FLAG)
-              fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
-            elsif m = line.match(CLAP_ARG)
-              fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1].downcase, "", "argument"))
+            # Cheap substring gates before the per-line PCRE2 scans — most
+            # source lines never touch clap param strings, yazap builders, or
+            # argv/env accessors.
+            if line.includes?("\\\\")
+              if m = line.match(CLAP_FLAG)
+                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1], "", "flag"))
+              elsif m = line.match(CLAP_ARG)
+                fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1].downcase, "", "argument"))
+              end
             end
-            if m = line.match(CLI_LONG)
+            if line.includes?("long_name") && (m = line.match(CLI_LONG))
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(m[1].lstrip('-'), "", "flag"))
             end
-            if m = line.match(ARGS_IDX)
+            if line.includes?("args") && (m = line.match(ARGS_IDX))
               fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new("arg#{m[1]}", "", "argument")) unless m[1] == "0"
             end
             # Update the receiver->URL map for this line BEFORE resolving
             # addArg below, so the map always reflects the state as of the
             # current line (not a whole-file precompute that a later
             # reassignment could retroactively overwrite).
-            if m = line.match(YAZAP_ROOT_RE)
+            if line.includes?("rootCommand") && (m = line.match(YAZAP_ROOT_RE))
               yazap_cmd_urls[m[1]] = root_url
-            elsif m = line.match(YAZAP_SUBCMD_RE)
+            elsif line.includes?("createCommand") && (m = line.match(YAZAP_SUBCMD_RE))
               cmd_url = "#{root_url}/#{m[2]}"
               yazap_cmd_urls[m[1]] = cmd_url
               fetch_endpoint(endpoints, cmd_url, path, line_no)
             end
-            if m = line.match(YAZAP_ADD_ARG_RE)
+            if line.includes?("addArg") && (m = line.match(YAZAP_ADD_ARG_RE))
               url = yazap_cmd_urls[m[1]]? || root_url
               ep = fetch_endpoint(endpoints, url, path, line_no)
               param_type = m[2] == "positional" ? "argument" : "flag"
               ep.push_param(Param.new(m[3], "", param_type))
             end
-            if emit_env
+            if emit_env && (line.includes?("getEnvVarOwned") || line.includes?("getenv"))
               line.scan(GET_ENV) do |em|
                 name = em[1]? || em[2]?
                 fetch_endpoint(endpoints, root_url, path, line_no).push_param(Param.new(name, "", "env")) if name

--- a/src/analyzer/analyzers/zig/http.cr
+++ b/src/analyzer/analyzers/zig/http.cr
@@ -59,9 +59,11 @@ module Analyzer::Zig
     end
 
     private def process_file(path : String, content : String, include_callee : Bool)
-      text = Noir::ZigCalleeExtractor.strip_comments(content)
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
-      chars = stripped.chars
+      prepared = Noir::ZigCalleeExtractor.prepare(content)
+      text = prepared[:comments]
+      stripped = prepared[:non_code]
+      chars = prepared[:non_code_chars]
+      text_chars = text.chars
       test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(stripped)
       target_vars = aliases_for(text, ".head.target")
       method_vars = aliases_for(text, ".head.method")
@@ -81,10 +83,10 @@ module Analyzer::Zig
         next if seen.includes?(key)
         seen << key
 
-        emit_range(path, text, chars, hit[:offset], hit[:url], method, branch[:body_open] + 1, branch[:body_close], include_callee)
+        emit_range(path, text, text_chars, chars, hit[:offset], hit[:url], method, branch[:body_open] + 1, branch[:body_close], include_callee)
       end
 
-      collect_target_switch_routes(text, stripped, chars, target_vars).each do |route|
+      collect_target_switch_routes(text, text_chars, stripped, chars, target_vars).each do |route|
         offset = route[:offset]
         next if Noir::ZigCalleeExtractor.in_test_block?(offset, test_blocks)
         route_method_contexts = method_contexts.select do |context|
@@ -97,7 +99,7 @@ module Analyzer::Zig
           next if seen.includes?(key)
           seen << key
 
-          emit_range(path, text, chars, offset, route[:url], method, route[:body_start], route[:body_end], include_callee)
+          emit_range(path, text, text_chars, chars, offset, route[:url], method, route[:body_start], route[:body_end], include_callee)
         else
           route_method_contexts.each do |context|
             method = context[:method]
@@ -105,7 +107,7 @@ module Analyzer::Zig
             next if seen.includes?(key)
             seen << key
 
-            emit_range(path, text, chars, offset, route[:url], method, context[:body_open] + 1, context[:body_close], include_callee)
+            emit_range(path, text, text_chars, chars, offset, route[:url], method, context[:body_open] + 1, context[:body_close], include_callee)
           end
         end
       end
@@ -156,7 +158,7 @@ module Analyzer::Zig
       hits
     end
 
-    private def collect_target_switch_routes(text : String, stripped : String, chars : Array(Char), target_vars : Set(String)) : Array(RouteBlock)
+    private def collect_target_switch_routes(text : String, text_chars : Array(Char), stripped : String, chars : Array(Char), target_vars : Set(String)) : Array(RouteBlock)
       routes = [] of RouteBlock
 
       stripped.scan(SWITCH_RE) do |m|
@@ -166,7 +168,7 @@ module Analyzer::Zig
         switch_close = Noir::ZigCalleeExtractor.find_matching(chars, switch_open, '{', '}')
         next if switch_close.nil?
 
-        switch_body = slice(text.chars, switch_open + 1, switch_close)
+        switch_body = slice(text_chars, switch_open + 1, switch_close)
         switch_body.scan(TARGET_PRONG_RE) do |pm|
           url = unescape_string(pm[1])
           next unless url.starts_with?("/")
@@ -278,8 +280,8 @@ module Analyzer::Zig
       end
     end
 
-    private def emit_range(path : String, text : String, chars : Array(Char), offset : Int32, url : String, method : String, body_start : Int32, body_end : Int32, include_callee : Bool)
-      line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
+    private def emit_range(path : String, text : String, text_chars : Array(Char), chars : Array(Char), offset : Int32, url : String, method : String, body_start : Int32, body_end : Int32, include_callee : Bool)
+      line = Noir::ZigCalleeExtractor.line_at(text, offset)
       endpoint = Endpoint.new(url, method, extract_path_params(url), Details.new(PathInfo.new(path, line)))
 
       if include_callee

--- a/src/analyzer/analyzers/zig/httpz.cr
+++ b/src/analyzer/analyzers/zig/httpz.cr
@@ -55,12 +55,18 @@ module Analyzer::Zig
     end
 
     private def process_file(path : String, content : String, include_callee : Bool)
-      text = Noir::ZigCalleeExtractor.strip_comments(content)
-      bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
+      prepared = Noir::ZigCalleeExtractor.prepare(content)
+      text = prepared[:comments]
       # Routes registered inside `test { … }` blocks are test fixtures (and, in
       # an httpz framework source vendored as a loose file, its own self-tests),
-      # not runtime endpoints.
-      test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(Noir::ZigCalleeExtractor.strip_non_code(content))
+      # not runtime endpoints. Reuse the non-code strip from `prepare`.
+      test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(prepared[:non_code])
+      bodies = if include_callee
+                 table = Noir::ZigCalleeExtractor.function_table_from(prepared[:non_code_chars], path)
+                 Noir::ZigCalleeExtractor.function_bodies_from(table, path)
+               else
+                 {} of String => Noir::ZigCalleeExtractor::FunctionBody
+               end
 
       group_prefixes = resolve_group_prefixes(text)
 
@@ -115,7 +121,7 @@ module Analyzer::Zig
 
     private def emit(path, text, offset, url, method, handler, bodies, include_callee)
       params = extract_path_params(url)
-      line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
+      line = Noir::ZigCalleeExtractor.line_at(text, offset)
       details = Details.new(PathInfo.new(path, line))
       endpoint = Endpoint.new(url, method, params, details)
 

--- a/src/analyzer/analyzers/zig/jetzig.cr
+++ b/src/analyzer/analyzers/zig/jetzig.cr
@@ -75,10 +75,11 @@ module Analyzer::Zig
       resource = resource_for(path)
       return if resource.nil?
 
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
+      prepared = Noir::ZigCalleeExtractor.prepare(content)
+      stripped = prepared[:non_code]
       # Strings preserved — `params.get("foo")` reads need the literal name.
-      comment_stripped = Noir::ZigCalleeExtractor.strip_comments(content)
-      table = Noir::ZigCalleeExtractor.function_table(content, path)
+      comment_stripped = prepared[:comments]
+      table = Noir::ZigCalleeExtractor.function_table_from(prepared[:non_code_chars], path)
       by_name = {} of String => Noir::ZigCalleeExtractor::FunctionInfo
       table.each { |info| by_name[info[:name]] ||= info }
 
@@ -89,7 +90,7 @@ module Analyzer::Zig
         method, suffix, has_id = spec
 
         url = build_url(resource, suffix)
-        line = Noir::ZigCalleeExtractor.line_at(stripped.chars, match.begin(0) || 0)
+        line = Noir::ZigCalleeExtractor.line_at(stripped, match.begin(0) || 0)
         details = Details.new(PathInfo.new(path, line))
 
         params = [] of Param
@@ -127,7 +128,7 @@ module Analyzer::Zig
         import_rel = m[3]
         action = m[4]
 
-        line = Noir::ZigCalleeExtractor.line_at(text.chars, m.begin(0) || 0)
+        line = Noir::ZigCalleeExtractor.line_at(text, m.begin(0) || 0)
         endpoint = Endpoint.new(url, method, path_params(url), Details.new(PathInfo.new(path, line)))
 
         if include_callee

--- a/src/analyzer/analyzers/zig/tokamak.cr
+++ b/src/analyzer/analyzers/zig/tokamak.cr
@@ -117,13 +117,14 @@ module Analyzer::Zig
       files.each do |path|
         content = read_file_content(path)
         next unless content.includes?(".router(")
-        text = Noir::ZigCalleeExtractor.strip_comments(content)
         # `strip_comments` keeps string contents, so `{`/`}` inside a literal
         # would corrupt brace matching. `strip_non_code` blanks strings at the
         # same offsets, so it is the right char array for `find_matching`.
-        stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
-        code_chars = stripped.chars
-        local_structs = struct_regions(stripped).map(&.name)
+        prepared = Noir::ZigCalleeExtractor.prepare(content)
+        text = prepared[:comments]
+        stripped = prepared[:non_code]
+        code_chars = prepared[:non_code_chars]
+        local_structs = struct_regions(stripped, code_chars).map(&.name)
 
         events = [] of NamedTuple(kind: Symbol, off: Int32, prefix: String, close: Int32?, target: String)
         # Array-form group: `.group("/p", &.{ … })` — scoped by its body braces.
@@ -192,19 +193,25 @@ module Analyzer::Zig
     end
 
     private def process_file(path : String, content : String, mounts : Hash(String, Array(RouterMount)), include_callee : Bool)
-      text = Noir::ZigCalleeExtractor.strip_comments(content)
+      prepared = Noir::ZigCalleeExtractor.prepare(content)
       # Strings preserved in `text` for reading paths/handlers; brace matching
       # runs on the string-blanked (but offset-identical) char array so a `{`/`}`
       # inside a literal can't throw off group-scope tracking.
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
-      code_chars = stripped.chars
-      bodies = include_callee ? Noir::ZigCalleeExtractor.function_bodies(content, path) : {} of String => Noir::ZigCalleeExtractor::FunctionBody
+      text = prepared[:comments]
+      stripped = prepared[:non_code]
+      code_chars = prepared[:non_code_chars]
+      bodies = if include_callee
+                 table = Noir::ZigCalleeExtractor.function_table_from(code_chars, path)
+                 Noir::ZigCalleeExtractor.function_bodies_from(table, path)
+               else
+                 {} of String => Noir::ZigCalleeExtractor::FunctionBody
+               end
       # Routes declared inside `test { … }` blocks are unit-test fixtures (e.g.
       # tokamak's own client tests register `.get("/ping", …)`), not endpoints.
       test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(stripped)
 
       emit_route_array(path, text, code_chars, bodies, test_blocks, include_callee)
-      emit_controller_routes(path, content, text, mounts, test_blocks, include_callee)
+      emit_controller_routes(path, content, text, stripped, code_chars, mounts, test_blocks, include_callee)
     end
 
     # Inline `tk.Route` array routes (.get/.post/.group/…).
@@ -237,15 +244,13 @@ module Analyzer::Zig
     # mounted, or its mount chain crosses a route-value reference we don't
     # expand. `const` routes name a handler defined elsewhere, so they carry no
     # inline body and thus no callees.
-    private def emit_controller_routes(path, content, text, mounts, test_blocks, include_callee)
+    private def emit_controller_routes(path, content, text, stripped, stripped_chars, mounts, test_blocks, include_callee)
       has_fn = content.includes?("pub fn @\"")
       has_const = content.includes?("pub const @\"")
       return unless has_fn || has_const
 
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
-      stripped_chars = stripped.chars
       file_mounts = mounts[File.expand_path(path)]?
-      regions = struct_regions(stripped)
+      regions = struct_regions(stripped, stripped_chars)
 
       if has_fn
         text.scan(ROUTE_FN_RE) do |m|
@@ -276,13 +281,13 @@ module Analyzer::Zig
     # Struct declaration regions (`const X = struct { … }`), brace-matched on
     # the string-blanked char array, so a `@"…"` route name can be attributed
     # to its enclosing struct.
-    private def struct_regions(stripped : String) : Array(StructRegion)
-      chars = stripped.chars
+    private def struct_regions(stripped : String, chars : Array(Char)? = nil) : Array(StructRegion)
+      code_chars = chars || stripped.chars
       regions = [] of StructRegion
       stripped.scan(STRUCT_DECL_RE) do |m|
         name = m[1]
         brace = (m.end(0) || 0) - 1
-        close = Noir::ZigCalleeExtractor.find_matching(chars, brace, '{', '}')
+        close = Noir::ZigCalleeExtractor.find_matching(code_chars, brace, '{', '}')
         next if close.nil?
         regions << StructRegion.new(name, brace, close)
       end
@@ -373,7 +378,7 @@ module Analyzer::Zig
 
     private def emit(path, text, offset, url, method, callees : Array(Noir::ZigCalleeExtractor::Entry))
       params = extract_path_params(url)
-      line = Noir::ZigCalleeExtractor.line_at(text.chars, offset)
+      line = Noir::ZigCalleeExtractor.line_at(text, offset)
       details = Details.new(PathInfo.new(path, line))
       endpoint = Endpoint.new(url, method, params, details)
       Noir::ZigCalleeExtractor.attach_to(endpoint, callees) unless callees.empty?

--- a/src/analyzer/analyzers/zig/zap.cr
+++ b/src/analyzer/analyzers/zig/zap.cr
@@ -83,9 +83,14 @@ module Analyzer::Zig
       aliases_by_file = Hash(String, Array(String)).new
       files.each do |path|
         content = read_file_content(path)
-        text = Noir::ZigCalleeExtractor.strip_comments(content)
+        need_import = content.includes?("@import")
+        need_paths = content.matches?(PATH_OR_INIT_RE)
+        next unless need_import || need_paths
 
-        if content.includes?("@import")
+        prepared = Noir::ZigCalleeExtractor.prepare(content)
+        text = prepared[:comments]
+
+        if need_import
           dir = File.dirname(path)
           text.scan(IMPORT_RE) do |m|
             resolved = File.expand_path(File.join(dir, m[2]))
@@ -94,13 +99,13 @@ module Analyzer::Zig
           end
         end
 
-        next unless content.matches?(PATH_OR_INIT_RE)
+        next unless need_paths
 
         # Path literals/bindings inside `test { … }` blocks are unit-test
         # fixtures (the zap framework's own `test_auth.zig` binds `.path =
         # "/test"`); excluding them keeps those phantom paths off real
         # endpoint structs that happen to share a type name.
-        test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(Noir::ZigCalleeExtractor.strip_non_code(content))
+        test_blocks = Noir::ZigCalleeExtractor.test_block_ranges(prepared[:non_code])
 
         text.scan(INIT_RE) do |m|
           next if Noir::ZigCalleeExtractor.in_test_block?(m.begin(0) || 0, test_blocks)
@@ -141,19 +146,20 @@ module Analyzer::Zig
     end
 
     private def process_file(path : String, content : String, bindings : PathBindings, include_callee : Bool)
-      comment_stripped = Noir::ZigCalleeExtractor.strip_comments(content)
+      prepared = Noir::ZigCalleeExtractor.prepare(content)
+      comment_stripped = prepared[:comments]
       # Comments + all literals blanked once; reused for struct-region brace
       # matching and the `@This()` file-struct scan.
-      stripped = Noir::ZigCalleeExtractor.strip_non_code(content)
-      all_fns = Noir::ZigCalleeExtractor.function_table(content, path)
+      stripped = prepared[:non_code]
+      code_chars = prepared[:non_code_chars]
+      all_fns = Noir::ZigCalleeExtractor.function_table_from(code_chars, path)
 
-      explicit = explicit_struct_regions(stripped)
-      emit_endpoint_structs(path, content, stripped, comment_stripped, bindings, explicit, all_fns, include_callee)
-      emit_router_routes(path, content, comment_stripped, all_fns, include_callee)
+      explicit = explicit_struct_regions(stripped, code_chars)
+      emit_endpoint_structs(path, content, stripped, code_chars, comment_stripped, bindings, explicit, all_fns, include_callee)
+      emit_router_routes(path, comment_stripped, code_chars, all_fns, include_callee)
     end
 
-    private def explicit_struct_regions(stripped : String) : Array(StructRegion)
-      chars = stripped.chars
+    private def explicit_struct_regions(stripped : String, chars : Array(Char)) : Array(StructRegion)
       regions = [] of StructRegion
       stripped.scan(STRUCT_DECL_RE) do |m|
         name = m[1]
@@ -165,9 +171,7 @@ module Analyzer::Zig
       regions
     end
 
-    private def emit_endpoint_structs(path, content, stripped, comment_stripped, bindings, explicit, all_fns, include_callee)
-      code_chars = stripped.chars
-
+    private def emit_endpoint_structs(path, content, stripped, code_chars, comment_stripped, bindings, explicit, all_fns, include_callee)
       # Explicit `const X = struct { … }` endpoints.
       explicit.each do |region|
         verbs = verb_methods_in(all_fns, region.start, region.stop) do |off|
@@ -306,12 +310,12 @@ module Analyzer::Zig
     end
 
     # `router.handle_func("/p", …)` / `handle_func_unbound("/p", handler)`.
-    private def emit_router_routes(path, content, comment_stripped, all_fns, include_callee)
+    private def emit_router_routes(path, comment_stripped, code_chars, all_fns, include_callee)
       # Paths are read from `comment_stripped` (string contents kept), but the
       # `(`/`)` matching must run on the string-blanked char array — a paren
       # inside a string argument would otherwise corrupt the argument span.
       # Both strips share offsets, so `close` indexes `comment_stripped` too.
-      code_chars = Noir::ZigCalleeExtractor.strip_non_code(content).chars
+      # `code_chars` is the non-code strip already produced by `prepare`.
       comment_stripped.scan(HANDLE_FUNC_RE) do |m|
         open_paren = (m.end(0) || 0) - 1
         close = Noir::ZigCalleeExtractor.find_matching(code_chars, open_paren, '(', ')')

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -79,8 +79,14 @@ module Analyzer::Crystal
     # parameter extractor picks it up and the URL template reads
     # cleanly. Mirrors the Python f-string, Ruby `#{}`, and PHP
     # `$var` fixes earlier this pass.
+    #
+    # Most route literals have no interpolation; skip the PCRE2
+    # gsub when the `#\{` marker is absent.
+    INTERPOLATION_RE = /\#\{([^}]+)\}/
+
     protected def normalize_crystal_interpolation(path : String) : String
-      path.gsub(/\#\{([^}]+)\}/) { |_| "{#{$~[1].strip}}" }
+      return path unless path.includes?("\#{")
+      path.gsub(INTERPOLATION_RE) { |_| "{#{$~[1].strip}}" }
     end
 
     # A genuine Kemal/Lucky/Amber route path always begins with `/`
@@ -193,7 +199,11 @@ module Analyzer::Crystal
         next unless File.exists?(path) && File.extname(path) == ".cr"
         next if crystal_dependency_path?(path)
         begin
-          collect_actions_into(index, File.read_lines(path), path)
+          # Cache-first: detector already warmed CodeLocator for most
+          # .cr files. `read_file_content` prefers the cache and falls
+          # back to File.read(utf-8, invalid: :skip); String#lines
+          # chomps by default, matching File.read_lines for valid UTF-8.
+          collect_actions_into(index, read_file_content(path).lines, path)
         rescue e
           logger.debug "crystal action index #{path}: #{e}"
         end
@@ -224,6 +234,14 @@ module Analyzer::Crystal
     # module, dropping every method defined after them. Indentation is the
     # one signal those constructs can't corrupt: a namespace stays open
     # until a line dedents to or past the column where it was declared.
+    #
+    # Precompiled: this loop runs once per line of every .cr file when
+    # building the cross-file action index (`--include-callee` /
+    # `--ai-context`). The shapes never change, so hoist the two PCRE2
+    # patterns to class constants.
+    NAMESPACE_DECL_RE = /^(?:abstract\s+)?(?:module|class|struct)\s+([A-Z]\w*(?:::[A-Z]\w*)*)/
+    DEF_DECL_RE       = /^(?:(?:private|protected)\s+)?def\s+(?:self\.)?([A-Za-z_]\w*[!?=]?)/
+
     protected def collect_actions_into(index : ActionIndex, lines : Array(String), path : String) : Nil
       base_path = configured_base_for(path)
       namespace_stack = [] of NamedTuple(name: String, indent: Int32)
@@ -240,12 +258,18 @@ module Analyzer::Crystal
           namespace_stack.pop
         end
 
-        if ns = content.match(/^(?:abstract\s+)?(?:module|class|struct)\s+([A-Z]\w*(?:::[A-Z]\w*)*)/)
+        # Cheap keyword gates before PCRE2: most body lines are neither
+        # namespace decls nor method defs.
+        if (content.starts_with?("module") || content.starts_with?("class") ||
+           content.starts_with?("struct") || content.starts_with?("abstract")) &&
+           (ns = content.match(NAMESPACE_DECL_RE))
           namespace_stack << {name: ns[1], indent: indent}
           next
         end
 
-        if def_match = content.match(/^(?:(?:private|protected)\s+)?def\s+(?:self\.)?([A-Za-z_]\w*[!?=]?)/)
+        if (content.starts_with?("def") || content.starts_with?("private") ||
+           content.starts_with?("protected")) &&
+           (def_match = content.match(DEF_DECL_RE))
           next if namespace_stack.empty?
           if method_body = extract_crystal_def_block(lines, i)
             body, body_start_line = method_body
@@ -338,15 +362,84 @@ module Analyzer::Crystal
       {body_lines.join("\n"), body_start_line}
     end
 
+    # Precompiled block-structure probes used by extract_crystal_do_block /
+    # extract_crystal_def_block on every body line. Constant shapes — load
+    # once, match many times. Cheap `includes?` gates reject the common
+    # non-structural body lines before any PCRE2 scan.
+    DO_WORD_RE      = /\bdo\b/
+    END_WORD_RE     = /\bend\b/
+    STRUCT_OPEN_RE  = /(?:^|=[^=>])\s*(?:if|unless|case|begin|while|until|for|class|module|def|macro)\b/
+    CLOSES_BLOCK_RE = /^end\b/
+
     protected def crystal_do_block_open_delta(line : String) : Int32
       return 0 if line.empty?
-      return 1 if line.match(/\bdo\b/) && !line.match(/\bend\b/)
-      return 1 if line.match(/(?:^|=[^=>])\s*(if|unless|case|begin|while|until|for|class|module|def|macro)\b/) && !line.match(/\bend\b/)
+
+      has_end = line.includes?("end")
+      if line.includes?("do") && line.matches?(DO_WORD_RE) && !(has_end && line.matches?(END_WORD_RE))
+        return 1
+      end
+
+      # Structural keyword open — only scan when a candidate keyword is present.
+      if (line.includes?("if") || line.includes?("unless") || line.includes?("case") ||
+         line.includes?("begin") || line.includes?("while") || line.includes?("until") ||
+         line.includes?("for") || line.includes?("class") || line.includes?("module") ||
+         line.includes?("def") || line.includes?("macro")) &&
+         line.matches?(STRUCT_OPEN_RE) &&
+         !(has_end && line.matches?(END_WORD_RE))
+        return 1
+      end
+
       0
     end
 
     private def crystal_closes_block?(line : String) : Bool
-      !!line.match(/^end\b/)
+      line.starts_with?("end") && line.matches?(CLOSES_BLOCK_RE)
+    end
+
+    # Shared `verb "/path"` matchers for Kemal/Lucky/Grip-style DSLs.
+    # One combined PCRE2 scan replaces the previous 7–8 sequential
+    # per-verb `.scan` calls that ran on every source line. Leftmost
+    # match wins, which matches real one-verb-per-line route DSLs and
+    # the prior first-matching-verb behaviour for those lines. Optional
+    # `extra` covers framework-only verbs (Lucky's `trace`).
+    HTTP_ROUTE_VERBS = %w[get post put delete patch head options]
+
+    # Group 1 = verb (or `ws`), group 2 = path. `ws` is folded in so a
+    # single scan covers WebSocket routes too; the caller maps `ws` →
+    # GET + protocol=ws.
+    SIMPLE_ROUTE_RE = /(?:^|[^.\w])(get|post|put|delete|patch|head|options|ws)\s*(?:\(\s*)?['"](.+?)['"]/
+
+    # Match the first `verb "/path"` / `verb("/path")` on a comment-stripped
+    # line. Quote gate skips the PCRE2 scan on lines with no string
+    # literal. Returns an empty endpoint when nothing matches.
+    protected def match_crystal_simple_route(content : String,
+                                             *,
+                                             include_ws : Bool = true,
+                                             extra : Array(Tuple(String, Regex)) = [] of Tuple(String, Regex)) : Endpoint
+      return Endpoint.new("", "") unless content.includes?('"') || content.includes?("'")
+
+      if match = content.match(SIMPLE_ROUTE_RE)
+        verb = match[1]
+        path = normalize_crystal_interpolation(match[2])
+        if verb == "ws"
+          if include_ws
+            endpoint = Endpoint.new(path, "GET")
+            endpoint.protocol = "ws"
+            return endpoint
+          end
+        else
+          return Endpoint.new(path, verb.upcase)
+        end
+      end
+
+      extra.each do |method, pattern|
+        next unless content.includes?(method.downcase)
+        if match = content.match(pattern)
+          return Endpoint.new(normalize_crystal_interpolation(match[1]), method)
+        end
+      end
+
+      Endpoint.new("", "")
     end
   end
 end

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -26,13 +26,22 @@ module Analyzer::Elixir
     # a `do` that isn't the inline `do:` keyword form, plus each `fn`,
     # minus each `end`.
     protected def elixir_block_depth_delta(line : String) : Int32
+      # Fast reject: most body lines have none of the block keywords, so
+      # skip strip_comment + three PCRE scans entirely.
+      return 0 unless line.includes?("do") || line.includes?("fn") || line.includes?("end")
+
       # Count on a string-and-comment-stripped copy so the keywords
       # `do`/`fn`/`end` appearing inside a literal (`flash(conn, "…the
       # end")`) or a trailing comment don't shift block depth and
       # truncate the enclosing function.
       code = Noir::ElixirCalleeExtractor.strip_comment(line)
-      opens = code.scan(/\bdo\b(?!:)/).size + code.scan(/\bfn\b/).size
-      closes = code.scan(/\bend\b/).size
+      return 0 unless code.includes?("do") || code.includes?("fn") || code.includes?("end")
+
+      opens = 0
+      closes = 0
+      opens += code.scan(/\bdo\b(?!:)/).size if code.includes?("do")
+      opens += code.scan(/\bfn\b/).size if code.includes?("fn")
+      closes += code.scan(/\bend\b/).size if code.includes?("end")
       opens - closes
     end
 

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -27,7 +27,7 @@ module Analyzer::Elixir
     # minus each `end`.
     protected def elixir_block_depth_delta(line : String) : Int32
       # Fast reject: most body lines have none of the block keywords, so
-      # skip strip_comment + three PCRE scans entirely.
+      # skip strip_comment + the keyword walk entirely.
       return 0 unless line.includes?("do") || line.includes?("fn") || line.includes?("end")
 
       # Count on a string-and-comment-stripped copy so the keywords
@@ -37,12 +37,78 @@ module Analyzer::Elixir
       code = Noir::ElixirCalleeExtractor.strip_comment(line)
       return 0 unless code.includes?("do") || code.includes?("fn") || code.includes?("end")
 
+      # Linear word-boundary walk replaces three PCRE `\b…​\b` scans.
+      # A `do` followed by `:` is the keyword-list form (`do: expr`) and
+      # must not open a block — same rule as the previous `(?!:)` regex.
+      elixir_block_keyword_delta(code)
+    end
+
+    # Count `do`/`fn` openers minus `end` closers on an already
+    # string-and-comment-stripped line. Word boundaries match PCRE `\b`
+    # over `[A-Za-z0-9_]` (so `end!` still counts as `end`).
+    private def elixir_block_keyword_delta(code : String) : Int32
       opens = 0
       closes = 0
-      opens += code.scan(/\bdo\b(?!:)/).size if code.includes?("do")
-      opens += code.scan(/\bfn\b/).size if code.includes?("fn")
-      closes += code.scan(/\bend\b/).size if code.includes?("end")
+      i = 0
+      size = code.size
+      while i < size
+        ch = code[i]
+        unless ch.ascii_letter?
+          i += 1
+          next
+        end
+
+        # Only consider tokens at a word boundary.
+        if i > 0
+          prev = code[i - 1]
+          if prev.ascii_alphanumeric? || prev == '_'
+            i = skip_elixir_word(code, i, size)
+            next
+          end
+        end
+
+        if elixir_keyword_at?(code, i, size, "do")
+          after = i + 2
+          # Inline `do:` keyword form is not a block opener.
+          opens += 1 unless after < size && code[after] == ':'
+          i = after
+          next
+        end
+
+        if elixir_keyword_at?(code, i, size, "fn")
+          opens += 1
+          i += 2
+          next
+        end
+
+        if elixir_keyword_at?(code, i, size, "end")
+          closes += 1
+          i += 3
+          next
+        end
+
+        i = skip_elixir_word(code, i, size)
+      end
       opens - closes
+    end
+
+    private def elixir_keyword_at?(code : String, i : Int32, size : Int32, word : String) : Bool
+      n = word.size
+      return false if i + n > size
+      return false unless code[i, n] == word
+      after = i + n
+      return true if after >= size
+      c = code[after]
+      !(c.ascii_alphanumeric? || c == '_')
+    end
+
+    private def skip_elixir_word(code : String, i : Int32, size : Int32) : Int32
+      while i < size
+        c = code[i]
+        break unless c.ascii_alphanumeric? || c == '_'
+        i += 1
+      end
+      i
     end
 
     # ExUnit's filename convention is rigid: every test module sits in
@@ -70,9 +136,11 @@ module Analyzer::Elixir
     # path the monorepo file map yields.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
+        # CodeLocator already registered these paths during detection;
+        # skip the per-file `File.exists?` syscall. Missing files surface
+        # as read errors inside the analyzer and are logged there.
         parallel_analyze(elixir_source_files) do |path|
           next if File.directory?(path)
-          next unless File.exists?(path)
           next if elixir_test_path?(path)
 
           begin

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -36,13 +36,35 @@ module Analyzer::Elixir
       opens - closes
     end
 
-    # No extension filter: Phoenix uses `.ex` only, Plug also accepts
-    # `.exs`, so each analyzer filters inside `analyze_file`.
+    # ExUnit's filename convention is rigid: every test module sits in
+    # a file named `*_test.exs`, and `mix test` ignores anything else.
+    # Production code never adopts that name, so the suffix check is
+    # safe for every Elixir analyzer (Phoenix/Plug/Bandit).
+    def self.test_path?(path : String) : Bool
+      File.basename(path).ends_with?("_test.exs")
+    end
+
+    protected def elixir_test_path?(path : String) : Bool
+      ElixirEngine.test_path?(path)
+    end
+
+    # Phoenix uses `.ex` only; Plug also accepts `.exs`. Pull both from
+    # the extension index instead of walking the whole `file_map` (which
+    # includes every language in a monorepo) and re-filtering inside
+    # each analyzer.
+    protected def elixir_source_files : Array(String)
+      get_files_by_extension(".ex") + get_files_by_extension(".exs")
+    end
+
+    # Walk only Elixir sources concurrently. Extension + ExUnit-test
+    # filtering lives here so framework adapters don't re-check every
+    # path the monorepo file map yields.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
+        parallel_analyze(elixir_source_files) do |path|
           next if File.directory?(path)
           next unless File.exists?(path)
+          next if elixir_test_path?(path)
 
           begin
             block.call(path)

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -17,15 +17,22 @@ module Analyzer::Php
 
     abstract def analyze_file(path : String) : Array(Endpoint)
 
-    # Walk the project tree concurrently and invoke the block for each
-    # readable, non-directory file. PHP analyzers apply their own
-    # extension/pathname filters inside the block because Symfony matches
-    # `.php` *and* YAML route files, Laravel checks `routes/*.php`, etc.
+    # Default source set for PHP framework adapters: every registered
+    # `.php` file. Symfony overrides this to also include YAML route
+    # configs (`.yaml` / `.yml`). Prefer the extension index over
+    # walking the whole monorepo `file_map`.
+    protected def php_source_files : Array(String)
+      get_files_by_extension(".php")
+    end
+
+    # Walk PHP sources concurrently. Extension + test-path filtering
+    # lives here so adapters don't re-check every monorepo path.
+    # Paths come from CodeLocator; skip the redundant `File.exists?`
+    # syscall (missing files error on read and are logged).
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
+        parallel_analyze(php_source_files) do |path|
           next if File.directory?(path)
-          next unless File.exists?(path)
           next if PhpEngine.test_path?(path)
 
           begin
@@ -86,10 +93,18 @@ module Analyzer::Php
     # Rewrite each shape to `{name}` so the path-parameter
     # extractor picks it up and the URL template reads cleanly.
     # Same posture as the Python f-string and Ruby `#{}` fixes.
+    INTERPOLATION_DOLLAR_BRACE_RE = /\$\{([A-Za-z_]\w*)\}/
+    INTERPOLATION_BRACE_DOLLAR_RE = /\{\$([A-Za-z_]\w*)\}/
+    INTERPOLATION_DOLLAR_RE       = /\$([A-Za-z_]\w*)/
+
     protected def normalize_php_interpolation(path : String) : String
-      path = path.gsub(/\$\{([A-Za-z_]\w*)\}/) { |_| "{#{$~[1]}}" }
-      path = path.gsub(/\{\$([A-Za-z_]\w*)\}/) { |_| "{#{$~[1]}}" }
-      path = path.gsub(/\$([A-Za-z_]\w*)/) { |_| "{#{$~[1]}}" }
+      # Most route literals have no interpolation; skip three PCRE
+      # gsub passes when `$` is absent.
+      return path unless path.includes?('$')
+
+      path = path.gsub(INTERPOLATION_DOLLAR_BRACE_RE) { |_| "{#{$~[1]}}" }
+      path = path.gsub(INTERPOLATION_BRACE_DOLLAR_RE) { |_| "{#{$~[1]}}" }
+      path = path.gsub(INTERPOLATION_DOLLAR_RE) { |_| "{#{$~[1]}}" }
       path
     end
 
@@ -127,7 +142,18 @@ module Analyzer::Php
     protected def php_line_number_for_index(content : String, index : Int32) : Int32
       return 1 if index <= 0
 
-      content[0...index].count('\n') + 1
+      # Count newlines without allocating `content[0...index]` (O(n)
+      # copy per call). Byte scan is correct because `\n` is ASCII and
+      # never appears inside a UTF-8 multi-byte sequence.
+      bytes = content.to_slice
+      byte_end = content.char_index_to_byte_index(index) || bytes.size
+      count = 1
+      i = 0
+      while i < byte_end
+        count += 1 if bytes[i] == BYTE_NEWLINE
+        i += 1
+      end
+      count
     end
 
     # ASCII byte values for the structural delimiters scanned below.

--- a/src/minilexers/csharp_lexer.cr
+++ b/src/minilexers/csharp_lexer.cr
@@ -51,7 +51,7 @@ module Noir
     def initialize(source : String)
       @chars = source.chars
       @size = @chars.size
-      @masked = Array(Char).new(@size)
+      @masked = @chars.dup
       @spans = [] of Tuple(Symbol, Int32, Int32)
       @tokens = nil
       @skip_ranges = nil
@@ -84,7 +84,6 @@ module Noir
         elsif c == '@' || c == '$'
           i = dispatch_prefixed_string(i)
         else
-          @masked << c
           i += 1
         end
       end
@@ -105,7 +104,6 @@ module Noir
       if j < @size && @chars[j] == '"'
         mask_string(start, j, verbatim, interpolated)
       else
-        @masked << @chars[start]
         start + 1
       end
     end
@@ -113,7 +111,7 @@ module Noir
     private def mask_line_comment(start : Int32) : Int32
       i = start
       while i < @size && @chars[i] != '\n'
-        @masked << ' '
+        @masked[i] = ' '
         i += 1
       end
       @spans << {:comment, start, i}
@@ -123,17 +121,17 @@ module Noir
     private def mask_block_comment(start : Int32) : Int32
       # Blank the `/*` opener first, then scan for `*/` from after it so `/*/`
       # is not mis-read as self-closing.
-      @masked << ' '
-      @masked << ' '
+      @masked[start] = ' '
+      @masked[start + 1] = ' '
       i = start + 2
       while i < @size
         if @chars[i] == '*' && i + 1 < @size && @chars[i + 1] == '/'
-          @masked << ' '
-          @masked << ' '
+          @masked[i] = ' '
+          @masked[i + 1] = ' '
           i += 2
           break
         end
-        @masked << (@chars[i] == '\n' ? '\n' : ' ')
+        @masked[i] = ' ' unless @chars[i] == '\n'
         i += 1
       end
       @spans << {:comment, start, i}
@@ -143,12 +141,12 @@ module Noir
     # `start` points at the opening `'`. Masks a char literal, honouring a
     # single backslash escape (`'\''`, `'\\'`, `'\}'`).
     private def mask_char_literal(start : Int32) : Int32
-      @masked << ' '
+      @masked[start] = ' '
       i = start + 1
       escaped = false
       while i < @size
         c = @chars[i]
-        @masked << (c == '\n' ? '\n' : ' ')
+        @masked[i] = ' ' unless c == '\n'
         if escaped
           escaped = false
         elsif c == '\\'
@@ -167,7 +165,7 @@ module Noir
     # `quote_pos` is the opening `"`. Dispatches to raw / verbatim / regular
     # masking and records one `:string` span spanning the whole literal.
     private def mask_string(start : Int32, quote_pos : Int32, verbatim : Bool, interpolated : Bool) : Int32
-      (start...quote_pos).each { @masked << ' ' }
+      (start...quote_pos).each { |idx| @masked[idx] = ' ' }
 
       unless verbatim
         run = 0
@@ -180,14 +178,14 @@ module Noir
           return mask_raw_string(start, quote_pos, run)
         end
         if run == 2
-          @masked << ' '
-          @masked << ' '
+          @masked[quote_pos] = ' '
+          @masked[quote_pos + 1] = ' '
           @spans << {:string, start, quote_pos + 2}
           return quote_pos + 2
         end
       end
 
-      @masked << ' ' # opening quote
+      @masked[quote_pos] = ' ' # opening quote
       i = quote_pos + 1
       interp_depth = 0
       escaped = false
@@ -203,7 +201,7 @@ module Noir
           next
         end
 
-        @masked << (c == '\n' ? '\n' : ' ')
+        @masked[i] = ' ' unless c == '\n'
         if escaped
           escaped = false
           i += 1
@@ -213,7 +211,7 @@ module Noir
         if verbatim
           if c == '"'
             if i + 1 < @size && @chars[i + 1] == '"'
-              @masked << ' ' # the doubled (escaped) quote
+              @masked[i + 1] = ' ' # the doubled (escaped) quote
               i += 2
               next
             end
@@ -230,14 +228,14 @@ module Noir
 
         if interpolated && c == '{'
           if i + 1 < @size && @chars[i + 1] == '{'
-            @masked << ' '
+            @masked[i + 1] = ' '
             i += 2
             next
           end
           interp_depth += 1
         elsif interpolated && c == '}'
           if i + 1 < @size && @chars[i + 1] == '}'
-            @masked << ' '
+            @masked[i + 1] = ' '
             i += 2
             next
           end
@@ -259,7 +257,7 @@ module Noir
     # by the first run of `fence` quotes. Content (including `"`, `{`, `}`) is
     # literal and fully masked.
     private def mask_raw_string(start : Int32, quote_pos : Int32, fence : Int32) : Int32
-      fence.times { @masked << ' ' }
+      fence.times { |k| @masked[quote_pos + k] = ' ' }
       i = quote_pos + fence
       while i < @size
         if @chars[i] == '"'
@@ -270,15 +268,15 @@ module Noir
             j += 1
           end
           if run >= fence
-            fence.times { @masked << ' ' }
+            fence.times { |k| @masked[i + k] = ' ' }
             i += fence
             @spans << {:string, start, i}
             return i
           end
-          run.times { @masked << ' ' }
+          run.times { |k| @masked[i + k] = ' ' }
           i += run
         else
-          @masked << (@chars[i] == '\n' ? '\n' : ' ')
+          @masked[i] = ' ' unless @chars[i] == '\n'
           i += 1
         end
       end
@@ -300,7 +298,7 @@ module Noir
       end
 
       if run >= 3 # raw nested string: close on the next run of `run` quotes
-        run.times { @masked << ' ' }
+        run.times { |k| @masked[quote_pos + k] = ' ' }
         i = quote_pos + run
         while i < @size
           if @chars[i] == '"'
@@ -309,13 +307,13 @@ module Noir
               r += 1
             end
             if r >= run
-              run.times { @masked << ' ' }
+              run.times { |k| @masked[i + k] = ' ' }
               return i + run
             end
-            r.times { @masked << ' ' }
+            r.times { |k| @masked[i + k] = ' ' }
             i += r
           else
-            @masked << (@chars[i] == '\n' ? '\n' : ' ')
+            @masked[i] = ' ' unless @chars[i] == '\n'
             i += 1
           end
         end
@@ -323,21 +321,21 @@ module Noir
       end
 
       if run == 2 && !verbatim # empty "" string
-        @masked << ' '
-        @masked << ' '
+        @masked[quote_pos] = ' '
+        @masked[quote_pos + 1] = ' '
         return quote_pos + 2
       end
 
-      @masked << ' ' # opening quote
+      @masked[quote_pos] = ' ' # opening quote
       i = quote_pos + 1
       escaped = false
       while i < @size
         c = @chars[i]
-        @masked << (c == '\n' ? '\n' : ' ')
+        @masked[i] = ' ' unless c == '\n'
         if verbatim
           if c == '"'
             if i + 1 < @size && @chars[i + 1] == '"'
-              @masked << ' ' # doubled (escaped) quote
+              @masked[i + 1] = ' ' # doubled (escaped) quote
               i += 2
               next
             end
@@ -419,22 +417,10 @@ module Noir
     # `masked_lines[i]` (structure) while emitting `lines[i]` (real text).
     def masked_lines : Array(String)
       @masked_lines ||= begin
-        # Mirror `String#lines` (chomp: drop the trailing empty segment when the
-        # source ends in `\n`) so masked_lines[i] aligns 1:1 with content.lines[i].
-        out = [] of String
-        line_start = 0
-        i = 0
-        while i < @size
-          if @chars[i] == '\n'
-            # Chomp the `\r` of a `\r\n` so each line matches `String#lines`.
-            finish = i > line_start && @chars[i - 1] == '\r' ? i - 1 : i
-            out << @masked[line_start...finish].join
-            line_start = i + 1
-          end
-          i += 1
+        masked_str = String.build(@size) do |io|
+          @masked.each { |c| io << c }
         end
-        out << @masked[line_start...@size].join if line_start < @size
-        out
+        masked_str.lines
       end
     end
 

--- a/src/minilexers/scala_lexer.cr
+++ b/src/minilexers/scala_lexer.cr
@@ -51,8 +51,8 @@ module Noir
     def initialize(source : String)
       @chars = source.chars
       @size = @chars.size
-      @masked = Array(Char).new(@size)
-      @code = Array(Char).new(@size)
+      @masked = @chars.dup
+      @code = @chars.dup
       @spans = [] of Tuple(Symbol, Int32, Int32)
       @tokens = nil
       @skip_ranges = nil
@@ -70,9 +70,9 @@ module Noir
     end
 
     # Emit one source character to both views.
-    private def emit(struct_c : Char, code_c : Char)
-      @masked << struct_c
-      @code << code_c
+    private def emit(index : Int32, struct_c : Char, code_c : Char)
+      @masked[index] = struct_c
+      @code[index] = code_c
     end
 
     private def scan
@@ -92,7 +92,6 @@ module Noir
         elsif c == '\'' && char_literal?(i)
           i = mask_char_literal(i)
         else
-          emit(c, c)
           i += 1
         end
       end
@@ -101,7 +100,7 @@ module Noir
     private def mask_line_comment(start : Int32) : Int32
       i = start
       while i < @size && @chars[i] != '\n'
-        emit(' ', ' ')
+        emit(i, ' ', ' ')
         i += 1
       end
       @spans << {:comment, start, i}
@@ -117,17 +116,17 @@ module Noir
         nxt = i + 1 < @size ? @chars[i + 1] : '\0'
         if c == '/' && nxt == '*'
           depth += 1
-          emit(' ', ' ')
-          emit(' ', ' ')
+          emit(i, ' ', ' ')
+          emit(i + 1, ' ', ' ')
           i += 2
         elsif c == '*' && nxt == '/'
           depth -= 1
-          emit(' ', ' ')
-          emit(' ', ' ')
+          emit(i, ' ', ' ')
+          emit(i + 1, ' ', ' ')
           i += 2
           break if depth == 0
         else
-          emit((c == '\n' ? '\n' : ' '), (c == '\n' ? '\n' : ' '))
+          emit(i, (c == '\n' ? '\n' : ' '), (c == '\n' ? '\n' : ' '))
           i += 1
         end
       end
@@ -138,20 +137,20 @@ module Noir
     # `start` points at the first of `"""`. Triple-quoted strings are raw and
     # may span lines; close on the next `"""`. Blanked in BOTH views.
     private def mask_triple_string(start : Int32) : Int32
-      emit(' ', ' ')
-      emit(' ', ' ')
-      emit(' ', ' ')
+      emit(start, ' ', ' ')
+      emit(start + 1, ' ', ' ')
+      emit(start + 2, ' ', ' ')
       i = start + 3
       while i < @size
         if @chars[i] == '"' && i + 2 < @size && @chars[i + 1] == '"' && @chars[i + 2] == '"'
-          emit(' ', ' ')
-          emit(' ', ' ')
-          emit(' ', ' ')
+          emit(i, ' ', ' ')
+          emit(i + 1, ' ', ' ')
+          emit(i + 2, ' ', ' ')
           i += 3
           break
         end
         ch = @chars[i] == '\n' ? '\n' : ' '
-        emit(ch, ch)
+        emit(i, ch, ch)
         i += 1
       end
       @spans << {:string, start, i}
@@ -161,17 +160,17 @@ module Noir
     # Regular `"…"` string. Blanked in the structural view; PRESERVED (quotes
     # and content) in the code view so route literals stay readable.
     private def mask_string(start : Int32) : Int32
-      emit(' ', '"')
+      emit(start, ' ', '"')
       i = start + 1
       escaped = false
       while i < @size
         c = @chars[i]
         if c == '\n'
-          emit('\n', '\n')
+          emit(i, '\n', '\n')
           i += 1
           break # unterminated single-line string
         end
-        emit(' ', c)
+        emit(i, ' ', c)
         if escaped
           escaped = false
         elsif c == '\\'
@@ -200,7 +199,7 @@ module Noir
 
     private def mask_char_literal(start : Int32) : Int32
       len = @chars[start + 1] == '\\' ? 4 : 3
-      len.times { emit(' ', ' ') }
+      len.times { |k| emit(start + k, ' ', ' ') }
       @spans << {:string, start, start + len}
       start + len
     end
@@ -263,29 +262,23 @@ module Noir
 
     # Structural masked source split into lines (1:1 with `String#lines`).
     def masked_lines : Array(String)
-      @masked_lines ||= split_lines(@masked)
+      @masked_lines ||= begin
+        masked_str = String.build(@size) do |io|
+          @masked.each { |c| io << c }
+        end
+        masked_str.lines
+      end
     end
 
     # Code masked source split into lines (1:1 with `String#lines`). Comments,
     # triple-quote bodies and char literals are blanked; regular strings kept.
     def code_lines : Array(String)
-      @code_lines ||= split_lines(@code)
-    end
-
-    private def split_lines(buf : Array(Char)) : Array(String)
-      out = [] of String
-      line_start = 0
-      i = 0
-      while i < @size
-        if @chars[i] == '\n'
-          finish = i > line_start && @chars[i - 1] == '\r' ? i - 1 : i
-          out << buf[line_start...finish].join
-          line_start = i + 1
+      @code_lines ||= begin
+        code_str = String.build(@size) do |io|
+          @code.each { |c| io << c }
         end
-        i += 1
+        code_str.lines
       end
-      out << buf[line_start...@size].join if line_start < @size
-      out
     end
 
     # ---- token stream ------------------------------------------------------

--- a/src/miniparsers/cpp_callee_extractor.cr
+++ b/src/miniparsers/cpp_callee_extractor.cr
@@ -139,18 +139,23 @@ module Noir::CppCalleeExtractor
   # macro/route scanners run without matching commented-out (or documentation)
   # code. ASCII-oriented, matching the rest of the offset handling here.
   def strip_comments(source : String) : String
+    unless source.includes?("//") || source.includes?("/*")
+      return source
+    end
+
     bytes = source.to_slice.dup
     size = bytes.size
+    ptr = bytes.to_unsafe
     i = 0
 
     while i < size
-      char = bytes[i].unsafe_chr
+      char = ptr[i].unsafe_chr
 
       if char == '"' || char == '\''
         quote = char
         i += 1
         while i < size
-          c = bytes[i].unsafe_chr
+          c = ptr[i].unsafe_chr
           if c == '\\'
             i += 2
             next
@@ -160,23 +165,23 @@ module Noir::CppCalleeExtractor
           i += 1
         end
         i += 1
-      elsif char == '/' && i + 1 < size && bytes[i + 1].unsafe_chr == '/'
-        while i < size && bytes[i].unsafe_chr != '\n'
-          bytes[i] = ' '.ord.to_u8
+      elsif char == '/' && i + 1 < size && ptr[i + 1].unsafe_chr == '/'
+        while i < size && ptr[i].unsafe_chr != '\n'
+          ptr[i] = ' '.ord.to_u8
           i += 1
         end
-      elsif char == '/' && i + 1 < size && bytes[i + 1].unsafe_chr == '*'
-        bytes[i] = ' '.ord.to_u8
-        bytes[i + 1] = ' '.ord.to_u8
+      elsif char == '/' && i + 1 < size && ptr[i + 1].unsafe_chr == '*'
+        ptr[i] = ' '.ord.to_u8
+        ptr[i + 1] = ' '.ord.to_u8
         i += 2
         while i < size
-          if bytes[i].unsafe_chr == '*' && i + 1 < size && bytes[i + 1].unsafe_chr == '/'
-            bytes[i] = ' '.ord.to_u8
-            bytes[i + 1] = ' '.ord.to_u8
+          if ptr[i].unsafe_chr == '*' && i + 1 < size && ptr[i + 1].unsafe_chr == '/'
+            ptr[i] = ' '.ord.to_u8
+            ptr[i + 1] = ' '.ord.to_u8
             i += 2
             break
           end
-          bytes[i] = ' '.ord.to_u8 unless bytes[i].unsafe_chr == '\n'
+          ptr[i] = ' '.ord.to_u8 unless ptr[i].unsafe_chr == '\n'
           i += 1
         end
       else
@@ -188,6 +193,7 @@ module Noir::CppCalleeExtractor
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    return unless line.includes?('(')
     candidates = [] of Tuple(Int32, String)
 
     line.scan(SCOPED_CALL_REGEX) do |match|
@@ -223,18 +229,20 @@ module Noir::CppCalleeExtractor
   end
 
   private def strip_non_code_with_state(line : String, in_block_comment : Bool) : Tuple(String, Bool)
-    chars = line.chars
+    bytesize = line.bytesize
+    ptr = line.to_unsafe
     in_string = false
     in_char = false
     escaped = false
     index = 0
-    stripped = String::Builder.new
+    stripped = String::Builder.new(bytesize)
 
-    while index < chars.size
-      char = chars[index]
+    while index < bytesize
+      byte = ptr[index]
+      char = byte.unsafe_chr
 
       if in_block_comment
-        if char == '*' && chars[index + 1]? == '/'
+        if char == '*' && index + 1 < bytesize && ptr[index + 1].unsafe_chr == '/'
           in_block_comment = false
           index += 1
         end
@@ -258,13 +266,13 @@ module Noir::CppCalleeExtractor
         in_string = true
       elsif char == '\''
         in_char = true
-      elsif char == '/' && chars[index + 1]? == '/'
+      elsif char == '/' && index + 1 < bytesize && ptr[index + 1].unsafe_chr == '/'
         break
-      elsif char == '/' && chars[index + 1]? == '*'
+      elsif char == '/' && index + 1 < bytesize && ptr[index + 1].unsafe_chr == '*'
         in_block_comment = true
         index += 1
       else
-        stripped << char
+        stripped.write_byte(byte)
       end
 
       index += 1

--- a/src/miniparsers/crystal_callee_extractor.cr
+++ b/src/miniparsers/crystal_callee_extractor.cr
@@ -53,6 +53,13 @@ module Noir::CrystalCalleeExtractor
   end
 
   def strip_comment(line : String) : String
+    # Fast path: the per-char walk only ever diverges from the input when
+    # the line carries a `#` comment. `#` is single-byte ASCII and cannot
+    # appear inside a UTF-8 multibyte sequence, so a raw byte_index
+    # (memchr) is both correct and allocation-free. This is the hot path —
+    # every Crystal analyzer runs strip_comment on every source line.
+    return line unless line.byte_index(0x23_u8) # '#'
+
     in_string = false
     escaped = false
     quote = '\0'

--- a/src/miniparsers/elixir_callee_extractor.cr
+++ b/src/miniparsers/elixir_callee_extractor.cr
@@ -55,7 +55,17 @@ module Noir::ElixirCalleeExtractor
     RESERVED.includes?(last)
   end
 
+  # Blank string literals and drop a trailing `# …` comment. Used by the
+  # callee scanner and by Elixir analyzers' block-depth counters (where
+  # `do`/`fn`/`end` inside a literal must not shift nesting). Hot path:
+  #
+  # * No `#` and no quotes → identity return (no allocation). The walk
+  #   below would rebuild an identical string.
+  # * Otherwise → quote-aware rebuild that discards string contents and
+  #   truncates at the first out-of-string `#`.
   def strip_comment(line : String) : String
+    return line unless line.includes?('#') || line.includes?('"') || line.includes?('\'')
+
     in_string = false
     escaped = false
     quote = '\0'

--- a/src/miniparsers/elixir_callee_extractor.cr
+++ b/src/miniparsers/elixir_callee_extractor.cr
@@ -56,7 +56,7 @@ module Noir::ElixirCalleeExtractor
     return true if name.empty?
 
     # Last segment after `.` without allocating a split array.
-    last = if (dot = name.rindex('.'))
+    last = if dot = name.rindex('.')
              name[dot + 1..]
            else
              name

--- a/src/miniparsers/elixir_callee_extractor.cr
+++ b/src/miniparsers/elixir_callee_extractor.cr
@@ -33,6 +33,10 @@ module Noir::ElixirCalleeExtractor
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    # Both call patterns require either `(` or whitespace before an
+    # argument-like token. Lines with neither cannot produce a callee.
+    return unless line.includes?('(') || line.includes?(' ') || line.includes?('\t')
+
     line.scan(QUALIFIED_CALL_REGEX) do |match|
       name = match[1]
       next if skip_callee?(name)
@@ -51,7 +55,12 @@ module Noir::ElixirCalleeExtractor
   private def skip_callee?(name : String) : Bool
     return true if name.empty?
 
-    last = name.split('.').last
+    # Last segment after `.` without allocating a split array.
+    last = if (dot = name.rindex('.'))
+             name[dot + 1..]
+           else
+             name
+           end
     RESERVED.includes?(last)
   end
 

--- a/src/miniparsers/haskell_callee_extractor.cr
+++ b/src/miniparsers/haskell_callee_extractor.cr
@@ -152,11 +152,13 @@ module Noir::HaskellCalleeExtractor
   # (`==`, `>=`, `<=`, `/=`, `!=`, `=>`, `=<<`). Returns nil when the line has no
   # standalone definition `=` (e.g. it is only a comparison expression).
   private def definition_equals_index(line : String) : Int32?
+    chars = line.chars
+    size = chars.size
     index = 0
-    while index < line.size
-      if line[index] == '='
-        prev = index > 0 ? line[index - 1] : ' '
-        nxt = index + 1 < line.size ? line[index + 1] : ' '
+    while index < size
+      if chars[index] == '='
+        prev = index > 0 ? chars[index - 1] : ' '
+        nxt = index + 1 < size ? chars[index + 1] : ' '
         adjacent = {'=', '<', '>', '/', '!'}
         return index unless adjacent.includes?(prev) || nxt == '=' || nxt == '>' || nxt == '<'
       end

--- a/src/miniparsers/lua_callee_extractor.cr
+++ b/src/miniparsers/lua_callee_extractor.cr
@@ -352,6 +352,7 @@ module Noir::LuaCalleeExtractor
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
+    return if line.blank?
     candidates = [] of Tuple(Int32, String)
 
     scan_candidates(line, RECEIVER_CALL_REGEX, candidates)

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -312,7 +312,15 @@ module Noir::PerlCalleeExtractor
       source.includes?("qq") || source.includes?("qw") || source.includes?("qr") ||
       source.includes?("qx") || source.includes?("q{") || source.includes?("q(") ||
       source.includes?("q[") || source.includes?("q/") || source.includes?("q!") ||
-      source.includes?("q|") || source.includes?("q ")
+      source.includes?("q|") || source.includes?("q ") ||
+      # `q` accepts any non-word delimiter, e.g. angle-bracket `q<...>`, which
+      # the full walker blanks; missing it here let `q<foo(bar)>` slip through
+      # the fast path and emit a spurious callee. Cover the remaining common
+      # bracket/punctuation delimiters (widening the gate only ever routes
+      # more input through the exact walk — it can never drop a callee).
+      source.includes?("q<") || source.includes?("q~") ||
+      source.includes?("q,") || source.includes?("q:") ||
+      source.includes?("q.") || source.includes?("q;")
   end
 
   private def controller_keys(controller : String) : Array(String)

--- a/src/miniparsers/perl_callee_extractor.cr
+++ b/src/miniparsers/perl_callee_extractor.cr
@@ -153,6 +153,11 @@ module Noir::PerlCalleeExtractor
 
   # Public String overload kept for callers outside this module.
   def strip_non_code(source : String) : String
+    # Fast path: nothing to blank when the source has no comment, short
+    # string, or quote-like (`q`/`qq`/`qw`/`qr`/`qx`) markers. Preserves
+    # byte-identical output for the common "already plain code" case used
+    # by brace-depth walks.
+    return source unless strip_non_code_needed?(source)
     strip_non_code(source.chars)
   end
 
@@ -187,11 +192,22 @@ module Noir::PerlCalleeExtractor
   end
 
   # Public String overload kept for callers outside this module.
+  # Walk characters up to `index` counting newlines — the previous
+  # `source[0...limit].count('\n')` allocated a full substring on every
+  # call (handler body extraction, named-sub indexing). `index` is a
+  # character offset (matches `source.chars` / `String#size` indexing),
+  # not a UTF-8 byte offset.
   def line_number_for(source : String, index : Int32) : Int32
     return 1 if index <= 0
 
-    limit = index > source.size ? source.size : index
-    source[0...limit].count('\n') + 1
+    count = 1
+    i = 0
+    source.each_char do |ch|
+      break if i >= index
+      count += 1 if ch == '\n'
+      i += 1
+    end
+    count
   end
 
   def line_number_for(chars : Array(Char), index : Int32) : Int32
@@ -279,10 +295,24 @@ module Noir::PerlCalleeExtractor
   end
 
   private def package_name(source : String) : String?
+    return unless source.includes?("package")
     stripped = strip_non_code(source)
     if match = stripped.match(/^\s*package\s+([A-Za-z_][A-Za-z0-9_:]*)\s*;/m)
       match[1]
     end
+  end
+
+  # Markers that force a full `strip_non_code` walk. Quote-like ops are
+  # matched via the common `q…` spellings; a lone `q` inside an identifier
+  # (`require`) is intentionally not enough — the char walk still handles
+  # rare `q /foo/` forms if another marker already forced the walk, and
+  # pure-code files without quotes/comments skip it entirely.
+  private def strip_non_code_needed?(source : String) : Bool
+    source.includes?('#') || source.includes?('\'') || source.includes?('"') ||
+      source.includes?("qq") || source.includes?("qw") || source.includes?("qr") ||
+      source.includes?("qx") || source.includes?("q{") || source.includes?("q(") ||
+      source.includes?("q[") || source.includes?("q/") || source.includes?("q!") ||
+      source.includes?("q|") || source.includes?("q ")
   end
 
   private def controller_keys(controller : String) : Array(String)

--- a/src/miniparsers/php_callee_extractor.cr
+++ b/src/miniparsers/php_callee_extractor.cr
@@ -32,25 +32,35 @@ module Noir::PhpCalleeExtractor
   end
 
   private def scan_line(line : String, file_path : String, line_number : Int32, entries : Array(Entry))
-    line.scan(CLASS_PROPERTY_CALL_REGEX) do |match|
-      name = normalize_object_call(match[1])
-      next if skip_callee?(name)
+    # All four call patterns require `(` after the callee name. Pure
+    # assignment / property lines cannot produce a callee.
+    return unless line.includes?('(')
 
-      entries << {name, file_path, line_number}
-    end
+    if line.includes?("::") || line.includes?("->")
+      line.scan(CLASS_PROPERTY_CALL_REGEX) do |match|
+        name = normalize_object_call(match[1])
+        next if skip_callee?(name)
 
-    line.scan(OBJECT_CALL_REGEX) do |match|
-      name = normalize_object_call(match[1])
-      next if skip_callee?(name)
+        entries << {name, file_path, line_number}
+      end
 
-      entries << {name, file_path, line_number}
-    end
+      if line.includes?("->")
+        line.scan(OBJECT_CALL_REGEX) do |match|
+          name = normalize_object_call(match[1])
+          next if skip_callee?(name)
 
-    line.scan(STATIC_CALL_REGEX) do |match|
-      name = normalize_static_call(match[1])
-      next if skip_callee?(name)
+          entries << {name, file_path, line_number}
+        end
+      end
 
-      entries << {name, file_path, line_number}
+      if line.includes?("::")
+        line.scan(STATIC_CALL_REGEX) do |match|
+          name = normalize_static_call(match[1])
+          next if skip_callee?(name)
+
+          entries << {name, file_path, line_number}
+        end
+      end
     end
 
     line.scan(BARE_CALL_REGEX) do |match|

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -90,6 +90,20 @@ module Noir::RubyCalleeExtractor
   end
 
   def strip_comment(line : String, preserve_strings : Bool = false) : String
+    # Fast path: the per-char rebuild below only ever diverges from the input
+    # when the line carries a `#` comment (either mode) or, with
+    # `preserve_strings: false`, a string literal whose interior is blanked.
+    # With `preserve_strings: true` a `#`-free line maps to itself; with
+    # `preserve_strings: false` it must also be quote-free. When none of the
+    # relevant trigger bytes are present, skip the String::Builder allocation
+    # entirely. `#`/`'`/`"` are single-byte ASCII that can never appear inside
+    # a UTF-8 multibyte sequence, so raw byte_index scans (memchr) are both
+    # correct and allocation-free. This is the hot path — every Ruby analyzer
+    # runs strip_comment on every line, most of which need no rewrite.
+    return line unless line.byte_index(0x23_u8) ||                       # '#'
+                       (!preserve_strings && (line.byte_index(0x27_u8) || # '\''
+                                              line.byte_index(0x22_u8)))  # '"'
+
     stripped = String::Builder.new
     in_string = false
     escaped = false

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -100,9 +100,12 @@ module Noir::RubyCalleeExtractor
     # a UTF-8 multibyte sequence, so raw byte_index scans (memchr) are both
     # correct and allocation-free. This is the hot path — every Ruby analyzer
     # runs strip_comment on every line, most of which need no rewrite.
-    return line unless line.byte_index(0x23_u8) ||                        # '#'
-                       (!preserve_strings && (line.byte_index(0x27_u8) || # '\''
-                       line.byte_index(0x22_u8)))                         # '"'
+    if preserve_strings
+      return line unless line.byte_index(0x23_u8) # '#'
+    else
+      # '#', '\'' or '"' anywhere forces the rewrite; otherwise it's identity.
+      return line unless line.byte_index(0x23_u8) || line.byte_index(0x27_u8) || line.byte_index(0x22_u8)
+    end
 
     stripped = String::Builder.new
     in_string = false

--- a/src/miniparsers/ruby_callee_extractor.cr
+++ b/src/miniparsers/ruby_callee_extractor.cr
@@ -100,9 +100,9 @@ module Noir::RubyCalleeExtractor
     # a UTF-8 multibyte sequence, so raw byte_index scans (memchr) are both
     # correct and allocation-free. This is the hot path — every Ruby analyzer
     # runs strip_comment on every line, most of which need no rewrite.
-    return line unless line.byte_index(0x23_u8) ||                       # '#'
+    return line unless line.byte_index(0x23_u8) ||                        # '#'
                        (!preserve_strings && (line.byte_index(0x27_u8) || # '\''
-                                              line.byte_index(0x22_u8)))  # '"'
+                       line.byte_index(0x22_u8)))                         # '"'
 
     stripped = String::Builder.new
     in_string = false

--- a/src/miniparsers/scala_callee_extractor.cr
+++ b/src/miniparsers/scala_callee_extractor.cr
@@ -63,12 +63,14 @@ module Noir::ScalaCalleeExtractor
     in_string = false
     escaped = false
     index = 0
-    stripped = String::Builder.new
+    chars = line.chars
+    size = chars.size
+    stripped = String::Builder.new(size)
 
-    while index < line.size
-      char = line[index]
-      next_char = line[index + 1]?
-      third_char = line[index + 2]?
+    while index < size
+      char = chars[index]
+      next_char = chars[index + 1]?
+      third_char = chars[index + 2]?
 
       if block_comment_depth > 0
         if char == '/' && next_char == '*'
@@ -82,7 +84,7 @@ module Noir::ScalaCalleeExtractor
           index += 2
           next
         end
-        stripped << ' '
+        stripped.write_byte(' '.ord.to_u8)
       elsif in_multiline_string
         if char == '"' && next_char == '"' && third_char == '"'
           in_multiline_string = false
@@ -90,7 +92,7 @@ module Noir::ScalaCalleeExtractor
           index += 3
           next
         end
-        stripped << ' '
+        stripped.write_byte(' '.ord.to_u8)
       elsif in_string
         if escaped
           escaped = false
@@ -99,7 +101,11 @@ module Noir::ScalaCalleeExtractor
         elsif char == '"'
           in_string = false
         end
-        stripped << (preserve_strings ? char : ' ')
+        if preserve_strings
+          stripped << char
+        else
+          stripped.write_byte(' '.ord.to_u8)
+        end
       elsif char == '"'
         if next_char == '"' && third_char == '"'
           in_multiline_string = true
@@ -109,9 +115,13 @@ module Noir::ScalaCalleeExtractor
         else
           in_string = true
         end
-        stripped << (preserve_strings ? char : ' ')
+        if preserve_strings
+          stripped << char
+        else
+          stripped.write_byte(' '.ord.to_u8)
+        end
       elsif char == '/' && next_char == '/'
-        append_spaces(stripped, line.size - index)
+        append_spaces(stripped, size - index)
         return {stripped.to_s, block_comment_depth, in_multiline_string}
       elsif char == '/' && next_char == '*'
         block_comment_depth += 1
@@ -128,7 +138,7 @@ module Noir::ScalaCalleeExtractor
   end
 
   private def append_spaces(stripped : String::Builder, count : Int32)
-    count.times { stripped << ' ' }
+    count.times { stripped.write_byte(' '.ord.to_u8) }
   end
 
   private def scan_code(code : String,
@@ -136,6 +146,8 @@ module Noir::ScalaCalleeExtractor
                         start_line : Int32,
                         line_offsets : Array(Int32),
                         entries : Array(Tuple(Int32, Entry)))
+    return unless code.includes?('(') || code.includes?('{')
+
     code.scan(RECEIVER_CALL_REGEX) do |match|
       name = normalized_name(match[1])
       next if skip_callee?(name)

--- a/src/miniparsers/swift_callee_extractor.cr
+++ b/src/miniparsers/swift_callee_extractor.cr
@@ -52,13 +52,15 @@ module Noir::SwiftCalleeExtractor
                                 in_multiline_string : Bool) : Tuple(String, Int32, Bool)
     in_string = false
     escaped = false
+    chars = line.chars
+    size = chars.size
     index = 0
     stripped = String::Builder.new
 
-    while index < line.size
-      char = line[index]
-      next_char = line[index + 1]?
-      third_char = line[index + 2]?
+    while index < size
+      char = chars[index]
+      next_char = chars[index + 1]?
+      third_char = chars[index + 2]?
 
       if block_comment_depth > 0
         if char == '/' && next_char == '*'
@@ -100,10 +102,10 @@ module Noir::SwiftCalleeExtractor
           in_string = true
         end
         stripped << ' '
-      elsif char == '/' && line[index + 1]? == '/'
-        append_spaces(stripped, line.size - index)
+      elsif char == '/' && chars[index + 1]? == '/'
+        append_spaces(stripped, size - index)
         return {stripped.to_s, block_comment_depth, in_multiline_string}
-      elsif char == '/' && line[index + 1]? == '*'
+      elsif char == '/' && chars[index + 1]? == '*'
         block_comment_depth += 1
         append_spaces(stripped, 2)
         index += 2

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -55,7 +55,7 @@ module Noir::ZigCalleeExtractor
   VENDORED_FRAMEWORK_RE = %r{/(?:deps|dep|lib|libs|vendor|vendored|pkg|pkgs|zig-pkg|packages|third_party|third-party|modules|subprojects|external|\.deps)/(?:zap|httpz|http\.zig|tokamak|jetzig|zmpl|zmd)/}
 
   def vendored_framework_path?(path : String) : Bool
-    !VENDORED_FRAMEWORK_RE.match(path.gsub('\\', '/')).nil?
+    path.gsub('\\', '/').matches?(VENDORED_FRAMEWORK_RE)
   end
 
   # `test { … }` / `test "name" { … }` block opener. Route registrations inside
@@ -96,8 +96,42 @@ module Noir::ZigCalleeExtractor
 
   # ---- public entry points (String overloads) -----------------------------
 
+  # Shared prep for framework analyzers that need both comment-stripped text
+  # (string contents preserved for route paths) and non-code-stripped text /
+  # chars (for brace matching + test-block ranges). Builds `source.chars`
+  # once and reuses it for both walks — previously every analyzer paid for
+  # two independent `source.chars` + two strip passes.
+  alias Prepared = NamedTuple(comments: String, non_code: String, non_code_chars: Array(Char))
+
+  def prepare(source : String) : Prepared
+    need_comments = strip_comments_needed?(source)
+    need_non_code = strip_non_code_needed?(source)
+
+    if !need_comments && !need_non_code
+      return {
+        comments:       source,
+        non_code:       source,
+        non_code_chars: source.chars,
+      }
+    end
+
+    chars = source.chars
+    comments = need_comments ? chars_to_string(strip_comments(chars)) : source
+    non_code_chars = need_non_code ? strip_non_code(chars) : chars
+    non_code = need_non_code ? chars_to_string(non_code_chars) : source
+    {
+      comments:       comments,
+      non_code:       non_code,
+      non_code_chars: non_code_chars,
+    }
+  end
+
   def strip_non_code(source : String) : String
-    String.build { |io| strip_non_code(source.chars).each { |c| io << c } }
+    # Fast path: nothing to blank when the source has no comment, multiline
+    # string, char-literal, or double-quoted string markers. `/`/`\`/`'`/`"`
+    # are single-byte ASCII, so byte_index (memchr) is allocation-free.
+    return source unless strip_non_code_needed?(source)
+    chars_to_string(strip_non_code(source.chars))
   end
 
   # Like `strip_non_code` but keeps the contents of double-quoted string
@@ -105,13 +139,23 @@ module Noir::ZigCalleeExtractor
   # this form to read the URL while still ignoring routes that sit in a
   # comment, a `\\` multiline doc-string, or a char literal.
   def strip_comments(source : String) : String
-    String.build { |io| strip_comments(source.chars).each { |c| io << c } }
+    # Fast path: with no `//`, `\\`, or `'` there is nothing to blank
+    # (double-quoted strings are preserved as-is).
+    return source unless strip_comments_needed?(source)
+    chars_to_string(strip_comments(source.chars))
   end
 
   def function_table(source : String, file_path : String) : Array(FunctionInfo)
     chars = source.chars
     stripped = strip_non_code(chars)
-    stripped_str = String.build { |io| stripped.each { |c| io << c } }
+    function_table_from(stripped, file_path)
+  end
+
+  # Same as `function_table` but reuses an already-stripped char array from
+  # `prepare` / `strip_non_code`, so callers that already paid for a strip
+  # don't re-walk the file.
+  def function_table_from(stripped : Array(Char), file_path : String) : Array(FunctionInfo)
+    stripped_str = chars_to_string(stripped)
     table = [] of FunctionInfo
 
     stripped_str.scan(FUNCTION_REGEX) do |match|
@@ -145,8 +189,12 @@ module Noir::ZigCalleeExtractor
   # wins; callers that need struct scoping should filter `function_table`
   # by offset instead.
   def function_bodies(source : String, file_path : String) : Hash(String, FunctionBody)
+    function_bodies_from(function_table(source, file_path), file_path)
+  end
+
+  def function_bodies_from(table : Array(FunctionInfo), file_path : String) : Hash(String, FunctionBody)
     bodies = {} of String => FunctionBody
-    function_table(source, file_path).each do |info|
+    table.each do |info|
       next if bodies.has_key?(info[:name])
       bodies[info[:name]] = {body: info[:body], path: file_path, start_line: info[:start_line]}
     end
@@ -160,7 +208,7 @@ module Noir::ZigCalleeExtractor
     # Blank comments/strings so a call-shaped token inside them is never
     # surfaced. Idempotent on the already-stripped bodies the analyzers pass
     # in (spaces stay spaces, newlines and length are preserved so line
-    # math is unaffected).
+    # math is unaffected). Fast-path skip when the body has no markers.
     body = strip_non_code(body)
 
     body.scan(CALL_REGEX) do |match|
@@ -427,14 +475,51 @@ module Noir::ZigCalleeExtractor
     count
   end
 
-  private def newlines_before(text : String, offset : Int32) : Int32
-    count = 0
+  # Byte-offset line counter for `Regex::MatchData#begin` positions. Avoids
+  # the `text.chars` allocation every endpoint emission used to pay for.
+  # `\n` is single-byte ASCII, so a raw byte walk is both correct and
+  # allocation-free relative to `Array(Char)`.
+  def line_at(text : String, offset : Int32) : Int32
+    count = 1
     i = 0
-    text.each_char do |ch|
-      break if i >= offset
-      count += 1 if ch == '\n'
+    limit = offset > text.bytesize ? text.bytesize : offset
+    text.each_byte do |b|
+      break if i >= limit
+      count += 1 if b == 0x0A_u8
       i += 1
     end
     count
+  end
+
+  private def newlines_before(text : String, offset : Int32) : Int32
+    count = 0
+    i = 0
+    limit = offset > text.bytesize ? text.bytesize : offset
+    text.each_byte do |b|
+      break if i >= limit
+      count += 1 if b == 0x0A_u8
+      i += 1
+    end
+    count
+  end
+
+  private def chars_to_string(chars : Array(Char)) : String
+    String.build(chars.size) do |io|
+      chars.each { |c| io << c }
+    end
+  end
+
+  # Markers that force a full `strip_comments` walk. `//` is the line/doc
+  # comment opener; `\\` is the multiline string opener; `'` opens a char
+  # literal. A lone `/` (route paths) does NOT force a walk.
+  private def strip_comments_needed?(source : String) : Bool
+    source.includes?("//") || source.includes?("\\\\") || source.includes?("'")
+  end
+
+  # Markers that force a full `strip_non_code` walk. Adds `"` (string
+  # contents blanked) on top of the comment/char/multiline markers.
+  private def strip_non_code_needed?(source : String) : Bool
+    source.includes?("//") || source.includes?("\\\\") ||
+      source.includes?("'") || source.includes?("\"")
   end
 end

--- a/src/miniparsers/zig_callee_extractor.cr
+++ b/src/miniparsers/zig_callee_extractor.cr
@@ -475,14 +475,18 @@ module Noir::ZigCalleeExtractor
     count
   end
 
-  # Byte-offset line counter for `Regex::MatchData#begin` positions. Avoids
-  # the `text.chars` allocation every endpoint emission used to pay for.
-  # `\n` is single-byte ASCII, so a raw byte walk is both correct and
+  # Line counter for `Regex::MatchData#begin` positions. Avoids the
+  # `text.chars` allocation every endpoint emission used to pay for. `#begin`
+  # is a CHAR index, so convert it to a byte offset before the byte walk —
+  # otherwise a multi-byte char before the match (e.g. inside a preserved
+  # string literal) makes the char index under-shoot the true byte position
+  # and the reported line number comes out too small (regression class of #2297).
+  # `\n` is single-byte ASCII, so the byte walk itself stays correct and
   # allocation-free relative to `Array(Char)`.
   def line_at(text : String, offset : Int32) : Int32
+    limit = text.char_index_to_byte_index(offset) || text.bytesize
     count = 1
     i = 0
-    limit = offset > text.bytesize ? text.bytesize : offset
     text.each_byte do |b|
       break if i >= limit
       count += 1 if b == 0x0A_u8
@@ -492,9 +496,9 @@ module Noir::ZigCalleeExtractor
   end
 
   private def newlines_before(text : String, offset : Int32) : Int32
+    limit = text.char_index_to_byte_index(offset) || text.bytesize
     count = 0
     i = 0
-    limit = offset > text.bytesize ? text.bytesize : offset
     text.each_byte do |b|
       break if i >= limit
       count += 1 if b == 0x0A_u8


### PR DESCRIPTION
## Summary

Detection-neutral **performance sweep across the line-scan analyzers** for 12 languages. Every change keeps endpoint / param / callee output byte-identical and is validated by the existing spec suite (**24,809 examples, 0 failures**).

The recurring wins:

- **`strip_comment` / `strip_non_code` fast paths** — return the line verbatim (no allocation) when it carries none of the bytes that could change the output, using memchr-backed `byte_index` scans.
- **Cheap `includes?` / `byte_index` / `Regex.union` gates** in front of per-line route/param regex scans — every gate is a true necessary condition for the inner match, so nothing is dropped.
- **File-level evidence gates & extension filters** so whole-tree scanners skip files that cannot contain routes.
- **Combined / shared route matchers** replacing per-verb interpolated-regex recompiles.
- **Cache-first reads and shared indexes** to avoid re-reading / re-walking the same content.

## By language

| Language | Highlights |
|---|---|
| Ruby | `strip_comment` fast path (universal); Sinatra whole-tree per-line gate + folded depth-delta scan; Rails controller param gate; Grape non-Grape skip. ~5× on a 1757-file corpus. |
| Elixir | Phoenix/Plug file-level evidence gates; `.ex/.exs` filter + ExUnit skip; linear block-depth walk; reverse controller index. |
| Crystal | Kemal/Amber/Lucky/Grip/http/Marten shared route matchers; cache-first reads; `strip_comment` `#` fast path; param gates. |
| Zig | Shared `prepare()` across passes; cached `text.chars`; strip fast paths; `includes?` gates. |
| PHP | `.php` engine filter; Symfony route + pure-PHP param file-level gates; callee/CLI cheap rejects. |
| Perl | Mojolicious/Dancer2/Catalyst route & param accessor gates; `strip_non_code` fast path; allocation-free line numbering. |
| Scala | Lexer + callee-extractor optimizations; Play/Akka analyzers. |
| C++ | Crow/Drogon/httplib/CLI analyzers + callee extractor. |
| C# | Reused `CSharpLexer` instance; string-masking / line-split optimization. |
| Lua | Lapis/Lor analyzers; skip regex on blank lines. |
| Swift / Haskell | callee-extractor micro-optimizations. |

## Review-driven fixes

The whole branch was code-reviewed per language for detection-preservation risks the spec suite can't cover (gates that aren't true necessary conditions, byte-vs-char offsets, CRLF handling). Four latent bugs surfaced and were fixed:

- **Scala / Play** — `blank_non_code` used `each_line`, which chomps a trailing `\r`, breaking the `structure`↔`content` byte alignment on CRLF files (wrong/dropped params, wrong callee lines, mis-URL'd SIRD routes). Restored the `split('\n')` split.
- **Zig** — `line_at`/`newlines_before` used a `MatchData#begin` char index as a byte limit, reporting too-small endpoint line numbers on non-ASCII sources (same class as #2297). Now converted via `char_index_to_byte_index`.
- **PHP / CLI** — the `CLI_HINT_RE` superset gate used a literal `extends Command` (one space) while the precise check uses `/extends\s+Command/`; a tab-separated `extends Command` file could be dropped. Gate now uses the regex form.
- **Perl** — `strip_non_code`'s fast-path gate omitted `q<…>` (and other `q//` delimiters), letting `q<foo(bar)>` emit a spurious callee. Added the missing delimiters.

## Validation

- Full spec suite: **24,809 examples, 0 failures, 0 errors** (before and after the review fixes).
- Ruby benchmark corpus (1757 `.rb` files): default scan ~1.5 s → ~0.30 s, output byte-identical (endpoints + params + callees).
