### PR TITLE
fix(cli): handle -V as version flag alias

### DIFF
--- a/spec/unit_test/cli/help_command_spec.cr
+++ b/spec/unit_test/cli/help_command_spec.cr
@@ -64,7 +64,7 @@ describe Noir::CLI::HelpCommand do
       end
       out.should contain("--no-color")
       out.should contain("--no-spinner")
-      out.should contain("-v, --version")
+      out.should contain("-v, -V, --version")
       out.should contain("-h, --help")
     end
 

--- a/spec/unit_test/cli/router_spec.cr
+++ b/spec/unit_test/cli/router_spec.cr
@@ -35,10 +35,12 @@ describe "Noir::CLI::Legacy.rewrite" do
     Noir::CLI::Legacy.rewrite(["--generate-completion", "bash", "./extra"]).should eq(["completion", "bash"])
   end
 
-  it "rewrites -v to the version subcommand (global anywhere in ARGV)" do
+  it "rewrites -v and -V to the version subcommand (global anywhere in ARGV)" do
     Noir::CLI::Legacy.rewrite(["-v"]).should eq(["version"])
+    Noir::CLI::Legacy.rewrite(["-V"]).should eq(["version"])
     Noir::CLI::Legacy.rewrite(["scan", "-v"]).should eq(["version"])
     Noir::CLI::Legacy.rewrite(["scan", "./app", "-v"]).should eq(["version"])
+    Noir::CLI::Legacy.rewrite(["scan", "./app", "-V"]).should eq(["version"])
   end
 
   it "rewrites --version the same way as -v" do

--- a/spec/unit_test/cli/version_command_spec.cr
+++ b/spec/unit_test/cli/version_command_spec.cr
@@ -10,8 +10,7 @@ describe Noir::CLI::VersionCommand do
       parsed.unknown.should be_nil
     end
 
-    it "flags -V / --verbose" do
-      Noir::CLI::VersionCommand.parse_argv(["-V"]).verbose.should be_true
+    it "flags --verbose" do
       Noir::CLI::VersionCommand.parse_argv(["--verbose"]).verbose.should be_true
     end
 

--- a/spec/unit_test/completions_spec.cr
+++ b/spec/unit_test/completions_spec.cr
@@ -58,7 +58,7 @@ describe "Completion Script Generation" do
       script.should contain("(-T --use-all-taggers)")
       script.should contain("(-t --techs)")
       script.should contain("(-d --debug)")
-      script.should contain("(-v --version)")
+      script.should contain("(-v -V --version)")
       script.should contain("(-h --help)")
     end
 

--- a/src/cli/commands/help.cr
+++ b/src/cli/commands/help.cr
@@ -85,10 +85,10 @@ module Noir::CLI::HelpCommand
         #{cyan.call("help")} [command]                    Show this overview or a command's help
 
       #{green.call("GLOBAL FLAGS:")}
-        --no-color     Strip ANSI color from every command's output (NO_COLOR env also works)
-        --no-spinner   Disable loading spinner animations while keeping normal logs
-        -v, --version  Print the noir version and exit (alias for `noir version`)
-        -h, --help     Show this overview, or, after a verb, that command's help
+        --no-color        Strip ANSI color from every command's output (NO_COLOR env also works)
+        --no-spinner      Disable loading spinner animations while keeping normal logs
+        -v, -V, --version Print the noir version and exit (alias for `noir version`)
+        -h, --help        Show this overview, or, after a verb, that command's help
 
       Run `noir help <command>` (or `noir <command> -h`) for command-specific flags.
       HELP

--- a/src/cli/commands/version.cr
+++ b/src/cli/commands/version.cr
@@ -19,7 +19,7 @@ module Noir::CLI::VersionCommand
       case a
       when "-h", "--help"
         help = true
-      when "-V", "--verbose"
+      when "--verbose"
         verbose = true
       else
         unknown ||= a
@@ -63,11 +63,12 @@ module Noir::CLI::VersionCommand
         noir version [--verbose]
 
       #{green.call("OPTIONS:")}
-        #{cyan.call("--verbose, -V")}          Also show Crystal/LLVM/target build details
-                               (replaces v0 `--build-info`).
+        #{cyan.call("--verbose")}              Also show Crystal/LLVM/target build details
+                                (replaces v0 `--build-info`).
 
       #{green.call("LEGACY ALIASES:")}
         noir -v
+        noir -V
         noir --version
         noir --build-info      → noir version --verbose
       HELP

--- a/src/cli/legacy.cr
+++ b/src/cli/legacy.cr
@@ -25,6 +25,7 @@ module Noir::CLI::Legacy
     "--build-info"   => ["version", "--verbose"],
     "--help-all"     => ["help"],
     "-v"             => ["version"],
+    "-V"             => ["version"],
     "--version"      => ["version"],
   }
 

--- a/src/completions.cr
+++ b/src/completions.cr
@@ -68,7 +68,7 @@ private SCAN_FLAGS = %w[
   --cache-clear
   -d --debug
   --verbose
-  -v --version
+  -v -V --version
   -h --help
 ]
 
@@ -199,7 +199,7 @@ def generate_zsh_completion_script
             '--cache-clear[Clear LLM cache before scan]' \\
             '(-d --debug)'{-d,--debug}'[Enable debug messages]' \\
             '--verbose[Verbose mode]' \\
-            '(-v --version)'{-v,--version}'[Show version]' \\
+            '(-v -V --version)'{-v,-V,--version}'[Show version]' \\
             '(-h --help)'{-h,--help}'[Show help]' \\
             '*:path:_files'
           return
@@ -462,7 +462,7 @@ def generate_fish_completion_script
     complete -c noir #{g}      -l cache-clear           -d 'Clear LLM cache before scan'
     complete -c noir #{g} -s d -l debug                 -d 'Enable debug messages'
     complete -c noir #{g}      -l verbose               -d 'Verbose mode'
-    complete -c noir #{g} -s v -l version               -d 'Show version'
+    complete -c noir #{g} -s v -s V -l version           -d 'Show version'
     complete -c noir #{g} -s h -l help                  -d 'Show help'
     SCRIPT
 end
@@ -511,7 +511,7 @@ def generate_elvish_completion_script
       --config-file --concurrency
       --cache-disable --cache-clear
       -d --debug --verbose
-      -v --version -h --help
+      -v -V --version -h --help
     ]
 
     set edit:completion:arg-completer[noir] = {|@cmd|


### PR DESCRIPTION
Handle `-V` as a version flag alias matching `-v` and `--version`.