### PR TITLE
perf(miniparsers): shared tree-sitter extraction result cache

### DIFF
--- a/spec/unit_test/miniparser/extraction_result_cache_spec.cr
+++ b/spec/unit_test/miniparser/extraction_result_cache_spec.cr
@@ -1,0 +1,65 @@
+require "spec"
+require "../../../src/miniparsers/extraction_result_cache"
+require "../../../src/miniparsers/python_route_extractor_ts"
+
+describe Noir::ExtractionResultCache do
+  it "fingerprints equal content identically" do
+    a = "hello world"
+    b = String.build { |io| io << "hello world" }
+    Noir::ExtractionResultCache.source_fingerprint(a).should eq(
+      Noir::ExtractionResultCache.source_fingerprint(b)
+    )
+  end
+
+  it "fingerprints different content differently" do
+    Noir::ExtractionResultCache.source_fingerprint("a").should_not eq(
+      Noir::ExtractionResultCache.source_fingerprint("b")
+    )
+  end
+end
+
+describe Noir::TreeSitterPythonRouteExtractor do
+  it "returns the same decorations on a second call (memo hit)" do
+    source = <<-PY
+      from flask import Flask
+      app = Flask(__name__)
+
+      @app.route("/ping")
+      def ping():
+          return "ok"
+      PY
+
+    first = Noir::TreeSitterPythonRouteExtractor.extract_decorations(source)
+    second = Noir::TreeSitterPythonRouteExtractor.extract_decorations(source)
+    first.should eq(second)
+    first.size.should eq(1)
+    first[0].path.should eq("/ping")
+  end
+
+  it "extracts decorations and blueprints in one combined call" do
+    source = <<-PY
+      from flask import Flask, Blueprint
+      app = Flask(__name__)
+      api = Blueprint("api", __name__, url_prefix="/api")
+
+      @app.route("/")
+      def index():
+          return "hi"
+
+      @api.get("/items")
+      def items():
+          return []
+      PY
+
+    decos, bps = Noir::TreeSitterPythonRouteExtractor.extract_decorations_and_blueprints(
+      source, ["flask"]
+    )
+    decos.map(&.path).sort.should eq(["/", "/items"])
+    bps.map(&.name).should eq(["api"])
+    bps[0].prefix.should eq("/api")
+
+    # Solo calls must hit the same memo entries.
+    Noir::TreeSitterPythonRouteExtractor.extract_decorations(source).map(&.path).sort.should eq(["/", "/items"])
+    Noir::TreeSitterPythonRouteExtractor.extract_blueprints(source, ["flask"]).map(&.name).should eq(["api"])
+  end
+end

--- a/src/analyzer/analyzers/python/flask.cr
+++ b/src/analyzer/analyzers/python/flask.cr
@@ -174,20 +174,20 @@ module Analyzer::Python
               registrar_substrings = (["add_resource"] + registrar_aliases).map { |r| ".#{r}(" }
             end
 
-            # Tree-sitter pre-pass: parse the file once and pull out every
+            # Tree-sitter pre-pass: one parse yields every
             # `@<router>.route(...)`/`@<router>.<method>(...)` decorator and
             # every `<name> = (flask.)?Blueprint(url_prefix=...)` declaration.
-            # Both pieces used to be rediscovered with a fresh regex on every
-            # single line; the parse is linear in file size instead of
-            # (lines × patterns) and also handles multi-line decorators that
-            # the regex can't see.
-            ts_decorations = Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content)
+            # Previously each table re-parsed the file; multi-line decorators
+            # still need the AST (regex can't see them).
+            ts_decorations, ts_blueprints = Noir::TreeSitterPythonRouteExtractor.extract_decorations_and_blueprints(
+              file_content, ["flask"]
+            )
             decorations_by_line = Hash(Int32, Array(Noir::TreeSitterPythonRouteExtractor::Decoration)).new
             ts_decorations.each do |d|
               decorations_by_line[d.decorator_line] ||= [] of Noir::TreeSitterPythonRouteExtractor::Decoration
               decorations_by_line[d.decorator_line] << d
             end
-            Noir::TreeSitterPythonRouteExtractor.extract_blueprints(file_content, ["flask"]).each do |bp|
+            ts_blueprints.each do |bp|
               blueprint_prefixes[{current_base_path, bp.name}] ||= bp.prefix
               api_instances[bp.name] ||= bp.prefix
             end

