### PR TITLE
fix(cli/cache): unit rollover, age clamp, --no-log gate, and global-flag routing

### DIFF
--- a/spec/unit_test/cli/cache_command_spec.cr
+++ b/spec/unit_test/cli/cache_command_spec.cr
@@ -209,6 +209,42 @@ describe Noir::CLI::CacheCommand do
     end
   end
 
+  describe ".format_bytes" do
+    it "prints raw bytes below 1 KiB" do
+      Noir::CLI::CacheCommand.format_bytes(0_i64).should eq("0 B")
+      Noir::CLI::CacheCommand.format_bytes(1023_i64).should eq("1023 B")
+    end
+
+    it "scales into KB / MB / GB" do
+      Noir::CLI::CacheCommand.format_bytes(1024_i64).should eq("1.0 KB")
+      Noir::CLI::CacheCommand.format_bytes(1500_i64).should eq("1.5 KB")
+      Noir::CLI::CacheCommand.format_bytes(1048576_i64).should eq("1.0 MB")
+      Noir::CLI::CacheCommand.format_bytes(1073741824_i64).should eq("1.0 GB")
+    end
+
+    it "rolls over to the next unit at a rounding boundary instead of printing 1024.0" do
+      # 1 MiB - 1 byte rounds to 1024.0 KB in one decimal; it must
+      # display as 1.0 MB, not 1024.0 KB. Same one level up for GB.
+      Noir::CLI::CacheCommand.format_bytes(1048575_i64).should eq("1.0 MB")
+      Noir::CLI::CacheCommand.format_bytes(1073741823_i64).should eq("1.0 GB")
+    end
+  end
+
+  describe ".format_age" do
+    it "renders sub-minute / minute / hour / day granularity" do
+      Noir::CLI::CacheCommand.format_age(Time.utc - 5.seconds).should eq("5s")
+      Noir::CLI::CacheCommand.format_age(Time.utc - 3.minutes).should eq("3m")
+      Noir::CLI::CacheCommand.format_age(Time.utc - 2.hours).should eq("2h")
+      Noir::CLI::CacheCommand.format_age(Time.utc - 4.days).should eq("4d")
+    end
+
+    it "clamps a future-dated entry to 0s instead of a negative age" do
+      # Clock skew / NTP jump / manual touch can leave a cache mtime in
+      # the future. The display must not read "-3599s".
+      Noir::CLI::CacheCommand.format_age(Time.utc + 1.hour).should eq("0s")
+    end
+  end
+
   describe ".print_help" do
     it "lists every supported action and the scan-time flags" do
       io = IO::Memory.new

--- a/spec/unit_test/cli/router_spec.cr
+++ b/spec/unit_test/cli/router_spec.cr
@@ -2,6 +2,7 @@ require "../../spec_helper"
 require "colorize"
 require "../../../src/cli/common"
 require "../../../src/cli/legacy"
+require "../../../src/cli/router"
 
 # These specs exercise the slim, side-effect-free portions of the v1 CLI
 # routing layer — terminal-flag rewriting, command lookup, and the
@@ -134,6 +135,34 @@ describe "Noir::CLI::KNOWN_COMMANDS" do
     %w[scan list cache config rules completion version help].each do |verb|
       Noir::CLI::KNOWN_COMMANDS.includes?(verb).should be_true
     end
