### PR TITLE
fix(cli/rules): robustness & correctness fixes for `noir rules`

### DIFF
--- a/spec/unit_test/cli/rules_command_spec.cr
+++ b/spec/unit_test/cli/rules_command_spec.cr
@@ -2,12 +2,17 @@ require "../../spec_helper"
 require "file_utils"
 require "../../../src/cli/commands/rules"
 
-# Isolated NOIR_HOME so each spec sees a clean rules directory.
+# Isolated NOIR_HOME so each spec sees a clean rules directory. Also pins
+# NOIR_BUNDLED_RULES_PATH at a nonexistent path so `effective_rules_path`
+# resolves deterministically to the user path regardless of whether the test
+# machine happens to have /opt/noir/passive_rules populated.
 private def with_isolated_rules_home(&)
   prev = ENV["NOIR_HOME"]?
+  prev_bundled = ENV["NOIR_BUNDLED_RULES_PATH"]?
   tmp = File.tempname("noir-rules-cli-spec")
   Dir.mkdir_p(tmp)
   ENV["NOIR_HOME"] = tmp
+  ENV["NOIR_BUNDLED_RULES_PATH"] = File.join(tmp, "no-bundled-rules")
   begin
     yield tmp
   ensure
@@ -15,6 +20,11 @@ private def with_isolated_rules_home(&)
       ENV["NOIR_HOME"] = prev
     else
       ENV.delete("NOIR_HOME")
+    end
+    if prev_bundled
+      ENV["NOIR_BUNDLED_RULES_PATH"] = prev_bundled
+    else
+      ENV.delete("NOIR_BUNDLED_RULES_PATH")
     end
     FileUtils.rm_rf(tmp)
   end
@@ -34,10 +44,38 @@ describe Noir::CLI::RulesCommand do
       Noir::CLI::RulesCommand.parse_argv(["path"]).action.should eq("path")
     end
 
-    it "first positional wins when extra args follow" do
-      # `rules update` ignores positionals — confirm parser doesn't
-      # accidentally promote a later argument to action.
-      Noir::CLI::RulesCommand.parse_argv(["update", "force"]).action.should eq("update")
+    it "reports an error for an unexpected second positional" do
+      # `noir rules list update` used to silently run only `list`. A typo'd
+      # or copy-pasted extra subcommand must now surface as an error.
+      parsed = Noir::CLI::RulesCommand.parse_argv(["list", "update"])
+      parsed.action.should eq("list")
+      parsed.error.should_not be_nil
+      parsed.error.not_nil!.should contain("Unexpected argument")
+      parsed.error.not_nil!.should contain("update")
+    end
+
+    it "reports an error for an unknown option" do
+      parsed = Noir::CLI::RulesCommand.parse_argv(["update", "--bogus"])
+      parsed.error.should_not be_nil
+      parsed.error.not_nil!.should contain("Unknown option")
+      parsed.error.not_nil!.should contain("--bogus")
+    end
+
+    it "parses --debug and -v/--verbose passthrough flags" do
+      Noir::CLI::RulesCommand.parse_argv(["update", "--debug"]).debug.should be_true
+      Noir::CLI::RulesCommand.parse_argv(["update", "-v"]).verbose.should be_true
+      Noir::CLI::RulesCommand.parse_argv(["update", "--verbose"]).verbose.should be_true
+
+      clean = Noir::CLI::RulesCommand.parse_argv(["update"])
+      clean.debug.should be_false
+      clean.verbose.should be_false
+      clean.error.should be_nil
+    end
+
+    it "accepts the global --no-color flag without treating it as unknown" do
+      parsed = Noir::CLI::RulesCommand.parse_argv(["update", "--no-color"])
+      parsed.action.should eq("update")
+      parsed.error.should be_nil
     end
 
     it "flags -h / --help anywhere" do
@@ -125,6 +163,47 @@ describe Noir::CLI::RulesCommand do
       %w[list update path].each { |action| out.should contain(action) }
       out.should contain("--passive-scan-path")
       out.should contain("NOIR_HOME")
