### PR TITLE
perf: cut detector/analyzer hotspots on large monorepos

### DIFF
--- a/spec/unit_test/analyzer/analyzer_selection_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_selection_spec.cr
@@ -15,4 +15,25 @@ describe "filter_redundant_generic_techs" do
     techs = ["php_laravel", "python_django", "js_express"]
     filter_redundant_generic_techs(techs).should eq(techs)
   end
+
+  it "drops js_http when a JS framework analyzer is present" do
+    filter_redundant_generic_techs(["js_http", "js_express"]).should eq(["js_express"])
+    filter_redundant_generic_techs(["js_hono", "js_http", "js_fastify"]).should eq(["js_hono", "js_fastify"])
+  end
+
+  it "keeps js_http when no JS framework analyzer is present" do
+    filter_redundant_generic_techs(["js_http"]).should eq(["js_http"])
+  end
+
+  it "drops python_starlette when python_fastapi is present" do
+    filter_redundant_generic_techs(["python_fastapi", "python_starlette"]).should eq(["python_fastapi"])
+  end
+
+  it "keeps python_starlette alone" do
+    filter_redundant_generic_techs(["python_starlette"]).should eq(["python_starlette"])
+  end
+
+  it "drops go_http when a Go framework analyzer is present" do
+    filter_redundant_generic_techs(["go_http", "go_gin"]).should eq(["go_gin"])
+  end
 end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -345,6 +345,42 @@ def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
     filtered.reject!("php_symfony")
   end
 
+  # `js_http` matches generic Node `http`/`https` createServer usage.
+  # When a real framework is present it owns the route table; running
+  # the stdlib analyzer too rescans every JS/TS file for low-signal
+  # patterns and doubles endpoint noise.
+  js_frameworks = Set{
+    "js_express", "js_fastify", "js_hono", "js_koa", "js_nestjs",
+    "js_restify", "js_adonisjs", "js_elysia", "js_hapi", "js_nextjs",
+    "js_nuxtjs", "js_nitro", "js_remix", "js_sveltekit", "js_astro",
+    "js_fresh", "js_apollo", "js_graphql_yoga", "js_socketio",
+    "ts_nestjs", "ts_trpc", "ts_tanstack_router",
+  }
+  if filtered.includes?("js_http") && filtered.any? { |tech| js_frameworks.includes?(tech) }
+    filtered.reject!("js_http")
+  end
+
+  # FastAPI is built on Starlette and reuses its routing primitives.
+  # Both detectors fire on FastAPI apps; the FastAPI analyzer already
+  # covers APIRouter / app.include_router / decorators, so the Starlette
+  # pass is pure duplicate work on the same .py set.
+  if filtered.includes?("python_fastapi") && filtered.includes?("python_starlette")
+    filtered.reject!("python_starlette")
+  end
+
+  # Same shape as js_http: bare `net/http` when a router framework is
+  # present is almost always the framework's own listener, not a second
+  # surface to analyze.
+  go_frameworks = Set{
+    "go_gin", "go_echo", "go_fiber", "go_chi", "go_mux", "go_beego",
+    "go_iris", "go_fasthttp", "go_hertz", "go_gozero", "go_goyave",
+    "go_gf", "go_restful", "go_httprouter", "go_huma", "go_pocketbase",
+    "go_connect_rpc",
+  }
+  if filtered.includes?("go_http") && filtered.any? { |tech| go_frameworks.includes?(tech) }
+    filtered.reject!("go_http")
+  end
+
   filtered
 end
 

--- a/src/analyzer/analyzers/crystal/kemal.cr
+++ b/src/analyzer/analyzers/crystal/kemal.cr
@@ -26,7 +26,7 @@ module Analyzer::Crystal
       # with the handler defined in a separate controller file. Build the
       # cross-file action index up front so those routes can carry callees.
       if any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-        @action_index = build_crystal_action_index(all_files)
+        @action_index = build_crystal_action_index(get_files_by_extension(".cr"))
       end
       super
       collect_public_dir_endpoints

--- a/src/analyzer/analyzers/java/spring.cr
+++ b/src/analyzer/analyzers/java/spring.cr
@@ -79,306 +79,269 @@ module Analyzer::Java
 
     def analyze
       include_callee = any_to_bool(@options["include_callee"]?) || any_to_bool(@options["ai_context"]?)
-      webflux_base_path_map = Hash(String, String).new
       dto_builder = Noir::TreeSitterJavaDtoIndex.new
 
-      file_list = all_files()
-      path_configs = path_configs_for(file_list)
-      stomp_prefixes = stomp_application_prefixes_for(file_list)
-      meta_annotation_index = collect_meta_annotation_index(file_list)
-      interface_route_index = collect_interface_route_index(file_list, meta_annotation_index)
-      file_list.each do |path|
-        # Extract the Webflux base path from 'application.yml' /
-        # 'application.properties' so route paths inherit it.
-        if File.directory?(path)
-          if path.ends_with?("/src")
-            application_yml_path = File.join(path, "main/resources/application.yml")
-            if File.exists?(application_yml_path)
-              begin
-                config = YAML.parse(read_file_content(application_yml_path))
-                spring = config["spring"]
-                webflux = spring["webflux"]
-                webflux_base_path = webflux["base-path"]
+      # `.java` from the extension index, tests dropped once. Previous
+      # shape walked the whole monorepo `file_map` four times (path
+      # configs, STOMP prefixes, meta annotations, interface routes)
+      # before the main route pass — each pass re-reading and often
+      # re-parsing the same files. Indexes are now built in at most two
+      # content walks over the Java source set only; webflux /
+      # servlet context paths come from `path_config_for` (application.yml
+      # / .properties under each project root).
+      java_files = get_files_by_extension(".java").reject { |path| JavaEngine.test_path?(path) }
+      path_configs, stomp_prefixes, meta_annotation_index, interface_route_index =
+        build_spring_indexes(java_files)
 
-                if webflux_base_path
-                  webflux_base_path_map[path] = webflux_base_path.as_s
+      java_files.each do |path|
+        project_root = project_root_for(path)
+        path_config = path_configs[project_root]? || SpringPathConfig.new
+        stomp_application_prefixes = stomp_prefixes[project_root]? || [""]
+        configured_base_path = path_config.web_base_path
+        content = read_file_content(path)
+
+        # Only files that mention Spring MVC / Feign bindings carry
+        # annotation-based routes. Reactive `router().route()` files
+        # land in the `else` branch below.
+        spring_web_bind_package = "org.springframework.web.bind.annotation."
+        feign_client_package = "org.springframework.cloud.openfeign.FeignClient"
+        http_exchange_package = "org.springframework.web.service.annotation."
+        has_spring_bindings = content.includes?(spring_web_bind_package)
+        has_feign_bindings = content.includes?(feign_client_package) || content.includes?("@FeignClient")
+        has_http_exchange_bindings = http_exchange_bindings?(content, http_exchange_package)
+        has_gateway_bindings = content.includes?("RouteLocatorBuilder") ||
+                               content.includes?("PredicateSpec") ||
+                               content.includes?("org.springframework.cloud.gateway")
+        has_websocket_bindings = content.includes?("org.springframework.web.socket.config.annotation") ||
+                                 content.includes?("WebSocketMessageBrokerConfigurer") ||
+                                 content.includes?("@EnableWebSocketMessageBroker")
+        has_message_mapping_bindings = content.includes?("org.springframework.messaging.handler.annotation") ||
+                                       content.includes?("@MessageMapping") ||
+                                       content.includes?("@SubscribeMapping")
+        has_resource_handler_bindings = content.includes?("ResourceHandlerRegistry") ||
+                                        content.includes?("addResourceHandler")
+
+        if has_spring_bindings || has_feign_bindings || has_http_exchange_bindings || has_gateway_bindings ||
+           has_websocket_bindings || has_message_mapping_bindings || has_resource_handler_bindings
+          # Single tree-sitter parse for the whole file — every
+          # extraction below pulls from the same root so a
+          # controller with N routes pays for 1 parse instead of
+          # the previous 4 + 2N. The DTO index, FeignClient
+          # detection, route discovery, consumes lookup, and
+          # parameter walks all consume `root`.
+          Noir::TreeSitter.parse_java(content) do |root|
+            # Skip files without a package declaration — legacy filter
+            # that avoids scanning test stubs / throwaway snippets.
+            package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
+            next if package_name.empty?
+
+            dto_index = dto_builder.build_for_with_root(path, content, root)
+            feign_clients = Noir::TreeSitterJavaParameterExtractor.extract_feign_client_classes_from(root, content)
+            http_exchange_clients = Noir::TreeSitterJavaParameterExtractor.extract_http_exchange_client_classes_from(root, content)
+            visible_meta_mappings = visible_meta_annotation_mappings(path, content, package_name, meta_annotation_index)
+            imports = java_imports(content)
+
+            # The file's String-constant table is identical for every
+            # route in the file, so build it once here and thread it into
+            # the per-route parameter walks (and the WebSocket branches
+            # below) instead of rebuilding it — a full recursive tree walk
+            # — on every emitted route.
+            file_constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+
+            # The method-declaration index used to resolve callee call
+            # sites is likewise file-scoped; build it once (only when
+            # callees are requested) and reuse it across every route in
+            # the file rather than rebuilding it per route.
+            file_decl_index = include_callee ? Noir::JavaCalleeExtractor.build_method_decl_index(root, content) : nil
+
+            Noir::TreeSitterJavaRouteExtractor.extract_routes_from(root, content, visible_meta_mappings).each do |route|
+              is_feign_client = feign_clients.includes?(route.class_name)
+              is_http_exchange_client = http_exchange_clients.includes?(route.class_name)
+              is_internal_client = is_feign_client || is_http_exchange_client
+
+              parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
+                root, content, route.class_name, route.method_name
+              )
+              # The POST form-binding default is applied per-parameter in
+              # the extractor so an explicit `@RequestBody` resolves to
+              # "json" rather than inheriting "form".
+
+              parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
+                root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index, route.line, constants: file_constants
+              )
+              merge_route_condition_params(parameters, route.params)
+
+              # Drop the trailing `/` on webflux_base_path when the
+              # route path already starts with one, so the join
+              # doesn't produce `//`.
+              base_path = is_internal_client ? "" : configured_base_path
+              if base_path.ends_with?("/") && route.path.starts_with?("/")
+                base_path = base_path[..-2]
+              end
+
+              line = route.line + 1
+              details = Details.new(PathInfo.new(path, line))
+
+              endpoint = Endpoint.new(
+                join_paths(base_path, route.path), route.verb, parameters, details, is_internal_client
+              )
+
+              # 1-hop callees out of the handler method body. Cross-file
+              # definition resolution is intentionally out of scope —
+              # `Callee#path` points at the call site, matching every
+              # other analyzer's first-cut honest scope.
+              if include_callee && !(route.class_name.empty? || route.method_name.empty?)
+                Noir::JavaCalleeExtractor.callees_in_method(
+                  root, content, path, route.class_name, route.method_name, route.line, decl_index: file_decl_index
+                ).each do |entry|
+                  name, callee_path, callee_line = entry
+                  endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
                 end
