### PR TITLE
fix(config): tighten `noir config` — dead keys, crashes, secret perms & docs

### DIFF
--- a/docs/content/usage/cli_commands/_index.ko.md
+++ b/docs/content/usage/cli_commands/_index.ko.md
@@ -147,6 +147,16 @@ noir config path      # 해석된 경로 출력
 Windows: `notepad`) 순서로 에디터를 결정합니다. 설정 파일이 없으면
 먼저 기본 파일을 만든 뒤 엽니다.
 
+기본 파일이 아닌 다른 설정 파일을 대상으로 하려면 `show`, `edit`,
+`path` 에 `--config-file PATH` 를 넘기면 됩니다:
+
+```bash
+noir config show --config-file ./ci/noir.yaml   # 특정 파일 출력
+noir config path --config-file ./ci/noir.yaml   # 절대 경로 해석
+```
+
+`init` 은 항상 기본 파일을 생성하며 `--config-file` 은 무시합니다.
+
 ## Rules
 
 `noir rules` 는 passive-scan 룰 저장소를 관리합니다.

--- a/docs/content/usage/cli_commands/_index.md
+++ b/docs/content/usage/cli_commands/_index.md
@@ -144,6 +144,16 @@ to `$HOME/.config/noir` on Unix and `%APPDATA%\noir` on Windows.
 `$EDITOR`, then a platform default (`vi` on Unix, `notepad` on Windows).
 The config file is created first if it does not exist yet.
 
+To target a config file other than the default, pass `--config-file
+PATH` to `show`, `edit`, or `path`:
+
+```bash
+noir config show --config-file ./ci/noir.yaml   # print a specific file
+noir config path --config-file ./ci/noir.yaml   # resolve its absolute path
+```
+
+`init` always creates the default file and ignores `--config-file`.
+
 ## Rules
 
 `noir rules` manages the passive-scan rules repository.

--- a/spec/unit_test/config_initializer_spec.cr
+++ b/spec/unit_test/config_initializer_spec.cr
@@ -77,6 +77,16 @@ describe ConfigInitializer do
     end
   end
 
+  it "uses defaults for an empty config file" do
+    # An empty config.yaml is a legitimate "no overrides" state, not a
+    # parse error — read_config returns defaults without churning
+    # through the (would-raise) YAML path.
+    with_noir_home("") do |options|
+      options.has_key?("color").should be_true
+      options["color"].should be_true
+    end
+  end
+
   describe "v0 -> v1 deliver/probe key migration" do
     # A v0.x `config.yaml` that hard-coded the old deliver keys must
     # keep working after the rename to PROBE/EXPORT internal keys.
@@ -143,6 +153,57 @@ describe ConfigInitializer do
         options["probe"].as_bool.should be_true
         options.has_key?("send_req").should be_false
       end
+    end
+  end
+
+  describe "generate_config_file" do
+    it "documents only_techs and tls_skip_verify (both are live config keys)" do
+      body = ConfigInitializer.new.generate_config_file
+      body.should contain("only_techs:")
+      body.should contain("tls_skip_verify:")
+    end
+
+    it "omits the removed analyze_feign key" do
+      # The --analyze-feign flag was dropped when Feign analysis became
+      # unconditional; the config key is dead and no longer emitted.
+      ConfigInitializer.new.generate_config_file.should_not contain("analyze_feign")
+    end
+
+    it "emits only keys that exist in default_options" do
+      # Guards against a template line drifting from the option set —
+      # a key in the generated file that noir doesn't recognize would
+      # silently do nothing for the user who set it.
+      ci = ConfigInitializer.new
+      defaults = ci.default_options
+      YAML.parse(ci.generate_config_file).as_h.each_key do |key|
+        defaults.has_key?(key.to_s).should be_true
+      end
+    end
+  end
+
+  describe "setup" do
+    it "creates the default config file with 0600 permissions" do
+      # The file carries an ai_key field (real provider API keys), so it
+      # must not be world-readable on a shared box.
+      {% unless flag?(:windows) %}
+        dir = File.tempname("noir-perm-spec-")
+        Dir.mkdir(dir)
+        saved = ENV["NOIR_HOME"]?
+        ENV["NOIR_HOME"] = dir
+        begin
+          ConfigInitializer.new.setup
+          path = File.join(dir, "config.yaml")
+          File.exists?(path).should be_true
+          (File.info(path).permissions.value & 0o777).should eq(0o600)
+        ensure
+          if s = saved
+            ENV["NOIR_HOME"] = s
+          else
+            ENV.delete("NOIR_HOME")
+          end
+          FileUtils.rm_rf(dir)
+        end
+      {% end %}
     end
   end
 

