### PR TITLE
fix: perf-series follow-ups — recover dropped endpoints, bound memo, widen rescue

### DIFF
--- a/spec/unit_test/analyzer/analyzer_selection_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_selection_spec.cr
@@ -16,24 +16,20 @@ describe "filter_redundant_generic_techs" do
     filter_redundant_generic_techs(techs).should eq(techs)
   end
 
-  it "drops js_http when a JS framework analyzer is present" do
-    filter_redundant_generic_techs(["js_http", "js_express"]).should eq(["js_express"])
-    filter_redundant_generic_techs(["js_hono", "js_http", "js_fastify"]).should eq(["js_hono", "js_fastify"])
+  # Regression guard: a repo-wide framework hit must never suppress a
+  # generic stdlib analyzer. In a monorepo the two can belong to different
+  # applications (a standalone net/http admin listener beside a Gin API,
+  # a standalone Starlette service beside a FastAPI one), so dropping the
+  # generic analyzer silently loses real endpoints.
+  it "keeps go_http when a Go framework analyzer is also present" do
+    filter_redundant_generic_techs(["go_http", "go_gin"]).should eq(["go_http", "go_gin"])
   end
 
-  it "keeps js_http when no JS framework analyzer is present" do
-    filter_redundant_generic_techs(["js_http"]).should eq(["js_http"])
+  it "keeps js_http when a JS framework analyzer is also present" do
+    filter_redundant_generic_techs(["js_http", "js_express"]).should eq(["js_http", "js_express"])
   end
 
-  it "drops python_starlette when python_fastapi is present" do
-    filter_redundant_generic_techs(["python_fastapi", "python_starlette"]).should eq(["python_fastapi"])
-  end
-
-  it "keeps python_starlette alone" do
-    filter_redundant_generic_techs(["python_starlette"]).should eq(["python_starlette"])
-  end
-
-  it "drops go_http when a Go framework analyzer is present" do
-    filter_redundant_generic_techs(["go_http", "go_gin"]).should eq(["go_gin"])
+  it "keeps python_starlette when python_fastapi is also present" do
+    filter_redundant_generic_techs(["python_fastapi", "python_starlette"]).should eq(["python_fastapi", "python_starlette"])
   end
 end

--- a/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
+++ b/spec/unit_test/detector/applicable_lookup_fidelity_spec.cr
@@ -27,26 +27,59 @@ end
 # This sweep is the oracle: for every real fixture path, a detector that
 # genuinely applies must survive the memo. Missing candidates mean the
 # detector never runs, which means silently dropped endpoints.
+private def memo_misses(paths : Array(String)) : Array(String)
+  options = create_test_options
+  detectors = every_detector(options)
+  lookup = detector_build_applicable_lookup(detectors)
+
+  missed = [] of String
+  paths.each do |path|
+    candidates = lookup.call(path).to_set
+    detectors.each_with_index do |detector, idx|
+      next unless detector.applicable?(path)
+      next if candidates.includes?(idx)
+      missed << "#{detector.name} skipped #{path}"
+    end
+  end
+  missed.uniq
+end
+
+# Layouts that isolate a directory gate from the basename: the path
+# matches the gate while the basename on its own does NOT. The fixture
+# corpus does not cover these — its Kamal fixture is `config/deploy.yml`,
+# whose basename contains "deploy" and so matches independently, leaving
+# the `/config/deploy` + `/.kamal/` clauses unguarded. Without these,
+# dropping a `path_sensitive?` declaration passes the corpus sweep.
+#
+# Add an entry here whenever a detector gains a directory gate.
+DIRECTORY_GATE_PROBES = [
+  # hasura: metadata/** with a per-table basename (CLI v3 layout)
+  "proj/metadata/databases/default/tables/public_movies.yaml",
+  "proj/metadata/actions.yaml",
+  # kamal: destination-named deploy files and the .kamal/ directory
+  "proj/config/deploy/production.yml",
+  "proj/.kamal/production.yml",
+  # supabase
+  "proj/supabase/migrations/001_init.sql",
+  "proj/migrations/001_init.sql",
+  # directus
+  "proj/directus/snapshots/snap.json",
+  # strapi
+  "proj/src/api/article/content-types/article/schema.json",
+  # grails: extension-free path under grails-app
+  "proj/grails-app/conf/application",
+]
+
 describe "detector applicable? memo fidelity" do
   it "never drops a detector that applies to a real fixture path" do
