### PR TITLE
fix(analyzer/php): resolve php_pure URLs against the document root

### DIFF
--- a/spec/functional_test/fixtures/php/pure_webroot/composer.json
+++ b/spec/functional_test/fixtures/php/pure_webroot/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "acme/webroot-app",
+  "require": {
+    "php": ">=8.1"
+  }
+}

--- a/spec/functional_test/fixtures/php/pure_webroot/config/app.php
+++ b/spec/functional_test/fixtures/php/pure_webroot/config/app.php
@@ -1,0 +1,3 @@
+<?php
+// Config, not a route. Must never be emitted as an endpoint.
+return ['debug' => $_SERVER['APP_DEBUG'] ?? false];

--- a/spec/functional_test/fixtures/php/pure_webroot/public/index.php
+++ b/spec/functional_test/fixtures/php/pure_webroot/public/index.php
@@ -1,0 +1,4 @@
+<?php
+// Front controller. Reachable at the document root.
+require __DIR__ . '/../src/Internal.php';
+$page = $_GET['page'];

--- a/spec/functional_test/fixtures/php/pure_webroot/public/legacy-upload.php
+++ b/spec/functional_test/fixtures/php/pure_webroot/public/legacy-upload.php
@@ -1,0 +1,6 @@
+<?php
+// A legacy script dropped straight into the document root. This is the
+// finding that the old repo-wide php_pure suppression used to lose.
+$doc = $_FILES['doc'];
+$user = $_GET['user_id'];
+$token = $_POST['token'];

--- a/spec/functional_test/fixtures/php/pure_webroot/src/Internal.php
+++ b/spec/functional_test/fixtures/php/pure_webroot/src/Internal.php
@@ -1,0 +1,7 @@
+<?php
+// Outside the document root: on disk, never addressable over HTTP.
+// Carries superglobals on purpose - presence of params must not make it
+// an endpoint.
+function internal_handler() {
+    return $_GET['secret'] . $_POST['payload'];
+}

--- a/spec/functional_test/testers/php/cli_spec.cr
+++ b/spec/functional_test/testers/php/cli_spec.cr
@@ -16,6 +16,10 @@ endpoints = [
     Param.new("username", "", "argument"),
     Param.new("admin", "", "flag"),
   ]),
