### PR TITLE
fix(detector): declare path-sensitive detectors explicitly

### DIFF
--- a/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
+++ b/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
@@ -1,0 +1,52 @@
+require "../../spec_helper"
+require "../../../src/detector/detector"
+require "../../../src/models/detector"
+
+# Instantiate every concrete Detector subclass. Using `all_subclasses`
+# rather than a hand-written list is deliberate: a new detector joins
+# this sweep automatically, so it cannot silently regress the memo.
+private def every_detector(options) : Array(Detector)
+  detectors = [] of Detector
+  {% for sub in Detector.all_subclasses %}
+    {% unless sub.abstract? %}
+      detector = {{ sub }}.new(options)
+      detector.set_name
+      detectors << detector.as(Detector)
+    {% end %}
+  {% end %}
+  detectors
+end
+
+# `detector_build_applicable_lookup` memoizes `applicable?` by basename
+# for every detector that `detector_path_sensitive?` does not flag. That
+# classifier is probe-based, and a probe whose *basename* independently
+# satisfies `applicable?` masks a directory gate behind it — which is how
+# the Hasura `metadata/**` gate was lost (46/46 → 16 failures) without any
+# unit test noticing.
+#
+# This sweep is the oracle: for every real fixture path, a detector that
+# genuinely applies must survive the memo. Missing candidates mean the
+# detector never runs, which means silently dropped endpoints.
+describe "detector applicable? memo fidelity" do
+  it "never drops a detector that applies to a real fixture path" do
+    options = create_test_options
+    detectors = every_detector(options)
+    lookup = detector_build_applicable_lookup(detectors)
+
+    paths = Dir.glob("spec/functional_test/fixtures/**/*").select { |path| File.file?(path) }
+    paths.size.should be > 0
+
+    missed = [] of String
+    paths.each do |path|
+      candidates = lookup.call(path).to_set
+      detectors.each_with_index do |detector, idx|
+        next unless detector.applicable?(path)
+        next if candidates.includes?(idx)
+        missed << "#{detector.name} skipped #{path}"
+      end
+    end
+
+    # Show a bounded sample so a broad regression stays readable.
+    missed.uniq.first(25).should eq([] of String)
+  end
+end

--- a/spec/unit_test/miniparser/extraction_result_cache_spec.cr
+++ b/spec/unit_test/miniparser/extraction_result_cache_spec.cr
@@ -54,12 +54,12 @@ describe Noir::TreeSitterPythonRouteExtractor do
     decos, bps = Noir::TreeSitterPythonRouteExtractor.extract_decorations_and_blueprints(
       source, ["flask"]
     )
-    decos.map(&.path).sort.should eq(["/", "/items"])
+    decos.map(&.path).sort!.should eq(["/", "/items"])
     bps.map(&.name).should eq(["api"])
     bps[0].prefix.should eq("/api")
 
     # Solo calls must hit the same memo entries.