+    end
+
+    it "points at the real passive-scan flag, not the nonexistent --passive" do
+      io = IO::Memory.new
+      Noir::CLI::RulesCommand.print_help(io)
+      out = io.to_s
+      out.should contain("-P")
+      out.should contain("--passive-scan")
+      # The bare `--passive` flag does not exist; the only `--passive*`
+      # tokens in the help are `--passive-scan` and `--passive-scan-path`.
+      out.gsub("--passive-scan-path", "").gsub("--passive-scan", "")
+        .should_not contain("--passive")
+    end
+  end
+
+  describe ".effective_rules_path" do
+    it "reports the bundled ruleset path when only the bundle is populated" do
+      # Simulates a Docker install: the user path is empty but the image-baked
+      # bundle has rules. `list`/`path` must report the bundle (what scan uses)
+      # instead of claiming the empty user path.
+      with_isolated_rules_home do |_|
+        bundled = File.tempname("noir-bundled-rules-spec")
+        Dir.mkdir_p(bundled)
+        File.write(File.join(bundled, "rule.yaml"), "id: bundled\n")
+        prev_bundled = ENV["NOIR_BUNDLED_RULES_PATH"]?
+        ENV["NOIR_BUNDLED_RULES_PATH"] = bundled
+        begin
+          Noir::CLI::RulesCommand.effective_rules_path.should eq(bundled)
+
+          io = IO::Memory.new
+          Noir::CLI::RulesCommand.list_rules(io)
+          io.to_s.should contain("rule.yaml")
+        ensure
+          if prev_bundled
+            ENV["NOIR_BUNDLED_RULES_PATH"] = prev_bundled
+          else
+            ENV.delete("NOIR_BUNDLED_RULES_PATH")
+          end
+          FileUtils.rm_rf(bundled)
+        end
+      end
     end
   end
 end

--- a/spec/unit_test/utils/home_spec.cr
+++ b/spec/unit_test/utils/home_spec.cr
@@ -7,6 +7,26 @@ describe "get_home test" do
     ENV.delete("NOIR_HOME")
   end
 
+  it "treats an exported-but-empty NOIR_HOME the same as unset" do
+    # `NOIR_HOME=""` (an unfilled container env template, a shell bug) used
+    # to resolve rules/config/cache to a *relative* `passive_rules` under the
+    # cwd. It must fall back to the OS default instead.
+    prev = ENV["NOIR_HOME"]?
+    ENV["NOIR_HOME"] = ""
+    begin
+      {% unless flag?(:windows) %}
+        get_home.should eq("#{ENV["HOME"]}/.config/noir")
+      {% end %}
+      get_home.should_not eq("")
+    ensure
+      if prev
+        ENV["NOIR_HOME"] = prev
+      else
+        ENV.delete("NOIR_HOME")
+      end
+    end
+  end
+
   it "returns default config directory on Windows" do
     {% if flag?(:windows) %}
       ENV.delete("NOIR_HOME")

--- a/src/cli/commands/rules.cr
+++ b/src/cli/commands/rules.cr
@@ -13,38 +13,88 @@ module Noir::CLI::RulesCommand
   ACTIONS = %w[list update path]
 
   # Parsed argv. Pulled out of `run` so the parser can be exercised in
-  # unit specs without triggering the `exit`/`die` side effects.
-  record Parsed, action : String?, help : Bool
+  # unit specs without triggering the `exit`/`die` side effects. `error`
+  # is recorded (rather than raised) when argv is malformed so `run` can
+  # turn it into a clean `Noir::CLI.die` line.
+  record Parsed,
+    action : String?,
+    help : Bool,
+    debug : Bool,
+    verbose : Bool,
+    error : String?
 
   def self.parse_argv(argv : Array(String)) : Parsed
     action = nil
     help = false
+    debug = false
+    verbose = false
+    error = nil
+    extra = [] of String
+
     argv.each do |a|
       case a
       when "-h", "--help"
         help = true
+      when "--debug"
+        debug = true
+      when "-v", "--verbose"
+        verbose = true
+      when "--no-color"
+        # Global flag — the router already applied it via
+        # `Noir::CLI.apply_global_color_flag!`. Accept it here so it isn't
+        # rejected as an unknown option.
       else
-        action ||= a
+        if a.starts_with?("-")
+          error ||= "Unknown option: #{a}. Run `noir rules --help`."
+        elsif action.nil?
+          action = a
+        else
+          extra << a
+        end
       end
     end
