### PR TITLE
fix: batch of CLI robustness fixes from build exploration

### DIFF
--- a/spec/unit_test/cli/scan_command_spec.cr
+++ b/spec/unit_test/cli/scan_command_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+require "../../../src/cli/commands/scan"
+
+describe Noir::CLI::ScanCommand do
+  describe "STRUCTURED_OUTPUT_FORMATS" do
+    # A zero-technology scan only calls the output builder for formats in
+    # this set; every format below already emits a well-formed envelope
+    # (paths: {}, item: [], header-only table, ...) for zero endpoints, so
+    # skipping any of them here regresses to silent zero-byte output (or,
+    # with `-o`, no file at all) on a "no technologies detected" scan.
+    it "includes every envelope-style format so a no-endpoint scan still emits a valid empty document" do
+      %w[json yaml jsonl toml sarif oas2 oas3 postman html mermaid markdown-table].each do |format|
+        Noir::CLI::ScanCommand::STRUCTURED_OUTPUT_FORMATS.includes?(format).should be_true
+      end
+    end
+
+    it "excludes line-list / command formats that have no envelope to render" do
+      %w[plain curl httpie powershell adb simctl only-url only-param only-header only-cookie only-tag].each do |format|
+        Noir::CLI::ScanCommand::STRUCTURED_OUTPUT_FORMATS.includes?(format).should be_false
+      end
+    end
+  end
+end

--- a/spec/unit_test/models/logger_spec.cr
+++ b/spec/unit_test/models/logger_spec.cr
@@ -139,6 +139,31 @@ describe "NoirLogger" do
     end
   end
 
+  describe ".broken_pipe?" do
+    it "recognizes a POSIX EPIPE" do
+      ex = IO::Error.from_os_error("broken", Errno::EPIPE)
+      NoirLogger.broken_pipe?(ex).should be_true
+    end
+
+    it "rejects an unrelated POSIX errno" do
+      ex = IO::Error.from_os_error("no space", Errno::ENOSPC)
+      NoirLogger.broken_pipe?(ex).should be_false
+    end
+
+    it "recognizes Windows' broken-pipe error codes via WinError#to_errno" do
+      ex = IO::Error.from_os_error("broken", WinError::ERROR_BROKEN_PIPE)
+      NoirLogger.broken_pipe?(ex).should be_true
+
+      ex = IO::Error.from_os_error("no data", WinError::ERROR_NO_DATA)
+      NoirLogger.broken_pipe?(ex).should be_true
+    end
+
+    it "rejects an unrelated WinError" do
+      ex = IO::Error.from_os_error("denied", WinError::ERROR_ACCESS_DENIED)
+      NoirLogger.broken_pipe?(ex).should be_false
+    end
+  end
+
   describe "LogLevel enum" do
     it "has all expected levels" do
       NoirLogger::LogLevel::DEBUG.should_not be_nil

--- a/spec/unit_test/options_spec.cr
+++ b/spec/unit_test/options_spec.cr
@@ -310,6 +310,24 @@ describe "run_options_parser" do
     end
   end
 
+  it "normalize_ai_context_flag routes a multi-token typo to --ai-context=... instead of a stray path" do
+    # A comma-joined multi-word token essentially never collides with a real
+    # directory name, so any multi-token comma list -- typo'd feature names
+    # included -- is folded into `--ai-context=...` and left for
+    # apply_ai_context's own vocabulary check to reject with a precise
+    # "unknown feature" error, instead of silently being scanned as a bogus
+    # base path ("Base path does not exist: bogus,guards").
+    normalize_ai_context_flag(["--ai-context", "bogus,guards"]).should eq(["--ai-context=bogus,guards"])
+    normalize_ai_context_flag(["--ai-context", "guards,sink"]).should eq(["--ai-context=guards,sink"])
+  end
+
+  it "normalize_ai_context_flag still treats a single unrecognized word as a positional path" do
+    # A bare single word is genuinely ambiguous with a real one-word
+    # directory name (`noir scan --ai-context myapp`), so it's left alone
+    # rather than folded in as a feature-list value.
+    normalize_ai_context_flag(["--ai-context", "myapp"]).should eq(["--ai-context=", "myapp"])
+  end
+
   it "legacy --set-pvalue-query alias still appends to set_pvalue_query" do
     original_argv = ARGV.dup
     ARGV.clear

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -25,13 +25,23 @@ module Noir::CLI::ScanCommand
   # rather than a bare magic number.
   WARNING_COLOR = Colorize::Color256.new(208)
 
