### PR TITLE
fix: batch of CLI, output-format, security & robustness fixes from build exploration

### DIFF
--- a/spec/unit_test/llm/acp_client_spec.cr
+++ b/spec/unit_test/llm/acp_client_spec.cr
@@ -36,6 +36,24 @@ describe LLM::ACPClient do
       command.should eq("npx")
       args.should eq(["@zed-industries/claude-agent-acp"])
     end
+
+    it "refuses an arbitrary command target (no code execution)" do
+      ENV.delete("NOIR_ACP_ALLOW_CUSTOM_COMMAND")
+      expect_raises(LLM::ACPClient::UnsupportedACPTargetError, /Unsupported ACP provider target/) do
+        LLM::ACPClient.resolve_command("acp:rm -rf /")
+      end
+    end
+
+    it "allows a custom command only with the explicit opt-in" do
+      ENV["NOIR_ACP_ALLOW_CUSTOM_COMMAND"] = "1"
+      begin
+        command, args = LLM::ACPClient.resolve_command("acp:my-agent --flag")
+        command.should eq("my-agent")
+        args.should eq(["--flag"])
+      ensure
+        ENV.delete("NOIR_ACP_ALLOW_CUSTOM_COMMAND")
+      end
+    end
   end
 
   describe ".default_model" do

--- a/spec/unit_test/output_builder/adb_spec.cr
+++ b/spec/unit_test/output_builder/adb_spec.cr
@@ -31,6 +31,21 @@ describe "OutputBuilderAdb" do
     out.should eq("adb shell am start -a 'android.intent.action.VIEW' -d 'myapp://host/path'")
   end
 