-    Parsed.new(action: action, help: help)
+
+    # A second positional (a typo'd or copy-pasted extra subcommand) used to
+    # be silently dropped — `noir rules list update` quietly ran only `list`.
+    # Surface it instead of guessing which one the user meant.
+    if error.nil? && !extra.empty?
+      plural = extra.size > 1 ? "s" : ""
+      error = "Unexpected argument#{plural}: #{extra.join(", ")}. `noir rules` takes a single action."
+    end
+
+    Parsed.new(action: action, help: help, debug: debug, verbose: verbose, error: error)
   end
 
   def self.run(argv : Array(String))
     parsed = parse_argv(argv)
 
-    if parsed.help || parsed.action.nil?
+    if parsed.help
+      print_help
+      exit
+    end
+
+    if err = parsed.error
+      Noir::CLI.die(err)
+    end
+
+    if parsed.action.nil?
       print_help
       exit
     end
 
     case parsed.action
     when "list"   then list_rules
-    when "update" then update_rules
-    when "path"   then puts rules_path
+    when "update" then update_rules(parsed.debug, parsed.verbose)
+    when "path"   then puts effective_rules_path
     else
       Noir::CLI.die("Unknown rules action: #{parsed.action}. Valid: #{ACTIONS.join(", ")}.")
     end
+  rescue ex : File::Error
+    # `Dir.exists?` / `Dir.glob` raise (rather than return false) when the
+    # rules path or an ancestor can't be stat'd — a permission-denied parent,
+    # a stale mount. Fail like every other subcommand: one clean line, not a
+    # raw Crystal stack trace.
+    Noir::CLI.die("Cannot access the rules directory: #{ex.message}")
   end
 
   def self.print_help(io : IO = STDOUT)
@@ -53,26 +103,43 @@ module Noir::CLI::RulesCommand
 
     io.puts <<-HELP
       #{green.call("USAGE:")}
-        noir rules <action>
+        noir rules <action> [options]
 
       #{green.call("ACTIONS:")}
         #{cyan.call("list")}                   Show rule files installed under the rules path
         #{cyan.call("update")}                 Pull the latest rules from the upstream repository
         #{cyan.call("path")}                   Print the configured rules directory
 
+      #{green.call("OPTIONS:")}
+        #{cyan.call("-v")}, #{cyan.call("--verbose")}          Show verbose progress (update)
+        #{cyan.call("--debug")}                Show debug diagnostics, e.g. why an update failed
+        #{cyan.call("-h")}, #{cyan.call("--help")}             Show this help
+
       Default rules path: ~/.config/noir/passive_rules (overridable via NOIR_HOME).
 
-      During scan, rules are activated with `noir scan ... --passive` and
-      can be aimed at a custom location with `--passive-scan-path PATH`.
+      During scan, rules are activated with `noir scan ... -P` (--passive-scan)
+      and can be aimed at a custom location with `--passive-scan-path PATH`.
       HELP
   end
 
+  # The writable, user-managed rules directory: where `noir rules update`
+  # clones/pulls. Kept distinct from `effective_rules_path` (which may resolve
+  # to the read-only image-baked bundle) so update always targets a path it
+  # can actually write to.
   def self.rules_path : String
-    File.join(get_home, "passive_rules")
+    PassiveRulesUpdater.user_rules_path
+  end
+
+  # What `noir scan -P` actually reads rules from: the user-managed path when
+  # populated, otherwise the image-baked bundle at /opt/noir/passive_rules.
+  # `list`/`path` report this so they never claim "no rules" on a Docker
+  # install where passive scanning is fully working off the bundled ruleset.
+  def self.effective_rules_path : String
+    PassiveRulesUpdater.effective_rules_path
   end
 
   def self.list_rules(io : IO = STDOUT)
-    path = rules_path
+    path = effective_rules_path
     unless Dir.exists?(path)
       io.puts "Rules directory does not exist: #{path}"
       io.puts "Run `noir rules update` to clone the upstream rules repository."
@@ -94,21 +161,32 @@ module Noir::CLI::RulesCommand
     end
   end
 
