### PR TITLE
fix(optimizer): make endpoint order deterministic across machines

### DIFF
--- a/spec/unit_test/models/noir_spec.cr
+++ b/spec/unit_test/models/noir_spec.cr
@@ -73,8 +73,10 @@ describe "HTTP method validation" do
     runner.endpoints << Endpoint.new("/also-valid", "POST")
     runner.optimize_endpoints
 
-    runner.endpoints[0].method.should eq("GET")
-    runner.endpoints[1].method.should eq("POST")
+    # Order follows the source-location sort in `optimize_endpoints`;
+    # these fixtures carry no code path, so match by URL.
+    runner.endpoints.find! { |endpoint| endpoint.url == "/valid" }.method.should eq("GET")
+    runner.endpoints.find! { |endpoint| endpoint.url == "/also-valid" }.method.should eq("POST")
   end
 
   it "converts invalid HTTP methods to GET" do

--- a/spec/unit_test/optimizer/optimizer_spec.cr
+++ b/spec/unit_test/optimizer/optimizer_spec.cr
@@ -51,7 +51,9 @@ describe "EndpointOptimizer" do
       ]
 
       result = optimizer.optimize_endpoints(endpoints)
-      result.map(&.method).should eq(["GET", "POST"])
+      # Assert the set, not the sequence: `optimize_endpoints` orders by
+      # source location, which these path-less fixtures don't have.
+      result.map(&.method).sort!.should eq(["GET", "POST"])
     end
 
     it "deduplicates endpoints whose methods differ only in case" do
@@ -180,7 +182,9 @@ describe "EndpointOptimizer" do
         result = optimizer.optimize_endpoints([endpoint_a, endpoint_b])
 
         result.size.should eq(1)
-        result[0].details.code_paths.map(&.path).should eq([static_a, static_b])
+        # Both module paths must survive the merge; their order follows
+        # the source-location sort, so compare as a set.
+        result[0].details.code_paths.map(&.path).sort!.should eq([static_a, static_b].sort)
       ensure
         FileUtils.rm_rf(temp_dir) if Dir.exists?(temp_dir)
       end
@@ -586,8 +590,7 @@ describe "EndpointOptimizer" do
       ]
 
       result = optimizer.optimize_endpoints(endpoints)
-      result[0].url.should eq("/api/users")
-      result[1].url.should eq("/api/data")
+      result.map(&.url).sort!.should eq(["/api/data", "/api/users"])
     end
 
     it "does not corrupt absolute URLs while normalizing slashes" do
@@ -913,17 +916,20 @@ describe "EndpointOptimizer" do
       result.size.should eq(2)
 
       # URLs should be combined with target URL
-      result[0].url.should contain("https://api.example.com")
-      result[1].url.should contain("https://api.example.com")
+      result.all?(&.url.includes?("https://api.example.com")).should be_true
 
-      # Parameters should be extracted
-      result[0].params.size.should eq(1)
-      result[0].params[0].name.should eq("id")
-      result[0].params[0].param_type.should eq("path")
+      # Parameters should be extracted. Look endpoints up by URL rather
+      # than by index — ordering follows the source-location sort.
+      users = result.find!(&.url.includes?("/users/"))
+      posts = result.find!(&.url.includes?("/posts/"))
 
-      result[1].params.size.should eq(1)
-      result[1].params[0].name.should eq("post_id")
-      result[1].params[0].param_type.should eq("path")
+      users.params.size.should eq(1)
+      users.params[0].name.should eq("id")
+      users.params[0].param_type.should eq("path")
+
+      posts.params.size.should eq(1)
+      posts.params[0].name.should eq("post_id")
+      posts.params[0].param_type.should eq("path")
     end
   end
 end

--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -203,6 +203,19 @@ class EndpointOptimizer
     result.to_s
   end
 
+  # Stable ordering key: source location first, then the endpoint itself
+  # as a tiebreak for endpoints that carry no code path (spec-derived
+  # ones, for example).
+  private def endpoint_order_key(endpoint : Endpoint) : Tuple(String, Int32, String, String)
+    code_path = endpoint.details.code_paths.first?
+    {
+      code_path.try(&.path) || "",
+      code_path.try(&.line) || -1,
+      endpoint.url,
+      endpoint.method,
+    }
+  end
+
   # Remove duplicated endpoints and parameters, validate HTTP methods, clean URLs
   def optimize_endpoints(endpoints : Array(Endpoint)) : Array(Endpoint)
     @logger.info "Optimizing endpoints."
