### PR TITLE
fix(analyzer/cfml): support backslash-escaped and doubled quotes in string parsing

### DIFF
--- a/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx
+++ b/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx
@@ -1,0 +1,1 @@
+<%@ Page Language="C#" CodeBehind="BugTest.aspx.cs" Inherits="BugTest" %>

--- a/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx.cs
+++ b/spec/functional_test/fixtures/aspnet/webforms/BugTest.aspx.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Web;
+
+public partial class BugTest : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        string a = "escaped \" // dummy"; string b = Request.QueryString["RealParam"];
+    }
+}

--- a/spec/functional_test/fixtures/cfml/fw1/Application.cfc
+++ b/spec/functional_test/fixtures/cfml/fw1/Application.cfc
@@ -15,6 +15,7 @@ component extends="framework.one" {
 
 			// `hint` labels the entry; only the second key is a route.
 			{ 'hint' = 'Standard Route', '$GET/old/path' = '/new/path' },
+			{ 'hint' = "Standard \" Route, with comma", '$GET/escaped/comma' = '/new/path' },
 
 			// Expands per the framework's resourceRouteTemplates.
 			{ 'hint' = 'Resource Routes', '$RESOURCES' = 'dogs' }

--- a/spec/functional_test/testers/aspnet/webforms_spec.cr
+++ b/spec/functional_test/testers/aspnet/webforms_spec.cr
@@ -48,6 +48,10 @@ expected_endpoints = [
     Param.new("count", "", "form"),
   ]),
   Endpoint.new("/QuoteService.asmx/Ping", "POST"),
+  Endpoint.new("/BugTest.aspx", "GET", [
+    Param.new("RealParam", "", "query"),
+  ]),
+  Endpoint.new("/BugTest.aspx", "POST"),
 ]
 
 FunctionalTester.new("fixtures/aspnet/webforms/", {

--- a/spec/functional_test/testers/cfml/fw1_spec.cr
+++ b/spec/functional_test/testers/cfml/fw1_spec.cr
@@ -20,6 +20,7 @@ expected_endpoints = [
   # `hint` labels the entry rather than declaring a route, but the
   # route beside it still counts.
   Endpoint.new("/old/path", "GET"),
+  Endpoint.new("/escaped/comma", "GET"),
 
   # `$RESOURCES` expands per framework/one.cfc's resourceRouteTemplates.
   # There is no `edit` route — FW/1 differs from Rails here.

--- a/src/analyzer/analyzers/aspnet/webforms.cr
+++ b/src/analyzer/analyzers/aspnet/webforms.cr
@@ -466,6 +466,11 @@ module Analyzer::Aspnet
       while index < characters.size
         character = characters[index]
 
+        if in_string && character == '\\' && !vb && index + 1 < characters.size
+          index += 2
+          next
+        end
+
         if character == '"'
           in_string = !in_string
         elsif !in_string && comment_start?(character, characters[index + 1]?, vb)

--- a/src/analyzer/engines/cfml_engine.cr
+++ b/src/analyzer/engines/cfml_engine.cr
@@ -62,6 +62,7 @@ module Analyzer::Cfml
     private BYTE_CLOSE_BRACKET = ']'.ord.to_u8
     private BYTE_DQUOTE        = '"'.ord.to_u8
     private BYTE_SQUOTE        = '\''.ord.to_u8
+    private BYTE_BACKSLASH     = '\\'.ord.to_u8
 
     # Route registrations are statements. An identifier as generic as
     # `get` or `delete` also appears inside expressions
@@ -158,10 +159,17 @@ module Analyzer::Cfml
       current = String::Builder.new
       depth = 0
       quote = nil.as(Char?)
+      escape = false
 
       raw.each_char do |char|
         if quote
-          quote = nil if char == quote
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            quote = nil
+          end
           current << char
           next
         end
@@ -257,12 +265,24 @@ module Analyzer::Cfml
       position = start
       size = bytes.size
       quote = 0_u8
+      escape = false
 
       while position < size
         byte = bytes[position]
 
         if quote != 0_u8
-          quote = 0_u8 if byte == quote
+          if escape
+            escape = false
+          elsif byte == BYTE_BACKSLASH
+            escape = true
+          elsif byte == quote
+            if position + 1 < size && bytes[position + 1] == quote
+              position += 2
+              next
+            else
+              quote = 0_u8
+            end
+          end
         elsif byte == BYTE_DQUOTE || byte == BYTE_SQUOTE
           quote = byte
         elsif byte == open_byte
@@ -338,12 +358,26 @@ module Analyzer::Cfml
       io = String::Builder.new(content.bytesize)
       index = 0
       quote = nil.as(Char?)
+      escape = false
 
       while index < size
         char = chars[index]
 
         if quote
-          quote = nil if char == quote
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            if index + 1 < size && chars[index + 1] == quote
+              io << char
+              io << chars[index + 1]
+              index += 2
+              next
+            else
+              quote = nil
+            end
+          end
           io << char
           index += 1
           next
@@ -407,10 +441,28 @@ module Analyzer::Cfml
     # the header mid-value and silently dropped every tokenised route.
     private def attributes_before_body(window : String) : String
       quote = nil.as(Char?)
+      escape = false
+      chars = window.chars
+      size = chars.size
+      index = 0
 
-      window.each_char_with_index do |char, index|
+      while index < size
+        char = chars[index]
+
         if quote
-          quote = nil if char == quote
+          if escape
+            escape = false
+          elsif char == '\\'
+            escape = true
+          elsif char == quote
+            if index + 1 < size && chars[index + 1] == quote
+              index += 2
+              next
+            else
+              quote = nil
+            end
+          end
+          index += 1
           next
         end
 
@@ -418,6 +470,7 @@ module Analyzer::Cfml
         when '"', '\'' then quote = char
         when '{'       then return window[0...index]
         end
+        index += 1
       end
 
       window


### PR DESCRIPTION
Fixes a bug in CFML parser engine where string parsing helpers (split_arguments, strip_script_comments, attributes_before_body, and matching_delimiter) failed to recognize backslash-escaped and doubled quotes within quoted strings. This caused routing structure parses (like braces/brackets matching) to fail when quotes/commas were present inside hints/names.