### PR TITLE
fix(docs/search): stop double-prefixing base path on result links

### DIFF
--- a/docs/static/js/search.js
+++ b/docs/static/js/search.js
@@ -18,6 +18,21 @@
   var base = (window.NOIR_BASE || "").replace(/\/+$/, "");
   var T = window.NOIR_I18N || {};
 
+  /* Path component of base_url — "/noir" for https://owasp-noir.github.io/noir,
+     "" for the bare host `hwaro serve` hands out. hwaro bakes this prefix into
+     the urls it writes to search.json, so results are already root-absolute and
+     ready to use; prepending base again produced /noir/noir/… 404s in
+     production while staying invisible on a path-less local server. The prefix
+     is only added when an entry is genuinely missing it. */
+  var basePath = base.replace(/^[a-z][a-z0-9+.-]*:\/\/[^\/]*/i, "").replace(/\/+$/, "");
+
+  function resolve(url) {
+    if (!url) return "#";
+    if (url.charAt(0) !== "/" || !basePath) return url;
+    if (url === basePath || url.indexOf(basePath + "/") === 0) return url;
+    return basePath + url;
+  }
+
   function load() {
     if (data || loading) return Promise.resolve(data || []);
     loading = true;
@@ -79,8 +94,7 @@
     }
 
     results.innerHTML = hits.map(function (h, n) {
-      var url = h.item.url || h.item.permalink || "#";
-      if (url.charAt(0) === "/" && base) url = base + url;
+      var url = resolve(h.item.url || h.item.permalink);
       return '<a class="search-result" role="option" aria-selected="false" data-i="' + n + '" href="' + escapeHtml(url) + '">' +
         "<strong>" + mark(h.item.title || "Untitled", q) + "</strong>" +
         "<span>" + mark(snippet(h.item.content, q), q) + "</span>" +


### PR DESCRIPTION
## Problem

Every search result on the deployed docs site 404s. Reported against the Korean docs, but **English is affected identically**.

Clicking 설치 / Installation lands on:

```
https://owasp-noir.github.io/noir/noir/ko/get_started/installation/
                                    ^^^^^ duplicated
```

## Cause

hwaro already bakes the `base_url` path into the urls it writes to `search.json`, but `search.js` prepended `NOIR_BASE` on top of that:

```
search.json  →  /noir/ko/get_started/installation/    (already carries /noir)
NOIR_BASE    →  https://owasp-noir.github.io/noir     (path is /noir)
concatenated →  .../noir/noir/ko/get_started/installation/   ← 404
```

### Why local testing never caught it

`hwaro serve` rewrites `base_url` to a bare host with no path, which in turn makes hwaro emit **unprefixed** urls in `search.json`:

| | `NOIR_BASE` | `search.json` url | result |
|---|---|---|---|
| `hwaro serve` | `http://127.0.0.1:3000` | `/ko/get_started/…` | correct |
| production | `https://owasp-noir.github.io/noir` | `/noir/ko/get_started/…` | **doubled** |

Both halves lose the prefix at the same time locally, so the concatenation happens to come out right. The bug only exists when `base_url` has a path component.

## Fix

Derive the path component of `base_url` and prepend it only when the entry is genuinely missing it. Matching is on a full path segment, so a url like `/noirbogus/` is still correctly prefixed rather than being mistaken for an already-prefixed one.

## Verification

`public/` was served mounted under a `/noir` sub-path to reproduce the production URL shape, then the built `search.js` was run against the real `search.json` and every emitted link was checked over HTTP:

| | result |
|---|---|
| before (fix reverted, to confirm the harness catches it) | 31 links checked, **31 broken** |
| after | 31 links checked, **0 broken** |

Covering `lang=ko` (설치, 사용법) and `lang=en` (Installation, usage).

Edge cases also verified: path-less local-serve base, root deployment, absolute URLs, and the `/noirbogus/` substring-vs-segment case.