-  def self.update_rules
-    logger = NoirLogger.new(false, false, true, false)
+  def self.update_rules(debug : Bool = false, verbose : Bool = false)
+    # Honour the global --no-color / NO_COLOR state the router already
+    # resolved (Colorize.enabled?) instead of forcing color on, and let
+    # --debug/-v surface why an update didn't complete.
+    logger = NoirLogger.new(debug, verbose, Colorize.enabled?, false)
+
     unless PassiveRulesUpdater.initialize_rules(logger)
       logger.warning "Could not initialize passive rules at #{rules_path}."
-      return
+      # A failed init means `-P` scans would silently run with no rules;
+      # exit non-zero so `noir rules update && noir scan . -P` is a usable
+      # precondition check in CI/scripts.
+      exit(1)
     end
 
     if PassiveRulesUpdater.check_for_updates(logger, true)
-      logger.success "Passive rules are ready (#{rules_path})."
+      logger.success "Passive rules are ready (#{effective_rules_path})."
     else
-      # `check_for_updates` returns false either because the fetch
-      # failed or because rules are behind and auto-update could not
-      # complete cleanly — surface that explicitly so `noir rules
-      # update` is never silent.
-      logger.warning "Passive rules update did not complete cleanly. See logs above."
+      # The specific reason (bad remote, non-git dir, fetch failure) is logged
+      # at debug level, so point the user at `--debug` rather than "logs above"
+      # that a default run never actually printed.
+      if debug || verbose
+        logger.warning "Passive rules update did not complete cleanly. See the diagnostics above."
+      else
+        logger.warning "Passive rules update did not complete cleanly. Re-run `noir rules update --debug` for details."
+      end
+      exit(1)
     end
   end
 end

--- a/src/config_initializer.cr
+++ b/src/config_initializer.cr
@@ -123,7 +123,7 @@ class ConfigInitializer
     # A missing file (e.g. a --config-file path that setup deliberately
     # didn't scaffold) or an empty one is a legitimate "no overrides"
     # state — fall back to defaults quietly. Only a file with real but
-    # unparseable content is worth warning about below.
+    # unparsable content is worth warning about below.
     raw = File.exists?(@config_file) ? File.read(@config_file) : ""
     return default_options if raw.strip.empty?
 

--- a/src/utils/home.cr
+++ b/src/utils/home.cr
@@ -1,22 +1,31 @@
-def get_home
-  config_dir = ""
+require "../cli/common"
 
-  if ENV.has_key? "NOIR_HOME"
-    config_dir = ENV["NOIR_HOME"]
+def get_home
+  # NOIR_HOME wins — but only when it's set to a real value. The previous
+  # `ENV.has_key? "NOIR_HOME"` check was also true for an exported-but-empty
+  # `NOIR_HOME=""` (a shell-script bug, an unfilled container env template),
+  # which then resolved rules/config/cache to *relative* paths under the
+  # current working directory: `File.join("", "passive_rules") == "passive_rules"`.
+  # Treat an empty value the same as unset and fall back to the OS default.
+  if noir_home = ENV["NOIR_HOME"]?.presence
     # Env vars set outside a shell (Docker `ENV`, systemd `Environment=`,
-    # some .env loaders) never get the shell's tilde expansion, so a
-    # literal "~/noir" would otherwise resolve to a bogus "./~/noir"
-    # under the cwd. Expand a leading ~ here so the path lands where the
-    # user meant.
-    config_dir = File.expand_path(config_dir, home: true) if config_dir.starts_with?('~')
-  else
-    # Define the config directory and file based on the OS
-    {% if flag?(:windows) %}
-      config_dir = "#{ENV["APPDATA"]}\\noir"
-    {% else %}
-      config_dir = "#{ENV["HOME"]}/.config/noir"
-    {% end %}
+    # some .env loaders) never get the shell's tilde expansion, so a literal
+    # "~/noir" would otherwise resolve to a bogus "./~/noir" under the cwd.
+    # Expand a leading ~ here so the path lands where the user meant.
+    return noir_home.starts_with?('~') ? File.expand_path(noir_home, home: true) : noir_home
   end
 