+  # php_pure's per-file GET pseudo-endpoint, same as cli_robo_fp below.
+  # This directory has no composer.json, so php_pure reads it as a plain-PHP
+  # tree where the directory itself is the document root (#2358).
+  Endpoint.new("/src/CreateUserCommand.php", "GET"),
 ]
 
 FunctionalTester.new("fixtures/php/cli_symfony/", {
@@ -91,6 +95,9 @@ artisan_endpoints = [
     Param.new("user", "", "argument"),
     Param.new("queue", "", "flag"),
   ]),
+  # See the cli_symfony note: no composer.json here either, so php_pure
+  # emits its per-file pseudo-endpoint.
+  Endpoint.new("/SendMail.php", "GET"),
 ]
 
 artisan_tester = FunctionalTester.new("fixtures/php/cli_artisan_fp/", {

--- a/spec/functional_test/testers/php/laminas_spec.cr
+++ b/spec/functional_test/testers/php/laminas_spec.cr
@@ -39,6 +39,10 @@ expected_endpoints = [
     Param.new("id", "", "path"),
     Param.new("force", "", "query"),
   ]),
+  # The front controller under the document root. php_pure resolves URLs
+  # against `public/` now, so this is the one genuinely servable `.php`
+  # file in the tree — the rest (config/, src/) is correctly skipped (#2358).
+  Endpoint.new("/index.php", "GET"),
 ]
 
 FunctionalTester.new("fixtures/php/laminas/", {

--- a/spec/functional_test/testers/php/lumen_spec.cr
+++ b/spec/functional_test/testers/php/lumen_spec.cr
@@ -27,6 +27,10 @@ FunctionalTester.new("fixtures/php/lumen/", {
 describe "Lumen analyzer filter" do
   it "drops php_laravel when php_lumen is detected so the redundant pass is skipped" do
     techs = ["php_lumen", "php_laravel", "php_pure"]
-    filter_redundant_generic_techs(techs).should eq ["php_lumen"]
+    # php_pure is deliberately kept: it resolves URLs against the document
+    # root now, so it no longer floods framework scans and can still find a
+    # legacy script sitting inside `public/` (#2358). Only the redundant
+    # framework-vs-framework pass is dropped.
+    filter_redundant_generic_techs(techs).should eq ["php_lumen", "php_pure"]
   end
 end

--- a/spec/functional_test/testers/php/pure_webroot_spec.cr
+++ b/spec/functional_test/testers/php/pure_webroot_spec.cr
@@ -1,0 +1,45 @@
+require "../../func_spec.cr"
+
+# Regression guard for #2358.
+#
+# `php_pure` used to emit a pseudo-endpoint for EVERY `.php` file, so a
+# framework scan filled up with paths that are not web-reachable
+# (`/config/app.php`, `/app/Models/User.php`). The workaround was to drop the
+# analyzer entirely whenever a framework was detected — which also lost a
+# legacy script sitting inside the document root, the one place it really is
+# reachable.
+#
+# The fixture is the shape that broke: a composer-managed project with a
+# `public/` document root, a legacy script inside it, and superglobal-carrying
+# files outside it. `src/Internal.php` and `config/app.php` both reference
+# `$_GET`/`$_POST` on purpose — carrying params must not be enough to make a
+# file an endpoint when it cannot be served.
+expected_endpoints = [
+  Endpoint.new("/index.php", "GET", [
+    Param.new("page", "", "query"),
+  ]),
+  Endpoint.new("/legacy-upload.php", "GET", [
+    Param.new("user_id", "", "query"),
+  ]),
+  Endpoint.new("/legacy-upload.php", "POST", [
+    Param.new("doc", "", "file"),
+    Param.new("token", "", "form"),
+  ]),
+]
+
+tester = FunctionalTester.new("fixtures/php/pure_webroot/", {
+  :techs     => 1,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+tester.perform_tests
+
+it "does not emit files outside the document root" do
+  urls = tester.app.endpoints.map(&.url)
+
+  # Both carry superglobals; neither is servable.
+  urls.should_not contain("/src/Internal.php")
+  urls.should_not contain("/config/app.php")
+
+  # URLs resolve against `public/`, not the scan base.
+  urls.should_not contain("/public/index.php")
+end

--- a/spec/unit_test/analyzer/analyzer_selection_spec.cr
+++ b/spec/unit_test/analyzer/analyzer_selection_spec.cr
@@ -2,9 +2,14 @@ require "../../spec_helper"
 require "../../../src/analyzer/analyzer.cr"
 
 describe "filter_redundant_generic_techs" do
-  it "drops php_pure when a framework-specific php analyzer is present" do
-    filter_redundant_generic_techs(["php_pure", "php_laravel"]).should eq(["php_laravel"])
-    filter_redundant_generic_techs(["php_symfony", "php_pure"]).should eq(["php_symfony"])
+  # php_pure used to be dropped here whenever a PHP framework was detected,
+  # because it emitted every `.php` file as an endpoint. It now resolves URLs
+  # against the document root, so the noise is gone at the source and the rule
+  # was removed — keeping it would still lose a legacy script living inside
+  # `public/` next to a framework app (#2358).
+  it "keeps php_pure when a framework-specific php analyzer is present" do
+    filter_redundant_generic_techs(["php_pure", "php_laravel"]).should eq(["php_pure", "php_laravel"])
+    filter_redundant_generic_techs(["php_symfony", "php_pure"]).should eq(["php_symfony", "php_pure"])
   end
 
   it "keeps php_pure when no framework-specific php analyzer is present" do

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -271,26 +271,15 @@ end
 def filter_redundant_generic_techs(techs : Array(String)) : Array(String)
   filtered = techs.dup
 
-  php_frameworks = Set{
-    "php_laravel",
-    "php_lumen",
-    "php_symfony",
-    "php_cakephp",
-    "php_codeigniter",
-    "php_hyperf",
-    "php_laminas",
-    "php_mautic",
-    "php_slim",
-    "php_thinkphp",
-    "php_wordpress",
-    "php_drupal",
-    "php_magento",
-    "php_yii",
-  }
-
-  if filtered.includes?("php_pure") && filtered.any? { |tech| php_frameworks.includes?(tech) }
-    filtered.reject!("php_pure")
-  end
+  # NOTE: `php_pure` is deliberately NOT dropped when a framework is
+  # present. It used to be, because it emitted every `.php` file in the
+  # tree as an endpoint and drowned framework scans in paths that are not
+  # web-reachable (`/config/app.php`, `/app/Models/User.php`). That was a
+  # workaround for a defect in the analyzer, and it cost real findings: a
+  # legacy script inside the document root — `public/upload.php` beside a
+  # Laravel app — vanished with it. `Analyzer::Php::Php` now resolves URLs
+  # against the document root, so the noise is gone at the source and the
+  # generic analyzer can run alongside the framework one. See #2358.
 
   # Same shape as php_pure: a CFML framework owns its route table, so the
   # generic `.cfm`/`remote`-method analyzer is redundant noise once one is

--- a/src/analyzer/analyzers/php/php.cr
+++ b/src/analyzer/analyzers/php/php.cr
@@ -10,11 +10,117 @@ module Analyzer::Php
     # file in the project, so the union regex is a straight win.
     ALLOW_PATTERNS_RE = Regex.union(["$_GET", "$_POST", "$_REQUEST", "$_SERVER", "$_COOKIE", "$_FILES", "filter_input"])
 
+    # Directory names that conventionally hold the document root. A
+    # directory only counts as one when it *also* contains an
+    # `index.php` front controller — that requirement is what keeps this
+    # safe: a static-site build output like `docs/public/` ships
+    # `index.html`, never `index.php`, so it is not mistaken for a web
+    # root. (See the warning in `Analyzer#web_root_path` about bare
+    # `public/` / `www/` markers.)
+    WEBROOT_DIR_NAMES = ["public", "webroot", "public_html", "htdocs", "www", "web"]
+
+    # Per document root: {expanded web root, normalized web root}.
+    # Lazily built; fibers are cooperative and nothing here yields, so a
+    # plain memo is safe under `parallel_file_scan`.
+    @php_web_roots : Array(Tuple(String, String))? = nil
+    # Normalized roots of composer-managed projects.
+    @php_managed_roots : Array(String)? = nil
+
+    # Document roots discovered in this scan.
+    #
+    # Framework layouts (Laravel, Slim → `public/`; CakePHP → `webroot/`)
+    # serve exactly one directory; everything else — controllers, config,
+    # `bootstrap/`, `bin/` — is on disk but not addressable over HTTP.
+    # Emitting those as endpoints invents attack surface that does not
+    # exist, which is why they used to be suppressed wholesale by dropping
+    # this analyzer whenever a framework was present.
+    #
+    # Returning an empty list means "no dedicated document root", which is
+    # the correct reading for WordPress and for plain-PHP trees: there the
+    # repository root *is* the web root, so every `.php` really is
+    # reachable and the caller keeps the base-relative behaviour.
+    private def php_web_roots : Array(Tuple(String, String))
+      cached = @php_web_roots
+      return cached if cached
+
+      roots = [] of Tuple(String, String)
+      get_files_by_extension(".php").each do |file|
+        next unless File.basename(file) == "index.php"
+
+        dir = File.dirname(file)
+        next unless WEBROOT_DIR_NAMES.includes?(File.basename(dir).downcase)
+
+        expanded = File.expand_path(dir)
+        next if roots.any? { |existing, _| existing == expanded }
+        roots << {expanded, Noir::PathScope.normalize_root(expanded)}
+      end
+
+      @php_web_roots = roots
+      roots
+    end
+
+    # Roots of composer-managed projects. A `composer.json` means the tree
+    # is an application or library with a defined entry point, not a
+    # directory of directly-served scripts.
+    private def php_managed_roots : Array(String)
+      cached = @php_managed_roots
+      return cached if cached
+
+      roots = [] of String
+      all_files.each do |file|
+        next unless File.basename(file) == "composer.json"
+        normalized = Noir::PathScope.normalize_root(File.dirname(file))
+        roots << normalized unless roots.includes?(normalized)
+      end
+
+      @php_managed_roots = roots
+      roots
+    end
+
+    # URL base for `path`, or nil when the file is not web-servable.
+    #
+    # Three layouts, decided per file so a monorepo can hold all of them:
+    #
+    #   1. Under a document root (`public/`, `webroot/`, …) — servable;
+    #      the URL is relative to that root. This is what keeps a legacy
+    #      `public/upload.php` visible next to a Laravel app.
+    #   2. Inside a composer-managed project but outside its document
+    #      root — not servable. Controllers, `config/`, `bootstrap/` and
+    #      `vendor/` live on disk but are never addressable, and emitting
+    #      them invents attack surface. This is the noise that used to be
+    #      suppressed by dropping the whole analyzer.
+    #   3. Neither — the directory *is* the document root. WordPress and
+    #      plain-PHP trees serve every `.php` where it sits, so the
+    #      original base-relative behaviour is correct and preserved.
+    # Returns {base, path} to hand to `get_relative_path`, or nil.
+    #
+    # Both elements must be in the same shape. Document roots are stored
+    # expanded (they are discovered via `File.expand_path`), while `path`
+    # arrives however the scan base was given — relative for `-b spec/...`.
+    # Mixing the two silently fails to strip the prefix and emits the whole
+    # path as the URL, so the doc-root branch pairs the expanded root with
+    # the expanded path, and the fallback keeps both as-given.
+    private def php_url_base_for(path : String) : Tuple(String, String)?
+      expanded = File.expand_path(path)
+
+      if inside = php_web_roots.find { |_, web_root| Noir::PathScope.under_normalized_root?(expanded, web_root) }
+        return {inside[0], expanded}
+      end
+
+      return if php_managed_roots.any? { |root| Noir::PathScope.under_normalized_root?(expanded, root) }
+
+      {php_base_path_for(path), path}
+    end
+
     def analyze_file(path : String) : Array(Endpoint)
       return [] of Endpoint unless File.extname(path) == ".php"
 
+      resolved = php_url_base_for(path)
+      return [] of Endpoint unless resolved
+      url_base, url_path = resolved
+
       endpoints = [] of Endpoint
-      relative_path = get_relative_path(php_base_path_for(path), path)
+      relative_path = get_relative_path(url_base, url_path)
       include_callee = callees_needed?
 
       content = read_file_content(path)


### PR DESCRIPTION
Closes #2358.

## Problem

`php_pure` emitted a pseudo-endpoint for **every** `.php` file, URL-ing it relative to the scan base with no notion of a document root. On a real Laravel checkout that means:

```
GET /config/database.php
GET /app/Models/User.php
GET /bootstrap/app.php
```

Files that exist on disk and are never addressable over HTTP — invented attack surface, in a tool whose entire output is a list of attack surface.

The existing mitigation dropped the analyzer whenever any PHP framework was detected. That removed the noise but cost real findings: a legacy script **inside** the document root — `public/upload.php` next to a Laravel app — disappeared with it.

## Fix

Fix the cause rather than suppress the symptom. Each file is classified:

| | condition | result |
|---|---|---|
| 1 | under a document root (`public/`, `webroot/`, `public_html/`, `htdocs/`, `www/`, `web/` — each required to contain `index.php`) | servable; URL relative to that root |
| 2 | inside a composer-managed project but outside its document root | not servable; emit nothing |
| 3 | neither | the directory **is** the document root; previous base-relative behaviour kept |

Case 3 is what keeps WordPress and plain-PHP trees correct — WordPress ships no `composer.json` and serves from the repository root.

Requiring `index.php` **inside** the directory is what makes the marker list safe. A static-site build in `docs/public/` ships `index.html`, never `index.php` — that is precisely the collision `Analyzer#web_root_path` warns about, and why I did not simply reuse a bare marker list.

## Document roots govern their own project, not the scan

A monorepo holding a Laravel service beside a plain-PHP one keeps both. Verified that `services/api/public/` does **not** silence `legacy/*.php`:

```
/index.php            <- laravel front controller
/legacy-hook.php      <- legacy script inside public/, relative to the doc root
/legacy/report.php    <- separate plain-PHP app, base-relative
/legacy/upload.php
```

Repeating the repo-wide-suppression mistake at a different layer would have traded one false negative for another.

## Measured on upstream checkouts

php_pure's contribution, before → after:

| repo | before | after |
|---|---|---|
| `laravel/laravel` | 27 fabricated | **1** (`public/index.php`) |
| `slimphp/Slim-Skeleton` | 31 fabricated | **1** |
| `cakephp/app` | 35 fabricated | **1** |
| `WordPress/WordPress` | 1753 | **1753** (unchanged — repo root is the document root) |

And the finding the old workaround lost, now recovered:

```
$ noir -b laravel-with-legacy/
GET  /index.php
GET  /upload.php     <- public/upload.php
POST /upload.php
```

With the analyzer correct, the `php_pure` entry in `filter_redundant_generic_techs` is removed — it was a workaround for this defect.

## Spec changes

All are behaviour changes, not weakened assertions:

- **new** `pure_webroot` fixture + spec — the shape that broke. `src/Internal.php` and `config/app.php` carry `$_GET`/`$_POST` **on purpose**, proving that carrying params is not enough to make an unservable file an endpoint.
- `laminas` gains `/index.php` — it has a real `public/index.php`, so the front controller is a true positive.
- `cli_symfony` / `cli_artisan_fp` gain their per-file pseudo-endpoint. Neither has a `composer.json`, so they fall in case 3 — consistent with `cli_robo_fp`, which already expected exactly that.
- `lumen` / `analyzer_selection` — php_pure now survives alongside a framework.

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4088 / 0 failures |
| `crystal spec spec/functional_test` | 22406 / 0 failures |
| `ameba` | 1794 / 0 failures |
| `crystal tool format --check` | clean |

Validated against real checkouts of laravel, Slim-Skeleton, cakephp/app and WordPress, plus a synthetic monorepo, in both relative (`-b spec/...`) and absolute scan-base forms — an early revision passed the absolute case while emitting full paths in the relative one.