-    options = create_test_options
-    detectors = every_detector(options)
-    lookup = detector_build_applicable_lookup(detectors)
-
     paths = Dir.glob("spec/functional_test/fixtures/**/*").select { |path| File.file?(path) }
     paths.size.should be > 0
 
-    missed = [] of String
-    paths.each do |path|
-      candidates = lookup.call(path).to_set
-      detectors.each_with_index do |detector, idx|
-        next unless detector.applicable?(path)
-        next if candidates.includes?(idx)
-        missed << "#{detector.name} skipped #{path}"
-      end
-    end
-
     # Show a bounded sample so a broad regression stays readable.
-    missed.uniq.first(25).should eq([] of String)
+    memo_misses(paths).first(25).should eq([] of String)
+  end
+
+  it "never drops a detector whose directory gate is isolated from the basename" do
+    memo_misses(DIRECTORY_GATE_PROBES).should eq([] of String)
   end
 end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -346,42 +346,16 @@ def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
     filtered.reject!("php_symfony")
   end
 
-  # `js_http` matches generic Node `http`/`https` createServer usage.
-  # When a real framework is present it owns the route table; running
-  # the stdlib analyzer too rescans every JS/TS file for low-signal
-  # patterns and doubles endpoint noise.
-  js_frameworks = Set{
-    "js_express", "js_fastify", "js_hono", "js_koa", "js_nestjs",
-    "js_restify", "js_adonisjs", "js_elysia", "js_hapi", "js_nextjs",
-    "js_nuxtjs", "js_nitro", "js_remix", "js_sveltekit", "js_astro",
-    "js_fresh", "js_apollo", "js_graphql_yoga", "js_socketio",
-    "ts_nestjs", "ts_trpc", "ts_tanstack_router",
-  }
-  if filtered.includes?("js_http") && filtered.any? { |tech| js_frameworks.includes?(tech) }
-    filtered.reject!("js_http")
-  end
-
-  # FastAPI is built on Starlette and reuses its routing primitives.
-  # Both detectors fire on FastAPI apps; the FastAPI analyzer already
-  # covers APIRouter / app.include_router / decorators, so the Starlette
-  # pass is pure duplicate work on the same .py set.
-  if filtered.includes?("python_fastapi") && filtered.includes?("python_starlette")
-    filtered.reject!("python_starlette")
-  end
-
-  # Same shape as js_http: bare `net/http` when a router framework is
-  # present is almost always the framework's own listener, not a second
-  # surface to analyze.
-  go_frameworks = Set{
-    "go_gin", "go_echo", "go_fiber", "go_chi", "go_mux", "go_beego",
-    "go_iris", "go_fasthttp", "go_hertz", "go_gozero", "go_goyave",
-    "go_gf", "go_restful", "go_httprouter", "go_huma", "go_pocketbase",
-    "go_connect_rpc",
-  }
-  if filtered.includes?("go_http") && filtered.any? { |tech| go_frameworks.includes?(tech) }
-    filtered.reject!("go_http")
-  end
-
+  # NOTE: do not add "generic stdlib analyzer is redundant when framework
+  # X is present" rules here. `techs` is a flat, repo-wide list with no
+  # path granularity, so a framework detected anywhere suppresses the
+  # generic analyzer *everywhere*. In a monorepo that silently drops real
+  # attack surface: a standalone `net/http` admin listener exposing
+  # /debug/pprof next to a Gin API, or a standalone Starlette service next
+  # to a FastAPI one. Framework-vs-framework rules above are safe because
+  # both analyzers target the same routing DSL; framework-vs-stdlib rules
+  # are not. Scoping this correctly needs a per-tech path map from the
+  # detector (the detect loop does know the file), not a global list.
   filtered
 end
 

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -845,6 +845,13 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
             end
           rescue File::NotFoundError
             logger.debug "File not found: #{file}"