-    Noir::TreeSitterPythonRouteExtractor.extract_decorations(source).map(&.path).sort.should eq(["/", "/items"])
+    Noir::TreeSitterPythonRouteExtractor.extract_decorations(source).map(&.path).sort!.should eq(["/", "/items"])
     Noir::TreeSitterPythonRouteExtractor.extract_blueprints(source, ["flask"]).map(&.name).should eq(["api"])
   end
 end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -179,6 +179,13 @@ DETECTOR_PATH_SEGMENT_PROBES = [
 # placement, directory segments, multi-hop path layout). Those
 # detectors must always see the real path in the hot loop.
 def detector_path_sensitive?(detector : Detector) : Bool
+  # Explicit declaration wins. The probe sweep below is a safety net,
+  # not the contract: it is fail-open by construction, so a detector
+  # whose directory gate happens to agree with its basename gate on
+  # every probe would otherwise be memoized as basename-only and lose
+  # the path check entirely.
+  return true if detector.path_sensitive?
+
   sample_suffixes = [
     ".java", ".js", ".ts", ".tsx", ".rb", ".py", ".go", ".json", ".yml",
     ".yaml", ".xml", ".cs", ".kt", ".php", ".cr", ".rs", ".ex", ".swift",

--- a/src/detector/detectors/groovy/grails.cr
+++ b/src/detector/detectors/groovy/grails.cr
@@ -44,6 +44,12 @@ module Detector::Groovy
       false
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (/grails-app/ gate), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       filename.ends_with?(".groovy") || filename.ends_with?(".gsp") || filename.ends_with?(".gradle") || filename.ends_with?(".gradle.kts") || filename.ends_with?(".java") || filename.ends_with?(".yml") || filename.ends_with?(".yaml") || filename.ends_with?(".xml") || filename.includes?("/grails-app/")
     end

--- a/src/detector/detectors/specification/apache_httpd.cr
+++ b/src/detector/detectors/specification/apache_httpd.cr
@@ -30,6 +30,12 @@ module Detector::Specification
       true
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (/nginx/ path exclusion), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       base = File.basename(filename)
       return true if base == HTACCESS

--- a/src/detector/detectors/specification/directus.cr
+++ b/src/detector/detectors/specification/directus.cr
@@ -38,6 +38,12 @@ module Detector::Specification
 
     # libyaml parses JSON as a YAML subset, so one code path covers the
     # `--format json` snapshot too.
+    # Memo safety: `applicable?` consults the path
+    # (/directus/ and /snapshots/ gates), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       return false unless SNAPSHOT_EXTENSIONS.includes?(File.extname(filename).downcase)
 

--- a/src/detector/detectors/specification/hasura.cr
+++ b/src/detector/detectors/specification/hasura.cr
@@ -39,6 +39,12 @@ module Detector::Specification
       detect_tables(filename, file_contents)
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (metadata/** directory gate), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       return false unless filename.ends_with?(".yaml") || filename.ends_with?(".yml")
 

--- a/src/detector/detectors/specification/kamal.cr
+++ b/src/detector/detectors/specification/kamal.cr
@@ -12,6 +12,12 @@ module Detector::Specification
       true
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (/.kamal/ and /config/deploy gates), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       return false unless filename.ends_with?(".yaml") || filename.ends_with?(".yml")
 

--- a/src/detector/detectors/specification/strapi.cr
+++ b/src/detector/detectors/specification/strapi.cr
@@ -35,6 +35,12 @@ module Detector::Specification
       detect_routes(filename, file_contents)
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (/content-types/ gate), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       path = normalize(filename)
       return true if schema_file?(filename)

--- a/src/detector/detectors/specification/supabase.cr
+++ b/src/detector/detectors/specification/supabase.cr
@@ -49,6 +49,12 @@ module Detector::Specification
       true
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (supabase/ and migrations/ gates), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       path = normalize(filename)
 

--- a/src/detector/detectors/specification/vercel.cr
+++ b/src/detector/detectors/specification/vercel.cr
@@ -15,6 +15,12 @@ module Detector::Specification
       true
     end
 
+    # Memo safety: `applicable?` consults the path
+    # (root-placement check via File.dirname), not just the basename.
+    def path_sensitive? : Bool
+      true
+    end
+
     def applicable?(filename : String) : Bool
       base = File.basename(filename)
       return false unless CONFIG_FILES.includes?(base)

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -45,6 +45,23 @@ class Detector
     true
   end
 
+  # Whether `applicable?` inspects more than the basename — directory
+  # segments (`/metadata/`, `/.kamal/`) or root placement.
+  #
+  # The detect loop memoizes `applicable?` by basename, so a detector
+  # that consults the path but does not declare it here has its path
+  # gate silently deleted: `applicable?` is only ever asked about the
+  # bare filename. That is a false-negative, not a crash, so nothing
+  # fails loudly. `detector_path_sensitive?` also probes for this, but
+  # the probe is fail-open — a probe whose basename independently
+  # matches masks the directory gate behind it (this is exactly how the
+  # Hasura `metadata/**` gate was lost). Declare it explicitly.
+  #
+  # Guarded by `spec/unit_test/detector/applicable_lookup_fidelity_spec.cr`.
+  def path_sensitive? : Bool
+    false
+  end
+
   # Whether the detector can be skipped on subsequent files once it
   # has matched. Defaults to `true` (idempotent — the detector only
   # signals tech presence). Detectors that perform side effects in


### PR DESCRIPTION
## Problem

`detector_build_applicable_lookup` memoizes `applicable?` by basename, and `detector_path_sensitive?` decides which detectors are exempt by probing them.

That probe is **fail-open**. When a probe's basename independently satisfies `applicable?`, the directory gate behind it is masked, the detector is classified basename-only, and its path check is effectively deleted. No error, no crash — just a silent false negative.

**Hasura hit exactly this.** Its gate is `path.includes?("metadata/")`, but the sole probe `proj/metadata/databases/tables.yaml` also matches on basename, so `applicable?(probe) == applicable?(basename)`. Every `metadata/**/*.yaml` whose basename isn't `tables.yaml` / `rest_endpoints.yaml` was skipped — which is the Hasura CLI v3 layout (one file per tracked table).

Two more were mismatched the same way:

| Detector | Consequence |
|---|---|
| `hasura` | `metadata/**` gate dead — 15 endpoints lost |
| `kamal` | `/.kamal/` + `/config/deploy` clauses could never fire |
| `apache_httpd` | `/nginx/` exclusion bypassed |

`main` CI has been red since cab448aa because of this.

```
083846f7  success   ← last green
cab448aa  failure   ← broke here
3850ce0e  failure
43f60f8d  failure
```

## Fix

Add `Detector#path_sensitive?` (default `false`) and declare it on the eight detectors whose `applicable?` reads the path. The probe sweep stays as a safety net, but correctness no longer depends on a heuristic that cannot see through an overlapping basename branch.

## Regression guard

The existing unit spec only checked hand-picked detectors, which is why nothing caught this. `applicable_lookup_fidelity_spec` replaces that with a sweep: every concrete `Detector.all_subclasses` against the real fixture corpus, failing if a detector that applies to a path gets dropped by the memo. New detectors join automatically, so this class of bug can't return silently.

It reproduces the bug on the pre-fix tree:

```
hasura skipped .../metadata/databases/default/tables/public_movies.yaml
hasura skipped .../metadata/databases/default/tables/public_directors.yaml
```

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4089 / 0 failures |
| `crystal spec spec/functional_test` | 22383 / 0 failures (**16 before**) |
| `ameba` | 1793 / 0 failures |
| `crystal tool format --check` | clean |
| Hasura tester | 46/46, matching baseline at 083846f7 |

Also fixes two `Performance/ChainedCallWithNoBang` lint failures in `extraction_result_cache_spec` so `ameba` is green again.

## Scope

Deliberately limited to restoring CI. The perf series has other findings that need their own discussion (the `filter_redundant_generic_techs` stdlib drops silently lose endpoints in monorepos, and the ZAP `*sites*` basename gate drops renamed exports) — those follow separately so this can land fast.