--- a/src/analyzer/analyzers/python/quart.cr
+++ b/src/analyzer/analyzers/python/quart.cr
@@ -115,12 +115,11 @@ module Analyzer::Python
           import_map_cache : Hash(::String, Tuple(::String, Int32))? = nil
           view_assignments = Hash(::String, ::String).new
 
-          # Tree-sitter pre-pass: harvest every `@<router>.route(...)`,
-          # `@<router>.<method>(...)`, and `@<router>.websocket(...)`
-          # decorator, plus every `<name> = (quart.)?Blueprint(...)`
-          # declaration. One parse per file vs. (lines × patterns) regex
-          # work; multi-line decorators come along for free.
-          ts_decorations = Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, nil, WEBSOCKET_ATTRIBUTES)
+          # Tree-sitter pre-pass: one parse yields decorations + blueprints
+          # (previously two full parses of the same buffer).
+          ts_decorations, ts_blueprints = Noir::TreeSitterPythonRouteExtractor.extract_decorations_and_blueprints(
+            file_content, ["quart"], nil, WEBSOCKET_ATTRIBUTES
+          )
           ts_decorations.each do |decoration|
             is_ws = decoration.attribute_name == "websocket"
             methods_literal = decoration.methods.map { |m| "'#{m}'" }.join(",")
@@ -132,7 +131,7 @@ module Analyzer::Python
             @routes[decoration.router_name] << router_info
           end
 
-          Noir::TreeSitterPythonRouteExtractor.extract_blueprints(file_content, ["quart"]).each do |bp|
+          ts_blueprints.each do |bp|
             blueprint_prefixes[bp.name] ||= bp.prefix
             api_instances[bp.name] ||= bp.prefix
           end

--- a/src/analyzer/analyzers/python/sanic.cr
+++ b/src/analyzer/analyzers/python/sanic.cr
@@ -91,18 +91,18 @@ module Analyzer::Python
           api_instances = Hash(::String, ::String).new
           path_api_instances[path] = api_instances
 
-          # Tree-sitter pre-pass: parse once and harvest every
-          # `@<router>.route(...)` / `@<router>.<method>(...)` decorator
-          # plus every `<name> = (sanic.)?Blueprint(url_prefix=...)`
-          # declaration. Replaces the per-line regex sweep in the loop
-          # below and handles multi-line decorators for free.
-          Noir::TreeSitterPythonRouteExtractor.extract_blueprints(file_content, ["sanic"]).each do |bp|
+          # Tree-sitter pre-pass: one parse for decorations + blueprints
+          # (was two full parses of the same buffer).
+          ts_decorations, ts_blueprints = Noir::TreeSitterPythonRouteExtractor.extract_decorations_and_blueprints(
+            file_content, ["sanic"], extra_attributes: {"websocket" => "GET"}
+          )
+          ts_blueprints.each do |bp|
             blueprint_prefixes[bp.name] ||= bp.prefix
             api_instances[bp.name] ||= bp.prefix
           end
           collect_blueprint_registrations(file_content, blueprint_registration_prefixes, current_base_path)
           collect_blueprint_groups_and_versions(file_content, blueprint_group_prefixes, blueprint_versions)
-          Noir::TreeSitterPythonRouteExtractor.extract_decorations(file_content, extra_attributes: {"websocket" => "GET"}).each do |decoration|
+          ts_decorations.each do |decoration|
             methods_literal = decoration.methods.map { |m| "'#{m}'" }.join(",")
             extra_params = "methods=[#{methods_literal}]"
             router_info = Tuple(Int32, ::String, ::String, ::String, ::String).new(decoration.decorator_line, path, decoration.path, extra_params, decoration.attribute_name)

