### PR TITLE
refactor(analyzer): drop @result_mutex, restore documented convention

### DIFF
--- a/docs/content/development/analyzer_architecture/index.ko.md
+++ b/docs/content/development/analyzer_architecture/index.ko.md
@@ -315,6 +315,8 @@ end
 
 Noir 는 **single-threaded** 로 빌드됩니다 (`preview_mt` 미사용). `parallel_analyze` 는 OS 스레드가 아니라 cooperative Crystal fiber 를 spawn 합니다. 따라서 여러 fiber 에서 `result << endpoint`, `result.concat(...)` 는 안전한데, `Array#<<` 와 `#concat` 에 yield 지점이 없기 때문입니다. 모든 per-file 분석기가 result 배열에 Mutex 를 쓰지 않는 이유가 여기에 있고, 코드베이스 전반이 그렇게 일관되게 작성되어 있습니다. 나중에 MT 모드를 켜게 되면 동기화는 `parallel_analyze` 레이어에 한 번 추가하면 되는 일이지, 분석기마다 흩어 둘 일이 아닙니다.
 
+#2353 에서 엔진들에 `@result_mutex` 와 `append_endpoint` 헬퍼가 추가되었다가 #2357 에서 다시 제거되었습니다. single-threaded 빌드에서는 발생할 수 없는 race 를 막고 있었고, 일부 엔진에만 적용되어 있었으며, 이 문서와 정면으로 어긋났기 때문입니다. Mutex 를 다시 넣으려 한다면 그 반복을 여는 셈입니다. MT 를 먼저 켜고, 동기화는 `parallel_analyze` 레이어에 한 번만 추가하세요.
+
 ## 다음에 볼 것
 
 - Reference analyzer: [`javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr)

--- a/docs/content/development/analyzer_architecture/index.md
+++ b/docs/content/development/analyzer_architecture/index.md
@@ -314,6 +314,8 @@ See [#1243](https://github.com/owasp-noir/noir/pull/1243) (Go `common.cr` split)
 
 Noir is built **single-threaded** (no `preview_mt`). `parallel_analyze` spawns cooperative Crystal fibers, not OS threads, so `result << endpoint` and `result.concat(...)` from multiple fibers are safe because `Array#<<` and `#concat` have no yield points. You'll notice that no per-file analyzer uses a `Mutex` around the result array; that's by design and matches the whole codebase. If noir ever enables MT mode, synchronization belongs at the `parallel_analyze` layer, not scattered across analyzers.
 
+A `@result_mutex` plus `append_endpoint` helpers were added to the engines in #2353 and removed again in #2357: they guarded a race that cannot occur in a single-threaded build, landed in only some engines, and contradicted this note. If you are about to add one, you are re-opening that loop — enable MT first, then synchronize once at the `parallel_analyze` layer.
+
 ## Where to look next
 
 - Reference analyzer: [`javascript/hono.cr`](https://github.com/owasp-noir/noir/blob/main/src/analyzer/analyzers/javascript/hono.cr)

--- a/src/analyzer/engines/crystal_engine.cr
+++ b/src/analyzer/engines/crystal_engine.cr
@@ -5,7 +5,7 @@ module Analyzer::Crystal
   abstract class CrystalEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/elixir_engine.cr
+++ b/src/analyzer/engines/elixir_engine.cr
@@ -5,7 +5,7 @@ module Analyzer::Elixir
   abstract class ElixirEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/perl_engine.cr
+++ b/src/analyzer/engines/perl_engine.cr
@@ -4,7 +4,7 @@ module Analyzer::Perl
   abstract class PerlEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/php_engine.cr
+++ b/src/analyzer/engines/php_engine.cr
@@ -10,7 +10,7 @@ module Analyzer::Php
 
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/rust_engine.cr
+++ b/src/analyzer/engines/rust_engine.cr
@@ -5,7 +5,7 @@ module Analyzer::Rust
   abstract class RustEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/scala_engine.cr
+++ b/src/analyzer/engines/scala_engine.cr
@@ -6,7 +6,7 @@ module Analyzer::Scala
   abstract class ScalaEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/analyzer/engines/swift_engine.cr
+++ b/src/analyzer/engines/swift_engine.cr
@@ -4,7 +4,7 @@ module Analyzer::Swift
   abstract class SwiftEngine < Analyzer
     def analyze
       parallel_file_scan do |path|
-        append_endpoints(analyze_file(path))
+        result.concat(analyze_file(path))
       end
       result
     end

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -32,18 +32,6 @@ class Analyzer
   # `configured_base_for`; only used on multi-base (monorepo) scans.
   @configured_base_cache = {} of String => String
   @configured_base_cache_mutex = Mutex.new
-  # Guards `@result` mutations from `parallel_analyze` workers.
-  #
-  # NOTE: this is forward-looking, not a fix for a live race. noir builds
-  # without `-Dpreview_mt`, so `parallel_analyze` runs cooperative fibers
-  # on one thread and `Array#<<` / `#concat` have no yield point — they
-  # cannot interleave today. It only becomes load-bearing under MT.
-  # See `docs/content/development/analyzer_architecture`, which documents
-  # the opposite convention (no mutex in per-file analyzers, synchronize
-  # at the `parallel_analyze` layer if MT lands); the helpers below are
-  # currently applied to only some engines, so that doc and this code
-  # disagree. Worth settling in one direction rather than half-applying.
-  @result_mutex = Mutex.new
 
   def initialize(options : Hash(String, YAML::Any))
     @base_paths = options["base"].as_a.map(&.to_s)
@@ -63,17 +51,6 @@ class Analyzer
 
   def analyze
     # After inheriting the class, write an action code here.
-  end
-
-  # Thread/fiber-safe append into `@result`. Prefer these helpers from
-  # code paths that run under `parallel_analyze` / `parallel_file_scan`.
-  protected def append_endpoint(endpoint : Endpoint) : Nil
-    @result_mutex.synchronize { @result << endpoint }
-  end
-
-  protected def append_endpoints(endpoints : Array(Endpoint)) : Nil
-    return if endpoints.empty?
-    @result_mutex.synchronize { @result.concat(endpoints) }
   end
 
   # Prefer the detector-populated cache over a fresh disk read. On


### PR DESCRIPTION
Closes #2357.

#2353 added `@result_mutex` plus `append_endpoint` / `append_endpoints` and wired them into 7 engines. Three things were wrong with that:

1. **It guards a race that cannot occur.** noir builds without `-Dpreview_mt` — verified across `shard.yml`, `justfile`, `ci.yml`, `release-binaries.yml`, `Dockerfile`, `snapcraft.yaml` — so `parallel_analyze` runs cooperative fibers on one thread and `Array#<<` / `#concat` have no yield point to interleave on.
2. **It contradicted the architecture docs**, which state the convention explicitly: no `Mutex` in per-file analyzers, and if MT ever lands, synchronize once at the `parallel_analyze` layer rather than scattering locks across analyzers.
3. **It was half-applied.** 7 engines got the helpers; the 5 Python analyzers the same series newly parallelized (`bottle`, `falcon`, `http_server`, `litestar`, `starlette`) still wrote bare `result <<`. A lock that only covers some writers is not a guarantee — it just reads like one.

## Which way to settle it

The issue listed two options — remove, or complete-and-document. This takes **remove**, the one the docs already argue for. It restores a single consistent convention, and keeps the per-endpoint append lock-free in the hot path.

If MT is ever enabled, the docs' prescription still stands and is the better design anyway: synchronize once inside `parallel_analyze`, where the fibers are actually created, instead of relying on every analyzer author remembering to reach for a helper.

## Preventing the round-trip

Added a short note to `analyzer_architecture` (EN + KO) recording that this was tried in #2353 and removed in #2357, why, and what to do instead. Without it the next reader sees only a doc asserting a convention with no trace of the argument, which is exactly how it got re-litigated the first time.

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4088 / 0 failures |
| `crystal spec spec/functional_test` | 22383 / 0 failures |
| `ameba` | 1793 / 0 failures |
| `crystal tool format --check` | clean |

Also grepped for stale references — no `append_endpoint` or `@result_mutex` remains in `src/` or `spec/`.