-              rescue
-                # Handle parsing errors if necessary
+              end
+
+              @result << endpoint
+            end
+
+            Noir::TreeSitterJavaRouteExtractor.extract_controller_interface_implementations_from(root, content, visible_meta_mappings).each do |implementation|
+              implementation.interface_names.each do |interface_name|
+                visible_interface_routes(interface_route_index, path, package_name, imports, interface_name).each do |entry|
+                  entry_route = entry.route
+                  # Concrete @Override that re-declares its own mapping
+                  # annotation shadows the interface's method-level
+                  # mapping (Spring closest-annotation-wins). The direct
+                  # scan already emitted that route — skip the duplicate.
+                  next if implementation.annotated_method_names.includes?(entry_route.method_name)
+                  implementation.paths.each do |implementation_path|
+                    inherited_path = join_paths(implementation_path, entry_route.path)
+                    parameter_format = nil
+                    parameters = [] of Param
+
+                    Noir::TreeSitter.parse_java(entry.source) do |interface_root|
+                      interface_dto_index = dto_builder.build_for_with_root(entry.path, entry.source, interface_root)
+                      parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
+                        interface_root, entry.source, entry_route.class_name, entry_route.method_name
+                      )
+                      # POST form-binding default applied per-parameter in
+                      # the extractor (keeps `@RequestBody` as "json").
+
+                      parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
+                        interface_root, entry.source, entry_route.class_name, entry_route.method_name,
+                        entry_route.verb, parameter_format, interface_dto_index, entry_route.line
+                      )
+                      merge_route_condition_params(parameters, implementation.params + entry_route.params)
+                    end
+
+                    details = Details.new(PathInfo.new(entry.path, entry_route.line + 1))
+                    endpoint = Endpoint.new(
+                      join_paths(configured_base_path, inherited_path), entry_route.verb, parameters, details
+                    )
+
+                    # The route is declared on the interface (springdoc /
+                    # OpenAPI `*Api` contracts), but the behaviour — and
+                    # thus the callees worth surfacing for ai-context —
+                    # lives in the `@Override` method on the concrete
+                    # controller currently being walked. Pull 1-hop
+                    # callees from that implementing body rather than the
+                    # empty interface method.
+                    if include_callee && !(implementation.class_name.empty? || entry_route.method_name.empty?)
+                      Noir::JavaCalleeExtractor.callees_in_method(
+                        root, content, path, implementation.class_name, entry_route.method_name, decl_index: file_decl_index
+                      ).each do |callee_entry|
+                        name, callee_path, callee_line = callee_entry
+                        endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
+                      end
+                    end
+
+                    @result << endpoint
+                  end
+                end
               end
             end
 
