### PR TITLE
fix(optimizer): break endpoint-order ties on technology, not just path/line

### DIFF
--- a/src/optimizer/optimizer.cr
+++ b/src/optimizer/optimizer.cr
@@ -203,16 +203,26 @@ class EndpointOptimizer
     result.to_s
   end
 
-  # Stable ordering key: source location first, then the endpoint itself
-  # as a tiebreak for endpoints that carry no code path (spec-derived
-  # ones, for example).
-  private def endpoint_order_key(endpoint : Endpoint) : Tuple(String, Int32, String, String)
+  # Stable ordering key: source location first, then technology as a
+  # tiebreak for endpoints that carry no code path (static/public-dir
+  # serving endpoints, spec-derived ones, etc). `url`/`method` alone
+  # cannot break such ties — every endpoint sharing a dedup key already
+  # has the same url and method, by definition — so without `technology`
+  # here, endpoints with an empty code path (a common shape: multiple
+  # frameworks each serving an identically-named asset from their own
+  # public/ dir) all collapse to the same `("", -1, url, method)` key.
+  # `Array#sort_by` is not a stable sort in Crystal, so those ties would
+  # still resolve to "whichever fiber won" — the exact non-determinism
+  # this sort exists to remove — making the winning `technology` flip
+  # between runs on a single machine, not just across machines.
+  private def endpoint_order_key(endpoint : Endpoint) : Tuple(String, Int32, String, String, String)
     code_path = endpoint.details.code_paths.first?
     {
       code_path.try(&.path) || "",
       code_path.try(&.line) || -1,
       endpoint.url,
       endpoint.method,
+      endpoint.details.technology || "",
     }
   end
 


### PR DESCRIPTION
## Problem

Follow-up to #2359 / #2361. That PR sorted endpoints by `(path, line, url, method)` before dedup to make first-wins deterministic, and concluded the "attribution flips between runs" symptom didn't reproduce — the synthetic test cases used always had a real code path, so no ties ever occurred.

In practice, ties do occur: any endpoint with no code path (static/public-dir serving, which many frameworks emit) collapses to the same `("", -1, url, method)` key. `url`/`method` can't break that tie — every endpoint in a duplicate group already shares them. And Crystal's `Array#sort_by` is **not a stable sort**, so tied elements fall back to the pre-sort array order — i.e. whichever fiber produced the endpoint first. That's the exact non-determinism the sort exists to remove, just one level deeper.

## Repro (single machine, no concurrency flag changes)

```
for i in $(seq 1 10); do
  noir scan spec/functional_test/fixtures -f json -o /tmp/run_$i.json
done
```

- `Found N endpoints` (pre-dedup) was **8267 every time** — raw analysis is deterministic.
- `Identified N endpoints` (post-dedup) flipped between **3283 and 3284**.
- `/1.html`'s `technology` rotated across runs: `crystal_kemal` / `crystal_marten` / `crystal_amber` / `crystal_lucky`.
- `/a/list`'s `technology` flipped `rust_actix_web` / `rust_rocket` (8:2 split over 10 runs).

## Fix

Add `technology` as a final tiebreaker in `endpoint_order_key`. Endpoints with no code path but different technologies (e.g. four Crystal frameworks each serving `/1.html` from their own `public/` dir) now sort deterministically by technology name instead of tying.

After the fix, 15 repeated runs of the same scan: `/1.html` → `crystal_amber` every time, `/a/list` → `rust_actix_web` every time.

## Note: residual non-determinism (separate issue, not fixed here)

The deduped *count* still flips (3283/3284) in ~3/8 runs even after this fix, centered on the `hono_route_mount_crossfile` fixture — its extracted routes (code paths, and in one case a whole `DELETE /todos/:id js_koa` endpoint) sometimes vanish from the output even though the raw pre-dedup count (8267) stays constant. That points to a deeper race in the analysis/extraction layer, not the optimizer's sort. Filing as a follow-up rather than blocking this fix on it.

## Verification

| Check | Result |
|---|---|
| `crystal spec spec/unit_test` | 4095 / 0 failures |
| `crystal spec spec/functional_test` | 22412 / 0 failures |
| `crystal tool format --check` | clean |
| `ameba` (optimizer.cr) | 0 failures |