-  config_dir
+  # Fall back to the per-OS default config location. The base env var must
+  # exist; hardened containers and some CI runners unset HOME/APPDATA, so
+  # fail with a clean CLI error instead of an unhandled `Missing ENV key`
+  # (KeyError) stack trace — matching how every other subcommand errors.
+  {% if flag?(:windows) %}
+    appdata = ENV["APPDATA"]?.presence ||
+              Noir::CLI.die("Cannot locate the noir config directory: neither NOIR_HOME nor APPDATA is set. Set NOIR_HOME to a writable directory.")
+    "#{appdata}\\noir"
+  {% else %}
+    home = ENV["HOME"]?.presence ||
+           Noir::CLI.die("Cannot locate the noir config directory: neither NOIR_HOME nor HOME is set. Set NOIR_HOME to a writable directory.")
+    "#{home}/.config/noir"
+  {% end %}
 end

--- a/src/utils/passive_rules_updater.cr
+++ b/src/utils/passive_rules_updater.cr
@@ -25,6 +25,24 @@ module PassiveRulesUpdater
     ENV["NOIR_BUNDLED_RULES_PATH"]? || DEFAULT_BUNDLED_RULES_PATH
   end
 
+  # `Dir.exists?` / `Dir.empty?` don't return false when an ancestor of the
+  # queried path can't be stat'd (a chmod 000 parent, a revoked mount) — they
+  # raise `File::AccessDeniedError`. Every rules-path existence/emptiness check
+  # runs through these guards so a permissions problem degrades to "no usable
+  # rules here" (scan then warns; the `noir rules` CLI dies cleanly) instead of
+  # surfacing an unhandled Crystal stack trace to the user.
+  private def self.dir_exists?(path : String) : Bool
+    Dir.exists?(path)
+  rescue File::Error
+    false
+  end
+
+  private def self.dir_populated?(path : String) : Bool
+    Dir.exists?(path) && !Dir.empty?(path)
+  rescue File::Error
+    false
+  end
+
   # The user-managed rules path: where `noir rules update` clones to,
   # where `noir rules path` reports, and the canonical writable
   # location an end-user owns. Kept out of `effective_rules_path` so
@@ -39,8 +57,8 @@ module PassiveRulesUpdater
   # fallback in `initialize_rules` something concrete to populate).
   def self.effective_rules_path : String
     user = user_rules_path
-    return user if Dir.exists?(user) && !Dir.empty?(user)
-    return bundled_rules_path if Dir.exists?(bundled_rules_path) && !Dir.empty?(bundled_rules_path)
+    return user if dir_populated?(user)
+    return bundled_rules_path if dir_populated?(bundled_rules_path)
     user
   end
 
@@ -48,9 +66,8 @@ module PassiveRulesUpdater
   # provided their own. Callers use this to skip the git-clone fallback
   # (which costs network + a git binary the image doesn't ship).
   def self.bundled_rules_available? : Bool
-    user = user_rules_path
-    return false if Dir.exists?(user) && !Dir.empty?(user)
-    Dir.exists?(bundled_rules_path) && !Dir.empty?(bundled_rules_path)
+    return false if dir_populated?(user_rules_path)
+    dir_populated?(bundled_rules_path)
   end
 
   # Check if the passive rules directory is a git repository and needs updates
@@ -62,7 +79,7 @@ module PassiveRulesUpdater
     # from upstream because the bundled rules are pinned to the image
     # tag — users who want fresher rules switch image tags or run
     # `noir rules update` to materialise the user path.
-    if !Dir.exists?(rules_path) || Dir.empty?(rules_path)
+    if !dir_populated?(rules_path)
       if bundled_rules_available?
         logger.debug "Passive rules: image-baked ruleset in use; skipping upstream update check."
         return true
@@ -70,14 +87,14 @@ module PassiveRulesUpdater
     end
 
     # Return early if directory doesn't exist
-    unless Dir.exists?(rules_path)
+    unless dir_exists?(rules_path)
       logger.debug "Passive rules directory does not exist: #{rules_path}"
       return false
     end
 
     # Check if it's a git repository
     git_dir = File.join(rules_path, ".git")
-    unless Dir.exists?(git_dir)
+    unless dir_exists?(git_dir)
       logger.debug "Passive rules directory is not a git repository"
       return check_revision_file(rules_path, logger)
     end
