### PR TITLE
fix(detector): fail loudly on a malformed --exclude-path glob

### DIFF
--- a/spec/unit_test/detector/detector_spec.cr
+++ b/spec/unit_test/detector/detector_spec.cr
@@ -112,4 +112,106 @@ describe "detect_techs file walker" do
       CodeLocator.instance.clear_all
     end
   end
+
+  # A malformed glob makes `File.match?` raise inside the reader fiber.
+  # Pre-fix the fiber died silently: the walk stopped where it was, the
+  # remaining files were never read, and the caller saw an empty tech
+  # list — a scan that looks "clean" but covered nothing, with exit 0.
+  describe "malformed --exclude-path globs" do
+    it "raises instead of silently abandoning the walk" do
+      temp_dir = File.tempname("noir_detector_bad_glob")
+      Dir.mkdir_p(temp_dir)
+
+      begin
+        File.write(File.join(temp_dir, "collection.json"), <<-JSON)
+          {
+            "info": {
+              "name": "Example",
+              "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+            },
+            "item": []
+          }
+          JSON
+
+        options = create_test_options
+        options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+        options["exclude_path"] = YAML::Any.new("[unterminated")
+        logger = NoirLogger.new(false, false, false, true)
+        CodeLocator.instance.clear_all
+
+        expect_raises(Noir::InvalidExcludePathError, /invalid glob pattern/) do
+          detect_techs([temp_dir], options, [] of PassiveScan, logger)
+        end
+      ensure
+        FileUtils.rm_rf(temp_dir) if temp_dir
+        CodeLocator.instance.clear_all
+      end
+    end
+
+    # `File.match?` only raises once traversal reaches the malformed
+    # part, so a pattern with a literal prefix stays dormant until the
+    # walk descends into it — the partial-scan case.
+    it "raises for a path-prefixed pattern that only fails deeper in the walk" do
+      temp_dir = File.tempname("noir_detector_bad_glob_prefixed")
+      Dir.mkdir_p(File.join(temp_dir, "src"))
+
+      begin
+        File.write(File.join(temp_dir, "src", "collection.json"), <<-JSON)
+          {
+            "info": {
+              "name": "Example",
+              "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+            },
+            "item": []
+          }
+          JSON
+
+        options = create_test_options
+        options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+        options["exclude_path"] = YAML::Any.new("src/[unterminated")
+        logger = NoirLogger.new(false, false, false, true)
+        CodeLocator.instance.clear_all
+
+        expect_raises(Noir::InvalidExcludePathError, /invalid glob pattern/) do
+          detect_techs([temp_dir], options, [] of PassiveScan, logger)
+        end
+      ensure
+        FileUtils.rm_rf(temp_dir) if temp_dir
+        CodeLocator.instance.clear_all
+      end
+    end
+
+    it "still walks normally for a valid glob" do
+      temp_dir = File.tempname("noir_detector_good_glob")
+      Dir.mkdir_p(temp_dir)
+
+      begin
+        postman_json = File.join(temp_dir, "collection.json")
+        File.write(postman_json, <<-JSON)
+          {
+            "info": {
+              "name": "Example",
+              "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+            },
+            "item": []
+          }
+          JSON
+
+        options = create_test_options
+        options["base"] = YAML::Any.new([YAML::Any.new(temp_dir)])
+        options["exclude_path"] = YAML::Any.new("*.md,src/[a-z]*.go")
+        logger = NoirLogger.new(false, false, false, true)
+        locator = CodeLocator.instance
+        locator.clear_all
+
+        detected = detect_techs([temp_dir], options, [] of PassiveScan, logger)
+
+        detected[0].should contain("postman")
+        locator.all("file_map").should contain(postman_json)
+      ensure
+        FileUtils.rm_rf(temp_dir) if temp_dir
+        CodeLocator.instance.clear_all
+      end
+    end
+  end
 end

--- a/src/cli/commands/scan.cr
+++ b/src/cli/commands/scan.cr
@@ -344,5 +344,10 @@ module Noir::CLI::ScanCommand
       app.logger.info "Generating Diff Report."
       app.diff_report(app_diff)
     end
+  rescue e : Noir::InvalidExcludePathError
+    # Raised from the detector's file walk once a malformed --exclude-path
+    # glob is actually reached. Without this the process printed a raw
+    # Crystal backtrace from a dead fiber and still exited 0.
+    Noir::CLI.die(e.message || "--exclude-path contains an invalid glob pattern.")
   end
 end

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -576,6 +576,22 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   # plus a short path-sensitive tail (see detector_build_applicable_lookup).
   applicable_lookup = detector_build_applicable_lookup(detector_list)
 
+  # A malformed `--exclude-path` glob makes `File.match?` raise
+  # `File::BadPatternError`. In practice that means an unterminated `[`
+  # character class: the pattern list is comma-separated (so a `{a,b}`
+  # brace group can never arrive intact) and backslashes are folded to
+  # `/` above, which rules out the escape-related raises.
+  #
+  # The raise fires inside the reader fiber below, mid-walk, and only
+  # once traversal actually reaches the malformed part — so `[bad`
+  # raises on the first file while `src/[bad` survives until the walk
+  # descends into `src/`. Left unhandled the fiber died silently: the
+  # walk stopped wherever it was, every remaining file went unscanned,
+  # and noir reported "No technologies detected" with exit 0 — an empty
+  # or partial scan indistinguishable from a genuinely empty codebase.
+  # Capture it here and fail loudly after the WaitGroup instead.
+  exclude_pattern_error : String? = nil
+
   # Thread for reading files and sending their contents to the channel
   wg.add(1)
   spawn do
@@ -779,6 +795,8 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
         budget_mb = (stats[:budget] / (1024.0 * 1024.0)).round(1)
         logger.debug "Content cache: #{stats[:files]} files / #{cached_mb} MB (budget #{budget_mb} MB, #{stats[:skipped]} skipped)"
       end
+    rescue e : File::BadPatternError
+      exclude_pattern_error = e.message || "invalid pattern"
     ensure
       channel.close
       wg.done
@@ -861,6 +879,17 @@ def detect_techs(base_paths : Array(String), options : Hash(String, YAML::Any), 
   end
 
   wg.wait
+
+  # The file walk aborted on a bad glob, so `techs` reflects only the
+  # files read before the raise. Reporting that as a result would be a
+  # silent lie; surface the pattern error and stop.
+  if pattern_error = exclude_pattern_error
+    raise Noir::InvalidExcludePathError.new(
+      "--exclude-path contains an invalid glob pattern (#{pattern_error}): #{options["exclude_path"]?.to_s.inspect}. " \
+      "Check the `[` character classes — each one must be closed with a `]`."
+    )
+  end
+
   logger.debug "Added #{locator.all("file_map").size} files to file_map"
   {techs.uniq, passive_result}
 end

--- a/src/models/detector.cr
+++ b/src/models/detector.cr
@@ -2,6 +2,15 @@ require "./logger"
 require "../utils/utils"
 require "yaml"
 
+module Noir
+  # Raised when a user-supplied `--exclude-path` glob is malformed.
+  # `File.match?` only raises once the walk reaches the bad construct, so
+  # this surfaces from inside the detector's file walk rather than at CLI
+  # parse time; `noir scan` catches it and exits with a clean error.
+  class InvalidExcludePathError < Exception
+  end
+end
+
 class Detector
   @logger : NoirLogger
   @is_debug : Bool


### PR DESCRIPTION
## Problem

A malformed glob in `--exclude-path` — in practice an unterminated `[` character class — makes `File.match?` raise `File::BadPatternError` from inside the detector's reader fiber (`src/detector/detector.cr:667`/`681`). Nothing rescued it, so the fiber died mid-walk: the remaining files were never read, `techs` came back empty or partial, and noir reported **"No technologies detected" while still exiting 0**.

```console
$ noir scan ./myapp --exclude-path "[invalid_glob"
⚬ Detecting technologies in the base directory.
Unhandled exception in spawn: unterminated character set (File::BadPatternError)
  from ... in 'File::match?<String, String>:Bool'
  from ... in '~procProc(Nil)@src/detector/detector.cr:581'
▲ No technologies detected.
$ echo $?
0
```

A raw Crystal backtrace goes to stderr, but the scan otherwise looks like it simply found nothing. In CI a typo'd exclude pattern silently turns a real scan into a green no-op.

The raise only fires once traversal actually reaches the malformed part, so the failure mode varies with the pattern:

| pattern | when it raises | result |
|---|---|---|
| `[bad` | first file walked | empty scan |
| `src/[bad` | once the walk descends into `src/` | **partial** scan |

Both are silent.

## Why not validate at CLI parse time

`File.match?` raises lazily, so pre-validating against a probe subject is unreliable — a pattern with a literal prefix (`src/[bad`) does not raise unless the subject shares that prefix, and an empty subject never raises at all. Re-implementing Crystal's glob grammar to check it statically would duplicate a non-trivial parser (escapes inside character sets, `-` ranges, brace stacks) and drift from it.

Instead the reader fiber captures the error and `detect_techs` re-raises it after the `WaitGroup`, where `noir scan` turns it into a normal `ERROR:` line and exit 1:

```console
$ noir scan ./myapp --exclude-path "[invalid_glob"
ERROR: --exclude-path contains an invalid glob pattern (unterminated character set): "[invalid_glob". Check the `[` character classes — each one must be closed with a `]`.
$ echo $?
1
```

Scoped to the two raise sites reachable here: the pattern list is comma-separated (so a `{a,b}` brace group can never arrive intact) and backslashes are folded to `/` before matching, which rules out the escape-related raises.

## Tests

Three regression tests in `spec/unit_test/detector/detector_spec.cr`: an immediately-failing pattern, a path-prefixed pattern that only fails deeper in the walk, and a valid pattern that must keep walking normally. Verified non-vacuous — with the error class present but the detector catch/raise removed, the first two fail with "Expected Noir::InvalidExcludePathError but nothing was raised".

Full suite green: 4152 unit + 22424 functional examples, 0 failures. `crystal tool format --check` and ameba clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)