### PR TITLE
fix(cli/list): repair dead tech aliases, metadata gaps, and add machine-readable output

### DIFF
--- a/spec/unit_test/cli/list_command_spec.cr
+++ b/spec/unit_test/cli/list_command_spec.cr
@@ -1,12 +1,16 @@
 require "../../spec_helper"
+require "json"
+require "yaml"
 require "../../../src/cli/commands/list"
 
 describe Noir::CLI::ListCommand do
   describe ".parse_argv" do
-    it "returns subject=nil, help=false when called with no args" do
+    it "returns subject=nil, format=text, help=false when called with no args" do
       parsed = Noir::CLI::ListCommand.parse_argv([] of String)
       parsed.subject.should be_nil
+      parsed.format.should eq("text")
       parsed.help.should be_false
+      parsed.errors.should be_empty
     end
 
     it "captures the first positional as the subject" do
@@ -15,14 +19,33 @@ describe Noir::CLI::ListCommand do
       Noir::CLI::ListCommand.parse_argv(["formats"]).subject.should eq("formats")
     end
 
-    it "first positional wins over subsequent positionals" do
-      Noir::CLI::ListCommand.parse_argv(["techs", "extra"]).subject.should eq("techs")
-    end
-
     it "flags -h / --help anywhere in argv" do
       Noir::CLI::ListCommand.parse_argv(["-h"]).help.should be_true
       Noir::CLI::ListCommand.parse_argv(["--help"]).help.should be_true
       Noir::CLI::ListCommand.parse_argv(["techs", "--help"]).help.should be_true
+    end
+
+    it "parses -f / --format (space and = forms)" do
+      Noir::CLI::ListCommand.parse_argv(["techs", "-f", "json"]).format.should eq("json")
+      Noir::CLI::ListCommand.parse_argv(["techs", "--format", "yaml"]).format.should eq("yaml")
+      Noir::CLI::ListCommand.parse_argv(["techs", "-f=json"]).format.should eq("json")
+      Noir::CLI::ListCommand.parse_argv(["techs", "--format=yaml"]).format.should eq("yaml")
+    end
+
+    it "records an error for a stray positional instead of silently ignoring it" do
+      parsed = Noir::CLI::ListCommand.parse_argv(["techs", "garbage"])
+      parsed.subject.should eq("techs")
+      parsed.errors.should_not be_empty
+    end
+
+    it "records an error for an unknown option" do
+      parsed = Noir::CLI::ListCommand.parse_argv(["techs", "--nope"])
+      parsed.errors.first.should contain("--nope")
+    end
+
+    it "records an error when -f is given without a value" do
+      parsed = Noir::CLI::ListCommand.parse_argv(["techs", "-f"])
+      parsed.errors.should_not be_empty
     end
   end
 
@@ -32,16 +55,65 @@ describe Noir::CLI::ListCommand do
     end
   end
 
+  describe "LIST_FORMATS constant" do
+    it "offers a human default plus the two machine formats" do
+      Noir::CLI::ListCommand::LIST_FORMATS.should eq(%w[text json yaml])
+    end
+  end
+
   describe ".print_help" do
-    it "names every supported subject" do
+    it "names every supported subject and the format option" do
       io = IO::Memory.new
       Noir::CLI::ListCommand.print_help(io)
       out = io.to_s
       %w[techs taggers formats].each { |subject| out.should contain(subject) }
+      out.should contain("--format")
       # Legacy aliases should be cross-referenced so users who knew the
       # v0 names can find the v1 verb.
       out.should contain("--list-techs")
       out.should contain("--list-taggers")