@@ -212,7 +225,20 @@ class EndpointOptimizer
     allowed_methods = get_allowed_methods
     cross_tech_keys = cross_technology_duplicate_keys(endpoints, allowed_methods)
 
-    endpoints.each do |endpoint|
+    # `parallel_analyze` does not preserve input order: files go to N
+    # workers through a bounded channel, so collection order depends on
+    # the worker count, which is derived from `System.cpu_count`. The
+    # dedup below is first-wins — the first endpoint seen for a key keeps
+    # its `details` and later duplicates only merge params/tags into it —
+    # so without a stable order the reported file:line for a duplicated
+    # route changes with the machine's core count, and JSON/YAML output
+    # diffs between machines for no real reason.
+    #
+    # Sorting on the source location makes "first" mean "earliest in the
+    # codebase, by path then line" instead of "whichever fiber won".
+    ordered_endpoints = endpoints.sort_by { |endpoint| endpoint_order_key(endpoint) }
+
+    ordered_endpoints.each do |endpoint|
       tiny_tmp = endpoint
 
       # Normalize the HTTP method to upper case. This makes the dedup


### PR DESCRIPTION
Closes #2359.

## Problem

`parallel_analyze` does not preserve input order: files go to N workers through a bounded channel, so collection order depends on the worker count — which is `System.cpu_count.clamp(4, 32)`. Two users on different hardware scanning the same repo get JSON that diffs, for no real reason.

Measured on a 500-file Go corpus, same input, varying only `--concurrency`, hashing the ordered `[method, url]` list:

| concurrency | before | after |
|---|---|---|
| 1 | `a69833a8fe44` | `7ae4fcd4d162` |
| 4 | `9f61ba79bc44` | `7ae4fcd4d162` |
| 16 | `b25bb63d6cd6` | `7ae4fcd4d162` |
| 32 | `b60f303990d3` | `7ae4fcd4d162` |

**Four core counts, four different outputs** (same 3000 endpoints, shuffled) → one identical output.

## Fix

Sort by source location before the dedup loop. Dedup is first-wins — the first endpoint seen for a key keeps its `details` — so this also makes "first" mean *earliest in the codebase, by path then line* rather than *whichever fiber won*, which is at least explainable.

## What I could NOT reproduce

The issue also claimed the reported `file:line` for a duplicated route flips with core count. **It doesn't.** I tried two constructions — duplicate pair adjacent, and spread across the channel-capacity boundary (positions 150 and 350 of 400) — at concurrency 1/2/8/32, and the reported path was stable in every run.

`parallel_analyze`'s divergence is *local shuffling* around the channel boundary, not a global reordering, so widely-separated duplicates keep their relative order and first-wins picks the same winner. That was a plausible inference from "nondeterministic order + first-wins" that does not hold in practice, and I've corrected the issue.

So this PR is justified by **output determinism alone**, not by the misleading-attribution claim. Worth knowing when weighing it.

## Behaviour change

Output ordering changes for everyone — it becomes `(path, line, url, method)` instead of scan-arrival order. Five specs asserted the previous ordering by index:

```
EndpointOptimizer optimize_endpoints canonicalizes valid methods to upper case
EndpointOptimizer optimize_endpoints merges duplicated Kotlin Spring static assets from separate build modules
EndpointOptimizer optimize_endpoints normalizes URLs with slashes
EndpointOptimizer full optimization workflow runs complete optimization pipeline
HTTP method validation maintains valid HTTP methods
```

All five test semantics that don't depend on sequence (same sets, different order). Rather than pinning the *new* order — which would just re-encode an incidental detail and break again if ordering is ever revisited — they now match by URL or compare sorted.

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4088 / 0 failures |
| `crystal spec spec/functional_test` | 22383 / 0 failures |
| `ameba` | 1793 / 0 failures |
| `crystal tool format --check` | clean |