--- a/src/miniparsers/extraction_result_cache.cr
+++ b/src/miniparsers/extraction_result_cache.cr
@@ -1,0 +1,87 @@
+# Process-wide memo helpers for pure tree-sitter / lexer extractors.
+#
+# Large monorepo scans re-enter the same extractors many times on the
+# same source string:
+#   * one analyzer calls decorations + blueprints (two full parses)
+#   * concurrent tech analyzers re-parse the same CodeLocator-cached
+#     content for sibling frameworks that both survived detection
+#
+# Trees themselves cannot be cached (lifetime is tied to the parse
+# block), but the *derived* route/decoration/constant tables can. Keys
+# combine a content fingerprint so GC reuse of `object_id` cannot
+# return a stale hit.
+module Noir::ExtractionResultCache
+  extend self
+
+  # Soft cap per typed store. Beyond this, the oldest half of entries
+  # is dropped (FIFO on insertion order). Extraction results are small
+  # relative to source text; the cap mainly bounds pathological cases.
+  DEFAULT_MAX_ENTRIES = 4096
+
+  # Stable-ish fingerprint for a source buffer. Prefer this over bare
+  # `object_id` — the CodeLocator content cache reuses String instances
+  # across analyzers (good hit rate), but object_id alone is unsafe if
+  # a short-lived string is freed and the id is recycled.
+  def source_fingerprint(source : String) : UInt64
+    # Crystal's String#hash is content-based; mix in object_id so two
+    # identical buffers that are distinct instances still share a key
+    # when content matches (hash) while remaining O(1) to compute for
+    # the already-interned CodeLocator path (same instance → same id).
+    h = source.hash.to_u64!
+    h &+= source.bytesize.to_u64! &* 0x9e3779b97f4a7c15_u64
+    h
+  end
+
+  # Combine source fingerprint with a cheap options tag (e.g. joined
+  # router names). Callers should keep the tag deterministic.
+  def key(source : String, *options : String) : UInt64
+    h = source_fingerprint(source)
+    options.each do |opt|
+      h &+= opt.hash.to_u64! &* 0xbf58476d1ce4e5b9_u64
+    end
+    h
+  end
+
+  # Insert-or-fetch with a typed Hash store. `store` and `order` are
+  # owned by the caller so each extractor keeps its own type-safe map.
+  def fetch(store : Hash(UInt64, T), order : Array(UInt64), key : UInt64, mutex : Mutex, & : -> T) : T forall T
+    fetch(store, order, key, mutex, DEFAULT_MAX_ENTRIES) { yield }
+  end
+
+  def fetch(store : Hash(UInt64, T), order : Array(UInt64), key : UInt64, mutex : Mutex, max_entries : Int32, & : -> T) : T forall T
+    mutex.synchronize do
+      if hit = store[key]?
+        return hit
+      end
+    end
+
+    value = yield
+
+    mutex.synchronize do
+      unless store.has_key?(key)
+        if store.size >= max_entries
+          # Drop oldest half.
+          drop = store.size // 2
+          drop = 1 if drop < 1
+          drop.times do
+            old = order.shift?
+            break unless old
+            store.delete(old)
+          end
+        end
+        store[key] = value
+        order << key
+      end
+      # Another fiber may have filled the same key first; prefer the
+      # stored entry so all callers share one array.
+      store[key]
+    end
+  end
+
+  def clear(store : Hash(UInt64, T), order : Array(UInt64), mutex : Mutex) : Nil forall T
+    mutex.synchronize do
+      store.clear
+      order.clear
+    end
+  end
+end

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../ext/tree_sitter/tree_sitter"
+require "./extraction_result_cache"
 require "../models/endpoint"
 
 module Noir
@@ -99,23 +100,38 @@ module Noir
       end
     end
 
+    # Memo for the source-level entry points. Spring's analyzer already
+    # amortises within a file via `_from(root)`, but other callers
+    # (and any future multi-tech overlap) still re-parse whole buffers.
+    @@routes_memo = Hash(UInt64, Array(Route)).new
+    @@routes_order = [] of UInt64
+    @@constants_memo = Hash(UInt64, Hash(String, String)).new
+    @@constants_order = [] of UInt64
+    @@memo_mutex = Mutex.new
+
     # Parses `source` and returns every Spring-style route it can
     # resolve. Top-level classes are scanned in order; nested classes
     # inherit their parent class's mapping prefix.
     def extract_routes(source : String) : Array(Route)
-      routes = [] of Route
-      Noir::TreeSitter.parse_java(source) do |root|
-        routes = extract_routes_from(root, source)
+      key = ExtractionResultCache.key(source, "java_routes")
+      ExtractionResultCache.fetch(@@routes_memo, @@routes_order, key, mutex: @@memo_mutex) do
+        routes = [] of Route
+        Noir::TreeSitter.parse_java(source) do |root|
+          routes = extract_routes_from(root, source)
+        end
+        routes
       end
-      routes
     end
 
     def extract_string_constants(source : String) : Hash(String, String)
