### PR TITLE
redesign(output/html): dark-tech report with semantic method/severity colors

### DIFF
--- a/spec/unit_test/output_builder/html_spec.cr
+++ b/spec/unit_test/output_builder/html_spec.cr
@@ -492,4 +492,241 @@ describe "OutputBuilderHtml" do
     output.should contain("data-filter-severity=\"high\"")
     output.should contain("data-filter-severity=\"medium\"")
   end
+
+  it "renders the card/table view toggle with persistence hooks" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/test", "GET")])
+    output = builder.io.to_s
+
+    output.should contain("data-action=\"set-view\"")
+    output.should contain("data-view-mode=\"cards\"")
+    output.should contain("data-view-mode=\"table\"")
+    output.should contain("table-head")
+    output.should contain("noir-view")
+  end
+
+  it "renders copy buttons with a precomputed curl command" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("/api/users", "POST")
+    endpoint.push_param(Param.new("username", "test", "json"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("data-action=\"copy-url\"")
+    output.should contain("data-action=\"copy-curl\"")
+    output.should contain("data-url=\"/api/users\"")
+    output.should contain("curl -i -X &#39;POST&#39; &#39;/api/users&#39;")
+    output.should contain("Content-Type: application/json")
+  end
+
+  it "expands synthetic ANY methods inside the curl attribute" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/wildcard", "ANY")])
+    output = builder.io.to_s
+
+    output.should contain("curl -i -X &#39;GET&#39; &#39;/wildcard&#39;")
+    output.should contain("curl -i -X &#39;DELETE&#39; &#39;/wildcard&#39;")
+    output.should_not contain("curl -i -X &#39;ANY&#39;")
+  end
+
+  it "omits copy-as-curl for non-HTTP endpoints" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    endpoint = Endpoint.new("myapp://profile", "GET")
+    endpoint.protocol = "mobile-scheme"
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    # The copy-curl selector always appears in the shared script, so assert
+    # on markup-only forms: the button title and the data attribute.
+    output.should contain("title=\"Copy URL\"")
+    output.should_not contain("title=\"Copy as curl\"")
+    output.should_not contain("data-curl=")
+  end
+
+  it "groups endpoints by first path segment with counts" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([
+      Endpoint.new("/users/1", "GET"),
+      Endpoint.new("/users/2", "POST"),
+      Endpoint.new("/admin", "GET"),
+    ])
+    output = builder.io.to_s
+
+    output.should contain("data-group-key=\"/users\"")
+    output.should contain("data-group-key=\"/admin\"")
+    output.should contain("class=\"group-header\"")
+    output.should contain("data-group-count")
+    output.should contain("data-action=\"toggle-group-collapse\"")
+    output.should contain("class=\"chip group-toggle\"")
+    output.should contain("noir-group")
+  end
+
+  it "skips grouping when all endpoints share one group" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([Endpoint.new("/users/a", "GET"), Endpoint.new("/users/b", "POST")])
+    output = builder.io.to_s
+
+    # CSS/JS always reference group selectors; assert on markup-only forms.
+    output.should_not contain("class=\"group-header\"")
+    output.should_not contain("class=\"chip group-toggle\"")
+  end
+
+  it "skips grouping when every endpoint is its own group" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([
+      Endpoint.new("/a", "GET"),
+      Endpoint.new("/b", "GET"),
+      Endpoint.new("/c", "GET"),
+    ])
+    output = builder.io.to_s
+
+    output.should_not contain("class=\"group-header\"")
+    output.should_not contain("class=\"chip group-toggle\"")
+  end
+
+  it "groups absolute URLs by authority and first path segment" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    builder.print([
+      Endpoint.new("https://api.example.com/v1/users", "GET"),
+      Endpoint.new("https://api.example.com/v1/orders", "GET"),
+      Endpoint.new("/local/x", "GET"),
+    ])
+    output = builder.io.to_s
+
+    output.should contain("data-group-key=\"https://api.example.com/v1\"")
+    output.should contain("data-group-key=\"/local\"")
+  end
+
+  it "renders semantic method and severity styles" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderHtml.new(options)
+    builder.io = IO::Memory.new
+
+    high = YAML.parse <<-YAML
+      id: high-rule
+      info:
+        name: "High Rule"
+        author: ["a"]
+        severity: "high"
+        description: "d"
+        reference: ["https://example.com"]
+      matchers-condition: "or"
+      matchers:
+        - type: "regex"
+          patterns: ["x"]
+          condition: "or"
+      category: "secret"
+      techs: ["*"]
+      YAML
+    info = YAML.parse <<-YAML
+      id: info-rule
+      info:
+        name: "Info Rule"
+        author: ["a"]
+        severity: "info"
+        description: "d"
+        reference: ["https://example.com"]
+      matchers-condition: "or"
+      matchers:
+        - type: "regex"
+          patterns: ["x"]
+          condition: "or"
+      category: "misconfig"
+      techs: ["*"]
+      YAML
+
+    results = [
+      PassiveScanResult.new(PassiveScan.new(high), "a.cr", 1, "x"),
+      PassiveScanResult.new(PassiveScan.new(info), "b.cr", 2, "y"),
+    ]
+
+    builder.print([Endpoint.new("/test", "GET")], results)
+    output = builder.io.to_s
+
+    output.should contain("--m-get")
+    output.should contain("--m-delete")
+    output.should contain("--sev-medium")
+    output.should contain("severity-high")
+    output.should contain("severity-info")
+  end
 end

--- a/spec/unit_test/utils/curl_command_spec.cr
+++ b/spec/unit_test/utils/curl_command_spec.cr
@@ -1,0 +1,38 @@
+require "../../../src/utils/curl_command"
+
+describe CurlCommand do
+  describe ".shell_quote" do
+    it "wraps strings in single quotes" do
+      CurlCommand.shell_quote("/test").should eq("'/test'")
+    end
+
+    it "escapes embedded single quotes" do
+      CurlCommand.shell_quote("it's").should eq("'it'\\''s'")
+    end
+  end
+
+  describe ".build" do
+    it "builds a bare request" do
+      cmd = CurlCommand.build("GET", "/test?id=1", "", "", [] of String, [] of String)
+      cmd.should eq("curl -i -X 'GET' '/test?id=1'")
+    end
+
+    it "adds a JSON body with content type" do
+      cmd = CurlCommand.build("POST", "/api/users", "{\"name\":\"noir\"}", "json", [] of String, [] of String)
+      cmd.should contain("--data-raw '{\"name\":\"noir\"}'")
+      cmd.should contain("-H 'Content-Type: application/json'")
+    end
+
+    it "adds a form body with content type" do
+      cmd = CurlCommand.build("PUT", "/api/products", "name=Updated Product&price=99.99", "form", [] of String, [] of String)
+      cmd.should contain("--data-raw 'name=Updated Product&price=99.99'")
+      cmd.should contain("-H 'Content-Type: application/x-www-form-urlencoded'")
+    end
+
+    it "adds headers and cookies" do
+      cmd = CurlCommand.build("GET", "/test", "", "", ["x-api-key: key123"], ["session=abc123"])
+      cmd.should contain("-H 'x-api-key: key123'")
+      cmd.should contain("--cookie 'session=abc123'")
+    end
+  end
+end

--- a/src/output_builder/curl.cr
+++ b/src/output_builder/curl.cr
@@ -1,6 +1,7 @@
 require "../models/output_builder"
 require "../models/endpoint"
 require "../utils/http_symbols"
+require "../utils/curl_command"
 
 class OutputBuilderCurl < OutputBuilder
   def print(endpoints : Array(Endpoint))
@@ -9,38 +10,8 @@ class OutputBuilderCurl < OutputBuilder
       baked = bake_endpoint(endpoint.url, endpoint.params)
 
       expand_synthetic_http_methods(endpoint.method).each do |method|
-        parts = ["curl", "-i", "-X", shell_quote(method), shell_quote(baked[:url])]
-
-        unless baked[:body].empty?
-          if baked[:body_type] == "json"
-            parts << "--data-raw"
-            parts << shell_quote(baked[:body])
-            parts << "-H"
-            parts << shell_quote("Content-Type: application/json")
-          else
-            parts << "--data-raw"
-            parts << shell_quote(baked[:body])
-            parts << "-H"
-            parts << shell_quote("Content-Type: application/x-www-form-urlencoded")
-          end
-        end
-
-        baked[:header].each do |header|
-          parts << "-H"
-          parts << shell_quote(header)
-        end
-
-        baked[:cookie].each do |cookie|
-          parts << "--cookie"
-          parts << shell_quote(cookie)
-        end
-
-        ob_puts parts.join(" ")
+        ob_puts CurlCommand.build(method, baked[:url], baked[:body], baked[:body_type], baked[:header], baked[:cookie])
       end
     end
-  end
-
-  private def shell_quote(str : String) : String
-    "'#{str.gsub("'", "'\\''")}'"
   end
 end

--- a/src/output_builder/html.cr
+++ b/src/output_builder/html.cr
@@ -1,6 +1,10 @@
 require "../models/output_builder"
 require "../models/endpoint"
 require "../utils/home"
+require "../utils/http_symbols"
+require "../utils/curl_command"
+require "./html_assets/css"
+require "./html_assets/js"
 require "html"
 
 class OutputBuilderHtml < OutputBuilder
@@ -63,463 +67,14 @@ class OutputBuilderHtml < OutputBuilder
   end
 
   private def build_head : String
-    <<-HTML
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="color-scheme" content="light dark">
-        <title>OWASP Noir — Attack Surface Report</title>
-        <style>
-          /* ===== OWASP Noir — monochrome report theme =====================
-             Ink-on-paper by default; true-black noir under [data-theme=dark].
-             Pure grayscale: hierarchy comes from fill weight and hairlines,
-             never from hue. */
-          :root {
-            --bg: #ffffff;
-            --bg-subtle: #f6f6f6;
-            --surface: #ffffff;
-            --ink: #0a0a0a;
-            --ink-2: #404040;
-            --ink-3: #767676;
-            --line: #e4e4e4;
-            --line-2: #d0d0d0;
-            --fill: #0a0a0a;
-            --on-fill: #ffffff;
-            --fill-mute: #555555;
-            --hover: #f2f2f2;
-            --selection: rgba(10, 10, 10, 0.12);
-            --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-            --font-mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace;
-          }
-          [data-theme="dark"] {
-            --bg: #050507;
-            --bg-subtle: #0a0a0e;
-            --surface: #0b0b10;
-            --ink: #ededf0;
-            --ink-2: #b4b4c2;
-            --ink-3: #74748a;
-            --line: #1a1a22;
-            --line-2: #2a2a36;
-            --fill: #ededf0;
-            --on-fill: #050507;
-            --fill-mute: #8a8a9c;
-            --hover: #131319;
-            --selection: rgba(237, 237, 240, 0.16);
-          }
-          * { margin: 0; padding: 0; box-sizing: border-box; }
-          ::selection { background: var(--selection); }
-          html { scroll-behavior: smooth; }
-          body {
-            font-family: var(--font-sans);
-            background: var(--bg);
-            color: var(--ink);
-            line-height: 1.6;
-            font-size: 15px;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-            transition: background-color 0.2s ease, color 0.2s ease;
-          }
-          .container { max-width: 1140px; margin: 0 auto; padding: 0 1.5rem; }
-          a { color: inherit; }
-
-          /* ===== Header ================================================= */
-          .report-header {
-            border-bottom: 1px solid var(--line);
-            background: var(--bg);
-          }
-          .report-header .container {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 1rem;
-            padding-top: 1.75rem;
-            padding-bottom: 1.75rem;
-          }
-          .brand { display: flex; align-items: center; gap: 0.85rem; min-width: 0; }
-          .brand-mark {
-            width: 38px; height: 38px;
-            flex-shrink: 0;
-            display: block;
-          }
-          .brand-mark rect.block { fill: var(--ink); }
-          .brand-mark rect.visor { fill: var(--bg); }
-          .brand-text { display: flex; flex-direction: column; min-width: 0; }
-          .brand-eyebrow {
-            font-family: var(--font-mono);
-            font-size: 0.66rem;
-            letter-spacing: 0.28em;
-            text-transform: uppercase;
-            color: var(--ink-3);
-          }
-          .brand-title {
-            font-family: var(--font-mono);
-            font-size: 1.4rem;
-            font-weight: 700;
-            letter-spacing: -0.02em;
-            line-height: 1.1;
-          }
-          .header-actions { display: flex; align-items: center; gap: 1.25rem; flex-shrink: 0; }
-          .header-tagline {
-            font-family: var(--font-mono);
-            font-size: 0.72rem;
-            color: var(--ink-3);
-            text-align: right;
-          }
-          .theme-toggle {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            width: 40px; height: 40px;
-            padding: 0;
-            background: var(--surface);
-            color: var(--ink);
-            border: 1px solid var(--line-2);
-            cursor: pointer;
-            transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
-          }
-          .theme-toggle:hover { background: var(--hover); border-color: var(--ink-3); }
-          .theme-toggle:active { transform: scale(0.95); }
-          .theme-toggle:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
-          .theme-toggle svg { width: 17px; height: 17px; display: block; }
-          .theme-toggle .icon-sun { display: none; }
-          [data-theme="dark"] .theme-toggle .icon-sun { display: block; }
-          [data-theme="dark"] .theme-toggle .icon-moon { display: none; }
-
-          /* ===== Layout ================================================= */
-          main.container { padding-top: 2.5rem; padding-bottom: 2.5rem; }
-          .section { margin-bottom: 3rem; }
-          .section-title {
-            font-family: var(--font-mono);
-            font-size: 0.8rem;
-            font-weight: 700;
-            letter-spacing: 0.18em;
-            text-transform: uppercase;
-            color: var(--ink-2);
-            display: flex;
-            align-items: center;
-            gap: 0.6rem;
-            padding-bottom: 0.6rem;
-            margin-bottom: 1.25rem;
-            border-bottom: 1px solid var(--line);
-          }
-          .section-title::before {
-            content: "";
-            width: 9px; height: 9px;
-            background: var(--ink);
-            flex-shrink: 0;
-          }
-          .section-count {
-            margin-left: auto;
-            font-weight: 500;
-            color: var(--ink-3);
-            letter-spacing: 0.08em;
-            font-variant-numeric: tabular-nums;
-          }
-
-          /* ===== Controls — search + filter chips ====================== */
-          .controls {
-            position: sticky;
-            top: 0;
-            z-index: 20;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-            flex-wrap: wrap;
-            padding: 0.7rem 0;
-            margin-bottom: 1.25rem;
-            background: var(--bg);
-            border-bottom: 1px solid var(--line);
-          }
-          .search { position: relative; flex: 1 1 260px; display: flex; align-items: center; }
-          .search svg {
-            position: absolute; left: 0.65rem;
-            width: 15px; height: 15px;
-            color: var(--ink-3);
-            pointer-events: none;
-          }
-          .search input {
-            width: 100%;
-            font-family: var(--font-mono);
-            font-size: 0.82rem;
-            color: var(--ink);
-            background: var(--surface);
-            border: 1px solid var(--line-2);
-            padding: 0.5rem 0.6rem 0.5rem 1.95rem;
-          }
-          .search input::placeholder { color: var(--ink-3); }
-          .search input:focus { outline: none; border-color: var(--ink); }
-          .search input::-webkit-search-cancel-button { -webkit-appearance: none; }
-          .chips { display: flex; gap: 0.4rem; flex-wrap: wrap; }
-          .chip {
-            font-family: var(--font-mono);
-            font-size: 0.68rem;
-            font-weight: 600;
-            letter-spacing: 0.06em;
-            text-transform: uppercase;
-            padding: 0.4rem 0.65rem;
-            color: var(--ink-2);
-            background: var(--surface);
-            border: 1px solid var(--line-2);
-            cursor: pointer;
-            transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-          }
-          .chip:hover { border-color: var(--ink-3); color: var(--ink); }
-          .chip[aria-pressed="true"] { background: var(--fill); color: var(--on-fill); border-color: var(--fill); }
-          .chip:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
-          .no-results { display: none; }
-          .no-results.show { display: block; }
-
-          /* ===== Summary stat strip ===================================== */
-          .summary {
-            display: grid;
-            grid-template-columns: repeat(4, 1fr);
-            border: 1px solid var(--line);
-            background: var(--surface);
-            margin-bottom: 3rem;
-          }
-          .summary-card {
-            padding: 1.5rem 1.5rem;
-            border-left: 1px solid var(--line);
-          }
-          .summary-card:first-child { border-left: none; }
-          .summary-card h3 {
-            font-family: var(--font-mono);
-            font-size: 2.4rem;
-            font-weight: 700;
-            line-height: 1;
-            letter-spacing: -0.03em;
-            font-variant-numeric: tabular-nums;
-          }
-          .summary-card p {
-            color: var(--ink-3);
-            font-family: var(--font-mono);
-            font-size: 0.68rem;
-            text-transform: uppercase;
-            letter-spacing: 0.16em;
-            margin-top: 0.55rem;
-          }
-
-          /* ===== Cards ================================================== */
-          .card {
-            background: var(--surface);
-            border: 1px solid var(--line);
-            margin-bottom: -1px;
-          }
-          .card:hover { border-color: var(--line-2); position: relative; z-index: 1; }
-          .card-header {
-            padding: 0.85rem 1rem;
-            display: flex;
-            align-items: center;
-            gap: 0.7rem;
-            flex-wrap: wrap;
-          }
-          button.card-header {
-            width: 100%;
-            font: inherit;
-            color: inherit;
-            text-align: left;
-            background: transparent;
-            border: none;
-            cursor: pointer;
-            transition: background-color 0.12s ease;
-          }
-          button.card-header:hover { background: var(--hover); }
-          button.card-header:focus-visible { outline: 2px solid var(--ink); outline-offset: -2px; }
-          .chevron {
-            width: 16px; height: 16px;
-            flex-shrink: 0;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--ink-3);
-            transition: transform 0.2s ease;
-          }
-          .chevron svg { width: 12px; height: 12px; display: block; }
-          .chevron-spacer { width: 16px; flex-shrink: 0; }
-          .card.collapsed .chevron { transform: rotate(-90deg); }
-          .card-collapse {
-            display: grid;
-            grid-template-rows: 1fr;
-            transition: grid-template-rows 0.22s ease;
-          }
-          .card.collapsed .card-collapse { grid-template-rows: 0fr; }
-          .card-collapse > .card-pane { overflow: hidden; min-height: 0; }
-          .url {
-            font-family: var(--font-mono);
-            font-size: 0.88rem;
-            font-weight: 500;
-            word-break: break-all;
-          }
-
-          /* ===== Method badges — grayscale risk ramp ===================
-             outline = safe read · gray = mutate · solid ink = destroy */
-          .method-badge {
-            display: inline-block;
-            padding: 0.2rem 0.6rem;
-            font-family: var(--font-mono);
-            font-size: 0.7rem;
-            font-weight: 700;
-            letter-spacing: 0.06em;
-            text-transform: uppercase;
-            border: 1px solid var(--ink);
-            min-width: 4.6em;
-            text-align: center;
-            flex-shrink: 0;
-          }
-          .method-get { background: transparent; color: var(--ink); border-color: var(--line-2); }
-          .method-post { background: var(--fill-mute); color: var(--on-fill); border-color: var(--fill-mute); }
-          .method-put { background: var(--fill-mute); color: var(--on-fill); border-color: var(--fill-mute); }
-          .method-patch { background: var(--fill-mute); color: var(--on-fill); border-color: var(--fill-mute); }
-          .method-delete { background: var(--fill); color: var(--on-fill); border-color: var(--fill); }
-          .method-default { background: transparent; color: var(--ink-3); border-color: var(--line-2); border-style: dashed; }
-
-          .protocol-badge {
-            font-family: var(--font-mono);
-            font-size: 0.66rem;
-            padding: 0.12rem 0.45rem;
-            border: 1px solid var(--line-2);
-            color: var(--ink-3);
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-          }
-          .tag-badge {
-            display: inline-block;
-            font-family: var(--font-mono);
-            font-size: 0.66rem;
-            padding: 0.12rem 0.45rem;
-            background: var(--bg-subtle);
-            border: 1px solid var(--line);
-            color: var(--ink-2);
-          }
-
-          /* ===== Card body ============================================= */
-          .card-body {
-            padding: 0 1rem 1rem;
-            border-top: 1px solid var(--line);
-            padding-top: 1rem;
-          }
-          .params-table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 0.84rem;
-          }
-          .params-table th, .params-table td {
-            padding: 0.5rem 0.6rem;
-            text-align: left;
-            border-bottom: 1px solid var(--line);
-          }
-          .params-table tr:last-child td { border-bottom: none; }
-          .params-table th {
-            font-family: var(--font-mono);
-            font-size: 0.64rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.12em;
-            color: var(--ink-3);
-          }
-          .params-table td:first-child { font-family: var(--font-mono); }
-          .params-table td:last-child { font-family: var(--font-mono); color: var(--ink-2); word-break: break-all; }
-
-          /* ===== Param-type chips — uniform monochrome ================= */
-          .param-type {
-            display: inline-block;
-            font-family: var(--font-mono);
-            padding: 0.1rem 0.4rem;
-            font-size: 0.64rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.06em;
-            border: 1px solid var(--line-2);
-            color: var(--ink-2);
-          }
-          .param-query, .param-json, .param-form,
-          .param-header, .param-cookie, .param-path { background: var(--bg-subtle); }
-          .param-path, .param-header { background: var(--ink); color: var(--on-fill); border-color: var(--ink); }
-
-          /* ===== Severity badges — grayscale ramp ====================== */
-          .severity-critical, .severity-high { background: var(--fill); color: var(--on-fill); border-color: var(--fill); }
-          .severity-medium { background: var(--fill-mute); color: var(--on-fill); border-color: var(--fill-mute); }
-          .severity-low { background: transparent; color: var(--ink); border-color: var(--line-2); }
-          .passive-card .card-header { gap: 0.7rem; }
-
-          .code-path {
-            font-family: var(--font-mono);
-            font-size: 0.76rem;
-            color: var(--ink-3);
-            margin-top: 0.35rem;
-          }
-          .code-path .marker { color: var(--ink-2); }
-          .card-body p { font-size: 0.86rem; }
-          .card-body p + p { margin-top: 0.5rem; }
-          .card-body code {
-            font-family: var(--font-mono);
-            font-size: 0.8rem;
-            background: var(--bg-subtle);
-            border: 1px solid var(--line);
-            padding: 0.05rem 0.3rem;
-          }
-
-          .empty-state {
-            text-align: center;
-            padding: 3rem 1rem;
-            color: var(--ink-3);
-            font-family: var(--font-mono);
-            font-size: 0.85rem;
-            border: 1px dashed var(--line-2);
-          }
-
-          /* ===== Footer ================================================ */
-          footer {
-            border-top: 1px solid var(--line);
-            padding: 2rem 0;
-            margin-top: 1rem;
-          }
-          footer .container {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 1rem;
-            flex-wrap: wrap;
-            color: var(--ink-3);
-            font-family: var(--font-mono);
-            font-size: 0.75rem;
-          }
-          footer a { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--line-2); }
-          footer a:hover { border-bottom-color: var(--ink); }
-
-          @media (max-width: 720px) {
-            .summary { grid-template-columns: repeat(2, 1fr); }
-            .summary-card:nth-child(3) { border-left: none; }
-            .summary-card:nth-child(n+3) { border-top: 1px solid var(--line); }
-            .header-tagline { display: none; }
-          }
-
-          @media (prefers-reduced-motion: reduce) {
-            * { transition: none !important; scroll-behavior: auto !important; }
-          }
-
-          @media print {
-            body { background: #fff; color: #000; }
-            .report-header, footer { border-color: #ccc; }
-            .card { break-inside: avoid; }
-            .card.collapsed .card-collapse { grid-template-rows: 1fr; }
-            .chevron, .theme-toggle, .controls { display: none; }
-          }
-        </style>
-        <script>
-          /* Apply the saved/preferred theme before first paint to avoid a flash. */
-          (function () {
-            try {
-              var saved = localStorage.getItem("noir-theme");
-              if (saved === "dark" || saved === "light") {
-                document.documentElement.setAttribute("data-theme", saved);
-              } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-                document.documentElement.setAttribute("data-theme", "dark");
-              }
-            } catch (e) {}
-          })();
-        </script>
-
-      HTML
+    String.build do |html|
+      html << "<meta charset=\"UTF-8\">\n"
+      html << "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n"
+      html << "<meta name=\"color-scheme\" content=\"light dark\">\n"
+      html << "<title>OWASP Noir · Attack Surface Report</title>\n"
+      html << "<style>\n" << HtmlReportAssets::STYLES << "\n</style>\n"
+      html << "<script>\n" << HtmlReportAssets::THEME_BOOT << "\n</script>\n"
+    end
   end
 
   private def build_header : String
@@ -593,10 +148,37 @@ class OutputBuilderHtml < OutputBuilder
       if endpoints.empty?
         html << "<div class=\"empty-state\"><p>No endpoints discovered.</p></div>\n"
       else
-        html << build_endpoint_controls(endpoints)
-        endpoints.each_with_index do |endpoint, index|
-          html << build_endpoint_card(endpoint, index)
+        groups = group_endpoints(endpoints)
+        grouped = groups.size >= 2 && groups.size < endpoints.size
+
+        html << build_endpoint_controls(endpoints, grouped)
+        html << build_table_head
+        html << "<div class=\"visually-hidden\" id=\"copy-status\" aria-live=\"polite\"></div>\n"
+
+        index = 0
+        if grouped
+          groups.each do |key, group_members|
+            html << "<div class=\"group\" data-group-key=\"#{HTML.escape(key)}\">\n"
+            html << "<button type=\"button\" class=\"group-header\" data-action=\"toggle-group-collapse\" aria-expanded=\"true\">\n"
+            html << "<span class=\"chevron\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.2\" stroke-linecap=\"square\"><path d=\"M6 9l6 6 6-6\"></path></svg></span>\n"
+            html << "<span class=\"group-name\">#{HTML.escape(key)}</span>\n"
+            html << "<span class=\"group-count\" data-group-count>#{group_members.size}</span>\n"
+            html << "</button>\n"
+            html << "<div class=\"group-body\">\n"
+            group_members.each do |endpoint|
+              html << build_endpoint_card(endpoint, index)
+              index += 1
+            end
+            html << "</div>\n"
+            html << "</div>\n"
+          end
+        else
+          endpoints.each do |endpoint|
+            html << build_endpoint_card(endpoint, index)
+            index += 1
+          end
         end
+
         html << "<div class=\"empty-state no-results\" id=\"endpoint-no-results\">No endpoints match the current filter.</div>\n"
       end
 
@@ -604,7 +186,7 @@ class OutputBuilderHtml < OutputBuilder
     end
   end
 
-  private def build_endpoint_controls(endpoints : Array(Endpoint)) : String
+  private def build_endpoint_controls(endpoints : Array(Endpoint), grouped : Bool) : String
     methods = present_methods(endpoints)
 
     String.build do |html|
@@ -617,11 +199,31 @@ class OutputBuilderHtml < OutputBuilder
       if methods.size > 1
         html << "<div class=\"chips\" role=\"group\" aria-label=\"Filter by HTTP method\">\n"
         methods.each do |method|
-          html << "<button type=\"button\" class=\"chip\" data-filter-method=\"#{HTML.escape(method)}\" aria-pressed=\"false\">#{HTML.escape(method)}</button>\n"
+          html << "<button type=\"button\" class=\"chip#{chip_hue_class(method)}\" data-filter-method=\"#{HTML.escape(method)}\" aria-pressed=\"false\">#{HTML.escape(method)}</button>\n"
         end
         html << "</div>\n"
       end
 
+      if grouped
+        html << "<button type=\"button\" class=\"chip group-toggle\" data-action=\"toggle-group\" aria-pressed=\"true\">Grouped</button>\n"
+      end
+
+      html << "<div class=\"view-seg\" role=\"group\" aria-label=\"Result layout\">\n"
+      html << "<button type=\"button\" class=\"view-btn\" data-action=\"set-view\" data-view-mode=\"cards\" aria-pressed=\"true\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><rect x=\"3\" y=\"4\" width=\"18\" height=\"7\"></rect><rect x=\"3\" y=\"14\" width=\"18\" height=\"7\"></rect></svg>Cards</button>\n"
+      html << "<button type=\"button\" class=\"view-btn\" data-action=\"set-view\" data-view-mode=\"table\" aria-pressed=\"false\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><path d=\"M3 6h18M3 12h18M3 18h18\"></path></svg>Table</button>\n"
+      html << "</div>\n"
+
+      html << "</div>\n"
+    end
+  end
+
+  private def build_table_head : String
+    String.build do |html|
+      html << "<div class=\"table-head\" aria-hidden=\"true\">\n"
+      html << "<span></span>\n"
+      html << "<span>Method</span>\n"
+      html << "<span>Path</span>\n"
+      html << "<span class=\"th-details\">Details</span>\n"
       html << "</div>\n"
     end
   end
@@ -632,30 +234,54 @@ class OutputBuilderHtml < OutputBuilder
     has_body = endpoint.params.size > 0 || !endpoint.details.code_paths.empty?
     search_text = endpoint_search_text(endpoint, baked[:url])
     body_id = "ep-body-#{index}"
+    curl = curl_attribute_for(endpoint, baked)
 
     String.build do |html|
-      html << "<div class=\"card\" data-endpoint data-method=\"#{HTML.escape(endpoint.method.upcase)}\" data-text=\"#{HTML.escape(search_text)}\">\n"
+      html << "<div class=\"card\" data-endpoint data-method=\"#{HTML.escape(endpoint.method.upcase)}\" data-text=\"#{HTML.escape(search_text)}\" data-url=\"#{HTML.escape(baked[:url])}\""
+      html << " data-curl=\"#{HTML.escape(curl)}\"" if curl
+      html << ">\n"
+      html << "<div class=\"card-header\">\n"
 
       if has_body
-        html << "<button type=\"button\" class=\"card-header\" data-action=\"toggle-card\" aria-expanded=\"true\" aria-controls=\"#{body_id}\">\n"
+        html << "<button type=\"button\" class=\"card-toggle\" data-action=\"toggle-card\" aria-expanded=\"true\" aria-controls=\"#{body_id}\">\n"
         html << "<span class=\"chevron\" aria-hidden=\"true\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.2\" stroke-linecap=\"square\"><path d=\"M6 9l6 6 6-6\"></path></svg></span>\n"
       else
-        html << "<div class=\"card-header\">\n"
+        html << "<div class=\"card-toggle\">\n"
         html << "<span class=\"chevron-spacer\" aria-hidden=\"true\"></span>\n"
       end
 
       html << "<span class=\"method-badge #{method_class}\">#{HTML.escape(endpoint.method)}</span>\n"
       html << "<span class=\"url\">#{HTML.escape(baked[:url])}</span>\n"
 
-      if endpoint.protocol != "http"
-        html << "<span class=\"protocol-badge\">#{HTML.escape(endpoint.protocol)}</span>\n"
-      end
-
-      endpoint.tags.each do |tag|
-        html << "<span class=\"tag-badge\">#{HTML.escape(tag.name)}</span>\n"
+      if endpoint.protocol != "http" || !endpoint.tags.empty? || endpoint.params.size > 0
+        html << "<span class=\"card-details\">\n"
+        if endpoint.protocol != "http"
+          html << "<span class=\"protocol-badge\">#{HTML.escape(endpoint.protocol)}</span>\n"
+        end
+        endpoint.tags.each do |tag|
+          html << "<span class=\"tag-badge\">#{HTML.escape(tag.name)}</span>\n"
+        end
+        if endpoint.params.size > 0
+          html << "<span class=\"card-meta\">#{endpoint.params.size} #{endpoint.params.size == 1 ? "param" : "params"}</span>\n"
+        end
+        html << "</span>\n"
       end
 
       html << (has_body ? "</button>\n" : "</div>\n")
+
+      html << "<span class=\"card-actions\">\n"
+      html << "<button type=\"button\" class=\"copy-btn\" data-action=\"copy-url\" aria-label=\"Copy URL\" title=\"Copy URL\">"
+      html << "<svg class=\"icon-copy\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><rect x=\"9\" y=\"9\" width=\"11\" height=\"11\"></rect><path d=\"M5 15V4h11\"></path></svg>"
+      html << "<svg class=\"icon-check\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.2\" aria-hidden=\"true\"><path d=\"M4 12l5 5L20 6\"></path></svg>"
+      html << "</button>\n"
+      if curl
+        html << "<button type=\"button\" class=\"copy-btn\" data-action=\"copy-curl\" aria-label=\"Copy as curl\" title=\"Copy as curl\">"
+        html << "<svg class=\"icon-copy\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" aria-hidden=\"true\"><path d=\"M4 6l6 6-6 6M13 18h7\"></path></svg>"
+        html << "<svg class=\"icon-check\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.2\" aria-hidden=\"true\"><path d=\"M4 12l5 5L20 6\"></path></svg>"
+        html << "</button>\n"
+      end
+      html << "</span>\n"
+      html << "</div>\n"
 
       if has_body
         html << "<div class=\"card-collapse\" id=\"#{body_id}\"><div class=\"card-pane\"><div class=\"card-body\">\n"
@@ -728,7 +354,7 @@ class OutputBuilderHtml < OutputBuilder
       html << "<div class=\"controls\">\n"
       html << "<div class=\"chips\" role=\"group\" aria-label=\"Filter by severity\">\n"
       severities.each do |severity|
-        html << "<button type=\"button\" class=\"chip\" data-filter-severity=\"#{HTML.escape(severity)}\" aria-pressed=\"false\">#{HTML.escape(severity)}</button>\n"
+        html << "<button type=\"button\" class=\"chip#{chip_hue_class(severity)}\" data-filter-severity=\"#{HTML.escape(severity)}\" aria-pressed=\"false\">#{HTML.escape(severity)}</button>\n"
       end
       html << "</div>\n"
       html << "</div>\n"
@@ -766,109 +392,9 @@ class OutputBuilderHtml < OutputBuilder
   end
 
   private def build_scripts : String
-    <<-HTML
-      <script>
-        (function () {
-          var root = document.documentElement;
-
-          function toArray(nodes) { return Array.prototype.slice.call(nodes); }
-
-          // Reflect the active theme on the toggle control (a11y state).
-          function syncThemeButtons() {
-            var dark = root.getAttribute("data-theme") === "dark";
-            toArray(document.querySelectorAll('[data-action="toggle-theme"]')).forEach(function (b) {
-              b.setAttribute("aria-pressed", String(dark));
-              b.setAttribute("aria-label", dark ? "Switch to light theme" : "Switch to dark theme");
-            });
-          }
-          syncThemeButtons();
-
-          // Theme toggle with persistence (initial theme is set in <head>).
-          document.addEventListener("click", function (e) {
-            var btn = e.target.closest && e.target.closest('[data-action="toggle-theme"]');
-            if (!btn) return;
-            var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
-            root.setAttribute("data-theme", next);
-            try { localStorage.setItem("noir-theme", next); } catch (err) {}
-            syncThemeButtons();
-          });
-
-          // Collapse / expand an endpoint card.
-          document.addEventListener("click", function (e) {
-            var header = e.target.closest && e.target.closest('[data-action="toggle-card"]');
-            if (!header) return;
-            var card = header.closest(".card");
-            if (!card) return;
-            var collapsed = card.classList.toggle("collapsed");
-            header.setAttribute("aria-expanded", String(!collapsed));
-          });
-
-          // Endpoint search + HTTP-method chip filter (combined with AND).
-          var search = document.getElementById("endpoint-search");
-          var methodChips = toArray(document.querySelectorAll("[data-filter-method]"));
-          var endpointCards = toArray(document.querySelectorAll("[data-endpoint]"));
-          var endpointCount = document.getElementById("endpoint-count");
-          var endpointEmpty = document.getElementById("endpoint-no-results");
-
-          function applyEndpointFilter() {
-            var q = (search ? search.value : "").trim().toLowerCase();
-            var active = methodChips
-              .filter(function (c) { return c.getAttribute("aria-pressed") === "true"; })
-              .map(function (c) { return c.getAttribute("data-filter-method"); });
-            var shown = 0;
-            endpointCards.forEach(function (card) {
-              var okText = !q || (card.getAttribute("data-text") || "").indexOf(q) !== -1;
-              var okMethod = active.length === 0 || active.indexOf(card.getAttribute("data-method")) !== -1;
-              var visible = okText && okMethod;
-              card.hidden = !visible;
-              if (visible) shown++;
-            });
-            if (endpointCount) {
-              endpointCount.textContent = shown === endpointCards.length ? String(shown) : shown + " / " + endpointCards.length;
-            }
-            if (endpointEmpty) endpointEmpty.classList.toggle("show", shown === 0);
-          }
-
-          if (search) search.addEventListener("input", applyEndpointFilter);
-          methodChips.forEach(function (chip) {
-            chip.addEventListener("click", function () {
-              chip.setAttribute("aria-pressed", chip.getAttribute("aria-pressed") === "true" ? "false" : "true");
-              applyEndpointFilter();
-            });
-          });
-
-          // Passive-finding severity chip filter.
-          var sevChips = toArray(document.querySelectorAll("[data-filter-severity]"));
-          var passiveCards = toArray(document.querySelectorAll("[data-passive]"));
-          var passiveCount = document.getElementById("passive-count");
-          var passiveEmpty = document.getElementById("passive-no-results");
-
-          function applyPassiveFilter() {
-            var active = sevChips
-              .filter(function (c) { return c.getAttribute("aria-pressed") === "true"; })
-              .map(function (c) { return c.getAttribute("data-filter-severity"); });
-            var shown = 0;
-            passiveCards.forEach(function (card) {
-              var visible = active.length === 0 || active.indexOf(card.getAttribute("data-severity")) !== -1;
-              card.hidden = !visible;
-              if (visible) shown++;
-            });
-            if (passiveCount) {
-              passiveCount.textContent = shown === passiveCards.length ? String(shown) : shown + " / " + passiveCards.length;
-            }
-            if (passiveEmpty) passiveEmpty.classList.toggle("show", shown === 0);
-          }
-
-          sevChips.forEach(function (chip) {
-            chip.addEventListener("click", function () {
-              chip.setAttribute("aria-pressed", chip.getAttribute("aria-pressed") === "true" ? "false" : "true");
-              applyPassiveFilter();
-            });
-          });
-        })();
-      </script>
-
-      HTML
+    String.build do |html|
+      html << "<script>\n" << HtmlReportAssets::SCRIPTS << "\n</script>\n"
+    end
   end
 
   # Lowercased haystack used by the client-side endpoint filter.
@@ -879,6 +405,55 @@ class OutputBuilderHtml < OutputBuilder
       endpoint.tags.each { |t| s << ' ' << t.name.downcase }
       s << ' ' << endpoint.protocol.downcase unless endpoint.protocol == "http"
     end
+  end
+
+  # Newline-separated curl commands for the copy-as-curl button, or nil for
+  # non-HTTP endpoints (mobile deep links / CLI commands).
+  private def curl_attribute_for(endpoint : Endpoint, baked) : String?
+    return if endpoint.non_http?
+
+    expand_synthetic_http_methods(endpoint.method).join("\n") do |method|
+      CurlCommand.build(method, baked[:url], baked[:body], baked[:body_type], baked[:header], baked[:cookie])
+    end
+  end
+
+  # Bucket key for the path-grouped endpoint list: authority plus first path
+  # segment for absolute URLs, "/" plus first segment for relative paths.
+  private def endpoint_group_key(endpoint : Endpoint) : String
+    path = endpoint.url.split('?', 2)[0]
+
+    if match = path.match(%r{\A([a-z][a-z0-9+.\-]*://[^/]*)(/.*)?}i)
+      head = match[1]
+      first = match[2]?.try(&.split('/').reject(&.empty?).first?)
+      first ? "#{head}/#{first}" : head
+    elsif path.starts_with?("//")
+      authority, _, tail = path[2..].partition('/')
+      first = tail.split('/').reject(&.empty?).first?
+      first ? "//#{authority}/#{first}" : "//#{authority}"
+    else
+      first = path.split('/').reject(&.empty?).first?
+      first ? "/#{first}" : "/"
+    end
+  end
+
+  # Ordered grouping that preserves within-group input order. Roots and
+  # relative paths sort alphabetically first; absolute URLs sort last.
+  private def group_endpoints(endpoints : Array(Endpoint)) : Array(Tuple(String, Array(Endpoint)))
+    order = [] of String
+    buckets = Hash(String, Array(Endpoint)).new
+    endpoints.each do |endpoint|
+      key = endpoint_group_key(endpoint)
+      unless buckets.has_key?(key)
+        order << key
+        buckets[key] = [] of Endpoint
+      end
+      buckets[key] << endpoint
+    end
+    order.sort_by! do |key|
+      remote = key.includes?("://") || key.starts_with?("//") ? 1 : 0
+      {remote, key == "/" ? "" : key.downcase}
+    end
+    order.map { |key| {key, buckets[key]} }
   end
 
   # Distinct HTTP methods present, ordered by a canonical verb priority.
@@ -893,6 +468,17 @@ class OutputBuilderHtml < OutputBuilder
     order = ["critical", "high", "medium", "low", "info"]
     severities = passive_results.map(&.info.severity.downcase).uniq!
     severities.sort_by! { |s| {order.index(s) || order.size, s} }
+  end
+
+  # Hue modifier for pressed filter chips; only known verbs/severities get one.
+  private def chip_hue_class(name : String) : String
+    case name.downcase
+    when "get", "post", "put", "patch", "delete",
+         "critical", "high", "medium", "low"
+      " chip-#{name.downcase}"
+    else
+      ""
+    end
   end
 
   private def get_method_class(method : String) : String
@@ -920,10 +506,11 @@ class OutputBuilderHtml < OutputBuilder
 
   private def get_severity_class(severity : String) : String
     case severity.downcase
-    when "critical", "high" then "severity-critical"
-    when "medium"           then "severity-medium"
-    when "low"              then "severity-low"
-    else                         ""
+    when "critical" then "severity-critical"
+    when "high"     then "severity-high"
+    when "medium"   then "severity-medium"
+    when "low"      then "severity-low"
+    else                 "severity-info"
     end
   end
 end

--- a/src/output_builder/html_assets/css.cr
+++ b/src/output_builder/html_assets/css.cr
@@ -1,0 +1,672 @@
+# Stylesheet for the self-contained HTML report.
+# Everything ships inline; no external fonts, images, or scripts.
+module HtmlReportAssets
+  STYLES = <<-CSS
+    /* ===== OWASP Noir report theme ==================================
+       Dark-tech base with restrained semantic color: hue is reserved
+       for meaning (HTTP method risk, finding severity, one emerald
+       brand accent). Chrome stays neutral in both themes. */
+    :root {
+      --bg: #fafafa;
+      --bg-subtle: #f3f3f4;
+      --surface: #fdfdfd;
+      --ink: #111114;
+      --ink-2: #404046;
+      --ink-3: #6f6f7a;
+      --line: #e6e6e9;
+      --line-2: #d2d2d8;
+      --fill: #141418;
+      --on-fill: #f7f7f8;
+      --hover: #f0f0f2;
+      --selection: rgba(17, 17, 20, 0.12);
+      --accent: #047857;
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      --font-mono: ui-monospace, "SF Mono", SFMono-Regular, "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace;
+      /* semantic method hues (AA on --bg / tint backgrounds) */
+      --m-get: #047857;
+      --m-get-soft: rgba(4, 120, 87, 0.08);
+      --m-get-line: rgba(4, 120, 87, 0.38);
+      --m-post: #854d0e;
+      --m-post-soft: rgba(180, 83, 9, 0.10);
+      --m-post-line: rgba(180, 83, 9, 0.42);
+      --m-put: #1d4ed8;
+      --m-put-soft: rgba(29, 78, 216, 0.08);
+      --m-put-line: rgba(29, 78, 216, 0.38);
+      --m-patch: #6d28d9;
+      --m-patch-soft: rgba(109, 40, 217, 0.08);
+      --m-patch-line: rgba(109, 40, 217, 0.38);
+      --m-delete: #be123c;
+      --m-delete-soft: rgba(190, 18, 60, 0.08);
+      --m-delete-line: rgba(190, 18, 60, 0.38);
+      /* semantic severity hues */
+      --sev-critical-bg: #b91c1c;
+      --sev-critical-ink: #fdf2f2;
+      --sev-high: #b91c1c;
+      --sev-high-soft: rgba(185, 28, 28, 0.08);
+      --sev-high-line: rgba(185, 28, 28, 0.40);
+      --sev-medium: #854d0e;
+      --sev-medium-soft: rgba(180, 83, 9, 0.10);
+      --sev-medium-line: rgba(180, 83, 9, 0.42);
+      --sev-low: #475569;
+      --sev-low-soft: rgba(71, 85, 105, 0.08);
+      --sev-low-line: rgba(71, 85, 105, 0.38);
+    }
+    [data-theme="dark"] {
+      --bg: #050507;
+      --bg-subtle: #0a0a0e;
+      --surface: #0b0b10;
+      --ink: #ededf0;
+      --ink-2: #b4b4c2;
+      --ink-3: #74748a;
+      --line: #1a1a22;
+      --line-2: #2a2a36;
+      --fill: #ededf0;
+      --on-fill: #0b0b10;
+      --hover: #131319;
+      --selection: rgba(237, 237, 240, 0.16);
+      --accent: #34d399;
+      --m-get: #34d399;
+      --m-get-soft: rgba(52, 211, 153, 0.09);
+      --m-get-line: rgba(52, 211, 153, 0.34);
+      --m-post: #fbbf24;
+      --m-post-soft: rgba(251, 191, 36, 0.09);
+      --m-post-line: rgba(251, 191, 36, 0.34);
+      --m-put: #60a5fa;
+      --m-put-soft: rgba(96, 165, 250, 0.09);
+      --m-put-line: rgba(96, 165, 250, 0.34);
+      --m-patch: #a78bfa;
+      --m-patch-soft: rgba(167, 139, 250, 0.09);
+      --m-patch-line: rgba(167, 139, 250, 0.34);
+      --m-delete: #f87171;
+      --m-delete-soft: rgba(248, 113, 113, 0.09);
+      --m-delete-line: rgba(248, 113, 113, 0.34);
+      --sev-critical-bg: #e05252;
+      --sev-critical-ink: #0b0b10;
+      --sev-high: #f87171;
+      --sev-high-soft: rgba(248, 113, 113, 0.09);
+      --sev-high-line: rgba(248, 113, 113, 0.36);
+      --sev-medium: #fbbf24;
+      --sev-medium-soft: rgba(251, 191, 36, 0.09);
+      --sev-medium-line: rgba(251, 191, 36, 0.34);
+      --sev-low: #94a3b8;
+      --sev-low-soft: rgba(148, 163, 184, 0.09);
+      --sev-low-line: rgba(148, 163, 184, 0.34);
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    ::selection { background: var(--selection); }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: var(--font-sans);
+      background: var(--bg);
+      color: var(--ink);
+      line-height: 1.6;
+      font-size: 15px;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      transition: background-color 0.2s ease, color 0.2s ease;
+    }
+    .container { max-width: 1200px; margin: 0 auto; padding: 0 1.5rem; }
+    a { color: inherit; }
+    .visually-hidden {
+      position: absolute;
+      width: 1px; height: 1px;
+      margin: -1px; padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    /* ===== Header ================================================= */
+    .report-header {
+      border-top: 2px solid var(--accent);
+      border-bottom: 1px solid var(--line);
+      background: var(--bg);
+    }
+    .report-header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding-top: 1.75rem;
+      padding-bottom: 1.75rem;
+    }
+    .brand { display: flex; align-items: center; gap: 0.85rem; min-width: 0; }
+    .brand-mark {
+      width: 38px; height: 38px;
+      flex-shrink: 0;
+      display: block;
+    }
+    .brand-mark rect.block { fill: var(--ink); }
+    .brand-mark rect.visor { fill: var(--accent); }
+    .brand-text { display: flex; flex-direction: column; min-width: 0; }
+    .brand-eyebrow {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      letter-spacing: 0.28em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+    }
+    .brand-title {
+      font-family: var(--font-mono);
+      font-size: 1.4rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      line-height: 1.1;
+    }
+    .header-actions { display: flex; align-items: center; gap: 1.25rem; flex-shrink: 0; }
+    .header-tagline {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--ink-3);
+      text-align: right;
+    }
+    .theme-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px; height: 40px;
+      padding: 0;
+      background: var(--surface);
+      color: var(--ink);
+      border: 1px solid var(--line-2);
+      cursor: pointer;
+      transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+    }
+    .theme-toggle:hover { background: var(--hover); border-color: var(--ink-3); }
+    .theme-toggle:active { transform: scale(0.95); }
+    .theme-toggle:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+    .theme-toggle svg { width: 17px; height: 17px; display: block; }
+    .theme-toggle .icon-sun { display: none; }
+    [data-theme="dark"] .theme-toggle .icon-sun { display: block; }
+    [data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+
+    /* ===== Layout ================================================= */
+    main.container { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+    .section { margin-bottom: 3rem; }
+    .section-title {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--ink-2);
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding-bottom: 0.6rem;
+      margin-bottom: 1.25rem;
+      border-bottom: 1px solid var(--line);
+    }
+    .section-title::before {
+      content: "";
+      width: 9px; height: 9px;
+      background: var(--accent);
+      flex-shrink: 0;
+    }
+    .section-count {
+      margin-left: auto;
+      font-weight: 500;
+      color: var(--ink-3);
+      letter-spacing: 0.08em;
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* ===== Controls: search, filter chips, view toggle ============ */
+    .controls {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      padding: 0.7rem 0;
+      margin-bottom: 1.25rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--line);
+    }
+    .search { position: relative; flex: 1 1 260px; display: flex; align-items: center; }
+    .search svg {
+      position: absolute; left: 0.65rem;
+      width: 15px; height: 15px;
+      color: var(--ink-3);
+      pointer-events: none;
+    }
+    .search input {
+      width: 100%;
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--ink);
+      background: var(--surface);
+      border: 1px solid var(--line-2);
+      padding: 0.5rem 0.6rem 0.5rem 1.95rem;
+    }
+    .search input::placeholder { color: var(--ink-3); }
+    .search input:focus { outline: none; border-color: var(--accent); }
+    .search input::-webkit-search-cancel-button { -webkit-appearance: none; }
+    .chips { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+    .chip {
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 0.4rem 0.65rem;
+      color: var(--ink-2);
+      background: var(--surface);
+      border: 1px solid var(--line-2);
+      cursor: pointer;
+      transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+    }
+    .chip:hover { border-color: var(--ink-3); color: var(--ink); }
+    .chip[aria-pressed="true"] { background: var(--fill); color: var(--on-fill); border-color: var(--fill); }
+    .chip:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+    .chip.chip-get[aria-pressed="true"] { color: var(--m-get); background: var(--m-get-soft); border-color: var(--m-get-line); }
+    .chip.chip-post[aria-pressed="true"] { color: var(--m-post); background: var(--m-post-soft); border-color: var(--m-post-line); }
+    .chip.chip-put[aria-pressed="true"] { color: var(--m-put); background: var(--m-put-soft); border-color: var(--m-put-line); }
+    .chip.chip-patch[aria-pressed="true"] { color: var(--m-patch); background: var(--m-patch-soft); border-color: var(--m-patch-line); }
+    .chip.chip-delete[aria-pressed="true"] { color: var(--m-delete); background: var(--m-delete-soft); border-color: var(--m-delete-line); }
+    .chip.chip-critical[aria-pressed="true"] { color: var(--sev-critical-ink); background: var(--sev-critical-bg); border-color: var(--sev-critical-bg); }
+    .chip.chip-high[aria-pressed="true"] { color: var(--sev-high); background: var(--sev-high-soft); border-color: var(--sev-high-line); }
+    .chip.chip-medium[aria-pressed="true"] { color: var(--sev-medium); background: var(--sev-medium-soft); border-color: var(--sev-medium-line); }
+    .chip.chip-low[aria-pressed="true"] { color: var(--sev-low); background: var(--sev-low-soft); border-color: var(--sev-low-line); }
+    .view-seg { display: inline-flex; border: 1px solid var(--line-2); }
+    .view-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      padding: 0.4rem 0.65rem;
+      color: var(--ink-3);
+      background: var(--surface);
+      border: none;
+      cursor: pointer;
+      transition: background-color 0.12s ease, color 0.12s ease;
+    }
+    .view-btn + .view-btn { border-left: 1px solid var(--line-2); }
+    .view-btn:hover { color: var(--ink); }
+    .view-btn[aria-pressed="true"] { background: var(--fill); color: var(--on-fill); }
+    .view-btn:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+    .view-btn svg { width: 13px; height: 13px; display: block; }
+    .no-results { display: none; }
+    .no-results.show { display: block; }
+
+    /* ===== Summary stat strip ===================================== */
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      border: 1px solid var(--line);
+      background: var(--surface);
+      margin-bottom: 3rem;
+    }
+    .summary-card {
+      padding: 1.5rem 1.5rem;
+      border-left: 1px solid var(--line);
+    }
+    .summary-card:first-child { border-left: none; }
+    .summary-card h3 {
+      font-family: var(--font-mono);
+      font-size: 2.4rem;
+      font-weight: 700;
+      line-height: 1;
+      letter-spacing: -0.03em;
+      font-variant-numeric: tabular-nums;
+    }
+    .summary-card p {
+      color: var(--ink-3);
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      margin-top: 0.55rem;
+    }
+
+    /* ===== Path groups ============================================ */
+    .group { border: 1px solid var(--line); margin-bottom: -1px; }
+    .group-header {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-family: var(--font-mono);
+      font-size: 0.74rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-align: left;
+      color: var(--ink-2);
+      background: var(--bg-subtle);
+      border: none;
+      border-bottom: 1px solid var(--line);
+      padding: 0.55rem 1rem;
+      cursor: pointer;
+      transition: background-color 0.12s ease, color 0.12s ease;
+    }
+    .group-header:hover { background: var(--hover); color: var(--ink); }
+    .group-header:focus-visible { outline: 2px solid var(--ink); outline-offset: -2px; }
+    .group-name { word-break: break-all; }
+    .group-count {
+      margin-left: auto;
+      font-weight: 500;
+      color: var(--ink-3);
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .group .card { border-left: none; border-right: none; }
+    .group .card:last-child { border-bottom: none; margin-bottom: 0; }
+    .group.collapsed .group-header { border-bottom: none; }
+    .group.collapsed .group-header .chevron { transform: rotate(-90deg); }
+    .group.collapsed .group-body { display: none; }
+    .section.filtering .group.collapsed .group-body { display: block; }
+    html[data-group="off"] .group-header { display: none; }
+    html[data-group="off"] .group { border: none; margin: 0; }
+    html[data-group="off"] .group .card { border: 1px solid var(--line); margin-bottom: -1px; }
+    html[data-group="off"] .group.collapsed .group-body { display: block; }
+
+    /* ===== Cards ================================================== */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      margin-bottom: -1px;
+    }
+    .card:hover { border-color: var(--line-2); position: relative; z-index: 1; }
+    .card-header { display: flex; align-items: stretch; }
+    .card-toggle {
+      flex: 1 1 auto;
+      min-width: 0;
+      padding: 0.85rem 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.7rem;
+      flex-wrap: wrap;
+    }
+    button.card-toggle {
+      font: inherit;
+      color: inherit;
+      text-align: left;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      transition: background-color 0.12s ease;
+    }
+    button.card-toggle:hover { background: var(--hover); }
+    button.card-toggle:focus-visible { outline: 2px solid var(--ink); outline-offset: -2px; }
+    .chevron {
+      width: 16px; height: 16px;
+      flex-shrink: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--ink-3);
+      transition: transform 0.2s ease;
+    }
+    .chevron svg { width: 12px; height: 12px; display: block; }
+    .chevron-spacer { width: 16px; flex-shrink: 0; }
+    .card.collapsed .chevron { transform: rotate(-90deg); }
+    .card-collapse {
+      display: grid;
+      grid-template-rows: 1fr;
+      transition: grid-template-rows 0.22s ease;
+    }
+    .card.collapsed .card-collapse { grid-template-rows: 0fr; }
+    .card-collapse > .card-pane { overflow: hidden; min-height: 0; }
+    .url {
+      font-family: var(--font-mono);
+      font-size: 0.88rem;
+      font-weight: 500;
+      word-break: break-all;
+    }
+    .card-details {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      flex-wrap: wrap;
+      min-width: 0;
+    }
+    .card-meta {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      color: var(--ink-3);
+      letter-spacing: 0.05em;
+      white-space: nowrap;
+    }
+    .card-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.15rem;
+      padding: 0 0.6rem;
+      border-left: 1px solid var(--line);
+    }
+    .copy-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 30px; height: 30px;
+      padding: 0;
+      background: transparent;
+      color: var(--ink-3);
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+    }
+    .copy-btn:hover { color: var(--ink); background: var(--hover); border-color: var(--line-2); }
+    .copy-btn:focus-visible { outline: 2px solid var(--ink); outline-offset: 1px; }
+    .copy-btn svg { width: 14px; height: 14px; display: block; }
+    .copy-btn .icon-check { display: none; }
+    .copy-btn.copied { color: var(--accent); }
+    .copy-btn.copied .icon-copy { display: none; }
+    .copy-btn.copied .icon-check { display: block; }
+
+    /* ===== Method badges: semantic risk hues ====================== */
+    .method-badge {
+      display: inline-block;
+      padding: 0.2rem 0.6rem;
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      border: 1px solid var(--line-2);
+      min-width: 4.6em;
+      text-align: center;
+      flex-shrink: 0;
+    }
+    .method-get { color: var(--m-get); background: var(--m-get-soft); border-color: var(--m-get-line); }
+    .method-post { color: var(--m-post); background: var(--m-post-soft); border-color: var(--m-post-line); }
+    .method-put { color: var(--m-put); background: var(--m-put-soft); border-color: var(--m-put-line); }
+    .method-patch { color: var(--m-patch); background: var(--m-patch-soft); border-color: var(--m-patch-line); }
+    .method-delete { color: var(--m-delete); background: var(--m-delete-soft); border-color: var(--m-delete-line); }
+    .method-default { background: transparent; color: var(--ink-3); border-color: var(--line-2); border-style: dashed; }
+
+    .protocol-badge {
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      padding: 0.12rem 0.45rem;
+      border: 1px solid var(--line-2);
+      color: var(--ink-3);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .tag-badge {
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: 0.66rem;
+      padding: 0.12rem 0.45rem;
+      background: var(--bg-subtle);
+      border: 1px solid var(--line);
+      color: var(--ink-2);
+    }
+
+    /* ===== Card body ============================================= */
+    .card-body {
+      padding: 0 1rem 1rem;
+      border-top: 1px solid var(--line);
+      padding-top: 1rem;
+    }
+    .params-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.84rem;
+    }
+    .params-table th, .params-table td {
+      padding: 0.5rem 0.6rem;
+      text-align: left;
+      border-bottom: 1px solid var(--line);
+    }
+    .params-table tr:last-child td { border-bottom: none; }
+    .params-table th {
+      font-family: var(--font-mono);
+      font-size: 0.64rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--ink-3);
+    }
+    .params-table td:first-child { font-family: var(--font-mono); }
+    .params-table td:last-child { font-family: var(--font-mono); color: var(--ink-2); word-break: break-all; }
+
+    /* ===== Param-type chips: uniform monochrome ================== */
+    .param-type {
+      display: inline-block;
+      font-family: var(--font-mono);
+      padding: 0.1rem 0.4rem;
+      font-size: 0.64rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      border: 1px solid var(--line-2);
+      color: var(--ink-2);
+    }
+    .param-query, .param-json, .param-form,
+    .param-header, .param-cookie, .param-path { background: var(--bg-subtle); }
+    .param-path, .param-header { background: var(--ink); color: var(--on-fill); border-color: var(--ink); }
+
+    /* ===== Severity badges: semantic ramp ======================== */
+    .severity-critical { background: var(--sev-critical-bg); color: var(--sev-critical-ink); border-color: var(--sev-critical-bg); }
+    .severity-high { color: var(--sev-high); background: var(--sev-high-soft); border-color: var(--sev-high-line); }
+    .severity-medium { color: var(--sev-medium); background: var(--sev-medium-soft); border-color: var(--sev-medium-line); }
+    .severity-low { color: var(--sev-low); background: var(--sev-low-soft); border-color: var(--sev-low-line); }
+    .severity-info { background: transparent; color: var(--ink-3); border-color: var(--line-2); }
+    .passive-card .card-header { padding: 0.85rem 1rem; align-items: center; gap: 0.7rem; flex-wrap: wrap; }
+
+    .code-path {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      color: var(--ink-3);
+      margin-top: 0.35rem;
+    }
+    .code-path .marker { color: var(--ink-2); }
+    .card-body p { font-size: 0.86rem; }
+    .card-body p + p { margin-top: 0.5rem; }
+    .card-body code {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      background: var(--bg-subtle);
+      border: 1px solid var(--line);
+      padding: 0.05rem 0.3rem;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 3rem 1rem;
+      color: var(--ink-3);
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      border: 1px dashed var(--line-2);
+    }
+
+    /* ===== Compact table view ==================================== */
+    .table-head { display: none; }
+    @media (min-width: 721px) {
+      html[data-view="table"] .table-head {
+        display: grid;
+        grid-template-columns: 16px 6.8em minmax(0, 1fr) auto;
+        column-gap: 0.7rem;
+        align-items: center;
+        padding: 0.45rem 1rem;
+        padding-right: 102px;
+        font-family: var(--font-mono);
+        font-size: 0.62rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: var(--ink-3);
+        background: var(--bg-subtle);
+        border: 1px solid var(--line);
+        border-bottom: none;
+      }
+      html[data-view="table"] .table-head .th-details { justify-self: end; }
+      html[data-view="table"] .card[data-endpoint] .card-toggle {
+        display: grid;
+        grid-template-columns: 16px 6.8em minmax(0, 1fr) auto;
+        column-gap: 0.7rem;
+        align-items: center;
+        padding: 0.5rem 1rem;
+      }
+      html[data-view="table"] .card[data-endpoint] .url {
+        font-size: 0.8rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        word-break: normal;
+      }
+      html[data-view="table"] .card[data-endpoint] .card-details {
+        justify-self: end;
+        flex-wrap: nowrap;
+        overflow: hidden;
+      }
+      html[data-view="table"] .card[data-endpoint] .card-actions {
+        width: 86px;
+        justify-content: flex-end;
+      }
+      /* Table view is a compact scan mode: bodies stay in the cards view. */
+      html[data-view="table"] .card[data-endpoint] .card-collapse { display: none; }
+      html[data-view="table"] .card[data-endpoint] .chevron { visibility: hidden; }
+      html[data-view="table"] .card[data-endpoint] button.card-toggle { cursor: default; }
+      html[data-view="table"] .card[data-endpoint] button.card-toggle:hover { background: transparent; }
+    }
+
+    /* ===== Footer ================================================ */
+    footer {
+      border-top: 1px solid var(--line);
+      padding: 2rem 0;
+      margin-top: 1rem;
+    }
+    footer .container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+      color: var(--ink-3);
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+    }
+    footer a { color: var(--ink); text-decoration: none; border-bottom: 1px solid var(--line-2); }
+    footer a:hover { border-bottom-color: var(--ink); }
+
+    @media (max-width: 720px) {
+      .summary { grid-template-columns: repeat(2, 1fr); }
+      .summary-card:nth-child(3) { border-left: none; }
+      .summary-card:nth-child(n+3) { border-top: 1px solid var(--line); }
+      .header-tagline { display: none; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      * { transition: none !important; scroll-behavior: auto !important; }
+    }
+
+    @media print {
+      body { background: #fff; color: #000; }
+      .report-header, footer { border-color: #ccc; }
+      .card { break-inside: avoid; }
+      .card.collapsed .card-collapse { grid-template-rows: 1fr; }
+      .group.collapsed .group-body { display: block; }
+      .chevron, .theme-toggle, .controls, .card-actions, .table-head { display: none; }
+    }
+    CSS
+end

--- a/src/output_builder/html_assets/js.cr
+++ b/src/output_builder/html_assets/js.cr
@@ -1,0 +1,229 @@
+# Client-side scripts for the self-contained HTML report.
+module HtmlReportAssets
+  # Applies persisted theme/view/group preferences before first paint
+  # so the page never flashes the wrong state.
+  THEME_BOOT = <<-JS
+    (function () {
+      try {
+        var saved = localStorage.getItem("noir-theme");
+        if (saved === "dark" || saved === "light") {
+          document.documentElement.setAttribute("data-theme", saved);
+        } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          document.documentElement.setAttribute("data-theme", "dark");
+        }
+        if (localStorage.getItem("noir-view") === "table") {
+          document.documentElement.setAttribute("data-view", "table");
+        }
+        if (localStorage.getItem("noir-group") === "off") {
+          document.documentElement.setAttribute("data-group", "off");
+        }
+      } catch (e) {}
+    })();
+    JS
+
+  SCRIPTS = <<-JS
+    (function () {
+      var root = document.documentElement;
+
+      function toArray(nodes) { return Array.prototype.slice.call(nodes); }
+
+      // Reflect the active theme on the toggle control (a11y state).
+      function syncThemeButtons() {
+        var dark = root.getAttribute("data-theme") === "dark";
+        toArray(document.querySelectorAll('[data-action="toggle-theme"]')).forEach(function (b) {
+          b.setAttribute("aria-pressed", String(dark));
+          b.setAttribute("aria-label", dark ? "Switch to light theme" : "Switch to dark theme");
+        });
+      }
+      syncThemeButtons();
+
+      // Theme toggle with persistence (initial theme is set in <head>).
+      document.addEventListener("click", function (e) {
+        var btn = e.target.closest && e.target.closest('[data-action="toggle-theme"]');
+        if (!btn) return;
+        var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+        root.setAttribute("data-theme", next);
+        try { localStorage.setItem("noir-theme", next); } catch (err) {}
+        syncThemeButtons();
+      });
+
+      // Cards <-> compact table view, persisted (initial value set in <head>).
+      function syncViewButtons() {
+        var mode = root.getAttribute("data-view") === "table" ? "table" : "cards";
+        toArray(document.querySelectorAll('[data-action="set-view"]')).forEach(function (b) {
+          b.setAttribute("aria-pressed", String(b.getAttribute("data-view-mode") === mode));
+        });
+      }
+      syncViewButtons();
+
+      document.addEventListener("click", function (e) {
+        var btn = e.target.closest && e.target.closest('[data-action="set-view"]');
+        if (!btn) return;
+        var mode = btn.getAttribute("data-view-mode") === "table" ? "table" : "cards";
+        if (mode === "table") { root.setAttribute("data-view", "table"); } else { root.removeAttribute("data-view"); }
+        try { localStorage.setItem("noir-view", mode); } catch (err) {}
+        syncViewButtons();
+      });
+
+      // Grouped <-> flat rendering of the endpoint list, persisted.
+      function syncGroupButtons() {
+        var on = root.getAttribute("data-group") !== "off";
+        toArray(document.querySelectorAll('[data-action="toggle-group"]')).forEach(function (b) {
+          b.setAttribute("aria-pressed", String(on));
+        });
+      }
+      syncGroupButtons();
+
+      document.addEventListener("click", function (e) {
+        var btn = e.target.closest && e.target.closest('[data-action="toggle-group"]');
+        if (!btn) return;
+        var turningOff = root.getAttribute("data-group") !== "off";
+        if (turningOff) { root.setAttribute("data-group", "off"); } else { root.removeAttribute("data-group"); }
+        try { localStorage.setItem("noir-group", turningOff ? "off" : "on"); } catch (err) {}
+        syncGroupButtons();
+      });
+
+      // Collapse / expand a path group.
+      document.addEventListener("click", function (e) {
+        var btn = e.target.closest && e.target.closest('[data-action="toggle-group-collapse"]');
+        if (!btn) return;
+        var group = btn.closest(".group");
+        if (!group) return;
+        var collapsed = group.classList.toggle("collapsed");
+        btn.setAttribute("aria-expanded", String(!collapsed));
+      });
+
+      // Collapse / expand an endpoint card.
+      document.addEventListener("click", function (e) {
+        var header = e.target.closest && e.target.closest('[data-action="toggle-card"]');
+        if (!header) return;
+        var card = header.closest(".card");
+        if (!card) return;
+        var collapsed = card.classList.toggle("collapsed");
+        header.setAttribute("aria-expanded", String(!collapsed));
+      });
+
+      // Copy URL / copy-as-curl with a fallback for file:// clipboard limits.
+      var copyStatus = document.getElementById("copy-status");
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.setAttribute("readonly", "");
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        var ok = false;
+        try { ok = document.execCommand("copy"); } catch (err) {}
+        document.body.removeChild(ta);
+        return ok;
+      }
+
+      function flashCopied(btn, ok, label) {
+        if (!ok) return;
+        btn.classList.add("copied");
+        setTimeout(function () { btn.classList.remove("copied"); }, 1400);
+        if (copyStatus) copyStatus.textContent = label;
+      }
+
+      function copyText(text, btn, label) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(
+            function () { flashCopied(btn, true, label); },
+            function () { flashCopied(btn, fallbackCopy(text), label); }
+          );
+        } else {
+          flashCopied(btn, fallbackCopy(text), label);
+        }
+      }
+
+      document.addEventListener("click", function (e) {
+        var btn = e.target.closest && e.target.closest('[data-action="copy-url"], [data-action="copy-curl"]');
+        if (!btn) return;
+        var card = btn.closest(".card");
+        if (!card) return;
+        var isCurl = btn.getAttribute("data-action") === "copy-curl";
+        var text = card.getAttribute(isCurl ? "data-curl" : "data-url") || "";
+        if (text) copyText(text, btn, isCurl ? "Copied curl command" : "Copied URL");
+      });
+
+      // Endpoint search + HTTP-method chip filter (combined with AND).
+      var search = document.getElementById("endpoint-search");
+      var methodChips = toArray(document.querySelectorAll("[data-filter-method]"));
+      var endpointCards = toArray(document.querySelectorAll("[data-endpoint]"));
+      var endpointCount = document.getElementById("endpoint-count");
+      var endpointEmpty = document.getElementById("endpoint-no-results");
+      var endpointSection = endpointEmpty ? endpointEmpty.closest(".section") : null;
+      var groups = toArray(document.querySelectorAll(".group[data-group-key]"));
+
+      function applyEndpointFilter() {
+        var q = (search ? search.value : "").trim().toLowerCase();
+        var active = methodChips
+          .filter(function (c) { return c.getAttribute("aria-pressed") === "true"; })
+          .map(function (c) { return c.getAttribute("data-filter-method"); });
+        var shown = 0;
+        endpointCards.forEach(function (card) {
+          var okText = !q || (card.getAttribute("data-text") || "").indexOf(q) !== -1;
+          var okMethod = active.length === 0 || active.indexOf(card.getAttribute("data-method")) !== -1;
+          var visible = okText && okMethod;
+          card.hidden = !visible;
+          if (visible) shown++;
+        });
+        groups.forEach(function (group) {
+          var cards = toArray(group.querySelectorAll("[data-endpoint]"));
+          var visible = cards.filter(function (c) { return !c.hidden; }).length;
+          var count = group.querySelector("[data-group-count]");
+          if (count) {
+            count.textContent = visible === cards.length ? String(cards.length) : visible + " / " + cards.length;
+          }
+          group.hidden = visible === 0;
+        });
+        if (endpointSection) {
+          endpointSection.classList.toggle("filtering", Boolean(q) || active.length > 0);
+        }
+        if (endpointCount) {
+          endpointCount.textContent = shown === endpointCards.length ? String(shown) : shown + " / " + endpointCards.length;
+        }
+        if (endpointEmpty) endpointEmpty.classList.toggle("show", shown === 0);
+      }
+
+      if (search) search.addEventListener("input", applyEndpointFilter);
+      methodChips.forEach(function (chip) {
+        chip.addEventListener("click", function () {
+          chip.setAttribute("aria-pressed", chip.getAttribute("aria-pressed") === "true" ? "false" : "true");
+          applyEndpointFilter();
+        });
+      });
+
+      // Passive-finding severity chip filter.
+      var sevChips = toArray(document.querySelectorAll("[data-filter-severity]"));
+      var passiveCards = toArray(document.querySelectorAll("[data-passive]"));
+      var passiveCount = document.getElementById("passive-count");
+      var passiveEmpty = document.getElementById("passive-no-results");
+
+      function applyPassiveFilter() {
+        var active = sevChips
+          .filter(function (c) { return c.getAttribute("aria-pressed") === "true"; })
+          .map(function (c) { return c.getAttribute("data-filter-severity"); });
+        var shown = 0;
+        passiveCards.forEach(function (card) {
+          var visible = active.length === 0 || active.indexOf(card.getAttribute("data-severity")) !== -1;
+          card.hidden = !visible;
+          if (visible) shown++;
+        });
+        if (passiveCount) {
+          passiveCount.textContent = shown === passiveCards.length ? String(shown) : shown + " / " + passiveCards.length;
+        }
+        if (passiveEmpty) passiveEmpty.classList.toggle("show", shown === 0);
+      }
+
+      sevChips.forEach(function (chip) {
+        chip.addEventListener("click", function () {
+          chip.setAttribute("aria-pressed", chip.getAttribute("aria-pressed") === "true" ? "false" : "true");
+          applyPassiveFilter();
+        });
+      });
+    })();
+    JS
+end

