### PR TITLE
fix: harden perf-path detector lookup and parallel result safety

### DIFF
--- a/spec/unit_test/detector/applicable_lookup_spec.cr
+++ b/spec/unit_test/detector/applicable_lookup_spec.cr
@@ -1,0 +1,58 @@
+require "../../spec_helper"
+require "../../../src/detector/detector"
+require "../../../src/detector/detectors/specification/supabase"
+require "../../../src/detector/detectors/groovy/grails"
+require "../../../src/detector/detectors/specification/vercel"
+require "../../../src/detector/detectors/java/spring"
+require "../../../src/models/detector"
+
+describe "detector_path_sensitive?" do
+  options = create_test_options
+
+  it "flags Supabase (migrations / supabase/ path gates)" do
+    detector_path_sensitive?(Detector::Specification::Supabase.new(options)).should be_true
+  end
+
+  it "flags Grails (grails-app path gate)" do
+    detector_path_sensitive?(Detector::Groovy::Grails.new(options)).should be_true
+  end
+
+  it "flags Vercel (root-placed vercel.json)" do
+    detector_path_sensitive?(Detector::Specification::Vercel.new(options)).should be_true
+  end
+
+  it "does not flag extension-only Spring detector" do
+    detector_path_sensitive?(Detector::Java::Spring.new(options)).should be_false
+  end
+end
+
+describe "detector_build_applicable_lookup" do
+  options = create_test_options
+
+  it "includes Supabase for a migration path but not a bare .sql basename probe" do
+    supabase = Detector::Specification::Supabase.new(options)
+    spring = Detector::Java::Spring.new(options)
+    # set_name is required for detector identity in some paths
+    supabase.set_name
+    spring.set_name
+    detectors = [supabase.as(Detector), spring.as(Detector)]
+    lookup = detector_build_applicable_lookup(detectors)
+
+    migration = "proj/supabase/migrations/001_init.sql"
+    idxs = lookup.call(migration)
+    idxs.should contain(0) # supabase
+
+    # Bare basename with no supabase path must not match supabase
+    supabase.applicable?("001_init.sql").should be_false
+  end
+
+  it "includes Grails for a grails-app path via path-sensitive recheck" do
+    grails = Detector::Groovy::Grails.new(options)
+    grails.set_name
+    detectors = [grails.as(Detector)]
+    lookup = detector_build_applicable_lookup(detectors)
+
+    path = "app/grails-app/controllers/Foo.groovy"
+    lookup.call(path).should contain(0)
+  end
+end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -1,5 +1,6 @@
 require "./analyzers/**"
 require "./analyzers/file_analyzers/*"
+require "../miniparsers/extraction_result_cache"
 
 macro define_analyzers(analyzers)
   {% for analyzer in analyzers %}
@@ -388,6 +389,10 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
   result = [] of Endpoint
   file_analyzer = FileAnalyzer.new options
   logger.info "Initializing analyzers"
+
+  # Drop process-wide extraction memos from any previous scan (diff mode
+  # / repeated library use) so fingerprints cannot serve stale tables.
+  Noir::ExtractionResultCache.clear_all
 
   analyzer = initialize_analyzers logger
 

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -5,7 +5,7 @@ module Analyzer::Crystal
   abstract class CrystalEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -5,7 +5,7 @@ module Analyzer::Elixir
   abstract class ElixirEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -4,7 +4,7 @@ module Analyzer::Perl
   abstract class PerlEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -10,7 +10,7 @@ module Analyzer::Php
 
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -5,7 +5,7 @@ module Analyzer::Rust
   abstract class RustEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -6,7 +6,7 @@ module Analyzer::Scala
   abstract class ScalaEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -4,7 +4,7 @@ module Analyzer::Swift
   abstract class SwiftEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        result.concat(analyze_file(path))
+        append_endpoints(analyze_file(path))
       end
       result
     end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -153,31 +153,60 @@ DETECTOR_SPECIAL_BASENAMES = Set{
   "swagger.json", "swagger.yaml",
 }
 