-      constants = Hash(String, String).new
-      Noir::TreeSitter.parse_java(source) do |root|
-        constants = extract_string_constants_from(root, source)
+      key = ExtractionResultCache.key(source, "java_constants")
+      ExtractionResultCache.fetch(@@constants_memo, @@constants_order, key, mutex: @@memo_mutex) do
+        constants = Hash(String, String).new
+        Noir::TreeSitter.parse_java(source) do |root|
+          constants = extract_string_constants_from(root, source)
+        end
+        constants
       end
-      constants
     end
 
     # `_from` variant — accept a pre-parsed `root` so the Spring

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -1,4 +1,5 @@
 require "../ext/tree_sitter/tree_sitter"
+require "./extraction_result_cache"
 
 module Noir
   # Tree-sitter-backed port of `PythonRouteExtractor`.
@@ -44,6 +45,14 @@ module Noir
       end
     end
 
+    # Process-wide memo: same CodeLocator source buffer is often fed to
+    # decorations + blueprints (and to multiple framework analyzers).
+    @@decoration_memo = Hash(UInt64, Array(Decoration)).new
+    @@decoration_order = [] of UInt64
+    @@blueprint_memo = Hash(UInt64, Array(BlueprintDecl)).new
+    @@blueprint_order = [] of UInt64
+    @@memo_mutex = Mutex.new
+
     # Parses `source` and returns every route decoration found.
     #
     # `router_names` optionally restricts which variable names count as
@@ -59,12 +68,28 @@ module Noir
     def extract_decorations(source : String,
                             router_names : Array(String)? = nil,
                             extra_attributes : Hash(String, String)? = nil) : Array(Decoration)
-      results = [] of Decoration
-      Noir::TreeSitter.parse_python(source) do |root|
-        walk(root) do |node|
-          next unless Noir::TreeSitter.node_type(node) == "decorated_definition"
-          collect_decorations(node, source, router_names, extra_attributes, results)
+      tag = decoration_options_tag(router_names, extra_attributes)
+      key = ExtractionResultCache.key(source, "decorations", tag)
+      ExtractionResultCache.fetch(@@decoration_memo, @@decoration_order, key, mutex: @@memo_mutex) do
+        results = [] of Decoration
+        Noir::TreeSitter.parse_python(source) do |root|
+          extract_decorations_from(root, source, router_names, extra_attributes, results)
         end
+        results
+      end
+    end
+
+    # Same as `extract_decorations` but reuses a pre-parsed root so a
+    # caller that also needs blueprints (Flask/Quart/Sanic) pays for one
+    # tree-sitter parse instead of two.
+    def extract_decorations_from(root : LibTreeSitter::TSNode,
+                                 source : String,
+                                 router_names : Array(String)? = nil,
+                                 extra_attributes : Hash(String, String)? = nil,
+                                 results : Array(Decoration) = [] of Decoration) : Array(Decoration)
+      walk(root) do |node|
+        next unless Noir::TreeSitter.node_type(node) == "decorated_definition"
+        collect_decorations(node, source, router_names, extra_attributes, results)
       end
       results
     end
@@ -82,29 +107,95 @@ module Noir
     # without one and the query language can't express "this keyword,
     # if present" cleanly.
     def extract_blueprints(source : String, module_names : Array(String)) : Array(BlueprintDecl)
-      results = [] of BlueprintDecl
+      tag = module_names.join(",")
+      key = ExtractionResultCache.key(source, "blueprints", tag)
+      ExtractionResultCache.fetch(@@blueprint_memo, @@blueprint_order, key, mutex: @@memo_mutex) do
+        results = [] of BlueprintDecl
+        Noir::TreeSitter.parse_python(source) do |root|
+          extract_blueprints_from(root, source, module_names, results)
+        end
+        results
+      end
+    end
+
+    def extract_blueprints_from(root : LibTreeSitter::TSNode,
+                                source : String,
+                                module_names : Array(String),
+                                results : Array(BlueprintDecl) = [] of BlueprintDecl) : Array(BlueprintDecl)
       allowed = module_names.to_set
       query = blueprint_query
-      Noir::TreeSitter.parse_python(source) do |root|
-        query.each_match_raw(root, source) do |pattern_index, caps|
-          captures = caps.to_h
-          name_node = captures["name"]?
-          call_node = captures["call"]?
-          next unless name_node && call_node
+      query.each_match_raw(root, source) do |pattern_index, caps|
+        captures = caps.to_h
+        name_node = captures["name"]?
+        call_node = captures["call"]?
+        next unless name_node && call_node
 
