### PR TITLE
test: add missing unit tests for detectors, extractors, builders, passive scan and LLM

### DIFF
--- a/spec/unit_test/detector/javascript/elysia_spec.cr
+++ b/spec/unit_test/detector/javascript/elysia_spec.cr
@@ -1,0 +1,16 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/*"
+
+describe "Detect JS Elysia" do
+  options = create_test_options
+  instance = Detector::Javascript::Elysia.new options
+
+  it "detects elysia import" do
+    instance.detect("index.ts", "import { Elysia } from 'elysia'").should be_true
+    instance.detect("index.js", "const { Elysia } = require('elysia')").should be_true
+  end
+
+  it "detects elysia package.json dependency" do
+    instance.detect("package.json", "{\"dependencies\": {\"elysia\": \"^1.0.0\"}}").should be_true
+  end
+end

--- a/spec/unit_test/detector/javascript/fastify_spec.cr
+++ b/spec/unit_test/detector/javascript/fastify_spec.cr
@@ -1,0 +1,13 @@
+require "../../../spec_helper"
+require "../../../../src/detector/detectors/javascript/*"
+
+describe "Detect JS Fastify" do
+  options = create_test_options
+  instance = Detector::Javascript::Fastify.new options
+
+  it "detects fastify require/import or calls" do
+    instance.detect("server.js", "const fastify = require('fastify')()").should be_true
+    instance.detect("server.ts", "import Fastify from 'fastify'").should be_true
+    instance.detect("server.js", "fastify.get('/path', (req, reply) => {})").should be_true
+  end
+end

--- a/spec/unit_test/llm/response_cleanup_spec.cr
+++ b/spec/unit_test/llm/response_cleanup_spec.cr
@@ -1,0 +1,16 @@
+require "../../spec_helper"
+require "../../../src/llm/response_cleanup"
+
+describe LLM do
+  describe ".strip_json_fences" do
+    it "strips markdown json fences and trims whitespace" do
+      input = "```json\n{\"key\": \"value\"}\n```"
+      LLM.strip_json_fences(input).should eq("{\"key\": \"value\"}")
+    end
+
+    it "handles text without fences" do
+      input = "  {\"key\": \"value\"}  "
+      LLM.strip_json_fences(input).should eq("{\"key\": \"value\"}")
+    end
+  end
+end

--- a/spec/unit_test/miniparser/go_request_param_extractor_spec.cr
+++ b/spec/unit_test/miniparser/go_request_param_extractor_spec.cr
@@ -1,0 +1,63 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/go_request_param_extractor"
+
+describe Noir::GoRequestParamExtractor do
+  describe "#package_function_bodies_for_dirs" do
+    it "packages function bodies by directory" do
+      contents = {
+        "/app/main.go" => "package main\n\nfunc hello() {}\n",
+      }
+      dirs = Set{"/app"}
+
+      result = Noir::GoRequestParamExtractor.package_function_bodies_for_dirs(contents, dirs)
+      result.has_key?("/app").should be_true
+      result["/app"].has_key?("hello").should be_true
+    end
+  end
+
+  describe "#package_method_bodies_for_dirs" do
+    it "packages method bodies by directory" do
+      contents = {
+        "/app/handler.go" => "package main\n\ntype H struct{}\nfunc (h *H) Serve() {}\n",
+      }
+      dirs = Set{"/app"}
+
+      result = Noir::GoRequestParamExtractor.package_method_bodies_for_dirs(contents, dirs)
+      result.has_key?("/app").should be_true
+      result["/app"].has_key?("Serve").should be_true
+    end
+  end
+
+  describe "#params_for_routes" do
+    it "extracts query and header parameters from go handler" do
+      source = <<-GO
+      package main
+      import "net/http"
+
+      func main() {
+          http.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+              q := r.URL.Query().Get("search")
+              h := r.Header.Get("X-API-Key")
+          })
+      }
+      GO
+
+      # Row index for http.HandleFunc
+      rows = Set{4}
+      methods = {4 => "GET"}
+
+      params_map = Noir::GoRequestParamExtractor.params_for_routes(
+        source,
+        rows,
+        methods,
+        Hash(String, Noir::GoCalleeExtractor::FunctionBody).new,
+        Hash(String, Array(Noir::GoCalleeExtractor::FunctionBody)).new
+      )
+
+      params_map.has_key?(4).should be_true
+      params = params_map[4]
+      params.any? { |p| p.name == "search" && p.param_type == "query" }.should be_true
+      params.any? { |p| p.name == "X-API-Key" && p.param_type == "header" }.should be_true
+    end
+  end
+end

--- a/spec/unit_test/miniparser/js_http_route_extractor_spec.cr
+++ b/spec/unit_test/miniparser/js_http_route_extractor_spec.cr
@@ -1,0 +1,32 @@
+require "../../spec_helper"
+require "../../../src/miniparsers/js_http_route_extractor"
+
+describe Noir::JSHttpRouteExtractor do
+  describe ".source_file?" do
+    it "identifies JS/TS source files" do
+      Noir::JSHttpRouteExtractor.source_file?("server.js").should be_true
+      Noir::JSHttpRouteExtractor.source_file?("server.ts").should be_true
+      Noir::JSHttpRouteExtractor.source_file?("README.md").should be_false
+    end
+  end
+
+  describe ".extract" do
+    it "extracts endpoints from node:http createServer" do
+      code = <<-JS
+      const http = require('http');
+      const server = http.createServer((req, res) => {
+        if (req.url === '/api/users' && req.method === 'GET') {
+          res.end('users');
+        } else if (req.url === '/api/posts' && req.method === 'POST') {
+          res.end('posts');
+        }
+      });
+      JS
+
+      endpoints = Noir::JSHttpRouteExtractor.extract("app.js", code)
+      endpoints.size.should eq(2)
+      endpoints.any? { |e| e.url == "/api/users" && e.method == "GET" }.should be_true
+      endpoints.any? { |e| e.url == "/api/posts" && e.method == "POST" }.should be_true
+    end
+  end
+end

--- a/spec/unit_test/output_builder/mobile_launch_spec.cr
+++ b/spec/unit_test/output_builder/mobile_launch_spec.cr
@@ -1,0 +1,74 @@
+require "../../spec_helper"
+require "../../../src/output_builder/mobile_launch"
+
+private struct MobileLaunchTestHelper
+  include MobileLaunch
+end
+
+describe MobileLaunch do
+  helper = MobileLaunchTestHelper.new
+
+  describe "#ios_origin?" do
+    it "returns true for technology 'ios'" do
+      ep = Endpoint.new("", "GET")
+      ep.details.technology = "ios"
+      helper.ios_origin?(ep).should be_true
+    end
+
+    it "returns false for technology 'android'" do
+      ep = Endpoint.new("", "GET")
+      ep.details.technology = "android"
+      helper.ios_origin?(ep).should be_false
+    end
+
+    it "handles well_known_applinks with apple-app-site-association file" do
+      ep = Endpoint.new("", "GET")
+      ep.details.technology = "well_known_applinks"
+      ep.details.code_paths << PathInfo.new("path/to/apple-app-site-association")
+      helper.ios_origin?(ep).should be_true
+    end
+
+    it "returns false for well_known_applinks with assetlinks.json" do
+      ep = Endpoint.new("", "GET")
+      ep.details.technology = "well_known_applinks"
+      ep.details.code_paths << PathInfo.new("path/to/assetlinks.json")
+      helper.ios_origin?(ep).should be_false
+    end
+  end
+
+  describe "#launchable?" do
+    it "returns true for scheme urls" do
+      helper.launchable?("myapp://path").should be_true
+      helper.launchable?("https://example.com").should be_true
+    end
+
+    it "returns false for relative path urls starting with /" do
+      helper.launchable?("/path/to/something").should be_false
+    end
+  end
+
+  describe "#shell_quote" do
+    it "quotes string for host shell" do
+      helper.shell_quote("hello").should eq("'hello'")
+      helper.shell_quote("hello'world").should eq("'hello'\\''world'")
+    end
+  end
+
+  describe "#device_shell_quote" do
+    it "quotes once if no device shell metacharacters" do
+      helper.device_shell_quote("hello").should eq("'hello'")
+    end
+
+    it "quotes twice if metacharacters are present" do
+      helper.device_shell_quote("hello&world").should eq("''\\''hello&world'\\'''")
+    end
+  end
+
+  describe "#plural" do
+    it "returns empty string for 1 and 's' for others" do
+      helper.plural(1).should eq("")
+      helper.plural(0).should eq("s")
+      helper.plural(2).should eq("s")
+    end
+  end
+end

--- a/spec/unit_test/output_builder/oas_common_spec.cr
+++ b/spec/unit_test/output_builder/oas_common_spec.cr
@@ -1,0 +1,76 @@
+require "../../spec_helper"
+require "../../../src/output_builder/oas_common"
+
+private struct OasCommonTestHelper
+  include OutputBuilderOasCommon
+
+  def test_normalize_oas_path(raw_url : String)
+    normalize_oas_path(raw_url)
+  end
+
+  def test_path_template_names(path : String)
+    path_template_names(path)
+  end
+
+  def test_operation_methods(method : String)
+    operation_methods(method)
+  end
+
+  def test_swagger_url_parts(raw_url : String)
+    swagger_url_parts(raw_url)
+  end
+end
+
+describe OutputBuilderOasCommon do
+  helper = OasCommonTestHelper.new
+
+  describe "#normalize_oas_path" do
+    it "normalizes express style optional segments and param syntax" do
+      helper.test_normalize_oas_path("/users/:id").should eq("/users/{id}")
+      helper.test_normalize_oas_path("/users/[id]").should eq("/users/{id}")
+      helper.test_normalize_oas_path("/users/<int:id>").should eq("/users/{id}")
+      helper.test_normalize_oas_path("/users/*id").should eq("/users/{id}")
+      helper.test_normalize_oas_path("/files/*").should eq("/files/{wildcard}")
+    end
+  end
+
+  describe "#path_template_names" do
+    it "extracts path template parameter names" do
+      helper.test_path_template_names("/users/{id}/posts/{post_id}").should eq(["id", "post_id"])
+    end
+  end
+
+  describe "#operation_methods" do
+    it "returns valid operation methods" do
+      helper.test_operation_methods("GET").should eq(["get"])
+      helper.test_operation_methods("POST").should eq(["post"])
+    end
+
+    it "expands ANY/ALL methods into all valid HTTP methods" do
+      methods = helper.test_operation_methods("ANY")
+      methods.should contain("get")
+      methods.should contain("post")
+      methods.should contain("delete")
+    end
+
+    it "returns empty array for unrecognized methods" do
+      helper.test_operation_methods("INVALID").should be_empty
+    end
+  end
+
+  describe "#swagger_url_parts" do
+    it "parses url parts properly" do
+      parts = helper.test_swagger_url_parts("https://api.example.com/v1")
+      parts[:host].should eq("api.example.com")
+      parts[:base_path].should eq("/v1")
+      parts[:schemes].should eq(["https"])
+    end
+
+    it "handles scheme-less urls" do
+      parts = helper.test_swagger_url_parts("api.example.com/v1")
+      parts[:host].should eq("api.example.com")
+      parts[:base_path].should eq("/v1")
+      parts[:schemes].should eq(["http", "https"])
+    end
+  end
+end

--- a/spec/unit_test/passive_scan/detect_spec.cr
+++ b/spec/unit_test/passive_scan/detect_spec.cr
@@ -1,0 +1,111 @@
+require "../../spec_helper"
+require "../../../src/passive_scan/detect"
+
+describe NoirPassiveScan do
+  logger = NoirLogger.new(false, true, false, true)
+
+  describe ".filter_rules_by_severity" do
+    it "filters rules below the threshold severity" do
+      high_rule_yaml = <<-YAML
+      id: test-high
+      category: sec
+      techs: []
+      info:
+        name: High Rule
+        author: []
+        severity: high
+        description: high severity
+        reference: []
+      matchers:
+        - type: word
+          condition: or
+          patterns:
+            - secret
+      matchers-condition: or
+      YAML
+
+      low_rule_yaml = <<-YAML
+      id: test-low
+      category: sec
+      techs: []
+      info:
+        name: Low Rule
+        author: []
+        severity: low
+        description: low severity
+        reference: []
+      matchers:
+        - type: word
+          condition: or
+          patterns:
+            - debug
+      matchers-condition: or
+      YAML
+
+      high_rule = PassiveScan.new(YAML.parse(high_rule_yaml))
+      low_rule = PassiveScan.new(YAML.parse(low_rule_yaml))
+
+      filtered = NoirPassiveScan.filter_rules_by_severity([high_rule, low_rule], "medium")
+      filtered.size.should eq(1)
+      filtered.first.info.name.should eq("High Rule")
+    end
+  end
+
+  describe ".detect" do
+    it "detects pattern matches on lines" do
+      rule_yaml = <<-YAML
+      id: test-key
+      category: sec
+      techs: []
+      info:
+        name: API Key Detector
+        author: []
+        severity: high
+        description: api key
+        reference: []
+      matchers:
+        - type: word
+          condition: or
+          patterns:
+            - AKIAIOSFODNN7EXAMPLE
+      matchers-condition: or
+      YAML
+      rule = PassiveScan.new(YAML.parse(rule_yaml))
+      content = "line 1\nkey = AKIAIOSFODNN7EXAMPLE\nline 3"
+
+      results = NoirPassiveScan.detect("config.py", content, [rule], logger)
+      results.size.should eq(1)
+      results.first.line_number.should eq(2)
+      results.first.extract.should contain("AKIAIOSFODNN7EXAMPLE")
+    end
+
+    it "supports AND condition for matchers" do
+      rule_yaml = <<-YAML
+      id: test-secret
+      category: sec
+      techs: []
+      info:
+        name: Secret Keyword
+        author: []
+        severity: high
+        description: secret
+        reference: []
+      matchers:
+        - type: word
+          condition: or
+          patterns:
+            - AWS_KEY
+        - type: word
+          condition: or
+          patterns:
+            - secret_value
+      matchers-condition: and
+      YAML
+      rule = PassiveScan.new(YAML.parse(rule_yaml))
+      content = "AWS_KEY = secret_value"
+
+      results = NoirPassiveScan.detect("config.py", content, [rule], logger)
+      results.size.should eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Description
This PR adds missing unit tests across several core components identified during a test coverage audit:
- Output Builder Helpers (, )
- Miniparsers & Extractors (, )
- Passive Scan ()
- LLM ()
- Detectors (, )

## Verification
- Ran `just build` and `just test` (22,424+ examples, 0 failures, 0 errors)
- Ran `just check` / `just fix` for formatting and linting