### PR TITLE
fix(output/mermaid): fidelity & render fixes for the mindmap format

### DIFF
--- a/docs/content/usage/output_formats/mermaid/index.ko.md
+++ b/docs/content/usage/output_formats/mermaid/index.ko.md
@@ -16,7 +16,7 @@ noir scan . -f mermaid
 
 ## 출력 예제
 
-마인드맵은 트리 구조로 구성됩니다. 루트 노드가 API 전체를 나타내고, 가지가 URL 경로 세그먼트, 잎이 HTTP 메서드와 파라미터(타입별로 `body`, `headers`, `cookies`로 분류)입니다.
+마인드맵은 트리 구조입니다. 루트 노드는 API 전체, 가지는 URL 경로 세그먼트이며, 각 HTTP 메서드는 자신이 담당하는 경로 아래에 놓입니다. 메서드 아래 파라미터는 요청에서 전달되는 위치별로 `query`, `body`, `headers`, `cookies`, `path` 그룹으로 나뉩니다. 경로 파라미터는 `param_*` 가지로도 표시되며(`/users/{user_id}` → `param_user_id` 세그먼트), WebSocket 경로에는 `websocket` 태그가 붙습니다.
 
 <details>
     <summary>Mermaid 출력</summary>
@@ -25,89 +25,34 @@ noir scan . -f mermaid
 mindmap
   root((API))
     GET
-    about
+    account
       GET
-      GET
-      POST
-        body
-          data
-          id
-    gems
-      GET
-    gems_json
-      GET
+        headers
+          authorization
         cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        cookies
-          cookie
-        body
-          query
-          sort
-    gems_yml
+          session
+    search
       GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      PUT
-        cookies
-          cookie
-        body
-          query
-          sort
-    path_111
-      PUT
-    pets
-      GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        body
-          name
-      param_petId
-        GET
-          body
-            petId
-        PUT
-          body
-            breed
-            name
-            petId
-    shards
-      GET
+        query
+          page
+          q
     users
       POST
         body
           email
           name
-      param_userId
+      param_user_id
         GET
-          headers
-            Authorization
-          body
-            userId
-    v1
-      pets
-        GET
-        POST
-        param_petId
-          GET
-            body
-              petId
-          PUT
-            body
-              petId
-    zz
-      GET
-      DELETE
+          query
+            verbose
+          path
+            user_id
+        DELETE
+          path
+            user_id
+    ws
+      feed
+        GET websocket
 ```
 
 </details>
@@ -118,89 +63,34 @@ mindmap
 mindmap
   root((API))
     GET
-    about
+    account
       GET
-      GET
-      POST
-        body
-          data
-          id
-    gems
-      GET
-    gems_json
-      GET
+        headers
+          authorization
         cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        cookies
-          cookie
-        body
-          query
-          sort
-    gems_yml
+          session
+    search
       GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      PUT
-        cookies
-          cookie
-        body
-          query
-          sort
-    path_111
-      PUT
-    pets
-      GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        body
-          name
-      param_petId
-        GET
-          body
-            petId
-        PUT
-          body
-            breed
-            name
-            petId
-    shards
-      GET
+        query
+          page
+          q
     users
       POST
         body
           email
           name
-      param_userId
+      param_user_id
         GET
-          headers
-            Authorization
-          body
-            userId
-    v1
-      pets
-        GET
-        POST
-        param_petId
-          GET
-            body
-              petId
-          PUT
-            body
-              petId
-    zz
-      GET
-      DELETE
+          query
+            verbose
+          path
+            user_id
+        DELETE
+          path
+            user_id
+    ws
+      feed
+        GET websocket
 {% end %}
 
 ## 팁

--- a/docs/content/usage/output_formats/mermaid/index.md
+++ b/docs/content/usage/output_formats/mermaid/index.md
@@ -16,7 +16,7 @@ noir scan . -f mermaid
 
 ## Example Output
 
-The mindmap is a tree: the root node represents the API, branches are URL path segments, and leaves show HTTP methods with their parameters (grouped by type: `body`, `headers`, `cookies`).
+The mindmap is a tree: the root node is the API, branches are URL path segments, and each HTTP method hangs off the path it serves. Parameters under a method are grouped by where they travel in the request — `query`, `body`, `headers`, `cookies`, and `path`. Path parameters also surface as `param_*` branches (so `/users/{user_id}` becomes a `param_user_id` segment), and WebSocket routes are tagged `websocket`.
 
 <details>
     <summary>Mermaid Output</summary>
@@ -25,89 +25,34 @@ The mindmap is a tree: the root node represents the API, branches are URL path s
 mindmap
   root((API))
     GET
-    about
+    account
       GET
-      GET
-      POST
-        body
-          data
-          id
-    gems
-      GET
-    gems_json
-      GET
+        headers
+          authorization
         cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        cookies
-          cookie
-        body
-          query
-          sort
-    gems_yml
+          session
+    search
       GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      PUT
-        cookies
-          cookie
-        body
-          query
-          sort
-    path_111
-      PUT
-    pets
-      GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        body
-          name
-      param_petId
-        GET
-          body
-            petId
-        PUT
-          body
-            breed
-            name
-            petId
-    shards
-      GET
+        query
+          page
+          q
     users
       POST
         body
           email
           name
-      param_userId
+      param_user_id
         GET
-          headers
-            Authorization
-          body
-            userId
-    v1
-      pets
-        GET
-        POST
-        param_petId
-          GET
-            body
-              petId
-          PUT
-            body
-              petId
-    zz
-      GET
-      DELETE
+          query
+            verbose
+          path
+            user_id
+        DELETE
+          path
+            user_id
+    ws
+      feed
+        GET websocket
 ```
 
 </details>