+    end
+  end
+
+  describe ".print_techs" do
+    it "emits valid JSON carrying the synthesized callee / ai_context flags" do
+      io = IO::Memory.new
+      Noir::CLI::ListCommand.print_techs("json", io)
+      doc = JSON.parse(io.to_s)
+      # go_gin now carries the schema keys that used to be missing.
+      supported = doc["go_gin"]["supported"]
+      supported["static_path"].as_bool.should be_false
+      supported["websocket"].as_bool.should be_false
+      supported["callee"].as_bool?.should_not be_nil
+      supported["ai_context"]["guards"].as_bool?.should_not be_nil
+    end
+
+    it "emits valid YAML" do
+      io = IO::Memory.new
+      Noir::CLI::ListCommand.print_techs("yaml", io)
+      doc = YAML.parse(io.to_s)
+      doc["js_express"]["supported"]["callee"].as_bool.should be_true
+    end
+  end
+
+  describe ".print_taggers" do
+    it "emits JSON without leaking the internal :runner class reference" do
+      io = IO::Memory.new
+      Noir::CLI::ListCommand.print_taggers("json", io)
+      doc = JSON.parse(io.to_s)
+      doc["taggers"].as_a.each do |tagger|
+        tagger.as_h.has_key?("runner").should be_false
+        tagger["id"].as_s.should_not be_empty
+      end
+    end
+  end
+
+  describe ".print_formats" do
+    it "emits the same catalog as the text view, as JSON" do
+      io = IO::Memory.new
+      Noir::CLI::ListCommand.print_formats("json", io)
+      doc = JSON.parse(io.to_s)
+      doc["formats"].as_a.map(&.as_s).should eq(Noir::CliValidation::VALID_OUTPUT_FORMATS)
     end
   end
 end

--- a/spec/unit_test/techs/techs_spec.cr
+++ b/spec/unit_test/techs/techs_spec.cr
@@ -18,6 +18,34 @@ describe "Similar to tech" do
   it "False case" do
     NoirTechs.similar_to_tech("Noir").should_not eq "ruby_rails"
   end
+
+  # Regression: mixed-case aliases used to be dead because only the user input
+  # was lowercased while the stored alias was compared verbatim. The comparison
+  # is now case-insensitive on both sides.
+  it "resolves mixed-case aliases regardless of typed casing" do
+    NoirTechs.similar_to_tech("BaseHTTPRequestHandler").should eq "python_http_server"
+    NoirTechs.similar_to_tech("basehttprequesthandler").should eq "python_http_server"
+    NoirTechs.similar_to_tech("WEBrick::HTTPServer").should eq "ruby_webrick"
+    NoirTechs.similar_to_tech("abstractservlet").should eq "ruby_webrick"
+  end
+end
+
+describe "Supported metadata schema" do
+  # Every framework-level tech (one with a :framework key) should declare
+  # :static_path and :websocket explicitly so `noir list techs` renders a
+  # consistent shape across siblings instead of silently omitting lines.
+  it "declares static_path and websocket for every framework tech" do
+    missing = [] of String
+    NoirTechs.techs.each do |key, info|
+      next unless info.has_key?(:framework)
+      supported = info[:supported]?
+      next unless supported.is_a?(Hash)
+      unless supported.has_key?(:static_path) && supported.has_key?(:websocket)
+        missing << key.to_s
+      end
+    end
+    missing.should be_empty
+  end
 end
 
 describe "Get Techs" do

--- a/src/cli/commands/list.cr
+++ b/src/cli/commands/list.cr
@@ -1,4 +1,6 @@
 require "colorize"
+require "json"
+require "yaml"
 require "../common"
 require "../../techs/techs"
 require "../../tagger/tagger"
@@ -13,36 +15,84 @@ module Noir::CLI::ListCommand
   SUBJECTS         = %w[techs taggers formats]
   AI_CONTEXT_KINDS = %w[guards sinks validators signals]
 
+  # Output formats `list` itself understands. `text` is the human-readable
+  # default; `json`/`yaml` re-serialize the same catalogs for scripting.
+  LIST_FORMATS = %w[text json yaml]
+
   # Parsed argv. Extracted from `run` so the parser stays unit-testable
-  # without going through the `exit`/`die` side effects.
-  record Parsed, subject : String?, help : Bool
+  # without going through the `exit`/`die` side effects. `errors` collects
+  # unrecognized flags / stray positionals so `run` can reject them instead
+  # of silently ignoring anything after the subject.
+  record Parsed,
+    subject : String?,
+    format : String,
+    help : Bool,
+    errors : Array(String)
 
   def self.parse_argv(argv : Array(String)) : Parsed
     subject = nil
+    format = "text"
     help = false
-    argv.each do |a|
-      case a
+    errors = [] of String
+
+    i = 0
+    while i < argv.size
+      arg = argv[i]
+      case arg
       when "-h", "--help"
         help = true