-# Build a lookup that turns a path into the list of detector indices
-# whose `applicable?` returns true — without re-walking every detector
-# on every file. Most detectors only inspect extension / basename, so
-# their answers are memoized by a small cache key. Detectors that look
-# at path segments or root placement (`/grails-app/`, vercel.json at
-# base root, …) are classified as path-sensitive and always evaluated
-# against the real path.
-def detector_build_applicable_lookup(detectors : Array(Detector)) : Proc(String, Array(Int32))
-  path_sensitive = [] of Int32
+# Paths that embed directory segments real detectors gate on
+# (`/grails-app/`, `/migrations/`, `/server/api/`, …). Used only to
+# classify path-sensitive detectors — not as production file samples.
+DETECTOR_PATH_SEGMENT_PROBES = [
+  # Extension-free path under grails-app: only matches via the directory
+  # gate (a bare `Foo.groovy` basename is true for other reasons).
+  "proj/grails-app/conf/application",
+  "proj/supabase/migrations/001.sql",
+  "proj/migrations/001.sql",
+  "proj/supabase/config.toml",
+  "proj/server/api/hello.js",
+  "proj/server/routes/hello.js",
+  "proj/pages/api/hello.js",
+  "proj/app/api/hello/route.ts",
+  "proj/routes/+server.ts",
+  "proj/routes/index.dart",
+  "proj/directus/snapshots/snap.json",
+  "proj/wp-content/plugins/x.php",
+  "proj/metadata/databases/tables.yaml",
+  "proj/Magento/module.xml",
+]
+
+# Whether `applicable?` depends on more than the basename (root
+# placement, directory segments, multi-hop path layout). Those
+# detectors must always see the real path in the hot loop.
+def detector_path_sensitive?(detector : Detector) : Bool
   sample_suffixes = [
     ".java", ".js", ".ts", ".tsx", ".rb", ".py", ".go", ".json", ".yml",
     ".yaml", ".xml", ".cs", ".kt", ".php", ".cr", ".rs", ".ex", ".swift",
     ".scala", ".dart", ".groovy", ".pl", ".clj", ".hs", ".lua", ".sql",
     ".toml", ".bru", ".http", ".sbt", ".gradle", ".aspx", ".fs",
   ]
-  # Bare names used to detect "parent must be project root" style checks
-  # (Vercel, Netlify, …) that return true for `name` but false for
-  # `a/b/c/name`.
-  path_probe_basenames = DETECTOR_SPECIAL_BASENAMES.to_a + sample_suffixes.map { |ext| "file#{ext}" }
+  # Bare names: catch "must sit at project root" checks (Vercel,
+  # Package.swift, …) where `name` is true but `a/b/c/name` is false.
+  basenames = DETECTOR_SPECIAL_BASENAMES.to_a + sample_suffixes.map { |ext| "file#{ext}" }
+  basenames.any? do |name|
+    detector.applicable?("a/b/c/#{name}") != detector.applicable?(name)
+  end || DETECTOR_PATH_SEGMENT_PROBES.any? do |probe|
+    # Directory-segment gates: same basename, different path → different
+    # answer (Supabase `/migrations/`, Grails `/grails-app/`, …).
+    detector.applicable?(probe) != detector.applicable?(File.basename(probe))
+  end
+end
 
+# Build a lookup that turns a path into the list of detector indices
+# whose `applicable?` returns true — without re-walking every detector
+# on every file. Most detectors only inspect extension / basename, so
+# their answers are memoized by basename. Detectors that look at path
+# segments or root placement are classified as path-sensitive and
+# always evaluated against the real path.
+def detector_build_applicable_lookup(detectors : Array(Detector)) : Proc(String, Array(Int32))
+  path_sensitive = [] of Int32
   detectors.each_with_index do |detector, idx|
-    sensitive = path_probe_basenames.any? do |name|
-      detector.applicable?("a/b/c/#{name}") != detector.applicable?(name)
-    end
-    path_sensitive << idx if sensitive
+    path_sensitive << idx if detector_path_sensitive?(detector)
   end
 
   path_sensitive_set = Set(Int32).new(path_sensitive)

--- a/src/miniparsers/extraction_result_cache.cr
+++ b/src/miniparsers/extraction_result_cache.cr
@@ -84,4 +84,19 @@ module Noir::ExtractionResultCache
       order.clear
     end
   end
+
+  # Registered clear callbacks for typed extractor stores. Invoked at
+  # the start of each scan so a long-lived process (diff mode, repeated
+  # library use) cannot serve memo entries from a previous codebase.
+  @@clearers = [] of -> Nil
+  @@clearers_mutex = Mutex.new
+
+  def register_clearer(&block : -> Nil) : Nil
+    @@clearers_mutex.synchronize { @@clearers << block }
+  end
+
+  def clear_all : Nil
+    clearers = @@clearers_mutex.synchronize { @@clearers.dup }
+    clearers.each(&.call)
+  end
 end

--- a/src/miniparsers/java_route_extractor_ts.cr
+++ b/src/miniparsers/java_route_extractor_ts.cr
@@ -108,11 +108,29 @@ module Noir
     @@constants_memo = Hash(UInt64, Hash(String, String)).new
     @@constants_order = [] of UInt64
     @@memo_mutex = Mutex.new
+    @@clearer_registered = false
+
+    private def ensure_clearer_registered : Nil
+      return if @@clearer_registered
+      @@memo_mutex.synchronize do
+        return if @@clearer_registered
+        ExtractionResultCache.register_clearer do
+          @@memo_mutex.synchronize do
+            @@routes_memo.clear
+            @@routes_order.clear
+            @@constants_memo.clear
+            @@constants_order.clear
+          end
+        end
+        @@clearer_registered = true
+      end
+    end
 
     # Parses `source` and returns every Spring-style route it can
     # resolve. Top-level classes are scanned in order; nested classes
     # inherit their parent class's mapping prefix.
     def extract_routes(source : String) : Array(Route)