@@ -118,89 +63,34 @@ Paste the raw output into the [Mermaid live editor](https://mermaid.live/) to re
 mindmap
   root((API))
     GET
-    about
+    account
       GET
-      GET
-      POST
-        body
-          data
-          id
-    gems
-      GET
-    gems_json
-      GET
+        headers
+          authorization
         cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        cookies
-          cookie
-        body
-          query
-          sort
-    gems_yml
+          session
+    search
       GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      PUT
-        cookies
-          cookie
-        body
-          query
-          sort
-    path_111
-      PUT
-    pets
-      GET
-        cookies
-          cookie
-        body
-          query
-          sort
-      POST
-        body
-          name
-      param_petId
-        GET
-          body
-            petId
-        PUT
-          body
-            breed
-            name
-            petId
-    shards
-      GET
+        query
+          page
+          q
     users
       POST
         body
           email
           name
-      param_userId
+      param_user_id
         GET
-          headers
-            Authorization
-          body
-            userId
-    v1
-      pets
-        GET
-        POST
-        param_petId
-          GET
-            body
-              petId
-          PUT
-            body
-              petId
-    zz
-      GET
-      DELETE
+          query
+            verbose
+          path
+            user_id
+        DELETE
+          path
+            user_id
+    ws
+      feed
+        GET websocket
 {% end %}
 
 ## Tips

--- a/spec/unit_test/output_builder/mermaid_spec.cr
+++ b/spec/unit_test/output_builder/mermaid_spec.cr
@@ -45,7 +45,8 @@ describe "OutputBuilderMermaid" do
     output.should contain("        email")
     output.should contain("        username")
     output.should contain("    GET")
-    output.should contain("      body")
+    # A query param lands in its own `query` group, not lumped into `body`.
+    output.should contain("      query")
     output.should contain("        limit")
   end
 
@@ -97,9 +98,12 @@ describe "OutputBuilderMermaid" do
     output.should contain("      body")
     output.should contain("        param1")
     output.should contain("        param2")
+    # The path parameter shows up twice, on purpose and complementarily:
+    # as a `param_*` segment node (its position in the URL hierarchy)...
     output.should contain("  param_user_id")
     output.should contain("    GET")
-    output.should contain("      body")
+    # ...and, named, inside the endpoint's own `path` group (not `body`).
+    output.should contain("      path")
     output.should contain("        user_id")
     output.should contain("public")
     output.should contain("  images")
@@ -110,7 +114,10 @@ describe "OutputBuilderMermaid" do
     output.should contain("      cookies")
     output.should contain("        session_id")
     output.should contain("socket")
-    output.should contain("  GET [websocket]")
+    # A bare ` websocket` word, not `[websocket]`: brackets are mindmap
+    # node-shape syntax and would hide the "GET" method on render.
+    output.should contain("  GET websocket")
+    output.should_not contain("[websocket]")
   end
 
   it "prints with endpoints and passive results" do
@@ -164,7 +171,7 @@ describe "OutputBuilderMermaid" do
     output.should contain("root((API))")
     output.should contain("test")
     output.should contain("  GET")
-    output.should contain("    body")
+    output.should contain("    query")
     output.should contain("      test_param")
 
     # Verify passive scan findings are rendered as a branch
@@ -172,5 +179,63 @@ describe "OutputBuilderMermaid" do
     output.should contain("test_rule")
     output.should contain("high")
     output.should contain("test_cr_10")
+  end
+
+  it "normalizes framework path-parameter notations to param_* segments" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderMermaid.new(options)
+    builder.io = IO::Memory.new
+
+    # Every framework spells path parameters differently; all four must
+    # collapse to a `param_*` segment so the notation never leaks into the
+    # node id (`:id` used to become `_id`, `*` used to become `_`).
+    e1 = Endpoint.new("/items/:id", "GET")       # colon (Sinatra/Rails/Express)
+    e2 = Endpoint.new("/files/*", "GET")         # bare splat / wildcard
+    e3 = Endpoint.new("/blob/*path", "GET")      # named splat
+    e4 = Endpoint.new("/users/{user_id}", "GET") # brace (OpenAPI)
+
+    builder.print([e1, e2, e3, e4])
+    output = builder.io.to_s
+
+    # Each is a second-level segment (6-space indent) under its parent.
+    output.should contain("      param_id")
+    output.should contain("      param_wildcard")
+    output.should contain("      param_path")
+    output.should contain("      param_user_id")
+  end
+
+  it "keeps same-named params in separate location groups (no overwrite)" do
+    options = {
+      "debug"   => YAML::Any.new(false),
+      "verbose" => YAML::Any.new(false),
+      "color"   => YAML::Any.new(false),
+      "nolog"   => YAML::Any.new(false),
+      "output"  => YAML::Any.new(""),
+    }
+    builder = OutputBuilderMermaid.new(options)
+    builder.io = IO::Memory.new
+
+    # A `token` in the query string and a `token` in the JSON body are two
+    # distinct attack-surface inputs. The old single "body" bucket keyed by
+    # name collapsed them into one node; each must now survive under its
+    # own location group.
+    endpoint = Endpoint.new("/auth", "POST")
+    endpoint.push_param(Param.new("token", "", "query"))
+    endpoint.push_param(Param.new("token", "", "json"))
+
+    builder.print([endpoint])
+    output = builder.io.to_s
+
+    output.should contain("      query")
+    output.should contain("      body")
+    output.should contain("        token")
+    # Both groups plus the two members => exactly two `token` leaf nodes.
+    output.scan("token").size.should eq(2)
   end
 end

--- a/src/output_builder/mermaid.cr
+++ b/src/output_builder/mermaid.cr
@@ -34,7 +34,7 @@ class OutputBuilderMermaid < OutputBuilder
       finding_indent = "  " * (indent + 1)
       location = "#{result.file_path}:#{result.line_number}"
       label = "#{result.id} [#{result.info.severity}] #{location}"
-      ob_puts "#{finding_indent}#{sanitize_segment(label)}"
+      ob_puts "#{finding_indent}#{sanitize_label(label)}"
     end
   end
 
@@ -72,8 +72,8 @@ class OutputBuilderMermaid < OutputBuilder
       # Navigate/create tree structure
       current_node = root
       segments.each do |segment|
-        # Sanitize segment for Mermaid compatibility
-        sanitized_segment = sanitize_segment(segment)
+        # Sanitize segment for Mermaid compatibility (path-param aware)
+        sanitized_segment = sanitize_path_segment(segment)
         if !current_node.children.has_key?(sanitized_segment)
           current_node.children[sanitized_segment] = TreeNode.new
         end
@@ -85,90 +85,91 @@ class OutputBuilderMermaid < OutputBuilder
     root
   end
 
-  private def sanitize_segment(segment : String) : String
-    # Handle path parameters (e.g., {user_id} -> param_user_id)
-    if segment.match(/^{.*}$/)
-      # Remove curly braces and prefix with 'param_'
-      sanitized = "param_#{segment.gsub(/[{}\s]/, "")}"
-    else
-      # Replace mermaid-unsafe characters with underscore, but keep Unicode
-      # letters/digits (\p{L}/\p{N}) intact. The old ASCII-only class turned
-      # a Korean/CJK/accented segment like `사용자` into `___`, destroying the
-      # label; \p{L}\p{N} preserves it while still stripping spaces and
-      # syntax chars ([], (), :) that would break the bare mindmap node.
-      sanitized = segment.gsub(/[^\p{L}\p{N}_]/, "_")
-      # If starts with an ASCII digit, prepend 'path_' (mindmap node ids
-      # can't lead with a digit).
-      if sanitized =~ /^\d/
-        sanitized = "path_#{sanitized}"
-      end
-    end
-    # Ensure non-empty and unique
+  # General-purpose Mermaid mindmap label sanitizer for free-text node
+  # labels (header / cookie / parameter names, passive findings). Mermaid
+  # treats (), [], {} as node-shape syntax, so anything outside Unicode
+  # letters/digits/underscore is collapsed to `_`. \p{L}\p{N} keeps CJK /
+  # accented text intact — an ASCII-only class turned `사용자` into `___`,
+  # destroying the label.
+  private def sanitize_label(text : String) : String
+    sanitized = text.gsub(/[^\p{L}\p{N}_]/, "_")
+    # Mindmap node ids can't lead with a digit.
+    sanitized = "path_#{sanitized}" if sanitized =~ /^\d/
+    # Ensure non-empty.
     sanitized.empty? ? "unnamed" : sanitized
+  end
+
+  # Sanitize a single URL path segment. Path parameters are spelled many
+  # ways across frameworks — `{id}` (OpenAPI), `:id` (Sinatra / Rails /
+  # Express), `*path` (named splat) and a bare `*` (splat / wildcard).
+  # Normalize every form to a `param_<name>` node so the mindmap marks the
+  # segment as a path parameter consistently, instead of leaking `:id` as
+  # `_id` and `*` as `_`, which erased that meaning entirely.
+  private def sanitize_path_segment(segment : String) : String
+    if md = segment.match(/^\{(.+)\}$/) || segment.match(/^:(.+)$/) || segment.match(/^\*(.+)$/)
+      return "param_#{sanitize_label(md[1])}"
+    end
+    return "param_wildcard" if segment == "*"
+    sanitize_label(segment)
+  end
+
+  # Render one parameter group (headers / cookies / query / body / path or
+  # a CLI bucket) as a labeled sub-node followed by its sorted members.
+  # A no-op for empty buckets so absent locations don't clutter the map.
+  private def render_param_group(bucket : Hash(String, String), label : String, indent : Int32)
+    return if bucket.empty?
+
+    group_indent = "  " * (indent + 1)
+    ob_puts "#{group_indent}#{label}"
+    item_indent = "  " * (indent + 2)
+    bucket.keys.sort!.each do |name|
+      ob_puts "#{item_indent}#{sanitize_label(name)}"
+    end
   end
 
   private def output_tree(node : TreeNode, indent : Int32)
     # Output endpoints for this node
     node.endpoints.each do |endpoint|
       indent_str = "  " * indent
-      # Use only the HTTP method as the endpoint label, add [websocket] if applicable.
-      # The protocol field is "ws" everywhere else in the codebase
-      # (analyzers, common output, websocket tagger).
+      # Label the node with the HTTP method, tagging websockets. The
+      # protocol field is "ws" everywhere else in the codebase (analyzers,
+      # common output, websocket tagger). NB: the tag is a bare ` websocket`
+      # word, NOT `[websocket]` — in a mindmap `[...]` is node-shape syntax,
+      # so `GET [websocket]` renders as a square node showing only
+      # "websocket" with the method silently dropped.
       endpoint_label = endpoint.method
-      endpoint_label += " [websocket]" if endpoint.protocol == "ws"
+      endpoint_label += " websocket" if endpoint.protocol == "ws"
       ob_puts "#{indent_str}#{endpoint_label}"
 
-      # Get parameters grouped by type
+      # Group parameters by their real request location. Each location is
+      # attack-surface-distinct, so it gets its own group instead of being
+      # flattened into one "body" bucket — the old merge also silently
+      # overwrote same-named params across locations (a `token` query param
+      # and a `token` json field collapsed into a single node).
       params_hash = endpoint.params_to_hash
 
-      # Output headers
-      unless params_hash["header"].empty?
-        headers_indent = "  " * (indent + 1)
-        ob_puts "#{headers_indent}headers"
-        params_hash["header"].keys.sort!.each do |header|
-          header_indent = "  " * (indent + 2)
-          ob_puts "#{header_indent}#{sanitize_segment(header)}"
-        end
-      end
+      render_param_group(params_hash["header"], "headers", indent)
+      render_param_group(params_hash["cookie"], "cookies", indent)
+      render_param_group(params_hash["query"], "query", indent)
 
-      # Output cookies
-      unless params_hash["cookie"].empty?
-        cookies_indent = "  " * (indent + 1)
-        ob_puts "#{cookies_indent}cookies"
-        params_hash["cookie"].keys.sort!.each do |cookie|
-          cookie_indent = "  " * (indent + 2)
-          ob_puts "#{cookie_indent}#{sanitize_segment(cookie)}"
-        end
-      end
-
-      # Output body parameters (json, form, query, path)
+      # `body` covers both JSON and form payloads: both are request-body
+      # namespaces and (unlike query vs body) a request never carries both.
       body_params = {} of String => String
-      ["json", "form", "query", "path"].each do |param_type|
-        params_hash[param_type].each do |key, value|
-          body_params[key] = value
-        end
-      end
-      unless body_params.empty?
-        body_indent = "  " * (indent + 1)
-        ob_puts "#{body_indent}body"
-        body_params.keys.sort!.each do |param|
-          param_indent = "  " * (indent + 2)
-          ob_puts "#{param_indent}#{sanitize_segment(param)}"
-        end
-      end
+      params_hash["json"].each { |key, value| body_params[key] = value }
+      params_hash["form"].each { |key, value| body_params[key] = value }
+      render_param_group(body_params, "body", indent)
+
+      # Path params get their own group. The tree already shows each path
+      # parameter as a `param_*` segment (its position in the URL); this
+      # group names the params the endpoint reads, which is complementary.
+      render_param_group(params_hash["path"], "path", indent)
 
       # CLI inputs (protocol "cli") live outside the six canonical HTTP
       # buckets — render flags / positional arguments / env reads as their
       # own groups so they aren't silently dropped from the mindmap.
       {"flag" => "flags", "argument" => "arguments", "env" => "env"}.each do |param_type, label|
         bucket = params_hash[param_type]?
-        next if bucket.nil? || bucket.empty?
-        group_indent = "  " * (indent + 1)
-        ob_puts "#{group_indent}#{label}"
-        bucket.keys.sort!.each do |name|
-          item_indent = "  " * (indent + 2)
-          ob_puts "#{item_indent}#{sanitize_segment(name)}"
-        end
+        render_param_group(bucket, label, indent) unless bucket.nil?
       end
     end
 


### PR DESCRIPTION
## Summary

Improves the `-f mermaid` mindmap output and syncs its documentation example.

### Output builder (`src/output_builder/mermaid.cr`)
- **Group parameters by real request location** — `query`, `body` (json+form), `headers`, `cookies`, `path` — instead of collapsing json/form/query/path into one `body` bucket. The old merge lost attack-surface fidelity and silently overwrote same-named params across locations (a `token` query param and a `token` json field collapsed into a single node).
- **Normalize path-parameter notation** across frameworks to `param_*`: `{id}` (OpenAPI), `:id` (Sinatra/Rails/Express), `*path` (named splat) and a bare `*` (wildcard). Previously `:id` leaked as `_id` and `*` as `_`, erasing the "this is a path parameter" meaning. The sanitizer is split into a general `sanitize_label` and a path-aware `sanitize_path_segment`.
- **Fix a websocket render bug**: `GET [websocket]` was parsed by mermaid as node-shape syntax, dropping the `GET` method on render. Now tagged with a bare ` websocket` word.

### Docs (`docs/content/usage/output_formats/mermaid/{index,index.ko}.md`)
- Replace the stale example (which showed the old merged-`body` grouping) with a compact, tool-generated example demonstrating the query/body/path split, `param_*` segments, multiple methods per path, and the websocket label. Prose updated to match. EN + KO.

## Verification
- Unit specs pass, including 2 new regression tests (path-param notation; same-named params kept in separate location groups).
- `ameba` lint clean; `crystal tool format` clean.
- Rendered the output with `mermaid-cli` on **10.9.1** (the docs-pinned renderer) and **11** — no parse errors, all groups / `param_*` / `GET websocket` nodes render correctly.