-  # Output formats whose downstream consumers (jq, SARIF parsers,
-  # CI report uploaders) treat empty stdout as a hard error. When a
-  # scan finds no endpoints, we still emit a valid empty document
-  # for these formats — `{"endpoints":[],"passive_results":[]}` for
-  # json, the matching shape for the others. Plain / human-oriented
-  # formats stay silent because there's nothing meaningful to render.
-  STRUCTURED_OUTPUT_FORMATS = Set{"json", "yaml", "jsonl", "toml", "sarif"}
+  # Output formats whose downstream consumers (jq, SARIF parsers, Swagger/
+  # Postman importers, CI report uploaders/archivers) treat empty or missing
+  # output as a hard error. When a scan finds no endpoints, we still emit a
+  # valid empty document for these formats — `{"endpoints":[],"passive_
+  # results":[]}` for json, a `"paths": {}` OAS document, a header-only
+  # Markdown table, an empty-mindmap Mermaid diagram, a full HTML shell,
+  # etc. Every format below already produces a well-formed document for
+  # zero endpoints (verified), so this is purely about not skipping the
+  # builder call entirely.
+  #
+  # Command-list / line-list formats (curl, httpie, powershell, adb, simctl,
+  # only-*) and `plain` are deliberately excluded: they have no envelope, so
+  # "nothing to render" is the correct empty output for them.
+  STRUCTURED_OUTPUT_FORMATS = Set{
+    "json", "yaml", "jsonl", "toml", "sarif",
+    "oas2", "oas3", "postman", "html", "mermaid", "markdown-table",
+  }
 
   def self.run(argv : Array(String))
     # Stage ARGV through OptionParser (positional path discovery happens
@@ -289,11 +299,8 @@ module Noir::CLI::ScanCommand
         app.report
         exit(0)
       else
-        # Structured output formats need a valid empty document on
-        # stdout even when no endpoints were discovered — downstream
-        # `jq` / SARIF parsers / CI report uploaders treat zero bytes
-        # as a hard error. Plain text formats stay silent because
-        # there's nothing meaningful to render.
+        # See STRUCTURED_OUTPUT_FORMATS above for which formats still get
+        # a report call (and why) when no endpoints were discovered.
         if STRUCTURED_OUTPUT_FORMATS.includes?(app.options["format"].to_s)
           app.report
         end

--- a/src/models/logger.cr
+++ b/src/models/logger.cr
@@ -25,6 +25,25 @@ class NoirLogger
 
   @stdout_busy : Atomic(Int8)
 
+  # `IO::Error#os_error` is `Errno | WinError | WasiError | Nil` — on
+  # Windows a broken pipe surfaces as a `WinError`, not an `Errno`, so
+  # comparing straight against `Errno::EPIPE` silently never matches
+  # there. `WinError#to_errno` normalizes it (`ERROR_BROKEN_PIPE` /
+  # `ERROR_NO_DATA` both map to `Errno::EPIPE`). Noir doesn't ship a WASI
+  # build, so `WasiError` — whose own `#to_errno` doesn't even compile on
+  # every native target (it references an `Errno` member some platforms'
+  # bindings omit) — is intentionally left out of this check.
+  def self.broken_pipe?(ex : IO::Error) : Bool
+    case os_error = ex.os_error
+    when Errno
+      os_error == Errno::EPIPE
+    when WinError
+      os_error.to_errno == Errno::EPIPE
+    else
+      false
+    end
+  end
+
   def initialize(debug : Bool, verbose : Bool, colorize : Bool, no_log : Bool, no_spinner : Bool = false)
     @debug = debug
     @verbose = verbose
