### PR TITLE
fix(github-action): CI coverage for the entrypoint, robust image-tag resolution, injection-safe examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
       - shard.lock
       - Dockerfile
       - "**/*.cr"
+      # The GitHub Action runtime (composite wrapper + container entrypoint)
+      # ships from this repo too, so changes to it must exercise the
+      # test-action job below.
+      - action.yml
+      - github-action/**
   push:
     branches: [main]
   workflow_dispatch:
@@ -65,6 +70,33 @@ jobs:
           platforms: ${{ matrix.arch }}
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+  test-action:
+    # End-to-end coverage for the GitHub Action runtime. The composite
+    # action `docker pull`s a pre-built published image and build-docker
+    # above never runs the container, so entrypoint.sh would otherwise ship
+    # untested. Build the image from the current tree and drive the
+    # entrypoint exactly as action.yml does, asserting the output contract.
+    name: GitHub Action entrypoint (e2e)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Unit-test image tag resolver
+        run: bash github-action/test-resolve-image-tag.sh
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build action image from current tree
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: linux/amd64
+          tags: noir-action:ci
+          cache-from: type=gha,scope=action-ci
+          cache-to: type=gha,mode=max,scope=action-ci
+      - name: Run entrypoint end-to-end
+        run: bash github-action/test-entrypoint.sh noir-action:ci
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/example-noir-action.yml
+++ b/.github/workflows/example-noir-action.yml
@@ -21,9 +21,16 @@ jobs:
           passive_scan: "true"
           include_path: "true"
 
+      # Pass the outputs through env vars, never inline them into the shell
+      # script. `endpoints` is JSON derived from the *scanned code*, so on an
+      # untrusted PR a crafted value could otherwise break out of the quotes
+      # and inject shell commands into the runner.
       - name: Display results
+        env:
+          NOIR_ENDPOINTS: ${{ steps.noir.outputs.endpoints }}
+          NOIR_PASSIVE: ${{ steps.noir.outputs.passive_results }}
         run: |
           echo "Endpoints found:"
-          echo '${{ steps.noir.outputs.endpoints }}' | jq .
+          echo "$NOIR_ENDPOINTS" | jq .
           echo "Passive scan results:"
-          echo '${{ steps.noir.outputs.passive_results }}' | jq .
+          echo "$NOIR_PASSIVE" | jq .

--- a/action.yml
+++ b/action.yml
@@ -120,26 +120,41 @@ runs:
   using: composite
   steps:
     # Resolve the ghcr.io tag from the ref the user pinned the action
-    # to. `@v1.0.0` → `1.0.0`, `@main` → `main`, no ref → `latest`.
-    # Mirrors the matching released image so locking the action to a
-    # tag locks the runtime too — no more `FROM noir:1.0.0` hardcoded
-    # in a sibling Dockerfile that the maintainer must keep bumping.
+    # to, mirroring the matching released image so locking the action to
+    # a tag locks the runtime too. `@v1.1.0` → `1.1.0`, `@v1` → `1`,
+    # `@main` → `main`, no ref → `latest`; commit-SHA / unknown refs
+    # degrade to `latest`. Full rules live in resolve-image-tag.sh so the
+    # mapping can be unit-tested without the Actions runtime.
     - name: Resolve Noir image tag
       id: resolve
       shell: bash
+      env:
+        NOIR_ACTION_REF: ${{ github.action_ref }}
       run: |
-        REF="${{ github.action_ref }}"
-        TAG="${REF#v}"
-        TAG="${TAG:-latest}"
-        echo "image=ghcr.io/owasp-noir/noir:${TAG}" >> "$GITHUB_OUTPUT"
-        echo "Using Noir image: ghcr.io/owasp-noir/noir:${TAG}"
+        tag="$(bash "$GITHUB_ACTION_PATH/github-action/resolve-image-tag.sh" "$NOIR_ACTION_REF")"
+        echo "image=ghcr.io/owasp-noir/noir:${tag}" >> "$GITHUB_OUTPUT"
+        echo "Using Noir image: ghcr.io/owasp-noir/noir:${tag}"
 
     # Pull explicitly so the next step's log only shows "running
     # noir", not the registry round-trip. Easier triage for registry
-    # vs runtime failures.
+    # vs runtime failures. Fall back to :latest when the resolved image
+    # isn't published (e.g. a branch ref with no built image) so the
+    # action degrades instead of hard-failing on `docker pull`.
     - name: Pull Noir image
+      id: pull
       shell: bash
-      run: docker pull "${{ steps.resolve.outputs.image }}"
+      env:
+        NOIR_IMAGE: ${{ steps.resolve.outputs.image }}
+      run: |
+        image="$NOIR_IMAGE"
+        if docker pull "$image"; then
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+        else
+          fallback="ghcr.io/owasp-noir/noir:latest"
+          echo "::warning title=OWASP Noir::Could not pull ${image}; falling back to ${fallback}"
+          docker pull "$fallback"
+          echo "image=$fallback" >> "$GITHUB_OUTPUT"
+        fi
 
     # Run the entrypoint inside the pre-built image. INPUT_* env vars
     # match the keys exposed via `with:`; the entrypoint reads them in
@@ -187,7 +202,7 @@ runs:
           -e INPUT_DIFF_PATH="${{ inputs.diff_path }}" \
           -e INPUT_NO_LOG="${{ inputs.no_log }}" \
           --entrypoint /entrypoint.sh \
-          "${{ steps.resolve.outputs.image }}"
+          "${{ steps.pull.outputs.image }}"
 
         # The container wrote to /github/workspace/.noir-output (its
         # view of $GITHUB_OUTPUT); promote that into the composite

--- a/github-action/README.md
+++ b/github-action/README.md
@@ -38,8 +38,14 @@ jobs:
         with:
           base_path: '.'
 
+      # Pass outputs via env vars, never inline `'${{ ... }}'` into the
+      # shell. `endpoints` is JSON derived from the scanned code, so on an
+      # untrusted PR a crafted value could break out of the quotes and inject
+      # commands into the runner.
       - name: Display results
-        run: echo '${{ steps.noir.outputs.endpoints }}' | jq .
+        env:
+          NOIR_ENDPOINTS: ${{ steps.noir.outputs.endpoints }}
+        run: echo "$NOIR_ENDPOINTS" | jq .
 ```
 
 ### Advanced Example
@@ -67,12 +73,15 @@ jobs:
           verbose: 'true'
 
       - name: Process Results
+        env:
+          NOIR_ENDPOINTS: ${{ steps.noir.outputs.endpoints }}
+          NOIR_PASSIVE: ${{ steps.noir.outputs.passive_results }}
         run: |
           echo "🔍 Endpoints discovered:"
-          echo '${{ steps.noir.outputs.endpoints }}' | jq '.endpoints | length'
+          echo "$NOIR_ENDPOINTS" | jq '.endpoints | length'
 
           echo "🚨 Security issues found:"
-          echo '${{ steps.noir.outputs.passive_results }}' | jq '. | length'
+          echo "$NOIR_PASSIVE" | jq '. | length'
 
       - name: Save detailed results
         uses: actions/upload-artifact@v4

--- a/github-action/resolve-image-tag.sh
+++ b/github-action/resolve-image-tag.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Resolve which ghcr.io/owasp-noir/noir image tag the action should run,
+# from the git ref the consumer pinned the action to (`github.action_ref`).
+# ============================================================================
+#
+# Prints the resolved tag on stdout; degrade warnings go to stderr so the
+# stdout capture in action.yml stays clean.
+#
+# Rules (first match wins):
+#   (empty)                  -> latest    local `uses: ./`, or an unpinned
+#                                          consumer — action_ref is empty
+#   v1.1.0 / 1.1.0 / v1 / v1.1
+#                            -> 1.1.0 / 1.1.0 / 1 / 1.1
+#                                          semver-ish release ref: strip a
+#                                          leading `v` to match the published
+#                                          image tags (which are unprefixed)
+#   <7-40 hex chars>         -> latest    commit-SHA pin: no per-commit image
+#                                          is published, so degrade rather
+#                                          than pull a tag that cannot exist.
+#                                          Warns; pin a release tag for a
+#                                          reproducible image.
+#   <anything else>          -> as-is     branch ref (e.g. main -> :main).
+#                                          action.yml pulls with a :latest
+#                                          fallback, so a branch with no
+#                                          published image still degrades
+#                                          instead of hard-failing.
+#
+# The old inline logic in action.yml was `TAG="${REF#v}"`, which stripped a
+# leading `v` from *any* ref (so a branch named `validate` became `alidate`)
+# and mapped commit-SHA pins to `noir:<sha>` — an image that is never
+# published, breaking the security-recommended SHA-pin usage outright.
+set -euo pipefail
+
+ref="${1-${GITHUB_ACTION_REF-}}"
+warn() { echo "noir-action: $*" >&2; }
+
+if [ -z "$ref" ]; then
+  tag="latest"
+elif printf '%s' "$ref" | grep -Eq '^v?[0-9]+(\.[0-9]+){0,2}([-+][0-9A-Za-z.-]+)?$'; then
+  # semver-ish (optionally v-prefixed): v1, v1.2, v1.2.3, 1.2.3-rc1, ...
+  tag="${ref#v}"
+elif printf '%s' "$ref" | grep -Eiq '^[0-9a-f]{7,40}$'; then
+  warn "pinned to commit SHA '$ref'; no per-commit image is published — using ':latest'. Pin a release tag (e.g. @v1.1.0) for a reproducible image."
+  tag="latest"
+else
+  tag="$ref"
+fi
+
+printf '%s\n' "$tag"

--- a/github-action/test-entrypoint.sh
+++ b/github-action/test-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# ============================================================================
+# GitHub Action entrypoint — end-to-end smoke test
+# ============================================================================
+#
+# Drives github-action/entrypoint.sh inside an image built from the CURRENT
+# tree, the same way action.yml's `docker run` step does, then asserts on the
+# $GITHUB_OUTPUT contract (`endpoints` / `passive_results`).
+#
+# Why this exists: the composite action `docker pull`s a *pre-built,
+# published* image, and ci.yml's docker build uses `push: false` and never
+# runs the container — so entrypoint.sh had no CI coverage and changes to it
+# shipped untested. This harness closes that gap and is the local
+# reproduction tool for entrypoint output-contract bugs.
+#
+# Usage:
+#   docker build -t noir-action:local .
+#   github-action/test-entrypoint.sh noir-action:local
+set -euo pipefail
+
+IMAGE="${1:?usage: test-entrypoint.sh <image-tag>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE="$REPO_ROOT/spec/functional_test/fixtures/crystal"
+
+fail_count=0
+note_pass() { printf '    \033[32m✓\033[0m %s\n' "$1"; }
+note_fail() { printf '    \033[31m✗\033[0m %s\n' "$1"; fail_count=$((fail_count + 1)); }
+
+# Run entrypoint.sh in the image the way action.yml does: mount an isolated
+# workspace (root-owned container writes stay out of the checkout), point the
+# container's $GITHUB_OUTPUT at a workspace file so we can read the promoted
+# outputs back, and forward INPUT_* env. Echoes the workspace dir on success,
+# or "__FAILED__ <dir>" if the container exited non-zero.
+run_action() {
+  local scenario="$1"; shift
+  local ws; ws="$(mktemp -d)"
+  cp -R "$FIXTURE" "$ws/src"
+  if docker run --rm \
+      -v "$ws":/github/workspace \
+      -w /github/workspace \
+      -e GITHUB_OUTPUT=/github/workspace/.noir-output \
+      -e INPUT_BASE_PATH="src" \
+      "$@" \
+      --entrypoint /entrypoint.sh \
+      "$IMAGE" >"$ws/stdout" 2>"$ws/stderr"; then
+    echo "$ws"
+  else
+    echo "__FAILED__ $ws"
+  fi
+}
+
+gh_output() { cat "$1/.noir-output" 2>/dev/null || true; }
+
+echo "==> image:   $IMAGE"
+echo "==> fixture: ${FIXTURE#"$REPO_ROOT"/}"
+
+# ---------------------------------------------------------------------------
+# Scenario 1: format=json + passive scan — the default, most-used contract.
+# ---------------------------------------------------------------------------
+echo "[1] format=json, passive_scan=true"
+ws="$(run_action json -e INPUT_FORMAT=json -e INPUT_PASSIVE_SCAN=true)"
+if [[ "$ws" == __FAILED__* ]]; then
+  note_fail "entrypoint exited non-zero"
+  cat "${ws#__FAILED__ }/stderr" >&2 || true
+else
+  out="$(gh_output "$ws")"
+  # Every emitted line must be a `name=value` pair. A stray continuation
+  # line means a multi-line value slipped into $GITHUB_OUTPUT, which breaks
+  # the single-line `name=value` format GitHub expects.
+  total=$(printf '%s\n' "$out" | grep -c . || true)
+  named=$(printf '%s\n' "$out" | grep -cE '^(endpoints|passive_results)=' || true)
+  if [[ "$total" -eq 2 && "$named" -eq 2 ]]; then
+    note_pass "exactly 2 well-formed output lines"
+  else
+    note_fail "expected 2 name=value lines, got total=$total named=$named"
+  fi
+  ep="$(printf '%s\n' "$out" | sed -n 's/^endpoints=//p')"
+  if printf '%s' "$ep" | jq -e '.endpoints | length >= 1' >/dev/null 2>&1; then
+    note_pass "endpoints is single-line JSON with >=1 endpoint"
+  else
+    note_fail "endpoints is not valid JSON with a non-empty endpoints[]"
+  fi
+  pr="$(printf '%s\n' "$out" | sed -n 's/^passive_results=//p')"
+  if printf '%s' "$pr" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    note_pass "passive_results is a JSON array"
+  else
+    note_fail "passive_results is not a JSON array"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario 2: non-JSON format (yaml) — outputs must degrade to the documented
+# empty contract, never to malformed JSON that breaks a downstream `jq`.
+# ---------------------------------------------------------------------------
+echo "[2] format=yaml (non-JSON contract)"
+ws="$(run_action yaml -e INPUT_FORMAT=yaml)"
+if [[ "$ws" == __FAILED__* ]]; then
+  note_fail "entrypoint exited non-zero"
+  cat "${ws#__FAILED__ }/stderr" >&2 || true
+else
+  out="$(gh_output "$ws")"
+  if grep -qxF 'endpoints=' <<<"$out"; then
+    note_pass "endpoints is empty"
+  else
+    note_fail "endpoints should be empty for a non-JSON format"
+  fi
+  if grep -qxF 'passive_results=[]' <<<"$out"; then
+    note_pass "passive_results is []"
+  else
+    note_fail "passive_results should be [] for a non-JSON format"
+  fi
+fi
+
+# NOTE: format=jsonl is intentionally not asserted here yet — the current
+# entrypoint mishandles the multi-object JSONL stream (emits multi-line
+# values that corrupt $GITHUB_OUTPUT). Add a jsonl scenario together with the
+# fix for that (stability review, finding M1).
+
+echo
+if [[ "$fail_count" -eq 0 ]]; then
+  echo "All action entrypoint checks passed."
+else
+  echo "$fail_count action entrypoint check(s) failed." >&2
+  exit 1
+fi

--- a/github-action/test-resolve-image-tag.sh
+++ b/github-action/test-resolve-image-tag.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Unit tests for resolve-image-tag.sh — pure, no Docker/registry needed.
+# ============================================================================
+#
+# Usage:  github-action/test-resolve-image-tag.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+RESOLVE="$HERE/resolve-image-tag.sh"
+
+fail_count=0
+check() {
+  local ref="$1" want="$2" got
+  # stderr (degrade warnings) is intentionally discarded — only the tag on
+  # stdout is the contract.
+  got="$(bash "$RESOLVE" "$ref" 2>/dev/null)"
+  if [ "$got" = "$want" ]; then
+    printf '    \033[32m✓\033[0m %-42s -> %s\n' "ref='${ref}'" "$got"
+  else
+    printf '    \033[31m✗\033[0m %-42s -> %s (want %s)\n' "ref='${ref}'" "$got" "$want"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+echo "resolve-image-tag.sh"
+
+# Release refs: strip a leading v, map to the unprefixed published tags.
+check "v1.1.0"      "1.1.0"
+check "1.1.0"       "1.1.0"
+check "v1"          "1"
+check "v1.1"        "1.1"
+check "v2.0.0-rc1"  "2.0.0-rc1"
+
+# Empty ref (local `uses: ./`, unpinned consumer) -> latest.
+check ""            "latest"
+
+# Commit-SHA pins -> latest (no per-commit image is published).
+check "a1b2c3d"                                    "latest"
+check "0123456789abcdef0123456789abcdef01234567"  "latest"
+
+# Branch refs pass through verbatim; action.yml's pull step falls back to
+# :latest if the branch has no published image.
+check "main"        "main"
+check "feature/x"   "feature/x"
+
+echo
+if [ "$fail_count" -eq 0 ]; then
+  echo "All resolver checks passed."
+else
+  echo "$fail_count resolver check(s) failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
## What

Stability pass over the **GitHub Action runtime** — the composite
`action.yml`, the container `entrypoint.sh`, and the ghcr image the action
runs. Three high-impact fixes:

### 1. The entrypoint had no CI coverage
The composite `docker pull`s a **pre-built published image**, and ci.yml's
docker build uses `push: false` and never runs the container — so
`entrypoint.sh` shipped untested, and PRs touching it (or `action.yml`)
weren't even in the CI `paths` filter.

- New `test-action` CI job: builds the image **from the current tree** and
  drives the entrypoint exactly as `action.yml` does, asserting the
  `$GITHUB_OUTPUT` contract (`endpoints` / `passive_results`).
- `paths` filter extended to `action.yml` and `github-action/**`.
- New harness `github-action/test-entrypoint.sh` (also runnable locally).

### 2. SHA-pinning broke the action entirely
`TAG="${REF#v}"` stripped a leading `v` from *any* ref (branch `validate`
→ `alidate`) and mapped commit-SHA pins to `noir:<sha>` — an image that is
**never published**. So the security-recommended way to pin a third-party
action (a full commit SHA, which Dependabot also uses) resolved to a
nonexistent tag and hard-failed on `docker pull`.

- Mapping extracted to `github-action/resolve-image-tag.sh` (unit-tested,
  no Actions runtime needed): strip `v` only from semver-ish refs
  (`@v1`, `@v1.1`, `@v1.1.0`), degrade commit-SHA / unknown refs to
  `:latest` with a warning, pass branch refs through.
- `action.yml`'s pull step now falls back to `:latest` when the resolved
  image isn't published, instead of hard-failing.
- New unit test `github-action/test-resolve-image-tag.sh`.

### 3. The documented examples taught a script-injection pattern
README and the example workflow inlined
`echo '${{ steps.noir.outputs.endpoints }}'` into the shell. That output
is JSON derived from the **scanned code**, so on an untrusted PR a crafted
endpoint value could break out of the quotes and inject commands into the
runner. All examples now route outputs through `env:` vars.

## Verification

Run locally against an image built from this tree:

- entrypoint harness — 5/5 green; proven to fail (exit 1) on a broken assertion
- resolver unit test — 10/10 green; proven to fail (exit 1) on a broken expectation
- pull-fallback `else` branch — exercised against the real registry (bad tag → `:latest`)
- all touched YAML validated

**Confirmed by this PR's own CI run** (needs the Actions runtime, not
reproducible locally): `action.yml`'s composite glue (`$GITHUB_ACTION_PATH`
resolution, the resolve→pull wiring), buildx `load: true`, and the Linux
runner's root-owned `.noir-output` read-back.

## Not in this PR (follow-ups)

Deferred, tracked from the same review: `format=jsonl` corrupts
`$GITHUB_OUTPUT` (emits multi-line values); default `output_file=/tmp/...`
is lost with `--rm`; container writes workspace files as root; URL-type
inputs (`export_es` / `export_webhook` / `probe_via`) can leak embedded
credentials to logs.