--- a/spec/unit_test/utils/home_spec.cr
+++ b/spec/unit_test/utils/home_spec.cr
@@ -20,4 +20,25 @@ describe "get_home test" do
       get_home.should eq("#{ENV["HOME"]}/.config/noir")
     {% end %}
   end
+
+  # Env vars set outside a shell (Docker ENV, systemd Environment=) never
+  # get the shell's tilde expansion, so a literal "~/noir" must be
+  # expanded here or it resolves to a bogus "./~/noir" under the cwd.
+  it "expands a leading ~ in NOIR_HOME" do
+    saved = ENV["NOIR_HOME"]?
+    ENV["NOIR_HOME"] = "~/some-noir-home"
+    begin
+      result = get_home
+      result.starts_with?('~').should be_false
+      {% unless flag?(:windows) %}
+        result.should eq("#{ENV["HOME"]}/some-noir-home")
+      {% end %}
+    ensure
+      if s = saved
+        ENV["NOIR_HOME"] = s
+      else
+        ENV.delete("NOIR_HOME")
+      end
+    end
+  end
 end

--- a/src/cli/commands/config.cr
+++ b/src/cli/commands/config.cr
@@ -41,7 +41,15 @@ module Noir::CLI::ConfigCommand
     case action
     when "show" then show(override_path)
     when "edit" then edit(override_path)
-    when "init" then init
+    when "init"
+      # `init` only ever creates the DEFAULT config file — it has no
+      # override_path parameter (auto-scaffolding at a user-supplied
+      # path would mask a typo). Passing --config-file here is a no-op,
+      # so say so instead of silently ignoring it.
+      if override_path && !override_path.empty?
+        STDERR.puts "NOTE: `noir config init` always creates the default config file; --config-file #{override_path} is ignored.".colorize(:yellow)
+      end
+      init
     when "path" then puts config_path(override_path)
     else
       Noir::CLI.die("Unknown config action: #{action}. Valid: #{ACTIONS.join(", ")}.")
@@ -62,6 +70,11 @@ module Noir::CLI::ConfigCommand
         #{cyan.call("init")}                   Create the default config file (idempotent)
         #{cyan.call("path")}                   Print the resolved config file path
 
+      #{green.call("OPTIONS:")}
+        #{cyan.call("--config-file PATH")}     Operate on PATH instead of the default config file.
+                               Applies to show, edit, and path; init always
+                               creates the default file and ignores this flag.
+
       The config directory is controlled by NOIR_HOME (defaults to
       $HOME/.config/noir on Unix and %APPDATA%\\noir on Windows).
 
@@ -73,9 +86,20 @@ module Noir::CLI::ConfigCommand
 
   def self.show(override_path : String? = nil)
     path = config_path(override_path)
-    unless File.exists?(path)
+
+    if override_path && !override_path.empty?
+      # A custom --config-file is validated the way the scan path does:
+      # a missing file or a directory is a user error. Crucially, don't
+      # print the `noir config init` hint here — init only ever creates
+      # the DEFAULT config, so following that advice can't fix a custom
+      # path. Reading a directory would also crash `File.read` with a
+      # raw backtrace, so reject it explicitly.
+      Noir::CLI.die("Config file does not exist: #{path}") unless File.exists?(path)
+      Noir::CLI.die("--config-file is not a file: #{path}") if File.directory?(path)
+    elsif !File.exists?(path)
       Noir::CLI.die("Config file does not exist: #{path}\nRun `noir config init` to create it.")
     end