@@ -92,26 +111,47 @@ class NoirLogger
     finished = Channel(Nil).new
 
     spawn do
-      index = 0
-      while stop.get == 0_i8
-        # Non-blocking lock try
-        _, success = @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)
-        if success
-          render_spinner(message, index)
-          index += 1
+      # The outer `ensure` guarantees `finished.send(nil)` fires no matter
+      # how this fiber body exits. It matters because an unhandled
+      # exception inside a spawned fiber doesn't crash the process —
+      # Crystal just prints "Unhandled exception in spawn" and lets the
+      # fiber die — so without this, any exception here (render_spinner
+      # and clear_spinner_line no longer raise on IO::Error, but a future
+      # change or an unrelated bug could still raise something) would kill
+      # the fiber before it ever calls `finished.send`, and the caller's
+      # `ensure { stop.set(1_i8); finished.receive }` below would then
+      # block forever on a channel nothing is left alive to send on.
+      # Confirmed empirically: an unhandled raise here previously hung a
+      # minimal repro of this exact fiber/channel shape indefinitely.
+      begin
+        index = 0
+        while stop.get == 0_i8
+          # Non-blocking lock try
+          _, success = @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)
+          if success
+            begin
+              render_spinner(message, index)
+              index += 1
+            ensure
+              @stdout_busy.set(0_i8)
+            end
+          end
+          sleep SPINNER_INTERVAL
+        end
+
+        # Spin-acquire for final cleanup
+        while @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)[1] == false
+          Fiber.yield
+        end
+        begin
+          clear_spinner_line
+          @spinner_active = false
+        ensure
           @stdout_busy.set(0_i8)
         end
-        sleep SPINNER_INTERVAL
+      ensure
+        finished.send(nil)
       end
-
-      # Spin-acquire for final cleanup
-      while @stdout_busy.compare_and_set(0_i8, 2_i8, :acquire_release, :acquire)[1] == false
-        Fiber.yield
-      end
-      clear_spinner_line
-      @spinner_active = false
-      @stdout_busy.set(0_i8)
-      finished.send(nil)
     end
 
     begin
@@ -126,10 +166,23 @@ class NoirLogger
 
   def puts(message)
     STDOUT.puts message
+  rescue ex : IO::Error
+    # Downstream reader closed its end of the pipe (`noir ... | head`, `|
+    # jq -e`, etc.) — nothing left to write for, exit quietly instead of a
+    # broken-pipe stack trace. `puts`/`puts_sub` also carry real report
+    # content (e.g. OutputBuilderPassiveScan's plain-text findings), so
+    # anything other than a broken pipe (disk full, a bad fd, ...) is a
+    # real failure and must still surface, not be swallowed into a lying
+    # exit(0).
+    raise ex unless NoirLogger.broken_pipe?(ex)
+    exit(0)
   end
 
   def puts_sub(message)
     STDOUT.puts "  " + message
+  rescue ex : IO::Error
+    raise ex unless NoirLogger.broken_pipe?(ex)
+    exit(0)
   end
 
   def heading(message)
@@ -191,6 +244,12 @@ class NoirLogger
 
     STDERR.print "\r\e[2K#{line}"
     STDERR.flush
+  rescue IO::Error
+    # STDERR here is pure progress UI, never primary report content — on
+    # any write failure (broken pipe, closed terminal, ...) there's
+    # nothing useful to do but stop trying. Swallowing rather than
+    # exiting/re-raising also guarantees this can never kill the spinner
+    # fiber before it reaches its `finished.send(nil)` cleanup in `loading`.
   end
 
   private def write_stderr_line(message : String)
@@ -202,14 +261,28 @@ class NoirLogger
     clear_spinner_line if @spinner_active
     STDERR.puts message
     STDERR.flush
-
-    @stdout_busy.set(0_i8)
     nil