+          rescue e : Exception
+            # Mirror `parallel_analyze`'s worker rescue. Without this a
+            # single detector/passive-rule exception unwinds the whole
+            # worker loop; once every worker has died the reader fiber
+            # blocks forever on `channel.send` and the scan hangs with
+            # no output instead of skipping one bad file.
+            logger.debug "Error detecting #{file}: #{e.message}"
           end
         end
       ensure

--- a/src/detector/detectors/specification/zap_sites_tree.cr
+++ b/src/detector/detectors/specification/zap_sites_tree.cr
@@ -27,12 +27,14 @@ module Detector::Specification
     end
 
     def applicable?(filename : String) : Bool
-      return false unless filename.ends_with?(".yaml") || filename.ends_with?(".yml")
-
-      # ZAP exports are named *sites* (sites.yml, sites_tree.yaml). The
-      # previous "any YAML" gate made every non-idempotent pass pay a
-      # content probe + occasional YAML parse on unrelated manifests.
-      File.basename(filename).downcase.includes?("sites")
+      # Extension only. A `*sites*` basename gate looks tempting, but ZAP
+      # export filenames are chosen by the user at export time — an export
+      # saved as `zap_export.yaml` or `target.yaml` would be dropped with
+      # no diagnostic. The expensive work (`yaml_any?`) is already gated
+      # in `detect` by the `includes?("Sites")` content guard, so the name
+      # gate only saved a substring scan and bought that at the price of a
+      # silent false negative.
+      filename.ends_with?(".yaml") || filename.ends_with?(".yml")
     end
 
     def set_name

--- a/src/miniparsers/extraction_result_cache.cr
+++ b/src/miniparsers/extraction_result_cache.cr
@@ -18,15 +18,15 @@ module Noir::ExtractionResultCache
   # relative to source text; the cap mainly bounds pathological cases.
   DEFAULT_MAX_ENTRIES = 4096
 
-  # Stable-ish fingerprint for a source buffer. Prefer this over bare
-  # `object_id` — the CodeLocator content cache reuses String instances
-  # across analyzers (good hit rate), but object_id alone is unsafe if
-  # a short-lived string is freed and the id is recycled.
+  # Content fingerprint for a source buffer. Deliberately *not* keyed on
+  # `object_id`: a short-lived string can be freed and its id recycled by
+  # a later buffer, which would serve another file's extraction table.
+  # Content-only means two distinct String instances holding identical
+  # source correctly share one entry, which is also the common case (the
+  # CodeLocator content cache hands the same text to sibling analyzers).
   def source_fingerprint(source : String) : UInt64
-    # Crystal's String#hash is content-based; mix in object_id so two
-    # identical buffers that are distinct instances still share a key
-    # when content matches (hash) while remaining O(1) to compute for
-    # the already-interned CodeLocator path (same instance → same id).
+    # Crystal's String#hash is content-based; bytesize is mixed in so
+    # collisions need matching length as well as matching hash.
     h = source.hash.to_u64!
     h &+= source.bytesize.to_u64! &* 0x9e3779b97f4a7c15_u64
     h
@@ -58,24 +58,34 @@ module Noir::ExtractionResultCache
     value = yield
 
     mutex.synchronize do
-      unless store.has_key?(key)
-        if store.size >= max_entries
-          # Drop oldest half.
-          drop = store.size // 2
-          drop = 1 if drop < 1
-          drop.times do
-            old = order.shift?
-            break unless old
-            store.delete(old)
-          end
-        end
-        store[key] = value
-        order << key
-      end
-      # Another fiber may have filled the same key first; prefer the
-      # stored entry so all callers share one array.
-      store[key]
+      store_capped(store, order, key, value, max_entries)
     end