+      ensure_clearer_registered
       key = ExtractionResultCache.key(source, "java_routes")
       ExtractionResultCache.fetch(@@routes_memo, @@routes_order, key, mutex: @@memo_mutex) do
         routes = [] of Route
@@ -124,6 +142,7 @@ module Noir
     end
 
     def extract_string_constants(source : String) : Hash(String, String)
+      ensure_clearer_registered
       key = ExtractionResultCache.key(source, "java_constants")
       ExtractionResultCache.fetch(@@constants_memo, @@constants_order, key, mutex: @@memo_mutex) do
         constants = Hash(String, String).new

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -52,6 +52,23 @@ module Noir
     @@blueprint_memo = Hash(UInt64, Array(BlueprintDecl)).new
     @@blueprint_order = [] of UInt64
     @@memo_mutex = Mutex.new
+    @@clearer_registered = false
+
+    private def ensure_clearer_registered : Nil
+      return if @@clearer_registered
+      @@memo_mutex.synchronize do
+        return if @@clearer_registered
+        ExtractionResultCache.register_clearer do
+          @@memo_mutex.synchronize do
+            @@decoration_memo.clear
+            @@decoration_order.clear
+            @@blueprint_memo.clear
+            @@blueprint_order.clear
+          end
+        end
+        @@clearer_registered = true
+      end
+    end
 
     # Parses `source` and returns every route decoration found.
     #
@@ -68,6 +85,7 @@ module Noir
     def extract_decorations(source : String,
                             router_names : Array(String)? = nil,
                             extra_attributes : Hash(String, String)? = nil) : Array(Decoration)
+      ensure_clearer_registered
       tag = decoration_options_tag(router_names, extra_attributes)
       key = ExtractionResultCache.key(source, "decorations", tag)
       ExtractionResultCache.fetch(@@decoration_memo, @@decoration_order, key, mutex: @@memo_mutex) do
@@ -107,6 +125,7 @@ module Noir
     # without one and the query language can't express "this keyword,
     # if present" cleanly.
     def extract_blueprints(source : String, module_names : Array(String)) : Array(BlueprintDecl)
+      ensure_clearer_registered
       tag = module_names.join(",")
       key = ExtractionResultCache.key(source, "blueprints", tag)
       ExtractionResultCache.fetch(@@blueprint_memo, @@blueprint_order, key, mutex: @@memo_mutex) do
@@ -151,6 +170,7 @@ module Noir
                                            module_names : Array(String),
                                            router_names : Array(String)? = nil,
                                            extra_attributes : Hash(String, String)? = nil) : Tuple(Array(Decoration), Array(BlueprintDecl))
+      ensure_clearer_registered
       deco_tag = decoration_options_tag(router_names, extra_attributes)
       bp_tag = module_names.join(",")
       deco_key = ExtractionResultCache.key(source, "decorations", deco_tag)

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -32,6 +32,10 @@ class Analyzer
   # `configured_base_for`; only used on multi-base (monorepo) scans.
   @configured_base_cache = {} of String => String
   @configured_base_cache_mutex = Mutex.new
+  # Guards `@result` mutations from `parallel_analyze` workers.
+  # Fibers can interleave on yield during Array reallocation; concurrent
+  # `result <<` / `result.concat` without a mutex is racy.
+  @result_mutex = Mutex.new
 
   def initialize(options : Hash(String, YAML::Any))
     @base_paths = options["base"].as_a.map(&.to_s)
@@ -51,6 +55,17 @@ class Analyzer
 
   def analyze
     # After inheriting the class, write an action code here.
+  end
+
+  # Thread/fiber-safe append into `@result`. Prefer these helpers from
+  # code paths that run under `parallel_analyze` / `parallel_file_scan`.
+  protected def append_endpoint(endpoint : Endpoint) : Nil
+    @result_mutex.synchronize { @result << endpoint }
+  end
+
+  protected def append_endpoints(endpoints : Array(Endpoint)) : Nil
+    return if endpoints.empty?
+    @result_mutex.synchronize { @result.concat(endpoints) }
   end
 
   # Prefer the detector-populated cache over a fresh disk read. On


### PR DESCRIPTION
## Summary

Hardens residual risks from #2351 / #2352:

1. **Path-sensitive `applicable?` classification** — probe real directory-segment layouts (`/migrations/`, `/grails-app/`, `/server/api/`, …) so Supabase/Grails/Next-style detectors are never basename-memoized incorrectly.
2. **Parallel result safety** — `Analyzer#append_endpoint(s)` under a mutex; language engines that `concat` under `parallel_file_scan` use it.
3. **Extraction memo lifecycle** — register clearers on first use; `ExtractionResultCache.clear_all` at `analysis_endpoints` start (diff / multi-scan).

## Test plan

- [x] `just build`
- [x] `crystal spec spec/unit_test/detector/applicable_lookup_spec.cr`
- [x] detector_spec + extraction_result_cache_spec
- [x] flask / spring / kemal functional smoke