+  rescue IO::Error
+    # STDERR here is pure progress/debug logging, never primary report
+    # content (see NoirLogger#puts for the stream that does carry content
+    # and needs the stricter broken-pipe-vs-real-failure distinction) — on
+    # any write failure there's nothing useful to do but give up on this
+    # line. Swallowing unconditionally (rather than exiting or re-raising)
+    # means this can never strand @stdout_busy at "held" (an unhandled
+    # exception inside a spawned fiber doesn't stop the whole process —
+    # Crystal just prints "Unhandled exception in spawn" and the fiber
+    # dies — so every other logging fiber would otherwise spin on the
+    # acquire loop above at 100% CPU for good) or skip `log`'s
+    # `exit(1) if level == LogLevel::FATAL`.
+    nil
+  ensure
+    @stdout_busy.set(0_i8)
   end
 
   private def clear_spinner_line
     STDERR.print "\r\e[2K"
     STDERR.flush
+  rescue IO::Error
   end
 
   private def shimmer(text : String, index : Int32) : String

--- a/src/models/output_builder.cr
+++ b/src/models/output_builder.cr
@@ -13,6 +13,7 @@ class OutputBuilder
   @is_color : Bool
   @is_log : Bool
   @output_file : String
+  @stdout_broken : Bool
 
   property io : IO
 
@@ -34,12 +35,25 @@ class OutputBuilder
     @is_log = any_to_bool(options["nolog"])
     @output_file = options["output"].to_s
     @io = STDOUT
+    @stdout_broken = false
 
     @logger = NoirLogger.new @is_debug, @is_verbose, @is_color, @is_log
   end
 
   def ob_puts(message)
-    @io.puts message
+    unless @stdout_broken
+      begin
+        @io.puts message
+      rescue ex : IO::Error
+        raise ex unless NoirLogger.broken_pipe?(ex)
+        # Downstream reader closed its end (`noir ... | head`, `| jq -e`,
+        # ...). Stop writing to it, but keep going below so a run that's
+        # both piped and saved via `-o` still ends up with a complete file
+        # instead of a truncated one — killing the whole process here
+        # would cut the `-o` write off mid-report.
+        @stdout_broken = true
+      end
+    end
     unless @output_file.empty?
       begin
         File.open(@output_file, output_file_mode) do |file|

--- a/src/options.cr
+++ b/src/options.cr
@@ -159,9 +159,17 @@ end
 #   --ai-context guards,sinks    → --ai-context=guards,sinks (heuristic)
 #   --ai-context ./app           → --ai-context=         (next token is a path)
 #
-# The heuristic for "is the next token a feature list?" is intentionally
-# tight: lowercase comma-separated words drawn from a fixed vocabulary.
-# This keeps `noir scan --ai-context ./app` working as a positional path.
+# The heuristic for "is the next token a feature list?": lowercase words
+# joined by commas, where either (a) there's more than one comma-separated
+# word, or (b) the single word matches the fixed vocabulary below exactly.
+# A real filesystem path essentially never contains a literal comma, so
+# any multi-word comma list — typo'd feature names included — is routed
+# to `--ai-context=...` and left for the vocabulary check in
+# `apply_ai_context` to reject with a precise "unknown feature" error,
+# rather than silently falling through to "Base path does not exist:
+# <the typo>". A single bare word still has to match a known feature
+# exactly, since that shape is genuinely ambiguous with a real one-word
+# directory name (`noir scan --ai-context myapp` must keep scanning `myapp`).
 AI_CONTEXT_FEATURES = ["guards", "sinks", "validators", "signals", "callee", "all"]
 
 def normalize_ai_context_flag(args : Array(String)) : Array(String)
@@ -200,7 +208,8 @@ private def ai_context_feature_list?(token : String) : Bool
   return false unless token.matches?(/\A[a-z,]+\z/)
   tokens = token.split(',').reject(&.empty?)
   return false if tokens.empty?