+  end
+
+  # Capped insert-or-keep. The caller must already hold the store's
+  # mutex. Extractors that fill two stores from a single parse cannot go
+  # through `fetch` (that would parse twice), so they call this directly
+  # instead of writing to the Hash — writing raw skips eviction and lets
+  # the store grow one entry per file for the whole scan.
+  def store_capped(store : Hash(UInt64, T), order : Array(UInt64), key : UInt64, value : T,
+                   max_entries : Int32 = DEFAULT_MAX_ENTRIES) : T forall T
+    unless store.has_key?(key)
+      if store.size >= max_entries
+        # Drop oldest half.
+        drop = store.size // 2
+        drop = 1 if drop < 1
+        drop.times do
+          old = order.shift?
+          break unless old
+          store.delete(old)
+        end
+      end
+      store[key] = value
+      order << key
+    end
+    # Another fiber may have filled the same key first; prefer the
+    # stored entry so all callers share one array.
+    store[key]
   end
 
   def clear(store : Hash(UInt64, T), order : Array(UInt64), mutex : Mutex) : Nil forall T

--- a/src/miniparsers/python_route_extractor_ts.cr
+++ b/src/miniparsers/python_route_extractor_ts.cr
@@ -192,16 +192,8 @@ module Noir
       end
 
       @@memo_mutex.synchronize do
-        unless @@decoration_memo.has_key?(deco_key)
-          @@decoration_memo[deco_key] = decorations
-          @@decoration_order << deco_key
-        end
-        unless @@blueprint_memo.has_key?(bp_key)
-          @@blueprint_memo[bp_key] = blueprints
-          @@blueprint_order << bp_key
-        end
-        decorations = @@decoration_memo[deco_key]
-        blueprints = @@blueprint_memo[bp_key]
+        decorations = ExtractionResultCache.store_capped(@@decoration_memo, @@decoration_order, deco_key, decorations)
+        blueprints = ExtractionResultCache.store_capped(@@blueprint_memo, @@blueprint_order, bp_key, blueprints)
       end
 
       {decorations, blueprints}

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -33,8 +33,16 @@ class Analyzer
   @configured_base_cache = {} of String => String
   @configured_base_cache_mutex = Mutex.new
   # Guards `@result` mutations from `parallel_analyze` workers.
-  # Fibers can interleave on yield during Array reallocation; concurrent
-  # `result <<` / `result.concat` without a mutex is racy.
+  #
+  # NOTE: this is forward-looking, not a fix for a live race. noir builds
+  # without `-Dpreview_mt`, so `parallel_analyze` runs cooperative fibers
+  # on one thread and `Array#<<` / `#concat` have no yield point — they
+  # cannot interleave today. It only becomes load-bearing under MT.
+  # See `docs/content/development/analyzer_architecture`, which documents
+  # the opposite convention (no mutex in per-file analyzers, synchronize
+  # at the `parallel_analyze` layer if MT lands); the helpers below are
+  # currently applied to only some engines, so that doc and this code
+  # disagree. Worth settling in one direction rather than half-applying.
   @result_mutex = Mutex.new
 
   def initialize(options : Hash(String, YAML::Any))


### PR DESCRIPTION
Follow-up to #2354. (Supersedes #2355, which GitHub auto-closed when #2354's branch was deleted on merge — same commits, now rebased onto `main`.)

## 1. Perf gates were dropping real endpoints

Two gates from the perf series trade false negatives for speed. For a tool whose job is enumerating attack surface that is the wrong direction, and both are silent — no warning, no diagnostic.

### `filter_redundant_generic_techs`

