### PR TITLE
fix(analyzer): find GraphQL operation documents without -u/--url

### DIFF
--- a/spec/functional_test/testers/specification/graphql_operations_spec.cr
+++ b/spec/functional_test/testers/specification/graphql_operations_spec.cr
@@ -14,3 +14,17 @@ FunctionalTester.new("fixtures/specification/graphql_operations/", {
     Param.new("graphql_operation_mutation_CreateUser", "", "json"),
   ]),
 ], {"url" => YAML::Any.new("https://ex.com")}).perform_tests
+
+# ...and they are found on a plain `noir scan ./app` too. `-u/--url` only
+# prefixes the discovered paths, but the whole file analyzer used to be
+# gated on it, so operation documents were silently invisible on every
+# default scan. Same fixture, no url override.
+FunctionalTester.new("fixtures/specification/graphql_operations/", {
+  :techs     => 0,
+  :endpoints => 1,
+}, [
+  Endpoint.new("/graphql", "POST", [
+    Param.new("graphql_operation_query_GetUser", "", "json"),
+    Param.new("graphql_operation_mutation_CreateUser", "", "json"),
+  ]),
+]).perform_tests

--- a/spec/unit_test/models/analyzer_spec.cr
+++ b/spec/unit_test/models/analyzer_spec.cr
@@ -66,4 +66,23 @@ describe "Initialize FileAnalyzer" do
   it "getter - hooks_count" do
     object.hooks_count.should_not eq(0)
   end
+
+  # Hooks that recognise an endpoint by matching against `-u/--url` cannot
+  # do anything without one, but the url-independent hooks (graphql
+  # operation documents) still have to run — a plain `noir scan ./app`
+  # used to skip the file analyzer wholesale and lose them.
+  it "keeps url-independent hooks active when no url is set" do
+    object.url.should eq("")
+    object.active_hooks.should_not be_empty
+    object.active_hooks.all?(&.requires_url.!).should be_true
+  end
+
+  it "activates every hook once a url is set" do
+    with_url = create_test_options
+    with_url["base"] = YAML::Any.new([YAML::Any.new("noir")])
+    with_url["url"] = YAML::Any.new("https://ex.com")
+
+    analyzer = FileAnalyzer.new(with_url)
+    analyzer.active_hooks.size.should be > object.active_hooks.size
+  end
 end

