### PR TITLE
fix(analyzer/js): stop shared JSRouteExtractor from cross-tagging sibling frameworks

### DIFF
--- a/spec/functional_test/fixtures/javascript/express_hono_foreign/app.js
+++ b/spec/functional_test/fixtures/javascript/express_hono_foreign/app.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const app = express();
+
+app.get('/express-home', (req, res) => {
+  const q = req.query.q;
+  res.json({ q });
+});
+
+module.exports = app;

--- a/spec/functional_test/fixtures/javascript/express_hono_foreign/service.ts
+++ b/spec/functional_test/fixtures/javascript/express_hono_foreign/service.ts
@@ -1,0 +1,12 @@
+// A Hono handler file in the same repo. It uses the same `.get()/.post()`
+// chaining shape Express's shared route extractor recognizes, but never
+// mentions express. The Express analyzer must NOT claim it (mislabeling
+// its routes js_express); the Hono analyzer owns it (#2368).
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+app.get('/hono-items', (c) => c.json([]))
+app.post('/hono-items', (c) => c.json({}))
+
+export default app

--- a/spec/functional_test/testers/javascript/express_hono_foreign_spec.cr
+++ b/spec/functional_test/testers/javascript/express_hono_foreign_spec.cr
@@ -1,0 +1,30 @@
+require "../../func_spec.cr"
+
+# A repo with BOTH an Express app (app.js) and a Hono handler file
+# (service.ts) that uses the same `.get()/.post()` chaining shape
+# Express's shared `Noir::JSRouteExtractor` recognizes, but never mentions
+# express. The Express analyzer must not claim it (mislabeling its routes
+# js_express); the Hono analyzer owns it (#2368).
+expected_endpoints = [
+  Endpoint.new("/express-home", "GET", [Param.new("q", "", "query")]),
+  Endpoint.new("/hono-items", "GET"),
+  Endpoint.new("/hono-items", "POST"),
+]
+
+tester = FunctionalTester.new("fixtures/javascript/express_hono_foreign/", {
+  :techs     => 2,
+  :endpoints => expected_endpoints.size,
+}, expected_endpoints)
+tester.perform_tests
+
+it "tags Hono handler-file routes js_hono, not js_express" do
+  hono_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/hono-items" && endpoint.method == "POST" }
+  hono_route.should_not be_nil
+  hono_route.try(&.details.technology).should eq("js_hono")
+end
+
+it "still tags Express's own routes js_express" do
+  express_route = tester.app.endpoints.find { |endpoint| endpoint.url == "/express-home" && endpoint.method == "GET" }
+  express_route.should_not be_nil
+  express_route.try(&.details.technology).should eq("js_express")
+end

--- a/src/analyzer/analyzers/javascript/express.cr
+++ b/src/analyzer/analyzers/javascript/express.cr
@@ -24,6 +24,7 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
+          next if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, :express)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|

--- a/src/analyzer/analyzers/javascript/fastify.cr
+++ b/src/analyzer/analyzers/javascript/fastify.cr
@@ -22,6 +22,7 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
+          next if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, :fastify)
           autoload_prefix = autoload_prefix_for(path, autoload_roots, content)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)

--- a/src/analyzer/analyzers/javascript/hono.cr
+++ b/src/analyzer/analyzers/javascript/hono.cr
@@ -16,6 +16,7 @@ module Analyzer::Javascript
       parallel_file_scan do |path|
         begin
           content = read_file_content(path)
+          next if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, :hono)
           include_callee = callees_needed?
           callees_by_route = include_callee ? Noir::JSCalleeExtractor.callees_for_routes(content, path) : {} of String => Array(Noir::JSCalleeExtractor::Entry)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,

--- a/src/analyzer/analyzers/javascript/koa.cr
+++ b/src/analyzer/analyzers/javascript/koa.cr
@@ -24,6 +24,7 @@ module Analyzer::Javascript
       parallel_file_scan([".js", ".ts", ".mjs"]) do |path|
         begin
           content = read_file_content(path)
+          next if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, :koa)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|

--- a/src/analyzer/analyzers/javascript/restify.cr
+++ b/src/analyzer/analyzers/javascript/restify.cr
@@ -12,6 +12,7 @@ module Analyzer::Javascript
         begin
           content = read_file_content(path)
           next if client_library_file?(content)
+          next if Noir::JSRouteExtractor.other_shared_extractor_framework?(content, :restify)
           parser_endpoints = Noir::JSRouteExtractor.extract_routes(path, content, @is_debug,
             include_callees: include_callee)
           parser_endpoints.each do |endpoint|