Dropped `js_http` / `go_http` / `python_starlette` whenever a same-language framework was detected. `techs` is a **flat, repo-wide list with no path granularity**, so a framework found *anywhere* suppresses the generic analyzer *everywhere*.

In a monorepo those belong to different applications. Measured on a 500-file Go corpus (400 Gin files + 100 `net/http` files):

| | unique URLs |
|---|---|
| before | 800 |
| after | **1000** |

+200 recovered, **0 lost**. The recovered set is exactly the raw `net/http` surface:

```
/debug/pprof/
/internal/secrets
/internal/shutdown
```

...i.e. the endpoints most worth finding. Same shape confirmed for Python — a standalone Starlette service beside a FastAPI one lost `/events/webhook` and `/events/internal/replay`.

Framework-vs-framework rules above are untouched and remain safe: both analyzers there target the same routing DSL. Scoping the stdlib rule correctly would need a per-tech path map from the detect loop (which does know the file) — a comment records that so it isn't re-added as-is.

### `zap_sites_tree`

Required a `*sites*` basename. ZAP export filenames are chosen by the user at export time, so an export saved as `zap_export.yaml` was dropped with no diagnostic — **0 endpoints, 7 after**. The expensive work is already gated in `detect` by the `includes?("Sites")` content guard, so the name gate only saved a substring scan.

## 2. Python memo bypassed its eviction cap

`extract_decorations_and_blueprints` wrote straight into the memo hashes, skipping the `DEFAULT_MAX_ENTRIES` eviction that `ExtractionResultCache.fetch` performs. It can't use `fetch` (that would parse twice), but the result was that the 4096 cap never applied to the **dominant** Python path — Flask, Quart and Sanic all use this combined entry point; the capped solo entries are the minority. On a large monorepo both memos grew one entry per file for the whole scan.

Extracted the capped insert as `ExtractionResultCache.store_capped`, so one parse still fills both stores but eviction applies.

## 3. Detector worker could hang the scan

The worker loop rescued only `File::NotFoundError`, unlike `parallel_analyze` which also has a broad `rescue e : Exception`. Any other exception from a detector or passive rule unwinds the worker to `ensure wg.done` and kills that fiber. Once every worker has died, the reader fiber blocks forever on `channel.send` — the scan hangs with no output and no crash. Mirrored `parallel_analyze`'s rescue.

## 4. Two comments describing behaviour the code doesn't have

- `source_fingerprint` claimed it mixes in `object_id`; it hashes content + bytesize only. Content-only is the *correct* choice — a recycled `object_id` would serve another file's table — the comment just described the opposite of the invariant.
- `@result_mutex` claimed fibers "can interleave on yield during Array reallocation". noir builds without `-Dpreview_mt`, so `Array#<<` has no yield point and cannot interleave today; the mutex is forward-looking for MT, not a fix for a live race.

## Left open deliberately

`@result_mutex` also **disagrees with `docs/content/development/analyzer_architecture`**, which documents the opposite convention (no mutex in per-file analyzers; synchronize at the `parallel_analyze` layer if MT lands), and the helpers are applied to only 7 engines — not the 5 Python analyzers this same series newly parallelized. Flagged in the comment rather than resolved: whether to remove it or apply it everywhere and update the docs is an architecture call, not a review fix.

Two other findings are **not** addressed here:
- `php_pure` is dropped by the same repo-wide rule when Laravel is present (pre-existing, not from this series) — a legacy `/upload.php` beside a Laravel app is lost.
- Parallelizing the Python walks makes endpoint ordering (and the reported `file:line` on duplicates) depend on worker count, i.e. on the host CPU count. Deterministic per machine, so CI won't see it; fixtures are far under the 128 channel capacity where divergence starts.

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4087 / 0 failures |
| `crystal spec spec/functional_test` | 22383 / 0 failures |
| `ameba` | 1793 / 0 failures |
| `crystal tool format --check` | clean |

Re-run after the rebase onto `main`. Endpoint counts measured on this branch's binary.