--- a/src/analyzer/analyzer.cr
+++ b/src/analyzer/analyzer.cr
@@ -405,8 +405,14 @@ def analysis_endpoints(options : Hash(String, YAML::Any), techs, logger : NoirLo
     end
   end
 
-  unless options["url"].to_s.empty?
-    logger.sub "➔ File-based Analyzer: #{file_analyzer.hooks_count} hook#{'s' unless file_analyzer.hooks_count == 1} in use"
+  # `hooks_count` reports only the hooks that can produce something for
+  # this scan: without `-u/--url` the url-matching hooks sit out and the
+  # url-independent ones (graphql operation documents) still run. This used
+  # to be `unless options["url"].empty?`, which skipped the whole
+  # FileAnalyzer — and with it GraphQL operations — on every default scan.
+  file_analyzer_hooks = file_analyzer.hooks_count
+  if file_analyzer_hooks > 0
+    logger.sub "➔ File-based Analyzer: #{file_analyzer_hooks} hook#{'s' unless file_analyzer_hooks == 1} in use"
     result = result + file_analyzer.analyze
   end
 

--- a/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
+++ b/src/analyzer/analyzers/file_analyzers/graphql_analyzer.cr
@@ -173,6 +173,11 @@ module InternalGraphqlParser
   end
 end
 
+# Operations are recognised by GraphQL syntax, not by matching a discovered
+# URL against `-u/--url`, so this hook runs whether or not one was given
+# (`requires_url: false`). It used to be skipped along with the url-matching
+# hooks, which meant `noir scan ./app` found no GraphQL operations at all
+# unless an unrelated `-u` was also passed.
 FileAnalyzer.add_hook(->(path : String, _url : String) : Array(Endpoint) {
   # Operation documents ship with either extension; `.graphqls` is
   # SDL-only by convention and is left to the graphql_sdl analyzer.
@@ -186,4 +191,4 @@ FileAnalyzer.add_hook(->(path : String, _url : String) : Array(Endpoint) {
   end
 
   InternalGraphqlParser.parse_content(path, file_content)
-})
+}, requires_url: false)

--- a/src/models/analyzer.cr
+++ b/src/models/analyzer.cr
@@ -238,17 +238,39 @@ class Analyzer
 end
 
 class FileAnalyzer < Analyzer
-  @@hooks = [] of Proc(String, String, Array(Endpoint))
+  # Most hooks (http, base64, string) recognise an endpoint by matching a
+  # URL they found in the file against the user-supplied `-u/--url`. With
+  # no url their `includes?(url)` test degenerates to "matches
+  # everything", so they must not run at all — that is what `requires_url`
+  # marks.
+  #
+  # A hook that identifies endpoints from file syntax instead (graphql
+  # operation documents) is url-independent and has to run either way.
+  # Gating the whole FileAnalyzer on `-u` used to drop those from every
+  # default scan, so the requirement is now declared per hook rather than
+  # assumed for all of them.
+  record Hook, func : Proc(String, String, Array(Endpoint)), requires_url : Bool
 
-  def hooks_count
-    @@hooks.size
+  @@hooks = [] of Hook
+
+  def self.add_hook(func : Proc(String, String, Array(Endpoint)), requires_url : Bool = true)
+    @@hooks << Hook.new(func, requires_url)
   end
 
-  def self.add_hook(func : Proc(String, String, Array(Endpoint)))
-    @@hooks << func
+  # Hooks that can actually produce something for this scan.
+  def active_hooks : Array(Hook)
+    url_present = !@url.empty?
+    @@hooks.select { |hook| url_present || !hook.requires_url }
+  end
+
+  def hooks_count
+    active_hooks.size
   end
 
   def analyze
+    hooks = active_hooks
+    return @result if hooks.empty?
+
     channel = Channel(String).new(DEFAULT_CHANNEL_CAPACITY)
 
     WaitGroup.wait do |wg|
@@ -269,8 +291,8 @@ class FileAnalyzer < Analyzer
 
               logger.debug "Analyzing: #{path}"
 
-              @@hooks.each do |hook|
-                file_results = hook.call(path, @url)
+              hooks.each do |hook|
+                file_results = hook.func.call(path, @url)
                 unless file_results.nil?
                   file_results.each do |file_result|
                     @result << file_result


### PR DESCRIPTION
## Problem

`-u/--url` is documented as *"prepend this base URL to every discovered path"* — a purely presentational flag. But `detect_endpoints` gated the **entire FileAnalyzer** on it (`src/analyzer/analyzer.cr:408`):

```crystal
unless options["url"].to_s.empty?
  logger.sub "➔ File-based Analyzer: ..."
  result = result + file_analyzer.analyze
end
```

So the same codebase reports different endpoints depending on a flag that should only affect formatting:

```console
$ noir scan spec/functional_test/fixtures/etc          # 13 endpoints, no /graphql
$ noir scan spec/functional_test/fixtures/etc -u http://x   # 14 endpoints, incl. POST /graphql
```

## Why

Three of the four hooks the FileAnalyzer owns (`http.cr`, `base64.cr`, `string.cr`) recognise an endpoint by matching a URL found in the file against the user's `-u` value. They genuinely cannot run without one — an empty url makes their `parsed_url.to_s.includes?(url)` test match *everything*, which would flood results.

The fourth (`graphql_analyzer.cr`) parses GraphQL operation documents (`.graphql` / `.gql`) by syntax and never looks at the url at all — its hook signature even names the parameter `_url`. It inherited the gate anyway when it was moved under `file_analyzers/` in faeea911 to reuse the hook plumbing.

Neither test covering this path would catch it: the functional test always passes `url => "https://ex.com"`, and the unit test calls `InternalGraphqlParser.parse_content` directly, bypassing the gate.

## Fix

The url requirement is now declared **per hook** (`requires_url`, default `true`) rather than assumed for all of them, and `hooks_count` reports only the hooks that can actually produce something for this scan:

```console
$ noir scan ./app            # ➔ File-based Analyzer: 1 hook in use
$ noir scan ./app -u http://x  # ➔ File-based Analyzer: 4 hooks in use
```

Declaring it per hook is what stops this recurring — the original bug was a hook silently inheriting a constraint that wasn't its own.

## Impact

Detection is otherwise unchanged. Scanning noir's own tree: **3122 endpoints vs 3121**, the single addition being `POST /graphql`, **zero removals**.

No measurable runtime cost, despite the walk now running on every scan — it reuses the already-cached file map, so the added per-file work is a stat plus an extension check:

| build | run 1 | run 2 | run 3 |
|---|---|---|---|
| main | 2.28s | 2.27s | 2.35s |
| this PR | 2.39s | 2.27s | 2.34s |

(`shards build --release --no-debug --production`, `noir scan .` on the noir repo, no `-u`.)

## Tests

- Functional: the existing `graphql_operations` fixture is now also asserted **without** a url override. Verified non-vacuous — pre-fix it fails with `expected endpoint [POST::/graphql] not found`.
- Unit: `active_hooks` keeps url-independent hooks live with no url, and activates every hook once one is set.

Full suite green: 4151 unit + 22432 functional examples, 0 failures. `crystal tool format --check` and ameba clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)