+      when "-f", "--format"
+        value = argv[i + 1]?
+        if value.nil?
+          errors << "#{arg} requires a value (one of: #{LIST_FORMATS.join(", ")})"
+        else
+          format = value
+          i += 1
+        end
+      when .starts_with?("-f=")
+        format = arg[3..]
+      when .starts_with?("--format=")
+        format = arg[9..]
+      when .starts_with?("-")
+        errors << "unknown option: #{arg}"
       else
-        subject ||= a
+        if subject.nil?
+          subject = arg
+        else
+          errors << "unexpected argument: #{arg}"
+        end
       end
+      i += 1
     end
-    Parsed.new(subject: subject, help: help)
+
+    Parsed.new(subject: subject, format: format, help: help, errors: errors)
   end
 
   def self.run(argv : Array(String))
     parsed = parse_argv(argv)
 
-    if parsed.help || parsed.subject.nil?
+    if parsed.help
       print_help
       exit
     end
 
+    unless parsed.errors.empty?
+      Noir::CLI.die("noir list: #{parsed.errors.join("; ")}")
+    end
+
+    if parsed.subject.nil?
+      print_help
+      exit
+    end
+
+    unless LIST_FORMATS.includes?(parsed.format)
+      Noir::CLI.die("noir list: unknown format \"#{parsed.format}\". Valid: #{LIST_FORMATS.join(", ")}.")
+    end
+
     case parsed.subject
-    when "techs"   then print_techs
-    when "taggers" then print_taggers
-    when "formats" then print_formats
+    when "techs"   then print_techs(parsed.format)
+    when "taggers" then print_taggers(parsed.format)
+    when "formats" then print_formats(parsed.format)
     else
       Noir::CLI.die("Unknown list subject: #{parsed.subject}. Valid: #{SUBJECTS.join(", ")}.")
     end
@@ -54,12 +104,15 @@ module Noir::CLI::ListCommand
 
     io.puts <<-HELP
       #{green.call("USAGE:")}
-        noir list <subject>
+        noir list <subject> [-f/--format text|json|yaml]
 
       #{green.call("SUBJECTS:")}
         #{cyan.call("techs")}                  Supported technologies and analyzer details
         #{cyan.call("taggers")}                Built-in and framework-specific taggers
         #{cyan.call("formats")}                Supported output formats
+
+      #{green.call("OPTIONS:")}
+        -f, --format <fmt>     Output as text (default), json, or yaml
 
       #{green.call("LEGACY ALIASES")} (still work in v1.x):
         --list-techs           → noir list techs
@@ -67,47 +120,112 @@ module Noir::CLI::ListCommand
       HELP
   end
 
-  def self.print_techs
-    puts "Available technologies:"
+  def self.print_techs(format : String = "text", io : IO = STDOUT)
+    case format
+    when "json" then io.puts techs_document.to_json
+    when "yaml" then io.puts techs_document.to_yaml
+    else             print_techs_text(io)
+    end
+  end
+
+  def self.print_taggers(format : String = "text", io : IO = STDOUT)
+    case format
+    when "json" then io.puts taggers_document.to_json
+    when "yaml" then io.puts taggers_document.to_yaml
+    else             print_taggers_text(io)
+    end
+  end
+
+  def self.print_formats(format : String = "text", io : IO = STDOUT)
+    case format
+    when "json" then io.puts({"formats" => Noir::CliValidation::VALID_OUTPUT_FORMATS}.to_json)
+    when "yaml" then io.puts({"formats" => Noir::CliValidation::VALID_OUTPUT_FORMATS}.to_yaml)
+    else             print_formats_text(io)
+    end
+  end
+
+  private def self.print_techs_text(io : IO)
+    io.puts "Available technologies:"
     NoirTechs.techs.each do |tech, info|
-      puts " #{tech.to_s.colorize(:green)}"
+      io.puts " #{tech.to_s.colorize(:green)}"
       info.each do |k, v|
         if v.is_a?(Hash)