+
     content = File.read(path)
     puts content
     warn_about_legacy_keys(content)
@@ -124,6 +148,13 @@ module Noir::CLI::ConfigCommand
 
   def self.edit(override_path : String? = nil)
     path = config_path(override_path)
+
+    # A custom --config-file pointing at a directory would otherwise be
+    # handed straight to the editor (or crash on the create path). Reject
+    # it up front, matching `show` and the scan-path validator.
+    if override_path && !override_path.empty? && File.directory?(path)
+      Noir::CLI.die("--config-file is not a file: #{path}")
+    end
 
     # `edit` launches an interactive terminal editor. In a non-interactive
     # context (CI, piped stdin, background job) that editor would block

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -31,7 +31,6 @@ class ConfigInitializer
     ai_agent
     cache_disable
     cache_clear
-    analyze_feign
   ]
 
   # Keys whose value should always end up as an Array(YAML::Any) so
@@ -103,22 +102,34 @@ class ConfigInitializer
     # surfaced by CliValidation later; auto-creating a default
     # template at the user-supplied path would silently mask the
     # typo with a generated file.
+    #
+    # Written 0600: the file carries an `ai_key` field documented as
+    # where real provider API keys go, so it should never be created
+    # world-readable on a shared box (matches ssh/aws-cli/gh).
     return if @is_override
-    File.write(@config_file, generate_config_file) unless File.exists?(@config_file)
+    File.write(@config_file, generate_config_file, perm: 0o600) unless File.exists?(@config_file)
   rescue e
-    # Silent failures here made permission/disk-full problems during startup
-    # hard to diagnose. Log at debug level so --debug surfaces the cause
-    # without noising up normal runs.
-    Log.debug { "ConfigInitializer.setup failed: #{e.message} (#{e.class})" }
+    # A silently-swallowed failure here (unwritable NOIR_HOME, disk full)
+    # left the config on defaults with no hint why. The old Log.debug
+    # never surfaced — nothing calls Log.setup — so report it on stderr
+    # the way the invalid-boolean warning in read_config already does.
+    STDERR.puts "WARNING: could not initialize noir config at #{@config_file} (#{e.message}); continuing with defaults.".colorize(:yellow)
   end
 
   def read_config
     # Ensure the config file is set up
     setup
 
+    # A missing file (e.g. a --config-file path that setup deliberately
+    # didn't scaffold) or an empty one is a legitimate "no overrides"
+    # state — fall back to defaults quietly. Only a file with real but
+    # unparseable content is worth warning about below.
+    raw = File.exists?(@config_file) ? File.read(@config_file) : ""
+    return default_options if raw.strip.empty?
+
     # Read the config file, or use the default config if reading fails
     begin
-      parsed_yaml = YAML.parse(File.read(@config_file)).as_h
+      parsed_yaml = YAML.parse(raw).as_h
       symbolized_hash = parsed_yaml.transform_keys(&.to_s)
 
       # Migrate v0 deliver/probe keys to their v1 equivalents before
@@ -176,10 +187,11 @@ class ConfigInitializer
       final_options = default_options.merge(symbolized_hash) { |_, _, new_val| new_val }
       final_options
     rescue e
-      # Falling back silently made malformed-YAML bugs hard to track down.
-      # Log the cause at debug level and keep the existing default-options
-      # fallback so behavior is unchanged.
-      Log.debug { "ConfigInitializer.read_config failed, using defaults: #{e.message} (#{e.class})" }
+      # A malformed config used to revert every setting to defaults with
+      # no explanation (the old Log.debug never surfaced — nothing calls
+      # Log.setup). Surface the cause on stderr, matching the
+      # invalid-boolean warning above, then keep the default fallback.
+      STDERR.puts "WARNING: could not parse config #{@config_file} (#{e.message}); using defaults.".colorize(:yellow)
       default_options
     end
   end
@@ -261,7 +273,6 @@ class ConfigInitializer
       "ai_max_token"                 => YAML::Any.new(0),
       "cache_disable"                => YAML::Any.new(false),
       "cache_clear"                  => YAML::Any.new(false),
-      "analyze_feign"                => YAML::Any.new(false),
     }
 
     noir_options