@@ -171,7 +188,7 @@ module PassiveRulesUpdater
     rules_path = user_rules_path
 
     # Return true if directory already exists and is not empty
-    if Dir.exists?(rules_path) && !Dir.empty?(rules_path)
+    if dir_populated?(rules_path)
       return true
     end
 
@@ -203,7 +220,7 @@ module PassiveRulesUpdater
         logger.sub "➔ You can manually clone it with: git clone #{REPO_URL} #{rules_path}"
 
         # Create empty directory as fallback
-        Dir.mkdir_p(rules_path) unless Dir.exists?(rules_path)
+        Dir.mkdir_p(rules_path) unless dir_exists?(rules_path)
         false
       end
     rescue ex : Exception
@@ -215,7 +232,7 @@ module PassiveRulesUpdater
 
       # Create empty directory as fallback
       begin
-        Dir.mkdir_p(rules_path) unless Dir.exists?(rules_path)
+        Dir.mkdir_p(rules_path) unless dir_exists?(rules_path)
       rescue err
         logger.warning "Could not create passive rules directory at #{rules_path}: #{err.message}"
       end


### PR DESCRIPTION
Fixes surfaced while exercising `noir rules list|update|path`. Each is an independent, low-risk fix; all verified end-to-end against a local build and covered by unit specs.

## Bugs fixed

1. **Help text pointed at a nonexistent flag.** `noir rules` suggested `noir scan ... --passive`; the real flag is `-P` / `--passive-scan`. Copy-pasting the hint failed immediately.
2. **Permission-denied ancestor dir crashed with a raw stack trace.** `Dir.exists?`/`Dir.empty?` *raise* `File::AccessDeniedError` when an ancestor can't be stat'd (e.g. a `chmod 000` parent) instead of returning false. All rules-path checks now route through rescuing guards, and the rules command boundary rescues `File::Error`, so it dies cleanly like every other subcommand.
3. **`get_home` crashed when `$HOME`/`$APPDATA` was unset** (`Missing ENV key` KeyError) — common in hardened containers / some CI runners. Now fails with a clean CLI error.
4. **`noir rules update` always exited 0**, even when git was missing, the remote was unreachable, or no rules existed — making it useless as a `noir rules update && noir scan . -P` precondition in CI. Now exits non-zero on failure.
5. **`--no-color` / `NO_COLOR` were ignored by `noir rules update`.** It constructed a logger with `colorize: true` hardcoded, and `.toggle(true)` re-enabled color even after the global disable. Now threads `Colorize.enabled?` through.
6. **"See logs above" pointed at logs that were never printed.** The failure reasons are logged at debug level, which the CLI hardcoded off with no way to enable. Added `--debug`/`-v` passthrough and reworded the message to point at `--debug`.
7. **Bundled-rules install was self-contradictory.** `update` said *"ready at `$NOIR_HOME/passive_rules`"* while `list` said that same path *"does not exist"*. `list`/`path`/`update` now report `effective_rules_path` (the user path when populated, else the image-baked bundle) — the path scan actually uses.
8. **`NOIR_HOME=""` (set but empty) silently resolved rules into the cwd.** `ENV.has_key?` is true for an empty value, so `File.join("", "passive_rules")` became a *relative* path. Now treated the same as unset via `.presence`.
9. **Extra/unknown arguments were silently dropped.** `noir rules list update` quietly ran only `list`. The parser now errors on unknown options and extra positionals.

## Intentionally deferred (not bugs)

- A `--path PATH` override for `list/update/path` (parity with scan's `--passive-scan-path`) — a genuine usability gap, but a feature rather than a fix; better as its own PR.
- Normalizing `NOIR_HOME` with `File.expand_path` (cosmetic double-slash) — would change relative-path semantics for legitimate uses.

## Testing

- `crystal spec spec/unit_test` → 3740 examples, 0 failures.
- Manually reproduced and confirmed each of the above against `./bin/noir` (help text, `env -u HOME`, empty `NOIR_HOME`, extra/unknown args, `NO_COLOR`, `chmod 000` ancestor, forced update failure, and the bundled-rules scenario).
- Added/updated specs: rules parser (error paths + `--debug`/`-v`), `get_home` empty-`NOIR_HOME` fallback, and effective-path reporting.