### PR TITLE
fix(analyzer/webforms): support backslash-escaped quotes in C# string literal

### DIFF
--- a/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx
+++ b/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx
@@ -1,0 +1,1 @@
+<%@ Page Language="C#" CodeBehind="BugTest.aspx.cs" Inherits="BugTest" %>

--- a/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx.cs
+++ b/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Web;
+
+public partial class BugTest : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string a = "escaped \" // dummy"; string b = Request.QueryString["RealParam"];
+    }
+}

--- a/spec/functional_test/testers/aspnet/webforms_spec.cr
+++ b/spec/functional_test/testers/aspnet/webforms_spec.cr
@@ -48,6 +48,10 @@ expected_endpoints = [
     Param.new("count", "", "form"),
   ]),
   Endpoint.new("/QuoteService.asmx/Ping", "POST"),
+  Endpoint.new("/BugTest.aspx", "GET", [
+    Param.new("RealParam", "", "query"),
+  ]),
+  Endpoint.new("/BugTest.aspx", "POST"),
 ]
 
 FunctionalTester.new("fixtures/aspnet/webforms/", {

--- a/src/analyzer/analyzers/aspnet/webforms.cr
+++ b/src/analyzer/analyzers/aspnet/webforms.cr
@@ -466,6 +466,11 @@ module Analyzer::Aspnet
       while index < characters.size
         character = characters[index]
 
+        if in_string && character == '\\' && !vb && index + 1 < characters.size
+          index += 2
+          next
+        end
+
         if character == '"'
           in_string = !in_string
         elsif !in_string && comment_start?(character, characters[index + 1]?, vb)


### PR DESCRIPTION
Fixes a bug where comments inside C# string literals (e.g. "//") with escaped quotes were misidentified as line comments, causing subsequent parameters on the same line to be truncated.