+  end
+end
+
+describe "Noir::CLI::Router.strip_global_flags" do
+  # The thin subcommands (list/cache/config/rules/completion/version/help)
+  # treat their first positional as the action/subject, so a leading
+  # `--no-color` was misread as one ("Unknown cache action: --no-color").
+  # The router consumes the global flags itself and strips them before
+  # handing argv to those parsers.
+  it "drops --no-color so a thin subcommand sees its real action" do
+    Noir::CLI::Router.strip_global_flags(["--no-color"]).should eq([] of String)
+    Noir::CLI::Router.strip_global_flags(["info", "--no-color"]).should eq(["info"])
+    Noir::CLI::Router.strip_global_flags(["--no-color", "info"]).should eq(["info"])
+  end
+
+  it "drops --no-spinner as well" do
+    Noir::CLI::Router.strip_global_flags(["--no-spinner", "techs"]).should eq(["techs"])
+  end
+
+  it "strips every occurrence and preserves the order of the rest" do
+    Noir::CLI::Router.strip_global_flags(
+      ["--no-color", "purge", "--no-spinner", "7"]
+    ).should eq(["purge", "7"])
+  end
+
+  it "leaves argv without global flags untouched" do
+    argv = ["purge", "7"]
+    Noir::CLI::Router.strip_global_flags(argv).should eq(argv)
   end
 end
 

--- a/src/cli/commands/cache.cr
+++ b/src/cli/commands/cache.cr
@@ -134,17 +134,29 @@ module Noir::CLI::CacheCommand
     io.puts msg
   end
 
-  private def self.format_bytes(bytes : Int64) : String
+  # Public so the unit ladder (B/KB/MB/GB) can be exercised directly,
+  # matching the testability philosophy the rest of this module follows.
+  #
+  # The unit decision compares against the *rounded* value, not the raw
+  # one: just below a 1024 boundary the raw value stays under 1024 while
+  # rounding to one decimal lands on 1024.0, which printed as e.g.
+  # "1024.0 KB" instead of rolling over to "1.0 MB".
+  def self.format_bytes(bytes : Int64) : String
     return "#{bytes} B" if bytes < 1024
     kb = bytes / 1024.0
-    return "#{kb.round(1)} KB" if kb < 1024
+    return "#{kb.round(1)} KB" if kb.round(1) < 1024
     mb = kb / 1024.0
-    return "#{mb.round(1)} MB" if mb < 1024
+    return "#{mb.round(1)} MB" if mb.round(1) < 1024
     "#{(mb / 1024.0).round(2)} GB"
   end
 
-  private def self.format_age(t : Time) : String
+  # Public for the same reason as `format_bytes`. Clamps to 0 for a
+  # future-dated `t` (clock skew, an NTP jump, a manually `touch`'d
+  # file) so the display never shows a negative "-3599s ago" that reads
+  # like a parsing bug.
+  def self.format_age(t : Time) : String
     seconds = (Time.utc - t.to_utc).total_seconds.to_i64
+    seconds = 0_i64 if seconds < 0
     return "#{seconds}s" if seconds < 60
     minutes = seconds // 60
     return "#{minutes}m" if minutes < 60

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -77,9 +77,17 @@ module Noir::CLI::ScanCommand
 
     begin
       outcome = LLM::Cache.clear
-      msg = "CACHE: Cleared #{outcome.deleted} entries."
-      msg += " (#{outcome.failed} failed)" if outcome.failed > 0
-      STDERR.puts msg
+      # Suppress the status line under --no-log ("Show only results"):
+      # every other scan log line respects it, and this one would
+      # otherwise leak into a result stream a script expects to be
+      # clean. The clear itself still happens — only the message is
+      # gated. The runner's logger isn't built yet at this point, so
+      # gate on the raw option rather than routing through it.
+      unless noir_options["nolog"] == true
+        msg = "CACHE: Cleared #{outcome.deleted} entries."
+        msg += " (#{outcome.failed} failed)" if outcome.failed > 0
+        STDERR.puts msg
+      end
     rescue
       # Cache may not be initialized yet; best-effort clear.
     end

--- a/src/cli/router.cr
+++ b/src/cli/router.cr
@@ -70,16 +70,32 @@ module Noir::CLI::Router
     true
   end
 