-  tokens.all? { |t| AI_CONTEXT_FEATURES.includes?(t) }
+  return true if tokens.size > 1
+  AI_CONTEXT_FEATURES.includes?(tokens.first)
 end
 
 private def base_help : String


### PR DESCRIPTION
## Summary

Found by manually building and exploratory-testing the CLI (`just build` + poking at flags/formats/pipes). Two rounds: an initial pass found 3 bugs, then a self-review pass on that fix found 2 more real issues in the fix itself (a residual deadlock path and a cross-platform correctness bug), both closed here too.

- **`logger.cr` / `output_builder.cr`** — `noir scan ... --debug 2>&1 | head` (or any consumer that closes the pipe early) reliably wedged the process at 100% CPU forever. Root cause: `write_stderr_line`'s hand-rolled `@stdout_busy` spinlock never released on a raised exception, and an unhandled exception inside a spawned fiber doesn't crash the whole process (Crystal just prints "Unhandled exception in spawn" and lets that one fiber die) — so every other logging fiber spun forever waiting on a lock nothing was left alive to release.
  - STDERR-only writes (pure progress/spinner UI, never primary content) now swallow any `IO::Error` unconditionally instead of exiting or re-raising. This also incidentally fixes a fatal-message-during-broken-pipe skipping its own `exit(1)`, and closes a `finished.receive` deadlock if the spinner fiber ever died mid-write (its body is now wrapped in an outer `ensure` that unconditionally signals completion).
  - STDOUT writes carrying real content (`puts`/`puts_sub`, `ob_puts`) keep a strict broken-pipe-vs-real-failure distinction via a shared `NoirLogger.broken_pipe?` classifier, so a genuine failure (disk full, bad fd) still surfaces instead of being silently swallowed. This classifier also fixes a real cross-platform bug: `IO::Error#os_error` is a `WinError` on Windows, not an `Errno`, so the naive `== Errno::EPIPE` comparison never matched there.
  - `ob_puts` specifically degrades (stops writing to stdout) rather than exiting on a broken pipe, so a run that's both piped and saved via `-o` still gets a complete file instead of a truncated one.

- **`cli/commands/scan.cr`** — a zero-technology scan (empty dir, `--exclude-path "*"`, unsupported codebase) silently produced zero bytes on stdout — or, with `-o`, no output file at all — for `oas2`/`oas3`/`postman`/`html`/`mermaid`/`markdown-table`, despite exit code 0. Every one of those builders already emits a well-formed empty document when actually invoked with zero endpoints (verified); the bug was purely that the early-return path only called the 5 formats already in `STRUCTURED_OUTPUT_FORMATS`.

- **`options.cr`** — `--ai-context bogus,guards` (space form) was misdiagnosed as "the next token is a positional path" (`ERROR: Base path does not exist: bogus,guards`) instead of the correct `unknown feature 'bogus'` that the `=` form already produces. Fixed the heuristic: any multi-token comma-shaped string is now routed to `--ai-context=...` for the real vocabulary check to reject precisely (a real path essentially never contains a literal comma); a single bare word stays ambiguous-with-a-path as before.

## Test plan

- [x] `just build`
- [x] `just test` — 4103 unit + 22424 functional examples, 0 failures
- [x] `just check` — format + ameba lint clean (1798 files)
- [x] Manually reproduced and re-verified all fixes: the hang (`--debug 2>&1 | head`, 5x in a row, no hang/no stray process), empty-format output (`-f html -o out.html` on an empty dir → valid non-empty file, exit 0), `-o` preserved when stdout pipe breaks mid-write, `--ai-context` typo now gives the right error, `WinError::ERROR_BROKEN_PIPE.to_errno == Errno::EPIPE` (Windows path can't be run here but the classifier logic is verified), and the spinner-fiber deadlock fix via an isolated minimal repro
- [x] New regression tests: `NoirLogger.broken_pipe?` classification (POSIX + Windows), `normalize_ai_context_flag` typo routing, `STRUCTURED_OUTPUT_FORMATS` membership