@@ -301,6 +312,10 @@ class ConfigInitializer
 
       # Technologies to exclude
       exclude_techs: "#{options["exclude_techs"]}"
+
+      # Restrict detection to these technologies only (comma-separated;
+      # empty = detect everything). The inverse of exclude_techs.
+      only_techs: "#{options["only_techs"]}"
 
       # File paths to exclude (comma-separated glob patterns, e.g. "*.test.js,*_test.go")
       exclude_path: "#{options["exclude_path"]}"
@@ -361,6 +376,9 @@ class ConfigInitializer
       set_pvalue_form:
       set_pvalue_json:
       set_pvalue_path:
+
+      # Skip TLS certificate verification when probing HTTPS endpoints
+      tls_skip_verify: #{options["tls_skip_verify"]}
 
       # The status codes to use
       status_codes: #{options["status_codes"]}

--- a/src/utils/home.cr
+++ b/src/utils/home.cr
@@ -3,6 +3,12 @@ def get_home
 
   if ENV.has_key? "NOIR_HOME"
     config_dir = ENV["NOIR_HOME"]
+    # Env vars set outside a shell (Docker `ENV`, systemd `Environment=`,
+    # some .env loaders) never get the shell's tilde expansion, so a
+    # literal "~/noir" would otherwise resolve to a bogus "./~/noir"
+    # under the cwd. Expand a leading ~ here so the path lands where the
+    # user meant.
+    config_dir = File.expand_path(config_dir, home: true) if config_dir.starts_with?('~')
   else
     # Define the config directory and file based on the OS
     {% if flag?(:windows) %}


### PR DESCRIPTION
## Summary

A batch of `noir config <show|edit|init|path>` fixes surfaced by a manual exploration of the subcommand. Each is small and independently verifiable; grouped because they all touch the config surface.

### Correctness / robustness
- **Dead `analyze_feign` key removed.** The `--analyze-feign` flag was dropped when Feign analysis became unconditional; nothing reads the key anymore, so setting it in `config.yaml` parsed to a real Bool and went nowhere.
- **`config show --config-file X` no longer suggests `noir config init`** for a missing custom path. `init` only ever creates the *default* file, so following that hint silently creates an unrelated file and leaves the original error in place. The default-path case still shows the hint.
- **`config show/edit --config-file <directory>` fails cleanly** with `--config-file is not a file: …` instead of a raw `File.read` `IO::Error` backtrace, matching the scan path's validator.
- **Config setup/parse failures now surface on stderr.** The old `Log.debug` calls never printed — nothing calls `Log.setup` — so an unwritable `NOIR_HOME` or malformed YAML silently reverted every setting to defaults with no explanation. An empty config stays a quiet "no overrides" state.
- **Leading `~` in `NOIR_HOME` is expanded.** Env vars set outside a shell (Docker `ENV`, systemd `Environment=`) never get tilde expansion, so `NOIR_HOME=~/noir` resolved to a bogus `./~/noir` under the cwd.

### Security
- **`config.yaml` is created `0600`.** It holds an `ai_key` field (documented as where provider API keys go), so it must not be world-readable on a shared/multi-user box (matches ssh/aws-cli/gh).

### Discoverability / UX
- **`only_techs` and `tls_skip_verify` added to the generated template.** Both are live CLI flags with config keys but were absent from `noir config init` output, making them undiscoverable from the file.
- **`config init --config-file X` warns** that the flag is ignored instead of silently creating the default file.
- **`--config-file` documented** in `noir config --help` and the docs site (EN + KO).

### Not done
- The exploration also noted that global-looking flags before a subcommand (`noir --debug config show`) fall through to `scan`. That's not config-specific and its only actionable fix is a router behavior change that risks v0 compatibility, so it's intentionally left out of this PR.

## Tests
Added unit coverage in `config_initializer_spec` (template keys present, dead key absent, template⊆option-set integrity, `0600` perms, empty-config path) and `home_spec` (tilde expansion). Full unit suite green (3740 examples, 0 failures); `crystal tool format --check` and `ameba` clean project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)