-          # Pattern 1 is the qualified form; enforce the module allowlist.
-          if pattern_index == 1
-            module_node = captures["module"]?
-            next unless module_node
-            next unless allowed.includes?(Noir::TreeSitter.node_text(module_node, source))
-          end
-
-          name = Noir::TreeSitter.node_text(name_node, source)
-          prefix = extract_url_prefix(call_node, source)
-          results << BlueprintDecl.new(name, prefix, Noir::TreeSitter.node_start_row(name_node))
+        # Pattern 1 is the qualified form; enforce the module allowlist.
+        if pattern_index == 1
+          module_node = captures["module"]?
+          next unless module_node
+          next unless allowed.includes?(Noir::TreeSitter.node_text(module_node, source))
         end
+
+        name = Noir::TreeSitter.node_text(name_node, source)
+        prefix = extract_url_prefix(call_node, source)
+        results << BlueprintDecl.new(name, prefix, Noir::TreeSitter.node_start_row(name_node))
       end
       results
+    end
+
+    # One parse → decorations + blueprints. Preferred entry for adapters
+    # that need both (Flask, Quart, Sanic); result arrays are also
+    # published into the individual memos so a later solo call hits.
+    def extract_decorations_and_blueprints(source : String,
+                                           module_names : Array(String),
+                                           router_names : Array(String)? = nil,
+                                           extra_attributes : Hash(String, String)? = nil) : Tuple(Array(Decoration), Array(BlueprintDecl))
+      deco_tag = decoration_options_tag(router_names, extra_attributes)
+      bp_tag = module_names.join(",")
+      deco_key = ExtractionResultCache.key(source, "decorations", deco_tag)
+      bp_key = ExtractionResultCache.key(source, "blueprints", bp_tag)
+
+      cached_deco = nil.as(Array(Decoration)?)
+      cached_bp = nil.as(Array(BlueprintDecl)?)
+      @@memo_mutex.synchronize do
+        cached_deco = @@decoration_memo[deco_key]?
+        cached_bp = @@blueprint_memo[bp_key]?
+      end
+      return {cached_deco, cached_bp} if cached_deco && cached_bp
+
+      decorations = cached_deco || [] of Decoration
+      blueprints = cached_bp || [] of BlueprintDecl
+      Noir::TreeSitter.parse_python(source) do |root|
+        extract_decorations_from(root, source, router_names, extra_attributes, decorations) unless cached_deco
+        extract_blueprints_from(root, source, module_names, blueprints) unless cached_bp
+      end
+
+      @@memo_mutex.synchronize do
+        unless @@decoration_memo.has_key?(deco_key)
+          @@decoration_memo[deco_key] = decorations
+          @@decoration_order << deco_key
+        end
+        unless @@blueprint_memo.has_key?(bp_key)
+          @@blueprint_memo[bp_key] = blueprints
+          @@blueprint_order << bp_key
+        end
+        decorations = @@decoration_memo[deco_key]
+        blueprints = @@blueprint_memo[bp_key]
+      end
+
+      {decorations, blueprints}
+    end
+
+    private def decoration_options_tag(router_names : Array(String)?,
+                                       extra_attributes : Hash(String, String)?) : String
+      routers = router_names ? router_names.join(",") : "*"
+      extras = if extra_attributes && !extra_attributes.empty?
+                 extra_attributes.to_a.sort_by!(&.first).map { |k, v| "#{k}=#{v}" }.join("&")
+               else
+                 ""
+               end
+      "#{routers}|#{extras}"
     end
 
     # Lazily compiled, cached across all calls. Two patterns keep bare


### PR DESCRIPTION
## Summary

- Introduce `Noir::ExtractionResultCache` — process-wide memo keyed by content fingerprint for pure extractors.
- **Python**: memoize `extract_decorations` / `extract_blueprints`; add `extract_decorations_and_blueprints` (one parse for both). Flask, Quart, Sanic switched over.
- **Java**: memoize source-level `extract_routes` / `extract_string_constants` (Spring already amortizes within a file via `_from(root)`).
- Trees themselves stay scoped to the parse block (cannot outlive it); only derived tables are cached.

Follow-up to #2351.

## Test plan

- [x] `just build`
- [x] `crystal spec spec/unit_test/miniparser/extraction_result_cache_spec.cr`
- [x] `crystal spec spec/unit_test/miniparser/python_route_extractor_ts_spec.cr`
- [x] Flask / Quart / Sanic functional specs
- [x] Spring functional specs