-          puts "   #{k.to_s.colorize(:blue)}:"
-          v.each { |sk, sv| puts "     #{sk.to_s.colorize(:cyan)}: #{sv}" }
-          print_context_support(tech.to_s) if k.to_s == "supported"
+          io.puts "   #{k.to_s.colorize(:blue)}:"
+          v.each { |sk, sv| io.puts "     #{sk.to_s.colorize(:cyan)}: #{sv}" }
+          print_context_support(tech.to_s, io) if k.to_s == "supported"
         else
-          puts "   #{k.to_s.colorize(:blue)}: #{v}"
+          io.puts "   #{k.to_s.colorize(:blue)}: #{v}"
         end
       end
     end
   end
 
-  def self.print_taggers
-    puts "Available taggers:"
+  private def self.print_taggers_text(io : IO)
+    io.puts "Available taggers:"
     NoirTaggers.taggers.each do |tagger, info|
-      puts " #{tagger.to_s.colorize(:green)}"
-      info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
+      io.puts " #{tagger.to_s.colorize(:green)}"
+      info.each { |k, v| io.puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
     end
-    puts "\nFramework-specific taggers:"
+    io.puts "\nFramework-specific taggers:"
     NoirTaggers.framework_taggers.each do |tagger, info|
-      puts " #{tagger.to_s.colorize(:green)}"
-      info.each { |k, v| puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
+      io.puts " #{tagger.to_s.colorize(:green)}"
+      info.each { |k, v| io.puts "   #{k.to_s.colorize(:blue)}: #{v}" unless k == :runner }
     end
   end
 
-  def self.print_formats
-    puts "Available output formats:"
+  private def self.print_formats_text(io : IO)
+    io.puts "Available output formats:"
     Noir::CliValidation::VALID_OUTPUT_FORMATS.each do |fmt|
-      puts " #{fmt.colorize(:green)}"
+      io.puts " #{fmt.colorize(:green)}"
     end
   end
 
-  private def self.print_context_support(tech : String)
-    puts "     #{"callee".colorize(:cyan)}: #{NoirTechs.context_supported?(tech, "callee")}"
-    puts "     #{"ai_context".colorize(:cyan)}:"
+  # Structured techs catalog: the raw `NoirTechs.techs` metadata augmented with
+  # the synthesized `callee` / `ai_context` support flags, so JSON/YAML output
+  # carries the exact same information the text view prints under `supported:`.
+  private def self.techs_document : JSON::Any
+    doc = JSON.parse(NoirTechs.techs.to_json)
+    doc.as_h.each do |tech, info|
+      next unless supported = info.as_h["supported"]?
+      target = supported.as_h
+      target["callee"] = JSON::Any.new(NoirTechs.context_supported?(tech, "callee"))
+      ai_context = {} of String => JSON::Any
+      AI_CONTEXT_KINDS.each do |feature|
+        ai_context[feature] = JSON::Any.new(NoirTechs.context_supported?(tech, feature))
+      end
+      target["ai_context"] = JSON::Any.new(ai_context)
+    end
+    doc
+  end
+
+  # Structured taggers catalog. The `:runner` class reference isn't
+  # serializable (and is an internal detail), so it's dropped — matching the
+  # text view, which also hides it.
+  private def self.taggers_document
+    {
+      "taggers"           => serialize_taggers(NoirTaggers.taggers),
+      "framework_taggers" => serialize_taggers(NoirTaggers.framework_taggers),
+    }
+  end
+
+  private def self.serialize_taggers(source) : Array(Hash(String, String))
+    entries = [] of Hash(String, String)
+    source.each do |name, info|
+      entry = {"id" => name.to_s}
+      info.each do |k, v|
+        next if k == :runner
+        entry[k.to_s] = v.to_s
+      end
+      entries << entry
+    end
+    entries
+  end
+
+  private def self.print_context_support(tech : String, io : IO)
+    io.puts "     #{"callee".colorize(:cyan)}: #{NoirTechs.context_supported?(tech, "callee")}"
+    io.puts "     #{"ai_context".colorize(:cyan)}:"
     AI_CONTEXT_KINDS.each do |feature|
-      puts "       #{feature.colorize(:cyan)}: #{NoirTechs.context_supported?(tech, feature)}"
+      io.puts "       #{feature.colorize(:cyan)}: #{NoirTechs.context_supported?(tech, feature)}"
     end
   end
 end

--- a/src/techs/techs.cr
+++ b/src/techs/techs.cr
@@ -963,6 +963,8 @@ module NoirTechs
           :header => true,
           :cookie => true,
         },
+        :static_path => false,
+        :websocket   => false,
       },
     },
     :go_hertz => {
@@ -979,6 +981,8 @@ module NoirTechs
           :header => true,
           :cookie => true,
         },