-            application_properties_path = File.join(path, "main/resources/application.properties")
-            if File.exists?(application_properties_path)
-              begin
-                properties = read_file_content(application_properties_path)
-                base_path = properties.match(/spring\.webflux\.base-path\s*=\s*(.*)/)
-                if base_path
-                  webflux_base_path = base_path[1]
-                  webflux_base_path_map[path] = webflux_base_path if webflux_base_path
-                end
-              rescue
-                # Handle parsing errors if necessary
+            if has_websocket_bindings
+              constants = file_constants
+              collect_stomp_endpoints(content, constants).each do |entry|
+                endpoint_path, line = entry
+                endpoint = Endpoint.new(join_paths(configured_base_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
+                endpoint.protocol = "ws"
+                @result << endpoint
+              end
+            end
+
+            if has_message_mapping_bindings
+              constants = file_constants
+              collect_message_mapping_endpoints(root, content, constants, stomp_application_prefixes).each do |entry|
+                verb, destination, line = entry
+                endpoint = Endpoint.new(destination, verb, Details.new(PathInfo.new(path, line)))
+                endpoint.protocol = "ws"
+                @result << endpoint
+              end
+            end
+
+            if has_resource_handler_bindings
+              constants = file_constants
+              collect_resource_handler_endpoints(content, constants).each do |entry|
+                endpoint_path, line = entry
+                @result << Endpoint.new(join_paths(configured_base_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
               end
             end
           end
-        elsif File.exists?(path) && path.ends_with?(".java")
-          # Skip Maven/Gradle test sources via the shared
-          # `JavaEngine.test_path?` helper; see the helper doc for
-          # the rationale (`src/test/`, `src/it/` are unambiguous
-          # JVM build-tool conventions).
-          next if JavaEngine.test_path?(path)
-          webflux_base_path = find_base_path(path, webflux_base_path_map)
-          project_root = project_root_for(path)
-          path_config = path_configs[project_root]? || SpringPathConfig.new
-          stomp_application_prefixes = stomp_prefixes[project_root]? || [""]
-          configured_base_path = path_config.web_base_path
-          configured_base_path = webflux_base_path if configured_base_path.empty?
-          content = read_file_content(path)
+        else
+          # Reactive routes declared via `router().route(...).andRoute(...)`
+          # — regex-scoped because the builder-pattern shape isn't
+          # worth a dedicated tree-sitter walk yet.
+          route_blocks = [] of Tuple(Array(Tuple(Int32, String, String, String)), Array(Tuple(Int32, Int32, String)))
+          reactive_callees = {} of String => Array(Callee)
 
-          # Only files that mention Spring MVC / Feign bindings carry
-          # annotation-based routes. Reactive `router().route()` files
-          # land in the `else` branch below.
-          spring_web_bind_package = "org.springframework.web.bind.annotation."
-          feign_client_package = "org.springframework.cloud.openfeign.FeignClient"
-          http_exchange_package = "org.springframework.web.service.annotation."
-          has_spring_bindings = content.includes?(spring_web_bind_package)
-          has_feign_bindings = content.includes?(feign_client_package) || content.includes?("@FeignClient")
-          has_http_exchange_bindings = http_exchange_bindings?(content, http_exchange_package)
-          has_gateway_bindings = content.includes?("RouteLocatorBuilder") ||
-                                 content.includes?("PredicateSpec") ||
-                                 content.includes?("org.springframework.cloud.gateway")
-          has_websocket_bindings = content.includes?("org.springframework.web.socket.config.annotation") ||
-                                   content.includes?("WebSocketMessageBrokerConfigurer") ||
-                                   content.includes?("@EnableWebSocketMessageBroker")
-          has_message_mapping_bindings = content.includes?("org.springframework.messaging.handler.annotation") ||
-                                         content.includes?("@MessageMapping") ||
-                                         content.includes?("@SubscribeMapping")
-          has_resource_handler_bindings = content.includes?("ResourceHandlerRegistry") ||
-                                          content.includes?("addResourceHandler")
-
-          if has_spring_bindings || has_feign_bindings || has_http_exchange_bindings || has_gateway_bindings ||
-             has_websocket_bindings || has_message_mapping_bindings || has_resource_handler_bindings
-            # Single tree-sitter parse for the whole file — every
-            # extraction below pulls from the same root so a
-            # controller with N routes pays for 1 parse instead of
-            # the previous 4 + 2N. The DTO index, FeignClient
-            # detection, route discovery, consumes lookup, and
-            # parameter walks all consume `root`.
-            Noir::TreeSitter.parse_java(content) do |root|
-              # Skip files without a package declaration — legacy filter
-              # that avoids scanning test stubs / throwaway snippets.
-              package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
-              next if package_name.empty?
-
-              dto_index = dto_builder.build_for_with_root(path, content, root)
-              feign_clients = Noir::TreeSitterJavaParameterExtractor.extract_feign_client_classes_from(root, content)
-              http_exchange_clients = Noir::TreeSitterJavaParameterExtractor.extract_http_exchange_client_classes_from(root, content)
-              visible_meta_mappings = visible_meta_annotation_mappings(path, content, package_name, meta_annotation_index)
-              imports = java_imports(content)
-
-              # The file's String-constant table is identical for every
-              # route in the file, so build it once here and thread it into
-              # the per-route parameter walks (and the WebSocket branches
-              # below) instead of rebuilding it — a full recursive tree walk
-              # — on every emitted route.
-              file_constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
-
-              # The method-declaration index used to resolve callee call
-              # sites is likewise file-scoped; build it once (only when
-              # callees are requested) and reuse it across every route in
-              # the file rather than rebuilding it per route.
-              file_decl_index = include_callee ? Noir::JavaCalleeExtractor.build_method_decl_index(root, content) : nil
-
-              Noir::TreeSitterJavaRouteExtractor.extract_routes_from(root, content, visible_meta_mappings).each do |route|
-                is_feign_client = feign_clients.includes?(route.class_name)
-                is_http_exchange_client = http_exchange_clients.includes?(route.class_name)
-                is_internal_client = is_feign_client || is_http_exchange_client
-
-                parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
-                  root, content, route.class_name, route.method_name
-                )
-                # The POST form-binding default is applied per-parameter in
-                # the extractor so an explicit `@RequestBody` resolves to
-                # "json" rather than inheriting "form".
-
-                parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
-                  root, content, route.class_name, route.method_name, route.verb, parameter_format, dto_index, route.line, constants: file_constants
-                )
-                merge_route_condition_params(parameters, route.params)
-
-                # Drop the trailing `/` on webflux_base_path when the
-                # route path already starts with one, so the join
-                # doesn't produce `//`.
-                base_path = is_internal_client ? "" : configured_base_path
-                if base_path.ends_with?("/") && route.path.starts_with?("/")
-                  base_path = base_path[..-2]
-                end
-
-                line = route.line + 1
-                details = Details.new(PathInfo.new(path, line))
-
-                endpoint = Endpoint.new(
-                  join_paths(base_path, route.path), route.verb, parameters, details, is_internal_client
-                )
-
-                # 1-hop callees out of the handler method body. Cross-file
-                # definition resolution is intentionally out of scope —
-                # `Callee#path` points at the call site, matching every
-                # other analyzer's first-cut honest scope.
-                if include_callee && !(route.class_name.empty? || route.method_name.empty?)
-                  Noir::JavaCalleeExtractor.callees_in_method(
-                    root, content, path, route.class_name, route.method_name, route.line, decl_index: file_decl_index
-                  ).each do |entry|
-                    name, callee_path, callee_line = entry
-                    endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                  end
-                end
-
-                @result << endpoint
-              end
-
-              Noir::TreeSitterJavaRouteExtractor.extract_controller_interface_implementations_from(root, content, visible_meta_mappings).each do |implementation|
-                implementation.interface_names.each do |interface_name|
-                  visible_interface_routes(interface_route_index, path, package_name, imports, interface_name).each do |entry|
-                    entry_route = entry.route
-                    # Concrete @Override that re-declares its own mapping
-                    # annotation shadows the interface's method-level
-                    # mapping (Spring closest-annotation-wins). The direct
-                    # scan already emitted that route — skip the duplicate.
-                    next if implementation.annotated_method_names.includes?(entry_route.method_name)
-                    implementation.paths.each do |implementation_path|
-                      inherited_path = join_paths(implementation_path, entry_route.path)
-                      parameter_format = nil
-                      parameters = [] of Param
-
-                      Noir::TreeSitter.parse_java(entry.source) do |interface_root|
-                        interface_dto_index = dto_builder.build_for_with_root(entry.path, entry.source, interface_root)
-                        parameter_format = Noir::TreeSitterJavaParameterExtractor.extract_consumes_from(
-                          interface_root, entry.source, entry_route.class_name, entry_route.method_name
-                        )
-                        # POST form-binding default applied per-parameter in
-                        # the extractor (keeps `@RequestBody` as "json").
-
-                        parameters = Noir::TreeSitterJavaParameterExtractor.extract_method_parameters_from(
-                          interface_root, entry.source, entry_route.class_name, entry_route.method_name,
-                          entry_route.verb, parameter_format, interface_dto_index, entry_route.line
-                        )
-                        merge_route_condition_params(parameters, implementation.params + entry_route.params)
-                      end
-
-                      details = Details.new(PathInfo.new(entry.path, entry_route.line + 1))
-                      endpoint = Endpoint.new(
-                        join_paths(configured_base_path, inherited_path), entry_route.verb, parameters, details
-                      )
-
-                      # The route is declared on the interface (springdoc /
-                      # OpenAPI `*Api` contracts), but the behaviour — and
-                      # thus the callees worth surfacing for ai-context —
-                      # lives in the `@Override` method on the concrete
-                      # controller currently being walked. Pull 1-hop
-                      # callees from that implementing body rather than the
-                      # empty interface method.
-                      if include_callee && !(implementation.class_name.empty? || entry_route.method_name.empty?)
-                        Noir::JavaCalleeExtractor.callees_in_method(
-                          root, content, path, implementation.class_name, entry_route.method_name, decl_index: file_decl_index
-                        ).each do |callee_entry|
-                          name, callee_path, callee_line = callee_entry
-                          endpoint.push_callee(Callee.new(name, path: callee_path, line: callee_line))
-                        end
-                      end
-
-                      @result << endpoint
-                    end
-                  end
-                end
-              end
-
-              if has_websocket_bindings
-                constants = file_constants
-                collect_stomp_endpoints(content, constants).each do |entry|
-                  endpoint_path, line = entry
-                  endpoint = Endpoint.new(join_paths(configured_base_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
-                  endpoint.protocol = "ws"
-                  @result << endpoint
-                end
-              end
-
-              if has_message_mapping_bindings
-                constants = file_constants
-                collect_message_mapping_endpoints(root, content, constants, stomp_application_prefixes).each do |entry|
-                  verb, destination, line = entry
-                  endpoint = Endpoint.new(destination, verb, Details.new(PathInfo.new(path, line)))
-                  endpoint.protocol = "ws"
-                  @result << endpoint
-                end
-              end
-
-              if has_resource_handler_bindings
-                constants = file_constants
-                collect_resource_handler_endpoints(content, constants).each do |entry|
-                  endpoint_path, line = entry
-                  @result << Endpoint.new(join_paths(configured_base_path, endpoint_path), "GET", Details.new(PathInfo.new(path, line)))
-                end
-              end
-            end
-          else
-            # Reactive routes declared via `router().route(...).andRoute(...)`
-            # — regex-scoped because the builder-pattern shape isn't
-            # worth a dedicated tree-sitter walk yet.
-            route_blocks = [] of Tuple(Array(Tuple(Int32, String, String, String)), Array(Tuple(Int32, Int32, String)))
-            reactive_callees = {} of String => Array(Callee)
-
-            # Single tree-sitter parse for the whole reactive file: the
-            # constant table and the `this::handler` callee resolution both
-            # read from this one `root`, so the file isn't parsed twice
-            # when callees are requested (and constants are resolved once,
-            # not once-per-block).
-            Noir::TreeSitter.parse_java(content) do |root|
-              constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
-              content.scan(REGEX_ROUTER_CODE_BLOCK) do |route_code|
-                method_code = route_code[0]
-                # Pick up `nest(RequestPredicates.path("/prefix"), ...)`
-                # / `nest(path("/prefix"), ...)` byte ranges so verb
-                # calls inside the nested lambda get the prefix added.
-                # Servlet-fn and WebFlux both use this idiom heavily;
-                # without prefix awareness routes like
-                # `route().nest(path("/product"), builder ->
-                # builder.GET("/name/{name}", ...))` surfaced as
-                # `GET /name/{name}` instead of `GET /product/name/{name}`.
-                route_blocks << {collect_router_route_calls(method_code, constants), collect_nest_prefixes(method_code, constants)}
-              end
-
-              # Resolve same-file `this::handler` method bodies to 1-hop
-              # callees so reactive endpoints carry handler context too.
-              if include_callee
-                wanted = Set(String).new
-                route_blocks.each { |calls, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
-                reactive_callees = build_reactive_method_callees(root, content, path, wanted)
-              end
+          # Single tree-sitter parse for the whole reactive file: the
+          # constant table and the `this::handler` callee resolution both
+          # read from this one `root`, so the file isn't parsed twice
+          # when callees are requested (and constants are resolved once,
+          # not once-per-block).
+          Noir::TreeSitter.parse_java(content) do |root|
+            constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
+            content.scan(REGEX_ROUTER_CODE_BLOCK) do |route_code|
+              method_code = route_code[0]
+              # Pick up `nest(RequestPredicates.path("/prefix"), ...)`
+              # / `nest(path("/prefix"), ...)` byte ranges so verb
+              # calls inside the nested lambda get the prefix added.
+              # Servlet-fn and WebFlux both use this idiom heavily;
+              # without prefix awareness routes like
+              # `route().nest(path("/product"), builder ->
+              # builder.GET("/name/{name}", ...))` surfaced as
+              # `GET /name/{name}` instead of `GET /product/name/{name}`.
+              route_blocks << {collect_router_route_calls(method_code, constants), collect_nest_prefixes(method_code, constants)}
             end
 
-            route_blocks.each do |calls, nest_prefixes|
-              calls.each do |call|
-                pos, method, endpoint, handler_ref = call
-                nest_prefix = ""
-                nest_prefixes.each do |start_b, end_b, prefix|
-                  if pos >= start_b && pos < end_b
-                    nest_prefix = join_paths(nest_prefix, prefix)
-                  end
-                end
-                composed = nest_prefix.empty? ? endpoint : join_paths(nest_prefix, endpoint)
-                details = Details.new(PathInfo.new(path))
-                reactive_endpoint = Endpoint.new(join_paths(configured_base_path, composed), method, details)
+            # Resolve same-file `this::handler` method bodies to 1-hop
+            # callees so reactive endpoints carry handler context too.
+            if include_callee
+              wanted = Set(String).new
+              route_blocks.each { |calls, _| calls.each { |call| wanted << call[3] unless call[3].empty? } }
+              reactive_callees = build_reactive_method_callees(root, content, path, wanted)
+            end
+          end
 
-                if include_callee && !handler_ref.empty?
-                  if handler_callees = reactive_callees[handler_ref]?
-                    handler_callees.each { |callee| reactive_endpoint.push_callee(callee) }
-                  end
+          route_blocks.each do |calls, nest_prefixes|
+            calls.each do |call|
+              pos, method, endpoint, handler_ref = call
+              nest_prefix = ""
+              nest_prefixes.each do |start_b, end_b, prefix|
+                if pos >= start_b && pos < end_b
+                  nest_prefix = join_paths(nest_prefix, prefix)
                 end
-
-                @result << reactive_endpoint
               end
+              composed = nest_prefix.empty? ? endpoint : join_paths(nest_prefix, endpoint)
+              details = Details.new(PathInfo.new(path))
+              reactive_endpoint = Endpoint.new(join_paths(configured_base_path, composed), method, details)
+
+              if include_callee && !handler_ref.empty?
+                if handler_callees = reactive_callees[handler_ref]?
+                  handler_callees.each { |callee| reactive_endpoint.push_callee(callee) }
+                end
+              end
+
+              @result << reactive_endpoint
             end
           end
         end
@@ -388,44 +351,71 @@ module Analyzer::Java
       @result
     end
 
-    private def collect_meta_annotation_index(file_list : Array(String)) : SpringMetaAnnotationIndex
-      index = SpringMetaAnnotationIndex.new
+    # Build path configs, STOMP destination prefixes, meta-annotation index,
+    # and interface-route index for the pre-filtered `.java` source set.
+    #
+    # Path roots + STOMP + meta annotations share one content walk and at
+    # most one tree-sitter parse per file (previously three independent
+    # passes). Interface routes need a complete meta index, so they run as
+    # a second pass over the same cached content.
+    private def build_spring_indexes(java_files : Array(String)) : Tuple(
+      Hash(String, SpringPathConfig),
+      Hash(String, Array(String)),
+      SpringMetaAnnotationIndex,
+      SpringInterfaceRouteIndex,
+    )
+      path_configs = Hash(String, SpringPathConfig).new
+      stomp_prefixes = Hash(String, Array(String)).new
+      meta_index = SpringMetaAnnotationIndex.new
+      project_roots = Set(String).new
       spring_web_bind_package = "org.springframework.web.bind.annotation."
 
-      file_list.each do |path|
-        next unless File.exists?(path) && path.ends_with?(".java")
-        next if JavaEngine.test_path?(path)
+      java_files.each do |path|
+        project_root = project_root_for(path)
+        project_roots << project_root
 
         content = read_file_content(path)
-        next unless content.includes?(spring_web_bind_package)
-        # Composed (meta) mapping annotations are declared as Java
-        # annotation types (`@interface`). A file without one cannot
-        # contribute to this index, so skip the tree-sitter parse for
-        # the (overwhelming) majority of regular controller classes.
-        next unless content.includes?("@interface")
+        needs_stomp = content.includes?("setApplicationDestinationPrefixes")
+        needs_meta = content.includes?(spring_web_bind_package) && content.includes?("@interface")
+        next unless needs_stomp || needs_meta
 
         Noir::TreeSitter.parse_java(content) do |root|
-          package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
           constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants_from(root, content)
-          Noir::TreeSitterJavaRouteExtractor.extract_meta_mappings_from(root, content, constants).each do |name, mapping|
-            index.add(project_root_for(path), package_name, name, mapping)
+
+          if needs_stomp
+            collected = collect_stomp_application_prefixes(content, constants)
+            unless collected.empty?
+              stomp_prefixes[project_root] ||= [] of String
+              stomp_prefixes[project_root].concat(collected)
+              stomp_prefixes[project_root] = stomp_prefixes[project_root].uniq
+            end
+          end
+
+          if needs_meta
+            package_name = Noir::TreeSitterJavaParameterExtractor.extract_package_name_from(root, content)
+            Noir::TreeSitterJavaRouteExtractor.extract_meta_mappings_from(root, content, constants).each do |name, mapping|
+              meta_index.add(project_root, package_name, name, mapping)
+            end
           end
         end
       end
 
-      index
+      project_roots.each do |root|
+        path_configs[root] = path_config_for(root)
+      end
+
+      interface_index = collect_interface_route_index(java_files, meta_index)
+      {path_configs, stomp_prefixes, meta_index, interface_index}
     end
 
-    private def collect_interface_route_index(file_list : Array(String),
+    private def collect_interface_route_index(java_files : Array(String),
                                               meta_annotation_index : SpringMetaAnnotationIndex) : SpringInterfaceRouteIndex
       index = SpringInterfaceRouteIndex.new
       spring_web_bind_package = "org.springframework.web.bind.annotation."
       http_exchange_package = "org.springframework.web.service.annotation."
 
-      file_list.each do |path|
-        next unless File.exists?(path) && path.ends_with?(".java")
-        next if JavaEngine.test_path?(path)
-
+      # `java_files` is already extension-filtered and test-path-free.
+      java_files.each do |path|
         content = read_file_content(path)
         # Inheritable routes come from Java interfaces (Feign, Spring HTTP
         # Interface, OpenAPI-style `*Api`) and from `abstract` base
@@ -1145,48 +1135,6 @@ module Analyzer::Java
         return i if depth.zero?
       end
       nil
-    end
-
-    private def path_configs_for(file_list : Array(String)) : Hash(String, SpringPathConfig)
-      configs = Hash(String, SpringPathConfig).new
-      project_roots = Set(String).new
-
-      file_list.each do |path|
-        next if JavaEngine.test_path?(path)
-        next unless File.exists?(path)
-        next unless path.ends_with?(".java")
-        project_roots << project_root_for(path)
-      end
-
-      project_roots.each do |root|
-        configs[root] = path_config_for(root)
-      end
-
-      configs
-    end
-
-    private def stomp_application_prefixes_for(file_list : Array(String)) : Hash(String, Array(String))
-      prefixes = Hash(String, Array(String)).new
-
-      file_list.each do |path|
-        next if JavaEngine.test_path?(path)
-        next unless File.exists?(path)
-        next unless path.ends_with?(".java")
-
-        content = read_file_content(path)
-        next unless content.includes?("setApplicationDestinationPrefixes")
-
-        constants = Noir::TreeSitterJavaRouteExtractor.extract_string_constants(content)
-        collected = collect_stomp_application_prefixes(content, constants)
-        next if collected.empty?
-
-        root = project_root_for(path)
-        prefixes[root] ||= [] of String
-        prefixes[root].concat(collected)
-        prefixes[root] = prefixes[root].uniq
-      end
-
-      prefixes
     end
 
     private def collect_stomp_application_prefixes(content : String,

--- a/src/analyzer/analyzers/python/aiohttp.cr
+++ b/src/analyzer/analyzers/python/aiohttp.cr
@@ -123,12 +123,10 @@ module Analyzer::Python
       class_view_routes = Hash(::String, Array(Tuple(::String, Int32, ::String))).new
       # path => [{route_path, line_index, class_name}]
 
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           # Prefer the detector-cached content over a fresh disk read;

--- a/src/analyzer/analyzers/python/bottle.cr
+++ b/src/analyzer/analyzers/python/bottle.cr
@@ -50,99 +50,90 @@ module Analyzer::Python
     @json_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
 
     def analyze
-      # Pulls from the detector-built file_map so subtree pruning and
-      # --exclude-path apply to this pass too.
-      python_files = get_files_by_extension(".py")
-      base_paths.each do |current_base_path|
-        python_files.each do |path|
-          next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
-          @logger.debug "Analyzing #{path}"
+      # Parallel per-file pass: Bottle routes are local to each module.
+      # Prefer detector-cached content via read_file_content.
+      parallel_python_sources do |path, current_base_path|
+        @logger.debug "Analyzing #{path}"
 
-          # Prefer the detector-cached content over a fresh disk read;
-          # falls back to File.read (same encoding: utf-8, invalid: :skip)
-          # when the file wasn't cached.
-          file_content = read_file_content(path)
-          lines = file_content.lines
-          next unless lines.any?(&.includes?("bottle"))
+        file_content = read_file_content(path)
+        lines = file_content.lines
+        next unless lines.any?(&.includes?("bottle"))
 
-          router_prefixes = collect_router_prefixes(lines)
+        router_prefixes = collect_router_prefixes(lines)
 
-          # Tree-sitter pre-pass for Form 1 (`@<var>.route(...)` /
-          # `@<var>.<method>(...)`). Replaces the per-line regex sweep.
-          Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
-            methods_literal = deco.methods.map { |m| "'#{m}'" }.join(",")
-            extra_params = "methods=[#{methods_literal}]"
-            prefixes = router_prefixes[deco.router_name]? || [""]
-            prefixes.each do |prefix|
-              process_route(
-                path,
-                lines,
-                line_index: deco.decorator_line,
-                route_path: Helper.join_paths(prefix, deco.path),
-                extra_params: extra_params,
-                definition_base_path: current_base_path,
-                source: file_content
-              )
+        # Tree-sitter pre-pass for Form 1 (`@<var>.route(...)` /
+        # `@<var>.<method>(...)`). Replaces the per-line regex sweep.
+        Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content).each do |deco|
+          methods_literal = deco.methods.map { |m| "'#{m}'" }.join(",")
+          extra_params = "methods=[#{methods_literal}]"
+          prefixes = router_prefixes[deco.router_name]? || [""]
+          prefixes.each do |prefix|
+            process_route(
+              path,
+              lines,
+              line_index: deco.decorator_line,
+              route_path: Helper.join_paths(prefix, deco.path),
+              extra_params: extra_params,
+              definition_base_path: current_base_path,
+              source: file_content
+            )
+          end
+        end
+
+        # Form 2 still needs per-line regex — bare `@route("/path")` has
+        # no router object, so the tree-sitter extractor (which gates
+        # on `<router>.<attr>`) doesn't match it.
+        lines.each_with_index do |line, line_index|
+          effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
+          stripped = effective_line.gsub(" ", "")
+          # `@deco` (contiguous in the source by both regex shapes) is a
+          # necessary condition for either match, so non-decorator lines
+          # skip the regex work entirely.
+          if stripped.includes?('@')
+            BARE_DECORATOR_PATTERNS.each do |deco_name, deco_guard, bare_re, orig_re, kw_re|
+              next unless stripped.includes?(deco_guard)
+              # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
+              if bare_match = stripped.match(bare_re)
+                # Recover spaces in path via the original line.
+                path_value = bare_match[1]
+                if orig_match = effective_line.match(orig_re)
+                  path_value = orig_match[1]
+                end
+                extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
+                process_route(
+                  path,
+                  lines,
+                  line_index,
+                  path_value,
+                  extra,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
+              elsif kw_path_match = effective_line.match(kw_re)
+                extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
+                process_route(
+                  path,
+                  lines,
+                  line_index,
+                  kw_path_match[1],
+                  extra,
+                  definition_base_path: current_base_path,
+                  source: file_content
+                )
+              end
             end
           end
 
-          # Form 2 still needs per-line regex — bare `@route("/path")` has
-          # no router object, so the tree-sitter extractor (which gates
-          # on `<router>.<attr>`) doesn't match it.
-          lines.each_with_index do |line, line_index|
-            effective_line = python_paren_delta(line) > 0 ? join_until_python_call_closes(lines, line_index, line) : line
-            stripped = effective_line.gsub(" ", "")
-            # `@deco` (contiguous in the source by both regex shapes) is a
-            # necessary condition for either match, so non-decorator lines
-            # skip the regex work entirely.
-            if stripped.includes?('@')
-              BARE_DECORATOR_PATTERNS.each do |deco_name, deco_guard, bare_re, orig_re, kw_re|
-                next unless stripped.includes?(deco_guard)
-                # `@route("/foo", method="POST")` or `@get("/foo")` on the stripped line.
-                if bare_match = stripped.match(bare_re)
-                  # Recover spaces in path via the original line.
-                  path_value = bare_match[1]
-                  if orig_match = effective_line.match(orig_re)
-                    path_value = orig_match[1]
-                  end
-                  extra = deco_name == "route" ? bare_match[2] : "methods=['#{deco_name.upcase}']"
-                  process_route(
-                    path,
-                    lines,
-                    line_index,
-                    path_value,
-                    extra,
-                    definition_base_path: current_base_path,
-                    source: file_content
-                  )
-                elsif kw_path_match = effective_line.match(kw_re)
-                  extra = deco_name == "route" ? effective_line : "methods=['#{deco_name.upcase}']"
-                  process_route(
-                    path,
-                    lines,
-                    line_index,
-                    kw_path_match[1],
-                    extra,
-                    definition_base_path: current_base_path,
-                    source: file_content
-                  )
-                end
-              end
-            end
-
-            if !line.lstrip.starts_with?("@") && effective_line.includes?(".route(")
-              process_programmatic_route(
-                path,
-                lines,
-                line_index,
-                effective_line,
-                router_prefixes,
-                definition_base_path: current_base_path,
-                source: file_content
-              )
-            end
+          if !line.lstrip.starts_with?("@") && effective_line.includes?(".route(")
+            process_programmatic_route(
+              path,
+              lines,
+              line_index,
+              effective_line,
+              router_prefixes,
+              definition_base_path: current_base_path,
+              source: file_content
+            )
           end
         end
       end

--- a/src/analyzer/analyzers/python/cli.cr
+++ b/src/analyzer/analyzers/python/cli.cr
@@ -75,14 +75,12 @@ module Analyzer::Python
     CLEO_OPTION_CALL_RE            = /\bself\.option\s*\(\s*[rf]?["']([^"']+)["']/
 
     def analyze
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       endpoints = {} of String => Endpoint
 
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
 
           begin
             content = read_file_content(path)

--- a/src/analyzer/analyzers/python/django_ninja.cr
+++ b/src/analyzer/analyzers/python/django_ninja.cr
@@ -59,7 +59,7 @@ module Analyzer::Python
     def analyze
       instances = Hash(::String, NinjaInstance).new
 
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
 
       # Phase 1 — collect NinjaAPI/Router instances, their operations and
       # `add_router(...)` edges.

--- a/src/analyzer/analyzers/python/falcon.cr
+++ b/src/analyzer/analyzers/python/falcon.cr
@@ -31,16 +31,9 @@ module Analyzer::Python
     @media_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
 
     def analyze
-      python_files = get_files_by_extension(".py")
-      base_paths.each do |current_base_path|
-        python_files.each do |path|
-          next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
-          @logger.debug "Analyzing #{path}"
-
-          analyze_file(path, current_base_path)
-        end
+      parallel_python_sources do |path, current_base_path|
+        @logger.debug "Analyzing #{path}"
+        analyze_file(path, current_base_path)
       end
 
       result

--- a/src/analyzer/analyzers/python/fastapi.cr
+++ b/src/analyzer/analyzers/python/fastapi.cr
@@ -57,12 +57,10 @@ module Analyzer::Python
         # Iterate through all Python files in all base paths. Pulls from
         # the detector-built file_map so subtree pruning and
         # --exclude-path apply to this pass too.
-        python_files = get_files_by_extension(".py")
+        python_files = python_source_files
         base_paths.each do |current_base_path|
           python_files.each do |path|
             next unless path_under_root?(path, current_base_path)
-            next if path.includes?("/site-packages/")
-            next if python_test_path?(path)
             source = read_file_content(path)
 
             import_modules = find_fastapi_imported_modules(current_base_path, path, source)

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -137,17 +137,14 @@ module Analyzer::Python
       # (namespace var name -> fully-resolved prefix) bridges the two files.
       namespace_prefixes = Hash(ScopedNameKey, ::String).new
 
-      # Iterate through all Python files in all base paths. Pulls from
-      # the detector-built file_map so subtree pruning and --exclude-path
-      # apply; current_base_path is still needed further down for import
-      # resolution, so keep the outer loop and filter by prefix.
-      python_files = get_files_by_extension(".py")
+      # Sequential: blueprint/namespace maps accumulate across files.
+      # Pre-filter .py sources once (no site-packages/tests) instead of
+      # O(bases × files) path_under_root checks.
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         flask_instances[{current_base_path, "app"}] ||= "" # Common flask instance name
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           file_content = fetch_file_content(path)

--- a/src/analyzer/analyzers/python/http_server.cr
+++ b/src/analyzer/analyzers/python/http_server.cr
@@ -47,20 +47,14 @@ module Analyzer::Python
     end
 
     def analyze
-      python_files = get_files_by_extension(".py")
-      base_paths.each do |current_base_path|
-        python_files.each do |path|
-          next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
-          @logger.debug "Analyzing #{path}"
+      parallel_python_sources do |path, current_base_path|
+        @logger.debug "Analyzing #{path}"
 
-          source = read_file_content(path)
-          lines = source.lines
-          next unless lines.any? { |l| l.includes?("http.server") || l.includes?("HTTPServer") || l.includes?("BaseHTTPRequestHandler") || l.includes?("SimpleHTTPRequestHandler") || l.includes?("wsgiref.simple_server") }
+        source = read_file_content(path)
+        lines = source.lines
+        next unless lines.any? { |l| l.includes?("http.server") || l.includes?("HTTPServer") || l.includes?("BaseHTTPRequestHandler") || l.includes?("SimpleHTTPRequestHandler") || l.includes?("wsgiref.simple_server") }
 
-          analyze_file(path, lines, source, current_base_path)
-        end
+        analyze_file(path, lines, source, current_base_path)
       end
 
       result

--- a/src/analyzer/analyzers/python/litestar.cr
+++ b/src/analyzer/analyzers/python/litestar.cr
@@ -54,40 +54,30 @@ module Analyzer::Python
     end
 
     def analyze
-      python_files = get_files_by_extension(".py")
       external_handler_prefixes = Hash(::String, Hash(::String, ::String)).new do |hash, key|
         hash[key] = Hash(::String, ::String).new
       end
 
-      base_paths.each do |current_base_path|
-        python_files.each do |path|
-          next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
+      # Pass 1 (sequential): build cross-file handler prefix map.
+      each_python_source do |path, current_base_path|
+        source = read_file_content(path)
+        next unless source.includes?("litestar")
 
-          source = read_file_content(path)
-          next unless source.includes?("litestar")
-
-          import_modules = find_imported_modules(current_base_path, path, source)
-          collect_external_handler_prefixes(source, collect_router_prefixes(source), import_modules).each do |handler_path, handler_map|
-            handler_map.each do |handler_name, prefix|
-              external_handler_prefixes[handler_path][handler_name] = prefix
-            end
+        import_modules = find_imported_modules(current_base_path, path, source)
+        collect_external_handler_prefixes(source, collect_router_prefixes(source), import_modules).each do |handler_path, handler_map|
+          handler_map.each do |handler_name, prefix|
+            external_handler_prefixes[handler_path][handler_name] = prefix
           end
         end
       end
 
-      base_paths.each do |current_base_path|
-        python_files.each do |path|
-          next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
+      # Pass 2 (parallel): per-file route extraction is independent once
+      # the prefix map is frozen.
+      parallel_python_sources do |path, current_base_path|
+        source = read_file_content(path)
+        next unless source.includes?("litestar")
 
-          source = read_file_content(path)
-          next unless source.includes?("litestar")
-
-          analyze_file(path, source, current_base_path, external_handler_prefixes[path]? || Hash(::String, ::String).new)
-        end
+        analyze_file(path, source, current_base_path, external_handler_prefixes[path]? || Hash(::String, ::String).new)
       end
 
       Fiber.yield

--- a/src/analyzer/analyzers/python/pyramid.cr
+++ b/src/analyzer/analyzers/python/pyramid.cr
@@ -58,12 +58,10 @@ module Analyzer::Python
     def analyze
       route_map = RouteMap.new # {base_path, name} => {path, decl_file}
 
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
 
           content = read_file_content(path)
           next unless content.includes?("pyramid") || content.includes?(".add_route") || content.includes?(".add_static_view")

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -100,12 +100,10 @@ module Analyzer::Python
       register_blueprint = Hash(::String, Hash(::String, ::String)).new
       blueprint_mounts = Hash(::String, Array(Tuple(::String, ::String, ::String))).new
 
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           file_content = fetch_file_content(path)

--- a/src/analyzer/analyzers/python/robyn.cr
+++ b/src/analyzer/analyzers/python/robyn.cr
@@ -34,7 +34,7 @@ module Analyzer::Python
     @json_var_regex_cache = Hash(::String, Tuple(Regex, Regex)).new
 
     def analyze
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         router_prefixes = Hash(::String, ::String).new
         # `app` is the canonical Robyn instance name — accept it implicitly
@@ -43,8 +43,6 @@ module Analyzer::Python
         router_prefixes["app"] = ""
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
 
           # Prefer the detector-cached content over a fresh disk read;
           # falls back to File.read (same encoding: utf-8, invalid: :skip)

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -76,12 +76,10 @@ module Analyzer::Python
       # Iterate through all Python files in all base paths. Pulls from
       # the detector-built file_map so subtree pruning and --exclude-path
       # apply to this pass too.
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           # Prefer the detector-cached content over a fresh disk read;

--- a/src/analyzer/analyzers/python/starlette.cr
+++ b/src/analyzer/analyzers/python/starlette.cr
@@ -54,18 +54,11 @@ module Analyzer::Python
     end
 
     def analyze
-      python_files = get_files_by_extension(".py")
-      base_paths.each do |current_base_path|
-        python_files.each do |path|
-          next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
+      parallel_python_sources do |path, current_base_path|
+        source = read_file_content(path)
+        next unless source.includes?("starlette")
 
-          source = read_file_content(path)
-          next unless source.includes?("starlette")
-
-          analyze_file(path, source, current_base_path)
-        end
+        analyze_file(path, source, current_base_path)
       end
 
       Fiber.yield

--- a/src/analyzer/analyzers/python/tornado.cr
+++ b/src/analyzer/analyzers/python/tornado.cr
@@ -42,12 +42,10 @@ module Analyzer::Python
       # Iterate through all Python files in all base paths. Pulls from
       # the detector-built file_map so subtree pruning and --exclude-path
       # apply to this pass too.
-      python_files = get_files_by_extension(".py")
+      python_files = python_source_files
       base_paths.each do |current_base_path|
         python_files.each do |path|
           next unless path_under_root?(path, current_base_path)
-          next if path.includes?("/site-packages/")
-          next if python_test_path?(path)
           @logger.debug "Analyzing #{path}"
 
           # Goes through this analyzer's own memoized read_file_content

--- a/src/analyzer/engines/cfml_engine.cr
+++ b/src/analyzer/engines/cfml_engine.cr
@@ -92,13 +92,13 @@ module Analyzer::Cfml
     end
 
     protected def cfml_components : Array(String)
-      get_files_by_extension(".cfc").reject { |path| File.directory?(path) || cfml_test_path?(path) }
+      get_files_by_extension(".cfc").reject { |path| cfml_test_path?(path) }
     end
 
     protected def cfml_pages : Array(String)
       (get_files_by_extension(".cfm") + get_files_by_extension(".cfml"))
         .uniq!
-        .reject { |path| File.directory?(path) || cfml_test_path?(path) }
+        .reject { |path| cfml_test_path?(path) }
     end
 
     protected def cfml_test_path?(path : String) : Bool

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -12,15 +12,15 @@ module Analyzer::Crystal
 
     abstract def analyze_file(path : String) : Array(Endpoint)
 
-    # `.cr` extension filter plus `lib/` exclusion baked in (shards puts
-    # dependencies under `lib/` and we don't want to analyze them).
-    # Subclasses that need a custom scan shape can override `analyze`
-    # (e.g. Amber/Kemal run a public-dir post-pass after the file walk).
+    # `.cr` sources from the extension index, plus `lib/` exclusion
+    # (shards puts dependencies under `lib/` and we don't want to
+    # analyze them). Subclasses that need a custom scan shape can
+    # override `analyze` (e.g. Amber/Kemal run a public-dir post-pass
+    # after the file walk). Paths are detector-registered regular
+    # files — no per-path `File.exists?` / `File.directory?`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path) && File.extname(path) == ".cr"
+        parallel_analyze(get_files_by_extension(".cr")) do |path|
           next if crystal_dependency_path?(path)
           # Crystal's standard test directory is `spec/`, and test
           # files always end in `_spec.cr`. Crystal framework repos
@@ -195,8 +195,10 @@ module Analyzer::Crystal
     protected def build_crystal_action_index(paths : Array(String)) : ActionIndex
       index = ActionIndex.new
       paths.each do |path|
-        next if File.directory?(path)
-        next unless File.exists?(path) && File.extname(path) == ".cr"
+        # Callers may pass a broader list (historically `all_files`); keep
+        # the cheap extension gate so non-Crystal paths never hit the
+        # lexer. Prefer `get_files_by_extension(".cr")` at the call site.
+        next unless path.ends_with?(".cr")
         next if crystal_dependency_path?(path)
         begin
           # Cache-first: detector already warmed CodeLocator for most

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -140,7 +140,6 @@ module Analyzer::Elixir
         # skip the per-file `File.exists?` syscall. Missing files surface
         # as read errors inside the analyzer and are logged there.
         parallel_analyze(elixir_source_files) do |path|
-          next if File.directory?(path)
           next if elixir_test_path?(path)
 
           begin

--- a/src/analyzer/engines/go_engine.cr
+++ b/src/analyzer/engines/go_engine.cr
@@ -53,7 +53,6 @@ module Analyzer::Go
       file_contents = Hash(String, String).new
 
       get_files_by_extension(".go").each do |path|
-        next if File.directory?(path)
         next if GoEngine.go_test_file?(path)
         dir = File.dirname(path)
         files_by_dir[dir] ||= [] of String
@@ -335,7 +334,6 @@ module Analyzer::Go
     def read_package_file_contents : Hash(String, String)
       file_contents = Hash(String, String).new
       get_files_by_extension(".go").each do |path|
-        next if File.directory?(path)
         next if GoEngine.go_test_file?(path)
         begin
           file_contents[path] = read_file_content(path)

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -67,17 +67,15 @@ module Analyzer::Javascript
     end
 
     protected def process_js_static_dirs(static_dirs : Array(Hash(String, String)), result : Array(Endpoint)) : Nil
-      expanded_files = nil.as(Array(Tuple(String, String))?)
+      # Reuse CodeLocator's once-built expanded file map instead of
+      # re-running File.expand_path + File.directory? across every
+      # static dir (and across every concurrent JS analyzer).
+      files = all_files_expanded
 
       static_dirs.each do |dir|
         root = Noir::PathScope.normalize_root(dir["file_path"])
         static_path = dir["static_path"]
         static_path = static_path[0..-2] if static_path.ends_with?("/") && static_path != "/"
-
-        files = expanded_files ||= all_files.compact_map do |file_path|
-          next if File.directory?(file_path)
-          {file_path, File.expand_path(file_path)}
-        end
 
         files.each do |file_path, expanded_file_path|
           next unless Noir::PathScope.under_normalized_root?(expanded_file_path, root)

--- a/src/analyzer/engines/javascript_engine.cr
+++ b/src/analyzer/engines/javascript_engine.cr
@@ -13,19 +13,16 @@ module Analyzer::Javascript
       "svelte.config.js", "svelte.config.ts", "svelte.config.mjs", "svelte.config.cjs",
     ]
 
-    # Walk the project tree concurrently, invoking the block for each
-    # readable source file whose extension matches. JS/TS analyzers vary
-    # in the exact filter (plain JS vs TS vs .mjs vs .tsx), so the filter
-    # is an argument with a sensible default.
+    # Walk matching source files concurrently. Candidates come from the
+    # CodeLocator extension index so monorepo `file_map` entries in other
+    # languages never enter the channel. Paths are detector-registered
+    # regular files — skip the redundant `File.exists?` / `File.directory?`
+    # syscalls (missing files surface as read errors and are logged).
     #
     # Name-consistent with the other engines' `parallel_file_scan` helpers.
     protected def parallel_file_scan(extensions : Array(String) = DEFAULT_EXTENSIONS, &block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path)
-          next unless extensions.any? { |ext| path.ends_with?(ext) }
-
+        parallel_analyze(get_files_by_extensions(extensions)) do |path|
           begin
             block.call(path)
           rescue e

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -11,14 +11,16 @@ module Analyzer::Perl
 
     abstract def analyze_file(path : String) : Array(Endpoint)
 
-    # No extension filter at the engine layer: Perl ships in `.pl`, `.pm`,
-    # `.psgi`, and `.t` files, so each analyzer filters inside `analyze_file`.
+    # Perl ships in `.pl`, `.pm`, `.psgi`, and `.t`. Pull those from the
+    # extension index instead of walking the whole monorepo `file_map`.
+    # Adapters still re-filter inside `analyze_file` for framework-specific
+    # rules (e.g. skipping `.t` tests). Paths are detector-registered
+    # regular files — no per-path `File.exists?` / `File.directory?`.
+    PERL_SOURCE_EXTENSIONS = [".pl", ".pm", ".psgi", ".t"]
+
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path)
-
+        parallel_analyze(get_files_by_extensions(PERL_SOURCE_EXTENSIONS)) do |path|
           begin
             block.call(path)
           rescue e

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -27,12 +27,11 @@ module Analyzer::Php
 
     # Walk PHP sources concurrently. Extension + test-path filtering
     # lives here so adapters don't re-check every monorepo path.
-    # Paths come from CodeLocator; skip the redundant `File.exists?`
-    # syscall (missing files error on read and are logged).
+    # Paths come from CodeLocator (regular files only); missing files
+    # error on read and are logged.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
         parallel_analyze(php_source_files) do |path|
-          next if File.directory?(path)
           next if PhpEngine.test_path?(path)
 
           begin

--- a/src/analyzer/engines/python_engine.cr
+++ b/src/analyzer/engines/python_engine.cr
@@ -53,6 +53,57 @@ module Analyzer::Python
       Noir::PathScope.relative_under(path, base_path)
     end
 
+    # Production `.py` sources from the extension index: drops
+    # site-packages and standard test paths once so adapters don't
+    # re-walk monorepo noise. Prefer this (or the helpers below) over
+    # `get_files_by_extension(".py")` + nested `base_paths.each`.
+    protected def python_source_files : Array(String)
+      get_files_by_extension(".py").reject do |path|
+        path.includes?("/site-packages/") || python_test_path?(path)
+      end
+    end
+
+    # Yield each production `.py` path with its owning configured base.
+    # Single-base scans skip multi-base resolution; multi-base uses the
+    # longest-match cache in `configured_base_for` instead of O(bases)
+    # `path_under_root?` checks per file.
+    protected def each_python_source(&block : String, String -> Nil) : Nil
+      files = python_source_files
+      if base_paths.size <= 1
+        base = base_paths.first? || ""
+        files.each { |path| block.call(path, base) }
+      else
+        files.each { |path| block.call(path, python_base_path_for(path)) }
+      end
+    end
+
+    # Parallel walk of production Python sources. Same fiber model as
+    # the other engines' `parallel_file_scan`. Use only when per-file
+    # work is independent (no shared cross-file maps mutated without
+    # synchronization). Analyzers that accumulate blueprint/app state
+    # across files should use `each_python_source` instead.
+    protected def parallel_python_sources(&block : String, String -> Nil) : Nil
+      files = python_source_files
+      if base_paths.size <= 1
+        base = base_paths.first? || ""
+        parallel_analyze(files) do |path|
+          begin
+            block.call(path, base)
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      else
+        parallel_analyze(files) do |path|
+          begin
+            block.call(path, python_base_path_for(path))
+          rescue e
+            logger.debug "Error analyzing #{path}: #{e}"
+          end
+        end
+      end
+    end
+
     # Parses the definition of a function from the source lines starting at a given index
     def parse_function_def(source_lines : Array(::String), start_index : Int32) : FunctionDefinition?
       parameters = [] of FunctionParameter

--- a/src/analyzer/engines/ruby_engine.cr
+++ b/src/analyzer/engines/ruby_engine.cr
@@ -148,17 +148,20 @@ module Analyzer::Ruby
       roots
     end
 
-    # Walk the project file tree in parallel, invoking the block for each
-    # readable non-directory file. Used by analyzers that scan the whole
-    # tree (Sinatra); Rails/Hanami target specific config files directly.
+    # Walk Ruby sources (`.rb` / `.ru`) in parallel. Used by analyzers
+    # that scan the whole tree (Sinatra, Grape, Roda, WEBrick);
+    # Rails/Hanami target specific config files directly. Candidates
+    # come from the extension index so monorepo `file_map` entries in
+    # other languages never enter the channel. Paths are detector-
+    # registered regular files — no per-path `File.exists?` /
+    # `File.directory?`.
     #
     # Name-consistent with the other engines' `parallel_file_scan` helpers.
+    RUBY_SOURCE_EXTENSIONS = [".rb", ".ru"]
+
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path)
-
+        parallel_analyze(get_files_by_extensions(RUBY_SOURCE_EXTENSIONS)) do |path|
           begin
             block.call(path)
           rescue e

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -30,15 +30,14 @@ module Analyzer::Rust
       end
     end
 
-    # `.rs` extension filter baked in. Subclasses that want a different scan
-    # shape (e.g. a post-pass after the file walk) can override `analyze`
-    # and call this helper directly; the default `analyze` above is the
-    # simpler path.
+    # `.rs` sources from the extension index. Subclasses that want a
+    # different scan shape (e.g. a post-pass after the file walk) can
+    # override `analyze` and call this helper directly; the default
+    # `analyze` above is the simpler path. Paths are detector-registered
+    # regular files — no per-path `File.exists?` / `File.directory?`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path) && File.extname(path) == ".rs"
+        parallel_analyze(get_files_by_extension(".rs")) do |path|
           next if RustEngine.test_path?(path)
 
           begin

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -13,14 +13,13 @@ module Analyzer::Scala
 
     abstract def analyze_file(path : String) : Array(Endpoint)
 
-    # `.scala` extension filter baked in. Subclasses that need a custom
-    # scan shape can override `analyze` and call this helper directly.
+    # `.scala` sources from the extension index. Subclasses that need a
+    # custom scan shape can override `analyze` and call this helper
+    # directly. Paths are detector-registered regular files — no per-path
+    # `File.exists?` / `File.directory?`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path) && File.extname(path) == ".scala"
-
+        parallel_analyze(get_files_by_extension(".scala")) do |path|
           begin
             block.call(path)
           rescue e

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -34,13 +34,13 @@ module Analyzer::Swift
       SwiftEngine.swift_vendor_path?(path)
     end
 
-    # `.swift` extension filter baked in. Subclasses that need a custom
-    # scan shape can override `analyze` and call this helper directly.
+    # `.swift` sources from the extension index. Subclasses that need a
+    # custom scan shape can override `analyze` and call this helper
+    # directly. Paths are detector-registered regular files — no per-path
+    # `File.exists?` / `File.directory?`.
     protected def parallel_file_scan(&block : String -> Nil) : Nil
       begin
-        parallel_analyze(all_files) do |path|
-          next if File.directory?(path)
-          next unless File.exists?(path) && File.extname(path) == ".swift"
+        parallel_analyze(get_files_by_extension(".swift")) do |path|
           # Swift Package Manager convention parks tests under
           # `Tests/<TargetName>Tests/`. Real route handlers never
           # live there, but vapor's own repo accounts for ~58

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -181,25 +181,23 @@ def detector_build_applicable_lookup(detectors : Array(Detector)) : Proc(String,
   end
 
   path_sensitive_set = Set(Int32).new(path_sensitive)
+  # Key by basename, not bare extension: many detectors gate on
+  # basename substrings (`*deploy*.yml`, `*sites*.yaml`) or exact
+  # names (`package.json`). An extension-only key would probe
+  # `file.yml` and drop every basename-qualified match.
   cache = {} of String => Array(Int32)
 
   ->(path : String) do
     base = File.basename(path)
-    key = if DETECTOR_SPECIAL_BASENAMES.includes?(base) || base.count('.') != 1
-            "b:#{base}"
-          else
-            "e:#{File.extname(base)}"
-          end
 
-    cached = cache[key]?
+    cached = cache[base]?
     unless cached
-      probe = key.starts_with?("b:") ? base : "file#{File.extname(base)}"
       idxs = [] of Int32
       detectors.each_with_index do |detector, idx|
         next if path_sensitive_set.includes?(idx)
-        idxs << idx if detector.applicable?(probe)
+        idxs << idx if detector.applicable?(base)
       end
-      cache[key] = idxs
+      cache[base] = idxs
       cached = idxs
     end
 

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -137,6 +137,82 @@ def detector_mobile_detector?(name : String) : Bool
   MOBILE_DETECTOR_NAMES.includes?(name)
 end
 
+# Filenames that detectors match by exact basename (often with path
+# constraints like "must sit at the project root"). These must not share
+# an extension-only cache bucket — e.g. `vercel.json` is not "any .json".
+DETECTOR_SPECIAL_BASENAMES = Set{
+  "package.json", "tsconfig.json", "composer.json", "composer.lock",
+  "vercel.json", "now.json", "netlify.toml", "wrangler.toml",
+  "Gemfile", "Gemfile.lock", "Package.swift", "Cargo.toml", "go.mod",
+  "mix.exs", "pubspec.yaml", "pubspec.lock", "shard.yml", "shard.lock",
+  "build.sbt", "pom.xml", "AndroidManifest.xml", "config.toml",
+  "rebar.config", "erlang.mk", "project.clj", "deps.edn", "stack.yaml",
+  "package.yaml", "gleam.toml", "manifest.toml", "paket.dependencies",
+  "Caddyfile", "Dockerfile", "Makefile", "Rakefile", "serverless.yml",
+  "serverless.yaml", "app.yaml", "openapi.yaml", "openapi.json",
+  "swagger.json", "swagger.yaml",
+}
+
+# Build a lookup that turns a path into the list of detector indices
+# whose `applicable?` returns true — without re-walking every detector
+# on every file. Most detectors only inspect extension / basename, so
+# their answers are memoized by a small cache key. Detectors that look
+# at path segments or root placement (`/grails-app/`, vercel.json at
+# base root, …) are classified as path-sensitive and always evaluated
+# against the real path.
+def detector_build_applicable_lookup(detectors : Array(Detector)) : Proc(String, Array(Int32))
+  path_sensitive = [] of Int32
+  sample_suffixes = [
+    ".java", ".js", ".ts", ".tsx", ".rb", ".py", ".go", ".json", ".yml",
+    ".yaml", ".xml", ".cs", ".kt", ".php", ".cr", ".rs", ".ex", ".swift",
+    ".scala", ".dart", ".groovy", ".pl", ".clj", ".hs", ".lua", ".sql",
+    ".toml", ".bru", ".http", ".sbt", ".gradle", ".aspx", ".fs",
+  ]
+  # Bare names used to detect "parent must be project root" style checks
+  # (Vercel, Netlify, …) that return true for `name` but false for
+  # `a/b/c/name`.
+  path_probe_basenames = DETECTOR_SPECIAL_BASENAMES.to_a + sample_suffixes.map { |ext| "file#{ext}" }
+
+  detectors.each_with_index do |detector, idx|
+    sensitive = path_probe_basenames.any? do |name|
+      detector.applicable?("a/b/c/#{name}") != detector.applicable?(name)
+    end
+    path_sensitive << idx if sensitive
+  end
+
+  path_sensitive_set = Set(Int32).new(path_sensitive)
+  cache = {} of String => Array(Int32)
+
+  ->(path : String) do
+    base = File.basename(path)
+    key = if DETECTOR_SPECIAL_BASENAMES.includes?(base) || base.count('.') != 1
+            "b:#{base}"
+          else
+            "e:#{File.extname(base)}"
+          end
+
+    cached = cache[key]?
+    unless cached
+      probe = key.starts_with?("b:") ? base : "file#{File.extname(base)}"
+      idxs = [] of Int32
+      detectors.each_with_index do |detector, idx|
+        next if path_sensitive_set.includes?(idx)
+        idxs << idx if detector.applicable?(probe)
+      end
+      cache[key] = idxs
+      cached = idxs
+    end
+
+    # Always dup: callers `reject!` android-scope / JSON-spec candidates
+    # in place and must not corrupt the memoized array.
+    result = cached.dup
+    path_sensitive.each do |idx|
+      result << idx if detectors[idx].applicable?(path)
+    end
+    result
+  end
+end
+
 def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), passive_scans : Array(PassiveScan), logger : NoirLogger)
   techs = [] of String
   passive_result = [] of PassiveScanResult
@@ -461,6 +537,10 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
 
   android_source_scope_active = detector_list.any? { |detector| detector_mobile_detector?(detector.name) }
   android_source_prefixes = [] of String
+  # Built once before the reader starts. Replaces the per-file
+  # O(detectors) `applicable?` walk with an extension/basename memo
+  # plus a short path-sensitive tail (see detector_build_applicable_lookup).
+  applicable_lookup = detector_build_applicable_lookup(detector_list)
 
   # Thread for reading files and sending their contents to the channel
   wg.add(1)
@@ -578,10 +658,7 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
                 next
               end
 
-              candidate_detector_indices = [] of Int32
-              detector_list.each_with_index do |detector, idx|
-                candidate_detector_indices << idx if detector.applicable?(full_path)
-              end
+              candidate_detector_indices = applicable_lookup.call(full_path)
 
               # An Android source-set file is normally narrowed to the
               # mobile detectors only (see ANDROID_EMBEDDED_SERVER_MARKER /

--- a/src/detector/detectors/specification/kamal.cr
+++ b/src/detector/detectors/specification/kamal.cr
@@ -13,7 +13,16 @@ module Detector::Specification
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+      return false unless filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+
+      # Kamal deploy files are almost always named *deploy*.yml (or live
+      # under `.kamal/`). Matching every YAML in a monorepo made this
+      # non-idempotent detector re-parse CI/K8s/Compose files on every
+      # path for zero signal.
+      base = File.basename(filename).downcase
+      return true if base.includes?("deploy") || base.includes?("kamal")
+      path = filename.includes?('\\') ? filename.gsub('\\', '/') : filename
+      path.includes?("/.kamal/") || path.includes?("/config/deploy")
     end
 
     def set_name

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -27,7 +27,12 @@ module Detector::Specification
     end
 
     def applicable?(filename : String) : Bool
-      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+      return false unless filename.ends_with?(".yaml") || filename.ends_with?(".yml")
+
+      # ZAP exports are named *sites* (sites.yml, sites_tree.yaml). The
+      # previous "any YAML" gate made every non-idempotent pass pay a
+      # content probe + occasional YAML parse on unrelated manifests.
+      File.basename(filename).downcase.includes?("sites")
     end
 
     def set_name

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -9,9 +9,12 @@ require "../utils/utils"
 class Analyzer
   include FileHelper
 
-  DEFAULT_CHANNEL_CAPACITY         = 128
-  DEFAULT_CONTENT_CHANNEL_CAPACITY =  16
-  MAX_ANALYZER_WORKERS             =  64
+  DEFAULT_CHANNEL_CAPACITY = 128
+  # Detector reader → worker content channel. 16 was too small under
+  # heavy passive-scan / multi-detector load: the single reader fiber
+  # blocked on send while workers drained slowly, stalling disk I/O.
+  DEFAULT_CONTENT_CHANNEL_CAPACITY = 64
+  MAX_ANALYZER_WORKERS             = 64
 
   @result : Array(Endpoint)
   @endpoint_references : Array(EndpointReference)

--- a/src/models/file_helper.cr
+++ b/src/models/file_helper.cr
@@ -43,6 +43,24 @@ module FileHelper
     CodeLocator.instance.files_by_extension(extension)
   end
 
+  # Union of files matching any of `extensions`. Prefer this over
+  # `parallel_analyze(all_files)` + per-file extension filter: the
+  # monorepo `file_map` can be 10–100× larger than the language's
+  # source set, and walking it only to `next` on every non-matching
+  # path is pure overhead.
+  def get_files_by_extensions(extensions : Array(String)) : Array(String)
+    case extensions.size
+    when 0
+      [] of String
+    when 1
+      get_files_by_extension(extensions[0])
+    else
+      result = [] of String
+      extensions.each { |ext| result.concat(get_files_by_extension(ext)) }
+      result
+    end
+  end
+
   # Get files filtered by both prefix and extension
   def get_files_by_prefix_and_extension(prefix : String, extension : String) : Array(String)
     return all_files.select { |file| !File.directory?(file) && File.extname(file) == extension } if prefix.empty?


### PR DESCRIPTION
## Summary

- **Detector**: memoize `applicable?` by basename (with path-sensitive tail), tighten Kamal/ZAP YAML gates, raise content channel capacity 16→64.
- **Analyzer engines**: walk extension-indexed source sets instead of the full monorepo `file_map`; drop redundant `File.exists?`/`File.directory?` on detector-registered files.
- **Spring**: collapse four pre-scan passes into two content walks over `.java` only.
- **Python**: shared `python_source_files` / `parallel_python_sources`; parallelize independent analyzers (Starlette, Falcon, Bottle, http.server, Litestar pass 2).
- **Multi-tech**: drop redundant `js_http` / `go_http` / `python_starlette` when a framework already owns the surface.
- **JS static**: reuse `expanded_file_map` instead of re-expanding every path.

## Test plan

- [x] `just build`
- [x] `crystal spec spec/unit_test/detector` (993)
- [x] Python functional suite (2311)
- [x] Smoke: spring / express / flask / starlette / fastapi / kamal / zap / analyzer_selection