### PR TITLE
fix(detector): revert content channel capacity from 64 to 16

### DIFF
--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -10,10 +10,19 @@ class Analyzer
   include FileHelper
 
   DEFAULT_CHANNEL_CAPACITY = 128
-  # Detector reader → worker content channel. 16 was too small under
-  # heavy passive-scan / multi-detector load: the single reader fiber
-  # blocked on send while workers drained slowly, stalling disk I/O.
-  DEFAULT_CONTENT_CHANNEL_CAPACITY = 64
+  # Detector reader → worker content channel. Each buffered entry holds a
+  # full file's content (up to MAX_FILE_SIZE), so this bounds worst-case
+  # unreclaimable memory as capacity * MAX_FILE_SIZE.
+  #
+  # Was raised 16 -> 64 under the theory that the single reader fiber was
+  # blocking on send and stalling disk I/O. Re-measured (#2362) on a
+  # heavy-load corpus (multi-detector + passive-scan + -T + --ai-context,
+  # ~80MB of large files): 16 and 64 perform identically (~14.7s avg
+  # either way over 9 interleaved runs). There is no preview_mt build, so
+  # reader and workers are cooperative fibers on one thread with no
+  # blocking-I/O yield point to recover — a deeper buffer just lets the
+  # reader run further ahead without unblocking anything. Kept at 16.
+  DEFAULT_CONTENT_CHANNEL_CAPACITY = 16
   MAX_ANALYZER_WORKERS             = 64
 
   @result : Array(Endpoint)


### PR DESCRIPTION
## Summary

Option 3 from #2362: re-measured whether the 16 -> 64 content-channel capacity bump (from the perf series, #2351-#2353) actually buys anything, and reverted since it doesn't.

- Built both binaries (capacity 16 vs 64) via `just build-release`.
- Benchmarked against a heavy-load corpus (900 route files across JS/Python/Go + 80 large ~1MB Python files, ~80MB total) with `--include=path,techs,callee --ai-context -T` to match the original PR's stated "heavy passive-scan / multi-detector load" rationale.
- 9 runs each (isolated + interleaved to control for system drift): cap64 avg 14.71s, cap16 avg 14.72s — no measurable difference, output endpoint counts identical (18080).

This matches the theoretical argument in #2362: there's no `preview_mt` build anywhere in the project, so the detector's reader and worker fibers are cooperative on a single OS thread. `File.read` on a regular file has no yield point, so a deeper channel buffer just lets the reader run further ahead — it doesn't unblock any I/O/CPU overlap that was never happening.

Reverting to 16 removes the memory-ceiling regression the issue flagged (worst-case buffered file content 64 × `MAX_FILE_SIZE` = 640MB -> 160MB) with zero measured throughput cost.

Fixes #2362

## Test plan

- [x] `just build-release`
- [x] `crystal spec` (26507 examples, 0 failures)
- [x] A/B benchmark described above