+        :static_path => false,
+        :websocket   => false,
       },
     },
     :go_iris => {
@@ -995,6 +999,8 @@ module NoirTechs
           :header => true,
           :cookie => true,
         },
+        :static_path => false,
+        :websocket   => false,
       },
     },
     :go_restful => {
@@ -1011,6 +1017,8 @@ module NoirTechs
           :header => true,
           :cookie => false,
         },
+        :static_path => false,
+        :websocket   => false,
       },
     },
     :go_chi => {
@@ -2135,7 +2143,7 @@ module NoirTechs
     :zig_http => {
       :framework => "std.http.Server",
       :language  => "Zig",
-      :similar   => ["zig-http", "zig_http", "std-http-server", "std.http.server", "std.http.Server"],
+      :similar   => ["zig-http", "zig_http", "std-http-server", "std.http.server"],
       :supported => {
         :endpoint => true,
         :method   => true,
@@ -2562,7 +2570,7 @@ module NoirTechs
       },
     },
     :php_pure => {
-      :framework => "",
+      :framework => "Pure",
       :language  => "PHP",
       :similar   => ["php", "php-pure", "php_pure"],
       :supported => {
@@ -3784,9 +3792,14 @@ module NoirTechs
       return key.to_s if key.to_s == w
     end
 
-    # Fall back to alias lookup
+    # Fall back to alias lookup. Compare case-insensitively on both sides so
+    # mixed-case aliases (e.g. "BaseHTTPRequestHandler", "WEBrick::HTTPServer")
+    # still resolve — downcasing only the user input left them permanently dead.
+    lowered = w.downcase
     TECHS.each do |key, value|
-      if value[:similar].includes?(w.downcase)
+      similar = value[:similar]
+      next unless similar.is_a?(Array)
+      if similar.any? { |alias_name| alias_name.downcase == lowered }
         return key.to_s
       end
     end


### PR DESCRIPTION
Findings from manually exercising `noir list techs|taggers|formats` and cross-checking `src/techs/techs.cr` / `src/cli/commands/list.cr`. Each was reproduced against the built binary.

## Fixes

**Case-insensitive `:similar` alias lookup** — `similar_to_tech` downcased only the user input while comparing against stored strings verbatim, so every mixed-case alias was permanently dead:

```
$ noir -b . -t BaseHTTPRequestHandler -f only-url   # before: ERROR unknown tech
$ noir -b . -t basehttprequesthandler -f only-url   # before: ERROR unknown tech
```

Now both sides are lowercased (root-cause fix), so `BaseHTTPRequestHandler`, `WEBrick::HTTPServer`, `AbstractServlet`, etc. resolve. Also dropped the redundant case-insensitive `std.http.Server` duplicate from `zig_http`.

**Consistent `:supported` schema** — `go_gin` / `go_hertz` / `go_iris` / `go_restful` omitted `:static_path` and `:websocket` entirely while every sibling framework declares them explicitly, making `noir list techs` render an inconsistent per-tech shape. Added explicit `false` (the analyzers implement neither feature).

**`php_pure` framework label** — was `:framework => ""`, rendering as a blank field; set to `"Pure"` to match the docs generator's label for frameworkless PHP.

**Strict argument handling** — `noir list` silently swallowed unknown flags and any positional after the subject. It now rejects them with a clear error and exit 1, aligning with the CLI's validate-early philosophy.

**Machine-readable output** — `noir list <subject> -f json|yaml` re-serializes the same catalogs for scripting. Techs include the synthesized `callee` / `ai_context` flags; taggers drop the internal `:runner` class reference.

## Tests

Adds regression specs for alias casing, `:supported` schema consistency, argument rejection, and JSON/YAML serialization. Full unit suite green (`crystal spec spec/unit_test`, 3744 examples).