--- a/src/utils/curl_command.cr
+++ b/src/utils/curl_command.cr
@@ -1,0 +1,32 @@
+# Shared curl command construction used by the curl output builder and the
+# HTML report's copy-as-curl feature.
+module CurlCommand
+  def self.shell_quote(str : String) : String
+    "'#{str.gsub("'", "'\\''")}'"
+  end
+
+  def self.build(method : String, url : String, body : String, body_type : String,
+                 headers : Array(String), cookies : Array(String)) : String
+    parts = ["curl", "-i", "-X", shell_quote(method), shell_quote(url)]
+
+    unless body.empty?
+      content_type = body_type == "json" ? "application/json" : "application/x-www-form-urlencoded"
+      parts << "--data-raw"
+      parts << shell_quote(body)
+      parts << "-H"
+      parts << shell_quote("Content-Type: #{content_type}")
+    end
+
+    headers.each do |header|
+      parts << "-H"
+      parts << shell_quote(header)
+    end
+
+    cookies.each do |cookie|
+      parts << "--cookie"
+      parts << shell_quote(cookie)
+    end
+
+    parts.join(" ")
+  end
+end


### PR DESCRIPTION
## Summary

Builds on the monochrome noir report (#2090) with a dark-tech redesign that keeps the identity but makes the report far easier to scan, and adds three workflow features.

### Semantic color
- HTTP method badges get restrained tint-outline hues: GET emerald, POST amber, PUT blue, PATCH violet, DELETE red; HEAD/OPTIONS/unknown stay neutral.
- Severity badges follow the same system (critical = filled red, high/medium/low = tints, info = outline).
- Light mode keeps the same hues at AA-contrast lightness (e.g. amber uses `#854d0e` on light because amber-700 fails 4.5:1). Chrome stays neutral; a single emerald accent marks the header edge, brand visor, and section markers.
- Filter chips take on their method/severity hue only when pressed.

### New features
- **Path grouping**: endpoints group by authority + first path segment with collapsible headers and live counts that track the search/method filters (`2 / 16` style, empty groups hide). A `Grouped` toggle flattens the list. Grouping only activates when it adds structure (>= 2 groups and at least one multi-member group), so small reports render flat exactly as before.
- **Cards <-> table view**: a persisted toggle re-lays the same card DOM as a dense aligned table (method | path | details | actions) for large scans. No DOM duplication, so filtering/copy work identically; preference is applied pre-paint to avoid flashes.
- **Copy buttons**: per-endpoint copy-URL and copy-as-curl. curl commands are precomputed in Crystal via a new shared `CurlCommand` module (also used by `-f curl`), synthetic `ANY` methods expand to one command per verb, and a `document.execCommand` fallback covers `file://` clipboard restrictions. Non-HTTP endpoints (mobile deep links / CLI) skip the curl button.

### Structure
- Report CSS/JS moved out of `html.cr` into `src/output_builder/html_assets/{css,js}.cr`; `html.cr` keeps the logic.
- Shared curl construction extracted to `src/utils/curl_command.cr`; `OutputBuilderCurl` output is byte-identical.
- The user `report-template.html` token contract and the existing DOM contract (classes/ids/data attributes) are unchanged: all 16 prior specs pass unmodified, and 15 new specs cover grouping, the view toggle, copy/curl attributes, and the semantic tokens.

## Screenshots

Dark cards / dark table / light cards / passive findings verified via headless Chrome renders of `spec/functional_test/fixtures/python/django` and a secrets fixture; filter interaction (search + POST chip) verified via DOM dump (`4 / 67` count, group counts update, empty groups hidden).

## Test plan

- `crystal spec spec/unit_test` (3731 examples, 0 failures)
- `crystal lib/ameba/bin/ameba.cr` on changed files (0 failures)
- `crystal tool format --check` clean
- Manual: generated kemal/django/passive reports; verified themes, view toggle, grouping, filters, copy attributes, template override via `NOIR_HOME/report-template.html`