--- a/src/miniparsers/js_route_extractor.cr
+++ b/src/miniparsers/js_route_extractor.cr
@@ -692,6 +692,107 @@ module Noir
       HTTP_SERVER_LIBRARY_MARKERS.none? { |m| content.includes?(m) }
     end
 
+    # Import markers for the five frameworks whose analyzers call
+    # `extract_routes` directly and therefore share its framework-agnostic
+    # verb-chaining shape (`.get(`/`.post(`/...). Keyed by the same Symbol
+    # each analyzer passes to `other_shared_extractor_framework?` below.
+    SHARED_EXTRACTOR_FRAMEWORK_MARKERS = {
+      :express => [
+        "from \"express\"", "from 'express'",
+        "require(\"express\")", "require('express')",
+      ],
+      :fastify => [
+        "from \"fastify\"", "from 'fastify'",
+        "require(\"fastify\")", "require('fastify')",
+        "from \"fastify-plugin\"", "from 'fastify-plugin'",
+        "require(\"fastify-plugin\")", "require('fastify-plugin')",
+        "from \"@fastify/", "from '@fastify/",
+        "require(\"@fastify/", "require('@fastify/",
+      ],
+      :koa => [
+        "from \"koa\"", "from 'koa'",
+        "require(\"koa\")", "require('koa')",
+        "from \"koa-router\"", "from 'koa-router'",
+        "require(\"koa-router\")", "require('koa-router')",
+        "from \"@koa/router\"", "from '@koa/router'",
+        "require(\"@koa/router\")", "require('@koa/router')",
+      ],
+      :hono => [
+        "from \"hono\"", "from 'hono'",
+        "require(\"hono\")", "require('hono')",
+        "from \"hono/", "from 'hono/",
+      ],
+      :restify => [
+        "from \"restify\"", "from 'restify'",
+        "require(\"restify\")", "require('restify')",
+        "from \"restify-router\"", "from 'restify-router'",
+        "require(\"restify-router\")", "require('restify-router')",
+      ],
+    }
+
+    # Sibling JS/TS server frameworks that DON'T call `extract_routes`
+    # (NestJS uses decorators, Hapi/Elysia/AdonisJS have their own
+    # tree-sitter extractors) but whose files are still walked by every
+    # JS/TS analyzer's `parallel_file_scan`. These markers are exclusion-
+    # only: recognizing "this file belongs to NestJS" keeps Express/
+    # Fastify/Koa/Hono/Restify from re-extracting a route-shaped call
+    # (an inline example, a raw `app.use()` bridge, ...) out of it.
+    OTHER_FRAMEWORK_MARKERS = {
+      :nestjs => [
+        "from \"@nestjs/", "from '@nestjs/",
+        "require(\"@nestjs/", "require('@nestjs/",
+      ],
+      :hapi => [
+        "from \"@hapi/hapi\"", "from '@hapi/hapi'",
+        "require(\"@hapi/hapi\")", "require('@hapi/hapi')",
+        "from \"hapi\"", "from 'hapi'",
+        "require(\"hapi\")", "require('hapi')",
+      ],
+      :elysia => [
+        "from \"elysia\"", "from 'elysia'",
+        "require(\"elysia\")", "require('elysia')",
+      ],
+      :adonisjs => [
+        "from \"@adonisjs/", "from '@adonisjs/",
+        "require(\"@adonisjs/", "require('@adonisjs/",
+        "from \"@ioc:Adonis/", "from '@ioc:Adonis/",
+      ],
+    }
+
+    # True when `content` carries definitive import evidence of a
+    # *different* shared-extractor (or sibling) framework than
+    # `framework`, with no evidence of `framework` itself. Guards the main
+    # `extract_routes` call in Express/Fastify/Koa/Hono/Restify's
+    # analyzers: a file that only imports 'hono' should never be
+    # re-attributed to js_express just because its `.get()/.post()`
+    # chaining looks the same as Express's (issue #2368) — whichever
+    # analyzer runs over it first no longer matters once #2367 made the
+    # dedup tiebreak deterministic, because the over-matching analyzer
+    # never produces a competing endpoint in the first place.
+    #
+    # Files with no shared-extractor/sibling import at all (a router
+    # module that only receives `app`/`router` as a bare parameter, with
+    # no import in that file) return false here and fall through to the
+    # existing, permissive whole-tree scan — there's no import to
+    # disambiguate on, so narrowing further is left as follow-up scope
+    # (a confirmed package.json dependency or cross-file mount signal
+    # would be needed to resolve those).
+    def self.other_shared_extractor_framework?(content : String, framework : Symbol) : Bool
+      own_markers = SHARED_EXTRACTOR_FRAMEWORK_MARKERS[framework]
+      return false if own_markers.any? { |m| content.includes?(m) }
+
+      SHARED_EXTRACTOR_FRAMEWORK_MARKERS.each do |other, markers|
+        next if other == framework
+        return true if markers.any? { |m| content.includes?(m) }
+      end
+
+      OTHER_FRAMEWORK_MARKERS.each do |_, markers|
+        return true if markers.any? { |m| content.includes?(m) }
+      end
+
+      false
+    end
+
     def self.attach_callees(endpoint : Endpoint,
                             callees_by_route : Hash(String, Array(JSCalleeExtractor::Entry)),
                             method : String,


### PR DESCRIPTION
## Summary

Fixes #2368.

Express, Fastify, Koa, Hono, and Restify all call `Noir::JSRouteExtractor.extract_routes`, whose verb-chaining shape (`.get()/.post()/.delete()/...`) is framework-agnostic. Each analyzer's `parallel_file_scan` walked every file in the scanned tree unconditionally, so in a multi-framework scan one analyzer would re-extract a sibling's routes and mislabel them under its own technology. #2367 made the resulting dedup tiebreak deterministic (previously it was fiber-scheduling-dependent), which is what turned this pre-existing over-matching bug from "randomly wrong" into "consistently wrong" and made it visible.

Root cause confirmed: the optimizer's dedup key is `{method, url}` only (no file path, no technology), so when two analyzers each produce an endpoint for the exact same file/line (one legitimately, one via over-matching), they collide into a single endpoint and only one technology tag survives.

## Fix

Added `Noir::JSRouteExtractor.other_shared_extractor_framework?(content, framework)` in `src/miniparsers/js_route_extractor.cr`, and gated the main extraction call in each of the five analyzers (`express.cr`, `fastify.cr`, `hono.cr`, `koa.cr`, `restify.cr`) on it:

- A file with a definitive import of a *different* framework (or of NestJS/Hapi/Elysia/AdonisJS, which share the same file-walk but not the extractor) and no evidence of the analyzer's own framework is skipped outright.
- A file with no shared-extractor/sibling import at all (e.g. a router module that only receives `app`/`router` as a bare parameter) falls through to the existing permissive scan, unchanged — there's no import to disambiguate on. This residual gap (raised in the issue itself) is left for a follow-up that would need a confirmed `package.json` dependency or cross-file mount signal.

## Verification

Repro from the issue:
```
noir scan spec/functional_test/fixtures/javascript/hono_route_mount_crossfile spec/functional_test/fixtures/javascript/express -f json
```
Before: `js_hono` wiped out (3 → 0), all 3 routes relabeled `js_express`.
After: `js_hono` stays at 3, `js_express` keeps its own 34.

All 9 framework fixtures scanned together (adonisjs/elysia/express/fastify/hapi/hono/koa/nestjs/restify):

| technology | standalone | before fix | after fix |
|---|---|---|---|
| js_hono | 11 | 0 | 3 |
| js_restify | 14 | 0 | 7 |
| js_fastify | 15 | 2 | 12 |
| js_koa | 20 | 4 | 16 |
| js_hapi | 12 | 4 | 5 |
| ts_nestjs | 11 | 6 | 7 |
| js_elysia | 12 | 8 | 11 |
| js_adonisjs | 22 | 22 | 22 |
| js_express | 34 | 75 | 31 |

The remaining after-fix gaps vs. standalone in that 9-way combined run are a separate, pre-existing issue: several fixtures' demo apps happen to define the same conventional path (`GET /health`, `GET /`, ...), and the optimizer's dedup key doesn't distinguish by file/technology — confirmed this is unrelated to analyzer over-matching (Express's own 34 routes are still all correctly extracted; only 3 collide with identical paths from other fixtures). Not addressed here, out of scope for #2368.

Added `spec/functional_test/testers/javascript/express_hono_foreign_spec.cr` (+ fixture) as a regression test, modeled on the existing `python/flask_foreign_spec.cr` pattern. Verified it fails on pre-fix code and passes after.

## Test plan
- [x] `crystal spec` — 26519 examples, 0 failures
- [x] `crystal spec spec/functional_test/testers/javascript/` — 2627 examples, 0 failures
- [x] Manually confirmed the issue's exact repro command before/after
- [x] `just build-release` succeeds