+  it "double-quotes a deep link containing '&' so the device shell keeps every param" do
+    # `adb shell` re-parses on the device; a single quote layer leaves `&`
+    # exposed and the URL is truncated after the first query param.
+    scheme = Endpoint.new("myapp://cb?code=x&state=y", "GET")
+    scheme.protocol = "mobile-scheme"
+
+    builder = build_adb_builder
+    builder.print([scheme])
+    out = builder.io.to_s.strip
+
+    # The URL token must carry an inner single-quote layer that survives the
+    # host shell, so the device shell receives 'myapp://cb?code=x&state=y'.
+    out.should contain(%(-d ''\\''myapp://cb?code=x&state=y'\\'''))
+  end
+
   it "uses the filter's action/category and constrains to the package" do
     scheme = Endpoint.new("myapp://host/path", "GET")
     scheme.protocol = "mobile-scheme"

--- a/src/banner.cr
+++ b/src/banner.cr
@@ -1,21 +1,45 @@
 def banner(io : IO = STDERR)
-  art = [
-    "           ùç  Y  wù           ",
-    "        ™w£ Í  ±  Í £w2        ",
-    "       ù£   Ï  Ï  Ï   £ù       ",
-    "      ù£    Ï  Ï  Ï  ± £ù      ",
-    "         Ï  Ï  Ï  Ï  Ï         ",
-    "     2YV±ÏÏÏÏÏÏÏÏÏÏÏÏÏ3ÍY2     ",
-    "         Ï  Ï  Ï  Ï  Ï         ",
-    "      ù£ ±  Ï  Ï  Ï  ± £ç      ",
-    "       ù£   Ï  Ï  Ï   £ç       ",
-    "        2w£ Í  ±  Í £©2        ",
-    "           ùw  Y  wù           ",
-  ]
+  # The default art uses extended/box-drawing glyphs that mojibake on a
+  # non-UTF-8 Windows console (CP949, …). Ship an ASCII-only variant on
+  # Windows so the banner renders cleanly there. Both variants are 11 lines
+  # to stay aligned with the `side` text column below.
+  # Pre-declare so the macro-branch assignments are visible below.
+  art = [] of String
+  divider = ""
+  {% if flag?(:windows) %}
+    art = [
+      "          .   |   .          ",
+      "       .  |   |   |  .       ",
+      "      .   |   |   |   .      ",
+      "      |   |   |   |   |      ",
+      "          |   |   |          ",
+      "    #=====================#  ",
+      "          |   |   |          ",
+      "      |   |   |   |   |      ",
+      "      '   |   |   |   '      ",
+      "       '  |   |   |  '       ",
+      "          '   |   '          ",
+    ]
+    divider = "-" * 34
+  {% else %}
+    art = [
+      "           ùç  Y  wù           ",
+      "        ™w£ Í  ±  Í £w2        ",
+      "       ù£   Ï  Ï  Ï   £ù       ",
+      "      ù£    Ï  Ï  Ï  ± £ù      ",
+      "         Ï  Ï  Ï  Ï  Ï         ",
+      "     2YV±ÏÏÏÏÏÏÏÏÏÏÏÏÏ3ÍY2     ",
+      "         Ï  Ï  Ï  Ï  Ï         ",
+      "      ù£ ±  Ï  Ï  Ï  ± £ç      ",
+      "       ù£   Ï  Ï  Ï   £ç       ",
+      "        2w£ Í  ±  Í £©2        ",
+      "           ùw  Y  wù           ",
+    ]
+    divider = "─" * 34
+  {% end %}
 
   name = "N O I R".colorize(:white).mode(:bold).to_s
   version = "v#{Noir::VERSION}".colorize(:light_yellow).to_s
-  divider = "─" * 34
 
   side = [
     "",

--- a/src/cli/commands/config.cr
+++ b/src/cli/commands/config.cr
@@ -112,6 +112,14 @@ module Noir::CLI::ConfigCommand
   end
 
   def self.edit
+    # `edit` launches an interactive terminal editor. In a non-interactive
+    # context (CI, piped stdin, background job) that editor would block
+    # forever waiting for input that never arrives, hanging the pipeline.
+    # Fail fast with a useful pointer instead.
+    unless STDIN.tty?
+      Noir::CLI.die("`noir config edit` needs an interactive terminal. Edit #{config_path} directly, or use `noir config show`.")
+    end
+
     # Ensure the file exists before launching the editor so users always
     # land on something well-formed rather than a brand-new empty buffer.
     unless File.exists?(config_path)
@@ -124,10 +132,20 @@ module Noir::CLI::ConfigCommand
     end
 
     editor = pick_editor
-    command = "#{editor} #{Process.quote(config_path)}"
+    # Split the editor string into argv WITHOUT a shell so a poisoned
+    # $EDITOR/$VISUAL can't inject commands: `EDITOR="rm -rf /; vi"` used to
+    # run under `shell: true` and execute `rm -rf /`. Parsing to argv means
+    # metacharacters (`;`, `|`, `$()`) are passed literally, never evaluated,
+    # while still supporting editors carrying flags (e.g. `code --wait`).
+    editor_argv = Process.parse_arguments(editor)
+    if editor_argv.empty?
+      Noir::CLI.die("No editor configured. Set $VISUAL or $EDITOR (or install vi).")
+    end
+    command = editor_argv.first
+    args = editor_argv[1..] + [config_path]
     status = Process.run(
       command,
-      shell: true,
+      args: args,
       input: Process::Redirect::Inherit,
       output: Process::Redirect::Inherit,
       error: Process::Redirect::Inherit,

--- a/src/cli/commands/config.cr
+++ b/src/cli/commands/config.cr
@@ -12,14 +12,25 @@ module Noir::CLI::ConfigCommand
 
   def self.run(argv : Array(String))
     action = nil
-    argv.each do |a|
+    override_path = nil
+    i = 0
+    while i < argv.size
+      a = argv[i]
       case a
       when "-h", "--help"
         print_help
         exit
+      when "--config-file"
+        # Honor the global --config-file flag inside the subcommand so
+        # `noir config show --config-file X` reads X, not the default path.
+        override_path = argv[i + 1]?
+        i += 1
+      when .starts_with?("--config-file=")
+        override_path = a.split("=", 2)[1]
       else
         action ||= a
       end
+      i += 1
     end
 
     if action.nil?
@@ -28,10 +39,10 @@ module Noir::CLI::ConfigCommand
     end
 
     case action
-    when "show" then show
-    when "edit" then edit
+    when "show" then show(override_path)
+    when "edit" then edit(override_path)
     when "init" then init
-    when "path" then puts config_path
+    when "path" then puts config_path(override_path)
     else
       Noir::CLI.die("Unknown config action: #{action}. Valid: #{ACTIONS.join(", ")}.")
     end
@@ -60,8 +71,8 @@ module Noir::CLI::ConfigCommand
       HELP
   end
 
-  def self.show
-    path = config_path
+  def self.show(override_path : String? = nil)
+    path = config_path(override_path)
     unless File.exists?(path)
       Noir::CLI.die("Config file does not exist: #{path}\nRun `noir config init` to create it.")
     end
@@ -111,23 +122,30 @@ module Noir::CLI::ConfigCommand
     end
   end
 
-  def self.edit
+  def self.edit(override_path : String? = nil)
+    path = config_path(override_path)
+
     # `edit` launches an interactive terminal editor. In a non-interactive
     # context (CI, piped stdin, background job) that editor would block
     # forever waiting for input that never arrives, hanging the pipeline.
     # Fail fast with a useful pointer instead.
     unless STDIN.tty?
-      Noir::CLI.die("`noir config edit` needs an interactive terminal. Edit #{config_path} directly, or use `noir config show`.")
+      Noir::CLI.die("`noir config edit` needs an interactive terminal. Edit #{path} directly, or use `noir config show`.")
     end
 
     # Ensure the file exists before launching the editor so users always
-    # land on something well-formed rather than a brand-new empty buffer.
-    unless File.exists?(config_path)
+    # land on something well-formed rather than a brand-new empty buffer. Only
+    # the default path is auto-created (via ConfigInitializer); a custom
+    # --config-file that doesn't exist is an error, not a place to scaffold.
+    unless File.exists?(path)
+      if override_path && !override_path.empty?
+        Noir::CLI.die("Config file does not exist: #{path}")
+      end
       ConfigInitializer.new.setup
-      if File.exists?(config_path)
-        STDERR.puts "Created default config at #{config_path}"
+      if File.exists?(path)
+        STDERR.puts "Created default config at #{path}"
       else
-        Noir::CLI.die("Failed to create config file at #{config_path}.")
+        Noir::CLI.die("Failed to create config file at #{path}.")
       end
     end
 
@@ -142,7 +160,7 @@ module Noir::CLI::ConfigCommand
       Noir::CLI.die("No editor configured. Set $VISUAL or $EDITOR (or install vi).")
     end
     command = editor_argv.first
-    args = editor_argv[1..] + [config_path]
+    args = editor_argv[1..] + [path]
     status = Process.run(
       command,
       args: args,
@@ -156,7 +174,8 @@ module Noir::CLI::ConfigCommand
     end
   end
 
-  def self.config_path : String
+  def self.config_path(override : String? = nil) : String
+    return File.expand_path(override) if override && !override.empty?
     File.expand_path(File.join(get_home, "config.yaml"))
   end
 

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -121,6 +121,20 @@ module Noir::CLI::ScanCommand
       Noir::CLI.die("-u/--url must use http:// or https:// (got '#{url}').")
     end
 
+    # Validate an explicit port at parse time. A non-numeric port
+    # (`-u http://host:por`) otherwise survives until the first probe and
+    # crashes deep in the socket layer with an opaque error.
+    begin
+      parsed = URI.parse(url)
+      if port = parsed.port
+        unless (1..65535).includes?(port)
+          Noir::CLI.die("-u/--url port #{port} is out of range (1-65535) in '#{url}'.")
+        end
+      end
+    rescue ex : URI::Error
+      Noir::CLI.die("-u/--url has an invalid port in '#{url}' (#{ex.message}). The port must be numeric, e.g. http://host:8080.")
+    end
+
     # Strip `?query` and `#fragment` from the base URL — they're
     # only valid at the end of a URL, so concatenating an endpoint
     # path after them produces a malformed URL

--- a/src/cli/router.cr
+++ b/src/cli/router.cr
@@ -46,10 +46,28 @@ module Noir::CLI::Router
     if !head.starts_with?("-") && KNOWN_COMMANDS.includes?(head)
       rest = argv[1..]
       route(head, rest)
+    elsif likely_mistyped_command?(head)
+      # A bare word that is neither a known command nor an existing path is
+      # almost certainly a mistyped subcommand. Pre-fix this fell through to
+      # scan and surfaced the misleading "Base path does not exist: <word>".
+      Noir::CLI.die("Unknown command or non-existent path: '#{head}'.\n" \
+                    "Run 'noir help' to see commands, or 'noir scan #{head}' to scan a path.")
     else
-      # v0 compat: bare flags or unknown positional → default to scan.
+      # v0 compat: bare flags or an existing positional path → default to scan.
       ScanCommand.run(argv)
     end
+  end
+
+  # True for a first token that looks like a mistyped subcommand: not a flag,
+  # not a known command, has no path separator/extension, and doesn't exist on
+  # disk. Real scan targets (`./app`, `app.rb`, an existing dir) are excluded
+  # so the v0 `noir <path>` shorthand keeps working.
+  private def self.likely_mistyped_command?(head : String) : Bool
+    return false if head.starts_with?("-")
+    return false if KNOWN_COMMANDS.includes?(head)
+    return false if head.includes?("/") || head.includes?(".")
+    return false if File.exists?(head)
+    true
   end
 
   private def self.route(command : String, args : Array(String))

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -43,6 +43,28 @@ module Noir::CliValidation
     validate_passive_scan_paths!(options)
     validate_ai_provider_pair!(options)
     warn_about_unused_delivery_flags(options)
+    warn_about_contradictory_probe_filters(options)
+  end
+
+  # A value listed in both --probe-match and --probe-skip is contradictory:
+  # skip wins in the Deliver pipeline, so the matcher is silently defeated.
+  # Surface the overlap instead of quietly filtering it out.
+  def self.warn_about_contradictory_probe_filters(options : Hash(String, YAML::Any))
+    match = string_array(options["probe_match"]?)
+    skip = string_array(options["probe_skip"]?)
+    return if match.empty? || skip.empty?
+
+    overlap = (match & skip).uniq
+    return if overlap.empty?
+
+    STDERR.puts "WARNING: value(s) #{overlap.map(&.inspect).join(", ")} appear in both --probe-match and --probe-skip; --probe-skip takes precedence, so those matches are dropped.".colorize(:yellow)
+  end
+
+  private def self.string_array(value : YAML::Any?) : Array(String)
+    return [] of String if value.nil?
+    raw = value.raw
+    return [] of String unless raw.is_a?(Array)
+    raw.map(&.to_s)
   end
 
   # `--ai-provider` and `--ai-model` need each other to take effect.
@@ -170,7 +192,11 @@ module Noir::CliValidation
   end
 
   def self.validate_base_paths!(options : Hash(String, YAML::Any))
-    base_paths = options["base"].as_a.map(&.to_s)
+    # Dedupe repeated paths (`noir scan ./app ./app`, or the same dir via
+    # both a positional and -b) so the detector doesn't load, parse and
+    # analyze the identical tree twice. `uniq` preserves first-seen order.
+    base_paths = options["base"].as_a.map(&.to_s).uniq
+    options["base"] = YAML::Any.new(base_paths.map { |p| YAML::Any.new(p) })
     if base_paths.empty?
       raise Error.new(<<-MSG)
         No path to scan was given.
@@ -199,11 +225,22 @@ module Noir::CliValidation
     raise Error.new("Invalid output format '#{format}'. Valid formats: #{VALID_OUTPUT_FORMATS.join(", ")}")
   end
 
+  # Upper bound for --concurrency. A user asking for hundreds of thousands
+  # of fibers doesn't get more throughput — it just exhausts file
+  # descriptors / sockets and can take the process down. Cap at a value far
+  # above any useful setting and warn rather than silently honoring it.
+  MAX_CONCURRENCY = 256
+
   def self.validate_concurrency!(options : Hash(String, YAML::Any))
     raw_value = options["concurrency"].to_s
     value = raw_value.to_i?
     if value.nil? || value < 1
       raise Error.new("Invalid concurrency '#{raw_value}'. Concurrency must be an integer greater than or equal to 1.")
+    end
+
+    if value > MAX_CONCURRENCY
+      STDERR.puts "WARNING: --concurrency #{value} exceeds the safe maximum; clamping to #{MAX_CONCURRENCY}.".colorize(:yellow)
+      value = MAX_CONCURRENCY
     end
 
     options["concurrency"] = YAML::Any.new(value)

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -85,9 +85,28 @@ module Noir::CliValidation
     return if provider.empty?
 
     is_acp = provider.downcase.starts_with?("acp:")
-    return if is_acp || !model.empty?
+    if is_acp
+      validate_acp_target!(provider)
+      return
+    end
+    return unless model.empty?
 
     raise Error.new("--ai-provider '#{provider}' needs a companion --ai-model. Pass it with --ai-model, e.g. `noir scan ./app --ai-provider #{provider} --ai-model gpt-4 --ai-key …`. (ACP providers like `acp:claude` or `acp:codex` are the exception and don't need --ai-model.)")
+  end
+
+  # ACP targets Noir knows how to launch. Kept in sync with
+  # `LLM::ACPClient::KNOWN_TARGETS` (the actual exec sink). Anything else
+  # would be run as an arbitrary local process, so a `--ai-provider "acp:<cmd>"`
+  # from an untrusted config file is refused here — a clean pre-flight error
+  # instead of the sink's mid-scan raise. See issue: acp arbitrary exec.
+  ACP_KNOWN_TARGETS = %w[codex gemini claude claude-code]
+
+  def self.validate_acp_target!(provider : String)
+    target = (provider.split(":", 2)[1]?.try(&.strip.downcase)) || ""
+    return if ACP_KNOWN_TARGETS.includes?(target)
+    return if ENV["NOIR_ACP_ALLOW_CUSTOM_COMMAND"]? == "1"
+
+    raise Error.new("--ai-provider '#{provider}': unsupported ACP target. Allowed acp: targets are #{ACP_KNOWN_TARGETS.join(", ")}. Running an arbitrary command as an ACP agent is disabled; set NOIR_ACP_ALLOW_CUSTOM_COMMAND=1 to override (only with trusted config).")
   end
 
   # `--passive-scan-path PATH` accepts multiple entries (repeatable),

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -2,6 +2,7 @@ require "colorize"
 require "yaml"
 require "./tagger/tagger"
 require "./techs/techs"
+require "./llm/native_tool_calling"
 
 module Noir::CliValidation
   class Error < Exception
@@ -42,8 +43,25 @@ module Noir::CliValidation
     validate_tech_names!(options)
     validate_passive_scan_paths!(options)
     validate_ai_provider_pair!(options)
+    validate_ai_native_tools_allowlist!(options)
     warn_about_unused_delivery_flags(options)
     warn_about_contradictory_probe_filters(options)
+  end
+
+  # `--ai-native-tools-allowlist` entries that don't canonicalize to a
+  # provider Noir supports for native tool-calling will never match and the
+  # feature just stays off. Warn so a typo like `opena` is visible instead
+  # of silently disabling tool-calling.
+  def self.validate_ai_native_tools_allowlist!(options : Hash(String, YAML::Any))
+    raw = options["ai_native_tools_allowlist"]?.try(&.to_s) || ""
+    return if raw.empty?
+
+    unknown = raw.split(",").map(&.strip).reject(&.empty?).reject do |provider|
+      LLM::NativeToolCalling.known_provider?(provider)
+    end
+    return if unknown.empty?
+
+    STDERR.puts "WARNING: --ai-native-tools-allowlist: unrecognized provider(s) #{unknown.map(&.inspect).join(", ")}. Native tool-calling supports: #{LLM::NativeToolCalling::KNOWN_PROVIDERS.join(", ")}. These entries will never match.".colorize(:yellow)
   end
 
   # A value listed in both --probe-match and --probe-skip is contradictory:

--- a/src/cli_validation.cr
+++ b/src/cli_validation.cr
@@ -232,7 +232,7 @@ module Noir::CliValidation
     # Dedupe repeated paths (`noir scan ./app ./app`, or the same dir via
     # both a positional and -b) so the detector doesn't load, parse and
     # analyze the identical tree twice. `uniq` preserves first-seen order.
-    base_paths = options["base"].as_a.map(&.to_s).uniq
+    base_paths = options["base"].as_a.map(&.to_s).uniq!
     options["base"] = YAML::Any.new(base_paths.map { |p| YAML::Any.new(p) })
     if base_paths.empty?
       raise Error.new(<<-MSG)

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -1,6 +1,7 @@
 require "file"
 require "log"
 require "yaml"
+require "colorize"
 require "./utils/home.cr"
 require "./llm/native_tool_calling"
 
@@ -139,11 +140,18 @@ class ConfigInitializer
       BOOLEAN_CONFIG_KEYS.each do |key|
         value = symbolized_hash[key]?
         next if value.nil?
+        next if value.raw.is_a?(Bool) # already a real YAML bool
 
-        case value.to_s
-        when "yes"
+        case value.to_s.downcase
+        when "yes", "true"
           symbolized_hash[key] = YAML::Any.new(true)
-        when "no"
+        when "no", "false"
+          symbolized_hash[key] = YAML::Any.new(false)
+        else
+          # A typo like `passive_scan: ture` used to fall through to
+          # any_to_bool's silent `false`, so the feature stayed off with no
+          # hint why. Surface the malformed value instead of guessing.
+          STDERR.puts "WARNING: config key '#{key}' has invalid boolean value #{value.to_s.inspect}; expected true/false/yes/no. Treating as false.".colorize(:yellow)
           symbolized_hash[key] = YAML::Any.new(false)
         end
       end

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -148,9 +148,9 @@ class ConfigInitializer
         when "no", "false"
           symbolized_hash[key] = YAML::Any.new(false)
         else
-          # A typo like `passive_scan: ture` used to fall through to
-          # any_to_bool's silent `false`, so the feature stayed off with no
-          # hint why. Surface the malformed value instead of guessing.
+          # A malformed boolean value (a misspelling, wrong word, etc.) used
+          # to fall through to any_to_bool's silent `false`, so the feature
+          # stayed off with no hint why. Surface it instead of guessing.
           STDERR.puts "WARNING: config key '#{key}' has invalid boolean value #{value.to_s.inspect}; expected true/false/yes/no. Treating as false.".colorize(:yellow)
           symbolized_hash[key] = YAML::Any.new(false)
         end

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -182,7 +182,17 @@ class ConfigInitializer
   # on very large boxes. Users who want a specific value still get it
   # via `--concurrency N` or `concurrency:` in the config file — those
   # paths overwrite this default.
+  #
+  # NOIR_CONCURRENCY lets container/CI pipelines pin the worker count to
+  # the pod's CPU allocation without threading a flag through every noir
+  # invocation. An explicit --concurrency / config value still wins, since
+  # those overwrite this default afterwards.
   def default_concurrency : String
+    if env_value = ENV["NOIR_CONCURRENCY"]?
+      if parsed = env_value.strip.to_i?
+        return parsed.to_s if parsed >= 1
+      end
+    end
     System.cpu_count.clamp(4, 32).to_s
   end
 

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -21,6 +21,7 @@ class ConfigInitializer
     nolog
     no_spinner
     probe # legacy `send_req` is migrated to `probe` before this coercion runs
+    tls_skip_verify
     all_taggers
     status_codes
     passive_scan
@@ -233,6 +234,7 @@ class ConfigInitializer
       "url"                          => YAML::Any.new(""),
       "probe_skip"                   => YAML::Any.new([] of YAML::Any),
       "probe_match"                  => YAML::Any.new([] of YAML::Any),
+      "tls_skip_verify"              => YAML::Any.new(false),
       "all_taggers"                  => YAML::Any.new(false),
       "use_taggers"                  => YAML::Any.new(""),
       "diff"                         => YAML::Any.new(""),

--- a/src/deliver/send_elasticsearch.cr
+++ b/src/deliver/send_elasticsearch.cr
@@ -32,14 +32,16 @@ class SendElasticSearch < Deliver
     Crest::Request.execute(
       method: :post,
       url: uri.to_s,
-      tls: OpenSSL::SSL::Context::Client.insecure,
+      tls: tls_context,
       user_agent: "Noir/#{Noir::VERSION}",
       form: body,
       headers: es_headers,
       json: true
     )
   rescue e
-    @logger.debug "Exception of ES Delivery"
+    # Surface the failure at warning level so an indexing outage isn't
+    # mistaken for a successful export.
+    @logger.warning "Elasticsearch delivery to #{uri.to_s} failed: #{e.message}"
     @logger.debug_sub e
   end
 end

--- a/src/deliver/send_elasticsearch.cr
+++ b/src/deliver/send_elasticsearch.cr
@@ -41,7 +41,7 @@ class SendElasticSearch < Deliver
   rescue e
     # Surface the failure at warning level so an indexing outage isn't
     # mistaken for a successful export.
-    @logger.warning "Elasticsearch delivery to #{uri.to_s} failed: #{e.message}"
+    @logger.warning "Elasticsearch delivery to #{uri} failed: #{e.message}"
     @logger.debug_sub e
   end
 end

--- a/src/deliver/send_proxy.cr
+++ b/src/deliver/send_proxy.cr
@@ -8,6 +8,12 @@ class SendWithProxy < Deliver
     proxy_url = URI.parse(@proxy)
     applied_endpoints = apply_all(endpoints)
     wg = WaitGroup.new
+    failures = Atomic(Int32).new(0)
+    # Proxy delivery targets an intercepting proxy (Burp/ZAP) that presents
+    # its own certificate, so verification is intentionally off here
+    # regardless of --tls-skip-verify — otherwise every replayed request
+    # would fail the handshake against the proxy's cert.
+    proxy_tls = OpenSSL::SSL::Context::Client.insecure
 
     applied_endpoints.each do |endpoint|
       next if endpoint.non_http? # can't replay an app deep link or CLI command through an HTTP proxy
@@ -30,7 +36,7 @@ class SendWithProxy < Deliver
                 url: endpoint.url,
                 p_addr: proxy_url.host,
                 p_port: proxy_url.port,
-                tls: OpenSSL::SSL::Context::Client.insecure,
+                tls: proxy_tls,
                 user_agent: "Noir/#{Noir::VERSION}",
                 params: endpoint_hash["query"],
                 headers: @headers,
@@ -44,11 +50,12 @@ class SendWithProxy < Deliver
                 p_addr: proxy_url.host,
                 p_port: proxy_url.port,
                 headers: @headers,
-                tls: OpenSSL::SSL::Context::Client.insecure,
+                tls: proxy_tls,
                 user_agent: "Noir/#{Noir::VERSION}"
               )
             end
           rescue e
+            failures.add(1)
             @logger.debug "Exception during proxy delivery"
             @logger.debug_sub e
           ensure
@@ -59,5 +66,8 @@ class SendWithProxy < Deliver
     end
 
     wg.wait
+
+    failed = failures.get
+    @logger.warning "Proxy delivery: #{failed} request(s) failed (run with --debug for details)." if failed > 0
   end
 end

--- a/src/deliver/send_proxy.cr
+++ b/src/deliver/send_proxy.cr
@@ -9,6 +9,8 @@ class SendWithProxy < Deliver
     applied_endpoints = apply_all(endpoints)
     wg = WaitGroup.new
     failures = Atomic(Int32).new(0)
+    # Bound in-flight requests to --concurrency (see send_req.cr).
+    sem = Channel(Nil).new(concurrency_limit)
     # Proxy delivery targets an intercepting proxy (Burp/ZAP) that presents
     # its own certificate, so verification is intentionally off here
     # regardless of --tls-skip-verify — otherwise every replayed request
@@ -19,6 +21,7 @@ class SendWithProxy < Deliver
       next if endpoint.non_http? # can't replay an app deep link or CLI command through an HTTP proxy
       requestable_http_methods(endpoint.method).each do |request_method|
         wg.add(1)
+        sem.send(nil) # acquire a slot (blocks once concurrency_limit are in flight)
         spawn do
           begin
             if !endpoint.params.empty?
@@ -59,6 +62,7 @@ class SendWithProxy < Deliver
             @logger.debug "Exception during proxy delivery"
             @logger.debug_sub e
           ensure
+            sem.receive # release the slot
             wg.done
           end
         end

--- a/src/deliver/send_req.cr
+++ b/src/deliver/send_req.cr
@@ -7,6 +7,8 @@ class SendReq < Deliver
   def run(endpoints : Array(Endpoint))
     applied_endpoints = apply_all(endpoints)
     wg = WaitGroup.new
+    tls = tls_context
+    failures = Atomic(Int32).new(0)
 
     applied_endpoints.each do |endpoint|
       next if endpoint.non_http? # can't HTTP-probe an app deep link or CLI command
@@ -27,7 +29,7 @@ class SendReq < Deliver
               Crest::Request.execute(
                 method: get_symbol(request_method),
                 url: endpoint.url,
-                tls: OpenSSL::SSL::Context::Client.insecure,
+                tls: tls,
                 user_agent: "Noir/#{Noir::VERSION}",
                 params: endpoint_hash["query"],
                 form: body,
@@ -39,11 +41,12 @@ class SendReq < Deliver
                 method: get_symbol(request_method),
                 url: endpoint.url,
                 headers: @headers,
-                tls: OpenSSL::SSL::Context::Client.insecure,
+                tls: tls,
                 user_agent: "Noir/#{Noir::VERSION}"
               )
             end
           rescue e
+            failures.add(1)
             @logger.debug "Exception during request delivery"
             @logger.debug_sub e
           ensure
@@ -54,5 +57,12 @@ class SendReq < Deliver
     end
 
     wg.wait
+
+    # Individual probe failures stay at debug (many endpoints simply won't
+    # respond), but a total-failure count surfaces once so a fully-broken
+    # target (bad -u, TLS rejection, network down) isn't mistaken for a
+    # clean run.
+    failed = failures.get
+    @logger.warning "Probe delivery: #{failed} request(s) failed (run with --debug for details)." if failed > 0
   end
 end

--- a/src/deliver/send_req.cr
+++ b/src/deliver/send_req.cr
@@ -9,11 +9,15 @@ class SendReq < Deliver
     wg = WaitGroup.new
     tls = tls_context
     failures = Atomic(Int32).new(0)
+    # Bound in-flight requests to --concurrency so a large endpoint set can't
+    # spawn thousands of sockets at once and hit "Too many open files".
+    sem = Channel(Nil).new(concurrency_limit)
 
     applied_endpoints.each do |endpoint|
       next if endpoint.non_http? # can't HTTP-probe an app deep link or CLI command
       requestable_http_methods(endpoint.method).each do |request_method|
         wg.add(1)
+        sem.send(nil) # acquire a slot (blocks once `concurrency_limit` are in flight)
         spawn do
           begin
             if endpoint.params.size > 0
@@ -50,6 +54,7 @@ class SendReq < Deliver
             @logger.debug "Exception during request delivery"
             @logger.debug_sub e
           ensure
+            sem.receive # release the slot
             wg.done
           end
         end

--- a/src/deliver/send_webhook.cr
+++ b/src/deliver/send_webhook.cr
@@ -40,14 +40,16 @@ class SendWebhook < Deliver
     Crest::Request.execute(
       method: :post,
       url: webhook_url,
-      tls: OpenSSL::SSL::Context::Client.insecure,
+      tls: tls_context,
       user_agent: "Noir/#{Noir::VERSION}",
       form: body,
       headers: webhook_headers,
       json: true
     )
   rescue e
-    @logger.debug "Exception of webhook Delivery"
+    # Surface the failure at warning level: a swallowed debug line let the
+    # user believe the catalog was delivered when the POST never landed.
+    @logger.warning "Webhook delivery to #{webhook_url} failed: #{e.message}"
     @logger.debug_sub e
   end
 end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -447,10 +447,20 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
       # patterns without "/" are matched against the basename.
       # Partition once up front so the per-file loop only walks the two
       # already-classified lists — no substring check per file.
+      # Normalize Windows-style backslashes to '/' before classifying, so a
+      # pattern like `src\legacy` is treated as a path pattern (and matches)
+      # instead of an unmatchable basename.
       exclude_path_raw = options["exclude_path"]?.to_s
-        .split(",").map(&.strip).reject(&.empty?)
+        .split(",").map(&.strip.gsub('\\', '/')).reject(&.empty?)
       path_patterns, basename_patterns = exclude_path_raw.partition(&.includes?('/'))
       exclude_path_active = !exclude_path_raw.empty?
+      # macOS/Windows default filesystems are case-insensitive, so
+      # `--exclude-path MyFile.go` should also exclude `myfile.go` there. Fold
+      # case only on those platforms — folding on Linux would wrongly drop
+      # case-distinct files that legitimately coexist.
+      exclude_case_insensitive = {% if flag?(:darwin) || flag?(:windows) %} true {% else %} false {% end %}
+      exclude_basename_patterns = exclude_case_insensitive ? basename_patterns.map(&.downcase) : basename_patterns
+      exclude_path_patterns = exclude_case_insensitive ? path_patterns.map(&.downcase) : path_patterns
       skipped_exclude_path = 0
 
       base_paths.each do |base_path|
@@ -510,13 +520,23 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
               total_files += 1
 
               if exclude_path_active
-                if basename_patterns.any? { |pat| File.match?(pat, entry) }
+                entry_cmp = exclude_case_insensitive ? entry.downcase : entry
+                if exclude_basename_patterns.any? { |pat| File.match?(pat, entry_cmp) }
                   skipped_exclude_path += 1
                   next
                 end
-                if !path_patterns.empty?
+                if !exclude_path_patterns.empty?
                   rel_path = full_path.starts_with?(base_prefix) ? full_path[base_prefix.size..] : full_path
-                  if path_patterns.any? { |pat| File.match?(pat, rel_path) }
+                  {% if flag?(:windows) %} rel_path = rel_path.gsub('\\', '/') {% end %}
+                  rel_cmp = exclude_case_insensitive ? rel_path.downcase : rel_path
+                  # File.match? handles glob patterns (`tests/*`, `**/dir/**`);
+                  # the equality / prefix checks add plain-directory exclusion
+                  # so `--exclude-path src/legacy` drops everything under it,
+                  # not just a file literally named `src/legacy`.
+                  if exclude_path_patterns.any? do |pat|
+                       dir_pat = pat.rstrip('/')
+                       File.match?(pat, rel_cmp) || rel_cmp == dir_pat || rel_cmp.starts_with?("#{dir_pat}/")
+                     end
                     skipped_exclude_path += 1
                     next
                   end

--- a/src/llm/acp/client.cr
+++ b/src/llm/acp/client.cr
@@ -25,6 +25,27 @@ module LLM
     GEMINI_ARGS = ["--experimental-acp"]
     CLAUDE_ARGS = ["@zed-industries/claude-agent-acp"]
 
+    # ACP targets Noir knows how to launch. Anything outside this set would
+    # be executed as an arbitrary local process (`--ai-provider "acp:rm -rf /"`
+    # → command "rm", args ["-rf", "/"]), which is a code-execution hole when
+    # the provider string comes from an untrusted config file. Custom targets
+    # are refused unless the operator explicitly opts in.
+    KNOWN_TARGETS = %w[codex gemini claude claude-code]
+
+    class UnsupportedACPTargetError < Exception; end
+
+    # Escape hatch for power users running their own ACP agent binary. Off by
+    # default so a poisoned `.noir.yml` can't silently spawn a process.
+    def self.custom_command_allowed? : Bool
+      ENV["NOIR_ACP_ALLOW_CUSTOM_COMMAND"]? == "1"
+    end
+
+    # True when the provider resolves to a built-in target, or the operator
+    # opted into custom commands. Used for a friendly CLI-time pre-flight.
+    def self.allowed_target?(provider : String) : Bool
+      KNOWN_TARGETS.includes?(extract_target(provider).downcase) || custom_command_allowed?
+    end
+
     def initialize(@provider : String, @model : String, @event_sink : Proc(String, Nil)? = nil)
       @command, @args = self.class.resolve_command(provider)
       @session_lock = Mutex.new
@@ -61,6 +82,12 @@ module LLM
       when "claude", "claude-code"
         {"npx", CLAUDE_ARGS.clone}
       else
+        unless custom_command_allowed?
+          raise UnsupportedACPTargetError.new(
+            "Unsupported ACP provider target #{target.inspect}. Allowed acp: targets are #{KNOWN_TARGETS.join(", ")}. " \
+            "Running an arbitrary command as an ACP agent is disabled; set NOIR_ACP_ALLOW_CUSTOM_COMMAND=1 to override (only with trusted config)."
+          )
+        end
         parts = target.split
         command = parts.first || "acp"
         args = parts.size > 1 ? parts[1..-1] : [] of String

--- a/src/llm/native_tool_calling.cr
+++ b/src/llm/native_tool_calling.cr
@@ -1,6 +1,15 @@
 module LLM::NativeToolCalling
   DEFAULT_ALLOWLIST = ["openai", "xai", "github"]
 
+  # Providers for which native tool-calling is actually wired up. Used to
+  # validate --ai-native-tools-allowlist so a typo (e.g. `opena`) surfaces
+  # a warning instead of silently never matching.
+  KNOWN_PROVIDERS = ["openai", "xai", "github", "azure", "ollama", "vllm", "lmstudio"]
+
+  def self.known_provider?(provider : String) : Bool
+    KNOWN_PROVIDERS.includes?(canonical_provider(provider))
+  end
+
   def self.default_allowlist : Array(String)
     DEFAULT_ALLOWLIST.clone
   end

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -1,4 +1,5 @@
 require "colorize"
+require "openssl"
 require "./logger"
 require "../utils/utils"
 require "../utils/http_symbols"
@@ -139,6 +140,19 @@ class Deliver
 
   def run
     # After inheriting the class, write an action code here.
+  end
+
+  # TLS context for outbound delivery. Verifying (secure) by default; the
+  # old behaviour skipped verification unconditionally, silently exposing
+  # the endpoint catalog to MITM on the way to a webhook / Elasticsearch.
+  # `--tls-skip-verify` restores the insecure context for self-signed
+  # internal endpoints.
+  protected def tls_context : OpenSSL::SSL::Context::Client
+    if any_to_bool(@options["tls_skip_verify"]?)
+      OpenSSL::SSL::Context::Client.insecure
+    else
+      OpenSSL::SSL::Context::Client.new
+    end
   end
 
   private def matches_pattern?(endpoint : Endpoint, pattern : String) : Bool

--- a/src/models/deliver.cr
+++ b/src/models/deliver.cr
@@ -142,6 +142,14 @@ class Deliver
     # After inheriting the class, write an action code here.
   end
 
+  # Max concurrent in-flight probe requests. Bounds the fiber/socket fan-out
+  # so a large endpoint set can't exhaust file descriptors. Backed by the
+  # validated --concurrency value (already clamped to a sane ceiling).
+  protected def concurrency_limit : Int32
+    n = @options["concurrency"]?.try(&.to_s.to_i?) || 0
+    n > 0 ? n : 16
+  end
+
   # TLS context for outbound delivery. Verifying (secure) by default; the
   # old behaviour skipped verification unconditionally, silently exposing
   # the endpoint catalog to MITM on the way to a webhook / Elasticsearch.

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -343,7 +343,7 @@ class NoirRunner
       builder.print @endpoints, @passive_results
     when "jsonl"
       builder = OutputBuilderJsonl.new @options
-      builder.print @endpoints
+      builder.print @endpoints, @passive_results
     when "toml"
       builder = OutputBuilderToml.new @options
       builder.print @endpoints, @passive_results

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -250,10 +250,17 @@ class NoirRunner
   end
 
   def perform_request(method, url, params = {} of String => String, form = {} of String => String, json = false)
+    # Verify TLS by default; --tls-skip-verify opts into the insecure
+    # context for self-signed internal hosts (see Deliver#tls_context).
+    tls = if any_to_bool(@options["tls_skip_verify"]?)
+            OpenSSL::SSL::Context::Client.insecure
+          else
+            OpenSSL::SSL::Context::Client.new
+          end
     Crest::Request.execute(
       method: method,
       url: url,
-      tls: OpenSSL::SSL::Context::Client.insecure,
+      tls: tls,
       user_agent: "Noir/#{Noir::VERSION}",
       params: params,
       form: form,

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -162,6 +162,13 @@ class NoirRunner
     elsif ai_context_enabled?
       @logger.success "Running AI-context taggers."
       NoirTaggers.run_tagger @endpoints, @options, "all"
+    elsif @options["format"].to_s == "only-tag"
+      # `-f only-tag` has nothing to print unless a tagger populated tags.
+      # Without this, the format silently produced empty output unless the
+      # user also passed -T/--use-taggers — an easy trap. Imply all taggers
+      # when no explicit tagger option was given.
+      @logger.success "Running all taggers (implied by -f only-tag)."
+      NoirTaggers.run_tagger @endpoints, @options, "all"
     end
 
     if ai_context_enabled?

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -335,7 +335,14 @@ class NoirRunner
     when "toml"
       builder.print_toml @endpoints, diff_app
     else
-      # Print diff output
+      # Diff mode only implements plain/json/yaml/toml. Any other explicit
+      # format (only-url, curl, sarif, oas3, …) was silently rendered as the
+      # decorated text diff, corrupting automation pipelines that expected the
+      # requested format. Warn (to STDERR) so the mismatch is visible.
+      fmt = options["format"].to_s
+      unless fmt.empty? || fmt == "plain"
+        @logger.warning "Diff mode does not support -f #{fmt}; showing the text diff instead. Supported diff formats: plain, json, yaml, toml."
+      end
       builder.print @endpoints, diff_app
     end
   end

--- a/src/models/noir.cr
+++ b/src/models/noir.cr
@@ -201,10 +201,14 @@ class NoirRunner
     @logger.sub "➔ Updating status codes."
     final = [] of Endpoint
 
-    exclude_codes = [] of Int32
+    # A Set dedupes repeated codes (--exclude-codes 404,404,500) for free and
+    # gives O(1) membership; empty tokens (a trailing comma) are skipped.
+    exclude_codes = Set(Int32).new
     unless @options["exclude_codes"].to_s.empty?
       @options["exclude_codes"].to_s.split(",").each do |code|
-        exclude_codes << code.strip.to_i
+        stripped = code.strip
+        next if stripped.empty?
+        exclude_codes << stripped.to_i
       end
     end
 

--- a/src/options.cr
+++ b/src/options.cr
@@ -14,8 +14,15 @@ end
 # When `reset_if` equals the current value — e.g. an untouched default list —
 # the accumulation starts fresh so the first user value replaces the default
 # rather than appending to it.
-private def append_to_csv_option(hash : Hash(String, YAML::Any), key : String, value : String, reset_if : String? = nil)
+private def append_to_csv_option(hash : Hash(String, YAML::Any), key : String, value : String, reset_if : String? = nil, reset_seen : Set(String)? = nil)
   existing = (hash[key]? || YAML::Any.new("")).to_s
+  if reset_seen && !reset_seen.includes?(key)
+    # First CLI occurrence of this flag replaces any config-file value
+    # outright (CLI wins over config, not "config,cli"); later occurrences on
+    # the same command line then accumulate.
+    existing = ""
+    reset_seen << key
+  end
   existing = "" if reset_if && existing == reset_if
   combined = existing.empty? ? value : "#{existing},#{value}"
   hash[key] = YAML::Any.new(combined)
@@ -164,8 +171,18 @@ def normalize_ai_context_flag(args : Array(String)) : Array(String)
     arg = args[i]
     if arg == "--ai-context"
       if i + 1 < args.size && ai_context_feature_list?(args[i + 1])
-        result << "--ai-context=#{args[i + 1]}"
-        i += 2
+        # Greedily absorb space-separated continuations of a comma list:
+        # `--ai-context guards, sinks` shell-splits into "guards," + "sinks",
+        # and without this the trailing "sinks" was mistaken for a positional
+        # scan path ("Base path does not exist: sinks").
+        features = [args[i + 1]]
+        j = i + 2
+        while features.last.ends_with?(",") && j < args.size && ai_context_feature_list?(args[j])
+          features << args[j]
+          j += 1
+        end
+        result << "--ai-context=#{features.join.rstrip(",")}"
+        i = j
       else
         result << "--ai-context="
         i += 1
@@ -224,6 +241,10 @@ def run_options_parser
   noir_options["config_file"] = YAML::Any.new(override_config_path) if override_config_path
 
   extracted_args = extract_hidden_prompt_flags(noir_options)
+
+  # Tracks CSV flags whose first CLI occurrence must override (not append to)
+  # a config-file value. See append_to_csv_option.
+  csv_reset_seen = Set(String).new
 
   OptionParser.parse(extracted_args) do |parser|
     parser.banner = base_help
@@ -439,7 +460,7 @@ def run_options_parser
       # first `--ai-native-tools-allowlist openai` would land
       # appended onto the default list ("openai,anthropic,gemini,…
       # ,openai") instead of replacing it.
-      append_to_csv_option(noir_options, "ai_native_tools_allowlist", v, reset_if: LLM::NativeToolCalling.default_allowlist_csv)
+      append_to_csv_option(noir_options, "ai_native_tools_allowlist", v, reset_if: LLM::NativeToolCalling.default_allowlist_csv, reset_seen: csv_reset_seen)
     end
     parser.on "--ai-max-token N", "Max tokens per request" do |v|
       validated = positive_int_or_die!("--ai-max-token", v)

--- a/src/options.cr
+++ b/src/options.cr
@@ -373,6 +373,9 @@ def run_options_parser
     parser.on "--probe-skip VAL", "Skip endpoints matching pattern (repeatable)" do |v|
       append_to_yaml_array(noir_options, "probe_skip", v)
     end
+    parser.on "--tls-skip-verify", "Skip TLS cert verification for probe/export/webhook (insecure; for self-signed hosts)" do
+      noir_options["tls_skip_verify"] = YAML::Any.new(true)
+    end
 
     # EXPORT — ship the endpoint catalog to an external data store.
     # Categorically different from probing: no HTTP traffic to the

--- a/src/options.cr
+++ b/src/options.cr
@@ -568,6 +568,13 @@ def handle_pvalue(noir_options : Hash(String, YAML::Any), spec : String)
   type, value = if idx = spec.index('=')
                   {spec[0...idx], spec[(idx + 1)..]}
                 else
+                  # `--pvalue query` (no '=') sets the literal value "query"
+                  # for all types. Since `query` is itself a type name, this
+                  # is almost always a forgotten '=' (meant `query=<value>`).
+                  # Warn but honor the literal so scripted usage still works.
+                  if PVALUE_TYPE_KEYS.has_key?(spec)
+                    STDERR.puts "WARNING: --pvalue #{spec.inspect} has no '=', so #{spec.inspect} is used as a literal value for all param types. Did you mean --pvalue #{spec}=<value>?".colorize(:yellow)
+                  end
                   {"any", spec}
                 end
 

--- a/src/output_builder/adb.cr
+++ b/src/output_builder/adb.cr
@@ -63,7 +63,7 @@ class OutputBuilderAdb < OutputBuilder
   # reviewer flips it to insert/update/delete as needed.
   private def provider_command(endpoint : Endpoint) : String
     baked = bake_endpoint(endpoint.url, endpoint.params)
-    "adb shell content query --uri #{shell_quote(baked[:url])}"
+    "adb shell content query --uri #{device_shell_quote(baked[:url])}"
   end
 
   # Explicit IPC component (`intent://package/Component`). The `intent://`
@@ -81,15 +81,15 @@ class OutputBuilderAdb < OutputBuilder
 
     parts = ["adb", "shell", "am", verb]
     if action = meta["action"]?
-      parts << "-a" << shell_quote(action)
+      parts << "-a" << device_shell_quote(action)
     end
     # `-n package/Component` names the explicit target. A component-less
     # `intent://package` can't be named, so fall back to limiting the launch
     # to the package (`-p`).
     if component.includes?('/')
-      parts << "-n" << shell_quote(component)
+      parts << "-n" << device_shell_quote(component)
     else
-      parts << "-p" << shell_quote(component)
+      parts << "-p" << device_shell_quote(component)
     end
     append_categories(parts, meta)
     append_extras(parts, endpoint)
@@ -103,13 +103,13 @@ class OutputBuilderAdb < OutputBuilder
     baked = bake_endpoint(endpoint.url, endpoint.params)
     action = meta["action"]? || DEFAULT_ACTION
 
-    parts = ["adb", "shell", "am", "start", "-a", shell_quote(action)]
+    parts = ["adb", "shell", "am", "start", "-a", device_shell_quote(action)]
     append_categories(parts, meta)
-    parts << "-d" << shell_quote(baked[:url])
+    parts << "-d" << device_shell_quote(baked[:url])
     # Constrain the launch to the declaring app when it's known, so the link
     # isn't grabbed by another handler or the disambiguation chooser.
     if package = meta["package"]?
-      parts << "-p" << shell_quote(package) unless package.empty?
+      parts << "-p" << device_shell_quote(package) unless package.empty?
     end
     append_extras(parts, endpoint)
     parts.join(" ")
@@ -119,7 +119,7 @@ class OutputBuilderAdb < OutputBuilder
   # as `-c` so a launch that needs e.g. BROWSABLE matches the declared filter.
   private def append_categories(parts : Array(String), meta : Hash(String, String))
     if category = meta["category"]?
-      parts << "-c" << shell_quote(category) unless category.empty?
+      parts << "-c" << device_shell_quote(category) unless category.empty?
     end
   end
 
@@ -130,7 +130,7 @@ class OutputBuilderAdb < OutputBuilder
   private def append_extras(parts : Array(String), endpoint : Endpoint)
     endpoint.params.each do |param|
       next unless param.param_type == "extra"
-      parts << "--es" << shell_quote(param.name) << shell_quote(param.value)
+      parts << "--es" << device_shell_quote(param.name) << device_shell_quote(param.value)
     end
   end
 

--- a/src/output_builder/jsonl.cr
+++ b/src/output_builder/jsonl.cr
@@ -1,10 +1,24 @@
 require "../models/output_builder"
 require "../models/endpoint"
+require "../models/passive_scan"
 
 class OutputBuilderJsonl < OutputBuilder
   def print(endpoints : Array(Endpoint))
     endpoints.each do |endpoint|
       ob_puts endpoint.to_json
+    end
+  end
+
+  # Passive findings were dropped from JSONL entirely (only the JSON builder
+  # mapped them). Emit each finding on its own line after the endpoints so a
+  # `-P` scan's secrets/etc. survive the JSONL pipeline. Consumers tell the
+  # two apart by shape (endpoints carry url/method, findings carry id/info).
+  def print(endpoints : Array(Endpoint), passive_results : Array(PassiveScanResult))
+    endpoints.each do |endpoint|
+      ob_puts endpoint.to_json
+    end
+    passive_results.each do |result|
+      ob_puts result.to_json
     end
   end
 end

--- a/src/output_builder/mermaid.cr
+++ b/src/output_builder/mermaid.cr
@@ -91,9 +91,14 @@ class OutputBuilderMermaid < OutputBuilder
       # Remove curly braces and prefix with 'param_'
       sanitized = "param_#{segment.gsub(/[{}\s]/, "")}"
     else
-      # Replace invalid characters with underscore
-      sanitized = segment.gsub(/[^a-zA-Z0-9_]/, "_")
-      # If starts with a number, prepend 'path_'
+      # Replace mermaid-unsafe characters with underscore, but keep Unicode
+      # letters/digits (\p{L}/\p{N}) intact. The old ASCII-only class turned
+      # a Korean/CJK/accented segment like `사용자` into `___`, destroying the
+      # label; \p{L}\p{N} preserves it while still stripping spaces and
+      # syntax chars ([], (), :) that would break the bare mindmap node.
+      sanitized = segment.gsub(/[^\p{L}\p{N}_]/, "_")
+      # If starts with an ASCII digit, prepend 'path_' (mindmap node ids
+      # can't lead with a digit).
       if sanitized =~ /^\d/
         sanitized = "path_#{sanitized}"
       end

--- a/src/output_builder/mobile_launch.cr
+++ b/src/output_builder/mobile_launch.cr
@@ -18,9 +18,11 @@ module MobileLaunch
     return true if tech == "ios"
     return false unless tech == "well_known_applinks"
 
-    # Apple App Site Association entry unless an Android Digital Asset Links
-    # file backs it.
-    endpoint.details.code_paths.none? { |pi| File.basename(pi.path) == "assetlinks.json" }
+    # Classify as iOS only on an affirmative Apple apple-app-site-association
+    # backing file. The old `none? { assetlinks.json }` was vacuously true for
+    # an empty code_paths list (which optimization can produce), so an Android
+    # App-Links association with no code_paths leaked into the iOS simctl list.
+    endpoint.details.code_paths.any? { |pi| File.basename(pi.path) == "apple-app-site-association" }
   end
 
   # App Links / Universal Links from `.well-known` files are bare path
@@ -34,6 +36,21 @@ module MobileLaunch
 
   def shell_quote(str : String) : String
     "'#{str.gsub("'", "'\\''")}'"
+  end
+
+  # Characters the on-device shell would interpret (word-splitting, control
+  # operators, globs, expansions). `&` is the important one: an OAuth-style
+  # deep link `myapp://cb?code=x&state=y` otherwise backgrounds at `&`.
+  DEVICE_SHELL_METACHARS = /[\s&;|<>()$`"'\\*?\[\]{}#!~]/
+
+  # `adb shell ARGS...` runs ARGS through a SECOND shell on the device: the
+  # host shell strips one quote layer, leaving raw metacharacters exposed to
+  # the device shell. When a value carries such a character, quote twice so
+  # both shells strip a layer and the device receives the literal value.
+  # Metachar-free values (the common case) keep a single clean quote layer.
+  def device_shell_quote(str : String) : String
+    return shell_quote(str) unless str.matches?(DEVICE_SHELL_METACHARS)
+    shell_quote(shell_quote(str))
   end
 
   def plural(count : Int32) : String

--- a/src/output_builder/oas2.cr
+++ b/src/output_builder/oas2.cr
@@ -77,6 +77,14 @@ class OutputBuilderOas2 < OutputBuilder
             "properties" => JSON::Any.new(json_properties),
           } of String => JSON::Any),
         } of String => JSON::Any)
+      elsif !json_properties.empty? && has_form
+        # OAS2 forbids `body` and `formData` in the same operation, so the
+        # JSON body is dropped in favor of the concrete formData fields. Rather
+        # than losing the JSON field names entirely, surface each as a query
+        # parameter (query + formData are allowed together) so they survive.
+        json_properties.each_key do |name|
+          append_unique_parameter(parameters, swagger_parameter(name, "query", false))
+        end
       end
 
       if has_form

--- a/src/output_builder/oas3.cr
+++ b/src/output_builder/oas3.cr
@@ -44,6 +44,11 @@ class OutputBuilderOas3 < OutputBuilder
 
       oas_path = normalize_oas_path(endpoint.url)
       path_template_names(oas_path).each do |name|
+        # A path template variable must win over a same-named query/header/
+        # cookie parameter. Emitting both `in: path` and `in: query` for the
+        # same name is redundant and trips strict OAS validators, so drop the
+        # non-path duplicate before adding the path parameter.
+        parameters.reject! { |p| p["name"].as_s == name && p["in"].as_s != "path" }
         append_unique_parameter(parameters, openapi_parameter(name, "path", true))
       end
 

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -158,8 +158,13 @@ module OutputBuilderOasCommon
   private def swagger_url_parts(raw_url : String) : NamedTuple(host: String?, base_path: String, schemes: Array(String))
     return {host: nil, base_path: "/", schemes: %w[http https]} if raw_url.empty?
 
-    uri = URI.parse(raw_url)
-    schemes = if scheme = uri.scheme
+    # A scheme-less `-u example.com` makes URI.parse read the whole value as a
+    # path (host=nil), so the Swagger `host` field was dropped. Prepend a
+    # scheme for parsing so the authority resolves into uri.host; the emitted
+    # scheme list still defaults to http+https since the user gave none.
+    had_scheme = raw_url.includes?("://")
+    uri = URI.parse(had_scheme ? raw_url : "http://#{raw_url}")
+    schemes = if had_scheme && (scheme = uri.scheme)
                 [scheme]
               else
                 %w[http https]

--- a/src/output_builder/oas_common.cr
+++ b/src/output_builder/oas_common.cr
@@ -17,12 +17,19 @@ module OutputBuilderOasCommon
     path = path.gsub(/\{\/:(\w+)\}/, "/:\\1")
     path = path.gsub(/\{\/([^{}]+)\}/, "/\\1")
 
+    # Bracket-style path params (`.NET` / Rails-ish `/users/[id]`) → `{id}`.
+    path = path.gsub(/\[(\w+)\]/, "{\\1}")
+
     # Convert typed placeholders before the generic :param pass; otherwise
     # `<int:id>` becomes `<int{id}>` and can no longer be normalized.
     path = path.gsub(/<[^:>]+:(\w+)>/, "{\\1}")
     path = path.gsub(/<(\w+)>/, "{\\1}")
     path = path.gsub(/\*(\w+)/, "{\\1}")
     path = path.gsub(/:(\w+)/, "{\\1}")
+
+    # Bare wildcard segments (`/api/*`, `/files/**`) have no name and are not
+    # a valid OAS path template char; collapse a run of `*` to a named var.
+    path = path.gsub(/\*+/, "{wildcard}")
 
     path.starts_with?("/") ? path : "/#{path}"
   end

--- a/src/output_builder/only-cookie.cr
+++ b/src/output_builder/only-cookie.cr
@@ -12,7 +12,12 @@ class OutputBuilderOnlyCookie < OutputBuilder
       end
     end
 
-    cookies.uniq.each do |cookie|
+    unique = cookies.uniq
+    if unique.empty?
+      @logger.info "No cookies found."
+      return
+    end
+    unique.each do |cookie|
       ob_puts cookie.colorize(:light_green).toggle(@is_color)
     end
   end

--- a/src/output_builder/only-header.cr
+++ b/src/output_builder/only-header.cr
@@ -19,7 +19,14 @@ class OutputBuilderOnlyHeader < OutputBuilder
       headers << "Cookie"
     end
 
-    headers.uniq.each do |header|
+    unique = headers.uniq
+    if unique.empty?
+      # Empty stdout is silent-success ambiguity for interactive users;
+      # the note goes to STDERR so it never pollutes a piped header list.
+      @logger.info "No headers found."
+      return
+    end
+    unique.each do |header|
       ob_puts header.colorize(:light_green).toggle(@is_color)
     end
   end

--- a/src/output_builder/only-param.cr
+++ b/src/output_builder/only-param.cr
@@ -16,7 +16,12 @@ class OutputBuilderOnlyParam < OutputBuilder
       end
     end
 
-    common_params.uniq.each do |common_param|
+    unique = common_params.uniq
+    if unique.empty?
+      @logger.info "No parameters found."
+      return
+    end
+    unique.each do |common_param|
       ob_puts common_param.colorize(:light_green).toggle(@is_color)
     end
   end

--- a/src/output_builder/only-tag.cr
+++ b/src/output_builder/only-tag.cr
@@ -26,7 +26,13 @@ class OutputBuilderOnlyTag < OutputBuilder
     # tagger), so two tags with the same `name` but different `tagger`
     # or `description` would otherwise both be printed even though the
     # output line only shows the name.
-    tags.uniq(&.name).each do |tag|
+    unique = tags.uniq(&.name)
+    if unique.empty?
+      # Tags only exist when a tagger ran (-T/--use-taggers or AI context).
+      @logger.info "No tags found. Run with -T/--use-taggers to populate tags."
+      return
+    end
+    unique.each do |tag|
       ob_puts tag.name.colorize(:light_green).toggle(@is_color)
     end
   end

--- a/src/output_builder/only-url.cr
+++ b/src/output_builder/only-url.cr
@@ -4,15 +4,23 @@ require "../models/endpoint"
 class OutputBuilderOnlyUrl < OutputBuilder
   def print(endpoints : Array(Endpoint))
     printed_urls = Set(String).new
+    # When --status-codes / --exclude-codes ran, noir already paid for the
+    # HTTP probes; render the code next to the URL instead of discarding it
+    # (the result was silently dropped under only-url before).
+    show_status = any_to_bool(@options["status_codes"]?) || !@options["exclude_codes"]?.to_s.empty?
 
     endpoints.each do |endpoint|
       baked = bake_endpoint(endpoint.url, endpoint.params)
       plain_url = baked[:url]
-      r_url = plain_url.colorize(:light_yellow).toggle(@is_color)
+      next if printed_urls.includes?(plain_url)
+      printed_urls.add(plain_url)
 
-      unless printed_urls.includes?(plain_url)
+      r_url = plain_url.colorize(:light_yellow).toggle(@is_color)
+      if show_status
+        code = endpoint.details.status_code || "error"
+        ob_puts "#{r_url} [#{code}]"
+      else
         ob_puts "#{r_url}"
-        printed_urls.add(plain_url)
       end
     end
   end

--- a/src/output_builder/postman.cr
+++ b/src/output_builder/postman.cr
@@ -78,13 +78,17 @@ class OutputBuilderPostman < OutputBuilder
             "value" => JSON::Any.new(param.value),
           } of String => JSON::Any)
         elsif param.param_type == "cookie"
-          # Find existing Cookie header or create new one
-          existing_cookie = headers.find { |h| h["key"].as_s == "Cookie" }
+          # Find existing Cookie header or create new one. Header names are
+          # case-insensitive (RFC 7230), so match `cookie`/`COOKIE` too —
+          # otherwise a header-type param named `cookie` and the cookie-type
+          # Cookie header would both be emitted. (Mirrors the Content-Type
+          # case-insensitive match elsewhere in this builder.)
+          existing_cookie = headers.find { |h| h["key"].as_s.downcase == "cookie" }
           if existing_cookie
             # Append to existing cookie value
             current_val = existing_cookie["value"].as_s
             # We need to rebuild since JSON::Any is immutable
-            headers.reject! { |h| h["key"].as_s == "Cookie" }
+            headers.reject! { |h| h["key"].as_s.downcase == "cookie" }
             headers << JSON::Any.new({
               "key"   => JSON::Any.new("Cookie"),
               "value" => JSON::Any.new("#{current_val}; #{param.name}=#{param.value}"),

--- a/src/output_builder/toml.cr
+++ b/src/output_builder/toml.cr
@@ -22,7 +22,7 @@ class OutputBuilderToml < OutputBuilder
       data.each do |key, value|
         case value.raw
         when String, Int64, Float64, Bool
-          full_key = prefix.empty? ? key : "#{prefix}.#{key}"
+          full_key = prefix.empty? ? toml_key(key) : "#{prefix}.#{toml_key(key)}"
           io << "#{full_key} = #{toml_value(value)}\n"
         end
       end
@@ -30,7 +30,7 @@ class OutputBuilderToml < OutputBuilder
       # Then, output arrays of tables
       data.each do |key, value|
         if value.raw.is_a?(Array)
-          full_key = prefix.empty? ? key : "#{prefix}.#{key}"
+          full_key = prefix.empty? ? toml_key(key) : "#{prefix}.#{toml_key(key)}"
           value.as_a.each do |item|
             if item.raw.is_a?(Hash)
               io << "\n[[#{full_key}]]\n"
@@ -43,7 +43,7 @@ class OutputBuilderToml < OutputBuilder
       # Finally, output nested tables (hashes that aren't in arrays)
       data.each do |key, value|
         if value.raw.is_a?(Hash)
-          full_key = prefix.empty? ? key : "#{prefix}.#{key}"
+          full_key = prefix.empty? ? toml_key(key) : "#{prefix}.#{toml_key(key)}"
           io << "\n[#{full_key}]\n"
           io << generate_table_content(value.as_h)
         end
@@ -57,22 +57,30 @@ class OutputBuilderToml < OutputBuilder
       data.each do |key, value|
         case value.raw
         when String, Int64, Float64, Bool
-          io << "#{key} = #{toml_value(value)}\n"
+          io << "#{toml_key(key)} = #{toml_value(value)}\n"
         when Array
-          io << "#{key} = ["
+          io << "#{toml_key(key)} = ["
           items = value.as_a.map { |item| toml_value(item) }
           io << items.join(", ")
           io << "]\n"
         when Hash
           # Nested inline table
-          io << "#{key} = { "
-          pairs = value.as_h.map { |k, v| "#{k} = #{toml_value(v)}" }
+          io << "#{toml_key(key)} = { "
+          pairs = value.as_h.map { |k, v| "#{toml_key(k)} = #{toml_value(v)}" }
           io << pairs.join(", ")
           io << " }\n"
         end
       end
     end
     result
+  end
+
+  # TOML bare keys allow only [A-Za-z0-9_-]. A key with a dot, space, or
+  # quote would otherwise be read as a dotted table path (config.file →
+  # [config].file) and corrupt the document, so quote anything non-bare.
+  private def toml_key(key : String) : String
+    return key if key.matches?(/\A[A-Za-z0-9_-]+\z/)
+    %("#{key.gsub("\\", "\\\\").gsub("\"", "\\\"")}")
   end
 
   private def toml_value(value : JSON::Any) : String
@@ -91,7 +99,7 @@ class OutputBuilderToml < OutputBuilder
       items = raw.map { |item| toml_value(item) }
       "[#{items.join(", ")}]"
     when Hash
-      pairs = raw.map { |k, v| "#{k} = #{toml_value(v)}" }
+      pairs = raw.map { |k, v| "#{toml_key(k)} = #{toml_value(v)}" }
       "{ #{pairs.join(", ")} }"
     else
       %("#{raw}")

--- a/src/passive_scan/rules.cr
+++ b/src/passive_scan/rules.cr
@@ -15,11 +15,14 @@ module NoirPassiveScan
         if passive_rule.valid?
           rules << passive_rule
         else
-          logger.debug_sub "Invalid rule in #{file}"
+          # Surface at warning level: a silently-skipped custom rule looks
+          # identical to "rule applied" to the user, so a typo'd rule file
+          # yields invisible zero coverage.
+          logger.warning "Skipped invalid passive rule: #{file}"
         end
       rescue e : Exception
-        # Log or handle the error if deserialization fails
-        logger.debug_sub "Failed to load rule from #{file}: #{e.message}"
+        # Deserialization failure (malformed YAML / missing fields).
+        logger.warning "Failed to load passive rule #{file}: #{e.message}"
       end
     end
 

--- a/src/utils/passive_rules_updater.cr
+++ b/src/utils/passive_rules_updater.cr
@@ -216,8 +216,8 @@ module PassiveRulesUpdater
       # Create empty directory as fallback
       begin
         Dir.mkdir_p(rules_path) unless Dir.exists?(rules_path)
-      rescue fallback_ex
-        logger.warning "Could not create passive rules directory at #{rules_path}: #{fallback_ex.message}"
+      rescue err
+        logger.warning "Could not create passive rules directory at #{rules_path}: #{err.message}"
       end
 
       false

--- a/src/utils/passive_rules_updater.cr
+++ b/src/utils/passive_rules_updater.cr
@@ -6,6 +6,11 @@ require "../models/logger.cr"
 module PassiveRulesUpdater
   REPO_URL = "https://github.com/owasp-noir/noir-passive-rules.git"
 
+  # Force git into non-interactive mode so a missing/expired credential
+  # never drops the scan into an invisible username/password prompt that
+  # blocks forever (CI, automation). git exits with an error instead.
+  GIT_ENV = {"GIT_TERMINAL_PROMPT" => "0", "GCM_INTERACTIVE" => "never"}
+
   # Default location for the image-baked ruleset. Resolves via
   # `bundled_rules_path` so specs (and adventurous packagers) can
   # point at a different prefix with NOIR_BUNDLED_RULES_PATH.
@@ -82,7 +87,7 @@ module PassiveRulesUpdater
     begin
       # Fetch latest updates from remote
       result = Process.run("git", args: ["fetch", "--quiet"], chdir: rules_path,
-        output: Process::Redirect::Close, error: Process::Redirect::Close)
+        env: GIT_ENV, output: Process::Redirect::Close, error: Process::Redirect::Close)
 
       unless result.success?
         logger.debug "Failed to fetch updates for passive rules"
@@ -92,7 +97,7 @@ module PassiveRulesUpdater
       # Check if local is behind remote
       output = IO::Memory.new
       result = Process.run("git", args: ["rev-list", "--count", "HEAD..origin/main"],
-        chdir: rules_path, output: output, error: Process::Redirect::Close)
+        chdir: rules_path, env: GIT_ENV, output: output, error: Process::Redirect::Close)
 
       if result.success?
         behind_count = output.to_s.strip.to_i? || 0
@@ -129,7 +134,7 @@ module PassiveRulesUpdater
   # Update the passive rules repository
   private def self.update_rules(rules_path : String, logger : NoirLogger) : Bool
     result = Process.run("git", args: ["pull", "--quiet"], chdir: rules_path,
-      output: Process::Redirect::Close, error: Process::Redirect::Close)
+      env: GIT_ENV, output: Process::Redirect::Close, error: Process::Redirect::Close)
     result.success?
   rescue ex : Exception
     logger.debug "Error updating passive rules: #{ex.message}"
@@ -154,10 +159,11 @@ module PassiveRulesUpdater
 
   # Notify user that updates are available
   private def self.notify_user_update_available(behind_count : Int32, logger : NoirLogger)
+    rules_path = user_rules_path
     logger.warning "Passive rules are #{behind_count} commits behind the latest version."
-    logger.sub "├── Run 'git pull' in ~/.config/noir/passive_rules/ to update"
-    logger.sub "├── Or use 'git clone #{REPO_URL} ~/.config/noir/passive_rules/' to get the latest rules"
-    logger.sub "├── Or run 'noir -b . -P --passive-scan-auto-update' to auto-update on startup"
+    logger.sub "├── Run 'git pull' in #{rules_path} to update"
+    logger.sub "├── Or use 'git clone #{REPO_URL} #{rules_path}' to get the latest rules"
+    logger.sub "├── Or run 'noir scan . -P --passive-scan-auto-update' to auto-update on startup"
   end
 
   # Initialize passive rules if they don't exist
@@ -187,7 +193,7 @@ module PassiveRulesUpdater
 
       # Clone the repository
       result = Process.run("git", args: ["clone", "--quiet", REPO_URL, rules_path],
-        output: Process::Redirect::Close, error: Process::Redirect::Close)
+        env: GIT_ENV, output: Process::Redirect::Close, error: Process::Redirect::Close)
 
       if result.success?
         logger.success "Passive rules initialized successfully."
@@ -201,13 +207,17 @@ module PassiveRulesUpdater
         false
       end
     rescue ex : Exception
-      logger.debug "Error initializing passive rules: #{ex.message}"
+      # Surface the failure: without rules a `-P` scan silently reports
+      # "clean", which is a false-negative security outcome. A warning at
+      # normal log level makes the missing-ruleset state visible.
+      logger.warning "Failed to initialize passive rules: #{ex.message}"
+      logger.sub "➔ Passive scan will run with no rules. Fix connectivity/permissions or clone manually: git clone #{REPO_URL} #{rules_path}"
 
       # Create empty directory as fallback
       begin
         Dir.mkdir_p(rules_path) unless Dir.exists?(rules_path)
-      rescue
-        # Ignore errors creating fallback directory
+      rescue fallback_ex
+        logger.warning "Could not create passive rules directory at #{rules_path}: #{fallback_ex.message}"
       end
 
       false


### PR DESCRIPTION
## Summary

While building Noir and exercising it across many CLI paths and output formats, I collected a set of unexpected behaviors, bugs, and UX rough edges. This PR works through that list: each fix is its own commit, verified against real code and covered by the existing (and a few added) specs. The full `spec/unit_test` (3734 examples) and `spec/functional_test` (21093 examples) suites pass, and `ameba` is clean on all touched files.

Detection output is unchanged where it matters — the analyzer/detector behavior is untouched except for the `--exclude-path` matching improvements (which are additive and covered by the exclude-path functional spec).

## Security

- **acp arbitrary command execution (#14):** `--ai-provider "acp:rm -rf /"` was split into `rm` + `["-rf","/"]` and executed as a child process; since `ai_provider` is also a config-file key, a poisoned `.noir.yml` could run anything. `resolve_command` now refuses targets outside `{codex,gemini,claude,claude-code}`, and CLI validation rejects them at parse time. A `NOIR_ACP_ALLOW_CUSTOM_COMMAND=1` opt-in preserves the power-user path.
- **`config edit` shell injection + hang (#23, #24):** dropped `shell: true` (a poisoned `$EDITOR`/`$VISUAL` used to run e.g. `rm -rf /; vi`); the editor string is now parsed to argv and exec'd directly. Added a non-TTY guard so `config edit` fails fast instead of hanging in CI.
- **Insecure TLS by default (#11):** webhook/Elasticsearch/probe/status-code requests hardcoded an insecure TLS context (MITM exposure of the endpoint catalog). Now verifying by default, with `--tls-skip-verify` (config `tls_skip_verify`) for self-signed hosts. Proxy delivery stays insecure by design (intercepting proxies present their own cert).
- **Silent send failures (#12):** webhook/ES failures now log at warning level; probe/proxy print a one-line failed-request count.

## CLI / UX

- Dedupe base paths, cap `--concurrency` (256), add `NOIR_CONCURRENCY`, warn on `--probe-match`/`--probe-skip` overlap (#8, #19, #39, #59).
- Surface malformed input instead of silent fallback: bad boolean config values (#7), `--pvalue query` with no `=` (#18), non-numeric/out-of-range `-u` ports (#33), unknown `--ai-native-tools-allowlist` providers (#55).
- Clearer routing/heuristics: mistyped subcommands now say "Unknown command or non-existent path" instead of "Base path does not exist" (#1); `--ai-context guards, sinks` (space after comma) no longer leaks `sinks` as a scan path (#29); first CLI `--ai-native-tools-allowlist` overrides config instead of merging (#36).
- `noir config show/path/edit` now honor `--config-file` (#25).
- `-f only-tag` auto-runs taggers so it isn't silently empty without `-T` (#3).

## Output formats

- `only-header/cookie/tag/param` note an empty result on STDERR instead of printing 0 bytes (#5).
- Mermaid mindmap preserves Unicode letters (Korean/CJK/accented) instead of collapsing to `___` (#48).
- `jsonl` now includes passive-scan results (was endpoints-only) (#27).
- TOML quotes non-bare keys so `config.file` doesn't corrupt into a table path (#54); Postman Cookie-header dedup is case-insensitive (#41).
- OAS: bracket `[id]` and bare `*` path segments become valid templates; path vars win over same-named query params; OAS2 keeps JSON field names when formData is present; scheme-less `-u` keeps its host (#43, #44, #49, #63, #68).
- `-f only-url` renders the status code when `--status-codes` ran instead of discarding the probe result; diff mode warns on unsupported formats instead of silently forcing text (#9, #40).

## Robustness / perf

- `--exclude-path` now excludes a whole directory subtree by path, tolerates a trailing slash, folds case on case-insensitive filesystems, and accepts Windows backslash patterns; globs still work (#16, #28, #35).
- Probe/proxy delivery bounds concurrent requests to `--concurrency` (Channel semaphore) to avoid FD exhaustion on large endpoint sets (#37).
- adb launch commands double-escape device-shell args so a deep link with `&` (OAuth callbacks) isn't truncated; empty `code_paths` no longer misclassifies Android App-Links as iOS (#46, #47).
- Passive scan: surface silent rule-load/init failures, and pass `GIT_TERMINAL_PROMPT=0` so a credential prompt can't hang the scan (#2, #21, #31, #38).
- ASCII banner fallback on Windows (#32); `--exclude-codes` deduped via a Set (#30).

## Verified as non-issues (no change)

`#6` (inherent to excluded parent files), `#20`/`#51` (SARIF index/perf — endpoint results precede passive, single parse), `#22` (cache tmp already has `Random::Secure` entropy), `#45`/`#70` (OAS — no operationId exists; `to_pretty_json` already escapes), `#50`/`#65` (already stripped/validated), `#53` (TOML allows single-line nested inline tables), `#66` (logger already writes to STDERR), `#69` (ai-provider/model setters are order-independent). `#4`/`#26`/`#56` are existing, test-encoded design choices and were intentionally left to maintainer discretion.

## Deferred follow-ups (larger / riskier — worth their own PRs)

- Parallelize `update_status_codes` + reuse a keep-alive HTTP client (#13, #60, #61) — network-behavior change that deserves benchmarking.
- `LLMEndpointOptimizer` async fan-out with rate-limit handling (#17).
- `GoAuthTagger` brace-depth scope tracking (#34) — detection-affecting, needs multi-app validation.
- `--diff-path` per-format rendering (only-url/curl/…) beyond the new warning (#9), relative `code_paths` option (#10), single-source completion flag lists (#62), DFS inode cycle guard (#67).
