### PR TITLE
fix(logger): run the spinner as a fiber, not a bare Thread (Crystal 1.21 crash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.19.0, 1.20.0]
+        crystal-version: [1.19.0, 1.20.0, 1.21.0]
     steps:
       - uses: actions/checkout@v7
       - uses: crystal-lang/install-crystal@v1
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.19.0, 1.20.0]
+        crystal-version: [1.19.0, 1.20.0, 1.21.0]
     steps:
       - uses: actions/checkout@v7
       - uses: crystal-lang/install-crystal@v1

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -5,7 +5,10 @@ lib LibC
 end
 
 class NoirLogger
-  SPINNER_FRAMES      = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+  SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+  # Frame delay. `sleep` (fiber-aware) rather than `LibC.usleep`, which
+  # would block the whole scheduler now that the spinner is a fiber.
+  SPINNER_INTERVAL    = 60.milliseconds
   SHIMMER_COLORS      = [159, 255, 250, 247, 245]
   SHIMMER_BAND_RADIUS = SHIMMER_COLORS.size - 1
 
@@ -79,7 +82,16 @@ class NoirLogger
     @spinner_active = true
     @stdout_busy.set(0_i8)
 
-    thread = Thread.new do
+    # Must be a fiber, not a `Thread`. Crystal 1.21 requires every thread
+    # that touches the scheduler to belong to an execution context, and a
+    # bare `Thread.new` has none — the `STDERR.print`/`flush` inside
+    # `render_spinner` then aborts the process with
+    # "Thread#execution_context cannot be nil (NilAssertionError)".
+    # Only reproducible on a TTY, because that is the sole condition under
+    # which `spinner_enabled?` is true.
+    finished = Channel(Nil).new
+
+    spawn do
       index = 0
       while stop.get == 0_i8
         # Non-blocking lock try
@@ -89,23 +101,26 @@ class NoirLogger
           index += 1
           @stdout_busy.set(0_i8)
         end
-        LibC.usleep(60000_u32)
+        sleep SPINNER_INTERVAL
       end
 
       # Spin-acquire for final cleanup
       while @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)[1] == false
-        LibC.usleep(100_u32)
+        Fiber.yield
       end
       clear_spinner_line
       @spinner_active = false
       @stdout_busy.set(0_i8)
+      finished.send(nil)
     end
 
     begin
       yield
     ensure
       stop.set(1_i8)
-      thread.join
+      # Wait for the frame loop to clear its line before returning, so the
+      # next writer doesn't land on top of a half-drawn spinner.
+      finished.receive
     end
   end
 


### PR DESCRIPTION
`noir` aborts on startup under **Crystal 1.21** whenever stderr is a TTY — i.e. every normal interactive run:

```
Unhandled exception: Thread#execution_context cannot be nil (NilAssertionError)
  from crystal/system/thread.cr:82:3 in 'execution_context'
  from fiber/execution_context.cr:166:5 in 'current'
```

## Cause

`NoirLogger#loading` drove the spinner from a raw `Thread.new`. Crystal 1.21 requires every thread that touches the scheduler to belong to an execution context; a bare `Thread.new` has none, so the `STDERR.print` / `STDERR.flush` inside `render_spinner` aborts the process.

TTY-only, because `spinner_enabled?` (`@color_mode && !@no_spinner && STDERR.tty?`) is the sole gate. That is why no spec and no CI job ever hit it, and why it appears the moment a user runs noir by hand.

## Not a regression from recent work

`083846f7` — the commit *before* the perf series — rebuilt with Crystal 1.21 crashes identically. The trigger was upgrading the toolchain (Homebrew now ships 1.21.0), not any code change.

| build | Crystal | TTY run |
|---|---|---|
| `083846f7` (pre-perf-series) | 1.21.0 | **crash** |
| `a057f03f` (current main) | 1.21.0 | **crash** |
| `32612587` | 1.20.3 | ok |
| this PR | 1.21.0 | **ok, 10/10** |

## Fix

`spawn` instead of `Thread.new`; `sleep` instead of `LibC.usleep` (a blocking usleep inside a fiber would stall the whole scheduler); join through a channel so the frame loop still clears its line before `loading` returns.

Reproduce with `script -q /dev/null ./bin/noir scan spec/functional_test/fixtures/crystal/kemal` — 5/5 crashes before, 0/10 after, with endpoints rendering correctly.

Swept for siblings: this was the only `Thread.new` and the only `LibC.usleep` in `src/`.

## CI gap

The matrix was `[1.19.0, 1.20.0]`, so nothing in CI ever compiled against the release that breaks. Added `1.21.0`.

Worth being clear about the limit: CI is not a TTY, so even with 1.21 in the matrix the spinner path stays unexercised. The new entry catches the next *compile-level* incompatibility, not this class of runtime-only, TTY-gated bug. Closing that properly would need a pty-driven smoke test, which I have not added here.

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4088 / 0 failures |
| `crystal spec spec/functional_test` | 22383 / 0 failures |
| `ameba` | 1793 / 0 failures |
| `crystal tool format --check` | clean |
| TTY run (`script`) | 10 / 10 clean |