+  # Router-consumed global flags. `apply_global_color_flag!` already
+  # acted on `--no-color`, and `--no-spinner` only means anything to a
+  # scan's loading spinner. Neither is meaningful to the thin
+  # subcommands, whose "first positional = action/subject" parsers would
+  # otherwise misread a leading `--no-color` as the action itself
+  # (`Unknown cache action: --no-color`). They're stripped before those
+  # commands parse. `scan` is deliberately excluded: its own OptionParser
+  # re-reads both flags to thread color/spinner state through
+  # NoirRunner, so scan keeps the full argv.
+  GLOBAL_FLAGS = ["--no-color", "--no-spinner"]
+
+  # Pure helper (no exit/die) so the strip rule stays unit-testable.
+  def self.strip_global_flags(args : Array(String)) : Array(String)
+    args.reject { |arg| GLOBAL_FLAGS.includes?(arg) }
+  end
+
   private def self.route(command : String, args : Array(String))
     case command
     when "scan"       then ScanCommand.run(args)
-    when "list"       then ListCommand.run(args)
-    when "cache"      then CacheCommand.run(args)
-    when "config"     then ConfigCommand.run(args)
-    when "rules"      then RulesCommand.run(args)
-    when "completion" then CompletionCommand.run(args)
-    when "version"    then VersionCommand.run(args)
-    when "help"       then HelpCommand.run(args)
+    when "list"       then ListCommand.run(strip_global_flags(args))
+    when "cache"      then CacheCommand.run(strip_global_flags(args))
+    when "config"     then ConfigCommand.run(strip_global_flags(args))
+    when "rules"      then RulesCommand.run(strip_global_flags(args))
+    when "completion" then CompletionCommand.run(strip_global_flags(args))
+    when "version"    then VersionCommand.run(strip_global_flags(args))
+    when "help"       then HelpCommand.run(strip_global_flags(args))
     else
       # KNOWN_COMMANDS guards this branch — should never be reached.
       Noir::CLI.die("Unknown command: #{command}")


### PR DESCRIPTION
Fixes four gaps found while manually exercising `noir cache` (info/clear/purge) and the scan-time cache flags. Existing spec coverage already handles argv/day parsing and the common edge cases; these are the ones that survived it.

### 1. `cache info` size formatting didn't roll over at unit boundaries
`format_bytes` picked the unit (B/KB/MB/GB) from the **unrounded** value but printed the **rounded** one. Just below a power-of-1024 boundary this printed e.g. `1024.0 KB` instead of rolling over to `1.0 MB` (same for the GB boundary at 1 GiB − 1).

```
# before:  Total size:  1024.0 KB
# after:   Total size:  1.0 MB
```

Now the unit decision compares the rounded value.

### 2. `cache info` showed a negative age for future-dated entries
`format_age` computed `Time.utc - t` and never clamped, so a cache file with a future mtime (clock skew, NTP jump, a manually `touch`'d file) printed a negative `-3599s ago` that reads like a parsing bug. Now clamped to `0s`.

### 3. `--cache-clear`'s status line ignored `--no-log`
`ScanCommand.apply_cache_flags` wrote `CACHE: Cleared N entries.` via a raw `STDERR.puts`, bypassing the `--no-log` contract ("Show only results") that every other scan log line respects — leaking one line into a result stream a script expects to be clean. The clear still happens; only the message is now gated on `nolog` (the runner's logger isn't built yet at this point).

### 4. `noir cache --no-color` was misparsed as the action
`apply_global_color_flag!` flipped `Colorize.enabled` for `--no-color` but left the token in `argv`, so the thin subcommands (`list`/`cache`/`config`/`rules`/`completion`/`version`) — whose first positional is the action/subject — misread it:

```
$ noir cache --no-color
ERROR: Unknown cache action: --no-color. Valid: info, clear, purge.
```

The router now strips its consumed global flags (`--no-color`, `--no-spinner`) before dispatching to those commands, so they behave like `noir cache` (uncolored help). `scan` is deliberately excluded — its own OptionParser re-reads both flags to thread color/spinner state through `NoirRunner`.

### Tests
- `format_bytes` / `format_age` boundary + clamp coverage (methods made public to match this module's testability philosophy).
- `Router.strip_global_flags` unit coverage.
- Full unit suite green (`3743 examples, 0 failures`).